### PR TITLE
TypedArray indexOf / lastIndexOf / includes: never match a wrapped, rounded or truncated search value (WebKit bump for oven-sh/WebKit#609)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-609-7a274ac4";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/typed-array-search-needle.test.ts
+++ b/test/js/bun/jsc/typed-array-search-needle.test.ts
@@ -95,13 +95,32 @@ describe("TypedArray indexOf / lastIndexOf / includes with an unrepresentable se
   });
 
   test("Float32Array: an integer a float cannot hold matches nothing", () => {
-    const array = new Float32Array([16777216, 2 ** 31, -0, Infinity, 0.1, 3.4028234663852886e38]);
-    // 2^24 + 1 was rounded to 2^24 and INT32_MAX to 2^31, and both were "found".
+    const array = new Float32Array([
+      16777216,
+      2 ** 31,
+      -0,
+      Infinity,
+      0.1,
+      3.4028234663852886e38,
+      -16777216,
+      -(2 ** 31),
+    ]);
+    // 2^24 + 1 was rounded to 2^24 and INT32_MAX to 2^31, and both were "found". The integer literals
+    // are int32-encoded, which is the path that skipped the check. asDouble() takes the other path.
     expect(search(array, 16777217)).toEqual([-1, -1, false]);
     expect(search(array, asDouble(16777217))).toEqual([-1, -1, false]);
+    expect(search(array, -16777217)).toEqual([-1, -1, false]);
     expect(search(array, 2147483647)).toEqual([-1, -1, false]);
     expect(search(array, asDouble(2147483647))).toEqual([-1, -1, false]);
+    expect(search(array, -2147483647)).toEqual([-1, -1, false]);
+    expect(search(array, 16777216.5)).toEqual([-1, -1, false]);
+    // The same integer out of arithmetic or parseInt behaves like the literal.
+    expect(search(array, 16777216.5 + 0.5)).toEqual([-1, -1, false]);
+    expect(search(array, parseInt("16777217"))).toEqual([-1, -1, false]);
+    expect(search(array, 16777216 | 1)).toEqual([-1, -1, false]);
+    expect(search(array, 2 ** 24 + 1)).toEqual([-1, -1, false]);
     expect(search(array, 16777216)).toEqual([0, 0, true]);
+    expect(search(array, asDouble(16777216))).toEqual([0, 0, true]);
     expect(search(array, asDouble(2 ** 31))).toEqual([1, 1, true]);
     expect(search(array, 0)).toEqual([2, 2, true]);
     expect(search(array, -0)).toEqual([2, 2, true]);
@@ -112,50 +131,70 @@ describe("TypedArray indexOf / lastIndexOf / includes with an unrepresentable se
     expect(search(array, 3.4028234663852886e38)).toEqual([5, 5, true]);
     expect(search(array, 1e300)).toEqual([-1, -1, false]);
     expect(search(array, Number.MAX_VALUE)).toEqual([-1, -1, false]);
+    expect(search(array, -16777216)).toEqual([6, 6, true]);
+    expect(search(array, -2147483648)).toEqual([7, 7, true]);
     expect(search(new Float32Array([1, NaN]), NaN)).toEqual([-1, -1, true]);
   });
 
   test("Float16Array: an integer a half float cannot hold matches nothing", () => {
-    const array = new Float16Array([2048, 65504, -0, Infinity, -Infinity, -65504]);
-    // 2049 was rounded to 2048, and 65536 / INT32_MAX / INT32_MIN became +/-Infinity.
+    const array = new Float16Array([2048, 65504, -0, Infinity, -Infinity, -65504, -2048]);
+    // 2049 was rounded to 2048 and 65505..65519 to 65504, and 65520 and above / INT32_MAX / INT32_MIN
+    // became +/-Infinity. Each was "found".
     expect(search(array, 2049)).toEqual([-1, -1, false]);
     expect(search(array, asDouble(2049))).toEqual([-1, -1, false]);
-    expect(search(array, 65536)).toEqual([-1, -1, false]);
+    expect(search(array, -2049)).toEqual([-1, -1, false]);
+    expect(search(array, 65505)).toEqual([-1, -1, false]);
+    expect(search(array, asDouble(65505))).toEqual([-1, -1, false]);
+    expect(search(array, 65519)).toEqual([-1, -1, false]);
     expect(search(array, 65520)).toEqual([-1, -1, false]);
+    expect(search(array, asDouble(65520))).toEqual([-1, -1, false]);
+    expect(search(array, 65535)).toEqual([-1, -1, false]);
+    expect(search(array, 65536)).toEqual([-1, -1, false]);
+    expect(search(array, -65520)).toEqual([-1, -1, false]);
+    expect(search(array, -65536)).toEqual([-1, -1, false]);
     expect(search(array, 2147483647)).toEqual([-1, -1, false]);
     expect(search(array, -2147483648)).toEqual([-1, -1, false]);
-    expect(search(array, -65536)).toEqual([-1, -1, false]);
     expect(search(array, 1e300)).toEqual([-1, -1, false]);
     expect(search(array, 2048)).toEqual([0, 0, true]);
+    expect(search(array, asDouble(2048))).toEqual([0, 0, true]);
     expect(search(array, 65504)).toEqual([1, 1, true]);
+    expect(search(array, asDouble(65504))).toEqual([1, 1, true]);
     expect(search(array, 0)).toEqual([2, 2, true]);
     expect(search(array, Infinity)).toEqual([3, 3, true]);
     expect(search(array, -Infinity)).toEqual([4, 4, true]);
     expect(search(array, -65504)).toEqual([5, 5, true]);
+    expect(search(array, -2048)).toEqual([6, 6, true]);
     expect(search(new Float16Array([1, NaN]), NaN)).toEqual([-1, -1, true]);
   });
 
   test("Float64Array: int32 search values are exact", () => {
-    const array = new Float64Array([16777217, 2147483647, -0, 2 ** 53]);
+    const array = new Float64Array([16777217, 2147483647, -0, 2 ** 53, -2147483648]);
     expect(search(array, 16777217)).toEqual([0, 0, true]);
     expect(search(array, 2147483647)).toEqual([1, 1, true]);
     expect(search(array, 0)).toEqual([2, 2, true]);
     expect(search(array, 2 ** 53)).toEqual([3, 3, true]);
+    expect(search(array, -2147483648)).toEqual([4, 4, true]);
+    expect(search(array, 16777216)).toEqual([-1, -1, false]);
     expect(search(array, 2 ** 53 + 2)).toEqual([-1, -1, false]);
+    // A BigInt is never strictly equal to a Number element.
+    expect(search(array, 2n ** 53n)).toEqual([-1, -1, false]);
   });
 
   test("BigInt64Array: a BigInt outside [-2^63, 2^63) matches nothing", () => {
-    const array = new BigInt64Array([1n, 0n, -1n, -(2n ** 63n), 2n ** 63n - 1n]);
+    const array = new BigInt64Array([1n, 0n, -1n, -(2n ** 63n), 2n ** 63n - 1n, 2n ** 32n, -(2n ** 32n)]);
     // Each of these was reduced modulo 2^64 onto one of the elements.
     for (const needle of [
       2n ** 64n + 1n,
       2n ** 64n,
       -(2n ** 64n),
+      -(2n ** 64n) + 1n,
       2n ** 64n - 1n,
       2n ** 63n,
       -(2n ** 63n) - 1n,
       2n ** 128n + 1n,
       (1n << 200n) - 1n,
+      -(1n << 200n) - 1n,
+      -(1n << 200n) + 1n,
     ]) {
       expect(search(array, needle), `needle ${needle}`).toEqual([-1, -1, false]);
     }
@@ -164,21 +203,29 @@ describe("TypedArray indexOf / lastIndexOf / includes with an unrepresentable se
     expect(search(array, -1n)).toEqual([2, 2, true]);
     expect(search(array, -(2n ** 63n))).toEqual([3, 3, true]);
     expect(search(array, 2n ** 63n - 1n)).toEqual([4, 4, true]);
+    expect(search(array, 2n ** 32n)).toEqual([5, 5, true]);
+    expect(search(array, -(2n ** 32n))).toEqual([6, 6, true]);
+    expect(search(array, 2n)).toEqual([-1, -1, false]);
+    // A Number or a string is never strictly equal to a BigInt element.
     expect(search(array, 1)).toEqual([-1, -1, false]);
+    expect(search(array, "1")).toEqual([-1, -1, false]);
   });
 
   test("BigUint64Array: a BigInt outside [0, 2^64) matches nothing", () => {
-    const array = new BigUint64Array([1n, 0n, 2n ** 64n - 1n, 2n ** 63n]);
+    const array = new BigUint64Array([1n, 0n, 2n ** 64n - 1n, 2n ** 63n, 2n ** 63n - 1n, 2n ** 32n]);
     // Each of these was reduced modulo 2^64 onto one of the elements.
     for (const needle of [
       -1n,
       -(2n ** 63n),
+      -(2n ** 63n) - 1n,
       2n ** 64n,
       2n ** 64n + 1n,
       -(2n ** 64n),
       -(2n ** 64n) + 1n,
+      -(2n ** 64n) - 1n,
       2n ** 128n,
       (1n << 200n) + 1n,
+      -(1n << 200n) + 1n,
     ]) {
       expect(search(array, needle), `needle ${needle}`).toEqual([-1, -1, false]);
     }
@@ -186,6 +233,52 @@ describe("TypedArray indexOf / lastIndexOf / includes with an unrepresentable se
     expect(search(array, 0n)).toEqual([1, 1, true]);
     expect(search(array, 2n ** 64n - 1n)).toEqual([2, 2, true]);
     expect(search(array, 2n ** 63n)).toEqual([3, 3, true]);
+    expect(search(array, 2n ** 63n - 1n)).toEqual([4, 4, true]);
+    expect(search(array, 2n ** 32n)).toEqual([5, 5, true]);
+    expect(search(array, 2n)).toEqual([-1, -1, false]);
+    // A Number is never strictly equal to a BigInt element, even one with the same mathematical value.
     expect(search(array, 0)).toEqual([-1, -1, false]);
+    expect(search(array, 2 ** 63)).toEqual([-1, -1, false]);
+  });
+
+  test("BigInt64Array / BigUint64Array: the same through a subarray, a resizable or shared buffer, and with a fromIndex", () => {
+    for (const constructor of [BigInt64Array, BigUint64Array]) {
+      const elements = [7n, 3n, 7n, 7n, 3n];
+      const byteLength = elements.length * 8;
+      const padded = new constructor(elements.length + 2);
+      padded.set(elements, 1);
+      const resizable = new ArrayBuffer(byteLength, { maxByteLength: byteLength + 64 });
+      const views = {
+        plain: new constructor(elements),
+        subarray: padded.subarray(1, elements.length + 1),
+        lengthTracking: new constructor(resizable),
+        fixedLength: new constructor(resizable, 0, elements.length),
+        shared: new constructor(new SharedArrayBuffer(byteLength)),
+      };
+      views.lengthTracking.set(elements);
+      views.shared.set(elements);
+      // Both reduce to an element modulo 2^64.
+      const seven = 7n + 2n ** 64n;
+      const three = 3n - 2n ** 64n;
+      for (const [kind, view] of Object.entries(views)) {
+        const name = `${constructor.name} ${kind}`;
+        expect(
+          [
+            view.indexOf(7n),
+            view.lastIndexOf(7n),
+            view.indexOf(7n, 1),
+            view.lastIndexOf(7n, -3),
+            view.includes(3n, -1),
+          ],
+          name,
+        ).toEqual([0, 3, 2, 2, true]);
+        expect([...search(view, seven), ...search(view, three)], name).toEqual([-1, -1, false, -1, -1, false]);
+        expect([view.indexOf(seven, 1), view.lastIndexOf(seven, -3), view.includes(three, -1)], name).toEqual([
+          -1,
+          -1,
+          false,
+        ]);
+      }
+    }
   });
 });

--- a/test/js/bun/jsc/typed-array-search-needle.test.ts
+++ b/test/js/bun/jsc/typed-array-search-needle.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+
+// %TypedArray%.prototype.indexOf / lastIndexOf compare with IsStrictlyEqual and includes with
+// SameValueZero. A search value the element type cannot represent exactly matches nothing. JSC
+// converts the search value to the element type once and scans raw storage, and three paths of that
+// conversion wrapped, rounded or truncated the value instead (oven-sh/WebKit#609).
+
+type AnyTypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float16Array
+  | Float32Array
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array;
+
+function search(array: AnyTypedArray, needle: unknown) {
+  const a = array as any;
+  return [a.indexOf(needle), a.lastIndexOf(needle), a.includes(needle)];
+}
+
+// A Float64Array element read always yields a double-encoded value, also for integers such as -1 or
+// 256 that a literal would encode as an int32. This is what puts a needle on the double path.
+const box = new Float64Array(1);
+function asDouble(n: number) {
+  box[0] = n;
+  return box[0];
+}
+
+describe("TypedArray indexOf / lastIndexOf / includes with an unrepresentable search value", () => {
+  test("Uint8ClampedArray: a double outside 0..255 matches nothing", () => {
+    const array = new Uint8ClampedArray([7, 0, 255]);
+    // In release builds each of these matched the low byte of cvttsd2si(needle): -1 found the 255,
+    // the others found the 0.
+    for (const needle of [-1, 256, 263, -249, 300, 1e10, -1e10, 2 ** 31, -(2 ** 31), 2 ** 31 - 1, 2 ** 32, 2 ** 53, Infinity, -Infinity, Number.MAX_VALUE]) {
+      expect(search(array, asDouble(needle)), `needle ${needle}`).toEqual([-1, -1, false]);
+    }
+    for (const needle of [0.5, -0.5, 7.5, 255.5, Number.MIN_VALUE]) {
+      expect(search(array, needle), `needle ${needle}`).toEqual([-1, -1, false]);
+    }
+    expect(search(array, NaN)).toEqual([-1, -1, false]);
+    // The same values read out of a double-backed array literal, as in the original report.
+    const needles = [1e10, 2 ** 31, Infinity, 2147483647, 256, -1, 0.5];
+    for (let i = 0; i < needles.length; i++) {
+      expect(search(array, needles[i]), `needle ${needles[i]}`).toEqual([-1, -1, false]);
+    }
+    // Representable doubles are still found, and -0 is SameValueZero / strictly equal to 0.
+    expect(search(array, asDouble(7))).toEqual([0, 0, true]);
+    expect(search(array, asDouble(255))).toEqual([2, 2, true]);
+    expect(search(array, -0)).toEqual([1, 1, true]);
+  });
+
+  test("integer element types: a double outside the type's range matches nothing", () => {
+    const cases: [AnyTypedArray, number[]][] = [
+      [new Int8Array([7, 0, -1, -128, 127]), [255, 128, -129, 383]],
+      [new Uint8Array([7, 0, 255]), [-1, 256, 511, -249]],
+      [new Int16Array([7, 0, -1, -32768, 32767]), [65535, 32768, -32769, 65543]],
+      [new Uint16Array([7, 0, 65535]), [-1, 65536, 65543, -65529]],
+      [new Int32Array([7, 0, -1, -(2 ** 31), 2 ** 31 - 1]), [2 ** 31, 2 ** 32 - 1, -(2 ** 31) - 1, 2 ** 32 + 7]],
+      [new Uint32Array([7, 0, 2 ** 32 - 1, 2 ** 31]), [-1, 2 ** 32, 2 ** 32 + 7, -(2 ** 31)]],
+    ];
+    for (const [array, missing] of cases) {
+      const name = array.constructor.name;
+      for (const needle of [...missing, 1e10, -1e10, 2 ** 53, 2 ** 64, Infinity, -Infinity, 0.5, 7.5]) {
+        expect(search(array, needle), `${name} needle ${needle}`).toEqual([-1, -1, false]);
+        expect(search(array, asDouble(needle)), `${name} double needle ${needle}`).toEqual([-1, -1, false]);
+      }
+      (array as any).forEach((element: number, index: number) => {
+        expect(search(array, element), `${name} element ${element}`).toEqual([index, index, true]);
+        expect(search(array, asDouble(element)), `${name} double element ${element}`).toEqual([index, index, true]);
+      });
+      expect(search(array, -0), `${name} -0`).toEqual([1, 1, true]);
+    }
+  });
+
+  test("Float32Array: an integer a float cannot hold matches nothing", () => {
+    const array = new Float32Array([16777216, 2 ** 31, -0, Infinity, 0.1, 3.4028234663852886e38]);
+    // 2^24 + 1 was rounded to 2^24 and INT32_MAX to 2^31, and both were "found".
+    expect(search(array, 16777217)).toEqual([-1, -1, false]);
+    expect(search(array, asDouble(16777217))).toEqual([-1, -1, false]);
+    expect(search(array, 2147483647)).toEqual([-1, -1, false]);
+    expect(search(array, asDouble(2147483647))).toEqual([-1, -1, false]);
+    expect(search(array, 16777216)).toEqual([0, 0, true]);
+    expect(search(array, asDouble(2 ** 31))).toEqual([1, 1, true]);
+    expect(search(array, 0)).toEqual([2, 2, true]);
+    expect(search(array, -0)).toEqual([2, 2, true]);
+    expect(search(array, Infinity)).toEqual([3, 3, true]);
+    // The element is Math.fround(0.1), not the double 0.1.
+    expect(search(array, 0.1)).toEqual([-1, -1, false]);
+    expect(search(array, Math.fround(0.1))).toEqual([4, 4, true]);
+    expect(search(array, 3.4028234663852886e38)).toEqual([5, 5, true]);
+    expect(search(array, 1e300)).toEqual([-1, -1, false]);
+    expect(search(array, Number.MAX_VALUE)).toEqual([-1, -1, false]);
+    expect(search(new Float32Array([1, NaN]), NaN)).toEqual([-1, -1, true]);
+  });
+
+  test("Float16Array: an integer a half float cannot hold matches nothing", () => {
+    const array = new Float16Array([2048, 65504, -0, Infinity, -Infinity, -65504]);
+    // 2049 was rounded to 2048, and 65536 / INT32_MAX / INT32_MIN became +/-Infinity.
+    expect(search(array, 2049)).toEqual([-1, -1, false]);
+    expect(search(array, asDouble(2049))).toEqual([-1, -1, false]);
+    expect(search(array, 65536)).toEqual([-1, -1, false]);
+    expect(search(array, 65520)).toEqual([-1, -1, false]);
+    expect(search(array, 2147483647)).toEqual([-1, -1, false]);
+    expect(search(array, -2147483648)).toEqual([-1, -1, false]);
+    expect(search(array, -65536)).toEqual([-1, -1, false]);
+    expect(search(array, 1e300)).toEqual([-1, -1, false]);
+    expect(search(array, 2048)).toEqual([0, 0, true]);
+    expect(search(array, 65504)).toEqual([1, 1, true]);
+    expect(search(array, 0)).toEqual([2, 2, true]);
+    expect(search(array, Infinity)).toEqual([3, 3, true]);
+    expect(search(array, -Infinity)).toEqual([4, 4, true]);
+    expect(search(array, -65504)).toEqual([5, 5, true]);
+    expect(search(new Float16Array([1, NaN]), NaN)).toEqual([-1, -1, true]);
+  });
+
+  test("Float64Array: int32 search values are exact", () => {
+    const array = new Float64Array([16777217, 2147483647, -0, 2 ** 53]);
+    expect(search(array, 16777217)).toEqual([0, 0, true]);
+    expect(search(array, 2147483647)).toEqual([1, 1, true]);
+    expect(search(array, 0)).toEqual([2, 2, true]);
+    expect(search(array, 2 ** 53)).toEqual([3, 3, true]);
+    expect(search(array, 2 ** 53 + 2)).toEqual([-1, -1, false]);
+  });
+
+  test("BigInt64Array: a BigInt outside [-2^63, 2^63) matches nothing", () => {
+    const array = new BigInt64Array([1n, 0n, -1n, -(2n ** 63n), 2n ** 63n - 1n]);
+    // Each of these was reduced modulo 2^64 onto one of the elements.
+    for (const needle of [2n ** 64n + 1n, 2n ** 64n, -(2n ** 64n), 2n ** 64n - 1n, 2n ** 63n, -(2n ** 63n) - 1n, 2n ** 128n + 1n, (1n << 200n) - 1n]) {
+      expect(search(array, needle), `needle ${needle}`).toEqual([-1, -1, false]);
+    }
+    expect(search(array, 1n)).toEqual([0, 0, true]);
+    expect(search(array, 0n)).toEqual([1, 1, true]);
+    expect(search(array, -1n)).toEqual([2, 2, true]);
+    expect(search(array, -(2n ** 63n))).toEqual([3, 3, true]);
+    expect(search(array, 2n ** 63n - 1n)).toEqual([4, 4, true]);
+    expect(search(array, 1)).toEqual([-1, -1, false]);
+  });
+
+  test("BigUint64Array: a BigInt outside [0, 2^64) matches nothing", () => {
+    const array = new BigUint64Array([1n, 0n, 2n ** 64n - 1n, 2n ** 63n]);
+    // Each of these was reduced modulo 2^64 onto one of the elements.
+    for (const needle of [-1n, -(2n ** 63n), 2n ** 64n, 2n ** 64n + 1n, -(2n ** 64n), -(2n ** 64n) + 1n, 2n ** 128n, (1n << 200n) + 1n]) {
+      expect(search(array, needle), `needle ${needle}`).toEqual([-1, -1, false]);
+    }
+    expect(search(array, 1n)).toEqual([0, 0, true]);
+    expect(search(array, 0n)).toEqual([1, 1, true]);
+    expect(search(array, 2n ** 64n - 1n)).toEqual([2, 2, true]);
+    expect(search(array, 2n ** 63n)).toEqual([3, 3, true]);
+    expect(search(array, 0)).toEqual([-1, -1, false]);
+  });
+});

--- a/test/js/bun/jsc/typed-array-search-needle.test.ts
+++ b/test/js/bun/jsc/typed-array-search-needle.test.ts
@@ -71,6 +71,22 @@ describe("TypedArray indexOf / lastIndexOf / includes with an unrepresentable se
     expect(search(array, -0)).toEqual([1, 1, true]);
   });
 
