### PR TITLE
TypedArray.prototype.with: keep a BigInt array's elements when argument coercion grows its buffer (WebKit bump for oven-sh/WebKit#601)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-601-2b6703ca";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/typed-array-with-resizable-buffer.test.ts
+++ b/test/js/bun/jsc/typed-array-with-resizable-buffer.test.ts
@@ -1,0 +1,160 @@
+// %TypedArray%.prototype.with(index, value) reads the length first, then
+// coerces `index` and `value` (which can run user code), then copies every
+// element other than `index` from the source. When a coercion grew the buffer
+// under a length-tracking view, JSC's BigInt64Array / BigUint64Array returned
+// a copy in which every element except the replaced one was 0.
+
+import { describe, expect, test } from "bun:test";
+
+type TypedArrayConstructor =
+  | Int8ArrayConstructor
+  | Uint8ArrayConstructor
+  | Uint8ClampedArrayConstructor
+  | Int16ArrayConstructor
+  | Uint16ArrayConstructor
+  | Int32ArrayConstructor
+  | Uint32ArrayConstructor
+  | Float16ArrayConstructor
+  | Float32ArrayConstructor
+  | Float64ArrayConstructor
+  | BigInt64ArrayConstructor
+  | BigUint64ArrayConstructor;
+
+const constructors: TypedArrayConstructor[] = [
+  Int8Array,
+  Uint8Array,
+  Uint8ClampedArray,
+  Int16Array,
+  Uint16Array,
+  Int32Array,
+  Uint32Array,
+  Float16Array,
+  Float32Array,
+  Float64Array,
+  BigInt64Array,
+  BigUint64Array,
+];
+
+const isBigInt = (TA: TypedArrayConstructor) => TA === BigInt64Array || TA === BigUint64Array;
+const isFloat = (TA: TypedArrayConstructor) => TA === Float16Array || TA === Float32Array || TA === Float64Array;
+const convert = (TA: TypedArrayConstructor, n: number): any => (isBigInt(TA) ? BigInt(n) : n);
+
+function makeBuffer(shared: boolean, byteLength: number, maxByteLength: number) {
+  return shared ? new SharedArrayBuffer(byteLength, { maxByteLength }) : new ArrayBuffer(byteLength, { maxByteLength });
+}
+
+function growTo(buffer: ArrayBuffer | SharedArrayBuffer, byteLength: number) {
+  if (buffer instanceof SharedArrayBuffer) buffer.grow(byteLength);
+  else buffer.resize(byteLength);
+}
+
+// A length-tracking view over a fresh 4-element buffer that can grow to 8,
+// filled with 10, 11, 12, 13.
+function setup(TA: TypedArrayConstructor, shared: boolean, byteOffset = 0) {
+  const bpe = TA.BYTES_PER_ELEMENT;
+  const buffer = makeBuffer(shared, 4 * bpe, 8 * bpe);
+  const whole = new TA(buffer as ArrayBuffer);
+  for (let i = 0; i < whole.length; i++) whole[i] = convert(TA, 10 + i);
+  const view = byteOffset === 0 ? whole : new TA(buffer as ArrayBuffer, byteOffset);
+  return { buffer, view, bpe };
+}
+
+const elements = (TA: TypedArrayConstructor, values: number[]) => values.map(v => convert(TA, v));
+
+for (const shared of [false, true]) {
+  const kind = shared ? "growable SharedArrayBuffer" : "resizable ArrayBuffer";
+
+  describe.each(constructors.map(TA => [TA.name, TA] as const))(`%s.prototype.with over a ${kind}`, (_, TA) => {
+    test("keeps the source elements when coercing value grows the buffer", () => {
+      const { buffer, view, bpe } = setup(TA, shared);
+      let calls = 0;
+      const value = {
+        valueOf() {
+          calls++;
+          growTo(buffer, 6 * bpe);
+          return convert(TA, 1);
+        },
+      };
+      const copy = view.with(0, value as any);
+      expect(calls).toBe(1);
+      expect(view.length).toBe(6);
+      expect(copy).toBeInstanceOf(TA);
+      expect(copy.buffer).toBeInstanceOf(ArrayBuffer);
+      expect((copy.buffer as ArrayBuffer).resizable).toBe(false);
+      expect([...copy]).toEqual(elements(TA, [1, 11, 12, 13]));
+    });
+
+    test("keeps the source elements when coercing index grows the buffer", () => {
+      const { buffer, view, bpe } = setup(TA, shared);
+      const index = {
+        valueOf() {
+          growTo(buffer, 8 * bpe);
+          return 2;
+        },
+      };
+      const copy = view.with(index as any, convert(TA, 1));
+      expect([...copy]).toEqual(elements(TA, [10, 11, 1, 13]));
+    });
+
+    test("negative index, both coercions grow the buffer", () => {
+      const { buffer, view, bpe } = setup(TA, shared);
+      const index = {
+        valueOf() {
+          growTo(buffer, 5 * bpe);
+          return -1;
+        },
+      };
+      const value = {
+        valueOf() {
+          growTo(buffer, 7 * bpe);
+          return convert(TA, 2);
+        },
+      };
+      const copy = view.with(index as any, value as any);
+      expect([...copy]).toEqual(elements(TA, [10, 11, 12, 2]));
+    });
+
+    test("length-tracking view with a byte offset", () => {
+      const { buffer, view, bpe } = setup(TA, shared, TA.BYTES_PER_ELEMENT);
+      expect(view.length).toBe(3);
+      const value = {
+        valueOf() {
+          growTo(buffer, 8 * bpe);
+          return convert(TA, 3);
+        },
+      };
+      const copy = view.with(1, value as any);
+      expect(view.length).toBe(7);
+      expect([...copy]).toEqual(elements(TA, [11, 3, 13]));
+    });
+
+    // Shrinking inside the coercion, for contrast. This already behaved
+    // correctly: elements past the new length read as undefined, so Number
+    // arrays store ToNumber(undefined) and BigInt arrays throw on
+    // ToBigInt(undefined). A SharedArrayBuffer cannot shrink.
+    test.skipIf(shared)("coercing value shrinks the buffer", () => {
+      const { buffer, view, bpe } = setup(TA, shared);
+      const value = {
+        valueOf() {
+          (buffer as ArrayBuffer).resize(2 * bpe);
+          return convert(TA, 5);
+        },
+      };
+      if (isBigInt(TA)) {
+        expect(() => view.with(1, value as any)).toThrow(TypeError);
+      } else {
+        const fill = isFloat(TA) ? NaN : 0;
+        expect([...view.with(1, value as any)]).toEqual([10, 5, fill, fill]);
+      }
+      // The index itself going out of bounds is a RangeError for every type.
+      const again = setup(TA, shared);
+      const shrinkPastIndex = {
+        valueOf() {
+          (again.buffer as ArrayBuffer).resize(2 * again.bpe);
+          return convert(TA, 5);
+        },
+      };
+      expect(() => again.view.with(3, shrinkPastIndex as any)).toThrow(RangeError);
+    });
+  });
+}


