### PR TITLE
bundler: start an HTML page's top-level-await scripts without holding back later scripts

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -928,23 +928,11 @@ impl<'a> LinkerContext<'a> {
         // Size the per-file part-liveness bitsets now that `scan_imports_and_exports`
         // has finished pushing wrapper / entry-point parts.
         {
-            let loaders = self.parse_graph().input_files.items_loader();
             let parts_col = self.graph.ast.items_parts();
             let mut parts_live: Vec<bun_collections::AutoBitSet> =
                 Vec::with_capacity(parts_col.len());
-            for (i, parts) in parts_col.iter().enumerate() {
-                let mut bits = bun_collections::AutoBitSet::init_empty(parts.len())?;
-                // `mark_file_live_for_tree_shaking` short-circuits for HTML and never
-                // walks its parts. The HTML loader's `ParseTask` builds one
-                // statement-less part per import record (so the JS-chunk visitor
-                // follows every embedded `<script src>` in document order), and all
-                // of them are live.
-                if loaders.get(i).is_some_and(|l| *l == Loader::Html) {
-                    for part_index in 1..parts.len() {
-                        bits.set(part_index);
-                    }
-                }
-                parts_live.push(bits);
+            for parts in parts_col.iter() {
+                parts_live.push(bun_collections::AutoBitSet::init_empty(parts.len())?);
             }
             self.graph.parts_live = parts_live;
         }
@@ -2315,11 +2303,52 @@ impl<'a> LinkerContext<'a> {
         Ok(true)
     }
 
+    /// In the browser a `<script type="module">` whose evaluation suspends on a
+    /// top-level await does not hold back the page's next `<script>`. Inlined
+    /// into one chunk it would, so once an HTML file has an async script (one
+    /// with a top-level await, or with a dependency that has one) followed by
+    /// another script, the page starts its async scripts the way the dev
+    /// server's module loader does: each one gets an `__esm` wrapper
+    /// (`scan_imports_and_exports`), `init_foo()` starts it at its tag without
+    /// an `await` (`append_html_script_wrapper_calls`), and the chunk settles
+    /// them together at its end (`generate_entry_point_tail_js`). Returns how
+    /// many async scripts such a page has, `None` for every other file.
+    pub(crate) fn html_started_async_scripts(
+        records: &[ImportRecord],
+        loaders: &[Loader],
+        flags: &[crate::js_meta::Flags],
+    ) -> Option<usize> {
+        let mut async_scripts: usize = 0;
+        let mut script_after_async = false;
+        for record in records {
+            if record.kind != ImportKind::Stmt || !record.source_index.is_valid() {
+                continue;
+            }
+            let other = record.source_index.get() as usize;
+            if loaders[other].is_css() {
+                continue;
+            }
+            if async_scripts > 0 {
+                script_after_async = true;
+            }
+            if flags[other].is_async_or_has_async_dependency {
+                async_scripts += 1;
+            }
+        }
+        if script_after_async {
+            Some(async_scripts)
+        } else {
+            None
+        }
+    }
+
     /// The HTML loader gives each `<script src>` its own statement-less part
     /// that holds only the import record. A script that resolved to a wrapped
     /// module runs nothing until its wrapper is called, so print that call where
     /// the tag was, like `should_remove_import_export_stmt` does for a bare
-    /// `import "./script"`: `require_foo()`, `init_foo()`, or `await init_foo()`.
+    /// `import "./script"`: `require_foo()`, `init_foo()`, or `await init_foo()`
+    /// (`init_foo()` alone when the page starts its async scripts without
+    /// waiting, see `html_started_async_scripts`).
     /// Nothing observes the namespace, so the result is not passed to `__toESM`.
     pub(crate) fn append_html_script_wrapper_calls(
         &self,
@@ -2327,6 +2356,12 @@ impl<'a> LinkerContext<'a> {
         part: &Part,
         ast: &JSAst<'_>,
     ) -> Result<(), AllocError> {
+        let awaits_in_place = Self::html_started_async_scripts(
+            ast.import_records.as_slice(),
+            self.parse_graph().input_files.items_loader(),
+            self.graph.meta.items_flags(),
+        )
+        .is_none();
         for &import_record_index in part.import_record_indices.slice() {
             let record = &ast.import_records[import_record_index as usize];
             if record.kind != ImportKind::Stmt
@@ -2358,7 +2393,10 @@ impl<'a> LinkerContext<'a> {
                 },
                 Loc::EMPTY,
             );
-            if other_flags.wrap == WrapKind::Esm && other_flags.is_async_or_has_async_dependency {
+            if other_flags.wrap == WrapKind::Esm
+                && other_flags.is_async_or_has_async_dependency
+                && awaits_in_place
+            {
                 call = Expr::init(E::Await { value: call }, Loc::EMPTY);
             }
             stmts
@@ -3153,9 +3191,12 @@ impl<'a> LinkerContext<'a> {
             return;
         }
 
-        // HTML files can reference non-JS/CSS assets (favicons, images, etc.)
-        // via .url kind import records. Follow all import records for HTML files
-        // so these assets are marked live and included in the manifest.
+        // Everything an HTML file references is live: every script runs, and
+        // non-JS/CSS assets (favicons, images, etc.) referenced via .url kind
+        // import records must be included in the manifest. Its parts (one per
+        // import record, see the HTML loader's `ParseTask`) are all live too, and
+        // go through the worklist so that the runtime helpers they depend on
+        // (`scan_imports_and_exports` step 6) are included.
         if self.parse_graph().input_files.items_loader()[source_index as usize] == Loader::Html {
             for record in ctx.import_records[source_index as usize].iter() {
                 if record.source_index.is_valid() {
@@ -3163,6 +3204,15 @@ impl<'a> LinkerContext<'a> {
                     if !self.graph.files_live.is_set(other as usize) {
                         ctx.worklist.push(TreeShakeWork::File(other));
                     }
+                }
+            }
+            let parts_len = ctx.parts[source_index as usize].len();
+            for part_index in (bun_ast::NAMESPACE_EXPORT_PART_INDEX as usize + 1)..parts_len {
+                if !ctx.parts_live[source_index as usize].is_set(part_index) {
+                    ctx.worklist.push(TreeShakeWork::Part {
+                        part_index: u32::try_from(part_index).expect("int cast"),
+                        source_index,
+                    });
                 }
             }
             return;

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1235,9 +1235,8 @@ pub mod parse_worker {
                 // The linker prints a part after the files it imports, so a
                 // `<script src>` that resolves to a wrapped module gets its
                 // `require_foo()` / `init_foo()` call at the tag's position
-                // (see `append_html_script_wrapper_calls`). Liveness for these
-                // parts is seeded in `tree_shaking_and_code_splitting` (the
-                // per-part bitset does not exist at parse time).
+                // (see `append_html_script_wrapper_calls`).
+                // `mark_file_live_for_tree_shaking` marks every one of them live.
                 ast.parts.truncate(1);
                 ast.parts.reserve(import_records_len);
                 for import_record_index in 0..u32::try_from(import_records_len).expect("int cast") {

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -821,6 +821,73 @@ pub(crate) fn post_process_js_chunk(
     Ok(())
 }
 
+/// See `LinkerContext::html_started_async_scripts`. Appends the statement that
+/// awaits every async script the HTML page started at its tag.
+fn html_settle_started_scripts(
+    c: &LinkerContext,
+    import_records: &[ImportRecord],
+    stmts: &mut Vec<Stmt>,
+) {
+    let loaders = c.parse_graph().input_files.items_loader();
+    let meta_flags = c.graph.meta.items_flags();
+    if LinkerContext::html_started_async_scripts(import_records, loaders, meta_flags).is_none() {
+        return;
+    }
+    let wrapper_refs = c.graph.ast.items_wrapper_ref();
+    let mut calls: Vec<Expr> = Vec::new();
+    for record in import_records {
+        if record.kind != bun_ast::ImportKind::Stmt || !record.source_index.is_valid() {
+            continue;
+        }
+        let other = record.source_index.get() as usize;
+        let other_flags = meta_flags[other];
+        let wrapper_ref = wrapper_refs[other];
+        if other_flags.wrap != crate::WrapKind::Esm
+            || !other_flags.is_async_or_has_async_dependency
+            || !c.graph.files_live.is_set(other)
+            || wrapper_ref.is_empty()
+        {
+            continue;
+        }
+        calls.push(Expr::init(
+            E::Call {
+                target: Expr::init_identifier(wrapper_ref, bun_ast::Loc::EMPTY),
+                ..Default::default()
+            },
+            bun_ast::Loc::EMPTY,
+        ));
+    }
+    let settled = match calls.as_slice() {
+        [] => return,
+        [only] => *only,
+        _ => {
+            let mut args = bun_ast::ExprNodeList::init_capacity(1);
+            args.append_assume_capacity(Expr::init(
+                E::Array {
+                    items: bun_ast::ExprNodeList::from_slice(&calls),
+                    ..Default::default()
+                },
+                bun_ast::Loc::EMPTY,
+            ));
+            Expr::init(
+                E::Call {
+                    target: Expr::init_identifier(c.promise_all_runtime_ref, bun_ast::Loc::EMPTY),
+                    args,
+                    ..Default::default()
+                },
+                bun_ast::Loc::EMPTY,
+            )
+        }
+    };
+    stmts.push(Stmt::alloc(
+        S::SExpr {
+            value: Expr::init(E::Await { value: settled }, bun_ast::Loc::EMPTY),
+            ..Default::default()
+        },
+        bun_ast::Loc::EMPTY,
+    ));
+}
+
 // `js_printer::print` ties bump/Options/import_records/renamer to a
 // single `'a`, and `Renamer<'r, 'src>` is invariant in `'src` — so the caller's
 // renamer lifetime fixes `'a`. All by-ref params that flow into `print` must
@@ -912,6 +979,17 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                                 bun_ast::Loc::EMPTY,
                             ));
                         }
+                    }
+
+                    // An HTML page that started its async scripts at their tags without
+                    // awaiting them (`html_started_async_scripts`) settles them here, so
+                    // that the chunk finishes evaluating after every script has and a
+                    // rejected one fails the chunk once:
+                    // "await init_foo();" / "await __promiseAll([init_foo(), init_bar()]);"
+                    if c.parse_graph().input_files.items_loader()[source_index as usize]
+                        == options::Loader::Html
+                    {
+                        html_settle_started_scripts(c, &ast.import_records, &mut stmts);
                     }
 
                     let sorted_and_filtered_export_aliases =

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -208,6 +208,17 @@ pub(crate) fn scan_imports_and_exports(
                 }
             }
 
+            // See `html_started_async_scripts`: such a page's async scripts run
+            // inside `__esm` wrappers so that each one starts at its tag without
+            // holding back the scripts after it.
+            let html_starts_async_scripts = col_ref!(loaders)[id] == Loader::Html
+                && LinkerContext::html_started_async_scripts(
+                    col_ref!(import_records_list)[id].as_slice(),
+                    col_ref!(loaders),
+                    col_ref!(flags),
+                )
+                .is_some();
+
             for (import_record_index, record) in col_ref!(import_records_list)[id]
                 .as_slice()
                 .iter()
@@ -224,6 +235,14 @@ pub(crate) fn scan_imports_and_exports(
                     continue;
                 }
                 let other_kind = col_ref!(exports_kind)[other_file];
+
+                if html_starts_async_scripts
+                    && record.kind == ImportKind::Stmt
+                    && other_kind == ExportsKind::Esm
+                    && col_ref!(flags)[other_file].is_async_or_has_async_dependency
+                {
+                    col!(flags)[other_file].wrap = WrapKind::Esm;
+                }
 
                 // Union, per importee, of the export names its importers can
                 // observe: named static imports contribute their aliases, a
@@ -1054,6 +1073,24 @@ pub(crate) fn scan_imports_and_exports(
                         source_index,
                         Index::part(entry_point_part_index),
                         b"__toCommonJS",
+                        1,
+                    )?;
+                }
+
+                // An HTML page that started several async scripts settles them with
+                // one "await __promiseAll([...])" (`generate_entry_point_tail_js`).
+                if is_html
+                    && LinkerContext::html_started_async_scripts(
+                        col_ref!(import_records_list)[id].as_slice(),
+                        col_ref!(loaders),
+                        col_ref!(flags),
+                    )
+                    .is_some_and(|started| started >= 2)
+                {
+                    this.graph.generate_runtime_symbol_import_and_use(
+                        source_index,
+                        Index::part(entry_point_part_index),
+                        b"__promiseAll",
                         1,
                     )?;
                 }

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -346,8 +346,10 @@ console.log("requires " + dep);`,
   });
 
   // Same, when the script resolved to a lazily-initialized ES module (here
-  // because another script also `import()`s it): the page calls `init_foo()`,
-  // with `await` when the module uses top-level await.
+  // because another script also `import()`s it): the page calls `init_foo()`.
+  // `tla.js` suspends on a top-level await and `main.js` comes after it, so the
+  // page starts both at their tags and awaits them at the end of the chunk:
+  // `main` runs while `tla` is suspended, as with separate module scripts.
   itBundled("html/script-src-lazy-esm", {
     outdir: "out/",
     files: {
@@ -375,10 +377,142 @@ console.log("lazy " + sync + " " + tla);`,
     entryPoints: ["/index.html"],
     onAfterBundle(api) {
       const js = api.readFile("out/index.html").match(/src="\.\/([^"]+\.js)"/)![1];
-      api.expectFile("out/" + js).toMatch(/init_sync\(\);\s*await init_tla\(\);/);
+      api.expectFile("out/" + js).toMatch(/init_sync\(\);\s*init_tla\(\);\s*init_main\(\);/);
+      api.expectFile("out/" + js).toMatch(/await __promiseAll\(\[\s*init_tla\(\),\s*init_main\(\)\s*\]\);\s*$/);
       api.writeFile("out/run.mjs", `import "./${js}";`);
     },
-    run: { file: "out/run.mjs", stdout: "sync\ntla\nmain\nlazy sync tla" },
+    run: { file: "out/run.mjs", stdout: "sync\nmain\ntla\nlazy sync tla" },
+  });
+
+  // In the browser a module script that suspends on a top-level await does not
+  // hold back the page's next script. Once a page has such a script with
+  // another script after it, every async script runs in an `__esm` wrapper
+  // that the page starts at the tag and awaits at the end of the chunk, so the
+  // chunk still settles after all of them.
+  for (const minify of [false, true]) {
+    itBundled("html/script-src-top-level-await-does-not-block-later-scripts" + (minify ? "-minify" : ""), {
+      outdir: "out/",
+      minifySyntax: minify,
+      minifyIdentifiers: minify,
+      minifyWhitespace: minify,
+      files: {
+        "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="module" src="./app.js"></script>
+  </head>
+  <body>
+    <main id="m">catalogue</main>
+    <script src="./legacy-badge.js"></script>
+    <script type="module" src="./widget.js"></script>
+  </body>
+</html>`,
+        "/app.js": `
+import { currencies } from "./currencies.js";
+console.log("app: start");
+const cfg = await new Promise(resolve => setTimeout(() => resolve({ currency: currencies[0] }), 0));
+console.log("app: loaded " + cfg.currency);`,
+        "/currencies.js": `export const currencies = ["EUR"];`,
+        "/legacy-badge.js": `
+(function (root, factory) {
+  if (typeof module === "object" && module.exports) module.exports = factory();
+  else root.Badge = factory();
+})(globalThis, function () {
+  console.log("legacy badge");
+  return {};
+});`,
+        "/widget.js": `
+console.log("widget: start");
+await 0;
+console.log("widget: ready");`,
+      },
+      entryPoints: ["/index.html"],
+      onAfterBundle(api) {
+        const js = api.readFile("out/index.html").match(/src="\.\/([^"]+\.js)"/)![1];
+        api.writeFile("out/run.mjs", `await import("./${js}");\nconsole.log("chunk settled");`);
+      },
+      run: {
+        file: "out/run.mjs",
+        stdout: "app: start\nlegacy badge\nwidget: start\nwidget: ready\napp: loaded EUR\nchunk settled",
+      },
+    });
+  }
+
+  // A rejected top-level await fails the chunk once, at the end, after every
+  // other script has started. It is not left behind as an unhandled rejection.
+  itBundled("html/script-src-top-level-await-rejection", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <body>
+    <script type="module" src="./a.js"></script>
+    <script src="./b.js"></script>
+    <script type="module" src="./c.js"></script>
+  </body>
+</html>`,
+      "/a.js": `
+console.log("a: start");
+await new Promise((_, reject) => setTimeout(() => reject(new Error("a failed")), 0));
+console.log("a: unreachable");`,
+      "/b.js": `console.log("b");`,
+      "/c.js": `
+console.log("c: start");
+await new Promise(resolve => setTimeout(resolve, 30));
+console.log("c: done");`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const js = api.readFile("out/index.html").match(/src="\.\/([^"]+\.js)"/)![1];
+      api.writeFile(
+        "out/run.mjs",
+        `process.on("unhandledRejection", e => console.log("unhandled: " + e.message));
+try {
+  await import("./${js}");
+  console.log("chunk settled");
+} catch (e) {
+  console.log("chunk failed: " + e.message);
+}`,
+      );
+    },
+    run: { file: "out/run.mjs", stdout: "a: start\nb\nc: start\nchunk failed: a failed\nc: done" },
+  });
+
+  // A page whose only async script is the last one has nothing to hold back:
+  // the top-level await stays inline and no wrapper is paid for.
+  itBundled("html/script-src-top-level-await-last-stays-inline", {
+    outdir: "out/",
+    files: {
+      "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="./styles.css">
+    <script src="./first.js"></script>
+    <script type="module" src="./app.js"></script>
+  </head>
+  <body>
+    <img src="./logo.png">
+  </body>
+</html>`,
+      "/styles.css": `body { color: red; }`,
+      "/logo.png": `not really a png`,
+      "/first.js": `console.log("first");`,
+      "/app.js": `
+console.log("app: start");
+await 0;
+console.log("app: ready");`,
+    },
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      const js = api.readFile("out/index.html").match(/src="\.\/([^"]+\.js)"/)![1];
+      api.expectFile("out/" + js).not.toContain("__esm");
+      api.expectFile("out/" + js).toContain("await 0");
+      api.writeFile("out/run.mjs", `await import("./${js}");\nconsole.log("chunk settled");`);
+    },
+    run: { file: "out/run.mjs", stdout: "first\napp: start\napp: ready\nchunk settled" },
   });
 
   // With code splitting the CommonJS script shared by two pages moves to its


### PR DESCRIPTION
Stacked on #42026 (the base branch). The diff here is only the top-level-await rule.

### Problem
- With `bun build ./index.html` or `Bun.serve({ development: false })`, a `<script type="module" src>` that suspends on a top-level `await` holds back every later script: the page's scripts are inlined into one chunk behind that `await`. A later classic `document.write` snippet then runs after load and erases the page. The browser and the dev server run the next script while the first is suspended.
- #42026 calls a wrapped script at its tag, but `await`s an async one in place, so later scripts still wait.

### Fix
- Once an HTML file has an async script (top-level await, or a dependency with one) with another script after it, every async script of the page gets an `__esm` wrapper.
- The page calls `init_x()` at the tag without `await` and awaits the started scripts at the end of the chunk (`await __promiseAll([...])` for several). The chunk still settles after every script. A rejected script fails it once.
- The HTML file's parts now go through the tree-shaking worklist, so the `__promiseAll` helper is included.
- Verified: `test/bundler/bundler_html.test.ts` (4 new cases fail on the base branch; `script-src-lazy-esm` now expects the browser order), plus the HTML serve, manifest, splitting and dev server suites.

### Background
- The linker hoists modules into one flat chunk. A module it cannot hoist gets a wrapper, `init_x = __esm(() => {...})`, `async` when a top-level await is involved, and import sites `await init_x()`.
- Per the HTML spec a module script's pending evaluation promise does not delay the next `<script>` element. The dev server's loader does the same: start each script, then `Promise.all` them.
- A page whose only async script is the last one keeps the await inline and pays for no wrapper.

<details><summary>Notes</summary>

- This is the top-level-await part of the closed #41999, redone on #42026's per-tag parts as its self-review suggested. #41982 answers the same question with `__scriptAsync(init_x)` plus per-script error boundaries; this PR is the smaller alternative for that direction call and adds no runtime helper beyond the existing `__promiseAll`.
- Why wrap the last async script too: if it stayed inline, the chunk would suspend on its `await` between starting an earlier script and awaiting it at the end, and a rejection in that window would surface as an unhandled rejection first and as the chunk's error second. With every async script wrapped, nothing between the first `init_x()` and the final `await` can suspend.
- Wrapping an async script wraps its dependencies (the existing `import()`-without-splitting machinery), so only pages that put a script after a top-level-await script pay for closures. Single-script pages are untouched.
- With `--splitting`, an async script shared by two pages lives in a shared chunk that exports `init_x` (and `__promiseAll`); each page chunk starts and awaits it. Checked by hand, also minified, along with the standalone HTML suite.
- Self-reviewed (on #41999's version of this rule): 4 concerns raised, 4 addressed here: rebuilt on #42026 instead of a second per-tag representation, one `__promiseAll` settle instead of one `await` per script, the last async script wrapped so no rejection goes unhandled, and the overlap with #41982 stated for the direction call.
- Output for the reported page:
  ```js
  // index.html
  init_app();

  // legacy-badge.js
  document.write('<p id="badge">secure checkout</p>');
  await init_app();
  ```

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_html.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [493.61ms]
(pass) bundler > html/implicit-relative-paths [124.84ms]
(pass) bundler > html/multiple-assets [120.75ms]
(pass) bundler > html/image-hashing [102.10ms]
(pass) bundler > html/external-assets [102.53ms]
(pass) bundler > html/mixed-assets [112.93ms]
(pass) bundler > html/js-imports [131.61ms]
(pass) bundler > html/script-that-is-also-an-entry-point [122.02ms]
(pass) bundler > html/script-src-commonjs [413.25ms]
(pass) bundler > html/script-src-type-commonjs-package [388.79ms]
(pass) bundler > html/script-src-commonjs-between-plain-scripts [475.05ms]
375 | console.log("lazy " + sync + " " + tla);`,
376 |     },
377 |     entryPoints: ["/index.html"],
378 |     onAfterBundle(api) {
379 |       const js = api.readFile("out/index.html").match(/src="\.\/([^"]+\.js)"/)![1];
380 |       api.expectFile("out/" + js).toMatch(/init_sync\(\);\s*init_tla\(\);\s*init_main\(\);/);
                                      
... (truncated)

release without fix: 8 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [13.66ms]
(pass) bundler > html/implicit-relative-paths [3.41ms]
(pass) bundler > html/multiple-assets [3.66ms]
(pass) bundler > html/image-hashing [4.14ms]
(pass) bundler > html/external-assets [2.77ms]
(pass) bundler > html/mixed-assets [3.88ms]
(pass) bundler > html/js-imports [3.28ms]
(pass) bundler > html/script-that-is-also-an-entry-point [3.70ms]
runtime failed file: /tmp/bun-build-tests/bun-VGeOHH/html/script-src-commonjs/out/run.mjs
stdout output:
plain
---
expected stdout:
umd
guarded
cjs extension
requires 7
plain
---
1913 |               console.log(`---`);
1914 |               console.log(`expected ${name}:`);
1915 |               console.log(expected);
1916 |               console.log(`---`);
1917 |             }
1918 |             expect(result).toBe(expected);
                                  ^
error: expect(received).toBe(expected)

- "umd
- guarded
- cjs extension
- requires 7
- plain"
+ "plain"

- Expected  - 5
+ Received  + 1

      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1918:28)