+  test("Uint8ClampedArray: a negated int32 stays unmatched once the JIT hands it over as a double", () => {
+    // Cold, `-i` is an int32 and took the (correct) int32 path. Once the negate has produced -0, the
+    // optimizing tiers represent its result as a double, so the same call reaches the double path that
+    // wrapped: in release builds hot(6) started returning 3 (the 250) after about 13k iterations.
+    const array = new Uint8ClampedArray([0, 3, 6, 250, 255]);
+    const hot = (i: number) => array.indexOf(-i);
+    for (let k = 0; k < 10; k++) hot(0);
+    const wrong: number[] = [];
+    for (let i = 0; i < 30000; i++) {
+      const n = i % 300;
+      if (hot(n) !== -1 && n !== 0) wrong.push(n);
+    }
+    expect(wrong).toEqual([]);
+    expect([hot(6), hot(250), hot(1), hot(0), hot(-3), hot(-250)]).toEqual([-1, -1, -1, 0, 1, 3]);
+  });
+
   test("integer element types: a double outside the type's range matches nothing", () => {
     const cases: [AnyTypedArray, number[]][] = [
       [new Int8Array([7, 0, -1, -128, 127]), [255, 128, -129, 383]],

--- a/test/js/bun/jsc/typed-array-search-needle.test.ts
+++ b/test/js/bun/jsc/typed-array-search-needle.test.ts
@@ -37,7 +37,23 @@ describe("TypedArray indexOf / lastIndexOf / includes with an unrepresentable se
     const array = new Uint8ClampedArray([7, 0, 255]);
     // In release builds each of these matched the low byte of cvttsd2si(needle): -1 found the 255,
     // the others found the 0.
-    for (const needle of [-1, 256, 263, -249, 300, 1e10, -1e10, 2 ** 31, -(2 ** 31), 2 ** 31 - 1, 2 ** 32, 2 ** 53, Infinity, -Infinity, Number.MAX_VALUE]) {
+    for (const needle of [
+      -1,
+      256,
+      263,
+      -249,
+      300,
+      1e10,
+      -1e10,
+      2 ** 31,
+      -(2 ** 31),
+      2 ** 31 - 1,
+      2 ** 32,
+      2 ** 53,
+      Infinity,
+      -Infinity,
+      Number.MAX_VALUE,
+    ]) {
       expect(search(array, asDouble(needle)), `needle ${needle}`).toEqual([-1, -1, false]);
     }
     for (const needle of [0.5, -0.5, 7.5, 255.5, Number.MIN_VALUE]) {
@@ -131,7 +147,16 @@ describe("TypedArray indexOf / lastIndexOf / includes with an unrepresentable se
   test("BigInt64Array: a BigInt outside [-2^63, 2^63) matches nothing", () => {
     const array = new BigInt64Array([1n, 0n, -1n, -(2n ** 63n), 2n ** 63n - 1n]);
     // Each of these was reduced modulo 2^64 onto one of the elements.
-    for (const needle of [2n ** 64n + 1n, 2n ** 64n, -(2n ** 64n), 2n ** 64n - 1n, 2n ** 63n, -(2n ** 63n) - 1n, 2n ** 128n + 1n, (1n << 200n) - 1n]) {
+    for (const needle of [
+      2n ** 64n + 1n,
+      2n ** 64n,
+      -(2n ** 64n),
+      2n ** 64n - 1n,
+      2n ** 63n,
+      -(2n ** 63n) - 1n,
+      2n ** 128n + 1n,
+      (1n << 200n) - 1n,
+    ]) {
       expect(search(array, needle), `needle ${needle}`).toEqual([-1, -1, false]);
     }
     expect(search(array, 1n)).toEqual([0, 0, true]);
@@ -145,7 +170,16 @@ describe("TypedArray indexOf / lastIndexOf / includes with an unrepresentable se
   test("BigUint64Array: a BigInt outside [0, 2^64) matches nothing", () => {
     const array = new BigUint64Array([1n, 0n, 2n ** 64n - 1n, 2n ** 63n]);
     // Each of these was reduced modulo 2^64 onto one of the elements.
-    for (const needle of [-1n, -(2n ** 63n), 2n ** 64n, 2n ** 64n + 1n, -(2n ** 64n), -(2n ** 64n) + 1n, 2n ** 128n, (1n << 200n) + 1n]) {
+    for (const needle of [
+      -1n,
+      -(2n ** 63n),
+      2n ** 64n,
+      2n ** 64n + 1n,
+      -(2n ** 64n),
+      -(2n ** 64n) + 1n,
+      2n ** 128n,
+      (1n << 200n) + 1n,
+    ]) {
       expect(search(array, needle), `needle ${needle}`).toEqual([-1, -1, false]);
     }
     expect(search(array, 1n)).toEqual([0, 0, true]);


### PR DESCRIPTION
### Problem
- `Uint8ClampedArray.prototype.indexOf`, `lastIndexOf` and `includes` match a byte that is not there when the search value is a double outside 0..255, in release builds only: `new Uint8ClampedArray([7, 0, 255]).indexOf(x)` is 2 for `x = -1` (double) and 1 for `256`, `1e10`, `2 ** 31`, `Infinity`. Every build also has `new Float32Array([16777216]).indexOf(16777217) === 0`, `new Float16Array([Infinity]).indexOf(65536) === 0` and `new BigInt64Array([1n]).includes(2n ** 64n + 1n) === true`. V8 answers -1 / false for all of them.
- The cause is one JSC helper, `toNativeFromValueWithoutCoercion<Adaptor>()` (`runtime/ToNativeFromValue.h`), which turns the search value into an element value before the scan. Its BigInt path used the modular `ToBigInt64` / `ToBigUint64`, its int32 path for float element types cast with no round-trip check, and its double path for `Uint8Clamped` did `static_cast<uint8_t>(double)`, undefined behavior outside (-1, 256), which the LTO link folds into "is the double integral" (see Background).

### Fix
- Pin WebKit to `autobuild-preview-pr-609-7a274ac4`, the preview build of oven-sh/WebKit#609. That change makes all three paths return "not representable" instead of a wrapped, rounded or truncated value, and moves the float adaptors' range check before the narrowing cast.
- The pin is a preview tag, not a merge commit. Do not merge before oven-sh/WebKit#609 lands. I move the pin to the merged commit then. The preview also carries oven-sh/WebKit#561, #566 and #568, which are on WebKit `main` past the current pin. (oven-sh/WebKit#609 has one later commit, 1f8219282c, that only touches its JSTests stress test, so this preview's `Source/` is what merges.)
- Verified: `test/js/bun/jsc/typed-array-search-needle.test.ts` (new, 9 tests over all 12 element types, including a warmed `u8c.indexOf(-i)` whose needle only becomes a double after DFG tier-up). bun 1.4.2 (release, LLD 22.1.8 link) fails 7 of them (both `Uint8ClampedArray` tests, `Float32Array`, `Float16Array` and the three BigInt tests), a non-LTO or debug build of `main` fails 5 (everything but the `Uint8ClampedArray`, integer-type and `Float64Array` tests), and `bun bd test` with this pin (debug + ASAN) passes all 9. oven-sh/WebKit#609 lists the JSC-side runs (new stress test, 714 test262 TypedArray search cases, the typed-array stress tests).

### Supersedes #42083 and #42089
- #42083 (bump for oven-sh/WebKit#604, the `Float32Array` / `Float16Array` int32 path) and #42089 (bump for oven-sh/WebKit#607, the `BigInt64Array` / `BigUint64Array` path) each fixed one of the three paths. oven-sh/WebKit#609 changes the same helper and contains both of those fixes plus the `Uint8Clamped` double path, so both pairs are closed in favour of this PR and oven-sh/WebKit#609.
- 7dbd53f612 carries their test rows into `typed-array-search-needle.test.ts`: negative and computed int32 needles on `Float32Array`, the 65505..65519 and 65535 needles on `Float16Array`, more wrapped BigInt needles (negative many-digit values, `-(2n ** 64n) ± 1n`, `-(2n ** 63n) - 1n` on `BigUint64Array`), and the same searches through a subarray, a resizable buffer, a shared buffer, and with a `fromIndex`.

### Background
- The spec compares the search value with each element's Number or BigInt value (IsStrictlyEqual for `indexOf` / `lastIndexOf`, SameValueZero for `includes`). JSC converts the search value to the element type once and scans raw storage with `memchr`-style helpers, which is only equivalent when that conversion is exact. The helper returns `std::optional` for that reason.
- Why only release builds show the `Uint8Clamped` face: the check after the cast, `static_cast<double>(integer) != value`, is `uitofp (fptoui x)` compared with `x` in LLVM IR, and an out-of-range `fptoui` is poison. LLVM 22 folds that pair into `ftrunc x` when only a compare observes it. bun's release link is ThinLTO through rust-lld (LLD 22.1.8), so the `-lto` WebKit prebuilt's bitcode is code-generated by LLVM 22, while the non-LTO prebuilt (local `build:release`, `release-asan`, debug) is compiled by clang 21, which keeps the round trip. In bun 1.4.2 the fold is visible as `roundsd $0xb; ucomisd` at `typedArrayViewProtoFuncIncludes+0xcfb`, and the needle that is then searched for is the low byte of a 32-bit `cvttsd2si`.
- oven-sh/WebKit#205 replaced the same cast in `IntegralTypedArrayAdaptor` (Int8 through Uint32) with `truncateDoubleToInt64`, which is why those element types were already correct.

<details><summary>Notes</summary>

- Standalone reproduction of the codegen difference: the old conversion compiled to bitcode with clang 21 (`-O3 -flto=thin`) and linked with `--ld-path=<rustup nightly-2026-07-20>/gcc-ld/ld.lld` emits `cvttsd2si %xmm0,%eax; roundsd $0xb,%xmm0,%xmm1` and reports `1e10` found at index 1; the fixed conversion emits `cvttsd2si %xmm0,%rax; cvtsi2sd` and is correct. Plain clang 21 `-O3` keeps the round trip in both.
- Artifact check: running the `-lto` prebuilt's `JSTypedArrayViewPrototypeFunctions2.cpp.o` bitcode through the same LLD 22.1.8 with `--lto-emit-asm` gives one `roundsd $11` + 32-bit `cvttsd2si` in each of `typedArrayViewProtoFuncIncludes` / `IndexOf` for the old pin (attributed to `TypedArrayAdaptors.h:340` by the line table) and none for the preview, which has a 64-bit `cvttsd2si` + `movzbl` at `TypedArrayAdaptors.h:343` instead.
- There is no DFG / FTL intrinsic for these three functions on typed arrays, so `BUN_JSC_useJIT=0` made no difference, as the report observed.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/typed-array-search-needle.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/typed-array-search-needle.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/jsc/typed-array-search-needle.test.ts:
(pass) TypedArray indexOf / lastIndexOf / includes with an unrepresentable search value > Uint8ClampedArray: a double outside 0..255 matches nothing [39.21ms]
(pass) TypedArray indexOf / lastIndexOf / includes with an unrepresentable search value > Uint8ClampedArray: a negated int32 stays unmatched once the JIT hands it over as a double [85.55ms]
(pass) TypedArray indexOf / lastIndexOf / includes with an unrepresentable search value > integer element types: a double outside the type's range matches nothing [72.03ms]
(pass) TypedArray indexOf / lastIndexOf / includes with an unrepresentable search value > Float32Array: an integer a float cannot hold matches nothing [14.86ms]
(pass) TypedArray indexOf / lastIndexOf / includes with an unrepresentable search value > Float16Array: an integer a half float cannot hold matches nothing [15.13ms]
(pass) TypedArray indexOf / lastIndexOf / includes with an unrepresentable search value > Float64Array: int32 search values are exact [5.74ms]
(pass) TypedArray indexOf / lastIndexOf / includes with an unrepresentable search value > BigInt64Array: a BigInt outside [-2^63, 2^63) matches nothing [12.30ms]
(pass) TypedArray indexOf / lastIndexOf / includes with an unrepresentable search value > BigUint64Array: a BigInt outside [0, 2^64) matches nothing [11.60ms]
(pass) TypedArray indexOf / lastIndexOf / includes with an unrepresentable search value > BigInt64Array / BigUint64Array: the same through a subarray, a resizable or shared buffer, and with a fromIndex [20.03ms]

 9 pass
 0 fail
 362 expect() calls
Ran 9 tests across 1 file. [2.33s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                      |   2 +-
 test/js/bun/jsc/typed-array-search-needle.test.ts | 300 ++++++++++++++++++++++
 2 files changed, 301 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
scripts/build/deps/webkit.ts                           1      1     14
test/js/bun/jsc/typed-array-search-needle.test.ts      2      2     14
```

</details>

**root cause** · written by the author bot

The typed array `indexOf`, `lastIndexOf`, and `includes` fast paths converted the search value from a double straight into the element's storage type with a cast that is undefined behavior when the value is out of range, so needles like `-1`, `256`, `1e10`, or `Infinity` ended up wrapping modulo 256 for `Uint8ClampedArray` and spuriously matching an unrelated byte. The fix replaces the unchecked cast with an explicit round-trip check: the double is converted to the element type and converted back, and the search proceeds only if the result is exactly equal to the original value, otherwise t…

<!-- robobun:evidence:end -->

