### PR TITLE
minify: linear memory when folding a `+` chain of template literals

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2120,8 +2120,7 @@ pub struct TemplatePart {
 }
 
 impl TemplatePart {
-    /// Field-wise copy. `TemplatePart` is not `Copy` only because `EString`
-    /// does not derive it; all fields are structurally `Copy`.
+    /// Field-wise copy (`EString` does not derive `Copy`).
     #[inline]
     pub fn shallow_clone(&self) -> TemplatePart {
         TemplatePart {

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2119,6 +2119,19 @@ pub struct TemplatePart {
     pub tail: TemplateContents,
 }
 
+impl TemplatePart {
+    /// Field-wise copy. `TemplatePart` is not `Copy` only because `EString`
+    /// does not derive it; all fields are structurally `Copy`.
+    #[inline]
+    pub fn shallow_clone(&self) -> TemplatePart {
+        TemplatePart {
+            value: self.value,
+            tail_loc: self.tail_loc,
+            tail: self.tail.shallow_clone(),
+        }
+    }
+}
+
 pub struct Template {
     pub tag: Option<ExprNodeIndex>,
     /// Arena-owned mutable slice. Stored as a
@@ -2197,13 +2210,7 @@ impl Template {
             bun_alloc::ArenaVec::<TemplatePart>::with_capacity_in(self.parts().len(), bump);
         let mut head = Expr::init(core::mem::take(self.head.cooked_mut()), loc);
         for part_src in self.parts() {
-            // Field-wise copy (TemplatePart is not `Copy` only
-            // because `EString` does not derive it; all fields are structurally `Copy`).
-            let mut part = TemplatePart {
-                value: part_src.value,
-                tail_loc: part_src.tail_loc,
-                tail: part_src.tail.shallow_clone(),
-            };
+            let mut part = part_src.shallow_clone();
             debug_assert!(matches!(part.tail, TemplateContents::Cooked(_)));
 
             part.value = part.value.unwrap_inlined();

--- a/src/ast/fold_string_addition.rs
+++ b/src/ast/fold_string_addition.rs
@@ -1,6 +1,8 @@
+use core::mem::ManuallyDrop;
+
 use crate::expr::{Data, PrimitiveType, data};
-use crate::{E, Expr, e};
-use bun_alloc::Arena; // bumpalo::Bump re-export
+use crate::{E, Expr, StoreRef, e};
+use bun_alloc::{Arena, ArenaVec};
 
 /// Links both ropes into the result (see `EString::push`); sound because shared strings are never ropes.
 fn join_strings(left: &E::EString, right: &E::EString) -> E::EString {
@@ -13,25 +15,70 @@ fn join_strings(left: &E::EString, right: &E::EString) -> E::EString {
     new
 }
 
-/// Concat two `TemplatePart` slices into the bump arena.
-/// `TemplatePart` is POD-shaped (no Drop) but not `Copy` because
-/// `EString` opted out; mirror `Template::fold`'s field-wise copy via
-/// `shallow_clone` instead of raw `copy_nonoverlapping`.
-fn concat_parts(
-    bump: &Arena,
-    a: &[e::TemplatePart],
-    b: &[e::TemplatePart],
-) -> crate::StoreSlice<e::TemplatePart> {
-    let mut v = bun_alloc::ArenaVec::<e::TemplatePart>::with_capacity_in(a.len() + b.len(), bump);
-    for p in a.iter().chain(b.iter()) {
-        // Field-wise copy (all fields structurally `Copy`).
-        v.push(e::TemplatePart {
-            value: p.value,
-            tail_loc: p.tail_loc,
-            tail: p.tail.shallow_clone(),
-        });
+/// The one template node a `TemplatePartsBuilder` may grow in place, and the
+/// buffer that backs its `parts`.
+struct Accumulator<'a> {
+    node: StoreRef<E::Template>,
+    /// Never dropped, so a buffer the builder stops using is not freed and
+    /// every view of it stays valid.
+    parts: ManuallyDrop<ArenaVec<'a, e::TemplatePart>>,
+}
+
+impl Accumulator<'_> {
+    /// Growing can move the buffer and free the old block. That is sound only
+    /// when `node` holds the one view of the whole buffer and `extra` lives
+    /// outside it.
+    fn can_grow_for(&self, node: StoreRef<E::Template>, extra: &[e::TemplatePart]) -> bool {
+        let view = node.parts;
+        let buffer = self.parts.as_ptr();
+        let buffer_end = buffer.wrapping_add(self.parts.capacity());
+        core::ptr::eq(self.node.as_ptr(), node.as_ptr())
+            && core::ptr::eq(buffer, view.as_ptr())
+            && self.parts.len() == view.len()
+            && (extra.as_ptr() >= buffer_end || extra.as_ptr().wrapping_add(extra.len()) <= buffer)
     }
-    crate::StoreSlice::from_bump(v)
+}
+
+/// Growable backing buffer for the `parts` of the template that a
+/// left-associated `+` chain folds into. `E::Template.parts` is a bare
+/// `(ptr, len)` view with no spare capacity, so without this every
+/// `` `a${x}` + `b${y}` `` step would copy all parts accumulated so far into
+/// a fresh arena slice: quadratic memory in the chain length.
+///
+/// One instance lives for one run of the iterative binary-expression visitor,
+/// i.e. one left-nested operator chain.
+#[derive(Default)]
+pub struct TemplatePartsBuilder<'a> {
+    accumulator: Option<Accumulator<'a>>,
+}
+
+impl<'a> TemplatePartsBuilder<'a> {
+    /// Append `extra` to `template`'s parts: in place when `template` is this
+    /// builder's accumulator, with one copy into a new buffer otherwise.
+    fn append(
+        &mut self,
+        bump: &'a Arena,
+        mut template: StoreRef<E::Template>,
+        extra: &[e::TemplatePart],
+    ) {
+        let mut accumulator = match self.accumulator.take() {
+            Some(accumulator) if accumulator.can_grow_for(template, extra) => accumulator,
+            _ => {
+                let current = template.parts();
+                let mut parts = ArenaVec::with_capacity_in(current.len() + extra.len(), bump);
+                parts.extend(current.iter().map(e::TemplatePart::shallow_clone));
+                Accumulator {
+                    node: template,
+                    parts: ManuallyDrop::new(parts),
+                }
+            }
+        };
+        accumulator
+            .parts
+            .extend(extra.iter().map(e::TemplatePart::shallow_clone));
+        template.parts = crate::StoreSlice::new_mut(accumulator.parts.as_mut_slice());
+        self.accumulator = Some(accumulator);
+    }
 }
 
 /// Transforming the left operand into a string is not safe if it comes from a
@@ -48,11 +95,12 @@ pub enum FoldStringAdditionKind {
 
 /// NOTE: unlike esbuild's js_ast_helpers.FoldStringAddition, this does mutate
 /// the input AST in the case of rope strings
-pub fn fold_string_addition(
+pub fn fold_string_addition<'a>(
     l: Expr,
     r: Expr,
-    bump: &Arena,
+    bump: &'a Arena,
     kind: FoldStringAdditionKind,
+    template_parts: &mut TemplatePartsBuilder<'a>,
 ) -> Option<Expr> {
     // "See through" inline enum constants
     // TODO: implement foldAdditionPreProcess to fold some more things :)
@@ -173,12 +221,9 @@ pub fn fold_string_addition(
                                     ));
                                     left.parts_mut()[i].tail = new_tail;
 
-                                    let new_parts = if right.parts().is_empty() {
-                                        left.parts
-                                    } else {
-                                        concat_parts(bump, left.parts(), right.parts())
-                                    };
-                                    left.parts = new_parts;
+                                    if !right.parts().is_empty() {
+                                        template_parts.append(bump, left, right.parts());
+                                    }
                                     return Some(lhs);
                                 }
                             } else if left.head.is_utf8() && right.head.is_utf8() {

--- a/src/ast/fold_string_addition.rs
+++ b/src/ast/fold_string_addition.rs
@@ -15,19 +15,15 @@ fn join_strings(left: &E::EString, right: &E::EString) -> E::EString {
     new
 }
 
-/// The one template node a `TemplatePartsBuilder` may grow in place, and the
-/// buffer that backs its `parts`.
+/// The template node a `+` chain folds into, and the buffer behind its `parts`.
 struct Accumulator<'a> {
     node: StoreRef<E::Template>,
-    /// Never dropped, so a buffer the builder stops using is not freed and
-    /// every view of it stays valid.
+    /// Never freed: nodes keep their views into buffers the builder has stopped using.
     parts: ManuallyDrop<ArenaVec<'a, e::TemplatePart>>,
 }
 
 impl Accumulator<'_> {
-    /// Growing can move the buffer and free the old block. That is sound only
-    /// when `node` holds the one view of the whole buffer and `extra` lives
-    /// outside it.
+    /// Growth reallocs: `node` must hold the only view, and `extra` must live outside the buffer.
     fn can_grow_for(&self, node: StoreRef<E::Template>, extra: &[e::TemplatePart]) -> bool {
         let view = node.parts;
         let buffer = self.parts.as_ptr();
@@ -39,22 +35,14 @@ impl Accumulator<'_> {
     }
 }
 
-/// Growable backing buffer for the `parts` of the template that a
-/// left-associated `+` chain folds into. `E::Template.parts` is a bare
-/// `(ptr, len)` view with no spare capacity, so without this every
-/// `` `a${x}` + `b${y}` `` step would copy all parts accumulated so far into
-/// a fresh arena slice: quadratic memory in the chain length.
-///
-/// One instance lives for one run of the iterative binary-expression visitor,
-/// i.e. one left-nested operator chain.
+/// Spare capacity behind `E::Template.parts`, so each template fold in a `+` chain appends, not copies.
 #[derive(Default)]
 pub struct TemplatePartsBuilder<'a> {
     accumulator: Option<Accumulator<'a>>,
 }
 
 impl<'a> TemplatePartsBuilder<'a> {
-    /// Append `extra` to `template`'s parts: in place when `template` is this
-    /// builder's accumulator, with one copy into a new buffer otherwise.
+    /// In place for this builder's accumulator; any other template is copied once first.
     fn append(
         &mut self,
         bump: &'a Arena,

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -5,7 +5,9 @@ use core::cmp::Ordering;
 use crate::p::P;
 use crate::parser::{ExprIn, float_to_int32, prefill};
 use crate::scan::scan_side_effects::SideEffects;
-use bun_ast::fold_string_addition::{FoldStringAdditionKind, fold_string_addition};
+use bun_ast::fold_string_addition::{
+    FoldStringAdditionKind, TemplatePartsBuilder, fold_string_addition,
+};
 use bun_ast::{
     self as js_ast, E, Expr, ExprData, Op, StoreRef, Symbol,
     expr::{Equality, LooseEql, StrictEql},
@@ -105,6 +107,7 @@ impl BinaryExpressionVisitor {
     pub(crate) fn visit_right_and_finish<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool>(
         v: &mut Self,
         p: &mut P<'a, TYPESCRIPT, SCAN_ONLY>,
+        template_parts: &mut TemplatePartsBuilder<'a>,
     ) -> Expr {
         // `v.e: StoreRef<E::Binary>` is the safe arena back-reference (Copy).
         // Snapshot the handle for the identity check / tail re-wrap, then take
@@ -430,6 +433,7 @@ impl BinaryExpressionVisitor {
                         e_.right,
                         p.arena,
                         FoldStringAdditionKind::Normal,
+                        template_parts,
                     ) {
                         return res;
                     }
@@ -442,6 +446,7 @@ impl BinaryExpressionVisitor {
                                 e_.right,
                                 p.arena,
                                 FoldStringAdditionKind::NestedLeft,
+                                template_parts,
                             ) {
                                 return p.new_expr(
                                     E::Binary {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -803,6 +803,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn e_binary(p: &mut Self, e: &mut Expr) {
         let expr = *e;
         use crate::visit::visit_binary::BinaryExpressionVisitor;
+        use bun_ast::fold_string_addition::TemplatePartsBuilder;
         let e_ = expr.data.e_binary().expect("infallible: variant checked");
 
         // The handling of binary expressions is convoluted because we're using
@@ -822,6 +823,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // should almost always be very small, and almost all visits should reuse
         // existing memory without allocating anything.
         let stack_bottom = p.binary_expression_stack.len();
+
+        // Shared by every `+` fold along this chain so a run of template
+        // literals appends to one `parts` buffer instead of re-copying it.
+        let mut template_parts = TemplatePartsBuilder::default();
 
         // Assigned on every `break` arm of the loop below; the initial input
         // `expr` is never read directly.
@@ -851,7 +856,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // statement).
             if left_binary.is_none() || left_in.assign_target != js_ast::AssignTarget::None {
                 p.visit_expr_in_out(&mut v.e.left, left_in);
-                current = BinaryExpressionVisitor::visit_right_and_finish(&mut v, p);
+                current =
+                    BinaryExpressionVisitor::visit_right_and_finish(&mut v, p, &mut template_parts);
                 break;
             }
 
@@ -871,7 +877,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         while p.binary_expression_stack.len() > stack_bottom {
             v = p.binary_expression_stack.pop().unwrap();
             v.e.left = current;
-            current = BinaryExpressionVisitor::visit_right_and_finish(&mut v, p);
+            current =
+                BinaryExpressionVisitor::visit_right_and_finish(&mut v, p, &mut template_parts);
         }
 
         *e = current;

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -824,8 +824,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // existing memory without allocating anything.
         let stack_bottom = p.binary_expression_stack.len();
 
-        // Shared by every `+` fold along this chain so a run of template
-        // literals appends to one `parts` buffer instead of re-copying it.
+        // One per chain: a run of template literals appends to one `parts` buffer.
         let mut template_parts = TemplatePartsBuilder::default();
 
         // Assigned on every `break` arm of the loop below; the initial input

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -4081,22 +4081,6 @@ pub(crate) mod __gated_printer {
                         },
                     };
                     if e.tag.is_none() && (self.options.minify_syntax || self.was_lazy_export) {
-                        // `TemplatePart` is structurally
-                        // `Copy` but `EString` doesn't derive it; field-wise copy.
-                        #[inline]
-                        fn part_clone(p: &E::TemplatePart) -> E::TemplatePart {
-                            E::TemplatePart {
-                                value: p.value,
-                                tail_loc: p.tail_loc,
-                                tail: match &p.tail {
-                                    E::TemplateContents::Cooked(c) => {
-                                        E::TemplateContents::Cooked(c.shallow_clone())
-                                    }
-                                    E::TemplateContents::Raw(r) => E::TemplateContents::Raw(*r),
-                                },
-                            }
-                        }
-
                         // Bump-allocated (printer arena) so the folded
                         // template's parts outlive the inner block: the
                         // thread-local `e` above keeps the parts slice alive
@@ -4104,7 +4088,7 @@ pub(crate) mod __gated_printer {
                         let mut replaced =
                             bun_alloc::ArenaVec::<E::TemplatePart>::new_in(self.bump);
                         for (i, _part) in e.parts().iter().enumerate() {
-                            let mut part = part_clone(_part);
+                            let mut part = _part.shallow_clone();
                             let inlined_value: Option<Expr> = match &part.value.data {
                                 ExprData::ENameOfSymbol(e2) => Some(Expr::init(
                                     E::String::init(self.mangled_prop_name(e2.ref_)),
@@ -4119,7 +4103,9 @@ pub(crate) mod __gated_printer {
 
                             if let Some(value) = inlined_value {
                                 if replaced.is_empty() {
-                                    replaced.extend(e.parts()[..i].iter().map(part_clone));
+                                    replaced.extend(
+                                        e.parts()[..i].iter().map(E::TemplatePart::shallow_clone),
+                                    );
                                 }
                                 part.value = value;
                                 replaced.push(part);

--- a/test/js/bun/transpiler/transpiler-template-chain-oom.test.ts
+++ b/test/js/bun/transpiler/transpiler-template-chain-oom.test.ts
@@ -7,7 +7,8 @@ import { bunEnv, bunExe } from "harness";
 
 test("long template literal `+` chain does not blow up memory with target: bun", async () => {
   const fixture = /* js */ `
-    const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    const rss = () =>
+      (process.platform === "darwin" ? Bun.unsafe.memoryFootprint?.() : undefined) ?? process.memoryUsage.rss();
     const n = 4096;
     const input = "capture(" + Array(n).fill("\`a\${x}b\`").join(" + ") + ");";
     const expected = "capture(\`" + Array(n).fill("a\${x}b").join("") + "\`);\\n";
@@ -28,14 +29,14 @@ test("long template literal `+` chain does not blow up memory with target: bun",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({
+  expect({ stdout: stdout.trim(), stderr }).toMatchObject({
     stdout: expect.stringMatching(/^\{"delta_mb":/),
-    exitCode: 0,
   });
   const { delta_mb } = JSON.parse(stdout);
   // Before the fix: ~525 MB in release for n=4096. After: under 10 MB in
   // release, ~10 MB in debug+ASAN.
   expect(delta_mb).toBeLessThan(100);
+  expect(exitCode).toBe(0);
 });
 
 test("template literal folding output is unchanged", () => {

--- a/test/js/bun/transpiler/transpiler-template-chain-oom.test.ts
+++ b/test/js/bun/transpiler/transpiler-template-chain-oom.test.ts
@@ -1,0 +1,75 @@
+// minify_syntax (enabled for target:"bun") folds `a${x}` + `b${y}` into one
+// template literal. Each step of a long left-associated chain used to copy
+// every part accumulated so far into a fresh arena slice and keep the old one,
+// giving O(n^2) memory: 44 KB of "`a${x}b` + `a${x}b` + ..." took over 500 MB.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("long template literal `+` chain does not blow up memory with target: bun", async () => {
+  const fixture = /* js */ `
+    const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    const n = 4096;
+    const input = "capture(" + Array(n).fill("\`a\${x}b\`").join(" + ") + ");";
+    const expected = "capture(\`" + Array(n).fill("a\${x}b").join("") + "\`);\\n";
+    const before = rss();
+    const out = new Bun.Transpiler({ target: "bun" }).transformSync(input);
+    const after = rss();
+    if (out !== expected) {
+      throw new Error("wrong output: " + JSON.stringify(out.slice(0, 80)));
+    }
+    console.log(JSON.stringify({ delta_mb: (after - before) / 1024 / 1024 }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({
+    stdout: expect.stringMatching(/^\{"delta_mb":/),
+    exitCode: 0,
+  });
+  const { delta_mb } = JSON.parse(stdout);
+  // Before the fix: ~525 MB in release for n=4096. After: under 10 MB in
+  // release, ~10 MB in debug+ASAN.
+  expect(delta_mb).toBeLessThan(100);
+});
+
+test("template literal folding output is unchanged", () => {
+  const t = new Bun.Transpiler({ loader: "ts", target: "bun" });
+  const cases: Record<string, string> = {
+    "capture(`a${x}b` + `c${y}d`)": "capture(`a${x}bc${y}d`);\n",
+    "capture(`a${x}b` + `c${y}d` + `e${z}f` + `g${w}h` + `i${v}j`)": "capture(`a${x}bc${y}de${z}fg${w}hi${v}j`);\n",
+    // the chain's accumulator starts at the second operand
+    "capture(x + `a${y}` + `b${z}` + `c${w}`)": "capture(x + `a${y}b${z}c${w}`);\n",
+    // the accumulator takes over the right operand's parts, then grows them
+    "capture(`head` + `a${x}` + `b${y}` + `c${z}`)": "capture(`heada${x}b${y}c${z}`);\n",
+    "capture('s' + `a${x}` + `b${y}` + 't' + `c${z}`)": "capture(`sa${x}b${y}tc${z}`);\n",
+    "capture(`a${x}` + 's' + `b${y}`)": "capture(`a${x}sb${y}`);\n",
+    "capture(`a${x}` + 1 + `b${y}` + null + `c${z}`)": "capture(`a${x}1b${y}nullc${z}`);\n",
+    "capture(`a${x}` + `b${y}c${z}d` + `e${w}`)": "capture(`a${x}b${y}c${z}de${w}`);\n",
+    // non-constant operands split the chain into several accumulators
+    "capture(`a${x}` + y + `b${z}` + `c${w}` + v + `d${u}` + `e${s}`)":
+      "capture(`a${x}` + y + `b${z}c${w}` + v + `d${u}e${s}`);\n",
+    // nested chains inside substitutions fold independently of the outer chain
+    "capture(`a${`b${x}` + `c${y}`}d` + `e${`f${z}` + `g${w}`}h` + `i${v}`)":
+      "capture(`a${`b${x}c${y}`}de${`f${z}g${w}`}hi${v}`);\n",
+    "capture(`a${x}` + (`b${y}` + `c${z}`) + `d${w}`)": "capture(`a${x}b${y}c${z}d${w}`);\n",
+    "capture((`a${x}` + `b${y}`) + (`c${z}` + `d${w}`))": "capture(`a${x}b${y}c${z}d${w}`);\n",
+    "capture(`${x}` + `${y}` + `${z}`)": "capture(`${x}${y}${z}`);\n",
+    "capture(`a${x}` + `` + `b${y}` + ``)": "capture(`a${x}b${y}`);\n",
+    "capture(tag`a${x}` + `b${y}` + `c${z}`)": "capture(tag`a${x}` + `b${y}c${z}`);\n",
+    "capture(`a${x}` + tag`b${y}` + `c${z}`)": "capture(`a${x}` + tag`b${y}` + `c${z}`);\n",
+    "capture(`a${1}` + `b${2}` + `c${'3'}`)": 'capture("a1b2c3");\n',
+    "const enum E { A = 'a', B = `b` } capture(`x${y}` + E.A + `z${w}` + E.B)":
+      'var E;\n((E) => {\n  E.A = "a";\n  E.B = "b";\n})(E ||= {});\ncapture(`x${y}az${w}b`);\n',
+  };
+  const got: Record<string, string> = {};
+  for (const input of Object.keys(cases)) {
+    got[input] = t.transformSync(input);
+  }
+  expect(got).toEqual(cases);
+});


### PR DESCRIPTION
### Problem
- With syntax minification on (`bun run file.ts`, `bun build --minify-syntax`, `Bun.Transpiler` with `target: "bun"`), a left-associated `+` chain of template literals with substitutions uses memory quadratic in its length: 4096 terms (44 KB) take 526 MB on 1.4.3.
- The cause was `concat_parts` in `src/ast/fold_string_addition.rs`. The `` `a${x}` + `b${y}` `` fold copied `left.parts` plus `right.parts` into a fresh arena slice at every step, and the left template is the accumulator of the chain. #41973 left this out of scope.

### Fix
- `TemplatePartsBuilder` replaces `concat_parts`: one growable `ArenaVec<TemplatePart>` plus the template node that owns it, one per chain. The fold appends the right operand's parts and re-points the node's `parts` at the buffer.
- The buffer grows in place only for its owner node, while that node holds the whole view and the appended parts lie outside the buffer. Any other template is copied once. A buffer the builder stops using is never freed (`ManuallyDrop`).
- `TemplatePart::shallow_clone` replaces three copies of one helper. Output is unchanged.
- Verified: `test/js/bun/transpiler/transpiler-template-chain-oom.test.ts` (526 MB before, 10 MB after). Self-reviewed: 7 concerns raised, 4 addressed, 3 declined (see Notes).

### Background
- `target: "bun"` turns on `minify_syntax`, so every `+` goes through `fold_string_addition`.
- `E::Template.parts` is a `StoreSlice<TemplatePart>`: a bare `(ptr, len)` into the AST arena. The arena is mimalloc-backed: `ArenaVec` growth reallocs and frees the old block.
- `e_binary` in `visit_expr.rs` visits a left-nested binary chain iteratively, one call per chain. That call owns the builder. #32717 fixed the same class of bug for comma chains.

<details><summary>Notes</summary>

Measurements, rss delta around one `transformSync` of `capture(` + n terms of `` `a${x}b` `` + `)`:

| n | 1.4.3 release | this PR, debug+ASAN |
| --: | --: | --: |
| 2048 | 135 MB, 77 ms | 7 MB |
| 4096 | 526 MB, 282 ms | 10 MB, 201 ms |
| 8192 | 2075 MB, 1039 ms | 13 MB, 371 ms |
| 16384 | n/a | 23 MB, 644 ms |

The same chain over plain strings takes 3 MB on 1.4.3. Other shapes at n=4096 (release before, debug after): `` `head` + T + T ... `` 526 MB to 10 MB, `T + 'k' + T + 'k' ...` 525 MB to 10 MB, `x + T + T ...` 525 MB to 10 MB, `(T + T) + (T + T) ...` 266 MB to 11 MB, terms with three substitutions 101 MB to 7 MB. `bun build --minify-syntax` of the 4096-term file: peak RSS 536 MB to 8 MB over an empty build, byte-identical output.

Output equivalence: 2400 randomized `+` chains (templates, strings, numbers, identifiers, tagged templates, parenthesized groups, nested chains inside substitutions) print byte-identical to 1.4.3, with no ASAN reports. The test file also carries an output matrix.

Review concerns and what happened to them:
- The reuse check was a `(ptr, len)` heuristic. Now the builder also records the owner node and checks that the appended slice lies outside its buffer, so an unexpected alias takes the copy path instead of reading freed memory.
- A misleading comment about `Option::take` is gone. The duplicated field-wise copy (the fold, `Template::fold`, the printer) became `TemplatePart::shallow_clone`.
- Declined: a right-nested chain written with explicit parentheses at every level (`` T + (T + (T + ...)) ``) still copies the right operand's parts per level. Each level is a separate recursive visit with its own builder, its depth is bounded by the parser's nesting limit, and 400 levels take 14 MB.
- Declined: the output matrix stays in the new file next to `transpiler-comma-chain-oom.test.ts` and `transpiler-enum-concat-chain-oom.test.ts`, which have the same shape.
- Declined: the commented-out "TODO: string template simplification" block in `test/bundler/transpiler/transpiler.test.js` is stale but unrelated to this change.
- The `+` chain over inlined string enum members that the review also found quadratic is the bug #41973 already fixed on main.

Why a parameter and not a field on the parser: a parser-wide builder would be shared with the nested `e_binary` runs that visit each right operand (for example a template chain inside a substitution). Those would take over the single buffer between two steps of the outer chain and force the outer chain to re-copy at every step.

Suites run on the debug build: `transpiler/transpiler.test.js`, `bundler_string.test.ts`, `bundler_minify.test.ts`, `bundler_minify_symbol_for.test.ts`, `bundler_edgecase.test.ts` (Template/String/Enum filter), `esbuild/ts.test.ts`, `esbuild/default.test.ts`, `esbuild/dce.test.ts`, `transpiler/react-compiler.test.ts`, `transpiler-comma-chain-oom.test.ts`, `transpiler-enum-concat-chain-oom.test.ts`. `cargo clippy` is clean for the touched files.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/transpiler/transpiler-template-chain-oom.test.ts

<!-- robobun:evidence:end -->