### PR TITLE
Bump WebKit: Temporal PlainDate.from options order, week rounding at the minimum date, exact era codes

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-600-cbbbe00e";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/temporal/temporal.test.ts
+++ b/test/js/web/temporal/temporal.test.ts
@@ -86,3 +86,77 @@ describe("Temporal core operations", () => {
     expect(() => structuredClone(Temporal.Instant.from("2024-06-15T00:00Z"))).toThrow(DOMException);
   });
 });
+
+// Divergences from V8 found by differential fuzzing. Expected values are what Node 26 / Chromium 148 print.
+describe("Temporal spec conformance", () => {
+  test("PlainDate.from rejects a non-object options before it resolves the calendar fields", () => {
+    // ToTemporalDate: PrepareCalendarFields, then GetOptionsObject (TypeError), then CalendarDateFromFields
+    // (era resolution and the ISODateWithinLimits check, both RangeError).
+    const lateFailingBags = [
+      { year: -271821, month: 2, day: 31 },
+      { year: 275760, month: 9, day: 14 },
+      { era: "xx", eraYear: 1, month: 1, day: 1, calendar: "gregory" },
+      { year: 2024, month: 13, day: 1 },
+    ];
+    for (const bag of lateFailingBags) {
+      for (const options of [null, "constrain", 1, true]) {
+        expect(() => Temporal.PlainDate.from(bag, options as any)).toThrow(TypeError);
+      }
+    }
+    // The bag is still read first, and PrepareCalendarFields errors still win.
+    const reads: PropertyKey[] = [];
+    const bag = new Proxy({ year: -271821, month: 2, day: 31 }, { get: (t, k, r) => (reads.push(k), Reflect.get(t, k, r)) });
+    expect(() => Temporal.PlainDate.from(bag, null as any)).toThrow(TypeError);
+    expect(reads).toEqual(["calendar", "day", "month", "monthCode", "year"]);
+    expect(() => Temporal.PlainDate.from({ year: 2024, month: 0, day: 1 }, null as any)).toThrow(RangeError);
+    // With a real options object the late RangeErrors surface.
+    expect(() => Temporal.PlainDate.from(lateFailingBags[0], {})).toThrow(RangeError);
+    expect(() => Temporal.PlainDate.from(lateFailingBags[2], {})).toThrow(RangeError);
+    expect(Temporal.PlainDate.from(lateFailingBags[3], {}).toString()).toBe("2024-12-01");
+  });
+
+  test("rounding to weeks accepts a window edge on the minimum PlainDate", () => {
+    const later = Temporal.PlainDate.from("2016-02-29");
+    const nearMin = Temporal.PlainDate.from("-271821-04-20");
+    const results = Object.fromEntries(
+      ["trunc", "floor", "expand", "halfExpand"].map(roundingMode => [
+        roundingMode,
+        later.since(nearMin, { smallestUnit: "weeks", roundingMode: roundingMode as Temporal.RoundingMode }).toString(),
+      ]),
+    );
+    expect(results).toEqual({
+      trunc: "P14288122W",
+      floor: "P14288122W",
+      expand: "P14288123W",
+      halfExpand: "P14288123W",
+    });
+    expect(nearMin.until(later, { smallestUnit: "weeks" }).toString()).toBe("P14288122W");
+    expect(later.since(nearMin, { smallestUnit: "days", roundingIncrement: 7 }).toString()).toBe("P100016854D");
+    expect(
+      Temporal.Duration.from({ days: -100016860 })
+        .round({ relativeTo: later, smallestUnit: "weeks", roundingMode: "trunc" })
+        .toString(),
+    ).toBe("-P14288122W");
+    // An edge that is really below the minimum still throws (here: the exact minimum as operand).
+    expect(() => later.since("-271821-04-19", { smallestUnit: "weeks" })).toThrow(RangeError);
+  });
+
+  test("era codes match the lowercase CLDR identifiers exactly", () => {
+    for (const [calendar, era] of [
+      ["gregory", "CE"],
+      ["gregory", "Bce"],
+      ["gregory", "AD"],
+      ["japanese", "Reiwa"],
+      ["hebrew", "AM"],
+    ]) {
+      expect(() => Temporal.PlainDate.from({ era, eraYear: 1, month: 1, day: 1, calendar })).toThrow(RangeError);
+    }
+    expect(Temporal.PlainDate.from({ era: "ce", eraYear: 1, month: 1, day: 1, calendar: "gregory" }).toString()).toBe(
+      "0001-01-01[u-ca=gregory]",
+    );
+    expect(Temporal.PlainDate.from({ era: "ad", eraYear: 1, month: 1, day: 1, calendar: "gregory" }).era).toBe("ce");
+    expect(Temporal.PlainDate.from({ era: "reiwa", eraYear: 1, month: 5, day: 1, calendar: "japanese" }).toString()).toBe(
+      "2019-05-01[u-ca=japanese]",
+    );
+  });
+});