(fail) bundler > html/script-src-commonjs [19
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_html.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/bundler_html.test.ts:
(pass) bundler > html/basic [487.12ms]
(pass) bundler > html/implicit-relative-paths [111.32ms]
(pass) bundler > html/multiple-assets [123.53ms]
(pass) bundler > html/image-hashing [101.11ms]
(pass) bundler > html/external-assets [112.76ms]
(pass) bundler > html/mixed-assets [149.26ms]
(pass) bundler > html/js-imports [141.67ms]
(pass) bundler > html/script-that-is-also-an-entry-point [138.89ms]
(pass) bundler > html/script-src-commonjs [488.84ms]
(pass) bundler > html/script-src-type-commonjs-package [396.71ms]
(pass) bundler > html/script-src-commonjs-between-plain-scripts [424.77ms]
(pass) bundler > html/script-src-lazy-esm [571.89ms]
(pass) bundler > html/script-src-top-level-await-does-not-block-later-scripts [508.85ms]
(pass) bundler > html/script-src-top-level-await-does-not-block-later-scripts-minify [413.58ms]
(pass) bundler > html/script-src-top-level-await-rejection [517.11ms]
(pass) bundler > html/script-src-top-level-await-last
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     35371e00a1
  features     baseline

23 deps, 131 codegen, 1172 objects in 790ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [14.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [7.00ms]
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] gen ErrorCode+*.h
[7/1243] gen .bind.ts → GeneratedBindings.cpp
[8/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 11ms

  react-refresh.js  4.81 KB  (entry point)

[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] fetch zlib
[zlib] up to date
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.serve
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs                       |  88 ++++++++++---
 src/bundler/ParseTask.rs                           |   5 +-
 src/bundler/linker_context/postProcessJSChunk.rs   |  78 +++++++++++
 .../linker_context/scanImportsAndExports.rs        |  37 ++++++
 test/bundler/bundler_html.test.ts                  | 142 ++++++++++++++++++++-
 5 files changed, 324 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/bundler/LinkerContext.rs                             9      9     21
src/bundler/ParseTask.rs                                 4      3     21
src/bundler/linker_context/postProcessJSChunk.rs         4      3     21
src/bundler/linker_context/scanImportsAndExports.rs      8      5     21
test/bundler/bundler_html.test.ts                        4      3     21
```

</details>

<!-- robobun:evidence:end -->