### PR TITLE
fetch: never pool an HTTP/1.1 connection that received bytes past the end of a response

### DIFF
--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1404,8 +1404,6 @@ impl<const SSL: bool> Handler<SSL> {
                 return;
             }
 
-            // No request is in flight on a pooled HTTP/1.1 socket, so any byte
-            // (a late `0\r\n\r\n` included) means the peer's framing diverged.
             bun_core::scoped_log!(
                 HTTPContext,
                 "Unexpected data on idle pooled socket, evicting"

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1404,12 +1404,11 @@ impl<const SSL: bool> Handler<SSL> {
                 return;
             }
 
-            // trailing zero is fine to ignore
-            if buf == http::END_OF_CHUNKED_HTTP1_1_ENCODING_RESPONSE_BODY {
-                return;
-            }
-
-            bun_core::scoped_log!(HTTPContext, "Unexpected data on socket");
+            // HTTP/1.1: no request is in flight on a pooled socket, so any byte
+            // here (a late `0\r\n\r\n` included) means the peer's framing no
+            // longer matches ours. Evict rather than let the next request
+            // read it as the start of its response.
+            bun_core::scoped_log!(HTTPContext, "Unexpected data on idle pooled socket, evicting");
             HTTPContext::<SSL>::terminate_socket(socket);
 
             return;

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1408,7 +1408,10 @@ impl<const SSL: bool> Handler<SSL> {
             // here (a late `0\r\n\r\n` included) means the peer's framing no
             // longer matches ours. Evict rather than let the next request
             // read it as the start of its response.
-            bun_core::scoped_log!(HTTPContext, "Unexpected data on idle pooled socket, evicting");
+            bun_core::scoped_log!(
+                HTTPContext,
+                "Unexpected data on idle pooled socket, evicting"
+            );
             HTTPContext::<SSL>::terminate_socket(socket);
 
             return;

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1404,10 +1404,8 @@ impl<const SSL: bool> Handler<SSL> {
                 return;
             }
 
-            // HTTP/1.1: no request is in flight on a pooled socket, so any byte
-            // here (a late `0\r\n\r\n` included) means the peer's framing no
-            // longer matches ours. Evict rather than let the next request
-            // read it as the start of its response.
+            // No request is in flight on a pooled HTTP/1.1 socket, so any byte
+            // (a late `0\r\n\r\n` included) means the peer's framing diverged.
             bun_core::scoped_log!(
                 HTTPContext,
                 "Unexpected data on idle pooled socket, evicting"

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3730,9 +3730,7 @@ impl<'a> HTTPClient<'a> {
         }
 
         if should_continue == ShouldContinue::Finished {
-            if !to_read.is_empty() {
-                self.state.flags.allow_keepalive = false;
-            }
+            self.on_bytes_past_response_end(to_read.len());
             if self.state.flags.is_redirect_pending {
                 self.do_redirect::<IS_SSL>(ctx, socket);
                 return;
@@ -4447,6 +4445,18 @@ impl<'a> HTTPClient<'a> {
         }
     }
 
+    /// Nothing is pipelined, so bytes past the framed end of a response desynchronize the socket.
+    fn on_bytes_past_response_end(&mut self, count: usize) {
+        if count > 0 && self.state.flags.allow_keepalive {
+            bun_core::scoped_log!(
+                fetch,
+                "{} bytes past the end of the response, disabling keep-alive",
+                count
+            );
+            self.state.flags.allow_keepalive = false;
+        }
+    }
+
     pub(crate) fn handle_response_body(
         &mut self,
         incoming_data: &[u8],
@@ -4454,10 +4464,9 @@ impl<'a> HTTPClient<'a> {
     ) -> crate::Result<bool> {
         debug_assert!(self.state.transfer_encoding == Encoding::Identity);
         let content_length = self.state.content_length;
-        if let Some(len) = content_length
-            && incoming_data.len() > len.saturating_sub(self.state.total_body_received)
-        {
-            self.state.flags.allow_keepalive = false;
+        if let Some(len) = content_length {
+            let remaining = len.saturating_sub(self.state.total_body_received);
+            self.on_bytes_past_response_end(incoming_data.len().saturating_sub(remaining));
         }
         // is it exactly as much as we need?
         if is_only_buffer
@@ -4576,6 +4585,13 @@ impl<'a> HTTPClient<'a> {
         }
     }
 
+    /// `bytes_after_terminator` is the non-negative return of `phr_decode_chunked`.
+    fn on_last_chunk(&mut self, bytes_after_terminator: isize) {
+        debug_assert!(bytes_after_terminator >= 0);
+        self.state.flags.received_last_chunk = true;
+        self.on_bytes_past_response_end(bytes_after_terminator.unsigned_abs());
+    }
+
     fn handle_response_body_chunked_encoding_from_multiple_packets(
         &mut self,
         incoming_data: &[u8],
@@ -4642,7 +4658,7 @@ impl<'a> HTTPClient<'a> {
             }
             // Done
             _ => {
-                self.state.flags.received_last_chunk = true;
+                self.on_last_chunk(pret);
                 // Move the
                 // bytes out so no `&` into self.state aliases the `&mut self.state` call.
                 let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
@@ -4720,7 +4736,7 @@ impl<'a> HTTPClient<'a> {
             }
             // Done
             _ => {
-                self.state.flags.received_last_chunk = true;
+                self.on_last_chunk(pret);
                 self.handle_response_body_from_single_packet(buffer)?;
                 debug_assert!(self.state.decoded_body.list.as_ptr() != buffer.as_ptr());
                 self.report_progress(buffer.len());

--- a/test/js/web/fetch/fetch-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-keepalive.test.ts
@@ -832,6 +832,75 @@ test.concurrent.each(
   expect({ result, exitCode }).toEqual({ result: { misattributed: [] }, exitCode: 0 });
 });
 
+// Nothing is in flight on a parked keep-alive connection, so any byte the
+// origin sends there means its framing no longer matches ours; undici, curl and
+// Chromium retire the connection. bun forgave exactly `0\r\n\r\n` (a chunked
+// terminator arriving after a response that had already ended) and handed the
+// connection to the next fetch. The stray bytes are written once the first body
+// has been read, by which time the connection is back in the pool, so they
+// arrive as a separate read on the idle socket. Extra bytes in the same read as
+// the end of the response take a different path (the overshoot tests in
+// fetch.test.ts). Subprocess so the pool is private.
+test.concurrent.each([
+  ["a late chunked terminator", "0\r\n\r\n"],
+  ["an unsolicited response", "HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\ninjected"],
+])("an idle pooled connection that receives %s is evicted", async (_, stray) => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      import net from "node:net";
+      let connections = 0;
+      let first;
+      const firstClosed = Promise.withResolvers();
+      const server = net.createServer(sock => {
+        const id = ++connections;
+        if (id === 1) {
+          first = sock;
+          sock.on("close", firstClosed.resolve);
+        }
+        sock.on("error", () => {});
+        let buf = "";
+        let n = 0;
+        sock.on("data", d => {
+          buf += d.toString("latin1");
+          while (buf.includes("\\r\\n\\r\\n")) {
+            buf = buf.slice(buf.indexOf("\\r\\n\\r\\n") + 4);
+            const body = id + "." + ++n;
+            sock.write("HTTP/1.1 200 OK\\r\\nContent-Length: " + body.length + "\\r\\n\\r\\n" + body);
+          }
+        });
+      });
+      server.listen(0, "127.0.0.1");
+      await new Promise(r => server.on("listening", r));
+      const url = "http://127.0.0.1:" + server.address().port + "/";
+
+      const res1 = await fetch(url);
+      const body1 = await res1.text();
+      first.write(${JSON.stringify(stray)});
+      // Eviction closes the connection and the origin sees that. If the bytes
+      // were swallowed nothing ever closes and the test times out here.
+      await firstClosed.promise;
+      const res2 = await fetch(url);
+      const body2 = await res2.text();
+      console.log(JSON.stringify({ body1, body2, connections }));
+      process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const result = stdout.startsWith("{") ? JSON.parse(stdout.trim()) : { stdout, stderr };
+  expect({ result, exitCode }).toEqual({
+    result: { body1: "1.1", body2: "2.1", connections: 2 },
+    exitCode: 0,
+  });
+});
+
 test.skipIf(isWindows)("a full keep-alive pool evicts the longest-idle connection", async () => {
   function makeServer() {
     let connections = 0;

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3415,6 +3415,88 @@ it("does not reuse a keep-alive connection whose response carried more bytes tha
   }
 });
 
+it("does not reuse a keep-alive connection whose chunked response carried bytes past the terminating chunk", async () => {
+  // The chunked analogue of the Content-Length overshoot above: anything the origin
+  // sends after the zero-length chunk that ends the body belongs to no request of ours,
+  // so the connection's framing can no longer be trusted. The response itself is still
+  // delivered, but the connection must be closed instead of being returned to the
+  // keep-alive pool, where the next request to reuse it would be answered by whatever
+  // followed the terminator.
+  const injected = Buffer.from(
+    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 8\r\n\r\ninjected",
+    "latin1",
+  );
+  const chunkedResponse = (payload: Buffer, headers: string = "") =>
+    Buffer.concat([
+      Buffer.from(
+        `HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n${headers}Transfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n` +
+          `${payload.length.toString(16)}\r\n`,
+        "latin1",
+      ),
+      payload,
+      Buffer.from("\r\n0\r\n\r\n", "latin1"),
+    ]);
+  // The chunked decoder runs in one of two modes depending on whether a packet fits the
+  // 16 KiB scratch buffer and on the content encoding; one overshoot per combination.
+  const largeBody = Buffer.alloc(64 * 1024, "x").toString();
+  const responses: Record<string, Buffer> = {
+    "/legit": chunkedResponse(Buffer.from("legit!")),
+    "/overshoot": Buffer.concat([chunkedResponse(Buffer.from("hello")), injected]),
+    "/overshoot-large": Buffer.concat([chunkedResponse(Buffer.from(largeBody)), injected]),
+    "/overshoot-gzip": Buffer.concat([
+      chunkedResponse(gzipSync(Buffer.from("hello")), "Content-Encoding: gzip\r\n"),
+      injected,
+    ]),
+  };
+
+  let connections = 0;
+  const sockets: net.Socket[] = [];
+  const server = net.createServer(socket => {
+    connections++;
+    sockets.push(socket);
+    socket.on("error", () => {});
+    let buffered = "";
+    socket.on("data", data => {
+      buffered += data.toString("latin1");
+      while (true) {
+        const headerEnd = buffered.indexOf("\r\n\r\n");
+        if (headerEnd === -1) break;
+        const head = buffered.slice(0, headerEnd);
+        buffered = buffered.slice(headerEnd + 4);
+        const path = head.split("\r\n")[0].split(" ")[1];
+        socket.write(responses[path]);
+      }
+    });
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  try {
+    const results: Array<[path: string, body: string, connections: number]> = [];
+    for (const path of ["/overshoot", "/legit", "/overshoot-large", "/legit", "/overshoot-gzip", "/legit", "/legit"]) {
+      const response = await fetch(`http://127.0.0.1:${port}${path}`);
+      const body = await response.text();
+      results.push([path, body === largeBody ? "<large body>" : body, connections]);
+    }
+    // Every mis-framed response is still delivered in full, the request following each
+    // one has to open a new connection, and a correctly framed chunked response is still
+    // pooled (each overshoot after the first, and the final request, reuse the connection
+    // that carried the preceding /legit response).
+    expect(results).toEqual([
+      ["/overshoot", "hello", 1],
+      ["/legit", "legit!", 2],
+      ["/overshoot-large", "<large body>", 2],
+      ["/legit", "legit!", 3],
+      ["/overshoot-gzip", "hello", 3],
+      ["/legit", "legit!", 4],
+      ["/legit", "legit!", 4],
+    ]);
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    server.close();
+  }
+});
+
 // https://github.com/oven-sh/bun/issues/16682
 it("an explicit numeric `timeout` extends the socket idle deadline past the default", async () => {
   // The child runs with a 1s idle default (BUN_CONFIG_HTTP_IDLE_TIMEOUT=1) and


### PR DESCRIPTION
### Problem
- `fetch()` never pipelines, so a byte after the framed end of an HTTP/1.1 response means the peer lost framing with us. Two arrival shapes still pooled the connection. undici, curl and Chromium retire it in both.
- Same read: bytes after the terminating chunk of a chunked body. Both chunked decoders in `src/http/lib.rs` dropped the leftover count from `phr_decode_chunked` and left `allow_keepalive` set.
- Later read: an idle pooled socket receives exactly `0\r\n\r\n`. `Handler::on_data` (`src/http/HTTPContext.rs:1404`) returned early for it ("trailing zero is fine to ignore"). Every other byte sequence reached `terminate_socket`.

### Fix
- The chunked decoders report the leftover to `on_bytes_past_response_end()`, which clears `allow_keepalive`. The Content-Length overshoot and bodyless-response checks share it. This part is #37436, folded in.
- The `0\r\n\r\n` special case is removed. Any byte on an idle pooled HTTP/1.1 socket evicts it.
- Correct because the decoder runs with `consume_trailer = 1` and never leaves a terminator unread. The response is delivered unchanged. Only reuse is lost.
- Verified: new tests in `fetch.test.ts` and `fetch-keepalive.test.ts`, both red on stock bun. Self-reviewed: 6 concerns raised, 6 addressed.

### Background
- A non-negative return from `phr_decode_chunked` is the count of bytes left after the final chunk and trailers.
- A finished connection is retagged as a `PooledSocket`. Later bytes reach the pooled branch of `on_data`.
- The special case is from #1496 (2022), where it only skipped a debug log. #31495 added eviction below it and made it an exemption.
- #37438 (merged) covers bytes after a response that ends at its headers. Excluded sibling: chunked 1xx/204/304 (#34919).

<details><summary>Notes</summary>

- Interplay with `Bun.serve`: a `type: "direct"` stream that does `write(); await flush(); ...; write(); close()` currently emits `0\r\n\r\n0\r\n\r\n` (fixed by #41894, open). Today bun's fetch pools that connection by accident, through whichever of the two paths the second terminator lands on. With this change it reconnects for the next request instead, until #41894 lands. Node clients already drop that connection (`HPE_INVALID_CONSTANT`).
- Probed `Bun.serve` and `node:http` on bun for GET and HEAD across string, empty, 204, 304, sync and async default streams, async iterators and files: none of those emit a stray or doubled terminator, so ordinary bun-to-bun keep-alive reuse is unaffected.
- `release_socket` retags the connection before the result callback runs, which is why the idle-socket test can write the stray bytes right after `await res.text()`.
- A Content-Length body has no terminator at all, so a `0\r\n\r\n` after one is never legitimate either.
- The idle-socket test (`an idle pooled connection that receives ... is evicted`) writes the stray bytes from the same process only after `await res.text()`. By then the socket is already pooled (release happens before the callback), so the bytes are a separate read on the idle socket. It then awaits the origin-side `close` of connection 1 instead of sleeping; without the fix nothing closes and the test times out. Its second row (a full unsolicited response) passed before this change too and documents the invariant.
- The chunked test (`...chunked response carried bytes past the terminating chunk`) sends one overshoot per decoder path (small identity: single-packet, 64 KiB identity: multi-packet, small gzip: single-packet compressed) and checks through the origin's connection counter that the request after each overshoot dials again while the well-framed chunked responses in between are still pooled.
- The checkout window (bytes already queued in the kernel when the pool hands the socket out, before the loop polled it) is covered by #41987's `MSG_PEEK` in `find_in`, now on main. This PR is rebased on top of it; the two are complementary: the peek handles bytes queued at checkout, this handles bytes read while parked and bytes in the same read as the response end.
- Local `fetch.test.ts` failures (utf16 "with gc" timeouts, ipv6 localhost, public-internet tests, root-permission tests, `very long redirect URLS` hitting the 5 s default under debug ASAN) are identical without this change. Also ran `chunked-trailing`, `fetch-retry-chunked`, `fetch-gzip`, `fetch-preconnect`, `fetch.unix`, `fetch.tls`, `fetch-redirect`, `node-http`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch.test.ts, test/js/web/fetch/fetch-keepalive.test.ts

<!-- robobun:evidence:end -->
