### PR TITLE
Remove dead code from the bun_runtime and bun_jsc error enums, bun_collections, and three JS builtins

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -598,14 +598,6 @@ pub fn rsplit_once_char(self_: &[u8], delimiter: u8) -> Option<(&[u8], &[u8])> {
     Some((&self_[..i], &self_[i + 1..]))
 }
 
-/// `str::split_once` for bytes with a multi-byte delimiter. An empty
-/// delimiter never matches.
-#[inline]
-pub fn split_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
-    let i = index_of(self_, delimiter)?;
-    Some((&self_[..i], &self_[i + delimiter.len()..]))
-}
-
 /// `str::rsplit_once` for bytes with a multi-byte delimiter. An empty
 /// delimiter never matches.
 #[inline]

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -598,6 +598,14 @@ pub fn rsplit_once_char(self_: &[u8], delimiter: u8) -> Option<(&[u8], &[u8])> {
     Some((&self_[..i], &self_[i + 1..]))
 }
 
+/// `str::split_once` for bytes with a multi-byte delimiter. An empty
+/// delimiter never matches.
+#[inline]
+pub fn split_once<'a>(self_: &'a [u8], delimiter: &[u8]) -> Option<(&'a [u8], &'a [u8])> {
+    let i = index_of(self_, delimiter)?;
+    Some((&self_[..i], &self_[i + delimiter.len()..]))
+}
+
 /// `str::rsplit_once` for bytes with a multi-byte delimiter. An empty
 /// delimiter never matches.
 #[inline]

--- a/src/collections/array_hash_map.rs
+++ b/src/collections/array_hash_map.rs
@@ -1735,11 +1735,6 @@ impl<V, A: Allocator + HashbrownAllocator + Clone + Default> StringHashMap<V, A>
         self.inner.values()
     }
 