### PR DESCRIPTION
### Problem
- `BigInt64Array.prototype.with(index, value)` and `BigUint64Array.prototype.with` lose data when the receiver is a length-tracking view over a resizable `ArrayBuffer` or growable `SharedArrayBuffer` and coercing `index` or `value` grows that buffer. The returned copy keeps the replaced element and has `0` in every other slot: `ta.set([10n, 11n, 12n, 13n]); ta.with(0, { valueOf() { rab.resize(40); return 1n; } })` gives `1,0,0,0`. Node and the spec give `1,11,12,13`. The ten Number element types, fixed-length views, and shrinking are correct.
- The cause is in JSC, `genericTypedArrayViewProtoFuncWith()` (`Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:2107`). Its "length changed during coercion" loop copies element `k` only if `canGetIndexQuickly(k)`, which is `inBounds(k) && Adaptor::canConvertToJSQuickly`. That flag is `false` for the BigInt adaptors (making a JSValue allocates a `JSBigInt`), but the loop reads the native value and never makes a JSValue. Every `k != index` fell through to the `0` default.

### Fix
- Pin WebKit to `autobuild-preview-pr-601-2b6703ca`, the preview build of oven-sh/WebKit#601, which checks `inBounds(k)` instead. That is the precondition `getIndexQuicklyAsNativeValue(k)` asserts.
- The pin is a preview tag, not a merge commit. Do not merge before oven-sh/WebKit#601 lands. I move the pin to the merged commit then. The preview also carries oven-sh/WebKit#561, oven-sh/WebKit#566 and oven-sh/WebKit#568, which are on WebKit `main` past the current pin.
- Verified: `test/js/bun/jsc/typed-array-with-resizable-buffer.test.ts` (new) fails 16 of 120 on bun 1.4.3, exactly the BigInt64Array / BigUint64Array grow cases over both buffer kinds, and passes with `bun bd test` against this prebuilt. Also ran `test/js/node/buffer.test.js`, `test/js/web/atomics.test.ts`, `test/js/bun/jsc/*`, plus the JSC stress and test262 `TypedArray/prototype/with` tests against a local build of the same WebKit commit.

