### PR TITLE
pm view, pm diff: an unknown dist-tag is an error, not `latest`

### DIFF
--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1532,8 +1532,7 @@ impl PackageManifest {
         self.pkg.prereleases.keys.get(&self.versions)
     }
 
-    /// Resolves the version part of `name@spec` as `npm view` does: a dist-tag with exactly that name
-    /// wins, otherwise a semver range picks the best published match. Other kinds of spec match nothing.
+    /// Resolves the spec of `name@spec` like `npm view`: an exact dist-tag name wins, else the best range match.
     pub fn find_by_spec(&self, spec: &[u8]) -> Result<FindResult<'_>, Error> {
         use crate::dependency::{Tag, TagExt as _};
         let spec = if spec.is_empty() { b"latest" } else { spec };

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1532,16 +1532,20 @@ impl PackageManifest {
         self.pkg.prereleases.keys.get(&self.versions)
     }
 
-    /// Resolves the version part of a `name@spec` CLI argument against this manifest, classified the way
-    /// `bun add` classifies it: a dist-tag only ever matches `dist-tags`, a semver range picks the best
-    /// published match, and any other kind of spec (git, tarball, folder, ...) matches nothing here.
+    /// Resolves the version part of a `name@spec` CLI argument against this manifest the way `npm view`
+    /// does: a dist-tag with exactly that name wins, otherwise a semver range picks the best published
+    /// match. A miss is classified with the `Tag::infer` that `bun add` uses, so an unknown tag is
+    /// `DistTagNotFound` and never reaches the range parser, and any other kind of spec (git, tarball,
+    /// folder, ...) matches nothing here.
     pub fn find_by_spec(&self, spec: &[u8]) -> Result<FindResult<'_>, Error> {
         use crate::dependency::{Tag, TagExt as _};
