### PR TITLE
bun test --isolate: drop a retired file's deferred work

### DIFF
--- a/src/jsc/bindings/JSCTaskScheduler.cpp
+++ b/src/jsc/bindings/JSCTaskScheduler.cpp
@@ -2,6 +2,7 @@
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/GlobalObjectMethodTable.h>
 #include "JSCTaskScheduler.h"
 #include "BunClientData.h"
 #include "ZigGlobalObject.h"
@@ -121,11 +122,19 @@ static void runPendingWork(const ::BunVmHandleRef* vmHandle, Bun::JSCTaskSchedul
     if (wasPending && !job->ticket->isCancelled() && Bun__VmHandle__scriptAllowed(vmHandle)) {
         auto& vm = job->vm();
         auto* globalObject = job->ticket->target()->globalObject();
-        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        job->task(job->ticket.get());
-        if (auto* exception = scope.exception(); exception && !vm.hasPendingTerminationException()) {
-            scope.clearException();
-            Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+        // The realm's own status, as DeferredWorkTimer::doWork asks it before it runs a
+        // task. A realm that `bun test --isolate` retired reports Stopped, so the
+        // finished file's leftover work is dropped instead of running under the next
+        // file. doWork re-queues a Suspended realm's task; no Bun realm reports that.
+        auto status = globalObject->globalObjectMethodTable()->scriptExecutionStatus(globalObject, job->ticket->scriptExecutionOwner());
+        ASSERT(status != ScriptExecutionStatus::Suspended);
+        if (status == ScriptExecutionStatus::Running) {
+            auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+            job->task(job->ticket.get());
+            if (auto* exception = scope.exception(); exception && !vm.hasPendingTerminationException()) {
+                scope.clearException();
+                Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
+            }
         }
     }
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -935,6 +935,9 @@ JSGlobalObject* GlobalObject::deriveShadowRealmGlobalObject(JSGlobalObject* glob
 extern "C" int Bun__VM__scriptExecutionStatus(void*);
 JSC::ScriptExecutionStatus Zig::GlobalObject::scriptExecutionStatus(JSC::JSGlobalObject* globalObject, JSC::JSObject*)
 {
+    // A finished file's realm is stopped while the VM runs on, as a detached document's is.
+    if (Bun::isRetiredTestIsolationRealm(globalObject))
+        return JSC::ScriptExecutionStatus::Stopped;
     switch (Bun__VM__scriptExecutionStatus(uncheckedDowncast<Zig::GlobalObject>(globalObject)->bunVM())) {
     case 0:
         return JSC::ScriptExecutionStatus::Running;
@@ -4381,7 +4384,9 @@ extern "C" void Zig__GlobalObject__stopActiveDOMObjectsForTestIsolation(Zig::Glo
 }
 
 // `bun test --isolate`: JSC drops microtasks queued against the finished file's realm from here on
-// (as WebCore does for a stopped document), so work it left in flight cannot resume its script.
+// (as WebCore does for a stopped document), and the realm reports ScriptExecutionStatus::Stopped so
+// its deferred work (FinalizationRegistry cleanup, wasm completions) is dropped too. Work the file
+// left in flight cannot resume its script.
 extern "C" void Zig__GlobalObject__retireForTestIsolation(Zig::GlobalObject* globalObject)
 {
     globalObject->setMicrotaskRunnability(JSC::QueuedTaskResult::Discard);
@@ -4391,7 +4396,7 @@ extern "C" void Zig__GlobalObject__retireForTestIsolation(Zig::GlobalObject* glo
 extern "C" bool Bun__JSValue__isFromRetiredTestIsolationRealm(JSC::EncodedJSValue encodedValue)
 {
     JSC::JSObject* object = JSC::JSValue::decode(encodedValue).getObject();
-    return object && object->globalObject()->microtaskRunnability() == JSC::QueuedTaskResult::Discard;
+    return object && Bun::isRetiredTestIsolationRealm(object->globalObject());
 }
 
 extern "C" void Zig__GlobalObject__destructOnExit(Zig::GlobalObject* globalObject)

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -870,6 +870,13 @@ ALWAYS_INLINE void* vm(JSC::JSGlobalObject* lexicalGlobalObject)
     return WebCore::clientData(lexicalGlobalObject->vm())->bunVM;
 }
 
+// A realm that `bun test --isolate` retired because its file finished
+// (Zig__GlobalObject__retireForTestIsolation). Nothing enters its script again.
+ALWAYS_INLINE bool isRetiredTestIsolationRealm(const JSC::JSGlobalObject* globalObject)
+{
+    return globalObject->microtaskRunnability() == JSC::QueuedTaskResult::Discard;
+}
+
 }
 
 #ifndef RENAMED_JSDOM_GLOBAL_OBJECT

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -1167,6 +1167,68 @@ describe.concurrent("--isolate: a finished file's late completions do not run in
     if (exitCode !== 0) expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
+
+  // A FinalizationRegistry cleanup that a finished file created reaches none of
+  // the checks above: JSC calls it directly from a DeferredWorkTimer job, not
+  // through a microtask, a Job or run_callback. The cleanup ran in the retired
+  // realm while a later file executed, and an error it threw was charged to
+  // that later file (which then lost its remaining tests to "Cannot call test()
+  // after the test run has completed"). The retired realm now reports its
+  // script execution as stopped, so Bun drops the job, as JSC's own
+  // DeferredWorkTimer::doWork does for a stopped realm.
+  test("a finished file's FinalizationRegistry cleanup does not run in the next file", async () => {
+    using dir = tempDir("isolate-finalization-registry", {
+      "a-registry.test.ts": `
+        import { test, expect } from "bun:test";
+        import { existsSync, writeFileSync } from "node:fs";
+        import { join } from "node:path";
+
+        const dir = import.meta.dir;
+        // The cleanup only acts once b-registry.test.ts says it is running, and it
+        // registers fresh garbage each time, so this registry has dead entries at
+        // every collection for as long as its realm is alive.
+        const registry = new FinalizationRegistry(() => {
+          if (existsSync(join(dir, "b-running"))) writeFileSync(join(dir, "a-acted"), "");
+          registry.register({}, 0);
+        });
+
+        test("registers objects that die at once", () => {
+          for (let i = 0; i < 200; i++) registry.register({ i }, i);
+          expect(existsSync(join(dir, "b-running"))).toBe(false);
+        });
+      `,
+      "b-registry.test.ts": `
+        import { test, expect } from "bun:test";
+        import { existsSync, writeFileSync } from "node:fs";
+        import { join } from "node:path";
+
+        const dir = import.meta.dir;
+        writeFileSync(join(dir, "b-running"), "");
+
+        test("A's FinalizationRegistry cleanup does not run here", async () => {
+          // Collect, then round-trip the thread pool, so a cleanup A left queued gets
+          // every chance to land here.
+          for (let i = 0; i < 20 && !existsSync(join(dir, "a-acted")); i++) {
+            Bun.gc(true);
+            await Bun.password.hash("pw", { algorithm: "bcrypt", cost: 4 });
+          }
+          expect(existsSync(join(dir, "a-acted"))).toBe(false);
+        });
+      `,
+    });
+    const { stderr, exitCode } = await runTests(
+      String(dir),
+      ["--isolate"],
+      ["./a-registry.test.ts", "./b-registry.test.ts"],
+      // A collects between its last drain and the swap, which is when the cleanup it
+      // leaves behind is queued. Natural GC timing does that only sometimes.
+      { ...bunEnv, BUN_JSC_collectContinuously: "1" },
+    );
+    expect(normalizeBunSnapshot(stderr, dir)).toContain("2 pass");
+    expect(normalizeBunSnapshot(stderr, dir)).toContain("0 fail");
+    if (exitCode !== 0) expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
 });
 
 // Each of these leaked handles used to pin its test file's ENTIRE global


### PR DESCRIPTION
### Problem
- `bun test --isolate`: a `FinalizationRegistry` cleanup that a FINISHED file created runs while a later file executes. A throw from it is charged to the later file, which then loses its remaining tests to `Cannot call test() after the test run has completed`. In the constructed repro (fuzz-found, no user report) 7 of 25 tests ran, exit 1.
- The fence of #41831 does not reach it: JSC schedules it as a `DeferredWorkTimer` ticket and calls the callback directly, so no microtask, `Job` or `run_callback` check applies. `Bun::runPendingWork` (`JSCTaskScheduler.cpp:122`) ran it with no realm check.

### Fix
- `Zig::GlobalObject::scriptExecutionStatus` reports `Stopped` for a retired realm, from the fence's own predicate (`microtaskRunnability() == Discard`, now `Bun::isRetiredTestIsolationRealm`).
- `runPendingWork` asks that status before it runs a task, as JSC's `DeferredWorkTimer::doWork` does, and drops the work, like the file's timers at the swap.
- Correct because the swap is that file's process exit: its script never runs again. WebCore answers `Stopped` for a detached document.
- Verified: a new `isolation.test.ts` case fails on main 20 of 20, passes 6 of 6 here. Self-reviewed: 5 concerns, 4 addressed, 1 deferred (Notes).

### Background
- `--isolate` gives each file a fresh `Zig::GlobalObject` on one `JSC::VM`. The old global lives until the GC takes it.
- `DeferredWorkTimer` carries native completions (registry cleanups, wasm compiles, `Atomics.waitAsync` wake-ups) to the JS thread, one ticket each. Bun installs `onScheduleWorkSoon`, so they run from its event loop, not JSC's `doWork`.
- `ScriptExecutionStatus` is how JSC asks the embedder whether a realm may run script. Bun answered from the VM alone, so a retired realm said `Running`.

<details><summary>Notes</summary>

- Reported internally (fuzz ledger #45175) against main d745f03c. There is no user report. The repro is constructed: `a.test.ts` creates a `FinalizationRegistry` whose callback throws and registers 500 objects, then six files each run `Bun.gc(true)` and a short sleep per test, all under `BUN_JSC_collectContinuously=1`. On main, 27 of 30 runs lose 15 to 19 of the 25 tests to the `Cannot call test()` path. The organic reach is lower than that: it needs `--isolate` or `--parallel`, a collection between the finished file's last loop drain and the swap, and a cleanup callback that throws or acts on shared state.
- The new test sets `BUN_JSC_collectContinuously=1` in the child for the same reason: natural GC timing queues the cleanup in that window only sometimes.
- What is still not fenced, unchanged from the list #41831 gave: calls into JS through an FFI `JSCallback`, a napi threadsafe function or napi async completion, functions of a `node:vm` context or `ShadowRealm` that the finished file created (those globals are not retired, so their own deferred work also still runs), and microtasks while a debugger is attached. The review of this change also pointed at the Worker `close` event: `WorkerMessagingProxy::workerGlobalScopeDestroyedInternal` dispatches it through `Worker::dispatchCloseEvent` (`src/jsc/bindings/webcore/Worker.cpp:139`), which has no realm check, so a finished file's `worker.on("close")` handler may run under the next file when the terminated worker's thread exits late. I have not reproduced that one and left it out of this PR.
- Scope: this PR is the realm fence only. The separate CRASH face of the same area (a queued job reads `ticket->scriptExecutionOwner()->vm()` after the realm's global is collected and the ticket cancelled: `ASSERTION FAILED: !isCancelled()` on debug, a stale read on release) belongs to #39994, which moves ticket ownership into JSC through oven-sh/WebKit#487. The status gate here is orthogonal to that: JSC's `doWork` performs the same check, so it survives the ownership move. The two touch adjacent lines in `runPendingWork` and will need a trivial rebase, nothing more.
- An earlier version of this change also cancelled pending tickets of unmarked realms at GC end, from a `VM::ClientData::reconcileWeakReferencesAtGCEnd` hook. That is the shape #39994 already tried and review rejected, so it is not here.
- `runPendingWork` is the only caller of `scriptExecutionStatus` this adds. JSC's `doWork` is the only other caller, and with Bun's hooks installed its task queue and ticket set are both empty, so the new `Stopped` answer changes nothing else. `Bun__VM__scriptExecutionStatus` (the VM-wide answer that timers use) is untouched. A debug `ASSERT` records that no Bun realm reports `Suspended`, which `doWork` would re-queue rather than drop.
- During process exit (`is_shutting_down`), deferred work that is still dispatched is now dropped as well, which is what timers already do and what Node does for a `FinalizationRegistry` callback queued from `process.on("exit")` (`test-finalization-registry-shutdown.js`).
- #41998 is complementary. It stops an unhandled error during collection from deleting the active file's tests, which is the sink this bug reached. With both, a stray error neither runs in a dead realm nor deletes a live file's tests.
- The new test's fixture re-registers fresh garbage from inside the cleanup, so the registry has dead entries at every collection for as long as its realm is alive. The cleanup writes its marker only once the second file says it is running, so the assertion cannot pass by accident.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/test/isolation.test.ts
bun test v1.4.3 (f42e98025)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [345.17ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [407.40ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [399.11ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [351.21ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [378.48ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [1167.65ms]
(pass) bun test --isolate > with --isolate, a file's process.env writes with native side effects are undone before the next file [1516.25ms]
(pass) bun test --isolate > with --isolate, cached module records keep short, Latin-1 and UTF-16 names [1226.39ms]
(pass) bun test --isolate > with --isolate, leaked outbound socket is closed before next file [1306.31ms]
(pass) bu
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > with --isolate, each file gets a fresh global [40.57ms]
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [44.40ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [40.08ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [41.71ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [38.39ms]
(pass) bun test --isolate > with --isolate, cached module records keep short, Latin-1 and UTF-16 names [41.16ms]
(pass) --isolate: JSC options survive a bunfig.toml with an install hoist pattern [27.69ms]
(pass) bun test --isolate > leaked subprocesses are killed for every isolated file, not just the first [40.26ms]
(pass) --isolate: delete require.cache evicts the SourceProvider cache [33.68ms]
(pass) bun test --isolate > module-scope subprocesses are killed for every isolated file, not just the first (--isolate) [42.58ms]
(pass) --isolate: SourceProvider cache covers node_modules .mjs and type:commonjs packages [32.06ms]
1146 |   con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/test/isolation.test.ts
bun test v1.4.3 (f42e98025)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [337.75ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [330.21ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [321.80ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [292.32ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [375.60ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [1223.25ms]
(pass) bun test --isolate > with --isolate, a file's process.env writes with native side effects are undone before the next file [1406.88ms]
(pass) bun test --isolate > with --isolate, cached module records keep short, Latin-1 and UTF-16 names [1240.66ms]
(pass) bun test --isolate > with --isolate, leaked outbound socket is closed before next file [1301.54ms]
(pass) bu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     dc8adebbee
  features     baseline

23 deps, 131 codegen, 1172 objects in 622ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] gen bindgenv2
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [7.00ms]
[6/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] fetch zlib
[zlib] up to date
[9/1217] fetch tinycc
[tinycc] up to date
[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSCTaskScheduler.cpp | 19 ++++++++---
 src/jsc/bindings/ZigGlobalObject.cpp  |  9 +++--
 src/jsc/bindings/ZigGlobalObject.h    |  7 ++++
 test/cli/test/isolation.test.ts       | 62 +++++++++++++++++++++++++++++++++++
 4 files changed, 90 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/bindings/JSCTaskScheduler.cpp      5     10     13
src/jsc/bindings/ZigGlobalObject.cpp       2      2     12
src/jsc/bindings/ZigGlobalObject.h         1      1     12
test/cli/test/isolation.test.ts            4      2     12
```

</details>

<!-- robobun:evidence:end -->