### PR TITLE
webcrypto: accept HMAC key lengths that are not a multiple of 8

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -308,7 +308,9 @@ static String agentClusterIDFromGlobalObject(JSGlobalObject& globalObject)
 
 // Version 2 added the AKP key class (ML-DSA/ML-KEM), the KEM usage tags, and
 // the ChaCha20-Poly1305/ML-* algorithm identifier tags.
-const uint32_t currentKeyFormatVersion = 2;
+// Version 3 added <lengthBits> to CryptoKeyHMAC.
+const uint32_t currentKeyFormatVersion = 3;
+const uint32_t firstKeyFormatVersionWithHMACLengthBits = 3;
 
 enum class CryptoKeyClassSubtag {
     HMAC = 0,
@@ -547,7 +549,7 @@ static constexpr unsigned StringDataIs8BitFlag = 0x80000000;
  *    SharedArrayBufferTag <value:uint32_t>
  *
  * CryptoKeyHMAC :-
- *    <keySize:uint32_t> <keyData:byte{keySize}> CryptoAlgorithmIdentifierTag // Algorithm tag inner hash function.
+ *    <keySize:uint32_t> <keyData:byte{keySize}> CryptoAlgorithmIdentifierTag <lengthBits:uint32_t> // Algorithm tag inner hash function; lengthBits since key format version 3.
  *
  * CryptoKeyAES :-
  *    CryptoAlgorithmIdentifierTag <keySize:uint32_t> <keyData:byte{keySize}>
@@ -1899,6 +1901,7 @@ private:
             write(CryptoKeyClassSubtag::HMAC);
             write(downcast<CryptoKeyHMAC>(*key).key());
             write(downcast<CryptoKeyHMAC>(*key).hashAlgorithmIdentifier());
+            write(static_cast<uint32_t>(downcast<CryptoKeyHMAC>(*key).lengthBits()));
             break;
         case CryptoKeyClass::AES:
             write(CryptoKeyClassSubtag::AES);
@@ -3051,7 +3054,7 @@ private:
         return true;
     }
 
-    bool readHMACKey(bool extractable, CryptoKeyUsageBitmap usages, RefPtr<CryptoKey>& result)
+    bool readHMACKey(uint32_t keyFormatVersion, bool extractable, CryptoKeyUsageBitmap usages, RefPtr<CryptoKey>& result)
     {
         Vector<uint8_t> keyData;
         if (!read(keyData))
@@ -3059,7 +3062,12 @@ private:
         CryptoAlgorithmIdentifier hash;
         if (!read(hash))
             return false;
-        result = CryptoKeyHMAC::importRaw(0, hash, WTF::move(keyData), extractable, usages);
+        uint32_t lengthBits = 0;
+        if (keyFormatVersion >= firstKeyFormatVersionWithHMACLengthBits) {
+            if (!read(lengthBits) || !CryptoKeyHMAC::lengthIsValidForKeyData(lengthBits, keyData.size()))
+                return false;
+        }
+        result = CryptoKeyHMAC::importRaw(lengthBits, hash, WTF::move(keyData), extractable, usages);
         return true;
     }
 
