### PR TITLE
TypedArray search: an integer needle that a Float32Array or Float16Array cannot hold matches nothing (oven-sh/WebKit#604)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-604-a9c83095";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/typed-array-indexof.test.ts
+++ b/test/js/bun/jsc/typed-array-indexof.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+// %TypedArray%.prototype.indexOf / lastIndexOf compare with IsStrictlyEqual and includes with
+// SameValueZero, on Number values. A needle that the element type cannot hold exactly is equal
+// to no element, so it must not match the element it would round to when stored.
+
+type FloatArray = Float16Array | Float32Array | Float64Array;
+
+function search(array: FloatArray, needle: number) {
+  return { indexOf: array.indexOf(needle), lastIndexOf: array.lastIndexOf(needle), includes: array.includes(needle) };
+}
+
+/** The expected result of search() when the only match is at `index` (-1 for none). */
+const at = (index: number) => ({ indexOf: index, lastIndexOf: index, includes: index !== -1 });
+
+const scratch = new Float64Array(1);
+/** The same number, read back from a Float64Array so that JSC holds it as a double rather than an int32. */
+function asDouble(value: number): number {
+  scratch[0] = value;
+  return scratch[0];
+}
+
+describe("integer needle that the element type cannot represent", () => {
+  // The needles below are integer literals at the call site on purpose: JSC encodes those as
+  // int32, which is the path that skipped the representability check.
+
+  test("Float32Array", () => {
+    const array = new Float32Array([16777216, 2147483648, -16777216, -2147483648, 1]);
+    // 24-bit significand: 2^24 + 1 rounds to 2^24 and 2^31 - 1 rounds to 2^31 as a float.
+    expect(search(array, 16777216)).toEqual(at(0));
+    expect(search(array, 16777217)).toEqual(at(-1));
+    expect(search(array, 2147483647)).toEqual(at(-1));
+    expect(search(array, 2147483648)).toEqual(at(1));
+    expect(search(array, -16777216)).toEqual(at(2));
+    expect(search(array, -16777217)).toEqual(at(-1));
+    expect(search(array, -2147483647)).toEqual(at(-1));
+    expect(search(array, -2147483648)).toEqual(at(3));
+    expect(search(array, 1)).toEqual(at(4));
+  });
+
+  test("Float16Array", () => {
+    const array = new Float16Array([Infinity, 2048, 65504, -Infinity, -2048, 1]);
+    // 11-bit significand, largest finite value 65504: 2049 rounds to 2048, 65505..65519 round to
+    // 65504, and 65520 and above become Infinity as a half.
+    expect(search(array, Infinity)).toEqual(at(0));
+    expect(search(array, 65520)).toEqual(at(-1));
+    expect(search(array, 65535)).toEqual(at(-1));
+    expect(search(array, 65536)).toEqual(at(-1));
+    expect(search(array, 2147483647)).toEqual(at(-1));
+    expect(search(array, 2048)).toEqual(at(1));
+    expect(search(array, 2049)).toEqual(at(-1));
+    expect(search(array, 65504)).toEqual(at(2));
+    expect(search(array, 65505)).toEqual(at(-1));
+    expect(search(array, 65519)).toEqual(at(-1));
+    expect(search(array, -Infinity)).toEqual(at(3));
+    expect(search(array, -65520)).toEqual(at(-1));
+    expect(search(array, -2147483648)).toEqual(at(-1));
+    expect(search(array, -2048)).toEqual(at(4));
+    expect(search(array, -2049)).toEqual(at(-1));
+    expect(search(array, 1)).toEqual(at(5));
+  });
+
+  test("Float64Array holds every int32 exactly", () => {
+    const array = new Float64Array([2147483647, -2147483648, 16777217]);
+    expect(search(array, 2147483647)).toEqual(at(0));
+    expect(search(array, -2147483648)).toEqual(at(1));
+    expect(search(array, 16777217)).toEqual(at(2));
+    expect(search(array, 16777216)).toEqual(at(-1));
+  });
+
+  test("integer arithmetic and parseInt results behave like the literal", () => {
+    const array = new Float32Array([16777216]);
+    expect(array.indexOf(16777216.5 + 0.5)).toBe(-1);
+    expect(array.indexOf(parseInt("16777217"))).toBe(-1);
+    expect(array.indexOf(16777216 | 1)).toBe(-1);
+    expect(array.includes(2 ** 24 + 1)).toBe(false);
+  });
+
+  test("the same needle held as a double gives the same answer", () => {
+    // This path already did the check. It is here so that both encodings stay in agreement.
+    const f32 = new Float32Array([16777216, 2147483648]);
+    expect(search(f32, asDouble(16777217))).toEqual(at(-1));
+    expect(search(f32, asDouble(2147483647))).toEqual(at(-1));
+    expect(search(f32, asDouble(16777216))).toEqual(at(0));
+    expect(search(f32, 16777216.5)).toEqual(at(-1));
+    const f16 = new Float16Array([Infinity, 2048, 65504]);
+    expect(search(f16, asDouble(65520))).toEqual(at(-1));
+    expect(search(f16, asDouble(2049))).toEqual(at(-1));
+    expect(search(f16, asDouble(65505))).toEqual(at(-1));
+    expect(search(f16, asDouble(65504))).toEqual(at(2));
+  });
+});


### PR DESCRIPTION
### Problem
- `Float32Array` / `Float16Array` `indexOf`, `lastIndexOf` and `includes` match the element an integer needle rounds to when the element type cannot hold it: `new Float32Array([16777216]).indexOf(16777217)` is `0` and `new Float16Array([Infinity]).includes(65520)` is `true`. V8 and the spec (IsStrictlyEqual / SameValueZero on Numbers) say -1 / false.
- Only an int32-encoded needle hits (a literal, `parseInt`, integer arithmetic). The same value read from a `Float64Array` already missed.
- Cause: `FloatTypedArrayAdaptor::toNativeFromInt32WithoutCoercion` and `Float16Adaptor::toNativeFromInt32WithoutCoercion` in JavaScriptCore's `runtime/TypedArrayAdaptors.h` were a bare `static_cast`. The double path checks that the conversion round-trips. The int32 path did not.

### Fix
- Pin WebKit to `autobuild-preview-pr-604-a9c83095`, the preview build of oven-sh/WebKit#604, which adds the round-trip check to both int32 conversions. `Float64Array` is unaffected: every int32 is a double.
- The pin is a preview tag. Do not merge before oven-sh/WebKit#604 lands. I move the pin to the merge commit's `autobuild-<sha>` release then. The preview is built on WebKit `main` 10350ddde9, three commits ahead of the current pin.
- Verified: `test/js/bun/jsc/typed-array-indexof.test.ts` fails 3 of 5 tests on 1.4.3 (the double-needle and `Float64Array` controls pass) and passes on a debug build with this pin. JSC-side runs are in the notes.

### Background
- A typed array stores raw machine values. The search converts the needle to the element type once and compares raw values. That is only valid when the conversion is exact, otherwise no element can be equal.
- A float has a 24-bit significand and a half 11 bits, so integers above 2^24 (2048 for a half) thin out, and a half rounds 65520 and above to infinity.
- JSC holds a Number as an int32 or as a double. Which one a value gets is an engine detail, so both paths must agree.

<details><summary>Notes</summary>

- Source: fuzz ledger #45462. The matrix that reproduced: Float16 × {2049, 65505, 65520, 65535, 65536, 2^24+1, 2^31-1} and Float32 × {2^24+1, 2^31-1} × all three methods, identical with the JITs off, so the C++ builtin. Impact as reported: `f32ids.includes(id)` is true for a neighbouring id once ids pass 2^24 (2048 for Float16), and `f16.indexOf(65520)` returns the position of an Infinity.
- JSC-side verification on a `jsc` shell built from the branch: the new `JSTests/stress/typed-array-index-of-int32-needle-not-representable.js` (fails on the current pin's shell at the first case), the existing `typedarray-indexOf.js`, `typedarray-includes.js`, `typedarray-lastIndexOf.js`, `non-suitable-typed-array-index-of.js` stress files, and the 130 test262 files under `built-ins/TypedArray/prototype/{indexOf,includes,lastIndexOf}` (130 pass before and after, test262 has no case for this).
- Upstream WebKit `main` has the same two functions.
- The only callers of `toNativeFromValueWithoutCoercion` are the three search builtins in `JSGenericTypedArrayViewPrototypeFunctions.h`, and each already maps "not representable" to not found (with the existing special case for an `undefined` needle in `includes`). There is no DFG/FTL intrinsic for typed array search, only for `Array.prototype`.
- While using node v26.3.0 as an oracle: V8 returns -1 for `new Float16Array([-1]).indexOf(-1)` and every other negative finite half. That is a V8 bug. JSC finds them before and after this change, and the new test keeps a `-2048` case.
- The ledger names two siblings, the `Uint8ClampedArray` double path (#45441) and the BigInt path (#45461). They are separate functions and not touched here.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/typed-array-indexof.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/typed-array-indexof.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/jsc/typed-array-indexof.test.ts:
(pass) integer needle that the element type cannot represent > Float32Array [14.59ms]
(pass) integer needle that the element type cannot represent > Float16Array [20.23ms]
(pass) integer needle that the element type cannot represent > Float64Array holds every int32 exactly [4.91ms]
(pass) integer needle that the element type cannot represent > integer arithmetic and parseInt results behave like the literal [2.97ms]
(pass) integer needle that the element type cannot represent > the same needle held as a double gives the same answer [6.66ms]

 5 pass
 0 fail
 41 expect() calls
Ran 5 tests across 1 file. [2.07s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                |  2 +-
 test/js/bun/jsc/typed-array-indexof.test.ts | 92 +++++++++++++++++++++++++++++
 2 files changed, 93 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
scripts/build/deps/webkit.ts                     2      2      4
test/js/bun/jsc/typed-array-indexof.test.ts      0      2      4
```

</details>

<!-- robobun:evidence:end -->