### PR TITLE
webcrypto: decode an unwrapped JWK as UTF-8 and skip a byte order mark

### DIFF
--- a/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
@@ -1557,8 +1557,15 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
                     keyData = bytes;
                     break;
                 case SubtleCrypto::KeyFormat::Jwk: {
-                    String jwkString(bytes.span());
-                    auto jwkObject = JSONParse(&state, jwkString);
+                    // https://w3c.github.io/webcrypto/#concept-parse-a-jwk: the bytes go through UTF-8 decode,
+                    // which skips a leading byte order mark. Invalid UTF-8 yields a null string and so a
+                    // DataError below, as in Node and Chromium.
+                    static constexpr std::array<uint8_t, 3> utf8ByteOrderMark { 0xEF, 0xBB, 0xBF };
+                    auto jwkBytes = bytes.span();
+                    if (spanHasPrefix(jwkBytes, std::span { utf8ByteOrderMark }))
+                        jwkBytes = jwkBytes.subspan(utf8ByteOrderMark.size());
+                    String jwkString = String::fromUTF8(jwkBytes);
+                    auto jwkObject = jwkString.isNull() ? JSValue() : JSONParse(&state, jwkString);
                     if (scope.exception()) [[unlikely]] {
                         weakThis->m_pendingPromises.remove(index);
                         promise->reject(Exception { ExistingExceptionError });

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -123,6 +123,38 @@ describe("Web Crypto", () => {
       return { key, iv, wrapped };
     }
 
+    // https://w3c.github.io/webcrypto/#concept-parse-a-jwk runs the bytes through UTF-8
+    // decode, which drops a leading byte order mark; the bytes used to be read as Latin-1.
+    // Invalid UTF-8 is a DataError, as in Node and Chromium.
+    it("decodes the wrapped bytes as UTF-8 and skips a byte order mark", async () => {
+      const jwk = (kid: string) => `{"kty":"oct","k":"AAECAwQFBgcICQoLDA0ODw","alg":"A128GCM","kid":"${kid}"}`;
+      const encode = (s: string) => new TextEncoder().encode(s);
+      const unwrap = async (payload: Uint8Array) => {
+        const { key, iv, wrapped } = await setup(payload);
+        return crypto.subtle
+          .unwrapKey("jwk", wrapped, key, { name: "AES-GCM", iv }, { name: "AES-GCM" }, true, ["encrypt", "decrypt"])
+          .then(
+            async k => Buffer.from(await crypto.subtle.exportKey("raw", k)).toString("hex"),
+            e => `${e.name}: ${e.message}`,
+          );
+      };
+      expect({
+        plain: await unwrap(encode(jwk("a"))),
+        bom: await unwrap(encode("\uFEFF" + jwk("a"))),
+        "bom twice": await unwrap(encode("\uFEFF\uFEFF" + jwk("a"))),
+        "non-ASCII member": await unwrap(encode(jwk("ключ"))),
+        "invalid UTF-8": await unwrap(
+          Buffer.concat([encode(jwk("a").slice(0, -2)), Buffer.from([0xff, 0xfe]), encode('"}')]),
+        ),
+      }).toEqual({
+        plain: "000102030405060708090a0b0c0d0e0f",
+        bom: "000102030405060708090a0b0c0d0e0f",
+        "bom twice": "DataError: WrappedKey cannot be converted to a JSON object",
+        "non-ASCII member": "000102030405060708090a0b0c0d0e0f",
+        "invalid UTF-8": "DataError: WrappedKey cannot be converted to a JSON object",
+      });
+    });
+
     it("rejects when wrapped bytes are not valid JSON", async () => {
       const { key, iv, wrapped } = await setup(new TextEncoder().encode("not json {{{"));
       const err = await crypto.subtle


### PR DESCRIPTION
### Problem
- `subtle.unwrapKey("jwk", ...)` rejects a wrapped JWK whose JSON starts with a UTF-8 byte order mark with `DataError: WrappedKey cannot be converted to a JSON object`. Node 26 and Chromium unwrap it. Bun also accepted a wrapped JWK that is not valid UTF-8, which both reject.
- The cause is `SubtleCrypto::unwrapKey` (`src/jsc/bindings/webcrypto/SubtleCrypto.cpp:1560`). It built the JSON text from the decrypted bytes with the Latin-1 `String` constructor, so the BOM became the three characters `ï»¿` and `JSON.parse` failed.

### Fix
- Skip a leading `EF BB BF`, then decode the bytes with `String::fromUTF8`. A null result (invalid UTF-8) takes the existing `DataError` path.
- This follows the spec's "parse a JWK" steps, which run the bytes through UTF-8 decode, and UTF-8 decode skips a leading BOM. Node does the same with a fatal `TextDecoder`.
- Verified: `test/js/web/crypto/web-crypto.test.ts` ("decodes the wrapped bytes as UTF-8 and skips a byte order mark", fails on 1.4.3). Also the rest of `test/js/web/crypto/` and the vendored `test-webcrypto-wrap-unwrap.js`.

### Background
- `unwrapKey` decrypts the wrapped bytes with the unwrapping key, then imports the result as if `importKey` was called with it. For the `jwk` format the decrypted bytes are JSON text, so they are parsed into a `JsonWebKey` dictionary first.
- `wrapKey` produces those bytes with `JSON.stringify` and UTF-8 encoding, so a BOM only appears in payloads wrapped by other tools.

<details><summary>Notes</summary>

Repro (ledger #45335):

```js
const S = crypto.subtle, te = new TextEncoder();
const kek = await S.importKey("raw", new Uint8Array(32).fill(7), "AES-GCM", false, ["encrypt", "unwrapKey"]);
for (const [label, json] of [["plain", '{"kty":"oct","k":"AAECAwQFBgcICQoLDA0ODw","alg":"A128GCM"}'], ["BOM", '\uFEFF{"kty":"oct","k":"AAECAwQFBgcICQoLDA0ODw","alg":"A128GCM"}']]) {
  const iv = new Uint8Array(12).fill(2), w = await S.encrypt({ name: "AES-GCM", iv }, kek, te.encode(json));
  console.log(label, await S.unwrapKey("jwk", w, kek, { name: "AES-GCM", iv }, "AES-GCM", true, ["encrypt"]).then(() => "unwrapped", e => e.name));
}
```

bun 1.4.3: plain unwrapped, BOM DataError. node 26.3.0 and Chromium 148: both unwrapped.

The Encoding spec's "UTF-8 decode" uses the replacement error mode, so strictly a lone invalid byte inside an ignored member would still import. Node (fatal `TextDecoder`) and Chromium (its JSON reader) both reject invalid UTF-8, and this change does the same.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [4.06ms]
(pass) Web Crypto > keeps event loop alive [330.60ms]
(pass) Web Crypto > has globals [3.39ms]
(pass) Web Crypto > should encrypt and decrypt [14.43ms]
(pass) Web Crypto > should verify and sign [38.14ms]
144 |         "bom twice": await unwrap(encode("\uFEFF\uFEFF" + jwk("a"))),
145 |         "non-ASCII member": await unwrap(encode(jwk("ключ"))),
146 |         "invalid UTF-8": await unwrap(
147 |           Buffer.concat([encode(jwk("a").slice(0, -2)), Buffer.from([0xff, 0xfe]), encode('"}')]),
148 |         ),
149 |       }).toEqual({
               ^
error: expect(received).toEqual(expected)

  {
-   "bom": "000102030405060708090a0b0c0d0e0f",
+   "bom": "DataError: WrappedKey cannot be converted to a JSON object",
    "bom twice": "DataError: WrappedKey cannot be converted to a JSON object",
-   "invalid UTF-8": "DataError: WrappedKey cannot be converted to a JSON object",

... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (293912558)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.04ms]
(pass) Web Crypto > keeps event loop alive [7.79ms]
(pass) Web Crypto > has globals [0.05ms]
(pass) Web Crypto > should encrypt and decrypt [0.32ms]
(pass) Web Crypto > should verify and sign [0.88ms]
144 |         "bom twice": await unwrap(encode("\uFEFF\uFEFF" + jwk("a"))),
145 |         "non-ASCII member": await unwrap(encode(jwk("ключ"))),
146 |         "invalid UTF-8": await unwrap(
147 |           Buffer.concat([encode(jwk("a").slice(0, -2)), Buffer.from([0xff, 0xfe]), encode('"}')]),
148 |         ),
149 |       }).toEqual({
               ^
error: expect(received).toEqual(expected)

  {
-   "bom": "000102030405060708090a0b0c0d0e0f",
+   "bom": "DataError: WrappedKey cannot be converted to a JSON object",
    "bom twice": "DataError: WrappedKey cannot be converted to a JSON object",
-   "invalid UTF-8": "DataError: WrappedKey cannot be converted to a JSON object",
+   "invalid UTF-8": "000102030405060708090a0b0c0d0e0f",
    "non-ASCII member": "000102030405060708090a0b0c0d0e0f",
    "plain": "000102030405060708090a0b0c0d0e0f",
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.77ms]
(pass) Web Crypto > keeps event loop alive [259.60ms]
(pass) Web Crypto > has globals [3.20ms]
(pass) Web Crypto > should encrypt and decrypt [14.52ms]
(pass) Web Crypto > should verify and sign [37.54ms]
(pass) Web Crypto > unwrapKey JWK error handling > decodes the wrapped bytes as UTF-8 and skips a byte order mark [46.79ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [10.31ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [10.85ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [11.44ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2528.26ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [316.61ms]
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 615ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/136] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/136] gen cpp.rs (cppbind)
[3/136] gen JS modules (bundle-modules)
Preprocess modules (7580ms)
Bundle modules (45ms)
Postprocesss modules (20ms)
Bundle Functions (487ms)
Generate Code (25ms)

[8.17s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/135] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_mimalloc_sys v0.0.0 (/workspace/bun/src/mimalloc_sys)
[1m[92m   Compiling[0m bun_alloc v0.0.0 (/workspace/bun/src/bun_alloc)
[1m[92m   Compiling[0m bun_libdeflate_sys v0.0.0 (/workspace/bun/src/libdeflate_sys)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcrypto/SubtleCrypto.cpp | 11 ++++++++--
 test/js/web/crypto/web-crypto.test.ts       | 32 +++++++++++++++++++++++++++++
 2 files changed, 41 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/webcrypto/SubtleCrypto.cpp      4      4     20
test/js/web/crypto/web-crypto.test.ts            6      6     19
```

</details>

<!-- robobun:evidence:end -->