### PR TITLE
webcrypto: report the modulus bit length as RsaKeyAlgorithm.modulusLength

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp
@@ -42,7 +42,7 @@ static size_t getRSAModulusLength(RSA* rsa)
 {
     if (!rsa)
         return 0;
-    return RSA_size(rsa) * 8;
+    return RSA_bits(rsa);
 }
 
 RefPtr<CryptoKeyRSA> CryptoKeyRSA::create(CryptoAlgorithmIdentifier identifier, CryptoAlgorithmIdentifier hash, bool hasHash, const CryptoKeyRSAComponents& keyData, bool extractable, CryptoKeyUsageBitmap usages)

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -402,6 +402,39 @@ describe("RSA-PSS saltLength", () => {
   });
 });
 
+describe("RsaKeyAlgorithm.modulusLength of an imported key", () => {
+  // A 2048-bit modulus. The cases below rewrite its leading byte, so the imported public
+  // keys are not usable, but import does not check that and modulusLength only reads n.
+  const n2048 = Buffer.from(
+    "tlDxtZRH4vbofKSZ8LrdGT3fCcx9t5bKCC6ereq1LV7El_sfVG3fw4c7DzSopwskZpTIO6OwzlejIGW3P_1dSGDUCokiXkeXXo74ioOwzPfJ8jkGCgRVNC3Ivbk_317MtPXt2f9hKOB9c4WAZlNYCubeDJdjkd7vXvAlcxvzM51hTa1-vFk3H27F3tdthu3alRKorOWW_O9XHQNv8mcx-5kILj-t_YbSQayRujvZA8Lq26O09uHg83R8STuouQeC0FuDWqrwyKsJ5k20VPxu--RxUossFzf2SK3iHdURG0lNEOQuLFyZpZJLTIhJAe3mw7n2N4Q9p--N4TdL0K9EeQ",
+    "base64url",
+  );
+  const withLeadingByte = (byte: number) => {
+    const n = Uint8Array.from(n2048);
+    n[0] = byte;
+    return n;
+  };
+  const modulusLength = (n: Uint8Array) =>
+    crypto.subtle
+      .importKey(
+        "jwk",
+        { kty: "RSA", n: Buffer.from(n).toString("base64url"), e: "AQAB" },
+        { name: "RSA-OAEP", hash: "SHA-256" },
+        true,
+        ["encrypt"],
+      )
+      .then(k => (k.algorithm as RsaKeyAlgorithm).modulusLength);
+
+  it("is the bit length of n, not its byte length times 8", async () => {
+    expect({
+      2048: await modulusLength(n2048),
+      2047: await modulusLength(withLeadingByte(0x40 | (n2048[0] & 0x3f))),
+      2041: await modulusLength(withLeadingByte(1)),
+      2049: await modulusLength(new Uint8Array([1, ...n2048])),
+    }).toEqual({ 2048: 2048, 2047: 2047, 2041: 2041, 2049: 2049 });
+  });
+});
+
 describe("Ed25519", () => {
   describe("generateKey", () => {
     it("should return CryptoKeys without namedCurve in algorithm field", async () => {


### PR DESCRIPTION
### Problem
- `algorithm.modulusLength` of an imported RSA key is the byte length of `n` times 8, not the bit length of the modulus. A JWK or SPKI key with a 2047-, 2041- or 2049-bit modulus reports 2048, 2048 and 2056. Node 26 and Chromium report 2047, 2041 and 2049. A `modulusLength >= 2048` gate then passes a 2041-bit key in Bun only.
- The cause is `getRSAModulusLength` (`src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp:41`), which returns `RSA_size(rsa) * 8`. `RSA_size` is the modulus size in bytes, rounded up.

### Fix
- Return `RSA_bits(rsa)`, which is `BN_num_bits(n)`.
- `CryptoKeyRSA::keySizeInBits()` uses the same helper. Its only callers compare the result with zero, so nothing else changes. Generated keys are unaffected: BoringSSL generates exactly `modulusLength` bits.
- Verified: `test/js/web/crypto/web-crypto.test.ts` ("RsaKeyAlgorithm.modulusLength of an imported key", fails on 1.4.3). Also the rest of `test/js/web/crypto/` and the vendored `test-webcrypto-*-rsa.js`, `test-crypto-key-objects-to-crypto-key.js` and `test-webcrypto-cryptokey-clone-transfer.js`.

### Background
- `RsaKeyAlgorithm.modulusLength` is "the length, in bits, of the RSA public modulus" (WebCrypto, RsaKeyAlgorithm dictionary).
- `CryptoKeyRSA::algorithm()` builds that dictionary from the `RSA*` inside the key's `EVP_PKEY` for every RSA key, whether generated or imported through jwk, spki or pkcs8.

<details><summary>Notes</summary>

Repro (ledger #45334):

```js
const S = crypto.subtle, b64u = u => Buffer.from(u).toString("base64url");
const kp = await S.generateKey({ name: "RSA-OAEP", modulusLength: 2048, publicExponent: new Uint8Array([1,0,1]), hash: "SHA-256" }, true, ["encrypt","decrypt"]);
const N = Buffer.from((await S.exportKey("jwk", kp.publicKey)).n, "base64url");
for (const [label, n] of [["2047-bit", (x => (x[0] = 0x40 | (x[0] & 0x3f), x))(Uint8Array.from(N))], ["2041-bit", (x => (x[0] = 1, x))(Uint8Array.from(N))], ["2049-bit", new Uint8Array([1, ...N])]])
  console.log(label, await S.importKey("jwk", { kty: "RSA", n: b64u(n), e: "AQAB" }, { name: "RSA-OAEP", hash: "SHA-256" }, true, ["encrypt"]).then(k => k.algorithm.modulusLength, e => e.name));
```

bun 1.4.3: 2048 / 2048 / 2056. node 26.3.0: 2047 / 2041 / 2049. With this change: 2047 / 2041 / 2049.

The test imports public keys whose modulus has a rewritten leading byte. Such a modulus is not a product of the original primes, so the keys are useless for encryption, but public key import cannot check that and `modulusLength` only reads `n`.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.59ms]
(pass) Web Crypto > keeps event loop alive [351.45ms]
(pass) Web Crypto > has globals [3.14ms]
(pass) Web Crypto > should encrypt and decrypt [14.66ms]
(pass) Web Crypto > should verify and sign [38.43ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [15.40ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [10.67ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [10.39ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2483.93ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [310.08ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [43.51
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.06ms]
(pass) Web Crypto > keeps event loop alive [8.87ms]
(pass) Web Crypto > has globals [0.06ms]
(pass) Web Crypto > should encrypt and decrypt [0.44ms]
(pass) Web Crypto > should verify and sign [0.67ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [0.52ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [0.20ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [0.16ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [25.67ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [7.89ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [6.86ms]
429 |     expect({
430 |       2048: await modulusLength(n2048),
431 |       2047: await modulusLength(withLeadingByte(0x40 | (n2048[0] & 0x3f))),
432 |       2041: awai
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.21ms]
(pass) Web Crypto > keeps event loop alive [258.62ms]
(pass) Web Crypto > has globals [3.20ms]
(pass) Web Crypto > should encrypt and decrypt [13.57ms]
(pass) Web Crypto > should verify and sign [36.03ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [15.29ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [9.80ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [9.96ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2469.31ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [371.47ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [74.24ms
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 587ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/136] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/136] gen cpp.rs (cppbind)
[3/136] gen JS modules (bundle-modules)
Preprocess modules (7464ms)
Bundle modules (48ms)
Postprocesss modules (26ms)
Bundle Functions (495ms)
Generate Code (35ms)

[8.08s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/135] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_mimalloc_sys v0.0.0 (/workspace/bun/src/mimalloc_sys)
[1m[92m   Compiling[0m bun_alloc v0.0.0 (/workspace/bun/src/bun_alloc)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_libdeflate_sys v0.0.0 (/workspace/bun/src/libdeflate_sys)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp |  2 +-
 test/js/web/crypto/web-crypto.test.ts              | 33 ++++++++++++++++++++++
 2 files changed, 34 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcrypto/CryptoKeyRSAOpenSSL.cpp      1      1     20
test/js/web/crypto/web-crypto.test.ts                   6      6     19
```

</details>

<!-- robobun:evidence:end -->