### PR TITLE
css: keep an unparsed width/height/color after the declarations written before it

### DIFF
--- a/src/css/properties/border_radius.rs
+++ b/src/css/properties/border_radius.rs
@@ -210,13 +210,18 @@ macro_rules! property_helper {
 
 macro_rules! logical_property_helper {
     ($self:expr, $d:expr, $ctx:expr, $prop:ident, $val:expr) => {{
-        if $self.category != PropertyCategory::Logical {
+        let val = $val;
+        // An unparsed value may be one browsers drop, so the value before it is kept
+        // as its fallback.
+        if $self.category != PropertyCategory::Logical
+            || ($self.$prop.is_some() && matches!(val, Property::Unparsed(_)))
+        {
             $self.flush($d, $ctx);
         }
 
         // `Property` itself
         // has no blanket `Clone`; callers pass an already-deep_clone'd `Property`.
-        $self.$prop = Some($val);
+        $self.$prop = Some(val);
         $self.category = PropertyCategory::Logical;
         $self.has_any = true;
     }};

--- a/src/css/properties/border_radius.rs
+++ b/src/css/properties/border_radius.rs
@@ -211,8 +211,7 @@ macro_rules! property_helper {
 macro_rules! logical_property_helper {
     ($self:expr, $d:expr, $ctx:expr, $prop:ident, $val:expr) => {{
         let val = $val;
-        // An unparsed value may be one browsers drop, so the value before it is kept
-        // as its fallback.
+        // An unparsed value keeps the one before it as its fallback.
         if $self.category != PropertyCategory::Logical
             || ($self.$prop.is_some() && matches!(val, Property::Unparsed(_)))
         {

--- a/src/css/properties/prefix_handler.rs
+++ b/src/css/properties/prefix_handler.rs
@@ -129,8 +129,7 @@ impl FallbackHandler {
                 return false;
             };
 
-            // Browsers drop a value they cannot parse, so it cannot stand in for the
-            // declaration before it. A later parsed value still replaces it.
+            // Appended, not replaced: the declaration before it is its fallback.
             context.add_unparsed_fallbacks(arena, &mut unparsed);
             *index = Some(dest.len());
             dest.push(Property::Unparsed(unparsed));

--- a/src/css/properties/prefix_handler.rs
+++ b/src/css/properties/prefix_handler.rs
@@ -129,13 +129,11 @@ impl FallbackHandler {
                 return false;
             };
 
+            // Browsers drop a value they cannot parse, so it cannot stand in for the
+            // declaration before it. A later parsed value still replaces it.
             context.add_unparsed_fallbacks(arena, &mut unparsed);
-            if let Some(i) = *index {
-                dest[i] = Property::Unparsed(unparsed);
-            } else {
-                *index = Some(dest.len());
-                dest.push(Property::Unparsed(unparsed));
-            }
+            *index = Some(dest.len());
+            dest.push(Property::Unparsed(unparsed));
 
             return true;
         }

--- a/src/css/properties/size.rs
+++ b/src/css/properties/size.rs
@@ -469,6 +469,7 @@ macro_rules! property_helper {
 
 macro_rules! logical_unparsed_helper {
     ($this:expr, $unparsed:expr, $physical_id:expr, $physical_flag:expr, $logical_supported:expr, $dest:expr, $context:expr) => {{
+        $this.flush($dest, $context);
         let bump = $dest.bump();
         if $logical_supported {
             $this.flushed_properties.insert(
@@ -697,6 +698,7 @@ impl SizeHandler {
                 | PropertyIdTag::MaxWidth
                 | PropertyIdTag::MinHeight
                 | PropertyIdTag::MaxHeight => {
+                    self.flush(dest, context);
                     self.flushed_properties.insert(
                         SizeProperty::try_from_property_id_tag(unparsed.property_id.tag()).unwrap(),
                     );

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -262,6 +262,23 @@ describe("css tests", () => {
       `,
       { safari: 8 << 16 },
     );
+    // The logical corner radii overwrote the buffered value instead.
+    minify_test(
+      `a { border-start-start-radius: 1px; border-start-start-radius: var(--r) }`,
+      `a{border-start-start-radius:1px;border-start-start-radius:var(--r)}`,
+    );
+    minify_test(
+      `a { border-end-end-radius: 1px; border-end-end-radius: banana }`,
+      `a{border-end-end-radius:1px;border-end-end-radius:banana}`,
+    );
+    minify_test(
+      `a { border-start-end-radius: var(--r); border-start-end-radius: 1px }`,
+      `a{border-start-end-radius:1px}`,
+    );
+    minify_test(
+      `a { border-top-left-radius: 1px; border-top-left-radius: var(--r) }`,
+      `a{border-top-left-radius:1px;border-top-left-radius:var(--r)}`,
+    );
   });
   describe("border_spacing", () => {
     minify_test(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -171,7 +171,7 @@ describe("css tests", () => {
   width: calc(infinity * -1px);
   height: infinity;
 }`,
-      indoc`.rounded-full{height:infinity;border-radius:3.40282e38px;width:-3.40282e38px}`,
+      indoc`.rounded-full{width:-3.40282e38px;height:infinity;border-radius:3.40282e38px}`,
     );
 
     // NaN is valid inside calc() (CSS Values 4 "Infinities, NaN, and Signed Zero").
@@ -231,6 +231,37 @@ describe("css tests", () => {
       `a{width:calc(6 - 400% - 2 - 4 - 8vh + 3ic)}`,
     ); // ideally -400% - 8vh + 3ic
     minify_test(`a { top: calc(100% - 1 * 2 - 8 * 2); }`, `a{top:calc(100% - 2 - 16)}`); // ideally 100% - 18
+  });
+  describe("a value that does not parse keeps the declaration before it", () => {
+    // Browsers drop a declaration they cannot parse, so the one before it applies. The
+    // minifier must neither let such a value replace the earlier one nor move it ahead of it.
+    minify_test(`a { color: red; color: banana }`, `a{color:red;color:banana}`);
+    minify_test(`a { color: red; color: rgb(1 2) }`, `a{color:red;color:rgb(1 2)}`);
+    minify_test(`a { color: red; color: var(--c) }`, `a{color:red;color:var(--c)}`);
+    minify_test(`a { color: banana; color: red }`, `a{color:red}`);
+    minify_test(`a { color: red; color: banana; color: blue }`, `a{color:red;color:#00f}`);
+    minify_test(
+      `a { text-shadow: 0 0 1px red; text-shadow: 0 0 banana }`,
+      `a{text-shadow:0 0 1px red;text-shadow:0 0 banana}`,
+    );
+    // lightningcss#547: these were emitted after the unparsed value, in the wrong order.
+    minify_test(`a { width: 100px; width: var(--w) }`, `a{width:100px;width:var(--w)}`);
+    minify_test(`a { height: 100vh; height: 100dvb; height: var(--h) }`, `a{height:100dvb;height:var(--h)}`);
+    minify_test(`a { width: 100px; width: anchor-size(width) }`, `a{width:100px;width:anchor-size(width)}`);
+    minify_test(`a { max-height: 1px; max-height: banana }`, `a{max-height:1px;max-height:banana}`);
+    minify_test(`a { inline-size: 1px; inline-size: var(--w) }`, `a{inline-size:1px;inline-size:var(--w)}`);
+    minify_test(`a { min-width: 1px; height: 2px; width: env(foo) }`, `a{min-width:1px;height:2px;width:env(foo)}`);
+    minify_test(`a { width: var(--w); width: 100px }`, `a{width:var(--w);width:100px}`);
+    prefix_test(
+      `a { inline-size: 1px; inline-size: var(--w) }`,
+      indoc`
+        a {
+          width: 1px;
+          width: var(--w);
+        }
+      `,
+      { safari: 8 << 16 },
+    );
   });
   describe("border_spacing", () => {
     minify_test(


### PR DESCRIPTION
### Problem
- `bun build` moves a size declaration it cannot parse ahead of the ones written before it: `.a{width:100px;width:var(--w)}` prints `.a{width:var(--w);width:100px}`, so the fallback wins over the `var()`. Same for `height`, `min-*`, `max-*`, `block-size`, `inline-size`, with or without `--minify`.
- Cause: `SizeHandler::handle_property` (`src/css/properties/size.rs`) pushes a `Property::Unparsed` size straight to the output while the parsed sizes before it stay buffered until `finalize`. lightningcss flushes first (parcel-bundler/lightningcss#547); the call was lost in the port.
- `FallbackHandler` (`src/css/properties/prefix_handler.rs`, `color` and `text-shadow`) overwrote the earlier declaration with a later unparsed one: `.a{color:red;color:banana}` printed `.a{color:banana}`. The logical corner radii (`border-start-start-radius` etc., `src/css/properties/border_radius.rs`) did the same. Browsers drop a value they cannot parse and apply the one before it.

### Fix
- `SizeHandler` flushes its buffer before it emits an unparsed size, in the physical arm and in `logical_unparsed_helper!`.
- `FallbackHandler` appends the unparsed value instead of overwriting, and `BorderRadiusHandler` flushes a buffered logical corner before an unparsed one, as the margin/padding/inset handler already does. A later parsed value still replaces an earlier one, so `color:banana;color:red` prints `color:red`.
- Verified: `test/js/bun/css/css.test.ts`, block `a value that does not parse keeps the declaration before it` (14 of 18 rows fail on 1.4.2). The #18064 row changes order only. `test/js/bun/css/` and `test/bundler/css/` pass.

### Background
- Minification runs each declaration block through per-family handlers. `SizeHandler` buffers sizes to merge duplicates and add prefixed keyword fallbacks, and writes them on `flush`. A value the typed parser rejects (`var()`, an unknown function, an invalid value) stays `Property::Unparsed` and must keep its source position relative to that buffer.
- `FallbackHandler` remembers the output slot of the last `color`/`text-shadow` so a later value can replace it and color-space fallbacks can go before it.

<details><summary>Notes</summary>

- Minifying the stylesheets in `test/js/bun/css/files` (bootstrap, bulma, foundation, materialize, pico, tailwind, ...) with this change keeps every file the same size; materialize and pico change declaration order in a few rules where a `var()` height or width followed parsed sizes, for example `nav{...;height:var(--navbar-height-mobile);...;width:100%}` now keeps `width:100%` where it was written.
- `color:red;color:var(--c)` now keeps `red`, as every other handler already does (`font-weight:700;font-weight:var(--x)`).
- This is the first of two changes from the same report. The second adds range and unit checks so that `width:-5px`, `font-weight:1001`, `calc(0)` as a length and `translate(10)` are treated as the invalid values they are. It builds on this branch and is a separate PR because it makes the parser stricter than lightningcss on purpose.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 15 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.07ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.01ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.97ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: wh
... (truncated)

release without fix: 15 failed, 67 skipped
bun test v1.4.2 (744846f84)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.14ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.03ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.03ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: var(--my-
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [2.74ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.00ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.99ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: wh
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4396ff575d
  features     baseline

23 deps, 131 codegen, 1172 objects in 573ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] mkdir stamps
[2/1248] mkdir codegen
[3/1248] mkdir obj
[4/1248] mkdir pch
[5/1248] install /workspace/bun
bun install v1.4.2 (744846f84)

Checked 22 installs across 61 packages (no changes) [8.00ms]
[6/1248] gen ErrorCode+*.h
[7/1248] install /workspace/bun/packages/bun-error
bun install v1.4.2 (744846f84)

Checked 1 install across 2 packages (no changes) [3.00ms]
[8/1248] install /workspace/bun/src/node-fallbacks
bun install v1.4.2 (744846f84)

Checked 111 installs across 104 packages (no changes) [4.00ms]
[9/1248] gen bindgenv2
[10/1248] fetch zlib
[zlib] up to date
[11/1248] fetch picohttpparser
[picohttpparser] up to date
[12/1248] gen node-fallbacks/react-refresh.js
Bundled 1 module in 13ms

  react-refresh.js  4.81 KB  (entry point)

[13/1248] fetch tinycc
[tinycc] up to date
[14/1248] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[15/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/properties/border_radius.rs  |  8 ++++--
 src/css/properties/prefix_handler.rs |  9 +++----
 src/css/properties/size.rs           |  2 ++
 test/js/bun/css/css.test.ts          | 50 +++++++++++++++++++++++++++++++++++-
 4 files changed, 60 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/css/properties/border_radius.rs       1      1     32
src/css/properties/prefix_handler.rs      1      1     32
src/css/properties/size.rs                5      4     31
test/js/bun/css/css.test.ts               5      8     31
```

</details>

<!-- robobun:evidence:end -->