### PR TITLE
Run CommonJS files imported from ES modules in import order

### DIFF
--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -224,9 +224,7 @@ impl Default for RuntimeTranspilerStore {
 // ImportOrder
 // ──────────────────────────────────────────────────────────────────────────
 
-/// The import index at each level of the first path by which a depth-first,
-/// source-order walk of the import graph reaches a module. For leaves (CommonJS
-/// records import nothing) slice order is `InnerModuleEvaluation`'s order.
+/// Import indices along the depth-first, source-order path that first reaches a module.
 type Position = Box<[u32]>;
 
 /// Hash of a module key (the resolved specifier).
@@ -468,8 +466,7 @@ impl RuntimeTranspilerStore {
         // SAFETY: `event_loop` is the VM's live event-loop self-pointer; no borrow of `*this` is live.
         let drain =
             || unsafe { (*event_loop.as_ptr()).drain_microtasks_with_global(global, jsc_vm) };
-        // Set while the last fulfilment's microtasks (where JSC makes the record and, for an ES
-        // module, fetches its imports) have yet to run; nothing is decided or fulfilled until they have.
+        // The last fulfilment's microtasks (record creation, and an ES module's fetches) are pending.
         let mut undrained = false;
         loop {
             let job = iter.next();

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -303,8 +303,7 @@ impl ImportOrder {
 
     /// Moves `key` and its imports to `position` unless an earlier path already reaches it.
     fn place(&mut self, key: ModuleKey, position: Position) {
-        // Depth-first in import order, so that each module below `key` is reached by its
-        // smallest path first and moves at most once: a later, larger path fails the test.
+        // Depth-first in import order: each module is reached by its smallest path first, so moves once.
         let mut stack = vec![(key, position)];
         while let Some((key, position)) = stack.pop() {
             let Some(node) = self.nodes.get_mut(&key) else {
@@ -321,8 +320,7 @@ impl ImportOrder {
             }
             let node = self.nodes.get(&key).unwrap();
             for (index, import) in node.imports.iter().enumerate().rev() {
-                // A module keeps pos(import) <= pos(self) ++ [index] for each of its imports,
-                // so one that does not move has nothing below it to move either.
+                // pos(import) <= pos(self) ++ [index] always holds, so an unmoved module has nothing to move below it.
                 if self
                     .nodes
                     .get(import)

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -443,7 +443,8 @@ impl RuntimeTranspilerStore {
                 self.store.put(job);
             }
         }
-        self.order.held.clear();
+        // Held results root JS promises; a Worker's VM is deallocated without `Drop`.
+        self.order = ImportOrder::default();
     }
 
     /// Fulfil every completed job's module promise. This drain is a dispatcher:
@@ -451,19 +452,22 @@ impl RuntimeTranspilerStore {
     /// folded here and the drain goes on; the VM's termination ends it, with
     /// the rest of the batch back on the queue (each still has its own posted
     /// task, or the teardown release, to pick it up).
-    // Note: takes `NonNull` rather than `&mut` for `event_loop`/`vm`
-    // because `&mut self` already aliases `vm.transpiler_store` (this `Self` is
-    // a field of `VirtualMachine`). Field-level derefs only.
-    pub fn run_from_js_thread(
-        &mut self,
+    ///
+    /// # Safety
+    /// `this` is the VM's store, on the JS thread. Raw because the microtask
+    /// drains below re-enter it (`transpile`, `Bun__onModuleResolved`).
+    pub unsafe fn run_from_js_thread(
+        this: *mut Self,
         event_loop: NonNull<EventLoop>,
         global: &JSGlobalObject,
         vm: NonNull<VirtualMachine>,
     ) {
-        let batch = self.queue.pop_batch();
-        // SAFETY: `vm` is the live owning VM (caller is the JS-thread tick loop).
-        let jsc_vm = unsafe { (*vm.as_ptr()).jsc_vm() };
+        // SAFETY: fn contract; `vm` is the live owning VM.
+        let (batch, jsc_vm) = unsafe { ((*this).queue.pop_batch(), (*vm.as_ptr()).jsc_vm()) };
         let mut iter = batch.iterator();
+        // SAFETY: `event_loop` is the VM's live event-loop self-pointer; no borrow of `*this` is live.
+        let drain =
+            || unsafe { (*event_loop.as_ptr()).drain_microtasks_with_global(global, jsc_vm) };
         // Set while the last fulfilment's microtasks (where JSC makes the record and, for an ES
         // module, fetches its imports) have yet to run; nothing is decided or fulfilled until they have.
         let mut undrained = false;
@@ -473,43 +477,45 @@ impl RuntimeTranspilerStore {
                 break;
             }
             if undrained {
-                // SAFETY: `event_loop` is the VM's live event-loop self-pointer.
-                let drained =
-                    unsafe { (*event_loop.as_ptr()).drain_microtasks_with_global(global, jsc_vm) };
-                if drained.is_err() {
-                    self.requeue(job, &mut iter);
+                if drain().is_err() {
+                    // SAFETY: fn contract; statement-scoped.
+                    unsafe { (*this).requeue(job, &mut iter) };
                     return;
                 }
                 undrained = false;
             }
-            // SAFETY: `job` is a live job popped from the intrusive queue.
-            let completed = unsafe { (*job).take_completed() };
-            if completed.evaluates_when_fulfilled()
-                && self.order.has_unfulfilled_predecessor(completed.order_key)
-            {
-                self.order.hold(completed);
-                continue;
-            }
-            undrained = true;
-            if self.fulfill(global, completed).is_err() {
-                self.requeue(iter.next(), &mut iter);
+            // SAFETY: `job` is a live job popped from the intrusive queue; `this` per fn
+            // contract, each access statement-scoped.
+            let fulfilled = unsafe {
+                let completed = (*job).take_completed();
+                if completed.evaluates_when_fulfilled()
+                    && (*this)
+                        .order
+                        .has_unfulfilled_predecessor(completed.order_key)
+                {
+                    (*this).order.hold(completed);
+                    continue;
+                }
+                undrained = true;
+                Self::fulfill(this, global, completed)
+            };
+            if fulfilled.is_err() {
+                // SAFETY: fn contract; statement-scoped.
+                unsafe { (*this).requeue(iter.next(), &mut iter) };
                 return;
             }
         }
         // Held CommonJS results whose turn has come.
         loop {
-            if undrained {
-                // SAFETY: as above.
-                let drained =
-                    unsafe { (*event_loop.as_ptr()).drain_microtasks_with_global(global, jsc_vm) };
-                if drained.is_err() {
-                    return;
-                }
+            if undrained && drain().is_err() {
+                return;
             }
-            let Some(completed) = self.order.next_ready() else {
+            // SAFETY: fn contract; statement-scoped, after the drain.
+            let Some(completed) = (unsafe { (*this).order.next_ready() }) else {
                 break;
             };
-            if self.fulfill(global, completed).is_err() {
+            // SAFETY: fn contract.
+            if unsafe { Self::fulfill(this, global, completed) }.is_err() {
                 return;
             }
             undrained = true;
@@ -518,7 +524,14 @@ impl RuntimeTranspilerStore {
     }
 
     /// Settle the module promise with the result. `Err` when the VM is terminating.
-    fn fulfill(&mut self, global: &JSGlobalObject, completed: CompletedJob) -> Result<(), ()> {
+    ///
+    /// # Safety
+    /// As for [`run_from_js_thread`](Self::run_from_js_thread).
+    unsafe fn fulfill(
+        this: *mut Self,
+        global: &JSGlobalObject,
+        completed: CompletedJob,
+    ) -> Result<(), ()> {
         let CompletedJob {
             order_key,
             global_this,
@@ -536,7 +549,8 @@ impl RuntimeTranspilerStore {
             &referrer,
             &mut log,
         );
-        self.order.fulfilled(order_key);
+        // SAFETY: fn contract.
+        unsafe { (*this).order.fulfilled(order_key) };
         if let Err(err) = fulfilled {
             if crate::task::report_error_or_terminate(global, err).is_err() {
                 return Err(());

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -5,6 +5,7 @@ use core::cell::Cell;
 use core::ffi::c_void;
 use core::ptr::{self, NonNull};
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::collections::BTreeSet;
 
 use bun_alloc::Arena;
 use bun_ast::Loader;
@@ -13,7 +14,7 @@ use bun_ast::{ImportRecord, ImportRecordFlags};
 use bun_bundler::analyze_transpiled_module;
 use bun_bundler::options::ModuleType;
 use bun_bundler::transpiler::{self as transpiler, AlreadyBundled, ParseOptions, Transpiler};
-use bun_collections::HiveArrayFallback;
+use bun_collections::{HashMap, HiveArrayFallback};
 use bun_core::{MutableString, String, strings};
 use bun_event_loop::{TaskTag, Taskable, task_tag};
 use bun_io::posix_event_loop::get_vm_ctx;
@@ -41,7 +42,7 @@ use crate::runtime_transpiler_cache::{
 };
 use crate::strong::Optional as StrongOptional;
 use crate::virtual_machine::{SourceMapHandlerGetter, VirtualMachine};
-use crate::{JSGlobalObject, JSInternalPromise, JSValue, JsResult, ResolvedSource};
+use crate::{JSGlobalObject, JSInternalPromise, JSValue, ResolvedSource};
 
 // LAYERING: `ParseOptions.runtime_transpiler_cache` carries the canonical
 // lower-tier type from `bun_js_parser` (re-exported via `bun_bundler`). The
@@ -201,6 +202,8 @@ pub struct RuntimeTranspilerStore {
     pub(crate) store: TranspilerJobStore,
     pub enabled: bool,
     pub(crate) queue: Queue,
+    /// JS thread only.
+    order: ImportOrder,
 }
 
 pub type Queue = UnboundedQueue<TranspilerJob>;
@@ -212,8 +215,198 @@ impl Default for RuntimeTranspilerStore {
             store: TranspilerJobStore::init(),
             enabled: true,
             queue: Queue::new(),
+            order: ImportOrder::default(),
         }
     }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// ImportOrder
+// ──────────────────────────────────────────────────────────────────────────
+
+/// The import index at each level of the first path by which a depth-first,
+/// source-order walk of the import graph reaches a module. For leaves (CommonJS
+/// records import nothing) slice order is `InnerModuleEvaluation`'s order.
+type Position = Box<[u32]>;
+
+/// Hash of a module key (the resolved specifier).
+type ModuleKey = u64;
+
+struct ModuleNode {
+    position: Position,
+    /// In resolve order, so that an earlier path found later moves them too.
+    imports: Vec<ModuleKey>,
+    /// Fetches of this module issued to the pool and not yet fulfilled.
+    outstanding: u32,
+}
+
+impl ModuleNode {
+    fn at(position: Position) -> Self {
+        Self {
+            position,
+            imports: Vec::new(),
+            outstanding: 0,
+        }
+    }
+}
+
+/// A CommonJS file imported from an ES module runs when its fetch settles (its
+/// synthetic record takes its export names from `module.exports`), and the pool
+/// finishes jobs in any order, so a CommonJS result is held here until every
+/// fetch before it in the import graph is fulfilled. ES module results are not
+/// held: fulfilling one runs nothing and is what makes JSC fetch its imports.
+#[derive(Default)]
+struct ImportOrder {
+    next_root: u32,
+    /// Every module resolved or fetched since the pool was last idle.
+    nodes: HashMap<ModuleKey, ModuleNode>,
+    /// Every issued fetch not yet fulfilled, held ones included.
+    outstanding: BTreeSet<(Position, ModuleKey)>,
+    held: Vec<CompletedJob>,
+}
+
+impl ImportOrder {
+    fn key(specifier: &[u8]) -> ModuleKey {
+        bun_wyhash::hash(specifier)
+    }
+
+    fn root(&mut self) -> Position {
+        let position = Box::new([self.next_root]);
+        self.next_root += 1;
+        position
+    }
+
+    /// The node for `key`, placed as a new root if the graph has not reached it.
+    fn node(&mut self, key: ModuleKey) -> &mut ModuleNode {
+        if !self.nodes.contains_key(&key) {
+            let position = self.root();
+            self.nodes.insert(key, ModuleNode::at(position));
+        }
+        self.nodes.get_mut(&key).unwrap()
+    }
+
+    /// `specifier` is the next import of `referrer` (empty for an entry point).
+    fn resolved(&mut self, referrer: &[u8], specifier: &[u8]) {
+        if self.outstanding.is_empty() {
+            self.reset();
+        }
+        let key = Self::key(specifier);
+        let position = if referrer.is_empty() {
+            self.root()
+        } else {
+            let parent = self.node(Self::key(referrer));
+            let position = child_position(&parent.position, parent.imports.len());
+            parent.imports.push(key);
+            position
+        };
+        self.place(key, position);
+    }
+
+    /// Moves `key` and its imports to `position` unless an earlier path already reaches it.
+    fn place(&mut self, key: ModuleKey, position: Position) {
+        let mut work = vec![(key, position)];
+        while let Some((key, position)) = work.pop() {
+            let Some(node) = self.nodes.get_mut(&key) else {
+                self.nodes.insert(key, ModuleNode::at(position));
+                continue;
+            };
+            if position >= node.position {
+                continue;
+            }
+            let previous = core::mem::replace(&mut node.position, position.clone());
+            if node.outstanding > 0 {
+                self.outstanding.remove(&(previous, key));
+                self.outstanding.insert((position.clone(), key));
+            }
+            for (index, import) in node.imports.iter().enumerate() {
+                work.push((*import, child_position(&position, index)));
+            }
+        }
+    }
+
+    /// A fetch of `specifier` went to the pool.
+    fn issue(&mut self, specifier: &[u8]) -> ModuleKey {
+        let key = Self::key(specifier);
+        let node = self.node(key);
+        node.outstanding += 1;
+        let position = node.position.clone();
+        bun_core::scoped_log!(
+            RuntimeTranspilerStore,
+            "issue {:?} {}",
+            &position[..],
+            bstr::BStr::new(specifier)
+        );
+        self.outstanding.insert((position, key));
+        key
+    }
+
+    /// True while a fetch of a module before `key` in graph order is unfulfilled.
+    fn has_unfulfilled_predecessor(&self, key: ModuleKey) -> bool {
+        self.outstanding
+            .first()
+            .is_some_and(|(_, first)| *first != key)
+    }
+
+    fn hold(&mut self, completed: CompletedJob) {
+        bun_core::scoped_log!(
+            RuntimeTranspilerStore,
+            "hold {} until {:?}",
+            completed.specifier,
+            self.outstanding.first().map(|(position, _)| &position[..])
+        );
+        self.held.push(completed);
+    }
+
+    /// A held result with no unfulfilled predecessor left, if any.
+    fn next_ready(&mut self) -> Option<CompletedJob> {
+        let (_, first) = self.outstanding.first()?;
+        let index = self
+            .held
+            .iter()
+            .position(|completed| completed.order_key == *first)?;
+        Some(self.held.swap_remove(index))
+    }
+
+    fn fulfilled(&mut self, key: ModuleKey) {
+        if let Some(node) = self.nodes.get_mut(&key) {
+            debug_assert!(node.outstanding > 0);
+            node.outstanding -= 1;
+            if node.outstanding == 0 {
+                self.outstanding.remove(&(node.position.clone(), key));
+            }
+        }
+        if self.outstanding.is_empty() {
+            self.reset();
+        }
+    }
+
+    /// No fetch in flight: nothing to order against, so forget the graph and restart positions.
+    fn reset(&mut self) {
+        debug_assert!(self.held.is_empty());
+        if !self.nodes.is_empty() {
+            self.nodes = HashMap::default();
+        }
+        self.next_root = 0;
+    }
+}
+
+fn child_position(parent: &Position, index: usize) -> Position {
+    let mut position = Vec::with_capacity(parent.len() + 1);
+    position.extend_from_slice(parent);
+    position.push(index as u32);
+    position.into_boxed_slice()
+}
+
+/// `GlobalObject::moduleLoaderResolve`: record one edge of the import graph.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Bun__onModuleResolved(
+    vm: *mut VirtualMachine,
+    referrer: &String,
+    specifier: &String,
+) {
+    // SAFETY: `vm` is the live per-thread VM the C++ global object holds; JS thread.
+    let order = unsafe { &mut (*vm).transpiler_store.order };
+    order.resolved(&referrer.to_utf8(), &specifier.to_utf8());
 }
 
 impl Taskable for RuntimeTranspilerStore {
@@ -250,6 +443,7 @@ impl RuntimeTranspilerStore {
                 self.store.put(job);
             }
         }
+        self.order.held.clear();
     }
 
     /// Fulfil every completed job's module promise. This drain is a dispatcher:
@@ -270,11 +464,15 @@ impl RuntimeTranspilerStore {
         // SAFETY: `vm` is the live owning VM (caller is the JS-thread tick loop).
         let jsc_vm = unsafe { (*vm.as_ptr()).jsc_vm() };
         let mut iter = batch.iterator();
-        let mut job = iter.next();
-        let mut first = true;
-        while !job.is_null() {
-            if !first {
-                // if there are more, we need to drain the microtasks from the previous run
+        // Set while the last fulfilment's microtasks (where JSC makes the record and, for an ES
+        // module, fetches its imports) have yet to run; nothing is decided or fulfilled until they have.
+        let mut undrained = false;
+        loop {
+            let job = iter.next();
+            if job.is_null() {
+                break;
+            }
+            if undrained {
                 // SAFETY: `event_loop` is the VM's live event-loop self-pointer.
                 let drained =
                     unsafe { (*event_loop.as_ptr()).drain_microtasks_with_global(global, jsc_vm) };
@@ -282,19 +480,69 @@ impl RuntimeTranspilerStore {
                     self.requeue(job, &mut iter);
                     return;
                 }
+                undrained = false;
             }
-            first = false;
             // SAFETY: `job` is a live job popped from the intrusive queue.
-            let fulfilled = unsafe { (*job).run_from_js_thread() };
-            job = iter.next();
-            if let Err(err) = fulfilled {
-                if crate::task::report_error_or_terminate(global, err).is_err() {
-                    self.requeue(job, &mut iter);
+            let completed = unsafe { (*job).take_completed() };
+            if completed.evaluates_when_fulfilled()
+                && self.order.has_unfulfilled_predecessor(completed.order_key)
+            {
+                self.order.hold(completed);
+                continue;
+            }
+            undrained = true;
+            if self.fulfill(global, completed).is_err() {
+                self.requeue(iter.next(), &mut iter);
+                return;
+            }
+        }
+        // Held CommonJS results whose turn has come.
+        loop {
+            if undrained {
+                // SAFETY: as above.
+                let drained =
+                    unsafe { (*event_loop.as_ptr()).drain_microtasks_with_global(global, jsc_vm) };
+                if drained.is_err() {
                     return;
                 }
             }
+            let Some(completed) = self.order.next_ready() else {
+                break;
+            };
+            if self.fulfill(global, completed).is_err() {
+                return;
+            }
+            undrained = true;
         }
         // immediately after this is called, the microtasks will be drained again.
+    }
+
+    /// Settle the module promise with the result. `Err` when the VM is terminating.
+    fn fulfill(&mut self, global: &JSGlobalObject, completed: CompletedJob) -> Result<(), ()> {
+        let CompletedJob {
+            order_key,
+            global_this,
+            mut promise,
+            result,
+            specifier,
+            referrer,
+            mut log,
+        } = completed;
+        let fulfilled = AsyncModule::fulfill(
+            &global_this,
+            promise.swap(),
+            result,
+            &specifier,
+            &referrer,
+            &mut log,
+        );
+        self.order.fulfilled(order_key);
+        if let Err(err) = fulfilled {
+            if crate::task::report_error_or_terminate(global, err).is_err() {
+                return Err(());
+            }
+        }
+        Ok(())
     }
 
     /// Put `job` and the rest of a popped batch back: each still has its posted
@@ -343,6 +591,8 @@ impl RuntimeTranspilerStore {
             }
         }
 
+        let order_key = self.order.issue(&input_specifier.to_utf8());
+
         // Build the job by value and `get_init` it into the hive — the `Box`
         // alloc, `JSInternalPromise::create`, and `StrongOptional::create`
         // above all happen *before* the slot is claimed, so an OOM/throw on
@@ -356,6 +606,7 @@ impl RuntimeTranspilerStore {
                 path: owned_path,
                 global_this: BackRef::new(global_object),
                 non_threadsafe_referrer: referrer,
+                order_key,
                 vm,
                 ticket: None,
                 log: bun_ast::Log::init(),
@@ -405,6 +656,8 @@ pub struct TranspilerJob {
     pub path: bun_paths::fs::Path<'static>,
     pub(crate) non_threadsafe_input_specifier: bun_core::String,
     pub(crate) non_threadsafe_referrer: bun_core::String,
+    /// See [`ImportOrder`].
+    order_key: ModuleKey,
     pub(crate) loader: Loader,
     pub(crate) promise: StrongOptional,
     // Note: struct is stored in a HiveArray and crosses to a worker thread;
@@ -433,6 +686,24 @@ unsafe impl unbounded_queue::Linked for TranspilerJob {
     unsafe fn link(item: *mut Self) -> *const unbounded_queue::Link<Self> {
         // SAFETY: `item` is valid and properly aligned per `UnboundedQueue` contract.
         unsafe { core::ptr::addr_of!((*item).next) }
+    }
+}
+
+/// A finished job's result, moved out of its pool slot; `promise` roots the module promise.
+struct CompletedJob {
+    order_key: ModuleKey,
+    global_this: BackRef<JSGlobalObject>,
+    promise: StrongOptional,
+    result: Result<ResolvedSource, crate::CrateError>,
+    specifier: String,
+    referrer: String,
+    log: bun_ast::Log,
+}
+
+impl CompletedJob {
+    /// A CommonJS result: JSC runs the module body when its fetch settles (`createCommonJSModule`).
+    fn evaluates_when_fulfilled(&self) -> bool {
+        matches!(&self.result, Ok(source) if source.is_commonjs_module)
     }
 }
 
@@ -512,19 +783,13 @@ impl TranspilerJob {
         ticket.post(ConcurrentTask::create_from(transpiler_store));
     }
 
-    fn run_from_js_thread(&mut self) -> JsResult<()> {
+    /// Move the result out and hand the slot back to the pool.
+    fn take_completed(&mut self) -> CompletedJob {
         let vm = self.vm;
-        let promise = self.promise.swap();
-        // Copy the BackRef out (it is `Copy`) so the borrow of `*self` ends
-        // before `reset_for_pool`/`put` need `&mut *self` below; deref at the
-        // `fulfill` call site instead.
-        let global_this = self.global_this;
         // Note: the KeepAlive takes an `EventLoopCtx`
         // vtable; resolve it via the `get_vm_ctx` hook (registered by `bun_runtime::init`).
         self.poll_ref.unref(get_vm_ctx(AllocatorType::Js));
 
-        let referrer = core::mem::take(&mut self.non_threadsafe_referrer);
-        let mut log = core::mem::replace(&mut self.log, bun_ast::Log::init());
         let (specifier, result) = match self.parse_error {
             Some(e) => (String::clone_utf8(self.path.text), Err(e)),
             None => {
@@ -535,8 +800,16 @@ impl TranspilerJob {
                 (out, Ok(resolved_source))
             }
         };
+        let completed = CompletedJob {
+            order_key: self.order_key,
+            global_this: self.global_this,
+            promise: core::mem::take(&mut self.promise),
+            result,
+            specifier,
+            referrer: core::mem::take(&mut self.non_threadsafe_referrer),
+            log: core::mem::replace(&mut self.log, bun_ast::Log::init()),
+        };
 
-        self.promise.deinit();
         self.reset_for_pool();
 
         // SAFETY: vm outlives the job; transpiler_store.store.put recycles the slot.
@@ -547,14 +820,7 @@ impl TranspilerJob {
                 .put(std::ptr::from_mut::<TranspilerJob>(self))
         };
 
-        AsyncModule::fulfill(
-            &global_this,
-            promise,
-            result,
-            &specifier,
-            &referrer,
-            &mut log,
-        )
+        completed
     }
 
     fn schedule(&mut self) {

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -260,7 +260,8 @@ struct ImportOrder {
     nodes: HashMap<ModuleKey, ModuleNode>,
     /// Every issued fetch not yet fulfilled, held ones included.
     outstanding: BTreeSet<(Position, ModuleKey)>,
-    held: Vec<CompletedJob>,
+    /// More than one per module only if the loader fetched it twice.
+    held: HashMap<ModuleKey, Vec<CompletedJob>>,
 }
 
 impl ImportOrder {
@@ -302,8 +303,10 @@ impl ImportOrder {
 
     /// Moves `key` and its imports to `position` unless an earlier path already reaches it.
     fn place(&mut self, key: ModuleKey, position: Position) {
-        let mut work = vec![(key, position)];
-        while let Some((key, position)) = work.pop() {
+        // Depth-first in import order, so that each module below `key` is reached by its
+        // smallest path first and moves at most once: a later, larger path fails the test.
+        let mut stack = vec![(key, position)];
+        while let Some((key, position)) = stack.pop() {
             let Some(node) = self.nodes.get_mut(&key) else {
                 self.nodes.insert(key, ModuleNode::at(position));
                 continue;
@@ -311,13 +314,22 @@ impl ImportOrder {
             if position >= node.position {
                 continue;
             }
-            let previous = core::mem::replace(&mut node.position, position.clone());
+            let previous = core::mem::replace(&mut node.position, position);
             if node.outstanding > 0 {
                 self.outstanding.remove(&(previous, key));
-                self.outstanding.insert((position.clone(), key));
+                self.outstanding.insert((node.position.clone(), key));
             }
-            for (index, import) in node.imports.iter().enumerate() {
-                work.push((*import, child_position(&position, index)));
+            let node = self.nodes.get(&key).unwrap();
+            for (index, import) in node.imports.iter().enumerate().rev() {
+                // A module keeps pos(import) <= pos(self) ++ [index] for each of its imports,
+                // so one that does not move has nothing below it to move either.
+                if self
+                    .nodes
+                    .get(import)
+                    .is_none_or(|below| precedes(&node.position, index, &below.position))
+                {
+                    stack.push((*import, child_position(&node.position, index)));
+                }
             }
         }
     }
@@ -352,17 +364,21 @@ impl ImportOrder {
             completed.specifier,
             self.outstanding.first().map(|(position, _)| &position[..])
         );
-        self.held.push(completed);
+        self.held
+            .entry(completed.order_key)
+            .or_default()
+            .push(completed);
     }
 
     /// A held result with no unfulfilled predecessor left, if any.
     fn next_ready(&mut self) -> Option<CompletedJob> {
-        let (_, first) = self.outstanding.first()?;
-        let index = self
-            .held
-            .iter()
-            .position(|completed| completed.order_key == *first)?;
-        Some(self.held.swap_remove(index))
+        let first = self.outstanding.first()?.1;
+        let same_module = self.held.get_mut(&first)?;
+        let completed = same_module.pop();
+        if same_module.is_empty() {
+            self.held.remove(&first);
+        }
+        completed
     }
 
     fn fulfilled(&mut self, key: ModuleKey) {
@@ -393,6 +409,22 @@ fn child_position(parent: &Position, index: usize) -> Position {
     position.extend_from_slice(parent);
     position.push(index as u32);
     position.into_boxed_slice()
+}
+
+/// `parent ++ [index] < other`, without building it.
+fn precedes(parent: &[u32], index: usize, other: &[u32]) -> bool {
+    let shared = parent.len().min(other.len());
+    match parent[..shared].cmp(&other[..shared]) {
+        core::cmp::Ordering::Less => true,
+        core::cmp::Ordering::Greater => false,
+        core::cmp::Ordering::Equal => match other.get(parent.len()) {
+            // `other` is `parent` or a prefix of it, so the longer child comes after it.
+            None => false,
+            Some(&next) => {
+                (index as u32) < next || ((index as u32) == next && other.len() > parent.len() + 1)
+            }
+        },
+    }
 }
 
 /// `GlobalObject::moduleLoaderResolve`: record one edge of the import graph.
@@ -538,6 +570,13 @@ impl RuntimeTranspilerStore {
             referrer,
             mut log,
         } = completed;
+        bun_core::scoped_log!(
+            RuntimeTranspilerStore,
+            "fulfill {} (outstanding {})",
+            specifier,
+            // SAFETY: fn contract.
+            unsafe { (*this).order.outstanding.len() }
+        );
         let fulfilled = AsyncModule::fulfill(
             &global_this,
             promise.swap(),

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3409,6 +3409,7 @@ extern "C" bool Bun__standaloneModuleHasModuleInfo(const Latin1Character*, size_
 extern "C" bool Bun__hasStandaloneModuleGraph();
 extern "C" int ModuleLoader__builtinAliasIndex(const Latin1Character*, size_t);
 extern "C" bool Bun__hasPluginRunner(void*);
+extern "C" void Bun__onModuleResolved(void* bunVM, const BunString* referrer, const BunString* key);
 JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject,
     JSModuleLoader* loader, JSValue key,
     JSValue referrer, RefPtr<JSC::ScriptFetcher>, bool)
@@ -3498,10 +3499,14 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
     }
     auto resolved = res.result.value.transferToWTFString();
     auto query = queryZ.transferToWTFString();
-
     if (!query.isEmpty()) {
-        return Identifier::fromString(vm, makeString(resolved, query));
+        resolved = makeString(resolved, query);
     }
+
+    // Once per import of each module, in source order: how the transpiler store learns the graph it is fetching.
+    BunString resolvedZ = Bun::toString(resolved);
+    Bun__onModuleResolved(globalObject->bunVM(), &referrerZ, &resolvedZ);
+
     return Identifier::fromString(vm, resolved);
 }
 

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -373,8 +373,15 @@ pub(crate) fn run_task(
             vm.modules.on_poll();
         }
         task_tag::RuntimeTranspilerStore => {
-            let store = cast!(RuntimeTranspilerStore);
-            store.run_from_js_thread(el.into(), global, vm.into());
+            // SAFETY: §Dispatch — the VM's own store; its drains re-enter it, so it stays raw.
+            unsafe {
+                RuntimeTranspilerStore::run_from_js_thread(
+                    cast_ptr!(RuntimeTranspilerStore),
+                    el.into(),
+                    global,
+                    vm.into(),
+                )
+            };
         }
 
         // ── hot-reload (early-returns from the drain loop) ───────────────

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -442,6 +442,71 @@ describe("When CJS and ESM are mixed", () => {
   it("loads reflect-metadata before tsyringe", async () => {
     expect(await bunRun(fixturePath)).toSpawn();
   });
+
+  // A CommonJS file imported from an ES module runs when its transpile
+  // finishes. The thread pool finishes a small file before a big one, so
+  // without ordering the imports below would run in reverse.
+  describe.concurrent("CommonJS imports run in import order", () => {
+    // Enough code that transpiling this file takes much longer than the others.
+    const big = Array.from(
+      { length: 4000 },
+      (_, i) => `module.exports.f${i} = function (a, b) { return a + b + ${i}; };`,
+    ).join("\n");
+    const trace = `globalThis.order ??= []; process.on("exit", () => console.log(JSON.stringify(globalThis.order))); module.exports = {};`;
+
+    async function run(files: Record<string, string>) {
+      using dir = tempDir("esm-imports-cjs-order", { "package.json": `{"name": "order"}`, ...files });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "entry.mjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return JSON.parse(stdout);
+    }
+
+    it("between siblings", async () => {
+      const order = await run({
+        "entry.mjs": `import "./trace.cjs";\nimport "./big.cjs";\nimport "./small.cjs";\nglobalThis.order.push("entry");`,
+        "trace.cjs": trace,
+        "big.cjs": `globalThis.order.push("big");\n${big}`,
+        "small.cjs": `globalThis.order.push("small"); module.exports = {};`,
+      });
+      expect(order).toEqual(["big", "small", "entry"]);
+    });
+
+    it("across a nested ES module", async () => {
+      // polyfill.cjs is below setup.mjs, so it is not even requested until
+      // setup.mjs has been transpiled and parsed. app.cjs must still wait for it.
+      const order = await run({
+        "entry.mjs": `import "./trace.cjs";\nimport "./setup.mjs";\nimport "./app.cjs";\nglobalThis.order.push("entry");`,
+        "trace.cjs": trace,
+        "setup.mjs": `import "./polyfill.cjs";\nexport {};`,
+        "polyfill.cjs": `globalThis.order.push("polyfill");\n${big}`,
+        "app.cjs": `globalThis.order.push("app"); module.exports = {};`,
+      });
+      expect(order).toEqual(["polyfill", "app", "entry"]);
+    });
+
+    it("when a module's first importer is not the first to fetch it", async () => {
+      // entry fetches handler.mjs and container.mjs together, but a depth-first
+      // walk reaches container.mjs through handler.mjs first, so polyfill.cjs
+      // (under container.mjs) comes before dep.cjs (handler.mjs's next import).
+      const order = await run({
+        "entry.mjs": `import "./trace.cjs";\nimport "./handler.mjs";\nimport "./container.mjs";\nglobalThis.order.push("entry");`,
+        "trace.cjs": trace,
+        "handler.mjs": `import "./container.mjs";\nimport "./dep.cjs";\nexport {};`,
+        "container.mjs": `import "./polyfill.cjs";\nimport "./dep.cjs";\nexport {};`,
+        "polyfill.cjs": `globalThis.order.push("polyfill");\n${big}`,
+        "dep.cjs": `globalThis.order.push("dep"); module.exports = {};`,
+      });
+      expect(order).toEqual(["polyfill", "dep", "entry"]);
+    });
+  });
 });
 
 // The "browser" map resolver copied the normalized input path into a 512-byte

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -443,6 +443,22 @@ describe("When CJS and ESM are mixed", () => {
     expect(await bunRun(fixturePath)).toSpawn();
   });
 
+  // Runs entry.mjs from a directory with `files` and returns its stdout parsed as JSON.
+  async function run(files: Record<string, string>) {
+    using dir = tempDir("esm-imports-cjs", { "package.json": `{"name": "fixture"}`, ...files });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
   // A CommonJS file imported from an ES module runs when its transpile
   // finishes. The thread pool finishes a small file before a big one, so
   // without ordering the imports below would run in reverse.
@@ -452,22 +468,11 @@ describe("When CJS and ESM are mixed", () => {
       { length: 4000 },
       (_, i) => `module.exports.f${i} = function (a, b) { return a + b + ${i}; };`,
     ).join("\n");
+    const bigEsm = Array.from({ length: 4000 }, (_, i) => `export function f${i}(a, b) { return a + b + ${i}; }`).join(
+      "\n",
+    );
+    // Imported first; prints the order on exit.
     const trace = `globalThis.order ??= []; process.on("exit", () => console.log(JSON.stringify(globalThis.order))); module.exports = {};`;
-
-    async function run(files: Record<string, string>) {
-      using dir = tempDir("esm-imports-cjs-order", { "package.json": `{"name": "order"}`, ...files });
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "entry.mjs"],
-        env: bunEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(exitCode).toBe(0);
-      return JSON.parse(stdout);
-    }
 
     it("between siblings", async () => {
       const order = await run({
@@ -505,6 +510,124 @@ describe("When CJS and ESM are mixed", () => {
         "dep.cjs": `globalThis.order.push("dep"); module.exports = {};`,
       });
       expect(order).toEqual(["polyfill", "dep", "entry"]);
+    });
+
+    it("ahead of a named import that reads what an earlier one set", async () => {
+      // The `import "dotenv/config"` shape: both files are CommonJS, and the
+      // second one's export is only right if the first one already ran.
+      const order = await run({
+        "entry.mjs": `import "./trace.cjs";\nimport "dotenv/config";\nimport { url } from "./db.cjs";\nglobalThis.order.push(String(url));`,
+        "trace.cjs": trace,
+        "node_modules/dotenv/package.json": `{"name": "dotenv", "version": "0.0.0"}`,
+        "node_modules/dotenv/config.js": `globalThis.order.push("dotenv/config");\nprocess.env.DB_URL = "postgres://from-dotenv";\n${big}`,
+        "db.cjs": `globalThis.order.push("db"); exports.url = process.env.DB_URL;`,
+      });
+      expect(order).toEqual(["dotenv/config", "db", "postgres://from-dotenv"]);
+    });
+
+    // Not yet: a CommonJS file still runs while the graph is being fetched,
+    // before any ES module in it evaluates. Node runs it at its depth-first
+    // slot among the ES modules too. These three cases come from #35971.
+    it.todo("after an ES module sibling that is imported first", async () => {
+      const order = await run({
+        "entry.mjs": `import "./trace.cjs";\nimport "./setup.mjs";\nimport "./dep.cjs";\nglobalThis.order.push("entry");`,
+        "trace.cjs": trace,
+        "setup.mjs": `globalThis.order.push("setup");\n${bigEsm}`,
+        "dep.cjs": `globalThis.order.push("dep"); module.exports = {};`,
+      });
+      expect(order).toEqual(["setup", "dep", "entry"]);
+    });
+
+    it.todo("between two ES module siblings", async () => {
+      const order = await run({
+        "entry.mjs": `import "./trace.cjs";\nimport "./a.mjs";\nimport "./b.cjs";\nimport "./c.mjs";\nglobalThis.order.push("entry");`,
+        "trace.cjs": trace,
+        "a.mjs": `globalThis.order.push("a");\n${bigEsm}`,
+        "b.cjs": `globalThis.order.push("b"); module.exports = {};`,
+        "c.mjs": `globalThis.order.push("c");\nexport {};`,
+      });
+      expect(order).toEqual(["a", "b", "c", "entry"]);
+    });
+
+    it.todo("ahead of a named import that reads what an ES module sibling set", async () => {
+      // Same as the dotenv/config case above, but the file that sets the
+      // variable is an ES module.
+      const order = await run({
+        "entry.mjs": `import "./trace.cjs";\nimport "./load-env.mjs";\nimport { url } from "./db.cjs";\nglobalThis.order.push(String(url));`,
+        "trace.cjs": trace,
+        "load-env.mjs": `globalThis.order.push("load-env");\nprocess.env.DB_URL = "postgres://from-load-env";\nexport {};`,
+        "db.cjs": `globalThis.order.push("db"); exports.url = process.env.DB_URL;`,
+      });
+      expect(order).toEqual(["load-env", "db", "postgres://from-load-env"]);
+    });
+  });
+
+  // Which names an ES module can import from a CommonJS file. These come
+  // from `module.exports` after the file has run.
+  describe.concurrent("named imports from CommonJS", () => {
+    it("exports.x, module.exports.x and module.exports = { ... } keys", async () => {
+      const result = await run({
+        "entry.mjs": `import def, { foo, bar, baz } from "./lib.cjs";\nimport { value, other } from "./literal.cjs";\nconsole.log(JSON.stringify({ def, foo, bar, baz, value, other }));`,
+        "lib.cjs": `exports.foo = 42;\nexports.bar = "bar";\nmodule.exports.baz = "baz";`,
+        "literal.cjs": `const value = 7;\nmodule.exports = { value, other: "x" };`,
+      });
+      expect(result).toEqual({
+        def: { foo: 42, bar: "bar", baz: "baz" },
+        foo: 42,
+        bar: "bar",
+        baz: "baz",
+        value: 7,
+        other: "x",
+      });
+    });
+
+    it("a getter-backed export is read once", async () => {
+      const result = await run({
+        "entry.mjs": `import def, { foo } from "./lib.cjs";\nconsole.log(JSON.stringify({ foo, hits: def.getHits() }));`,
+        "lib.cjs": `Object.defineProperty(exports, "__esModule", { value: true });
+let hits = 0;
+Object.defineProperty(exports, "foo", { enumerable: true, get() { hits++; return 1; } });
+exports.getHits = () => hits;`,
+      });
+      expect(result).toEqual({ foo: 1, hits: 1 });
+    });
+
+    it("__exportStar re-exports are importable by name", async () => {
+      const result = await run({
+        "entry.mjs": `import { inner, own } from "./pkg.cjs";\nconsole.log(JSON.stringify({ inner, own }));`,
+        "pkg.cjs": `var tslib = { __exportStar(m, e) { for (var k in m) if (k !== "default") Object.defineProperty(e, k, { enumerable: true, get: () => m[k] }); } };
+tslib.__exportStar(require("./inner.cjs"), exports);
+exports.own = "own";`,
+        "inner.cjs": `exports.inner = 7;`,
+      });
+      expect(result).toEqual({ inner: 7, own: "own" });
+    });
+
+    it("module.exports = require(...) chosen at runtime (prod/dev shims)", async () => {
+      const result = await run({
+        "entry.mjs": `import { tag } from "./shim.cjs";\nconsole.log(JSON.stringify({ tag }));`,
+        "shim.cjs": `if (process.env.NODE_ENV === "production") {
+  module.exports = require("./a.cjs");
+} else {
+  module.exports = require("./b.cjs");
+}`,
+        "a.cjs": `exports.tag = "a";`,
+        "b.cjs": `exports.tag = "b";`,
+      });
+      expect(result).toEqual({ tag: "b" });
+    });
+
+    it("a throw in the CommonJS body rejects the import() promise", async () => {
+      const result = await run({
+        "entry.mjs": `try {
+  await import("./throws.cjs");
+  console.log(JSON.stringify({ caught: null }));
+} catch (e) {
+  console.log(JSON.stringify({ caught: e.message }));
+}`,
+        "throws.cjs": `exports.x = 1;\nthrow new Error("boom from cjs");`,
+      });
+      expect(result).toEqual({ caught: "boom from cjs" });
     });
   });
 });


### PR DESCRIPTION
### Problem
- An ES module that imports several CommonJS files runs them in thread-pool completion order. `import "./big.cjs"; import "./small.cjs"` runs `small.cjs` first. A polyfill imported by a sibling ES module runs after the CommonJS file that needs it. Node runs both in depth-first source order.
- Cause: a CommonJS file imported from ESM runs when its fetch settles (`commonJSModuleSyntheticSourceCode`, `src/jsc/bindings/JSCommonJSModule.cpp:1557`), because its synthetic record takes its export names from `module.exports`. `RuntimeTranspilerStore::run_from_js_thread` settled fetches as the pool finished them.

### Fix
- `moduleLoaderResolve` reports each import edge to `RuntimeTranspilerStore`, which keeps each module's position: the first path by which a depth-first, source-order walk reaches it. A CommonJS result is held until every fetch before it has been fulfilled. ES module results are fulfilled as they arrive.
- Correct because a CommonJS record imports nothing, so depth-first order over these leaves is Node's order. Transpiling stays parallel. The `reflect-metadata` special case from #18086 stays.
- Verified: four new ordering tests in `test/js/bun/resolve/resolve.test.ts` (siblings, nested, diamond, the `dotenv/config` shape), all failing on stock bun, plus guards on the named-import surface and three `todo` cases for the CommonJS-before-ESM limitation.
- Self-reviewed: 5 concerns, 3 addressed, 2 noted in Notes (synchronous fetch paths, overlap with #40383 and #42051).

### Background
- JSC loads an ESM graph in three phases: fetch and parse, link, evaluate. Bun represents a CommonJS file as a `SyntheticModuleRecord` built from `module.exports`, so the file runs in the fetch phase.
- `RuntimeTranspilerStore` (`src/jsc/RuntimeTranspilerStore.rs`) transpiles imported files on the thread pool and settles each fetch promise on the JS thread.
- CommonJS still runs before the ES modules of its graph, as today. #35971 explores that.

<details><summary>Notes</summary>

Orders observed. `order` is pushed by each file's first statement, ES modules included where shown:

```
entry.mjs: import trace.cjs, big.cjs (180 KB), small.cjs
  node / this PR   ["big","small","entry"]
  bun 1.4.3        ["small","big","entry"]

entry.mjs: import trace.cjs, setup.mjs (imports polyfill.cjs), app.cjs
  node / this PR   ["polyfill","app","entry"]
  bun 1.4.3        ["app","polyfill","entry"]

entry.mjs: import trace.cjs, handler.mjs, container.mjs
handler.mjs: import container.mjs, dep.cjs;  container.mjs: import polyfill.cjs, dep.cjs
  node / this PR   ["polyfill","dep:ok","container","handler","C"]
  bun 1.4.3        ["dep:MISSING POLYFILL","polyfill","container","handler","C"]

entry.mjs: import trace.cjs, a.mjs (imports x.cjs), y.cjs
  node             ["x","a","y","entry"]
  this PR          ["x","y","a","entry"]   (CommonJS still runs before sibling ESM)
  bun 1.4.3        ["y","x","a","entry"]
```

Why positions come from import edges and not from the fetch referrer: in the third shape `container.mjs` is fetched as `entry`'s second import, but a depth-first walk reaches it through `handler.mjs` first. A first version of this change keyed positions on the fetch referrer and got that shape wrong. When an earlier path to a module turns up after it was placed, the module and what it imports move with it.

JSC calls `moduleLoaderResolve` once per import of each module, in source order, while it processes the importing module, and microtasks are drained after each ES module is fulfilled, so by the time a held CommonJS result is reconsidered every earlier ES module has had its imports resolved and fetched.

The `reflect-metadata` special case from #18086 (transpile on the main thread) stays. It loads that package ahead of imports that precede it, which code written against Bun may rely on even though Node would reject that order.

Not covered: fetches that do not go through the thread pool (`Bun.plugin` with an `onLoad`, `NODE_COMPILE_CACHE`, `BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER`, `bun test --isolate` cache hits). Those settle synchronously in request order, as before: deterministic, but breadth-first.

Overlap: #40383 rewrites this drain loop to remove `unsafe`, and #42051 hands every result back in request order for a deterministic `import()` graph order. This touches the same function and I will rebase it on whichever lands first. Request order alone does not fix the nested and diamond shapes above.

Suites run on the debug build: `test/js/bun/resolve/`, `test/js/node/module/`, the module tests in `test/cli/run/`, `test/js/bun/plugin/`, `test/cli/test/isolation.test.ts`, `test/js/bun/test/mock/`, `test/cli/hot/hot.test.ts`, and the 43 regression tests that mention CommonJS. Failures seen there also fail on an unpatched debug build (timeouts in `load-same-js-file-a-lot`, `require-cache` leak fixtures, one worker terminate test).

Other shapes checked by hand: a CommonJS body that calls `import()` of another CommonJS file while the graph loads (settles after the graph, as in Node), `require()` of a sibling `.mjs` whose transpile is in flight, a CommonJS sibling that throws, a syntax error in a large ESM sibling while a CommonJS result is held (errors reported, exit 1, no hang), a `require()` cycle back into the importing `.mjs`, `bun test` with and without `--isolate`, and a `Worker` terminated mid-load.

A `.cjs` file that uses none of `module`, `exports`, `require` is classified as ESM by the transpiler today, so it evaluates with the ES modules. That is a separate classification question and is why the tests give `trace.cjs` a `module.exports`.

Bookkeeping is one node per module and one entry per import edge seen while any fetch is in flight, dropped as soon as the pool is idle and at VM teardown (a Worker's `VirtualMachine` is deallocated without field `Drop`; the first CI run caught the node for a worker's entry point leaking under LeakSanitizer).

`run_from_js_thread` takes the store as a raw pointer because its microtask drains re-enter the store through `transpile()` and `Bun__onModuleResolved`.

When a shorter path to an already placed module turns up, `place()` walks what it imports depth-first in source order, so each module below is reached by its smallest path first and moves at most once, and it does not descend below a module that did not move. An earlier revision walked in reverse order and was exponential on elysia's typebox graph (the test-bun timeouts on the first CI runs).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->