### PR TITLE
css: only synthesize `border` / `transition` when the rule sets every longhand they reset

### DIFF
--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -1148,6 +1148,14 @@ mod border_handler_body {
                     fc_prop!(f, $inline_end_prop, inline_end.to_border(f.arena));
                 }, false);
             }
+        } else if all_valid && !$is_logical && !(is_eq!(width) || is_eq!(style) || is_eq!(color)) {
+            // Without `border`, and with no component that repeats on all four
+            // sides, the four sides as written beat three multi-value shorthands
+            // (`border-top: 0; ...; border-bottom: 1px solid` stays as is).
+            fc_prop!(f, $block_start_prop, block_start.to_border(f.arena));
+            fc_prop!(f, $block_end_prop, block_end.to_border(f.arena));
+            fc_prop!(f, $inline_start_prop, inline_start.to_border(f.arena));
+            fc_prop!(f, $inline_end_prop, inline_end.to_border(f.arena));
         } else {
             // Four complete but unequal logical sides are shorter as the
             // `border-block` / `border-inline` properties below than as what

--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -609,6 +609,9 @@ pub struct BorderHandler {
     border_image_handler: BorderImageHandler,
     border_radius_handler: BorderRadiusHandler,
     flushed_properties: BorderProperty,
+    /// A `border` declaration was seen since the last flush. It resets
+    /// `border-image`, so writing a `border` shorthand keeps that reset.
+    has_border_shorthand: bool,
     has_any: bool,
 }
 
@@ -649,6 +652,9 @@ mod border_handler_body {
         arena: &'bump Bump,
         logical_supported: bool,
         logical_shorthand_supported: bool,
+        /// `border` also resets `border-image`, so it may only be synthesized
+        /// when this block resets or fully redeclares `border-image` anyway.
+        border_shorthand_safe: bool,
     }
 
     // `f.logicalProp(ltr, ltr_key, rtl, rtl_key, val)` — ltr_key/rtl_key were unused.
@@ -1039,11 +1045,12 @@ mod border_handler_body {
             }};
         }
 
-        if block_start.is_valid()
+        let all_valid = block_start.is_valid()
             && block_end.is_valid()
             && inline_start.is_valid()