-    #[inline]
-    pub fn values_mut(&mut self) -> hashbrown::hash_map::ValuesMut<'_, StringHashMapKey<A>, V> {
-        self.inner.values_mut()
-    }
-
     pub fn ensure_total_capacity(&mut self, n: usize) -> Result<(), AllocError> {
         let need = n.saturating_sub(self.inner.len());
         self.inner.reserve(need);

--- a/src/js/internal/repl/node-inspect.js
+++ b/src/js/internal/repl/node-inspect.js
@@ -1,8 +1,8 @@
 // Shim for Node's `internal/util/inspect` as consumed by the ported
 // node:repl / internal/readline stack. getStringWidth/stripVTControlCharacters
 // go straight to the native bindings so `require("node:readline")` does not
-// pull in the 99 KB internal/util/inspect; inspect/format load it lazily on
-// first access (REPL output / completion rendering).
+// pull in the 99 KB internal/util/inspect; inspect loads it lazily on first
+// access (REPL output / completion rendering).
 
 const stripANSI = Bun.stripANSI;
 const nativeStringWidth = $newCppFunction("stringWidth.cpp", "jsFunctionBunStringWidth", 1);

--- a/src/js/internal/repl/node-inspect.js
+++ b/src/js/internal/repl/node-inspect.js
@@ -31,10 +31,4 @@ export default {
   get inspect() {
     return load().inspect;
   },
-  get format() {
-    return load().format;
-  },
-  get formatWithOptions() {
-    return load().formatWithOptions;
-  },
 };

--- a/src/js/internal/repl/node-inspect.js
+++ b/src/js/internal/repl/node-inspect.js
@@ -1,8 +1,8 @@
 // Shim for Node's `internal/util/inspect` as consumed by the ported
 // node:repl / internal/readline stack. getStringWidth/stripVTControlCharacters
 // go straight to the native bindings so `require("node:readline")` does not
-// pull in the 99 KB internal/util/inspect; inspect loads it lazily on first
-// access (REPL output / completion rendering).
+// pull in the 99 KB internal/util/inspect; inspect loads it lazily on
+// first access (REPL output / completion rendering).
 
 const stripANSI = Bun.stripANSI;
 const nativeStringWidth = $newCppFunction("stringWidth.cpp", "jsFunctionBunStringWidth", 1);

--- a/src/js/internal/shared.ts
+++ b/src/js/internal/shared.ts
@@ -413,7 +413,6 @@ export default {
   getLazy,
   guardCallback,
   isInsideNodeModules,
-  reportUncaughtException,
   resistStopPropagation,
 
   hasObserver,

--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -1074,30 +1074,6 @@ Url.prototype.parseHost = function parseHost() {
   if (host) this.hostname = host;
 };
 
-// function fileURLToPath(...args) {
-//   // Since we use WTF::URL::fileSystemPath directly in Bun.fileURLToPath, we don't get invalid windows
-//   // path checking. We patch this in to `node:url` for compatibility. Note that
-//   // this behavior is missing from WATWG URL.
-//   if (process.platform === "win32") {
-//     var url: string;
-//     if ($isObject(args[0]) && args[0] instanceof Url) {
-//       url = (args[0] as { href: string }).href;
-//     } else if (typeof args[0] === "string") {
-//       url = args[0];
-//     } else {
-//       throw $ERR_INVALID_ARG_TYPE("url", ["string", "URL"], args[0]);
-//     }
-
-//     for (var i = 0; i < url.length; i++) {
-//       if (url.charCodeAt(i) === Char.PERCENT && (i + 1) < url.length) {
-//         switch (url.charCodeAt(i + 1)) {
-//         break;
-//       }
-//     }
-//   }
-//   return Bun.fileURLToPath.$call(args);
-// }
-
 /**
  * Add new characters as needed from
  * [here](https://github.com/nodejs/node/blob/main/lib/internal/constants.js).

--- a/src/jsc/error.rs
+++ b/src/jsc/error.rs
@@ -46,8 +46,6 @@ pub enum Error {
     UnexpectedPendingResolution,
     #[error("WorkerTerminated")]
     WorkerTerminated,
-    #[error("JSErrorObject")]
-    JSErrorObject,
     #[error("ThreadSpawnFailed")]
     ThreadSpawnFailed,
     #[error("MissingDebugInfo")]
@@ -115,7 +113,6 @@ impl Error {
             Self::ServerEntryPointGenerate => "ServerEntryPointGenerate",
             Self::UnexpectedPendingResolution => "UnexpectedPendingResolution",
             Self::WorkerTerminated => "WorkerTerminated",
-            Self::JSErrorObject => "JSErrorObject",
             Self::ThreadSpawnFailed => "ThreadSpawnFailed",
             Self::MissingDebugInfo => "MissingDebugInfo",
             Self::EndOfFile => "EndOfFile",

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -238,24 +238,11 @@ pub trait HotReloaderCtx {
 
 /// Type-erased view of a `Task<Ctx, EventLoopType, RELOAD_IMMEDIATELY>` so
 /// `HotReloaderCtx::reload` doesn't need to name the const generics.
-pub trait HotReloadTaskView {
-    fn count(&self) -> u8;
-    fn hashes(&self) -> &[u32];
-    fn paths(&self) -> &[&'static [u8]];
-}
+pub trait HotReloadTaskView {}
 
 impl<Ctx, EventLoopType, const RELOAD_IMMEDIATELY: bool> HotReloadTaskView
     for Task<Ctx, EventLoopType, RELOAD_IMMEDIATELY>
 {
-    fn count(&self) -> u8 {
-        self.count
-    }
-    fn hashes(&self) -> &[u32] {
-        &self.hashes[..self.count as usize]
-    }
-    fn paths(&self) -> &[&'static [u8]] {
-        &self.paths[..self.count as usize]
-    }
 }
 
 /// When non-null, `on_file_update` records the absolute path of every file

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1412,19 +1412,8 @@ pub mod command {
     /// pair — kept out-of-line so `start` is a jump table, but *not* `#[cold]`.
     #[inline(never)]
     fn exec_auto_or_run(tag: Tag, log: &mut bun_ast::Log) -> CmdResult {
-        // The AutoCommand arm swallows
-        // `error.MissingEntryPoint` from `Command.init` and prints help;
-        // every other tag (including RunCommand) propagates the error.
-        // Note: nothing currently produces `MissingEntryPoint`; bare
-        // `bun` help is served by the empty-positionals fallthrough. This arm
-        // exists in case a producer is ever added (Arguments.rs).
-        let ctx = match init(tag, log) {
-            Ok(ctx) => ctx,
-            Err(e) if tag == Tag::AutoCommand && matches!(e, crate::Error::MissingEntryPoint) => {
-                return HelpCommand::exec();
-            }
-            Err(e) => return Err(e),
-        };
+        // Bare `bun` help is served by the empty-positionals fallthrough.
+        let ctx = init(tag, log)?;
         ctx.args.target = Some(bun_options_types::schema::api::Target::Bun);
 
         if ctx.parallel || ctx.sequential {

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -22,28 +22,12 @@ pub enum Error {
     SnapshotInConcurrentGroup,
     #[error("SyntaxError")]
     SyntaxError,
-    #[error("FmtError")]
-    FmtError,
     #[error("JSError")]
     JSError,
-    #[error("ERR_TLS_CERT_ALTNAME_INVALID")]
-    ERR_TLS_CERT_ALTNAME_INVALID,
-    #[error("ConnectionClosed")]
-    ConnectionClosed,
     #[error("FailedToOpenSocket")]
     FailedToOpenSocket,
-    #[error("MissingCredentials")]
-    MissingCredentials,
-    #[error("InvalidMethod")]
-    InvalidMethod,
     #[error("InvalidPath")]
     InvalidPath,
-    #[error("InvalidEndpoint")]
-    InvalidEndpoint,
-    #[error("InvalidSessionToken")]
-    InvalidSessionToken,
-    #[error("SignError")]
-    SignError,
     #[error("failed to parse multipart data")]
     FailedToParseMultipartData,
     #[error("boundary is too long")]
@@ -68,8 +52,6 @@ pub enum Error {
     FailedToInitPipe,
     #[error("FailedToBindPipe")]
     FailedToBindPipe,
-    #[error("MissingPackageJSON")]
-    MissingPackageJSON,
     #[error("HTTPForbidden")]
     HTTPForbidden,
     #[error("ExampleNotFound")]
@@ -82,8 +64,6 @@ pub enum Error {
     NPMIsDown,
     #[error("HTTPError")]
     HTTPError,
-    #[error("MissingEntryPoint")]
-    MissingEntryPoint,
     #[error("UnrecognizedCommand")]
     UnrecognizedCommand,
     #[error("MissingShell")]
@@ -110,8 +90,6 @@ pub enum Error {
     ProcessWatchFailed,
     #[error("JUnitReportFailed")]
     JUnitReportFailed,
-    #[error("lcovCoverageError")]
-    lcovCoverageError,
     #[error("HTTP404")]
     HTTP404,
     #[error("GitHubIsDown")]
@@ -150,16 +128,12 @@ pub enum Error {
     ReadError,
     #[error("OpenError")]
     OpenError,
-    #[error("CompilationFailed")]
-    CompilationFailed,
     #[error("UnexpectedPendingResolution")]
     UnexpectedPendingResolution,
     #[error("AsyncModule")]
     AsyncModule,
     #[error("BlobNotFound")]
     BlobNotFound,
-    #[error("JSErrorObject")]
-    JSErrorObject,
     #[error("InvalidRoutePattern")]
     InvalidRoutePattern,
     #[error("InvalidRequest")]
@@ -184,8 +158,6 @@ pub enum Error {
     ChromeNotFound,
     #[error("WatchFailed")]
     WatchFailed,
-    #[error("Unsupported")]
-    Unsupported,
     #[error("UnsupportedAlgorithm")]
     UnsupportedAlgorithm,
     #[error("PasswordVerificationFailed")]
@@ -401,17 +373,9 @@ impl Error {
             Self::TestNotActive => "TestNotActive",
             Self::SnapshotInConcurrentGroup => "SnapshotInConcurrentGroup",
             Self::SyntaxError => "SyntaxError",
-            Self::FmtError => "FmtError",
             Self::JSError => "JSError",
-            Self::ERR_TLS_CERT_ALTNAME_INVALID => "ERR_TLS_CERT_ALTNAME_INVALID",
-            Self::ConnectionClosed => "ConnectionClosed",
             Self::FailedToOpenSocket => "FailedToOpenSocket",
-            Self::MissingCredentials => "MissingCredentials",
-            Self::InvalidMethod => "InvalidMethod",
             Self::InvalidPath => "InvalidPath",
-            Self::InvalidEndpoint => "InvalidEndpoint",
-            Self::InvalidSessionToken => "InvalidSessionToken",
-            Self::SignError => "SignError",
             Self::FailedToParseMultipartData => "failed to parse multipart data",
             Self::BoundaryIsTooLong => "boundary is too long",
             Self::MissingFinalBoundary => "missing final boundary",
@@ -424,14 +388,12 @@ impl Error {
             Self::InvalidOptions => "InvalidOptions",
             Self::FailedToInitPipe => "FailedToInitPipe",
             Self::FailedToBindPipe => "FailedToBindPipe",
-            Self::MissingPackageJSON => "MissingPackageJSON",
             Self::HTTPForbidden => "HTTPForbidden",
             Self::ExampleNotFound => "ExampleNotFound",
             Self::GitHubRepositoryNotFound => "GitHubRepositoryNotFound",
             Self::HTTPTooManyRequests => "HTTPTooManyRequests",
             Self::NPMIsDown => "NPMIsDown",
             Self::HTTPError => "HTTPError",
-            Self::MissingEntryPoint => "MissingEntryPoint",
             Self::UnrecognizedCommand => "UnrecognizedCommand",
             Self::MissingShell => "MissingShell",
             Self::NotFound => "NotFound",
@@ -445,7 +407,6 @@ impl Error {
             Self::ChannelAdoptFailed => "ChannelAdoptFailed",
             Self::ProcessWatchFailed => "ProcessWatchFailed",
             Self::JUnitReportFailed => "JUnitReportFailed",
-            Self::lcovCoverageError => "lcovCoverageError",
             Self::HTTP404 => "HTTP404",
             Self::GitHubIsDown => "GitHubIsDown",
             Self::UpgradeFailedMissingExecutable => "UpgradeFailedMissingExecutable",
@@ -467,11 +428,9 @@ impl Error {
             Self::FormatError => "FormatError",
             Self::ReadError => "ReadError",
             Self::OpenError => "OpenError",
-            Self::CompilationFailed => "CompilationFailed",
             Self::UnexpectedPendingResolution => "UnexpectedPendingResolution",
             Self::AsyncModule => "AsyncModule",
             Self::BlobNotFound => "BlobNotFound",
-            Self::JSErrorObject => "JSErrorObject",
             Self::InvalidRoutePattern => "InvalidRoutePattern",
             Self::InvalidRequest => "InvalidRequest",
             Self::FailedToCreateCoreFoudationSourceLoop => "FailedToCreateCoreFoudationSourceLoop",
@@ -484,7 +443,6 @@ impl Error {
             Self::TCCMissing => "TCCMissing",
             Self::ChromeNotFound => "ChromeNotFound",
             Self::WatchFailed => "WatchFailed",
-            Self::Unsupported => "Unsupported",
             Self::UnsupportedAlgorithm => "UnsupportedAlgorithm",
             Self::PasswordVerificationFailed => "PasswordVerificationFailed",
             Self::InvalidEncoding => "InvalidEncoding",

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2161,7 +2161,6 @@ fn to_jsc_fetch_error(err: &crate::Error) -> bun_jsc::CrateError {
         crate::Error::ModuleNotFound => bun_jsc::CrateError::ModuleNotFound,
         crate::Error::WriteFailed => bun_jsc::CrateError::WriteFailed,
         crate::Error::JSError | crate::Error::Js(_) => bun_jsc::CrateError::JSError,
-        crate::Error::JSErrorObject => bun_jsc::CrateError::JSErrorObject,
         _ => bun_jsc::CrateError::ParseError,
     }
 }

--- a/src/runtime/webview/HostProcess.rs
+++ b/src/runtime/webview/HostProcess.rs
@@ -149,11 +149,6 @@ bun_spawn::link_impl_ProcessExit! {
 
 #[cfg(target_os = "macos")]
 fn spawn(vm: *mut VirtualMachine, stdout_inherit: bool, stderr_inherit: bool) -> Result<Fd, Error> {
-    #[cfg(not(target_os = "macos"))]
-    {
-        let _ = (vm, stdout_inherit, stderr_inherit);
-        return Err(crate::Error::Unsupported);
-    }
     #[cfg(target_os = "macos")]
     {
         // Both ends nonblocking — parent uses usockets; child sets O_NONBLOCK

--- a/src/runtime/webview/HostProcess.rs
+++ b/src/runtime/webview/HostProcess.rs
@@ -149,102 +149,99 @@ bun_spawn::link_impl_ProcessExit! {
 
 #[cfg(target_os = "macos")]
 fn spawn(vm: *mut VirtualMachine, stdout_inherit: bool, stderr_inherit: bool) -> Result<Fd, Error> {
-    #[cfg(target_os = "macos")]
-    {
-        // Both ends nonblocking — parent uses usockets; child sets O_NONBLOCK
-        // again after dup2 (socketpair flags are per-fd, not per-pair).
-        let fds: [Fd; 2] = bun_sys::socketpair(
-            libc::AF_UNIX as i32,
-            libc::SOCK_STREAM as i32,
-            0,
-            true, // .nonblocking
-        )?;
-        // fd0_guard rolls back fds[0] on any error below.
-        let fd0_guard = scopeguard::guard(fds[0], |fd| fd.close());
-        // fds[1] is closed by spawnProcess after dup2 into the child.
+    // Both ends nonblocking — parent uses usockets; child sets O_NONBLOCK
+    // again after dup2 (socketpair flags are per-fd, not per-pair).
+    let fds: [Fd; 2] = bun_sys::socketpair(
+        libc::AF_UNIX as i32,
+        libc::SOCK_STREAM as i32,
+        0,
+        true, // .nonblocking
+    )?;
+    // fd0_guard rolls back fds[0] on any error below.
+    let fd0_guard = scopeguard::guard(fds[0], |fd| fd.close());
+    // fds[1] is closed by spawnProcess after dup2 into the child.
 
-        let exe = bun_core::self_exe_path()?;
+    let exe = bun_core::self_exe_path()?;
 
-        // Child sees fd 3 (first extra_fd → 3+0). The env var is the only
-        // signal; no argv changes so `ps` shows a normal `bun` invocation.
-        // Same pattern as NODE_CHANNEL_FD in js_bun_spawn_bindings.rs.
-        // SAFETY: vm is the per-thread VirtualMachine (valid for the call);
-        // `transpiler.env` is set during VM init and lives for VM lifetime.
-        let base = unsafe { (*(*vm).transpiler.env).map.create_null_delimited_env_map() }?;
-        let base_slice = base.as_slice();
-        // base_slice already has a trailing None sentinel; drop it, append our
-        // var, then re-terminate.
-        let base_entries = &base_slice[..base_slice.len().saturating_sub(1)];
-        let mut env: Vec<*const c_char> = Vec::with_capacity(base_entries.len() + 2);
-        env.extend(base_entries.iter().copied());
-        env.push(c"BUN_INTERNAL_WEBVIEW_HOST=3".as_ptr());
-        env.push(ptr::null());
+    // Child sees fd 3 (first extra_fd → 3+0). The env var is the only
+    // signal; no argv changes so `ps` shows a normal `bun` invocation.
+    // Same pattern as NODE_CHANNEL_FD in js_bun_spawn_bindings.rs.
+    // SAFETY: vm is the per-thread VirtualMachine (valid for the call);
+    // `transpiler.env` is set during VM init and lives for VM lifetime.
+    let base = unsafe { (*(*vm).transpiler.env).map.create_null_delimited_env_map() }?;
+    let base_slice = base.as_slice();
+    // base_slice already has a trailing None sentinel; drop it, append our
+    // var, then re-terminate.
+    let base_entries = &base_slice[..base_slice.len().saturating_sub(1)];
+    let mut env: Vec<*const c_char> = Vec::with_capacity(base_entries.len() + 2);
+    env.extend(base_entries.iter().copied());
+    env.push(c"BUN_INTERNAL_WEBVIEW_HOST=3".as_ptr());
+    env.push(ptr::null());
 
-        let argv: [*const c_char; 2] = [exe.as_ptr(), ptr::null()];
+    let argv: [*const c_char; 2] = [exe.as_ptr(), ptr::null()];
 
-        let opts = SpawnOptions {
-            stdin: Stdio::Ignore,
-            // Default ignore — the child runs no JS or user code, so output is
-            // only panics/NSLog from WebKit. Opt-in via backend.stderr when
-            // debugging a silent host crash.
-            stdout: if stdout_inherit {
-                Stdio::Inherit
-            } else {
-                Stdio::Ignore
-            },
-            stderr: if stderr_inherit {
-                Stdio::Inherit
-            } else {
-                Stdio::Ignore
-            },
-            extra_fds: vec![Stdio::Pipe(fds[1])].into_boxed_slice(),
-            argv0: Some(exe.as_ptr()),
-            ..SpawnOptions::default()
-        };
+    let opts = SpawnOptions {
+        stdin: Stdio::Ignore,
+        // Default ignore — the child runs no JS or user code, so output is
+        // only panics/NSLog from WebKit. Opt-in via backend.stderr when
+        // debugging a silent host crash.
+        stdout: if stdout_inherit {
+            Stdio::Inherit
+        } else {
+            Stdio::Ignore
+        },
+        stderr: if stderr_inherit {
+            Stdio::Inherit
+        } else {
+            Stdio::Ignore
+        },
+        extra_fds: vec![Stdio::Pipe(fds[1])].into_boxed_slice(),
+        argv0: Some(exe.as_ptr()),
+        ..SpawnOptions::default()
+    };
 
-        // SAFETY: `argv`/`env` are local null-terminated C-string arrays with
-        // argv[0] non-null; valid for this call.
-        let spawned = unsafe { bun_spawn::spawn_process(&opts, argv.as_ptr(), env.as_ptr()) }??;
+    // SAFETY: `argv`/`env` are local null-terminated C-string arrays with
+    // argv[0] non-null; valid for this call.
+    let spawned = unsafe { bun_spawn::spawn_process(&opts, argv.as_ptr(), env.as_ptr()) }??;
 
-        // SAFETY: `vm` is the live thread-local VM; `event_loop()` is its
-        // per-thread `jsc::EventLoop`.
-        let event_loop = unsafe { EventLoopHandle::init((*vm).event_loop().cast()) };
-        let self_ptr = bun_core::heap::into_raw(Box::new(HostProcess {
-            process: spawned.to_process_handle(event_loop),
-            retired: false,
-        }));
-        // SAFETY: `self_ptr` is the freshly-allocated Box that owns `process`
-        // and outlives it.
-        let process = unsafe {
-            let process = &(*self_ptr).process;
-            process
-                .process_mut()
-                .set_exit_handler(ProcessExit::new(ProcessExitKind::HostProcess, self_ptr));
-            process
-        };
-        match process.process_mut().watch() {
-            Ok(()) => {
-                // Weak handle: parent exits when no views + nothing pending,
-                // child gets socket EOF and exits, EVFILT_PROC fires into a
-                // dead process (kernel discards). If we ref'd, parent would
-                // stay alive forever waiting on a child that is waiting on us.
-                // dispatchOnExit also SIGKILLs via Bun__WebViewHost__kill.
-                process.process_mut().disable_keeping_event_loop_alive();
-            }
-            Err(e) => {
-                scoped_log!(WebViewHost, "watch failed: {}", e);
-                // SAFETY: reclaim the Box (drops our process ref).
-                drop(unsafe { bun_core::heap::take(self_ptr) });
-                // fd0_guard (declared at the top) closes fds[0]; don't double-close here.
-                return Err(crate::Error::WatchFailed);
-            }
+    // SAFETY: `vm` is the live thread-local VM; `event_loop()` is its
+    // per-thread `jsc::EventLoop`.
+    let event_loop = unsafe { EventLoopHandle::init((*vm).event_loop().cast()) };
+    let self_ptr = bun_core::heap::into_raw(Box::new(HostProcess {
+        process: spawned.to_process_handle(event_loop),
+        retired: false,
+    }));
+    // SAFETY: `self_ptr` is the freshly-allocated Box that owns `process`
+    // and outlives it.
+    let process = unsafe {
+        let process = &(*self_ptr).process;
+        process
+            .process_mut()
+            .set_exit_handler(ProcessExit::new(ProcessExitKind::HostProcess, self_ptr));
+        process
+    };
+    match process.process_mut().watch() {
+        Ok(()) => {
+            // Weak handle: parent exits when no views + nothing pending,
+            // child gets socket EOF and exits, EVFILT_PROC fires into a
+            // dead process (kernel discards). If we ref'd, parent would
+            // stay alive forever waiting on a child that is waiting on us.
+            // dispatchOnExit also SIGKILLs via Bun__WebViewHost__kill.
+            process.process_mut().disable_keeping_event_loop_alive();
         }
-        INSTANCE.store(self_ptr, core::sync::atomic::Ordering::Relaxed);
-        // fd handed to C++ which adopts it into usockets. Not stored here —
-        // usockets owns the socket; Rust only owns process lifetime.
-        let fd0 = scopeguard::ScopeGuard::into_inner(fd0_guard);
-        Ok(fd0)
+        Err(e) => {
+            scoped_log!(WebViewHost, "watch failed: {}", e);
+            // SAFETY: reclaim the Box (drops our process ref).
+            drop(unsafe { bun_core::heap::take(self_ptr) });
+            // fd0_guard (declared at the top) closes fds[0]; don't double-close here.
+            return Err(crate::Error::WatchFailed);
+        }
     }
+    INSTANCE.store(self_ptr, core::sync::atomic::Ordering::Relaxed);
+    // fd handed to C++ which adopts it into usockets. Not stored here —
+    // usockets owns the socket; Rust only owns process lifetime.
+    let fd0 = scopeguard::ScopeGuard::into_inner(fd0_guard);
+    Ok(fd0)
 }
 
 // Implemented in WebKitBackend.cpp. Rejects all pending promises, marks the

--- a/src/runtime/webview/HostProcess.rs
+++ b/src/runtime/webview/HostProcess.rs
@@ -149,99 +149,102 @@ bun_spawn::link_impl_ProcessExit! {
 
 #[cfg(target_os = "macos")]
 fn spawn(vm: *mut VirtualMachine, stdout_inherit: bool, stderr_inherit: bool) -> Result<Fd, Error> {
-    // Both ends nonblocking — parent uses usockets; child sets O_NONBLOCK
-    // again after dup2 (socketpair flags are per-fd, not per-pair).
-    let fds: [Fd; 2] = bun_sys::socketpair(
-        libc::AF_UNIX as i32,
-        libc::SOCK_STREAM as i32,
-        0,
-        true, // .nonblocking
-    )?;
-    // fd0_guard rolls back fds[0] on any error below.
-    let fd0_guard = scopeguard::guard(fds[0], |fd| fd.close());
-    // fds[1] is closed by spawnProcess after dup2 into the child.
+    #[cfg(target_os = "macos")]
+    {
+        // Both ends nonblocking — parent uses usockets; child sets O_NONBLOCK
+        // again after dup2 (socketpair flags are per-fd, not per-pair).
+        let fds: [Fd; 2] = bun_sys::socketpair(
+            libc::AF_UNIX as i32,
+            libc::SOCK_STREAM as i32,
+            0,
+            true, // .nonblocking
+        )?;
+        // fd0_guard rolls back fds[0] on any error below.
+        let fd0_guard = scopeguard::guard(fds[0], |fd| fd.close());
+        // fds[1] is closed by spawnProcess after dup2 into the child.
 
-    let exe = bun_core::self_exe_path()?;
+        let exe = bun_core::self_exe_path()?;
 
-    // Child sees fd 3 (first extra_fd → 3+0). The env var is the only
-    // signal; no argv changes so `ps` shows a normal `bun` invocation.
-    // Same pattern as NODE_CHANNEL_FD in js_bun_spawn_bindings.rs.
-    // SAFETY: vm is the per-thread VirtualMachine (valid for the call);
-    // `transpiler.env` is set during VM init and lives for VM lifetime.
-    let base = unsafe { (*(*vm).transpiler.env).map.create_null_delimited_env_map() }?;
-    let base_slice = base.as_slice();
-    // base_slice already has a trailing None sentinel; drop it, append our
-    // var, then re-terminate.
-    let base_entries = &base_slice[..base_slice.len().saturating_sub(1)];
-    let mut env: Vec<*const c_char> = Vec::with_capacity(base_entries.len() + 2);
-    env.extend(base_entries.iter().copied());
-    env.push(c"BUN_INTERNAL_WEBVIEW_HOST=3".as_ptr());
-    env.push(ptr::null());
+        // Child sees fd 3 (first extra_fd → 3+0). The env var is the only
+        // signal; no argv changes so `ps` shows a normal `bun` invocation.
+        // Same pattern as NODE_CHANNEL_FD in js_bun_spawn_bindings.rs.
+        // SAFETY: vm is the per-thread VirtualMachine (valid for the call);
+        // `transpiler.env` is set during VM init and lives for VM lifetime.
+        let base = unsafe { (*(*vm).transpiler.env).map.create_null_delimited_env_map() }?;
+        let base_slice = base.as_slice();
+        // base_slice already has a trailing None sentinel; drop it, append our
+        // var, then re-terminate.
+        let base_entries = &base_slice[..base_slice.len().saturating_sub(1)];
+        let mut env: Vec<*const c_char> = Vec::with_capacity(base_entries.len() + 2);
+        env.extend(base_entries.iter().copied());
+        env.push(c"BUN_INTERNAL_WEBVIEW_HOST=3".as_ptr());
+        env.push(ptr::null());
 
-    let argv: [*const c_char; 2] = [exe.as_ptr(), ptr::null()];
+        let argv: [*const c_char; 2] = [exe.as_ptr(), ptr::null()];
 
-    let opts = SpawnOptions {
-        stdin: Stdio::Ignore,
-        // Default ignore — the child runs no JS or user code, so output is
-        // only panics/NSLog from WebKit. Opt-in via backend.stderr when
-        // debugging a silent host crash.
-        stdout: if stdout_inherit {
-            Stdio::Inherit
-        } else {
-            Stdio::Ignore
-        },
-        stderr: if stderr_inherit {
-            Stdio::Inherit
-        } else {
-            Stdio::Ignore
-        },
-        extra_fds: vec![Stdio::Pipe(fds[1])].into_boxed_slice(),
-        argv0: Some(exe.as_ptr()),
-        ..SpawnOptions::default()
-    };
+        let opts = SpawnOptions {
+            stdin: Stdio::Ignore,
+            // Default ignore — the child runs no JS or user code, so output is
+            // only panics/NSLog from WebKit. Opt-in via backend.stderr when
+            // debugging a silent host crash.
+            stdout: if stdout_inherit {
+                Stdio::Inherit
+            } else {
+                Stdio::Ignore
+            },
+            stderr: if stderr_inherit {
+                Stdio::Inherit
+            } else {
+                Stdio::Ignore
+            },
+            extra_fds: vec![Stdio::Pipe(fds[1])].into_boxed_slice(),
+            argv0: Some(exe.as_ptr()),
+            ..SpawnOptions::default()
+        };
 
-    // SAFETY: `argv`/`env` are local null-terminated C-string arrays with
-    // argv[0] non-null; valid for this call.
-    let spawned = unsafe { bun_spawn::spawn_process(&opts, argv.as_ptr(), env.as_ptr()) }??;
+        // SAFETY: `argv`/`env` are local null-terminated C-string arrays with
+        // argv[0] non-null; valid for this call.
+        let spawned = unsafe { bun_spawn::spawn_process(&opts, argv.as_ptr(), env.as_ptr()) }??;
 
-    // SAFETY: `vm` is the live thread-local VM; `event_loop()` is its
-    // per-thread `jsc::EventLoop`.
-    let event_loop = unsafe { EventLoopHandle::init((*vm).event_loop().cast()) };
-    let self_ptr = bun_core::heap::into_raw(Box::new(HostProcess {
-        process: spawned.to_process_handle(event_loop),
-        retired: false,
-    }));
-    // SAFETY: `self_ptr` is the freshly-allocated Box that owns `process`
-    // and outlives it.
-    let process = unsafe {
-        let process = &(*self_ptr).process;
-        process
-            .process_mut()
-            .set_exit_handler(ProcessExit::new(ProcessExitKind::HostProcess, self_ptr));
-        process
-    };
-    match process.process_mut().watch() {
-        Ok(()) => {
-            // Weak handle: parent exits when no views + nothing pending,
-            // child gets socket EOF and exits, EVFILT_PROC fires into a
-            // dead process (kernel discards). If we ref'd, parent would
-            // stay alive forever waiting on a child that is waiting on us.
-            // dispatchOnExit also SIGKILLs via Bun__WebViewHost__kill.
-            process.process_mut().disable_keeping_event_loop_alive();
+        // SAFETY: `vm` is the live thread-local VM; `event_loop()` is its
+        // per-thread `jsc::EventLoop`.
+        let event_loop = unsafe { EventLoopHandle::init((*vm).event_loop().cast()) };
+        let self_ptr = bun_core::heap::into_raw(Box::new(HostProcess {
+            process: spawned.to_process_handle(event_loop),
+            retired: false,
+        }));
+        // SAFETY: `self_ptr` is the freshly-allocated Box that owns `process`
+        // and outlives it.
+        let process = unsafe {
+            let process = &(*self_ptr).process;
+            process
+                .process_mut()
+                .set_exit_handler(ProcessExit::new(ProcessExitKind::HostProcess, self_ptr));
+            process
+        };
+        match process.process_mut().watch() {
+            Ok(()) => {
+                // Weak handle: parent exits when no views + nothing pending,
+                // child gets socket EOF and exits, EVFILT_PROC fires into a
+                // dead process (kernel discards). If we ref'd, parent would
+                // stay alive forever waiting on a child that is waiting on us.
+                // dispatchOnExit also SIGKILLs via Bun__WebViewHost__kill.
+                process.process_mut().disable_keeping_event_loop_alive();
+            }
+            Err(e) => {
+                scoped_log!(WebViewHost, "watch failed: {}", e);
+                // SAFETY: reclaim the Box (drops our process ref).
+                drop(unsafe { bun_core::heap::take(self_ptr) });
+                // fd0_guard (declared at the top) closes fds[0]; don't double-close here.
+                return Err(crate::Error::WatchFailed);
+            }
         }
-        Err(e) => {
-            scoped_log!(WebViewHost, "watch failed: {}", e);
-            // SAFETY: reclaim the Box (drops our process ref).
-            drop(unsafe { bun_core::heap::take(self_ptr) });
-            // fd0_guard (declared at the top) closes fds[0]; don't double-close here.
-            return Err(crate::Error::WatchFailed);
-        }
+        INSTANCE.store(self_ptr, core::sync::atomic::Ordering::Relaxed);
+        // fd handed to C++ which adopts it into usockets. Not stored here —
+        // usockets owns the socket; Rust only owns process lifetime.
+        let fd0 = scopeguard::ScopeGuard::into_inner(fd0_guard);
+        Ok(fd0)
     }
-    INSTANCE.store(self_ptr, core::sync::atomic::Ordering::Relaxed);
-    // fd handed to C++ which adopts it into usockets. Not stored here —
-    // usockets owns the socket; Rust only owns process lifetime.
-    let fd0 = scopeguard::ScopeGuard::into_inner(fd0_guard);
-    Ok(fd0)
 }
 
 // Implemented in WebKitBackend.cpp. Rejects all pending promises, marks the


### PR DESCRIPTION
### Problem
- 25 dead-code PRs are already open, so a name grep finds little that is unclaimed. This run used the compiler instead: demote each `pub` item to `pub(crate)` and let rustc's `dead_code` lint say what nothing uses.
- What survived that check on all nine CI target triples, and is not already in an open PR, is the list below.

### Fix
- `bun_runtime::Error`: remove 14 variants that nothing constructs (`FmtError`, `ERR_TLS_CERT_ALTNAME_INVALID`, `ConnectionClosed`, `MissingCredentials`, `InvalidMethod`, `InvalidEndpoint`, `InvalidSessionToken`, `SignError`, `MissingPackageJSON`, `MissingEntryPoint`, `lcovCoverageError`, `CompilationFailed`, `JSErrorObject`, `Unsupported`), their `name()` arms, the two match arms that tested for them (`cli/mod.rs`, `jsc_hooks.rs`), and a `cfg(not(macos))` block inside a `cfg(macos)` function in `webview/HostProcess.rs`.
- `bun_jsc`: remove `CrateError::JSErrorObject` (its only producer was the arm above) and the three never-called `HotReloadTaskView` methods. The trait stays as the type-erasure marker that `HotReloaderCtx::reload` takes.
- `bun_collections`: `StringHashMap::values_mut` has no caller in any crate.
- JS builtins: a 23-line commented-out `fileURLToPath` in `node/url.ts` (unchanged since 2025-01), the unused `format` / `formatWithOptions` getters in `internal/repl/node-inspect.js`, and the unused `reportUncaughtException` export in `internal/shared.ts`.
- Verified: `cargo check --workspace` on all nine triples from `rust:check-all`, `bun bd`, then `repl.test.ts`, `readline.node.test.ts`, `hot.test.ts`, `watch.test.ts`, and the `node/url` tests.

### Background
- The workspace denies `dead_code` and `unreachable_pub`, so rustc already rejects unused private items. The blind spot is a `pub` item that is reachable from its crate root but that no other crate imports. Demoting it to `pub(crate)` puts it back under the lint.
- A demoted inherent method can silently lose to a trait method of the same name in other crates (`Blob::finalize` against the blanket `JsFinalize`, `__IsFreeze::IS_FREEZE` against `__NotFreeze`). rustc then reports the inherent item as dead while behavior changed. Every method hit was checked for a same-named path in other crates and those were left alone.

<details><summary>Notes</summary>

- Scope: 87 Rust crates (everything under `src/` except the proc-macro crates), `src/js`, the C++ `extern "C"` definitions in `src/jsc/bindings`, `Cargo.toml` dependencies, and orphan `.rs` files (via cargo dep-info). No unused dependencies and no orphan files were found.
- Found dead but already removed by an open PR, so not repeated here: the `bindgen.rs` marker structs and `ExportRenamer` (#40915, #40557), the `uws_sys`/`mimalloc_sys`/`lsquic_sys` externs (#40172), `has_termination_request`, `clear_exception`, `from_typed_array`, `INTERNAL_MODULE_REGISTRY_FLAG`, and the 20 orphaned C++ `extern "C"` functions (#40232).
- Probably dead, left out of the diff: 119 never-constructed `Feature` variants in `src/css/prefixes.rs` (the file is generated by `build-prefixes.js`), the never-constructed `bake::Mode::ProductionDynamic`, and several struct fields rustc reports as never read that exist to own an allocation (`JSTranspiler::arena`, `CurrentBundle::{bv2, heap, ast_alloc_state}`).
- rustc's lint misreports inherent associated types (`ThreadPool::Worker`, `EntryPoint::Kind`) as unused. They are used and were kept.
- `bun_core::strings::split_once` (the multi-byte variant) has no caller, but `clippy.toml` names it as the replacement for `str::split_once` and `bstr`'s `split_once_str`, so it stays.

</details>