@@ -3329,7 +3337,7 @@ private:
         RefPtr<CryptoKey> result;
         switch (cryptoKeyClass) {
         case CryptoKeyClassSubtag::HMAC:
-            if (!readHMACKey(extractable, usages, result))
+            if (!readHMACKey(keyFormatVersion, extractable, usages, result))
                 return false;
             break;
         case CryptoKeyClassSubtag::AES:

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp
@@ -114,10 +114,6 @@ void CryptoAlgorithmHMAC::importKey(CryptoKeyFormat format, KeyData&& data, cons
         exceptionCallback(DataError, "HmacImportParams.length cannot be 0"_s);
         return;
     }
-    if (hmacParameters.length && *hmacParameters.length % 8) {
-        exceptionCallback(NotSupportedError, "Unsupported HmacImportParams.length"_s);
-        return;
-    }
 
     RefPtr<CryptoKeyHMAC> result;
     switch (format) {
@@ -128,7 +124,7 @@ void CryptoAlgorithmHMAC::importKey(CryptoKeyFormat format, KeyData&& data, cons
             exceptionCallback(DataError, "Zero-length key is not supported"_s);
             return;
         }
-        if (hmacParameters.length && *hmacParameters.length != keyData.size() * 8) {
+        if (hmacParameters.length && !CryptoKeyHMAC::lengthIsValidForKeyData(*hmacParameters.length, keyData.size())) {
             exceptionCallback(DataError, "Invalid key length"_s);
             return;
         }
@@ -198,7 +194,7 @@ void CryptoAlgorithmHMAC::importKey(CryptoKeyFormat format, KeyData&& data, cons
             exceptionCallback(DataError, "Zero-length key is not supported"_s);
             return;
         }
-        if (hmacParameters.length && *hmacParameters.length != keyBytes->size() * 8) {
+        if (hmacParameters.length && !CryptoKeyHMAC::lengthIsValidForKeyData(*hmacParameters.length, keyBytes->size())) {
             exceptionCallback(DataError, "Invalid key length"_s);
             return;
         }

--- a/src/jsc/bindings/webcrypto/CryptoKeyHMAC.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyHMAC.cpp
@@ -60,11 +60,17 @@ static size_t getKeyLengthFromHash(CryptoAlgorithmIdentifier hash)
     }
 }
 
-CryptoKeyHMAC::CryptoKeyHMAC(Vector<uint8_t>&& key, CryptoAlgorithmIdentifier hash, bool extractable, CryptoKeyUsageBitmap usage)
+CryptoKeyHMAC::CryptoKeyHMAC(Vector<uint8_t>&& key, size_t lengthBits, CryptoAlgorithmIdentifier hash, bool extractable, CryptoKeyUsageBitmap usage)
     : CryptoKey(CryptoAlgorithmIdentifier::HMAC, CryptoKeyType::Secret, extractable, usage)
     , m_hash(hash)
     , m_key(WTF::move(key))
+    , m_lengthBits(lengthBits)
 {
+    ASSERT(lengthIsValidForKeyData(m_lengthBits, m_key.size()));
+    // The key is "the first length bits of data" (https://w3c.github.io/webcrypto/#hmac-operations-import-key),
+    // so clear the bits of the last byte that are past the length, as Chromium does.
+    if (size_t trailingBits = m_key.size() * 8 - m_lengthBits)
+        m_key.last() &= static_cast<uint8_t>(0xFF << trailingBits);
 }
 
 CryptoKeyHMAC::~CryptoKeyHMAC() = default;
@@ -76,25 +82,20 @@ RefPtr<CryptoKeyHMAC> CryptoKeyHMAC::generate(size_t lengthBits, CryptoAlgorithm
         if (!lengthBits)
             return nullptr;
     }
-    // CommonHMAC only supports key length that is a multiple of 8. Therefore, here we are a little bit different
-    // from the spec as of 11 December 2014: https://www.w3.org/TR/WebCryptoAPI/#hmac-operations
-    if (lengthBits % 8)
-        return nullptr;
 
-    return adoptRef(new CryptoKeyHMAC(randomData(lengthBits / 8), hash, extractable, usages));
+    return adoptRef(new CryptoKeyHMAC(randomData((lengthBits + 7) / 8), lengthBits, hash, extractable, usages));
 }
 
 RefPtr<CryptoKeyHMAC> CryptoKeyHMAC::importRaw(size_t lengthBits, CryptoAlgorithmIdentifier hash, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap usages)
 {
-    size_t length = keyData.size() * 8;
-    if (!length)
+    if (keyData.isEmpty())
         return nullptr;
-    // CommonHMAC only supports key length that is a multiple of 8. Therefore, here we are a little bit different
-    // from the spec as of 11 December 2014: https://www.w3.org/TR/WebCryptoAPI/#hmac-operations
-    if (lengthBits && lengthBits != length)
+    if (!lengthBits)
+        lengthBits = keyData.size() * 8;
+    else if (!lengthIsValidForKeyData(lengthBits, keyData.size()))
         return nullptr;
 
-    return adoptRef(new CryptoKeyHMAC(WTF::move(keyData), hash, extractable, usages));
+    return adoptRef(new CryptoKeyHMAC(WTF::move(keyData), lengthBits, hash, extractable, usages));
 }
 
 JsonWebKey CryptoKeyHMAC::exportJwk() const
@@ -124,7 +125,7 @@ auto CryptoKeyHMAC::algorithm() const -> KeyAlgorithm
     CryptoHmacKeyAlgorithm result;
     result.name = CryptoAlgorithmRegistry::singleton().name(algorithmIdentifier());
     result.hash.name = CryptoAlgorithmRegistry::singleton().name(m_hash);
-    result.length = m_key.size() * 8;
+    result.length = m_lengthBits;
     return result;
 }
 

