### PR TITLE
Bump WebKit (oven-sh/WebKit#606 preview): constant-time Temporal month differences in the lunisolar calendars (chinese, dangi, hebrew)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-606-5040c89c";
+export const WEBKIT_VERSION = "autobuild-preview-pr-606-cd3f8469";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-606-cd3f8469";
+export const WEBKIT_VERSION = "autobuild-preview-pr-606-1baab80e";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-606-5040c89c";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/temporal/temporal.test.ts
+++ b/test/js/web/temporal/temporal.test.ts
@@ -87,9 +87,9 @@ describe("Temporal core operations", () => {
   });
 });
 
-// Month differences in the calendars whose months follow the moon. JSC counts the months from the
-// day span and confirms the count with one ICU month addition, so the cost of until()/since() does
-// not grow with the span (a chinese century used to take a second, two millennia tens of seconds).
+// Month differences in the lunisolar calendars (chinese, dangi, hebrew). JSC counts the months from
+// the day span and confirms the count with one ICU month addition, so the cost of until()/since()
+// does not grow with the span (a chinese century used to take a second, two millennia tens of seconds).
 describe("Temporal lunar-calendar month arithmetic over long spans", () => {
   function expectRoundTrip(one: Temporal.PlainDate, two: Temporal.PlainDate, months: number) {
     const until = one.until(two, { largestUnit: "months" });
@@ -121,22 +121,54 @@ describe("Temporal lunar-calendar month arithmetic over long spans", () => {
     });
   });
 
-  // 235 hebrew months are exactly 19 years. ICU 75+ mis-adds 229 or more months forward from
-  // Adar..Elul of a common year; JSC routes around it.
+  // 235 hebrew months are exactly 19 years. ICU 75+ lands one month late when a forward add from
+  // Adar..Elul of a common year carries past a whole 19-year cycle into Tishri..Adar I (223 or more
+  // months from Elul, 229 or more from Adar); JSC adds the whole cycles as years and leaves ICU a
+  // remainder of at most 222.
   describe("hebrew", () => {
-    const nisan5720 = Temporal.PlainDate.from({ calendar: "hebrew", year: 5720, monthCode: "M07", day: 25 });
+    const common5720 = (monthCode: string, day = 25) =>
+      Temporal.PlainDate.from({ calendar: "hebrew", year: 5720, monthCode, day });
+    const nisan5720 = common5720("M07");
 
     test.each([
-      [229, "5739 M01 25"],
-      [235, "5739 M07 25"],
-      [463, "5757 M12 25"],
-      [464, "5758 M01 25"],
-      [2351, "5910 M08 25"],
-    ] as const)("5720 Nisan 25 + %d months is %s", (months, expected) => {
-      expect(nisan5720.inLeapYear).toBe(false);
-      const sum = nisan5720.add({ months });
+      ["M07", 229, "5739 M01 25"],
+      ["M07", 235, "5739 M07 25"],
+      ["M07", 463, "5757 M12 25"],
+      ["M07", 464, "5758 M01 25"],
+      ["M07", 2351, "5910 M08 25"],
+      // Elul reaches the ICU bug first: 222 is the largest count ICU still gets whole, 223 and 458
+      // the smallest ones split into one and two cycles, 457 the largest remainder (222) left to ICU.
+      ["M12", 222, "5738 M11 25"],
+      ["M12", 223, "5738 M12 25"],
+      ["M12", 228, "5739 M05 25"],
+      ["M12", 457, "5757 M11 25"],
+      ["M12", 458, "5757 M12 25"],
+      // Adar is the earliest month the ICU bug affects.
+      ["M06", 229, "5738 M12 25"],
+      ["M06", 464, "5757 M12 25"],
+    ] as const)("5720 %s 25 + %d months is %s", (monthCode, months, expected) => {
+      const start = common5720(monthCode);
+      expect(start.inLeapYear).toBe(false);
+      const sum = start.add({ months });
       expect(`${sum.year} ${sum.monthCode} ${sum.day}`).toBe(expected);
-      expect(sum.subtract({ months }).equals(nisan5720)).toBe(true);
+      expect(sum.subtract({ months }).equals(start)).toBe(true);
+      expect(start.until(sum, { largestUnit: "months" }).months).toBe(months);
+    });
+
+    test("day 30 across the 19-year step", () => {
+      // Kislev 30 5715 + 38 years is Kislev 5753, which has 29 days; the day comes from the start
+      // date again once the remaining months land in Nisan (30 days).
+      const kislev30 = Temporal.PlainDate.from({ calendar: "hebrew", year: 5715, monthCode: "M03", day: 30 });
+      expect(kislev30.day).toBe(30);
+      const nisan5752 = kislev30.add({ months: 462 });
+      expect(`${nisan5752.year} ${nisan5752.monthCode} ${nisan5752.day}`).toBe("5752 M07 30");
+      expect(kislev30.until(nisan5752, { largestUnit: "months" }).toString()).toBe("P462M");
+      // Av 30 + 224 months is Elul, which has 29 days.
+      const av30 = common5720("M11", 30);
+      const elul5738 = av30.add({ months: 224 });
+      expect(`${elul5738.year} ${elul5738.monthCode} ${elul5738.day}`).toBe("5738 M12 29");
+      expect(() => av30.add({ months: 224 }, { overflow: "reject" })).toThrow(RangeError);
+      expect(av30.until(elul5738, { largestUnit: "months" }).toString()).toBe("P223M29D");
     });
 
     test("counting more than 19 years of months", () => {
@@ -152,7 +184,8 @@ describe("Temporal lunar-calendar month arithmetic over long spans", () => {
     });
   });
 
-  // Twelve lunar months to every year, so whole years are a closed form for the shared month tail.
+  // islamic-* still probes one ICU month step per month on this WebKit (oven-sh/WebKit#598 moves it to
+  // a fixed twelve-months-a-year closed form), so the span here stays short; kept as a cross-check.
   describe.each(["islamic-civil", "islamic-tbla", "islamic-umalqura"] as const)("%s", calendar => {
     test("two centuries of months", () => {
       const one = Temporal.PlainDate.from({ calendar, year: 1300, monthCode: "M01", day: 1 });

--- a/test/js/web/temporal/temporal.test.ts
+++ b/test/js/web/temporal/temporal.test.ts
@@ -152,11 +152,12 @@ describe("Temporal lunar-calendar month arithmetic over long spans", () => {
     });
   });
 
+  // Twelve lunar months to every year, so whole years are a closed form for the shared month tail.
   describe.each(["islamic-civil", "islamic-tbla", "islamic-umalqura"] as const)("%s", calendar => {
-    test("1600 years of months", () => {
-      const one = Temporal.PlainDate.from({ calendar, year: 1, monthCode: "M01", day: 1 });
-      const two = Temporal.PlainDate.from({ calendar, year: 1601, monthCode: "M01", day: 1 });
-      expectRoundTrip(one, two, 19200);
+    test("two centuries of months", () => {
+      const one = Temporal.PlainDate.from({ calendar, year: 1300, monthCode: "M01", day: 1 });
+      const two = Temporal.PlainDate.from({ calendar, year: 1500, monthCode: "M01", day: 1 });
+      expectRoundTrip(one, two, 2400);
     });
   });
 });

--- a/test/js/web/temporal/temporal.test.ts
+++ b/test/js/web/temporal/temporal.test.ts
@@ -86,3 +86,69 @@ describe("Temporal core operations", () => {
     expect(() => structuredClone(Temporal.Instant.from("2024-06-15T00:00Z"))).toThrow(DOMException);
   });
 });
+
+// Month differences in the calendars whose months follow the moon. JSC counts the months from the
+// day span and confirms the count with one ICU month addition, so the cost of until()/since() does
+// not grow with the span (a chinese century used to take a second, two millennia tens of seconds).
+describe("Temporal lunar-calendar month arithmetic over long spans", () => {
+  function expectRoundTrip(one: Temporal.PlainDate, two: Temporal.PlainDate, months: number) {
+    const until = one.until(two, { largestUnit: "months" });
+    expect(until.months).toBe(months);
+    expect(Math.abs(until.days)).toBeLessThan(30);
+    expect(one.add(until).equals(two)).toBe(true);
+    expect(two.until(one, { largestUnit: "months" }).months).toBe(-months);
+    expect(one.since(two, { largestUnit: "months" }).months).toBe(-months);
+  }
+
+  test.each(["chinese", "dangi"] as const)("%s: two millennia of months", calendar => {
+    // Both ends sit mid-month, so the count does not depend on which day ICU starts a month on.
+    const one = Temporal.PlainDate.from("0001-01-25").withCalendar(calendar);
+    const two = Temporal.PlainDate.from("2034-03-05").withCalendar(calendar);
+    expectRoundTrip(one, two, 25146);
+    expect(one.until(two, { largestUnit: "years" }).years).toBe(2033);
+    expectRoundTrip(
+      Temporal.PlainDate.from("-002000-04-20").withCalendar(calendar),
+      Temporal.PlainDate.from("-000001-12-12").withCalendar(calendar),
+      24732,
+    );
+    // A leap month (2023 has M02L) and a day-30 start that clamps along the way.
+    const day30 = Temporal.PlainDate.from({ calendar, year: 2020, monthCode: "M04", day: 30 });
+    expect(day30.day).toBe(30);
+    expectRoundTrip(day30, Temporal.PlainDate.from({ calendar, year: 2031, monthCode: "M09", day: 29 }), 141);
+  });
+
+  test("hebrew: adding and counting more than 19 years of months", () => {
+    // 235 hebrew months are exactly 19 years. ICU 75+ mis-adds 229 or more months forward from
+    // Adar..Elul of a common year; JSC routes around it.
+    const nisan5720 = Temporal.PlainDate.from({ calendar: "hebrew", year: 5720, monthCode: "M07", day: 25 });
+    expect(nisan5720.inLeapYear).toBe(false);
+    const sums = [
+      [229, "5739 M01 25"],
+      [235, "5739 M07 25"],
+      [463, "5757 M12 25"],
+      [464, "5758 M01 25"],
+      [2351, "5910 M08 25"],
+    ] as const;
+    for (const [months, expected] of sums) {
+      const sum = nisan5720.add({ months });
+      expect(`${sum.year} ${sum.monthCode} ${sum.day}`).toBe(expected);
+      expect(sum.subtract({ months }).equals(nisan5720)).toBe(true);
+    }
+
+    const tishri5758 = Temporal.PlainDate.from({ calendar: "hebrew", year: 5758, monthCode: "M01", day: 14 });
+    expect(nisan5720.until(tishri5758, { largestUnit: "months" }).toString()).toBe("P463M18D");
+    expect(tishri5758.since(nisan5720, { largestUnit: "months" }).toString()).toBe("P463M19D");
+    expect(nisan5720.until(tishri5758, { largestUnit: "years" }).toString()).toBe("P37Y5M18D");
+    expectRoundTrip(
+      Temporal.PlainDate.from("1880-08-06").withCalendar("hebrew"),
+      Temporal.PlainDate.from("2943-11-02").withCalendar("hebrew"),
+      13150,
+    );
+  });
+
+  test.each(["islamic-civil", "islamic-tbla", "islamic-umalqura"] as const)("%s: 1600 years of months", calendar => {
+    const one = Temporal.PlainDate.from({ calendar, year: 1, monthCode: "M01", day: 1 });
+    const two = Temporal.PlainDate.from({ calendar, year: 1601, monthCode: "M01", day: 1 });
+    expectRoundTrip(one, two, 19200);
+  });
+});

--- a/test/js/web/temporal/temporal.test.ts
+++ b/test/js/web/temporal/temporal.test.ts
@@ -100,55 +100,63 @@ describe("Temporal lunar-calendar month arithmetic over long spans", () => {
     expect(one.since(two, { largestUnit: "months" }).months).toBe(-months);
   }
 
-  test.each(["chinese", "dangi"] as const)("%s: two millennia of months", calendar => {
-    // Both ends sit mid-month, so the count does not depend on which day ICU starts a month on.
-    const one = Temporal.PlainDate.from("0001-01-25").withCalendar(calendar);
-    const two = Temporal.PlainDate.from("2034-03-05").withCalendar(calendar);
-    expectRoundTrip(one, two, 25146);
-    expect(one.until(two, { largestUnit: "years" }).years).toBe(2033);
-    expectRoundTrip(
-      Temporal.PlainDate.from("-002000-04-20").withCalendar(calendar),
-      Temporal.PlainDate.from("-000001-12-12").withCalendar(calendar),
-      24732,
-    );
-    // A leap month (2023 has M02L) and a day-30 start that clamps along the way.
-    const day30 = Temporal.PlainDate.from({ calendar, year: 2020, monthCode: "M04", day: 30 });
-    expect(day30.day).toBe(30);
-    expectRoundTrip(day30, Temporal.PlainDate.from({ calendar, year: 2031, monthCode: "M09", day: 29 }), 141);
+  describe.each(["chinese", "dangi"] as const)("%s", calendar => {
+    test("two millennia of months", () => {
+      // Both ends sit mid-month, so the count does not depend on which day ICU starts a month on.
+      const one = Temporal.PlainDate.from("0001-01-25").withCalendar(calendar);
+      const two = Temporal.PlainDate.from("2034-03-05").withCalendar(calendar);
+      expectRoundTrip(one, two, 25146);
+      expect(one.until(two, { largestUnit: "years" }).years).toBe(2033);
+      expectRoundTrip(
+        Temporal.PlainDate.from("-002000-04-20").withCalendar(calendar),
+        Temporal.PlainDate.from("-000001-12-12").withCalendar(calendar),
+        24732,
+      );
+    });
+
+    test("a leap month (2023 has M02L) and a day-30 start that clamps along the way", () => {
+      const day30 = Temporal.PlainDate.from({ calendar, year: 2020, monthCode: "M04", day: 30 });
+      expect(day30.day).toBe(30);
+      expectRoundTrip(day30, Temporal.PlainDate.from({ calendar, year: 2031, monthCode: "M09", day: 29 }), 141);
+    });
   });
 
-  test("hebrew: adding and counting more than 19 years of months", () => {
-    // 235 hebrew months are exactly 19 years. ICU 75+ mis-adds 229 or more months forward from
-    // Adar..Elul of a common year; JSC routes around it.
+  // 235 hebrew months are exactly 19 years. ICU 75+ mis-adds 229 or more months forward from
+  // Adar..Elul of a common year; JSC routes around it.
+  describe("hebrew", () => {
     const nisan5720 = Temporal.PlainDate.from({ calendar: "hebrew", year: 5720, monthCode: "M07", day: 25 });
-    expect(nisan5720.inLeapYear).toBe(false);
-    const sums = [
+
+    test.each([
       [229, "5739 M01 25"],
       [235, "5739 M07 25"],
       [463, "5757 M12 25"],
       [464, "5758 M01 25"],
       [2351, "5910 M08 25"],
-    ] as const;
-    for (const [months, expected] of sums) {
+    ] as const)("5720 Nisan 25 + %d months is %s", (months, expected) => {
+      expect(nisan5720.inLeapYear).toBe(false);
       const sum = nisan5720.add({ months });
       expect(`${sum.year} ${sum.monthCode} ${sum.day}`).toBe(expected);
       expect(sum.subtract({ months }).equals(nisan5720)).toBe(true);
-    }
+    });
 
-    const tishri5758 = Temporal.PlainDate.from({ calendar: "hebrew", year: 5758, monthCode: "M01", day: 14 });
-    expect(nisan5720.until(tishri5758, { largestUnit: "months" }).toString()).toBe("P463M18D");
-    expect(tishri5758.since(nisan5720, { largestUnit: "months" }).toString()).toBe("P463M19D");
-    expect(nisan5720.until(tishri5758, { largestUnit: "years" }).toString()).toBe("P37Y5M18D");
-    expectRoundTrip(
-      Temporal.PlainDate.from("1880-08-06").withCalendar("hebrew"),
-      Temporal.PlainDate.from("2943-11-02").withCalendar("hebrew"),
-      13150,
-    );
+    test("counting more than 19 years of months", () => {
+      const tishri5758 = Temporal.PlainDate.from({ calendar: "hebrew", year: 5758, monthCode: "M01", day: 14 });
+      expect(nisan5720.until(tishri5758, { largestUnit: "months" }).toString()).toBe("P463M18D");
+      expect(tishri5758.since(nisan5720, { largestUnit: "months" }).toString()).toBe("P463M19D");
+      expect(nisan5720.until(tishri5758, { largestUnit: "years" }).toString()).toBe("P37Y5M18D");
+      expectRoundTrip(
+        Temporal.PlainDate.from("1880-08-06").withCalendar("hebrew"),
+        Temporal.PlainDate.from("2943-11-02").withCalendar("hebrew"),
+        13150,
+      );
+    });
   });
 
-  test.each(["islamic-civil", "islamic-tbla", "islamic-umalqura"] as const)("%s: 1600 years of months", calendar => {
-    const one = Temporal.PlainDate.from({ calendar, year: 1, monthCode: "M01", day: 1 });
-    const two = Temporal.PlainDate.from({ calendar, year: 1601, monthCode: "M01", day: 1 });
-    expectRoundTrip(one, two, 19200);
+  describe.each(["islamic-civil", "islamic-tbla", "islamic-umalqura"] as const)("%s", calendar => {
+    test("1600 years of months", () => {
+      const one = Temporal.PlainDate.from({ calendar, year: 1, monthCode: "M01", day: 1 });
+      const two = Temporal.PlainDate.from({ calendar, year: 1601, monthCode: "M01", day: 1 });
+      expectRoundTrip(one, two, 19200);
+    });
   });
 });


### PR DESCRIPTION
### Problem
- `Temporal.PlainDate#until` / `#since` with `largestUnit: "months"` in the `chinese` or `dangi` calendar cost about 1 ms per month of span, all in one uninterruptible native call on the JS thread: 100 years took 1.1 s and `0001-01-01` to `2034-02-18` (25,146 months) took 23 s on bun 1.4.2. V8 answers in 0 to 3 ms.
- The cause is in JSC's Temporal ICU bridge (`CalendarICUBridge.cpp`, `nonISODateUntil`): it probed one candidate month at a time, and for chinese/dangi each probe re-walked the year from its first month, about 30 ICU field resolutions with new-moon astronomy each. `hebrew` and `islamic-*` took the same loop.
- On the same path, `hebrew` `add({ months: n })` was one month late for `n >= 229` from Adar..Elul of a common year (an ICU 75+ bug in `HebrewCalendar::add`), so `until()` over more than 19 hebrew years threw `RangeError` or was off by one.

### Fix
- Engine fix in oven-sh/WebKit#606: count the months of the lunisolar calendars (chinese, dangi, hebrew) from the day span and confirm the count with one ICU month addition, and route hebrew month additions around the ICU bug. `islamic-*` keeps its existing path there; oven-sh/WebKit#598 moves it to the fixed-month closed form. This PR pins `WEBKIT_VERSION` at its preview build `autobuild-preview-pr-606-1baab80e` (PR head `1baab80efa`). That tag is deleted when oven-sh/WebKit#606 merges, so the pin moves to the merge commit's `autobuild-<sha>` release first; do not merge this PR before that swap.
- The range from `2e2aa2290fac` also contains oven-sh/WebKit#561, oven-sh/WebKit#566 and oven-sh/WebKit#568, which are already on oven-sh/WebKit `main`.
- Verified: `test/js/web/temporal/temporal.test.ts` gains a "lunar-calendar month arithmetic over long spans" group (21 cases: chinese/dangi two-millennia and leap-month round trips, hebrew bulk adds pinned at the Nisan, Elul and Adar boundaries of the 19-year reroute (222/223 and 457/458 months) plus a day-30 start across the year step, and a short islamic-* cross-check). On the old pin the chinese and dangi cases time out (each call runs about 2 minutes) and the hebrew cases fail; on the `1baab80e` pin all 29 tests in the file pass in 3.2 s under debug ASAN, the two-millennia chinese case in 18 ms. `USE_SYSTEM_BUN=1` (bun 1.4.3) fails 10 of the 14 hebrew cases (e.g. `+463 months` gives `5758 M01 25`, Elul `+223` gives `5739 M01 25`).

### Background
- Temporal's `CalendarDateUntil` for a non-ISO calendar finds the largest month count whose addition to the earlier date does not pass the later one. JSC implements non-ISO calendars on ICU4C; V8 uses icu4x, whose dates carry precomputed year data.
- A chinese or dangi month runs from one new moon to the next, which ICU4C computes astronomically on every field resolution. Hebrew and islamic months are arithmetic, 29 or 30 days.

<details><summary>Notes</summary>

- Release-build numbers from the WebKit PR: chinese 400 years of months 3975 ms -> 0.3 ms, the 23 s case -> 0.5 ms, hebrew 400 years 48 ms -> 0.01 ms. A ~90,000-pair differential corpus over eleven calendars is unchanged except the hebrew spans the ICU bug affected. islamic-* is unchanged by oven-sh/WebKit#606 (still linear, about 0.7 s for 1600 years of months under debug ASAN here); oven-sh/WebKit#598 makes it a closed form.
- The gate's fail-before step restores `src/` and `packages/` only, and the fix lives in the WebKit pin under `scripts/`, so it cannot reproduce the failing side. Fail-before was checked by hand with `USE_SYSTEM_BUN=1 bun test test/js/web/temporal/temporal.test.ts` (bun 1.4.3).
- Seen while testing, not changed here: ICU reports every negative `islamic-*` year as a leap year (30-day M12), which skews day-30 arithmetic before 622 CE. That is what oven-sh/WebKit#598 fixes.
</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/temporal/temporal.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/temporal/temporal.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/temporal/temporal.test.ts:
(pass) Temporal global > is installed with the spec property attributes [2.73ms]
(pass) Temporal global > exposes all nine namespaces [2.59ms]
(pass) Temporal core operations > Temporal.Now [154.59ms]
(pass) Temporal core operations > parsing, arithmetic, and formatting round-trip [8.20ms]
(pass) Temporal core operations > DST disambiguation [6.17ms]
(pass) Temporal core operations > Date.prototype.toTemporalInstant [1.74ms]
(pass) Temporal core operations > Intl.DateTimeFormat formats Temporal objects [28.11ms]
(pass) Temporal core operations > structuredClone rejects Temporal objects [6.92ms]
(pass) Temporal lunar-calendar month arithmetic over long spans > chinese > two millennia of months [17.51ms]
(pass) Temporal lunar-calendar month arithmetic over long spans > chinese > a leap month (2023 has M02L) and a day-30 start that clamps along the way [25.28ms]
(pass) Temporal lunar-calendar month arithmetic over long spans > dangi > two millennia of months [11.49ms]
(pass) Temporal lunar-calendar month arithmetic over long spans > dangi > a leap month (2023 has M02L) and a day-30 start that clamps along the way [22.82ms]
(pass) Temporal lunar-calendar month arithmetic over long spans > hebrew > 5720 M07 25 + 229 months is 5739 M01 25 [4.75ms]
(pass) Temporal lunar-calendar month arithmetic over long spans > hebrew > 5720 M07 25 + 235 months is 5739 M07 25 [2.33ms]
(pass) Temporal lunar-calendar month arithmetic over long spans > hebrew > 5720 M07 25 + 463 months is 5757 M12 25 [1.56ms]
(pass) Temporal lunar-calendar month arithmetic over long spans > hebrew > 5720 M07 25 + 464 months is 5758 M01 25 [1.80ms]
(pass) Temporal lunar-calendar month arithmetic over long spans > hebrew > 5720 M07 25 + 2351 months is 5910 M08 25 [1.81ms]
(pass) Temporal lunar-calendar month arithme
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts          |   2 +-
 test/js/web/temporal/temporal.test.ts | 108 ++++++++++++++++++++++++++++++++++
 2 files changed, 109 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
scripts/build/deps/webkit.ts               0      0     12
test/js/web/temporal/temporal.test.ts      3      4     11
```

</details>

<!-- robobun:evidence:end -->
