### PR TITLE
node:http: release the server socket after a response that closes the connection

### DIFF
--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -844,6 +844,12 @@ private:
                     && httpResponseData->onWritable == nullptr) {
                     responseDone = true;
                 }
+                /* socket.destroySoon() issued while bytes were queued: Node's
+                 * destroy() on 'finish' closes once they are out, whether or
+                 * not the response in flight ever ends. */
+                if (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_CLOSE_AFTER_DRAIN) {
+                    responseDone = true;
+                }
             }
             if (responseDone && asyncSocket->hasFullyDrained()) {
                 asyncSocket->shutdown();

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -150,13 +150,18 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
          * shutdown sweep; the shouldCloseConnection() gates act on it once the
          * in-flight work completes. */
         HTTP_CLOSE_WHEN_IDLE = 1 << 17,
+        /* node:http socket.destroySoon() with outgoing bytes still queued: shut
+         * down and close as soon as they have flushed, whether or not the
+         * response in flight has ended (Node's destroy() on 'finish'). */
+        HTTP_NODE_CLOSE_AFTER_DRAIN = 1 << 18,
 
         /* Bits that describe the connection rather than the response in flight.
          * There is one HttpResponseData per socket, reused by every request on a
          * keep-alive connection, so starting a new response clears the rest of the
          * word (resetResponseState) - these have to survive that. */
         HTTP_CONNECTION_SCOPED = HTTP_NODE_PARSING_STOPPED | HTTP_NODE_READS_PAUSED
-            | HTTP_NODE_TUNNEL_AFTER_BODY | HTTP_NODE_RECEIVED_FIN | HTTP_CLOSE_WHEN_IDLE,
+            | HTTP_NODE_TUNNEL_AFTER_BODY | HTTP_NODE_RECEIVED_FIN | HTTP_CLOSE_WHEN_IDLE
+            | HTTP_NODE_CLOSE_AFTER_DRAIN,
     };
 
     /* Begin a new response on this connection. Clearing the word in one go is
@@ -228,7 +233,7 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
     /* Whether the connection should be torn down once the in-flight response (if
      * any) has completed and all buffered outgoing data has been flushed. */
     bool shouldCloseConnection() const {
-        return (state & HTTP_CONNECTION_CLOSE)
+        return (state & (HTTP_CONNECTION_CLOSE | HTTP_NODE_CLOSE_AFTER_DRAIN))
             || ((state & HTTP_NODE_RECEIVED_FIN) && nodeHttpQueuedPipelinedCount == 0)
             || ((state & HTTP_CLOSE_WHEN_IDLE) && this->isIdle);
     }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1298,9 +1298,10 @@ function onServerClientError(ssl: boolean, socket: unknown, errorCode: number, r
 // reaches socketOnError and 'clientError' never fires for it.
 function replyMissingHostHeader(socket) {
   if (!socket.writable) return;
-  socket.end(
+  socket.write(
     `HTTP/1.1 400 Bad Request\r\nConnection: close\r\nDate: ${new Date().toUTCString()}\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n`,
   );
+  socket.destroySoon();
 }
 
 const kBytesWritten = Symbol("kBytesWritten");
@@ -1333,6 +1334,8 @@ function resolveHandoffPromise(promise) {
 }
 const kSocketTimeoutTimer = Symbol("socketTimeoutTimer");
 const kStreamingEnabled = Symbol("kStreamingEnabled");
+// destroySoon() was called: _final closes the connection right behind the FIN.
+const kDestroySoon = Symbol("kDestroySoon");
 // Scratch options object for the builtin ServerResponse (see the dispatcher).
 const scratchResponseOptions = {
   [kHandle]: undefined,
@@ -1485,6 +1488,7 @@ function getNodeHTTPServerSocket() {
     [kBytesWritten] = 0;
     [kHandle];
     [kUpgradeIncoming] = undefined;
+    [kDestroySoon] = false;
     server: Server;
     _httpMessage;
     _secureEstablished = false;
@@ -1765,8 +1769,20 @@ function getNodeHTTPServerSocket() {
         callback();
         return;
       }
-      handle.end();
+      handle.end(this[kDestroySoon]);
       callback();
+    }
+
+    // Not destroy() on 'finish' like net.Socket: 'finish' does not wait for bytes uWS still queues.
+    destroySoon() {
+      if (this[kDestroySoon]) return;
+      const handle = this[kHandle];
+      if (this.writable && handle && !handle.closed) {
+        this[kDestroySoon] = true;
+        this.end();
+        return;
+      }
+      super.destroySoon();
     }
 
     get localAddress() {
@@ -2405,7 +2421,13 @@ function emitResponseFinish() {
 // is eventually closed.
 function onResponseFinishHandleSocket(server, socket, res) {
   if (res[kMustCloseConnection]) {
-    socket?.end();
+    if (socket != null) {
+      if (typeof socket.destroySoon === "function") {
+        socket.destroySoon();
+      } else {
+        socket.end();
+      }
+    }
     return;
   }
   if (!socket || socket.destroyed || typeof socket.setTimeout !== "function") {

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -243,7 +243,7 @@ bool JSNodeHTTPServerSocket::isClosed() const
 }
 
 template<bool SSL>
-static bool deferShutdownUntilResponseDrains(us_socket_t* socket)
+static bool deferShutdownUntilResponseDrains(us_socket_t* socket, bool thenClose)
 {
     if (reinterpret_cast<uWS::AsyncSocket<SSL>*>(socket)->getBufferedAmount() == 0) {
         return false;
@@ -253,18 +253,22 @@ static bool deferShutdownUntilResponseDrains(us_socket_t* socket)
      * is sequenced after the response bytes (like Node's destroySoon). */
     auto* httpResponseData = reinterpret_cast<uWS::HttpResponseData<SSL>*>(us_socket_ext(socket));
     httpResponseData->state |= uWS::HttpResponseData<SSL>::HTTP_CONNECTION_CLOSE;
+    if (thenClose) {
+        /* destroySoon(): and closes it there, even if the response never ends. */
+        httpResponseData->state |= uWS::HttpResponseData<SSL>::HTTP_NODE_CLOSE_AFTER_DRAIN;
+    }
     return true;
 }
 
-bool JSNodeHTTPServerSocket::shutdownAfterResponseDrains()
+bool JSNodeHTTPServerSocket::shutdownAfterResponseDrains(bool thenClose)
 {
     if (!socket || upgraded || us_socket_is_closed(socket) || us_socket_is_shut_down(socket)) {
         return false;
     }
     if (is_ssl) {
-        return deferShutdownUntilResponseDrains<true>(socket);
+        return deferShutdownUntilResponseDrains<true>(socket, thenClose);
     }
-    return deferShutdownUntilResponseDrains<false>(socket);
+    return deferShutdownUntilResponseDrains<false>(socket, thenClose);
 }
 
 template<bool SSL>

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
@@ -106,7 +106,7 @@ public:
     /* node:http socket.end(): when the in-flight response still has bytes in
      * uWS's send buffer, a shutdown now would put the FIN ahead of them and
      * truncate the response. Returns true after handing the close to uWS. */
-    bool shutdownAfterResponseDrains();
+    bool shutdownAfterResponseDrains(bool thenClose);
 
     /* Switch the connection into CONNECT-style tunnel mode after an accepted
      * Upgrade: subsequent bytes bypass the HTTP parser and stream to the

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp
@@ -13,6 +13,7 @@ extern "C" uint64_t uws_res_get_remote_address_info(void* res, const char** dest
 extern "C" uint64_t uws_res_get_local_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
 extern "C" void us_socket_resume(us_socket_t*);
 extern "C" void us_socket_pause(us_socket_t*);
+extern "C" void us_socket_shutdown(us_socket_t*);
 
 namespace Bun {
 
@@ -216,12 +217,24 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeHTTPServerSocketEnd, (JSC::JSGlobalObject
     }
 
     thisObject->ended = true;
+    // end(true) is Node's destroySoon(): close right behind the FIN instead of waiting for the peer's.
+    bool destroySoon = callFrame->argument(0).toBoolean(globalObject);
     // The response's buffered body must reach the kernel before the FIN; uWS
     // performs the shutdown after its send buffer drains.
-    if (thisObject->shutdownAfterResponseDrains()) {
+    if (thisObject->shutdownAfterResponseDrains(destroySoon)) {
         return JSValue::encode(JSC::jsUndefined());
     }
     auto bufferedSize = thisObject->streamBuffer.bufferedSize();
+    if (destroySoon) {
+        // One flush for raw socket.write() bytes; the close drops the rest, as destroy() did.
+        if (bufferedSize == 0) {
+            us_socket_shutdown(thisObject->socket);
+        } else {
+            us_socket_buffered_js_write(thisObject->socket, thisObject->is_ssl, thisObject->ended, &thisObject->streamBuffer, globalObject, JSValue::encode(JSC::jsUndefined()), JSValue::encode(JSC::jsUndefined()));
+        }
+        thisObject->close();
+        return JSValue::encode(JSC::jsUndefined());
+    }
     if (bufferedSize == 0) {
         // onNodeHTTPRequest no longer pauses at dispatch; pause here so the
         // shutdown+resume below still cycles kqueue's EVFILT_READ (delete then

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2708,34 +2708,142 @@ it("removing only Content-Length falls back to chunked encoding and keeps the co
   }
 });
 
-it("an explicit Connection: close response header closes the server-side socket after finish", async () => {
-  // Node.js's matchHeader sets _last for a user-set Connection: close, and
-  // resOnFinish then ends the socket; the transport must match the header.
-  const server = createServer((req, res) => {
-    res.setHeader("Connection", "close");
-    res.end("ok");
-  });
-  try {
+// Node.js's resOnFinish destroySoon()s the socket after a response that ends the
+// connection: the server sends its FIN and releases the socket right behind it
+// ('close' on the server-side socket, fd gone) without waiting for the peer to
+// close its side. A half-close that waits for the client's FIN lets a client
+// that never closes pin one socket per completed request.
+describe("a response that closes the connection releases the server-side socket without waiting for the peer", () => {
+  const cases = [
+    {
+      name: "Connection: close response header",
+      request: "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
+      prepare: (res: ServerResponse) => res.setHeader("Connection", "close"),
+      expected: /^HTTP\/1\.1 200 OK\r\n[^]*ok$/,
+    },
+    {
+      name: "Connection: close request header",
+      request: "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+      expected: /^HTTP\/1\.1 200 OK\r\n[^]*ok$/,
+    },
+    {
+      name: "HTTP/1.0 request",
+      request: "GET / HTTP/1.0\r\nHost: localhost\r\n\r\n",
+      expected: /^HTTP\/1\.1 200 OK\r\n[^]*ok$/,
+    },
+    {
+      // Node answers this itself with res.writeHead(400, ['Connection', 'close']).
+      name: "HTTP/1.1 request without a Host header",
+      request: "GET / HTTP/1.1\r\n\r\n",
+      expected: /^HTTP\/1\.1 400 Bad Request\r\n[^]*\r\n0\r\n\r\n$/,
+    },
+  ];
+  for (const { name, request, prepare, expected } of cases) {
+    it.concurrent(name, async () => {
+      const { promise: serverSocketClosed, resolve: onServerSocketClose } = Promise.withResolvers<void>();
+      const server = createServer((req, res) => {
+        prepare?.(res);
+        res.end("ok");
+      });
+      server.on("connection", socket => socket.on("close", onServerSocketClose));
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as AddressInfo;
+      // allowHalfOpen: the client keeps its side open after the server's FIN, so
+      // only the server can release the server-side socket.
+      const client = connect({ port, host: "127.0.0.1", allowHalfOpen: true });
+      try {
+        const out = await new Promise<string>((resolve, reject) => {
+          let data = "";
+          client.setEncoding("latin1");
+          client.on("data", chunk => (data += chunk));
+          client.on("end", () => resolve(data));
+          client.on("error", reject);
+          client.write(request);
+        });
+        expect(out).toMatch(expected);
+        expect(out).toContain("\r\nConnection: close\r\n");
+        // The client has the whole response and the server's FIN, and has not
+        // sent its own. The server-side socket must close on its own now.
+        await serverSocketClosed;
+        expect(client.writableEnded).toBe(false);
+      } finally {
+        client.destroy();
+        server.close();
+      }
+    });
+  }
+
+  // net.Socket.destroySoon() is what Node's resOnFinish uses: end(), then
+  // destroy() once the write side is done, without waiting for the peer.
+  it.concurrent("socket.destroySoon() from a handler", async () => {
+    const { promise: serverSocketClosed, resolve: onServerSocketClose } = Promise.withResolvers<void>();
+    const server = createServer((req, res) => {
+      req.socket.write("raw bytes\r\n");
+      req.socket.destroySoon();
+    });
+    server.on("connection", socket => socket.on("close", onServerSocketClose));
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
     const { port } = server.address() as AddressInfo;
+    const client = connect({ port, host: "127.0.0.1", allowHalfOpen: true });
+    try {
+      const out = await new Promise<string>((resolve, reject) => {
+        let data = "";
+        client.setEncoding("latin1");
+        client.on("data", chunk => (data += chunk));
+        client.on("end", () => resolve(data));
+        client.on("error", reject);
+        client.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+      });
+      expect(out).toBe("raw bytes\r\n");
+      await serverSocketClosed;
+      expect(client.writableEnded).toBe(false);
+    } finally {
+      client.destroy();
+      server.close();
+    }
+  });
 
-    const out = await new Promise<string>((resolve, reject) => {
-      const socket = connect(port, "127.0.0.1");
-      let data = "";
-      socket.on("data", chunk => (data += chunk));
-      // The server must send FIN on its own; the client never half-closes.
-      socket.on("end", () => resolve(data));
-      socket.on("error", reject);
-      socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+  // destroySoon() with response bytes still queued in the transport (the client
+  // is not reading yet) and no res.end(): the queued bytes are delivered first,
+  // then the connection closes, like Node's destroy() on the socket's 'finish'.
+  it.concurrent("socket.destroySoon() behind a backed-up response that never ends", async () => {
+    const CHUNK = Buffer.alloc(16 * 1024, "a");
+    const CHUNKS = 1024; // 16 MB: more than the loopback socket buffers absorb
+    const { promise: serverSocketClosed, resolve: onServerSocketClose } = Promise.withResolvers<void>();
+    const { promise: destroyed, resolve: onDestroySoonCalled } = Promise.withResolvers<void>();
+    const server = createServer((req, res) => {
+      res.on("error", () => {});
+      for (let i = 0; i < CHUNKS; i++) res.write(CHUNK);
+      req.socket.destroySoon();
+      onDestroySoonCalled();
     });
-
-    expect(out).toContain("HTTP/1.1 200");
-    expect(out).toContain("Connection: close");
-    expect(out).toEndWith("ok");
-  } finally {
-    server.close();
-  }
+    server.on("connection", socket => socket.on("close", onServerSocketClose));
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+    const client = connect({ port, host: "127.0.0.1", allowHalfOpen: true });
+    try {
+      let received = 0;
+      const ended = new Promise<void>((resolve, reject) => {
+        client.on("data", chunk => (received += chunk.length));
+        client.on("end", resolve);
+        client.on("error", reject);
+      });
+      client.pause();
+      client.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+      await destroyed;
+      client.resume();
+      await ended;
+      expect(received).toBeGreaterThan(CHUNK.length * CHUNKS);
+      await serverSocketClosed;
+      expect(client.writableEnded).toBe(false);
+    } finally {
+      client.destroy();
+      server.close();
+    }
+  });
 });
 
 it("a pipelined request behind Connection: close is never dispatched (clientError HPE_CLOSED_CONNECTION)", async () => {


### PR DESCRIPTION
### Problem
- A `node:http` server response that ends the connection (`Connection: close` in the response or the request, or an HTTP/1.0 request) only half-closes the socket. The server sends its FIN, then keeps the fd and the `net.Socket` (no `'close'` event) until the client sends its FIN. Node.js closes behind the FIN.
- `onResponseFinishHandleSocket` (`src/js/node/_http_server.ts`) called `socket.end()` where Node's `resOnFinish` calls `socket.destroySoon()`. The native `end()` only runs `us_socket_shutdown`. That shutdown also makes uWS skip its post-parse close gate (the request handler in `HttpContext.h` returns `nullptr` once `us_socket_is_shut_down`).

### Fix
- `NodeHTTPServerSocket.destroySoon()` sets a flag and ends the socket. `_final` passes it to the native `end(true)`, which sends the FIN and closes at once. When response bytes are still buffered, `HttpContext::onWritable` closes once they drain (`HTTP_NODE_CLOSE_AFTER_DRAIN`, ended response or not).
- `onResponseFinishHandleSocket` and the missing-`Host` 400 reply call `destroySoon()`. A `socket.end()` from user code keeps its half-close behavior.
- Verified: `test/js/node/http/node-http.test.ts` (6 new cases, 5 fail on stock bun), Linux and Windows. Also `test/js/node/http/` and `test/parallel/test-http-*`, same results as `main`.

### Background
- `NodeHTTPServerSocket` is the `net.Socket` subclass that `node:http` server code sees. Its `kHandle` is a C++ `JSNodeHTTPServerSocket` that wraps the uWS connection.
- Node's `net.Socket.destroySoon()` is `end()` plus `destroy()` on `'finish'`. Here `'finish'` does not wait for the transport's send buffer, so a `destroy()` on it could drop response bytes. The close is sequenced natively instead.
- uWS ends a `Connection: close` connection with `shutdown()` then `close()` once the response has drained, so `Bun.serve` already matches Node.

<details><summary>Notes</summary>

- No user report. Found by comparing connection teardown with Node v26: 5 `node:net` clients with `allowHalfOpen`, one `GET` each against a handler that sets `Connection: close`, then hold the sockets. Stock bun 1.4.2: `server-side 'close' events 0/5; socket fds 12` after 20 s. With this change: `5/5; socket fds 6` within the first second, same as Node.
- TLS: `end(true)` sends close_notify and FIN through `us_socket_shutdown`, then closes with `LIBUS_SOCKET_CLOSE_CODE_FAST_SHUTDOWN` like `_destroy()` does, so the fd does not wait for the peer's close_notify. Checked with an `https` server: full body plus `'end'` on the client, `'close'` on the server socket right after.
- Backpressure: a 32 MB `Connection: close` response to a paused client is delivered in full and the socket closes once it drains (this path already closed before the change).
- `socket.destroySoon()` from user code while `res.write()` bytes are still queued and `res.end()` never comes: the queued bytes are delivered, then the connection closes (16 MB case in the test). Stock bun destroyed on `'finish'` and truncated (2.6 MB of 16 MB delivered); the first revision of this PR left that connection open, hence `HTTP_NODE_CLOSE_AFTER_DRAIN`.
- Raw `socket.write()` bytes that the kernel has not taken when `end(true)` runs get one more flush, and the close drops what is left. That is what `destroy()` did before on these sockets: only CONNECT/Upgrade tunnel sockets receive drain events, and their writes complete before `_final` runs. A `res.write()` tail above 16 KB that is held by reference rather than buffered is the subject of #35027 and behaves as before.
- #38196 adds the same `_final` to `end(flag)` argument for another reason (keep parsing a body that is still arriving). The two should share one flag. Whichever lands second rebases onto the other.
- HTTP/1 fallback connections of `node:http2` servers (`allowHTTP1`) use real `net.Socket`s and a separate finish path. They are not touched here (#37767 covers them).
- Self-reviewed: 4 concerns raised, 4 addressed (a dead drain-event arm was removed in favor of the flush-then-close above, the overlap with #38196 and the fallback scope are stated here).
- Other suites run with the debug build: `test/js/node/http/` (all files), `test/js/bun/http/node-http-halfclose-midupload.test.ts`, `test/js/node/test/parallel/test-http-*` and `test-https-*` (same pass/fail set as a build of `main`), express, socket.io, hono.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/164] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/164] gen cpp.rs (cppbind)
[3/164] gen JS modules (bundle-modules)
Preprocess modules (7816ms)
Bundle modules (63ms)
Postprocesss modules (123ms)
Bundle Functions (468ms)
Generate Code (35ms)

[8.52s] Bundled "src/js" for development
  2786 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/164] cargo bun_runtime → libbun_runtime.a
[4/164] cc obj/codegen/InternalModuleRegistryConstants.S.o
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --en
... (truncated)

release without fix: 1 failed, 1 skipped
bun test v1.4.3-canary.1 (638ff17b7)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [11.42ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [2.44ms]
(pass) node:http > createServer > request & response body streaming (large) [4.16ms]
(pass) node:http > createServer > request & response body streaming (small) [1.85ms]
(pass) node:http > createServer > listen should return server [0.99ms]
(pass) node:http > createServer > listen callback should be bound to server [0.72ms]
(pass) node:http > createServer > emits 'listening' on the next tick, before the event loop polls [1.06ms]
(pass) node:http > createServer > emits a listen() error on the next tick, before the event loop polls [1.23ms]
(pass) node:http > createServer > calls the listen() callback after a retry from the EADDRINUSE 'error' handler [1.56ms]
(pass) node:http > createServer > http: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [33.28ms]
(pass) node:http > createServer > https: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [34.94ms]
(pass) node:http > createServer > should use the provided port [1.20ms]
(pa
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http.test.ts
bun test v1.4.3 (a3e0ab60c)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [438.15ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [70.98ms]
(pass) node:http > createServer > request & response body streaming (large) [109.78ms]
(pass) node:http > createServer > request & response body streaming (small) [70.92ms]
(pass) node:http > createServer > listen should return server [20.04ms]
(pass) node:http > createServer > listen callback should be bound to server [26.57ms]
(pass) node:http > createServer > emits 'listening' on the next tick, before the event loop polls [36.59ms]
(pass) node:http > createServer > emits a listen() error on the next tick, before the event loop polls [45.21ms]
(pass) node:http > createServer > calls the listen() callback after a retry from the EADDRINUSE 'error' handler [48.83ms]
(pass) node:http > createServer > http: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [1267.08ms]
(pass) node:http > crea
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 763ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/125] gen cpp.rs (cppbind)
[3/125] gen JS modules (bundle-modules)
Preprocess modules (7988ms)
Bundle modules (60ms)
Postprocesss modules (191ms)
Bundle Functions (521ms)
Generate Code (43ms)

[8.81s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/124] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpContext.h                 |   6 +
 packages/bun-uws/src/HttpResponseData.h            |   9 +-
 src/js/node/_http_server.ts                        |  28 +++-
 src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp   |  12 +-
 src/jsc/bindings/node/JSNodeHTTPServerSocket.h     |   2 +-
 .../node/JSNodeHTTPServerSocketPrototype.cpp       |  15 +-
 test/js/node/http/node-http.test.ts                | 154 ++++++++++++++++++---
 7 files changed, 192 insertions(+), 34 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
packages/bun-uws/src/HttpContext.h                            5      1     28
packages/bun-uws/src/HttpResponseData.h                       2      3     28
src/js/node/_http_server.ts                                   9     13     28
src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp              5      5     28
src/jsc/bindings/node/JSNodeHTTPServerSocket.h                3      5     28
…c/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.cpp      6      7     28
test/js/node/http/node-http.test.ts                           5      6     28
```

</details>

<!-- robobun:evidence:end -->