--- a/src/jsc/bindings/webcrypto/CryptoKeyHMAC.h
+++ b/src/jsc/bindings/webcrypto/CryptoKeyHMAC.h
@@ -41,12 +41,17 @@ class CryptoKeyHMAC final : public CryptoKey {
 public:
     virtual ~CryptoKeyHMAC();
 
+    // A lengthBits of 0 selects the default: the hash block size for generate(), every bit of keyData for importRaw().
     static RefPtr<CryptoKeyHMAC> generate(size_t lengthBits, CryptoAlgorithmIdentifier hash, bool extractable, CryptoKeyUsageBitmap);
     static RefPtr<CryptoKeyHMAC> importRaw(size_t lengthBits, CryptoAlgorithmIdentifier hash, Vector<uint8_t>&& keyData, bool extractable, CryptoKeyUsageBitmap);
+
+    // HmacImportParams.length must select a prefix of keyData that ends in its last byte.
+    static bool lengthIsValidForKeyData(size_t lengthBits, size_t keyDataSize) { return lengthBits && keyDataSize == (lengthBits + 7) / 8; }
 
     CryptoKeyClass keyClass() const final { return CryptoKeyClass::HMAC; }
 
     const Vector<uint8_t>& key() const { return m_key; }
+    size_t lengthBits() const { return m_lengthBits; }
     JsonWebKey exportJwk() const;
 
     CryptoAlgorithmIdentifier hashAlgorithmIdentifier() const { return m_hash; }
@@ -54,12 +59,14 @@ public:
     static ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&);
 
 private:
-    CryptoKeyHMAC(Vector<uint8_t>&& key, CryptoAlgorithmIdentifier hash, bool extractable, CryptoKeyUsageBitmap);
+    CryptoKeyHMAC(Vector<uint8_t>&& key, size_t lengthBits, CryptoAlgorithmIdentifier hash, bool extractable, CryptoKeyUsageBitmap);
 
     KeyAlgorithm algorithm() const final;
 
     CryptoAlgorithmIdentifier m_hash;
     Vector<uint8_t> m_key;
+    // The trailing (m_key.size() * 8 - m_lengthBits) bits of m_key are zero.
+    size_t m_lengthBits;
 };
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
@@ -55,6 +55,7 @@
 #include "CryptoAlgorithmMLDSA.h"
 #include "CryptoKeyAKP.h"
 #include "CryptoKeyEC.h"
+#include "CryptoKeyHMAC.h"
 #include "CryptoKeyRSA.h"
 #include "ErrorCode.h"
 #include "JSDOMExceptionHandling.h"
@@ -2121,8 +2122,10 @@ bool SubtleCrypto::supports(JSC::JSGlobalObject& state, const String& operation,
         case CryptoAlgorithmIdentifier::PBKDF2:
             break;
         case CryptoAlgorithmIdentifier::HMAC: {
+            // The ML-KEM shared secret that becomes the key is 32 bytes for every parameter set.
+            constexpr size_t sharedSecretSize = 32;
             auto hmacLength = downcast<CryptoAlgorithmHmacKeyParams>(*additionalParams).length;
-            if (!hmacLength || *hmacLength == 256)
+            if (!hmacLength || CryptoKeyHMAC::lengthIsValidForKeyData(*hmacLength, sharedSecretSize))
                 break;
             return false;
         }

--- a/test/js/node/test/parallel/test-webcrypto-export-import.js
+++ b/test/js/node/test/parallel/test-webcrypto-export-import.js
@@ -66,14 +66,18 @@ const { createPrivateKey, createPublicKey, createSecretKey } = require('crypto')
         name: 'DataError',
         message: 'HmacImportParams.length cannot be 0'
       });
