### PR TITLE
Keep a ShadowRealm alive while a crypto.subtle operation started in it is pending

### DIFF
--- a/src/jsc/bindings/webcore/JSDOMGuardedObject.cpp
+++ b/src/jsc/bindings/webcore/JSDOMGuardedObject.cpp
@@ -29,11 +29,13 @@
 namespace WebCore {
 using namespace JSC;
 
-DOMGuardedObject::DOMGuardedObject(JSDOMGlobalObject& globalObject, JSCell& guarded)
+DOMGuardedObject::DOMGuardedObject(JSDOMGlobalObject& globalObject, JSCell& guarded, HasPendingActivity hasPendingActivity)
     : ActiveDOMCallback(globalObject.scriptExecutionContext())
     , m_guarded(&guarded)
     , m_globalObject(&globalObject)
 {
+    if (hasPendingActivity == HasPendingActivity::Yes)
+        m_pendingActivity.set(globalObject.vm(), &guarded);
     if (globalObject.vm().heap.mutatorShouldBeFenced()) {
         Locker locker { globalObject.gcLock() };
         globalObject.guardedObjects().add(this);
@@ -52,6 +54,7 @@ void DOMGuardedObject::clear()
     ASSERT(!m_guarded || m_globalObject);
     removeFromGlobalObject();
     m_guarded.clear();
+    m_pendingActivity.clear();
 }
 
 void DOMGuardedObject::removeFromGlobalObject()

--- a/src/jsc/bindings/webcore/JSDOMGuardedObject.h
+++ b/src/jsc/bindings/webcore/JSDOMGuardedObject.h
@@ -52,22 +52,31 @@ public:
     void clear();
 
 protected:
-    DOMGuardedObject(JSDOMGlobalObject&, JSC::JSCell&);
+    // Yes when native code owes the guarded cell a settlement (DeferredPromise): the cell is a GC
+    // root until it is settled or cleared. That keeps a ShadowRealm or node:vm global that script
+    // no longer references alive until the operation started in it completes. No (DOMPromise):
+    // the cell is only visited through its global object, for as long as that global is reachable.
+    enum class HasPendingActivity : bool { No,
+        Yes };
+    DOMGuardedObject(JSDOMGlobalObject&, JSC::JSCell&, HasPendingActivity);
 
     void contextDestroyed();
     bool isEmpty() const { return !m_guarded; }
+    void pendingActivityDone() { m_pendingActivity.clear(); }
 
     JSC::Weak<JSC::JSCell> m_guarded;
     JSC::Weak<JSDOMGlobalObject> m_globalObject;
 
 private:
     void removeFromGlobalObject();
+
+    JSC::Strong<JSC::JSCell> m_pendingActivity;
 };
 
 template<typename T> class DOMGuarded : public DOMGuardedObject {
 protected:
-    DOMGuarded(JSDOMGlobalObject& globalObject, T& guarded)
-        : DOMGuardedObject(globalObject, guarded)
+    DOMGuarded(JSDOMGlobalObject& globalObject, T& guarded, HasPendingActivity hasPendingActivity)
+        : DOMGuardedObject(globalObject, guarded, hasPendingActivity)
     {
     }
     T* guarded() const { return dynamicDowncast<T>(guardedObject()); }

--- a/src/jsc/bindings/webcore/JSDOMGuardedObject.h
+++ b/src/jsc/bindings/webcore/JSDOMGuardedObject.h
@@ -53,9 +53,10 @@ public:
 
 protected:
     // Yes when native code owes the guarded cell a settlement (DeferredPromise): the cell is a GC
-    // root until it is settled or cleared. That keeps a ShadowRealm or node:vm global that script
-    // no longer references alive until the operation started in it completes. No (DOMPromise):
-    // the cell is only visited through its global object, for as long as that global is reachable.
+    // root until it is settled or cleared. That keeps a global that script no longer references
+    // (a dropped ShadowRealm, a retired `bun test --isolate` global) alive until the operation
+    // started in it completes. No (DOMPromise): the cell is only visited through its global
+    // object, for as long as that global is reachable.
     enum class HasPendingActivity : bool { No,
         Yes };
     DOMGuardedObject(JSDOMGlobalObject&, JSC::JSCell&, HasPendingActivity);

--- a/src/jsc/bindings/webcore/JSDOMPromise.h
+++ b/src/jsc/bindings/webcore/JSDOMPromise.h
@@ -51,7 +51,7 @@ public:
 
 private:
     DOMPromise(JSDOMGlobalObject& globalObject, JSC::JSPromise& promise)
-        : DOMGuarded<JSC::JSPromise>(globalObject, promise)
+        : DOMGuarded<JSC::JSPromise>(globalObject, promise, HasPendingActivity::No)
     {
     }
 };

--- a/src/jsc/bindings/webcore/JSDOMPromiseDeferred.cpp
+++ b/src/jsc/bindings/webcore/JSDOMPromiseDeferred.cpp
@@ -72,6 +72,7 @@ void DeferredPromise::callFunction(JSGlobalObject& lexicalGlobalObject, ResolveM
         break;
     }
 
+    pendingActivityDone();
     if (m_mode == Mode::ClearPromiseOnResolve)
         clear();
 }

