### PR TITLE
Bump WebKit (oven-sh/WebKit#596 preview): Set methods compare a set-like size of 2^32 or more correctly

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "cf1b36ec8703d8e87436094d21d478d358c7d886";
+export const WEBKIT_VERSION = "autobuild-preview-pr-596-50c11bf6";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/set-methods-set-like-size.test.ts
+++ b/test/js/bun/jsc/set-methods-set-like-size.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+
+// The Set methods take any "set-like" with a numeric `size`, a `has()` and a
+// `keys()`. GetSetRecord (https://tc39.es/ecma262/#sec-getsetrecord) keeps that
+// size as an unbounded integer or +Infinity, and each method compares it with
+// the receiver's size to pick a strategy: ask `other.has()` about each of the
+// receiver's elements, or iterate `other.keys()`. JSC used to truncate the size
+// to uint32 first, so a set-like reporting 2^32 or more elements compared as
+// size mod 2^32 and the methods consulted the wrong side.
+
+const sizes = [
+  0,
+  1,
+  2,
+  3,
+  2 ** 31,
+  2 ** 32 - 1,
+  2 ** 32,
+  2 ** 32 + 1,
+  2 ** 32 + 2,
+  2 ** 33,
+  2 ** 53 - 1,
+  2 ** 53,
+  2 ** 53 + 2,
+  2 ** 64,
+  1e300,
+  Number.MAX_VALUE,
+  Infinity,
+];
+
+// A set-like whose has() claims exactly the value 1 and whose keys() yields
+// exactly the value 1, independent of the size it reports. It logs every
+// observable interaction so the chosen strategy is visible.
+function makeSetLike(size: number) {
+  const log: string[] = [];
+  const setLike = {
+    get size() {
+      log.push("size");
+      return size;
+    },
+    has(v: unknown) {
+      log.push("has:" + String(v));
+      return v === 1;
+    },
+    keys() {
+      log.push("keys");
+      let done = false;
+      return {
+        next() {
+          log.push("next");
+          if (done) return { value: undefined, done: true };
+          done = true;
+          return { value: 1, done: false };
+        },
+        return() {
+          log.push("return");
+          return {};
+        },
+      };
+    },
+  };
+  return { setLike, log };
+}
+
+// What the spec algorithms do for a receiver of `thisSize` elements against a
+// set-like reporting `otherSize`, given the has()/keys() behaviour above.
+function expected(method: string, receiver: number[], otherSize: number) {
+  const thisSize = receiver.length;
+  const hasCalls = receiver.map(v => "has:" + v);
+  switch (method) {
+    case "union":
+      return { result: [...new Set([...receiver, 1])], log: ["size", "keys", "next", "next"] };
+    case "symmetricDifference":
+      return {
+        result: receiver.includes(1) ? receiver.filter(v => v !== 1) : [...receiver, 1],
+        log: ["size", "keys", "next", "next"],
+      };
+    case "intersection":
+      return thisSize <= otherSize
+        ? { result: receiver.filter(v => v === 1), log: ["size", ...hasCalls] }
+        : { result: receiver.includes(1) ? [1] : [], log: ["size", "keys", "next", "next"] };
+    case "difference":
+      return thisSize <= otherSize
+        ? { result: receiver.filter(v => v !== 1), log: ["size", ...hasCalls] }
+        : { result: receiver.filter(v => v !== 1), log: ["size", "keys", "next", "next"] };
+    case "isSubsetOf":
+      if (thisSize > otherSize) return { result: false, log: ["size"] };
+      // Stops at the first element other.has() rejects.
+      return {
+        result: receiver.every(v => v === 1),
+        log: ["size", ...hasCalls.slice(0, receiver.findIndex(v => v !== 1) + 1 || receiver.length)],
+      };
+    case "isSupersetOf":
+      if (thisSize < otherSize) return { result: false, log: ["size"] };
+      // keys() yields 1; if the receiver lacks it the iterator is closed early.
+      return receiver.includes(1)
+        ? { result: true, log: ["size", "keys", "next", "next"] }
+        : { result: false, log: ["size", "keys", "next", "return"] };
+    case "isDisjointFrom":
+      if (thisSize <= otherSize) {
+        // Stops at the first element other.has() accepts.
+        const i = receiver.indexOf(1);
+        return { result: i === -1, log: ["size", ...hasCalls.slice(0, i === -1 ? receiver.length : i + 1)] };
+      }
+      return receiver.includes(1)
+        ? { result: false, log: ["size", "keys", "next", "return"] }
+        : { result: true, log: ["size", "keys", "next", "next"] };
+  }
+  throw new Error(method);
+}
+
+const methods = [
+  "union",
+  "intersection",
+  "difference",
+  "symmetricDifference",
+  "isSubsetOf",
+  "isSupersetOf",
+  "isDisjointFrom",
+] as const;
+
+const receivers = [[], [1], [2], [1, 2], [2, 3], [2, 1, 3]];
+
+describe.each(methods)("Set.prototype.%s", method => {
+  test.each(sizes)("set-like with size %p", size => {
+    for (const receiver of receivers) {
+      const { setLike, log } = makeSetLike(size);
+      const raw = (new Set(receiver) as any)[method](setLike);
+      const result = raw instanceof Set ? [...raw] : raw;
+      expect({ receiver, size, result, log }).toEqual({ receiver, size, ...expected(method, receiver, size) });
+    }
+  });
+
+  test("negative sizes throw RangeError, even beyond -2^32", () => {
+    for (const size of [-1, -(2 ** 31), -(2 ** 32), -(2 ** 32) - 1, -(2 ** 53), -1e300, -Infinity]) {
+      const { setLike, log } = makeSetLike(size);
+      expect(() => (new Set([1]) as any)[method](setLike)).toThrow(RangeError);
+      expect(log).toEqual(["size"]);
+    }
+  });
+
+  test("sizes that coerce to NaN throw TypeError", () => {
+    for (const size of [NaN, undefined, "x", {}]) {
+      const { setLike, log } = makeSetLike(size as number);
+      expect(() => (new Set([1]) as any)[method](setLike)).toThrow(TypeError);
+      expect(log).toEqual(["size"]);
+    }
+  });
+
+  test("fractional sizes truncate toward zero before the comparison", () => {
+    // 1.9 truncates to 1, so a two-element receiver is larger than the set-like.
+    const { setLike, log } = makeSetLike(1.9);
+    const raw = (new Set([1, 2]) as any)[method](setLike);
+    const result = raw instanceof Set ? [...raw] : raw;
+    expect({ result, log }).toEqual(expected(method, [1, 2], 1));
+  });
+});

--- a/test/js/bun/jsc/set-methods-set-like-size.test.ts
+++ b/test/js/bun/jsc/set-methods-set-like-size.test.ts
@@ -83,13 +83,12 @@ function expected(method: string, receiver: number[], otherSize: number) {
       return thisSize <= otherSize
         ? { result: receiver.filter(v => v !== 1), log: ["size", ...hasCalls] }
         : { result: receiver.filter(v => v !== 1), log: ["size", "keys", "next", "next"] };
-    case "isSubsetOf":
+    case "isSubsetOf": {
       if (thisSize > otherSize) return { result: false, log: ["size"] };
       // Stops at the first element other.has() rejects.
-      return {
-        result: receiver.every(v => v === 1),
-        log: ["size", ...hasCalls.slice(0, receiver.findIndex(v => v !== 1) + 1 || receiver.length)],
-      };
+      const i = receiver.findIndex(v => v !== 1);
+      return { result: i === -1, log: ["size", ...hasCalls.slice(0, i === -1 ? receiver.length : i + 1)] };
+    }
     case "isSupersetOf":
       if (thisSize < otherSize) return { result: false, log: ["size"] };
       // keys() yields 1; if the receiver lacks it the iterator is closed early.
@@ -139,8 +138,9 @@ describe.each(methods)("Set.prototype.%s", method => {
     }
   });
 
-  test("sizes that coerce to NaN throw TypeError", () => {
-    for (const size of [NaN, undefined, "x", {}]) {
+  test("sizes that coerce to NaN or cannot coerce throw TypeError", () => {
+    // NaN after ToNumber, or ToNumber itself throws (BigInt, Symbol).
+    for (const size of [NaN, undefined, "x", {}, 1n, Symbol("size")]) {
       const { setLike, log } = makeSetLike(size as number);
       expect(() => (new Set([1]) as any)[method](setLike)).toThrow(TypeError);
       expect(log).toEqual(["size"]);


### PR DESCRIPTION
### Problem
- The ES2025 Set methods give wrong results for a set-like whose `size` is 2^32 or more. `new Set([1]).isSubsetOf({ size: 2 ** 32, has: v => v === 1, keys })` returns `false`, `isDisjointFrom` returns `true`, `intersection` is empty. `2^32 - 1` and `Infinity` are correct. Node follows the spec.
- The cause is `getSetSizeAsInt()` in JSC's `runtime/SetPrototype.cpp:215`. It special-cases `Infinity` and passes every other double through `static_cast<uint32_t>`, which wraps. So `2^32` compares as `0` and each method takes the wrong branch of "`thisSize <= otherSize`: call `other.has()`, else iterate `other.keys()`".

### Fix
- Pin WebKit to `autobuild-preview-pr-596-50c11bf6`, the preview build of oven-sh/WebKit#596. That change clamps the size at `UINT32_MAX` instead of casting it. A `JSSet` never holds that many elements (its storage is capped at 2^28 slots), so every comparison keeps the spec result.
- The pin is a preview tag. Do not merge before oven-sh/WebKit#596 lands. I move the pin to the merged commit then. The preview is the current pin (`cf1b36ec8703`) plus the one commit of oven-sh/WebKit#596.
- Verified: `test/js/bun/jsc/set-methods-set-like-size.test.ts` (new) fails 45 of 140 on bun 1.4.3 and passes with `bun bd test` against this prebuilt. More in the notes.

### Background
- The seven Set methods accept any "set-like": an object with a numeric `size` and callable `has` and `keys`. A real `Set` takes a fast path instead.
- [GetSetRecord](https://tc39.es/ecma262/#sec-getsetrecord) applies `ToIntegerOrInfinity` to `size` and keeps it unbounded. Five methods compare it with the receiver's size to choose between calling `other.has()` per element and iterating `other.keys()`.

<details><summary>Notes</summary>

- The choice between `has()` and `keys()` shows in the result whenever the two disagree, which is normal for a predicate-backed set-like such as `{ size: Number.MAX_SAFE_INTEGER, has }`.
- The test drives all seven methods with one set-like whose `has()` accepts only `1` and whose `keys()` yields only `1`. It logs each `size` / `has` / `keys` / `next` / `return` interaction and compares the result and the log with what the spec algorithm does for that receiver and size, for 17 sizes from 0 through 2^64, 1e300, `Number.MAX_VALUE` and `Infinity`. The same oracle passes all 721 cells under Node 26 (V8). Under bun 1.4.3 it fails exactly the five size-dependent methods (`intersection`, `difference`, `isSubsetOf`, `isSupersetOf`, `isDisjointFrom`) for the nine sizes from 2^32 up.
- `2^53 - 1` passes on the old engine by accident: it is `2^32 - 1` mod 2^32. `2^53 + 2` behaved as `2`. `isSupersetOf` on the old engine iterated `keys()` where the spec returns `false` after reading `size`.
- Also ran `test/js/bun/jsc/bun-jsc.test.ts` and `test/js/web/web-globals.test.js` with this prebuilt, and the 162 JSC `set-*` stress tests and 764 test262 `built-ins/Set` cases against a local `jsc` built from the same WebKit commit.
- Upstream WebKit `main` has the same code; the WebKit patch applies to it unchanged.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/set-methods-set-like-size.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/set-methods-set-like-size.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/jsc/set-methods-set-like-size.test.ts:
(pass) Set.prototype.union > set-like with size 0 [44.90ms]
(pass) Set.prototype.union > set-like with size 1 [6.02ms]
(pass) Set.prototype.union > set-like with size 2 [8.44ms]
(pass) Set.prototype.union > set-like with size 3 [10.22ms]
(pass) Set.prototype.union > set-like with size 2147483648 [9.03ms]
(pass) Set.prototype.union > set-like with size 4294967295 [9.70ms]
(pass) Set.prototype.union > set-like with size 4294967296 [6.52ms]
(pass) Set.prototype.union > set-like with size 4294967297 [5.45ms]
(pass) Set.prototype.union > set-like with size 4294967298 [8.00ms]
(pass) Set.prototype.union > set-like with size 8589934592 [4.85ms]
(pass) Set.prototype.union > set-like with size 9007199254740991 [7.89ms]
(pass) Set.prototype.union > set-like with size 9007199254740992 [5.55ms]
(pass) Set.prototype.union > set-like with size 9007199254740994 [5.37ms]
(pass) Set.prototype.union > set-like with size 18446744073709552000 [4.94ms]
(pass) Set.prototype.union > set-like with size 1e+300 [4.98ms]
(pass) Set.prototype.union > set-like with size 1.7976931348623157e+308 [4.03ms]
(pass) Set.prototype.union > set-like with size Infinity [5.27ms]
(pass) Set.prototype.union > negative sizes throw RangeError, even beyond -2^32 [12.61ms]
(pass) Set.prototype.union > sizes that coerce to NaN or cannot coerce throw TypeError [12.93ms]
(pass) Set.prototype.union > fractional sizes truncate toward zero before the comparison [3.78ms]
(pass) Set.prototype.intersection > set-like with size 0 [7.20ms]
(pass) Set.prototype.intersection > set-like with size 1 [9.03ms]
(pass) Set.prototype.intersection > set-like with size 2 [4.28ms]
(pass) Set.prototype.intersection > set-like with size 3 [4.80ms]
(pass) Set.prototype.intersection > set-like with size 2147483648 [5.47ms
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                      |   2 +-
 test/js/bun/jsc/set-methods-set-like-size.test.ts | 157 ++++++++++++++++++++++
 2 files changed, 158 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
scripts/build/deps/webkit.ts                           1      1     10
test/js/bun/jsc/set-methods-set-like-size.test.ts      1      3     10
```

</details>

<!-- robobun:evidence:end -->