+    // Diverges from upstream: Bun supports an HmacImportParams.length that is not a
+    // multiple of 8, as https://w3c.github.io/webcrypto/#hmac-operations-import-key
+    // and Chromium do. A length that does not end in the last byte of the key data is
+    // the spec's DataError, not Node's NotSupportedError.
     await assert.rejects(
       subtle.importKey('raw', keyData, {
         name: 'HMAC',
         hash: 'SHA-256',
         length: 1
       }, false, ['sign', 'verify']), {
-        name: 'NotSupportedError',
-        message: 'Unsupported HmacImportParams.length'
+        name: 'DataError',
+        message: 'Invalid key length'
       });
     await assert.rejects(
       subtle.importKey('jwk', null, {

--- a/test/js/node/test/parallel/test-webcrypto-export-import.js
+++ b/test/js/node/test/parallel/test-webcrypto-export-import.js
@@ -66,10 +66,6 @@ const { createPrivateKey, createPublicKey, createSecretKey } = require('crypto')
         name: 'DataError',
         message: 'HmacImportParams.length cannot be 0'
       });
-    // Diverges from upstream: Bun supports an HmacImportParams.length that is not a
-    // multiple of 8, as https://w3c.github.io/webcrypto/#hmac-operations-import-key
-    // and Chromium do. A length that does not end in the last byte of the key data is
-    // the spec's DataError, not Node's NotSupportedError.
     await assert.rejects(
       subtle.importKey('raw', keyData, {
         name: 'HMAC',
@@ -87,6 +83,55 @@ const { createPrivateKey, createPublicKey, createSecretKey } = require('crypto')
         name: 'DataError',
         message: 'Invalid keyData'
       });
+  }
+
+  test().then(common.mustCall());
+}
+
+// HMAC non-byte key lengths
+{
+  async function test() {
+    const generated = await subtle.generateKey(
+      { name: 'HMAC', hash: 'SHA-256', length: 9 },
+      true,
+      ['sign', 'verify']);
+    const generatedRaw = await subtle.exportKey('raw', generated);
+    assert.strictEqual(generated.algorithm.length, 9);
+    assert.strictEqual(generatedRaw.byteLength, 2);
+    assert.strictEqual(new Uint8Array(generatedRaw)[1] & 0b01111111, 0);
+
+    const importedExplicit = await subtle.importKey(
+      'raw',
+      new Uint8Array([0xff, 0xff]),
+      { name: 'HMAC', hash: 'SHA-256', length: 9 },
+      true,
+      ['sign', 'verify']);
+    const importedExplicitRaw = await subtle.exportKey('raw', importedExplicit);
+    assert.strictEqual(importedExplicit.algorithm.length, 9);
+    assert.deepStrictEqual(
+      new Uint8Array(importedExplicitRaw),
+      new Uint8Array([0xff, 0x80]));
+
+    const importedImplicit = await subtle.importKey(
+      'raw',
+      new Uint8Array([0xff, 0xff]),
+      { name: 'HMAC', hash: 'SHA-256' },
+      true,
+      ['sign', 'verify']);
+    const importedImplicitRaw = await subtle.exportKey('raw', importedImplicit);
+    assert.strictEqual(importedImplicit.algorithm.length, 16);
+    assert.deepStrictEqual(
+      new Uint8Array(importedImplicitRaw),
+      new Uint8Array([0xff, 0xff]));
+
+    await assert.rejects(
+      subtle.importKey(
+        'raw',
+        new Uint8Array([0xff]),
+        { name: 'HMAC', hash: 'SHA-256', length: 9 },
+        true,
+        ['sign', 'verify']),
+      { name: 'DataError', message: 'Invalid key length' });
   }
 
   test().then(common.mustCall());
@@ -234,6 +279,69 @@ if (hasOpenSSL(3)) {
         true,
         [/* empty usages */]),
       { name: 'SyntaxError', message: 'Usages cannot be empty when importing a secret key.' });