--- a/src/jsc/bindings/webcore/JSDOMPromiseDeferred.h
+++ b/src/jsc/bindings/webcore/JSDOMPromiseDeferred.h
@@ -158,7 +158,7 @@ public:
 
 private:
     DeferredPromise(JSDOMGlobalObject& globalObject, JSC::JSPromise& deferred, Mode mode)
-        : DOMGuarded<JSC::JSPromise>(globalObject, deferred)
+        : DOMGuarded<JSC::JSPromise>(globalObject, deferred, HasPendingActivity::Yes)
         , m_mode(mode)
     {
     }

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -66,10 +66,11 @@ describe("Web Crypto", () => {
       cmd: [bunExe(), "-e", script],
       env: bunEnv,
       stdout: "pipe",
-      stderr: "inherit",
+      stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(JSON.parse(stdout)).toEqual(["4000000: true 32", "4: true 32"]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe(`["4000000: true 32","4: true 32"]`);
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -35,6 +35,44 @@ describe("Web Crypto", () => {
     expect(lines).toStrictEqual(results);
   });
 
+  // An operation started inside a ShadowRealm must settle even when script drops its last
+  // reference to the realm before the result comes back: the pending promise keeps the realm
+  // alive. 4 bytes is hashed synchronously and only the settlement is posted to the event loop,
+  // 4e6 bytes is hashed on the work pool.
+  it("a pending digest keeps an unreferenced ShadowRealm alive until it settles", async () => {
+    const script = /* js */ `
+      const results = [];
+      for (const size of [4, 4_000_000]) {
+        new ShadowRealm().evaluate(
+          \`(size, report) => {
+            crypto.subtle.digest("SHA-256", new Uint8Array(size)).then(
+              d => report(size + ": " + (d instanceof ArrayBuffer) + " " + d.byteLength),
+              e => report(size + ": " + String(e)),
+            );
+          }\`,
+        )(size, line => results.push(line));
+      }
+      // Collect now, while both settlements are still queued or in flight, and again from later
+      // event loop turns (no realm frame on the stack) until both arrive or we give up.
+      Bun.gc(true);
+      let turns = 0;
+      (function collect() {
+        Bun.gc(true);
+        if (results.length < 2 && turns++ < 20) setImmediate(collect);
+      })();
+      process.on("exit", () => console.log(JSON.stringify(results.sort())));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual(["4000000: true 32", "4: true 32"]);
+    expect(exitCode).toBe(0);
+  });
+
   it("has globals", () => {
     expect(crypto.subtle !== undefined).toBe(true);
     expect(CryptoKey.name).toBe("CryptoKey");


### PR DESCRIPTION
### Problem
- A `crypto.subtle.digest()` started inside a `ShadowRealm` never settles if script drops the realm before the result arrives: `new ShadowRealm().evaluate('(cb) => { crypto.subtle.digest("SHA-256", new Uint8Array(4e6)).then(d => cb(d.byteLength)) }')(cb); Bun.gc(true)` loses `cb` on 1.4.3. Found by fuzzing, not by a user.
- SubtleCrypto settles through `WebCore::DeferredPromise`, whose base `DOMGuardedObject` (`src/jsc/bindings/webcore/JSDOMGuardedObject.h`) holds only `Weak` handles. The promise is visited from `GlobalObject::visitChildrenImpl`, so it lives only while the realm global is otherwise reachable. Nothing roots the realm.

### Fix
- `DeferredPromise` takes a `JSC::Strong` on its promise at creation and drops it when it resolves, rejects, or is cleared. The promise's `Structure` keeps the realm alive for that time, as Bun's native operations already do with `JSPromise.Strong`.
- `DOMPromise` observes a script-created promise and owes it nothing, so it stays weak and cannot pin a realm. Unlike the root that #29891 removed, this one is released on settlement and cannot form a permanent cycle.
- Verified: `test/js/web/crypto/web-crypto.test.ts` (the new test fails on 1.4.3 and on an unfixed ASAN build), plus the worker suites that terminate with a digest in flight. Self-reviewed: 5 concerns raised, 5 addressed.

### Background
- In Bun a `ShadowRealm` global is a full `Zig::GlobalObject` with its own `crypto.subtle`. The main global is `gcProtect`ed. A realm global lives only while something references it.
- `DeferredPromise` is WebCore's handle for a promise that native code will settle. SubtleCrypto keeps one per pending operation and settles it from a task posted back to the realm.
- A `JSC::Strong` is a GC root. A cell keeps its `Structure` alive, and the `Structure` its global.

Refs #37982.

<details><summary>Notes</summary>

- #37982's census lists SubtleCrypto tasks as rooted through `ActiveDOMObject` pending activity. `SubtleCrypto` is a `ContextDestructionObserver` and its `DeferredPromise`s were weak, so that row was not true before this change.
- Teardown is unchanged: `Zig__GlobalObject__destructOnExit` and `WebWorker__teardownJSCVM` run `clearDOMGuardedObjects()` → `clear()` before `destroyVM`, and `clear()` drops the root too.
- With allocation churn instead of `Bun.gc(true)` about half of the continuations were lost (12 of 19 runs).
- Both digest paths are covered by the test: under 64 bytes the hash is computed synchronously and only the settlement is posted to the event loop, larger inputs go through the work pool (`PhonyWorkQueue` / `ConcurrentCppTask`). Every other SubtleCrypto operation uses the same `m_pendingPromises` + `DeferredPromise` path (a work-pool `decrypt` that rejects with a realm `DOMException`, and a digest, timer, `generateKey`, `sign`, digest chain inside a dropped realm, both complete with the fix).
- Without the fix the posted settlement is dropped in one of two ways: `DeferredPromise::shouldIgnoreRequestToFulfill()` sees the cleared `Weak`, or `ScriptExecutionContext::postTaskTo` finds no context because `~GlobalObject` removed it from the map. Neither touches freed memory (no ASAN signal, only a lost continuation).
- #29891 removed a `DOMGuardedObject` registration for `InternalWritableStream` because global-rooting an object that referenced its own wrapper made every unclosed `TransformStream` immortal. That class is gone. Here the root lives exactly as long as an entry in `SubtleCrypto::m_pendingPromises`, which the completion callback always takes out, and `~DOMGuardedObject`, `clear()` and `contextDestroyed()` all release it. 20 realms with pending digests are pinned while pending and all collected after they settle.
- `node:vm` contexts are not affected and not changed: `NodeVMGlobalObject` is not a `JSDOMGlobalObject` and has no `crypto` of its own (same as Node). A digest called through the main realm's injected `crypto` creates its promise in the main realm.
- `bun test --isolate`: a digest still pending when a file ends now keeps the retired global alive until it settles, then the global is collected as before (at most one extra retired global alive at a time in a 10-file probe).
- #25608 (node:http callbacks never run inside a ShadowRealm) is the same family of symptom but a different mechanism (the realm's nextTick queue), and is not fixed here.
- The root is dropped in `callFunction` before the `ClearPromiseOnResolve` check, so a `RetainPromiseOnResolve` promise is weak again once settled.
- ASAN-clean: `process.exit()` with realm and main digests of 64 MB in flight, natural exit after the realm is collected, and `worker.terminate()` with a nested-realm digest in flight.
- Suites run with the debug ASAN build: `test/js/web/crypto/web-crypto.test.ts`, `web-crypto-sha3.test.ts`, `test/js/bun/jsc/shadow.test.js`, `test/js/web/workers/worker-late-completion.test.ts`, `worker-terminate-funnels.test.ts`, and `test-webcrypto-{digest,encrypt-decrypt-aes,sign-verify-hmac,derivebits-hkdf,export-import,cryptokey-workers,encrypt-decrypt-rsa,sign-verify-ecdsa,methods-not-async}.js`, `test-global-webcrypto.js`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.66ms]
(pass) Web Crypto > keeps event loop alive [279.72ms]
68 |       stdout: "pipe",
69 |       stderr: "pipe",
70 |     });
71 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
72 |     expect(stderr).toBe("");
73 |     expect(stdout.trim()).toBe(`["4000000: true 32","4: true 32"]`);
                               ^
error: expect(received).toBe(expected)

Expected: "["4000000: true 32","4: true 32"]"
Received: "[]"

      at <anonymous> (/workspace/bun/test/js/web/crypto/web-crypto.test.ts:73:27)
(fail) Web Crypto > a pending digest keeps an unreferenced ShadowRealm alive until it settles [642.68ms]
(pass) Web Crypto > has globals [3.54ms]
(pass) Web Crypto > should encrypt and decrypt [10.58ms]
(pass) Web Crypto > should verify and sign [37.70ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.06ms]
(pass) Web Crypto > keeps event loop alive [9.81ms]
68 |       stdout: "pipe",
69 |       stderr: "pipe",
70 |     });
71 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
72 |     expect(stderr).toBe("");
73 |     expect(stdout.trim()).toBe(`["4000000: true 32","4: true 32"]`);
                               ^
error: expect(received).toBe(expected)

Expected: "["4000000: true 32","4: true 32"]"
Received: "[]"

      at <anonymous> (/workspace/bun/test/js/web/crypto/web-crypto.test.ts:73:27)
(fail) Web Crypto > a pending digest keeps an unreferenced ShadowRealm alive until it settles [14.73ms]
(pass) Web Crypto > has globals [0.07ms]
(pass) Web Crypto > should encrypt and decrypt [0.38ms]
(pass) Web Crypto > should verify and sign [0.98ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [0.28ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [0.17ms]
(pass) Web
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.39ms]
(pass) Web Crypto > keeps event loop alive [333.97ms]
(pass) Web Crypto > a pending digest keeps an unreferenced ShadowRealm alive until it settles [475.04ms]
(pass) Web Crypto > has globals [3.07ms]
(pass) Web Crypto > should encrypt and decrypt [10.38ms]
(pass) Web Crypto > should verify and sign [36.89ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [16.52ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [10.46ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [23.53ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2525.49ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [409.97ms]
(pass) RSA-PSS sal
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     d439ae6feb
  features     baseline

23 deps, 131 codegen, 1172 objects in 693ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [12.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [19.00ms]
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 4ms

  react-refresh.js  4.81 KB  (entry point)

[8/1217] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1217] fetch zlib
[zlib] up to date
[10/1217] gen .bind.ts → GeneratedBindings.cpp
[11/1217] gen ProcessBi
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSDOMGuardedObject.cpp   |  5 ++-
 src/jsc/bindings/webcore/JSDOMGuardedObject.h     | 16 ++++++++--
 src/jsc/bindings/webcore/JSDOMPromise.h           |  2 +-
 src/jsc/bindings/webcore/JSDOMPromiseDeferred.cpp |  1 +
 src/jsc/bindings/webcore/JSDOMPromiseDeferred.h   |  2 +-
 test/js/web/crypto/web-crypto.test.ts             | 39 +++++++++++++++++++++++
 6 files changed, 59 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/jsc/bindings/webcore/JSDOMGuardedObject.cpp        1      2     13
src/jsc/bindings/webcore/JSDOMGuardedObject.h          2      2     13
src/jsc/bindings/webcore/JSDOMPromise.h                1      1     13
src/jsc/bindings/webcore/JSDOMPromiseDeferred.cpp      1      1     13
src/jsc/bindings/webcore/JSDOMPromiseDeferred.h        1      1     13
test/js/web/crypto/web-crypto.test.ts                  3      3     13
```

</details>

<!-- robobun:evidence:end -->