### PR TITLE
Native sinks root only their controller cell; fix a leaked flush(true) promise when end() hits backpressure

### DIFF
--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -229,6 +229,10 @@ public:
     mutable WriteBarrier<JSC::JSPromise> m_closePromise; // DirectStream: readDirectStream's result while pull() is sync and open
     mutable WriteBarrier<JSC::Unknown> m_failReason; // close(error)'s error, so the owner's promise rejects even though pull() itself resolved
     mutable JSC::Weak<JSObject> m_weakReadableStream;
+    // While a native sink pipes a stream in, it roots only this cell; these hold the rest (streams.rs PipeCell).
+    mutable WriteBarrier<JSC::JSObject> m_pipeStream;
+    mutable WriteBarrier<JSC::JSPromise> m_pipeDone;
+    mutable WriteBarrier<JSC::Unknown> m_pipeError;
     uintptr_t m_onDestroy { 0 };
     bool m_destinationClosed { false }; // the sink closed underneath the source (peer abort, write error): write()/flush() report 0 instead of throwing
 
@@ -838,6 +842,9 @@ void ${controller}::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_source);
     visitor.append(thisObject->m_closePromise);
     visitor.append(thisObject->m_failReason);
+    visitor.append(thisObject->m_pipeStream);
+    visitor.append(thisObject->m_pipeDone);
+    visitor.append(thisObject->m_pipeError);
 
     void* ptr = thisObject->m_sinkPtr;
     if (ptr)
@@ -1024,6 +1031,58 @@ extern "C" JSC::EncodedJSValue JSSinkController__assignToStream(JSC::JSGlobalObj
 {
     Zig::GlobalObject* globalObject = reinterpret_cast<Zig::GlobalObject*>(arg0);
     return globalObject->assignToStream(JSC::JSValue::decode(stream), JSC::JSValue::decode(controllerValue));
+}
+
+static WebCore::JSReadableSinkControllerBase* pipeCell(JSC::EncodedJSValue value)
+{
+    return static_cast<WebCore::JSReadableSinkControllerBase*>(JSC::JSValue::decode(value).getObject());
+}
+
+extern "C" void JSSinkController__setPipe(JSC::EncodedJSValue cell, JSC::EncodedJSValue stream, JSC::EncodedJSValue done)
+{
+    auto* controller = pipeCell(cell);
+    auto& vm = controller->vm();
+    controller->m_pipeStream.setMayBeNull(vm, controller, JSC::JSValue::decode(stream).getObject());
+    controller->m_pipeDone.setMayBeNull(vm, controller, dynamicDowncast<JSC::JSPromise>(JSC::JSValue::decode(done)));
+}
+
+extern "C" JSC::EncodedJSValue JSSinkController__pipeStream(JSC::EncodedJSValue cell)
+{
+    auto* stream = pipeCell(cell)->m_pipeStream.get();
+    return JSC::JSValue::encode(stream ? JSC::JSValue(stream) : JSC::JSValue());
+}
+
+extern "C" void JSSinkController__clearPipeStream(JSC::EncodedJSValue cell)
+{
+    pipeCell(cell)->m_pipeStream.clear();
+}
+
+extern "C" JSC::EncodedJSValue JSSinkController__takePipeDone(JSC::EncodedJSValue cell)
+{
+    auto* controller = pipeCell(cell);
+    auto* done = controller->m_pipeDone.get();
+    controller->m_pipeDone.clear();
+    return JSC::JSValue::encode(done ? JSC::JSValue(done) : JSC::JSValue());
+}
+
+extern "C" bool JSSinkController__hasPipeDone(JSC::EncodedJSValue cell)
+{
+    return !!pipeCell(cell)->m_pipeDone;
+}
+
+extern "C" void JSSinkController__setPipeError(JSC::EncodedJSValue cell, JSC::EncodedJSValue error)
+{
+    auto* controller = pipeCell(cell);
+    if (!controller->m_pipeError)
+        controller->m_pipeError.set(controller->vm(), controller, JSC::JSValue::decode(error));
+}
+
+extern "C" JSC::EncodedJSValue JSSinkController__takePipeError(JSC::EncodedJSValue cell)
+{
+    auto* controller = pipeCell(cell);
+    JSC::JSValue error = controller->m_pipeError.get();
+    controller->m_pipeError.clear();
+    return JSC::JSValue::encode(error);
 }
 
 extern "C" void JSSinkController__detachPtr(JSC::EncodedJSValue controllerValue)

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -1057,17 +1057,24 @@ extern "C" void JSSinkController__clearPipeStream(JSC::EncodedJSValue cell)
     pipeCell(cell)->m_pipeStream.clear();
 }
 
+extern "C" void JSSinkController__setPipeDone(JSC::EncodedJSValue cell, JSC::EncodedJSValue done)
+{
+    auto* controller = pipeCell(cell);
+    controller->m_pipeDone.setMayBeNull(controller->vm(), controller, dynamicDowncast<JSC::JSPromise>(JSC::JSValue::decode(done)));
+}
+
+extern "C" JSC::EncodedJSValue JSSinkController__pipeDone(JSC::EncodedJSValue cell)
+{
+    auto* done = pipeCell(cell)->m_pipeDone.get();
+    return JSC::JSValue::encode(done ? JSC::JSValue(done) : JSC::JSValue());
+}
+
 extern "C" JSC::EncodedJSValue JSSinkController__takePipeDone(JSC::EncodedJSValue cell)
 {
     auto* controller = pipeCell(cell);
     auto* done = controller->m_pipeDone.get();
     controller->m_pipeDone.clear();
     return JSC::JSValue::encode(done ? JSC::JSValue(done) : JSC::JSValue());
-}
-
-extern "C" bool JSSinkController__hasPipeDone(JSC::EncodedJSValue cell)
-{
-    return !!pipeCell(cell)->m_pipeDone;
 }
 
 extern "C" void JSSinkController__setPipeError(JSC::EncodedJSValue cell, JSC::EncodedJSValue error)

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -723,6 +723,9 @@ void JS${controllerName}::detach(JSC::JSValue reason) {
         clearReadableStream();
         return;
     }
