### PR TITLE
WebKit preview pr-602: BigInt("+"), BigInt("-") and BigInt("0x ") throw SyntaxError instead of returning 0n

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-602-aadfbc86";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/bigint-from-string.test.ts
+++ b/test/js/bun/jsc/bigint-from-string.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+
+// StringToBigInt (BigInt(string), and a BigInt compared with a string through
+// ==, <, <=, >, >=) accepts a sign or a radix prefix only when at least one
+// digit follows it. The whitespace-only string is the one input with no digits
+// that has a value (0n). JSC gave "+", "-" and "0x" followed by nothing but
+// whitespace the value 0n too, so BigInt("-") was 0n and 0n == "-" was true.
+
+const whitespace = ["", " ", "\t", "\n", "\r\n", "\u00a0", "\u2028", "\u3000", "\ufeff", " \t\n "];
+
+/** `body` with each kind of whitespace before it, after it, and on both sides. */
+function padded(body: string): string[] {
+  const out = new Set<string>();
+  for (const ws of whitespace) {
+    out.add(ws + body);
+    out.add(body + ws);
+    out.add(ws + body + ws);
+  }
+  return [...out];
+}
+
+const noDigits = ["+", "-", "0x", "0X", "0b", "0B", "0o", "0O"].flatMap(padded);
+
+const withDigits: [string, bigint][] = [
+  ["0", 0n],
+  ["+0", 0n],
+  ["-0", 0n],
+  ["7", 7n],
+  ["+7", 7n],
+  ["-7", -7n],
+  ["007", 7n],
+  ["-007", -7n],
+  ["0x1f", 31n],
+  ["0B101", 5n],
+  ["0o17", 15n],
+  ["123456789012345678901234567890", 123456789012345678901234567890n],
+  ["-123456789012345678901234567890", -123456789012345678901234567890n],
+];
+
+describe("a sign or radix prefix with no digits", () => {
+  test("BigInt() throws SyntaxError", () => {
+    for (const string of noDigits) {
+      expect(() => BigInt(string), JSON.stringify(string)).toThrow(SyntaxError);
+    }
+  });
+
+  test("is never loosely equal to a BigInt", () => {
+    for (const string of noDigits) {
+      for (const bigint of [0n, 1n, -1n]) {
+        // @ts-expect-error
+        expect(bigint == string, `${bigint}n == ${JSON.stringify(string)}`).toBe(false);
+        // @ts-expect-error
+        expect(string == bigint, `${JSON.stringify(string)} == ${bigint}n`).toBe(false);
+        // @ts-expect-error
+        expect(bigint != string, `${bigint}n != ${JSON.stringify(string)}`).toBe(true);
+      }
+    }
+  });
+
+  test("compares as undefined (every relational operator is false)", () => {
+    for (const string of noDigits) {
+      for (const bigint of [0n, 1n, -1n, 2n ** 64n, -(2n ** 64n)]) {
+        expect(
+          [
+            bigint < string,
+            bigint <= string,
+            bigint > string,
+            bigint >= string,
+            string < bigint,
+            string <= bigint,
+            string > bigint,
+            string >= bigint,
+          ],
+          `${bigint}n vs ${JSON.stringify(string)}`,
+        ).toEqual([false, false, false, false, false, false, false, false]);
+      }
+    }
+  });
+
+  test("other malformed signs and prefixes still throw", () => {
+    for (const string of ["+ 1", "- 1", "0x 1", "+-", "-+", "++1", "--1", "+-1", "+0x1", "-0b1", "0x+1", "0b-1", "1+", "1-"]) {
+      expect(() => BigInt(string), JSON.stringify(string)).toThrow(SyntaxError);
+    }
+  });
+});
+
+describe("controls", () => {
+  test("whitespace alone is 0n", () => {
+    for (const string of whitespace) {
+      expect(BigInt(string), JSON.stringify(string)).toBe(0n);
+      // @ts-expect-error
+      expect(0n == string, `0n == ${JSON.stringify(string)}`).toBe(true);
+      expect(1n > string, `1n > ${JSON.stringify(string)}`).toBe(true);
+    }
+  });
+
+  test("digits with a sign or prefix parse with whitespace on either side", () => {
+    for (const [body, expected] of withDigits) {
+      for (const string of padded(body)) {
+        expect(BigInt(string), JSON.stringify(string)).toBe(expected);
+        // @ts-expect-error
+        expect(expected == string, `${expected}n == ${JSON.stringify(string)}`).toBe(true);
+        expect(expected + 1n > string, `${expected + 1n}n > ${JSON.stringify(string)}`).toBe(true);
+        expect(expected - 1n < string, `${expected - 1n}n < ${JSON.stringify(string)}`).toBe(true);
+      }
+    }
+  });
+});

