### PR TITLE
Round binary, octal and hex numbers above 2^53 to the nearest double (parseInt, Number("0x…"), literals)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-597-bb05ee47";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1038,9 +1038,7 @@ unsafe extern "C" {
 pub fn parse_power_of_two_radix_digits(digits: &[u8], radix: u32) -> f64 {
     debug_assert!(matches!(radix, 2 | 4 | 8 | 16 | 32));
     debug_assert!(
-        digits
-            .iter()
-            .all(|&c| (c as char).to_digit(radix).is_some()),
+        digits.iter().all(|&c| (c as char).is_digit(radix)),
         "not base-{radix} digits: {:?}",
         bstr::BStr::new(digits)
     );

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1021,10 +1021,31 @@ pub fn parse_double(buf: &[u8]) -> Result<f64, InvalidCharacter> {
 
 // `WTF__parseDouble` — WebKit's JS-semantics double parser (Latin-1 input,
 // reports prefix length). Declared here (not via `bun_string`) so tier-0
-// callers can parse floats with no UTF-8 validation. Link-time symbol
+// callers can parse floats with no UTF-8 validation. Link-time symbols
 // provided by `src/jsc/bindings/wtf-bindings.cpp`.
 unsafe extern "C" {
     fn WTF__parseDouble(bytes: *const u8, length: usize, counted: *mut usize) -> f64;
+    fn JSC__parsePowerOfTwoRadixDigits(digits: *const u8, length: usize, radix: i32) -> f64;
+}
+
+/// The nearest `f64` (ties to even) to the integer spelled by `digits` in
+/// `radix` 2, 4, 8, 16 or 32: what `parseInt(digits, radix)` and a `0b` / `0o`
+/// / `0x` literal evaluate to in JSC. `digits` is only digits of that radix —
+/// no prefix, sign or `_` separators. `f64::INFINITY` past `f64::MAX`.
+///
+/// Accumulating `value * radix + digit` in an `f64` rounds at every step past
+/// 2^53 and can end up one ulp off; use this once a value reaches 2^53.
+pub fn parse_power_of_two_radix_digits(digits: &[u8], radix: u32) -> f64 {
+    debug_assert!(matches!(radix, 2 | 4 | 8 | 16 | 32));
+    debug_assert!(
+        digits
+            .iter()
+            .all(|&c| (c as char).to_digit(radix).is_some()),
+        "not base-{radix} digits: {:?}",
+        bstr::BStr::new(digits)
+    );
+    // SAFETY: `digits` is a valid slice; JSC reads exactly `length` Latin-1 bytes.
+    unsafe { JSC__parsePowerOfTwoRadixDigits(digits.as_ptr(), digits.len(), radix as i32) }
 }
 
 /// Full-match parse of `s` as an `f64`.

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1028,13 +1028,9 @@ unsafe extern "C" {
     fn JSC__parsePowerOfTwoRadixDigits(digits: *const u8, length: usize, radix: i32) -> f64;
 }
 
-/// The nearest `f64` (ties to even) to the integer spelled by `digits` in
-/// `radix` 2, 4, 8, 16 or 32: what `parseInt(digits, radix)` and a `0b` / `0o`
-/// / `0x` literal evaluate to in JSC. `digits` is only digits of that radix —
-/// no prefix, sign or `_` separators. `f64::INFINITY` past `f64::MAX`.
-///
-/// Accumulating `value * radix + digit` in an `f64` rounds at every step past
-/// 2^53 and can end up one ulp off; use this once a value reaches 2^53.
+/// The nearest `f64` to the integer that `digits` (digits only: no prefix, sign
+/// or `_`) spell in radix 2, 4, 8, 16 or 32, as JSC's `parseInt` computes it.
+/// Summing `value * radix + digit` in an `f64` instead is inexact past 2^53.
 pub fn parse_power_of_two_radix_digits(digits: &[u8], radix: u32) -> f64 {
     debug_assert!(matches!(radix, 2 | 4 | 8 | 16 | 32));
     debug_assert!(

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -3183,15 +3183,11 @@ impl<'a> Lexer<'a> {
                         }
                     }
                 } else {
-                    // A legacy octal literal's digits start right after its leading 0; the others have a
-                    // two-byte prefix.
-                    let digits = if self.is_legacy_octal_literal {
-                        text
-                    } else {
-                        &text[2..]
-                    };
-                    self.number =
-                        bun_core::fmt::parse_power_of_two_radix_digits(digits, base as u32);
+                    let prefix_len = if self.is_legacy_octal_literal { 1 } else { 2 }; // "0" or "0x"
+                    self.number = bun_core::fmt::parse_power_of_two_radix_digits(
+                        &text[prefix_len..],
+                        base as u32,
+                    );
                 }
             }
         } else {

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -3138,9 +3138,13 @@ impl<'a> Lexer<'a> {
             }
 
             let is_big_integer_literal = self.code_point == 0x6E && !has_dot_or_exponent;
+            // From 2^53 up the additions above round, possibly more than once.
+            let is_rounded = !is_big_integer_literal
+                && !is_invalid_legacy_octal_literal
+                && self.number >= 9007199254740992.0;
 
             // Slow path: do we need to re-scan the input as text?
-            if is_big_integer_literal || is_invalid_legacy_octal_literal {
+            if is_big_integer_literal || is_invalid_legacy_octal_literal || is_rounded {
                 let mut text = self.raw();
 
                 // Can't use a leading zero for bigint literals;
@@ -3178,6 +3182,16 @@ impl<'a> Lexer<'a> {
                             )?;
                         }
                     }
+                } else {
+                    // A legacy octal literal's digits start right after its leading 0; the others have a
+                    // two-byte prefix.
+                    let digits = if self.is_legacy_octal_literal {
+                        text
+                    } else {
+                        &text[2..]
+                    };
+                    self.number =
+                        bun_core::fmt::parse_power_of_two_radix_digits(digits, base as u32);
                 }
             }
         } else {

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -230,9 +230,7 @@ extern "C" double WTF__parseDouble(const Latin1Character* string, size_t length,
     return WTF::parseDouble({ string, length }, *position);
 }
 
-// The digits of a binary, base-4, octal, hex or base-32 integer (no prefix, sign or separators) to the
-// nearest double. This is the function behind JSC's own numeric literals and parseInt, so a literal the
-// transpiler prints and the same literal given to eval() agree.
+// bun_core::fmt::parse_power_of_two_radix_digits. The same function JSC's lexer and parseInt use.
 extern "C" double JSC__parsePowerOfTwoRadixDigits(const Latin1Character* digits, size_t length, int radix)
 {
     return JSC::parseIntOverflow(std::span<const Latin1Character> { digits, length }, radix);

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -7,6 +7,7 @@
 #include <wtf/dtoa.h>
 #include <wtf/DateMath.h>
 #include <wtf/NumberOfCores.h>
+#include <JavaScriptCore/ParseInt.h>
 #include <atomic>
 #include <cassert>
 
@@ -227,6 +228,14 @@ extern "C" int Bun__ttySetMode(int fd, int mode, void* rawState, int drain)
 extern "C" double WTF__parseDouble(const Latin1Character* string, size_t length, size_t* position)
 {
     return WTF::parseDouble({ string, length }, *position);
+}
+
+// The digits of a binary, base-4, octal, hex or base-32 integer (no prefix, sign or separators) to the
+// nearest double. This is the function behind JSC's own numeric literals and parseInt, so a literal the
+// transpiler prints and the same literal given to eval() agree.
+extern "C" double JSC__parsePowerOfTwoRadixDigits(const Latin1Character* digits, size_t length, int radix)
+{
+    return JSC::parseIntOverflow(std::span<const Latin1Character> { digits, length }, radix);
 }
 
 extern "C" size_t WTF__base64URLEncode(const char* __restrict inputDataBuffer, size_t inputDataBufferSize,

--- a/src/parsers/json_stage2.rs
+++ b/src/parsers/json_stage2.rs
@@ -1138,6 +1138,15 @@ impl<'a, 's, 'i> Parser<'a, 's, 'i> {
                     return Err(crate::Error::SyntaxError);
                 }
             }
+        } else if value >= 9007199254740992.0 {
+            // From 2^53 up the additions above round, possibly more than once.
+            let digits = &t[prefix_len..i];
+            value = if last_underscore_end == usize::MAX {
+                bun_core::fmt::parse_power_of_two_radix_digits(digits, radix)
+            } else {
+                let digits: Vec<u8> = digits.iter().copied().filter(|&c| c != b'_').collect();
+                bun_core::fmt::parse_power_of_two_radix_digits(&digits, radix)
+            };
         }
         Ok((value, i))
     }

