### PR TITLE
css: print explicitly prefixed selectors as written in every vendor prefix pass

### DIFF
--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -268,9 +268,8 @@ impl VendorPrefix {
         self.bits()
     }
 
-    /// The prefix that a selector component with this set of prefixes is written
-    /// with outside of a matching vendor prefix pass: unprefixed if it has an
-    /// unprefixed variant, otherwise the last of its prefixes in `FIELDS` order.
+    /// The prefix a selector component with these prefixes is written with: none
+    /// if it has an unprefixed variant, else the last of them in `FIELDS` order.
     #[inline]
     pub(crate) fn canonical(self) -> VendorPrefix {
         if self.is_empty() || self.contains(VendorPrefix::NONE) {

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -268,6 +268,17 @@ impl VendorPrefix {
         self.bits()
     }
 
+    /// The prefix that a selector component with this set of prefixes is written
+    /// with outside of a matching vendor prefix pass: unprefixed if it has an
+    /// unprefixed variant, otherwise the last of its prefixes in `FIELDS` order.
+    #[inline]
+    pub(crate) fn canonical(self) -> VendorPrefix {
+        if self.is_empty() || self.contains(VendorPrefix::NONE) {
+            return VendorPrefix::NONE;
+        }
+        VendorPrefix::from_bits_retain(1 << (u8::BITS - 1 - self.bits().leading_zeros()))
+    }
+
     /// Detects a leading vendor prefix on `name` (case-insensitive, ASCII) and
     /// returns it together with the slice that follows the prefix.
     ///

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -1104,7 +1104,6 @@ fn merge_style_rules<R>(
     src_compat: &mut Option<bool>,
     dst_compat: &mut Option<bool>,
 ) -> bool {
-    use css::VendorPrefix;
     // Merge declarations if the selectors are equivalent, and both are compatible with all targets.
     // Does not apply if css modules are enabled.
     if src.selectors.eql(&dst.selectors)
@@ -1137,18 +1136,18 @@ fn merge_style_rules<R>(
 
     if src.declarations.eql(&dst.declarations) && src.rules.v.is_empty() && dst.rules.v.is_empty() {
         // If both selectors are potentially vendor prefixable, and they are
-        // equivalent minus prefixes, add the prefix to the last rule.
+        // equivalent minus prefixes, add the prefixes to the last rule.
         if !src.vendor_prefix.is_empty()
             && !dst.vendor_prefix.is_empty()
             && css::selector::is_equivalent(src.selectors.v.slice(), dst.selectors.v.slice())
+            && css::selector::merge_prefixes(
+                dst.selectors.v.slice_mut(),
+                src.selectors.v.slice(),
+                context.targets,
+            )
         {
-            if src.vendor_prefix.contains(VendorPrefix::NONE)
-                && context.targets.should_compile_selectors()
-            {
-                dst.vendor_prefix = src.vendor_prefix;
-            } else {
-                dst.vendor_prefix.insert(src.vendor_prefix);
-            }
+            dst.vendor_prefix = css::selector::prefix_passes(dst.selectors.v.slice());
+            *dst_compat = None;
             return true;
         }
 
@@ -1167,13 +1166,7 @@ fn merge_style_rules<R>(
             // Both sides were just proven compatible, so the combined selector
             // list is too.
             *dst_compat = Some(true);
-            if src.vendor_prefix.contains(VendorPrefix::NONE)
-                && context.targets.should_compile_selectors()
-            {
-                dst.vendor_prefix = src.vendor_prefix;
-            } else {
-                dst.vendor_prefix.insert(src.vendor_prefix);
-            }
+            dst.vendor_prefix.insert(src.vendor_prefix);
             return true;
         }
     }

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -14,7 +14,8 @@ use crate::{PrintErr, Printer, VendorPrefix};
 pub struct StyleRule<R> {
     /// The selectors for the style rule.
     pub(crate) selectors: selector::parser::SelectorList,
-    /// A vendor prefix override, used during selector printing.
+    /// The vendor prefix passes to print this rule with (see
+    /// `selector::prefix_passes`), or empty to print it once as written.
     pub(crate) vendor_prefix: VendorPrefix,
     /// The declarations within the style rule.
     pub(crate) declarations: DeclarationBlock<'static>,
@@ -62,6 +63,9 @@ impl<R> StyleRule<R> {
                 self.selectors.v.slice_mut(),
                 context.targets,
             );
+        }
+        if !self.vendor_prefix.is_empty() {
+            self.vendor_prefix = selector::prefix_passes(self.selectors.v.slice());
         }
     }
 

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -100,14 +100,22 @@ impl<R> StyleRule<R> {
         if self.vendor_prefix.is_empty() {
             self.to_css_base(dest, true)?;
         } else {
+            // With nesting compiled away, the parent selectors substituted for
+            // `&` print in this rule's passes too.
+            let passes = match dest.ctx {
+                Some(parents) => {
+                    selector::nested_prefix_passes(self.selectors.v.slice(), Some(parents))
+                }
+                None => self.vendor_prefix,
+            };
             let mut first_rule = true;
             let mut emitted_first_pass = false;
-            let mut remaining_prefixes = self.vendor_prefix;
+            let mut remaining_prefixes = passes;
             // `inline for (css.VendorPrefix.FIELDS) |field|` — iterate the bool fields of the
             // packed struct in declared order. In Rust the bitflags type exposes the same
             // ordered single-bit table directly.
             for &prefix in VendorPrefix::FIELDS {
-                if self.vendor_prefix.contains(prefix) {
+                if passes.contains(prefix) {
                     remaining_prefixes.remove(prefix);
                     if !first_rule {
                         if !dest.minify {

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -1072,20 +1072,30 @@ impl PseudoClass {
         }
     }
 
-    pub(crate) fn get_necessary_prefixes(
+    /// The vendor prefixes of a prefixable pseudo class, with the feature that
+    /// decides which prefixes the browser targets need.
+    pub(crate) fn prefix_mut(
         &mut self,
-        targets: &css::targets::Targets,
-    ) -> css::VendorPrefix {
+    ) -> Option<(&mut css::VendorPrefix, css::prefixes::Feature)> {
         use PseudoClass as P;
         use css::prefixes::Feature as F;
-        let (p, feature): (&mut css::VendorPrefix, F) = match self {
+        Some(match self {
             P::Fullscreen(p) => (p, F::PseudoClassFullscreen),
             P::AnyLink(p) => (p, F::PseudoClassAnyLink),
             P::ReadOnly(p) => (p, F::PseudoClassReadOnly),
             P::ReadWrite(p) => (p, F::PseudoClassReadWrite),
             P::PlaceholderShown(p) => (p, F::PseudoClassPlaceholderShown),
             P::Autofill(p) => (p, F::PseudoClassAutofill),
-            _ => return css::VendorPrefix::empty(),
+            _ => return None,
+        })
+    }
+
+    pub(crate) fn get_necessary_prefixes(
+        &mut self,
+        targets: &css::targets::Targets,
+    ) -> css::VendorPrefix {
+        let Some((p, feature)) = self.prefix_mut() else {
+            return css::VendorPrefix::empty();
         };
         *p = targets.prefixes(*p, feature);
         *p
@@ -3015,18 +3025,28 @@ impl PseudoElement {
         self.clone()
     }
 
-    pub(crate) fn get_necessary_prefixes(
+    /// The vendor prefixes of a prefixable pseudo element, with the feature
+    /// that decides which prefixes the browser targets need.
+    pub(crate) fn prefix_mut(
         &mut self,
-        targets: &css::targets::Targets,
-    ) -> css::VendorPrefix {
+    ) -> Option<(&mut css::VendorPrefix, css::prefixes::Feature)> {
         use PseudoElement as PE;
         use css::prefixes::Feature as F;
-        let (p, feature): (&mut css::VendorPrefix, F) = match self {
+        Some(match self {
             PE::Selection(p) => (p, F::PseudoElementSelection),
             PE::Placeholder(p) => (p, F::PseudoElementPlaceholder),
             PE::Backdrop(p) => (p, F::PseudoElementBackdrop),
             PE::FileSelectorButton(p) => (p, F::PseudoElementFileSelectorButton),
-            _ => return css::VendorPrefix::empty(),
+            _ => return None,
+        })
+    }
+
+    pub(crate) fn get_necessary_prefixes(
+        &mut self,
+        targets: &css::targets::Targets,
+    ) -> css::VendorPrefix {
+        let Some((p, feature)) = self.prefix_mut() else {
+            return css::VendorPrefix::empty();
         };
         *p = targets.prefixes(*p, feature);
         *p

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -128,25 +128,14 @@ fn downlevel_component<'bump>(
             let mut necessary_prefixes = downlevel_selectors(bump, selectors, targets);
 
             // Convert :is to :-webkit-any/:-moz-any if needed.
-            // All selectors must be simple, no combinators are supported.
-            if targets.should_compile_same(Feature::IsSelector)
-                && !should_unwrap_is(selectors)
-                && 'brk: {
-                    for selector in selectors.iter() {
-                        if selector.has_combinator() {
-                            break 'brk false;
-                        }
-                    }
-                    break 'brk true;
-                }
-            {
-                necessary_prefixes.insert(
-                    targets.prefixes(VendorPrefix::NONE, css::prefixes::Feature::AnyPseudo),
-                );
-            } else {
-                necessary_prefixes.insert(VendorPrefix::NONE);
+            let prefixes = is_prefixes(selectors, targets);
+            if prefixes != VendorPrefix::NONE {
+                *component = Component::Any {
+                    vendor_prefix: prefixes,
+                    selectors: core::mem::take(selectors),
+                };
             }
-
+            necessary_prefixes.insert(prefixes);
             necessary_prefixes
         }
         Component::Negation(selectors) => {
@@ -156,30 +145,43 @@ fn downlevel_component<'bump>(
             // We need to use :is() / :-webkit-any() rather than :not(.a):not(.b) to ensure the specificity is equivalent.
             // https://drafts.csswg.org/selectors/#specificity-rules
             if selectors.len() > 1 && targets.should_compile_same(Feature::NotSelectorList) {
-                let is: Selector = Selector::from_component(Component::Is({
-                    // `Component::Is` carries `Box<[Selector]>` (heap, not arena);
-                    // could re-thread `&'bump [Selector]` once the arena lifetime is plumbed.
-                    let mut new_selectors: Vec<Selector> = Vec::with_capacity(selectors.len());
-                    for sel in selectors.iter() {
-                        new_selectors.push(sel.deep_clone());
-                    }
-                    new_selectors.into_boxed_slice()
-                }));
-                *component = Component::Negation(vec![is].into_boxed_slice());
-
-                if targets.should_compile_same(Feature::IsSelector) {
-                    necessary_prefixes.insert(
-                        targets.prefixes(VendorPrefix::NONE, css::prefixes::Feature::AnyPseudo),
-                    );
-                } else {
-                    necessary_prefixes.insert(VendorPrefix::NONE);
+                // `Component::Is` carries `Box<[Selector]>` (heap, not arena);
+                // could re-thread `&'bump [Selector]` once the arena lifetime is plumbed.
+                let mut new_selectors: Vec<Selector> = Vec::with_capacity(selectors.len());
+                for sel in selectors.iter() {
+                    new_selectors.push(sel.deep_clone());
                 }
+                let new_selectors = new_selectors.into_boxed_slice();
+                let prefixes = if targets.should_compile_same(Feature::IsSelector) {
+                    targets.prefixes(VendorPrefix::NONE, css::prefixes::Feature::AnyPseudo)
+                } else {
+                    VendorPrefix::NONE
+                };
+                necessary_prefixes.insert(prefixes);
+                let is = if prefixes != VendorPrefix::NONE {
+                    Component::Any {
+                        vendor_prefix: prefixes,
+                        selectors: new_selectors,
+                    }
+                } else {
+                    Component::Is(new_selectors)
+                };
+                *component =
+                    Component::Negation(vec![Selector::from_component(is)].into_boxed_slice());
             }
 
             necessary_prefixes
         }
         Component::Where(s) | Component::Has(s) => downlevel_selectors(bump, s, targets),
-        Component::Any { selectors, .. } => downlevel_selectors(bump, selectors, targets),
+        Component::Any {
+            vendor_prefix,
+            selectors,
+        } => {
+            let mut necessary_prefixes = downlevel_selectors(bump, selectors, targets);
+            *vendor_prefix = any_prefixes(*vendor_prefix, selectors, targets);
+            necessary_prefixes.insert(*vendor_prefix);
+            necessary_prefixes
+        }
         _ => VendorPrefix::empty(),
     }
 }
@@ -222,10 +224,12 @@ fn lang_list_to_selectors<'bump>(_bump: &'bump Bump, langs: &[&'static [u8]]) ->
     selectors.into_boxed_slice()
 }
 
-/// Returns the vendor prefix (if any) used in the given selector list.
-/// If multiple vendor prefixes are seen, this is invalid, and an empty result is returned.
+/// Returns the vendor prefixes used in the given selector list.
+/// If two components use different explicit vendor prefixes, this is invalid, and an empty result is returned.
 pub(crate) fn get_prefix(selectors: &SelectorList) -> VendorPrefix {
     let mut prefix = VendorPrefix::empty();
+    // The prefixes that every explicitly prefixed component seen so far has.
+    let mut explicit = VendorPrefix::all();
     for selector in selectors.v.slice() {
         for component in selector.components.iter() {
             let component: &Component = component;
@@ -246,19 +250,258 @@ pub(crate) fn get_prefix(selectors: &SelectorList) -> VendorPrefix {
             };
 
             if !p.is_empty() {
-                // Allow none to be mixed with a prefix.
-                let mut prefix_without_none = prefix;
-                prefix_without_none.remove(VendorPrefix::NONE);
-                if prefix_without_none.is_empty() || prefix_without_none == p {
-                    prefix.insert(p);
-                } else {
-                    return VendorPrefix::empty();
+                // Allow none to be mixed with a prefix. A component that an
+                // equivalent rule was merged into has every prefix of the two.
+                if !p.contains(VendorPrefix::NONE) {
+                    explicit &= p;
+                    if explicit.is_empty() {
+                        return VendorPrefix::empty();
+                    }
                 }
+                prefix.insert(p);
             }
         }
     }
 
     prefix
+}
+
+/// Returns the vendor prefix passes that `StyleRule::to_css` needs to print the
+/// given selectors: one pass per extra prefix that a component picked up from
+/// the browser targets (`downlevel_selectors`) or from an equivalent rule that
+/// was merged into this one (`merge_prefixes`), plus one pass in which every
+/// prefixable component prints as written (see `VendorPrefix::canonical`). For
+/// selectors with no extra prefixes, that pass is their explicit prefix, if they
+/// use one, so that parent selectors substituted for `&` print their matching
+/// variant.
+pub(crate) fn prefix_passes(selectors: &[Selector]) -> VendorPrefix {
+    let mut sets = Vec::new();
+    prefix_sets(selectors, &mut sets);
+    passes_for(&sets)
+}
+
+/// The set of prefixes of each prefixable component in `selectors`, in the
+/// order that `is_equivalent` and `merge_prefixes` pair them up. An `:is()`
+/// counts as an unprefixed `:-webkit-any()`.
+fn prefix_sets(selectors: &[Selector], sets: &mut Vec<VendorPrefix>) {
+    for selector in selectors {
+        for component in selector.components.iter() {
+            match component {
+                Component::NonTsPseudoClass(pc) => {
+                    let prefixes = pc.get_prefix();
+                    if !prefixes.is_empty() {
+                        sets.push(prefixes);
+                    }
+                }
+                Component::PseudoElement(pe) => {
+                    let prefixes = pe.get_prefix();
+                    if !prefixes.is_empty() {
+                        sets.push(prefixes);
+                    }
+                }
+                Component::Any {
+                    vendor_prefix,
+                    selectors,
+                } => {
+                    sets.push(*vendor_prefix);
+                    prefix_sets(selectors, sets);
+                }
+                Component::Is(selectors) => {
+                    sets.push(VendorPrefix::NONE);
+                    prefix_sets(selectors, sets);
+                }
+                Component::Where(selectors)
+                | Component::Has(selectors)
+                | Component::Negation(selectors) => prefix_sets(selectors, sets),
+                _ => {}
+            }
+        }
+    }
+}
+
+/// `prefix_passes` for components with the given sets of prefixes.
+fn passes_for(sets: &[VendorPrefix]) -> VendorPrefix {
+    // Prefixes other than the one each component is written with.
+    let mut extra = VendorPrefix::empty();
+    // Prefixes of the components that have no unprefixed variant.
+    let mut explicit = VendorPrefix::empty();
+    for &prefixes in sets {
+        extra.insert(prefixes.difference(prefixes.canonical()));
+        if !prefixes.contains(VendorPrefix::NONE) {
+            explicit.insert(prefixes);
+        }
+    }
+    if extra.is_empty() && explicit.bits().count_ones() == 1 {
+        explicit
+    } else {
+        extra | VendorPrefix::NONE
+    }
+}
+
+/// The prefixes that components with the given sets of prefixes print with, for
+/// each of their `passes_for`.
+fn printed_variants(sets: &[VendorPrefix]) -> Vec<Vec<VendorPrefix>> {
+    let passes = passes_for(sets);
+    VendorPrefix::FIELDS
+        .iter()
+        .filter(|pass| passes.contains(**pass))
+        .map(|&pass| {
+            sets.iter()
+                .map(|&prefixes| {
+                    if prefixes.contains(pass) {
+                        pass
+                    } else {
+                        prefixes.canonical()
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Merges the vendor prefixes of `src` into `dst`, which must be equivalent to it
+/// (see `is_equivalent`), so that `dst` also prints the variants `src` prints.
+/// Returns false, and leaves `dst` as it is, if the merged selectors would print
+/// a variant that neither `dst` nor `src` prints, or would lose one, e.g. for
+/// `.a:-moz-read-only::placeholder` and `.a:read-only::-moz-placeholder`.
+///
+/// With browser targets, a rule with no explicit prefixes also absorbs every
+/// equivalent rule: a component with an unprefixed variant keeps exactly the
+/// prefixes that the targets need (`Targets::prefixes`), so explicitly prefixed
+/// copies of the rule fold into the variants printed for the targets.
+pub(crate) fn merge_prefixes(dst: &mut [Selector], src: &[Selector], targets: &Targets) -> bool {
+    let mut dst_sets = Vec::new();
+    let mut src_sets = Vec::new();
+    prefix_sets(dst, &mut dst_sets);
+    prefix_sets(src, &mut src_sets);
+    if dst_sets.len() != src_sets.len() {
+        return false;
+    }
+    let unprefixed = |sets: &[VendorPrefix]| {
+        sets.iter()
+            .all(|prefixes| prefixes.contains(VendorPrefix::NONE))
+    };
+    if !(targets.should_compile_selectors() && (unprefixed(&dst_sets) || unprefixed(&src_sets))) {
+        let merged_sets: Vec<VendorPrefix> = dst_sets
+            .iter()
+            .zip(&src_sets)
+            .map(|(a, b)| *a | *b)
+            .collect();
+        let merged = printed_variants(&merged_sets);
+        let (dst_variants, src_variants) =
+            (printed_variants(&dst_sets), printed_variants(&src_sets));
+        if !merged
+            .iter()
+            .all(|variant| dst_variants.contains(variant) || src_variants.contains(variant))
+            || !dst_variants
+                .iter()
+                .chain(&src_variants)
+                .all(|variant| merged.contains(variant))
+        {
+            return false;
+        }
+    }
+    merge_prefix_sets(dst, src, targets);
+    true
+}
+
+fn merge_prefix_sets(dst: &mut [Selector], src: &[Selector], targets: &Targets) {
+    for (dst_selector, src_selector) in dst.iter_mut().zip(src.iter()) {
+        let pairs = dst_selector
+            .components
+            .iter_mut()
+            .zip(src_selector.components.iter());
+        for (dst_component, src_component) in pairs {
+            let replacement = match (&mut *dst_component, src_component) {
+                (Component::NonTsPseudoClass(a), Component::NonTsPseudoClass(b)) => {
+                    let b = b.get_prefix();
+                    if let Some((a, feature)) = a.prefix_mut() {
+                        *a = targets.prefixes(*a | b, feature);
+                    }
+                    None
+                }
+                (Component::PseudoElement(a), Component::PseudoElement(b)) => {
+                    let b = b.get_prefix();
+                    if let Some((a, feature)) = a.prefix_mut() {
+                        *a = targets.prefixes(*a | b, feature);
+                    }
+                    None
+                }
+                (
+                    Component::Any {
+                        vendor_prefix: a,
+                        selectors: a_selectors,
+                    },
+                    Component::Any {
+                        vendor_prefix: b,
+                        selectors: b_selectors,
+                    },
+                ) => {
+                    merge_prefix_sets(a_selectors, b_selectors, targets);
+                    *a = any_prefixes(*a | *b, a_selectors, targets);
+                    None
+                }
+                (
+                    Component::Any {
+                        vendor_prefix: a,
+                        selectors: a_selectors,
+                    },
+                    Component::Is(b_selectors),
+                ) => {
+                    merge_prefix_sets(a_selectors, b_selectors, targets);
+                    *a = any_prefixes(*a | VendorPrefix::NONE, a_selectors, targets);
+                    None
+                }
+                (
+                    Component::Is(a_selectors),
+                    Component::Any {
+                        vendor_prefix: b,
+                        selectors: b_selectors,
+                    },
+                ) => {
+                    merge_prefix_sets(a_selectors, b_selectors, targets);
+                    let selectors = core::mem::take(a_selectors);
+                    Some(Component::Any {
+                        vendor_prefix: any_prefixes(*b | VendorPrefix::NONE, &selectors, targets),
+                        selectors,
+                    })
+                }
+                (Component::Is(a_selectors), Component::Is(b_selectors)) => {
+                    merge_prefix_sets(a_selectors, b_selectors, targets);
+                    None
+                }
+                _ => None,
+            };
+            if let Some(replacement) = replacement {
+                *dst_component = replacement;
+            }
+        }
+    }
+}
+
+/// Returns the vendor prefixes that an unprefixed `:is()` with the given
+/// arguments needs for the browser targets, as `:-webkit-any()` / `:-moz-any()`.
+fn is_prefixes(selectors: &[Selector], targets: &Targets) -> VendorPrefix {
+    // All selectors must be simple, no combinators are supported.
+    if targets.should_compile_same(Feature::IsSelector)
+        && !should_unwrap_is(selectors)
+        && !selectors.iter().any(|selector| selector.has_combinator())
+    {
+        targets.prefixes(VendorPrefix::NONE, css::prefixes::Feature::AnyPseudo)
+    } else {
+        VendorPrefix::NONE
+    }
+}
+
+/// `Targets::prefixes` for an `:is()` / `:-webkit-any()` whose set of prefixes is
+/// `prefixes`: with browser targets, one that has an unprefixed variant gets
+/// exactly the prefixes the targets need.
+fn any_prefixes(prefixes: VendorPrefix, selectors: &[Selector], targets: &Targets) -> VendorPrefix {
+    if prefixes.contains(VendorPrefix::NONE) && targets.should_compile_selectors() {
+        is_prefixes(selectors, targets)
+    } else {
+        prefixes
+    }
 }
 
 pub(crate) fn is_compatible(selectors: &[parser::Selector], targets: &Targets) -> bool {
@@ -572,6 +815,19 @@ fn is_selector_unused(
 pub(crate) mod serialize {
     use super::*;
 
+    /// The prefix to write for a component whose set of prefixes is `prefixes`:
+    /// the printer's current vendor prefix pass if the component has that
+    /// variant, otherwise the component as written (lightningcss writes it
+    /// unprefixed instead, which prints selectors that the source never had).
+    fn pass_prefix(dest: &Printer, prefixes: VendorPrefix) -> VendorPrefix {
+        let pass = dest.vendor_prefix & prefixes;
+        if pass.is_empty() {
+            prefixes.canonical()
+        } else {
+            pass
+        }
+    }
+
     pub(crate) fn serialize_selector_list(
         list: &[parser::Selector],
         dest: &mut Printer,
@@ -866,20 +1122,16 @@ pub(crate) mod serialize {
                             return serialize_selector(&selectors[0], dest, context, false);
                         }
 
-                        let vp = dest.vendor_prefix;
-                        if vp.contains(VendorPrefix::WEBKIT) || vp.contains(VendorPrefix::MOZ) {
-                            dest.write_char(b':')?;
-                            vp.to_css(dest)?;
-                            dest.write_str(b"any(")?;
-                        } else {
-                            dest.write_str(b":is(")?;
-                        }
+                        // An `:is()` that needs `:-webkit-any()` / `:-moz-any()` passes
+                        // for the targets was converted to `Component::Any` by
+                        // `downlevel_selectors`.
+                        dest.write_str(b":is(")?;
                     }
                     Component::Negation(_) => {
                         dest.write_str(b":not(")?;
                     }
                     Component::Any { vendor_prefix, .. } => {
-                        let vp = dest.vendor_prefix.or(*vendor_prefix);
+                        let vp = pass_prefix(dest, *vendor_prefix);
                         if vp.contains(VendorPrefix::WEBKIT) || vp.contains(VendorPrefix::MOZ) {
                             dest.write_char(b':')?;
                             vp.to_css(dest)?;
@@ -999,13 +1251,7 @@ pub(crate) mod serialize {
             val: &'static [u8],
         ) -> Result<(), PrintErr> {
             d.write_char(b':')?;
-            // If the printer has a vendor prefix override, use that.
-            let vp = if !d.vendor_prefix.is_empty() {
-                (d.vendor_prefix & prefix).or_none()
-            } else {
-                prefix
-            };
-            vp.to_css(d)?;
+            pass_prefix(d, prefix).to_css(d)?;
             d.write_str(val)
         }
 
@@ -1050,11 +1296,7 @@ pub(crate) mod serialize {
             // https://fullscreen.spec.whatwg.org/#:fullscreen-pseudo-class
             PseudoClass::Fullscreen(prefix) => {
                 dest.write_char(b':')?;
-                let vp = if !dest.vendor_prefix.is_empty() {
-                    (dest.vendor_prefix & *prefix).or_none()
-                } else {
-                    *prefix
-                };
+                let vp = pass_prefix(dest, *prefix);
                 vp.to_css(dest)?;
                 if vp.contains(VendorPrefix::WEBKIT) || vp.contains(VendorPrefix::MOZ) {
                     dest.write_str(b"full-screen")?;
@@ -1156,19 +1398,8 @@ pub(crate) mod serialize {
     ) -> Result<(), PrintErr> {
         fn write_prefix(d: &mut Printer, prefix: VendorPrefix) -> Result<VendorPrefix, PrintErr> {
             d.write_str(b"::")?;
-            // If the printer has a vendor prefix override, use that.
-            let vp = if !d.vendor_prefix.is_empty() {
-                (d.vendor_prefix & prefix).or_none()
-            } else {
-                prefix
-            };
+            let vp = pass_prefix(d, prefix);
             vp.to_css(d)?;
-            bun_core::scoped_log!(
-                CSS_SELECTORS,
-                "VENDOR PREFIX {} OVERRIDE {}",
-                vp.as_bits(),
-                d.vendor_prefix.as_bits()
-            );
             Ok(vp)
         }
 

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -1001,7 +1001,7 @@ pub(crate) mod serialize {
             d.write_char(b':')?;
             // If the printer has a vendor prefix override, use that.
             let vp = if !d.vendor_prefix.is_empty() {
-                (d.vendor_prefix | prefix).or_none()
+                (d.vendor_prefix & prefix).or_none()
             } else {
                 prefix
             };

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -266,23 +266,19 @@ pub(crate) fn get_prefix(selectors: &SelectorList) -> VendorPrefix {
     prefix
 }
 
-/// Returns the vendor prefix passes that `StyleRule::to_css` needs to print the
-/// given selectors: one pass per extra prefix that a component picked up from
-/// the browser targets (`downlevel_selectors`) or from an equivalent rule that
-/// was merged into this one (`merge_prefixes`), plus one pass in which every
-/// prefixable component prints as written (see `VendorPrefix::canonical`). For
-/// selectors with no extra prefixes, that pass is their explicit prefix, if they
-/// use one, so that parent selectors substituted for `&` print their matching
-/// variant.
+/// The vendor prefix passes that `StyleRule::to_css` prints these selectors in:
+/// each prefix a component has besides the one it is written with (added by
+/// `downlevel_selectors` or `merge_prefixes`), plus one pass as written. For
+/// selectors with an explicit prefix and nothing extra that pass is the explicit
+/// prefix, so that parent selectors substituted for `&` print the same variant.
 pub(crate) fn prefix_passes(selectors: &[Selector]) -> VendorPrefix {
     let mut sets = Vec::new();
     prefix_sets(selectors, &mut sets);
     passes_for(&sets)
 }
 
-/// The set of prefixes of each prefixable component in `selectors`, in the
-/// order that `is_equivalent` and `merge_prefixes` pair them up. An `:is()`
-/// counts as an unprefixed `:-webkit-any()`.
+/// The prefix set of each prefixable component, in the order `is_equivalent` and
+/// `merge_prefixes` pair components up. An `:is()` counts as unprefixed.
 fn prefix_sets(selectors: &[Selector], sets: &mut Vec<VendorPrefix>) {
     for selector in selectors {
         for component in selector.components.iter() {
@@ -359,16 +355,12 @@ fn printed_variants(sets: &[VendorPrefix]) -> Vec<Vec<VendorPrefix>> {
         .collect()
 }
 
-/// Merges the vendor prefixes of `src` into `dst`, which must be equivalent to it
-/// (see `is_equivalent`), so that `dst` also prints the variants `src` prints.
-/// Returns false, and leaves `dst` as it is, if the merged selectors would print
-/// a variant that neither `dst` nor `src` prints, or would lose one, e.g. for
-/// `.a:-moz-read-only::placeholder` and `.a:read-only::-moz-placeholder`.
-///
-/// With browser targets, a rule with no explicit prefixes also absorbs every
-/// equivalent rule: a component with an unprefixed variant keeps exactly the
-/// prefixes that the targets need (`Targets::prefixes`), so explicitly prefixed
-/// copies of the rule fold into the variants printed for the targets.
+/// ORs the prefix set of each prefixable component of `src` into its pair in
+/// `dst` (the two are `is_equivalent`) if the result prints exactly the variants
+/// that `dst` and `src` print, else returns false and leaves `dst` alone (as for
+/// `.a:-moz-read-only::placeholder` and `.a:read-only::-moz-placeholder`). With
+/// browser targets, a rule without explicit prefixes absorbs any equivalent rule,
+/// and `Targets::prefixes` then keeps only the prefixes the targets need.
 pub(crate) fn merge_prefixes(dst: &mut [Selector], src: &[Selector], targets: &Targets) -> bool {
     let mut dst_sets = Vec::new();
     let mut src_sets = Vec::new();
@@ -493,9 +485,8 @@ fn is_prefixes(selectors: &[Selector], targets: &Targets) -> VendorPrefix {
     }
 }
 
-/// `Targets::prefixes` for an `:is()` / `:-webkit-any()` whose set of prefixes is
-/// `prefixes`: with browser targets, one that has an unprefixed variant gets
-/// exactly the prefixes the targets need.
+/// `Targets::prefixes` for `:is()` / `:-webkit-any()`: with browser targets, a
+/// set with an unprefixed variant becomes exactly what the targets need.
 fn any_prefixes(prefixes: VendorPrefix, selectors: &[Selector], targets: &Targets) -> VendorPrefix {
     if prefixes.contains(VendorPrefix::NONE) && targets.should_compile_selectors() {
         is_prefixes(selectors, targets)
@@ -815,10 +806,9 @@ fn is_selector_unused(
 pub(crate) mod serialize {
     use super::*;
 
-    /// The prefix to write for a component whose set of prefixes is `prefixes`:
-    /// the printer's current vendor prefix pass if the component has that
-    /// variant, otherwise the component as written (lightningcss writes it
-    /// unprefixed instead, which prints selectors that the source never had).
+    /// The prefix to print a component with: the current pass if the component
+    /// has that prefix, else the one it is written with (lightningcss prints it
+    /// unprefixed instead, which adds selectors the source never had).
     fn pass_prefix(dest: &Printer, prefixes: VendorPrefix) -> VendorPrefix {
         let pass = dest.vendor_prefix & prefixes;
         if pass.is_empty() {
@@ -1122,9 +1112,7 @@ pub(crate) mod serialize {
                             return serialize_selector(&selectors[0], dest, context, false);
                         }
 
-                        // An `:is()` that needs `:-webkit-any()` / `:-moz-any()` passes
-                        // for the targets was converted to `Component::Any` by
-                        // `downlevel_selectors`.
+                        // One that needs `:-webkit-any()` is a `Component::Any` by now.
                         dest.write_str(b":is(")?;
                     }
                     Component::Negation(_) => {

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -152,11 +152,7 @@ fn downlevel_component<'bump>(
                     new_selectors.push(sel.deep_clone());
                 }
                 let new_selectors = new_selectors.into_boxed_slice();
-                let prefixes = if targets.should_compile_same(Feature::IsSelector) {
-                    targets.prefixes(VendorPrefix::NONE, css::prefixes::Feature::AnyPseudo)
-                } else {
-                    VendorPrefix::NONE
-                };
+                let prefixes = is_prefixes(&new_selectors, targets);
                 necessary_prefixes.insert(prefixes);
                 let is = if prefixes != VendorPrefix::NONE {
                     Component::Any {
@@ -268,12 +264,25 @@ pub(crate) fn get_prefix(selectors: &SelectorList) -> VendorPrefix {
 
 /// The vendor prefix passes that `StyleRule::to_css` prints these selectors in:
 /// each prefix a component has besides the one it is written with (added by
-/// `downlevel_selectors` or `merge_prefixes`), plus one pass as written. For
-/// selectors with an explicit prefix and nothing extra that pass is the explicit
-/// prefix, so that parent selectors substituted for `&` print the same variant.
+/// `downlevel_selectors` or `merge_prefixes`), plus one pass as written.
 pub(crate) fn prefix_passes(selectors: &[Selector]) -> VendorPrefix {
     let mut sets = Vec::new();
     prefix_sets(selectors, &mut sets);
+    passes_for(&sets)
+}
+
+/// `prefix_passes` for a nested rule printed with its parent rules substituted
+/// for `&`: the parents' components print in the same passes as its own.
+pub(crate) fn nested_prefix_passes(
+    selectors: &[Selector],
+    mut parent: Option<&StyleContext>,
+) -> VendorPrefix {
+    let mut sets = Vec::new();
+    prefix_sets(selectors, &mut sets);
+    while let Some(context) = parent {
+        prefix_sets(context.selectors.v.slice(), &mut sets);
+        parent = context.parent;
+    }
     passes_for(&sets)
 }
 
@@ -317,21 +326,11 @@ fn prefix_sets(selectors: &[Selector], sets: &mut Vec<VendorPrefix>) {
 
 /// `prefix_passes` for components with the given sets of prefixes.
 fn passes_for(sets: &[VendorPrefix]) -> VendorPrefix {
-    // Prefixes other than the one each component is written with.
-    let mut extra = VendorPrefix::empty();
-    // Prefixes of the components that have no unprefixed variant.
-    let mut explicit = VendorPrefix::empty();
+    let mut passes = VendorPrefix::NONE;
     for &prefixes in sets {
-        extra.insert(prefixes.difference(prefixes.canonical()));
-        if !prefixes.contains(VendorPrefix::NONE) {
-            explicit.insert(prefixes);
-        }
+        passes.insert(prefixes.difference(prefixes.canonical()));
     }
-    if extra.is_empty() && explicit.bits().count_ones() == 1 {
-        explicit
-    } else {
-        extra | VendorPrefix::NONE
-    }
+    passes
 }
 
 /// The prefixes that components with the given sets of prefixes print with, for

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "path";
 import {
+  Browsers,
   cssTest,
   indoc,
   minify_error_test_with_options,
@@ -135,6 +136,8 @@ describe("css tests", () => {
   });
 
   describe("pseudo-class edge case", () => {
+    // `::file-selector-button` needs a `-webkit-` pass for these targets. The
+    // explicit `:-moz-any()` stays as written in both passes.
     cssTest(
       indoc`[type="file"]::file-selector-button:-moz-any() {
       --pico-background-color: var(--pico-primary-hover-background);
@@ -142,13 +145,13 @@ describe("css tests", () => {
       --pico-box-shadow: var(--pico-button-hover-box-shadow, 0 0 0 #0000);
       --pico-color: var(--pico-primary-inverse);
     }`,
-      indoc`[type="file"]::-webkit-file-upload-button:-webkit-any() {
+      indoc`[type="file"]::-webkit-file-upload-button:-moz-any() {
       --pico-background-color: var(--pico-primary-hover-background);
       --pico-border-color: var(--pico-primary-hover-border);
       --pico-box-shadow: var(--pico-button-hover-box-shadow, 0 0 0 #0000);
       --pico-color: var(--pico-primary-inverse);
     }
-    [type="file"]::file-selector-button:is() {
+    [type="file"]::file-selector-button:-moz-any() {
       --pico-background-color: var(--pico-primary-hover-background);
       --pico-border-color: var(--pico-primary-hover-border);
       --pico-box-shadow: var(--pico-button-hover-box-shadow, 0 0 0 #0000);
@@ -164,24 +167,211 @@ describe("css tests", () => {
     );
   });
 
-  describe("vendor prefixed pseudo classes", () => {
-    // chrome <= 109 needs :-webkit-autofill.
-    minify_prefix_test(".a:autofill{color:red}", ".a:-webkit-autofill{color:red}.a:autofill{color:red}", {
-      chrome: 103 << 16,
+  describe("explicitly vendor prefixed selectors", () => {
+    // A selector component that the author wrote with a vendor prefix keeps
+    // that prefix. Only unprefixed components get extra prefixed variants (from
+    // the browser targets), and a rule only gets an unprefixed variant of a
+    // prefixed component when an equivalent unprefixed rule is merged into it.
+    //
+    // Every case also runs as the first of two `@media` rules with the same
+    // query: the minifier appends the rules of the second to the first and
+    // minifies the first again, so its style rules go through `update_prefix`
+    // and rule merging a second time and must come out the same.
+    const again = (source: string) => `@media print{${source}}@media print{.zz{--zz:1}}`;
+    const again_expected = (expected: string) => `@media print{${expected}.zz{--zz:1}}`;
+    function minify_test_again(source: string, expected: string) {
+      minify_test(source, expected);
+      minify_test(again(source), again_expected(expected));
+    }
+    function minify_prefix_test_again(source: string, expected: string, targets: Browsers) {
+      minify_prefix_test(source, expected, targets);
+      minify_prefix_test(again(source), again_expected(expected), targets);
+    }
+
+    describe("print once, as written, without targets", () => {
+      minify_test_again("input:-moz-read-only::placeholder{color:red}", "input:-moz-read-only::placeholder{color:red}");
+      minify_test_again(".a:read-only:-moz-read-only{color:red}", ".a:read-only:-moz-read-only{color:red}");
+      minify_test_again(".a:-moz-read-only .b::selection{color:red}", ".a:-moz-read-only .b::selection{color:red}");
+      minify_test_again(".a:fullscreen:-moz-read-only{color:red}", ".a:fullscreen:-moz-read-only{color:red}");
+      minify_test_again(".a:not(:-moz-read-only){color:red}", ".a:not(:-moz-read-only){color:red}");
+      minify_test_again(
+        ".p::placeholder,.p::-moz-placeholder{color:red}",
+        ".p::placeholder,.p::-moz-placeholder{color:red}",
+      );
+      minify_test_again(".b:read-only,.a:-moz-read-only{color:red}", ".b:read-only,.a:-moz-read-only{color:red}");
+      minify_test_again(
+        ".a:placeholder-shown .x,.b:-webkit-autofill .y{color:red}",
+        ".a:placeholder-shown .x,.b:-webkit-autofill .y{color:red}",
+      );
+      minify_test_again(".a:is(.x,.y):-webkit-autofill{color:red}", ".a:is(.x,.y):-webkit-autofill{color:red}");
+      minify_test_again(
+        ".a:-webkit-any(.x,.y)::placeholder{color:red}",
+        ".a:-webkit-any(.x,.y)::placeholder{color:red}",
+      );
+      minify_test_again(
+        ".a:-webkit-autofill:-moz-read-only{color:red}",
+        ".a:-webkit-autofill:-moz-read-only{color:red}",
+      );
+      // Nested in a rule that safari 8 needs a `-webkit-` and an unprefixed
+      // pass for, with nesting compiled away: the nested selector mixes two
+      // explicit prefixes, so it has no passes of its own and is printed in
+      // each pass of its parent.
+      minify_prefix_test(
+        ":fullscreen{.a:-webkit-autofill:-moz-read-only{color:red}}",
+        ":-webkit-full-screen .a:-webkit-autofill:-moz-read-only{color:red}:fullscreen .a:-webkit-autofill:-moz-read-only{color:red}",
+        { safari: 8 << 16 },
+      );
+      // A nested rule with only an explicit prefix is printed once, in the
+      // pass of its prefix.
+      minify_prefix_test(
+        ":fullscreen{.a::-webkit-input-placeholder{color:red}}",
+        ":-webkit-full-screen .a::-webkit-input-placeholder{color:red}",
+        { safari: 8 << 16 },
+      );
     });
-    minify_prefix_test(
-      ".a:placeholder-shown .b:autofill{color:red}",
-      ".a:placeholder-shown .b:-webkit-autofill{color:red}.a:placeholder-shown .b:autofill{color:red}",
-      { chrome: 103 << 16 },
-    );
-    minify_prefix_test(".a:read-only{color:red}", ".a:-moz-read-only{color:red}.a:read-only{color:red}", {
-      firefox: 50 << 16,
+
+    describe("unprefixed components still get the prefixes the targets need", () => {
+      // https://caniuse.com/css-placeholder: firefox 19-50 needs ::-moz-placeholder.
+      minify_prefix_test_again(
+        "input:-moz-read-only::placeholder{color:red}",
+        "input:-moz-read-only::-moz-placeholder{color:red}input:-moz-read-only::placeholder{color:red}",
+        { firefox: 30 << 16 },
+      );
+      // chrome <= 109 needs :-webkit-autofill.
+      minify_prefix_test_again(".a:autofill{color:red}", ".a:-webkit-autofill{color:red}.a:autofill{color:red}", {
+        chrome: 103 << 16,
+      });
+      minify_prefix_test_again(
+        ".a:placeholder-shown .b:autofill{color:red}",
+        ".a:placeholder-shown .b:-webkit-autofill{color:red}.a:placeholder-shown .b:autofill{color:red}",
+        { chrome: 103 << 16 },
+      );
+      minify_prefix_test_again(".a:read-only{color:red}", ".a:-moz-read-only{color:red}.a:read-only{color:red}", {
+        firefox: 50 << 16,
+      });
+      minify_prefix_test_again(
+        ".a:any-link{color:red}",
+        ".a:-webkit-any-link{color:red}.a:-moz-any-link{color:red}.a:any-link{color:red}",
+        { chrome: 40 << 16, firefox: 30 << 16 },
+      );
+      // `:is()` is supported by chrome 103, so the `-webkit-` pass for
+      // `:autofill` does not turn it into `:-webkit-any()`, which only accepts
+      // compound selectors.
+      minify_prefix_test_again(
+        ".x:is(.a .b,.c):autofill{color:red}",
+        ".x:is(.a .b,.c):-webkit-autofill{color:red}.x:is(.a .b,.c):autofill{color:red}",
+        { chrome: 103 << 16 },
+      );
+      // chrome <= 87 has `:-webkit-any()` but not `:is()`.
+      minify_prefix_test_again(
+        ".x:is(.a,.b):autofill{color:red}",
+        ".x:-webkit-any(.a,.b):-webkit-autofill{color:red}.x:is(.a,.b):autofill{color:red}",
+        { chrome: 80 << 16 },
+      );
+      minify_prefix_test_again(".x:is(.a,.b){color:red}", ".x:-webkit-any(.a,.b){color:red}.x:is(.a,.b){color:red}", {
+        chrome: 80 << 16,
+      });
+      minify_prefix_test_again(
+        ".x:not(.a,.b){color:red}",
+        ".x:not(:-webkit-any(.a,.b)){color:red}.x:not(:is(.a,.b)){color:red}",
+        { safari: 8 << 16 },
+      );
+      minify_prefix_test_again(
+        ".x:lang(en,fr){color:red}",
+        ".x:-webkit-any(:lang(en),:lang(fr)){color:red}.x:-moz-any(:lang(en),:lang(fr)){color:red}.x:is(:lang(en),:lang(fr)){color:red}",
+        { safari: 11 << 16, firefox: 50 << 16 },
+      );
     });
-    minify_prefix_test(
-      ".a:any-link{color:red}",
-      ".a:-webkit-any-link{color:red}.a:-moz-any-link{color:red}.a:any-link{color:red}",
-      { chrome: 40 << 16, firefox: 30 << 16 },
-    );
+
+    describe("merging equivalent rules keeps every variant that was written", () => {
+      minify_test_again(
+        ".a:-moz-read-only{color:red}.a:read-only{color:red}",
+        ".a:-moz-read-only{color:red}.a:read-only{color:red}",
+      );
+      minify_test_again(
+        ".a:read-only{color:red}.a:-moz-read-only{color:red}",
+        ".a:-moz-read-only{color:red}.a:read-only{color:red}",
+      );
+      minify_test_again(
+        ".a::-webkit-input-placeholder{color:red}.a::-moz-placeholder{color:red}",
+        ".a::-webkit-input-placeholder{color:red}.a::-moz-placeholder{color:red}",
+      );
+      minify_test_again(
+        ".a::-webkit-input-placeholder{color:red}.a::-moz-placeholder{color:red}.a::placeholder{color:red}",
+        ".a::-webkit-input-placeholder{color:red}.a::-moz-placeholder{color:red}.a::placeholder{color:red}",
+      );
+      minify_test_again(
+        ".a::placeholder{color:red}.a::-webkit-input-placeholder{color:red}.a::-moz-placeholder{color:red}",
+        ".a::-webkit-input-placeholder{color:red}.a::-moz-placeholder{color:red}.a::placeholder{color:red}",
+      );
+      minify_test_again(
+        ".a:-moz-read-only::placeholder{color:red}.a:read-only::placeholder{color:red}",
+        ".a:-moz-read-only::placeholder{color:red}.a:read-only::placeholder{color:red}",
+      );
+      minify_test_again(
+        ".x:-webkit-autofill::-webkit-input-placeholder{color:red}.x:-webkit-autofill::-moz-placeholder{color:red}",
+        ".x:-webkit-autofill::-webkit-input-placeholder{color:red}.x:-webkit-autofill::-moz-placeholder{color:red}",
+      );
+      minify_test_again(
+        ".a:-webkit-any(.b,.c):after{color:red}.a:is(.b,.c):after{color:red}",
+        ".a:-webkit-any(.b,.c):after{color:red}.a:is(.b,.c):after{color:red}",
+      );
+      minify_test_again(
+        ".a:is(.b,.c):after{color:red}.a:-webkit-any(.b,.c):after{color:red}",
+        ".a:-webkit-any(.b,.c):after{color:red}.a:is(.b,.c):after{color:red}",
+      );
+      // The output of a prefix pass merges back into the rule it came from.
+      minify_prefix_test_again(
+        ".a:placeholder-shown .b:-webkit-autofill{color:red}.a:placeholder-shown .b:autofill{color:red}",
+        ".a:placeholder-shown .b:-webkit-autofill{color:red}.a:placeholder-shown .b:autofill{color:red}",
+        { chrome: 103 << 16 },
+      );
+      minify_prefix_test_again(
+        ".x:-webkit-any(.a,.b){color:red}.x:is(.a,.b){color:red}",
+        ".x:-webkit-any(.a,.b){color:red}.x:is(.a,.b){color:red}",
+        { chrome: 80 << 16 },
+      );
+      // Two rules whose prefixes differ in two places the other way around are
+      // not variants of one rule: merging them would print
+      // `.a:-moz-read-only::-moz-placeholder` and `.a:read-only::placeholder`
+      // instead.
+      minify_test_again(
+        ".a:-moz-read-only::placeholder{color:red}.a:read-only::-moz-placeholder{color:red}",
+        ".a:-moz-read-only::placeholder{color:red}.a:read-only::-moz-placeholder{color:red}",
+      );
+    });
+
+    describe("merging drops a prefix that the targets do not need, in either order", () => {
+      minify_prefix_test_again(".a:-moz-read-only{color:red}.a:read-only{color:red}", ".a:read-only{color:red}", {
+        firefox: 100 << 16,
+      });
+      minify_prefix_test_again(".a:read-only{color:red}.a:-moz-read-only{color:red}", ".a:read-only{color:red}", {
+        firefox: 100 << 16,
+      });
+      minify_prefix_test_again(
+        ".a:read-only{color:red}.a:-moz-read-only{color:red}",
+        ".a:-moz-read-only{color:red}.a:read-only{color:red}",
+        { firefox: 50 << 16 },
+      );
+      // With targets, a rule written without prefixes absorbs an equivalent
+      // prefixed rule even when that rule is not one of its variants: the
+      // targets decide which variants it prints.
+      minify_prefix_test_again(
+        ".a:read-only::placeholder{color:red}.a:-moz-read-only::placeholder{color:red}",
+        ".a:read-only::-webkit-input-placeholder{color:red}.a:-moz-read-only::-moz-placeholder{color:red}.a:read-only::placeholder{color:red}",
+        { chrome: 40 << 16, firefox: 30 << 16 },
+      );
+      minify_prefix_test_again(
+        ".a:is(.b,.c):after{color:red}.a:-webkit-any(.b,.c):after{color:red}",
+        ".a:is(.b,.c):after{color:red}",
+        { safari: 16 << 16 },
+      );
+      minify_prefix_test_again(
+        ".a:is(.b,.c):after{color:red}.a:-webkit-any(.b,.c):after{color:red}",
+        ".a:-webkit-any(.b,.c):after{color:red}.a:is(.b,.c):after{color:red}",
+        { safari: 12 << 16 },
+      );
+    });
   });
 
   describe("calc edge case", () => {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -221,11 +221,21 @@ describe("css tests", () => {
         ":-webkit-full-screen .a:-webkit-autofill:-moz-read-only{color:red}:fullscreen .a:-webkit-autofill:-moz-read-only{color:red}",
         { safari: 8 << 16 },
       );
-      // A nested rule with only an explicit prefix is printed once, in the
-      // pass of its prefix.
+      // A nested rule with prefixable components of its own prints in every
+      // pass of its parents too, and keeps its explicit prefix in all of them.
       minify_prefix_test(
         ":fullscreen{.a::-webkit-input-placeholder{color:red}}",
-        ":-webkit-full-screen .a::-webkit-input-placeholder{color:red}",
+        ":-webkit-full-screen .a::-webkit-input-placeholder{color:red}:fullscreen .a::-webkit-input-placeholder{color:red}",
+        { safari: 8 << 16 },
+      );
+      minify_prefix_test(
+        ":fullscreen{.a:read-only:-webkit-any-link{color:red}}",
+        ":-webkit-full-screen .a:read-only:-webkit-any-link{color:red}:-moz-full-screen .a:-moz-read-only:-webkit-any-link{color:red}:fullscreen .a:read-only:-webkit-any-link{color:red}",
+        { safari: 8 << 16, firefox: 30 << 16 },
+      );
+      minify_prefix_test(
+        ":fullscreen{.x::selection{color:red}}",
+        ":-webkit-full-screen .x::selection{color:red}:fullscreen .x::selection{color:red}",
         { safari: 8 << 16 },
       );
     });
@@ -276,6 +286,11 @@ describe("css tests", () => {
         ".x:not(:-webkit-any(.a,.b)){color:red}.x:not(:is(.a,.b)){color:red}",
         { safari: 8 << 16 },
       );
+      // `:-webkit-any()` takes compound selectors only, so a `:not()` list with
+      // a combinator gets no `-webkit-` copy either.
+      minify_prefix_test_again(".x:not(.a .b,.c){color:red}", ".x:not(:is(.a .b,.c)){color:red}", {
+        safari: 8 << 16,
+      });
       minify_prefix_test_again(
         ".x:lang(en,fr){color:red}",
         ".x:-webkit-any(:lang(en),:lang(fr)){color:red}.x:-moz-any(:lang(en),:lang(fr)){color:red}.x:is(:lang(en),:lang(fr)){color:red}",

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -9,6 +9,7 @@ import {
   cssTest,
   indoc,
   minify_error_test_with_options,
+  minify_prefix_test,
   minify_test,
   minifyTestWithOptions as minify_test_with_options,
   ParserFlags,
@@ -160,6 +161,26 @@ describe("css tests", () => {
         safari: 14 << 16,
         opera: 67 << 16,
       },
+    );
+  });
+
+  describe("vendor prefixed pseudo classes", () => {
+    // chrome <= 109 needs :-webkit-autofill.
+    minify_prefix_test(".a:autofill{color:red}", ".a:-webkit-autofill{color:red}.a:autofill{color:red}", {
+      chrome: 103 << 16,
+    });
+    minify_prefix_test(
+      ".a:placeholder-shown .b:autofill{color:red}",
+      ".a:placeholder-shown .b:-webkit-autofill{color:red}.a:placeholder-shown .b:autofill{color:red}",
+      { chrome: 103 << 16 },
+    );
+    minify_prefix_test(".a:read-only{color:red}", ".a:-moz-read-only{color:red}.a:read-only{color:red}", {
+      firefox: 50 << 16,
+    });
+    minify_prefix_test(
+      ".a:any-link{color:red}",
+      ".a:-webkit-any-link{color:red}.a:-moz-any-link{color:red}.a:any-link{color:red}",
+      { chrome: 40 << 16, firefox: 30 << 16 },
     );
   });
 

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -123,66 +123,62 @@ test("bun build --target=browser does not blow up on deeply nested prefixed sele
 // Regression for a CSS-minifier output bomb found by fuzzing: a ~1.5 KB input
 // minified to ~884 MB (≈577,000× amplification), a DoS vector.
 //
-// When a rule's selector list mixes a vendor-prefixed pseudo-class
-// (`:-webkit-autofill`) with an unprefixed one (`:placeholder-shown`),
-// `get_prefix` sets two prefix bits and `StyleRule::to_css` serializes the
-// whole rule once per bit. Each pass re-serializes the rule's nested rules, so
-// nesting such rules repeats the inner subtree once per prefix at every level
-// — (prefix count)^depth. The earlier fix (PR #31270) deduplicated this only
-// when nesting was compiled away for browser targets; with no targets (or
-// nesting-capable targets) nesting is preserved, `&` is printed literally, and
-// every ancestor prefix pass genuinely needs its own copy of the body, so the
-// output cannot be collapsed. The minifier now bounds the total bytes emitted
-// by those duplicate prefix passes and errors out instead of allocating
-// gigabytes.
-
-const VENDOR_PREFIX_LIMIT_ERROR = "Maximum vendor-prefix expansion exceeded";
+// A rule whose selector list mixes an explicitly prefixed pseudo-class
+// (`:-webkit-autofill`) with an unprefixed one (`:placeholder-shown`) used to
+// be printed once per prefix: `get_prefix` set two prefix bits, and the second
+// pass rewrote `:-webkit-autofill` to an `:autofill` the source never had. With
+// no targets (or nesting-capable targets) nesting is preserved, every pass
+// re-serialized the nested rules too, and nesting such rules grew the output by
+// 2^depth. An explicitly prefixed component is now printed as written and adds
+// no pass of its own, so these rules print once per level.
 
 // `depth` nested copies of a rule whose selector list mixes a prefixed pseudo
-// (`:-webkit-autofill`, prefix bit) with an unprefixed one
-// (`:placeholder-shown`, NONE bit), innermost holding `color: red`.
+// (`:-webkit-autofill`) with an unprefixed one (`:placeholder-shown`),
+// innermost holding `color: red`.
 function nestedMixedPrefix(depth: number): string {
   return ".a:placeholder-shown .x, .b:-webkit-autofill .y {\n".repeat(depth) + "color: red;\n" + "}\n".repeat(depth);
 }
 
-test("deeply nested mixed vendor-prefix rules error instead of exploding with no targets", () => {
-  // Each level doubles the number of printed rule copies, so without a bound
-  // this is ~2^depth copies of the leaf — hundreds of MB by the mid-teens.
-  // The bound turns it into a thrown error.
-  expect(() => minifyTest(nestedMixedPrefix(20), "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+// The minified `nestedMixedPrefix(depth)`: each level once, nested levels with
+// an explicit `&`. `wrap` wraps each selector list in `:is()`, which the
+// minifier does for targets that support `:is()` but not every selector in the
+// list (`:-webkit-autofill` counts as unsupported).
+function nestedMixedPrefixOutput(depth: number, wrap = (list: string) => list): string {
+  const outer = wrap(".a:placeholder-shown .x,.b:-webkit-autofill .y") + "{";
+  const nested = wrap("& .a:placeholder-shown .x,& .b:-webkit-autofill .y") + "{";
+  return outer + nested.repeat(depth - 1) + "color:red" + "}".repeat(depth);
+}
+
+test("nested rules that mix a prefixed and an unprefixed pseudo-class print once per level", () => {
+  expect(minifyTest(nestedMixedPrefix(2), "")).toBe(
+    ".a:placeholder-shown .x,.b:-webkit-autofill .y{& .a:placeholder-shown .x,& .b:-webkit-autofill .y{color:red}}",
+  );
+  // ~2^20 copies of the leaf before the fix (bounded by an error since #31642).
+  expect(minifyTest(nestedMixedPrefix(20), "")).toBe(nestedMixedPrefixOutput(20));
 });
 
-test("the fuzzer reproduction shape errors instead of amplifying", () => {
+test("the fuzzer reproduction shape prints once per level", () => {
   // The fuzzer's shape: unclosed nested rules (the CSS parser closes them at
-  // EOF). 884 MB of output on the original 1.5 KB input; now a thrown error.
+  // EOF). 884 MB of output on the original 1.5 KB input.
   const src = ".a:placeholder-shown .x, .b:-webkit-autofill .y {\n".repeat(20) + "color: red;";
-  expect(() => minifyTest(src, "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+  expect(minifyTest(src, "")).toBe(nestedMixedPrefixOutput(20));
 });
 
-test("nesting-capable targets also bound the mixed vendor-prefix expansion", () => {
-  // Modern targets preserve nesting (no de-nesting), so the same per-prefix
-  // re-serialization of the body applies and must be bounded too.
-  expect(() => minifyTest(nestedMixedPrefix(20), "", { chrome: 130 << 16 })).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+test("nesting-capable targets print mixed-prefix nested rules once per level", () => {
+  // Modern targets preserve nesting (no de-nesting) and need no prefixes here.
+  expect(minifyTest(nestedMixedPrefix(20), "", { chrome: 130 << 16 })).toBe(
+    nestedMixedPrefixOutput(20, list => `:is(${list})`),
+  );
 });
 
-test("shallow mixed vendor-prefix nesting still minifies with both prefix variants", () => {
-  // Below the limit, the rule is still emitted once per prefix variant — the
-  // expansion is correct and necessary, just bounded.
-  const output = minifyTest(nestedMixedPrefix(2), "");
-  expect(output).toContain(":-webkit-autofill");
-  expect(output).toContain(":autofill");
-  expect(output).toContain("color:red");
-  expect(output.length).toBeLessThan(10_000);
-});
-
-test("deeply nested single-prefix rules stay linear and do not trip the bound", () => {
-  // A single selector with one vendor prefix (no mixing with an unprefixed
-  // selector) sets one prefix bit, so the rule is serialized once per level —
-  // linear, not multiplicative. This must not hit the bound.
+test("deeply nested single-prefix rules stay linear", () => {
+  // A single selector with one explicit vendor prefix is serialized once per
+  // level.
   const src = ".b:-webkit-autofill .y {\n".repeat(40) + "color: red;\n" + "}\n".repeat(40);
   const output = minifyTest(src, "");
-  expect(output).toContain("color:red");
-  expect(output.length).toBeLessThan(10_000);
+  expect(output).toBe(
+    ".b:-webkit-autofill .y{" + "& .b:-webkit-autofill .y{".repeat(39) + "color:red" + "}".repeat(40),
+  );
 });
 
 test("a large flat stylesheet of fanning-out rules does not trip the bound", () => {
@@ -192,12 +188,13 @@ test("a large flat stylesheet of fanning-out rules does not trip the bound", () 
   // the byte budget, but only a few dozen bytes per rule, so the total stays
   // far under the cap without nesting to compound it. Old targets downlevel a
   // single `::placeholder` into four prefix variants (`-webkit-input-`,
-  // `-moz-`, `-ms-input-`, unprefixed); 20_000 such rules charge ~3 duplicate
-  // passes of a tiny declaration each (a few MB total), well under the 64 MB
+  // `-moz-`, `-ms-input-`, unprefixed); 10_000 such rules charge ~3 duplicate
+  // passes of a tiny declaration each (~1.3 MB total), well under the 64 MB
   // byte limit. Distinct declarations keep the rules from being merged. This
-  // stays linear instead of throwing.
+  // stays linear instead of throwing. (10_000 keeps a debug build under the
+  // default per-test timeout.)
   const oldTargets = { safari: 8 << 16, firefox: 20 << 16, chrome: 30 << 16, edge: 12 << 16 };
-  const count = 20_000;
+  const count = 10_000;
   let src = "";
   for (let i = 0; i < count; i++) src += `input.c${i}::placeholder{--v${i}:1}`;
   const output = minifyTest(src, "", oldTargets);
@@ -206,36 +203,22 @@ test("a large flat stylesheet of fanning-out rules does not trip the bound", () 
   expect(output.split("::-webkit-input-placeholder").length - 1).toBe(count);
 });
 
-test("leaf rules nested under a fanning-out ancestor are bounded", () => {
-  // The amplification is driven by the whole nested body re-serialized once per
-  // ancestor prefix, so it must be bounded by the *output* emitted under a
-  // fan-out — not by whether each nested rule fans out on its own. Each nesting
-  // level is a two-prefix rule holding K plain leaf siblings plus one recursive
-  // child; the leaves never fan out themselves but are duplicated
-  // (prefix count)^depth times. A ~1.4 KB input expands past 9 MB here unless
-  // those duplicated leaves count against the bound; it becomes a thrown error.
-  const K = 1;
-  const depth = 15;
-  const leaves = Array.from(
-    { length: K },
-    (_, i) => `.x${i}:placeholder-shown,.y${i}:-webkit-autofill{--v${i}:1}`,
-  ).join("");
+test("the body of a nested mixed-prefix rule is printed once per level", () => {
+  // Sibling leaf rules and declarations under each level were re-serialized
+  // once per ancestor prefix pass too: ~1.4 KB and ~1.8 KB of input printed
+  // 9 MB and tens of MB.
   const level = ".a:placeholder-shown,.b:-webkit-autofill{";
-  const src = (level + leaves).repeat(depth) + "}".repeat(depth);
-  expect(() => minifyTest(src, "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
-});
+  const nestedLevel = "& .a:placeholder-shown,& .b:-webkit-autofill{";
 
-test("a large declaration block under a fanning-out ancestor is bounded", () => {
-  // The duplicated payload need not be nested rules: a fan-out pass also
-  // re-serializes the rule's own declarations. Each nesting level is a
-  // two-prefix rule whose body is one large custom-property declaration plus a
-  // recursive child, so the declaration bytes are duplicated (prefix count)^depth
-  // times — ~1.8 KB of input emits tens of MB. Counting only nested rules would
-  // miss this (the declaration is not a rule); bounding the emitted bytes of
-  // each duplicate pass catches it.
-  const depth = 16;
-  const payload = `--p:${Buffer.alloc(64, "a").toString()};`;
-  const level = ".a:placeholder-shown,.b:-webkit-autofill{";
-  const src = (level + payload).repeat(depth) + "}".repeat(depth);
-  expect(() => minifyTest(src, "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+  const depth = 15;
+  const leaf = ".x0:placeholder-shown,.y0:-webkit-autofill{--v0:1}";
+  const nestedLeaf = "& .x0:placeholder-shown,& .y0:-webkit-autofill{--v0:1}";
+  expect(minifyTest((level + leaf).repeat(depth) + "}".repeat(depth), "")).toBe(
+    level + (nestedLeaf + nestedLevel).repeat(depth - 1) + nestedLeaf + "}".repeat(depth),
+  );
+
+  const payload = `--p:${Buffer.alloc(64, "a").toString()}`;
+  expect(minifyTest((level + payload + ";").repeat(depth) + "}".repeat(depth), "")).toBe(
+    level + (payload + ";" + nestedLevel).repeat(depth - 1) + payload + "}".repeat(depth),
+  );
 });

--- a/test/js/bun/css/util.ts
+++ b/test/js/bun/css/util.ts
@@ -53,6 +53,12 @@ export function minify_test(source: string, expected: string) {
   });
 }
 
+export function minify_prefix_test(source: string, expected: string, targets: Browsers) {
+  test(source, () => {
+    expect(minifyTest(source, expected, targets)).toEqual(expected);
+  });
+}
+
 export function prefix_test(source: string, expected: string, targets: Browsers, skip?: boolean) {
   const testf = skip ? test.skip : test;
   testf(source, () => {


### PR DESCRIPTION
### Problem
- `bun build --minify` prints `input:-moz-read-only::placeholder{color:red}` plus an extra `input:read-only::placeholder{color:red}` that is not in the source and matches in Chrome and Safari (lightningcss does the same).
- Cause: `StyleRule::to_css` prints a rule once per vendor prefix pass. A prefixed component printed unprefixed in a pass it had no variant for (`src/css/selectors/selector.rs`), `get_prefix` gave author-mixed rules an unprefixed pass, and `merge_style_rules` merged the passes of equivalent rules but not their components' prefixes.
- The pseudo class path also used `|` for `&`: `.a:autofill` with chrome 103 printed `.a:autofill{}` twice. The first commit fixes only that and stands alone.

### Fix
- A prefixed component prints the pass prefix only when it has that variant, else as written. An `:is()` that needs `:-webkit-any()` becomes `Component::Any` with those prefixes.
- A rule's passes are the extra prefixes its components got from the targets or from merged rules, plus one pass as written. Merging equivalent rules merges the prefix set of each component pair.
- Correct because a prefix prints only for a component written with it, needing it for the targets, or merged with an equivalent rule that has it.
- Verified: `test/js/bun/css/css.test.ts` (84 new cases, 61 fail on 1.4.2), `nested-vendor-prefix-duplication.test.ts`, all of `test/js/bun/css/` and `test/bundler/css/`. Self-reviewed: 5 concerns raised, 4 addressed. Not taken: a separate PR for the `&` fix. It is the first commit instead.

### Background
- `src/css` ports lightningcss. A prefixable pseudo class or element stores a `VendorPrefix` bit set: its written prefix, or `NONE` plus what the targets need. `StyleRule::to_css` serializes the rule once per pass: `.a::placeholder` becomes `.a::-webkit-input-placeholder{…}.a::placeholder{…}` for old Safari.
- The minifier merges adjacent rules with equal declarations and selectors equal up to prefixes into one rule with several passes.

<details><summary>Notes</summary>

- Upstream lightningcss 1.33.0 prints the same output as bun 1.4.3 for every case here except the `|` typo, which is bun-only. The upstream mixing rule in `get_prefix` is also order dependent: `.b:autofill .a:placeholder-shown` (chrome 103) round-trips through a second minify unchanged, `.a:placeholder-shown .b:autofill` grows a duplicate rule. Both are stable now.
- More symptoms of the same cause, all fixed: `.p::placeholder,.p::-moz-placeholder{}` gained a `.p::placeholder,.p::placeholder{}` rule; `.a:read-only{c}.a:-moz-read-only{c}` printed `.a:read-only{c}` twice and lost the `-moz-` rule; `.a::-webkit-input-placeholder{c}.a::-moz-placeholder{c}` printed the second rule as `::placeholder` (bulma.css); `.a:not(:-moz-read-only)` printed as `.a:not(:read-only)`; `.a:is(.x,.y):-webkit-autofill` printed as `:-webkit-any(.x,.y):-webkit-autofill` plus `:is(.x,.y):autofill`; a nested `.x:-moz-read-only { .a::placeholder {} }` printed the parent as `.x:read-only`.
- `:is()` in a `-webkit-` pass: `.x:is(.a .b,.c):autofill` with chrome 103 printed `.x:-webkit-any(.a .b,.c):-webkit-autofill`, which Chrome rejects (`-webkit-any()` takes compound selectors only), so the `-webkit-autofill` styling was lost. It now prints `.x:is(.a .b,.c):-webkit-autofill`. `:is()` still becomes `:-webkit-any()` / `:-moz-any()` when the targets lack `:is()`: `downlevel_selectors` converts it (and the `:is()` it builds for `:not(a, b)`) to `Component::Any` with the needed prefixes, which prints the same strings as before (`test/bundler/css/is-selector-21169.test.ts` and `test/regression/issue/25794.test.ts` are unchanged).
- `update_prefix` runs again on every style rule of an `@media` rule when an adjacent `@media` with the same query is merged into it. Every new test case also runs inside such a pair, so the converted `:is()`, the merged prefix sets and the passes have to come out the same the second time. An earlier revision of this branch printed `.a:is(.b,.c)` only (no `-webkit-any`/`-moz-any` copies) in that position.
- Merging: `selector::merge_prefixes` ORs the prefix set of each component pair and first checks, from the sets alone, that the merged rule prints exactly the variants the two rules print. `.a:-moz-read-only::placeholder{c}` + `.a:read-only::-moz-placeholder{c}` stays two rules: one merged rule would print `-moz-read-only::-moz-placeholder` and `read-only::placeholder`. With targets, a rule with no explicit prefixes absorbs any equivalent rule regardless, and a component with an unprefixed variant keeps exactly the prefixes the targets need (`Targets::prefixes`). That is lightningcss's removal of unneeded prefixed copies, now in either rule order: `.a:-moz-read-only{c}` next to `.a:read-only{c}` is `.a:read-only{c}` for firefox 100 whichever comes first (before: only when the unprefixed rule came second). A kept `:is()` becomes `Component::Any` when an explicit `:-webkit-any()` rule merges into it.
- Nested rules with nesting compiled away: a nested rule with prefixes of its own is printed once, in its own passes, with the parent selectors substituted for `&` (#31270). Those passes now also include the extra prefixes of the parents' components (`selector::nested_prefix_passes`, used by `StyleRule::to_css` when a parent context is set). `:fullscreen { .x::selection {} }` with safari 8 printed only `:fullscreen .x::selection` on main and now also prints `:-webkit-full-screen .x::selection`; `:fullscreen { .a::-webkit-input-placeholder {} }` prints the `:-webkit-full-screen` and `:fullscreen` variants, both with `::-webkit-input-placeholder`. A rule that mixes two explicit vendors (`.a:-webkit-autofill:-moz-read-only`) still gets no passes of its own and prints in each parent pass.
- The `:is()` that `:not(a, b)` lowers to now gets the same combinator check as a written `:is()`: `.x:not(.a .b,.c)` with safari 8 prints `.x:not(:is(.a .b,.c))` instead of an extra `:not(:-webkit-any(.a .b,.c))` copy that browsers reject.
- Cross-vendor passes are kept: `input:-moz-read-only::placeholder` with firefox 30 and safari 8 targets prints a `::-webkit-input-placeholder` pass that keeps `:-moz-read-only`. No browser matches it, but it is valid, it never applies where the source does not, and dropping it would put a vendor heuristic on top of the prefix tables.
- The tests from #31642 in `nested-vendor-prefix-duplication.test.ts` reached the 64 MB prefix-expansion bound through author-mixed selectors (`.a:placeholder-shown .x, .b:-webkit-autofill .y` nested 20 deep fanned out 2^20 times). Those inputs now print once per level, so the tests assert the exact linear output instead of the error. The bound stays but has no test now: reaching it needs a multi-pass rule with nested rules printed with nesting preserved, and with the current prefix tables every browser version that needs a selector prefix predates nesting support, while merged rules never have nested rules. It still guards a minify whose targets differ from the printer's.
- The 20k-rule flat fan-out test in the same file spends 3.6 s in minify in a debug build, before and after this change, and timed out at the 5 s default here, so it now uses 10k rules.
- Merge order side effect without targets: `::-ms-input-placeholder{c} ::placeholder{c} .x{c}` (foundation.css) now merges the first two rules, so `.x` no longer joins `::placeholder`'s selector list: one more rule, same meaning (+19 bytes on foundation.css with `--target=bun`, -62 bytes with browser targets).
- Corpus: `test/js/bun/css/files/*.css` with `--minify` for `--target=browser` and `--target=bun`: 4 of 30 outputs change, all in placeholder rules. foundation keeps `::-moz-placeholder` and bulma keeps `::-webkit-input-placeholder`; both were printed as `::placeholder` before.
- Overlap: #42100 (keep selector lists with a vendor-prefixed member whole) adds a guard to `update_prefix` that prints a rule mixing `NONE` with a vendor prefix once as written, with no downlevel of its unprefixed members; this change covers that case (with the downlevel) and the guard can go when both land. #42029 changes the same `:is()` lowering arm and serializer branch (it gates `-webkit-any()` copies on specificity); its gate would decide whether `downlevel_selectors` converts an `:is()` here. #40464 shares `update_prefix`. Whichever lands second needs a rebase.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 66 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts test/js/bun/css/nested-vendor-prefix-duplication.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.01ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.08ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.01ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cas
... (truncated)

release without fix: 12 failed, 67 skipped
bun test v1.4.3-canary.1 (c8b90a7ee)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.11ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.02ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.03ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts test/js/bun/css/nested-vendor-prefix-duplication.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [2.89ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.01ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.11ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cas
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 618ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/138] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/138] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/lib.rs                                     |  10 +
 src/css/rules/mod.rs                               |  25 +-
 src/css/rules/style.rs                             |  18 +-
 src/css/selectors/parser.rs                        |  40 ++-
 src/css/selectors/selector.rs                      | 372 ++++++++++++++++-----
 test/js/bun/css/css.test.ts                        | 230 ++++++++++++-
 .../css/nested-vendor-prefix-duplication.test.ts   | 139 ++++----
 test/js/bun/css/util.ts                            |   6 +
 8 files changed, 654 insertions(+), 186 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/css/lib.rs                                                1      1     45
src/css/rules/mod.rs                                          3      4     45
src/css/rules/style.rs                                        2      3     45
src/css/selectors/parser.rs                                   5      2     45
src/css/selectors/selector.rs                                17     23     45
test/js/bun/css/css.test.ts                                   5      7     38
test/js/bun/css/nested-vendor-prefix-duplication.test.ts      4      3     18
test/js/bun/css/util.ts                                       1      1     47
```

</details>

<!-- robobun:evidence:end -->