### PR TITLE
webcrypto: reject trailing bytes after the DER in RSA spki/pkcs8 importKey

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
@@ -237,6 +237,8 @@ RefPtr<CryptoKeyRSA> CryptoKeyRSA::importSpki(CryptoAlgorithmIdentifier identifi
     auto pkey = EvpPKeyPtr(d2i_PUBKEY(nullptr, &ptr, keyData.size()));
     if (!pkey)
         return nullptr;
+    if (ptr - keyData.begin() != (ptrdiff_t)keyData.size())
+        return nullptr;
     if (EVP_PKEY_id(pkey.get()) != EVP_PKEY_RSA) {
         if (keyTypeMismatch)
             *keyTypeMismatch = true;
@@ -254,6 +256,8 @@ RefPtr<CryptoKeyRSA> CryptoKeyRSA::importPkcs8(CryptoAlgorithmIdentifier identif
     // We use d2i_PKCS8_PRIV_KEY_INFO() to import a private key.
     auto p8inf = PKCS8PrivKeyInfoPtr(d2i_PKCS8_PRIV_KEY_INFO(nullptr, &ptr, keyData.size()));
     if (!p8inf)
+        return nullptr;
+    if (ptr - keyData.begin() != (ptrdiff_t)keyData.size())
         return nullptr;
 
     auto pkey = EvpPKeyPtr(EVP_PKCS82PKEY(p8inf.get()));

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -1289,6 +1289,57 @@ it("RSA importKey with an unsupported usage names the algorithm", async () => {
   });
 });
 
+// https://w3c.github.io/webcrypto/#concept-parse-a-spki and #concept-parse-a-privateKeyInfo
+// parse with exactData set: bytes left after the DER structure are a DataError.
+// The EC, OKP and ML-DSA/ML-KEM importers already reject them; the RSA importer
+// took whatever prefix d2i_PUBKEY / d2i_PKCS8_PRIV_KEY_INFO consumed.
+it("RSA spki/pkcs8 import rejects trailing bytes after the DER structure", async () => {
+  const { publicKey, privateKey } = await crypto.subtle.generateKey(
+    { name: "RSA-OAEP", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
+    true,
+    ["encrypt", "decrypt"],
+  );
+  const spki = new Uint8Array(await crypto.subtle.exportKey("spki", publicKey));
+  const pkcs8 = new Uint8Array(await crypto.subtle.exportKey("pkcs8", privateKey));
+
+  const withTail = (der: Uint8Array, tail: ArrayLike<number>) => {
+    const out = new Uint8Array(der.length + tail.length);
+    out.set(der);
+    out.set(tail, der.length);
+    return out;
+  };
+  const tails = (der: Uint8Array) => [withTail(der, [0]), withTail(der, [0x30, 0]), withTail(der, der)];
+  const outcome = (p: Promise<unknown>) =>
+    p.then(
+      () => "imported",
+      e => `${e.name}: ${e.message}`,
+    );
+  const importAs = (name: string, format: "spki" | "pkcs8", data: Uint8Array) =>
+    outcome(
+      crypto.subtle.importKey(format, data, { name, hash: "SHA-256" }, true, [
+        name === "RSA-OAEP" ? (format === "spki" ? "encrypt" : "decrypt") : format === "spki" ? "verify" : "sign",
+      ]),
+    );
+
+  const results: Record<string, unknown> = {};
+  for (const name of ["RSA-OAEP", "RSA-PSS", "RSASSA-PKCS1-v1_5"]) {
+    results[name] = {
+      spki: await importAs(name, "spki", spki),
+      pkcs8: await importAs(name, "pkcs8", pkcs8),
+      spkiWithTail: await Promise.all(tails(spki).map(data => importAs(name, "spki", data))),
+      pkcs8WithTail: await Promise.all(tails(pkcs8).map(data => importAs(name, "pkcs8", data))),
+    };
+  }
+  const rejected = "DataError: Invalid keyData";
+  const expected = {
+    spki: "imported",
+    pkcs8: "imported",
+    spkiWithTail: [rejected, rejected, rejected],
+    pkcs8WithTail: [rejected, rejected, rejected],
+  };
+  expect(results).toEqual({ "RSA-OAEP": expected, "RSA-PSS": expected, "RSASSA-PKCS1-v1_5": expected });
+});
+
 // CryptoKey.usages and the JWK key_ops it is built from are ordered by the
 // KeyUsage enum in https://w3c.github.io/webcrypto/#dfn-KeyUsage, not
 // alphabetically, and not by the order the caller passed them in.


### PR DESCRIPTION
### Problem
- `crypto.subtle.importKey('spki' | 'pkcs8', ...)` for the RSA algorithms (RSA-OAEP, RSA-PSS, RSASSA-PKCS1-v1_5, RSAES-PKCS1-v1_5) accepts arbitrary bytes after the DER structure. `spki ‖ 1 KiB junk` imports, and the re-export silently drops the tail. Chromium rejects the same input with `DataError`, and so do Bun's EC, Ed25519/X25519 and ML-DSA/ML-KEM importers.
- The cause is `CryptoKeyRSA::importSpki` / `importPkcs8` (`src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp:237`, `:257`). `d2i_PUBKEY` and `d2i_PKCS8_PRIV_KEY_INFO` stop at the end of the first structure and advance `ptr`. Nothing checked that `ptr` reached the end of `keyData`.

### Fix
- After each `d2i_*` call, return `nullptr` when `ptr - keyData.begin() != keyData.size()`. This is the same check `CryptoKeyEC::platformImportSpki` / `platformImportPkcs8` already make. The caller maps `nullptr` to `DataError: Invalid keyData`.
- Correct per spec: [parse a subjectPublicKeyInfo](https://w3c.github.io/webcrypto/#concept-parse-a-spki) and [parse a privateKeyInfo](https://w3c.github.io/webcrypto/#concept-parse-a-privateKeyInfo) run "parse an ASN.1 structure" with *exactData* set to true, which throws a `DataError` if not all bytes are consumed.
- Verified: `test/js/web/crypto/web-crypto.test.ts` ("RSA spki/pkcs8 import rejects trailing bytes after the DER structure", 18 of 24 cells fail on 1.4.3). Also the rest of that file and the vendored Node `test-webcrypto-export-import*.js`, `test-webcrypto-wrap-unwrap.js`, `test-webcrypto-encrypt-decrypt-rsa.js`, `test-webcrypto-sign-verify.js`.

### Background
- `spki` and `pkcs8` key data are DER-encoded ASN.1: a `SubjectPublicKeyInfo` (RFC 5280) or a `PrivateKeyInfo` (RFC 5208) `SEQUENCE`. DER is a TLV encoding, so the outer `SEQUENCE` header states its own length and a parser knows where the structure ends without looking at the buffer length.
- BoringSSL's `d2i_X(nullptr, &ptr, len)` functions parse one structure starting at `*ptr`, advance `*ptr` past it, and ignore anything after. Callers that need "exactly one structure, nothing else" compare the advanced pointer with the end of the buffer (or use the `CBS` API and check `CBS_len(&cbs) == 0`, as `CryptoKeyAKP` does).
- All four WebCrypto RSA algorithms share `CryptoKeyRSA::importSpki` / `importPkcs8`, so one check covers them.

<details><summary>Notes</summary>

- Node.js v26 accepts trailing bytes for every key type here (RSA, EC, OKP). Bun already diverged from Node for EC/OKP/AKP in favour of the spec and Chromium. This change makes RSA consistent with the rest of Bun's importers rather than introducing a new policy.
- Upstream WebKit's OpenSSL port (`Source/WebCore/crypto/openssl/CryptoKeyRSAOpenSSL.cpp`) has the same gap. Its EC importer has the check, which is where Bun's EC check came from.
- The `reportKeyTypeMismatch` probes in the EC and OKP importers also call `d2i_PUBKEY` on the whole buffer without an exact-length check. They only choose between the two `DataError` messages ("Invalid key type" vs "Invalid keyData"), so they are left alone.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.57ms]
(pass) Web Crypto > keeps event loop alive [312.32ms]
(pass) Web Crypto > has globals [5.66ms]
(pass) Web Crypto > should encrypt and decrypt [12.88ms]
(pass) Web Crypto > should verify and sign [46.73ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [23.90ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [11.27ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [11.53ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2818.28ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [338.25ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [89.57
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.07ms]
(pass) Web Crypto > keeps event loop alive [11.02ms]
(pass) Web Crypto > has globals [0.09ms]
(pass) Web Crypto > should encrypt and decrypt [0.38ms]
(pass) Web Crypto > should verify and sign [0.77ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [0.33ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [0.23ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [0.20ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [36.27ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [8.94ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [15.17ms]
(pass) Ed25519 > generateKey > should return CryptoKeys without namedCurve in algorithm field [0.17ms]
(pass) Ed25519 > importKey > rejects a 64-byte JWK d whose trail
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.83ms]
(pass) Web Crypto > keeps event loop alive [378.30ms]
(pass) Web Crypto > has globals [3.84ms]
(pass) Web Crypto > should encrypt and decrypt [16.98ms]
(pass) Web Crypto > should verify and sign [40.65ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [16.46ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [10.75ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [11.65ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2836.67ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [348.66ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [63.29
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 961ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcrypto-1.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 5m 01s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.3-canary.1+0f526c583
[build] done
bun test v1.4.3-canary.1 (0f526c583)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.07ms]
(pass) Web Crypto > keeps event loop alive [8.35ms]
(pass) Web Crypto > has globals [0.06ms]
(pass) Web Crypto > should encrypt and decrypt [0.33ms]
(pass) Web Crypto > should verify and sign [0.68ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [0.31ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [0.18ms]
(pass) Web Crypto > unwrapKey JWK error handling >
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp |  4 ++
 test/js/web/crypto/web-crypto.test.ts              | 51 ++++++++++++++++++++++
 2 files changed, 55 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp      1      2      6
test/js/web/crypto/web-crypto.test.ts                   1      1      6
```

</details>

<!-- robobun:evidence:end -->