### PR TITLE
webcrypto: read JWK key_ops as plain strings, reject duplicates for every key class

### DIFF
--- a/src/jsc/bindings/webcrypto/CryptoAlgorithm.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithm.cpp
@@ -115,6 +115,19 @@ std::optional<Vector<uint8_t>> CryptoAlgorithm::extractDerivedBits(std::optional
     return WTF::move(secret);
 }
 
+bool CryptoAlgorithm::validateJwkKeyOps(const JsonWebKey& jwk, CryptoKeyUsageBitmap usages, const ExceptionCallback& exceptionCallback)
+{
+    if (hasDuplicateJwkKeyOps(jwk.key_ops)) {
+        exceptionCallback(DataError, "Duplicate key operation"_s);
+        return false;
+    }
+    if (jwk.key_ops && (jwk.usages & usages) != usages) {
+        exceptionCallback(DataError, "Key operations and usage mismatch"_s);
+        return false;
+    }
+    return true;
+}
+
 template<typename ResultCallbackType, typename OperationType>
 static void dispatchAlgorithmOperation(WorkQueue& workQueue, ScriptExecutionContext& context, ResultCallbackType&& callback, CryptoAlgorithm::ExceptionCallback&& exceptionCallback, OperationType&& operation)
 {

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithm.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithm.h
@@ -88,6 +88,11 @@ public:
     // final byte, per https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveBits. A null
     // `length` returns `secret` unchanged; a `length` larger than `secret` yields nullopt.
     static std::optional<Vector<uint8_t>> extractDerivedBits(std::optional<size_t> length, Vector<uint8_t>&& secret);
+
+    // The key_ops step shared by every jwk import: no duplicate entries (RFC 7517
+    // section 4.3), then every requested usage present, with Node's messages and
+    // order. Reports a DataError through exceptionCallback and returns false.
+    static bool validateJwkKeyOps(const JsonWebKey&, CryptoKeyUsageBitmap, const ExceptionCallback&);
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CBC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CBC.cpp
@@ -123,6 +123,8 @@ void CryptoAlgorithmAES_CBC::importKey(CryptoKeyFormat format, KeyData&& data, c
         result = CryptoKeyAES::importRaw(parameters.identifier, WTF::move(std::get<Vector<uint8_t>>(data)), extractable, usages);
         break;
     case CryptoKeyFormat::Jwk: {
+        if (!validateJwkKeyOps(std::get<JsonWebKey>(data), usages, exceptionCallback))
+            return;
         auto checkAlgCallback = [](size_t length, const String& alg) -> bool {
             switch (length) {
             case CryptoKeyAES::s_length128:

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CFB.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CFB.cpp
@@ -123,6 +123,8 @@ void CryptoAlgorithmAES_CFB::importKey(CryptoKeyFormat format, KeyData&& data, c
         result = CryptoKeyAES::importRaw(parameters.identifier, WTF::move(std::get<Vector<uint8_t>>(data)), extractable, usages);
         break;
     case CryptoKeyFormat::Jwk: {
+        if (!validateJwkKeyOps(std::get<JsonWebKey>(data), usages, exceptionCallback))
+            return;
         auto checkAlgCallback = [](size_t length, const String& alg) -> bool {
             switch (length) {
             case CryptoKeyAES::s_length128:

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CTR.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CTR.cpp
@@ -132,6 +132,8 @@ void CryptoAlgorithmAES_CTR::importKey(CryptoKeyFormat format, KeyData&& data, c
         result = CryptoKeyAES::importRaw(parameters.identifier, WTF::move(std::get<Vector<uint8_t>>(data)), extractable, usages);
         break;
     case CryptoKeyFormat::Jwk: {
+        if (!validateJwkKeyOps(std::get<JsonWebKey>(data), usages, exceptionCallback))
+            return;
         auto checkAlgCallback = [](size_t length, const String& alg) -> bool {
             switch (length) {
             case CryptoKeyAES::s_length128:

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_GCM.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_GCM.cpp
@@ -171,6 +171,8 @@ void CryptoAlgorithmAES_GCM::importKey(CryptoKeyFormat format, KeyData&& data, c
         result = CryptoKeyAES::importRaw(parameters.identifier, WTF::move(std::get<Vector<uint8_t>>(data)), extractable, usages);
         break;
     case CryptoKeyFormat::Jwk: {
+        if (!validateJwkKeyOps(std::get<JsonWebKey>(data), usages, exceptionCallback))
+            return;
         auto checkAlgCallback = [](size_t length, const String& alg) -> bool {
             switch (length) {
             case CryptoKeyAES::s_length128:

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_KW.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAES_KW.cpp
@@ -87,6 +87,8 @@ void CryptoAlgorithmAES_KW::importKey(CryptoKeyFormat format, KeyData&& data, co
         result = CryptoKeyAES::importRaw(parameters.identifier, WTF::move(std::get<Vector<uint8_t>>(data)), extractable, usages);
         break;
     case CryptoKeyFormat::Jwk: {
+        if (!validateJwkKeyOps(std::get<JsonWebKey>(data), usages, exceptionCallback))
+            return;
         result = CryptoKeyAES::importJwk(parameters.identifier, WTF::move(std::get<JsonWebKey>(data)), extractable, usages, [](size_t length, const String& alg) -> bool {
             switch (length) {
             case CryptoKeyAES::s_length128:

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmAKPShared.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmAKPShared.h
@@ -113,14 +113,8 @@ inline void importAkpKey(CryptoAlgorithmIdentifier identifier, const AkpAlgorith
             exceptionCallback(DataError, "Invalid JWK \"use\" Parameter"_s);
             return;
         }
-        if (hasDuplicateJwkKeyOps(jwk.key_ops)) {
-            exceptionCallback(DataError, "Duplicate key operation"_s);
+        if (!CryptoAlgorithm::validateJwkKeyOps(jwk, usages, exceptionCallback))
             return;
-        }
-        if (jwk.key_ops && ((jwk.usages & usages) != usages)) {
-            exceptionCallback(DataError, "Key operations and usage mismatch"_s);
-            return;
-        }
         if (jwk.ext && !jwk.ext.value() && extractable) {
             exceptionCallback(DataError, "JWK \"ext\" Parameter and extractable mismatch"_s);
             return;

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmChaCha20Poly1305.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmChaCha20Poly1305.cpp
@@ -215,7 +215,7 @@ void CryptoAlgorithmChaCha20Poly1305::exportKey(CryptoKeyFormat format, Ref<Cryp
         jwk.kty = "oct"_s;
         jwk.k = Bun::base64URLEncodeToString(rawKey.key());
         jwk.alg = String(ALG);
-        jwk.key_ops = rawKey.usages();
+        jwk.key_ops = toJwkKeyOps(rawKey.usages());
         jwk.ext = rawKey.extractable();
         result = WTF::move(jwk);
         break;

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmChaCha20Poly1305.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmChaCha20Poly1305.cpp
@@ -158,14 +158,8 @@ void CryptoAlgorithmChaCha20Poly1305::importKey(CryptoKeyFormat format, KeyData&
             exceptionCallback(DataError, "Invalid JWK \"use\" Parameter"_s);
             return;
         }
-        if (hasDuplicateJwkKeyOps(jwk.key_ops)) {
-            exceptionCallback(DataError, "Duplicate key operation"_s);
+        if (!validateJwkKeyOps(jwk, usages, exceptionCallback))
             return;
-        }
-        if (jwk.key_ops && ((jwk.usages & usages) != usages)) {
-            exceptionCallback(DataError, "Key operations and usage mismatch"_s);
-            return;
-        }
         if (jwk.ext && !jwk.ext.value() && extractable) {
             exceptionCallback(DataError, "JWK \"ext\" Parameter and extractable mismatch"_s);
             return;

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.cpp
@@ -146,6 +146,8 @@ void CryptoAlgorithmECDH::importKey(CryptoKeyFormat format, KeyData&& data, cons
             exceptionCallback(DataError, "Invalid JWK \"use\" Parameter"_s);
             return;
         }
+        if (!validateJwkKeyOps(key, usages, exceptionCallback))
+            return;
 
         // A present-but-wrong "crv" is a curve mismatch; an absent "crv" falls through
         // to importJwk's "Invalid keyData".

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmECDSA.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmECDSA.cpp
@@ -127,6 +127,8 @@ void CryptoAlgorithmECDSA::importKey(CryptoKeyFormat format, KeyData&& data, con
             exceptionCallback(DataError, "Invalid JWK \"use\" Parameter"_s);
             return;
         }
+        if (!validateJwkKeyOps(key, usages, exceptionCallback))
+            return;
 
         // A present-but-wrong "crv" is a curve mismatch and outranks the "alg" check; an
         // absent "crv" is neither, and falls through to importJwk's "Invalid keyData".

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmEd25519.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmEd25519.cpp
@@ -137,6 +137,8 @@ void CryptoAlgorithmEd25519::importKey(CryptoKeyFormat format, KeyData&& data, c
             exceptionCallback(DataError, "Invalid JWK \"use\" Parameter"_s);
             return;
         }
+        if (!validateJwkKeyOps(key, usages, exceptionCallback))
+            return;
         // RFC 8037: "crv" names the curve, and "alg" — when present — is either the
         // curve name or "EdDSA".
         if (!key.crv.isNull() && key.crv != "Ed25519"_s) {

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp
@@ -175,14 +175,8 @@ void CryptoAlgorithmHMAC::importKey(CryptoKeyFormat format, KeyData&& data, cons
             exceptionCallback(DataError, "Invalid JWK \"use\" Parameter"_s);
             return;
         }
-        if (hasDuplicateJwkKeyOps(jwk.key_ops)) {
-            exceptionCallback(DataError, "Duplicate key operation"_s);
+        if (!validateJwkKeyOps(jwk, usages, exceptionCallback))
             return;
-        }
-        if (jwk.key_ops && ((jwk.usages & usages) != usages)) {
-            exceptionCallback(DataError, "Key operations and usage mismatch"_s);
-            return;
-        }
         if (jwk.ext && !jwk.ext.value() && extractable) {
             exceptionCallback(DataError, "JWK \"ext\" Parameter and extractable mismatch"_s);
             return;

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp
@@ -120,6 +120,8 @@ void CryptoAlgorithmRSASSA_PKCS1_v1_5::importKey(CryptoKeyFormat format, KeyData
             exceptionCallback(DataError, "Invalid JWK \"use\" Parameter"_s);
             return;
         }
+        if (!validateJwkKeyOps(key, usages, exceptionCallback))
+            return;
 
         bool isMatched = false;
         switch (rsaParameters.hashIdentifier) {

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmRSA_OAEP.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmRSA_OAEP.cpp
@@ -134,6 +134,8 @@ void CryptoAlgorithmRSA_OAEP::importKey(CryptoKeyFormat format, KeyData&& data, 
             exceptionCallback(DataError, "Invalid JWK \"use\" Parameter"_s);
             return;
         }
+        if (!validateJwkKeyOps(key, usages, exceptionCallback))
+            return;
 
         bool isMatched = false;
         switch (rsaParameters.hashIdentifier) {

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmRSA_PSS.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmRSA_PSS.cpp
@@ -122,6 +122,8 @@ void CryptoAlgorithmRSA_PSS::importKey(CryptoKeyFormat format, KeyData&& data, c
             exceptionCallback(DataError, "Invalid JWK \"use\" Parameter"_s);
             return;
         }
+        if (!validateJwkKeyOps(key, usages, exceptionCallback))
+            return;
 
         bool isMatched = false;
         switch (rsaParameters.hashIdentifier) {

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmX25519.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmX25519.cpp
@@ -154,6 +154,8 @@ void CryptoAlgorithmX25519::importKey(CryptoKeyFormat format, KeyData&& data, co
             exceptionCallback(ExceptionCode::DataError, "Invalid JWK \"use\" Parameter"_s);
             return;
         }
+        if (!validateJwkKeyOps(key, usages, exceptionCallback))
+            return;
 
         // RFC 8037: "crv" must name the requested curve.
         if (!key.crv.isNull() && key.crv != "X25519"_s) {

--- a/src/jsc/bindings/webcrypto/CryptoKeyAES.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyAES.cpp
@@ -88,6 +88,8 @@ RefPtr<CryptoKeyAES> CryptoKeyAES::importJwk(CryptoAlgorithmIdentifier algorithm
         return nullptr;
     if (usages && !keyData.use.isNull() && keyData.use != "enc"_s)
         return nullptr;
+    if (hasDuplicateJwkKeyOps(keyData.key_ops))
+        return nullptr;
     if (keyData.key_ops && ((keyData.usages & usages) != usages))
         return nullptr;
     if (keyData.ext && !keyData.ext.value() && extractable)
@@ -101,7 +103,7 @@ JsonWebKey CryptoKeyAES::exportJwk() const
     JsonWebKey result {};
     result.kty = "oct"_s;
     result.k = Bun::base64URLEncodeToString(m_key);
-    result.key_ops = usages();
+    result.key_ops = toJwkKeyOps(usages());
     result.ext = extractable();
     return result;
 }

--- a/src/jsc/bindings/webcrypto/CryptoKeyAES.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyAES.cpp
@@ -88,8 +88,6 @@ RefPtr<CryptoKeyAES> CryptoKeyAES::importJwk(CryptoAlgorithmIdentifier algorithm
         return nullptr;
     if (usages && !keyData.use.isNull() && keyData.use != "enc"_s)
         return nullptr;
-    if (hasDuplicateJwkKeyOps(keyData.key_ops))
-        return nullptr;
     if (keyData.key_ops && ((keyData.usages & usages) != usages))
         return nullptr;
     if (keyData.ext && !keyData.ext.value() && extractable)

--- a/src/jsc/bindings/webcrypto/CryptoKeyAKP.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyAKP.cpp
@@ -325,7 +325,7 @@ ExceptionOr<JsonWebKey> CryptoKeyAKP::exportJwk() const
     JsonWebKey result;
     result.kty = "AKP"_s;
     result.alg = CryptoAlgorithmRegistry::singleton().name(algorithmIdentifier());
-    result.key_ops = usages();
+    result.key_ops = toJwkKeyOps(usages());
     result.ext = extractable();
 
     if (type() == CryptoKeyType::Private) {

--- a/src/jsc/bindings/webcrypto/CryptoKeyEC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyEC.cpp
@@ -85,8 +85,6 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::importJwk(CryptoAlgorithmIdentifier identifier,
 {
     if (keyData.kty != "EC"_s)
         return nullptr;
-    if (hasDuplicateJwkKeyOps(keyData.key_ops))
-        return nullptr;
     if (keyData.key_ops && ((keyData.usages & usages) != usages))
         return nullptr;
     if (keyData.ext && !keyData.ext.value() && extractable)

--- a/src/jsc/bindings/webcrypto/CryptoKeyEC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyEC.cpp
@@ -85,6 +85,8 @@ RefPtr<CryptoKeyEC> CryptoKeyEC::importJwk(CryptoAlgorithmIdentifier identifier,
 {
     if (keyData.kty != "EC"_s)
         return nullptr;
+    if (hasDuplicateJwkKeyOps(keyData.key_ops))
+        return nullptr;
     if (keyData.key_ops && ((keyData.usages & usages) != usages))
         return nullptr;
     if (keyData.ext && !keyData.ext.value() && extractable)
@@ -160,7 +162,7 @@ ExceptionOr<JsonWebKey> CryptoKeyEC::exportJwk() const
         result.crv = P521;
         break;
     }
-    result.key_ops = usages();
+    result.key_ops = toJwkKeyOps(usages());
     result.ext = extractable();
     if (!platformAddFieldElements(result))
         return Exception { OperationError };

--- a/src/jsc/bindings/webcrypto/CryptoKeyHMAC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyHMAC.cpp
@@ -103,7 +103,7 @@ JsonWebKey CryptoKeyHMAC::exportJwk() const
     JsonWebKey result {};
     result.kty = "oct"_s;
     result.k = Bun::base64URLEncodeToString(m_key);
-    result.key_ops = usages();
+    result.key_ops = toJwkKeyOps(usages());
     result.ext = extractable();
     return result;
 }

--- a/src/jsc/bindings/webcrypto/CryptoKeyOKP.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyOKP.cpp
@@ -142,6 +142,8 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifie
             return nullptr;
         if (usages && !keyData.use.isEmpty() && keyData.use != "sig"_s)
             return nullptr;
+        if (hasDuplicateJwkKeyOps(keyData.key_ops))
+            return nullptr;
         if (keyData.key_ops && ((keyData.usages & usages) != usages))
             return nullptr;
         if (keyData.ext && !keyData.ext.value() && extractable)
@@ -153,6 +155,8 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifie
         if (keyData.crv != "X25519"_s)
             return nullptr;
         if (usages && !keyData.use.isEmpty() && keyData.use != "enc"_s)
+            return nullptr;
+        if (hasDuplicateJwkKeyOps(keyData.key_ops))
             return nullptr;
         if (keyData.key_ops && ((keyData.usages & usages) != usages))
             return nullptr;
@@ -203,7 +207,7 @@ ExceptionOr<JsonWebKey> CryptoKeyOKP::exportJwk() const
         break;
     }
 
-    result.key_ops = usages();
+    result.key_ops = toJwkKeyOps(usages());
     result.ext = extractable();
 
     switch (type()) {

--- a/src/jsc/bindings/webcrypto/CryptoKeyOKP.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyOKP.cpp
@@ -142,8 +142,6 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifie
             return nullptr;
         if (usages && !keyData.use.isEmpty() && keyData.use != "sig"_s)
             return nullptr;
-        if (hasDuplicateJwkKeyOps(keyData.key_ops))
-            return nullptr;
         if (keyData.key_ops && ((keyData.usages & usages) != usages))
             return nullptr;
         if (keyData.ext && !keyData.ext.value() && extractable)
@@ -155,8 +153,6 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::importJwk(CryptoAlgorithmIdentifier identifie
         if (keyData.crv != "X25519"_s)
             return nullptr;
         if (usages && !keyData.use.isEmpty() && keyData.use != "enc"_s)
-            return nullptr;
-        if (hasDuplicateJwkKeyOps(keyData.key_ops))
             return nullptr;
         if (keyData.key_ops && ((keyData.usages & usages) != usages))
             return nullptr;

--- a/src/jsc/bindings/webcrypto/CryptoKeyRSA.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyRSA.cpp
@@ -39,6 +39,8 @@ RefPtr<CryptoKeyRSA> CryptoKeyRSA::importJwk(CryptoAlgorithmIdentifier algorithm
 {
     if (keyData.kty != "RSA"_s)
         return nullptr;
+    if (hasDuplicateJwkKeyOps(keyData.key_ops))
+        return nullptr;
     if (keyData.key_ops && ((keyData.usages & usages) != usages))
         return nullptr;
     if (keyData.ext && !keyData.ext.value() && extractable)
@@ -135,7 +137,7 @@ JsonWebKey CryptoKeyRSA::exportJwk() const
 {
     JsonWebKey result {};
     result.kty = "RSA"_s;
-    result.key_ops = usages();
+    result.key_ops = toJwkKeyOps(usages());
     result.ext = extractable();
 
     auto rsaComponents = exportData();

--- a/src/jsc/bindings/webcrypto/CryptoKeyRSA.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyRSA.cpp
@@ -39,8 +39,6 @@ RefPtr<CryptoKeyRSA> CryptoKeyRSA::importJwk(CryptoAlgorithmIdentifier algorithm
 {
     if (keyData.kty != "RSA"_s)
         return nullptr;
-    if (hasDuplicateJwkKeyOps(keyData.key_ops))
-        return nullptr;
     if (keyData.key_ops && ((keyData.usages & usages) != usages))
         return nullptr;
     if (keyData.ext && !keyData.ext.value() && extractable)

--- a/src/jsc/bindings/webcrypto/JSCryptoKeyUsage.cpp
+++ b/src/jsc/bindings/webcrypto/JSCryptoKeyUsage.cpp
@@ -71,7 +71,11 @@ template<> JSString* convertEnumerationToJS(JSGlobalObject& lexicalGlobalObject,
 
 template<> std::optional<CryptoKeyUsage> parseEnumeration<CryptoKeyUsage>(JSGlobalObject& lexicalGlobalObject, JSValue value)
 {
-    auto stringValue = value.toWTFString(&lexicalGlobalObject);
+    return parseEnumerationFromString<CryptoKeyUsage>(value.toWTFString(&lexicalGlobalObject));
+}
+
+template<> std::optional<CryptoKeyUsage> parseEnumerationFromString<CryptoKeyUsage>(const String& stringValue)
+{
     static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, CryptoKeyUsage>>({
         { "decapsulateBits"_s, CryptoKeyUsage::DecapsulateBits },
         { "decapsulateKey"_s, CryptoKeyUsage::DecapsulateKey },

--- a/src/jsc/bindings/webcrypto/JSCryptoKeyUsage.h
+++ b/src/jsc/bindings/webcrypto/JSCryptoKeyUsage.h
@@ -31,6 +31,7 @@ String convertEnumerationToString(CryptoKeyUsage);
 template<> JSC::JSString* convertEnumerationToJS(JSC::JSGlobalObject&, CryptoKeyUsage);
 
 template<> std::optional<CryptoKeyUsage> parseEnumeration<CryptoKeyUsage>(JSC::JSGlobalObject&, JSC::JSValue);
+template<> std::optional<CryptoKeyUsage> parseEnumerationFromString<CryptoKeyUsage>(const String&);
 
 } // namespace WebCore
 

--- a/src/jsc/bindings/webcrypto/JSJsonWebKey.cpp
+++ b/src/jsc/bindings/webcrypto/JSJsonWebKey.cpp
@@ -24,9 +24,7 @@
 
 #include "JSJsonWebKey.h"
 
-#include "JSCryptoKeyUsage.h"
 #include "JSDOMConvertBoolean.h"
-#include "JSDOMConvertEnumeration.h"
 #include "JSDOMConvertSequences.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMGlobalObject.h"
@@ -147,7 +145,7 @@ template<> JsonWebKey convertDictionary<JsonWebKey>(JSGlobalObject& lexicalGloba
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     if (!key_opsValue.isUndefined()) {
-        result.key_ops = convert<IDLSequence<IDLEnumeration<CryptoKeyUsage>>>(lexicalGlobalObject, key_opsValue);
+        result.key_ops = convert<IDLSequence<IDLDOMString>>(lexicalGlobalObject, key_opsValue);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
     JSValue ktyValue;
@@ -321,8 +319,8 @@ JSC::JSObject* convertDictionaryToJS(JSC::JSGlobalObject& lexicalGlobalObject, J
         RETURN_IF_EXCEPTION(throwScope, {});
         Bun::putDirectNamed(vm, result, "k"_s, kValue);
     }
-    if (!IDLSequence<IDLEnumeration<CryptoKeyUsage>>::isNullValue(dictionary.key_ops)) {
-        auto key_opsValue = toJS<IDLSequence<IDLEnumeration<CryptoKeyUsage>>>(lexicalGlobalObject, globalObject, throwScope, IDLSequence<IDLEnumeration<CryptoKeyUsage>>::extractValueFromNullable(dictionary.key_ops));
+    if (!IDLSequence<IDLDOMString>::isNullValue(dictionary.key_ops)) {
+        auto key_opsValue = toJS<IDLSequence<IDLDOMString>>(lexicalGlobalObject, globalObject, throwScope, IDLSequence<IDLDOMString>::extractValueFromNullable(dictionary.key_ops));
         RETURN_IF_EXCEPTION(throwScope, {});
         Bun::putDirectNamed(vm, result, "key_ops"_s, key_opsValue);
     }

--- a/src/jsc/bindings/webcrypto/JsonWebKey.cpp
+++ b/src/jsc/bindings/webcrypto/JsonWebKey.cpp
@@ -23,53 +23,33 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#include "CryptoKeyUsage.h"
-#include "RsaOtherPrimesInfo.h"
-#include <wtf/Vector.h>
+#include "config.h"
+#include "JsonWebKey.h"
 
 #if ENABLE(WEB_CRYPTO)
 
+#include "JSCryptoKeyUsage.h"
+#include <wtf/HashSet.h>
+#include <wtf/text/StringHash.h>
+
 namespace WebCore {
 
-struct JsonWebKey {
-    String kty;
-    String use;
-    // RFC 7517 section 4.3: key_ops can hold values that are not WebCrypto
-    // usages. `usages` is the recognized subset, set by normalizeJsonWebKey().
-    std::optional<Vector<String>> key_ops;
-    CryptoKeyUsageBitmap usages;
-    String alg;
+Vector<String> toJwkKeyOps(const Vector<CryptoKeyUsage>& usages)
+{
+    return usages.map([](CryptoKeyUsage usage) { return convertEnumerationToString(usage); });
+}
 
-    std::optional<bool> ext;
-
-    String crv;
-    String x;
-    String y;
-    String d;
-    String n;
-    String e;
-    String p;
-    String q;
-    String dp;
-    String dq;
-    String qi;
-    std::optional<Vector<RsaOtherPrimesInfo>> oth;
-    String k;
-    // JWK "AKP" key type (ML-DSA / ML-KEM), RFC draft-ietf-cose-dilithium.
-    String pub;
-    String priv;
-};
-
-// The key_ops member for an exported key: its usages, in KeyUsage enum order.
-Vector<String> toJwkKeyOps(const Vector<CryptoKeyUsage>&);
-
-// RFC 7517 section 4.3: "Duplicate key operation values MUST NOT be present",
-// whether or not WebCrypto knows the value (Chromium enforces both, Node only
-// the values it knows). Importers check this before the key_ops/usages
-// mismatch, in Node's order.
-bool hasDuplicateJwkKeyOps(const std::optional<Vector<String>>&);
+bool hasDuplicateJwkKeyOps(const std::optional<Vector<String>>& keyOps)
+{
+    if (!keyOps)
+        return false;
+    HashSet<String> seenOps;
+    for (auto& op : *keyOps) {
+        if (!seenOps.add(op).isNewEntry)
+            return true;
+    }
+    return false;
+}
 
 } // namespace WebCore
 

--- a/src/jsc/bindings/webcrypto/JsonWebKey.h
+++ b/src/jsc/bindings/webcrypto/JsonWebKey.h
@@ -67,8 +67,7 @@ Vector<String> toJwkKeyOps(const Vector<CryptoKeyUsage>&);
 
 // RFC 7517 section 4.3: "Duplicate key operation values MUST NOT be present",
 // whether or not WebCrypto knows the value (Chromium enforces both, Node only
-// the values it knows). Importers check this before the key_ops/usages
-// mismatch, in Node's order.
+// the values it knows).
 bool hasDuplicateJwkKeyOps(const std::optional<Vector<String>>&);
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcrypto/JsonWebKey.idl
+++ b/src/jsc/bindings/webcrypto/JsonWebKey.idl
@@ -30,7 +30,7 @@
     // The following fields are defined in Section 3.1 of JSON Web Key
     DOMString kty;
     DOMString use;
-    sequence<CryptoKeyUsage> key_ops;
+    sequence<DOMString> key_ops;
     DOMString alg;
 
     // The following fields are defined in JSON Web Key Parameters Registration

--- a/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
@@ -586,7 +586,7 @@ static void normalizeJsonWebKey(JsonWebKey& webKey)
 {
     // Importers only test that key_ops covers the requested usages, so entries
     // that are not a KeyUsage (valid per RFC 7517) drop out of the bitmap.
-    // hasDuplicateJwkKeyOps() still sees them in key_ops.
+    // CryptoAlgorithm::validateJwkKeyOps() still sees them in key_ops.
     webKey.usages = 0;
     if (!webKey.key_ops)
         return;

--- a/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
@@ -40,6 +40,7 @@
 #include "JSCryptoAlgorithmParameters.h"
 #include "JSCryptoKey.h"
 #include "JSCryptoKeyPair.h"
+#include "JSCryptoKeyUsage.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSDOMWrapper.h"
 #include "JSEcKeyParams.h"
@@ -583,8 +584,16 @@ static void rejectWithException(Ref<DeferredPromise>&& passedPromise, ExceptionC
 
 static void normalizeJsonWebKey(JsonWebKey& webKey)
 {
-    // Maybe we shouldn't silently bypass duplicated usages?
-    webKey.usages = webKey.key_ops ? SubtleCrypto::toCryptoKeyUsageBitmap(webKey.key_ops.value()) : 0;
+    // Importers only test that key_ops covers the requested usages, so entries
+    // that are not a KeyUsage (valid per RFC 7517) drop out of the bitmap.
+    // hasDuplicateJwkKeyOps() still sees them in key_ops.
+    webKey.usages = 0;
+    if (!webKey.key_ops)
+        return;
+    for (auto& op : *webKey.key_ops) {
+        if (auto usage = parseEnumerationFromString<CryptoKeyUsage>(op))
+            webKey.usages |= WebCore::toCryptoKeyUsageBitmap(*usage);
+    }
 }
 
 // FIXME: This returns an std::optional<KeyData> and takes a promise, rather than returning an

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -150,12 +150,12 @@ describe("Web Crypto", () => {
     });
 
     // Previously this promise never settled: the error thrown during
-    // JsonWebKey dictionary conversion (here an invalid key_ops enum entry)
-    // escaped as an uncaught exception and the DeferredPromise was left in
-    // m_pendingPromises forever. kty is optional now, so an invalid enum is
-    // what still reaches the conversion-exception branch.
+    // JsonWebKey dictionary conversion escaped as an uncaught exception and
+    // the DeferredPromise was left in m_pendingPromises forever. kty is
+    // optional and key_ops entries are plain strings, so a key_ops value that
+    // is not a sequence is what still reaches the conversion-exception branch.
     it("settles when JsonWebKey dictionary conversion itself throws", async () => {
-      const { key, iv, wrapped } = await setup(new TextEncoder().encode(JSON.stringify({ key_ops: ["bogus"] })));
+      const { key, iv, wrapped } = await setup(new TextEncoder().encode(JSON.stringify({ key_ops: "sign" })));
       const err = await crypto.subtle
         .unwrapKey("jwk", wrapped, key, { name: "AES-GCM", iv }, { name: "AES-GCM" }, true, ["encrypt", "decrypt"])
         .then(
@@ -163,7 +163,7 @@ describe("Web Crypto", () => {
           e => e,
         );
       expect(err).toBeInstanceOf(TypeError);
-      expect(err.message).toBe("value must be enumeration (string)");
+      expect(err.message).toBe("Value is not a sequence");
     });
 
     it("does not leak DeferredPromise in m_pendingPromises on JWK parse errors", async () => {
@@ -179,13 +179,13 @@ describe("Web Crypto", () => {
         const key = await crypto.subtle.importKey("raw", keyData, { name: "AES-GCM" }, false, [
           "encrypt", "decrypt", "wrapKey", "unwrapKey",
         ]);
-        // key_ops with an invalid enum entry throws during dictionary
+        // A key_ops value that is not a sequence throws during dictionary
         // conversion, which is the leaky branch this fixture guards (a
-        // merely-unusable JWK now converts fine and rejects downstream).
+        // merely-unusable JWK converts fine and rejects downstream).
         const wrapped = await crypto.subtle.encrypt(
           { name: "AES-GCM", iv },
           key,
-          new TextEncoder().encode(JSON.stringify({ key_ops: ["bogus"] })),
+          new TextEncoder().encode(JSON.stringify({ key_ops: "sign" })),
         );
         async function once() {
           await crypto.subtle
@@ -1141,6 +1141,138 @@ describe("X25519 JWK import", () => {
       extFalse: await outcome({ ...x25519Public, ext: false }, true, []),
       extTrue: await outcome({ ...x25519Public, ext: true }, true, []),
     }).toEqual({ extFalse: "DataError", extTrue: "imported" });
+  });
+});
+
+// JsonWebKey.key_ops is `sequence<DOMString>` in the WebCrypto IDL, and RFC 7517
+// section 4.3 allows key_ops values that WebCrypto does not define. The jwk
+// import steps only require key_ops to be duplicate-free and to contain the
+// requested usages, which is what Node and Chromium implement. Converting the
+// member as `sequence<KeyUsage>` instead makes a JWK minted by another stack
+// fail with a TypeError before the import algorithm runs.
+describe("JWK key_ops entries that are not a KeyUsage", () => {
+  const k = "AAECAwQFBgcICQoLDA0ODw";
+  const rsaPublic = {
+    kty: "RSA",
+    n: "ylJkPUUI1WdwPhfxioPyUeFOVdmpIAMNID4uCvhtnqdH3P-yDl4V9Qvcjvb4SnB1eHOWKpXhpkA1uD3gmmebqvmRJB242EbTaf89mLr6BxFvSDUBwHxMzYgewnXFUJiA85rOUrVL9mDZcwwVvpCT3836iq4_RfDIuQEKOi5OntU",
+    e: "AQAB",
+  };
+  const ecPublic = {
+    kty: "EC",
+    crv: "P-256",
+    x: "3DyR3pdz7BDZtoAVvm4Mn55Ashdl84LCJB9kcUI3IrQ",
+    y: "r6xDaTpWl7d958Y4HMq6OR4F8PLe1wl7m41I2ZX1yoU",
+  };
+  const okpPublic = { kty: "OKP", crv: "Ed25519", x: "S89QWE7a6JwjIPX04rf9qxlJ9vQxs5bSW1NxjR03mls" };
+  const outcome = (p: Promise<CryptoKey>) =>
+    p.then(
+      key => `imported ${JSON.stringify(key.usages)}`,
+      e => e.name,
+    );
+  const aes = (key_ops: unknown) =>
+    outcome(crypto.subtle.importKey("jwk", { kty: "oct", k, key_ops } as JsonWebKey, "AES-GCM", true, ["encrypt"]));
+  const rsa = (key_ops: unknown) =>
+    outcome(
+      crypto.subtle.importKey(
+        "jwk",
+        { ...rsaPublic, key_ops } as JsonWebKey,
+        { name: "RSA-OAEP", hash: "SHA-256" },
+        true,
+        ["encrypt"],
+      ),
+    );
+  const ec = (key_ops: unknown, usages: KeyUsage[] = ["verify"]) =>
+    outcome(
+      crypto.subtle.importKey(
+        "jwk",
+        { ...ecPublic, key_ops } as JsonWebKey,
+        { name: usages.length ? "ECDSA" : "ECDH", namedCurve: "P-256" },
+        true,
+        usages,
+      ),
+    );
+  const okp = (key_ops: unknown) =>
+    outcome(crypto.subtle.importKey("jwk", { ...okpPublic, key_ops } as JsonWebKey, "Ed25519", true, ["verify"]));
+  const hmac = (key_ops: unknown) =>
+    outcome(
+      crypto.subtle.importKey(
+        "jwk",
+        { kty: "oct", k, key_ops } as JsonWebKey,
+        { name: "HMAC", hash: "SHA-256" },
+        true,
+        ["sign"],
+      ),
+    );
+
+  it("are ignored on import when key_ops still covers the requested usages", async () => {
+    expect({
+      foreign: await aes(["encrypt", "fly"]),
+      unrequestedUsageAndForeign: await aes(["encrypt", "deriveBits", "x-custom"]),
+      // sequence<DOMString> stringifies these instead of throwing.
+      number: await aes([1, "encrypt"]),
+      null: await aes(["encrypt", null]),
+      onlyForeign: await aes(["fly"]),
+      onlyForeignNoUsages: await ec(["fly"], []),
+      empty: await aes([]),
+      notASequence: await aes("encrypt"),
+      rsa: await rsa(["encrypt", "urn:example:op"]),
+      ec: await ec(["verify", "urn:example:op"]),
+      okp: await okp(["verify", "urn:example:op"]),
+      hmac: await hmac(["sign", "urn:example:op"]),
+    }).toEqual({
+      foreign: `imported ["encrypt"]`,
+      unrequestedUsageAndForeign: `imported ["encrypt"]`,
+      number: `imported ["encrypt"]`,
+      null: `imported ["encrypt"]`,
+      onlyForeign: "DataError",
+      onlyForeignNoUsages: "imported []",
+      empty: "DataError",
+      notASequence: "TypeError",
+      rsa: `imported ["encrypt"]`,
+      ec: `imported ["verify"]`,
+      okp: `imported ["verify"]`,
+      hmac: `imported ["sign"]`,
+    });
+  });
+
+  // RFC 7517 section 4.3: "Duplicate key operation values MUST NOT be present
+  // in the array." This holds for values WebCrypto does not know, as in Chromium.
+  it("must still be unique, for every key class", async () => {
+    expect({
+      aes: await aes(["encrypt", "encrypt"]),
+      aesForeign: await aes(["encrypt", "fly", "fly"]),
+      rsa: await rsa(["encrypt", "wrapKey", "encrypt"]),
+      ec: await ec(["verify", "verify"]),
+      okp: await okp(["verify", "verify"]),
+      hmac: await hmac(["sign", "verify", "sign"]),
+    }).toEqual({
+      aes: "DataError",
+      aesForeign: "DataError",
+      rsa: "DataError",
+      ec: "DataError",
+      okp: "DataError",
+      hmac: "DataError",
+    });
+  });
+
+  it("survive unwrapKey, and exportKey emits only the key's usages", async () => {
+    const iv = new Uint8Array(12).fill(2);
+    const wrappingKey = await crypto.subtle.importKey("raw", new Uint8Array(32).fill(1), "AES-GCM", false, [
+      "encrypt",
+      "unwrapKey",
+    ]);
+    const wrapped = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      wrappingKey,
+      new TextEncoder().encode(JSON.stringify({ kty: "oct", k, key_ops: ["decrypt", "JOSE-only-op", 7, "encrypt"] })),
+    );
+    const key = await crypto.subtle.unwrapKey("jwk", wrapped, wrappingKey, { name: "AES-GCM", iv }, "AES-GCM", true, [
+      "decrypt",
+      "encrypt",
+    ]);
+    expect(key.usages).toEqual(["encrypt", "decrypt"]);
+    const exported = await crypto.subtle.exportKey("jwk", key);
+    expect(exported.key_ops).toEqual(["encrypt", "decrypt"]);
   });
 });
 

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -1151,7 +1151,7 @@ describe("X25519 JWK import", () => {
 // member as `sequence<KeyUsage>` instead makes a JWK minted by another stack
 // fail with a TypeError before the import algorithm runs.
 describe("JWK key_ops entries that are not a KeyUsage", () => {
-  const k = "AAECAwQFBgcICQoLDA0ODw";
+  const k = Buffer.alloc(32, 1).toString("base64url");
   const rsaPublic = {
     kty: "RSA",
     n: "ylJkPUUI1WdwPhfxioPyUeFOVdmpIAMNID4uCvhtnqdH3P-yDl4V9Qvcjvb4SnB1eHOWKpXhpkA1uD3gmmebqvmRJB242EbTaf89mLr6BxFvSDUBwHxMzYgewnXFUJiA85rOUrVL9mDZcwwVvpCT3836iq4_RfDIuQEKOi5OntU",
@@ -1164,10 +1164,11 @@ describe("JWK key_ops entries that are not a KeyUsage", () => {
     y: "r6xDaTpWl7d958Y4HMq6OR4F8PLe1wl7m41I2ZX1yoU",
   };
   const okpPublic = { kty: "OKP", crv: "Ed25519", x: "S89QWE7a6JwjIPX04rf9qxlJ9vQxs5bSW1NxjR03mls" };
+  const x25519Public = { kty: "OKP", crv: "X25519", x: "hSDwCYkwp1R0i33ctD73Wg2_Og0mOBr06uFD1q1y5Go" };
   const outcome = (p: Promise<CryptoKey>) =>
     p.then(
       key => `imported ${JSON.stringify(key.usages)}`,
-      e => e.name,
+      e => `${e.name}: ${e.message}`,
     );
   const aes = (key_ops: unknown) =>
     outcome(crypto.subtle.importKey("jwk", { kty: "oct", k, key_ops } as JsonWebKey, "AES-GCM", true, ["encrypt"]));
@@ -1224,10 +1225,10 @@ describe("JWK key_ops entries that are not a KeyUsage", () => {
       unrequestedUsageAndForeign: `imported ["encrypt"]`,
       number: `imported ["encrypt"]`,
       null: `imported ["encrypt"]`,
-      onlyForeign: "DataError",
+      onlyForeign: "DataError: Key operations and usage mismatch",
       onlyForeignNoUsages: "imported []",
-      empty: "DataError",
-      notASequence: "TypeError",
+      empty: "DataError: Key operations and usage mismatch",
+      notASequence: "TypeError: Value is not a sequence",
       rsa: `imported ["encrypt"]`,
       ec: `imported ["verify"]`,
       okp: `imported ["verify"]`,
@@ -1236,23 +1237,46 @@ describe("JWK key_ops entries that are not a KeyUsage", () => {
   });
 
   // RFC 7517 section 4.3: "Duplicate key operation values MUST NOT be present
-  // in the array." This holds for values WebCrypto does not know, as in Chromium.
-  it("must still be unique, for every key class", async () => {
-    expect({
-      aes: await aes(["encrypt", "encrypt"]),
-      aesForeign: await aes(["encrypt", "fly", "fly"]),
-      rsa: await rsa(["encrypt", "wrapKey", "encrypt"]),
-      ec: await ec(["verify", "verify"]),
-      okp: await okp(["verify", "verify"]),
-      hmac: await hmac(["sign", "verify", "sign"]),
-    }).toEqual({
-      aes: "DataError",
-      aesForeign: "DataError",
-      rsa: "DataError",
-      ec: "DataError",
-      okp: "DataError",
-      hmac: "DataError",
-    });
+  // in the array." This holds for values WebCrypto does not know, as in
+  // Chromium, and every algorithm reports it with Node's message.
+  it("must still be unique, for every algorithm", async () => {
+    const oct = { kty: "oct", k };
+    const cases: [
+      Record<string, unknown>,
+      AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams,
+      KeyUsage[],
+    ][] = [
+      [oct, "AES-GCM", ["encrypt"]],
+      [oct, "AES-CBC", ["encrypt"]],
+      [oct, "AES-CTR", ["encrypt"]],
+      [oct, "AES-CFB-8", ["encrypt"]],
+      [oct, "AES-KW", ["wrapKey"]],
+      [oct, "ChaCha20-Poly1305", ["encrypt"]],
+      [oct, { name: "HMAC", hash: "SHA-256" }, ["sign"]],
+      [rsaPublic, { name: "RSA-OAEP", hash: "SHA-256" }, ["encrypt"]],
+      [rsaPublic, { name: "RSA-PSS", hash: "SHA-256" }, ["verify"]],
+      [rsaPublic, { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" }, ["verify"]],
+      [ecPublic, { name: "ECDSA", namedCurve: "P-256" }, ["verify"]],
+      [ecPublic, { name: "ECDH", namedCurve: "P-256" }, []],
+      [okpPublic, "Ed25519", ["verify"]],
+      [x25519Public, "X25519", []],
+    ];
+    const results: Record<string, string> = {};
+    for (const [jwk, algorithm, usages] of cases) {
+      const name = typeof algorithm === "string" ? algorithm : algorithm.name;
+      const op = usages[0] ?? "deriveBits";
+      for (const key_ops of [
+        [op, op],
+        [op, "urn:example:op", "urn:example:op"],
+      ]) {
+        results[`${name} ${JSON.stringify(key_ops)}`] = await outcome(
+          crypto.subtle.importKey("jwk", { ...jwk, key_ops } as JsonWebKey, algorithm, true, usages),
+        );
+      }
+    }
+    const expected = Object.fromEntries(Object.keys(results).map(name => [name, "DataError: Duplicate key operation"]));
+    expect(Object.keys(results)).toHaveLength(cases.length * 2);
+    expect(results).toEqual(expected);
   });
 
   it("survive unwrapKey, and exportKey emits only the key's usages", async () => {


### PR DESCRIPTION
### Problem
- `importKey("jwk", { kty: "oct", k, key_ops: ["encrypt", "fly"] }, "AES-GCM", true, ["encrypt"])` rejects with `TypeError: value must be enumeration (string)`. Node 26 and Chromium 148 import the key. A JWK with a JOSE-side or vendor `key_ops` value fails only in bun.
- Cause: `JSJsonWebKey.cpp` converts `key_ops` as `sequence<KeyUsage>`. The spec IDL says `sequence<DOMString>`, and RFC 7517 section 4.3 allows other values.
- The inverse also held: `key_ops: ["encrypt", "encrypt"]` imported for AES, RSA, EC and OKP keys. RFC 7517 forbids duplicates. Node and Chromium reject them.

### Fix
- `JsonWebKey.key_ops` becomes `std::optional<Vector<String>>`. `normalizeJsonWebKey` builds the `usages` bitmap from the entries that name a `KeyUsage` and skips the rest.
- A new `CryptoAlgorithm::validateJwkKeyOps` rejects duplicate strings, then `key_ops` that miss a requested usage, with Node's `Duplicate key operation` and `Key operations and usage mismatch` messages. Every jwk import branch calls it after the `use` check. HMAC, ChaCha20-Poly1305 and AKP had this inline. The other key classes gain it.
- Verified: `test/js/web/crypto/web-crypto.test.ts` (three new tests, stock bun fails all three), the Node `test-webcrypto-export-import*` tests, and the key_ops blocks upstream Node main adds for EC, RSA and CFRG.
- Self-reviewed: 2 concerns raised, 1 addressed (one helper with Node's messages). The other also folds `use` and `ext` into it, a wider refactor.

### Background
- `JsonWebKey` (`src/jsc/bindings/webcrypto/JsonWebKey.h`) is the C++ struct behind the WebIDL `JsonWebKey` dictionary. `importKey("jwk")` and `unwrapKey(..., "jwk")` both convert into it. Each `CryptoAlgorithm*::importKey` jwk branch checks its members, then calls `CryptoKey*::importJwk`.
- JWK `key_ops` shares its strings with the WebCrypto `KeyUsage` enum, but a JWK is a JOSE object and can name operations WebCrypto does not define.

<details><summary>Notes</summary>

Behavior matrix for `importKey("jwk", { kty: "oct", k, key_ops }, "AES-GCM", true, ["encrypt"])`:

| `key_ops` | bun before | bun after | node 26.3 | Chromium 148 |
| --- | --- | --- | --- | --- |
| `["encrypt","fly"]` | TypeError | imported | imported | imported |
| `["encrypt","deriveBits","x-custom"]` | TypeError | imported | imported | imported |
| `[1,"encrypt"]` | TypeError | imported | imported | imported |
| `["encrypt",null]` | TypeError | imported | imported | imported |
| `["fly"]` | TypeError | DataError | DataError | DataError |
| `["encrypt","encrypt"]` | imported | DataError | DataError | DataError |
| `["encrypt","fly","fly"]` | TypeError | DataError | imported | DataError |
| `"encrypt"` (not a sequence) | TypeError | TypeError | TypeError | TypeError |

Export sites map `usages()` to strings with the new `toJwkKeyOps` helper in `JsonWebKey.cpp`.

Upstream WebKit still converts `key_ops` as `sequence<CryptoKeyUsage>`, so this diverges from it on purpose.

The one cell where Node and Chromium differ is a repeated unknown value. Node's `validateKeyOps` skips unknown values in its duplicate scan. Chromium's `GetWebCryptoUsagesFromJwkKeyOps` tracks them in a set and rejects. RFC 7517 section 4.3 ("Duplicate key operation values MUST NOT be present in the array") does not limit the rule to registered values, so this follows Chromium. Node's reading would be a one-line change in `hasDuplicateJwkKeyOps`.

Upstream Node main (newer than v26.3.0) asserts `{ name: 'DataError', message: 'Duplicate key operation' }` for EC, RSA and CFRG JWKs in `test-webcrypto-export-import-{ec,rsa,cfrg}.js`, after a `SyntaxError` for an unsupported usage. Those blocks pass on this branch. The vendored copies in `test/js/node/test/parallel/` do not have them yet.

For AES the `key_ops` check runs in the algorithm's jwk branch before `CryptoKeyAES::importJwk`, which still holds the `kty`, `use`, `alg` and `ext` checks with the generic message. So for an AES JWK that is wrong in two ways at once, the `key_ops` message wins where Node reports `kty` or `use` first. Both are `DataError`.

`CryptoKey{AES,RSA,EC,OKP}::importJwk` keep their own "key_ops covers the usages" test from WebKit. It cannot fire after `validateJwkKeyOps`, and it stays as the guard for a caller that skips the branch checks.

Two existing tests used `key_ops: ["bogus"]` to force a dictionary-conversion `TypeError` in the `unwrapKey` leak regression test. That input is valid now, so they use `key_ops: "sign"` (not a sequence), which still throws during conversion.

Other suites run locally: `test-webcrypto-export-import{,-cfrg,-ec,-rsa,-ml-dsa,-ml-kem}.js`, `test-webcrypto-wrap-unwrap.js`, `test-webcrypto-encrypt-decrypt-{aes,chacha20-poly1305}.js`, `test-webcrypto-cryptokey-hidden-slots.js`, `test-webcrypto-internal-slots.mjs`, `test-webcrypto-sign-verify-{hmac,ml-dsa}.js`, `test-webcrypto-encap-decap-ml-kem.js`, `test-webcrypto-derivekey.js`, `test/js/deno/crypto/webcrypto.test.ts`, `web-crypto-sha3.test.ts`, `x25519-derive-bits.test.ts`.

#33902 (July, conflicting) covered only the duplicate half. It rejected in `normalizeJsonWebKey` before algorithm dispatch, which puts the duplicate error ahead of the `use` check that main now orders like Node. This PR supersedes it.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 31 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [6.93ms]
(pass) Web Crypto > keeps event loop alive [329.99ms]
(pass) Web Crypto > has globals [3.06ms]
(pass) Web Crypto > should encrypt and decrypt [15.30ms]
(pass) Web Crypto > should verify and sign [37.17ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [15.78ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [11.03ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [10.66ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2321.56ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [310.33ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [87.65
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.06ms]
(pass) Web Crypto > keeps event loop alive [9.16ms]
(pass) Web Crypto > has globals [0.06ms]
(pass) Web Crypto > should encrypt and decrypt [0.37ms]
(pass) Web Crypto > should verify and sign [0.69ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [0.31ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [0.53ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [0.17ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [27.13ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [9.59ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [10.33ms]
(pass) Ed25519 > generateKey > should return CryptoKeys without namedCurve in algorithm field [0.18ms]
(pass) Ed25519 > importKey > rejects a 64-byte JWK d whose traili
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.57ms]
(pass) Web Crypto > keeps event loop alive [347.58ms]
(pass) Web Crypto > has globals [3.19ms]
(pass) Web Crypto > should encrypt and decrypt [14.82ms]
(pass) Web Crypto > should verify and sign [37.12ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [15.52ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [10.63ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [10.52ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2290.48ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [320.00ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [50.99
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     6604d1767e
  features     baseline

23 deps, 131 codegen, 1172 objects in 688ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [10.00ms]
[3/1244] fetch tinycc
[tinycc] up to date
[4/1243] fetch zlib
[zlib] up to date
[5/1243] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[7/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1216] gen bindgenv2
[9/1216] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[10/1216] fetch picohttpparser
[picohttpparser] up to date
[11/1216] instal
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcrypto/CryptoAlgorithm.cpp     |  13 ++
 src/jsc/bindings/webcrypto/CryptoAlgorithm.h       |   5 +
 .../bindings/webcrypto/CryptoAlgorithmAES_CBC.cpp  |   2 +
 .../bindings/webcrypto/CryptoAlgorithmAES_CFB.cpp  |   2 +
 .../bindings/webcrypto/CryptoAlgorithmAES_CTR.cpp  |   2 +
 .../bindings/webcrypto/CryptoAlgorithmAES_GCM.cpp  |   2 +
 .../bindings/webcrypto/CryptoAlgorithmAES_KW.cpp   |   2 +
 .../bindings/webcrypto/CryptoAlgorithmAKPShared.h  |   8 +-
 .../webcrypto/CryptoAlgorithmChaCha20Poly1305.cpp  |  10 +-
 src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.cpp |   2 +
 .../bindings/webcrypto/CryptoAlgorithmECDSA.cpp    |   2 +
 .../bindings/webcrypto/CryptoAlgorithmEd25519.cpp  |   2 +
 src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp |   8 +-
 .../webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp |   2 +
 .../bindings/webcrypto/CryptoAlgorithmRSA_OAEP.cpp |   2 +
 .../bindings/webcrypto/CryptoAlgorithmRSA_PSS.cpp  |   2 +
 .../bindings/webcrypto/CryptoAlgorithmX25519.cpp   |   2 +
 src/jsc/bindings/webcrypto/CryptoKeyAES.cpp        |   2 +-
 src/jsc/bindings/webcrypto/CryptoKeyAKP.cpp        |   2 +-
 src/jsc/bindings/webcrypto/CryptoKeyEC.cpp         |   2 +-
 src/jsc/bindings/webcrypto/CryptoKeyHMAC.cpp       |   2 +-
 src/jsc/bindings/webcrypto/CryptoKeyOKP.cpp        |   2 +-
 src/jsc/bindings/webcrypto/CryptoKeyRSA.cpp        |   2 +-
 src/jsc/bindings/webcrypto/JSCryptoKeyUsage.cpp    |   6 +-
 src/jsc/bindings/webcrypto/JSCryptoKeyUsage.h      |   1 +
 src/jsc/bindings/webcrypto/JSJsonWebKey.cpp        |   8 +-
 src/jsc/bindings/webcrypto/JsonWebKey.cpp          |  56 +++++++
 src/jsc/bindings/webcrypto/JsonWebKey.h            |  28 ++--
 src/jsc/bindings/webcrypto/JsonWebKey.idl          |   2 +-
 src/jsc/bindings/webcrypto/SubtleCrypto.cpp        |  13 +-
 test/js/web/crypto/web-crypto.test.ts              | 174 +++++++++++++++++++--
 31 files changed, 304 insertions(+), 64 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/webcrypto/CryptoAlgorithm.cpp                1      1     13
src/jsc/bindings/webcrypto/CryptoAlgorithm.h                  1      1     13
src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CBC.cpp         0      0     13
src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CFB.cpp         0      0     13
src/jsc/bindings/webcrypto/CryptoAlgorithmAES_CTR.cpp         0      0     13
src/jsc/bindings/webcrypto/CryptoAlgorithmAES_GCM.cpp         0      0     13
src/jsc/bindings/webcrypto/CryptoAlgorithmAES_KW.cpp          0      0     13
src/jsc/bindings/webcrypto/CryptoAlgorithmAKPShared.h         0      0     13
…/bindings/webcrypto/CryptoAlgorithmChaCha20Poly1305.cpp      0      0     13
src/jsc/bindings/webcrypto/CryptoAlgorithmECDH.cpp            0      0     13
src/jsc/bindings/webcrypto/CryptoAlgorithmECDSA.cpp           0      0     13
src/jsc/bindings/webcrypto/CryptoAlgorithmEd25519.cpp         0      0     13
src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp            0      0     13
…bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp      0      0     13
src/jsc/bindings/webcrypto/CryptoAlgorithmRSA_OAEP.cpp        0      0     13
src/jsc/bindings/webcrypto/CryptoAlgorithmRSA_PSS.cpp         0      0     13
(+ 15 more files)
```

</details>

<!-- robobun:evidence:end -->