### PR TITLE
css: keep a selector list whole when a member is vendor prefixed

### DIFF
--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -784,9 +784,13 @@ impl<'a> Printer<'a> {
         self.write_separated(iter, |d| d.delim(b',', false), f)
     }
 
+    /// `vendor_prefix` and `as_written` describe how `selectors` were just printed (see
+    /// `StyleContext`), so `&` in the nested rules expands to the same text.
     pub(crate) fn with_context<C, F>(
         &mut self,
         selectors: &css::SelectorList,
+        vendor_prefix: css::VendorPrefix,
+        as_written: bool,
         closure: C,
         func: F,
     ) -> PrintResult<()>
@@ -800,7 +804,12 @@ impl<'a> Printer<'a> {
             None
         };
 
-        let ctx = css::StyleContext { selectors, parent };
+        let ctx = css::StyleContext {
+            selectors,
+            parent,
+            vendor_prefix,
+            as_written,
+        };
 
         // `&ctx` is stack-local but the field type is `&'a StyleContext<'a>`;
         // soundness relies on restoring `parent` before this frame returns.

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -784,8 +784,7 @@ impl<'a> Printer<'a> {
         self.write_separated(iter, |d| d.delim(b',', false), f)
     }
 
-    /// `vendor_prefix` and `as_written` describe how `selectors` were just printed (see
-    /// `StyleContext`), so `&` in the nested rules expands to the same text.
+    /// `vendor_prefix` and `as_written`: how `selectors` were just printed, see `StyleContext`.
     pub(crate) fn with_context<C, F>(
         &mut self,
         selectors: &css::SelectorList,

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -1190,10 +1190,9 @@ pub use crate::Location;
 pub struct StyleContext<'a> {
     pub(crate) selectors: &'a crate::selectors::SelectorList,
     pub(crate) parent: Option<&'a StyleContext<'a>>,
-    /// The printer's vendor prefix while `selectors` themselves were printed. A nested rule
-    /// without a prefix pass of its own prints them with it again when it expands `&`.
+    /// The printer's vendor prefix while `selectors` were printed, reused when `&` expands them.
     pub(crate) vendor_prefix: crate::VendorPrefix,
-    /// `selectors` print their pseudos as written, whatever pass a nested rule is in.
+    /// `selectors` print their pseudos as written, whatever prefix pass a nested rule is in.
     pub(crate) as_written: bool,
 }
 

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -664,9 +664,8 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
 
     // If some of the selectors in this rule are not compatible with the targets,
     // we need to either wrap in :is() or split them into multiple rules.
-    let mut incompatible: SmallList<Selector, 1> = if sty.selectors.v.len() > 1
-        && context.targets.should_compile_selectors()
-        && !sty.is_compatible(context.targets)
+    let mut incompatible: SmallList<Selector, 1> = if sty
+        .should_compile_selector_list(context.targets)
     {
         // The :is() selector accepts a forgiving selector list, so use that if possible.
         // Note that :is() does not allow pseudo elements, so we need to check for that.

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -1190,6 +1190,11 @@ pub use crate::Location;
 pub struct StyleContext<'a> {
     pub(crate) selectors: &'a crate::selectors::SelectorList,
     pub(crate) parent: Option<&'a StyleContext<'a>>,
+    /// The printer's vendor prefix while `selectors` themselves were printed. A nested rule
+    /// without a prefix pass of its own prints them with it again when it expands `&`.
+    pub(crate) vendor_prefix: crate::VendorPrefix,
+    /// `selectors` print their pseudos as written, whatever pass a nested rule is in.
+    pub(crate) as_written: bool,
 }
 
 /// Upper bound on the number of selectors that compiling nested rules away for