+
+    {
+      const importedZeroImplicit = await subtle.importKey(
+        'raw-secret',
+        new Uint8Array(),
+        name,
+        true,
+        ['sign', 'verify']);
+      const importedZeroImplicitRaw =
+        await subtle.exportKey('raw-secret', importedZeroImplicit);
+      assert.strictEqual(importedZeroImplicit.algorithm.length, 0);
+      assert.strictEqual(importedZeroImplicitRaw.byteLength, 0);
+
+      const importedZeroExplicit = await subtle.importKey(
+        'raw-secret',
+        new Uint8Array(),
+        { name, length: 0 },
+        true,
+        ['sign', 'verify']);
+      const importedZeroExplicitRaw =
+        await subtle.exportKey('raw-secret', importedZeroExplicit);
+      assert.strictEqual(importedZeroExplicit.algorithm.length, 0);
+      assert.strictEqual(importedZeroExplicitRaw.byteLength, 0);
+
+      await assert.rejects(
+        subtle.importKey(
+          'raw-secret',
+          new Uint8Array([0xff]),
+          { name, length: 0 },
+          true,
+          ['sign', 'verify']),
+        { name: 'DataError', message: 'Invalid key length' });
+
+      const generated = await subtle.generateKey(
+        { name, length: 9 },
+        true,
+        ['sign', 'verify']);
+      const generatedRaw = await subtle.exportKey('raw-secret', generated);
+      assert.strictEqual(generated.algorithm.length, 9);
+      assert.strictEqual(generatedRaw.byteLength, 2);
+      assert.strictEqual(new Uint8Array(generatedRaw)[1] & 0b01111111, 0);
+
+      const importedExplicit = await subtle.importKey(
+        'raw-secret',
+        new Uint8Array([0xff, 0xff]),
+        { name, length: 9 },
+        true,
+        ['sign', 'verify']);
+      const importedExplicitRaw = await subtle.exportKey('raw-secret', importedExplicit);
+      assert.strictEqual(importedExplicit.algorithm.length, 9);
+      assert.deepStrictEqual(
+        new Uint8Array(importedExplicitRaw),
+        new Uint8Array([0xff, 0x80]));
+
+      await assert.rejects(
+        subtle.importKey(
+          'raw-secret',
+          new Uint8Array([0xff]),
+          { name, length: 9 },
+          true,
+          ['sign', 'verify']),
+        { name: 'DataError', message: 'Invalid key length' });
+    }
   }
 
   test('KMAC128').then(common.mustCall());

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -1104,6 +1104,116 @@ describe("SubtleCrypto.deriveBits length", () => {
   });
 });
 
