### PR TITLE
Promise.withResolvers: return keys in spec order promise, resolve, reject (oven-sh/WebKit#603)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-603-dca9df12";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/promise-withResolvers.test.ts
+++ b/test/js/bun/jsc/promise-withResolvers.test.ts
@@ -56,6 +56,11 @@ test("resolve and reject still settle the promise they came with", async () => {
     const { promise, resolve, reject } = Promise.withResolvers<number>();
     reject(42);
     resolve(7);
-    expect(await promise.then(() => "fulfilled", (reason: unknown) => ["rejected", reason])).toEqual(["rejected", 42]);
+    expect(
+      await promise.then(
+        () => "fulfilled",
+        (reason: unknown) => ["rejected", reason],
+      ),
+    ).toEqual(["rejected", 42]);
   }
 });

--- a/test/js/bun/jsc/promise-withResolvers.test.ts
+++ b/test/js/bun/jsc/promise-withResolvers.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+
+// https://tc39.es/ecma262/#sec-promise.withResolvers creates the result's data
+// properties in the order promise, resolve, reject. JSC built the object on a
+// structure laid out as resolve, reject, promise (oven-sh/WebKit#603).
+
+test("Promise.withResolvers() result has its keys in spec order", () => {
+  const result = Promise.withResolvers<number>();
+  expect(Object.keys(result)).toEqual(["promise", "resolve", "reject"]);
+  expect(Reflect.ownKeys(result)).toEqual(["promise", "resolve", "reject"]);
+  expect(JSON.stringify(result, (key, value) => (typeof value === "function" ? "function" : value))).toBe(
+    `{"promise":{},"resolve":"function","reject":"function"}`,
+  );
+  expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+  for (const key of ["promise", "resolve", "reject"] as const) {
+    expect(Object.getOwnPropertyDescriptor(result, key)).toMatchObject({
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+});
+
+test("Promise.withResolvers() on a subclass and on a foreign constructor uses the same order", () => {
+  class Derived<T> extends Promise<T> {}
+  const derived = Promise.withResolvers.call(Derived);
+  expect(Object.keys(derived)).toEqual(["promise", "resolve", "reject"]);
+  expect(derived.promise).toBeInstanceOf(Derived);
+
+  const calls: unknown[][] = [];
+  function NotAPromise(this: any, executor: (resolve: (v: unknown) => void, reject: (r: unknown) => void) => void) {
+    executor(
+      value => calls.push(["resolve", value]),
+      reason => calls.push(["reject", reason]),
+    );
+  }
+  const foreign = Promise.withResolvers.call(NotAPromise as any);
+  expect(Object.keys(foreign)).toEqual(["promise", "resolve", "reject"]);
+  expect(foreign.promise).toBeInstanceOf(NotAPromise);
+  foreign.resolve(1);
+  foreign.reject(2);
+  expect(calls).toEqual([
+    ["resolve", 1],
+    ["reject", 2],
+  ]);
+});
+
+test("resolve and reject still settle the promise they came with", async () => {
+  {
+    const { promise, resolve, reject } = Promise.withResolvers<number>();
+    resolve(42);
+    reject(new Error("ignored"));
+    expect(await promise).toBe(42);
+  }
+  {
+    const { promise, resolve, reject } = Promise.withResolvers<number>();
+    reject(42);
+    resolve(7);
+    expect(await promise.then(() => "fulfilled", (reason: unknown) => ["rejected", reason])).toEqual(["rejected", 42]);
+  }
+});


### PR DESCRIPTION
### Problem
- `Object.keys(Promise.withResolvers())` is `["resolve", "reject", "promise"]`. [Promise.withResolvers](https://tc39.es/ecma262/#sec-promise.withResolvers) steps 3 to 5 create the properties in the order `promise`, `resolve`, `reject`, and that order is observable through `[[OwnPropertyKeys]]`: enumeration, `JSON.stringify`, spread, `toEqual` diffs and snapshots. node v26.3.0 and Chromium 148 return `promise,resolve,reject`. The values themselves were always right.
- The cause is in JavaScriptCore. `Promise.withResolvers` returns the object that `JSPromise::createPromiseCapability()` builds on a cached Structure (`createPromiseCapabilityObjectStructure()` in `runtime/JSPromise.cpp`), and that Structure was laid out as `resolve`, `reject`, `promise`, the field order of the spec's internal PromiseCapability Record.

### Fix
- Pin WebKit to `autobuild-preview-pr-603-dca9df12`, the preview build of oven-sh/WebKit#603. That change lays the Structure out as `promise`, `resolve`, `reject` and renumbers the three offset constants. Every reader of a capability object goes through the property names, so nothing else moves.
- The pin is a preview tag, not a merge commit. Do not merge before oven-sh/WebKit#603 lands. I move the pin to the `autobuild-<sha>` release of the merge commit then. The preview is built on oven-sh/WebKit `main` (10350ddde9), three commits ahead of the current pin.
- Verified: `test/js/bun/jsc/promise-withResolvers.test.ts` (new) fails 2 of 3 cases on 1.4.3 and passes on a debug build with this pin. Also ran `test/js/bun/jsc/bun-jsc.test.ts`, `test/js/node/promise/`, `test/js/web/web-globals.test.js`, `test/js/node/util/util-promisify.test.js`, two `test-promise-unhandled*` node tests, and a dynamic `import()` / subclass / async-generator smoke script, all green on the pinned build.

### Background
- A PromiseCapability Record is the spec's `{ [[Promise]], [[Resolve]], [[Reject]] }` triple from `NewPromiseCapability(C)`. JSC materializes it as a JS object for `Promise.withResolvers` and on the generic path (subclass or foreign constructor), with one cached Structure per global object so the object gets its final shape at allocation.
- A Structure records property names in insertion order and `[[OwnPropertyKeys]]` reports string keys in that order, which is why the layout of an internal object became visible once `withResolvers` started returning it.
- test262's `built-ins/Promise/withResolvers/result.js` checks the attributes of the three properties but not their order, which is how this passed unnoticed since `withResolvers` shipped.

<details><summary>Notes</summary>

- Source: a differential run of the ES2024-2026 built-ins (bun 1.4.2 and canary vs node v26.3.0, Chromium 148 as tie-breaker). This was the only `Promise.withResolvers` divergence; subclass receivers and the non-constructor TypeError already matched.
- Engine side: `JSTests/stress/promise-withResolvers-property-order.js` in oven-sh/WebKit#603 fails before and passes after on a local JSCOnly build; the other 190 promise/async stress files and the 463 synchronous test262 `built-ins/Promise` cases are unchanged. JSTests do not run in CI in either repo, so the test in this PR is the CI coverage.
- Upstream tracks this as [bug 320831](https://bugs.webkit.org/show_bug.cgi?id=320831); WebKit/WebKit#72191 (2026-08-22, still open, reviewed as good pending a commit message update) is the same source change as oven-sh/WebKit#603. Upstream `main` still has the old layout today.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/promise-withResolvers.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/promise-withResolvers.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/jsc/promise-withResolvers.test.ts:
(pass) Promise.withResolvers() result has its keys in spec order [17.27ms]
(pass) Promise.withResolvers() on a subclass and on a foreign constructor uses the same order [28.96ms]
(pass) resolve and reject still settle the promise they came with [7.63ms]

 3 pass
 0 fail
 14 expect() calls
Ran 3 tests across 1 file. [2.00s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                  |  2 +-
 test/js/bun/jsc/promise-withResolvers.test.ts | 66 +++++++++++++++++++++++++++
 2 files changed, 67 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
scripts/build/deps/webkit.ts                       1      1      4
test/js/bun/jsc/promise-withResolvers.test.ts      0      1      4
```

</details>

<!-- robobun:evidence:end -->
