### PR TITLE
dev server: make CSS module imports work under `bun ./index.html`

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -946,9 +946,7 @@ impl<'a> LinkerContext<'a> {
                 if loaders.get(i).is_some_and(|l| *l == Loader::Html) && parts.len() > 1 {
                     bits.set(1);
                 }
-                // Same for the JS stub of a client CSS module in the dev format:
-                // tree shaking short-circuits for CSS files and dev imports link
-                // at runtime, so nothing else marks the stub live.
+                // Likewise for a client CSS module's stub: the dev format links imports at runtime.
                 if is_bake_dev
                     && parts.len() > 1
                     && loaders.get(i).is_some_and(|l| l.is_css())

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -929,6 +929,10 @@ impl<'a> LinkerContext<'a> {
         // has finished pushing wrapper / entry-point parts.
         {
             let loaders = self.parse_graph().input_files.items_loader();
+            let sources = self.parse_graph().input_files.items_source();
+            let targets = self.graph.ast.items_target();
+            let is_bake_dev =
+                self.options.output_format == crate::options::OutputFormat::InternalBakeDev;
             let parts_col = self.graph.ast.items_parts();
             let mut parts_live: Vec<bun_collections::AutoBitSet> =
                 Vec::with_capacity(parts_col.len());
@@ -940,6 +944,16 @@ impl<'a> LinkerContext<'a> {
                 // walks its parts, so seed the bit here to preserve the old
                 // `Part::is_live = true` initializer.
                 if loaders.get(i).is_some_and(|l| *l == Loader::Html) && parts.len() > 1 {
+                    bits.set(1);
+                }
+                // Same for the JS stub of a client CSS module in the dev format:
+                // tree shaking short-circuits for CSS files and dev imports link
+                // at runtime, so nothing else marks the stub live.
+                if is_bake_dev
+                    && parts.len() > 1
+                    && loaders.get(i).is_some_and(|l| l.is_css())
+                    && crate::is_client_css_module(targets[i], sources[i].path.pretty)
+                {
                     bits.set(1);
                 }
                 parts_live.push(bits);
@@ -4958,6 +4972,18 @@ impl<'a> LinkerContext<'a> {
         source_index: crate::IndexInt,
     ) -> Result<(), AllocError> {
         crate::linker_context::generate_code_for_lazy_export::generate_code_for_lazy_export(
+            self,
+            source_index,
+        )
+    }
+
+    /// See `linker_context/generateCodeForLazyExport.rs`.
+    #[inline]
+    pub(crate) fn populate_css_module_lazy_export(
+        &mut self,
+        source_index: crate::IndexInt,
+    ) -> Result<(), AllocError> {
+        crate::linker_context::generate_code_for_lazy_export::populate_css_module_lazy_export(
             self,
             source_index,
         )

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1266,10 +1266,7 @@ pub mod parse_worker {
                 // `temp_log` is flushed into `log` on every exit path via linear
                 // control flow (scopeguard would alias `log`/`temp_log`).
 
-                const CSS_MODULE_SUFFIX: &[u8] = b".module.css";
-                let enable_css_modules = source.path.pretty.len() > CSS_MODULE_SUFFIX.len()
-                    && &source.path.pretty[source.path.pretty.len() - CSS_MODULE_SUFFIX.len()..]
-                        == CSS_MODULE_SUFFIX;
+                let enable_css_modules = crate::is_css_module_path(source.path.pretty);
                 // `parse_bundler` takes `ParserOptions<'static>` (the
                 // `'a` on `ParserOptions` is PhantomData-only; storage is a raw
                 // `NonNull<Log>`). Construct via `default(None)` to get `'static`,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -390,7 +390,13 @@ pub mod bv2_impl {
             Unknown = 0,
             Js = 1,
             Asset = 2,
+            /// A stylesheet. The page loads it through a `<link>` tag, so an
+            /// import of it from JS carries no binding.
             Css = 3,
+            /// A client CSS module: a stylesheet as above, plus a module in
+            /// the HMR registry (keyed by the file's path) that exports the
+            /// class-name map. An import of it from JS stays a dependency.
+            CssModule = 4,
         }
         #[derive(Copy, Clone)]
         pub struct CacheEntry {
@@ -5510,6 +5516,7 @@ pub mod bv2_impl {
 
             self.dynamic_import_entry_points = ArrayHashMap::new();
             let mut html_files: ArrayHashMap<Index, ()> = ArrayHashMap::new();
+            let mut css_module_stubs: Vec<Index> = Vec::new();
 
             // Separate non-failing files into two lists: JS and CSS
             let js_reachable_files: &[Index] = 'reachable_files: {
@@ -5657,6 +5664,24 @@ pub mod bv2_impl {
                     }
                 }
 
+                // A client CSS module also ships its class-name map as a module in
+                // the JS chunk, so `import styles from "./x.module.css"` resolves in
+                // the HMR runtime.
+                for entry_point in start.css_entry_points.keys() {
+                    let idx = entry_point.get() as usize;
+                    // SAFETY: `idx < ast.len()`; see the column aliasing note above.
+                    let part_count = unsafe { (*parts_col.add(idx)).len() };
+                    if part_count > 1
+                        && crate::is_client_css_module(
+                            asts.items_target()[idx],
+                            sources[idx].path.pretty,
+                        )
+                    {
+                        js_files.push(*entry_point);
+                        css_module_stubs.push(*entry_point);
+                    }
+                }
+
                 // SAFETY: `alloc_slice_copy` returns into the bundler arena which outlives
                 // this function. Erase the `&self` lifetime via `*const` so the borrow on
                 // `self.arena()` does not extend across the `&mut self` calls below
@@ -5696,6 +5721,13 @@ pub mod bv2_impl {
                     .linker
                     .load(bundle_ptr, ep, scbs, js_reachable_files)
                     .map_err(|_| AllocError)?;
+            }
+
+            // The full link fills a CSS module's class-name map in
+            // `generate_code_for_lazy_export`, which this pipeline skips.
+            for source_index in &css_module_stubs {
+                self.linker
+                    .populate_css_module_lazy_export(source_index.get())?;
             }
 
             // HMR skips tree-shaking, so size and seed the part-liveness bitsets

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -390,12 +390,9 @@ pub mod bv2_impl {
             Unknown = 0,
             Js = 1,
             Asset = 2,
-            /// A stylesheet. The page loads it through a `<link>` tag, so an
-            /// import of it from JS carries no binding.
+            /// A stylesheet the page loads through a `<link>` tag; a JS import of it binds nothing.
             Css = 3,
-            /// A client CSS module: a stylesheet as above, plus a module in
-            /// the HMR registry (keyed by the file's path) that exports the
-            /// class-name map. An import of it from JS stays a dependency.
+            /// A stylesheet plus an HMR module, keyed by the file's path, that exports its class names.
             CssModule = 4,
         }
         #[derive(Copy, Clone)]
@@ -5664,9 +5661,7 @@ pub mod bv2_impl {
                     }
                 }
 
-                // A client CSS module also ships its class-name map as a module in
-                // the JS chunk, so `import styles from "./x.module.css"` resolves in
-                // the HMR runtime.
+                // A client CSS module also ships a module with its class-name map in the JS chunk.
                 for entry_point in start.css_entry_points.keys() {
                     let idx = entry_point.get() as usize;
                     // SAFETY: `idx < ast.len()`; see the column aliasing note above.
@@ -5723,8 +5718,7 @@ pub mod bv2_impl {
                     .map_err(|_| AllocError)?;
             }
 
-            // The full link fills a CSS module's class-name map in
-            // `generate_code_for_lazy_export`, which this pipeline skips.
+            // This pipeline skips `generate_code_for_lazy_export`, so fill the class-name maps here.
             for source_index in &css_module_stubs {
                 self.linker
                     .populate_css_module_lazy_export(source_index.get())?;

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -42,6 +42,7 @@ pub(crate) use bun_ast::UseDirective;
 pub(crate) use bun_ast::{Part, Ref};
 pub use bun_js_printer::MangledProps;
 pub use options_impl::PathTemplate;
+pub(crate) use options_impl::{is_client_css_module, is_css_module_path};
 
 pub use HTMLImportManifest::html_import_manifest;
 pub use bun_core::cheap_prefix_normalizer;

--- a/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
+++ b/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
@@ -57,19 +57,38 @@ pub(crate) fn convert_stmts_for_chunk_for_dev_server<'bump>(
     let input_files = &c.parse_graph().input_files;
     let loaders = input_files.items_loader();
     let sources = input_files.items_source();
-    for record in ast.import_records.as_mut_slice() {
-        if record.path.is_disabled {
-            continue;
-        }
-        if record.source_index.is_valid()
-            && loaders[record.source_index.get() as usize] == Loader::Css
-        {
-            record.path.is_disabled = true;
-            continue;
-        }
-        // Make sure the printer gets the resolved path
-        if record.source_index.is_valid() {
-            record.path = sources[record.source_index.get() as usize].path;
+    // A CSS file's records belong to its stylesheet (`@import`, `composes`,
+    // `url()`), which the CSS chunk reads on another thread. Its JS stub has
+    // no import statements, so there is nothing to rewrite.
+    if ast.css.is_none() {
+        let targets = c.graph.ast.items_target();
+        for record in ast.import_records.as_mut_slice() {
+            if record.path.is_disabled {
+                continue;
+            }
+            if record.source_index.is_valid() {
+                let imported = record.source_index.get() as usize;
+                let is_css = loaders[imported] == Loader::Css;
+                // A stylesheet reaches the page through a <link> tag, not
+                // through the module registry.
+                if is_css
+                    && !crate::is_client_css_module(
+                        targets[imported],
+                        sources[imported].path.pretty,
+                    )
+                {
+                    record.path.is_disabled = true;
+                    continue;
+                }
+                // Make sure the printer gets the resolved path
+                record.path = sources[imported].path;
+                // The class-name map of a client CSS module is a module in the
+                // registry, keyed by this path. Link to it at runtime like to
+                // any other module, so that `require()` and `import()` work too.
+                if is_css {
+                    record.source_index = bun_ast::Index::INVALID;
+                }
+            }
         }
     }
 

--- a/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
+++ b/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
@@ -57,9 +57,7 @@ pub(crate) fn convert_stmts_for_chunk_for_dev_server<'bump>(
     let input_files = &c.parse_graph().input_files;
     let loaders = input_files.items_loader();
     let sources = input_files.items_source();
-    // A CSS file's records belong to its stylesheet (`@import`, `composes`,
-    // `url()`), which the CSS chunk reads on another thread. Its JS stub has
-    // no import statements, so there is nothing to rewrite.
+    // A CSS file's own records belong to the CSS chunk (another thread); its stub imports nothing.
     if ast.css.is_none() {
         let targets = c.graph.ast.items_target();
         for record in ast.import_records.as_mut_slice() {
@@ -69,8 +67,7 @@ pub(crate) fn convert_stmts_for_chunk_for_dev_server<'bump>(
             if record.source_index.is_valid() {
                 let imported = record.source_index.get() as usize;
                 let is_css = loaders[imported] == Loader::Css;
-                // A stylesheet reaches the page through a <link> tag, not
-                // through the module registry.
+                // A plain stylesheet reaches the page through a <link> tag, not the module registry.
                 if is_css
                     && !crate::is_client_css_module(
                         targets[imported],
@@ -82,9 +79,7 @@ pub(crate) fn convert_stmts_for_chunk_for_dev_server<'bump>(
                 }
                 // Make sure the printer gets the resolved path
                 record.path = sources[imported].path;
-                // The class-name map of a client CSS module is a module in the
-                // registry, keyed by this path. Link to it at runtime like to
-                // any other module, so that `require()` and `import()` work too.
+                // A CSS module's class-name map is a registry module; link it at runtime like JS.
                 if is_css {
                     record.source_index = bun_ast::Index::INVALID;
                 }

--- a/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
+++ b/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
@@ -95,10 +95,7 @@ pub(crate) fn convert_stmts_for_chunk_for_dev_server<'bump>(
                 let has_bindings =
                     !st.star_name_loc.is_empty() || st.items.len() > 0 || st.default_name.is_some();
 
-                // Nothing to link to: a plain stylesheet (it arrives through a <link> tag), a
-                // path the `browser` field maps to false, or a deferred barrel import. The body
-                // may still read the binding, so declare the namespace as the empty module a
-                // production bundle gives these (`{ default: {} }`; `{}` for a deferred import).
+                // Nothing to link to (stylesheet, `browser: false` path, deferred barrel import): bind an empty module.
                 let is_deferred = record.flags.contains(ImportRecordFlags::IS_UNUSED);
                 if record.path.is_disabled || is_deferred {
                     if has_bindings {

--- a/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
+++ b/src/bundler/linker_context/convertStmtsForChunkForDevServer.rs
@@ -92,17 +92,24 @@ pub(crate) fn convert_stmts_for_chunk_for_dev_server<'bump>(
         match &stmt.data {
             StmtData::SImport(st) => {
                 let record = &mut ast.import_records[st.import_record_index as usize];
-                if record.path.is_disabled {
-                    continue;
-                }
+                let has_bindings =
+                    !st.star_name_loc.is_empty() || st.items.len() > 0 || st.default_name.is_some();
 
-                if record.flags.contains(ImportRecordFlags::IS_UNUSED) {
-                    // Barrel optimization: this import was deferred (unused submodule).
-                    // Don't add to dep array, but declare the namespace ref as an
-                    // empty object so body code referencing it doesn't throw.
-                    // SAFETY: `st.items` is an arena-owned fat ptr; len is always sound to read.
-                    let items_len = st.items.len();
-                    if !st.star_name_loc.is_empty() || items_len > 0 || st.default_name.is_some() {
+                // Nothing to link to: a plain stylesheet (it arrives through a <link> tag), a
+                // path the `browser` field maps to false, or a deferred barrel import. The body
+                // may still read the binding, so declare the namespace as the empty module a
+                // production bundle gives these (`{ default: {} }`; `{}` for a deferred import).
+                let is_deferred = record.flags.contains(ImportRecordFlags::IS_UNUSED);
+                if record.path.is_disabled || is_deferred {
+                    if has_bindings {
+                        let mut namespace = E::Object::default();
+                        if !is_deferred {
+                            namespace.put(
+                                bump,
+                                b"default",
+                                Expr::init(E::Object::default(), stmt.loc),
+                            )?;
+                        }
                         stmts
                             .inside_wrapper_prefix
                             .append_non_dependency(Stmt::alloc(
@@ -116,7 +123,7 @@ pub(crate) fn convert_stmts_for_chunk_for_dev_server<'bump>(
                                             },
                                             stmt.loc,
                                         ),
-                                        value: Some(Expr::init(E::Object::default(), stmt.loc)),
+                                        value: Some(Expr::init(namespace, stmt.loc)),
                                     }]),
                                     ..Default::default()
                                 },
@@ -129,8 +136,7 @@ pub(crate) fn convert_stmts_for_chunk_for_dev_server<'bump>(
                 let is_builtin = record.tag == ImportRecordTag::Builtin
                     || record.tag == ImportRecordTag::Bun
                     || record.tag == ImportRecordTag::Runtime;
-                let is_bare_import =
-                    st.star_name_loc.is_empty() && st.items.len() == 0 && st.default_name.is_none();
+                let is_bare_import = !has_bindings;
 
                 if is_builtin {
                     if !is_bare_import {

--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -18,10 +18,7 @@ use bun_collections::DynamicBitSetUnmanaged as BitSet;
 
 type SymbolList<'a> = bun_ast::symbol::List<'a>;
 
-/// Fills the lazy-export object of a CSS file's JS stub with the file's
-/// class-name map (`local_scope` plus `composes`). A no-op for other
-/// lazy-export files. The dev server calls this on its own because it skips
-/// `generate_code_for_lazy_export` and prints the `SLazyExport` directly.
+/// Fills a CSS file's lazy-export object with its class-name map. A no-op for other lazy exports.
 pub(crate) fn populate_css_module_lazy_export(
     this: &mut LinkerContext,
     source_index: IndexInt,
@@ -361,11 +358,7 @@ pub(crate) fn generate_code_for_lazy_export(
     source_index: IndexInt,
 ) -> Result<(), AllocError> {
     let mut exports_kind = this.graph.ast.items_exports_kind()[source_index as usize];
-    // The dev server's module format represents lazy-export modules (JSON,
-    // TOML, CSS modules, ...) as CommonJS modules evaluated by the HMR
-    // runtime, so always generate the `module.exports = ...` form below.
-    // The ESM form would synthesize `export` parts that
-    // `print_dev_server_module` cannot represent.
+    // `print_dev_server_module` only has a CommonJS form (`module.exports = ...`) for lazy exports.
     if this.options.output_format == crate::options::OutputFormat::InternalBakeDev
         && exports_kind != bun_ast::ExportsKind::Cjs
     {

--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -18,24 +18,16 @@ use bun_collections::DynamicBitSetUnmanaged as BitSet;
 
 type SymbolList<'a> = bun_ast::symbol::List<'a>;
 
-pub(crate) fn generate_code_for_lazy_export(
+/// Fills the lazy-export object of a CSS file's JS stub with the file's
+/// class-name map (`local_scope` plus `composes`). A no-op for other
+/// lazy-export files. The dev server calls this on its own because it skips
+/// `generate_code_for_lazy_export` and prints the `SLazyExport` directly.
+pub(crate) fn populate_css_module_lazy_export(
     this: &mut LinkerContext,
     source_index: IndexInt,
 ) -> Result<(), AllocError> {
-    let mut exports_kind = this.graph.ast.items_exports_kind()[source_index as usize];
-    // The dev server's module format represents lazy-export modules (JSON,
-    // TOML, CSS modules, ...) as CommonJS modules evaluated by the HMR
-    // runtime, so always generate the `module.exports = ...` form below.
-    // The ESM form would synthesize `export` parts that
-    // `print_dev_server_module` cannot represent.
-    if this.options.output_format == crate::options::OutputFormat::InternalBakeDev
-        && exports_kind != bun_ast::ExportsKind::Cjs
-    {
-        exports_kind = bun_ast::ExportsKind::Cjs;
-        this.graph.ast.items_exports_kind_mut()[source_index as usize] = exports_kind;
-    }
     // Take `parts` as a raw pointer *before* the
-    // long-lived immutable `items_css()` borrow below; re-borrowed again later as needed.
+    // long-lived immutable `items_css()` borrow below.
     let parts: *mut [Part] = this.graph.ast.items_parts_mut()[source_index as usize].as_mut_slice();
     // SAFETY: parse_graph backref; raw deref because `all_sources` is held
     // across `&mut *this.log` below (split borrow).
@@ -44,19 +36,17 @@ pub(crate) fn generate_code_for_lazy_export(
     let maybe_css_ast: Option<&BundlerStyleSheet> = all_css_asts[source_index as usize].as_deref();
 
     // SAFETY: `parts` is a stable SoA column slice valid for the link pass.
-    if unsafe { (&*parts).len() } < 1 {
-        panic!("Internal error: expected at least one part for lazy export");
+    if unsafe { (&*parts).len() } < 2 {
+        panic!("Internal error: expected a lazy export part");
     }
 
-    // SAFETY: `parts.ptr[1]` — Vec raw indexing; using index 1 here.
+    // SAFETY: index 1 is in bounds (checked above).
     let part: &mut Part = unsafe { &mut (*parts)[1] };
 
     // `Part.stmts: StoreSlice<Stmt>` — safe `Deref` to `&[Stmt]`.
     if part.stmts.is_empty() {
         panic!("Internal error: expected at least one statement in the lazy export");
     }
-
-    let module_ref = this.graph.ast.items_module_ref()[source_index as usize];
 
     // Handle css modules
     //
@@ -363,6 +353,34 @@ pub(crate) fn generate_code_for_lazy_export(
             }
         }
     }
+    Ok(())
+}
+
+pub(crate) fn generate_code_for_lazy_export(
+    this: &mut LinkerContext,
+    source_index: IndexInt,
+) -> Result<(), AllocError> {
+    let mut exports_kind = this.graph.ast.items_exports_kind()[source_index as usize];
+    // The dev server's module format represents lazy-export modules (JSON,
+    // TOML, CSS modules, ...) as CommonJS modules evaluated by the HMR
+    // runtime, so always generate the `module.exports = ...` form below.
+    // The ESM form would synthesize `export` parts that
+    // `print_dev_server_module` cannot represent.
+    if this.options.output_format == crate::options::OutputFormat::InternalBakeDev
+        && exports_kind != bun_ast::ExportsKind::Cjs
+    {
+        exports_kind = bun_ast::ExportsKind::Cjs;
+        this.graph.ast.items_exports_kind_mut()[source_index as usize] = exports_kind;
+    }
+
+    populate_css_module_lazy_export(this, source_index)?;
+
+    let parts: *mut [Part] = this.graph.ast.items_parts_mut()[source_index as usize].as_mut_slice();
+    // SAFETY: stable SoA column slice valid for the link pass; index 1 was
+    // bounds-checked by `populate_css_module_lazy_export`.
+    let part: &mut Part = unsafe { &mut (*parts)[1] };
+
+    let module_ref = this.graph.ast.items_module_ref()[source_index as usize];
 
     let stmt: Stmt = part.stmts[0];
     let StmtData::SLazyExport(lazy) = stmt.data else {

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -98,8 +98,7 @@ pub(crate) fn is_css_module_path(pretty_path: &[u8]) -> bool {
     pretty_path.len() > CSS_MODULE_SUFFIX.len() && pretty_path.ends_with(CSS_MODULE_SUFFIX)
 }
 
-/// A CSS module whose class-name map the dev server ships as an HMR module,
-/// next to the stylesheet asset. Server-side CSS stays a stylesheet only.
+/// A CSS module whose class-name map the dev server ships to the browser as an HMR module.
 pub(crate) fn is_client_css_module(target: Target, pretty_path: &[u8]) -> bool {
     target == Target::Browser && is_css_module_path(pretty_path)
 }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -92,6 +92,18 @@ pub(crate) fn is_node_builtin(str: &[u8]) -> bool {
     bun_resolve_builtins::Alias::has(str, bun_ast::Target::Node, Default::default())
 }
 
+/// Whether the CSS parser enables CSS modules for this path.
+pub(crate) fn is_css_module_path(pretty_path: &[u8]) -> bool {
+    const CSS_MODULE_SUFFIX: &[u8] = b".module.css";
+    pretty_path.len() > CSS_MODULE_SUFFIX.len() && pretty_path.ends_with(CSS_MODULE_SUFFIX)
+}
+
+/// A CSS module whose class-name map the dev server ships as an HMR module,
+/// next to the stylesheet asset. Server-side CSS stays a stylesheet only.
+pub(crate) fn is_client_css_module(target: Target, pretty_path: &[u8]) -> bool {
+    target == Target::Browser && is_css_module_path(pretty_path)
+}
+
 const DEFAULT_WILDCARD_PATTERNS: &[(&[u8], &[u8])] = &[
     (b"/bun:", b""),
     // (b"/src:", b""),

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -3160,12 +3160,7 @@ impl<'a> Transpiler<'a> {
         // this arm, before any other `log_mut()` reborrow above.
         let mut opts = bun_css::ParserOptions::default(None);
         opts.logger = Some(core::ptr::NonNull::new(self.log).unwrap());
-        const CSS_MODULE_SUFFIX: &[u8] = b".module.css";
-        let enable_css_modules = file_path_text.len() > CSS_MODULE_SUFFIX.len()
-            && strings::eql_comptime(
-                &file_path_text[file_path_text.len() - CSS_MODULE_SUFFIX.len()..],
-                CSS_MODULE_SUFFIX,
-            );
+        let enable_css_modules = crate::is_css_module_path(file_path_text);
         if enable_css_modules {
             opts.filename = bun_paths::basename(file_path_text);
             opts.css_modules = Some(bun_css::CssModuleConfig::default());

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4167,6 +4167,11 @@ pub(super) fn finalize_bundle(
     // changed file, removing dependencies. This pass also flags what routes
     // have been modified.
     for part_range in js_chunk.content.javascript().parts_in_chunk_in_order.iter() {
+        // The class-name map of a CSS module. Its import records belong to the
+        // stylesheet, and the CSS chunk loop below attaches those edges.
+        if input_file_loaders[part_range.source_index.get() as usize].is_css() {
+            continue;
+        }
         match targets[part_range.source_index.get() as usize].bake_graph() {
             bake::Graph::Server | bake::Graph::Ssr => dev.server_graph.process_chunk_dependencies(
                 &mut ctx,
@@ -5062,10 +5067,7 @@ impl DevServer {
     }
 }
 
-#[derive(Copy, Clone)]
-pub struct CacheEntry {
-    pub(crate) kind: FileKind,
-}
+pub use bun_bundler::bake_types::CacheEntry;
 
 impl DevServer {
     pub(crate) fn is_file_cached(&mut self, path: &[u8], side: bake::Graph) -> Option<CacheEntry> {
@@ -5086,7 +5088,7 @@ impl DevServer {
                             .get_file_by_index(incremental_graph::FileIndex::init(
                                 u32::try_from(index).expect("int cast"),
                             ))
-                            .file_kind(),
+                            .cache_kind(),
                     });
                 }
                 return None;

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5083,13 +5083,12 @@ impl DevServer {
                 let g = $g;
                 let index = g.bundled_files.get_index(path)?;
                 if !g.stale_files.is_set(index) {
-                    return Some(CacheEntry {
-                        kind: g
-                            .get_file_by_index(incremental_graph::FileIndex::init(
-                                u32::try_from(index).expect("int cast"),
-                            ))
-                            .cache_kind(),
-                    });
+                    return g
+                        .get_file_by_index(incremental_graph::FileIndex::init(
+                            u32::try_from(index).expect("int cast"),
+                        ))
+                        .cache_kind()
+                        .map(|kind| CacheEntry { kind });
                 }
                 return None;
             }};

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4167,8 +4167,7 @@ pub(super) fn finalize_bundle(
     // changed file, removing dependencies. This pass also flags what routes
     // have been modified.
     for part_range in js_chunk.content.javascript().parts_in_chunk_in_order.iter() {
-        // The class-name map of a CSS module. Its import records belong to the
-        // stylesheet, and the CSS chunk loop below attaches those edges.
+        // A CSS module's stub: its records are the stylesheet's, which the CSS loop below handles.
         if input_file_loaders[part_range.source_index.get() as usize].is_css() {
             continue;
         }

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -87,6 +87,13 @@ pub enum Content {
     /// First file in a CSS bundle (the one HTML/JS points into). Re-bundles
     /// of any downstream `CssChild` re-queue the root.
     CssRoot(u64),
+    /// A `CssRoot` that is a client CSS module. Next to the stylesheet asset
+    /// it holds the module that exports the class-name map, so that
+    /// `import styles from "./x.module.css"` resolves in the HMR runtime.
+    CssModule {
+        css: u64,
+        code: Box<[u8]>,
+    },
     CssChild,
 }
 
@@ -95,6 +102,14 @@ impl Content {
     fn js_code(&self) -> Option<&[u8]> {
         match self {
             Content::Js(c) | Content::Asset(c) => Some(c),
+            Content::CssModule { code, .. } => Some(code),
+            _ => None,
+        }
+    }
+    #[inline]
+    fn css_root(&self) -> Option<u64> {
+        match self {
+            Content::CssRoot(css) | Content::CssModule { css, .. } => Some(*css),
             _ => None,
         }
     }
@@ -104,7 +119,7 @@ impl Content {
             Content::Unknown => FileKind::Unknown,
             Content::Js(_) => FileKind::Js,
             Content::Asset(_) => FileKind::Asset,
-            Content::CssRoot(_) | Content::CssChild => FileKind::Css,
+            Content::CssRoot(_) | Content::CssModule { .. } | Content::CssChild => FileKind::Css,
         }
     }
 }
@@ -134,6 +149,20 @@ impl File {
     #[inline]
     pub(crate) fn file_kind(&self) -> FileKind {
         self.kind
+    }
+
+    /// What the bundler may assume about this file when it skips parsing it.
+    pub(crate) fn cache_kind(&self) -> bun_bundler::bake_types::CacheKind {
+        use bun_bundler::bake_types::CacheKind;
+        match self.content {
+            Content::CssModule { .. } => CacheKind::CssModule,
+            _ => match self.kind {
+                FileKind::Unknown => CacheKind::Unknown,
+                FileKind::Js => CacheKind::Js,
+                FileKind::Asset => CacheKind::Asset,
+                FileKind::Css => CacheKind::Css,
+            },
+        }
     }
 
     /// `ServerFile.stopsDependencyTrace` / `ClientFile.stopsDependencyTrace`.
@@ -453,7 +482,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             Content::Js(_) | Content::Asset(_) => {
                 // Box<[u8]> dropped here.
             }
-            Content::CssRoot(_) | Content::CssChild => {
+            Content::CssRoot(_) | Content::CssModule { .. } | Content::CssChild => {
                 if css == FreeCssMode::UnrefCss {
                     // SAFETY: see `owner()`; touches `assets` sibling only.
                     unsafe { (*self.owner()).assets.unref_by_path(key) };
@@ -604,6 +633,11 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             Side::Client => {
                 let mut html_route_bundle_index: Option<route_bundle::Index> = None;
                 let mut is_special_framework_file = false;
+                // A client CSS module receives two chunks per bundle: the module
+                // with its class-name map in the JS pass, then its stylesheet in
+                // the CSS pass. Each pass keeps the half that the other one owns.
+                let mut css_module_code: Option<(Box<[u8]>, packed_map::Shared)> = None;
+                let mut css_root: Option<u64> = None;
 
                 if found_existing {
                     // Note: take the existing slot out so `free_file_content`
@@ -611,6 +645,13 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                     let mut existing = core::mem::take(
                         &mut self.bundled_files.values_mut()[file_index.get() as usize],
                     );
+                    css_root = existing.content.css_root();
+                    if let Content::CssModule { code, .. } = &mut existing.content {
+                        css_module_code = Some((
+                            core::mem::take(code),
+                            core::mem::take(&mut existing.source_map),
+                        ));
+                    }
                     self.free_file_content(key, &mut existing, FreeCssMode::IgnoreCss);
 
                     if existing.failed {
@@ -630,13 +671,29 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                 }
 
                 let (new_content, new_source_map, code_len) = match content {
-                    ReceiveChunkContent::Css(css) => {
-                        (Content::CssRoot(css), packed_map::Shared::None, None)
-                    }
+                    ReceiveChunkContent::Css(css) => match css_module_code {
+                        Some((code, source_map)) => {
+                            (Content::CssModule { css, code }, source_map, None)
+                        }
+                        None => (Content::CssRoot(css), packed_map::Shared::None, None),
+                    },
                     ReceiveChunkContent::Js { code, source_map } => {
                         let len = code.len();
-                        let kind = if ctx.loaders[index.get() as usize].is_javascript_like() {
+                        let loader = ctx.loaders[index.get() as usize];
+                        // An unchanged class-name map stays out of the hot
+                        // update, so that a style-only edit of a CSS module
+                        // swaps the stylesheet without re-evaluating importers.
+                        let unchanged = css_module_code
+                            .as_ref()
+                            .is_some_and(|(prior, _)| strings::eql(prior, &code));
+                        let kind = if loader.is_javascript_like() {
                             Content::Js(code)
+                        } else if loader.is_css() {
+                            // The CSS pass of this bundle delivers the stylesheet next.
+                            Content::CssModule {
+                                css: css_root.unwrap_or(0),
+                                code,
+                            }
                         } else {
                             Content::Asset(code)
                         };
@@ -653,16 +710,13 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                             _ => {
                                 // Must precompute line count so source-map
                                 // concatenation knows how many newlines to skip.
-                                let count = match &kind {
-                                    Content::Js(c) | Content::Asset(c) => {
-                                        strings::count_char(&c[..], b'\n') as u32
-                                    }
-                                    _ => 0,
-                                };
+                                let count = kind
+                                    .js_code()
+                                    .map_or(0, |c| strings::count_char(c, b'\n') as u32);
                                 packed_map::Shared::LineCount(packed_map::LineCount::init(count))
                             }
                         };
-                        (kind, sm, Some(len))
+                        (kind, sm, if unchanged { None } else { Some(len) })
                     }
                 };
 
@@ -1242,6 +1296,20 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                             // CSS can't import JS; trace is done.
                             return Ok(());
                         }
+                        Content::CssModule { css, code } => {
+                            match goal {
+                                TraceImportGoal::FindCss => self.current_css_files.push(*css),
+                                TraceImportGoal::FindClientModules => {
+                                    let len = code.len();
+                                    self.current_chunk_parts.push(file_index);
+                                    self.current_chunk_len += len;
+                                }
+                                _ => {}
+                            }
+                            // The edges of a CSS file lead to stylesheets and
+                            // assets, never to modules; trace is done.
+                            return Ok(());
+                        }
                         _ => {}
                     }
                 }
@@ -1625,11 +1693,12 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             let owned_path = owned_path.slice();
             match SIDE {
                 Side::Client => match &self.bundled_files.values()[index].content {
-                    Content::CssRoot(_) | Content::CssChild => {
-                        if matches!(
-                            self.bundled_files.values()[index].content,
-                            Content::CssRoot(_),
-                        ) {
+                    Content::CssRoot(_) | Content::CssModule { .. } | Content::CssChild => {
+                        if self.bundled_files.values()[index]
+                            .content
+                            .css_root()
+                            .is_some()
+                        {
                             entry_points.append_css(owned_path)?;
                         }
                         let mut it = self.edge_lists[index].first_dep;
@@ -1637,10 +1706,11 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                             let entry = self.edges[edge_index.get() as usize];
                             let dep = entry.dependency;
                             self.stale_files.set(dep.get() as usize);
-                            if matches!(
-                                self.bundled_files.values()[dep.get() as usize].content,
-                                Content::CssRoot(_),
-                            ) {
+                            if self.bundled_files.values()[dep.get() as usize]
+                                .content
+                                .css_root()
+                                .is_some()
+                            {
                                 let k = bun_ptr::RawSlice::new(
                                     &*self.bundled_files.keys()[dep.get() as usize],
                                 );
@@ -1659,10 +1729,11 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                                 &*self.bundled_files.keys()[dep.get() as usize],
                             );
                             let k = k.slice();
-                            if matches!(
-                                self.bundled_files.values()[dep.get() as usize].content,
-                                Content::CssRoot(_),
-                            ) {
+                            if self.bundled_files.values()[dep.get() as usize]
+                                .content
+                                .css_root()
+                                .is_some()
+                            {
                                 entry_points.append_css(k)?;
                             } else {
                                 self.append_client_entry_point(entry_points, dep.get() as usize)?;

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -151,10 +151,13 @@ impl File {
         self.kind
     }
 
-    /// What the bundler may assume about this file when it skips parsing it.
-    pub(crate) fn cache_kind(&self) -> bun_bundler::bake_types::CacheKind {
+    /// What an importer may link to without this file being bundled again.
+    /// `None` when there is nothing: a stylesheet that was only reached
+    /// through `@import` or `composes` has no asset and no module of its own.
+    pub(crate) fn cache_kind(&self) -> Option<bun_bundler::bake_types::CacheKind> {
         use bun_bundler::bake_types::CacheKind;
-        match self.content {
+        Some(match self.content {
+            Content::CssChild => return None,
             Content::CssModule { .. } => CacheKind::CssModule,
             _ => match self.kind {
                 FileKind::Unknown => CacheKind::Unknown,
@@ -162,7 +165,7 @@ impl File {
                 FileKind::Asset => CacheKind::Asset,
                 FileKind::Css => CacheKind::Css,
             },
-        }
+        })
     }
 
     /// `ServerFile.stopsDependencyTrace` / `ClientFile.stopsDependencyTrace`.

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -87,9 +87,7 @@ pub enum Content {
     /// First file in a CSS bundle (the one HTML/JS points into). Re-bundles
     /// of any downstream `CssChild` re-queue the root.
     CssRoot(u64),
-    /// A `CssRoot` that is a client CSS module. Next to the stylesheet asset
-    /// it holds the module that exports the class-name map, so that
-    /// `import styles from "./x.module.css"` resolves in the HMR runtime.
+    /// A `CssRoot` that is a client CSS module: also holds the module that exports its class names.
     CssModule {
         css: u64,
         code: Box<[u8]>,
@@ -151,9 +149,7 @@ impl File {
         self.kind
     }
 
-    /// What an importer may link to without this file being bundled again.
-    /// `None` when there is nothing: a stylesheet that was only reached
-    /// through `@import` or `composes` has no asset and no module of its own.
+    /// What an importer may link to without bundling this file again; a `CssChild` has nothing.
     pub(crate) fn cache_kind(&self) -> Option<bun_bundler::bake_types::CacheKind> {
         use bun_bundler::bake_types::CacheKind;
         Some(match self.content {
@@ -636,9 +632,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             Side::Client => {
                 let mut html_route_bundle_index: Option<route_bundle::Index> = None;
                 let mut is_special_framework_file = false;
-                // A client CSS module receives two chunks per bundle: the module
-                // with its class-name map in the JS pass, then its stylesheet in
-                // the CSS pass. Each pass keeps the half that the other one owns.
+                // A client CSS module gets a JS pass, then a CSS pass; each keeps the other's half.
                 let mut css_module_code: Option<(Box<[u8]>, packed_map::Shared)> = None;
                 let mut css_root: Option<u64> = None;
 
@@ -683,9 +677,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                     ReceiveChunkContent::Js { code, source_map } => {
                         let len = code.len();
                         let loader = ctx.loaders[index.get() as usize];
-                        // An unchanged class-name map stays out of the hot
-                        // update, so that a style-only edit of a CSS module
-                        // swaps the stylesheet without re-evaluating importers.
+                        // An unchanged class-name map stays out of the hot update: the edit was style-only.
                         let unchanged = css_module_code
                             .as_ref()
                             .is_some_and(|(prior, _)| strings::eql(prior, &code));
@@ -1309,8 +1301,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                                 }
                                 _ => {}
                             }
-                            // The edges of a CSS file lead to stylesheets and
-                            // assets, never to modules; trace is done.
+                            // A CSS file's edges lead to stylesheets and assets only; trace is done.
                             return Ok(());
                         }
                         _ => {}

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -44,8 +44,8 @@ pub use super::dev_server_body::{
     TestingBatchEvents, deferred_request, entry_point_list,
 };
 
-/// `DevServer.FileKind` — kept in lockstep with `bun_bundler::bake_types::CacheKind`
-/// (the vtable boundary maps between them via an exhaustive match).
+/// `DevServer.FileKind`. `File::cache_kind` maps it to what the bundler sees,
+/// `bun_bundler::bake_types::CacheKind`.
 #[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum FileKind {
@@ -1144,19 +1144,7 @@ bun_bundler::link_impl_DevServerHandle! {
                 .track_resolution_failure(import_source, specifier, renderer, loader)
                 .map_err(Into::into)
         },
-        is_file_cached(abs_path, side) => {
-            (*this).is_file_cached(abs_path, side).map(|e| {
-                use bun_bundler::bake_types::CacheKind;
-                bun_bundler::bake_types::CacheEntry {
-                    kind: match e.kind {
-                        FileKind::Unknown => CacheKind::Unknown,
-                        FileKind::Js => CacheKind::Js,
-                        FileKind::Asset => CacheKind::Asset,
-                        FileKind::Css => CacheKind::Css,
-                    },
-                }
-            })
-        },
+        is_file_cached(abs_path, side) => (*this).is_file_cached(abs_path, side),
         asset_hash(abs_path) => (*this).assets.get_hash(abs_path),
         current_bundle_start_data() => {
             (*this)

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -44,8 +44,7 @@ pub use super::dev_server_body::{
     TestingBatchEvents, deferred_request, entry_point_list,
 };
 
-/// `DevServer.FileKind`. `File::cache_kind` maps it to what the bundler sees,
-/// `bun_bundler::bake_types::CacheKind`.
+/// `DevServer.FileKind`. `File::cache_kind` maps it to the bundler's `CacheKind`.
 #[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum FileKind {

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -303,6 +303,9 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
         require: mod.require.bind(mod),
       };
       mod.exports = null;
+    } else {
+      // Drop the ESM view of the previous evaluation's `cjs.exports`.
+      mod.exports = null;
     }
     if (importer) {
       mod.importers.add(importer);
@@ -402,6 +405,9 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
         exports: {},
         require: mod.require.bind(mod),
       };
+      mod.exports = null;
+    } else {
+      // Drop the ESM view of the previous evaluation's `cjs.exports`.
       mod.exports = null;
     }
     if (importer) {

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -1008,6 +1008,34 @@ devTest("plain css import stays side-effect only next to css modules", {
     expect(await c.js<number>`globalThis.evalCount`).toBe(1);
   },
 });
+devTest("plain css imported with a binding is an empty module, as in bun build", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "plain.css": `
+      body { color: red; }
+    `,
+    "other.css": `
+      h1 { color: blue; }
+    `,
+    "index.ts": `
+      import sheet from "./plain.css";
+      import * as ns from "./other.css";
+      console.log(JSON.stringify({ sheet, ns: Object.keys(ns), nsDefault: ns.default }));
+      import.meta.hot.accept();
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage(JSON.stringify({ sheet: {}, ns: ["default"], nsDefault: {} }));
+    await c.style("body").color.expect.toBe("red");
+    await c.style("h1").color.expect.toBe("#00f");
+    // The same holds when the importer is bundled again and the stylesheets are cached.
+    await dev.patch("index.ts", { find: "JSON.stringify({", replace: `"again:" + JSON.stringify({` });
+    await c.expectMessage("again:" + JSON.stringify({ sheet: {}, ns: ["default"], nsDefault: {} }));
+  },
+});
 
 function extractCssUrl(backgroundImage: string): string {
   const url = backgroundImage.match(/url\((['"])(.*?)\1\)/);

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -697,6 +697,192 @@ devTest("css import before create project relative", {
     await dev.fetch("/").expect.toContain("HELLO");
   },
 });
+// https://github.com/oven-sh/bun/issues/18258
+devTest("css module exports its class names to the importer", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+      body: `<h1>Hello</h1>`,
+    }),
+    "styles.module.css": `
+      .title {
+        color: red;
+      }
+    `,
+    "index.ts": `
+      import styles from "./styles.module.css";
+      document.querySelector("h1").className = styles.title;
+      globalThis.evalCount = (globalThis.evalCount ?? 0) + 1;
+      globalThis.classKeys = Object.keys(styles).sort().join(",");
+      console.log("class:" + styles.title);
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    const msg = await c.getStringMessage();
+    assert(msg.startsWith("class:title_"), `expected a scoped class name, got ${JSON.stringify(msg)}`);
+    const className = msg.slice("class:".length);
+    await c.style("." + className).color.expect.toBe("red");
+
+    // The scoped name only depends on the file path, so a style edit keeps the
+    // class map. It must arrive as a CSS-only update: no reload, no re-evaluation.
+    await dev.patch("styles.module.css", { find: "red", replace: "blue" });
+    await c.style("." + className).color.expect.toBe("#00f");
+    expect(await c.js<[string, number]>`[document.querySelector("h1").className, globalThis.evalCount]`).toEqual([
+      className,
+      1,
+    ]);
+
+    // A new class changes the class map. The importer does not accept hot
+    // updates, so the page reloads and evaluates against the new map.
+    await c.expectReload(async () => {
+      await dev.write(
+        "styles.module.css",
+        `
+          .extra { font-weight: 700; }
+          .title { color: blue; }
+        `,
+      );
+    });
+    await c.expectMessage("class:" + className);
+    await c.style("." + className).color.expect.toBe("#00f");
+    expect(await c.js<string>`globalThis.classKeys`).toBe("extra,title");
+  },
+});
+devTest("css module import shapes", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "shapes.module.css": `
+      .a { color: red; }
+      .b-c { color: blue; }
+    `,
+    "empty.module.css": `/* no local names */`,
+    "plain.css": `
+      body { background-color: green; }
+    `,
+    "index.ts": `
+      import styles, { a } from "./shapes.module.css";
+      import * as ns from "./shapes.module.css";
+      import empty from "./empty.module.css";
+      import "./plain.css";
+      const dyn = await import("./shapes.module.css");
+      const req = require("./shapes.module.css");
+      console.log(JSON.stringify({
+        named: a === styles.a,
+        ns: ns.default === styles && ns.a === a,
+        dyn: dyn.default === styles && dyn.a === a,
+        req: req === styles,
+        keys: Object.keys(styles).sort(),
+        scoped: styles.a.startsWith("a_") && styles["b-c"].startsWith("b-c_"),
+        empty,
+      }));
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage(
+      JSON.stringify({ named: true, ns: true, dyn: true, req: true, keys: ["a", "b-c"], scoped: true, empty: {} }),
+    );
+    await c.style("body").backgroundColor.expect.toBe("green");
+  },
+});
+devTest("css module class list edits reach an accepting importer", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "styles.module.css": `
+      .a { color: red; }
+    `,
+    "index.ts": `
+      import styles from "./styles.module.css";
+      console.log("keys:" + Object.keys(styles).sort().join(","));
+      import.meta.hot.accept();
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("keys:a");
+    await dev.write(
+      "styles.module.css",
+      `
+        .a { color: red; }
+        .b { color: blue; }
+      `,
+    );
+    await c.expectMessage("keys:a,b");
+    await dev.write("styles.module.css", ` `, { dedent: false });
+    await c.expectMessage("keys:");
+    await dev.write("styles.module.css", `.b { color: blue; }`);
+    await c.expectMessage("keys:b");
+  },
+});
+devTest("css module binding survives an edit of the importer", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "styles.module.css": `
+      .a { color: red; }
+    `,
+    "index.ts": `
+      import styles from "./styles.module.css";
+      console.log("v1:" + Object.keys(styles).join(","));
+      import.meta.hot.accept();
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("v1:a");
+    // The css module is cached in the incremental graph and is not parsed
+    // again here. The importer must still list it as a dependency.
+    await dev.patch("index.ts", { find: "v1", replace: "v2" });
+    await c.expectMessage("v2:a");
+    await dev.patch("index.ts", { find: "v2", replace: "v3" });
+    await c.expectMessage("v3:a");
+    await dev.patch("styles.module.css", { find: "red", replace: "blue" });
+    await dev.write(
+      "styles.module.css",
+      `
+        .a { color: red; }
+        .b { color: blue; }
+      `,
+    );
+    await c.expectMessage("v3:a,b");
+  },
+});
+devTest("css module composes from another file", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+      body: `<button>ok</button>`,
+    }),
+    "base.module.css": `
+      .base { font-weight: 700; }
+    `,
+    "button.module.css": `
+      .btn {
+        composes: base from "./base.module.css";
+        color: red;
+      }
+    `,
+    "index.ts": `
+      import styles from "./button.module.css";
+      document.querySelector("button").className = styles.btn;
+      console.log("btn:" + styles.btn);
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    const msg = await c.getStringMessage();
+    const classes = msg.slice("btn:".length).split(" ").sort();
+    expect(classes).toEqual([expect.stringMatching(/^base_/), expect.stringMatching(/^btn_/)]);
+    await c.style("." + classes[1]).color.expect.toBe("red");
+    await c.style("." + classes[0]).fontWeight.expect.toBe("700");
+  },
+});
 
 function extractCssUrl(backgroundImage: string): string {
   const url = backgroundImage.match(/url\((['"])(.*?)\1\)/);

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -928,6 +928,86 @@ devTest("css module that was only composed from gets imported directly", {
     await c.expectMessage("base:base true");
   },
 });
+devTest("two importers share one css module instance", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "styles.module.css": `
+      .shared { color: red; }
+    `,
+    "a.ts": `
+      import styles from "./styles.module.css";
+      export const mapA = styles;
+    `,
+    "b.ts": `
+      import styles from "./styles.module.css";
+      export const mapB = styles;
+    `,
+    "index.ts": `
+      import { mapA } from "./a";
+      import { mapB } from "./b";
+      console.log("same:" + (mapA === mapB) + " " + mapA.shared);
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    const msg = await c.getStringMessage();
+    assert(msg.startsWith("same:true shared_"), msg);
+  },
+});
+devTest("emptying a css module removes its styles and class map", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+      body: `<h1>Hello</h1>`,
+    }),
+    "styles.module.css": `
+      .title { color: red; }
+    `,
+    "index.ts": `
+      import styles from "./styles.module.css";
+      document.querySelector("h1").className = styles.title ?? "";
+      console.log("keys:" + Object.keys(styles).sort().join(","));
+      import.meta.hot.accept();
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("keys:title");
+    const className = await c.js<string>`document.querySelector("h1").className`;
+    await c.style("." + className).color.expect.toBe("red");
+
+    await dev.write("styles.module.css", " ", { dedent: false });
+    await c.expectMessage("keys:");
+    await c.style("." + className).notFound();
+
+    await dev.write("styles.module.css", `.title { color: blue; }`);
+    await c.expectMessage("keys:title");
+    await c.style("." + className).color.expect.toBe("#00f");
+  },
+});
+devTest("plain css import stays side-effect only next to css modules", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "plain.css": `
+      body { color: red; }
+    `,
+    "index.ts": `
+      import "./plain.css";
+      globalThis.evalCount = (globalThis.evalCount ?? 0) + 1;
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.style("body").color.expect.toBe("red");
+    await dev.patch("plain.css", { find: "red", replace: "blue" });
+    await c.style("body").color.expect.toBe("#00f");
+    expect(await c.js<number>`globalThis.evalCount`).toBe(1);
+  },
+});
 
 function extractCssUrl(backgroundImage: string): string {
   const url = backgroundImage.match(/url\((['"])(.*?)\1\)/);

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -883,6 +883,51 @@ devTest("css module composes from another file", {
     await c.style("." + classes[0]).fontWeight.expect.toBe("700");
   },
 });
+devTest("css module that was only composed from gets imported directly", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "base.module.css": `
+      .base { font-weight: 700; }
+    `,
+    "button.module.css": `
+      .btn { color: red; }
+    `,
+    "index.ts": `
+      import styles from "./button.module.css";
+      console.log("btn:" + styles.btn.split(" ").length);
+      import.meta.hot.accept();
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("btn:1");
+    // base.module.css enters the graph as a child of button.module.css only.
+    await dev.write(
+      "button.module.css",
+      `
+        .btn {
+          composes: base from "./base.module.css";
+          color: red;
+        }
+      `,
+    );
+    await c.expectMessage("btn:2");
+    // Now a module imports it directly. It has no module of its own yet, so it
+    // must be bundled again instead of being treated as cached.
+    await dev.write(
+      "index.ts",
+      `
+        import styles from "./button.module.css";
+        import base from "./base.module.css";
+        console.log("base:" + Object.keys(base).join(",") + " " + (styles.btn.split(" ")[0] === base.base));
+        import.meta.hot.accept();
+      `,
+    );
+    await c.expectMessage("base:base true");
+  },
+});
 
 function extractCssUrl(backgroundImage: string): string {
   const url = backgroundImage.match(/url\((['"])(.*?)\1\)/);

--- a/test/bake/dev/react-spa.test.ts
+++ b/test/bake/dev/react-spa.test.ts
@@ -357,6 +357,50 @@ devTest("two functions with hooks should be independently tracked", {
     await c.expectMessage("PASS");
   },
 });
+// https://github.com/oven-sh/bun/issues/18258
+devTest("css module class list edit refreshes the importing component without a reload", {
+  framework: minimalFramework,
+  files: {
+    ...reactAndRefreshStub,
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.tsx"],
+    }),
+    "index.tsx": `
+      import App from "./App.tsx";
+      console.log("root:" + typeof App);
+    `,
+    "App.module.css": `
+      .title { color: red; }
+    `,
+    "App.tsx": `
+      import styles from "./App.module.css";
+      console.log("App:" + Object.keys(styles).sort().join(","));
+      export default function App() {
+        return <h1 className={styles.title}>hello</h1>;
+      }
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/", {});
+    await c.expectMessage("App:title", "root:function");
+    // App.tsx is a Fast Refresh boundary: it re-evaluates with the new class
+    // map, the root module does not, and the page does not reload.
+    await dev.write(
+      "App.module.css",
+      `
+        .title { color: red; }
+        .subtitle { color: blue; }
+      `,
+    );
+    await c.expectMessage("App:subtitle,title");
+    // A style-only edit re-evaluates nothing. The App.tsx edit after it shows
+    // that exactly one message arrived since.
+    await dev.patch("App.module.css", { find: "blue", replace: "green" });
+    await dev.patch("App.tsx", { find: "hello", replace: "world" });
+    await c.expectMessage("App:subtitle,title");
+  },
+});
 devTest("custom hook tracking", {
   framework: minimalFramework,
   files: {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -681,9 +681,9 @@ describe("bundler", async () => {
       },
     });
 
-    // CSS imports are delivered out-of-band by the dev server, so the JS
-    // chunk only contains the importing module. This used to panic while
-    // linking the CSS file's lazy-export JS stub.
+    // The stylesheet of a CSS module is delivered out-of-band by the dev
+    // server. Its class-name map is a module of its own that the importer
+    // lists as a dependency.
     itBundled("bake-dev/loader-css-module-import", {
       format: "internal_bake_dev",
       outdir: "/out",
@@ -696,9 +696,16 @@ describe("bundler", async () => {
       },
       onAfterBundle(api) {
         const jsFile = readdirSync(api.outdir).find(x => x.endsWith(".js"))!;
-        expect(api.readFile(join("/out", jsFile))).toContain('"entry.ts"');
+        const js = api.readFile(join("/out", jsFile));
+        expect(js).toContain('"entry.ts"');
+        expect(js).toContain('"styles.module.css", 1, "default"');
+        expect(js).toContain('"styles.module.css"(hmr, module, exports)');
+        const scoped = js.match(/foo_[A-Za-z0-9_-]+/)?.[0];
+        expect(scoped).toBeString();
         const cssFile = readdirSync(api.outdir).find(x => x.endsWith(".css"))!;
-        expect(api.readFile(join("/out", cssFile))).toContain("color: red");
+        const css = api.readFile(join("/out", cssFile));
+        expect(css).toContain("color: red");
+        expect(css).toContain(`.${scoped} {`);
       },
     });
   });


### PR DESCRIPTION
### Problem
- Under the dev server (`bun ./index.html`, HTML routes in `Bun.serve`), `import styles from "./x.module.css"` compiles to a body that reads `import_x_module.default.foo`, but nothing declares the binding: `ReferenceError: import_x_module is not defined`. `bun build` is correct. Fixes #18258.
- `finish_from_bake_dev_server` (`src/bundler/bundle_v2.rs`) puts a file with a stylesheet into a CSS chunk only, so the stub with the class-name map is never printed. `convert_stmts_for_chunk_for_dev_server` then drops every import record that points at a CSS file.

### Fix
- A client `.module.css` also goes into the JS chunk. Its stub prints as `"x.module.css"(hmr) { hmr.cjs.exports = { foo: "foo_-MSaAA" } }` and the importer keeps the record, so `import`, `import()` and `require()` link through the registry. A plain stylesheet imported with a binding binds `{ default: {} }`, as in `bun build`.
- `IncrementalGraph` stores the module next to the stylesheet (`Content::CssModule`) and keeps it out of a hot update when it did not change: a style-only edit stays CSS-only. `is_file_cached` reports `CacheKind::CssModule` so a rebuilt importer keeps the dependency, and reports a stylesheet that was only an `@import`/`composes` child as not cached.
- Verified: `test/bake/dev/css.test.ts` (10 new), `react-spa.test.ts` (1 new), `bundler_loader.test.ts`; they fail on 1.4.3. The other `test/bake/dev` suites pass.
- Self-reviewed: 3 concerns raised, 2 addressed. Left out: server-side `.module.css` under `bun/app` (see notes).

### Background
- The dev server links at runtime. Each file prints as a registry entry, ESM as `"path": [deps, exports, stars, load, isAsync]` and CommonJS or JSON as `"path"(hmr, module, exports) {}`. An importer receives its `deps` through `hmr.imports`.
- Class names are scoped as `name_` plus a hash of the file path. The map changes only when a class is added, removed or renamed.
- `receive_chunk` runs once per chunk a file appears in. A CSS module now gets two calls per bundle, and each keeps the half the other owns.

<details><summary>Notes</summary>

- This follows the approach of #33405 by @bgrcs, who is credited as co-author of the commit. It is rebased onto current `main` and narrowed: the `replaceModules` ordering change from that PR is not included. In addition it handles the cached-importer path (`is_file_cached` / `CacheKind::CssModule`, without which the binding broke again after the first edit of the importer) and the `import()` / `require()` forms (the record's source index is cleared so the printer emits `hmr.dynamicImport` / `hmr.require`).
- `populate_css_module_lazy_export` is split out of `generate_code_for_lazy_export` so the dev pipeline, which skips that step and prints the `SLazyExport` directly, can fill the map with the same code the full link uses.
- The HMR runtime now drops the cached ESM view of a CommonJS module when it re-evaluates it. Without that, importers of an updated class map (or of an updated JSON file) kept reading the old object.
- Before the second commit, a stylesheet that had entered the graph only as a `CssChild` (through `@import` or `composes`) and was then imported from JS while not stale was treated as a cached stylesheet: the import was dropped and the route trace reached a `CssChild` through a JS edge (`only CSS roots should be found by tracing` in debug builds). That path predates this PR for plain stylesheets; for a `.module.css` it left the binding undefined again. `File::cache_kind` now returns `None` for a `CssChild`.
- Scope is the client graph. A `.module.css` imported by server-side code under `bun/app` (Bake framework) is unchanged. With `separateSSRGraph`, `mangle_local_css` hashes the `ssr:`-prefixed pretty path, so server and client scoped names would differ; that is the first thing to settle before server-side support.
- `require()` / `import()` of a plain (non-module) stylesheet under the dev server still print `hmr.require(...)` for a file that has no registry entry. Only the static import forms get the empty-module binding here.
- Recovering a `.module.css` from a syntax error sends its module once more (the graph drops content on failure), so an importer that does not accept hot updates reloads the page at that point. Plain stylesheets are unaffected.
- A `.module.css` that is only referenced from a `<link>` tag still gets its (unused) registry entry. It is a few bytes and avoids a per-importer analysis.
- `bun build --format=internal_bake_dev` (a debug-only CLI format) prints the stub too. `tree_shaking_and_code_splitting` seeds its part live there because tree shaking short-circuits for CSS files and dev imports do not bind symbols.
- Other suites run locally: `test/bake/dev/{hot,bundle,esm,html,sourcemap,plugins,stress,vfile,incremental-graph-edge-deletion}.test.ts`, `test/bake/dev-and-prod.test.ts`, `test/bundler/css/css-modules.test.ts`, and the `bake-dev/*` cases of `test/bundler/bundler_loader.test.ts`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 15 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bake/dev/css.test.ts test/bake/dev/react-spa.test.ts test/bundler/bundler_loader.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/180] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/178] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[3/178] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - Match
... (truncated)

release without fix: 11 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/bundler_loader.test.ts:
(pass) bundler > bun loader > bun/loader-yaml-file [21.67ms]
(pass) bundler > bun loader > bun/loader-text-file [11.09ms]
(pass) bundler > bun loader > bun/loader-json-file [10.59ms]
(pass) bundler > bun loader > bun/loader-toml-file [11.49ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-shadowed-temporal-global [10.78ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-imported-temporal-binding [9.05ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-no-bundle [8.97ms]
(pass) bundler > bun loader > bun/loader-toml-datetime [11.38ms]
(pass) bundler > bun loader > bun/loader-text-file [10.64ms]
(pass) bundler > bun loader > bun/loader-xml-file [10.44ms]
(pass) bundler > node loader > bun/loader-yaml-file [10.55ms]
(pass) bundler > node loader > bun/loader-text-file [10.04ms]
(pass) bundler > node loader > bun/loader-json-file [10.81ms]
(pass) bundler > node loader > bun/loader-toml-file [9.21ms]
(pass) bundler > node loader > bun/loader-toml-datetime-shadowed-temporal-global [9.76ms]
(pass) bundler > node loader > bun/loader-toml-datetime-imported-temporal-binding [10.48
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bake/dev/css.test.ts test/bake/dev/react-spa.test.ts test/bundler/bundler_loader.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_loader.test.ts:
(pass) bundler > bun loader > bun/loader-yaml-file [729.37ms]
(pass) bundler > bun loader > bun/loader-text-file [321.56ms]
(pass) bundler > bun loader > bun/loader-json-file [328.34ms]
(pass) bundler > bun loader > bun/loader-toml-file [397.91ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-shadowed-temporal-global [406.07ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-imported-temporal-binding [336.69ms]
(pass) bundler > bun loader > bun/loader-toml-datetime-no-bundle [458.72ms]
(pass) bundler > bun loader > bun/loader-toml-datetime [360.47ms]
(pass) bundler > bun loader > bun/loader-text-file [336.02ms]
(pass) bundler > bun loader > bun/loader-xml-file [405.11ms]
(pass) bundler > node loader > bun/loader-yaml-file [392.30ms]
(pass) bundler > node loader > bun/loader-text-file [316.21ms]
(pass) bundler > node loader > bun/loader-json-file [402.26ms]
(pass) 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     81136b2500
  features     baseline

23 deps, 131 codegen, 1172 objects in 617ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [13.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [4.00ms]
[5/1244] fetch zlib
[zlib] up to date
[6/1244] gen .bind.ts → GeneratedBindings.cpp
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [4.00ms]
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 22ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.serve
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs                       |  24 ++
 src/bundler/ParseTask.rs                           |   5 +-
 src/bundler/bundle_v2.rs                           |  26 ++
 src/bundler/lib.rs                                 |   1 +
 .../convertStmtsForChunkForDevServer.rs            |  69 +++--
 .../linker_context/generateCodeForLazyExport.rs    |  49 +--
 src/bundler/options.rs                             |  11 +
 src/bundler/transpiler.rs                          |   7 +-
 src/runtime/bake/DevServer.rs                      |  22 +-
 src/runtime/bake/dev_server/incremental_graph.rs   | 117 +++++--
 src/runtime/bake/dev_server/mod.rs                 |  17 +-
 src/runtime/bake/hmr-module.ts                     |   6 +
 test/bake/dev/css.test.ts                          | 339 +++++++++++++++++++++
 test/bake/dev/react-spa.test.ts                    |  44 +++
 test/bundler/bundler_loader.test.ts                |  17 +-
 15 files changed, 642 insertions(+), 112 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/LinkerContext.rs                                  5      3     33
src/bundler/ParseTask.rs                                      1      1     33
src/bundler/bundle_v2.rs                                     12      8     33
src/bundler/lib.rs                                            1      2     33
…dler/linker_context/convertStmtsForChunkForDevServer.rs      6      8     33
src/bundler/linker_context/generateCodeForLazyExport.rs       4      5     33
src/bundler/options.rs                                        1      2     33
src/bundler/transpiler.rs                                     1      1     33
src/runtime/bake/DevServer.rs                                 5      5     33
src/runtime/bake/dev_server/incremental_graph.rs             12     15     33
src/runtime/bake/dev_server/mod.rs                            1      4     33
src/runtime/bake/hmr-module.ts                                4      2     33
test/bake/dev/css.test.ts                                     5     13     24
test/bake/dev/react-spa.test.ts                               2      2      7
test/bundler/bundler_loader.test.ts                           1      1      9
```

</details>

<!-- robobun:evidence:end -->