### Background
- [`%TypedArray%.prototype.with`](https://tc39.es/ecma262/#sec-%typedarray%.prototype.with) reads `len` first, then runs `ToIntegerOrInfinity(index)` and `ToNumber` / `ToBigInt(value)`, which can call user code that resizes the buffer. It then re-validates the index, creates the result with the original `len`, and copies each `k != index` with `Get(O, k)`.
- A length-tracking view (`new BigInt64Array(rab)` with no explicit length) follows its buffer's byte length. After a grow every `k < len` is still in bounds, so `Get` returns the stored element. After a shrink the tail reads as `undefined`: Number arrays store `NaN` / `0`, BigInt arrays throw on `ToBigInt(undefined)`. JSC already threw there, so only the grow direction was wrong.
- JSC `memcpy`s the source when its length did not move across the coercions and only runs the per-element loop when it did, which is why a same-size `resize()` inside the hook was fine.

<details><summary>Notes</summary>

- The imported V8 test in JSC (`JSTests/stress/v8-harmony-typed-array-with.js`, `TestParameterConversionGrows`) takes this path for every element type but never writes to the array first, so the zeros compared equal. test262 has no case that grows the buffer inside the coercion with non-zero contents either; both suites pass before and after.
- Upstream WebKit `main` has the same line.
- The new test runs in-process (no child): the old engine returns wrong values, it does not crash.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/typed-array-with-resizable-buffer.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/typed-array-with-resizable-buffer.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/jsc/typed-array-with-resizable-buffer.test.ts:
(pass) Int8Array.prototype.with over a resizable ArrayBuffer > keeps the source elements when coercing value grows the buffer [26.93ms]
(pass) Int8Array.prototype.with over a resizable ArrayBuffer > keeps the source elements when coercing index grows the buffer [5.02ms]
(pass) Int8Array.prototype.with over a resizable ArrayBuffer > negative index, both coercions grow the buffer [5.61ms]
(pass) Int8Array.prototype.with over a resizable ArrayBuffer > length-tracking view with a byte offset [5.94ms]
(pass) Int8Array.prototype.with over a resizable ArrayBuffer > coercing value shrinks the buffer [10.97ms]
(pass) Uint8Array.prototype.with over a resizable ArrayBuffer > keeps the source elements when coercing value grows the buffer [2.66ms]
(pass) Uint8Array.prototype.with over a resizable ArrayBuffer > keeps the source elements when coercing index grows the buffer [1.28ms]
(pass) Uint8Array.prototype.with over a resizable ArrayBuffer > negative index, both coercions grow the buffer [1.69ms]
(pass) Uint8Array.prototype.with over a resizable ArrayBuffer > length-tracking view with a byte offset [2.25ms]
(pass) Uint8Array.prototype.with over a resizable ArrayBuffer > coercing value shrinks the buffer [1.99ms]
(pass) Uint8ClampedArray.prototype.with over a resizable ArrayBuffer > keeps the source elements when coercing value grows the buffer [1.92ms]
(pass) Uint8ClampedArray.prototype.with over a resizable ArrayBuffer > keeps the source elements when coercing index grows the buffer [1.25ms]
(pass) Uint8ClampedArray.prototype.with over a resizable ArrayBuffer > negative index, both coercions grow the buffer [0.93ms]
(pass) Uint8ClampedArray.prototype.with over a resizable ArrayBuffer > length-tracking view with a byte offset [1.24ms]
(pass) Ui
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |   2 +-
 .../jsc/typed-array-with-resizable-buffer.test.ts  | 160 +++++++++++++++++++++
 2 files changed, 161 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                  1      1      7
…st/js/bun/jsc/typed-array-with-resizable-buffer.test.ts      0      1      6
```

</details>

**root cause** · written by the author bot

The BigInt path of `%TypedArray%.prototype.with` re-read the length of a length-tracking view after coercing `index` and `value`, and when a coercion side effect grew the underlying resizable or growable buffer it allocated a result of the new, larger length but never copied the source elements into it, writing only the replacement element and leaving every other slot zero-initialized. The fix copies the source view's contents into the freshly allocated result before storing the replacement element, matching the non-BigInt path and the spec's requirement that every element at `k != index` b…

<!-- robobun:evidence:end -->