+        let spec = if spec.is_empty() { b"latest" } else { spec };
+        // Checked before classifying because published tag names like `v12-lts` read as a range.
+        if let Some((_, version)) = self.dist_tags().find(|(tag, _)| *tag == spec) {
+            return self.find_by_version(version).ok_or(Error::DistTagNotFound);
+        }
         match Tag::infer(spec) {
-            Tag::DistTag => {
-                let tag = if spec.is_empty() { b"latest" } else { spec };
-                self.find_by_dist_tag(tag).ok_or(Error::DistTagNotFound)
-            }
+            Tag::DistTag => Err(Error::DistTagNotFound),
             Tag::Npm => {
                 // `v1.2.3` -> `1.2.3`, as `dependency::parse_with_tag` does.
                 let range = if spec.len() > 1 && spec[0] == b'v' {

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1527,6 +1527,41 @@ impl PackageManifest {
         self.pkg.releases.keys.get(&self.versions)
     }
 
+    /// Published prerelease versions, oldest first, as sorted at serialization time.
+    pub fn prerelease_versions(&self) -> &[Semver::Version] {
+        self.pkg.prereleases.keys.get(&self.versions)
+    }
+
+    /// Resolves the version part of a `name@spec` CLI argument against this manifest, classified the way
+    /// `bun add` classifies it: a dist-tag only ever matches `dist-tags`, a semver range picks the best
+    /// published match, and any other kind of spec (git, tarball, folder, ...) matches nothing here.
+    pub fn find_by_spec(&self, spec: &[u8]) -> Result<FindResult<'_>, Error> {
+        use crate::dependency::{Tag, TagExt as _};
+        match Tag::infer(spec) {
+            Tag::DistTag => {
+                let tag = if spec.is_empty() { b"latest" } else { spec };
+                self.find_by_dist_tag(tag).ok_or(Error::DistTagNotFound)
+            }
+            Tag::Npm => {
+                // `v1.2.3` -> `1.2.3`, as `dependency::parse_with_tag` does.
+                let range = if spec.len() > 1 && spec[0] == b'v' {
+                    &spec[1..]
+                } else {
+                    spec
+                };
+                let query = Semver::query::parse(range, SlicedString::init(range, range))?;
+                // The range parser skips words it does not understand, so junk parses to an empty
+                // (match-anything) group. Nothing was asked for, so nothing matches.
+                if query.is_empty() {
+                    return Err(Error::NoMatchingVersion);
+                }
+                self.find_best_version(&query, range)
+                    .ok_or(Error::NoMatchingVersion)
+            }
+            _ => Err(Error::NoMatchingVersion),
+        }
+    }
+
     /// `(tag, version)` pairs of the dist-tags.
     pub fn dist_tags(&self) -> impl Iterator<Item = (&[u8], Semver::Version)> + '_ {
         let versions = self.pkg.dist_tags.versions.get(&self.versions);

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1532,11 +1532,8 @@ impl PackageManifest {
         self.pkg.prereleases.keys.get(&self.versions)
     }
 
-    /// Resolves the version part of a `name@spec` CLI argument against this manifest the way `npm view`
-    /// does: a dist-tag with exactly that name wins, otherwise a semver range picks the best published
-    /// match. A miss is classified with the `Tag::infer` that `bun add` uses, so an unknown tag is
-    /// `DistTagNotFound` and never reaches the range parser, and any other kind of spec (git, tarball,
-    /// folder, ...) matches nothing here.
+    /// Resolves the version part of `name@spec` as `npm view` does: a dist-tag with exactly that name
+    /// wins, otherwise a semver range picks the best published match. Other kinds of spec match nothing.
     pub fn find_by_spec(&self, spec: &[u8]) -> Result<FindResult<'_>, Error> {
         use crate::dependency::{Tag, TagExt as _};
         let spec = if spec.is_empty() { b"latest" } else { spec };
@@ -1554,8 +1551,7 @@ impl PackageManifest {
                     spec
                 };
                 let query = Semver::query::parse(range, SlicedString::init(range, range))?;
-                // The range parser skips words it does not understand, so junk parses to an empty
-                // (match-anything) group. Nothing was asked for, so nothing matches.
+                // Only unknown words (e.g. `npm:x@1`): the lenient parser produced a match-all group.
                 if query.is_empty() {
                     return Err(Error::NoMatchingVersion);
                 }

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -763,8 +763,10 @@ fn fetch_registry_tree(
         version
     };
     let found = 'found: {
-        if let Ok(r) = manifest.find_by_spec(version) {
-            break 'found r;
+        match manifest.find_by_spec(version) {
+            Ok(r) => break 'found r,
+            Err(bun_install::Error::DistTagNotFound | bun_install::Error::NoMatchingVersion) => {}
+            Err(err) => return Err(err.into()),
         }
         Status::clear();
         Output::err_generic(

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -763,14 +763,8 @@ fn fetch_registry_tree(
         version
     };
     let found = 'found: {
-        if let Some(r) = manifest.find_by_dist_tag(version) {
+        if let Ok(r) = manifest.find_by_spec(version) {
             break 'found r;
-        }
-        let sliced = Semver::SlicedString::init(version, version);
-        if let Ok(query) = Semver::query::parse(version, sliced) {
-            if let Some(r) = manifest.find_best_version(&query, version) {
-                break 'found r;
-            }
         }
         Status::clear();
         Output::err_generic(

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -180,13 +180,13 @@ pub(crate) fn view(
         }
     };
 
-    // Now use the existing version resolution logic from outdated_command
     let mut manifest;
 
     let versions_len: usize;
 
     // Note: reshaped for borrowck.
     'brk: {
+        let mut not_found = bun_install::Error::NoMatchingVersion;
         'from_versions: {
             if let Some(versions_obj) = json.get_object(b"versions") {
                 // Find the version string from JSON that matches the resolved version
@@ -197,20 +197,16 @@ pub(crate) fn view(
                 let versions = versions_e_obj.properties.slice();
                 versions_len = versions.len();
 
-                let wanted_version: Semver::Version = 'brk2: {
-                    // First try dist-tag lookup (like "latest", "beta", etc.)
-                    if let Some(result) = parsed_manifest.find_by_dist_tag(version) {
-                        break 'brk2 result.version;
-                    } else {
-                        // Parse as semver query and find best version
-                        let sliced_literal = Semver::SlicedString::init(version, version);
-                        let query = Semver::query::parse(version, sliced_literal)?;
-                        if let Some(result) = parsed_manifest.find_best_version(&query, version) {
-                            break 'brk2 result.version;
-                        }
+                let wanted_version: Semver::Version = match parsed_manifest.find_by_spec(version) {
+                    Ok(result) => result.version,
+                    Err(
+                        err @ (bun_install::Error::DistTagNotFound
+                        | bun_install::Error::NoMatchingVersion),
+                    ) => {
+                        not_found = err;
+                        break 'from_versions;
                     }
-
-                    break 'from_versions;
+                    Err(err) => return Err(err.into()),
                 };
 
                 for prop in versions {
@@ -231,15 +227,45 @@ pub(crate) fn view(
             }
         }
 
+        let is_dist_tag = matches!(not_found, bun_install::Error::DistTagNotFound);
         if json_output {
             Output::print(format_args!(
-                "{{ \"error\": \"No matching version found\", \"version\": {} }}\n",
+                "{{ \"error\": \"{}\", \"version\": {} }}\n",
+                if is_dist_tag {
+                    "Dist-tag not found"
+                } else {
+                    "No matching version found"
+                },
                 bun_fmt::format_json_string_utf8(
                     spec_,
                     bun_fmt::JSONFormatterUTF8Options { quote: true }
                 ),
             ));
             Output::flush();
+        } else if is_dist_tag {
+            Output::err_generic(
+                "Package <b>{}<r> with tag <b>{}<r> not found, but package exists",
+                (bun_fmt::quote(name), bun_fmt::quote(version)),
+            );
+
+            let max_tags_to_display: usize = 10;
+            let tags_len = parsed_manifest.dist_tags().count();
+            if tags_len > 0 {
+                bun_core::pretty_errorln!("\nTags:<r>");
+                for (tag, v) in parsed_manifest.dist_tags().take(max_tags_to_display) {
+                    bun_core::pretty_errorln!(
+                        "<d>-<r> {}<d>:<r> {}",
+                        BStr::new(tag),
+                        v.fmt(&parsed_manifest.string_buf),
+                    );
+                }
+                if tags_len > max_tags_to_display {
+                    bun_core::pretty_errorln!(
+                        "  <d>... and {} more<r>",
+                        tags_len - max_tags_to_display
+                    );
+                }
+            }
         } else {
             Output::err_generic(
                 "No version of <b>{}<r> satisfying <b>{}<r> found",
@@ -248,13 +274,13 @@ pub(crate) fn view(
 
             let max_versions_to_display: usize = 5;
 
-            let start_index = parsed_manifest
-                .versions
-                .len()
-                .saturating_sub(max_versions_to_display);
-            let mut versions_to_display = &parsed_manifest.versions[start_index..];
-            versions_to_display =
-                &versions_to_display[..versions_to_display.len().min(max_versions_to_display)];
+            // Newest published versions; prereleases only when nothing else was ever published.
+            let mut all_versions = parsed_manifest.release_versions();
+            if all_versions.is_empty() {
+                all_versions = parsed_manifest.prerelease_versions();
+            }
+            let start_index = all_versions.len().saturating_sub(max_versions_to_display);
+            let versions_to_display = &all_versions[start_index..];
             if !versions_to_display.is_empty() {
                 bun_core::pretty_errorln!("\nRecent versions:<r>");
                 for v in versions_to_display {

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -506,7 +506,7 @@ describe.concurrent("bun info version spec", () => {
     });
   });
 
-  test.each(["github:a/b", "npm:other@1.0.0", "1.0.0.tgz"])(
+  test.each(["github:a/b", "file:./zz-tags", "npm:other@1.0.0", "1.0.0.tgz"])(
     "a spec that is neither a tag nor a range matches nothing: %s",
     async spec => {
       const { stdout, stderr, exitCode } = await info(`zz-tags@${spec}`, "version");

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -372,8 +372,9 @@ describe.concurrent("bun info", () => {
   });
 });
 
-// The version part of `name@spec` is classified the way `bun add` classifies it: a dist-tag only ever
-// matches `dist-tags` (an unknown tag is an error, never `latest`), a range picks the best published match.
+// The version part of `name@spec` resolves like `npm view`: a dist-tag with exactly that name wins, otherwise a
+// range picks the best published match. An unknown tag is an error; it is never handed to the range parser
+// (which skips unknown words and would match `latest`).
 describe.concurrent("bun info version spec", () => {
   const packument = (name: string, tags: Record<string, string>, published: string[]) => ({
     name,
@@ -386,14 +387,16 @@ describe.concurrent("bun info version spec", () => {
     ),
   });
   const packuments: Record<string, object> = {
-    "zz-tags": packument("zz-tags", { latest: "2.0.0", next: "3.0.0", beta: "2.5.0" }, [
+    // `v1-lts` (the Angular `vNN-lts` shape) reads as the range `1` to the spec classifier; it is a tag.
+    "zz-tags": packument("zz-tags", { latest: "2.0.0", next: "3.0.0", beta: "2.5.0", "v1-lts": "1.0.0" }, [
       "1.0.0",
+      "1.5.0",
       "2.0.0",
       "2.5.0",
       "3.0.0",
     ]),
     "zz-case": packument("zz-case", { latest: "1.0.0", Next: "2.0.0" }, ["1.0.0", "2.0.0"]),
-    "zz-dangling": packument("zz-dangling", { latest: "9.9.9" }, ["1.0.0"]),
+    "zz-dangling": packument("zz-dangling", { latest: "9.9.9", "v0-legacy": "0.5.0" }, ["1.0.0"]),
     "zz-onlypre": packument("zz-onlypre", { latest: "1.0.0-beta.2" }, ["1.0.0-beta.1", "1.0.0-beta.2"]),
   };
   let server: ReturnType<typeof Bun.serve>;
@@ -438,6 +441,7 @@ describe.concurrent("bun info version spec", () => {
         - latest: 2.0.0
         - next: 3.0.0
         - beta: 2.5.0
+        - v1-lts: 1.0.0
         "
       `);
       expect(exitCode).toBe(1);
@@ -462,11 +466,16 @@ describe.concurrent("bun info version spec", () => {
     expect(exact.exitCode).toBe(0);
   });
 
-  test("a `latest` tag that points at an unpublished version is an error", async () => {
-    for (const args of [["zz-dangling"], ["zz-dangling@latest"], ["zz-dangling", "version"]]) {
+  test("a tag that points at an unpublished version is an error", async () => {
+    for (const [args, tag] of [
+      [["zz-dangling"], "latest"],
+      [["zz-dangling@latest"], "latest"],
+      [["zz-dangling", "version"], "latest"],
+      [["zz-dangling@v0-legacy", "version"], "v0-legacy"],
+    ] as const) {
       const { stdout, stderr, exitCode } = await info(...args);
       expect(stdout).toBe("");
-      expect(stderr).toStartWith(`error: Package "zz-dangling" with tag "latest" not found, but package exists\n`);
+      expect(stderr).toStartWith(`error: Package "zz-dangling" with tag "${tag}" not found, but package exists\n`);
       expect(exitCode).toBe(1);
     }
   });
@@ -477,6 +486,7 @@ describe.concurrent("bun info version spec", () => {
       "zz-tags",
       "zz-tags@next",
       "zz-tags@beta",
+      "zz-tags@v1-lts",
       "zz-tags@3.0.0",
       "zz-tags@v3.0.0",
       "zz-tags@^1",
@@ -491,9 +501,11 @@ describe.concurrent("bun info version spec", () => {
       "zz-tags": "2.0.0",
       "zz-tags@next": "3.0.0",
       "zz-tags@beta": "2.5.0",
+      // the tag, not the newest `1.x`
+      "zz-tags@v1-lts": "1.0.0",
       "zz-tags@3.0.0": "3.0.0",
       "zz-tags@v3.0.0": "3.0.0",
-      "zz-tags@^1": "1.0.0",
+      "zz-tags@^1": "1.5.0",
       "zz-onlypre": "1.0.0-beta.2",
     });
   });
@@ -517,6 +529,7 @@ describe.concurrent("bun info version spec", () => {
 
       Recent versions:
       - 1.0.0
+      - 1.5.0
       - 2.0.0
       - 2.5.0
       - 3.0.0

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -426,12 +426,9 @@ describe.concurrent("bun info version spec", () => {
     return { stdout, stderr, exitCode };
   }
 
-  test("an unknown dist-tag is an error and lists the tags that exist", async () => {
-    for (const args of [
-      ["zz-tags@nosuchtag"],
-      ["zz-tags@nosuchtag", "version"],
-      ["zz-tags@nosuchtag", "dist.tarball"],
-    ]) {
+  test.each([[["zz-tags@nosuchtag"]], [["zz-tags@nosuchtag", "version"]], [["zz-tags@nosuchtag", "dist.tarball"]]])(
+    "an unknown dist-tag is an error and lists the tags that exist: %p",
+    async args => {
       const { stdout, stderr, exitCode } = await info(...args);
       expect(stdout).toBe("");
       expect(stderr).toMatchInlineSnapshot(`
@@ -445,8 +442,8 @@ describe.concurrent("bun info version spec", () => {
         "
       `);
       expect(exitCode).toBe(1);
-    }
-  });
+    },
+  );
 
   test("an unknown dist-tag is an error with --json", async () => {
     const { stdout, stderr, exitCode } = await info("zz-tags@nosuchtag", "version", "--json");
@@ -466,18 +463,17 @@ describe.concurrent("bun info version spec", () => {
     expect(exact.exitCode).toBe(0);
   });
 
-  test("a tag that points at an unpublished version is an error", async () => {
-    for (const [args, tag] of [
-      [["zz-dangling"], "latest"],
-      [["zz-dangling@latest"], "latest"],
-      [["zz-dangling", "version"], "latest"],
-      [["zz-dangling@v0-legacy", "version"], "v0-legacy"],
-    ] as const) {
-      const { stdout, stderr, exitCode } = await info(...args);
-      expect(stdout).toBe("");
-      expect(stderr).toStartWith(`error: Package "zz-dangling" with tag "${tag}" not found, but package exists\n`);
-      expect(exitCode).toBe(1);
-    }
+  // Same message as `bun add pkg@<tag>` for this state; the `Tags:` list under it shows where the tag points.
+  test.each([
+    [["zz-dangling"], "latest"],
+    [["zz-dangling@latest"], "latest"],
+    [["zz-dangling", "version"], "latest"],
+    [["zz-dangling@v0-legacy", "version"], "v0-legacy"],
+  ] as const)("a tag that points at an unpublished version is an error: %p", async (args, tag) => {
+    const { stdout, stderr, exitCode } = await info(...args);
+    expect(stdout).toBe("");
+    expect(stderr).toStartWith(`error: Package "zz-dangling" with tag "${tag}" not found, but package exists\n`);
+    expect(exitCode).toBe(1);
   });
 
   test("known dist-tags, exact versions and ranges resolve", async () => {
@@ -510,16 +506,15 @@ describe.concurrent("bun info version spec", () => {
     });
   });
 
-  test("a spec that is neither a tag nor a range matches nothing", async () => {
-    for (const spec of ["zz-tags@github:a/b", "zz-tags@npm:other@1.0.0", "zz-tags@1.0.0.tgz"]) {
-      const { stdout, stderr, exitCode } = await info(spec, "version");
+  test.each(["github:a/b", "npm:other@1.0.0", "1.0.0.tgz"])(
+    "a spec that is neither a tag nor a range matches nothing: %s",
+    async spec => {
+      const { stdout, stderr, exitCode } = await info(`zz-tags@${spec}`, "version");
       expect(stdout).toBe("");
-      expect(stderr).toStartWith(
-        `error: No version of "zz-tags" satisfying "${spec.slice("zz-tags@".length)}" found\n`,
-      );
+      expect(stderr).toStartWith(`error: No version of "zz-tags" satisfying "${spec}" found\n`);
       expect(exitCode).toBe(1);
-    }
-  });
+    },
+  );
 
   test("`Recent versions:` lists each published version once, newest last", async () => {
     const release = await info("zz-tags@9.9.9", "version");

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "bun";
-import { describe, expect, it, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDirWithFiles } from "harness";
 import { join } from "node:path";
 
@@ -233,12 +233,12 @@ describe.concurrent("bun info", () => {
         "error: No version of "is-number" satisfying "999.0.0" found
 
         Recent versions:
+        - 3.0.0
         - 4.0.0
         - 5.0.0
         - 6.0.0
         - 7.0.0
-        - 7.0.0
-          ... and 11 more
+          ... and 10 more
         "
       `);
       expect(code).toBe(1);
@@ -369,6 +369,172 @@ describe.concurrent("bun info", () => {
         "
       `);
     });
+  });
+});
+
+// The version part of `name@spec` is classified the way `bun add` classifies it: a dist-tag only ever
+// matches `dist-tags` (an unknown tag is an error, never `latest`), a range picks the best published match.
+describe.concurrent("bun info version spec", () => {
+  const packument = (name: string, tags: Record<string, string>, published: string[]) => ({
+    name,
+    "dist-tags": tags,
+    versions: Object.fromEntries(
+      published.map(v => [
+        v,
+        { name, version: v, dist: { tarball: `http://localhost/${name}/-/${name}-${v}.tgz`, shasum: "0".repeat(40) } },
+      ]),
+    ),
+  });
+  const packuments: Record<string, object> = {
+    "zz-tags": packument("zz-tags", { latest: "2.0.0", next: "3.0.0", beta: "2.5.0" }, [
+      "1.0.0",
+      "2.0.0",
+      "2.5.0",
+      "3.0.0",
+    ]),
+    "zz-case": packument("zz-case", { latest: "1.0.0", Next: "2.0.0" }, ["1.0.0", "2.0.0"]),
+    "zz-dangling": packument("zz-dangling", { latest: "9.9.9" }, ["1.0.0"]),
+    "zz-onlypre": packument("zz-onlypre", { latest: "1.0.0-beta.2" }, ["1.0.0-beta.1", "1.0.0-beta.2"]),
+  };
+  let server: ReturnType<typeof Bun.serve>;
+  let dir: string;
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const body = packuments[decodeURIComponent(new URL(req.url).pathname).replace(/^\/+|\/+$/g, "")];
+        return body ? Response.json(body) : Response.json({ error: "Not found" }, { status: 404 });
+      },
+    });
+    dir = tempDirWithFiles("view-spec", { "package.json": JSON.stringify({ name: "app", version: "0.0.0" }) });
+  });
+  afterAll(() => server?.stop(true));
+
+  async function info(...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), "info", ...args],
+      cwd: dir,
+      env: { ...bunEnv, BUN_CONFIG_REGISTRY: server.url.origin, NPM_CONFIG_REGISTRY: server.url.origin, NO_COLOR: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("an unknown dist-tag is an error and lists the tags that exist", async () => {
+    for (const args of [
+      ["zz-tags@nosuchtag"],
+      ["zz-tags@nosuchtag", "version"],
+      ["zz-tags@nosuchtag", "dist.tarball"],
+    ]) {
+      const { stdout, stderr, exitCode } = await info(...args);
+      expect(stdout).toBe("");
+      expect(stderr).toMatchInlineSnapshot(`
+        "error: Package "zz-tags" with tag "nosuchtag" not found, but package exists
+
+        Tags:
+        - latest: 2.0.0
+        - next: 3.0.0
+        - beta: 2.5.0
+        "
+      `);
+      expect(exitCode).toBe(1);
+    }
+  });
+
+  test("an unknown dist-tag is an error with --json", async () => {
+    const { stdout, stderr, exitCode } = await info("zz-tags@nosuchtag", "version", "--json");
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ error: "Dist-tag not found", version: "zz-tags@nosuchtag" });
+    expect(exitCode).toBe(1);
+  });
+
+  test("dist-tags are case-sensitive", async () => {
+    const lower = await info("zz-case@next", "version");
+    expect(lower.stdout).toBe("");
+    expect(lower.stderr).toStartWith(`error: Package "zz-case" with tag "next" not found, but package exists\n`);
+    expect(lower.exitCode).toBe(1);
+    const exact = await info("zz-case@Next", "version");
+    expect(exact.stderr).toBe("");
+    expect(exact.stdout).toBe("2.0.0\n");
+    expect(exact.exitCode).toBe(0);
+  });
+
+  test("a `latest` tag that points at an unpublished version is an error", async () => {
+    for (const args of [["zz-dangling"], ["zz-dangling@latest"], ["zz-dangling", "version"]]) {
+      const { stdout, stderr, exitCode } = await info(...args);
+      expect(stdout).toBe("");
+      expect(stderr).toStartWith(`error: Package "zz-dangling" with tag "latest" not found, but package exists\n`);
+      expect(exitCode).toBe(1);
+    }
+  });
+
+  test("known dist-tags, exact versions and ranges resolve", async () => {
+    const resolved: Record<string, string> = {};
+    for (const spec of [
+      "zz-tags",
+      "zz-tags@next",
+      "zz-tags@beta",
+      "zz-tags@3.0.0",
+      "zz-tags@v3.0.0",
+      "zz-tags@^1",
+      "zz-onlypre",
+    ]) {
+      const { stdout, stderr, exitCode } = await info(spec, "version");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      resolved[spec] = stdout.trim();
+    }
+    expect(resolved).toEqual({
+      "zz-tags": "2.0.0",
+      "zz-tags@next": "3.0.0",
+      "zz-tags@beta": "2.5.0",
+      "zz-tags@3.0.0": "3.0.0",
+      "zz-tags@v3.0.0": "3.0.0",
+      "zz-tags@^1": "1.0.0",
+      "zz-onlypre": "1.0.0-beta.2",
+    });
+  });
+
+  test("a spec that is neither a tag nor a range matches nothing", async () => {
+    for (const spec of ["zz-tags@github:a/b", "zz-tags@npm:other@1.0.0", "zz-tags@1.0.0.tgz"]) {
+      const { stdout, stderr, exitCode } = await info(spec, "version");
+      expect(stdout).toBe("");
+      expect(stderr).toStartWith(
+        `error: No version of "zz-tags" satisfying "${spec.slice("zz-tags@".length)}" found\n`,
+      );
+      expect(exitCode).toBe(1);
+    }
+  });
+
+  test("`Recent versions:` lists each published version once, newest last", async () => {
+    const release = await info("zz-tags@9.9.9", "version");
+    expect(release.stdout).toBe("");
+    expect(release.stderr).toMatchInlineSnapshot(`
+      "error: No version of "zz-tags" satisfying "9.9.9" found
+
+      Recent versions:
+      - 1.0.0
+      - 2.0.0
+      - 2.5.0
+      - 3.0.0
+      "
+    `);
+    expect(release.exitCode).toBe(1);
+    // Prereleases are listed only when nothing else was ever published.
+    const pre = await info("zz-onlypre@9.9.9", "version");
+    expect(pre.stdout).toBe("");
+    expect(pre.stderr).toMatchInlineSnapshot(`
+      "error: No version of "zz-onlypre" satisfying "9.9.9" found
+
+      Recent versions:
+      - 1.0.0-beta.1
+      - 1.0.0-beta.2
+      "
+    `);
+    expect(pre.exitCode).toBe(1);
   });
 });
 

--- a/test/cli/install/bun-pm-diff.test.ts
+++ b/test/cli/install/bun-pm-diff.test.ts
@@ -468,7 +468,7 @@ diffme@1.0.0 → diffme@2.0.0
     expect(hits.some(h => h.endsWith(" /@priv/diffme"))).toBe(true);
   });
 
-  test("errors: unknown package, no matching version; a third argument is a file filter", async () => {
+  test("errors: unknown package, no matching version or tag; a third argument is a file filter", async () => {
     const unknown = await diff(["nope-nope@1.0.0", "2.0.0"]);
     expect(unknown.exitCode).toBe(1);
     expect(unknown.stderr).toContain("404");
@@ -478,6 +478,11 @@ diffme@1.0.0 → diffme@2.0.0
     // …and what exists instead, newest first, plus the tags.
     expect(nover.stderr).toContain("recent versions: 2.0.0, 1.0.0");
     expect(nover.stderr).toMatch(/tags: .*latest: 2\.0\.0/);
+    // An unknown dist-tag is looked up only in `dist-tags`; it never falls back to `latest`.
+    const notag = await diff(["diffme@nosuchtag", "2.0.0", "--name-only"]);
+    expect(notag.stdout).toBe("");
+    expect(notag.stderr).toContain("no version of diffme matches nosuchtag");
+    expect(notag.exitCode).toBe(1);
     const many = await diff(["diffme@1", "diffme@2", "diffme@3"]);
     expect(many.stderr).toContain("no file in either side matches diffme@3");
     expect(many.exitCode).toBe(1);


### PR DESCRIPTION
### Problem
- `bun pm view pkg@nosuchtag` (and `bun info`, `bun pm diff`) prints the `latest` version's data with exit code 0 when the tag does not exist. `bun add` errors on that spec (`Package "pkg" with tag "nosuchtag" not found, but package exists`) and `npm view` gives E404. A wrong-case tag and a dangling `latest` fell through too.
- Cause: `pm_view_command.rs:200` (and `pm_diff_command.rs:766`) tries `dist-tags` and, on a miss, hands the spec to `Semver::query::parse`, which skips unknown words. `nosuchtag` becomes a match-all group and `find_best_version` picks `latest`.
- `Recent versions:` sliced the flat `[releases | prereleases | dist-tag targets]` buffer, so it listed one version twice.

### Fix
- New `PackageManifest::find_by_spec`, used by both commands, resolves like `npm view`: a dist-tag with exactly that name wins. `Tag::infer` classifies a miss: tag-shaped is `DistTagNotFound` and never reaches the range parser, a range picks the best version or `NoMatchingVersion`, anything else matches nothing.
- `pm view` prints that `bun add` message plus the existing tags, or a JSON error under `--json`, exit code 1. `Recent versions:` reads `release_versions()`.
- Self-reviewed: 1 concern raised, addressed (classifying before the tag lookup broke published `vNN-lts` tags).
- Verified: `test/cli/install/bun-info.test.ts` (6 of 7 new tests fail on stock bun) and `bun-pm-diff.test.ts`.

### Background
- `bun info` is `bun pm view`. It parses the packument into a `PackageManifest`, the structure the installer resolves against.
- `Tag::infer` (`src/install/dependency.rs`) classifies a version string as `DistTag`, `Npm` (a range), `Git`, and so on. The installer dispatches on it, so a tag never reaches the range parser. That parser is lenient on purpose: `1.0.0 || boop` must parse.

<details><summary>Notes</summary>

- `npm view` (`lib/commands/view.js`) reads `dist-tags[spec]` first and only then filters versions with `semver.satisfies`, so a tag that exists is a tag whatever it looks like. `find_by_spec` copies that order. `Tag::infer` reads Angular-style `v1-lts` as a range, and a test covers that tag.
- `--json` error shape: `{ "error": "Dist-tag not found", "version": "<spec>" }`, next to the existing `"No matching version found"`.
- `Recent versions:` falls back to the new `prerelease_versions()` when a package never published a release.
- Behaviour for valid input is unchanged: `pkg`, `pkg@latest`, `pkg@next`, `pkg@1.2.3`, `pkg@v1.2.3`, `pkg@^1`, `pkg@'>=2 <3'`, `pkg@'1.0.0 - 2.0.0'`, `pkg@*`, `pkg@x`, and an existing `pkg@v1-lts` tag all resolve as before (checked against a local stub registry).
- A range that parses to no comparator at all (only unknown words) is `NoMatchingVersion` too, so junk like `pkg@npm:other@1.0.0` no longer matches `latest` either.
- Remaining gap, owned by the classifier and tracked separately: `Tag::infer` treats any `v` + digit string as a range, so a `vNN-lts`-shaped tag that does NOT exist still resolves as the range `NN` here (and `bun add pkg@v1-lts` installs the newest `1.x` even when the tag exists). npm decides tag-vs-range with `semver.validRange`, which rejects `1-lts`. Fixing that belongs in `Tag::infer` so `bun add` and `bun info` agree. `find_by_spec` follows it with no change.
- A dangling `latest` now errors in `pm view` the way `bun add pkg@latest` does today. #36671 proposes a fallback to the highest version for the installer. If that lands inside `find_by_dist_tag`/`find_by_version`, `pm view` follows it with no further change.
- Intentionally not touched: the test-only `parseManifest` binding in `src/install_jsc/npm_jsc.rs` still dumps the raw `versions` buffer (its consumers only check `versions.length > 0`), so `PackageManifest.versions` stays `pub`.
- Overlap: #42052 (`pm view` npm-parity rewrite) rewrites the same resolution lines in `pm_view_command.rs` and also rejects `pkg@notatag` there (via an empty-range check), so the two PRs conflict textually. This PR keeps the tag logic in the shared `PackageManifest::find_by_spec` (exact dist-tag first, also used by `pm diff`, dangling `latest` included). Whichever lands second needs a small rebase; the order is the maintainer's call.
- #38671 and the install mega-branch #39403 touch the same region of `pm_view_command.rs` but do not change the tag fall-through.
- The existing real-registry snapshot for `is-number@999.0.0` changes from `4.0.0 5.0.0 6.0.0 7.0.0 7.0.0 ... and 11 more` to `3.0.0 ... 7.0.0 ... and 10 more` (15 published versions, 5 shown).
- Also ran `test/cli/install/redacted-config-logs.test.ts` (uses `bun info` against a mock registry).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-pm-diff.test.ts

<!-- robobun:evidence:end -->
