### PR TITLE
dev server: let the error page drop failures that a build fixed before its HMR socket subscribed

### DIFF
--- a/src/runtime/bake/client/overlay.ts
+++ b/src/runtime/bake/client/overlay.ts
@@ -365,7 +365,7 @@ function expandHighlight(line: string, col: number) {
  * Call this for each error, then call `updateErrorOverlay` to commit the
  * changes to the UI in one smooth motion.
  */
-export function decodeAndAppendServerError(r: DataViewReader) {
+export function decodeAndAppendServerError(r: DataViewReader): FailureOwner {
   const owner = r.u32();
   const file = r.string32() || null;
   const messageCount = r.u32();
@@ -378,6 +378,7 @@ export function decodeAndAppendServerError(r: DataViewReader) {
 
   activeErrorIndex = -1;
   needUpdateNavbar = true;
+  return owner;
 }
 
 /**

--- a/src/runtime/bake/dev_server/hmr_socket.rs
+++ b/src/runtime/bake/dev_server/hmr_socket.rs
@@ -6,8 +6,10 @@ use bun_uws_sys::{Opcode, SendStatus};
 
 use crate::timer::EventLoopTimerState;
 
+use super::serialized_failure::{Owner, OwnerPacked, Packed};
 use super::source_map_store::{self, RemoveOrUpgradeMode};
 use super::{ConsoleLogKind, DevServer, HmrTopic, IncomingMessageId, MessageId};
+use crate::bake::Side;
 use crate::bake::dev_server_body::HmrTopicBits;
 
 // Struct definition lives in `dev_server/mod.rs` so the public
@@ -293,6 +295,32 @@ impl HmrSocket {
                 };
                 // SAFETY: JS-thread only; sole `&mut DevServer` for this scope.
                 unsafe { self.dev() }.source_maps.unref(kv.0);
+            }
+            x if x == IncomingMessageId::CheckErrors as u8 => {
+                let (owners, trailing) = msg[1..].as_chunks::<4>();
+                if !trailing.is_empty() {
+                    return ws.close();
+                }
+                // SAFETY: JS-thread only; sole `&mut DevServer` for this scope.
+                let dev = unsafe { self.dev() };
+                let mut response: Vec<u8> = vec![MessageId::Errors.char(), 0, 0, 0, 0];
+                let mut removed: u32 = 0;
+                for owner in owners {
+                    let key = match Packed::from_bits(u32::from_le_bytes(*owner)).decode() {
+                        Owner::Client(file) => OwnerPacked::new(Side::Client, file.get()),
+                        Owner::Server(file) => OwnerPacked::new(Side::Server, file.get()),
+                        Owner::None | Owner::Route(_) => continue,
+                    };
+                    if !dev.bundling_failures.contains_key(&key) {
+                        response.extend_from_slice(owner);
+                        removed += 1;
+                    }
+                }
+                if removed == 0 {
+                    return;
+                }
+                response[1..5].copy_from_slice(&removed.to_le_bytes());
+                let _ = ws.send(&response, Opcode::Binary, false, true);
             }
             _ => ws.close(),
         }

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -112,6 +112,11 @@ pub enum IncomingMessageId {
     TestingBatchEvents = b'H',
     ConsoleLog = b'l',
     UnrefSourceMap = b'u',
+    /// The error page lists the owner (`u32`) of every failure it was rendered
+    /// with. Owners that no longer have an entry in `bundling_failures` are
+    /// sent back as removed in a `MessageId::Errors` frame. This covers a
+    /// build that finished before this socket subscribed to `HmrTopic::Errors`.
+    CheckErrors = b'e',
 }
 
 /// `DevServer.HmrTopic`. Discriminants are the HMR wire protocol and MUST

--- a/src/runtime/bake/hmr-runtime-error.ts
+++ b/src/runtime/bake/hmr-runtime-error.ts
@@ -6,20 +6,22 @@
 // This is embedded in `DevServer.sendSerializedFailures`. SSR is
 // left unused for simplicity; a flash of unstyled content is
 // stopped by the fact this script runs synchronously.
-import { DataViewReader } from "./client/data-view";
+import { DataViewReader, DataViewWriter } from "./client/data-view";
 import { decodeAndAppendServerError, onServerErrorPayload, updateErrorOverlay } from "./client/overlay";
 import { initWebSocket } from "./client/websocket";
 import "./debug";
-import { MessageId } from "./generated";
+import { IncomingMessageId, MessageId } from "./generated";
 
 /** Injected by DevServer */
 declare const error: Uint8Array<ArrayBuffer>;
 
+/** The owner of every failure this page was rendered with. */
+const embeddedOwners: number[] = [];
 {
   const reader = new DataViewReader(new DataView(error.buffer), 0);
   while (reader.hasMoreData()) {
     try {
-      decodeAndAppendServerError(reader);
+      embeddedOwners.push(decodeAndAppendServerError(reader));
     } catch (e) {
       console.error(e);
       break;
@@ -41,6 +43,16 @@ const ws = initWebSocket({
       location.reload();
     }
     ws.send("se"); // IncomingMessageId.subscribe with errors
+    // A build that finished between this page being rendered and the
+    // subscribe above published its `errors` frame to nobody. Ask which of
+    // the embedded failures are already resolved; the reply is an `errors`
+    // frame that removes them.
+    const check = DataViewWriter.initCapacity(1 + 4 * embeddedOwners.length);
+    check.u8(IncomingMessageId.check_errors);
+    for (const owner of embeddedOwners) {
+      check.u32(owner);
+    }
+    ws.send(check.view.buffer);
   },
 
   [MessageId.errors]: onServerErrorPayload,

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -154,6 +154,108 @@ devTest("import then create", {
     await c.expectMessage("data");
   },
 });
+devTest("error page drops failures that a build fixed before its hmr socket subscribed", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["/script.ts"],
+    }),
+    "script.ts": `
+      import { a } from "./a";
+      import { b } from "./b";
+      console.log(a, b);
+    `,
+    "a.ts": `
+      export const a = (1;
+    `,
+    "b.ts": `
+      export const b = (2;
+    `,
+  },
+  async test(dev) {
+    // Walks the failures embedded in the error page as `let error=...`. The
+    // layout is written by serialized_failure.rs and read by overlay.ts.
+    function embeddedFailures(html: string) {
+      const match = html.match(/error=Uint8Array\.from\(atob\("([^"]*)"\)/);
+      expect(match).not.toBeNull();
+      const bytes = Buffer.from(match![1], "base64");
+      let cursor = 0;
+      const u32 = () => ((cursor += 4), bytes.readUInt32LE(cursor - 4));
+      const string32 = () => {
+        const length = u32();
+        cursor += length;
+        return bytes.toString("utf8", cursor - length, cursor);
+      };
+      const location = () => {
+        if (u32() === 0) return; // line, 0 means no location
+        u32(); // column
+        u32(); // length
+        string32(); // line text
+      };
+      const failures: { owner: number; file: string }[] = [];
+      while (cursor < bytes.length) {
+        const owner = u32();
+        const file = string32();
+        for (let messages = u32(); messages > 0; messages--) {
+          cursor += 1; // kind
+          string32(); // text
+          location();
+          for (let notes = u32(); notes > 0; notes--) {
+            string32();
+            location();
+          }
+        }
+        failures.push({ owner, file });
+      }
+      return failures;
+    }
+
+    // The route fails to bundle, so a page load gets the error page. Its
+    // script renders the embedded failures, opens /_bun/hmr, subscribes to
+    // the errors topic and reloads once every failure it knows is removed.
+    const page = await dev.fetch("/");
+    expect(page.status).toBe(500);
+    const failures = embeddedFailures(await page.text());
+    expect(failures.map(f => f.file).sort()).toEqual(["a.ts", "b.ts"]);
+    const ownerA = failures.find(f => f.file === "a.ts")!.owner;
+    const ownerB = failures.find(f => f.file === "b.ts")!.owner;
+
+    // a.ts is fixed before that page's socket subscribed. The errors frame of
+    // this build is published to nobody.
+    await dev.write("a.ts", "export const a = 1;");
+
+    // Replay the error page handshake. After subscribing it lists the owners
+    // it was rendered with, and the server answers with an errors frame that
+    // removes the ones that no longer fail. b.ts still fails and must stay.
+    const reply = await new Promise<Buffer>((resolve, reject) => {
+      const ws = new WebSocket(dev.baseUrl.replace(/^http/, "ws") + "/_bun/hmr");
+      ws.binaryType = "arraybuffer";
+      ws.onmessage = event => {
+        const data = Buffer.from(event.data as ArrayBuffer);
+        switch (String.fromCharCode(data[0])) {
+          case "V": {
+            ws.send("se"); // IncomingMessageId.subscribe, HmrTopic.errors
+            const check = Buffer.alloc(1 + 4 + 4);
+            check.write("e", 0); // IncomingMessageId.check_errors
+            check.writeUInt32LE(ownerA, 1);
+            check.writeUInt32LE(ownerB, 5);
+            ws.send(check);
+            break;
+          }
+          case "e": // MessageId.errors
+            resolve(data);
+            ws.close();
+            break;
+        }
+      };
+      ws.onerror = () => reject(new Error("hmr socket error"));
+      ws.onclose = () => reject(new Error("hmr socket closed without an errors frame"));
+    });
+    const removedCount = reply.readUInt32LE(1);
+    const removed = Array.from({ length: removedCount }, (_, i) => reply.readUInt32LE(5 + 4 * i));
+    const addedBytes = reply.length - (5 + 4 * removedCount);
+    expect({ removed, addedBytes }).toEqual({ removed: [ownerA], addedBytes: 0 });
+  },
+});
 devTest("external links", {
   files: {
     "index.html": `


### PR DESCRIPTION
### Problem
- The dev server error page never reloads if the build that fixes its failures ends before the page's HMR socket subscribed to the errors topic. Topic frames only reach current subscribers, and the page reloads only once `errors` frames removed every embedded failure.
- No user reported this. Found by reading the code, reproduced by a socket replay.

### Fix
- After `se`, the error page sends a new `IncomingMessageId::CheckErrors` (`e`) frame with the `u32` owner of each embedded failure.
- The server answers with a normal `errors` frame that removes the owners absent from `dev.bundling_failures` (nothing if all still fail). The existing handler reloads once none are left.
- Correct because frames run in order on the JS thread: a build finished before the check, or it publishes to this socket, now subscribed. uWS drains queued topic frames before a direct `send`.
- Verified: new test in `test/bake/dev/html.test.ts` (fails on stock bun) and the other `test/bake/dev` suites. Self-reviewed: surviving concerns were about this description (see Notes), none about code.

### Background
- `send_serialized_failures` (`DevServer.rs`) answers a page load of a failing route with HTML that embeds the failures and `bake.error.js` (`hmr-runtime-error.ts`). It opens `/_bun/hmr` and sends `se` on the `V` frame.
- Frames start with a one-byte id (`dev_server/mod.rs`). An `errors` frame is: `u32` removed count, removed owners, added `SerializedFailure` records.
- A wire owner is `serialized_failure::Packed` (kind, file index), which `HmrSocket::on_message` maps to the `bundling_failures` key. File slots are never reused, so owners cannot alias.

<details><summary>Notes</summary>

- Repro without a browser, on bun 1.4.3-canary (f42e98025): `index.html` loads `main.js`, which imports `dep.js` with a syntax error. `GET /` returns the 500 error page with the failure embedded. Fix `dep.js`, poll `GET /` until the real page is served, then open `/_bun/hmr` and send `se` on the `V` frame. The only frame that ever arrives is `V`, so the page's reload condition can never fire. With this change the same socket, after also sending the check frame, receives an `e` frame `[1, owner]`.
- The new test does the same through the dev test harness with two failing files, fixes one, and expects the reply to remove exactly that owner and keep the other. On stock bun the server closes the socket on the unknown incoming frame, so the test fails there.
- Suites run locally on the debug build: `html`, `bundle`, `hot`, `css`, `esm`, `harness` in `test/bake/dev/`, all green. `cargo clippy -p bun_runtime` is clean.
- Reach. The window is wider than the socket handshake. A save that lands while a build runs is queued (`next_bundle.reload_event`) and bundled right after it (`start_next_bundle_if_present`), so the fixing build can finish before the browser has parsed the error page and opened its socket. In release builds `check_route_failures` also rebuilds a failing route on every page load (`assume_perfect_incremental_bundling` is off there), which puts one more build in front of the page. One manual reload recovers, and a fresh tab is never affected.
- Why a page-scoped query instead of pushing the error state when a socket subscribes (what webpack-dev-server, rsbuild and Next.js do): the server does not know which failures a given page was rendered with. `check_route_failures` embeds only the failures reachable from the route, `finalize_bundle` embeds all current ones, and an `errors` frame removes by owner id. A push of the full current set cannot remove a stale owner the page holds without a new "replace all" frame that both runtimes would have to handle. The query reuses the existing frame and handler and costs one small frame per error page load, answered only when something is stale.
- #42041 closes the same kind of gap for the normal client runtime: it sends `i` plus its bundle generation after subscribing and gets a `FullReload` (`R`) reply when that generation is gone. The error page loads no bundle and has no generation, so it cannot use that check. The two PRs touch different enums and different arms of `on_message` and do not depend on each other. A maintainer may later fold both into one on-subscribe hook in `HmrSocket`.
- The normal client runtime has no embedded failures at load and full-reloads on every reconnect, so it does not send the new frame.
- `Owner::None` and `Owner::Route` never reach a client today (`index_failures` treats them as unreachable). The handler skips them instead of reporting them removed, so a future route-owned failure cannot cause a reload loop.
- The reply only removes. If another file started failing in the missed build, the page reloads once its own failures are gone and gets a fresh error page for whatever still fails on that route.
- `generated.ts` is produced by `bake-codegen.ts` from the Rust enum, so the client reads the new id as `IncomingMessageId.check_errors`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bake/dev/html.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/165] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/165] gen compressed/codegen/bake.error.js.zst
[3/165] gen compressed/codegen/bake.client.js.zst
[4/165] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[5/165] gen cpp.rs (cppbind)
[5/165] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-2
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/bake/dev/html.test.ts:
Dev server testing directory: /tmp/bun-dev-test-f23FBC
[0;30mdev|[0m Started development server: http://localhost:35361
[0;30mdev|[0m [32mBundled page in 2ms[0m[2m:[0m index.html
[0;30mdev|[0m [32mReloaded in 1ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 1ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x3][0m [32mReloaded in 3ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x4][0m [32mReloaded in 1ms[0m[2m:[0m script.ts
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV:html-1: html file is watched [737.32ms]
[0;30mdev|[0m Started development server: http://localhost:46243
[0;30mdev|[0m [32mBundled page in 3ms[0m[2m:
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bake/dev/html.test.ts
bun test v1.4.3 (f42e98025)

test/bake/dev/html.test.ts:
Dev server testing directory: /tmp/bun-dev-test-i7JgS9
[0;30mdev|[0m Started development server: http://localhost:43935
[0;30mdev|[0m [32mBundled page in 50ms[0m[2m:[0m index.html
[0;30mdev|[0m [32mReloaded in 45ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 33ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x3][0m [32mReloaded in 29ms[0m[2m:[0m index.html
[0;30mweb|[0m [I] [Bun] Server-side code changed, reloading!
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [36m[x4][0m [32mReloaded in 27ms[0m[2m:[0m script.ts
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
(pass)  DEV:h
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3e26dc108a
  features     baseline

23 deps, 131 codegen, 1172 objects in 665ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [11.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [3.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [9.00ms]
[7/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[8/1243] gen .bind.ts → GeneratedBindings.cpp
[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] fetch zlib
[zlib] up to date
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/client/overlay.ts        |   3 +-
 src/runtime/bake/dev_server/hmr_socket.rs |  28 ++++++++
 src/runtime/bake/dev_server/mod.rs        |   5 ++
 src/runtime/bake/hmr-runtime-error.ts     |  18 +++++-
 test/bake/dev/html.test.ts                | 102 ++++++++++++++++++++++++++++++
 5 files changed, 152 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/bake/client/overlay.ts             1      2     12
src/runtime/bake/dev_server/hmr_socket.rs      2      3     12
src/runtime/bake/dev_server/mod.rs             1      1     12
src/runtime/bake/hmr-runtime-error.ts          1      1     12
test/bake/dev/html.test.ts                     2      1     12
```

</details>

<!-- robobun:evidence:end -->