--- a/test/js/bun/jsc/string-to-number-power-of-two-radix.test.ts
+++ b/test/js/bun/jsc/string-to-number-power-of-two-radix.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import vm from "node:vm";
+import { join } from "path";
+
+// A string of binary, octal, base-4, hex or base-32 digits with more than 53
+// significant bits must convert to the nearest double (ties to even), the way
+// a decimal string does. One JSC function (parseIntOverflow, oven-sh/WebKit#597)
+// does this for parseInt with a power-of-two radix, for ToNumber on "0x" /
+// "0o" / "0b" strings, for numeric literals that JSC lexes itself (eval,
+// new Function, node:vm), and, through Bun's lexers, for literals in
+// transpiled files and in imported JSONC. Number(BigInt) is the reference:
+// BigInt holds the digits exactly and its ToNumber rounds once.
+
+const prefix: Record<number, string> = { 2: "0b", 8: "0o", 16: "0x" };
+
+function nearestDouble(digits: string, radix: number): number {
+  let value = 0n;
+  for (const c of digits) value = value * BigInt(radix) + BigInt(parseInt(c, radix));
+  return Number(value);
+}
+
+// Summing the digits in a double from the left gets the first group wrong and
+// the second right. Summing from the right, as JSC did, is the other way round.
+const wrongLeftToRight = ["2f32df6d0cf0355a", "a0761d6478bd642f", "ffffffffffffffff"];
+const wrongRightToLeft = ["97b89d834f82bbef", "130000000000009", "16000000000000a"];
+
+// What a source expression evaluates to after Bun's transpiler has lexed and
+// printed it, rather than JSC.
+const transpiler = new Bun.Transpiler({ loader: "js" });
+function transpiledValue(expression: string): unknown {
+  return new Function(transpiler.transformSync(`var value = ${expression};`) + "return value;")();
+}
+
+describe("power-of-two radix strings above 2^53 round to the nearest double", () => {
+  test("parseInt", () => {
+    // The reported values. Each came out one ulp too high.
+    expect(parseInt("97b89d834f82bbef", 16)).toBe(10932661282742122496);
+    expect(parseInt("0x97b89d834f82bbef")).toBe(10932661282742122496);
+    expect(parseInt("1700774500551360345014", 8)).toBe(17311718268872018432);
+    expect(parseInt("1kqg9a599t95", 32)).toBe(59479501168768296);
+
+    // 2^55 + 2^53 + 5: accumulating the digits in a double rounds twice and
+    // lands on ...960. The nearest double is ...968.
+    const cases: [string, number][] = [
+      ["10100000000000000000000000000000000000000000000000000101", 2],
+      ["2200000000000000000000000011", 4],
+      ["3500000000000000005", 8],
+      ["130000000000009", 16],
+      ["16000000000000a", 16],
+      ["2f32df6d0cf0355a", 16],
+      ["1i000000000r", 32],
+      // Ties at 2^53 and carries into the next power of two.
+      ["20000000000001", 16],
+      ["20000000000003", 16],
+      ["20000000000001000000000001", 16],
+      ["ffffffffffffffff", 16],
+      ["1777777777777777777777", 8],
+      ["vvvvvvvvvvvvv", 32],
+    ];
+    for (const [digits, radix] of cases) {
+      const want = nearestDouble(digits, radix);
+      expect(parseInt(digits, radix)).toBe(want);
+      expect(parseInt("-" + digits, radix)).toBe(-want);
+      expect(parseInt("0000000000" + digits, radix)).toBe(want);
+      // A 16-bit string takes the char16_t instantiation.
+      expect(parseInt("\u3000" + digits + "\u{1F600}", radix)).toBe(want);
+    }
+    expect(parseInt("10100000000000000000000000000000000000000000000000000101", 2)).toBe(45035996273704968);
+  });
+
+  test("Number() and ToNumber on 0x / 0o / 0b strings", () => {
+    expect(Number("0x97b89d834f82bbef")).toBe(10932661282742122496);
+    expect(Number("0o1700774500551360345014")).toBe(17311718268872018432);
+    expect(Number("0b10100000000000000000000000000000000000000000000000000101")).toBe(45035996273704968);
+    expect(Number("0X16000000000000A")).toBe(99079191802150928);
+    expect(+"0x130000000000009").toBe(nearestDouble("130000000000009", 16));
+    // @ts-expect-error arithmetic on a string is the point
+    expect("0o3500000000000000005" - 0).toBe(nearestDouble("3500000000000000005", 8));
+    expect(Number(" 0x97b89d834f82bbef\u3000")).toBe(10932661282742122496);
+  });
+
+  test("literals that JSC lexes at runtime", () => {
+    expect(eval("0x97b89d834f82bbef")).toBe(10932661282742122496);
+    expect(eval("0x97b8_9d83_4f82_bbef")).toBe(10932661282742122496);
+    expect(eval("0o1700774500551360345014")).toBe(17311718268872018432);
+    expect(eval("0b10100000000000000000000000000000000000000000000000000101")).toBe(45035996273704968);
+    expect(new Function("return 0x16000000000000a;")()).toBe(99079191802150928);
+    expect(vm.runInNewContext("0x97b89d834f82bbef")).toBe(10932661282742122496);
+    expect(vm.runInNewContext("01700774500551360345014")).toBe(17311718268872018432); // legacy octal
+    // A 16-bit source string.
+    expect(eval("'\u3000', 0x130000000000009")).toBe(nearestDouble("130000000000009", 16));
+    for (const digits of [...wrongLeftToRight, ...wrongRightToLeft]) {
+      expect(eval("0x" + digits)).toBe(nearestDouble(digits, 16));
+    }
+  });
+
+  test("literals in a transpiled file", () => {
+    // This file goes through Bun's lexer, which hands a literal of 2^53 or more
+    // to the same JSC function, so these hex literals and eval() must agree with
+    // the decimal literals and with BigInt.
+    expect(0x2f32df6d0cf0355a).toBe(3401026328079644160);
+    expect(0x2f32df6d0cf0355a).toBe(Number(0x2f32df6d0cf0355an));
+    expect(0x2f32df6d0cf0355a).toBe(eval("0x2f32df6d0cf0355a"));
+    expect(0xa0761d6478bd642f).toBe(11562461410679941120);
+    expect(0xa076_1d64_78bd_642f).toBe(11562461410679941120);
+    expect(0xffffffffffffffff).toBe(18446744073709551616);
+    expect(0x97b89d834f82bbef).toBe(10932661282742122496);
+    expect(0o274626766641474032532).toBe(3401026328079644160);
+    expect(0b1010000001110110000111010110010001111000101111010110010000101111).toBe(11562461410679941120);
+    expect(0b1010000001110110000111010110010001111000101111010110010000101111).toBe(0xa0761d6478bd642f);
+
+    for (const digits of [...wrongLeftToRight, ...wrongRightToLeft]) {
+      const want = nearestDouble(digits, 16);
+      for (const literal of [
+        "0x" + digits,
+        "0X" + digits.toUpperCase(),
+        "0x" + digits.replace(/(....)(?=.)/g, "$1_"),
+        "0o" + BigInt("0x" + digits).toString(8),
+        "0" + BigInt("0x" + digits).toString(8), // legacy octal
+        "0b" + BigInt("0x" + digits).toString(2),
+      ]) {
+        expect({ literal, value: transpiledValue(literal) }).toEqual({ literal, value: want });
+      }
+    }
+    // Infinity and the largest double still print as something that evaluates back.
+    expect(transpiledValue("0x1" + "0".repeat(256))).toBe(Infinity);
+    expect(transpiledValue("-0b1" + "0".repeat(1024))).toBe(-Infinity);
+    expect(transpiledValue("0xfffffffffffff8" + "0".repeat(242))).toBe(Number.MAX_VALUE);
+  });
+
+  test("hex and octal numbers in JSONC", async () => {
+    using dir = tempDir("pow2-radix-jsonc", {
+      "values.jsonc": `{
+        // JSONC takes JS number syntax
+        "a": 0x2f32df6d0cf0355a, "b": 0xa076_1d64_78bd_642f, "c": 0x97b89d834f82bbef, "d": 0o274626766641474032532,
+        "big": 0x1${"0".repeat(256)}, "small": [0x1fffffffffffff, 0XA, 017]
+      }`,
+    });
+    const { default: jsonc } = await import(join(String(dir), "values.jsonc"));
+    expect(jsonc).toEqual({
+      a: 3401026328079644160,
+      b: 11562461410679941120,
+      c: 10932661282742122496,
+      d: 3401026328079644160,
+      big: Infinity,
+      small: [2 ** 53 - 1, 10, 15],
+    });
+    expect(Bun.JSONC.parse("[0x2f32df6d0cf0355a, 0xa0761d6478bd642f, 0x97b89d834f82bbef]")).toEqual([
+      3401026328079644160, 11562461410679941120, 10932661282742122496,
+    ]);
+  });
+
+  test("the Number.MAX_VALUE / Infinity boundary", () => {
+    // (2^53 - 1) * 2^971 is the largest double. The midpoint to 2^1024 ties to
+    // even, which is up, to Infinity. One below the midpoint is still finite.
+    expect(parseInt("fffffffffffff8" + "0".repeat(242), 16)).toBe(Number.MAX_VALUE);
+    expect(parseInt("fffffffffffffb" + "f".repeat(242), 16)).toBe(Number.MAX_VALUE);
+    expect(parseInt("fffffffffffffc" + "0".repeat(242), 16)).toBe(Infinity);
+    expect(Number("0x1" + "0".repeat(256))).toBe(Infinity);
+    expect(parseInt("-1" + "0".repeat(1024), 2)).toBe(-Infinity);
+    expect(eval("0x" + "0".repeat(300) + "1fffffffffffff" + "0".repeat(10))).toBe(2 ** 93 - 2 ** 40);
+  });
+
+  test("a sweep of 64-bit values agrees with Number(BigInt) in every power-of-two radix", () => {
+    let state = 12345;
+    const random32 = () => {
+      state = (state + 0x6d2b79f5) >>> 0;
+      let t = state;
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return (t ^ (t >>> 14)) >>> 0;
+    };
+    const mismatches: string[] = [];
+    const literals: string[] = [];
+    const wanted: number[] = [];
+    for (let i = 0; i < 2000; i++) {
+      const value = (BigInt((random32() | 0x80000000) >>> 0) << 32n) | BigInt(random32());
+      const want = Number(value);
+      for (const radix of [2, 4, 8, 16, 32]) {
+        const digits = value.toString(radix);
+        if (parseInt(digits, radix) !== want) mismatches.push(`parseInt("${digits}", ${radix})`);
+        if (radix in prefix && Number(prefix[radix] + digits) !== want)
+          mismatches.push(`Number("${prefix[radix]}${digits}")`);
+      }
+      if (i % 10 === 0) {
+        literals.push(prefix[[2, 8, 16][i % 3]] + value.toString([2, 8, 16][i % 3]));
+        wanted.push(want);
+      }
+    }
+    const source = "[" + literals.join(", ") + "]";
+    const lexedByJSC: number[] = (0, eval)(source);
+    const lexedByBun = transpiledValue(source) as number[];
+    for (let i = 0; i < wanted.length; i++) {
+      if (lexedByJSC[i] !== wanted[i]) mismatches.push(`eval("${literals[i]}")`);
+      if (lexedByBun[i] !== wanted[i]) mismatches.push(`transpiled ${literals[i]}`);
+    }
+    expect(mismatches).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Problem
- Binary, octal and hex digit strings with more than 53 significant bits do not convert to the nearest double. `parseInt("97b89d834f82bbef", 16)`, `Number("0x97b89d834f82bbef")` and `eval("0x97b89d834f82bbef")` give 10932661282742124544; node and `Number(0x97b89d834f82bbefn)` give 10932661282742122496. About 7% of 64-bit values are one ulp high. JSC's `parseIntOverflow()` (`runtime/ParseInt.h`) summed `digit * radix^k` in a `double`, rounding at every step.
- A literal in a file goes through Bun's lexer instead (`src/js_parser/lexer.rs:3095`, `number * base + digit` in an `f64`), which is one ulp low for a different 10%: `0x2f32df6d0cf0355a` is 3401026328079643648, node says 3401026328079644160. So `0x… !== eval("0x…")`. The JSONC parser (`json_stage2.rs`) has the same loop.

### Fix
- Pin the preview build of oven-sh/WebKit#597. Its `parseIntOverflow()` collects the bits in a 64-bit significand with a sticky bit and rounds once, half to even. Do not merge before oven-sh/WebKit#597 lands; I move the pin to the merged commit then.
- From 2^53 up, Bun's lexer and JSONC parser re-read the digits through that same JSC function (`JSC__parsePowerOfTwoRadixDigits`), as decimal literals already use `WTF::parseDouble`. A file literal and `eval()` then agree by construction.
- Verified: `test/js/bun/jsc/string-to-number-power-of-two-radix.test.ts` (new, 7 tests, all fail on 1.4.3). Also `transpiler.test.js`, the JSON5/JSONC suites, `resolve/jsonc.test.ts`, `bundler_minify.test.ts`, `rust:check-all`.
- Self-reviewed: no defect found in the JSC change; one gap (Bun's own lexer), covered here.

### Background
- A double holds 53 significant bits. A wider integer must drop its low bits and round once; rounding a rounded value again can land one ulp off.
- ECMA-262 allows `parseInt` to approximate only for a radix outside {2, 4, 8, 10, 16, 32}; numeric literals and string-to-number take the nearest double, ties to even. Radix 10 was already exact.
- In a power-of-two radix each digit is an exact bit group, so integer shifts plus one rounding step give the nearest double, as in V8.

<details><summary>Notes</summary>

- The new test covers the reported values, double-rounding cases in radix 2/4/8/16/32, ties at 2^53, the `Number.MAX_VALUE` / `Infinity` boundary (`parseInt("fffffffffffffb" + "f".repeat(242), 16)` was `Infinity`), 16-bit strings, numeric separators, legacy octal, `node:vm`, `Bun.Transpiler` output, an imported `.jsonc` and `Bun.JSONC.parse`, and a 2,000-value sweep against `Number(BigInt)`.
- The JSC function was checked standalone against glibc `strtod` hex-float parsing and `unsigned __int128` conversion on 280,069 inputs up to 1,100 bits in all five radixes (0 mismatches; the old code differs on 17,185). The WebKit PR adds `JSTests/stress/string-to-number-power-of-two-radix-rounding.js`, which passes under a local `jsc` in default, eager-JIT and no-JIT modes, with test262 `built-ins/parseInt`, `built-ins/Number`, `language/literals/numeric` and mozilla `15.1.2.2-*`.
- The preview tag is built on the currently pinned WebKit commit plus this one change.
- `Bun.JSON5` is untouched: it parses hex through `u64`, which rounds once and is exact below 2^64. Its rejection of wider hex numbers is a separate issue.
- Upstream WebKit `main` has the same `parseIntOverflow()`.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/jsc/string-to-number-power-of-two-radix.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/jsc/string-to-number-power-of-two-radix.test.ts:
(pass) power-of-two radix strings above 2^53 round to the nearest double > parseInt [46.84ms]
(pass) power-of-two radix strings above 2^53 round to the nearest double > Number() and ToNumber on 0x / 0o / 0b strings [7.82ms]
(pass) power-of-two radix strings above 2^53 round to the nearest double > literals that JSC lexes at runtime [78.00ms]
 97 | 
 98 |   test("literals in a transpiled file", () => {
 99 |     // This file goes through Bun's lexer, which hands a literal of 2^53 or more
100 |     // to the same JSC function, so these hex literals and eval() must agree with
101 |     // the decimal literals and with BigInt.
102 |     expect(0x2f32df6d0cf0355a).toBe(3401026328079644160);
                                     ^
error: expect(received).toBe(expected)

Expected: 3401026328079644000
Received: 3401026328079643600

      at <anonymous> (/workspace/bun/test/js/bun/jsc/string-to-numb
... (truncated)

release without fix: 7 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/jsc/string-to-number-power-of-two-radix.test.ts:
33 | }
34 | 
35 | describe("power-of-two radix strings above 2^53 round to the nearest double", () => {
36 |   test("parseInt", () => {
37 |     // The reported values. Each came out one ulp too high.
38 |     expect(parseInt("97b89d834f82bbef", 16)).toBe(10932661282742122496);
                                                  ^
error: expect(received).toBe(expected)

Expected: 10932661282742122000
Received: 10932661282742125000

      at <anonymous> (/workspace/bun/test/js/bun/jsc/string-to-number-power-of-two-radix.test.ts:38:46)
(fail) power-of-two radix strings above 2^53 round to the nearest double > parseInt [0.21ms]
68 |     }
69 |     expect(parseInt("10100000000000000000000000000000000000000000000000000101", 2)).toBe(45035996273704968);
70 |   });
71 | 
72 |   test("Number() and ToNumber on 0x / 0o / 0b strings", () => {
73 |     expect(Number("0x97b89d834f82bbef")).toBe(10932661282742122496);
                                              ^
error: expect(received).toBe(expected)

Expected: 10932661282742122000
Received: 10932661282742125000

      at <anonymou
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/jsc/string-to-number-power-of-two-radix.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/jsc/string-to-number-power-of-two-radix.test.ts:
(pass) power-of-two radix strings above 2^53 round to the nearest double > parseInt [50.89ms]
(pass) power-of-two radix strings above 2^53 round to the nearest double > Number() and ToNumber on 0x / 0o / 0b strings [8.23ms]
(pass) power-of-two radix strings above 2^53 round to the nearest double > literals that JSC lexes at runtime [78.33ms]
(pass) power-of-two radix strings above 2^53 round to the nearest double > literals in a transpiled file [85.47ms]
(pass) power-of-two radix strings above 2^53 round to the nearest double > hex and octal numbers in JSONC [35.00ms]
(pass) power-of-two radix strings above 2^53 round to the nearest double > the Number.MAX_VALUE / Infinity boundary [5.75ms]
(pass) power-of-two radix strings above 2^53 round to the nearest double > a sweep of 64-bit values agrees with Number(BigInt) in every power-of-two radix [936.16ms]

 7 pass
 0 fail
 136 expect() calls
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 781ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/145] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/145] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |   2 +-
 src/bun_core/fmt.rs                                |  17 +-
 src/js_parser/lexer.rs                             |  12 +-
 src/jsc/bindings/wtf-bindings.cpp                  |   7 +
 src/parsers/json_stage2.rs                         |   9 +
 .../string-to-number-power-of-two-radix.test.ts    | 200 +++++++++++++++++++++
 6 files changed, 244 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                  0      0     18
src/bun_core/fmt.rs                                           4      4     18
src/js_parser/lexer.rs                                        3      4     18
src/jsc/bindings/wtf-bindings.cpp                             3      4     18
src/parsers/json_stage2.rs                                    1      1     19
…/js/bun/jsc/string-to-number-power-of-two-radix.test.ts      1     10     18
```

</details>

<!-- robobun:evidence:end -->