### PR TITLE
Report a ShadowRealm's unhandled rejections and uncaught errors through the realm that created it

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1326,7 +1326,8 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
 {
     if (!lexicalGlobalObject->inherits(Zig::GlobalObject::info()))
         return false;
-    auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    // An exception raised inside a ShadowRealm goes to the `process` of the realm that created it.
+    auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject)->hostGlobal();
     auto* process = globalObject->processObject();
     auto& wrapped = process->wrapped();
     auto& vm = JSC::getVM(globalObject);
@@ -1372,14 +1373,14 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
     auto capture = process->getUncaughtExceptionCaptureCallback();
     if (!capture.isEmpty() && !capture.isUndefinedOrNull()) {
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        (void)call(lexicalGlobalObject, capture, args, "uncaughtExceptionCaptureCallback"_s);
+        (void)call(globalObject, capture, args, "uncaughtExceptionCaptureCallback"_s);
         if (auto ex = scope.exception()) {
             (void)scope.tryClearException();
             if (vm.hasPendingTerminationException()) [[unlikely]]
                 return true;
             // if an exception is thrown in the uncaughtException handler, we abort
             Bun__logUnhandledException(JSValue::encode(JSValue(ex)));
-            Bun__Process__exit(lexicalGlobalObject, 1);
+            Bun__Process__exit(globalObject, 1);
         }
     } else if (wrapped.listenerCount(uncaughtExceptionIdent) > 0) {
         auto emitScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
@@ -1481,7 +1482,7 @@ extern "C" int Bun__handleUnhandledRejection(JSC::JSGlobalObject* lexicalGlobalO
 {
     if (!lexicalGlobalObject->inherits(Zig::GlobalObject::info()))
         return false;
-    auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject)->hostGlobal();
     auto& vm = JSC::getVM(globalObject);
     if (vm.hasPendingTerminationException()) [[unlikely]]
         return true;
@@ -1510,7 +1511,7 @@ extern "C" bool Bun__emitHandledPromiseEvent(JSC::JSGlobalObject* lexicalGlobalO
         return false;
     if (vm.hasPendingTerminationException()) [[unlikely]]
         return true;
-    auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject)->hostGlobal();
     auto* process = globalObject->processObject();
 
     auto eventType = Identifier::fromString(vm, "rejectionHandled"_s);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -928,6 +928,9 @@ JSGlobalObject* GlobalObject::deriveShadowRealmGlobalObject(JSGlobalObject* glob
         Zig::GlobalObject::createStructure(vm),
         ScriptExecutionContext::generateIdentifier());
     shadow->setConsole(shadow);
+    // A node:vm context is not a Zig::GlobalObject; defaultGlobalObject() maps it to
+    // the thread's global, the same one promiseRejectionTrackerForNodeVM reports to.
+    shadow->m_shadowRealmHost.set(vm, shadow, defaultGlobalObject(globalObject)->hostGlobal());
 
     return shadow;
 }
@@ -1089,7 +1092,9 @@ extern "C" void Bun__handleHandledPromise(Zig::GlobalObject* JSGlobalObject, JSC
 void GlobalObject::promiseRejectionTracker(JSGlobalObject* obj, JSC::JSPromise* promise,
     JSC::JSPromiseRejectionOperation operation)
 {
-    auto* globalObj = static_cast<GlobalObject*>(obj);
+    // JSC reports a promise to its own realm's global. A ShadowRealm's promises go on
+    // the list of the global that created the realm, the one the event loop drains.
+    auto* globalObj = static_cast<GlobalObject*>(obj)->hostGlobal();
 
     switch (operation) {
     case JSPromiseRejectionOperation::Reject:

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -327,6 +327,19 @@ public:
     uint8_t drainMicrotasks();
 
     void handleRejectedPromises();
+
+    // The non-ShadowRealm global that stands in for this one wherever per-global state is
+    // serviced by the event loop or observed through `process` from outside the realm: the
+    // rejected-promise list, the nextTick queue, the process event emitters. For a
+    // ShadowRealm global this is the global of the realm that created it (the outermost
+    // one when realms nest). For every other global it is `this`.
+    GlobalObject* hostGlobal()
+    {
+        if (auto* host = m_shadowRealmHost.get())
+            return host;
+        return this;
+    }
+
     ALWAYS_INLINE void initGeneratedLazyClasses();
 
     template<typename Visitor>
@@ -523,6 +536,10 @@ public:
     /* node:worker_threads worker: { stdin?, stdout, stderr } MessagePorts from the parent Worker; */        \
     /* process.stdin/stdout/stderr are built over these lazily (BunProcess.cpp constructStd*). */            \
     V(private, WriteBarrier<JSObject>, m_nodeWorkerStdioPorts)                                               \
+                                                                                                             \
+    /* Set only on a ShadowRealm global: the non-ShadowRealm global it derives from (see */                  \
+    /* hostGlobal()). Nested realms point at the outermost one, never at each other. */                      \
+    V(private, WriteBarrier<GlobalObject>, m_shadowRealmHost)                                                \
                                                                                                              \
     /* The original, unmodified Error.prepareStackTrace. */                                                  \
     /* */                                                                                                    \

--- a/src/jsc/bindings/webcore/JSEventListener.cpp
+++ b/src/jsc/bindings/webcore/JSEventListener.cpp
@@ -141,11 +141,13 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionEmitUncaughtException, (JSC::JSGlobalObject *
 }
 JSC_DEFINE_HOST_FUNCTION(jsFunctionEmitUncaughtExceptionNextTick, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
-    Zig::GlobalObject* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    // A listener created inside a ShadowRealm reports through the realm's host global:
+    // the realm global's own nextTick queue is never drained.
+    Zig::GlobalObject* globalObject = defaultGlobalObject(lexicalGlobalObject)->hostGlobal();
     Bun::Process* process = globalObject->processObject();
     auto exception = callFrame->argument(0);
     auto func = JSFunction::create(globalObject->vm(), globalObject, 1, String(), jsFunctionEmitUncaughtException, JSC::ImplementationVisibility::Private);
-    process->queueNextTick(lexicalGlobalObject, func, exception);
+    process->queueNextTick(globalObject, func, exception);
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 

--- a/test/js/bun/jsc/shadow.test.js
+++ b/test/js/bun/jsc/shadow.test.js
@@ -1,4 +1,5 @@
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 it("shadow realm works", () => {
   const red = new ShadowRealm();
@@ -7,4 +8,116 @@ it("shadow realm works", () => {
   const result = red.evaluate("globalThis.someValue = 2;");
   expect(globalThis.someValue).toBe(1);
   expect(result).toBe(2);
+});
+
+async function run(code) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+}
+
+// A ShadowRealm gets its own global. JSC reports a rejected promise, and an exception that
+// escapes a microtask, to the global of the realm they happened in. These must reach the
+// `process` of the realm that created the ShadowRealm, like the same code outside a realm
+// (and like Node), instead of being dropped or bypassing its handlers.
+// https://github.com/oven-sh/bun/issues/11845
+describe.concurrent("errors inside a ShadowRealm", () => {
+  it("an unhandled rejection is reported and fails the process", async () => {
+    const [stdout, stderr, exitCode] = await run(`
+      const r = new ShadowRealm();
+      r.evaluate("Promise.reject(new Error('rejected-in-realm')); 1");
+    `);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("error: rejected-in-realm");
+    expect(exitCode).toBe(1);
+  });
+
+  it("unhandled rejections reach process.on('unhandledRejection')", async () => {
+    const [stdout, stderr, exitCode] = await run(`
+      const seen = [];
+      process.on("unhandledRejection", reason => seen.push(reason.message));
+      process.on("exit", () => console.log(JSON.stringify(seen.sort())));
+      const r = new ShadowRealm();
+      r.evaluate("Promise.reject(new Error('from evaluate')); 1");
+      r.evaluate("Promise.resolve().then(() => { throw new Error('from a reaction') }); 1");
+      const viaWrapped = r.evaluate("() => { (async () => { throw new Error('from a wrapped function') })(); }");
+      viaWrapped();
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(`["from a reaction","from a wrapped function","from evaluate"]\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  it("a rejection handled inside the realm is not reported", async () => {
+    const [stdout, stderr, exitCode] = await run(`
+      process.on("unhandledRejection", reason => { console.log("unhandledRejection", reason.message); process.exitCode = 1; });
+      const r = new ShadowRealm();
+      r.evaluate("Promise.reject(new Error('caught')).catch(() => {}); 1");
+      r.evaluate("var p = Promise.reject(new Error('caught later in the same tick')); queueMicrotask(() => p.catch(() => {})); 1");
+      process.on("exit", () => console.log("done"));
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("done\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("handling a reported rejection later emits 'rejectionHandled'", async () => {
+    const [stdout, stderr, exitCode] = await run(`
+      const r = new ShadowRealm();
+      const attach = r.evaluate("var p = Promise.reject(new Error('late')); () => { p.catch(() => {}); }");
+      process.on("unhandledRejection", reason => { console.log("unhandledRejection", reason.message); setImmediate(attach); });
+      process.on("rejectionHandled", () => console.log("rejectionHandled"));
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("unhandledRejection late\nrejectionHandled\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("an exception thrown from a microtask reaches process.on('uncaughtException')", async () => {
+    const [stdout, stderr, exitCode] = await run(`
+      process.on("uncaughtException", (err, origin) => console.log(origin, err.message));
+      const r = new ShadowRealm();
+      r.evaluate("queueMicrotask(() => { throw new Error('thrown in a realm microtask') }); 1");
+      process.on("exit", code => console.log("exit", code));
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("uncaughtException thrown in a realm microtask\nexit 0\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("EventTarget listeners that throw or reject reach process.on('uncaughtException')", async () => {
+    const [stdout, stderr, exitCode] = await run(`
+      const seen = [];
+      process.on("uncaughtException", (err, origin) => seen.push(origin + " " + err.message));
+      process.on("exit", code => console.log(JSON.stringify(seen.sort()), "exit", code));
+      const r = new ShadowRealm();
+      r.evaluate(\`
+        const target = new EventTarget();
+        target.addEventListener("ping", () => { throw new Error("thrown in a realm listener") });
+        target.addEventListener("ping", async () => { throw new Error("rejected in a realm listener") });
+        target.dispatchEvent(new Event("ping"));
+        1
+      \`);
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(
+      `["uncaughtException rejected in a realm listener","uncaughtException thrown in a realm listener"] exit 0\n`,
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  it("a nested ShadowRealm reports to the outermost realm's process", async () => {
+    const [stdout, stderr, exitCode] = await run(`
+      process.on("unhandledRejection", reason => console.log("unhandledRejection", reason.message));
+      const outer = new ShadowRealm();
+      outer.evaluate("new ShadowRealm().evaluate(\\"Promise.reject(new Error('nested')); 1\\")");
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("unhandledRejection nested\n");
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- An unhandled rejection inside a `ShadowRealm` is silently dropped: no output, exit code 0. An exception from a microtask or an `EventTarget` listener inside a realm skips `process.on("uncaughtException")` and is fatal. Node reports all of them through `process`.
- Cause: `deriveShadowRealmGlobalObject` (`ZigGlobalObject.cpp:919`) makes the realm global a full `Zig::GlobalObject`. JSC reports a rejected promise to its own global, so it landed on the realm global's rejection list, which the event loop never drains. `Bun__handleUncaughtException` used the realm global's own `process`, which code outside the realm never sees.

### Fix
- The realm global records its host global: the non-ShadowRealm global it derives from (`m_shadowRealmHost`, the outermost one when realms nest). `hostGlobal()` returns it, or `this` for other globals.
- `promiseRejectionTracker` uses the host's list, the process-event emitters use the host's `process`, and the rejected-listener path (`JSEventListener.cpp:144`) queues on the host's nextTick queue.
- Correct because only the thread's main global has its list and nextTick queue drained, and its `process` is the one the program observes. No host object becomes reachable inside the realm. Other globals are unchanged.
- Verified: `test/js/bun/jsc/shadow.test.js` (7 new cases, 6 fail on 1.4.3-canary) and the suites in Notes. Self-reviewed, see Notes.

### Background
- A `ShadowRealm` (TC39 stage 3) is a fresh global with its own intrinsics on the same `JSC::VM`. Bun builds it as a full `Zig::GlobalObject`, so the realm has its own `process`, `queueMicrotask` and `EventTarget`.
- JSC tracks unhandled rejections per global through `promiseRejectionTracker`. Bun's event loop drains that list on `vm.global` only.

<details><summary>Notes</summary>

- Self-review: 10 concerns raised, each addressed in the diff or scoped in these notes.
- `node:vm` contexts had the same shape of bug and already forward their tracker to the thread's default global (`NodeVM.cpp:946`). A realm created inside a `node:vm` context maps through `defaultGlobalObject()` to that same target.
- Supersedes #35646 (July, never reviewed, now conflicting), which forwarded only `promiseRejectionTracker` through a second method table. This change also covers the `uncaughtException` lookup, the `EventTarget` rejection path and nested realms, with one field instead of a copied table. I closed #35646 in favour of this one.
- Merge order with #39992 (the matching `process` lookup for `node:vm` contexts, which left ShadowRealm out of scope): the two touch the same statement in `Bun__handleUncaughtException`. Whichever lands second writes `defaultGlobalObject(lexicalGlobalObject)->hostGlobal()` there.
- Out of scope, on purpose: `process.nextTick` called by realm code (#25608, handled by #37931, which can replace its `!= defaultGlobalObject()` check with `hostGlobal()`), and the worker `self.onerror` dispatch for a realm error when no `process` handler claims it (the Worker `error` event on the parent side does fire, verified below).
- Other suites run on the debug ASAN build: the node `test-shadow-realm*`, `test-eventtarget*`, `test-events-*` and `test-promise*-unhandled*` parallel tests, `test/js/node/vm/vm.test.ts`, `test/regression/issue/29519.test.ts` (realm creation under `collectContinuously`), the worker and worker_threads error tests, and the #11845 repro (`importValue` plus an async function, now prints the `ReferenceError` and exits 1).
- Probed, each matching node v26 where node can express it: a realm created inside a `vm.createContext()` context (reported to the main process), a realm inside a `worker_threads` Worker with and without a worker-side handler (handler runs, else the Worker `error` event and worker exit code 1), `worker.terminate()` with 200 pending realm rejections and a throwing realm microtask under `Malloc=1` with and without `BUN_JSC_collectContinuously=1` (clean), 20 dropped realms with 50 pending rejections each plus `Bun.gc(true)` under `collectContinuously` (all 1000 reported, no crash), and `bun test` (the rejection fails the running test, the next test is clean).
- Timer callbacks created inside a realm already reached the outer `uncaughtException` handler before this change: Bun's timers run and report on `vm.global`. Only the JSC-attributed paths (promise rejection, microtask exception, `FinalizationRegistry` callbacks, listener functions) went to the realm global.
- GC: the new `WriteBarrier` makes a realm global keep its host alive. The host is the thread's main global (already protected) or a `bun test --isolate` file global that is itself the only thing able to reach the realm, so this adds no retention in practice.

</details>

Fixes #11845

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/jsc/shadow.test.js
bun test v1.4.3 (f42e98025)

test/js/bun/jsc/shadow.test.js:
(pass) shadow realm works [40.03ms]
30 |     const [stdout, stderr, exitCode] = await run(`
31 |       const r = new ShadowRealm();
32 |       r.evaluate("Promise.reject(new Error('rejected-in-realm')); 1");
33 |     `);
34 |     expect(stdout).toBe("");
35 |     expect(stderr).toContain("error: rejected-in-realm");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "error: rejected-in-realm"
Received: ""

      at <anonymous> (/workspace/bun/test/js/bun/jsc/shadow.test.js:35:20)
(fail) errors inside a ShadowRealm > an unhandled rejection is reported and fails the process [285.63ms]
46 |       r.evaluate("Promise.resolve().then(() => { throw new Error('from a reaction') }); 1");
47 |       const viaWrapped = r.evaluate("() => { (async () => { throw new Error('from a wrapped function') })(); }");
48 |       viaWrapped();
49 |     `);
50 |     expect(stderr).toBe("");
51 |     expect(stdout).toBe(`["from a r
... (truncated)

release without fix: 6 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/jsc/shadow.test.js:
(pass) shadow realm works [0.49ms]
71 |       const attach = r.evaluate("var p = Promise.reject(new Error('late')); () => { p.catch(() => {}); }");
72 |       process.on("unhandledRejection", reason => { console.log("unhandledRejection", reason.message); setImmediate(attach); });
73 |       process.on("rejectionHandled", () => console.log("rejectionHandled"));
74 |     `);
75 |     expect(stderr).toBe("");
76 |     expect(stdout).toBe("unhandledRejection late\nrejectionHandled\n");
                        ^
error: expect(received).toBe(expected)

- "unhandledRejection late
- rejectionHandled
- "
+ ""

- Expected  - 3
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/jsc/shadow.test.js:76:20)
(fail) errors inside a ShadowRealm > handling a reported rejection later emits 'rejectionHandled' [5.53ms]
82 |       process.on("uncaughtException", (err, origin) => console.log(origin, err.message));
83 |       const r = new ShadowRealm();
84 |       r.evaluate("queueMicrotask(() => { throw new Error('thrown in a realm microtask') }); 1");
85 |       process.on("exit", code => console.log("ex
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/jsc/shadow.test.js
bun test v1.4.3 (f42e98025)

test/js/bun/jsc/shadow.test.js:
(pass) shadow realm works [67.79ms]
(pass) errors inside a ShadowRealm > an unhandled rejection is reported and fails the process [605.39ms]
(pass) errors inside a ShadowRealm > unhandled rejections reach process.on('unhandledRejection') [597.07ms]
(pass) errors inside a ShadowRealm > a rejection handled inside the realm is not reported [651.64ms]
(pass) errors inside a ShadowRealm > an exception thrown from a microtask reaches process.on('uncaughtException') [623.73ms]
(pass) errors inside a ShadowRealm > handling a reported rejection later emits 'rejectionHandled' [756.27ms]
(pass) errors inside a ShadowRealm > a nested ShadowRealm reports to the outermost realm's process [447.57ms]
(pass) errors inside a ShadowRealm > EventTarget listeners that throw or reject reach process.on('uncaughtException') [527.38ms]

 8 pass
 0 fail
 23 expect() calls
Ran 8 tests across 1 file. [4.42s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     7e3f4d977e
  features     baseline

23 deps, 131 codegen, 1172 objects in 1170ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] gen bindgenv2
[5/1244] fetch zlib
[zlib] up to date
[6/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[7/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 14ms

  react-refresh.js  4.81 KB  (entry point)

[8/1244] gen .bind.ts → GeneratedBindings.cpp
[9/1244] fetch tinycc
[tinycc] up to date
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1216] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunProcess.cpp              |  11 +--
 src/jsc/bindings/ZigGlobalObject.cpp         |   7 +-
 src/jsc/bindings/ZigGlobalObject.h           |  17 ++++
 src/jsc/bindings/webcore/JSEventListener.cpp |   6 +-
 test/js/bun/jsc/shadow.test.js               | 115 ++++++++++++++++++++++++++-
 5 files changed, 147 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/bindings/BunProcess.cpp                   2      4      9
src/jsc/bindings/ZigGlobalObject.cpp              5      4      9
src/jsc/bindings/ZigGlobalObject.h                6      4      9
src/jsc/bindings/webcore/JSEventListener.cpp      2      1      9
test/js/bun/jsc/shadow.test.js                    2      3      9
```

</details>

**root cause** · written by the author bot

A ShadowRealm's global object in Bun is a full `Zig::GlobalObject`, so JSC reported realm-originated promise rejections into that realm global's own rejection list and dispatched realm uncaught errors to that global's own `process` object, neither of which is ever drained or observed by user listeners; the result was that errors thrown or rejected inside a realm vanished silently with a zero exit code instead of reaching the outer process as they do in Node. The fix gives each realm global a reference to the global that created it (`m_shadowRealmHost`, exposed via `hostGlobal()`) and routes…

<!-- robobun:evidence:end -->