+describe("HMAC key length that is not a multiple of 8", () => {
+  // https://w3c.github.io/webcrypto/#hmac-operations: the key is the first `length` bits of
+  // the data, and only a length that does not end in the last byte is a DataError. Chromium
+  // implements it this way; the expectations below match Chromium.
+  const keyData = new Uint8Array(32).map((_, i) => (i == 31 ? 0xff : i));
+  const hex = (b: ArrayBuffer) => Buffer.from(b).toString("hex");
+  const importRaw = (length: number) =>
+    crypto.subtle.importKey("raw", keyData, { name: "HMAC", hash: "SHA-256", length }, true, ["sign"]);
+  const describeKey = async (p: Promise<CryptoKey>) =>
+    p
+      .then(
+        async k =>
+          `${(k.algorithm as HmacKeyAlgorithm).length} ${hex(await crypto.subtle.exportKey("raw", k)).slice(56)}`,
+      )
+      .catch(e => `${e.name}: ${e.message}`);
+
+  it("importKey keeps the requested length and clears the bits past it", async () => {
+    const jwk = { kty: "oct", k: Buffer.from(keyData).toString("base64url"), alg: "HS256" };
+    expect({
+      256: await describeKey(importRaw(256)),
+      255: await describeKey(importRaw(255)),
+      252: await describeKey(importRaw(252)),
+      249: await describeKey(importRaw(249)),
+      248: await describeKey(importRaw(248)),
+      257: await describeKey(importRaw(257)),
+      1: await describeKey(importRaw(1)),
+      0: await describeKey(importRaw(0)),
+      "jwk 250": await describeKey(
+        crypto.subtle.importKey("jwk", jwk, { name: "HMAC", hash: "SHA-256", length: 250 }, true, ["sign"]),
+      ),
+      "jwk 264": await describeKey(
+        crypto.subtle.importKey("jwk", jwk, { name: "HMAC", hash: "SHA-256", length: 264 }, true, ["sign"]),
+      ),
+    }).toEqual({
+      256: "256 1c1d1eff",
+      255: "255 1c1d1efe",
+      252: "252 1c1d1ef0",
+      249: "249 1c1d1e80",
+      248: "DataError: Invalid key length",
+      257: "DataError: Invalid key length",
+      1: "DataError: Invalid key length",
+      0: "DataError: HmacImportParams.length cannot be 0",
+      "jwk 250": "250 1c1d1ec0",
+      "jwk 264": "DataError: Invalid key length",
+    });
+  });
+
+  it("a truncated key signs like its zero-padded bytes", async () => {
+    const padded = keyData.slice();
+    padded[31] = 0xf0;
+    const [truncatedKey, paddedKey] = await Promise.all([
+      importRaw(252),
+      crypto.subtle.importKey("raw", padded, { name: "HMAC", hash: "SHA-256" }, true, ["sign"]),
+    ]);
+    const data = new TextEncoder().encode("hello");
+    expect(hex(await crypto.subtle.sign("HMAC", truncatedKey, data))).toBe(
+      hex(await crypto.subtle.sign("HMAC", paddedKey, data)),
+    );
+  });
+
+  it("generateKey rounds the key data up to whole bytes and clears the bits past the length", async () => {
+    const results: Record<number, unknown> = {};
+    for (const length of [1, 7, 9, 17, 255]) {
+      const key = await crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-256", length }, true, ["sign", "verify"]);
+      const raw = new Uint8Array(await crypto.subtle.exportKey("raw", key));
+      results[length] = {
+        length: (key.algorithm as HmacKeyAlgorithm).length,
+        bytes: raw.byteLength,
+        bitsPastLength: raw[raw.byteLength - 1] & (0xff >> length % 8),
+      };
+    }
+    expect(results).toEqual({
+      1: { length: 1, bytes: 1, bitsPastLength: 0 },
+      7: { length: 7, bytes: 1, bitsPastLength: 0 },
+      9: { length: 9, bytes: 2, bitsPastLength: 0 },
+      17: { length: 17, bytes: 3, bitsPastLength: 0 },
+      255: { length: 255, bytes: 32, bitsPastLength: 0 },
+    });
+    // A zero length is still an OperationError (generate-key step 2).
+    expect(
+      await crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-256", length: 0 }, true, ["sign"]).then(
+        () => "resolved",
+        e => e.name,
+      ),
+    ).toBe("OperationError");
+  });
+
+  it("structuredClone preserves the length", async () => {
+    const key = await importRaw(249);
+    const clone = structuredClone(key);
+    expect((clone.algorithm as HmacKeyAlgorithm).length).toBe(249);
+    expect(hex(await crypto.subtle.exportKey("raw", clone))).toBe(hex(await crypto.subtle.exportKey("raw", key)));
+  });
+
+  it("deriveKey can derive an HMAC key of such a length", async () => {
+    const { privateKey, publicKey } = (await crypto.subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, [
+      "deriveKey",
+      "deriveBits",
+    ])) as CryptoKeyPair;
+    const alg = { name: "ECDH", public: publicKey };
+    const key = await crypto.subtle.deriveKey(alg, privateKey, { name: "HMAC", hash: "SHA-256", length: 255 }, true, [
+      "sign",
+    ]);
+    expect((key.algorithm as HmacKeyAlgorithm).length).toBe(255);
+    expect(hex(await crypto.subtle.exportKey("raw", key))).toBe(
+      hex(await crypto.subtle.deriveBits(alg, privateKey, 255)),
+    );
+  });
+});
+
 describe("X25519 JWK import", () => {
   const x25519Public: JsonWebKey = {
     kty: "OKP",

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -1212,6 +1212,36 @@ describe("HMAC key length that is not a multiple of 8", () => {
       hex(await crypto.subtle.deriveBits(alg, privateKey, 255)),
     );
   });
+
+  // ML-KEM's 32-byte shared secret becomes the HMAC key, so exactly the lengths that end in
+  // byte 32 work, and SubtleCrypto.supports() must predict the same set.
+  it("encapsulateKey accepts the lengths a 32-byte key can have and supports() agrees", async () => {
+    const { publicKey, privateKey } = (await crypto.subtle.generateKey("ML-KEM-768", false, [
+      "encapsulateKey",
+      "decapsulateKey",
+    ])) as CryptoKeyPair;
+    const results: Record<number, unknown> = {};
+    for (const length of [256, 252, 249, 248, 264]) {
+      const hmac = { name: "HMAC", hash: "SHA-256", length };
+      results[length] = {
+        supports: SubtleCrypto.supports("encapsulateKey", "ML-KEM-768", hmac),
+        encapsulate: await crypto.subtle.encapsulateKey("ML-KEM-768", publicKey, hmac, true, ["sign"]).then(
+          async ({ sharedKey, ciphertext }) => {
+            const back = await crypto.subtle.decapsulateKey("ML-KEM-768", privateKey, ciphertext, hmac, true, ["sign"]);
+            return `${(sharedKey.algorithm as HmacKeyAlgorithm).length} ${(back.algorithm as HmacKeyAlgorithm).length}`;
+          },
+          e => e.name,
+        ),
+      };
+    }
+    expect(results).toEqual({
+      256: { supports: true, encapsulate: "256 256" },
+      252: { supports: true, encapsulate: "252 252" },
+      249: { supports: true, encapsulate: "249 249" },
+      248: { supports: false, encapsulate: "DataError" },
+      264: { supports: false, encapsulate: "DataError" },
+    });
+  });
 });
 
 describe("X25519 JWK import", () => {


### PR DESCRIPTION
### Problem
- An HMAC key whose `length` is not a multiple of 8 cannot be created. `importKey` with `{ name: "HMAC", hash, length: 255 }` rejects with `NotSupportedError: Unsupported HmacImportParams.length`. `generateKey` with `length: 9` rejects with `OperationError`. The spec, Chromium, and Node since v26.4.0 (nodejs/node#63988) accept both.
- The cause is a `length % 8` rejection in `CryptoAlgorithmHMAC::importKey` (`src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp:117`, Node v26.3.0 parity from #34838) and in `CryptoKeyHMAC::generate` (`CryptoKeyHMAC.cpp:81`). `CryptoKeyHMAC` had no bit-length field.

### Fix
- `CryptoKeyHMAC` stores `lengthBits`, clears the bits of the last byte past it, and reports it as `algorithm.length`. `generate()` draws `ceil(length / 8)` bytes. Import accepts a length that ends in the last byte of the data, else `DataError: Invalid key length`. `supports()` for `encapsulateKey`/`decapsulateKey` with an HMAC key admits the same lengths (was 256 only).
- Structured clone carries `lengthBits`: CryptoKey format version 3. An older Bun cannot read a version 3 key, as with the version 2 bump in #34838. Version 2 payloads still read.
- `test-webcrypto-export-import.js` becomes the verbatim upstream v26.4.0 file. It expects `DataError` for `length: 1` and adds an "HMAC non-byte key lengths" block.
- Verified: `test/js/web/crypto/web-crypto.test.ts` ("HMAC key length that is not a multiple of 8", 6 tests) and that vendored file, all failing on 1.4.3. Also `test/js/web/crypto/`, `wpt-webcrypto.generateKey`, `bun-jsc`, every vendored `test-webcrypto-*`.

### Background
- WebCrypto HMAC import-key throws `DataError` only if `length` is greater than the bit length of the data, or at most that length minus 8. The key is the first `length` bits. Generate-key takes any non-zero `length`. Chromium and Node zero the unused low bits of the last byte and export `ceil(length / 8)` bytes. So does this change.
- HMAC consumes whole bytes, so a 252-bit key signs like its zero-padded 32 bytes. Only `algorithm.length` and the cleared bits differ.

<details><summary>Notes</summary>

Repro (ledger #45333):

```js
const S = crypto.subtle, key = new Uint8Array(32).map((_, i) => i);
for (const length of [256, 255, 249, 248, 257])
  console.log("import  ", length, await S.importKey("raw", key, { name: "HMAC", hash: "SHA-256", length }, true, ["sign"]).then(k => "ok len=" + k.algorithm.length, e => e.name));
for (const length of [8, 1, 7, 9])
  console.log("generate", length, await S.generateKey({ name: "HMAC", hash: "SHA-256", length }, true, ["sign"]).then(async k => "ok " + (await S.exportKey("raw", k)).byteLength + " B", e => e.name));
```

| | bun 1.4.3 | node 26.3.0 | node 26.4.0+ / Chromium 148 | this PR |
|---|---|---|---|---|
| import 255 / 249 | NotSupportedError | NotSupportedError | ok, length 255 / 249 | ok, length 255 / 249 |
| import 248 | DataError | DataError | DataError | DataError |
| import 257 | NotSupportedError | NotSupportedError | DataError | DataError |
| generate 1 / 7 / 9 | OperationError | NotSupportedError | ok, 1 / 1 / 2 bytes | ok, 1 / 1 / 2 bytes |

Node's change: nodejs/node@1eef57293d "crypto: support non-byte WebCrypto lengths and cSHAKE" (nodejs/node#63988), in v26.4.0 and v24.19.0. Its `mac.js` uses `numBitsToBytes` + `truncateToBitLength` and throws `DataError('Invalid key length')` when the byte count does not match, which is the check `CryptoKeyHMAC::lengthIsValidForKeyData` implements. Its `supports()` arm for `encapsulateKey` HMAC is `length === undefined || numBitsToBytes(length) === 32`. The vendored test is pinned at v26.4.0 rather than a newer tag because later revisions also need `isBoringSSL`/`getFips` from `test/common`, which is a separate sync. The KMAC block in that file is gated on `hasOpenSSL(3)` and does not run in Bun.

Interaction with open PRs: #35374 adds a `supports()` rule "HMAC length must be a non-zero multiple of 8" with `[25, false]` / `[255, false]` rows for importKey/generateKey. With this change (and in Node 26.4+) those lengths are supported, so that arm should become `!keyLength || *keyLength` on rebase. On main, `supports('importKey', { name: 'HMAC', hash, length: 255 })` already returns `true`; this PR makes the runtime agree with it.

`deriveKey` with `{ name: "HMAC", hash, length: 255 }` as the derived key type now works for ECDH/X25519 (it used to hit the same `NotSupportedError` in the inner import). HKDF and PBKDF2 still reject a non-multiple-of-8 length in derive-bits, as the spec says. `encapsulateKey`/`decapsulateKey` with an HMAC shared key accept lengths 249..256 (the ML-KEM shared secret is 32 bytes).

`KeyObject.from()` of such a key sees the `ceil(length / 8)` bytes with the trailing bits cleared.

A version 3 CryptoKey payload only matters across Bun versions for `bun:jsc` `serialize()` output or advanced-serialization IPC, the same as the version 2 bump.

Self-reviewed: 3 concerns raised, 3 addressed (verbatim upstream test instead of a hand edit, the stale `supports()` arm, and naming the format bump and the #35374 overlap here).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.27ms]
(pass) Web Crypto > keeps event loop alive [272.73ms]
(pass) Web Crypto > has globals [3.20ms]
(pass) Web Crypto > should encrypt and decrypt [14.05ms]
(pass) Web Crypto > should verify and sign [35.69ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [15.53ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [10.44ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [11.37ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2463.66ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [315.70ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [67.62
... (truncated)

release without fix: 6 FAILED
bun test v1.4.3-canary.1 (f7c975dae)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.04ms]
(pass) Web Crypto > keeps event loop alive [7.98ms]
(pass) Web Crypto > has globals [0.05ms]
(pass) Web Crypto > should encrypt and decrypt [0.67ms]
(pass) Web Crypto > should verify and sign [0.98ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [0.31ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [0.18ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [0.20ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [25.15ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [6.11ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [12.44ms]
(pass) Ed25519 > generateKey > should return CryptoKeys without namedCurve in algorithm field [0.14ms]
(pass) Ed25519 > importKey > rejects a 64-byte JWK d whose traili
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.45ms]
(pass) Web Crypto > keeps event loop alive [272.62ms]
(pass) Web Crypto > has globals [3.35ms]
(pass) Web Crypto > should encrypt and decrypt [14.25ms]
(pass) Web Crypto > should verify and sign [37.44ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [16.06ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [10.19ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [11.68ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2542.34ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [383.39ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [77.35
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 795ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/136] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/136] gen cpp.rs (cppbind)
[3/136] gen JS modules (bundle-modules)
Preprocess modules (7541ms)
Bundle modules (34ms)
Postprocesss modules (21ms)
Bundle Functions (494ms)
Generate Code (27ms)

[8.13s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/135] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_mimalloc_sys v0.0.0 (/workspace/bun/src/mimalloc_sys)
[1m[92m   Compiling[0m bun_alloc v0.0.0 (/workspace/bun/src/bun_alloc)
[1m[92m   Compiling[0m bun_libdeflate_sys v0.0.0 (/workspace/bun/src/libdeflate_sys)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/SerializedScriptValue.cpp |  18 ++-
 src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp |   8 +-
 src/jsc/bindings/webcrypto/CryptoKeyHMAC.cpp       |  27 ++--
 src/jsc/bindings/webcrypto/CryptoKeyHMAC.h         |   9 +-
 src/jsc/bindings/webcrypto/SubtleCrypto.cpp        |   5 +-
 .../test/parallel/test-webcrypto-export-import.js  | 116 ++++++++++++++++-
 test/js/web/crypto/web-crypto.test.ts              | 140 +++++++++++++++++++++
 7 files changed, 295 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/webcore/SerializedScriptValue.cpp            4      5     20
src/jsc/bindings/webcrypto/CryptoAlgorithmHMAC.cpp            1      3     21
src/jsc/bindings/webcrypto/CryptoKeyHMAC.cpp                  1      2     20
src/jsc/bindings/webcrypto/CryptoKeyHMAC.h                    1      2     20
src/jsc/bindings/webcrypto/SubtleCrypto.cpp                   4      4     20
…t/js/node/test/parallel/test-webcrypto-export-import.js      1      1     30
test/js/web/crypto/web-crypto.test.ts                         6      6     19
```

</details>

<!-- robobun:evidence:end -->