-            && inline_end.is_valid()
-        {
+            && inline_end.is_valid();
+
+        if all_valid && f.border_shorthand_safe {
             let top_eq_bottom = block_start.eql(block_end);
             let left_eq_right = inline_start.eql(inline_end);
             let top_eq_left = block_start.eql(inline_start);
@@ -1142,9 +1149,17 @@ mod border_handler_body {
                 }, false);
             }
         } else {
-            shorthand!(BorderStyle, BorderStyle, style);
-            shorthand!(BorderWidth, BorderWidth, width);
-            shorthand!(BorderColor, BorderColor, color);
+            // Four complete but unequal logical sides are shorter as the
+            // `border-block` / `border-inline` properties below than as what
+            // is left over after three four-sided physical shorthands.
+            let all_equal = block_start.eql(block_end)
+                && block_start.eql(inline_start)
+                && block_start.eql(inline_end);
+            if !$is_logical || !all_valid || all_equal {
+                shorthand!(BorderStyle, BorderStyle, style);
+                shorthand!(BorderWidth, BorderWidth, width);
+                shorthand!(BorderColor, BorderColor, color);
+            }
 
             if $is_logical && block_start.eql(block_end) && block_start.is_valid() {
                 if f.logical_supported {
@@ -1424,6 +1439,7 @@ mod border_handler_body {
 
                     // Setting the `border` property resets `border-image`
                     self.border_image_handler.reset();
+                    self.has_border_shorthand = true;
                     self.has_any = true;
                 }
                 Property::Unparsed(val) => {
@@ -1476,8 +1492,10 @@ mod border_handler_body {
 
             self.has_any = false;
 
-            self.flush_physical(dest, context);
-            self.flush_logical(dest, context);
+            let border_shorthand_safe =
+                self.has_border_shorthand || self.border_image_handler.will_flush_shorthand();
+            self.flush_physical(dest, context, border_shorthand_safe);
+            self.flush_logical(dest, context, border_shorthand_safe);
 
             let arena = dest.bump();
             self.border_top.reset(arena);
@@ -1488,6 +1506,7 @@ mod border_handler_body {
             self.border_block_end.reset(arena);
             self.border_inline_start.reset(arena);
             self.border_inline_end.reset(arena);
+            self.has_border_shorthand = false;
         }
 
         #[inline(never)]
@@ -1495,6 +1514,7 @@ mod border_handler_body {
             &mut self,
             dest: &mut DeclarationList,
             context: &mut PropertyHandlerContext,
+            border_shorthand_safe: bool,
         ) {
             let logical_supported = !context.should_compile_logical(Feature::LogicalBorders);
             let logical_shorthand_supported =
@@ -1510,6 +1530,7 @@ mod border_handler_body {
                 arena,
                 logical_supported,
                 logical_shorthand_supported,
+                border_shorthand_safe,
             };
 
             flush_category!(
@@ -1543,6 +1564,7 @@ mod border_handler_body {
             &mut self,
             dest: &mut DeclarationList,
             context: &mut PropertyHandlerContext,
+            border_shorthand_safe: bool,
         ) {
             let logical_supported = !context.should_compile_logical(Feature::LogicalBorders);
             let logical_shorthand_supported =
@@ -1556,6 +1578,7 @@ mod border_handler_body {
                 arena,
                 logical_supported,
                 logical_shorthand_supported,
+                border_shorthand_safe,
             };
 
             flush_category!(

--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -609,8 +609,7 @@ pub struct BorderHandler {
     border_image_handler: BorderImageHandler,
     border_radius_handler: BorderRadiusHandler,
     flushed_properties: BorderProperty,
-    /// A `border` declaration was seen since the last flush. It resets
-    /// `border-image`, so writing a `border` shorthand keeps that reset.
+    /// A `border` (which also resets `border-image`) was seen since the last flush.
     has_border_shorthand: bool,
     has_any: bool,
 }
@@ -652,8 +651,7 @@ mod border_handler_body {
         arena: &'bump Bump,
         logical_supported: bool,
         logical_shorthand_supported: bool,
-        /// `border` also resets `border-image`, so it may only be synthesized
-        /// when this block resets or fully redeclares `border-image` anyway.
+        /// This block resets or fully redeclares `border-image`, as `border` does.
         border_shorthand_safe: bool,
     }
 
@@ -1141,8 +1139,7 @@ mod border_handler_body {
                     side_diff!(block_end, inline_start, $inline_start_prop, $inline_start_width, $inline_start_style, $inline_start_color);
                 }, true);
             } else {
-                // `border` always goes out on this path, so a `border` in the
-                // source keeps resetting `border-image` here too.
+                // Still leads with `border`, so a source `border` keeps its reset.
                 prop_diff!(block_start, {
                     fc_prop!(f, $block_end_prop, block_end.to_border(f.arena));
                     fc_prop!(f, $inline_start_prop, inline_start.to_border(f.arena));
@@ -1154,17 +1151,13 @@ mod border_handler_body {
             && !(is_eq!(width) || is_eq!(style) || is_eq!(color))
             && !(block_start.eql(block_end) && inline_start.eql(inline_end))
         {
-            // Without `border`, and with no component that repeats on all four
-            // sides, the four sides as written beat three multi-value shorthands
-            // (`border-top: 0; ...; border-bottom: 1px solid` stays as is).
+            // Shorter than three multi-value shorthands (`border-top: 0; ...; border-bottom: 1px solid`).
             fc_prop!(f, $block_start_prop, block_start.to_border(f.arena));
             fc_prop!(f, $block_end_prop, block_end.to_border(f.arena));
             fc_prop!(f, $inline_start_prop, inline_start.to_border(f.arena));
             fc_prop!(f, $inline_end_prop, inline_end.to_border(f.arena));
         } else {
-            // Four complete but unequal logical sides are shorter as the
-            // `border-block` / `border-inline` properties below than as what
-            // is left over after three four-sided physical shorthands.
+            // Complete, unequal logical sides are shorter as `border-block` / `border-inline` below.
             let all_equal = block_start.eql(block_end)
                 && block_start.eql(inline_start)
                 && block_start.eql(inline_end);

--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -1141,14 +1141,19 @@ mod border_handler_body {
                     side_diff!(block_end, inline_start, $inline_start_prop, $inline_start_width, $inline_start_style, $inline_start_color);
                 }, true);
             } else {
+                // `border` always goes out on this path, so a `border` in the
+                // source keeps resetting `border-image` here too.
                 prop_diff!(block_start, {
-                    fc_prop!(f, $block_start_prop, block_start.to_border(f.arena));
                     fc_prop!(f, $block_end_prop, block_end.to_border(f.arena));
                     fc_prop!(f, $inline_start_prop, inline_start.to_border(f.arena));
                     fc_prop!(f, $inline_end_prop, inline_end.to_border(f.arena));
-                }, false);
+                }, true);
             }
-        } else if all_valid && !$is_logical && !(is_eq!(width) || is_eq!(style) || is_eq!(color)) {
+        } else if all_valid
+            && !$is_logical
+            && !(is_eq!(width) || is_eq!(style) || is_eq!(color))
+            && !(block_start.eql(block_end) && inline_start.eql(inline_end))
+        {
             // Without `border`, and with no component that repeats on all four
             // sides, the four sides as written beat three multi-value shorthands
             // (`border-top: 0; ...; border-bottom: 1px solid` stays as is).
@@ -1453,6 +1458,10 @@ mod border_handler_body {
                 Property::Unparsed(val) => {
                     if is_border_property(val.property_id.tag()) {
                         self.flush(dest, context);
+                        if val.property_id.tag() == PropertyIdTag::Border {
+                            // `border: var(..)` still resets the `border-image` buffered before it.
+                            self.border_image_handler.reset();
+                        }
                         self.flush_unparsed(val, dest, context);
                     } else {
                         if self.border_image_handler.will_flush(property) {

--- a/src/css/properties/border_image.rs
+++ b/src/css/properties/border_image.rs
@@ -583,9 +583,7 @@ impl BorderImageHandler {
         self.repeat = None;
     }
 
-    /// A complete unprefixed `border-image` is buffered and nothing was written
-    /// for this block yet, so the next flush overrides every `border-image-*`
-    /// longhand that a declaration written before it resets.
+    /// A complete unprefixed `border-image` is buffered as this block's first `border-image` output.
     pub(crate) fn will_flush_shorthand(&self) -> bool {
         self.has_any
             && self.flushed_properties.is_empty()

--- a/src/css/properties/border_image.rs
+++ b/src/css/properties/border_image.rs
@@ -583,6 +583,20 @@ impl BorderImageHandler {
         self.repeat = None;
     }
 
+    /// A complete unprefixed `border-image` is buffered and nothing was written
+    /// for this block yet, so the next flush overrides every `border-image-*`
+    /// longhand that a declaration written before it resets.
+    pub(crate) fn will_flush_shorthand(&self) -> bool {
+        self.has_any
+            && self.flushed_properties.is_empty()
+            && self.vendor_prefix.contains(VendorPrefix::NONE)
+            && self.source.is_some()
+            && self.slice.is_some()
+            && self.width.is_some()
+            && self.outset.is_some()
+            && self.repeat.is_some()
+    }
+
     pub(crate) fn will_flush(&self, property: &Property) -> bool {
         match property {
             Property::BorderImageSource(_)

--- a/src/css/properties/properties_generated.rs
+++ b/src/css/properties/properties_generated.rs
@@ -246,6 +246,7 @@ pub enum PropertyIdTag {
     TransitionDelay,
     TransitionTimingFunction,
     Transition,
+    TransitionBehavior,
     Animation,
     AnimationName,
     Transform,
@@ -561,6 +562,7 @@ impl PropertyIdTag {
             PropertyIdTag::TransitionDelay => b"transition-delay",
             PropertyIdTag::TransitionTimingFunction => b"transition-timing-function",
             PropertyIdTag::Transition => b"transition",
+            PropertyIdTag::TransitionBehavior => b"transition-behavior",
             PropertyIdTag::Animation => b"animation",
             PropertyIdTag::AnimationName => b"animation-name",
             PropertyIdTag::Transform => b"transform",
@@ -829,6 +831,7 @@ pub enum PropertyId {
     TransitionDelay(VendorPrefix),
     TransitionTimingFunction(VendorPrefix),
     Transition(VendorPrefix),
+    TransitionBehavior,
     Animation(VendorPrefix),
     AnimationName(VendorPrefix),
     Transform(VendorPrefix),
@@ -1114,6 +1117,7 @@ impl PropertyId {
             PropertyId::TransitionDelay(..) => PropertyIdTag::TransitionDelay,
             PropertyId::TransitionTimingFunction(..) => PropertyIdTag::TransitionTimingFunction,
             PropertyId::Transition(..) => PropertyIdTag::Transition,
+            PropertyId::TransitionBehavior => PropertyIdTag::TransitionBehavior,
             PropertyId::Animation(..) => PropertyIdTag::Animation,
             PropertyId::AnimationName(..) => PropertyIdTag::AnimationName,
             PropertyId::Transform(..) => PropertyIdTag::Transform,
@@ -1496,6 +1500,7 @@ impl PropertyId {
                 b"transition-delay" => (VendorPrefix::NONE.union(VendorPrefix::WEBKIT).union(VendorPrefix::MOZ).union(VendorPrefix::MS), PropertyId::TransitionDelay),
                 b"transition-timing-function" => (VendorPrefix::NONE.union(VendorPrefix::WEBKIT).union(VendorPrefix::MOZ).union(VendorPrefix::MS), PropertyId::TransitionTimingFunction),
                 b"transition" => (VendorPrefix::NONE.union(VendorPrefix::WEBKIT).union(VendorPrefix::MOZ).union(VendorPrefix::MS), PropertyId::Transition),
+                b"transition-behavior" => (VendorPrefix::NONE, |_| PropertyId::TransitionBehavior),
                 b"animation-name" => (VendorPrefix::NONE.union(VendorPrefix::WEBKIT).union(VendorPrefix::MOZ).union(VendorPrefix::O).union(VendorPrefix::MS), PropertyId::AnimationName),
                 b"animation" => (VendorPrefix::NONE.union(VendorPrefix::WEBKIT).union(VendorPrefix::MOZ).union(VendorPrefix::O).union(VendorPrefix::MS), PropertyId::Animation),
                 b"transform" => (VendorPrefix::NONE.union(VendorPrefix::WEBKIT).union(VendorPrefix::MOZ).union(VendorPrefix::MS).union(VendorPrefix::O), PropertyId::Transform),
@@ -1819,6 +1824,7 @@ pub enum Property {
         ),
     ),
     Transition((SmallList<transition::Transition, 1>, VendorPrefix)),
+    TransitionBehavior(SmallList<transition::TransitionBehavior, 1>),
     Animation((SmallList<animation::Animation, 1>, VendorPrefix)),
     AnimationName((SmallList<animation::AnimationName, 1>, VendorPrefix)),
     Transform((transform::TransformList, VendorPrefix)),
@@ -2099,6 +2105,7 @@ impl Property {
             Property::TransitionDelay(v) => PropertyId::TransitionDelay(v.1),
             Property::TransitionTimingFunction(v) => PropertyId::TransitionTimingFunction(v.1),
             Property::Transition(v) => PropertyId::Transition(v.1),
+            Property::TransitionBehavior(..) => PropertyId::TransitionBehavior,
             Property::Animation(v) => PropertyId::Animation(v.1),
             Property::AnimationName(v) => PropertyId::AnimationName(v.1),
             Property::Transform(v) => PropertyId::Transform(v.1),
@@ -2371,6 +2378,7 @@ impl Property {
             Property::TransitionDelay(v) => css::generic::to_css(&v.0, dest),
             Property::TransitionTimingFunction(v) => css::generic::to_css(&v.0, dest),
             Property::Transition(v) => css::generic::to_css(&v.0, dest),
+            Property::TransitionBehavior(v) => css::generic::to_css(v, dest),
             Property::Animation(v) => css::generic::to_css(&v.0, dest),
             Property::AnimationName(v) => css::generic::to_css(&v.0, dest),
             Property::Transform(v) => css::generic::to_css(&v.0, dest),
@@ -3602,6 +3610,13 @@ impl Property {
                     return Ok(Property::Transition((c, pre)));
                 }
             }
+            PropertyId::TransitionBehavior => {
+                if let Some(c) =
+                    parse_value::<SmallList<transition::TransitionBehavior, 1>>(input, options)
+                {
+                    return Ok(Property::TransitionBehavior(c));
+                }
+            }
             PropertyId::Animation(pre) => {
                 if let Some(c) = parse_value::<SmallList<animation::Animation, 1>>(input, options) {
                     return Ok(Property::Animation((c, pre)));
@@ -4358,6 +4373,9 @@ impl Property {
             Property::Transition(v) => {
                 Property::Transition((css::generic::deep_clone(&v.0, arena), v.1))
             }
+            Property::TransitionBehavior(v) => {
+                Property::TransitionBehavior(css::generic::deep_clone(v, arena))
+            }
             Property::Animation(v) => {
                 Property::Animation((css::generic::deep_clone(&v.0, arena), v.1))
             }
@@ -4902,6 +4920,9 @@ impl Property {
             }
             (Property::Transition(a), Property::Transition(b)) => {
                 css::generic::eql(&a.0, &b.0) && a.1 == b.1
+            }
+            (Property::TransitionBehavior(a), Property::TransitionBehavior(b)) => {
+                css::generic::eql(a, b)
             }
             (Property::Animation(a), Property::Animation(b)) => {
                 css::generic::eql(&a.0, &b.0) && a.1 == b.1

--- a/src/css/properties/transition.rs
+++ b/src/css/properties/transition.rs
@@ -73,7 +73,16 @@ impl Transition {
             }
 
             if property.is_none() {
-                if let Ok(value) = parser.try_parse(PropertyId::parse) {
+                if let Ok(value) = parser.try_parse(|p: &mut Parser| -> CssResult<PropertyId> {
+                    let id = PropertyId::parse(p)?;
+                    // These are the `<transition-behavior-value>` of the shorthand, not
+                    // property names. This struct does not hold one, so such a value
+                    // stays unparsed.
+                    if TransitionBehavior::is_keyword(id.name()) {
+                        return Err(p.new_custom_error(crate::ParserError::invalid_value));
+                    }
+                    Ok(id)
+                }) {
                     property = Some(value);
                     continue;
                 }
@@ -122,6 +131,13 @@ pub enum TransitionBehavior {
     AllowDiscrete,
 }
 
+impl TransitionBehavior {
+    fn is_keyword(name: &[u8]) -> bool {
+        bun_core::strings::eql_case_insensitive_ascii_check_length(name, b"normal")
+            || bun_core::strings::eql_case_insensitive_ascii_check_length(name, b"allow-discrete")
+    }
+}
+
 /// A value for the [view-transition-name](https://drafts.csswg.org/css-view-transitions-1/#view-transition-name-prop) property.
 ///
 /// Under CSS modules the `<custom-ident>` is scoped with the same hash as the
@@ -158,9 +174,13 @@ pub struct TransitionHandler {
     pub(crate) durations: Option<(SmallList<Time, 1>, VendorPrefix)>,
     pub(crate) delays: Option<(SmallList<Time, 1>, VendorPrefix)>,
     pub(crate) timing_functions: Option<(SmallList<EasingFunction, 1>, VendorPrefix)>,
-    /// `transition-behavior` has no vendor prefixes. The `transition` shorthand
-    /// resets it, so the shorthand is only written when this is known too.
+    /// `transition-behavior` has no vendor prefixes. The unprefixed `transition`
+    /// shorthand resets it, so that shorthand is only synthesized from
+    /// longhands when this is known too.
     pub(crate) behaviors: Option<SmallList<TransitionBehavior, 1>>,
+    /// Prefixes a `transition` shorthand was seen with since the last flush.
+    /// Writing the shorthand back out with these is always faithful.
+    pub(crate) shorthand_prefixes: VendorPrefix,
     pub(crate) has_any: bool,
 }
 
@@ -265,6 +285,18 @@ mod transition_handler_body {
                     let val: &SmallList<Transition, 1> = &x.0;
                     let vp: VendorPrefix = x.1;
 
+                    // Only the unprefixed shorthand resets `transition-behavior` in every
+                    // engine. A prefixed one is an alias in some engines and ignored in
+                    // others, so it must keep its source order with a non-default value.
+                    let resets_behavior = vp.contains(VendorPrefix::NONE);
+                    if !resets_behavior
+                        && self.behaviors.as_ref().is_some_and(|b| {
+                            b.slice().iter().any(|b| *b != TransitionBehavior::Normal)
+                        })
+                    {
+                        self.flush(dest, context);
+                    }
+
                     let mut properties = SmallList::<PropertyId, 1>::init_capacity(val.len());
                     let mut durations = SmallList::<Time, 1>::init_capacity(val.len());
                     let mut delays = SmallList::<Time, 1>::init_capacity(val.len());
@@ -339,13 +371,15 @@ mod transition_handler_body {
                         vp
                     );
 
-                    // The shorthand resets `transition-behavior` to `normal` for each entry.
-                    let mut behaviors =
-                        SmallList::<TransitionBehavior, 1>::init_capacity(val.len());
-                    for _ in val.slice() {
-                        behaviors.append(TransitionBehavior::Normal);
+                    self.shorthand_prefixes.insert(vp);
+                    if resets_behavior {
+                        let mut behaviors =
+                            SmallList::<TransitionBehavior, 1>::init_capacity(val.len());
+                        for _ in val.slice() {
+                            behaviors.append(TransitionBehavior::Normal);
+                        }
+                        self.behaviors = Some(behaviors);
                     }
-                    self.behaviors = Some(behaviors);
                 }
                 Property::TransitionBehavior(x) => {
                     self.behaviors = Some(x.deep_clone(arena));
@@ -400,32 +434,37 @@ mod transition_handler_body {
                     None
                 };
             let mut shorthand_is_logical = false;
-            // `Some(true)` when every buffered `transition-behavior` is `normal`,
-            // which any `transition` shorthand already implies.
-            let behaviors_all_normal: Option<bool> = _behaviors
+            let behaviors_all_normal = _behaviors
                 .as_ref()
-                .map(|b| b.slice().iter().all(|b| *b == TransitionBehavior::Normal));
+                .is_some_and(|b| b.slice().iter().all(|b| *b == TransitionBehavior::Normal));
+            // The shorthand also resets `transition-behavior`, so synthesizing it
+            // from longhands is only equivalent when that is written too. With a
+            // prefix the source used for a shorthand it is always faithful.
+            let shorthand_allowed = if _behaviors.is_some() {
+                VendorPrefix::all()
+            } else {
+                self.shorthand_prefixes
+            };
 
-            // The shorthand resets every `transition-*` longhand, so it is only
-            // equivalent to the declarations seen when all of them were set.
             if let (
                 Some((properties, property_prefixes)),
                 Some((durations, duration_prefixes)),
                 Some((delays, delay_prefixes)),
                 Some((timing_functions, timing_prefixes)),
-                Some(behaviors_all_normal),
             ) = (
                 &mut _properties,
                 &mut _durations,
                 &mut _delays,
                 &mut _timing_functions,
-                behaviors_all_normal,
             ) {
                 // Find the intersection of prefixes with the same value.
                 // Remove that from the prefixes of each of the properties. The remaining
                 // prefixes will be handled by outputting individual properties below.
-                let intersection =
-                    *property_prefixes & *duration_prefixes & *delay_prefixes & *timing_prefixes;
+                let intersection = *property_prefixes
+                    & *duration_prefixes
+                    & *delay_prefixes
+                    & *timing_prefixes
+                    & shorthand_allowed;
                 if !intersection.is_empty() {
                     let transitions =
                         get_transitions(arena, properties, durations, delays, timing_functions);
@@ -455,7 +494,8 @@ mod transition_handler_body {
                     timing_prefixes.remove(intersection);
                     delay_prefixes.remove(intersection);
 
-                    if behaviors_all_normal {
+                    // The unprefixed shorthand already says `transition-behavior: normal`.
+                    if intersection.contains(VendorPrefix::NONE) && behaviors_all_normal {
                         _behaviors = None;
                     }
                 }
@@ -516,6 +556,7 @@ mod transition_handler_body {
             self.delays = None;
             self.timing_functions = None;
             self.behaviors = None;
+            self.shorthand_prefixes = VendorPrefix::empty();
             self.has_any = false;
         }
     }

--- a/src/css/properties/transition.rs
+++ b/src/css/properties/transition.rs
@@ -110,6 +110,18 @@ impl Transition {
     }
 }
 
+/// A value for the [transition-behavior](https://drafts.csswg.org/css-transitions-2/#transition-behavior-property) property.
+#[derive(
+    Clone, Copy, PartialEq, Eq, Default, crate::Parse, crate::ToCss, crate::CssEql, crate::DeepClone,
+)]
+pub enum TransitionBehavior {
+    /// Transitions do not start for discretely animatable properties.
+    #[default]
+    Normal,
+    /// Transitions start for discretely animatable properties too.
+    AllowDiscrete,
+}
+
 /// A value for the [view-transition-name](https://drafts.csswg.org/css-view-transitions-1/#view-transition-name-prop) property.
 ///
 /// Under CSS modules the `<custom-ident>` is scoped with the same hash as the
@@ -146,6 +158,9 @@ pub struct TransitionHandler {
     pub(crate) durations: Option<(SmallList<Time, 1>, VendorPrefix)>,
     pub(crate) delays: Option<(SmallList<Time, 1>, VendorPrefix)>,
     pub(crate) timing_functions: Option<(SmallList<EasingFunction, 1>, VendorPrefix)>,
+    /// `transition-behavior` has no vendor prefixes. The `transition` shorthand
+    /// resets it, so the shorthand is only written when this is known too.
+    pub(crate) behaviors: Option<SmallList<TransitionBehavior, 1>>,
     pub(crate) has_any: bool,
 }
 
@@ -323,6 +338,18 @@ mod transition_handler_body {
                         &timing_functions,
                         vp
                     );
+
+                    // The shorthand resets `transition-behavior` to `normal` for each entry.
+                    let mut behaviors =
+                        SmallList::<TransitionBehavior, 1>::init_capacity(val.len());
+                    for _ in val.slice() {
+                        behaviors.append(TransitionBehavior::Normal);
+                    }
+                    self.behaviors = Some(behaviors);
+                }
+                Property::TransitionBehavior(x) => {
+                    self.behaviors = Some(x.deep_clone(arena));
+                    self.has_any = true;
                 }
                 Property::Unparsed(x) => {
                     if is_transition_property(&x.property_id) {
@@ -364,6 +391,7 @@ mod transition_handler_body {
             let mut _delays: Option<(SmallList<Time, 1>, VendorPrefix)> = self.delays.take();
             let mut _timing_functions: Option<(SmallList<EasingFunction, 1>, VendorPrefix)> =
                 self.timing_functions.take();
+            let mut _behaviors: Option<SmallList<TransitionBehavior, 1>> = self.behaviors.take();
 
             let mut rtl_properties: Option<SmallList<PropertyId, 1>> =
                 if let Some(p) = &mut _properties {
@@ -371,17 +399,27 @@ mod transition_handler_body {
                 } else {
                     None
                 };
+            let mut shorthand_is_logical = false;
+            // `Some(true)` when every buffered `transition-behavior` is `normal`,
+            // which any `transition` shorthand already implies.
+            let behaviors_all_normal: Option<bool> = _behaviors
+                .as_ref()
+                .map(|b| b.slice().iter().all(|b| *b == TransitionBehavior::Normal));
 
+            // The shorthand resets every `transition-*` longhand, so it is only
+            // equivalent to the declarations seen when all of them were set.
             if let (
                 Some((properties, property_prefixes)),
                 Some((durations, duration_prefixes)),
                 Some((delays, delay_prefixes)),
                 Some((timing_functions, timing_prefixes)),
+                Some(behaviors_all_normal),
             ) = (
                 &mut _properties,
                 &mut _durations,
                 &mut _delays,
                 &mut _timing_functions,
+                behaviors_all_normal,
             ) {
                 // Find the intersection of prefixes with the same value.
                 // Remove that from the prefixes of each of the properties. The remaining
@@ -404,6 +442,7 @@ mod transition_handler_body {
                             Property::Transition((transitions, intersection)),
                             Property::Transition((rtl_transitions, intersection)),
                         );
+                        shorthand_is_logical = true;
                     } else {
                         dest.push(Property::Transition((
                             transitions.deep_clone(arena),
@@ -415,6 +454,10 @@ mod transition_handler_body {
                     duration_prefixes.remove(intersection);
                     timing_prefixes.remove(intersection);
                     delay_prefixes.remove(intersection);
+
+                    if behaviors_all_normal {
+                        _behaviors = None;
+                    }
                 }
             }
 
@@ -452,6 +495,18 @@ mod transition_handler_body {
                 }
             }
 
+            if let Some(behaviors) = _behaviors.take() {
+                if shorthand_is_logical {
+                    // Keep it after the shorthand, which went into the `:dir()` rules.
+                    context.add_logical_rule(
+                        Property::TransitionBehavior(behaviors.deep_clone(arena)),
+                        Property::TransitionBehavior(behaviors),
+                    );
+                } else {
+                    dest.push(Property::TransitionBehavior(behaviors));
+                }
+            }
+
             self.reset();
         }
 
@@ -460,6 +515,7 @@ mod transition_handler_body {
             self.durations = None;
             self.delays = None;
             self.timing_functions = None;
+            self.behaviors = None;
             self.has_any = false;
         }
     }
@@ -843,6 +899,7 @@ mod transition_handler_body {
                 | PropertyId::TransitionDuration(..)
                 | PropertyId::TransitionDelay(..)
                 | PropertyId::TransitionTimingFunction(..)
+                | PropertyId::TransitionBehavior
                 | PropertyId::Transition(..)
         )
     }

--- a/src/css/properties/transition.rs
+++ b/src/css/properties/transition.rs
@@ -75,9 +75,7 @@ impl Transition {
             if property.is_none() {
                 if let Ok(value) = parser.try_parse(|p: &mut Parser| -> CssResult<PropertyId> {
                     let id = PropertyId::parse(p)?;
-                    // These are the `<transition-behavior-value>` of the shorthand, not
-                    // property names. This struct does not hold one, so such a value
-                    // stays unparsed.
+                    // `<transition-behavior-value>` keywords, which this struct does not hold.
                     if TransitionBehavior::is_keyword(id.name()) {
                         return Err(p.new_custom_error(crate::ParserError::invalid_value));
                     }
@@ -174,12 +172,9 @@ pub struct TransitionHandler {
     pub(crate) durations: Option<(SmallList<Time, 1>, VendorPrefix)>,
     pub(crate) delays: Option<(SmallList<Time, 1>, VendorPrefix)>,
     pub(crate) timing_functions: Option<(SmallList<EasingFunction, 1>, VendorPrefix)>,
-    /// `transition-behavior` has no vendor prefixes. The unprefixed `transition`
-    /// shorthand resets it, so that shorthand is only synthesized from
-    /// longhands when this is known too.
+    /// No vendor prefixes. The unprefixed `transition` shorthand resets it.
     pub(crate) behaviors: Option<SmallList<TransitionBehavior, 1>>,
-    /// Prefixes a `transition` shorthand was seen with since the last flush.
-    /// Writing the shorthand back out with these is always faithful.
+    /// Prefixes the source used a `transition` shorthand with since the last flush.
     pub(crate) shorthand_prefixes: VendorPrefix,
     pub(crate) has_any: bool,
 }
@@ -285,9 +280,7 @@ mod transition_handler_body {
                     let val: &SmallList<Transition, 1> = &x.0;
                     let vp: VendorPrefix = x.1;
 
-                    // Only the unprefixed shorthand resets `transition-behavior` in every
-                    // engine. A prefixed one is an alias in some engines and ignored in
-                    // others, so it must keep its source order with a non-default value.
+                    // Other engines ignore a prefixed shorthand, so it does not reset `transition-behavior`.
                     let resets_behavior = vp.contains(VendorPrefix::NONE);
                     if !resets_behavior
                         && self.behaviors.as_ref().is_some_and(|b| {
@@ -437,9 +430,7 @@ mod transition_handler_body {
             let behaviors_all_normal = _behaviors
                 .as_ref()
                 .is_some_and(|b| b.slice().iter().all(|b| *b == TransitionBehavior::Normal));
-            // The shorthand also resets `transition-behavior`, so synthesizing it
-            // from longhands is only equivalent when that is written too. With a
-            // prefix the source used for a shorthand it is always faithful.
+            // A synthesized shorthand would also reset an unknown `transition-behavior`.
             let shorthand_allowed = if _behaviors.is_some() {
                 VendorPrefix::all()
             } else {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -502,6 +502,72 @@ describe("css tests", () => {
     cssTest(
       `
       .foo {
+        border: 1px solid red;
+        border-top: 2px dashed blue;
+        border-right: 3px dotted green;
+        border-bottom: 4px double white;
+      }
+    `,
+      `
+      .foo {
+        border: 2px dashed #00f;
+        border-bottom: 4px double #fff;
+        border-left: 1px solid red;
+        border-right: 3px dotted green;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border-top: 1px solid red;
+        border-bottom: 1px solid red;
+        border-left: 2px dashed blue;
+        border-right: 2px dashed blue;
+      }
+    `,
+      `
+      .foo {
+        border-style: solid dashed;
+        border-width: 1px 2px;
+        border-color: red #00f;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border-image: linear-gradient(red, blue) 1;
+        border: var(--b);
+      }
+    `,
+      `
+      .foo {
+        border: var(--b);
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border: var(--b);
+        border-image: linear-gradient(red, blue) 1;
+      }
+    `,
+      `
+      .foo {
+        border: var(--b);
+        border-image: linear-gradient(red, #00f) 1;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
         border-block: 2px solid red;
         border-inline: 2px solid red;
       }
@@ -6961,9 +7027,74 @@ describe("css tests", () => {
     `,
     );
     minify_test(".foo { transition-behavior: Allow-Discrete , NORMAL }", ".foo{transition-behavior:allow-discrete,normal}");
+    // `allow-discrete` / `normal` inside the shorthand are its behavior value,
+    // not property names; the typed shorthand does not model them, so these
+    // pass through as written.
     minify_test(
       ".foo { transition: display 2s allow-discrete, opacity 2s }",
       ".foo{transition:display 2s allow-discrete,opacity 2s}",
+    );
+    minify_test(
+      ".foo { transition: .3s allow-discrete; transition-behavior: normal }",
+      ".foo{transition:.3s allow-discrete;transition-behavior:normal}",
+    );
+    minify_test(".foo { transition: 1s Normal, opacity 2s }", ".foo{transition:1s Normal,opacity 2s}");
+    // Only the unprefixed shorthand resets `transition-behavior` everywhere. A
+    // prefixed one is an alias in some engines only, so it keeps its place
+    // relative to a non-default `transition-behavior` and never implies one.
+    minify_test(".foo { -webkit-transition: opacity 1s }", ".foo{-webkit-transition:opacity 1s}");
+    minify_test(
+      ".foo { transition-behavior: allow-discrete; -moz-transition: opacity 1s }",
+      ".foo{transition-behavior:allow-discrete;-moz-transition:opacity 1s}",
+    );
+    minify_test(
+      ".foo { -moz-transition: opacity 1s; transition-behavior: allow-discrete }",
+      ".foo{-moz-transition:opacity 1s;transition-behavior:allow-discrete}",
+    );
+    minify_test(
+      ".foo { -moz-transition: opacity 1s; transition-behavior: normal }",
+      ".foo{-moz-transition:opacity 1s;transition-behavior:normal}",
+    );
+    minify_test(
+      ".foo { transition: opacity 1s; transition-behavior: allow-discrete; -moz-transition: opacity 1s }",
+      ".foo{transition:opacity 1s;transition-behavior:allow-discrete;-moz-transition:opacity 1s}",
+    );
+    minify_test(
+      ".foo { -webkit-transition: opacity 1s; -moz-transition: opacity 1s; transition: opacity 1s; transition-behavior: allow-discrete }",
+      ".foo{-webkit-transition:opacity 1s;-moz-transition:opacity 1s;transition:opacity 1s;transition-behavior:allow-discrete}",
+    );
+    prefix_test(
+      `
+      .foo {
+        -moz-transition: opacity 1s;
+        transition-property: opacity;
+      }
+    `,
+      `
+      .foo {
+        transition-property: opacity;
+        -moz-transition-duration: 1s;
+        -moz-transition-delay: 0s;
+        -moz-transition-timing-function: ease;
+      }
+    `,
+      { chrome: 120 << 16 },
+    );
+    prefix_test(
+      `
+      .foo {
+        transition: opacity 1s;
+        transition-behavior: allow-discrete;
+      }
+    `,
+      `
+      .foo {
+        -webkit-transition: opacity 1s;
+        transition: opacity 1s;
+        transition-behavior: allow-discrete;
+      }
+    `,
+      { safari: 6 << 16 },
     );
     cssTest(
       `

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -293,6 +293,9 @@ describe("css tests", () => {
   });
 
   describe("border", () => {
+    // The `border` shorthand also resets `border-image`, which none of these
+    // declarations touch, so it is only synthesized when the rule had a
+    // `border` itself or declares a complete `border-image` too.
     cssTest(
       `
       .foo {
@@ -304,7 +307,172 @@ describe("css tests", () => {
     `,
       `
       .foo {
+        border-style: solid;
+        border-width: 2px;
+        border-color: red;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border-width: 2px;
+        border-style: solid;
+        border-color: red;
+      }
+    `,
+      `
+      .foo {
+        border-style: solid;
+        border-width: 2px;
+        border-color: red;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border: 1px dotted green;
+        border-width: 2px;
+        border-style: solid;
+        border-color: red;
+      }
+    `,
+      `
+      .foo {
         border: 2px solid red;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border-image: linear-gradient(red, blue) 10 / 4px round;
+        border-width: 2px;
+        border-style: solid;
+        border-color: red;
+      }
+    `,
+      `
+      .foo {
+        border: 2px solid red;
+        border-image: linear-gradient(red, #00f) 10 / 4px round;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border-width: 2px;
+        border-style: solid;
+        border-color: red;
+        border-image-source: linear-gradient(red, blue);
+      }
+    `,
+      `
+      .foo {
+        border-style: solid;
+        border-width: 2px;
+        border-color: red;
+        border-image-source: linear-gradient(red, #00f);
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        -webkit-border-image: linear-gradient(red, blue) 10;
+        border-width: 2px;
+        border-style: solid;
+        border-color: red;
+      }
+    `,
+      `
+      .foo {
+        border-style: solid;
+        border-width: 2px;
+        border-color: red;
+        -webkit-border-image: linear-gradient(red, #00f) 10;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border-image: linear-gradient(red, blue) 10;
+        border-image-width: var(--w);
+        border-width: 2px;
+        border-style: solid;
+        border-color: red;
+      }
+    `,
+      `
+      .foo {
+        border-image: linear-gradient(red, #00f) 10;
+        border-image-width: var(--w);
+        border-style: solid;
+        border-width: 2px;
+        border-color: red;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border: 1px dotted green;
+        border-top-color: var(--c);
+        border-width: 2px;
+        border-style: solid;
+        border-color: red;
+      }
+    `,
+      `
+      .foo {
+        border: 1px dotted green;
+        border-top-color: var(--c);
+        border-style: solid;
+        border-width: 2px;
+        border-color: red;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border-style: solid double;
+        border-width: 0 1px;
+        border-color: black;
+      }
+    `,
+      `
+      .foo {
+        border-style: solid double;
+        border-width: 0 1px;
+        border-color: #000;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border-block: 2px solid red;
+        border-inline: 2px solid red;
+      }
+    `,
+      `
+      .foo {
+        border-style: solid;
+        border-width: 2px;
+        border-color: red;
       }
     `,
     );
@@ -640,6 +808,23 @@ describe("css tests", () => {
     `,
       `
       .foo {
+        border-style: solid;
+        border-width: 1px 2px;
+        border-color: #000;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border: 1px solid black;
+        border-left: 2px solid black;
+        border-right: 2px solid black;
+      }
+    `,
+      `
+      .foo {
         border: 1px solid #000;
         border-width: 1px 2px;
       }
@@ -653,6 +838,22 @@ describe("css tests", () => {
         border-bottom: 1px solid black;
         border-left: 2px solid black;
         border-right: 1px solid black;
+      }
+    `,
+      `
+      .foo {
+        border-style: solid;
+        border-width: 1px 1px 1px 2px;
+        border-color: #000;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border: 1px solid black;
+        border-left: 2px solid black;
       }
     `,
       `
@@ -674,8 +875,42 @@ describe("css tests", () => {
     `,
       `
       .foo {
+        border-style: solid;
+        border-width: 1px;
+        border-color: #000 red;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border: 1px solid black;
+        border-left-color: red;
+        border-right-color: red;
+      }
+    `,
+      `
+      .foo {
         border: 1px solid #000;
         border-color: #000 red;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border: 1px solid black;
+        border-top: 1px solid red;
+        border-left: 2px dotted red;
+      }
+    `,
+      `
+      .foo {
+        border: 1px solid #000;
+        border-top-color: red;
+        border-left: 2px dotted red;
       }
     `,
     );
@@ -691,8 +926,8 @@ describe("css tests", () => {
     `,
       `
       .foo {
-        border: 1px solid #000;
-        border-inline-color: red;
+        border-block: 1px solid #000;
+        border-inline: 1px solid red;
       }
     `,
     );
@@ -708,8 +943,8 @@ describe("css tests", () => {
     `,
       `
       .foo {
-        border: 1px solid #000;
-        border-inline-width: 2px;
+        border-block: 1px solid #000;
+        border-inline: 2px solid #000;
       }
     `,
     );
@@ -725,7 +960,7 @@ describe("css tests", () => {
     `,
       `
       .foo {
-        border: 1px solid #000;
+        border-block: 1px solid #000;
         border-inline: 2px solid red;
       }
     `,
@@ -742,7 +977,7 @@ describe("css tests", () => {
     `,
       `
       .foo {
-        border: 1px solid #000;
+        border-block: 1px solid #000;
         border-inline-start: 2px solid red;
         border-inline-end: 3px solid red;
       }
@@ -760,9 +995,9 @@ describe("css tests", () => {
     `,
       `
       .foo {
-        border: 2px solid red;
-        border-block-start-color: #000;
+        border-block-start: 2px solid #000;
         border-block-end: 1px solid #000;
+        border-inline: 2px solid red;
       }
     `,
     );
@@ -778,8 +1013,9 @@ describe("css tests", () => {
     `,
       `
       .foo {
-        border: 2px solid red;
-        border-block-end-width: 1px;
+        border-block-start: 2px solid red;
+        border-block-end: 1px solid red;
+        border-inline: 2px solid red;
       }
     `,
     );
@@ -795,8 +1031,9 @@ describe("css tests", () => {
     `,
       `
       .foo {
-        border: 2px solid red;
-        border-inline-end-width: 1px;
+        border-block: 2px solid red;
+        border-inline-start: 2px solid red;
+        border-inline-end: 1px solid red;
       }
     `,
     );
@@ -6575,6 +6812,8 @@ describe("css tests", () => {
     minify_test(".foo { transition: width 2s ease 1s }", ".foo{transition:width 2s 1s}");
     minify_test(".foo { transition: ease-in 1s width 4s }", ".foo{transition:width 1s ease-in 4s}");
     minify_test(".foo { transition: opacity 0s .6s }", ".foo{transition:opacity 0s .6s}");
+    // The `transition` shorthand also resets `transition-behavior`, so the
+    // longhands only fold into it when the rule sets that one too.
     cssTest(
       `
       .foo {
@@ -6586,9 +6825,107 @@ describe("css tests", () => {
     `,
       `
       .foo {
+        transition-property: opacity;
+        transition-duration: 90ms;
+        transition-delay: .5s;
+        transition-timing-function: ease-in-out;
+      }
+    `,
+    );
+    cssTest(
+      `
+      .foo {
+        transition-property: opacity;
+        transition-duration: 0.09s;
+        transition-timing-function: ease-in-out;
+        transition-delay: 500ms;
+        transition-behavior: normal;
+      }
+    `,
+      `
+      .foo {
         transition: opacity 90ms ease-in-out .5s;
       }
     `,
+    );
+    cssTest(
+      `
+      .foo {
+        transition-behavior: allow-discrete;
+        transition-property: opacity;
+        transition-duration: 0.09s;
+        transition-timing-function: ease-in-out;
+        transition-delay: 500ms;
+      }
+    `,
+      `
+      .foo {
+        transition: opacity 90ms ease-in-out .5s;
+        transition-behavior: allow-discrete;
+      }
+    `,
+    );
+    cssTest(
+      `
+      .foo {
+        transition: opacity 2s, display 2s;
+        transition-behavior: allow-discrete;
+      }
+    `,
+      `
+      .foo {
+        transition: opacity 2s, display 2s;
+        transition-behavior: allow-discrete;
+      }
+    `,
+    );
+    cssTest(
+      `
+      .foo {
+        transition-behavior: allow-discrete;
+        transition: opacity 2s, display 2s;
+      }
+    `,
+      `
+      .foo {
+        transition: opacity 2s, display 2s;
+      }
+    `,
+    );
+    cssTest(
+      `
+      .foo {
+        transition: opacity 2s;
+        transition-behavior: var(--b);
+        transition-delay: 1s;
+      }
+    `,
+      `
+      .foo {
+        transition: opacity 2s;
+        transition-behavior: var(--b);
+        transition-delay: 1s;
+      }
+    `,
+    );
+    cssTest(
+      `
+      .foo {
+        transition-property: opacity;
+        transition-behavior: allow-discrete, normal;
+      }
+    `,
+      `
+      .foo {
+        transition-property: opacity;
+        transition-behavior: allow-discrete, normal;
+      }
+    `,
+    );
+    minify_test(".foo { transition-behavior: Allow-Discrete , NORMAL }", ".foo{transition-behavior:allow-discrete,normal}");
+    minify_test(
+      ".foo { transition: display 2s allow-discrete, opacity 2s }",
+      ".foo{transition:display 2s allow-discrete,opacity 2s}",
     );
     cssTest(
       `
@@ -6645,6 +6982,25 @@ describe("css tests", () => {
     `,
       `
       .foo {
+        transition-property: opacity, color;
+        transition-duration: 2s, 4s;
+        transition-delay: .5s, 0s;
+        transition-timing-function: ease-in-out, ease-in;
+      }
+    `,
+    );
+    cssTest(
+      `
+      .foo {
+        transition: none;
+        transition-property: opacity, color;
+        transition-duration: 2s, 4s;
+        transition-timing-function: ease-in-out, ease-in;
+        transition-delay: 500ms, 0s;
+      }
+    `,
+      `
+      .foo {
         transition: opacity 2s ease-in-out .5s, color 4s ease-in;
       }
     `,
@@ -6652,6 +7008,7 @@ describe("css tests", () => {
     cssTest(
       `
       .foo {
+        transition: none;
         transition-property: opacity, color;
         transition-duration: 2s;
         transition-timing-function: ease-in-out;
@@ -6667,6 +7024,7 @@ describe("css tests", () => {
     cssTest(
       `
       .foo {
+        transition: none;
         transition-property: opacity, color, width, height;
         transition-duration: 2s, 4s;
         transition-timing-function: ease;
@@ -6691,6 +7049,26 @@ describe("css tests", () => {
     `,
       `
       .foo {
+        -webkit-transition-property: opacity, color;
+        -webkit-transition-duration: 2s, 4s;
+        -webkit-transition-delay: .5s, 0s;
+        -webkit-transition-timing-function: ease-in-out, ease-in;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        -webkit-transition: none;
+        -webkit-transition-property: opacity, color;
+        -webkit-transition-duration: 2s, 4s;
+        -webkit-transition-timing-function: ease-in-out, ease-in;
+        -webkit-transition-delay: 500ms, 0s;
+      }
+    `,
+      `
+      .foo {
         -webkit-transition: opacity 2s ease-in-out .5s, color 4s ease-in;
       }
     `,
@@ -6699,6 +7077,7 @@ describe("css tests", () => {
     cssTest(
       `
       .foo {
+        transition-behavior: normal;
         -webkit-transition-property: opacity, color;
         -webkit-transition-duration: 2s, 4s;
         -webkit-transition-timing-function: ease-in-out, ease-in;
@@ -6737,6 +7116,7 @@ describe("css tests", () => {
         -webkit-transition-delay: 500ms, 0s;
         -moz-transition-delay: 500ms, 0s;
         transition-delay: 500ms, 0s;
+        transition-behavior: normal;
       }
     `,
       `

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7026,7 +7026,10 @@ describe("css tests", () => {
       }
     `,
     );
-    minify_test(".foo { transition-behavior: Allow-Discrete , NORMAL }", ".foo{transition-behavior:allow-discrete,normal}");
+    minify_test(
+      ".foo { transition-behavior: Allow-Discrete , NORMAL }",
+      ".foo{transition-behavior:allow-discrete,normal}",
+    );
     // `allow-discrete` / `normal` inside the shorthand are its behavior value,
     // not property names; the typed shorthand does not model them, so these
     // pass through as written.

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -464,6 +464,44 @@ describe("css tests", () => {
     cssTest(
       `
       .foo {
+        border-top: 0;
+        border-right: 0;
+        border-bottom: 1px solid #cacaca;
+        border-left: 0;
+      }
+    `,
+      `
+      .foo {
+        border-top: 0;
+        border-bottom: 1px solid #cacaca;
+        border-left: 0;
+        border-right: 0;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
+        border-top: 1px solid red;
+        border-right: 2px dashed blue;
+        border-bottom: 3px dotted green;
+        border-left: 4px double white;
+      }
+    `,
+      `
+      .foo {
+        border-top: 1px solid red;
+        border-bottom: 3px dotted green;
+        border-left: 4px double #fff;
+        border-right: 2px dashed #00f;
+      }
+    `,
+    );
+
+    cssTest(
+      `
+      .foo {
         border-block: 2px solid red;
         border-inline: 2px solid red;
       }


### PR DESCRIPTION
### Problem
- The CSS minifier folded `border-width; border-style; border-color` (or four `border-<side>`) into `border`, and the four classic `transition-*` longhands into `transition`. But `border` also resets every `border-image-*` longhand, and `transition` resets `transition-behavior`. So `#i1 { border-color: #000; border-style: solid; border-width: 2px }` became `border: 2px solid #000` and wiped a `border-image` set by another rule.
- `transition-behavior` was not a known property. `transition: opacity 1s; transition-behavior: allow-discrete` printed in the opposite order, so `transition` reset it (same as parcel-bundler/lightningcss#1084).

### Fix
- `BorderHandler` only writes `border` when the rule had a `border` since the last flush, or still buffers a complete unprefixed `border-image` that prints after it. Otherwise it keeps `border-style` / `border-width` / `border-color`, or the four sides when shorter.
- `transition-behavior` is now a known property and a fifth longhand of `TransitionHandler`. The unprefixed shorthand is only synthesized when it is known too. A value other than `normal` prints after the shorthand, never inside it, so browsers without `transition-behavior` keep the transition.
- Self-reviewed: 4 concerns raised, 4 addressed (see Notes).
- Verified: `test/js/bun/css/css.test.ts` (41 changed or new expectations fail on 1.4.3-canary). Also ran `test/js/bun/css/` and `test/bundler/css/`.

### Background
- `src/css` is a port of lightningcss. Each shorthand family has a handler that buffers the longhands of a rule and writes the shortest equivalent set when the rule ends.
- A shorthand sets every longhand it covers. Omitted ones reset to their initial value. css-backgrounds-3 puts `border-image` under `border`. css-transitions-2 puts `transition-behavior` under `transition`.
- Unknown properties are not buffered. They print at once, ahead of a buffered shorthand of the same rule.

<details><summary>Notes</summary>

Repro on bun 1.4.3-canary (f42e98025), `bun build ./a.css`:

```css
div.b { border-image: linear-gradient(red, blue) 10 / 4px round }
#i1   { border-color: #000; border-style: solid; border-width: 2px }
.f    { transition-behavior: allow-discrete }
ul.f  { transition-property: opacity; transition-duration: 1s; transition-timing-function: ease; transition-delay: 0s }
.e    { transition: opacity 1s; transition-behavior: allow-discrete }
```

printed `#i1 { border: 2px solid #000 }`, `ul.f { transition: opacity 1s }` and `.e { transition-behavior: allow-discrete; transition: opacity 1s }`. In Chromium, `<div class=b id=i1>` then loses its border image and `ul.f` / `.e` compute `transition-behavior: normal`. With this change the output is `#i1 { border-style: solid; border-width: 2px; border-color: #000 }`, the four `transition-*` longhands for `ul.f`, and `.e { transition: opacity 1s; transition-behavior: allow-discrete }`. Four `border-<side>` declarations had the same problem as the three four-sided longhands.

When `border` is still written:
- the rule contains `border` itself (it already resets `border-image`), for example `border: 1px solid; border-color: red` still prints `border: 1px solid red`. On that path a `border` now always goes out, also when all four sides end up different.
- the rule buffers a complete, unprefixed `border-image` and the border-image handler has not written anything for this rule yet. The border handler always flushes before the border-image handler, so that `border-image` lands after the `border` and overrides the reset.

A lone `border-image-source`, a `-webkit-border-image`, or a `border-image` that an unparsable `border-image-*` already flushed do not qualify. `border: var(..)` now drops a `border-image` buffered before it, the same as a parsed `border`. Without `border`, four complete sides print as `border-style` / `border-width` / `border-color`, or as the four sides when no component repeats on all of them (`border-top: 0; border-right: 0; border-bottom: 1px solid #cacaca; border-left: 0` stays as written). Four complete but unequal logical sides print as `border-block` / `border-inline` (or their `-start` / `-end` forms).

Transition details:
- Only the unprefixed `transition` implies `transition-behavior: normal`. `-moz-transition` / `-ms-transition` are ignored by other engines, so they neither imply nor swallow a `transition-behavior`, and a prefixed shorthand that follows a non-default `transition-behavior` flushes first to keep source order. A shorthand is written back for any prefix the source used it with, and synthesized from longhands only once `transition-behavior` is known.
- `normal` and `allow-discrete` inside a `transition` value are its `<transition-behavior-value>`. The typed shorthand does not hold one, so such a value now stays unparsed and prints as written (before, `transition: .3s allow-discrete` parsed `allow-discrete` as a property name and printed `transition: allow-discrete .3s`). Folding a separate `transition-behavior` into the shorthand value would need compat data (Chrome 117, Firefox 129, Safari 17.4), because an unknown keyword drops the whole declaration and `bun build` targets older browsers by default.

Output size: on the CSS fixtures in `test/js/bun/css/files/` (bootstrap, bulma, foundation, materialize, tailwind, uikit, ...) only `foundation.css` changes, 112471 to 112773 bytes minified (+302, its CSS-triangle rules use `border-style; border-width; border-<side>-width: 0; border-color`). Four `transition-*` longhands without the shorthand stay four declarations.

The existing lightningcss tests that asserted the unsafe collapse were updated. Cases that exercised the `border` diffing logic now start from a `border` declaration, so that path stays covered.

Self-review concerns and what changed for them: a prefixed-only `-moz-transition` implied `transition-behavior: normal` and could swallow an explicit one (now only the unprefixed shorthand implies it, and the prefixed one keeps its order); `normal` / `allow-discrete` inside a `transition` value were read as property names (now unparsed); `border: var(..)` left a `border-image` buffered before it alive (now dropped); four unequal sides without `border` grew past the input (now kept as the four sides).

Related open PRs: #38592 changes the logical diffing path in `border.rs` that is now only reached with `border` or a pending `border-image` in the rule, and its expectations assume the old collapse, so it needs a rebase on top of this one. #38551 touches the `Property::Border` arm (category tracking) and should merge cleanly either way. #41990 fixes the same-rule reorder for the `font-*` sub-properties and, by name, for `transition-behavior`; with this change `transition-behavior` is typed, so that arm of #41990 becomes unnecessary, and the two otherwise do not overlap. `FontHandler` still synthesizes `font` from its seven longhands although `font` resets `font-kerning`, `font-variant-*`, `font-feature-settings` and more that it does not track; that is left for a follow-up.

`cargo clippy -p bun_css` and `cargo fmt` are clean.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] gen cpp.rs (cppbind)
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocation-model=static
... (truncated)

release without fix: 41 failed, 67 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.19ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.03ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.04ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.07ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.14ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.09ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: wh
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 618ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/properties/border.rs               |  53 ++-
 src/css/properties/border_image.rs         |  12 +
 src/css/properties/properties_generated.rs |  21 ++
 src/css/properties/transition.rs           |  95 ++++-
 test/js/bun/css/css.test.ts                | 576 ++++++++++++++++++++++++++++-
 5 files changed, 732 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/css/properties/border.rs                    7     12     14
src/css/properties/border_image.rs              1      1     14
src/css/properties/properties_generated.rs      1      0     14
src/css/properties/transition.rs                8     17     14
test/js/bun/css/css.test.ts                    10      7     14
```

</details>

<!-- robobun:evidence:end -->