--- a/test/js/bun/jsc/bigint-from-string.test.ts
+++ b/test/js/bun/jsc/bigint-from-string.test.ts
@@ -78,7 +78,22 @@ describe("a sign or radix prefix with no digits", () => {
   });
 
   test("other malformed signs and prefixes still throw", () => {
-    for (const string of ["+ 1", "- 1", "0x 1", "+-", "-+", "++1", "--1", "+-1", "+0x1", "-0b1", "0x+1", "0b-1", "1+", "1-"]) {
+    for (const string of [
+      "+ 1",
+      "- 1",
+      "0x 1",
+      "+-",
+      "-+",
+      "++1",
+      "--1",
+      "+-1",
+      "+0x1",
+      "-0b1",
+      "0x+1",
+      "0b-1",
+      "1+",
+      "1-",
+    ]) {
       expect(() => BigInt(string), JSON.stringify(string)).toThrow(SyntaxError);
     }
   });


### PR DESCRIPTION
### Problem
- `BigInt("+")`, `BigInt("-")`, `BigInt(" - ")` and `BigInt("\n+\t")` return `0n`. The spec and V8 throw `SyntaxError`: in StringToBigInt only the whitespace-only string has a value (`0n`), and `SignedInteger ::: DecimalDigits | + DecimalDigits | - DecimalDigits` has no bare-sign form. `==`, `<`, `<=`, `>`, `>=` between a BigInt and a string use the same routine, so `0n == "-"`, `"+" == 0n` and `1n > "-"` are `true` (node: `false`). A radix prefix followed by only whitespace (`BigInt("0x ")`, `BigInt("0b\n")`) has the same bug.
- The cause is `JSBigInt::parseInt` in JavaScriptCore (`runtime/JSBigInt.cpp`). The sign path parses the remainder in the mode meant for the whitespace-only string, and the "no digits" check for a prefix runs before trailing whitespace is trimmed. Upstream WebKit has the same code.

### Fix
- Pin WebKit to `autobuild-preview-pr-602-aadfbc86`, the preview build of oven-sh/WebKit#602 at its head `aadfbc86dea2`, on top of the current pin `2e2aa2290fac`. That change makes the sign branch require a digit like the `0b`/`0o`/`0x` branches, and trims trailing whitespace before the empty check.
- The pin is a preview tag, not a merge commit. Do not merge before oven-sh/WebKit#602 lands. I move the pin to the `autobuild-<sha>` release of the merge commit then.
- Verified: `test/js/bun/jsc/bigint-from-string.test.ts` fails 3 of 6 tests on bun 1.4.3 and passes on a debug build linked against the patched JavaScriptCore. The JSTests stress file in the WebKit PR passes unchanged under node v26.3.0, so the expectations match V8.

### Background
- StringToBigInt is the spec routine behind `BigInt(string)` and behind comparing a BigInt with a string. When the string does not parse, `BigInt()` throws `SyntaxError`, `==` is `false`, and every relational operator is `false` (the comparison result is undefined, like NaN).
- Its grammar is `StrWhiteSpace? (StrIntegerLiteral StrWhiteSpace?)?`: optional whitespace around either decimal digits with an optional sign, or a `0b`/`0o`/`0x` literal. Whitespace alone is `0n`. A sign or prefix must be followed by at least one digit.

<details><summary>Notes</summary>

- Source: fuzz-ledger #45422, a `BigInt(s)` differential of bun 1.4.2 / canary / 1.3.14 against node v26.3.0 and Chromium 148. 1,308 of 80,000 generated inputs diverged, all the bare-sign shape. The prefix + trailing whitespace shape (`"0x "`) was not in that set; I found it reading the parser and it has the same root cause.
- Before/after table and the JSC-side reasoning are in oven-sh/WebKit#602.
- The local verification build used `bun run build:local` against the oven-sh/WebKit#602 branch (debug + ASan). The new JSTests stress file also passed there with the JIT off and with eager FTL thresholds.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/bigint-from-string.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/bigint-from-string.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/jsc/bigint-from-string.test.ts:
(pass) a sign or radix prefix with no digits > BigInt() throws SyntaxError [108.87ms]
(pass) a sign or radix prefix with no digits > is never loosely equal to a BigInt [466.13ms]
(pass) a sign or radix prefix with no digits > compares as undefined (every relational operator is false) [631.95ms]
(pass) a sign or radix prefix with no digits > other malformed signs and prefixes still throw [9.73ms]
(pass) controls > whitespace alone is 0n [8.39ms]
(pass) controls > digits with a sign or prefix parse with whitespace on either side [381.10ms]

 6 pass
 0 fail
 4860 expect() calls
Ran 6 tests across 1 file. [3.47s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts               |   2 +-
 test/js/bun/jsc/bigint-from-string.test.ts | 123 +++++++++++++++++++++++++++++
 2 files changed, 124 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
scripts/build/deps/webkit.ts                    2      2      6
test/js/bun/jsc/bigint-from-string.test.ts      1      2      6
```

</details>

<!-- robobun:evidence:end -->