### PR TITLE
Resolve blob: URLs that carry a #fragment in import(), new Worker() and resolveObjectURL

### DIFF
--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -514,7 +514,7 @@ pub fn get_loader_and_virtual_source<'a>(
     }
 
     if jsc_vm.is_blob_url(specifier) {
-        if let Some(blob) = jsc_vm.resolve_blob(&specifier[b"blob:".len()..]) {
+        if let Some(blob) = jsc_vm.resolve_blob(specifier) {
             *blob_to_deinit = Some(blob);
             loader = jsc_vm.blob_loader(blob);
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2267,8 +2267,8 @@ pub struct RuntimeHooks {
     /// `NodeFS` lives in `bun_runtime`; the high tier boxes one and returns
     /// the type-erased pointer. Stored back into `vm.node_fs`.
     pub create_node_fs: unsafe fn(vm: *mut VirtualMachine) -> *mut c_void,
-    /// `ObjectURLRegistry` lookup. Registry lives in `bun_runtime::webcore`.
-    pub has_blob_url: fn(blob_id: &[u8]) -> bool,
+    /// `ObjectURLRegistry` lookup of a `blob:` URL. Registry lives in `bun_runtime::webcore`.
+    pub has_blob_url: fn(url: &[u8]) -> bool,
     /// `Response::get_blob_without_call_frame` /
     /// `Request::get_blob_without_call_frame`. If
     /// `value` downcasts to a `Response` or `Request` (both live in
@@ -4498,12 +4498,12 @@ impl VirtualMachine {
             ret.path = self.dupe_resolved_path(specifier);
             return Ok(());
         }
-        if let Some(blob_id) = specifier.strip_prefix(b"blob:".as_slice()) {
+        if specifier.starts_with(b"blob:") {
             ret.result = None;
             // `WebCore.ObjectURLRegistry` lives in `bun_runtime`; routed
             // through [`RuntimeHooks::has_blob_url`].
             let has = runtime_hooks()
-                .map(|h| (h.has_blob_url)(blob_id))
+                .map(|h| (h.has_blob_url)(specifier))
                 .unwrap_or(false);
             if has {
                 ret.path = self.dupe_resolved_path(specifier);

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -633,6 +633,16 @@ extern "C" BunString URL__getHref(const BunString* input)
     return Bun::toStringRef(url.string());
 }
 
+extern "C" BunString URL__getHrefWithoutFragment(const BunString* input)
+{
+    auto&& str = input->toWTFString();
+    auto url = WTF::URL(str);
+    if (!url.isValid() || url.isEmpty())
+        return { BunStringTag::Dead };
+
+    return Bun::toStringRef(url.stringWithoutFragmentIdentifier());
+}
+
 extern "C" BunString URL__pathFromFileURL(const BunString* input)
 {
     auto&& str = input->toWTFString();

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1302,7 +1302,7 @@ unsafe fn resolve_entry_point_specifier<'s>(
     const BLOB_SPECIFIER_LEN: usize = b"blob:".len() + crate::uuid::UUID::STRING_LENGTH;
     if str.len() >= BLOB_SPECIFIER_LEN && str.starts_with(b"blob:") {
         let hooks = runtime_hooks().expect("RuntimeHooks not installed");
-        if (hooks.has_blob_url)(&str[b"blob:".len()..]) {
+        if (hooks.has_blob_url)(str) {
             return Some(str);
         } else {
             *error_message = BunString::static_("Blob URL is missing");

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1338,9 +1338,8 @@ unsafe fn create_node_fs(vm: *mut VirtualMachine) -> *mut c_void {
     .cast::<c_void>()
 }
 
-/// `WebCore.ObjectURLRegistry.singleton().has(specifier["blob:".len..])`.
-fn has_blob_url(blob_id: &[u8]) -> bool {
-    crate::webcore::object_url_registry::ObjectURLRegistry::singleton().has(blob_id)
+fn has_blob_url(url: &[u8]) -> bool {
+    crate::webcore::object_url_registry::ObjectURLRegistry::singleton().has(url)
 }
 
 /// `Response::get_blob_without_call_frame` /
@@ -3991,7 +3990,7 @@ unsafe fn get_loader_and_virtual_source<'a>(
     if crate::webcore::object_url_registry::is_blob_url(specifier) {
         match crate::webcore::object_url_registry::ObjectURLRegistry::singleton()
             // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-            .resolve_and_dupe(&specifier[b"blob:".len()..], unsafe { &*jsc_vm }.global())
+            .resolve_and_dupe(specifier, unsafe { &*jsc_vm }.global())
         {
             Some(blob) => {
                 *blob_to_deinit = Some(blob);

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -70,10 +70,10 @@ impl ObjectURLRegistry {
 
     pub(crate) fn resolve_and_dupe(
         &self,
-        pathname: &[u8],
+        url: &[u8],
         global_object: &JSGlobalObject,
     ) -> Option<Blob> {
-        let uuid = uuid_from_pathname(pathname)?;
+        let uuid = uuid_from_url(url)?;
         let map = self.map.lock();
         let entry = map.get(&uuid.bytes)?;
         let blob = entry.blob.dupe_with_content_type(true);
@@ -83,32 +83,48 @@ impl ObjectURLRegistry {
 
     pub(crate) fn resolve_and_dupe_to_js(
         &self,
-        pathname: &[u8],
+        url: &[u8],
         global_object: &JSGlobalObject,
     ) -> Option<JSValue> {
-        let blob = Blob::new(self.resolve_and_dupe(pathname, global_object)?);
+        let blob = Blob::new(self.resolve_and_dupe(url, global_object)?);
         // SAFETY: `Blob::new` returns a freshly-boxed heap pointer.
         Some(unsafe { (*blob).to_js(global_object) })
     }
 
-    pub(crate) fn revoke(&self, pathname: &[u8]) {
-        let Some(uuid) = uuid_from_pathname(pathname) else {
+    /// Only the exact `blob:<uuid>` revokes. A URL with a query or a fragment
+    /// was never registered (WPT: "Only exact matches should revoke URLs").
+    pub(crate) fn revoke(&self, url: &[u8]) {
+        let url = bun_core::String::borrow_utf8(url);
+        let Some(uuid) = uuid_from_key(bun_url::href_from_string(&url)) else {
             return;
         };
         // Box<Entry> dropped here
         let _ = self.map.lock().remove(&uuid.bytes);
     }
 
-    pub(crate) fn has(&self, pathname: &[u8]) -> bool {
-        let Some(uuid) = uuid_from_pathname(pathname) else {
+    pub(crate) fn has(&self, url: &[u8]) -> bool {
+        let Some(uuid) = uuid_from_url(url) else {
             return false;
         };
         self.map.lock().contains_key(&uuid.bytes)
     }
 }
 
-fn uuid_from_pathname(pathname: &[u8]) -> Option<UUID> {
-    UUID::parse(pathname).ok()
+/// https://w3c.github.io/FileAPI/#blob-url-resolve: the store key is the URL
+/// serialized without its fragment, so `blob:<uuid>#frag` names the entry and
+/// `blob:<uuid>?query` does not.
+fn uuid_from_url(url: &[u8]) -> Option<UUID> {
+    let url = bun_core::String::borrow_utf8(url);
+    uuid_from_key(bun_url::href_from_string_without_fragment(&url))
+}
+
+/// `href` is the parser's serialization: a lowercase scheme, then, for a URL
+/// this registry minted, exactly the 36-byte UUID.
+fn uuid_from_key(href: bun_core::String) -> Option<UUID> {
+    if href.is_dead() {
+        return None;
+    }
+    UUID::parse(href.to_utf8().strip_prefix(b"blob:")?).ok()
 }
 
 #[bun_jsc::host_fn(export = "Bun__createObjectURL")]
@@ -155,16 +171,11 @@ fn bun_revoke_object_url(
     // `is_string()` is `is_string_like()` and admits `StringObject`, so
     // `to_bun_string` can still observe a user `toString` that throws.
     let str = url_arg.to_bun_string(global_object)?;
+    // O(prefix) reject, so a long non-blob string is never transcoded or parsed.
     if !str.starts_with_ascii(b"blob:") {
         return Ok(JSValue::UNDEFINED);
     }
-
-    let slice = str.to_utf8();
-    let sliced = slice.slice();
-    if sliced.len() < b"blob:".len() + UUID::STRING_LENGTH {
-        return Ok(JSValue::UNDEFINED);
-    }
-    ObjectURLRegistry::singleton().revoke(&sliced[b"blob:".len()..]);
+    ObjectURLRegistry::singleton().revoke(&str.to_utf8());
     Ok(JSValue::UNDEFINED)
 }
 
@@ -182,16 +193,11 @@ fn js_function_resolve_object_url(
         return Ok(JSValue::UNDEFINED);
     }
     let str = url_arg.to_bun_string(global_object)?;
-
-    if !str.starts_with_ascii(b"blob:") || str.length() < SPECIFIER_LEN {
+    // O(prefix) reject, so a long non-blob string is never transcoded or parsed.
+    if !str.starts_with_ascii(b"blob:") {
         return Ok(JSValue::UNDEFINED);
     }
-
-    let slice = str.to_utf8();
-    let sliced = slice.slice();
-
-    let registry = ObjectURLRegistry::singleton();
-    let blob = registry.resolve_and_dupe_to_js(&sliced[b"blob:".len()..], global_object);
+    let blob = ObjectURLRegistry::singleton().resolve_and_dupe_to_js(&str.to_utf8(), global_object);
     Ok(blob.unwrap_or(JSValue::UNDEFINED))
 }
 

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -91,8 +91,7 @@ impl ObjectURLRegistry {
         Some(unsafe { (*blob).to_js(global_object) })
     }
 
-    /// Only the exact `blob:<uuid>` revokes. A URL with a query or a fragment
-    /// was never registered (WPT: "Only exact matches should revoke URLs").
+    /// Exact matches only: a URL with a query or a fragment was never registered.
     pub(crate) fn revoke(&self, url: &[u8]) {
         let url = bun_core::String::borrow_utf8(url);
         let Some(uuid) = uuid_from_key(bun_url::href_from_string(&url)) else {
@@ -110,16 +109,13 @@ impl ObjectURLRegistry {
     }
 }
 
-/// https://w3c.github.io/FileAPI/#blob-url-resolve: the store key is the URL
-/// serialized without its fragment, so `blob:<uuid>#frag` names the entry and
-/// `blob:<uuid>?query` does not.
+/// https://w3c.github.io/FileAPI/#blob-url-resolve: the key is the URL serialized without its fragment.
 fn uuid_from_url(url: &[u8]) -> Option<UUID> {
     let url = bun_core::String::borrow_utf8(url);
     uuid_from_key(bun_url::href_from_string_without_fragment(&url))
 }
 
-/// `href` is the parser's serialization: a lowercase scheme, then, for a URL
-/// this registry minted, exactly the 36-byte UUID.
+/// `href` is the parser's serialization, so a registered URL is exactly `blob:` + 36-byte UUID.
 fn uuid_from_key(href: bun_core::String) -> Option<UUID> {
     if href.is_dead() {
         return None;

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1213,7 +1213,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // Support blob: urls
             if url_type == URLType::Blob {
                 if let Some(blob) =
-                    ObjectURLRegistry::singleton().resolve_and_dupe(url_path_decoded, global_this)
+                    ObjectURLRegistry::singleton().resolve_and_dupe(url.href, global_this)
                 {
                     url_string = BunString::create_format(format_args!(
                         "blob:{}",

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -72,6 +72,7 @@ pub mod whatwg {
         safe fn URL__fragmentIdentifier(url: &URL) -> String;
         fn URL__deinit(url: *mut URL);
         safe fn URL__getHref(input: &String) -> String;
+        safe fn URL__getHrefWithoutFragment(input: &String) -> String;
         safe fn URL__getFileURLString(input: &String) -> String;
         safe fn URL__pathFromFileURL(input: &String) -> String;
         safe fn URL__getHrefJoin(base: &String, relative: &String) -> String;
@@ -82,6 +83,10 @@ pub mod whatwg {
     /// href. If parsing fails, the returned String's tag is `Dead`.
     pub fn href_from_string(str: &String) -> String {
         URL__getHref(str)
+    }
+    /// [`href_from_string`], serialized with *exclude fragment* set.
+    pub fn href_from_string_without_fragment(str: &String) -> String {
+        URL__getHrefWithoutFragment(str)
     }
     pub fn join(base: &String, relative: &String) -> String {
         URL__getHrefJoin(base, relative)
@@ -186,7 +191,8 @@ pub mod whatwg {
 // Re-export the free helpers at crate root so lower-tier callers can write
 // `bun_url::join(...)` / `bun_url::href_from_string(...)` (install, http, bake, js_parser).
 pub use whatwg::{
-    file_url_from_string, href_from_string, join, origin_from_slice, path_from_file_url,
+    file_url_from_string, href_from_string, href_from_string_without_fragment, join,
+    origin_from_slice, path_from_file_url,
 };
 
 // URL is a pure view struct — every field is a slice into `href` (or a

--- a/test/js/node/buffer-resolveObjectURL.test.ts
+++ b/test/js/node/buffer-resolveObjectURL.test.ts
@@ -47,3 +47,41 @@ test("buffer.resolveObjectURL args", async () => {
   ).toBeUndefined();
   URL.revokeObjectURL(id);
 });
+
+// The blob URL store is keyed by the URL serialized without its fragment
+// (https://w3c.github.io/FileAPI/#blob-url-resolve), the same rule fetch(),
+// import() and new Worker() resolve by. Node keys by pathname instead, so it
+// also ignores a ?query. Bun treats a query as a different URL, like browsers.
+test("buffer.resolveObjectURL ignores the URL fragment", async () => {
+  const blob = new Blob(["hello"]);
+  const id = URL.createObjectURL(blob);
+  const uuid = id.slice("blob:".length);
+
+  for (const url of [id + "#frag", id + "#", id + "#frag?not-a-query", id + "#frag\n"]) {
+    const resolved = resolveObjectURL(url);
+    expect(resolved).toBeInstanceOf(Blob);
+    expect(await resolved!.text()).toBe("hello");
+  }
+
+  // A different scheme, path or query is a different URL.
+  for (const url of [uuid, "file:" + uuid, id + "/", id + "?query", id + "?query#frag", id + "?"]) {
+    expect(resolveObjectURL(url)).toBeUndefined();
+  }
+
+  URL.revokeObjectURL(id);
+  expect(resolveObjectURL(id + "#frag")).toBeUndefined();
+});
+
+// WPT FileAPI/url: "Only exact matches should revoke URLs".
+test("URL.revokeObjectURL only revokes an exact match", async () => {
+  const blob = new Blob(["hello"]);
+  const id = URL.createObjectURL(blob);
+
+  for (const url of [id + "#frag", id + "#", id + "?query", id + "/"]) {
+    URL.revokeObjectURL(url);
+    expect(await resolveObjectURL(id)?.text()).toBe("hello");
+  }
+
+  URL.revokeObjectURL(id);
+  expect(resolveObjectURL(id)).toBeUndefined();
+});

--- a/test/js/node/buffer-resolveObjectURL.test.ts
+++ b/test/js/node/buffer-resolveObjectURL.test.ts
@@ -59,13 +59,13 @@ test("buffer.resolveObjectURL ignores the URL fragment", async () => {
 
   for (const url of [id + "#frag", id + "#", id + "#frag?not-a-query", id + "#frag\n"]) {
     const resolved = resolveObjectURL(url);
-    expect(resolved).toBeInstanceOf(Blob);
-    expect(await resolved!.text()).toBe("hello");
+    expect(resolved, JSON.stringify(url)).toBeInstanceOf(Blob);
+    expect(await resolved!.text(), JSON.stringify(url)).toBe("hello");
   }
 
   // A different scheme, path or query is a different URL.
   for (const url of [uuid, "file:" + uuid, id + "/", id + "?query", id + "?query#frag", id + "?"]) {
-    expect(resolveObjectURL(url)).toBeUndefined();
+    expect(resolveObjectURL(url), JSON.stringify(url)).toBeUndefined();
   }
 
   URL.revokeObjectURL(id);
@@ -79,7 +79,7 @@ test("URL.revokeObjectURL only revokes an exact match", async () => {
 
   for (const url of [id + "#frag", id + "#", id + "?query", id + "/"]) {
     URL.revokeObjectURL(url);
-    expect(await resolveObjectURL(id)?.text()).toBe("hello");
+    expect(await resolveObjectURL(id)?.text(), `revokeObjectURL(${JSON.stringify(url)})`).toBe("hello");
   }
 
   URL.revokeObjectURL(id);

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -157,6 +157,24 @@ test("blob: can be imported", async () => {
   }).toThrow();
 });
 
+test("blob: can be imported with a fragment", async () => {
+  const blob = new Blob([`export const loaded = true;`], { type: "application/javascript" });
+  const url = URL.createObjectURL(blob);
+  try {
+    const { loaded } = await import(url + "#frag");
+    expect(loaded).toBe(true);
+    // A query is part of the blob URL store key, so it names no entry.
+    expect(async () => {
+      await import(url + "?query");
+    }).toThrow();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+  expect(async () => {
+    await import(url + "#other");
+  }).toThrow();
+});
+
 test("blob: can reliable get type from fetch #10072", async () => {
   using server = Bun.serve({
     fetch() {

--- a/test/js/web/workers/worker_blob.test.ts
+++ b/test/js/web/workers/worker_blob.test.ts
@@ -57,6 +57,24 @@ test("TypeScript Worker from a Blob", async () => {
   expect(result).toBe("i support typescript");
 });
 
+test("Worker from a Blob URL with a fragment", async () => {
+  const url = URL.createObjectURL(
+    new Blob([`self.onmessage = e => self.postMessage(e.data);`], { type: "application/javascript" }),
+  );
+  const worker = new Worker(url + "#frag");
+  try {
+    const result = await new Promise((resolve, reject) => {
+      worker.onmessage = e => resolve(e.data);
+      worker.onerror = e => reject(e.message);
+      worker.postMessage("hello");
+    });
+    expect(result).toBe("hello");
+  } finally {
+    worker.terminate();
+    URL.revokeObjectURL(url);
+  }
+});
+
 test("Worker from a blob errors on invalid blob", async () => {
   const { promise, reject } = Promise.withResolvers();
   const worker = new Worker("blob:i dont exist!");

--- a/test/js/web/workers/worker_blob.test.ts
+++ b/test/js/web/workers/worker_blob.test.ts
@@ -61,16 +61,17 @@ test("Worker from a Blob URL with a fragment", async () => {
   const url = URL.createObjectURL(
     new Blob([`self.onmessage = e => self.postMessage(e.data);`], { type: "application/javascript" }),
   );
-  const worker = new Worker(url + "#frag");
+  let worker: Worker | undefined;
   try {
+    worker = new Worker(url + "#frag");
     const result = await new Promise((resolve, reject) => {
-      worker.onmessage = e => resolve(e.data);
-      worker.onerror = e => reject(e.message);
-      worker.postMessage("hello");
+      worker!.onmessage = e => resolve(e.data);
+      worker!.onerror = e => reject(e.message);
+      worker!.postMessage("hello");
     });
     expect(result).toBe("hello");
   } finally {
-    worker.terminate();
+    worker?.terminate();
     URL.revokeObjectURL(url);
   }
 });


### PR DESCRIPTION
### Problem
- `import(url + "#frag")` fails with `Cannot find package 'blob:<uuid>#frag'`, `new Worker(url + "#frag")` fails with `Blob URL is missing`, and `buffer.resolveObjectURL(url + "#frag")` returns `undefined`. Browsers and Node resolve all three.
- The cause is `uuid_from_pathname` (`src/runtime/webcore/ObjectURLRegistry.rs:110`). Every caller sliced off `blob:` and passed the rest, so `UUID::parse` got `<uuid>#frag` and failed its 36-byte length check.

### Fix
- `ObjectURLRegistry::{has, resolve_and_dupe, revoke}` take the whole URL. A lookup derives the store key the way the File API [resolves a blob URL](https://w3c.github.io/FileAPI/#blob-url-resolve): the URL parser serializes it without the fragment, and the result must be exactly `blob:<uuid>`. `bun_url` gets `href_from_string_without_fragment` for this, backed by `WTF::URL::stringWithoutFragmentIdentifier()`.
- Correct because WPT `FileAPI/url` checks this rule: a fragment resolves, a query or an extra path does not, and "Only exact matches should revoke URLs". So `revokeObjectURL(url + "#frag")` stays a no-op.
- Verified: new cases in `buffer-resolveObjectURL.test.ts`, `blob.test.ts` and `worker_blob.test.ts` fail on bun 1.4.3 and pass here. Also ran `worker.test.ts`, `worker_threads.test.ts` and `url.test.ts`. Self-reviewed: 5 concerns raised, 3 addressed, 2 left by design (see Notes).

### Background
- `URL.createObjectURL(blob)` stores a copy of the blob in the process-wide `ObjectURLRegistry` under a fresh UUID and returns `blob:<uuid>`. `fetch()`, the module loader, `new Worker()` and `buffer.resolveObjectURL` look it up there.
- `bun_url::whatwg` wraps WebKit's `WTF::URL`, the WHATWG parser. It lowercases the scheme and splits off the query and the fragment.
- `fetch(url + "#frag")` is not changed here. #33499 and #36264 cover `fetch()` with the same rule.

<details><summary>Notes</summary>

Behaviour table (`url` from `URL.createObjectURL`):

```
                                        browsers/WPT   node 26     bun 1.4.3     this PR
import(url + "#frag")                   loads          (no blob:)  not found     loads
new Worker(url + "#frag")               runs           n/a         URL missing   runs
resolveObjectURL(url + "#frag")         n/a            Blob        undefined     Blob
resolveObjectURL(url + "?query")        (fetch fails)  Blob        undefined     undefined
import(url + "?query")                  fails          n/a         not found     not found
revokeObjectURL(url + "#frag") revokes  no             yes         no            no
revokeObjectURL(url + "?q") revokes     no             yes         no            no
```

Node keys its store by the parsed URL's `pathname`, so it also ignores a query and revokes through a fragment or a query. The File API spec, WPT (`FileAPI/url/resources/fetch-tests.js`: "fetch with a fragment should succeed", "Appending a query string should cause fetch to fail", "Only exact matches should revoke URLs"), WebKit, Chromium and Deno do not, and neither does #36264 for `fetch()` (`assertStoreMiss(url + "?x=1")`). This PR follows the spec so that `resolveObjectURL(x)` returns a Blob exactly when `fetch(x)` resolves from the store. The first revision of this branch keyed by pathname like Node. Review caught the conflict with WPT and with #36264, and this version is the result.

The callers that now pass the whole URL instead of slicing off `blob:`: the module loader's resolve and transpile paths (`VirtualMachine.rs`, `jsc_hooks.rs`, `bundler/options.rs`), the Worker entry point (`web_worker.rs`), `fetch.rs`, and the two host functions.

Review concerns left as they are:
- `fetch(url + "#frag")` still goes to the network because of `URL::is_blob()`'s exact-length check in `fetch()`. #33499 (fragment stripped at the `fetch()` entry) and #36264 (blob scheme fetch) both fix that line, so it is not touched a third time here. The `fetch.rs` hunk in this diff only adapts the call to the new signature. It passes the already-normalized 41-byte href.
- #41471 rewrites the same three call sites in `VirtualMachine.rs`, `web_worker.rs` and `jsc_hooks.rs`. Whichever lands second rebases. The conflict is mechanical (`blob_id` slice vs whole URL).

`href_from_string_without_fragment` and `URL__getHrefWithoutFragment` are byte-identical to the helpers #33499 adds, so the two PRs agree apart from the duplicate hunk.

`import(url + "#a")` and `import(url + "#b")` are two module records, as in browsers, because the module map key is the full specifier. Only the registry lookup drops the fragment.

The scheme check in the host functions stays the case-sensitive `starts_with("blob:")` it was before, so `resolveObjectURL("BLOB:<uuid>")` still returns `undefined`. `URL.createObjectURL` always returns the lowercase scheme, and the O(prefix) gate is what keeps `test/js/web/url/url.test.ts` ("ASCII prefix/equality checks on huge strings are O(k), not O(n)") passing: it calls both functions 2000 times with 16 MB strings.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/blob.test.ts

<!-- robobun:evidence:end -->