### PR TITLE
RegExp: accept a raw U+0000 inside a v-flag character class (oven-sh/WebKit#595)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-595-25396e7c";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/regexp-v-flag.test.ts
+++ b/test/js/bun/jsc/regexp-v-flag.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+// Tests for the RegExp `v` flag (UnicodeSets mode) parser in JavaScriptCore's Yarr.
+
+describe("raw U+0000 in a v-mode class set", () => {
+  // U+0000 is a SourceCharacter that is neither a ClassSetSyntaxCharacter nor half of a
+  // ClassSetReservedDoublePunctuator, so it is a valid ClassSetCharacter. It already parsed
+  // with the `u` flag, outside a class with `v`, and as `\0` / `\x00`.
+  const NUL = "\0";
+
+  test.each([
+    ["[" + NUL + "]", [NUL], ["a", "0"]],
+    ["[a" + NUL + "]", [NUL, "a"], ["b"]],
+    ["[" + NUL + "a]", [NUL, "a"], ["b"]],
+    ["[" + NUL + NUL + "]", [NUL], ["a"]],
+    ["[" + NUL + "-a]", [NUL, "\x01", "A", "a"], ["b"]],
+    ["[\\x00-" + NUL + "]", [NUL], ["\x01"]],
+    ["[^" + NUL + "]", ["a", "\x01"], [NUL]],
+    ["[[" + NUL + "]]", [NUL], ["a"]],
+    ["[[a-z]" + NUL + "]", [NUL, "q"], ["Q"]],
+    ["[\\q{" + NUL + "}]", [NUL], ["a"]],
+    ["[\\q{a" + NUL + "b|c}]", ["a" + NUL + "b", "c"], ["ab", NUL]],
+    ["[" + NUL + "&&" + NUL + "]", [NUL], ["a"]],
+    ["[\\x00&&" + NUL + "]", [NUL], ["a"]],
+    ["[a&&" + NUL + "]", [], [NUL, "a"]],
+    ["[\\w--" + NUL + "]", ["a"], [NUL]],
+    ["[[" + NUL + "a]--" + NUL + "]", ["a"], [NUL]],
+  ] as [string, string[], string[]][])("%j", (source, matching, nonMatching) => {
+    const regExp = new RegExp("^" + source + "$", "v");
+    for (const string of matching) expect(regExp.test(string)).toBe(true);
+    for (const string of nonMatching) expect(regExp.test(string)).toBe(false);
+  });
+
+  test("the RegExp.escape composition accepts an input with a NUL", () => {
+    // RegExp.escape leaves U+0000 as is, so this is the documented way to build a class
+    // from arbitrary input.
+    const regExp = new RegExp("[" + RegExp.escape("a" + NUL + "b") + "]", "v");
+    expect(regExp.test(NUL)).toBe(true);
+    expect(regExp.test("b")).toBe(true);
+    expect(regExp.test("c")).toBe(false);
+  });
+
+  test("syntax characters and reserved punctuators next to a NUL are still rejected", () => {
+    for (const source of [
+      "[" + NUL + "(]",
+      "[" + NUL + "|]",
+      "[" + NUL + "&&&a]",
+      "[" + NUL + "!!]",
+      "[" + NUL + "-]",
+      "[\\q{" + NUL + "(}]",
+      "[\\" + NUL + "]",
+    ]) {
+      expect(() => new RegExp(source, "v")).toThrow(SyntaxError);
+    }
+  });
+});


### PR DESCRIPTION
### Problem
- A raw U+0000 inside a character class is a `SyntaxError: Invalid regular expression: invalid class set character` with the `v` flag. The `u` flag, a NUL outside a class, and the escaped forms `\0` / `\x00` all parse. V8 (node v26.3.0, Chromium 148) and the spec accept it: U+0000 is a SourceCharacter that is neither a ClassSetSyntaxCharacter nor a ClassSetReservedDoublePunctuator.
- `RegExp.escape()` leaves U+0000 as is by design, so the documented composition `new RegExp("[" + RegExp.escape(s) + "]", "v")` throws for any input that contains a NUL. `\q{...}` with a raw NUL fails the same way.
- The cause is `consumeAndCheckIfValidClassSetCharacter()` in JavaScriptCore's `yarr/YarrParser.h`. It returns an error for `ch == 0` before its `strchr()` syntax-character checks. `strchr(s, 0)` matches the string terminator, so NUL has to skip those checks, but the early return reported an error instead of returning the character.

### Fix
- Pin WebKit to `autobuild-preview-pr-595-25396e7c`, the preview build of oven-sh/WebKit#595. That change returns the character when it is 0. The parser delegates already handle code point 0: the escaped forms reach them with the same value.
- The pin is a preview tag, not a merge commit. Do not merge before oven-sh/WebKit#595 lands. I move the pin to the `autobuild-<sha>` release of the merge commit then. The preview is built on oven-sh/WebKit `main` (10350ddde9), three commits ahead of the current pin.
- Verified: `test/js/bun/jsc/regexp-v-flag.test.ts` fails 17 of 18 cases on 1.4.3 and passes on a debug build with this pin. Also ran `test/js/web/urlpattern/` and `test/js/bun/util/escapeRegExp.test.ts` (410 pass), and 345 `regexp*`/`yarr*` JSTests stress files on the preview `jsc` shell with no change against the current pin.

### Background
- The `v` flag (ES2024 UnicodeSets mode) gives character classes a stricter grammar than `u`: nested classes, `\q{...}` string alternatives, and the `&&` / `--` set operations. Yarr parses a `v`-mode class in `parseClassSet()`, separate from the `u`-mode `parseCharacterClass()`, which never had this check.
- In that grammar `( ) [ ] { } / - \ |` are ClassSetSyntaxCharacters and must be escaped, and a doubled punctuator such as `&&` or `!!` is reserved. Every other code point stands for itself.
- Yarr is JSC's RegExp engine. Bun links a prebuilt JSC from oven-sh/WebKit releases, selected by `WEBKIT_VERSION` in `scripts/build/deps/webkit.ts`.

<details><summary>Notes</summary>

- Source: a `RegExp.escape` then compile self-match sweep (600 generated strings x flags) against node v26.3.0. This was the only divergence attributable to bun in that round. `RegExp.escape` output itself was byte-identical to V8 on all inputs.
- Upstream WebKit `main` has the same code in `consumeAndCheckIfValidClassSetCharacter()`.
- The sibling function `isIdentityEscapeAnError()` has the mirror-image `|| !ch`, which is correct there: `\` + NUL is not a valid IdentityEscape in Unicode mode, and V8 rejects it too. The new test keeps that case as a SyntaxError.
- The 11 JSTests stress files that fail on the preview `jsc` shell fail identically on the current pin's shell (missing `$vm` / `--useRegExpBufferBoundaries` options, debug+ASAN timeouts, and `regexp-unicode-code-unit-read-for-bmp-terms.js`).

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/regexp-v-flag.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/regexp-v-flag.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/jsc/regexp-v-flag.test.ts:
(pass) raw U+0000 in a v-mode class set > "[\u0000]" [22.71ms]
(pass) raw U+0000 in a v-mode class set > "[a\u0000]" [3.26ms]
(pass) raw U+0000 in a v-mode class set > "[\u0000a]" [2.10ms]
(pass) raw U+0000 in a v-mode class set > "[\u0000\u0000]" [2.05ms]
(pass) raw U+0000 in a v-mode class set > "[\u0000-a]" [2.26ms]
(pass) raw U+0000 in a v-mode class set > "[\\x00-\u0000]" [1.99ms]
(pass) raw U+0000 in a v-mode class set > "[^\u0000]" [1.60ms]
(pass) raw U+0000 in a v-mode class set > "[[\u0000]]" [1.99ms]
(pass) raw U+0000 in a v-mode class set > "[[a-z]\u0000]" [1.72ms]
(pass) raw U+0000 in a v-mode class set > "[\\q{\u0000}]" [1.93ms]
(pass) raw U+0000 in a v-mode class set > "[\\q{a\u0000b|c}]" [2.82ms]
(pass) raw U+0000 in a v-mode class set > "[\u0000&&\u0000]" [1.41ms]
(pass) raw U+0000 in a v-mode class set > "[\\x00&&\u0000]" [1.92ms]
(pass) raw U+0000 in a v-mode class set > "[a&&\u0000]" [1.39ms]
(pass) raw U+0000 in a v-mode class set > "[\\w--\u0000]" [2.28ms]
(pass) raw U+0000 in a v-mode class set > "[[\u0000a]--\u0000]" [1.93ms]
(pass) raw U+0000 in a v-mode class set > the RegExp.escape composition accepts an input with a NUL [9.28ms]
(pass) raw U+0000 in a v-mode class set > syntax characters and reserved punctuators next to a NUL are still rejected [18.35ms]

 18 pass
 0 fail
 52 expect() calls
Ran 18 tests across 1 file. [2.58s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts          |  2 +-
 test/js/bun/jsc/regexp-v-flag.test.ts | 56 +++++++++++++++++++++++++++++++++++
 2 files changed, 57 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
scripts/build/deps/webkit.ts               1      1      4
test/js/bun/jsc/regexp-v-flag.test.ts      0      1      4
```

</details>

**root cause** · written by the author bot

The class set tokenizer in Yarr used a return value of 0 to signal "no valid class set character," which made a literal U+0000 in the pattern indistinguishable from a parse failure, so `[\0]` with the `v` flag was rejected as an invalid class set character even though the spec treats NUL as an ordinary SourceCharacter. The fix changes `consumeAndCheckIfValidClassSetCharacter()` to report validity separately from the consumed code point instead of overloading 0 as a sentinel, so U+0000 is accepted and matched like any other class set character. This restores the documented `new RegExp('[' + …

<!-- robobun:evidence:end -->