--- a/test/js/web/temporal/temporal.test.ts
+++ b/test/js/web/temporal/temporal.test.ts
@@ -89,33 +89,36 @@ describe("Temporal core operations", () => {
 
 // Divergences from V8 found by differential fuzzing. Expected values are what Node 26 / Chromium 148 print.
 describe("Temporal spec conformance", () => {
-  test("PlainDate.from rejects a non-object options before it resolves the calendar fields", () => {
-    // ToTemporalDate: PrepareCalendarFields, then GetOptionsObject (TypeError), then CalendarDateFromFields
-    // (era resolution and the ISODateWithinLimits check, both RangeError).
-    const lateFailingBags = [
-      { year: -271821, month: 2, day: 31 },
-      { year: 275760, month: 9, day: 14 },
-      { era: "xx", eraYear: 1, month: 1, day: 1, calendar: "gregory" },
-      { year: 2024, month: 13, day: 1 },
-    ];
-    for (const bag of lateFailingBags) {
+  // ToTemporalDate: PrepareCalendarFields, then GetOptionsObject (TypeError), then CalendarDateFromFields
+  // (era resolution and the ISODateWithinLimits check, both RangeError).
+  describe("PlainDate.from rejects a non-object options before it resolves the calendar fields", () => {
+    test.each([
+      [{ year: -271821, month: 2, day: 31 }, RangeError],
+      [{ year: 275760, month: 9, day: 14 }, RangeError],
+      [{ era: "xx", eraYear: 1, month: 1, day: 1, calendar: "gregory" }, RangeError],
+      [{ year: 2024, month: 13, day: 1 }, "2024-12-01"],
+    ] as const)("%j", (bag, withValidOptions) => {
       for (const options of [null, "constrain", 1, true]) {
         expect(() => Temporal.PlainDate.from(bag, options as any)).toThrow(TypeError);
       }
-    }
-    // The bag is still read first, and PrepareCalendarFields errors still win.
-    const reads: PropertyKey[] = [];
-    const bag = new Proxy(
-      { year: -271821, month: 2, day: 31 },
-      { get: (t, k, r) => (reads.push(k), Reflect.get(t, k, r)) },
-    );
-    expect(() => Temporal.PlainDate.from(bag, null as any)).toThrow(TypeError);
-    expect(reads).toEqual(["calendar", "day", "month", "monthCode", "year"]);
-    expect(() => Temporal.PlainDate.from({ year: 2024, month: 0, day: 1 }, null as any)).toThrow(RangeError);
-    // With a real options object the late RangeErrors surface.
-    expect(() => Temporal.PlainDate.from(lateFailingBags[0], {})).toThrow(RangeError);
-    expect(() => Temporal.PlainDate.from(lateFailingBags[2], {})).toThrow(RangeError);
-    expect(Temporal.PlainDate.from(lateFailingBags[3], {}).toString()).toBe("2024-12-01");
+      // With a real options object the late RangeError (or the constrained date) surfaces.
+      if (typeof withValidOptions === "string") {
+        expect(Temporal.PlainDate.from(bag, {}).toString()).toBe(withValidOptions);
+      } else {
+        expect(() => Temporal.PlainDate.from(bag, {})).toThrow(withValidOptions);
+      }
+    });
+
+    test("the bag is read first, and PrepareCalendarFields errors still win", () => {
+      const reads: PropertyKey[] = [];
+      const bag = new Proxy(
+        { year: -271821, month: 2, day: 31 },
+        { get: (t, k, r) => (reads.push(k), Reflect.get(t, k, r)) },
+      );
+      expect(() => Temporal.PlainDate.from(bag, null as any)).toThrow(TypeError);
+      expect(reads).toEqual(["calendar", "day", "month", "monthCode", "year"]);
+      expect(() => Temporal.PlainDate.from({ year: 2024, month: 0, day: 1 }, null as any)).toThrow(RangeError);
+    });
   });
 
   test("rounding to weeks accepts a window edge on the minimum PlainDate", () => {
@@ -144,22 +147,25 @@ describe("Temporal spec conformance", () => {
     expect(() => later.since("-271821-04-19", { smallestUnit: "weeks" })).toThrow(RangeError);
   });
 
-  test("era codes match the lowercase CLDR identifiers exactly", () => {
-    for (const [calendar, era] of [
+  describe("era codes match the lowercase CLDR identifiers exactly", () => {
+    test.each([
       ["gregory", "CE"],
       ["gregory", "Bce"],
       ["gregory", "AD"],
       ["japanese", "Reiwa"],
       ["hebrew", "AM"],
-    ]) {
+    ])("%s rejects %s", (calendar, era) => {
       expect(() => Temporal.PlainDate.from({ era, eraYear: 1, month: 1, day: 1, calendar })).toThrow(RangeError);
-    }
-    expect(Temporal.PlainDate.from({ era: "ce", eraYear: 1, month: 1, day: 1, calendar: "gregory" }).toString()).toBe(
-      "0001-01-01[u-ca=gregory]",
-    );
-    expect(Temporal.PlainDate.from({ era: "ad", eraYear: 1, month: 1, day: 1, calendar: "gregory" }).era).toBe("ce");
-    expect(
-      Temporal.PlainDate.from({ era: "reiwa", eraYear: 1, month: 5, day: 1, calendar: "japanese" }).toString(),
-    ).toBe("2019-05-01[u-ca=japanese]");
+    });
+
+    test("lowercase codes and aliases resolve", () => {
+      expect(Temporal.PlainDate.from({ era: "ce", eraYear: 1, month: 1, day: 1, calendar: "gregory" }).toString()).toBe(
+        "0001-01-01[u-ca=gregory]",
+      );
+      expect(Temporal.PlainDate.from({ era: "ad", eraYear: 1, month: 1, day: 1, calendar: "gregory" }).era).toBe("ce");
+      expect(
+        Temporal.PlainDate.from({ era: "reiwa", eraYear: 1, month: 5, day: 1, calendar: "japanese" }).toString(),
+      ).toBe("2019-05-01[u-ca=japanese]");
+    });
   });
 });

--- a/test/js/web/temporal/temporal.test.ts
+++ b/test/js/web/temporal/temporal.test.ts
@@ -105,7 +105,10 @@ describe("Temporal spec conformance", () => {
     }
     // The bag is still read first, and PrepareCalendarFields errors still win.
     const reads: PropertyKey[] = [];
-    const bag = new Proxy({ year: -271821, month: 2, day: 31 }, { get: (t, k, r) => (reads.push(k), Reflect.get(t, k, r)) });
+    const bag = new Proxy(
+      { year: -271821, month: 2, day: 31 },
+      { get: (t, k, r) => (reads.push(k), Reflect.get(t, k, r)) },
+    );
     expect(() => Temporal.PlainDate.from(bag, null as any)).toThrow(TypeError);
     expect(reads).toEqual(["calendar", "day", "month", "monthCode", "year"]);
     expect(() => Temporal.PlainDate.from({ year: 2024, month: 0, day: 1 }, null as any)).toThrow(RangeError);
@@ -155,8 +158,8 @@ describe("Temporal spec conformance", () => {
       "0001-01-01[u-ca=gregory]",
     );
     expect(Temporal.PlainDate.from({ era: "ad", eraYear: 1, month: 1, day: 1, calendar: "gregory" }).era).toBe("ce");
-    expect(Temporal.PlainDate.from({ era: "reiwa", eraYear: 1, month: 5, day: 1, calendar: "japanese" }).toString()).toBe(
-      "2019-05-01[u-ca=japanese]",
-    );
+    expect(
+      Temporal.PlainDate.from({ era: "reiwa", eraYear: 1, month: 5, day: 1, calendar: "japanese" }).toString(),
+    ).toBe("2019-05-01[u-ca=japanese]");
   });
 });


### PR DESCRIPTION
Bumps `WEBKIT_VERSION` to the preview build of oven-sh/WebKit#600 and adds the three cases to `test/js/web/temporal/temporal.test.ts`.

### Problem
- `Temporal.PlainDate.from(bag, null)` throws `RangeError` instead of `TypeError` when the bag only fails during calendar resolution, for example `{ era: "xx", eraYear: 1, month: 1, day: 1, calendar: "gregory" }` or `{ year: -271821, month: 2, day: 31 }`. JSC resolved the bag with a forced `constrain` before it checked the options type.
- `PlainDate.from("2016-02-29").since("-271821-04-20", { smallestUnit: "weeks" })` throws `RangeError: date is outside the representable range` for every rounding mode. The rounding window edge lands on the minimum date -271821-04-19, which a stale `|epoch days| > 1e8` guard rejected (the minimum is day -100000001). Node 26 and Chromium 148 print `P14288122W` (trunc) and `P14288123W` (expand).
- `era: "CE"`, `"Bce"`, `"Reiwa"` were accepted. The era-monthcode proposal compares era codes with the lowercase CLDR identifiers exactly, and V8 does that.

### Fix
- All three are JSC changes in oven-sh/WebKit#600 (`TemporalPlainDate.cpp`, `temporal/core/DurationArithmetic.cpp`, `temporal/core/CalendarICUBridge.cpp`). This PR only picks them up and pins the behavior on the Bun side.
- `WEBKIT_VERSION` points at `autobuild-preview-pr-600-cbbbe00e` until #600 merges. Then it moves to the merge commit.
- Verified: `bun bd test test/js/web/temporal/temporal.test.ts` (the three new tests fail on 1.4.3 and pass here). Also `test/js/bun/jsc/temporal-global.test.ts`, `deep-equals-temporal.test.ts`, `toml.test.ts`.

### Background
- ToTemporalDate for a property bag runs PrepareCalendarFields (bag getters are observable), then GetOptionsObject (TypeError for a non-object), then CalendarDateFromFields, which resolves `era`/`eraYear` and applies ISODateWithinLimits. So the options TypeError must come before those RangeErrors and after the field reads.
- Rounding a date difference to weeks computes two candidate dates from the receiver with CalendarDateAdd and places the other date between them. For `since` both candidates lie in the past, so the far one can be exactly the minimum date while the operand is a day above it.
- ISODateWithinLimits accepts -271821-04-19 through +275760-09-13. In epoch days that is -100000001 through +100000000, so a symmetric 1e8 bound is off by one on the negative side.

<details><summary>Notes</summary>

- Found by a differential run of Bun 1.4.2 against Node 26.3 and Chromium 148 (ledger #45364, #45365, #45366).
- The preview tag also carries the three oven-sh/WebKit `main` commits after `2e2aa2290f` (#561, #566, #568).
- The chinese calendar leap-month placement from the same run (#45363) is ICU4C data (unicode-org/icu#4070) and is not part of this change.
</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/temporal/temporal.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/temporal/temporal.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/temporal/temporal.test.ts:
(pass) Temporal global > is installed with the spec property attributes [26.57ms]
(pass) Temporal global > exposes all nine namespaces [9.62ms]
(pass) Temporal core operations > Temporal.Now [263.28ms]
(pass) Temporal core operations > parsing, arithmetic, and formatting round-trip [8.54ms]
(pass) Temporal core operations > DST disambiguation [6.94ms]
(pass) Temporal core operations > Date.prototype.toTemporalInstant [2.06ms]
(pass) Temporal core operations > Intl.DateTimeFormat formats Temporal objects [55.15ms]
(pass) Temporal core operations > structuredClone rejects Temporal objects [14.84ms]
(pass) Temporal spec conformance > PlainDate.from rejects a non-object options before it resolves the calendar fields > {"year":-271821,"month":2,"day":31} [7.36ms]
(pass) Temporal spec conformance > PlainDate.from rejects a non-object options before it resolves the calendar fields > {"year":275760,"month":9,"day":14} [2.66ms]
(pass) Temporal spec conformance > PlainDate.from rejects a non-object options before it resolves the calendar fields > {"era":"xx","eraYear":1,"month":1,"day":1,"calendar":"gregory"} [2.44ms]
(pass) Temporal spec conformance > PlainDate.from rejects a non-object options before it resolves the calendar fields > {"year":2024,"month":13,"day":1} [1.81ms]
(pass) Temporal spec conformance > PlainDate.from rejects a non-object options before it resolves the calendar fields > the bag is read first, and PrepareCalendarFields errors still win [9.49ms]
(pass) Temporal spec conformance > rounding to weeks accepts a window edge on the minimum PlainDate [11.98ms]
(pass) Temporal spec conformance > era codes match the lowercase CLDR identifiers exactly > gregory rejects CE [3.42ms]
(pass) Temporal spec conformance > era codes match the lowercase CLDR identifiers exactly 
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts          |  2 +-
 test/js/web/temporal/temporal.test.ts | 83 +++++++++++++++++++++++++++++++++++
 2 files changed, 84 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
scripts/build/deps/webkit.ts               1      2     12
test/js/web/temporal/temporal.test.ts      2      3     12
```

</details>

<!-- robobun:evidence:end -->