### PR TITLE
fuzzilli: stub process.exit and process.kill in the REPRL wrapper

### DIFF
--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -42,6 +42,13 @@ if (responseBytes !== 4) {
   throw new Error(`REPRL handshake failed: expected 4 bytes, got ${responseBytes}`);
 }
 
+// process.exit ends the REPRL child, and process.kill reaches the child, the
+// fuzzer (its parent) and every other REPRL child in the same process group.
+// Fuzzed scripts must not be able to do either.
+process.exit = process.reallyExit = () => {};
+process.kill = () => true;
+process._kill = () => 0;
+
 // Main REPRL loop
 while (true) {
   // Read command

--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -42,9 +42,8 @@ if (responseBytes !== 4) {
   throw new Error(`REPRL handshake failed: expected 4 bytes, got ${responseBytes}`);
 }
 
-// process.exit ends the REPRL child, and process.kill reaches the child, the
-// fuzzer (its parent) and every other REPRL child in the same process group.
-// Fuzzed scripts must not be able to do either.
+// Fuzzed scripts must not end the REPRL child, or signal it, the fuzzer (its
+// parent) or the other REPRL children in the same process group.
 process.exit = process.reallyExit = () => {};
 process.kill = () => true;
 process._kill = () => 0;

--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -42,8 +42,7 @@ if (responseBytes !== 4) {
   throw new Error(`REPRL handshake failed: expected 4 bytes, got ${responseBytes}`);
 }
 
-// Fuzzed scripts must not end the REPRL child, or signal it, the fuzzer (its
-// parent) or the other REPRL children in the same process group.
+// Likewise for exiting, and for signalling this process, the fuzzer, or sibling REPRL children.
 process.exit = process.reallyExit = () => {};
 process.kill = () => true;
 process._kill = () => 0;

--- a/test/js/bun/util/fuzzilli-reprl.fixture.ts
+++ b/test/js/bun/util/fuzzilli-reprl.fixture.ts
@@ -32,7 +32,8 @@ const statuses: number[] = [];
 const realFstatSync = fs.fstatSync;
 const realReadSync = fs.readSync;
 const realWriteSync = fs.writeSync;
-const realExit = process.exit.bind(process);
+// process.exit goes through process.reallyExit, which the wrapper stubs.
+const realExit = process.reallyExit.bind(process);
 
 (fs as any).fstatSync = function (fd: any, ...rest: any[]) {
   if (fd === REPRL_CRFD) return {} as any;

--- a/test/js/bun/util/fuzzilli-reprl.fixture.ts
+++ b/test/js/bun/util/fuzzilli-reprl.fixture.ts
@@ -1,9 +1,8 @@
 // Drives the fuzzilli REPRL loop with in-process mocks for the control/data
 // FDs so the real src/js/eval/fuzzilli-reprl.ts source can be exercised in a
-// normal (non-fuzzilli) build. Feeds a payload that calls process.execve with
-// a nonexistent path: the real implementation prints an error and aborts the
-// process (SIGABRT) when exec fails, so the REPRL wrapper must stub it out
-// before running fuzzed scripts.
+// normal (non-fuzzilli) build. Each argv entry is fed to the loop as one exec
+// cycle, followed by EOF. Prints `STATUSES=<exit codes> LIVE=<bool>` and exits
+// 0 only if every payload got a status back and the last one still ran.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -12,10 +11,7 @@ const REPRL_CRFD = 100;
 const REPRL_CWFD = 101;
 const REPRL_DRFD = 102;
 
-const payloads = [
-  Buffer.from(`process.execve("fuzzilli-reprl-execve-does-not-exist", []);`, "utf8"),
-  Buffer.from(`globalThis.stillAlive = true;`, "utf8"),
-];
+const payloads = [...process.argv.slice(2), `globalThis.stillAlive = true;`].map(p => Buffer.from(p, "utf8"));
 
 // Script the control-read pipe (fd 100): HELO handshake, then one exec cycle
 // per payload (each followed by the 8-byte length), then EOF.
@@ -31,11 +27,12 @@ let controlStream = Buffer.concat(controlChunks);
 // Data-read pipe (fd 102): the payload for each exec cycle.
 let dataStream = Buffer.concat(payloads);
 
-let statusWrites = 0;
+const statuses: number[] = [];
 
 const realFstatSync = fs.fstatSync;
 const realReadSync = fs.readSync;
 const realWriteSync = fs.writeSync;
+const realExit = process.exit.bind(process);
 
 (fs as any).fstatSync = function (fd: any, ...rest: any[]) {
   if (fd === REPRL_CRFD) return {} as any;
@@ -61,7 +58,7 @@ const realWriteSync = fs.writeSync;
 (fs as any).writeSync = function (fd: any, buffer: any, ...rest: any[]) {
   if (fd === REPRL_CWFD) {
     if (Buffer.isBuffer(buffer) && buffer.length === 4 && buffer.toString() !== "HELO") {
-      statusWrites++;
+      statuses.push(buffer.readUInt32LE(0) >> 8);
     }
     return Buffer.isBuffer(buffer) ? buffer.length : String(buffer).length;
   }
@@ -77,6 +74,6 @@ const reprlSource = fs.readFileSync(
 );
 (0, eval)(reprlSource);
 
-const liveAfterExecve = (globalThis as any).stillAlive === true;
-realWriteSync.call(fs, 1, `STATUS_WRITES=${statusWrites} LIVE=${liveAfterExecve}\n`);
-process.exit(statusWrites === 2 && liveAfterExecve ? 0 : 1);
+const live = (globalThis as any).stillAlive === true;
+realWriteSync.call(fs, 1, `STATUSES=${statuses.join(",")} LIVE=${live}\n`);
+realExit(statuses.length === payloads.length && live ? 0 : 1);

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -6,18 +6,42 @@ import path from "node:path";
 // fuzzer-generated scripts in-process. APIs that intentionally kill the
 // process outside of normal exception handling must be stubbed out before the
 // loop starts, otherwise every fuzz case reaching them is reported as a
-// crash. process.execve is one of those: on success it replaces the process
-// image, which would silently end the REPRL loop.
-test("REPRL loop survives a payload that calls process.execve", async () => {
+// crash. The fixture drives the real wrapper source with mocked REPRL fds,
+// feeds it each payload plus a final `globalThis.stillAlive = true`, and
+// prints the exit code the wrapper reported for every payload.
+async function run(...payloads: string[]) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "fuzzilli-reprl-execve.fixture.ts")],
+    cmd: [bunExe(), path.join(import.meta.dir, "fuzzilli-reprl.fixture.ts"), ...payloads],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "pipe",
+    stderr: "inherit",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  return { stdout: stdout.trim(), exitCode };
+}
 
-  expect(stdout).toContain("STATUS_WRITES=2 LIVE=true");
-  expect(exitCode).toBe(0);
+// process.execve replaces the process image on success, which would silently
+// end the REPRL loop.
+test.concurrent("REPRL loop survives a payload that calls process.execve", async () => {
+  expect(await run(`process.execve("fuzzilli-reprl-execve-does-not-exist", []);`)).toEqual({
+    stdout: "STATUSES=0,0 LIVE=true",
+    exitCode: 0,
+  });
+});
+
+// process.exit ends the child. process.kill can signal the child itself, the
+// fuzzer (its parent) and the other REPRL children (pid 0 is the whole
+// process group). Only the child's own pid is used here, so that a regression
+// cannot signal the test runner.
+test.concurrent("REPRL loop survives payloads that call process.exit and process.kill", async () => {
+  expect(
+    await run(
+      `process.exit(3); process.reallyExit(4);`,
+      `process.kill(process.pid, "SIGKILL"); process.kill(process.pid); process._kill(process.pid, 9);`,
+    ),
+  ).toEqual({
+    stdout: "STATUSES=0,0,0 LIVE=true",
+    exitCode: 0,
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fuzzilli filed a flaky crash (fingerprint `6cd5c4817cd3fef2`): `TERMSIG: 9`, empty stderr, execution time 2575 ms against the profile's 2500 ms timeout. The program is harmless (a resizable `ArrayBuffer`, a `MessageChannel`, `URLPattern`, `Temporal`, then the `Bun.gc(true)` suffix). It runs clean in about 50 ms with `build/debug-fuzz/bun-debug`, standalone and 500 times in a row in one REPRL child over real REPRL fds. I could not reproduce the kill.

A SIGKILL with no sanitizer output comes from outside the child. It is not libreprl's timeout: that kill returns status `0x10000` and Fuzzilli files it as a timeout, not as signal 9. That leaves the kernel OOM killer, or another process that calls `kill(2)`. Fuzzed scripts are such a process. The wrapper runs them in-process and the Bun profile hands them `process`:

- `process.exit()` / `process.reallyExit()` end the child. Fuzzilli sees EOF, scores the program by its exit code, and respawns the child.
- `process.kill(process.pid, sig)` ends the child with a signal. Fuzzilli files that as a crash.
- `process.kill(process.ppid, sig)` signals FuzzilliCli.
- `process.kill(0, sig)` signals the whole process group: FuzzilliCli and every REPRL child of every job. libreprl does not move children into their own group.
- Any other pid (for example a `Bun.spawn(...).pid`, which `BunSpawnGenerator` loads into a variable, plus a small mutation) can be a sibling REPRL child. That sibling is then filed as a flaky `TERMSIG 9` crash with empty stderr for whatever program it was running. That is the shape of this report.

This PR stubs `process.exit`, `process.reallyExit`, `process.kill` and `process._kill` before the loop starts, next to the `process.execve` stub from #31759. (`process.abort` is already stubbed by the profile's code prefix.) The stubs go in after the handshake because the fd check before it still uses the real `process.exit`.

Checked over real REPRL fds, with `build/debug-fuzz/bun-debug` running the wrapper source and a small libreprl stand-in as the parent, in its own session and process group:

| program | old wrapper | this PR |
| --- | --- | --- |
| `process.exit(0)` | child gone, `exit 0` | status 0, next program runs |
| `process.kill(process.pid, "SIGKILL")` | `signal 9` | status 0, next program runs |
| `process.kill(0, 9)` | child and the parent driver killed | status 0, parent alive |
| `process.kill(-1, 9)` (as root in a container) | every process in the container killed | not rerun, same stub |

Trade-off: a script can no longer deliver a signal to its own process, so a `process.on("SIGUSR1")` listener plus `process.kill(process.pid, "SIGUSR1")` is not exercised under the fuzzer. The Bun profile has no generator for signal listeners.

Relation to #42027: that PR replaces this wrapper with a native loop and a fresh global per program. It addresses the other explanation for kills like this one (resource growth in a long-lived child). Its per-global prelude stubs only `process.execve`, so it needs these four stubs too, whichever PR lands first.

### How did you verify your code works?

- `test/js/bun/util/fuzzilli-reprl.test.ts`: the fixture (renamed from `fuzzilli-reprl-execve.fixture.ts`) now takes its payloads from argv and prints the status the wrapper reported for each one. The execve test keeps its payload. The new test feeds `process.exit(3); process.reallyExit(4);` and `process.kill(process.pid, "SIGKILL"); process.kill(process.pid); process._kill(process.pid, 9);`, and expects three status-0 reports and a live loop. It only targets the fixture's own pid, so a regression cannot signal the test runner.
- With the wrapper source from main, the new test fails (the fixture exits with code 3 at `process.exit(3)`) and the execve test passes. With this change both pass. The test reads the wrapper from `src/`, so this holds for `USE_SYSTEM_BUN=1 bun test` and for the debug build alike.
- The REPRL runs in the table above.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/fuzzilli-reprl.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/util/fuzzilli-reprl.test.ts:
(pass) REPRL loop survives a payload that calls process.execve [581.26ms]
38 |   expect(
39 |     await run(
40 |       `process.exit(3); process.reallyExit(4);`,
41 |       `process.kill(process.pid, "SIGKILL"); process.kill(process.pid); process._kill(process.pid, 9);`,
42 |     ),
43 |   ).toEqual({
         ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stdout": "STATUSES=0,0,0 LIVE=true",
+   "exitCode": 3,
+   "stdout": "",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/bun/util/fuzzilli-reprl.test.ts:43:5)
(fail) REPRL loop survives payloads that call process.exit and process.kill [593.40ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [2.81s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (7c8d1d4c1)

test/js/bun/util/fuzzilli-reprl.test.ts:
38 |   expect(
39 |     await run(
40 |       `process.exit(3); process.reallyExit(4);`,
41 |       `process.kill(process.pid, "SIGKILL"); process.kill(process.pid); process._kill(process.pid, 9);`,
42 |     ),
43 |   ).toEqual({
         ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stdout": "STATUSES=0,0,0 LIVE=true",
+   "exitCode": 3,
+   "stdout": "",
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/bun/util/fuzzilli-reprl.test.ts:43:5)
(fail) REPRL loop survives payloads that call process.exit and process.kill [10.37ms]
(pass) REPRL loop survives a payload that calls process.execve [13.54ms]

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [81.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/fuzzilli-reprl.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/util/fuzzilli-reprl.test.ts:
(pass) REPRL loop survives payloads that call process.exit and process.kill [479.18ms]
(pass) REPRL loop survives a payload that calls process.execve [600.89ms]

 2 pass
 0 fail
 2 expect() calls
Ran 2 tests across 1 file. [2.71s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 812ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (13264ms)
Bundle modules (79ms)
Postprocesss modules (28ms)
Bundle Functions (635ms)
Generate Code (38ms)

[14.05s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/eval/fuzzilli-reprl.ts                      |  5 +++
 ...execve.fixture.ts => fuzzilli-reprl.fixture.ts} | 24 ++++++-------
 test/js/bun/util/fuzzilli-reprl.test.ts            | 40 +++++++++++++++++-----
 3 files changed, 48 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js/eval/fuzzilli-reprl.ts                   5      7     17
test/js/bun/util/fuzzilli-reprl.fixture.ts      3      6     15
test/js/bun/util/fuzzilli-reprl.test.ts         3      6     12
```

</details>

<!-- robobun:evidence:end -->