### PR TITLE
Bump mordant so an alias used by an impl counts as used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ exclude = ["vendor"]
 # (see its rust-toolchain), which must still be able to compile this workspace.
 [workspace.metadata.dylint]
 libraries = [
-    { git = "https://github.com/scarletindustries/mordant", rev = "0ad62943c6e649d05057554703d571aa7f7c6654" },
+    { git = "https://github.com/scarletindustries/mordant", rev = "0d9bacefbd6d6a5f3c8341205b31f2fbe7dea750" },
 ]
 
 [workspace.package]

--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -184,7 +184,7 @@
 "unused_pub:src/runtime/api/bun/h2/connection.rs" = 5
 "unused_pub:src/runtime/api/bun/h2/wire.rs" = 2
 "unused_pub:src/runtime/ipc.rs" = 3
-"unused_pub:src/runtime/node.rs" = 2
+"unused_pub:src/runtime/node.rs" = 1
 "unused_pub:src/runtime/node/node_fs.rs" = 2
 "unused_pub:src/runtime/node/types.rs" = 1
 "unused_pub:src/runtime/webcore/Blob.rs" = 1


### PR DESCRIPTION
Bumps Mordant so an `impl` written against a type alias counts as a use of the alias and `--tests` builds are ignored; the baseline drops the one finding that fixes.