### PR TITLE
Bun.serve: keep text/plain for a string body whose .body was read

### DIFF
--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -159,8 +159,9 @@ impl StaticRoute {
             // The user may want to pass in the same Response object multiple endpoints
             // Let's let them do that.
             let body_value = response.get_body_value();
-            let was_string = body_value.was_string();
+            // Unwrap an unread `.body` stream first: `was_string` comes back with it.
             body_value.to_blob_if_possible();
+            let was_string = body_value.was_string();
 
             let blob: AnyBlob = 'brk: {
                 match body_value {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -754,6 +754,7 @@ impl Value {
             Value::Empty => ReadableStream::empty(global_this),
             Value::Null => Ok(JSValue::NULL),
             Value::InternalBlob(_) | Value::Blob(_) | Value::WTFStringImpl(_) => {
+                let was_string = self.was_string();
                 // `deinit` must run on every exit incl. `?` paths.
                 let blob = scopeguard::guard(self.use_(), |mut b| b.deinit());
                 blob.resolve_size();
@@ -761,6 +762,13 @@ impl Value {
                 let value = ReadableStream::from_blob_copy_ref(global_this, &blob, blob_size)?;
 
                 let stream = ReadableStream::from_js_direct(value).unwrap();
+                if was_string {
+                    if let webcore::readable_stream::Source::Blob(loader) = stream.ptr {
+                        // SAFETY: `Source::Blob` holds the live `*mut ByteBlobLoader` that
+                        // `from_blob_copy_ref` just created; the JS wrapper in `value` owns it.
+                        unsafe { (*loader).was_string = true };
+                    }
+                }
                 *self = Value::Locked(PendingValue {
                     readable: webcore::readable_stream::Strong::init(stream, global_this),
                     ..PendingValue::new(global_this)

--- a/src/runtime/webcore/ByteBlobLoader.rs
+++ b/src/runtime/webcore/ByteBlobLoader.rs
@@ -19,6 +19,11 @@ pub struct ByteBlobLoader {
     /// Necessary for converting a ByteBlobLoader from a Blob -> back into a Blob
     /// Especially for DOMFormData, where the specific content-type might've been serialized into the data.
     pub(crate) content_type: blob::BlobContentType,
+    /// Same round trip for a string body (`Body::Value::WTFStringImpl` /
+    /// `InternalBlob { was_string }`), which `.body` wraps in an untyped Blob: lets
+    /// `to_any_blob` hand back `InternalBlob { was_string: true }`, the form Bun.serve
+    /// derives `text/plain` from, instead of anonymous bytes.
+    pub(crate) was_string: bool,
 }
 
 impl Default for ByteBlobLoader {
@@ -30,6 +35,7 @@ impl Default for ByteBlobLoader {
             remain: 1024 * 1024 * 2,
             done: false,
             content_type: blob::BlobContentType::default(),
+            was_string: false,
         }
     }
 }
@@ -95,6 +101,7 @@ impl ByteBlobLoader {
             remain: size,
             done: false,
             content_type,
+            was_string: false,
         };
     }
 
@@ -149,8 +156,11 @@ impl ByteBlobLoader {
         if self.offset == 0 && self.remain == store.size() && self.content_type.is_empty() {
             // SAFETY: `RefPtr<Store>` deref is `&Store`; `to_any_blob` needs `&mut` to move bytes out.
             // We hold the only outstanding ref (just detached) so exclusive access is sound.
-            if let Some(blob) = unsafe { (*store.as_ptr()).to_any_blob() } {
+            if let Some(mut blob) = unsafe { (*store.as_ptr()).to_any_blob() } {
                 drop(store);
+                if let blob::Any::InternalBlob(internal) = &mut blob {
+                    internal.was_string = self.was_string;
+                }
                 return Some(blob);
             }
         }
@@ -193,6 +203,7 @@ impl ByteBlobLoader {
 
     fn clear_data(&mut self) {
         self.content_type = blob::BlobContentType::default();
+        self.was_string = false;
 
         if let Some(store) = self.store.take() {
             drop(store); // store.deref()

--- a/src/runtime/webcore/ByteBlobLoader.rs
+++ b/src/runtime/webcore/ByteBlobLoader.rs
@@ -19,10 +19,7 @@ pub struct ByteBlobLoader {
     /// Necessary for converting a ByteBlobLoader from a Blob -> back into a Blob
     /// Especially for DOMFormData, where the specific content-type might've been serialized into the data.
     pub(crate) content_type: blob::BlobContentType,
-    /// Same round trip for a string body (`Body::Value::WTFStringImpl` /
-    /// `InternalBlob { was_string }`), which `.body` wraps in an untyped Blob: lets
-    /// `to_any_blob` hand back `InternalBlob { was_string: true }`, the form Bun.serve
-    /// derives `text/plain` from, instead of anonymous bytes.
+    /// Same round trip for a string body: `to_any_blob` returns `InternalBlob { was_string }`.
     pub(crate) was_string: bool,
 }
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2448,6 +2448,51 @@ it("does propagate type for Blob", async () => {
   expect(res.headers.get("Content-Type")).toBe("text/plain;charset=utf-8");
 });
 
+it("derives the same content-type when .body was read before the Response is returned", async () => {
+  // `new Response(res.body, res)` is the usual middleware shape for adding headers or
+  // logging, and `if (res.body)` a null-body check. Both wrap the body in a
+  // ReadableStream that nothing reads before Bun.serve gets the Response.
+  const bodies = {
+    "string": () => new Response("hello"),
+    "string-non-ascii": () => new Response("héllo ☃"),
+    "blob-typed": () => new Response(new Blob(["hello"], { type: "text/html" })),
+    "bytes": () => new Response(new TextEncoder().encode("hello")),
+  };
+  const modes = {
+    "direct": (res: Response) => res,
+    "rewrap": (res: Response) => new Response(res.body, res),
+    "rewrap-body-only": (res: Response) => new Response(res.body),
+    "headers-then-rewrap": (res: Response) => (res.headers, new Response(res.body, res)),
+    "bodycheck": (res: Response) => (res.body, res),
+  };
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const [, body, mode] = new URL(req.url).pathname.split("/");
+      return modes[mode](bodies[body]());
+    },
+  });
+
+  const actual = {};
+  const expected = {};
+  for (const body of Object.keys(bodies)) {
+    for (const mode of Object.keys(modes)) {
+      const res = await fetch(`${server.url.origin}/${body}/${mode}`);
+      actual[`${body} ${mode}`] = { type: res.headers.get("content-type"), text: await res.text() };
+      expected[`${body} ${mode}`] = {
+        type: {
+          "string": "text/plain;charset=utf-8",
+          "string-non-ascii": "text/plain;charset=utf-8",
+          "blob-typed": "text/html;charset=utf-8",
+          "bytes": "application/octet-stream",
+        }[body],
+        text: body === "string-non-ascii" ? "héllo ☃" : "hello",
+      };
+    }
+  }
+  expect(actual).toEqual(expected);
+});
+
 it("unix socket connection in Bun.serve", async () => {
   const unix = join(tmpdir(), "bun." + Date.now() + ((Math.random() * 32) | 0).toString(16) + ".sock");
   using server = Bun.serve({

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2465,8 +2465,15 @@ it("derives the same content-type when .body was read before the Response is ret
     "headers-then-rewrap": (res: Response) => (res.headers, new Response(res.body, res)),
     "bodycheck": (res: Response) => (res.body, res),
   };
+  // A `routes` entry snapshots the Response when the server starts, through a
+  // different path (StaticRoute) than a handler's return value.
+  const routes = {};
+  for (const body of Object.keys(bodies)) {
+    routes[`/${body}/static-route`] = modes.bodycheck(bodies[body]());
+  }
   using server = Bun.serve({
     port: 0,
+    routes,
     fetch(req) {
       const [, body, mode] = new URL(req.url).pathname.split("/");
       return modes[mode](bodies[body]());
@@ -2476,7 +2483,9 @@ it("derives the same content-type when .body was read before the Response is ret
   const actual = {};
   const expected = {};
   for (const body of Object.keys(bodies)) {
-    for (const mode of Object.keys(modes)) {
+    for (const mode of [...Object.keys(modes), "static-route"]) {
+      // Untyped bytes imply no type; what each path falls back to then is not under test.
+      if (body === "bytes" && mode === "static-route") continue;
       const res = await fetch(`${server.url.origin}/${body}/${mode}`);
       actual[`${body} ${mode}`] = { type: res.headers.get("content-type"), text: await res.text() };
       expected[`${body} ${mode}`] = {


### PR DESCRIPTION
### Problem
- Bun.serve sends a string-bodied `Response` as `Content-Type: application/octet-stream` once something read `.body` first: the middleware rewrap `new Response(res.body, res)`, or only `if (res.body) {}`. Served directly, the same Response is `text/plain;charset=utf-8`. A plain-text page turns into a browser download as soon as such a middleware is in the chain (1.3.14 through canary).
- Cause: `.body` wraps the string in an untyped Blob-backed `ReadableStream` (`Value::to_readable_stream`, `src/runtime/webcore/Body.rs:756`). When nothing reads that stream, Bun.serve (`to_blob_if_possible`) and `new Response(stream)` (`Value::from_js`) unwrap it back into the bytes through `ByteBlobLoader::to_any_blob`, which yields `InternalBlob { was_string: false }`. `get_content_type` (`src/runtime/server/RequestContext.rs:4791`) then falls through to `MimeType::OTHER`.

### Fix
- `ByteBlobLoader` gets a `was_string` flag next to the `content_type` it already carries for typed Blob / FormData / URLSearchParams bodies (#14988). `to_readable_stream` sets it for a string body, and `to_any_blob` hands back `InternalBlob { was_string: true }`.
- Correct because that is the exact value the direct path gives the server for a string body, so both paths now reach `get_content_type` with the same input. Nothing else reads the flag: the header list, `fetch()` request headers, and `.blob().type` are unchanged, and a stream that was read, piped, or tee'd still streams untyped.
- Self-reviewed. A first version typed the stream's Blob `text/plain` with `content_type_was_set`; review found that this leaked as a user-set type (`fetch(url, { body: res.body })` gained a Content-Type undici does not send, and an explicit `Content-Type` header stopped typing `.blob()`). This version carries only `was_string` and has neither effect. The review also preferred the header-list shape below; see Notes for why this PR does not take it.
- Verified: `test/js/bun/http/serve.test.ts` "derives the same content-type when .body was read before the Response is returned" (10 of 23 cells fail on stock bun). Also ran the rest of `serve.test.ts`, `bun-serve-static`, `bun-serve-file`, `body*`, `response`, `request`, `blob`, `FormData`, `streams`, `fetch`, `fetch.stream`, the spawn stdin-stream tests, and elysia 1.4.28's suite.

### Background
- `Body::Value` keeps a string body as `WTFStringImpl` or `InternalBlob { was_string: true }` rather than as a `Blob`, to skip an allocation. `text/plain` is implied by that variant; it is not stored in the headers, which Bun creates lazily.
- `ByteBlobLoader` is the native source of a `ReadableStream` over in-memory Blob bytes. While the stream is undisturbed, consumers take the store straight back out of it instead of streaming.
- With no `Content-Type` header, Bun.serve picks one at send time from the body: a Blob's type, else a sniff, else `text/plain;charset=utf-8` when the body was a string or is all ASCII, else `application/octet-stream`.

<details><summary>Notes</summary>

- `content-type` the client sees, 1.4.3-canary (f42e98025) vs this branch:

  | body | direct | `new Response(res.body, res)` | `if (res.body)` |
  |---|---|---|---|
  | `"hello"` | text/plain | octet-stream → **text/plain** | octet-stream → **text/plain** |
  | `"héllo ☃"` | text/plain | octet-stream → **text/plain** | octet-stream → **text/plain** |
  | `new Blob(["hello"], { type: "text/html" })` | text/html | text/html | text/html |
  | `new Blob(["hello"])` | text/plain | octet-stream (unchanged) | octet-stream (unchanged) |
  | `Uint8Array` | octet-stream | octet-stream | octet-stream |

- The typeless-Blob row is left alone on purpose. Its direct-path `text/plain` comes from the all-ASCII sniff, a heuristic #35244 proposes to narrow; a typeless Blob has no type per the Fetch spec.
- The spec-level fix is different and larger: Fetch's "extract a body" puts a string body's `text/plain;charset=UTF-8` in the header list at construction (#8530, #17085, attempted in #33677), which would also cover `pipeThrough`, `tee`, and `clone()` of a non-ASCII string. I built that shape too and ran elysia 1.4.28 against it: besides the two HEAD tests #33677 already had to skip, it changes what elysia serves. `mergeHeaders` (`src/adapter/utils.ts`) only applies `set.headers['content-type']` when the returned Response has none, so a handler that sets `set.headers['content-type'] = 'text/html'` and returns `new Response(htmlString)` would start serving `text/plain` (their `map-response` / `map-early-response` tests catch it). That is a direction call rather than a bug fix, so it is not in here; this change does not conflict with it.
- A static route (`routes: { "/x": res }`) registered after `res.body` was read now serves `text/plain` too; before it sent no `Content-Type`. `StaticRoute::from_js` read `was_string` before unwrapping the stream and only worked because `FileRoute::from_js` unwraps the same body first; the two lines are swapped so it stands on its own, and the test covers `routes:` entries.
- Related open PRs in this area and how this composes: #42015 (typed-body Content-Type lost when the body is read before `.headers`, via a pending type on `Init`) and #42021 (do not re-derive a Content-Type the handler deleted) both leave the string-body `.body` case to a follow-up; neither touches `ByteBlobLoader` or `to_readable_stream`, so there is no textual overlap.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->