### PR TITLE
Bun.write: unwind when a worker's termination lands while piping a stream body into a file

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1587,7 +1587,19 @@ impl BlobExt for Blob {
         }
 
         if !assignment_result.is_empty_or_undefined_or_null() {
-            global_this.bun_vm().as_mut().drain_microtasks();
+            if let Err(stopped) = global_this
+                .bun_vm()
+                .as_mut()
+                .event_loop_mut()
+                .drain_microtasks()
+            {
+                // The VM is stopping (a worker's terminate() met in `pull()` or in this checkpoint).
+                // The pump will never end()/close() the controller now, so detach it while the sink
+                // is alive: its destructor at teardown would otherwise finalize a freed sink.
+                let mut source = file_sink.source.replace(streams::SourceHandle::None);
+                webcore::file_sink::JSSink::detach(&mut source, global_this);
+                return Err(stopped.throw(global_this));
+            }
 
             assignment_result.ensure_still_alive();
             // it returns a Promise when it goes through ReadableStreamDefaultReader

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -242,12 +242,13 @@ impl<T: JsSinkAbi> JSSink<T> {
             *src = streams::SourceHandle::JSController(controller);
         }
         let result = streams::controller_abi::assign_to_stream(global, stream, controller);
-        // Setup threw (e.g. a direct stream's `pull` getter): nothing will ever
-        // end()/close() the controller, and its destructor would otherwise run
-        // `${name}__finalize` on the sink after the caller has freed it. Detach
-        // it while `ptr` is live; that reaches `js_controller_detached`, which
-        // drops it from `source()` (a no-op if it already detached in the call).
-        if result.to_error().is_some() {
+        // Setup threw (e.g. a direct stream's `pull` getter, or the VM's termination landed in
+        // `pull()`: `to_error()` does not unwrap that cell): nothing will ever end()/close() the
+        // controller, and its destructor would otherwise run `${name}__finalize` on the sink
+        // after the caller has freed it. Detach it while `ptr` is live; that reaches
+        // `js_controller_detached`, which drops it from `source()` (a no-op if it already
+        // detached in the call).
+        if result.to_error().is_some() || result.is_termination_exception() {
             let _ = ::bun_jsc::call_check_slow(global, || {
                 streams::controller_abi::detach_ptr(controller)
             });

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1062,6 +1062,60 @@ test(
   timeout,
 );
 
+// The Bun.write(file, Response(stream)) side of the test above. The pipe into the FileSink starts the
+// pump (which runs `pull()`), drains microtasks, then attaches its continuation to the pump's promise.
+// A terminate() that landed in `pull()` or in that checkpoint left the TerminationException pending
+// while the pipe carried on: JSC assertNoException in the promise `then`, or the sink freed with its
+// JS controller still attached (heap-use-after-free in the controller's destructor at teardown). The
+// pipe now detaches the controller and unwinds.
+test(
+  "terminate() while the worker's Bun.write() pipes a stream body stuck in pull() or a microtask",
+  async () => {
+    const workers = slow ? 4 : 8;
+    using dir = tempDir("worker-terminate-bun-write", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("node:worker_threads");
+        const { join } = require("node:path");
+        // SPIN=sync never leaves pull(); SPIN=microtask suspends pull() and spins in the checkpoint.
+        const src =
+          "const { parentPort } = require('worker_threads');" +
+          "const spin = process.env.SPIN === 'sync' ? () => { for (;;) {} } : async () => { for (;;) await 1; };" +
+          "const body = process.env.SHAPE === 'direct'" +
+          "  ? new ReadableStream({ type: 'direct', async pull(c) { c.write('x'); parentPort.postMessage('pulled'); await spin(); } })" +
+          "  : new ReadableStream({ async pull(c) { c.enqueue(new TextEncoder().encode('x')); parentPort.postMessage('pulled'); await spin(); } });" +
+          "Bun.write(process.env.OUT, new Response(body)).then(() => parentPort.postMessage('settled'), () => parentPort.postMessage('settled'));";
+        (async () => {
+          for (let i = 0; i < ${workers}; i++) {
+            const SHAPE = i % 2 ? "default" : "direct";
+            const SPIN = i % 4 < 2 ? "microtask" : "sync";
+            const OUT = join(${JSON.stringify(String(dir))}, "out-" + i + ".txt");
+            const w = new Worker(src, { eval: true, env: { ...process.env, SHAPE, SPIN, OUT } });
+            const message = await new Promise((resolve, reject) => { w.once("message", resolve); w.once("error", reject); });
+            if (message !== "pulled") throw new Error("unexpected message from worker " + i + ": " + message);
+            await w.terminate();
+          }
+          console.log("PASS");
+          process.exit(0);
+        })();
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("PASS\n");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
+
 // A worker terminated while HTMLRewriter transforms with async element handlers are in flight: a
 // handler's promise reaction resumes the rewrite (more handlers, sink writes, stream delivery) beneath a
 // microtask, and the reaction returned a value with the termination it met still pending ("host fn


### PR DESCRIPTION
### Problem
- `worker.terminate()` on a Worker inside `Bun.write(path, new Response(stream))` crashes bun 1.4.2 when it lands in a direct stream's `pull()`: `Segmentation fault at address 0xB0` at worker teardown (ASAN: heap-use-after-free in `JSSink<FileSink>::js_controller_detached`). If it lands in the pipe's microtask checkpoint instead, debug builds abort: `ASSERTION FAILED: !exception()` via `JSC__JSValue___then`.
- `pipe_readable_stream_to_blob` (`src/runtime/webcore/Blob.rs:1590`) starts the JS pump, drains microtasks, drops the drain's `Err(Stopped)`, and carries on with the TerminationException pending: `.then()` on the pump promise, or a return that frees the `FileSink` with its JS controller attached.

### Fix
- Take the drain's `Stopped`, detach the sink controller while the sink lives, and unwind with `Err(stopped.throw(global))`, as #38660 did for `Bun.serve`.
- `JSSink::assign_to_stream` (`Sink.rs`) already detaches the controller when the pump setup throws, and now also when the thrown value is the TerminationException cell (`to_error()` does not unwrap it).
- Correct because the host call now unwinds like any other throw, and a detached controller never touches the freed sink.
- Verified: `test/js/web/workers/worker-terminate-lifetime.test.ts` (new, four shapes, fails on 1.4.2 and the unfixed debug build). Plus `bun-write.test.js`, related stream suites (see Notes), a 60-worker ASAN storm.

### Background
- `worker.terminate()` closes the VM's script gate and makes JSC throw the TerminationException in running JS. Beneath a host function it stays pending for JSC to unwind. Loop-level code gets `Stopped` instead, and `Stopped::throw` converts back.
- `JSSink::assign_to_stream` creates a `JSReadableFileSinkController` cell with a raw `m_sinkPtr` that `end()`, `close()` or `detachPtr` null. Otherwise its destructor, which worker teardown always runs, calls `FileSink__finalize`.

<details><summary>Notes</summary>

- Deterministic repro: the worker's `pull()` posts a message and then never settles (`for (;;) await 1;` spins in the checkpoint, or `for (;;) {}` never leaves `pull()`). The parent terminates the worker on that message. Unfixed debug build: direct or default stream stuck in a microtask, and default stream stuck in `pull()`: `assertNoException` via `JSValue::then`, 3/3. Direct stream stuck in `pull()`: `heap-use-after-free` in `js_controller_detached` from `~JSReadableFileSinkController` during `WebWorker__teardownJSCVM` (`Heap::lastChanceToFinalize`), freed by the `RefPtr<FileSink>` drop in `pipe_readable_stream_to_blob`. Stock 1.4.2 release: the direct stream stuck in `pull()` segfaults the process, 4/4. The microtask shapes carry on there (the `FileStreamWrapper` leaks and the controller's finalize releases the sink at teardown).
- `GlobalObject::drainMicrotasks` returns STOPPED when the VM is stopping or the drain met the termination, and `EventLoop::drain_microtasks` maps that to `Err(Stopped)`. `RequestContext::drain_microtasks` already consumes it this way.
- Which change covers which shape, checked with a build that had only the `Sink.rs` guard: it handles the direct stream stuck in `pull()` (the termination cell comes back from `assign_to_stream`). The other three shapes return the pump promise, so only the `Blob.rs` arm sees the stop, and without its detach they were a `heap-use-after-free` at teardown instead of the assert.
- `JSSink::detach` clears the `SourceHandle` and calls `JSSinkController__detachPtr`. The controller's `detach()` runs no JS here: it skips `onClose` when a termination is pending, and `AsyncContextFrame::call` is gated on a stopping VM. Taking the handle out of the `JsCell` first (`replace(SourceHandle::None)`) is the idiom `html_rewriter.rs` uses, so no borrow of the cell is held across the re-entrant `FileSink__controllerDetached`.
- Related open PRs on the same function: #41895 and #41897 rework its settle paths for a different bug (the sink freed while a settled JS pump's controller is still attached, e.g. a late `controller.write()`: `FileSink::write_latin1` use-after-free), and draft #41917 reroutes the JS-stream path through `FileSink::pipe_stream`. None of them handles the drain's `Stopped`. This change applies cleanly next to #41897. If #41897 lands first, the `Blob.rs` arm can call its `FileSink::end_js_pump` instead of the inline detach.
- The other `assign_to_stream` owners (`Bun.spawn({ stdin: stream })` through `FileSink::assign_to_stream`, `Bun.write(s3file, ...)` through `s3/client.rs` `upload_stream`, `Bun.serve`, `fetch()` request bodies, HTMLRewriter) were probed or are covered by the existing termination tests in the same file with the same shapes: no crash before or after on the debug ASAN build. The `Sink.rs` guard now detaches their controller too when `pull()` meets the termination, the same thing it already did for any other throw from the setup.
- Self-reviewed: 3 concerns raised (the body understated the release impact, the `assign_to_stream` guard missed the termination cell for every owner, overlap with #41895/#41897/#41917), 3 addressed above.
- Suites run on the debug ASAN build: `worker-terminate-lifetime.test.ts`, `bun-write.test.js`, `spawn-stdin-readable-stream.test.ts`, `spawn-stdin-readable-stream-edge-cases.test.ts`, `serve-direct-readable-stream.test.ts`, `test/js/workerd/html-rewriter.test.js`, `fetch-backpressure.test.ts`, and `cargo check` for `x86_64-pc-windows-msvc`.
- Pre-existing local failures, also on the unfixed build in this container: the `dns.lookup()` teardown LSAN report in the same file, `bun-write.test.js` "on large files" timeout, S3 cases in `fetch-backpressure.test.ts`, `worker-terminate-funnels.test.ts` timeouts.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->