### PR TITLE
css: treat out-of-range and unit-less numeric values as invalid instead of merging or repairing them

### DIFF
--- a/src/css/media_query.rs
+++ b/src/css/media_query.rs
@@ -1121,8 +1121,7 @@ impl MediaFeatureValue {
         if expected_type == MediaFeatureType::Unknown || vt == MediaFeatureType::Unknown {
             return true;
         }
-        // `(min-width: 600)` is well-formed and never matches. It is kept as written
-        // rather than failing the build.
+        // `(min-width: 600)` never matches; keep it as written instead of erroring.
         if expected_type == MediaFeatureType::Length && vt == MediaFeatureType::Number {
             return true;
         }

--- a/src/css/media_query.rs
+++ b/src/css/media_query.rs
@@ -1121,6 +1121,11 @@ impl MediaFeatureValue {
         if expected_type == MediaFeatureType::Unknown || vt == MediaFeatureType::Unknown {
             return true;
         }
+        // `(min-width: 600)` is well-formed and never matches. It is kept as written
+        // rather than failing the build.
+        if expected_type == MediaFeatureType::Length && vt == MediaFeatureType::Number {
+            return true;
+        }
         expected_type == vt
     }
 

--- a/src/css/properties/align.rs
+++ b/src/css/properties/align.rs
@@ -601,6 +601,7 @@ pub enum GapValue {
     /// Equal to `1em` for multi-column containers, and zero otherwise.
     Normal,
     /// An explicit length.
+    #[css(non_negative)]
     LengthPercentage(LengthPercentage),
 }
 

--- a/src/css/properties/background.rs
+++ b/src/css/properties/background.rs
@@ -4,6 +4,7 @@ use crate::css_values::color::ColorFallbackKind;
 use crate::css_values::color::CssColor;
 use crate::css_values::image::Image;
 use crate::css_values::length::LengthPercentageOrAuto;
+use crate::css_values::number::parse_non_negative;
 use crate::css_values::position::{HorizontalPosition, Position, VerticalPosition};
 use crate::generics::{CssEql, DeepClone};
 use crate::properties::{Property, PropertyId};
@@ -285,9 +286,10 @@ pub struct ExplicitBackgroundSize {
 
 impl BackgroundSize {
     pub(crate) fn parse(input: &mut Parser) -> css::Result<Self> {
-        if let Ok(width) = input.try_parse(LengthPercentageOrAuto::parse) {
+        let parse_length = |i: &mut Parser| parse_non_negative(i, LengthPercentageOrAuto::parse);
+        if let Ok(width) = input.try_parse(parse_length) {
             let height = input
-                .try_parse(LengthPercentageOrAuto::parse)
+                .try_parse(parse_length)
                 .unwrap_or(LengthPercentageOrAuto::Auto);
             return Ok(BackgroundSize::Explicit(ExplicitBackgroundSize {
                 width,

--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -229,6 +229,7 @@ pub enum BorderSideWidth {
     /// A UA defined `thick` value.
     Thick,
     /// An explicit width.
+    #[css(non_negative)]
     Length(Length),
 }
 

--- a/src/css/properties/border_radius.rs
+++ b/src/css/properties/border_radius.rs
@@ -7,6 +7,7 @@ use crate::PropertyHandlerContext;
 use crate::VendorPrefix;
 use crate::css_properties::{Property, PropertyId, PropertyIdTag};
 use crate::css_values::length::LengthPercentage;
+use crate::css_values::number::parse_non_negative;
 use crate::css_values::rect::Rect;
 use crate::css_values::size::Size2D;
 use bun_alloc::ArenaVecExt as _;
@@ -45,10 +46,11 @@ impl BorderRadius {
     }
 
     pub fn parse(input: &mut css::Parser) -> css::Result<BorderRadius> {
-        let widths = Rect::<LengthPercentage>::parse_with(input, LengthPercentage::parse)?;
+        let parse_length = |i: &mut css::Parser| parse_non_negative(i, LengthPercentage::parse);
+        let widths = Rect::<LengthPercentage>::parse_with(input, parse_length)?;
         let heights = if input.try_parse(|i| i.expect_delim(b'/')).is_ok() {
             // errdefer-style cleanup of `widths` is implicit via Drop on the `?` path.
-            Rect::<LengthPercentage>::parse_with(input, LengthPercentage::parse)?
+            Rect::<LengthPercentage>::parse_with(input, parse_length)?
         } else {
             // `LengthPercentage` is
             // `Clone`-via-derive (no arena indirection), so per-field `.clone()` is exact.

--- a/src/css/properties/border_radius.rs
+++ b/src/css/properties/border_radius.rs
@@ -210,13 +210,18 @@ macro_rules! property_helper {
 
 macro_rules! logical_property_helper {
     ($self:expr, $d:expr, $ctx:expr, $prop:ident, $val:expr) => {{
-        if $self.category != PropertyCategory::Logical {
+        let val = $val;
+        // An unparsed value may be one browsers drop, so the value before it is kept
+        // as its fallback.
+        if $self.category != PropertyCategory::Logical
+            || ($self.$prop.is_some() && matches!(val, Property::Unparsed(_)))
+        {
             $self.flush($d, $ctx);
         }
 
         // `Property` itself
         // has no blanket `Clone`; callers pass an already-deep_clone'd `Property`.
-        $self.$prop = Some($val);
+        $self.$prop = Some(val);
         $self.category = PropertyCategory::Logical;
         $self.has_any = true;
     }};

--- a/src/css/properties/border_radius.rs
+++ b/src/css/properties/border_radius.rs
@@ -211,8 +211,7 @@ macro_rules! property_helper {
 macro_rules! logical_property_helper {
     ($self:expr, $d:expr, $ctx:expr, $prop:ident, $val:expr) => {{
         let val = $val;
-        // An unparsed value may be one browsers drop, so the value before it is kept
-        // as its fallback.
+        // An unparsed value keeps the one before it as its fallback.
         if $self.category != PropertyCategory::Logical
             || ($self.$prop.is_some() && matches!(val, Property::Unparsed(_)))
         {

--- a/src/css/properties/box_shadow.rs
+++ b/src/css/properties/box_shadow.rs
@@ -7,6 +7,7 @@ use crate::css_properties::Property;
 use crate::css_values::color::ColorFallbackKind;
 use crate::css_values::color::CssColor;
 use crate::css_values::length::Length;
+use crate::css_values::number::{ClampNegative as _, peek_number_literal};
 use crate::generics::{CssEql, DeepClone, IsCompatible};
 use crate::prefixes::Feature;
 use bun_alloc::Arena;
@@ -78,7 +79,14 @@ impl BoxShadow {
                 let value = input.try_parse(|p: &mut css::Parser| -> css::Result<Lengths> {
                     let horizontal = Length::parse(p)?;
                     let vertical = Length::parse(p)?;
-                    let blur = p.try_parse(Length::parse).ok().unwrap_or_else(Length::zero);
+                    // A third length is the blur radius (`<length [0,∞]>`). A negative
+                    // literal there makes the shadow invalid rather than being the spread.
+                    if peek_number_literal(p).is_some_and(|v| v < 0.0) {
+                        return Err(p.new_custom_error(css::ParserError::invalid_value));
+                    }
+                    let blur = p
+                        .try_parse(Length::parse)
+                        .map_or_else(|_| Length::zero(), |v| v.clamp_negative());
                     let spread = p.try_parse(Length::parse).ok().unwrap_or_else(Length::zero);
                     Ok(Lengths {
                         x: horizontal,

--- a/src/css/properties/box_shadow.rs
+++ b/src/css/properties/box_shadow.rs
@@ -79,8 +79,7 @@ impl BoxShadow {
                 let value = input.try_parse(|p: &mut css::Parser| -> css::Result<Lengths> {
                     let horizontal = Length::parse(p)?;
                     let vertical = Length::parse(p)?;
-                    // A third length is the blur radius (`<length [0,∞]>`). A negative
-                    // literal there makes the shadow invalid rather than being the spread.
+                    // A negative third length is an invalid blur radius, not the spread.
                     if peek_number_literal(p).is_some_and(|v| v < 0.0) {
                         return Err(p.new_custom_error(css::ParserError::invalid_value));
                     }

--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -418,7 +418,12 @@ impl TokenList {
                         has_whitespace = false;
                     }
                     Token::Number(v) => {
-                        CSSNumberFns::to_css(v.value, dest)?;
+                        if v.int_value.is_none() && v.value.fract() == 0.0 {
+                            // `1e1` and `2.0` are not `<integer>`s, and `10` and `2` are.
+                            token.to_css(dest)?;
+                        } else {
+                            CSSNumberFns::to_css(v.value, dest)?;
+                        }
                         has_whitespace = false;
                     }
                     _ => {

--- a/src/css/properties/flex.rs
+++ b/src/css/properties/flex.rs
@@ -5,7 +5,7 @@ use bun_alloc::ArenaVecExt as _;
 use crate::properties::{Property, PropertyId};
 use css::css_properties::align::{AlignContent, AlignItems, AlignSelf, JustifyContent};
 use css::css_values::length::{LengthPercentage, LengthPercentageOrAuto};
-use css::css_values::number::{CSSInteger, CSSNumber, CSSNumberFns};
+use css::css_values::number::{CSSInteger, CSSNumber, CSSNumberFns, parse_non_negative};
 use css::prefixes::Feature as PrefixFeature;
 use css::{PrintErr, Printer, VendorPrefix};
 
@@ -139,17 +139,20 @@ impl Flex {
         let mut shrink: Option<CSSNumber> = None;
         let mut basis: Option<LengthPercentageOrAuto> = None;
 
+        let parse_factor = |i: &mut css::Parser| parse_non_negative(i, CSSNumberFns::parse);
         loop {
             if grow.is_none() {
-                if let Ok(value) = input.try_parse(CSSNumberFns::parse) {
+                if let Ok(value) = input.try_parse(parse_factor) {
                     grow = Some(value);
-                    shrink = input.try_parse(CSSNumberFns::parse).ok();
+                    shrink = input.try_parse(parse_factor).ok();
                     continue;
                 }
             }
 
             if basis.is_none() {
-                if let Ok(value) = input.try_parse(LengthPercentageOrAuto::parse) {
+                if let Ok(value) =
+                    input.try_parse(|i| parse_non_negative(i, LengthPercentageOrAuto::parse))
+                {
                     basis = Some(value);
                     continue;
                 }

--- a/src/css/properties/font.rs
+++ b/src/css/properties/font.rs
@@ -20,7 +20,7 @@ use bun_alloc::ArenaVecExt as _;
 use crate::values as css_values;
 use css_values::angle::Angle;
 use css_values::length::{LengthPercentage, LengthValue};
-use css_values::number::{CSSNumber, CSSNumberFns};
+use css_values::number::{CSSNumber, CSSNumberFns, parse_non_negative, peek_number_literal};
 use css_values::percentage::{DimensionPercentage, Percentage};
 
 use bun_collections::VecExt;
@@ -93,9 +93,15 @@ pub enum AbsoluteFontWeight {
 }
 
 impl AbsoluteFontWeight {
-    // Payload (`CSSNumber`) first, then keyword variants.
+    // Payload (`<number [1,1000]>`) first, then keyword variants.
     fn parse(input: &mut css::Parser) -> CssResult<Self> {
-        if let Ok(n) = input.try_parse(CSSNumberFns::parse) {
+        if let Ok(n) = input.try_parse(|i: &mut css::Parser| {
+            // The range applies to a literal; a math result clamps to it instead.
+            if peek_number_literal(i).is_some_and(|n| !(1.0..=1000.0).contains(&n)) {
+                return Err(i.new_custom_error(ParserError::invalid_value));
+            }
+            CSSNumberFns::parse(i).map(|n| n.clamp(1.0, 1000.0))
+        }) {
             return Ok(AbsoluteFontWeight::Weight(n));
         }
         let location = input.current_source_location();
@@ -143,6 +149,7 @@ impl AbsoluteFontWeight {
 #[derive(Clone, PartialEq, css::Parse, css::ToCss)]
 pub enum FontSize {
     /// An explicit size.
+    #[css(non_negative)]
     Length(LengthPercentage),
     /// An absolute font size keyword.
     Absolute(AbsoluteFontSize),
@@ -229,7 +236,7 @@ impl FontStretch {
         if let Ok(kw) = input.try_parse(FontStretchKeyword::parse) {
             return Ok(FontStretch::Keyword(kw));
         }
-        Percentage::parse(input).map(FontStretch::Percentage)
+        parse_non_negative(input, Percentage::parse).map(FontStretch::Percentage)
     }
 
     pub(crate) fn to_css(self, dest: &mut Printer) -> PrintResult<()> {
@@ -642,10 +649,10 @@ impl LineHeight {
         {
             return Ok(LineHeight::Normal);
         }
-        if let Ok(n) = input.try_parse(CSSNumberFns::parse) {
+        if let Ok(n) = input.try_parse(|i| parse_non_negative(i, CSSNumberFns::parse)) {
             return Ok(LineHeight::Number(n));
         }
-        LengthPercentage::parse(input).map(LineHeight::Length)
+        parse_non_negative(input, LengthPercentage::parse).map(LineHeight::Length)
     }
 
     pub(crate) fn to_css(&self, dest: &mut Printer) -> PrintResult<()> {

--- a/src/css/properties/margin_padding.rs
+++ b/src/css/properties/margin_padding.rs
@@ -27,12 +27,19 @@ impl_size_shorthand!(
     inline_start,
     inline_end
 );
-impl_size_shorthand!(PaddingBlock, LengthPercentageOrAuto, block_start, block_end);
+impl_size_shorthand!(
+    PaddingBlock,
+    LengthPercentageOrAuto,
+    block_start,
+    block_end,
+    non_negative
+);
 impl_size_shorthand!(
     PaddingInline,
     LengthPercentageOrAuto,
     inline_start,
-    inline_end
+    inline_end,
+    non_negative
 );
 impl_size_shorthand!(
     ScrollMarginBlock,
@@ -183,7 +190,8 @@ define_rect_shorthand! {
     top: PaddingTop,
     right: PaddingRight,
     bottom: PaddingBottom,
-    left: PaddingLeft
+    left: PaddingLeft,
+    non_negative
 }
 
 /// A value for the [scroll-margin-block](https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-margin-block) shorthand property.

--- a/src/css/properties/mod.rs
+++ b/src/css/properties/mod.rs
@@ -27,9 +27,18 @@
 // submodules without `#[macro_export]`.
 macro_rules! impl_rect_shorthand {
     ($T:ident, $V:ty) => {
+        impl_rect_shorthand!(@with $T, $V, <$V>::parse);
+    };
+    // Each side is `<$V [0,∞]>`.
+    ($T:ident, $V:ty, non_negative) => {
+        impl_rect_shorthand!(@with $T, $V, |i: &mut $crate::css_parser::Parser| {
+            $crate::css_values::number::parse_non_negative(i, <$V>::parse)
+        });
+    };
+    (@with $T:ident, $V:ty, $parse:expr) => {
         impl $T {
             pub fn parse(input: &mut $crate::css_parser::Parser) -> $crate::Result<Self> {
-                let r = $crate::css_values::rect::Rect::<$V>::parse(input)?;
+                let r = $crate::css_values::rect::Rect::<$V>::parse_with(input, $parse)?;
                 Ok(Self {
                     top: r.top,
                     right: r.right,
@@ -62,7 +71,7 @@ macro_rules! define_rect_shorthand {
         right: $right_id:ident,
         bottom: $bottom_id:ident,
         left: $left_id:ident
-        $(, fallbacks)?
+        $(, $range:ident)?
     ) => {
         $(#[$meta])*
         #[derive(Clone, PartialEq)]
@@ -74,15 +83,27 @@ macro_rules! define_rect_shorthand {
         }
 
         // parse/to_css via `Rect<V>`.
-        impl_rect_shorthand!($name, $inner);
+        impl_rect_shorthand!($name, $inner $(, $range)?);
     };
 }
 
 macro_rules! impl_size_shorthand {
     ($T:ident, $V:ty, $start:ident, $end:ident) => {
+        impl_size_shorthand!(@with $T, $V, $start, $end, <$V>::parse);
+    };
+    // Both sides are `<$V [0,∞]>`.
+    ($T:ident, $V:ty, $start:ident, $end:ident, non_negative) => {
+        impl_size_shorthand!(
+            @with $T, $V, $start, $end,
+            |i: &mut $crate::css_parser::Parser| {
+                $crate::css_values::number::parse_non_negative(i, <$V>::parse)
+            }
+        );
+    };
+    (@with $T:ident, $V:ty, $start:ident, $end:ident, $parse:expr) => {
         impl $T {
             pub fn parse(input: &mut $crate::css_parser::Parser) -> $crate::Result<Self> {
-                let s = $crate::css_values::size::Size2D::<$V>::parse(input)?;
+                let s = $crate::css_values::size::Size2D::<$V>::parse_with(input, $parse)?;
                 Ok(Self {
                     $start: s.a,
                     $end: s.b,

--- a/src/css/properties/prefix_handler.rs
+++ b/src/css/properties/prefix_handler.rs
@@ -129,8 +129,7 @@ impl FallbackHandler {
                 return false;
             };
 
-            // Browsers drop a value they cannot parse, so it cannot stand in for the
-            // declaration before it. A later parsed value still replaces it.
+            // Appended, not replaced: the declaration before it is its fallback.
             context.add_unparsed_fallbacks(arena, &mut unparsed);
             *index = Some(dest.len());
             dest.push(Property::Unparsed(unparsed));

--- a/src/css/properties/prefix_handler.rs
+++ b/src/css/properties/prefix_handler.rs
@@ -129,13 +129,11 @@ impl FallbackHandler {
                 return false;
             };
 
+            // Browsers drop a value they cannot parse, so it cannot stand in for the
+            // declaration before it. A later parsed value still replaces it.
             context.add_unparsed_fallbacks(arena, &mut unparsed);
-            if let Some(i) = *index {
-                dest[i] = Property::Unparsed(unparsed);
-            } else {
-                *index = Some(dest.len());
-                dest.push(Property::Unparsed(unparsed));
-            }
+            *index = Some(dest.len());
+            dest.push(Property::Unparsed(unparsed));
 
             return true;
         }

--- a/src/css/properties/properties_generated.rs
+++ b/src/css/properties/properties_generated.rs
@@ -9,6 +9,8 @@
 use crate as css;
 use crate::SmallList;
 use crate::VendorPrefix;
+use crate::css_values::number::{NonNegative, parse_non_negative};
+use crate::css_values::size::Size2D;
 use crate::prefixes::Feature as PrefixFeature;
 use crate::targets::Targets;
 
@@ -1892,6 +1894,26 @@ fn parse_value<T: css::generic::ParseWithOptions>(
     input.expect_exhausted().is_ok().then_some(value)
 }
 
+/// [parse_value] for a value type whose range in this property is `[0,∞]`.
+fn parse_non_negative_value<T>(input: &mut css::Parser, options: &css::ParserOptions) -> Option<T>
+where
+    NonNegative<T>: css::generic::ParseWithOptions,
+{
+    parse_value::<NonNegative<T>>(input, options).map(|v| v.0)
+}
+
+/// `<length-percentage [0,∞]>{1,2}`, a corner radius.
+fn parse_radius(
+    input: &mut css::Parser,
+    _options: &css::ParserOptions,
+) -> Option<Size2D<css::css_values::length::LengthPercentage>> {
+    let value = Size2D::parse_with(input, |i| {
+        parse_non_negative(i, css::css_values::length::LengthPercentage::parse)
+    })
+    .ok()?;
+    input.expect_exhausted().is_ok().then_some(value)
+}
+
 impl Property {
     /// Returns the [`PropertyId`] for this declaration.
     pub(crate) fn property_id(&self) -> PropertyId {
@@ -2833,66 +2855,42 @@ impl Property {
                 }
             }
             PropertyId::BorderTopLeftRadius(pre) => {
-                if let Some(c) = parse_value::<
-                    css::css_values::size::Size2D<css::css_values::length::LengthPercentage>,
-                >(input, options)
-                {
+                if let Some(c) = parse_radius(input, options) {
                     return Ok(Property::BorderTopLeftRadius((c, pre)));
                 }
             }
             PropertyId::BorderTopRightRadius(pre) => {
-                if let Some(c) = parse_value::<
-                    css::css_values::size::Size2D<css::css_values::length::LengthPercentage>,
-                >(input, options)
-                {
+                if let Some(c) = parse_radius(input, options) {
                     return Ok(Property::BorderTopRightRadius((c, pre)));
                 }
             }
             PropertyId::BorderBottomLeftRadius(pre) => {
-                if let Some(c) = parse_value::<
-                    css::css_values::size::Size2D<css::css_values::length::LengthPercentage>,
-                >(input, options)
-                {
+                if let Some(c) = parse_radius(input, options) {
                     return Ok(Property::BorderBottomLeftRadius((c, pre)));
                 }
             }
             PropertyId::BorderBottomRightRadius(pre) => {
-                if let Some(c) = parse_value::<
-                    css::css_values::size::Size2D<css::css_values::length::LengthPercentage>,
-                >(input, options)
-                {
+                if let Some(c) = parse_radius(input, options) {
                     return Ok(Property::BorderBottomRightRadius((c, pre)));
                 }
             }
             PropertyId::BorderStartStartRadius => {
-                if let Some(c) = parse_value::<
-                    css::css_values::size::Size2D<css::css_values::length::LengthPercentage>,
-                >(input, options)
-                {
+                if let Some(c) = parse_radius(input, options) {
                     return Ok(Property::BorderStartStartRadius(c));
                 }
             }
             PropertyId::BorderStartEndRadius => {
-                if let Some(c) = parse_value::<
-                    css::css_values::size::Size2D<css::css_values::length::LengthPercentage>,
-                >(input, options)
-                {
+                if let Some(c) = parse_radius(input, options) {
                     return Ok(Property::BorderStartEndRadius(c));
                 }
             }
             PropertyId::BorderEndStartRadius => {
-                if let Some(c) = parse_value::<
-                    css::css_values::size::Size2D<css::css_values::length::LengthPercentage>,
-                >(input, options)
-                {
+                if let Some(c) = parse_radius(input, options) {
                     return Ok(Property::BorderEndStartRadius(c));
                 }
             }
             PropertyId::BorderEndEndRadius => {
-                if let Some(c) = parse_value::<
-                    css::css_values::size::Size2D<css::css_values::length::LengthPercentage>,
-                >(input, options)
-                {
+                if let Some(c) = parse_radius(input, options) {
                     return Ok(Property::BorderEndEndRadius(c));
                 }
             }
@@ -3073,18 +3071,23 @@ impl Property {
                 }
             }
             PropertyId::FlexGrow(pre) => {
-                if let Some(c) = parse_value::<css::css_values::number::CSSNumber>(input, options) {
+                if let Some(c) =
+                    parse_non_negative_value::<css::css_values::number::CSSNumber>(input, options)
+                {
                     return Ok(Property::FlexGrow((c, pre)));
                 }
             }
             PropertyId::FlexShrink(pre) => {
-                if let Some(c) = parse_value::<css::css_values::number::CSSNumber>(input, options) {
+                if let Some(c) =
+                    parse_non_negative_value::<css::css_values::number::CSSNumber>(input, options)
+                {
                     return Ok(Property::FlexShrink((c, pre)));
                 }
             }
             PropertyId::FlexBasis(pre) => {
-                if let Some(c) =
-                    parse_value::<css::css_values::length::LengthPercentageOrAuto>(input, options)
+                if let Some(c) = parse_non_negative_value::<
+                    css::css_values::length::LengthPercentageOrAuto,
+                >(input, options)
                 {
                     return Ok(Property::FlexBasis((c, pre)));
                 }
@@ -3317,57 +3320,65 @@ impl Property {
                 }
             }
             PropertyId::PaddingTop => {
-                if let Some(c) =
-                    parse_value::<css::css_values::length::LengthPercentageOrAuto>(input, options)
+                if let Some(c) = parse_non_negative_value::<
+                    css::css_values::length::LengthPercentageOrAuto,
+                >(input, options)
                 {
                     return Ok(Property::PaddingTop(c));
                 }
             }
             PropertyId::PaddingBottom => {
-                if let Some(c) =
-                    parse_value::<css::css_values::length::LengthPercentageOrAuto>(input, options)
+                if let Some(c) = parse_non_negative_value::<
+                    css::css_values::length::LengthPercentageOrAuto,
+                >(input, options)
                 {
                     return Ok(Property::PaddingBottom(c));
                 }
             }
             PropertyId::PaddingLeft => {
-                if let Some(c) =
-                    parse_value::<css::css_values::length::LengthPercentageOrAuto>(input, options)
+                if let Some(c) = parse_non_negative_value::<
+                    css::css_values::length::LengthPercentageOrAuto,
+                >(input, options)
                 {
                     return Ok(Property::PaddingLeft(c));
                 }
             }
             PropertyId::PaddingRight => {
-                if let Some(c) =
-                    parse_value::<css::css_values::length::LengthPercentageOrAuto>(input, options)
+                if let Some(c) = parse_non_negative_value::<
+                    css::css_values::length::LengthPercentageOrAuto,
+                >(input, options)
                 {
                     return Ok(Property::PaddingRight(c));
                 }
             }
             PropertyId::PaddingBlockStart => {
-                if let Some(c) =
-                    parse_value::<css::css_values::length::LengthPercentageOrAuto>(input, options)
+                if let Some(c) = parse_non_negative_value::<
+                    css::css_values::length::LengthPercentageOrAuto,
+                >(input, options)
                 {
                     return Ok(Property::PaddingBlockStart(c));
                 }
             }
             PropertyId::PaddingBlockEnd => {
-                if let Some(c) =
-                    parse_value::<css::css_values::length::LengthPercentageOrAuto>(input, options)
+                if let Some(c) = parse_non_negative_value::<
+                    css::css_values::length::LengthPercentageOrAuto,
+                >(input, options)
                 {
                     return Ok(Property::PaddingBlockEnd(c));
                 }
             }
             PropertyId::PaddingInlineStart => {
-                if let Some(c) =
-                    parse_value::<css::css_values::length::LengthPercentageOrAuto>(input, options)
+                if let Some(c) = parse_non_negative_value::<
+                    css::css_values::length::LengthPercentageOrAuto,
+                >(input, options)
                 {
                     return Ok(Property::PaddingInlineStart(c));
                 }
             }
             PropertyId::PaddingInlineEnd => {
-                if let Some(c) =
-                    parse_value::<css::css_values::length::LengthPercentageOrAuto>(input, options)
+                if let Some(c) = parse_non_negative_value::<
+                    css::css_values::length::LengthPercentageOrAuto,
+                >(input, options)
                 {
                     return Ok(Property::PaddingInlineEnd(c));
                 }
@@ -3576,9 +3587,10 @@ impl Property {
                 }
             }
             PropertyId::TransitionDuration(pre) => {
-                if let Some(c) =
-                    parse_value::<SmallList<css::css_values::time::Time, 1>>(input, options)
-                {
+                if let Some(c) = parse_value::<SmallList<NonNegative<css::css_values::time::Time>, 1>>(
+                    input, options,
+                ) {
+                    let c = c.into_iter().map(|time| time.0).collect();
                     return Ok(Property::TransitionDuration((c, pre)));
                 }
             }

--- a/src/css/properties/size.rs
+++ b/src/css/properties/size.rs
@@ -10,6 +10,7 @@ use crate::properties::{Property, PropertyId, PropertyIdTag};
 use css::logical::PropertyCategory;
 
 use css::css_values::length::LengthPercentage;
+use css::css_values::number::parse_non_negative;
 use css::css_values::ratio::Ratio;
 
 use css::DeclarationList;
@@ -110,7 +111,7 @@ impl Size {
             return Ok(Size::FitContentFunction(v));
         }
 
-        let lp = input.try_parse(LengthPercentage::parse)?;
+        let lp = input.try_parse(parse_length)?;
         Ok(Size::LengthPercentage(lp))
     }
 
@@ -244,7 +245,7 @@ impl MaxSize {
             return Ok(MaxSize::FitContentFunction(v));
         }
 
-        match input.try_parse(LengthPercentage::parse) {
+        match input.try_parse(parse_length) {
             Ok(v) => Ok(MaxSize::LengthPercentage(v)),
             Err(e) => Err(e),
         }
@@ -379,9 +380,14 @@ impl AspectRatio {
     }
 }
 
+/// `<length-percentage [0,∞]>`
+fn parse_length(input: &mut css::Parser) -> css::Result<LengthPercentage> {
+    parse_non_negative(input, LengthPercentage::parse)
+}
+
 fn parse_fit_content(input: &mut css::Parser) -> css::Result<LengthPercentage> {
     input.expect_function_matching(b"fit-content")?;
-    input.parse_nested_block(LengthPercentage::parse)
+    input.parse_nested_block(parse_length)
 }
 
 bitflags::bitflags! {

--- a/src/css/properties/size.rs
+++ b/src/css/properties/size.rs
@@ -469,6 +469,7 @@ macro_rules! property_helper {
 
 macro_rules! logical_unparsed_helper {
     ($this:expr, $unparsed:expr, $physical_id:expr, $physical_flag:expr, $logical_supported:expr, $dest:expr, $context:expr) => {{
+        $this.flush($dest, $context);
         let bump = $dest.bump();
         if $logical_supported {
             $this.flushed_properties.insert(
@@ -697,6 +698,7 @@ impl SizeHandler {
                 | PropertyIdTag::MaxWidth
                 | PropertyIdTag::MinHeight
                 | PropertyIdTag::MaxHeight => {
+                    self.flush(dest, context);
                     self.flushed_properties.insert(
                         SizeProperty::try_from_property_id_tag(unparsed.property_id.tag()).unwrap(),
                     );

--- a/src/css/properties/text.rs
+++ b/src/css/properties/text.rs
@@ -32,8 +32,7 @@ impl TextShadow {
                 let value = input.try_parse(|i: &mut css::Parser| -> css::Result<Lengths> {
                     let horizontal = Length::parse(i)?;
                     let vertical = Length::parse(i)?;
-                    // A third length is the blur radius (`<length [0,∞]>`). A negative
-                    // literal there makes the shadow invalid rather than being the spread.
+                    // A negative third length is an invalid blur radius, not the spread.
                     if peek_number_literal(i).is_some_and(|v| v < 0.0) {
                         return Err(i.new_custom_error(css::ParserError::invalid_value));
                     }

--- a/src/css/properties/text.rs
+++ b/src/css/properties/text.rs
@@ -4,6 +4,7 @@ use crate::PrintErr;
 use crate::Printer;
 use crate::css_values::color::CssColor;
 use crate::css_values::length::LengthValue as Length;
+use crate::css_values::number::peek_number_literal;
 
 /// A value for the [text-shadow](https://www.w3.org/TR/2020/WD-css-text-decor-4-20200506/#text-shadow-property) property.
 #[derive(Clone, PartialEq)]
@@ -31,6 +32,11 @@ impl TextShadow {
                 let value = input.try_parse(|i: &mut css::Parser| -> css::Result<Lengths> {
                     let horizontal = Length::parse(i)?;
                     let vertical = Length::parse(i)?;
+                    // A third length is the blur radius (`<length [0,∞]>`). A negative
+                    // literal there makes the shadow invalid rather than being the spread.
+                    if peek_number_literal(i).is_some_and(|v| v < 0.0) {
+                        return Err(i.new_custom_error(css::ParserError::invalid_value));
+                    }
                     let blur = i.try_parse(Length::parse).ok().unwrap_or_else(Length::zero);
                     let spread = i.try_parse(Length::parse).ok().unwrap_or_else(Length::zero);
                     Ok((horizontal, vertical, blur, spread))

--- a/src/css/properties/transition.rs
+++ b/src/css/properties/transition.rs
@@ -13,7 +13,9 @@ use crate::css_properties::PropertyId;
 use crate::css_properties::masking;
 use crate::css_values::easing::EasingFunction;
 use crate::css_values::ident::CustomIdent;
+use crate::css_values::number::{ClampNegative as _, peek_number_literal};
 use crate::css_values::time::Time;
+use crate::error::ParserError;
 
 use crate::VendorPrefix;
 use crate::compat;
@@ -52,8 +54,14 @@ impl Transition {
 
         loop {
             if duration.is_none() {
+                // The first <time> is the duration (`<time [0,∞]>`). A negative literal
+                // there makes the transition invalid rather than being the delay.
+                let negative = peek_number_literal(parser).is_some_and(|v| v < 0.0);
                 if let Ok(value) = parser.try_parse(Time::parse) {
-                    duration = Some(value);
+                    if negative {
+                        return Err(parser.new_custom_error(ParserError::invalid_value));
+                    }
+                    duration = Some(value.clamp_negative());
                     continue;
                 }
             }

--- a/src/css/properties/transition.rs
+++ b/src/css/properties/transition.rs
@@ -54,8 +54,7 @@ impl Transition {
 
         loop {
             if duration.is_none() {
-                // The first <time> is the duration (`<time [0,∞]>`). A negative literal
-                // there makes the transition invalid rather than being the delay.
+                // The first <time> is the duration; a negative literal is not the delay.
                 let negative = peek_number_literal(parser).is_some_and(|v| v < 0.0);
                 if let Ok(value) = parser.try_parse(Time::parse) {
                     if negative {

--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -114,8 +114,7 @@ pub enum Calc<V> {
 }
 
 impl<V> Calc<V> {
-    /// Whether this resolves to a `<number>` rather than a `V` (sum operands and
-    /// `min()`/`max()`/`hypot()` arguments share one type, so the first decides).
+    /// Whether this resolves to a `<number>`, not a `V`; the first operand or argument decides.
     pub(crate) fn resolves_to_number(&self) -> bool {
         match self {
             Calc::Value(_) => false,

--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -114,11 +114,8 @@ pub enum Calc<V> {
 }
 
 impl<V> Calc<V> {
-    /// Whether this expression resolves to a `<number>` rather than to a `V`, which
-    /// makes it invalid where a dimension or a percentage is required: there is no
-    /// unit-less zero inside a math function. The operands of a sum and the
-    /// arguments of `min()`, `max()` and `hypot()` have one type, so the first one
-    /// decides.
+    /// Whether this resolves to a `<number>` rather than a `V` (sum operands and
+    /// `min()`/`max()`/`hypot()` arguments share one type, so the first decides).
     pub(crate) fn resolves_to_number(&self) -> bool {
         match self {
             Calc::Value(_) => false,

--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -113,6 +113,34 @@ pub enum Calc<V> {
     Function(Box<MathFunction<V>>),
 }
 
+impl<V> Calc<V> {
+    /// Whether this expression resolves to a `<number>` rather than to a `V`, which
+    /// makes it invalid where a dimension or a percentage is required: there is no
+    /// unit-less zero inside a math function. The operands of a sum and the
+    /// arguments of `min()`, `max()` and `hypot()` have one type, so the first one
+    /// decides.
+    pub(crate) fn resolves_to_number(&self) -> bool {
+        match self {
+            Calc::Value(_) => false,
+            Calc::Number(_) => true,
+            Calc::Sum { left, .. } => left.resolves_to_number(),
+            Calc::Product { expression, .. } => expression.resolves_to_number(),
+            Calc::Function(f) => match &**f {
+                MathFunction::Sign(_) => true,
+                MathFunction::Calc(c)
+                | MathFunction::Abs(c)
+                | MathFunction::Clamp { min: c, .. }
+                | MathFunction::Round { value: c, .. }
+                | MathFunction::Rem { dividend: c, .. }
+                | MathFunction::Mod { dividend: c, .. } => c.resolves_to_number(),
+                MathFunction::Min(args) | MathFunction::Max(args) | MathFunction::Hypot(args) => {
+                    args.first().is_some_and(|c| c.resolves_to_number())
+                }
+            },
+        }
+    }
+}
+
 // ───────────────────────────── CalcValue trait ─────────────────────────────
 // Every type that can appear inside `Calc<V>` implements this.
 //

--- a/src/css/values/length.rs
+++ b/src/css/values/length.rs
@@ -4,7 +4,7 @@ use crate::css_parser::{CssResult, Maybe, Parser, PrintErr, Printer, Token};
 use crate::targets::Browsers;
 use crate::values::angle::Angle;
 use crate::values::calc::{Calc, MathFunction};
-use crate::values::number::CSSNumber;
+use crate::values::number::{CSSNumber, ClampNegative};
 use crate::values::percentage::DimensionPercentage;
 use crate::values::protocol;
 
@@ -55,6 +55,34 @@ impl LengthPercentageOrAuto {
         match self {
             Self::Length(l) => l.is_compatible(browsers),
             _ => true,
+        }
+    }
+}
+
+impl ClampNegative for LengthPercentageOrAuto {
+    fn clamp_negative(self) -> Self {
+        match self {
+            Self::Auto => Self::Auto,
+            Self::Length(l) => Self::Length(l.clamp_negative()),
+        }
+    }
+}
+
+impl ClampNegative for LengthValue {
+    fn clamp_negative(self) -> Self {
+        if self.value() < 0.0 {
+            self.map_value(|_| 0.0)
+        } else {
+            self
+        }
+    }
+}
+
+impl ClampNegative for Length {
+    fn clamp_negative(self) -> Self {
+        match self {
+            Self::Value(v) => Self::Value(v.clamp_negative()),
+            Self::Calc(c) => Self::Calc(c),
         }
     }
 }
@@ -274,7 +302,8 @@ impl LengthValue {
                     return Ok(v);
                 }
             }
-            Token::Number(num) => return Ok(Self::Px(num.value)),
+            // Outside quirks mode only `0` may be written without a unit.
+            Token::Number(num) if num.value == 0.0 => return Ok(Self::Px(num.value)),
             _ => {}
         }
         Err(location.new_unexpected_token_error(token))
@@ -414,12 +443,14 @@ impl Length {
     }
 
     pub(crate) fn parse(input: &mut Parser) -> CssResult<Length> {
-        if let Ok(calc_value) = input.try_parse(Calc::<Length>::parse) {
+        match input.try_parse(Calc::<Length>::parse) {
             // PERF: I don't like this redundant allocation
-            if let Calc::Value(v) = calc_value {
-                return Ok(*v);
+            Ok(Calc::Value(v)) => return Ok(*v),
+            Ok(calc) if calc.resolves_to_number() => {
+                return Err(input.new_custom_error(css::ParserError::invalid_value));
             }
-            return Ok(Self::Calc(Box::new(calc_value)));
+            Ok(calc) => return Ok(Self::Calc(Box::new(calc))),
+            Err(_) => {}
         }
 
         let len = LengthValue::parse(input)?;

--- a/src/css/values/number.rs
+++ b/src/css/values/number.rs
@@ -6,8 +6,7 @@ use crate::values::calc::Calc;
 
 pub type CSSNumber = f32;
 
-/// The value of the next token if it is a `<number>`, `<percentage>` or
-/// `<dimension>` literal, without consuming it.
+/// The next token's value if it is a number, percentage or dimension; not consumed.
 pub(crate) fn peek_number_literal(input: &mut Parser) -> Option<CSSNumber> {
     let start = input.state();
     let value = match input.next() {
@@ -20,16 +19,10 @@ pub(crate) fn peek_number_literal(input: &mut Parser) -> Option<CSSNumber> {
     value
 }
 
-/// A numeric value whose property grammar carries a `[0,∞]` range
-/// (`<length-percentage [0,∞]>`, `<number [0,∞]>`, `<time [0,∞]>`, ...).
-///
-/// Range restrictions apply to literals only: a negative literal makes the
-/// declaration invalid, while a math function is never range-checked at parse
-/// time and its result is clamped to the range instead
-/// (https://drafts.csswg.org/css-values-4/#calc-range).
+/// A value parsed with a `[0,∞]` range: a negative literal is invalid, a math
+/// result clamps to 0 (https://drafts.csswg.org/css-values-4/#calc-range).
 pub(crate) trait ClampNegative: Sized {
-    /// Clamps a fully resolved negative value to zero. Unresolved math is left
-    /// for the browser to clamp.
+    /// Clamps a resolved negative value to zero; unresolved math is left alone.
     fn clamp_negative(self) -> Self;
 }
 
@@ -50,8 +43,7 @@ pub(crate) fn parse_non_negative<T: ClampNegative>(
     parse(input).map(T::clamp_negative)
 }
 
-/// Parse-only wrapper that applies [parse_non_negative] to `T`, for use inside
-/// generic containers (`SmallList`, `parse_value`).
+/// Applies [parse_non_negative] to `T` inside generic containers (`SmallList`).
 pub struct NonNegative<T>(pub T);
 
 impl<T: Parse + ClampNegative> Parse for NonNegative<T> {

--- a/src/css/values/number.rs
+++ b/src/css/values/number.rs
@@ -19,8 +19,7 @@ pub(crate) fn peek_number_literal(input: &mut Parser) -> Option<CSSNumber> {
     value
 }
 
-/// A value parsed with a `[0,∞]` range: a negative literal is invalid, a math
-/// result clamps to 0 (https://drafts.csswg.org/css-values-4/#calc-range).
+/// A `[0,∞]` range: a negative literal is invalid, a math result clamps (css-values-4 #calc-range).
 pub(crate) trait ClampNegative: Sized {
     /// Clamps a resolved negative value to zero; unresolved math is left alone.
     fn clamp_negative(self) -> Self;

--- a/src/css/values/number.rs
+++ b/src/css/values/number.rs
@@ -1,9 +1,69 @@
 use crate::css_parser as css;
-use crate::css_parser::{CssResult, Parser, ParserError, PrintErr, Printer};
+use crate::css_parser::{CssResult, Parser, ParserError, ParserOptions, PrintErr, Printer, Token};
+use crate::generics::{Parse, ParseWithOptions};
 use crate::values::angle::Angle;
 use crate::values::calc::Calc;
 
 pub type CSSNumber = f32;
+
+/// The value of the next token if it is a `<number>`, `<percentage>` or
+/// `<dimension>` literal, without consuming it.
+pub(crate) fn peek_number_literal(input: &mut Parser) -> Option<CSSNumber> {
+    let start = input.state();
+    let value = match input.next() {
+        Ok(Token::Number(num)) => Some(num.value),
+        Ok(Token::Dimension(dim)) => Some(dim.num.value),
+        Ok(Token::Percentage { unit_value, .. }) => Some(*unit_value),
+        _ => None,
+    };
+    input.reset(&start);
+    value
+}
+
+/// A numeric value whose property grammar carries a `[0,∞]` range
+/// (`<length-percentage [0,∞]>`, `<number [0,∞]>`, `<time [0,∞]>`, ...).
+///
+/// Range restrictions apply to literals only: a negative literal makes the
+/// declaration invalid, while a math function is never range-checked at parse
+/// time and its result is clamped to the range instead
+/// (https://drafts.csswg.org/css-values-4/#calc-range).
+pub(crate) trait ClampNegative: Sized {
+    /// Clamps a fully resolved negative value to zero. Unresolved math is left
+    /// for the browser to clamp.
+    fn clamp_negative(self) -> Self;
+}
+
+impl ClampNegative for CSSNumber {
+    fn clamp_negative(self) -> Self {
+        if self < 0.0 { 0.0 } else { self }
+    }
+}
+
+/// Parses a value with a `[0,∞]` range. See [ClampNegative].
+pub(crate) fn parse_non_negative<T: ClampNegative>(
+    input: &mut Parser,
+    parse: impl FnOnce(&mut Parser) -> CssResult<T>,
+) -> CssResult<T> {
+    if peek_number_literal(input).is_some_and(|v| v < 0.0) {
+        return Err(input.new_custom_error(ParserError::invalid_value));
+    }
+    parse(input).map(T::clamp_negative)
+}
+
+/// Parse-only wrapper that applies [parse_non_negative] to `T`, for use inside
+/// generic containers (`SmallList`, `parse_value`).
+pub struct NonNegative<T>(pub T);
+
+impl<T: Parse + ClampNegative> Parse for NonNegative<T> {
+    fn parse(input: &mut Parser) -> CssResult<Self> {
+        parse_non_negative(input, T::parse).map(NonNegative)
+    }
+}
+impl<T: Parse + ClampNegative> ParseWithOptions for NonNegative<T> {
+    fn parse_with_options(input: &mut Parser, _options: &ParserOptions) -> CssResult<Self> {
+        <Self as Parse>::parse(input)
+    }
+}
 
 pub struct CSSNumberFns;
 

--- a/src/css/values/percentage.rs
+++ b/src/css/values/percentage.rs
@@ -3,13 +3,31 @@ use crate::css_parser::{CssResult, ParserError, PrintErr, Printer, Token};
 use crate::targets::Browsers;
 use crate::values::angle::Angle;
 use crate::values::calc::Calc;
-use crate::values::number::CSSNumber;
+use crate::values::number::{CSSNumber, ClampNegative};
 use crate::values::protocol;
 use core::cmp::Ordering;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Percentage {
     pub(crate) v: CSSNumber,
+}
+
+impl ClampNegative for Percentage {
+    fn clamp_negative(self) -> Self {
+        Percentage {
+            v: self.v.clamp_negative(),
+        }
+    }
+}
+
+impl<D: ClampNegative> ClampNegative for DimensionPercentage<D> {
+    fn clamp_negative(self) -> Self {
+        match self {
+            Self::Dimension(d) => Self::Dimension(d.clamp_negative()),
+            Self::Percentage(p) => Self::Percentage(p.clamp_negative()),
+            Self::Calc(c) => Self::Calc(c),
+        }
+    }
 }
 
 impl Percentage {
@@ -160,11 +178,13 @@ impl<D> DimensionPercentage<D> {
         Self: crate::values::calc::CalcValue,
         D: protocol::Parse,
     {
-        if let Ok(calc_value) = input.try_parse(Calc::<Self>::parse) {
-            if let Calc::Value(v) = calc_value {
-                return Ok(*v);
+        match input.try_parse(Calc::<Self>::parse) {
+            Ok(Calc::Value(v)) => return Ok(*v),
+            Ok(calc) if calc.resolves_to_number() => {
+                return Err(input.new_custom_error(ParserError::invalid_value));
             }
-            return Ok(Self::Calc(Box::new(calc_value)));
+            Ok(calc) => return Ok(Self::Calc(Box::new(calc))),
+            Err(_) => {}
         }
 
         if let Ok(length) = input.try_parse(D::parse) {

--- a/src/css/values/size.rs
+++ b/src/css/values/size.rs
@@ -17,23 +17,19 @@ impl<T> Size2D<T>
 where
     T: Clone + PartialEq,
 {
-    fn parse_val(input: &mut Parser) -> Result<T>
-    where
-        T: Parse,
-    {
-        // f32 → CSSNumberFns::parse, LengthPercentage → LengthPercentage::parse,
-        // else → T::parse — all unified under the `Parse` trait in Rust.
-        T::parse(input)
-    }
-
     pub(crate) fn parse(input: &mut Parser) -> Result<Size2D<T>>
     where
         T: Parse,
     {
-        let first = Self::parse_val(input)?;
-        let second = input
-            .try_parse(Self::parse_val)
-            .unwrap_or_else(|_| first.clone());
+        Self::parse_with(input, T::parse)
+    }
+
+    pub(crate) fn parse_with(
+        input: &mut Parser,
+        parse_fn: impl Fn(&mut Parser) -> Result<T>,
+    ) -> Result<Size2D<T>> {
+        let first = parse_fn(input)?;
+        let second = input.try_parse(&parse_fn).unwrap_or_else(|_| first.clone());
         Ok(Size2D {
             a: first,
             b: second,

--- a/src/css/values/time.rs
+++ b/src/css/values/time.rs
@@ -1,7 +1,7 @@
 use crate::css_parser as css;
 use crate::css_parser::{CssResult as Result, Maybe, PrintErr, Printer, Token};
 use crate::values::calc::Calc;
-use crate::values::number::{CSSNumber, CSSNumberFns};
+use crate::values::number::{CSSNumber, CSSNumberFns, ClampNegative};
 
 /// A CSS [`<time>`](https://www.w3.org/TR/css-values-4/#time) value, in either
 /// seconds or milliseconds.
@@ -23,6 +23,15 @@ pub enum Time {
     Seconds(CSSNumber) = 1,
     /// A time in milliseconds.
     Milliseconds(CSSNumber) = 2,
+}
+
+impl ClampNegative for Time {
+    fn clamp_negative(self) -> Self {
+        match self {
+            Time::Seconds(v) => Time::Seconds(v.clamp_negative()),
+            Time::Milliseconds(v) => Time::Milliseconds(v.clamp_negative()),
+        }
+    }
 }
 
 impl Time {

--- a/src/css_derive/lib.rs
+++ b/src/css_derive/lib.rs
@@ -798,8 +798,7 @@ enum VariantShape<'a> {
         ident: &'a syn::Ident,
         keyword: String,
     },
-    /// `Foo(Payload)` — single unnamed field. `#[css(non_negative)]` parses the
-    /// payload with `values::number::parse_non_negative` (a `[0,∞]` range).
+    /// `Foo(Payload)` — single unnamed field; `#[css(non_negative)]` adds a `[0,∞]` range.
     Payload {
         ident: &'a syn::Ident,
         ty: &'a syn::Type,

--- a/src/css_derive/lib.rs
+++ b/src/css_derive/lib.rs
@@ -798,10 +798,12 @@ enum VariantShape<'a> {
         ident: &'a syn::Ident,
         keyword: String,
     },
-    /// `Foo(Payload)` — single unnamed field
+    /// `Foo(Payload)` — single unnamed field. `#[css(non_negative)]` parses the
+    /// payload with `values::number::parse_non_negative` (a `[0,∞]` range).
     Payload {
         ident: &'a syn::Ident,
         ty: &'a syn::Type,
+        non_negative: bool,
     },
     /// `Foo { f1, f2, … }` — inline struct payload; the printer is the field
     /// sequence (see [`gen_field_seq_to_css`]).
@@ -822,6 +824,7 @@ fn classify<'a>(data: &'a syn::DataEnum) -> syn::Result<Vec<VariantShape<'a>>> {
             Fields::Unnamed(fs) if fs.unnamed.len() == 1 => out.push(VariantShape::Payload {
                 ident: &v.ident,
                 ty: &fs.unnamed.first().unwrap().ty,
+                non_negative: has_css_flag(&v.attrs, "non_negative"),
             }),
             Fields::Named(fs) => out.push(VariantShape::NamedFields {
                 ident: &v.ident,
@@ -1043,12 +1046,16 @@ fn expand_derive_parse(input: &DeriveInput) -> syn::Result<TokenStream2> {
     // tried in declaration-block order: split into the two contiguous groups
     // and emit whichever is declared first, first.
     let mut units: Vec<(&syn::Ident, String)> = Vec::new();
-    let mut payloads: Vec<(&syn::Ident, &syn::Type)> = Vec::new();
+    let mut payloads: Vec<(&syn::Ident, &syn::Type, bool)> = Vec::new();
     let units_first = matches!(shapes.first(), Some(VariantShape::Unit { .. }));
     for s in &shapes {
         match s {
             VariantShape::Unit { ident, keyword } => units.push((ident, keyword.clone())),
-            VariantShape::Payload { ident, ty } => payloads.push((ident, ty)),
+            VariantShape::Payload {
+                ident,
+                ty,
+                non_negative,
+            } => payloads.push((ident, ty, *non_negative)),
             VariantShape::NamedFields { ident, .. } => {
                 // The derive only dispatches on void variants and payload
                 // types that themselves expose `parse`; inline named-field
@@ -1101,21 +1108,31 @@ fn expand_derive_parse(input: &DeriveInput) -> syn::Result<TokenStream2> {
             return quote! {};
         }
         let last = payloads.len() - 1;
-        let stmts = payloads.iter().enumerate().map(|(i, (ident, ty))| {
-            if terminal && i == last {
-                quote! {
-                    return <#ty>::parse(__input).map(#name::#ident);
-                }
-            } else {
-                quote! {
-                    if let ::core::result::Result::Ok(__v) =
-                        __input.try_parse(<#ty>::parse)
-                    {
-                        return ::core::result::Result::Ok(#name::#ident(__v));
+        let stmts = payloads
+            .iter()
+            .enumerate()
+            .map(|(i, (ident, ty, non_negative))| {
+                let parser = if *non_negative {
+                    quote! {
+                        |__p: &mut ::bun_css::css_parser::Parser<'_>| {
+                            ::bun_css::css_values::number::parse_non_negative(__p, <#ty>::parse)
+                        }
+                    }
+                } else {
+                    quote! { <#ty>::parse }
+                };
+                if terminal && i == last {
+                    quote! {
+                        return (#parser)(__input).map(#name::#ident);
+                    }
+                } else {
+                    quote! {
+                        if let ::core::result::Result::Ok(__v) = __input.try_parse(#parser) {
+                            return ::core::result::Result::Ok(#name::#ident(__v));
+                        }
                     }
                 }
-            }
-        });
+            });
         quote! { #(#stmts)* }
     };
 

--- a/test/js/bun/css/angle-serialization-hang.test.ts
+++ b/test/js/bun/css/angle-serialization-hang.test.ts
@@ -21,7 +21,7 @@ const cases: [css: string, expected: string][] = [
   ["a { ro: 1.3157e308rad }", "a{ro:3.40282e38rad}"],
   [
     "a { rotate: 0.0000000000000000000000000000000000000\t00000000000000000000000000000000000200000000000000000000000000000001rad }",
-    "a{rotate:0 2e+32rad}",
+    "a{rotate:0.0 2e+32rad}",
   ],
   // Other paths that serialize an Angle: transform functions and filters.
   ["a { transform: rotate(3.3e33rad) }", "a{transform:rotate(3.3e+33rad)}"],

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -262,6 +262,23 @@ describe("css tests", () => {
       `,
       { safari: 8 << 16 },
     );
+    // The logical corner radii overwrote the buffered value instead.
+    minify_test(
+      `a { border-start-start-radius: 1px; border-start-start-radius: var(--r) }`,
+      `a{border-start-start-radius:1px;border-start-start-radius:var(--r)}`,
+    );
+    minify_test(
+      `a { border-end-end-radius: 1px; border-end-end-radius: banana }`,
+      `a{border-end-end-radius:1px;border-end-end-radius:banana}`,
+    );
+    minify_test(
+      `a { border-start-end-radius: var(--r); border-start-end-radius: 1px }`,
+      `a{border-start-end-radius:1px}`,
+    );
+    minify_test(
+      `a { border-top-left-radius: 1px; border-top-left-radius: var(--r) }`,
+      `a{border-top-left-radius:1px;border-top-left-radius:var(--r)}`,
+    );
   });
   describe("border_spacing", () => {
     minify_test(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -171,7 +171,7 @@ describe("css tests", () => {
   width: calc(infinity * -1px);
   height: infinity;
 }`,
-      indoc`.rounded-full{height:infinity;border-radius:3.40282e38px;width:-3.40282e38px}`,
+      indoc`.rounded-full{width:-3.40282e38px;height:infinity;border-radius:3.40282e38px}`,
     );
 
     // NaN is valid inside calc() (CSS Values 4 "Infinities, NaN, and Signed Zero").
@@ -231,6 +231,37 @@ describe("css tests", () => {
       `a{width:calc(6 - 400% - 2 - 4 - 8vh + 3ic)}`,
     ); // ideally -400% - 8vh + 3ic
     minify_test(`a { top: calc(100% - 1 * 2 - 8 * 2); }`, `a{top:calc(100% - 2 - 16)}`); // ideally 100% - 18
+  });
+  describe("a value that does not parse keeps the declaration before it", () => {
+    // Browsers drop a declaration they cannot parse, so the one before it applies. The
+    // minifier must neither let such a value replace the earlier one nor move it ahead of it.
+    minify_test(`a { color: red; color: banana }`, `a{color:red;color:banana}`);
+    minify_test(`a { color: red; color: rgb(1 2) }`, `a{color:red;color:rgb(1 2)}`);
+    minify_test(`a { color: red; color: var(--c) }`, `a{color:red;color:var(--c)}`);
+    minify_test(`a { color: banana; color: red }`, `a{color:red}`);
+    minify_test(`a { color: red; color: banana; color: blue }`, `a{color:red;color:#00f}`);
+    minify_test(
+      `a { text-shadow: 0 0 1px red; text-shadow: 0 0 banana }`,
+      `a{text-shadow:0 0 1px red;text-shadow:0 0 banana}`,
+    );
+    // lightningcss#547: these were emitted after the unparsed value, in the wrong order.
+    minify_test(`a { width: 100px; width: var(--w) }`, `a{width:100px;width:var(--w)}`);
+    minify_test(`a { height: 100vh; height: 100dvb; height: var(--h) }`, `a{height:100dvb;height:var(--h)}`);
+    minify_test(`a { width: 100px; width: anchor-size(width) }`, `a{width:100px;width:anchor-size(width)}`);
+    minify_test(`a { max-height: 1px; max-height: banana }`, `a{max-height:1px;max-height:banana}`);
+    minify_test(`a { inline-size: 1px; inline-size: var(--w) }`, `a{inline-size:1px;inline-size:var(--w)}`);
+    minify_test(`a { min-width: 1px; height: 2px; width: env(foo) }`, `a{min-width:1px;height:2px;width:env(foo)}`);
+    minify_test(`a { width: var(--w); width: 100px }`, `a{width:var(--w);width:100px}`);
+    prefix_test(
+      `a { inline-size: 1px; inline-size: var(--w) }`,
+      indoc`
+        a {
+          width: 1px;
+          width: var(--w);
+        }
+      `,
+      { safari: 8 << 16 },
+    );
   });
   describe("border_spacing", () => {
     minify_test(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -310,7 +310,10 @@ describe("css tests", () => {
       minify_test(`a { padding: 1px; padding: 0 -1px }`, `a{padding:1px;padding:0 -1px}`);
       minify_test(`a { border-radius: 1px; border-radius: 1px / -1px }`, `a{border-radius:1px;border-radius:1px/-1px}`);
       minify_test(`a { width: 1px; width: fit-content(-1px) }`, `a{width:1px;width:fit-content(-1px)}`);
-      minify_test(`a { border: 1px solid red; border: -1px solid red }`, `a{border:1px solid red;border:-1px solid red}`);
+      minify_test(
+        `a { border: 1px solid red; border: -1px solid red }`,
+        `a{border:1px solid red;border:-1px solid red}`,
+      );
       minify_test(`a { flex-grow: 1; flex-grow: -1 }`, `a{flex-grow:1;flex-grow:-1}`);
       minify_test(`a { flex-shrink: 1; flex-shrink: -1 }`, `a{flex-shrink:1;flex-shrink:-1}`);
       minify_test(`a { flex: 2; flex: -1 }`, `a{flex:2;flex:-1}`);
@@ -347,7 +350,10 @@ describe("css tests", () => {
       // Negative values are in range here.
       minify_test(`a { margin: 1px; margin: -1px }`, `a{margin:-1px}`);
       minify_test(`a { inset: 1px; inset: -1px }`, `a{inset:-1px}`);
-      minify_test(`a { box-shadow: 0 0 1px red; box-shadow: -1px -1px 0 -1px red }`, `a{box-shadow:-1px -1px 0 -1px red}`);
+      minify_test(
+        `a { box-shadow: 0 0 1px red; box-shadow: -1px -1px 0 -1px red }`,
+        `a{box-shadow:-1px -1px 0 -1px red}`,
+      );
       minify_test(`a { transition-delay: 1s; transition-delay: -1s }`, `a{transition-delay:-1s}`);
       minify_test(`a { transition: all 1s; transition: all 1s -1s }`, `a{transition:all 1s -1s}`);
       minify_test(`a { width: 1px; width: -0px }`, `a{width:0}`);

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -171,7 +171,7 @@ describe("css tests", () => {
   width: calc(infinity * -1px);
   height: infinity;
 }`,
-      indoc`.rounded-full{width:-3.40282e38px;height:infinity;border-radius:3.40282e38px}`,
+      indoc`.rounded-full{width:0;height:infinity;border-radius:3.40282e38px}`,
     );
 
     // NaN is valid inside calc() (CSS Values 4 "Infinities, NaN, and Signed Zero").
@@ -207,7 +207,7 @@ describe("css tests", () => {
     // compared with the center after the maximum has replaced it.
     minify_test(`a { width: clamp(20px, 15px, 10px) }`, `a{width:20px}`);
     minify_test(`a { width: clamp(30px, 100px, 20px) }`, `a{width:30px}`);
-    minify_test(`a { width: clamp(-10px, 100px, -30px) }`, `a{width:-10px}`);
+    minify_test(`a { left: clamp(-10px, 100px, -30px) }`, `a{left:-10px}`);
     // A lower bound that cannot be compared at parse time is kept, whether or not the center
     // was above the maximum.
     minify_test(`a { width: clamp(10vw, 5px, 20px) }`, `a{width:max(10vw,5px)}`);
@@ -228,8 +228,8 @@ describe("css tests", () => {
     minify_test(`a { width: calc(100% - 2 - 1 + 5vh - 10vh) }`, `a{width:calc(100% - 2 - 1 - 5vh)}`); // ideally 100% - 3 + 5vh
     minify_test(
       `a { width: calc(10 - 4 - 100% - 2 - 4 - 300% - 8vh + 3ic) }`,
-      `a{width:calc(6 - 400% - 2 - 4 - 8vh + 3ic)}`,
-    ); // ideally -400% - 8vh + 3ic
+      `a{width:calc(10 - 4 - 100% - 2 - 4 - 300% - 8vh + 3ic)}`,
+    );
     minify_test(`a { top: calc(100% - 1 * 2 - 8 * 2); }`, `a{top:calc(100% - 2 - 16)}`); // ideally 100% - 18
   });
   describe("a value that does not parse keeps the declaration before it", () => {
@@ -279,6 +279,131 @@ describe("css tests", () => {
       `a { border-top-left-radius: 1px; border-top-left-radius: var(--r) }`,
       `a{border-top-left-radius:1px;border-top-left-radius:var(--r)}`,
     );
+  });
+  describe("invalid values are not merged or repaired", () => {
+    // Browsers drop a declaration whose value is out of the property's range or of the wrong
+    // type, so the declaration before it applies. The minifier must neither let such a value
+    // replace the earlier one nor print it in a form that browsers accept.
+    describe("negative literals where the range is [0,∞]", () => {
+      for (const property of [
+        "width",
+        "min-height",
+        "max-width",
+        "block-size",
+        "padding-left",
+        "padding-inline-start",
+        "padding",
+        "padding-block",
+        "border-top-width",
+        "border-width",
+        "border-radius",
+        "border-top-left-radius",
+        "gap",
+        "row-gap",
+        "font-size",
+        "flex-basis",
+        "background-size",
+      ]) {
+        minify_test(`a { ${property}: 1px; ${property}: -1px }`, `a{${property}:1px;${property}:-1px}`);
+        minify_test(`a { ${property}: 1px; ${property}: -1% }`, `a{${property}:1px;${property}:-1%}`);
+      }
+      minify_test(`a { padding: 1px; padding: 0 -1px }`, `a{padding:1px;padding:0 -1px}`);
+      minify_test(`a { border-radius: 1px; border-radius: 1px / -1px }`, `a{border-radius:1px;border-radius:1px/-1px}`);
+      minify_test(`a { width: 1px; width: fit-content(-1px) }`, `a{width:1px;width:fit-content(-1px)}`);
+      minify_test(`a { border: 1px solid red; border: -1px solid red }`, `a{border:1px solid red;border:-1px solid red}`);
+      minify_test(`a { flex-grow: 1; flex-grow: -1 }`, `a{flex-grow:1;flex-grow:-1}`);
+      minify_test(`a { flex-shrink: 1; flex-shrink: -1 }`, `a{flex-shrink:1;flex-shrink:-1}`);
+      minify_test(`a { flex: 2; flex: -1 }`, `a{flex:2;flex:-1}`);
+      minify_test(`a { flex: 2; flex: 1 -1 }`, `a{flex:2;flex:1 -1}`);
+      minify_test(`a { flex: 2; flex: 1 1 -1px }`, `a{flex:2;flex:1 1 -1px}`);
+      minify_test(`a { font-weight: bold; font-weight: 1001 }`, `a{font-weight:700;font-weight:1001}`);
+      minify_test(`a { font-weight: bold; font-weight: 0 }`, `a{font-weight:700;font-weight:0}`);
+      minify_test(`a { font-weight: bold; font-weight: 0.5 }`, `a{font-weight:700;font-weight:.5}`);
+      minify_test(`a { font-weight: bold; font-weight: 1000 }`, `a{font-weight:1000}`);
+      minify_test(`a { font-weight: bold; font-weight: 1 }`, `a{font-weight:1}`);
+      minify_test(`a { font: bold 12px serif; font: 1001 12px serif }`, `a{font:700 12px serif;font:1001 12px serif}`);
+      minify_test(`a { font: 12px serif; font: -1px serif }`, `a{font:12px serif;font:-1px serif}`);
+      minify_test(`a { font-stretch: 50%; font-stretch: -1% }`, `a{font-stretch:50%;font-stretch:-1%}`);
+      minify_test(`a { line-height: 2; line-height: -1 }`, `a{line-height:2;line-height:-1}`);
+      minify_test(`a { line-height: 2; line-height: -1px }`, `a{line-height:2;line-height:-1px}`);
+      minify_test(
+        `a { box-shadow: 0 0 1px red; box-shadow: 0 0 -1px red }`,
+        `a{box-shadow:0 0 1px red;box-shadow:0 0 -1px red}`,
+      );
+      minify_test(
+        `a { text-shadow: 0 0 1px red; text-shadow: 0 0 -1px red }`,
+        `a{text-shadow:0 0 1px red;text-shadow:0 0 -1px red}`,
+      );
+      minify_test(
+        `a { transition-duration: 1s; transition-duration: -1s }`,
+        `a{transition-duration:1s;transition-duration:-1s}`,
+      );
+      minify_test(
+        `a { transition-duration: 1s; transition-duration: 1s, -1ms }`,
+        `a{transition-duration:1s;transition-duration:1s,-1ms}`,
+      );
+      minify_test(`a { transition: all 1s; transition: all -1s }`, `a{transition:all 1s;transition:all -1s}`);
+      minify_test(`a { transition: all 1s; transition: all -1s 2s }`, `a{transition:all 1s;transition:all -1s 2s}`);
+      // Negative values are in range here.
+      minify_test(`a { margin: 1px; margin: -1px }`, `a{margin:-1px}`);
+      minify_test(`a { inset: 1px; inset: -1px }`, `a{inset:-1px}`);
+      minify_test(`a { box-shadow: 0 0 1px red; box-shadow: -1px -1px 0 -1px red }`, `a{box-shadow:-1px -1px 0 -1px red}`);
+      minify_test(`a { transition-delay: 1s; transition-delay: -1s }`, `a{transition-delay:-1s}`);
+      minify_test(`a { transition: all 1s; transition: all 1s -1s }`, `a{transition:all 1s -1s}`);
+      minify_test(`a { width: 1px; width: -0px }`, `a{width:0}`);
+    });
+
+    describe("a math function is not range-checked, its value is clamped", () => {
+      minify_test(`a { width: 1px; width: calc(10px - 20px) }`, `a{width:0}`);
+      minify_test(`a { padding: 8px; padding: calc(8px - 12px) }`, `a{padding:0}`);
+      minify_test(`a { padding: 8px; padding: 1px calc(10% - 20%) }`, `a{padding:1px 0%}`);
+      minify_test(`a { border-width: calc(1px - 2px) }`, `a{border-width:0}`);
+      minify_test(`a { font-size: max(-2px, -1em) }`, `a{font-size:max(-2px,-1em)}`);
+      minify_test(`a { flex-grow: calc(1 - 2) }`, `a{flex-grow:0}`);
+      minify_test(`a { line-height: calc(1 - 2) }`, `a{line-height:0}`);
+      minify_test(`a { font-weight: calc(200 * 10) }`, `a{font-weight:1000}`);
+      minify_test(`a { font-weight: calc(200 - 300) }`, `a{font-weight:1}`);
+      minify_test(`a { transition-duration: calc(1s - 2s) }`, `a{transition-duration:0s}`);
+      minify_test(`a { box-shadow: 0 0 calc(1px - 2px) red }`, `a{box-shadow:0 0 red}`);
+      minify_test(`a { margin: calc(10px - 20px) }`, `a{margin:-10px}`);
+    });
+
+    describe("a number is not a length", () => {
+      minify_test(`a { width: 100px; width: calc(0) }`, `a{width:100px;width:calc(0)}`);
+      minify_test(`a { width: 100px; width: calc(2 * 5) }`, `a{width:100px;width:calc(2*5)}`);
+      minify_test(`a { width: 100px; width: min(0, 1) }`, `a{width:100px;width:min(0,1)}`);
+      minify_test(`a { margin: 1px; margin: calc(0) }`, `a{margin:1px;margin:calc(0)}`);
+      minify_test(`a { border-width: 1px; border-width: calc(1) }`, `a{border-width:1px;border-width:calc(1)}`);
+      minify_test(`a { width: 100px; width: 10 }`, `a{width:100px;width:10}`);
+      minify_test(`a { margin: 4px; margin-top: 10 }`, `a{margin:4px;margin-top:10}`);
+      minify_test(`a { top: 1px; top: 10 }`, `a{top:1px;top:10}`);
+      minify_test(`a { font-size: 12px; font-size: 10 }`, `a{font-size:12px;font-size:10}`);
+      minify_test(`a { border-width: 1px; border-width: 2 }`, `a{border-width:1px;border-width:2}`);
+      minify_test(
+        `a { transform: rotate(10deg); transform: translate(10) }`,
+        `a{transform:rotate(10deg);transform:translate(10)}`,
+      );
+      minify_test(`a { translate: 1px; translate: 10 20 }`, `a{translate:1px;translate:10 20}`);
+      // A length media feature compared with a number never matches. It is kept as written.
+      minify_test(`@media (min-width: 600) { a { color: red } }`, `@media (width>=600){a{color:red}}`);
+      minify_test(`@media (400 <= width <= 600px) { a { color: red } }`, `@media (400<=width<=600px){a{color:red}}`);
+      // Numbers and unit-less zero lengths still parse.
+      minify_test(`@media (min-width: 0) { a { color: red } }`, `@media (width>=0){a{color:red}}`);
+      minify_test(`a { width: 100px; width: calc(2 * 5px) }`, `a{width:10px}`);
+      minify_test(`a { width: 100px; width: 0 }`, `a{width:0}`);
+      minify_test(`a { line-height: 1; line-height: calc(2) }`, `a{line-height:2}`);
+      minify_test(`a { flex: 2; flex: 1 1 0 }`, `a{flex:1 1 0}`);
+      minify_test(`a { transform: rotate(10deg); transform: translate(0) }`, `a{transform:translate(0)}`);
+    });
+
+    describe("a number with an exponent or a fraction is not an integer", () => {
+      minify_test(`a { order: 1; order: 1e1 }`, `a{order:1;order:10.0}`);
+      minify_test(`a { order: 3; order: 2.0 }`, `a{order:3;order:2.0}`);
+      minify_test(`a { z-index: 1; z-index: 1e1 }`, `a{z-index:1;z-index:10.0}`);
+      minify_test(`a { --x: 2.0 }`, `a{--x:2.0}`);
+      minify_test(`a { order: 3; order: 2 }`, `a{order:2}`);
+      minify_test(`a { --x: 2.5 }`, `a{--x:2.5}`);
+    });
   });
   describe("border_spacing", () => {
     minify_test(

--- a/test/regression/issue/21907.test.ts
+++ b/test/regression/issue/21907.test.ts
@@ -85,9 +85,9 @@ test("CSS parser should handle extremely large floating-point values without cra
   expect(normalizeCSSOutput(outputContent)).toMatchInlineSnapshot(`
     "/* [path] */
     .test-rounded-full {
-      border-radius: 3.40282e+38px;
       width: 2147480000px;
       height: -2147480000px;
+      border-radius: 3.40282e+38px;
     }
 
     .test-negative {
@@ -109,8 +109,8 @@ test("CSS parser should handle extremely large floating-point values without cra
     }
 
     .test-boundaries {
-      margin: 2147480000px;
       padding: -2147480000px;
+      margin: 2147480000px;
       left: 4294970000px;
     }
 


### PR DESCRIPTION
Stacked on #42101. This part makes the parser stricter than lightningcss on purpose and needs a maintainer decision (last Background bullet).

### Problem
- Browsers drop a declaration whose numeric value is out of range or of the wrong type, and the one before it applies. The parser accepted such values, so `--minify` let them replace the earlier declaration: `.a{width:100px;width:-5px}` printed `.a{width:-5px}`, likewise `font-weight:1001`, `font-size:-1px`, `flex-grow:-1`.
- It also printed invalid input as valid (`width:calc(0)` as `0`, `translate(10)` as `translate(10px)`, `order:1e1` as `10`) and the valid `padding:calc(8px - 12px)` as the invalid `-4px`.

### Fix
- `parse_non_negative` (`src/css/values/number.rs`) rejects a negative literal and clamps a math result to 0, for every `[0,∞]` property the minifier merges; `font-weight` takes `[1,1000]`. A rejected value stays `Property::Unparsed` and prints as written.
- `Length` rejects math that resolves to a `<number>` and unit-less numbers other than `0`. Token lists print `1e1` as `10.0`. `@media (min-width:600)` is kept as written.
- Verified: `test/js/bun/css/css.test.ts`, block `invalid values are not merged or repaired` (83 of 103 rows fail on 1.4.2), `test/js/bun/css/`, `test/bundler/css/`.

### Background
- Minification keeps the last value of each property, which is sound only if that value is valid.
- A range like `<length [0,∞]>` applies to literals. Math is not range-checked at parse time and clamps at computed-value time (CSS Values 4 §10.12): `width:calc(5px - 10px)` equals `width:0`.
- lightningcss 1.30.2 is as lenient as Bun 1.4.3 here. For these inputs the reference stops being the spec; that is the decision asked for.

<details><summary>Notes</summary>

- Properties covered by the range check: `width`/`height`/`min-*`/`max-*`/`block-size`/`inline-size` (and `fit-content()`), `padding*`, `border-*-width`/`border-width`/`border`/`outline` (through `BorderSideWidth`), `border-*-radius`/`border-radius`, `gap`/`row-gap`/`column-gap`, `font-size`, `font-stretch`, `font-weight`, `line-height`, `font`, `flex-grow`/`flex-shrink`/`flex-basis`/`flex`, `background-size` (and in `background`), `box-shadow`/`text-shadow` blur, `transition-duration` (and in `transition`). `#[css(non_negative)]` on a `#[derive(Parse)]` payload variant applies the same check (`BorderSideWidth`, `GapValue`, `FontSize`).
- In the `box-shadow`, `text-shadow` and `transition` shorthands a negative literal in the blur/duration slot makes the value invalid instead of sliding into the spread/delay slot, as in browsers.
- Behavior changes for input that used to build, all to what browsers do with the source: `@media (min-width: 600)` prints `600` instead of `600px` (the query never matches either way; `(min-width: 10%)` and `(min-width: red)` still fail the build as before). `@property` `initial-value: 10` with `syntax: "<length>"` is rejected, as `initial-value: red` already is. Unparsed and custom-property values keep a trailing `.0` (`--x: 2.0` prints `2.0`, was `2`), because `var()` substitution into an `<integer>` property depends on it; #38482 edits the same `Token::Number` arm for exact large integers and the two changes compose.
- Existing expectations that changed because they pinned invalid output: `width: calc(infinity * -1px)` prints `width:0` instead of `-3.40282e38px` (#18064's crash test); the `clamp(-10px, 100px, -30px)` row now uses `left`; `width: calc(10 - 4 - 100% ...)` (#20128's stack-overflow test) prints as written because a sum that starts with a number is not a length; `21907.test.ts` reorders two rules because their negative `height`/`padding` are now unparsed; one fuzzer row in `angle-serialization-hang.test.ts` prints `0.0` for a `0.000…0` literal.
- Minifying the 15 stylesheets in `test/js/bun/css/files` (bootstrap, bulma, tailwind, ...) with this build changes no file size; bootstrap's `font:0/0 a` is now parsed as a `font` shorthand instead of taking `0` as a weight and failing.
- Not covered, same class: `scroll-padding` (no handler merges it), legacy `-webkit-box-flex`/`-ms-flex-positive`, `calc()` sums that put a number after a length (`calc(1px + 2)`), `padding: auto`, `perspective()` and radial-gradient radii, `steps()`/`cubic-bezier()` ranges.
- Self-reviewed: the review asked to land the ordering fix separately (#42101) and to flag this part as a deliberate divergence; done.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 26 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 101 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/angle-serialization-hang.test.ts test/js/bun/css/css.test.ts "test/regression/issue/21907.test.ts"
bun test v1.4.3 (f42e98025)

test/regression/issue/21907.test.ts:
80 |       .trim();
81 |   }
82 | 
83 |   // Test the actual output with inline snapshot - this ensures all intFromFloat
84 |   // conversions work correctly and captures any changes in output format
85 |   expect(normalizeCSSOutput(outputContent)).toMatchInlineSnapshot(`
                                                 ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "/* [path] */
  .test-rounded-full {
+   border-radius: 3.40282e+38px;
    width: 2147480000px;
    height: -2147480000px;
-   border-radius: 3.40282e+38px;
  }
  
  .test-negative {
    border-radius: -3.40282e+38px;
  }
  
  .test-very-large, .test-large-integer {
    border-radius: 3.40282e38px;
  }
  
  .test-colors {
    color: #f0f;
    background: red;
  }
  
  .test-percentages {
    width: 1000000000000000000%;
    height: -1000000000000000000%;
  }
  
  .test-boundaries 
... (truncated)

release without fix: 87 failed, 67 skipped
bun test v1.4.3-canary.1 (4396ff575)

test/regression/issue/21907.test.ts:
80 |       .trim();
81 |   }
82 | 
83 |   // Test the actual output with inline snapshot - this ensures all intFromFloat
84 |   // conversions work correctly and captures any changes in output format
85 |   expect(normalizeCSSOutput(outputContent)).toMatchInlineSnapshot(`
                                                 ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "/* [path] */
  .test-rounded-full {
+   border-radius: 3.40282e+38px;
    width: 2147480000px;
    height: -2147480000px;
-   border-radius: 3.40282e+38px;
  }
  
  .test-negative {
    border-radius: -3.40282e+38px;
  }
  
  .test-very-large, .test-large-integer {
    border-radius: 3.40282e38px;
  }
  
  .test-colors {
    color: #f0f;
    background: red;
  }
  
  .test-percentages {
    width: 1000000000000000000%;
    height: -1000000000000000000%;
  }
  
  .test-boundaries {
-   padding: -2147480000px;
    margin: 2147480000px;
+   padding: -2147480000px;
    left: 4294970000px;
  }
  
  .test-normal {
    width: 10px;
    height: 20.5px;
    margin: 0;
  }"
  

- Expected  - 2
+ Received  + 2

      at <an
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/angle-serialization-hang.test.ts test/js/bun/css/css.test.ts "test/regression/issue/21907.test.ts"
bun test v1.4.3 (f42e98025)

test/regression/issue/21907.test.ts:
(pass) CSS parser should handle extremely large floating-point values without crashing [260.32ms]

test/js/bun/css/angle-serialization-hang.test.ts:
(pass) huge and non-finite radian angle values serialize instead of hanging [1194.17ms]

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [12.82ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.24ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 804ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_css_derive v0.0.0 (/workspace/bun/src/css_derive)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/worksp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/media_query.rs                           |   4 +
 src/css/properties/align.rs                      |   1 +
 src/css/properties/background.rs                 |   6 +-
 src/css/properties/border.rs                     |   1 +
 src/css/properties/border_radius.rs              |  14 +-
 src/css/properties/box_shadow.rs                 |   9 +-
 src/css/properties/custom.rs                     |   7 +-
 src/css/properties/flex.rs                       |  11 +-
 src/css/properties/font.rs                       |  19 ++-
 src/css/properties/margin_padding.rs             |  14 +-
 src/css/properties/mod.rs                        |  29 +++-
 src/css/properties/prefix_handler.rs             |   9 +-
 src/css/properties/properties_generated.rs       | 122 ++++++++-------
 src/css/properties/size.rs                       |  14 +-
 src/css/properties/text.rs                       |   5 +
 src/css/properties/transition.rs                 |   9 +-
 src/css/values/calc.rs                           |  24 +++
 src/css/values/length.rs                         |  43 +++++-
 src/css/values/number.rs                         |  53 ++++++-
 src/css/values/percentage.rs                     |  30 +++-
 src/css/values/size.rs                           |  20 +--
 src/css/values/time.rs                           |  11 +-
 src/css_derive/lib.rs                            |  48 ++++--
 test/js/bun/css/angle-serialization-hang.test.ts |   2 +-
 test/js/bun/css/css.test.ts                      | 187 ++++++++++++++++++++++-
 test/regression/issue/21907.test.ts              |   4 +-
 26 files changed, 558 insertions(+), 138 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/css/media_query.rs                          3      1     39
src/css/properties/align.rs                     1      1     39
src/css/properties/background.rs                0      0     39
src/css/properties/border.rs                    1      1     39
src/css/properties/border_radius.rs             1      1     40
src/css/properties/box_shadow.rs                0      0     39
src/css/properties/custom.rs                    1      1     39
src/css/properties/flex.rs                      1      0     39
src/css/properties/font.rs                      1      5     39
src/css/properties/margin_padding.rs            0      0     39
src/css/properties/mod.rs                       1      2     39
src/css/properties/prefix_handler.rs            1      1     40
src/css/properties/properties_generated.rs      0      0     39
src/css/properties/size.rs                      5      4     39
src/css/properties/text.rs                      0      0     39
src/css/properties/transition.rs                0      0     39
(+ 10 more files)
```

</details>

<!-- robobun:evidence:end -->