### PR TITLE
fs: make COPYFILE_FICLONE_FORCE overwrite an existing destination on macOS

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -412,9 +412,7 @@ const PREALLOCATE_LENGTH: usize = 2048 * 1024;
 #[cfg(target_os = "macos")]
 const CLONE_NOFOLLOW: u32 = 0x0001;
 
-/// `clonefile(2)` for `COPYFILE_FICLONE_FORCE`. `clonefile` refuses an existing
-/// `dest` with `EEXIST`, so without `COPYFILE_EXCL` unlink `dest` and retry.
-/// `EINVAL` when `src` and `dest` are the same inode: the unlink would delete `src`.
+/// `clonefile(2)` for `COPYFILE_FICLONE_FORCE`: on `EEXIST` unlink `dest` and retry, unless `src` is `dest`.
 #[cfg(target_os = "macos")]
 fn clonefile_force(
     src: &ZStr,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -412,8 +412,7 @@ const PREALLOCATE_LENGTH: usize = 2048 * 1024;
 #[cfg(target_os = "macos")]
 const CLONE_NOFOLLOW: u32 = 0x0001;
 
-/// `clonefile(2)` for `COPYFILE_FICLONE_FORCE`. `clonefile` refuses an existing `dest`, so
-/// without `COPYFILE_EXCL` clone to a temporary name next to `dest` and rename over it.
+/// `clonefile(2)` for `COPYFILE_FICLONE_FORCE`: clone to a temporary name, then rename over `dest`.
 #[cfg(target_os = "macos")]
 fn clonefile_force(
     src: &ZStr,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -412,7 +412,8 @@ const PREALLOCATE_LENGTH: usize = 2048 * 1024;
 #[cfg(target_os = "macos")]
 const CLONE_NOFOLLOW: u32 = 0x0001;
 
-/// `clonefile(2)` for `COPYFILE_FICLONE_FORCE`: on `EEXIST` unlink `dest` and retry, unless `src` is `dest`.
+/// `clonefile(2)` for `COPYFILE_FICLONE_FORCE`. `clonefile` refuses an existing `dest`, so
+/// without `COPYFILE_EXCL` clone to a temporary name next to `dest` and rename over it.
 #[cfg(target_os = "macos")]
 fn clonefile_force(
     src: &ZStr,
@@ -421,31 +422,44 @@ fn clonefile_force(
     syscall: sys::Tag,
 ) -> Maybe<ret::CopyFile> {
     // https://www.manpagez.com/man/2/clonefile/
-    let Some(result) =
-        Maybe::<ret::CopyFile>::errno_sys_p(bun_sys::c::clonefile_rc(src, dest, 0), syscall, src)
-    else {
-        return Ok(());
-    };
-    if mode.shouldnt_overwrite() || result.get_errno() != E::EEXIST {
-        return result;
+    if mode.shouldnt_overwrite() {
+        return Maybe::<ret::CopyFile>::errno_sys_p(
+            bun_sys::c::clonefile_rc(src, dest, 0),
+            syscall,
+            src,
+        )
+        .unwrap_or(Ok(()));
     }
-    let src_stat = match Syscall::stat(src) {
-        Ok(stat_) => stat_,
-        Err(err) => return Err(err.with_path(src)),
+
+    let name_too_long = || sys::Error {
+        errno: E::ENAMETOOLONG as _,
+        syscall,
+        path: dest.as_bytes().into(),
+        ..Default::default()
     };
-    if let Ok(dst_stat) = Syscall::stat(dest) {
-        if src_stat.st_ino == dst_stat.st_ino && src_stat.st_dev == dst_stat.st_dev {
-            return Err(sys::Error {
-                errno: SystemErrno::EINVAL as _,
-                syscall,
-                path: src.as_bytes().into(),
-                ..Default::default()
-            });
-        }
+    let mut name_buf = [0u8; 64];
+    let name = FileSystem::tmpname(b"tmp", &mut name_buf, bun_core::fast_random())
+        .map_err(|_| name_too_long())?;
+    let mut tmp_buf = bun_paths::path_buffer_pool::get();
+    let tmp_len = dest.len() + name.len();
+    if tmp_len >= tmp_buf.len() {
+        return Err(name_too_long());
     }
-    let _ = Syscall::unlink(dest);
-    Maybe::<ret::CopyFile>::errno_sys_p(bun_sys::c::clonefile_rc(src, dest, 0), syscall, src)
-        .unwrap_or(Ok(()))
+    tmp_buf[..dest.len()].copy_from_slice(dest.as_bytes());
+    tmp_buf[dest.len()..tmp_len].copy_from_slice(name.as_bytes());
+    tmp_buf[tmp_len] = 0;
+    let tmp = ZStr::from_buf(&tmp_buf[..], tmp_len);
+
+    if let Some(err) =
+        Maybe::<ret::CopyFile>::errno_sys_p(bun_sys::c::clonefile_rc(src, tmp, 0), syscall, src)
+    {
+        return err;
+    }
+    if let Err(err) = Syscall::rename(tmp, dest) {
+        let _ = Syscall::unlink(tmp);
+        return Err(err.with_path(dest));
+    }
+    Ok(())
 }
 
 /// Path-length field width.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -412,6 +412,47 @@ const PREALLOCATE_LENGTH: usize = 2048 * 1024;
 #[cfg(target_os = "macos")]
 const CLONE_NOFOLLOW: u32 = 0x0001;
 
+/// `clonefile(2)` for `COPYFILE_FICLONE_FORCE`. The syscall refuses an
+/// existing destination with `EEXIST`. Without `COPYFILE_EXCL` the copy must
+/// overwrite, so remove `dest` and clone again. Errors on `src` are reported
+/// before the unlink, so they leave `dest` intact. When `src` and `dest` are
+/// the same file the unlink would delete the source, so refuse with `EINVAL`
+/// like the read/write copy paths do.
+#[cfg(target_os = "macos")]
+fn clonefile_force(
+    src: &ZStr,
+    dest: &ZStr,
+    mode: constants::Copyfile,
+    syscall: sys::Tag,
+) -> Maybe<ret::CopyFile> {
+    // https://www.manpagez.com/man/2/clonefile/
+    let Some(result) =
+        Maybe::<ret::CopyFile>::errno_sys_p(bun_sys::c::clonefile_rc(src, dest, 0), syscall, src)
+    else {
+        return Ok(());
+    };
+    if mode.shouldnt_overwrite() || result.get_errno() != E::EEXIST {
+        return result;
+    }
+    let src_stat = match Syscall::stat(src) {
+        Ok(stat_) => stat_,
+        Err(err) => return Err(err.with_path(src)),
+    };
+    if let Ok(dst_stat) = Syscall::stat(dest) {
+        if src_stat.st_ino == dst_stat.st_ino && src_stat.st_dev == dst_stat.st_dev {
+            return Err(sys::Error {
+                errno: SystemErrno::EINVAL as _,
+                syscall,
+                path: src.as_bytes().into(),
+                ..Default::default()
+            });
+        }
+    }
+    let _ = Syscall::unlink(dest);
+    Maybe::<ret::CopyFile>::errno_sys_p(bun_sys::c::clonefile_rc(src, dest, 0), syscall, src)
+        .unwrap_or(Ok(()))
+}
+
 /// Path-length field width.
 type PathInt = u32;
 
@@ -4703,17 +4744,7 @@ impl NodeFS {
             let dest = args.dest.slice_z(&mut dest_buf);
 
             if args.mode.is_force_clone() {
-                // https://www.manpagez.com/man/2/clonefile/
-                if !args.mode.shouldnt_overwrite() {
-                    // clonefile() will fail if it already exists
-                    let _ = Syscall::unlink(dest);
-                }
-                return Maybe::<ret::CopyFile>::errno_sys_p(
-                    bun_sys::c::clonefile_rc(src, dest, 0),
-                    sys::Tag::copyfile,
-                    src,
-                )
-                .unwrap_or(Ok(()));
+                return clonefile_force(src, dest, args.mode, sys::Tag::copyfile);
             } else {
                 let stat_ = match Syscall::stat(src) {
                     Ok(result) => result,
@@ -8242,17 +8273,7 @@ impl NodeFS {
         #[cfg(target_os = "macos")]
         {
             if mode.is_force_clone() {
-                // https://www.manpagez.com/man/2/clonefile/
-                if !mode.shouldnt_overwrite() {
-                    // clonefile() will fail if it already exists
-                    let _ = Syscall::unlink(dest);
-                }
-                return Maybe::<ret::CopyFile>::errno_sys_p(
-                    bun_sys::c::clonefile_rc(src, dest, 0),
-                    sys::Tag::clonefile,
-                    src.as_bytes(),
-                )
-                .unwrap_or(Ok(()));
+                return clonefile_force(src, dest, mode, sys::Tag::clonefile);
             }
             let stat_ = match reuse_stat {
                 Some(s) => *s,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -412,12 +412,9 @@ const PREALLOCATE_LENGTH: usize = 2048 * 1024;
 #[cfg(target_os = "macos")]
 const CLONE_NOFOLLOW: u32 = 0x0001;
 
-/// `clonefile(2)` for `COPYFILE_FICLONE_FORCE`. The syscall refuses an
-/// existing destination with `EEXIST`. Without `COPYFILE_EXCL` the copy must
-/// overwrite, so remove `dest` and clone again. Errors on `src` are reported
-/// before the unlink, so they leave `dest` intact. When `src` and `dest` are
-/// the same file the unlink would delete the source, so refuse with `EINVAL`
-/// like the read/write copy paths do.
+/// `clonefile(2)` for `COPYFILE_FICLONE_FORCE`. `clonefile` refuses an existing
+/// `dest` with `EEXIST`, so without `COPYFILE_EXCL` unlink `dest` and retry.
+/// `EINVAL` when `src` and `dest` are the same inode: the unlink would delete `src`.
 #[cfg(target_os = "macos")]
 fn clonefile_force(
     src: &ZStr,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4704,6 +4704,10 @@ impl NodeFS {
 
             if args.mode.is_force_clone() {
                 // https://www.manpagez.com/man/2/clonefile/
+                if !args.mode.shouldnt_overwrite() {
+                    // clonefile() will fail if it already exists
+                    let _ = Syscall::unlink(dest);
+                }
                 return Maybe::<ret::CopyFile>::errno_sys_p(
                     bun_sys::c::clonefile_rc(src, dest, 0),
                     sys::Tag::copyfile,
@@ -8239,6 +8243,10 @@ impl NodeFS {
         {
             if mode.is_force_clone() {
                 // https://www.manpagez.com/man/2/clonefile/
+                if !mode.shouldnt_overwrite() {
+                    // clonefile() will fail if it already exists
+                    let _ = Syscall::unlink(dest);
+                }
                 return Maybe::<ret::CopyFile>::errno_sys_p(
                     bun_sys::c::clonefile_rc(src, dest, 0),
                     sys::Tag::clonefile,

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5,6 +5,7 @@ import {
   gc,
   getMaxFD,
   isBroken,
+  isCI,
   isDebug,
   isGlibc,
   isIntelMacOS,
@@ -971,8 +972,9 @@ describe("copyFileSync", () => {
   });
 
   // clonefile(2) fails with EEXIST when the destination exists. Without
-  // COPYFILE_EXCL, copyFile must overwrite it anyway. A volume without clone
-  // support reports ENOTSUP or EXDEV. That is not the bug this test covers.
+  // COPYFILE_EXCL, copyFile must overwrite it anyway. A local volume without
+  // clone support reports ENOTSUP or EXDEV. That is not the bug this test
+  // covers. The CI runners use APFS, so the checks must run there.
   it.if(isMacOS)("COPYFILE_FICLONE_FORCE overwrites an existing destination", async () => {
     const tempdir = tmpdirTestMkdir();
     const src = join(tempdir, "src.bin");
@@ -994,7 +996,7 @@ describe("copyFileSync", () => {
       try {
         await copy(src, dest, force);
       } catch (e: any) {
-        if (e.code === "ENOTSUP" || e.code === "EXDEV") continue;
+        if (!isCI && (e.code === "ENOTSUP" || e.code === "EXDEV")) continue;
         throw e;
       }
       expect(readFileSync(dest).equals(content)).toBe(true);

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1008,13 +1008,16 @@ describe("copyFileSync", () => {
       );
       expect(readFileSync(dest).equals(content)).toBe(true);
 
-      // The same file as source and destination must not be deleted.
-      await expect(copy(dest, dest, force)).rejects.toThrow(expect.objectContaining({ code: "EINVAL" }));
+      // The same file as source and destination must keep its content.
+      await copy(dest, dest, force);
       expect(readFileSync(dest).equals(content)).toBe(true);
       const link = join(tempdir, `${name}.link`);
       symlinkSync(dest, link);
-      await expect(copy(link, dest, force)).rejects.toThrow(expect.objectContaining({ code: "EINVAL" }));
+      await copy(link, dest, force);
       expect(readFileSync(dest).equals(content)).toBe(true);
+
+      // No temporary file is left behind.
+      expect(readdirSync(tempdir).filter(f => f.startsWith(`${name}.bin.`))).toEqual([]);
     }
   });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1001,6 +1001,20 @@ describe("copyFileSync", () => {
 
       await expect(copy(src, dest, force | excl)).rejects.toThrow(eexist);
       expect(readFileSync(dest).equals(content)).toBe(true);
+
+      // A failure on the source must not remove the destination.
+      await expect(copy(join(tempdir, "missing.bin"), dest, force)).rejects.toThrow(
+        expect.objectContaining({ code: "ENOENT" }),
+      );
+      expect(readFileSync(dest).equals(content)).toBe(true);
+
+      // The same file as source and destination must not be deleted.
+      await expect(copy(dest, dest, force)).rejects.toThrow(expect.objectContaining({ code: "EINVAL" }));
+      expect(readFileSync(dest).equals(content)).toBe(true);
+      const link = join(tempdir, `${name}.link`);
+      symlinkSync(dest, link);
+      await expect(copy(link, dest, force)).rejects.toThrow(expect.objectContaining({ code: "EINVAL" }));
+      expect(readFileSync(dest).equals(content)).toBe(true);
     }
   });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -9,6 +9,7 @@ import {
   isGlibc,
   isIntelMacOS,
   isLinux,
+  isMacOS,
   isPosix,
   isWindows,
   tempDir,
@@ -967,6 +968,40 @@ describe("copyFileSync", () => {
     copyFileSync(import.meta.path, tempdir + "/copyFileSync.js", fs.constants.COPYFILE_FICLONE);
     copyFileSync(import.meta.path, tempdir + "/copyFileSync.js", fs.constants.COPYFILE_FICLONE);
     copyFileSync(import.meta.path, tempdir + "/copyFileSync.js", fs.constants.COPYFILE_FICLONE);
+  });
+
+  // clonefile(2) fails with EEXIST when the destination exists. Without
+  // COPYFILE_EXCL, copyFile must overwrite it anyway. A volume without clone
+  // support reports ENOTSUP or EXDEV. That is not the bug this test covers.
+  it.if(isMacOS)("COPYFILE_FICLONE_FORCE overwrites an existing destination", async () => {
+    const tempdir = tmpdirTestMkdir();
+    const src = join(tempdir, "src.bin");
+    const content = Buffer.alloc(1024 * 1024, "A");
+    writeFileSync(src, content);
+    const force = fs.constants.COPYFILE_FICLONE_FORCE;
+    const excl = fs.constants.COPYFILE_EXCL;
+    const eexist = expect.objectContaining({ code: "EEXIST" });
+
+    const variants: Record<string, (src: string, dest: string, mode: number) => Promise<void>> = {
+      sync: async (src, dest, mode) => copyFileSync(src, dest, mode),
+      callback: promisify(fs.copyFile),
+      promises: fs.promises.copyFile,
+    };
+
+    for (const [name, copy] of Object.entries(variants)) {
+      const dest = join(tempdir, `${name}.bin`);
+      writeFileSync(dest, "placeholder");
+      try {
+        await copy(src, dest, force);
+      } catch (e: any) {
+        if (e.code === "ENOTSUP" || e.code === "EXDEV") continue;
+        throw e;
+      }
+      expect(readFileSync(dest).equals(content)).toBe(true);
+
+      await expect(copy(src, dest, force | excl)).rejects.toThrow(eexist);
+      expect(readFileSync(dest).equals(content)).toBe(true);
+    }
   });
 
   it("COPYFILE_EXCL works", () => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1017,7 +1017,7 @@ describe("copyFileSync", () => {
       expect(readFileSync(dest).equals(content)).toBe(true);
 
       // No temporary file is left behind.
-      expect(readdirSync(tempdir).filter(f => f.startsWith(`${name}.bin.`))).toEqual([]);
+      expect(readdirSync(tempdir).filter(f => f.startsWith(`${name}.bin`) && f !== `${name}.bin`)).toEqual([]);
     }
   });
 


### PR DESCRIPTION
### Problem
- On macOS, `fs.copyFile(src, dest, COPYFILE_FICLONE_FORCE)` throws `EEXIST` when `dest` exists. `COPYFILE_FICLONE` overwrites the same file. `copyFile` must overwrite unless `COPYFILE_EXCL` is set.
- The cause is the forced clone branch in `copy_file_inner` (`src/runtime/node/node_fs.rs`). It calls `clonefile(2)` directly, and `clonefile` refuses an existing destination. `copy_single_file_sync` has the same shape.

### Fix
- Both forced clone branches now call one helper, `clonefile_force`. Without `COPYFILE_EXCL` it clones `src` to a temporary name next to `dest`, then renames the clone over `dest`. The rename replaces `dest` atomically.
- A failed `clonefile` (`EXDEV`, `ENOTSUP`, a missing `src`) returns before `dest` is touched, so no failure removes the existing file. A failed rename removes the temporary clone.
- With `COPYFILE_EXCL`, nothing changes: `clonefile` goes straight to `dest` and returns `EEXIST`. Linux is not affected. Its forced path opens `dest` with `O_CREAT` and then calls `ioctl(FICLONE)`.
- Verified: `test/js/node/fs/fs.test.ts`, new test `COPYFILE_FICLONE_FORCE overwrites an existing destination` (macOS only). I have no macOS machine here. The macOS build was checked with `cargo check -p bun_runtime --target aarch64-apple-darwin`. The macOS CI lanes prove the fix.

### Background
- `clonefile(2)` is the macOS syscall that creates a copy-on-write clone of a file on APFS. It fails with `EEXIST` when the destination path exists, with `EXDEV` across volumes, and with `ENOTSUP` on a file system without clone support. The kernel checks `EEXIST` first, so an unlink-and-retry would delete `dest` before it learns that the clone is impossible.
- `COPYFILE_FICLONE` asks for a clone but falls back to a normal copy. `COPYFILE_FICLONE_FORCE` asks for a clone and fails when a clone is not possible. Neither flag changes the overwrite rule. Only `COPYFILE_EXCL` does.
- Node (libuv) returns `ENOSYS` for `COPYFILE_FICLONE_FORCE` on macOS. Bun supports the flag through `clonefile`, so this is Bun's own semantics, and the two flags must agree on overwrite.

<details><summary>Notes</summary>

- Self-reviewed: three concerns raised, all addressed. The first version unlinked `dest` before `clonefile`. That deleted `dest` on any clone failure and deleted the file when `src` and `dest` were the same inode. The second version cloned first and unlinked on `EEXIST`, which still lost `dest` on `EXDEV` or `ENOTSUP`. The temporary name plus rename closes all of these.
- The temporary name is `dest` plus the `FileSystem::tmpname` suffix (`.<hex>-<counter>.tmp`), so it is always in the same directory and on the same volume as `dest`. `ENAMETOOLONG` is returned when it does not fit in a path buffer.
- The same file as `src` and `dest` (same path, or a symlink to `dest`) now succeeds and keeps the content: the clone of the file replaces the file.
- The test accepts `ENOTSUP` and `EXDEV` from the first forced copy, the same as Node's `test-fs-copyfile.js`, so a runner whose temp volume cannot clone does not fail. `EEXIST` (the bug) is still reported.
- The test covers `copyFileSync`, callback `fs.copyFile`, and `fs.promises.copyFile`. It checks the overwrite, that `COPYFILE_EXCL` still throws `EEXIST`, that a missing `src` leaves `dest` intact, the same-file cases, and that no temporary file is left behind.
- `fs.cp` does not pass `COPYFILE_FICLONE_FORCE` into `copy_single_file_sync` today. That branch is changed to keep the two copies in sync.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->