+    // A sink whose close re-enters here (FileSink's on_close runs inside close(error)) detaches before closeWithReason passes the reason; m_failReason already has it.
+    if (!reason)
+        reason = m_failReason.get();
     Bun::WebStreams::sinkControllerOnClose(this->globalObject(), this, reason ? reason : JSC::jsUndefined(), /* sinkClosed */ false);
 }
 `;

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -214,11 +214,17 @@ public:
 
     void start(JSC::VM& vm, JSC::JSObject* readableStream, SinkSource kind, JSC::JSCell* source)
     {
-        m_weakReadableStream = JSC::Weak<JSC::JSObject>(readableStream);
+        m_readableStream.set(vm, this, readableStream);
         m_sourceKind = kind;
         m_source.set(vm, this, source);
     }
-    JSC::JSObject* readableStream() const { return m_weakReadableStream.get(); }
+    JSC::JSObject* readableStream() const { return m_readableStream.get(); }
+    // Two users: this cell's close handler (until m_sourceKind is None) and a sink that set it through setPipe. The last one out drops it.
+    void clearReadableStream()
+    {
+        if (!m_pipeHoldsStream && m_sourceKind == SinkSource::None)
+            m_readableStream.clear();
+    }
     JSC::EncodedJSValue end(JSC::JSGlobalObject*); // the JS-visible end(): finish the native sink, then detach()
     JSC::EncodedJSValue close(JSC::JSGlobalObject*, JSC::JSValue reason); // the JS-visible close(reason): a truthy reason fails the sink without flushing
 
@@ -228,12 +234,12 @@ public:
     mutable WriteBarrier<JSC::JSCell> m_source;
     mutable WriteBarrier<JSC::JSPromise> m_closePromise; // DirectStream: readDirectStream's result while pull() is sync and open
     mutable WriteBarrier<JSC::Unknown> m_failReason; // close(error)'s error, so the owner's promise rejects even though pull() itself resolved
-    mutable JSC::Weak<JSObject> m_weakReadableStream;
-    // While a native sink pipes a stream in, it roots only this cell; these hold the rest (streams.rs PipeCell).
-    mutable WriteBarrier<JSC::JSObject> m_pipeStream;
+    // Strong, and cleared as soon as the pipe is over, so a controller the user still holds does not keep the stream alive.
+    mutable WriteBarrier<JSC::JSObject> m_readableStream;
+    // While a native sink pipes a stream in, it roots only this cell; this and m_readableStream hold the rest (streams.rs PipeCell).
     mutable WriteBarrier<JSC::JSPromise> m_pipeDone;
-    mutable WriteBarrier<JSC::Unknown> m_pipeError;
     uintptr_t m_onDestroy { 0 };
+    bool m_pipeHoldsStream { false };
     bool m_destinationClosed { false }; // the sink closed underneath the source (peer abort, write error): write()/flush() report 0 instead of throwing
 
 protected:
@@ -714,7 +720,7 @@ void JS${controllerName}::detach(JSC::JSValue reason) {
     }
 
     if (m_sourceKind == SinkSource::None) {
-        m_weakReadableStream.clear();
+        clearReadableStream();
         return;
     }
     Bun::WebStreams::sinkControllerOnClose(this->globalObject(), this, reason ? reason : JSC::jsUndefined(), /* sinkClosed */ false);
@@ -842,9 +848,8 @@ void ${controller}::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_source);
     visitor.append(thisObject->m_closePromise);
     visitor.append(thisObject->m_failReason);
-    visitor.append(thisObject->m_pipeStream);
+    visitor.append(thisObject->m_readableStream);
     visitor.append(thisObject->m_pipeDone);
-    visitor.append(thisObject->m_pipeError);
 
     void* ptr = thisObject->m_sinkPtr;
     if (ptr)
@@ -1042,19 +1047,27 @@ extern "C" void JSSinkController__setPipe(JSC::EncodedJSValue cell, JSC::Encoded
 {
     auto* controller = pipeCell(cell);
     auto& vm = controller->vm();
-    controller->m_pipeStream.setMayBeNull(vm, controller, JSC::JSValue::decode(stream).getObject());
+    if (auto* streamObject = JSC::JSValue::decode(stream).getObject()) {
+        controller->m_readableStream.set(vm, controller, streamObject);
+        controller->m_pipeHoldsStream = true;
+    } else {
+        controller->m_pipeHoldsStream = false;
+        controller->clearReadableStream();
+    }
     controller->m_pipeDone.setMayBeNull(vm, controller, dynamicDowncast<JSC::JSPromise>(JSC::JSValue::decode(done)));
 }
 
 extern "C" JSC::EncodedJSValue JSSinkController__pipeStream(JSC::EncodedJSValue cell)
 {
-    auto* stream = pipeCell(cell)->m_pipeStream.get();
+    auto* stream = pipeCell(cell)->m_readableStream.get();
     return JSC::JSValue::encode(stream ? JSC::JSValue(stream) : JSC::JSValue());
 }
 
 extern "C" void JSSinkController__clearPipeStream(JSC::EncodedJSValue cell)
 {
-    pipeCell(cell)->m_pipeStream.clear();
+    auto* controller = pipeCell(cell);
+    controller->m_pipeHoldsStream = false;
+    controller->clearReadableStream();
 }
 
 extern "C" void JSSinkController__setPipeDone(JSC::EncodedJSValue cell, JSC::EncodedJSValue done)
@@ -1077,19 +1090,17 @@ extern "C" JSC::EncodedJSValue JSSinkController__takePipeDone(JSC::EncodedJSValu
     return JSC::JSValue::encode(done ? JSC::JSValue(done) : JSC::JSValue());
 }
 
+// The pipe's failure value shares m_failReason: close(error) stores the same value there, and every other writer runs after pull() settled.
 extern "C" void JSSinkController__setPipeError(JSC::EncodedJSValue cell, JSC::EncodedJSValue error)
 {
     auto* controller = pipeCell(cell);
-    if (!controller->m_pipeError)
-        controller->m_pipeError.set(controller->vm(), controller, JSC::JSValue::decode(error));
+    if (!controller->m_failReason)
+        controller->m_failReason.set(controller->vm(), controller, JSC::JSValue::decode(error));
 }
 
-extern "C" JSC::EncodedJSValue JSSinkController__takePipeError(JSC::EncodedJSValue cell)
+extern "C" JSC::EncodedJSValue JSSinkController__pipeError(JSC::EncodedJSValue cell)
 {
-    auto* controller = pipeCell(cell);
-    JSC::JSValue error = controller->m_pipeError.get();
-    controller->m_pipeError.clear();
-    return JSC::JSValue::encode(error);
+    return JSC::JSValue::encode(pipeCell(cell)->m_failReason.get());
 }
 
 extern "C" void JSSinkController__detachPtr(JSC::EncodedJSValue controllerValue)

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -1214,7 +1214,7 @@ void sinkControllerOnClose(JSGlobalObject* globalObject, WebCore::JSReadableSink
     JSC::EnsureStillAliveScope streamCell(controller->readableStream());
     controller->m_source.clear();
     controller->m_closePromise.clear();
-    controller->m_weakReadableStream.clear();
+    controller->clearReadableStream();
     // Re-entering JS on a terminated worker trips executeCallImpl's assertNoException().
     if (vm.hasPendingTerminationException() || WebCore::clientData(vm)->isStoppingOrStopped(vm)) [[unlikely]]
         return;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2910,13 +2910,8 @@ where
         // from `&self`.
         let global_this = self.server().global_this();
         if let Some(resp) = self.response_mut() {
-            if let Some(stream) = resp.get_body_readable_stream() {
-                stream.value.ensure_still_alive();
-                resp.detach_readable_stream(global_this);
-
-                stream.done();
-            }
-
+            release_body_stream(resp, global_this);
+            // Unlike the reject path: used whatever it held, not only when `Locked`.
             *resp.get_body_value() = Body::Value::Used;
         }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2202,7 +2202,7 @@ where
         // above resolves it) instead of falling through to the cancel path.
         let mut effective_result = assignment_result;
         if effective_result.is_empty_or_undefined_or_null() {
-            if let Some(flush) = response_stream.sink.pending_flush {
+            if let Some(flush) = response_stream.sink.pending_flush() {
                 // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
                 effective_result = jsc::JSPromise::opaque_ref(flush).to_js();
             }
@@ -2867,7 +2867,7 @@ where
                 // flush_promise) is armed on `resp`. With no response the flush
                 // can never settle, so taking a ref and attaching here would
                 // leak the ref and hang the request; fall through to teardown.
-                if let Some(flush) = wrapper.sink.pending_flush
+                if let Some(flush) = wrapper.sink.pending_flush()
                     && self.resp.get().is_some()
                 {
                     stream_log!("handleResolveStream: waiting for pending flush");
@@ -3002,14 +3002,8 @@ where
                 self.flags.set_request_body_paused(false);
                 self.detach_request_body_producer();
             }
-            if let Some(prom) = wrapper.sink.pending_flush.take() {
-                // The promise value was protected when pending_flush was
-                // assigned (flushFromJS / endFromJS). Drop that root before
-                // abandoning the pointer, otherwise it leaks for the
-                // lifetime of the VM.
-                // S008: `JSPromise` is an `opaque_ffi!` ZST — safe deref.
-                bun_opaque::opaque_deref_mut(prom).to_js().unprotect();
-            }
+            // The body failed: a parked flush()/end() promise is abandoned, not resolved by the teardown below.
+            let _ = wrapper.sink.take_pending_flush();
             wrapper.sink.set_done();
             let aborted = self.flags.aborted() || wrapper.sink.is_aborted();
             self.flags.set_aborted(aborted);

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -98,6 +98,20 @@ pub(crate) enum UpgradeState {
     Upgraded,
 }
 
+/// The root on the Response being rendered. A plain Blob body is read in the frame that returned it, so it is left unrooted (see `response_weakref`); a file or streaming body is read after that frame, so [`set_rooted`](Self::set_rooted) roots it.
+#[derive(Default)]
+pub(crate) struct ResponseRoot(JsCell<bun_jsc::strong::Optional>);
+
+impl ResponseRoot {
+    pub(crate) fn set_rooted(&self, value: JSValue, global: &JSGlobalObject) {
+        self.0.set(bun_jsc::strong::Optional::create(value, global));
+    }
+
+    pub(crate) fn clear(&self) {
+        self.0.set(bun_jsc::strong::Optional::empty());
+    }
+}
+
 /// `align(16)`: `NativePromiseContext`'s deferred-deref task packs a 4-bit
 /// type tag into the low bits of a pointer to this.
 #[repr(align(16))]
@@ -132,12 +146,7 @@ pub struct RequestContext<
 
     /// We can only safely free once the request body promise is finalized
     /// and the response is rejected
-    // Deliberately a bare JSValue with manual protect()/unprotect() gated by
-    // the `response_protected` flag: plain Blob/InternalBlob
-    // bodies intentionally leave the value unprotected on the hot path and
-    // fall back to `response_weakref` (see its doc below), so a `Strong`
-    // here would root the Response unconditionally and change GC behavior.
-    pub(crate) response_jsvalue: Cell<JSValue>,
+    pub(crate) response_root: ResponseRoot,
     root: Cell<*mut Self>,
     pub(crate) ref_count: Cell<u8>,
     pub(crate) pin_count: Cell<u8>,
@@ -147,7 +156,7 @@ pub struct RequestContext<
     /// on tryEnd() backpressure. onAbort / handleResolveStream /
     /// handleRejectStream only use this for best-effort readable-stream
     /// cleanup and safely observe null instead of UAF. File/.Locked
-    /// bodies still protect() response_jsvalue, so the pointer stays
+    /// bodies still root it through `response_root`, so the pointer stays
     /// valid for renderMetadata() on those paths.
     pub(crate) response_weakref: JsCell<response::WeakRef>,
     pub(crate) blob: JsCell<AnyBlob>,
@@ -837,15 +846,7 @@ where
         if self.reject_unsendable_response(unsafe { (*response).status_code() }) {
             return;
         }
-        // An async error() Response may replace a still-protected streaming
-        // Response; release the original before overwriting.
-        if self.flags.response_protected() {
-            self.response_jsvalue.get().unprotect();
-            self.flags.set_response_protected(false);
-        }
-        self.response_jsvalue.set(value);
-        self.flags.set_response_protected(true);
-        value.protect();
+        self.response_root.set_rooted(value, global_this);
 
         if self.method == Method::HEAD {
             if let Some(resp) = self.resp.get() {
@@ -1431,7 +1432,7 @@ where
                 cookies: JsCell::new(None),
                 flags: Flags::<DEBUG_MODE>::default(),
                 upgrade_context: Cell::new(UpgradeState::None),
-                response_jsvalue: Cell::new(JSValue::ZERO),
+                response_root: ResponseRoot::default(),
                 ref_count: Cell::new(1),
                 pin_count: Cell::new(0),
                 response_weakref: JsCell::new(response::WeakRef::EMPTY),
@@ -1591,15 +1592,7 @@ where
             release_body_stream(resp, global_this);
         }
 
-        let response_jsvalue = self.response_jsvalue.get();
-        if !response_jsvalue.is_empty() {
-            ctx_log!("finalizeWithoutDeinit: response_jsvalue != .zero");
-            if self.flags.response_protected() {
-                response_jsvalue.unprotect();
-                self.flags.set_response_protected(false);
-            }
-            self.response_jsvalue.set(JSValue::ZERO);
-        }
+        self.response_root.clear();
         self.response_weakref.set(response::WeakRef::EMPTY);
 
         // The stream ref itself is errored and released by `end_request_streaming()` below.
@@ -2761,9 +2754,8 @@ where
             if ctx.reject_unsendable_response(unsafe { (*response).status_code() }) {
                 return;
             }
-            ctx.response_jsvalue.set(response_value);
+            ctx.response_root.clear();
             response_value.ensure_still_alive();
-            ctx.flags.set_response_protected(false);
             if ctx.method == Method::HEAD {
                 if let Some(resp) = ctx.resp.get() {
                     let mut pair = HeaderResponsePair {
@@ -2820,9 +2812,8 @@ where
                         return;
                     }
 
-                    ctx.response_jsvalue.set(fulfilled_value);
+                    ctx.response_root.clear();
                     fulfilled_value.ensure_still_alive();
-                    ctx.flags.set_response_protected(false);
                     if ctx.method == Method::HEAD {
                         if let Some(resp) = ctx.resp.get() {
                             let mut pair = HeaderResponsePair {
@@ -3679,11 +3670,7 @@ where
                             // so root the Response the way the async error
                             // path does or the deferred flush can read a
                             // collected weakref.
-                            if self.flags.response_protected() {
-                                self.response_jsvalue.get().unprotect();
-                            }
-                            self.response_jsvalue.set(result);
-                            self.flags.set_response_protected(false);
+                            self.response_root.clear();
                             // SAFETY: as above.
                             unsafe { self.protect_for_body_and_render(result, response) };
                             return;
@@ -3733,13 +3720,8 @@ where
                     return;
                 }
 
-                // Same as handle_resolve: release a still-protected original.
-                if ctx.flags.response_protected() {
-                    ctx.response_jsvalue.get().unprotect();
-                }
-                ctx.response_jsvalue.set(fulfilled_value);
+                ctx.response_root.clear();
                 fulfilled_value.ensure_still_alive();
-                ctx.flags.set_response_protected(false);
 
                 // SAFETY: `response` is the live, rooted cell pointer.
                 unsafe { ctx.protect_for_body_and_render(fulfilled_value, response) };
@@ -4011,11 +3993,10 @@ where
         self.do_render();
     }
 
-    /// [`Self::render`] for the Response a handler just returned, whose JS
-    /// wrapper `response_value` is already stored in `response_jsvalue`. A
-    /// file or streaming body is still being sent after this frame returns,
-    /// so for those the wrapper is protected first; in-memory bodies leave it
-    /// unprotected (see `response_jsvalue`).
+    /// [`Self::render`] for the Response a handler just returned. A file or
+    /// streaming body is still being sent after this frame returns, so for
+    /// those `response_root` roots the wrapper first; in-memory bodies leave
+    /// it unrooted.
     ///
     /// # Safety
     /// Same contract as [`Self::render`].
@@ -4030,8 +4011,8 @@ where
             _ => false,
         };
         if sent_after_return {
-            response_value.protect();
-            self.flags.set_response_protected(true);
+            self.response_root
+                .set_rooted(response_value, self.server().global_this());
         }
         // SAFETY: caller contract.
         unsafe { self.render(response) };
@@ -4658,7 +4639,6 @@ bitflags::bitflags! {
         /// Used to avoid looking at the uws.Request struct after it's been freed
         const IS_WEB_BROWSER_NAVIGATION   = 1 << 10;
         const HAS_WRITTEN_STATUS          = 1 << 11;
-        const RESPONSE_PROTECTED          = 1 << 12;
         const ABORTED                     = 1 << 13;
         const HAS_FINALIZED               = 1 << 14;
         const IS_ERROR_PROMISE_PENDING    = 1 << 15;
@@ -4730,11 +4710,6 @@ impl<const DEBUG_MODE: bool> Flags<DEBUG_MODE> {
         has_written_status,
         set_has_written_status,
         HAS_WRITTEN_STATUS
-    );
-    flag_accessor!(
-        response_protected,
-        set_response_protected,
-        RESPONSE_PROTECTED
     );
     flag_accessor!(aborted, set_aborted, ABORTED);
     flag_accessor!(

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3758,7 +3758,7 @@ where
         // For plain in-memory bodies this runs synchronously from
         // render() before any backpressure gap, so the Response is
         // always live here. File / stream bodies that call this after
-        // an async hop keep the Response rooted via response_protected.
+        // an async hop keep the Response rooted via `response_root`.
         let response: &mut Response = self.response_mut().unwrap();
         let sendfile = self.sendfile.get();
         let mut status = response.status_code();

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -54,13 +54,11 @@ pub struct FileSink {
     pub(crate) auto_flusher: JsCell<AutoFlusher>,
     pub(crate) run_pending_later: FlushPendingTask,
 
-    /// The stream `assign_to_stream` (spawn stdin) or `pipe_stream` (`Bun.write`) is piping in.
-    pub(crate) readable_stream: JsCell<readable_stream::Strong>,
-
-    /// `pipe_stream`: settled from `on_close` with `stream_bytes`, or with the error that ended
-    /// the stream or the write.
-    stream_done: JsCell<bun_jsc::JSPromiseStrong>,
+    /// While `assign_to_stream` (spawn stdin) or `pipe_stream` (`Bun.write`) pipes a stream in: the controller cell that holds the stream, `pipe_stream`'s done-promise and a JS failure value.
+    pipe: JsCell<streams::PipeCell>,
+    /// A write or source failure that is not a JS value; a JS one lives on `pipe` and sets `stream_js_error`.
     stream_error: JsCell<Option<streams::StreamError>>,
+    stream_js_error: Cell<bool>,
     /// Bytes accepted since `pipe_stream` (`written` counts buffered bytes again when flushed).
     pub(crate) stream_bytes: Cell<Option<u64>>,
 
@@ -191,6 +189,7 @@ impl Options {
 impl Drop for FileSink {
     fn drop(&mut self) {
         LIVE_COUNT.fetch_sub(1, Ordering::Relaxed);
+        self.release_pipe();
         if let Some(global) = self.js_global() {
             let vm = global.bun_vm().as_mut();
             AutoFlusher::unregister_deferred_microtask_with_type::<Self>(self, vm);
@@ -298,26 +297,19 @@ impl FileSink {
             let _guard = RefPtr::init_ref(this);
 
             (*this).done.set(true);
-            let mut readable_stream = (*this)
-                .readable_stream
-                .replace(readable_stream::Strong::default());
-            if readable_stream.has() {
+            if let Some(stream) = (*this).pipe.get().take_stream() {
                 if let Some(global) = (*this).js_global() {
-                    if let Some(stream) = readable_stream.get().as_mut() {
-                        if !status.is_ok() {
-                            // SAFETY: `bun_vm()` is non-null when `global_object()` was;
-                            // `event_loop()` returns the live VM-owned `*mut EventLoop`.
-                            let _entered = bun_jsc::event_loop::EventLoop::enter_scope(
-                                global.bun_vm().as_mut().event_loop(),
-                            );
-                            crate::dispatch::fold(stream.cancel(global));
-                        } else {
-                            stream.done();
-                        }
+                    if !status.is_ok() {
+                        // SAFETY: `bun_vm()` is non-null when `global_object()` was;
+                        // `event_loop()` returns the live VM-owned `*mut EventLoop`.
+                        let _entered = bun_jsc::event_loop::EventLoop::enter_scope(
+                            global.bun_vm().as_mut().event_loop(),
+                        );
+                        crate::dispatch::fold(stream.cancel(global));
+                    } else {
+                        stream.done();
                     }
                 }
-                // Clean up the readable stream reference
-                drop(readable_stream);
             }
 
             // SAFETY(JsCell): `IOWriter::close` does not call into JS directly; the
@@ -506,9 +498,8 @@ impl FileSink {
         bun_core::scoped_log!(FileSink, "onClose()");
         // SAFETY: caller contract — `this` is live with write+dealloc provenance.
         unsafe {
-            // SAFETY(JsCell): `Strong::has`/`get` are read-only on the GC root.
-            if (*this).readable_stream.get_mut().has() && (*this).js_global().is_some() {
-                if let Some(stream) = (*this).readable_stream.get().get() {
+            if (*this).js_global().is_some() {
+                if let Some(stream) = (*this).pipe.get().stream() {
                     stream.done();
                 }
             }
@@ -522,6 +513,7 @@ impl FileSink {
             src.close(err);
 
             (*this).settle_stream_done();
+            (*this).release_pipe();
 
             // The writer is fully closed; no further callbacks will arrive. Release
             // the ref taken when a write returned `.pending`. This must be the last
@@ -536,26 +528,63 @@ impl FileSink {
         #[cfg(windows)]
         if !self.writer.get().owns_fd {
             self.settle_stream_done();
+            self.release_pipe();
         }
         self.writer.with_mut(|w| w.end());
     }
 
     fn settle_stream_done(&self) {
-        let mut promise = self.stream_done.replace(bun_jsc::JSPromiseStrong::empty());
-        if !promise.has_value() {
+        let Some(promise) = self.pipe.get().take_done() else {
             return;
-        }
+        };
+        // SAFETY: `take_done` returned a live `JSPromise` cell; the stack keeps it alive for this call.
+        let promise = unsafe { &mut *promise };
+        let _keep = bun_jsc::EnsureStillAlive(promise.to_js());
         let Some(global) = self.js_global() else {
             return;
         };
-        let result = match self.stream_error.replace(None) {
-            Some(err) => promise.reject(global, Ok(err.to_js(global))),
+        let error = match self.stream_error.replace(None) {
+            Some(err) => Some(err.to_js(global)),
+            None => self.pipe.get().take_error(),
+        };
+        self.stream_js_error.set(false);
+        let result = match error {
+            Some(error) => promise.reject(global, Ok(error)),
             None => promise.resolve(
                 global,
                 JSValue::js_number(self.stream_bytes.get().unwrap_or(0) as f64),
             ),
         };
         crate::dispatch::fold(result);
+    }
+
+    /// The pipe is over: detach the controller cell (its destructor must never see this sink) and drop the root on it.
+    fn release_pipe(&self) {
+        let pipe = self.pipe.replace(streams::PipeCell::default());
+        let (Some(cell), Some(global)) = (pipe.cell(), self.js_global()) else {
+            return;
+        };
+        if let streams::SourceHandle::JSController(source) = *self.source.get() {
+            if source == cell {
+                self.source.set(streams::SourceHandle::None);
+            }
+        }
+        crate::dispatch::fold(::bun_jsc::call_check_slow(global, || {
+            streams::controller_abi::detach_ptr(cell)
+        }));
+    }
+
+    fn has_stream_error(&self) -> bool {
+        self.stream_error.get().is_some() || self.stream_js_error.get()
+    }
+
+    /// `record_stream_error` for a JS value: it is held by the pipe's controller cell, not rooted here.
+    fn record_js_stream_error(&self, error: JSValue) {
+        if self.has_stream_error() {
+            return;
+        }
+        self.pipe.get().set_error(error);
+        self.stream_js_error.set(true);
     }
 
     /// Release the ref taken in `toResult`/`end`/`endFromJS` when a write
@@ -608,8 +637,7 @@ impl FileSink {
     }
 
     pub(crate) fn setup(&self, options: &Options) -> sys::Result<()> {
-        // SAFETY: JsCell — `Strong::has` is a read-only GC-root probe; no JS re-entry.
-        if unsafe { self.readable_stream.get_mut() }.has() {
+        if self.pipe.get().has_stream() {
             // Already started.
             return sys::Result::Ok(());
         }
@@ -1008,7 +1036,7 @@ impl FileSink {
         // belongs to the wrapper it's about to be stored in, so no extra
         // `ref_()` there. Callers that allocate via `init`/`create` and then
         // `to_js()` must `deref()` once to release init's +1 (see
-        // `Blob::get_writer`). `pending`/`readable_stream` are left for
+        // `Blob::get_writer`). `pending`/`pipe` are left for
         // `deinit` (Box drop) since in-flight IO may still need them.
         // SAFETY: as above; the `deref` is the last use of `this`.
         unsafe {
@@ -1082,8 +1110,16 @@ impl FileSink {
     }
 
     fn record_stream_error(&self, err: streams::StreamError) {
-        if self.stream_error.get().is_none() {
-            self.stream_error.set(Some(err));
+        if self.has_stream_error() {
+            return;
+        }
+        match err {
+            streams::StreamError::JSValue(value) => {
+                if let Some(value) = value.get() {
+                    self.record_js_stream_error(value);
+                }
+            }
+            err => self.stream_error.set(Some(err)),
         }
     }
 
@@ -1131,7 +1167,7 @@ impl FileSink {
         }
         let errored = err.is_some();
         // A failed `write()` recorded its error before the source called back here.
-        let write_failed = self.stream_error.get().is_some();
+        let write_failed = self.has_stream_error();
         let sys_err = match &err {
             Some(streams::StreamError::Error(e)) => Some(e.clone()),
             _ => None,
@@ -1149,11 +1185,9 @@ impl FileSink {
         self.done.set(true);
         // The source stopped because a write failed (it cleared its sink first): nothing reads
         // the rest, so cancel it. A source that failed on its own is already done.
-        let readable_stream = self
-            .readable_stream
-            .replace(readable_stream::Strong::default());
+        let stream = self.pipe.get().take_stream();
         if write_failed {
-            if let (Some(stream), Some(global)) = (readable_stream.get(), self.js_global()) {
+            if let (Some(stream), Some(global)) = (stream, self.js_global()) {
                 crate::dispatch::fold(stream.cancel(global));
             }
         }
@@ -1381,17 +1415,18 @@ impl crate::webcore::sink::JsSinkType for FileSink {
     /// The JS pump's source failed, or `controller.close(error)`: a piped stream rejects with `reason`.
     unsafe fn close_with_error(
         this: *mut Self,
-        global: &JSGlobalObject,
+        _global: &JSGlobalObject,
         reason: JSValue,
     ) -> sys::Result<()> {
-        // `end_from_stream` can re-enter `on_close`, which releases the keep-alive ref; hold one
+        // `end` can re-enter `on_close`, which releases the keep-alive ref; hold one
         // across the call like `on_write`/`on_attached_process_exit` do.
         // SAFETY: caller contract; `this` is live.
         let _guard = unsafe { RefPtr::init_ref(this) };
         // SAFETY: `_guard` keeps `this` live for this borrow.
-        unsafe { &*this }.end_from_stream(Some(streams::StreamError::JSValue(
-            bun_jsc::strong::Optional::create(reason, global),
-        )));
+        let this = unsafe { &*this };
+        this.record_js_stream_error(reason);
+        // Not a ByteStream source: `end_from_stream` would flush and end the same way.
+        let _ = this.end(None);
         sys::Result::Ok(())
     }
     fn source(&mut self) -> Option<&mut streams::SourceHandle> {
@@ -1511,9 +1546,9 @@ impl FileSink {
             fd: Cell::new(fd),
             auto_flusher: JsCell::new(AutoFlusher::default()),
             run_pending_later: FlushPendingTask::default(),
-            readable_stream: JsCell::new(readable_stream::Strong::default()),
-            stream_done: JsCell::new(bun_jsc::JSPromiseStrong::empty()),
+            pipe: JsCell::new(streams::PipeCell::default()),
             stream_error: JsCell::new(None),
+            stream_js_error: Cell::new(false),
             stream_bytes: Cell::new(None),
             js_sink_ref: JsCell::new(bun_jsc::strong::Optional::empty()),
         }
@@ -1568,12 +1603,12 @@ impl FlushPendingTask {
 impl FileSink {
     /// The JS pump finished: flush what it wrote and end. Does not ref or unref.
     fn handle_resolve_stream(&self, global_this: &JSGlobalObject) {
-        if let Some(stream) = self.readable_stream.get().get().as_mut() {
+        if let Some(stream) = self.pipe.get().stream() {
             stream.done();
         }
 
         if !self.done.get() {
-            // A flush error is recorded in `stream_error` and reaches `stream_done`.
+            // A flush error is recorded in `stream_error` and reaches the done-promise.
             let _ = self.end(None);
         }
         self.detach_js_controller(global_this);
@@ -1581,13 +1616,8 @@ impl FileSink {
 
     /// Does not ref or unref.
     fn handle_reject_stream(&self, global_this: &JSGlobalObject, err: JSValue) -> JsResult<()> {
-        self.record_stream_error(streams::StreamError::JSValue(
-            bun_jsc::strong::Optional::create(err, global_this),
-        ));
-        let readable_stream = self
-            .readable_stream
-            .replace(readable_stream::Strong::default());
-        let aborted = match readable_stream.get() {
+        self.record_js_stream_error(err);
+        let aborted = match self.pipe.get().take_stream() {
             Some(stream) => stream.abort(global_this),
             None => Ok(()),
         };
@@ -1646,11 +1676,15 @@ impl FileSink {
         let _guard = unsafe { RefPtr::init_ref(std::ptr::from_mut::<FileSink>(self)) };
 
         self.stream_bytes.set(Some(0));
-        self.stream_done
-            .set(bun_jsc::JSPromiseStrong::init(global_this));
-        let promise = self.stream_done.get().value();
-        self.readable_stream
-            .set(readable_stream::Strong::init(*stream, global_this));
+        let promise = bun_jsc::JSPromise::create(global_this).to_js();
+        let controller =
+            JSSink::create_controller(global_this, core::ptr::NonNull::from(&mut *self));
+        self.pipe.set(streams::PipeCell::create(
+            controller,
+            stream.value,
+            promise,
+            global_this,
+        ));
 
         match stream.wire_native_sink(
             global_this,
@@ -1661,7 +1695,7 @@ impl FileSink {
             readable_stream::NativeWireResult::Wired => {
                 // A synchronous source (FileReader over a regular file) may have run to the
                 // end inside `wire_native_sink`; the promise is settled then.
-                if self.stream_done.get().has_value() && !self.done.get() {
+                if self.pipe.get().has_done() && !self.done.get() {
                     self.writer
                         .with_mut(|w| w.enable_keeping_process_alive(self.io_evtloop()));
                     if !self.must_be_kept_alive_until_eof.get() {
@@ -1677,14 +1711,12 @@ impl FileSink {
                 promise
             }
             readable_stream::NativeWireResult::NotNative => {
-                let result = self.assign_to_js_stream(stream, global_this);
+                let result = self.assign_to_js_stream(stream, controller, global_this);
                 if let Some(err) = result.to_error() {
-                    self.stream_done.set(bun_jsc::JSPromiseStrong::empty());
-                    self.readable_stream.set(readable_stream::Strong::default());
                     self.stream_bytes.set(None);
                     return err;
                 }
-                // A pump that already failed reports through `stream_done`.
+                // A pump that already failed reports through the done-promise.
                 if let Some(pump) = result.as_any_promise() {
                     if pump.status() == bun_jsc::js_promise::Status::Rejected {
                         pump.set_handled(global_this.vm());
@@ -1703,8 +1735,14 @@ impl FileSink {
         // SAFETY: `&mut self` carries write+dealloc provenance over the allocation.
         let _guard = unsafe { RefPtr::init_ref(std::ptr::from_mut::<FileSink>(self)) };
 
-        self.readable_stream
-            .set(readable_stream::Strong::init(*stream, global_this));
+        let controller =
+            JSSink::create_controller(global_this, core::ptr::NonNull::from(&mut *self));
+        self.pipe.set(streams::PipeCell::create(
+            controller,
+            stream.value,
+            JSValue::UNDEFINED,
+            global_this,
+        ));
 
         // Native ByteStream/FileReader fast-path: wire the SinkHandle
         // directly, skipping the JS pump.
@@ -1740,24 +1778,26 @@ impl FileSink {
             readable_stream::NativeWireResult::NotNative => {}
         }
 
-        self.assign_to_js_stream(stream, global_this)
+        self.assign_to_js_stream(stream, controller, global_this)
     }
 
-    /// Pump a JS `stream` in through a controller; the writer is ended when the pump settles.
+    /// Pump a JS `stream` in through the pipe's `controller`; the writer is ended when the pump settles.
     fn assign_to_js_stream(
         &mut self,
         stream: &mut ReadableStream,
+        controller: JSValue,
         global_this: &JSGlobalObject,
     ) -> JSValue {
-        // No +1 for the controller: ending the writer detaches it before this sink is freed.
-        let promise_result = JSSink::assign_to_stream(
+        // No +1 for the controller: `release_pipe` detaches it before this sink is freed.
+        let promise_result = JSSink::assign_controller_to_stream(
             global_this,
             stream.value,
+            controller,
             core::ptr::NonNull::from(&mut *self),
         );
 
         if let Some(err) = promise_result.to_error() {
-            self.readable_stream.set(readable_stream::Strong::default());
+            self.release_pipe();
             return err;
         }
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -545,7 +545,7 @@ impl FileSink {
         };
         let error = match self.stream_error.replace(None) {
             Some(err) => Some(err.to_js(global)),
-            None => self.pipe.get().take_error(),
+            None => self.pipe.get().error(),
         };
         self.stream_js_error.set(false);
         let result = match error {
@@ -561,6 +561,7 @@ impl FileSink {
     /// The pipe is over: detach the controller cell (its destructor must never see this sink) and drop the root on it.
     fn release_pipe(&self) {
         let pipe = self.pipe.replace(streams::PipeCell::default());
+        pipe.clear_slots();
         let (Some(cell), Some(global)) = (pipe.cell(), self.js_global()) else {
             return;
         };

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -2,7 +2,7 @@ use core::ffi::c_void;
 use core::ptr::NonNull;
 
 use crate::api::bun_subprocess::Subprocess;
-use crate::webcore::streams::{self, SourceHandle};
+use crate::webcore::streams::{self, SourceHandle, controller_abi};
 use bun_collections::TaggedPtrUnion;
 use bun_jsc::{JSGlobalObject, JSValue};
 use bun_sys::{self as sys, Error as SysError};
@@ -300,15 +300,14 @@ impl<T: JsSinkAbi> JSSink<T> {
 /// instantiations share one copy.
 #[inline(never)]
 fn start_pump(global: &JSGlobalObject, stream: JSValue, controller: JSValue) -> JSValue {
-    let result = streams::controller_abi::assign_to_stream(global, stream, controller);
+    let result = controller_abi::assign_to_stream(global, stream, controller);
     // Setup threw (e.g. a direct stream's `pull` getter): nothing will ever
     // end()/close() the controller, and its destructor would otherwise run
     // `${name}__finalize` on the sink after its owner has freed it. Detach it
     // while the sink is live; that reaches `js_controller_detached`, which
     // drops it from `source()` (a no-op if it already detached in the call).
     if result.to_error().is_some() {
-        let _ =
-            ::bun_jsc::call_check_slow(global, || streams::controller_abi::detach_ptr(controller));
+        let _ = bun_jsc::call_check_slow(global, || controller_abi::detach_ptr(controller));
     }
     result
 }

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -265,6 +265,7 @@ impl<T: JsSinkAbi> JSSink<T> {
         // SAFETY: `ptr` is a live sink owned by the caller for this synchronous
         // call; the pointer is only stashed in C++ `m_sinkPtr`.
         let ptr = unsafe { ptr.as_mut() };
+        ptr.controller_created(controller, global);
         if let Some(src) = ptr.source() {
             *src = streams::SourceHandle::JSController(controller);
         }
@@ -369,6 +370,13 @@ pub trait JsSinkType: Sized + JsSinkAbi {
     }
     fn source(&mut self) -> Option<&mut SourceHandle> {
         None
+    }
+    /// `assign_to_stream` made `controller` for this sink: a sink that keeps JS values roots it and puts them on it.
+    fn controller_created(
+        &mut self,
+        _controller: crate::webcore::jsc::JSValue,
+        _global: &crate::webcore::jsc::JSGlobalObject,
+    ) {
     }
     /// Called from `js_controller_detached`: once per JS-pump controller, on
     /// every detach path including its GC destructor. A sink co-owned by

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -232,6 +232,31 @@ impl<T: JsSinkAbi> JSSink<T> {
     pub fn assign_to_stream(
         global: &crate::webcore::jsc::JSGlobalObject,
         stream: crate::webcore::jsc::JSValue,
+        ptr: NonNull<T>,
+    ) -> crate::webcore::jsc::JSValue
+    where
+        T: JsSinkType,
+    {
+        let controller = Self::create_controller(global, ptr);
+        Self::assign_controller_to_stream(global, stream, controller, ptr)
+    }
+
+    /// A new `JSReadable*SinkController` attached to the sink at `ptr`; it must be detached before the sink is freed.
+    pub fn create_controller(
+        global: &crate::webcore::jsc::JSGlobalObject,
+        ptr: NonNull<T>,
+    ) -> crate::webcore::jsc::JSValue
+    where
+        T: JsSinkType,
+    {
+        T::create_controller_extern(global, ptr.as_ptr().cast::<c_void>())
+    }
+
+    /// [`assign_to_stream`](Self::assign_to_stream) through a `controller` from [`create_controller`](Self::create_controller).
+    pub fn assign_controller_to_stream(
+        global: &crate::webcore::jsc::JSGlobalObject,
+        stream: crate::webcore::jsc::JSValue,
+        controller: crate::webcore::jsc::JSValue,
         mut ptr: NonNull<T>,
     ) -> crate::webcore::jsc::JSValue
     where
@@ -240,8 +265,6 @@ impl<T: JsSinkAbi> JSSink<T> {
         // SAFETY: `ptr` is a live sink owned by the caller for this synchronous
         // call; the pointer is only stashed in C++ `m_sinkPtr`.
         let ptr = unsafe { ptr.as_mut() };
-        let controller =
-            T::create_controller_extern(global, std::ptr::from_mut::<T>(ptr).cast::<c_void>());
         if let Some(src) = ptr.source() {
             *src = streams::SourceHandle::JSController(controller);
         }

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -269,18 +269,7 @@ impl<T: JsSinkAbi> JSSink<T> {
         if let Some(src) = ptr.source() {
             *src = streams::SourceHandle::JSController(controller);
         }
-        let result = streams::controller_abi::assign_to_stream(global, stream, controller);
-        // Setup threw (e.g. a direct stream's `pull` getter): nothing will ever
-        // end()/close() the controller, and its destructor would otherwise run
-        // `${name}__finalize` on the sink after the caller has freed it. Detach
-        // it while `ptr` is live; that reaches `js_controller_detached`, which
-        // drops it from `source()` (a no-op if it already detached in the call).
-        if result.to_error().is_some() {
-            let _ = ::bun_jsc::call_check_slow(global, || {
-                streams::controller_abi::detach_ptr(controller)
-            });
-        }
-        result
+        start_pump(global, stream, controller)
     }
 
     /// Disconnect the upstream source: JSController → detachPtr; ByteStream → clear its SinkHandle.
@@ -304,6 +293,24 @@ impl<T: JsSinkAbi> JSSink<T> {
             _ => {}
         }
     }
+}
+
+/// Start the pump from `stream` into `controller`, whose sink is live and
+/// already holds it as its `source()`. Out of line so the `JSSink<T>`
+/// instantiations share one copy.
+#[inline(never)]
+fn start_pump(global: &JSGlobalObject, stream: JSValue, controller: JSValue) -> JSValue {
+    let result = streams::controller_abi::assign_to_stream(global, stream, controller);
+    // Setup threw (e.g. a direct stream's `pull` getter): nothing will ever
+    // end()/close() the controller, and its destructor would otherwise run
+    // `${name}__finalize` on the sink after its owner has freed it. Detach it
+    // while the sink is live; that reaches `js_controller_detached`, which
+    // drops it from `source()` (a no-op if it already detached in the call).
+    if result.to_error().is_some() {
+        let _ =
+            ::bun_jsc::call_check_slow(global, || streams::controller_abi::detach_ptr(controller));
+    }
+    result
 }
 
 /// Trait collecting every method `JSSink` may call on the wrapped `SinkType`.

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -796,8 +796,10 @@ pub(crate) mod controller_abi {
         pub(crate) safe fn clear_pipe_stream(c: ::bun_jsc::JSValue);
         #[link_name = "JSSinkController__takePipeDone"]
         pub(crate) safe fn take_pipe_done(c: ::bun_jsc::JSValue) -> ::bun_jsc::JSValue;
-        #[link_name = "JSSinkController__hasPipeDone"]
-        pub(crate) safe fn has_pipe_done(c: ::bun_jsc::JSValue) -> bool;
+        #[link_name = "JSSinkController__pipeDone"]
+        pub(crate) safe fn pipe_done(c: ::bun_jsc::JSValue) -> ::bun_jsc::JSValue;
+        #[link_name = "JSSinkController__setPipeDone"]
+        pub(crate) safe fn set_pipe_done(c: ::bun_jsc::JSValue, done: ::bun_jsc::JSValue);
         #[link_name = "JSSinkController__setPipeError"]
         pub(crate) safe fn set_pipe_error(c: ::bun_jsc::JSValue, error: ::bun_jsc::JSValue);
         #[link_name = "JSSinkController__takePipeError"]
@@ -844,10 +846,25 @@ impl PipeCell {
         stream
     }
 
+    /// Root `cell` with nothing on it yet.
+    pub(crate) fn root(cell: JSValue, global: &JSGlobalObject) -> PipeCell {
+        PipeCell(::bun_jsc::strong::Optional::create(cell, global))
+    }
+
     pub(crate) fn has_done(&self) -> bool {
-        self.0
-            .get()
-            .is_some_and(|cell| controller_abi::has_pipe_done(cell))
+        self.done().is_some()
+    }
+
+    /// The promise the sink's owner or source awaits, until it is taken to be settled.
+    pub(crate) fn done(&self) -> Option<*mut JSPromise> {
+        controller_abi::pipe_done(self.0.get()?).as_promise()
+    }
+
+    pub(crate) fn set_done(&self, done: JSValue) {
+        debug_assert!(self.0.has(), "no controller cell to hold the promise");
+        if let Some(cell) = self.0.get() {
+            controller_abi::set_pipe_done(cell, done);
+        }
     }
 
     pub(crate) fn take_done(&self) -> Option<*mut JSPromise> {
@@ -1110,7 +1127,8 @@ pub struct HTTPServerWritable<const SSL: bool> {
     // allocator field dropped — global mimalloc per §Allocators
     pub(crate) state: HTTPServerWritableState,
     pub(crate) source: SourceHandle,
-    pub(crate) pending_flush: Option<*mut JSPromise>,
+    /// The controller cell, rooted for the sink's life; it holds the `flush(true)` / `end()` promise ([`Self::pending_flush`]).
+    pub(crate) pipe: PipeCell,
     /// Backpressure promise returned from `write()` to a JS controller (direct
     /// stream `pull` or `readStreamIntoSink`). Resolved on drain via
     /// `flush_promise()` → `pending.run()`.
@@ -1158,7 +1176,7 @@ impl<const SSL: bool> Default for HTTPServerWritable<SSL> {
             wrote: 0,
             state: HTTPServerWritableState::Writing,
             source: SourceHandle::default(),
-            pending_flush: None,
+            pipe: PipeCell::default(),
             pending: WritablePending::default(),
             wrote_at_start_of_flush: 0,
             global_this: None,
@@ -1504,7 +1522,7 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
                 self.finalize();
                 return true;
             }
-            let had_flush_waiter = self.pending_flush.is_some();
+            let had_flush_waiter = self.pending_flush().is_some();
             self.flush_promise();
             if core::mem::take(&mut self.source_pending_pull)
                 && !had_flush_waiter
@@ -1566,7 +1584,7 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         }
 
         // flush the javascript promise from calling .flush()
-        let had_flush_waiter = self.pending_flush.is_some();
+        let had_flush_waiter = self.pending_flush().is_some();
         self.flush_promise();
 
         // pending_flush or callback could have caused another send()
@@ -1667,7 +1685,7 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
             return self.flush_from_js_no_wait();
         }
 
-        if let Some(prom) = self.pending_flush {
+        if let Some(prom) = self.pending_flush() {
             // A prior `flush(true)` is already waiting on the drain. Push any
             // data buffered since (below highWaterMark) so it reaches uWS now
             // rather than when `on_writable` fires.
@@ -1700,13 +1718,7 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
             }
         }
         self.wrote_at_start_of_flush = self.wrote;
-        self.pending_flush = Some(JSPromise::create(global_this));
-        self.global_this = Some(BackRef::new(global_this));
-        // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
-        let promise_value = JSPromise::opaque_ref(self.pending_flush.unwrap()).to_js();
-        promise_value.protect();
-
-        bun_sys::Result::Ok(promise_value)
+        bun_sys::Result::Ok(self.park_pending_flush(global_this))
     }
 
     pub fn flush(&mut self) -> bun_sys::Result<()> {
@@ -1907,12 +1919,7 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
 
         if readable_len > 0 {
             if !self.send_readable(0) {
-                self.pending_flush = Some(JSPromise::create(global_this));
-                self.global_this = Some(BackRef::new(global_this));
-                // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
-                let value = JSPromise::opaque_ref(self.pending_flush.unwrap()).to_js();
-                value.protect();
-                return bun_sys::Result::Ok(value);
+                return bun_sys::Result::Ok(self.park_pending_flush(global_this));
             }
         } else if let Some(res) = self.any_res() {
             res.end(b"", false);
@@ -2025,10 +2032,6 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         // Drop the GC root so the promise can be collected.
         this.pending.result = Writable::Done;
         this.pending.run();
-        if let Some(prom) = this.pending_flush.take() {
-            // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
-            JSPromise::opaque_ref(prom).to_js().unprotect();
-        }
         // A sink torn down without finalize() (assignToStream failed synchronously) still holds its pool checkout.
         this.release_pooled_buffer();
         this.buffer.clear_and_free();
@@ -2103,16 +2106,31 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
     /// Settle a parked `write()` and the pending `flush(true)`/`end()` promise.
     /// Terminal like the settle primitives (`Pending::run`): both resolve with
     /// values built here.
+    /// The unsettled `flush(true)` / `end()` promise, held by the controller cell.
+    pub(crate) fn pending_flush(&self) -> Option<*mut JSPromise> {
+        self.pipe.done()
+    }
+
+    pub(crate) fn take_pending_flush(&mut self) -> Option<*mut JSPromise> {
+        self.pipe.take_done()
+    }
+
+    fn park_pending_flush(&mut self, global_this: &JSGlobalObject) -> JSValue {
+        let promise = JSPromise::create(global_this).to_js();
+        self.global_this = Some(BackRef::new(global_this));
+        self.pipe.set_done(promise);
+        promise
+    }
+
     pub(crate) fn flush_promise(&mut self) {
         // Settle any `write()` → `Pending` promise first so a parked JS writer
         // wakes on every drain/teardown path that reaches here.
         self.pending.run();
-        if let Some(prom) = self.pending_flush.take() {
+        if let Some(prom) = self.take_pending_flush() {
             bun_core::scoped_log!(HTTPServerWritableLog, "flushPromise()");
 
             let global_this = self.global_this();
-            // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `* → &`/`&mut` deref.
-            JSPromise::opaque_ref(prom).to_js().unprotect();
+            let _keep = ::bun_jsc::EnsureStillAlive(JSPromise::opaque_ref(prom).to_js());
             let result = JSPromise::opaque_mut(prom).resolve(
                 global_this,
                 JSValue::js_number(self.wrote.saturating_sub(self.wrote_at_start_of_flush) as f64),
@@ -2167,6 +2185,9 @@ impl<const SSL: bool> crate::webcore::sink::JsSinkType for HTTPServerWritable<SS
         // SAFETY: caller contract; `fail` does not free the sink.
         unsafe { (*this).fail() };
         bun_sys::Result::Ok(())
+    }
+    fn controller_created(&mut self, controller: JSValue, global: &JSGlobalObject) {
+        self.pipe = PipeCell::root(controller, global);
     }
     fn end_from_js(&mut self, global: &JSGlobalObject) -> bun_sys::Result<JSValue> {
         Self::end_from_js(self, global)

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -784,6 +784,85 @@ pub(crate) mod controller_abi {
             stream: ::bun_jsc::JSValue,
             c: ::bun_jsc::JSValue,
         ) -> ::bun_jsc::JSValue;
+        #[link_name = "JSSinkController__setPipe"]
+        pub(crate) safe fn set_pipe(
+            c: ::bun_jsc::JSValue,
+            stream: ::bun_jsc::JSValue,
+            done: ::bun_jsc::JSValue,
+        );
+        #[link_name = "JSSinkController__pipeStream"]
+        pub(crate) safe fn pipe_stream(c: ::bun_jsc::JSValue) -> ::bun_jsc::JSValue;
+        #[link_name = "JSSinkController__clearPipeStream"]
+        pub(crate) safe fn clear_pipe_stream(c: ::bun_jsc::JSValue);
+        #[link_name = "JSSinkController__takePipeDone"]
+        pub(crate) safe fn take_pipe_done(c: ::bun_jsc::JSValue) -> ::bun_jsc::JSValue;
+        #[link_name = "JSSinkController__hasPipeDone"]
+        pub(crate) safe fn has_pipe_done(c: ::bun_jsc::JSValue) -> bool;
+        #[link_name = "JSSinkController__setPipeError"]
+        pub(crate) safe fn set_pipe_error(c: ::bun_jsc::JSValue, error: ::bun_jsc::JSValue);
+        #[link_name = "JSSinkController__takePipeError"]
+        pub(crate) safe fn take_pipe_error(c: ::bun_jsc::JSValue) -> ::bun_jsc::JSValue;
+    }
+}
+
+/// The one GC root a native sink keeps while a stream is piped into it: its controller cell, which holds the stream, the done-promise and the failure value.
+#[derive(Default)]
+pub(crate) struct PipeCell(::bun_jsc::strong::Optional);
+
+impl PipeCell {
+    pub(crate) fn create(
+        cell: JSValue,
+        stream: JSValue,
+        done: JSValue,
+        global: &JSGlobalObject,
+    ) -> PipeCell {
+        controller_abi::set_pipe(cell, stream, done);
+        PipeCell(::bun_jsc::strong::Optional::create(cell, global))
+    }
+
+    pub(crate) fn cell(&self) -> Option<JSValue> {
+        self.0.get()
+    }
+
+    pub(crate) fn has_stream(&self) -> bool {
+        self.stream().is_some()
+    }
+
+    pub(crate) fn stream(&self) -> Option<crate::webcore::ReadableStream> {
+        let stream = controller_abi::pipe_stream(self.0.get()?);
+        if stream.is_empty() {
+            return None;
+        }
+        crate::webcore::ReadableStream::from_js_direct(stream)
+    }
+
+    pub(crate) fn take_stream(&self) -> Option<crate::webcore::ReadableStream> {
+        let stream = self.stream();
+        if let Some(cell) = self.0.get() {
+            controller_abi::clear_pipe_stream(cell);
+        }
+        stream
+    }
+
+    pub(crate) fn has_done(&self) -> bool {
+        self.0
+            .get()
+            .is_some_and(|cell| controller_abi::has_pipe_done(cell))
+    }
+
+    pub(crate) fn take_done(&self) -> Option<*mut JSPromise> {
+        controller_abi::take_pipe_done(self.0.get()?).as_promise()
+    }
+
+    pub(crate) fn set_error(&self, error: JSValue) {
+        if let Some(cell) = self.0.get() {
+            controller_abi::set_pipe_error(cell, error);
+        }
+    }
+
+    pub(crate) fn take_error(&self) -> Option<JSValue> {
+        let error = controller_abi::take_pipe_error(self.0.get()?);
+        (!error.is_empty()).then_some(error)
     }
 }
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -2116,6 +2116,10 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
     }
 
     fn park_pending_flush(&mut self, global_this: &JSGlobalObject) -> JSValue {
+        // end() while a flush(true) waits on the same drain: one promise settles both.
+        if let Some(parked) = self.pending_flush() {
+            return JSPromise::opaque_ref(parked).to_js();
+        }
         let promise = JSPromise::create(global_this).to_js();
         self.global_this = Some(BackRef::new(global_this));
         self.pipe.set_done(promise);

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -2110,9 +2110,6 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         }
     }
 
-    /// Settle a parked `write()` and the pending `flush(true)`/`end()` promise.
-    /// Terminal like the settle primitives (`Pending::run`): both resolve with
-    /// values built here.
     /// The unsettled `flush(true)` / `end()` promise, held by the controller cell.
     pub(crate) fn pending_flush(&self) -> Option<*mut JSPromise> {
         self.pipe.done()
@@ -2133,6 +2130,9 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
         promise
     }
 
+    /// Settle a parked `write()` and the pending `flush(true)`/`end()` promise.
+    /// Terminal like the settle primitives (`Pending::run`): both resolve with
+    /// values built here.
     pub(crate) fn flush_promise(&mut self) {
         // Settle any `write()` → `Pending` promise first so a parked JS writer
         // wakes on every drain/teardown path that reaches here.

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -802,8 +802,8 @@ pub(crate) mod controller_abi {
         pub(crate) safe fn set_pipe_done(c: ::bun_jsc::JSValue, done: ::bun_jsc::JSValue);
         #[link_name = "JSSinkController__setPipeError"]
         pub(crate) safe fn set_pipe_error(c: ::bun_jsc::JSValue, error: ::bun_jsc::JSValue);
-        #[link_name = "JSSinkController__takePipeError"]
-        pub(crate) safe fn take_pipe_error(c: ::bun_jsc::JSValue) -> ::bun_jsc::JSValue;
+        #[link_name = "JSSinkController__pipeError"]
+        pub(crate) safe fn pipe_error(c: ::bun_jsc::JSValue) -> ::bun_jsc::JSValue;
     }
 }
 
@@ -824,6 +824,13 @@ impl PipeCell {
 
     pub(crate) fn cell(&self) -> Option<JSValue> {
         self.0.get()
+    }
+
+    /// The pipe is over: a controller the user still holds must not keep the stream or the promise alive.
+    pub(crate) fn clear_slots(&self) {
+        if let Some(cell) = self.0.get() {
+            controller_abi::set_pipe(cell, JSValue::UNDEFINED, JSValue::UNDEFINED);
+        }
     }
 
     pub(crate) fn has_stream(&self) -> bool {
@@ -877,8 +884,8 @@ impl PipeCell {
         }
     }
 
-    pub(crate) fn take_error(&self) -> Option<JSValue> {
-        let error = controller_abi::take_pipe_error(self.0.get()?);
+    pub(crate) fn error(&self) -> Option<JSValue> {
+        let error = controller_abi::pipe_error(self.0.get()?);
         (!error.is_empty()).then_some(error)
     }
 }

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -1663,11 +1663,9 @@ describe("close() under transport backpressure sends the buffered tail", () => {
     ["from a later task", true],
   ] as const;
 
-  test.each(modes)("over http/1.1, close() %s", async (_mode, later) => {
-    const state = newState();
-    using server = Bun.serve({ port: 0, idleTimeout: 0, fetch: () => new Response(body(state, later)) });
-
-    const socket = net.connect(server.port, "127.0.0.1");
+  // A raw client that stops reading until the source has closed, then decodes the chunked body.
+  async function readPausedH1(port: number, state: State) {
+    const socket = net.connect(port, "127.0.0.1");
     const chunks: Buffer[] = [];
     const done = Promise.withResolvers<void>();
     socket.on("error", done.reject);
@@ -1703,12 +1701,59 @@ describe("close() under transport backpressure sends the buffered tail", () => {
       rest = rest.subarray(lineEnd + 2 + size + 2);
     }
     const decoded = Buffer.concat(payload);
-    expect({
+    return {
       terminated,
       trailing: rest.length,
       length: decoded.length,
       end: decoded.subarray(-8).toString("latin1"),
-    }).toEqual({ terminated: true, trailing: 0, length: state.bigBytes + 4, end: "xxxxtail" });
+    };
+  }
+
+  test.each(modes)("over http/1.1, close() %s", async (_mode, later) => {
+    const state = newState();
+    using server = Bun.serve({ port: 0, idleTimeout: 0, fetch: () => new Response(body(state, later)) });
+    expect(await readPausedH1(server.port, state)).toEqual({
+      terminated: true,
+      trailing: 0,
+      length: state.bigBytes + 4,
+      end: "xxxxtail",
+    });
+  });
+
+  // end() used to replace a parked flush(true) promise: the first one stayed protect()ed for the life of the VM and never settled.
+  test("over http/1.1, end() while a flush(true) is parked on the same drain settles both", async () => {
+    const state = newState();
+    const flushed = Promise.withResolvers<number>();
+    using server = Bun.serve({
+      port: 0,
+      idleTimeout: 0,
+      fetch: () =>
+        new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(c: any) {
+              for (;;) {
+                const wrote = c.write(big);
+                state.bigBytes += big.length;
+                if (wrote instanceof Promise) break;
+                if (state.bigBytes >= 512 * 1024 * 1024) throw new Error("no backpressure after 512 MB");
+              }
+              const parked = c.flush(true);
+              c.write("tail");
+              const ended = c.end();
+              state.closed.resolve();
+              flushed.resolve(await Promise.all([parked, ended]).then(() => 1));
+            },
+          } as any),
+        ),
+    });
+    expect(await readPausedH1(server.port, state)).toEqual({
+      terminated: true,
+      trailing: 0,
+      length: state.bigBytes + 4,
+      end: "xxxxtail",
+    });
+    expect(await flushed.promise).toBe(1);
   });
 
   // Over h2 the backpressure is the stream's flow-control window: the client

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1107,6 +1107,39 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       expect(exitCode).toBe(0);
     });
 
+    // close(error) fails the sink from inside FileSink's own close path, which re-enters the controller before the
+    // C++ caller passes the reason along. The stream must still end Errored with that reason, not Closed.
+    it.each([
+      ["inside a sync pull()", c => (c.write("a"), c.close(new Error("boom")))],
+      ["inside an async pull() after a flush", async c => (c.write("a"), await c.flush(), c.close(new Error("boom")))],
+      ["from a later task on a kept controller", null],
+    ])("close(error) %s errors the direct stream it came from", async (_where, pull) => {
+      using dir = tempDir("bun-write-direct-close-error-state", {});
+      let kept;
+      const stream = new ReadableStream({
+        type: "direct",
+        pull: pull ?? (c => ((kept = c), c.write("a"))),
+      });
+      const written = Bun.write(join(String(dir), "out.txt"), stream);
+      if (!pull) {
+        await new Promise(resolve => setImmediate(resolve));
+        kept.close(new Error("boom"));
+      }
+      expect(
+        await written.then(
+          () => "resolved",
+          e => "rejected: " + e.message,
+        ),
+      ).toBe("rejected: boom");
+      // directStreamOnClose released the sink's lock, so the terminal state is observable through a reader.
+      expect(
+        await stream.getReader().closed.then(
+          () => "closed",
+          e => "errored: " + e.message,
+        ),
+      ).toBe("errored: boom");
+    });
+
     it("a stream whose source fails rejects with that error", async () => {
       using dir = tempDir("bun-write-stream-reject", {});
       const nextTask = () => new Promise(resolve => setImmediate(resolve));


### PR DESCRIPTION
### What does this PR do?

Native sinks keep one GC root while a stream is piped into them: their controller cell. The other JS values they need are traced fields on that cell instead of separate `Strong`s or hand-rolled `protect()` calls. One of those hand-rolled roots leaked, and that is fixed here.

#### The leak

`HTTPServerWritable.pending_flush` was an `Option<*mut JSPromise>` rooted with a manual `protect()`. `end_from_js` assigned it without checking for one already parked:

```js
c.write(big);              // socket is now backpressured
const p = c.flush(true);   // promise A parked and protect()ed
c.write("tail");
c.end();                   // send fails again: pending_flush = promise B
await p;
```

Promise A's `protect()` was never released, so A and everything it retains (the `pull()` frame, its closures, the controller) stayed alive for the life of the VM. A was also never settled, so `await p` hung.

Fix: `park_pending_flush` returns the promise that is already parked, so `flush(true)` and `end()` settle on the same drain. The promise itself is now a traced slot (below), so an overwrite could no longer leak even without that check.

#### One root per sink

`streams::PipeCell` (Rust) holds one `Strong` to the sink's controller cell and reads and writes traced fields on it. `JSReadableSinkControllerBase` changes by one field:

- Added: `m_pipeDone`, the promise the sink's owner or source awaits.
- `m_weakReadableStream` (`JSC::Weak`) becomes `m_readableStream` (`WriteBarrier`). The weak reference was there so a controller the user still holds does not keep the stream alive. An explicit clear now gives the same guarantee without depending on GC timing, and drops one `WeakImpl` allocation per pipe. The field has two users, the cell's own close handler and a sink that set it through `setPipe`; the last one out clears it (`clearReadableStream()`), because the close handler needs the stream to close or cancel it and `FileSink` needs it until its own `on_close`.
- The pipe's JS failure value shares the existing `m_failReason`: `close(error)` already stores the same value there, and every other writer runs after `pull()` has settled.

**`FileSink`** (`Bun.write(file, stream)`, `Bun.spawn({ stdin: stream })`)

- Removed: `readable_stream: Strong`, `stream_done: JSPromiseStrong`, the `Strong` inside `stream_error`'s `StreamError::JSValue`, and the two `strong::Optional::create` calls in `close_with_error` / `handle_reject_stream`.
- Added: `pipe: PipeCell`. `pipe_stream` and `assign_to_stream` create the controller cell up front, so a natively wired source (Blob / File / Bytes) has one too.
- `release_pipe()` clears the cell's fields, detaches the cell, and drops the root. It runs from `on_close`, from the synchronous-error path, and from `Drop`, so the controller's destructor can never see a freed sink.

**`HTTPServerWritable`** (`Bun.serve` streaming bodies)

- Removed: `pending_flush` and its four separate `unprotect()` sites (`flush_promise`, `destroy`, `handle_reject_stream`, and the overwrite that was missing one).
- Added: `pipe: PipeCell`, rooted when `assign_to_stream` creates the controller (a new `JsSinkType::controller_created` hook) and dropped with the sink. The promise lives in `m_pipeDone`.

**`RequestContext`**

- `response_jsvalue` was a `Cell<JSValue>` that nothing read, next to a `response_protected` flag and nine paired `protect()` / `unprotect()` sites. It is now `response_root: ResponseRoot`, a `strong::Optional`: `set_rooted()` for file and streaming bodies, `clear()` everywhere else. Plain Blob bodies stay unrooted on the hot path, as before. The flag bit is gone.

#### Not changed

- `NetworkSink.flush_promise` / `end_promise` and `WritablePending.future` stay `JSPromiseStrong`. Those sinks have two JS faces (the `writer()` wrapper, which the sink does not root, and the controller), and a slot on an unrooted wrapper would leave a dropped writer's pending `end()` unsettled. They are RAII and guarded by `has_value()`, so they do not have the overwrite problem.
- `request_body_readable_stream_ref` / `response_body_readable_stream_ref` on `RequestContext`: these are the request's base roots.

### How did you verify your code works?

- New test in `test/js/bun/http/serve-direct-readable-stream.test.ts`: "end() while a flush(true) is parked on the same drain settles both". It fills the socket until `write()` returns a promise, parks `flush(true)`, writes a tail, calls `end()`, and asserts the full body arrives terminated and both promises settle. On main the `flush(true)` promise never settles.
- Existing suites: `streams.test.js` (510 pass), `bun-write.test.js`, `spawn-stdin-readable-stream.test.ts` on a debug ASAN build.
- `serve-direct-readable-stream` (140 pass), `serve-stream-body-error`, `serve-error-handler-stream`, `serve-async-stream-client-abort`, `serve-stream-reject-flush-leak`, `body-stream` (9086 pass) on the same build.
- Live-object counts on the debug build, each after a forced GC:
  - `Bun.write` with 8 direct-stream shapes (clean and failing, sync and async), 200 runs each: 0 live `FileSink`s.
  - 14 consumer x shape pairs (`Bun.write`, `.text()`, `getReader()`), 300 runs each: no growth in `ReadableStream`, `DirectStreamController`, `ReadableFileSinkController`, or reader cells.
  - A controller kept in user code after `Bun.write` finished, 200 runs: 0 streams still alive.
  - 4 natively wired sources (`Blob` stream, `Bun.file` stream, `Response(Blob).body`, a missing file that fails): 0 leaked sinks, controllers, or streams; byte counts correct.
- `serve-response-stream-sink-leak`, one case in `serve-body-leak` ("parked in pull()"), and one in `bun-write` ("writes as the body arrives") fail on my macOS debug build; they fail the same way with `origin/main`'s `src/` built in the same tree, so CI is the reference for those.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->