--- a/src/css/rules/scope.rs
+++ b/src/css/rules/scope.rs
@@ -50,8 +50,11 @@ impl<R> ScopeRule<R> {
             if let Some(scope_start) = &self.scope_start {
                 // `Printer::with_context` carries the captured state as the
                 // first closure arg (no `&self` capture across `&mut dest`).
+                let vendor_prefix = dest.vendor_prefix;
                 dest.with_context(
                     scope_start,
+                    vendor_prefix,
+                    false,
                     scope_end,
                     |scope_end: &SelectorList, d: &mut Printer| -> Result<(), PrintErr> {
                         let ctx = d.ctx;

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -181,8 +181,7 @@ impl<R> StyleRule<R> {
             self.declarations.declarations.len() + self.declarations.important_declarations.len();
         let has_declarations = supports_nesting || len > 0 || self.rules.v.len() == 0;
 
-        // A rule with prefixed pseudos but no prefix pass of its own (`x:-moz-any-link, .b`)
-        // prints them as written, also inside an ancestor's pass.
+        // Prefixed pseudos but no prefix pass: print them as written, even in an ancestor's pass.
         let inherited_prefix = dest.vendor_prefix;
         let as_written = self.vendor_prefix.is_empty()
             && (!inherited_prefix.is_empty() || !self.rules.v.is_empty())

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -58,9 +58,8 @@ impl<R> StyleRule<R> {
             return;
         }
         if self.vendor_prefix != VendorPrefix::NONE {
-            // The author put an unprefixed pseudo next to a vendor-prefixed one. One printing
-            // pass per prefix would write the prefixed one without its prefix in the unprefixed
-            // pass, so print the rule once, as written.
+            // The author mixed prefixed and unprefixed pseudos. Print once, as written: a pass
+            // per prefix would print the prefixed one unprefixed in the `NONE` pass.
             self.vendor_prefix = VendorPrefix::empty();
         } else if context.targets.should_compile_selectors() {
             self.vendor_prefix = selector::downlevel_selectors(
@@ -75,12 +74,8 @@ impl<R> StyleRule<R> {
         selector::is_compatible(self.selectors.v.slice(), targets)
     }
 
-    /// Whether the targets call for rewriting this rule's selector list: an `:is()` wrap or a
-    /// split, so that the selectors every target supports keep applying in the targets that lack
-    /// a feature another selector uses. A vendor-prefixed selector keeps the list as written: the
-    /// other engines drop the whole rule because of it, browser hacks such as
-    /// `_:-ms-lang(x), .ie-only {}` rely on that, and any rewrite would revive the other selectors
-    /// there.
+    /// Whether to `:is()`-wrap or split this rule's selector list so the selectors every target
+    /// supports keep applying. A vendor-prefixed member keeps the list as written.
     pub(crate) fn should_compile_selector_list(&self, targets: &css::targets::Targets) -> bool {
         self.selectors.v.len() > 1
             && targets.should_compile_selectors()

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -181,6 +181,18 @@ impl<R> StyleRule<R> {
             self.declarations.declarations.len() + self.declarations.important_declarations.len();
         let has_declarations = supports_nesting || len > 0 || self.rules.v.len() == 0;
 
+        // A rule with prefixed pseudos but no prefix pass of its own (`x:-moz-any-link, .b`)
+        // prints them as written, also inside an ancestor's pass.
+        let inherited_prefix = dest.vendor_prefix;
+        let as_written = self.vendor_prefix.is_empty()
+            && (!inherited_prefix.is_empty() || !self.rules.v.is_empty())
+            && selector::has_vendor_prefixed_pseudo(&self.selectors);
+        let own_prefix = if as_written {
+            VendorPrefix::empty()
+        } else {
+            inherited_prefix
+        };
+
         if has_declarations {
             //   #[cfg(feature = "sourcemap")]
             //   dest.add_mapping(self.loc);
@@ -191,12 +203,15 @@ impl<R> StyleRule<R> {
             // Each rule prelude gets its own budget for `&` substitutions when
             // compiling nesting (see `serialize::serialize_nesting`).
             dest.nesting_expansions = 0;
-            selector::serialize::serialize_selector_list(
+            dest.vendor_prefix = own_prefix;
+            let result = selector::serialize::serialize_selector_list(
                 self.selectors.v.slice(),
                 dest,
                 ctx,
                 false,
-            )?;
+            );
+            dest.vendor_prefix = inherited_prefix;
+            result?;
             dest.whitespace()?;
             dest.write_char(b'{')?;
             dest.indent();
@@ -312,8 +327,13 @@ impl<R> StyleRule<R> {
             dest.skip_prefixed_nested_rules = skip_prefixed_nested;
             // `with_context` keeps the (closure-data, fn) split so the
             // `Printer` reborrow lives only inside `func`.
-            let result =
-                dest.with_context(&self.selectors, &self.rules, |rules, d| rules.to_css(d));
+            let result = dest.with_context(
+                &self.selectors,
+                own_prefix,
+                as_written,
+                &self.rules,
+                |rules, d| rules.to_css(d),
+            );
             dest.skip_prefixed_nested_rules = saved_skip;
             result?;
         }

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -58,8 +58,7 @@ impl<R> StyleRule<R> {
             return;
         }
         if self.vendor_prefix != VendorPrefix::NONE {
-            // The author mixed prefixed and unprefixed pseudos. Print once, as written: a pass
-            // per prefix would print the prefixed one unprefixed in the `NONE` pass.
+            // Mixed as written. A pass per prefix would print the prefixed pseudo unprefixed.
             self.vendor_prefix = VendorPrefix::empty();
         } else if context.targets.should_compile_selectors() {
             self.vendor_prefix = selector::downlevel_selectors(
@@ -74,8 +73,7 @@ impl<R> StyleRule<R> {
         selector::is_compatible(self.selectors.v.slice(), targets)
     }
 
-    /// Whether to `:is()`-wrap or split this rule's selector list so the selectors every target
-    /// supports keep applying. A vendor-prefixed member keeps the list as written.
+    /// Whether the targets need this selector list `:is()`-wrapped or split. See `Compatibility`.
     pub(crate) fn should_compile_selector_list(&self, targets: &css::targets::Targets) -> bool {
         self.selectors.v.len() > 1
             && targets.should_compile_selectors()

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -54,9 +54,15 @@ impl<R> StyleRule<R> {
 
     pub(crate) fn update_prefix(&mut self, context: &mut MinifyContext<'_, '_>) {
         self.vendor_prefix = selector::get_prefix(&self.selectors);
-        if self.vendor_prefix.contains(VendorPrefix::NONE)
-            && context.targets.should_compile_selectors()
-        {
+        if !self.vendor_prefix.contains(VendorPrefix::NONE) {
+            return;
+        }
+        if self.vendor_prefix != VendorPrefix::NONE {
+            // The author put an unprefixed pseudo next to a vendor-prefixed one. One printing
+            // pass per prefix would write the prefixed one without its prefix in the unprefixed
+            // pass, so print the rule once, as written.
+            self.vendor_prefix = VendorPrefix::empty();
+        } else if context.targets.should_compile_selectors() {
             self.vendor_prefix = selector::downlevel_selectors(
                 context.arena,
                 self.selectors.v.slice_mut(),
@@ -67,6 +73,19 @@ impl<R> StyleRule<R> {
 
     pub(crate) fn is_compatible(&self, targets: &css::targets::Targets) -> bool {
         selector::is_compatible(self.selectors.v.slice(), targets)
+    }
+
+    /// Whether the targets call for rewriting this rule's selector list: an `:is()` wrap or a
+    /// split, so that the selectors every target supports keep applying in the targets that lack
+    /// a feature another selector uses. A vendor-prefixed selector keeps the list as written: the
+    /// other engines drop the whole rule because of it, browser hacks such as
+    /// `_:-ms-lang(x), .ie-only {}` rely on that, and any rewrite would revive the other selectors
+    /// there.
+    pub(crate) fn should_compile_selector_list(&self, targets: &css::targets::Targets) -> bool {
+        self.selectors.v.len() > 1
+            && targets.should_compile_selectors()
+            && selector::compatibility(self.selectors.v.slice(), targets)
+                == selector::Compatibility::Incompatible
     }
 }
 
@@ -432,10 +451,7 @@ impl<R> StyleRule<R> {
         // nesting is compiled away the printed output still fans out per
         // selector, which is why the nesting branch bumps unconditionally.
         let saved_expansion_multiplier = context.selector_expansion_multiplier;
-        let selectors_incompatible = self.selectors.v.len() > 1
-            && context.targets.should_compile_selectors()
-            && !self.is_compatible(context.targets);
-        let splits_selectors = selectors_incompatible
+        let splits_selectors = self.should_compile_selector_list(context.targets)
             && !(context.targets.is_compatible(css::Feature::IsSelector)
                 && !self.selectors.any_has_pseudo_element()
                 && self.selectors.specifities_all_equal());

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -1366,8 +1366,7 @@ pub(crate) mod serialize {
                     None,
                 );
             }
-            // A rule in a prefix pass of its own prints the parent selectors in that pass too.
-            // Otherwise they print as they did in the parent rule itself.
+            // Outside a prefix pass of its own, a rule prints its parents as they printed.
             let saved_prefix = dest.vendor_prefix;
             if ctx.as_written || saved_prefix.is_empty() {
                 dest.vendor_prefix = ctx.vendor_prefix;

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -261,18 +261,14 @@ pub(crate) fn get_prefix(selectors: &SelectorList) -> VendorPrefix {
     prefix
 }
 
-/// How the browser targets support a selector list. A browser drops the whole style rule when it
-/// does not support one selector in the list. Ordered so that the worst verdict of the list wins.
+/// How the browser targets support a selector list. The worst member wins, hence `Ord`.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub(crate) enum Compatibility {
-    /// Every target supports every selector.
     Compatible,
-    /// Some target lacks (or, with no support data, may lack) a feature that a selector uses.
+    /// Some target lacks, or (with no support data) may lack, a feature that a selector uses.
     Incompatible,
-    /// A selector uses a vendor-prefixed pseudo-class or pseudo-element (or `:-webkit-any()`),
-    /// which only that engine will ever accept. The other engines drop the rule, and browser hacks
-    /// such as `_:-ms-lang(x), .ie-only {}` rely on that, so no rewrite of the list is right for
-    /// every browser.
+    /// A selector is vendor prefixed, so every other engine drops the whole rule. Browser hacks
+    /// rely on that, and no rewrite of the list is right for every browser.
     VendorPrefixed,
 }
 
@@ -280,8 +276,7 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
     compatibility(selectors, targets) == Compatibility::Compatible
 }
 
-/// `feature` taking `selectors` as an unforgiving argument list, where one unsupported argument
-/// invalidates the whole selector.
+/// `feature` with an unforgiving argument list: one unsupported argument invalidates the selector.
 fn unforgiving(
     feature: Feature,
     selectors: &[parser::Selector],
@@ -293,8 +288,7 @@ fn unforgiving(
     }
 }
 
-/// Whether an unknown pseudo-class or pseudo-element name is vendor specific (`-moz-focusring`).
-/// The parser uses the same test to skip its unsupported-pseudo warning.
+/// `-moz-focusring` and the like. The parser skips its unsupported-pseudo warning by the same test.
 fn is_vendor_name(name: &[u8]) -> bool {
     bun_core::strings::starts_with_char(name, b'-')
 }

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -267,8 +267,7 @@ pub(crate) enum Compatibility {
     Compatible,
     /// Some target lacks, or (with no support data) may lack, a feature that a selector uses.
     Incompatible,
-    /// A selector is vendor prefixed, so every other engine drops the whole rule. Browser hacks
-    /// rely on that, and no rewrite of the list is right for every browser.
+    /// A member is vendor prefixed: other engines drop the whole rule, and browser hacks use that.
     VendorPrefixed,
 }
 

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -261,6 +261,21 @@ pub(crate) fn get_prefix(selectors: &SelectorList) -> VendorPrefix {
     prefix
 }
 
+/// Whether some pseudo in the list carries an explicit vendor prefix, as `::-moz-placeholder` does.
+pub(crate) fn has_vendor_prefixed_pseudo(selectors: &SelectorList) -> bool {
+    selectors.v.slice().iter().any(|selector| {
+        selector.components.iter().any(|component| {
+            let prefix = match component {
+                Component::NonTsPseudoClass(pc) => pc.get_prefix(),
+                Component::PseudoElement(pe) => pe.get_prefix(),
+                Component::Any { vendor_prefix, .. } => *vendor_prefix,
+                _ => return false,
+            };
+            !prefix.difference(VendorPrefix::NONE).is_empty()
+        })
+    })
+}
+
 /// How the browser targets support a selector list. The worst member wins, hence `Ord`.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub(crate) enum Compatibility {
@@ -1351,21 +1366,31 @@ pub(crate) mod serialize {
                     None,
                 );
             }
+            // A rule in a prefix pass of its own prints the parent selectors in that pass too.
+            // Otherwise they print as they did in the parent rule itself.
+            let saved_prefix = dest.vendor_prefix;
+            if ctx.as_written || saved_prefix.is_empty() {
+                dest.vendor_prefix = ctx.vendor_prefix;
+            }
             // If there's only one simple selector, just serialize it directly.
             // Otherwise, use an :is() pseudo class.
             // Type selectors are only allowed at the start of a compound selector,
             // so use :is() if that is not the case.
-            if ctx.selectors.v.len() == 1
+            let result = if ctx.selectors.v.len() == 1
                 && (first
                     || (!has_type_selector(ctx.selectors.v.at(0))
                         && is_simple(ctx.selectors.v.at(0))))
             {
-                serialize_selector(ctx.selectors.v.at(0), dest, ctx.parent, false)?;
+                serialize_selector(ctx.selectors.v.at(0), dest, ctx.parent, false)
             } else {
-                dest.write_str(b":is(")?;
-                serialize_selector_list(ctx.selectors.v.slice(), dest, ctx.parent, false)?;
-                dest.write_char(b')')?;
-            }
+                dest.write_str(b":is(")
+                    .and_then(|()| {
+                        serialize_selector_list(ctx.selectors.v.slice(), dest, ctx.parent, false)
+                    })
+                    .and_then(|()| dest.write_char(b')'))
+            };
+            dest.vendor_prefix = saved_prefix;
+            result?;
         } else {
             // If there is no context, we are at the root if nesting is supported. This is equivalent to :scope.
             // Otherwise, if nesting is supported, serialize the nesting selector directly.

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -261,10 +261,49 @@ pub(crate) fn get_prefix(selectors: &SelectorList) -> VendorPrefix {
     prefix
 }
 
+/// How the browser targets support a selector list. A browser drops the whole style rule when it
+/// does not support one selector in the list. Ordered so that the worst verdict of the list wins.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub(crate) enum Compatibility {
+    /// Every target supports every selector.
+    Compatible,
+    /// Some target lacks (or, with no support data, may lack) a feature that a selector uses.
+    Incompatible,
+    /// A selector uses a vendor-prefixed pseudo-class or pseudo-element (or `:-webkit-any()`),
+    /// which only that engine will ever accept. The other engines drop the rule, and browser hacks
+    /// such as `_:-ms-lang(x), .ie-only {}` rely on that, so no rewrite of the list is right for
+    /// every browser.
+    VendorPrefixed,
+}
+
 pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -> bool {
+    compatibility(selectors, targets) == Compatibility::Compatible
+}
+
+/// `feature` taking `selectors` as an unforgiving argument list, where one unsupported argument
+/// invalidates the whole selector.
+fn unforgiving(
+    feature: Feature,
+    selectors: &[parser::Selector],
+    targets: &Targets,
+) -> Compatibility {
+    match compatibility(selectors, targets) {
+        Compatibility::Compatible if !targets.is_compatible(feature) => Compatibility::Incompatible,
+        other => other,
+    }
+}
+
+/// Whether an unknown pseudo-class or pseudo-element name is vendor specific (`-moz-focusring`).
+/// The parser uses the same test to skip its unsupported-pseudo warning.
+fn is_vendor_name(name: &[u8]) -> bool {
+    bun_core::strings::starts_with_char(name, b'-')
+}
+
+pub(crate) fn compatibility(selectors: &[parser::Selector], targets: &Targets) -> Compatibility {
     use Feature as F;
+    let mut result = Compatibility::Compatible;
     for selector in selectors {
-        for component in selector.components.iter() {
+        'components: for component in selector.components.iter() {
             let feature = match component {
                 Component::Id(_) | Component::Class(_) | Component::LocalName(_) => continue,
 
@@ -320,9 +359,7 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
                 Component::Empty | Component::Root => F::Selectors3,
                 Component::Negation(sels) => {
                     // :not() selector list is not forgiving.
-                    if !targets.is_compatible(F::Selectors3) || !is_compatible(sels, targets) {
-                        return false;
-                    }
+                    result = result.max(unforgiving(F::Selectors3, sels, targets));
                     continue;
                 }
 
@@ -331,16 +368,14 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
                         break 'brk F::Selectors2;
                     }
                     if data.ty == parser::NthType::Col || data.ty == parser::NthType::LastCol {
-                        return false;
+                        // No support data.
+                        result = result.max(Compatibility::Incompatible);
+                        continue 'components;
                     }
                     F::Selectors3
                 }
                 Component::NthOf(n) => {
-                    if !targets.is_compatible(F::NthChildOf)
-                        || !is_compatible(&n.selectors, targets)
-                    {
-                        return false;
-                    }
+                    result = result.max(unforgiving(F::NthChildOf, &n.selectors, targets));
                     continue;
                 }
 
@@ -353,11 +388,9 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
                     F::IsSelector
                 }
                 Component::Where(_) | Component::Nesting => F::IsSelector,
-                Component::Any { .. } => return false,
+                Component::Any { .. } => return Compatibility::VendorPrefixed,
                 Component::Has(sels) => {
-                    if !targets.is_compatible(F::HasSelector) || !is_compatible(sels, targets) {
-                        return false;
-                    }
+                    result = result.max(unforgiving(F::HasSelector, sels, targets));
                     continue;
                 }
 
@@ -422,29 +455,29 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
                             }
                         }
 
-                        // Experimental, no browser support.
-                        PseudoClass::Current
-                        | PseudoClass::Past
-                        | PseudoClass::Future
-                        | PseudoClass::Playing
-                        | PseudoClass::Paused
-                        | PseudoClass::Seeking
-                        | PseudoClass::Stalled
-                        | PseudoClass::Buffering
-                        | PseudoClass::Muted
-                        | PseudoClass::VolumeLocked
-                        | PseudoClass::TargetWithin
-                        | PseudoClass::LocalLink
-                        | PseudoClass::Blank
-                        | PseudoClass::UserInvalid
-                        | PseudoClass::UserValid
-                        | PseudoClass::Defined => return false,
+                        // CSS modules print these as the selector they wrap.
+                        PseudoClass::Local { selector } | PseudoClass::Global { selector } => {
+                            result = result
+                                .max(compatibility(core::slice::from_ref(&**selector), targets));
+                            continue 'components;
+                        }
 
-                        PseudoClass::Custom { .. } => {}
+                        PseudoClass::WebkitScrollbar(_) => {}
+                        PseudoClass::Custom { name } | PseudoClass::CustomFunction { name, .. } => {
+                            if !is_vendor_name(name) {
+                                result = result.max(Compatibility::Incompatible);
+                                continue 'components;
+                            }
+                        }
 
-                        _ => {}
+                        // No support data (`:modal`, `:popover-open`, `:defined`, ...).
+                        _ => {
+                            result = result.max(Compatibility::Incompatible);
+                            continue 'components;
+                        }
                     }
-                    return false;
+                    // What reaches here is vendor prefixed.
+                    return Compatibility::VendorPrefixed;
                 }
 
                 Component::PseudoElement(pseudo) => 'brk: {
@@ -470,10 +503,30 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
                         }
                         PseudoElement::Cue => break 'brk F::Cue,
                         PseudoElement::CueFunction { .. } => break 'brk F::CueFunction,
-                        PseudoElement::Custom { .. } => return false,
-                        _ => {}
+
+                        PseudoElement::FileSelectorButton(prefix) => {
+                            if *prefix == VendorPrefix::NONE {
+                                result = result.max(Compatibility::Incompatible);
+                                continue 'components;
+                            }
+                        }
+                        PseudoElement::WebkitScrollbar(_) => {}
+                        PseudoElement::Custom { name }
+                        | PseudoElement::CustomFunction { name, .. } => {
+                            if !is_vendor_name(name) {
+                                result = result.max(Compatibility::Incompatible);
+                                continue 'components;
+                            }
+                        }
+
+                        // No support data (`::view-transition`, `::details-content`, ...).
+                        _ => {
+                            result = result.max(Compatibility::Incompatible);
+                            continue 'components;
+                        }
                     }
-                    return false;
+                    // What reaches here is vendor prefixed.
+                    return Compatibility::VendorPrefixed;
                 }
 
                 Component::Combinator(combinator) => match combinator {
@@ -484,12 +537,12 @@ pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -
             };
 
             if !targets.is_compatible(feature) {
-                return false;
+                result = result.max(Compatibility::Incompatible);
             }
         }
     }
 
-    true
+    result
 }
 
 /// Determines whether a selector list contains only unused selectors.

--- a/test/bundler/css/unsupported-selector-list.test.ts
+++ b/test/bundler/css/unsupported-selector-list.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import path from "node:path";
+
+// A browser drops a whole style rule when it does not support one selector in
+// the list. Browser hacks such as `_:-ms-lang(x), .ie-only {}` and vendor
+// pseudo-element lists in CSS resets rely on that. The default browser targets
+// made the bundler split such a list into one rule per selector, which turned
+// the other selectors live in every browser and duplicated the declarations.
+describe("css", () => {
+  test("a selector list with a vendor-prefixed member is not split", async () => {
+    using dir = tempDir("css-unsupported-selector-list", {
+      "in.css": `
+        x:-moz-any-link, .b { border-style: solid }
+        _:-ms-lang(x), .c { color: red }
+        .e, ::-webkit-foo { color: red }
+        .i, input::-moz-placeholder { color: red }
+        button::-moz-focus-inner, [type="button"]::-moz-focus-inner { border-style: none }
+        .p::placeholder, .p::-moz-placeholder { opacity: 1 }
+      `,
+    });
+    const result = await Bun.build({
+      entrypoints: [path.join(String(dir), "in.css")],
+      minify: true,
+      throw: true,
+    });
+    const out = await result.outputs[0].text();
+    expect(out.trim().split("}")).toEqual([
+      "x:-moz-any-link,.b{border-style:solid",
+      "_:-ms-lang(x),.c{color:red",
+      ".e,::-webkit-foo{color:red",
+      ".i,input::-moz-placeholder{color:red",
+      "button::-moz-focus-inner,[type=button]::-moz-focus-inner{border-style:none",
+      ".p::placeholder,.p::-moz-placeholder{opacity:1",
+      "",
+    ]);
+  });
+});

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5839,57 +5839,66 @@ describe("css tests", () => {
     );
     // A vendor-prefixed member keeps the list as written. The other engines drop the whole rule
     // because of it, which browser hacks rely on.
-    for (const targets of [{ chrome: 80 << 16 }, { safari: 14 << 16 }]) {
-      prefix_test(
-        "x:-moz-any-link, .b { border-style: solid }",
-        "x:-moz-any-link, .b { border-style: solid; }",
-        targets,
-      );
-      prefix_test("_:-ms-lang(x), .c { color: red }", "_:-ms-lang(x), .c { color: red; }", targets);
-      prefix_test(".e, ::-webkit-foo { color: red }", ".e, ::-webkit-foo { color: red; }", targets);
-      prefix_test(".i, input::-moz-placeholder { color: red }", ".i, input::-moz-placeholder { color: red; }", targets);
-      prefix_test(".h, :-moz-focusring { outline: none }", ".h, :-moz-focusring { outline: none; }", targets);
-      prefix_test(
-        "button::-moz-focus-inner, [type=button]::-moz-focus-inner { border-style: none }",
-        'button::-moz-focus-inner, [type="button"]::-moz-focus-inner { border-style: none; }',
-        targets,
-      );
-      prefix_test(
-        ".a::-webkit-scrollbar, .b::-webkit-scrollbar { width: 0 }",
-        ".a::-webkit-scrollbar, .b::-webkit-scrollbar { width: 0; }",
-        targets,
-      );
-      prefix_test(
-        ".a, [type=file]::-webkit-file-upload-button { color: red }",
-        '.a, [type="file"]::-webkit-file-upload-button { color: red; }',
-        targets,
-      );
-      prefix_test(".a, :-webkit-any(.b, .c) { color: red }", ".a, :-webkit-any(.b, .c) { color: red; }", targets);
-      // The vendor-prefixed member wins over one that the targets only lack a feature for.
-      prefix_test(
-        ".a, .b:focus-visible, x:-moz-any-link { color: red }",
-        ".a, .b:focus-visible, x:-moz-any-link { color: red; }",
-        targets,
-      );
-      // :not(), :has() and :nth-child(of) take unforgiving lists: a vendor-prefixed argument drops the rule.
-      prefix_test(".a, .b:not(:-moz-any-link) { color: red }", ".a, .b:not(:-moz-any-link) { color: red; }", targets);
-      prefix_test(".a, .b:has(:-moz-any-link) { color: red }", ".a, .b:has(:-moz-any-link) { color: red; }", targets);
-      prefix_test(
-        ".a, :nth-child(2n of :-moz-any-link) { color: red }",
-        ".a, :nth-child(2n of :-moz-any-link) { color: red; }",
-        targets,
-      );
-      // An unprefixed pseudo next to its prefixed form prints once, as written, not once per prefix.
-      prefix_test(
-        ".p::placeholder, .p::-moz-placeholder { color: red }",
-        ".p::placeholder, .p::-moz-placeholder { color: red; }",
-        targets,
-      );
-      prefix_test(
-        "input:-moz-read-only::placeholder { color: red }",
-        "input:-moz-read-only::placeholder { color: red; }",
-        targets,
-      );
+    for (const [label, targets] of [
+      ["chrome 80", { chrome: 80 << 16 }],
+      ["safari 14", { safari: 14 << 16 }],
+    ] as const) {
+      describe(label, () => {
+        prefix_test(
+          "x:-moz-any-link, .b { border-style: solid }",
+          "x:-moz-any-link, .b { border-style: solid; }",
+          targets,
+        );
+        prefix_test("_:-ms-lang(x), .c { color: red }", "_:-ms-lang(x), .c { color: red; }", targets);
+        prefix_test(".e, ::-webkit-foo { color: red }", ".e, ::-webkit-foo { color: red; }", targets);
+        prefix_test(
+          ".i, input::-moz-placeholder { color: red }",
+          ".i, input::-moz-placeholder { color: red; }",
+          targets,
+        );
+        prefix_test(".h, :-moz-focusring { outline: none }", ".h, :-moz-focusring { outline: none; }", targets);
+        prefix_test(
+          "button::-moz-focus-inner, [type=button]::-moz-focus-inner { border-style: none }",
+          'button::-moz-focus-inner, [type="button"]::-moz-focus-inner { border-style: none; }',
+          targets,
+        );
+        prefix_test(
+          ".a::-webkit-scrollbar, .b::-webkit-scrollbar { width: 0 }",
+          ".a::-webkit-scrollbar, .b::-webkit-scrollbar { width: 0; }",
+          targets,
+        );
+        prefix_test(
+          ".a, [type=file]::-webkit-file-upload-button { color: red }",
+          '.a, [type="file"]::-webkit-file-upload-button { color: red; }',
+          targets,
+        );
+        prefix_test(".a, :-webkit-any(.b, .c) { color: red }", ".a, :-webkit-any(.b, .c) { color: red; }", targets);
+        // The vendor-prefixed member wins over one that the targets only lack a feature for.
+        prefix_test(
+          ".a, .b:focus-visible, x:-moz-any-link { color: red }",
+          ".a, .b:focus-visible, x:-moz-any-link { color: red; }",
+          targets,
+        );
+        // :not(), :has() and :nth-child(of) take unforgiving lists: a vendor-prefixed argument drops the rule.
+        prefix_test(".a, .b:not(:-moz-any-link) { color: red }", ".a, .b:not(:-moz-any-link) { color: red; }", targets);
+        prefix_test(".a, .b:has(:-moz-any-link) { color: red }", ".a, .b:has(:-moz-any-link) { color: red; }", targets);
+        prefix_test(
+          ".a, :nth-child(2n of :-moz-any-link) { color: red }",
+          ".a, :nth-child(2n of :-moz-any-link) { color: red; }",
+          targets,
+        );
+        // An unprefixed pseudo next to its prefixed form prints once, as written, not once per prefix.
+        prefix_test(
+          ".p::placeholder, .p::-moz-placeholder { color: red }",
+          ".p::placeholder, .p::-moz-placeholder { color: red; }",
+          targets,
+        );
+        prefix_test(
+          "input:-moz-read-only::placeholder { color: red }",
+          "input:-moz-read-only::placeholder { color: red; }",
+          targets,
+        );
+      });
     }
     minify_test(
       ".p::placeholder, .p::-moz-placeholder { color: red }",

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -141,13 +141,8 @@ describe("css tests", () => {
       --pico-box-shadow: var(--pico-button-hover-box-shadow, 0 0 0 #0000);
       --pico-color: var(--pico-primary-inverse);
     }`,
-      indoc`[type="file"]::-webkit-file-upload-button:-webkit-any() {
-      --pico-background-color: var(--pico-primary-hover-background);
-      --pico-border-color: var(--pico-primary-hover-border);
-      --pico-box-shadow: var(--pico-button-hover-box-shadow, 0 0 0 #0000);
-      --pico-color: var(--pico-primary-inverse);
-    }
-    [type="file"]::file-selector-button:is() {
+      // `:-moz-any()` only parses in Firefox, so the rule prints once, as written.
+      indoc`[type="file"]::file-selector-button:-moz-any() {
       --pico-background-color: var(--pico-primary-hover-background);
       --pico-border-color: var(--pico-primary-hover-border);
       --pico-box-shadow: var(--pico-button-hover-box-shadow, 0 0 0 #0000);
@@ -5759,6 +5754,168 @@ describe("css tests", () => {
     );
     minify_test(".foo ::unknown(something(foo)) .bar {width: 20px}", ".foo ::unknown(something(foo)) .bar{width:20px}");
     minify_test(".foo ::unknown([abc]) .bar {width: 20px}", ".foo ::unknown([abc]) .bar{width:20px}");
+
+    // A selector list with a member that the targets lack splits (or wraps in :is()), so the
+    // supported members keep applying in old browsers. A member with no support data counts as
+    // one the targets lack.
+    prefix_test(
+      ".a, .b:focus-visible { color: red }",
+      `
+      .a {
+        color: red;
+      }
+
+      .b:focus-visible {
+        color: red;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+    prefix_test(".a, :focus-visible { color: red }", ":is(.a, :focus-visible) { color: red; }", {
+      safari: 14 << 16,
+    });
+    prefix_test(
+      ".d, :unknown-pseudo { color: red }",
+      `
+      .d {
+        color: red;
+      }
+
+      :unknown-pseudo {
+        color: red;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+    prefix_test(".d, :unknown-pseudo { color: red }", ":is(.d, :unknown-pseudo) { color: red; }", {
+      safari: 14 << 16,
+    });
+    prefix_test(
+      "dialog:modal, dialog.polyfilled { color: red }",
+      `
+      dialog.polyfilled {
+        color: red;
+      }
+
+      dialog:modal {
+        color: red;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+    prefix_test(
+      ".a, :nth-col(2n) { color: red }",
+      `
+      .a {
+        color: red;
+      }
+
+      :nth-col(2n) {
+        color: red;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+    prefix_test(
+      "*, ::before, ::after, ::backdrop, ::file-selector-button { border: 0 solid }",
+      `
+      *, :before, :after {
+        border: 0 solid;
+      }
+
+      ::backdrop {
+        border: 0 solid;
+      }
+
+      ::-webkit-file-upload-button {
+        border: 0 solid;
+      }
+
+      ::file-selector-button {
+        border: 0 solid;
+      }
+      `,
+      { chrome: 80 << 16, firefox: 78 << 16, safari: 14 << 16 },
+    );
+    // A vendor-prefixed member keeps the list as written. The other engines drop the whole rule
+    // because of it, which browser hacks rely on.
+    for (const targets of [{ chrome: 80 << 16 }, { safari: 14 << 16 }]) {
+      prefix_test(
+        "x:-moz-any-link, .b { border-style: solid }",
+        "x:-moz-any-link, .b { border-style: solid; }",
+        targets,
+      );
+      prefix_test("_:-ms-lang(x), .c { color: red }", "_:-ms-lang(x), .c { color: red; }", targets);
+      prefix_test(".e, ::-webkit-foo { color: red }", ".e, ::-webkit-foo { color: red; }", targets);
+      prefix_test(
+        ".i, input::-moz-placeholder { color: red }",
+        ".i, input::-moz-placeholder { color: red; }",
+        targets,
+      );
+      prefix_test(".h, :-moz-focusring { outline: none }", ".h, :-moz-focusring { outline: none; }", targets);
+      prefix_test(
+        "button::-moz-focus-inner, [type=button]::-moz-focus-inner { border-style: none }",
+        'button::-moz-focus-inner, [type="button"]::-moz-focus-inner { border-style: none; }',
+        targets,
+      );
+      prefix_test(
+        ".a::-webkit-scrollbar, .b::-webkit-scrollbar { width: 0 }",
+        ".a::-webkit-scrollbar, .b::-webkit-scrollbar { width: 0; }",
+        targets,
+      );
+      prefix_test(
+        ".a, [type=file]::-webkit-file-upload-button { color: red }",
+        '.a, [type="file"]::-webkit-file-upload-button { color: red; }',
+        targets,
+      );
+      prefix_test(".a, :-webkit-any(.b, .c) { color: red }", ".a, :-webkit-any(.b, .c) { color: red; }", targets);
+      // The vendor-prefixed member wins over one that the targets only lack a feature for.
+      prefix_test(
+        ".a, .b:focus-visible, x:-moz-any-link { color: red }",
+        ".a, .b:focus-visible, x:-moz-any-link { color: red; }",
+        targets,
+      );
+      // :not(), :has() and :nth-child(of) take unforgiving lists: a vendor-prefixed argument drops the rule.
+      prefix_test(".a, .b:not(:-moz-any-link) { color: red }", ".a, .b:not(:-moz-any-link) { color: red; }", targets);
+      prefix_test(".a, .b:has(:-moz-any-link) { color: red }", ".a, .b:has(:-moz-any-link) { color: red; }", targets);
+      prefix_test(
+        ".a, :nth-child(2n of :-moz-any-link) { color: red }",
+        ".a, :nth-child(2n of :-moz-any-link) { color: red; }",
+        targets,
+      );
+      // An unprefixed pseudo next to its prefixed form prints once, as written, not once per prefix.
+      prefix_test(
+        ".p::placeholder, .p::-moz-placeholder { color: red }",
+        ".p::placeholder, .p::-moz-placeholder { color: red; }",
+        targets,
+      );
+      prefix_test(
+        "input:-moz-read-only::placeholder { color: red }",
+        "input:-moz-read-only::placeholder { color: red; }",
+        targets,
+      );
+    }
+    minify_test(
+      ".p::placeholder, .p::-moz-placeholder { color: red }",
+      ".p::placeholder,.p::-moz-placeholder{color:red}",
+    );
+    // :where() is forgiving, so a vendor-prefixed argument does not drop the rule. Only :where() support counts.
+    prefix_test(
+      ".a, .b:where(:-moz-any-link) { color: red }",
+      `
+      .a {
+        color: red;
+      }
+
+      .b:where(:-moz-any-link) {
+        color: red;
+      }
+      `,
+      { chrome: 80 << 16 },
+    );
+    prefix_test(".a, .b:where(:-moz-any-link) { color: red }", ".a, .b:where(:-moz-any-link) { color: red; }", {
+      chrome: 90 << 16,
+    });
 
     let deep_options: ParserOptions = {
       flags: [ParserFlags.DEEP_SELECTOR_COMBINATOR],

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5847,11 +5847,7 @@ describe("css tests", () => {
       );
       prefix_test("_:-ms-lang(x), .c { color: red }", "_:-ms-lang(x), .c { color: red; }", targets);
       prefix_test(".e, ::-webkit-foo { color: red }", ".e, ::-webkit-foo { color: red; }", targets);
-      prefix_test(
-        ".i, input::-moz-placeholder { color: red }",
-        ".i, input::-moz-placeholder { color: red; }",
-        targets,
-      );
+      prefix_test(".i, input::-moz-placeholder { color: red }", ".i, input::-moz-placeholder { color: red; }", targets);
       prefix_test(".h, :-moz-focusring { outline: none }", ".h, :-moz-focusring { outline: none; }", targets);
       prefix_test(
         "button::-moz-focus-inner, [type=button]::-moz-focus-inner { border-style: none }",

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -125,18 +125,17 @@ test("bun build --target=browser does not blow up on deeply nested prefixed sele
 //
 // When a rule's selector list mixes a vendor-prefixed pseudo-class
 // (`:-webkit-autofill`) with an unprefixed one (`:placeholder-shown`),
-// `get_prefix` sets two prefix bits and `StyleRule::to_css` serializes the
+// `get_prefix` set two prefix bits and `StyleRule::to_css` serialized the
 // whole rule once per bit. Each pass re-serializes the rule's nested rules, so
-// nesting such rules repeats the inner subtree once per prefix at every level
+// nesting such rules repeated the inner subtree once per prefix at every level
 // — (prefix count)^depth. The earlier fix (PR #31270) deduplicated this only
 // when nesting was compiled away for browser targets; with no targets (or
 // nesting-capable targets) nesting is preserved, `&` is printed literally, and
-// every ancestor prefix pass genuinely needs its own copy of the body, so the
-// output cannot be collapsed. The minifier now bounds the total bytes emitted
-// by those duplicate prefix passes and errors out instead of allocating
-// gigabytes.
-
-const VENDOR_PREFIX_LIMIT_ERROR = "Maximum vendor-prefix expansion exceeded";
+// every ancestor prefix pass needs its own copy of the body. The minifier
+// bounds the total bytes emitted by duplicate prefix passes as a backstop, and
+// a rule that the author wrote with mixed prefixes no longer fans out at all:
+// the unprefixed pass used to print `.b:-webkit-autofill` as `.b:autofill`, a
+// selector the author never wrote, so such a rule now prints once, as written.
 
 // `depth` nested copies of a rule whose selector list mixes a prefixed pseudo
 // (`:-webkit-autofill`, prefix bit) with an unprefixed one
@@ -145,34 +144,40 @@ function nestedMixedPrefix(depth: number): string {
   return ".a:placeholder-shown .x, .b:-webkit-autofill .y {\n".repeat(depth) + "color: red;\n" + "}\n".repeat(depth);
 }
 
-test("deeply nested mixed vendor-prefix rules error instead of exploding with no targets", () => {
-  // Each level doubles the number of printed rule copies, so without a bound
-  // this is ~2^depth copies of the leaf — hundreds of MB by the mid-teens.
-  // The bound turns it into a thrown error.
-  expect(() => minifyTest(nestedMixedPrefix(20), "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+// The rule as written, nested `depth` levels deep, printed exactly once.
+function nestedMixedPrefixMinified(depth: number): string {
+  return (
+    ".a:placeholder-shown .x,.b:-webkit-autofill .y{" +
+    "& .a:placeholder-shown .x,& .b:-webkit-autofill .y{".repeat(depth - 1) +
+    "color:red" +
+    "}".repeat(depth)
+  );
+}
+
+test("deeply nested mixed vendor-prefix rules print once instead of exploding with no targets", () => {
+  // Each level used to double the number of printed rule copies: ~2^depth
+  // copies of the leaf, hundreds of MB by the mid-teens.
+  expect(minifyTest(nestedMixedPrefix(20), "")).toBe(nestedMixedPrefixMinified(20));
 });
 
-test("the fuzzer reproduction shape errors instead of amplifying", () => {
+test("the fuzzer reproduction shape prints once instead of amplifying", () => {
   // The fuzzer's shape: unclosed nested rules (the CSS parser closes them at
-  // EOF). 884 MB of output on the original 1.5 KB input; now a thrown error.
+  // EOF). 884 MB of output on the original 1.5 KB input.
   const src = ".a:placeholder-shown .x, .b:-webkit-autofill .y {\n".repeat(20) + "color: red;";
-  expect(() => minifyTest(src, "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+  expect(minifyTest(src, "")).toBe(nestedMixedPrefixMinified(20));
 });
 
-test("nesting-capable targets also bound the mixed vendor-prefix expansion", () => {
+test("nesting-capable targets also print mixed vendor-prefix rules once", () => {
   // Modern targets preserve nesting (no de-nesting), so the same per-prefix
-  // re-serialization of the body applies and must be bounded too.
-  expect(() => minifyTest(nestedMixedPrefix(20), "", { chrome: 130 << 16 })).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+  // re-serialization of the body applied.
+  expect(minifyTest(nestedMixedPrefix(20), "", { chrome: 130 << 16 })).toBe(nestedMixedPrefixMinified(20));
 });
 
-test("shallow mixed vendor-prefix nesting still minifies with both prefix variants", () => {
-  // Below the limit, the rule is still emitted once per prefix variant — the
-  // expansion is correct and necessary, just bounded.
+test("shallow mixed vendor-prefix nesting prints the selectors as written", () => {
   const output = minifyTest(nestedMixedPrefix(2), "");
-  expect(output).toContain(":-webkit-autofill");
-  expect(output).toContain(":autofill");
-  expect(output).toContain("color:red");
-  expect(output.length).toBeLessThan(10_000);
+  expect(output).toBe(nestedMixedPrefixMinified(2));
+  // No pass prints `.b:-webkit-autofill` as `.b:autofill`.
+  expect(output).not.toContain(":autofill");
 });
 
 test("deeply nested single-prefix rules stay linear and do not trip the bound", () => {
@@ -206,14 +211,10 @@ test("a large flat stylesheet of fanning-out rules does not trip the bound", () 
   expect(output.split("::-webkit-input-placeholder").length - 1).toBe(count);
 });
 
-test("leaf rules nested under a fanning-out ancestor are bounded", () => {
-  // The amplification is driven by the whole nested body re-serialized once per
-  // ancestor prefix, so it must be bounded by the *output* emitted under a
-  // fan-out — not by whether each nested rule fans out on its own. Each nesting
-  // level is a two-prefix rule holding K plain leaf siblings plus one recursive
-  // child; the leaves never fan out themselves but are duplicated
-  // (prefix count)^depth times. A ~1.4 KB input expands past 9 MB here unless
-  // those duplicated leaves count against the bound; it becomes a thrown error.
+test("leaf rules nested under a mixed vendor-prefix ancestor stay linear", () => {
+  // Each nesting level is a mixed-prefix rule holding K plain leaf siblings plus
+  // one recursive child. The leaves never fanned out themselves but were
+  // duplicated (prefix count)^depth times: a ~1.4 KB input expanded past 9 MB.
   const K = 1;
   const depth = 15;
   const leaves = Array.from(
@@ -222,20 +223,22 @@ test("leaf rules nested under a fanning-out ancestor are bounded", () => {
   ).join("");
   const level = ".a:placeholder-shown,.b:-webkit-autofill{";
   const src = (level + leaves).repeat(depth) + "}".repeat(depth);
-  expect(() => minifyTest(src, "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+  const output = minifyTest(src, "");
+  expect(output.split("--v0:1").length - 1).toBe(depth);
+  expect(output.length).toBeLessThan(2 * src.length);
 });
 
-test("a large declaration block under a fanning-out ancestor is bounded", () => {
+test("a large declaration block under a mixed vendor-prefix ancestor stays linear", () => {
   // The duplicated payload need not be nested rules: a fan-out pass also
   // re-serializes the rule's own declarations. Each nesting level is a
-  // two-prefix rule whose body is one large custom-property declaration plus a
-  // recursive child, so the declaration bytes are duplicated (prefix count)^depth
-  // times — ~1.8 KB of input emits tens of MB. Counting only nested rules would
-  // miss this (the declaration is not a rule); bounding the emitted bytes of
-  // each duplicate pass catches it.
+  // mixed-prefix rule whose body is one large custom-property declaration plus
+  // a recursive child, so the declaration bytes were duplicated
+  // (prefix count)^depth times: ~1.8 KB of input emitted tens of MB.
   const depth = 16;
   const payload = `--p:${Buffer.alloc(64, "a").toString()};`;
   const level = ".a:placeholder-shown,.b:-webkit-autofill{";
   const src = (level + payload).repeat(depth) + "}".repeat(depth);
-  expect(() => minifyTest(src, "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+  const output = minifyTest(src, "");
+  expect(output.split("--p:").length - 1).toBe(depth);
+  expect(output.length).toBeLessThan(2 * src.length);
 });

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -1,6 +1,6 @@
 import { cssInternals } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import path from "node:path";
 
 // Regression test for exponential output when nested rules are re-serialized
@@ -200,9 +200,10 @@ test("a large flat stylesheet of fanning-out rules does not trip the bound", () 
   // `-moz-`, `-ms-input-`, unprefixed); 20_000 such rules charge ~3 duplicate
   // passes of a tiny declaration each (a few MB total), well under the 64 MB
   // byte limit. Distinct declarations keep the rules from being merged. This
-  // stays linear instead of throwing.
+  // stays linear instead of throwing. Debug/ASAN builds minify 20_000 rules in
+  // about the default per-test timeout, so they use a smaller sheet.
   const oldTargets = { safari: 8 << 16, firefox: 20 << 16, chrome: 30 << 16, edge: 12 << 16 };
-  const count = 20_000;
+  const count = isDebug || isASAN ? 5_000 : 20_000;
   let src = "";
   for (let i = 0; i < count; i++) src += `input.c${i}::placeholder{--v${i}:1}`;
   const output = minifyTest(src, "", oldTargets);

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -180,6 +180,32 @@ test("shallow mixed vendor-prefix nesting prints the selectors as written", () =
   expect(output).not.toContain(":autofill");
 });
 
+test("a mixed vendor-prefix rule nested in a prefixed rule keeps its prefixes in every ancestor pass", () => {
+  // The nested rule has no prefix pass of its own, so it is printed inside each
+  // pass of `:fullscreen` (`-webkit-` and unprefixed for Safari 8, where nesting
+  // is compiled away). Its own pseudos must not pick up the ancestor's pass.
+  expect(minifyTest(":fullscreen { input:-moz-read-only::placeholder { color: red } }", "", safari8)).toBe(
+    ":-webkit-full-screen input:-moz-read-only::placeholder{color:red}" +
+      ":fullscreen input:-moz-read-only::placeholder{color:red}",
+  );
+  expect(minifyTest(":fullscreen { .p::placeholder, .q::-moz-placeholder { color: red } }", "", safari8)).toBe(
+    ":-webkit-full-screen .p::placeholder,:-webkit-full-screen .q::-moz-placeholder{color:red}" +
+      ":fullscreen .p::placeholder,:fullscreen .q::-moz-placeholder{color:red}",
+  );
+  // Two different explicit prefixes in one list: also printed as written.
+  expect(minifyTest(":-webkit-full-screen { .a:-webkit-autofill, .b:-moz-any-link { color: red } }", "", safari8)).toBe(
+    ":-webkit-full-screen .a:-webkit-autofill,:-webkit-full-screen .b:-moz-any-link{color:red}",
+  );
+  // With nesting preserved the rule is printed in place, once.
+  expect(minifyTest(":fullscreen { input:-moz-read-only::placeholder { color: red } }", "")).toBe(
+    ":fullscreen{& input:-moz-read-only::placeholder{color:red}}",
+  );
+  // A plain rule between the two still pairs the ancestor's pass with a prefixed descendant's.
+  expect(minifyTest(":fullscreen { .x { ::placeholder { color: red } } }", "", safari8)).toBe(
+    ":-webkit-full-screen .x ::-webkit-input-placeholder{color:red}:fullscreen .x ::placeholder{color:red}",
+  );
+});
+
 test("deeply nested single-prefix rules stay linear and do not trip the bound", () => {
   // A single selector with one vendor prefix (no mixing with an unprefixed
   // selector) sets one prefix bit, so the rule is serialized once per level —


### PR DESCRIPTION
### Problem
- `bun build` splits a selector list when one member is vendor prefixed: `x:-moz-any-link, .b { border-style: solid }` becomes `.b{border-style:solid}x:-moz-any-link{border-style:solid}`. A browser drops a whole rule when it cannot parse one selector, so the source rule is dead in Chrome and the output is live there. The same hits `_:-ms-lang(x), .c` and resets like `button::-moz-focus-inner, [type=button]::-moz-focus-inner`.
- Cause: `selector::is_compatible` (`src/css/selectors/selector.rs`) answers `false` both for "a target lacks this feature" and for "vendor-prefixed pseudo". `minify_style_arm` (`src/css/rules/mod.rs`) splits the list for either once browser targets are set. The bundler always sets them.

### Fix
- `selector::compatibility()` returns `Compatible`, `Incompatible` or `VendorPrefixed`. Pseudos with no support data (`:modal`, `::file-selector-button`, unprefixed unknown names) stay `Incompatible` and keep splitting, as lightningcss intends.
- `StyleRule::should_compile_selector_list()` gates the split. A `VendorPrefixed` list stays as written. Rule merging is unchanged.
- `update_prefix` prints a rule that mixes an unprefixed pseudo with a prefixed one once, as written, not once per prefix with the prefixed member rewritten.
- Verified: `test/bundler/css/unsupported-selector-list.test.ts`, 40 cases in `test/js/bun/css/css.test.ts` (32 fail on 1.4.3), plus `test/js/bun/css/`, `test/bundler/css/`, `bundler_regressions`.

### Background
- CSS makes a selector list atomic: one invalid selector drops the rule. Browser hacks use that to scope a rule to one engine.
- For a feature an old target lacks (`.a, .b:focus-visible` at chrome 80) the split keeps `.a` working there, and a browser that supports every member sees no difference. With a vendor-prefixed member no browser supports every member.
- lightningcss with targets splits these too (parcel-bundler/lightningcss#311, #759 defend it for standard selectors, which stays). Without targets, and in esbuild, the list is kept.

<details><summary>Notes</summary>

- Repro on 1.4.3: `printf 'x:-moz-any-link, .b { border-style: solid }\n' > in.css && bun build ./in.css --minify` prints `.b{border-style:solid}x:-moz-any-link{border-style:solid}`. After: `x:-moz-any-link,.b{border-style:solid}`.
- Classified `VendorPrefixed`: the non-`NONE` arms of `AnyLink`, `Fullscreen`, `PlaceholderShown`, `ReadOnly`, `ReadWrite`, `Autofill`, `Selection`, `Placeholder`, `Backdrop`, `FileSelectorButton`; `WebkitScrollbar` (class and element); `Custom`/`CustomFunction` names that start with `-` (the parser's own test for skipping its unsupported-pseudo warning); `Component::Any` (`:-webkit-any()`). It propagates out of `:not()`, `:has()` and `:nth-child(An+B of S)` (unforgiving arguments) and not out of `:is()`/`:where()` (forgiving). `is_compatible()` still means `Compatible`, so `merge_style_rules` behaves as before. CSS-modules `:local()`/`:global()` are classified by the selector they wrap, so `.a, :global(.b)` is one rule and `:global(.x){color:red}` can merge with `.y{color:red}`.
- Still split under the default targets, unchanged from main, and pinned by tests: Tailwind v4 preflight `*, ::after, ::before, ::backdrop, ::file-selector-button`, `dialog:modal, dialog.polyfilled`, `.d, :unknown-pseudo`, `.a, :nth-col(2n)`.
- Nested under a rule that prints once per prefix (nesting compiled away, or a downleveled parent), a rule without a pass of its own used to inherit the ancestor's pass, which stripped explicitly prefixed pseudos (`:fullscreen { input:-moz-read-only::placeholder {} }` at safari 8 printed `input:read-only::placeholder`). `to_css_base` now clears the printer's prefix while such a rule's own selectors print, and `StyleContext` records how each ancestor printed (its pass, or as written) so `&` expansion restores it. Prefixed descendants under prefixed ancestors still pair passes as before (`:-webkit-full-screen .x ::-webkit-input-placeholder` / `:fullscreen .x ::placeholder`).
- The mixed-prefix guard in `update_prefix` (`src/css/rules/style.rs`): `get_prefix` allows `NONE` to mix with one vendor bit, and `to_css` then prints the rule once per bit; in the unprefixed pass the serializer writes the explicitly prefixed member without its prefix. `.p::placeholder, .p::-moz-placeholder` printed a second rule `.p::placeholder, .p::placeholder`, and `input:-moz-read-only::placeholder` an extra `input:read-only::placeholder` (both also in lightningcss, with and without targets). Such a rule now prints once, verbatim, with no downlevel of its unprefixed members: the rule is dead outside that engine anyway.
- The fuzz-found shape in `nested-vendor-prefix-duplication.test.ts` (`.a:placeholder-shown .x, .b:-webkit-autofill .y` nested 20 deep) no longer fans out at all, so those tests now assert single-pass output instead of the "Maximum vendor-prefix expansion exceeded" error. The byte bound stays as a backstop for prefix passes that downleveling generates.
- The "pseudo-class edge case" test (pico.css, #15806) changes expectation: `[type="file"]::file-selector-button:-moz-any()` parses only in Firefox, so it now prints as written instead of as `::-webkit-file-upload-button:-webkit-any()` plus `::file-selector-button:is()`.
- #40369 (raise the default targets) does not remove the split: it runs whenever targets are set, and with `:is()`-capable targets lightningcss still turns `x:-moz-any-link, .b` into two rules (different specificity). #40464 (group split selectors by reason) gives a prefixed selector its own rule; on top of this change its `Unknown` bucket maps to "keep the list".
- The walker no longer returns at the first incompatible component, because a later member can be vendor prefixed. Timing of the heavy cases in `nested-selector-expansion.test.ts` and a 20k-rule flat stylesheet is unchanged against main in a debug build.
- Self-reviewed: 4 concerns raised, 4 addressed (narrowed the bucket from "no support data" to "vendor prefixed", kept the upstream split for standard selectors with tests for Tailwind preflight and `dialog:modal`, added the mixed-prefix print guard, stated the lightningcss divergence).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/css/unsupported-selector-list.test.ts test/js/bun/css/css.test.ts test/js/bun/css/nested-vendor-prefix-duplication.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/175] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/175] gen cpp.rs (cppbind)
[3/175] gen JS modules (bundle-modules)
Preprocess modules (7615ms)
Bundle modules (50ms)
Postprocesss modules (23ms)
Bundle Functions (529ms)
Generate Code (26ms)

[8.25s] Bundled "src/js" for development
  2786 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/175] cargo bun_runtime → libbun_runtime.a
[15/175] cc obj/codegen/InternalModuleRegistryConstants.S.o
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib
... (truncated)

release without fix: 1 failed, 67 skipped
bun test v1.4.3-canary.1 (797b0e729)

test/bundler/css/unsupported-selector-list.test.ts:
(pass) css > a selector list with a vendor-prefixed member is not split [3.76ms]

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.08ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.02ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.03ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/css/unsupported-selector-list.test.ts test/js/bun/css/css.test.ts test/js/bun/css/nested-vendor-prefix-duplication.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/css/unsupported-selector-list.test.ts:
(pass) css > a selector list with a vendor-prefixed member is not split [121.74ms]

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.48ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [14.87ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.38ms]
Output :root {
  --my-color: red;
  -
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 610ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/136] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/136] gen cpp.rs (cppbind)
[3/136] gen JS modules (bundle-modules)
Preprocess modules (7401ms)
Bundle modules (37ms)
Postprocesss modules (186ms)
Bundle Functions (462ms)
Generate Code (34ms)

[8.13s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/135] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_mimalloc_sys v0.0.0 (/workspace/bun/src/mimalloc_sys)
[1m[92m   Compiling[0m bun_alloc v0.0.0 (/workspace/bun/src/bun_alloc)
[1m[92m   Compiling[0m bun_libdeflate_sys v0.0.0 (/workspace/bun/src/libdeflate_sys)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/printer.rs                                 |  10 +-
 src/css/rules/mod.rs                               |   9 +-
 src/css/rules/scope.rs                             |   3 +
 src/css/rules/style.rs                             |  50 ++++--
 src/css/selectors/selector.rs                      | 164 +++++++++++++------
 test/bundler/css/unsupported-selector-list.test.ts |  38 +++++
 test/js/bun/css/css.test.ts                        | 176 ++++++++++++++++++++-
 .../css/nested-vendor-prefix-duplication.test.ts   | 120 ++++++++------
 8 files changed, 456 insertions(+), 114 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/css/printer.rs                                            1      1     47
src/css/rules/mod.rs                                          3      2     47
src/css/rules/scope.rs                                        1      1     47
src/css/rules/style.rs                                        7     10     47
src/css/selectors/selector.rs                                15     10     47
test/bundler/css/unsupported-selector-list.test.ts            1      4      9
test/js/bun/css/css.test.ts                                   2      3     34
test/js/bun/css/nested-vendor-prefix-duplication.test.ts      5      5     15
```

</details>

<!-- robobun:evidence:end -->