### PR TITLE
Bun.serve: end a direct-stream response once when pull() throws after it ended it

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2162,22 +2162,13 @@ where
             return;
         }
 
-        #[cfg(debug_assertions)]
-        if resp.has_responded() {
-            stream_log!("responded");
-        }
-
-        if let Some(err_value) = assignment_result.to_error() {
-            stream_log!("returned an error");
-            ResponseStreamJSSink::<SSL_ENABLED>::detach(
-                &mut response_stream.sink.source,
-                global_this,
-            );
-            this.sink.set(None);
-            Self::destroy_sink(response_stream_ptr);
-            return this.handle_reject(err_value);
-        }
-
+        // Checked before the thrown-error arm below: a sync `pull()` that ends
+        // the response and then throws has already put a complete body on the
+        // wire, so the throw must not end the response again. `handle_reject()`
+        // does nothing once the response has responded, which leaves the
+        // request looking unanswered: the handler tail
+        // (`should_render_missing()` in `mod.rs`) then ends it a second time,
+        // writing a second chunked last-chunk.
         if resp.has_responded() {
             stream_log!("done");
             ResponseStreamJSSink::<SSL_ENABLED>::detach(
@@ -2191,6 +2182,17 @@ where
                 .with_mut(|s| s.deinit());
             this.end_stream(this.should_close_connection());
             return;
+        }
+
+        if let Some(err_value) = assignment_result.to_error() {
+            stream_log!("returned an error");
+            ResponseStreamJSSink::<SSL_ENABLED>::detach(
+                &mut response_stream.sink.source,
+                global_this,
+            );
+            this.sink.set(None);
+            Self::destroy_sink(response_stream_ptr);
+            return this.handle_reject(err_value);
         }
 
         // A fully-synchronous ReadableStream can drain through writeBytes

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -1263,6 +1263,56 @@ describe("close() with unflushed data writes the chunked terminator exactly once
       rest: "",
     });
   });
+
+  // A sync pull() that ends the response and then throws in the same call. The
+  // body is already complete on the wire, so the throw must not end the
+  // response again. do_render_stream read the thrown error before it checked
+  // whether the response had responded, so handle_reject() left the request
+  // looking unanswered and the handler tail wrote a second last-chunk.
+  describe("pull() throws after it ended the response", () => {
+    const throwingShapes: Record<string, { body: string; pull: (c: any) => unknown }> = {
+      "write, flush(), close(), throw": {
+        body: "hello",
+        pull(c) {
+          c.write("hello");
+          c.flush();
+          c.close();
+          throw new Error("boom");
+        },
+      },
+      "write, flush(), end(), throw": {
+        body: "hello",
+        pull(c) {
+          c.write("hello");
+          c.flush();
+          c.end();
+          throw new Error("boom");
+        },
+      },
+      // Over the sink's high water mark: write() already put a chunk on the
+      // wire, so close() ends a chunked response and not a Content-Length one.
+      "write(800 bytes), close(), throw": {
+        body: x800,
+        pull(c) {
+          c.write(x800);
+          c.close();
+          throw new Error("boom");
+        },
+      },
+    };
+
+    test.concurrent.each(Object.keys(throwingShapes))("%s", async name => {
+      const { body, pull } = throwingShapes[name];
+      using server = serve(pull);
+      const { decoded, terminated, rest } = await exchange(server);
+      expect({ decoded, terminated }).toEqual({ decoded: body, terminated: true });
+      // The very next bytes are the second response, framed by Content-Length,
+      // and nothing else is on the connection.
+      expect(rest.slice(0, 15)).toBe("HTTP/1.1 200 OK");
+      expect(rest).toEndWith("\r\n\r\nok");
+      expect(rest.split("\r\n0\r\n\r\n").length - 1).toBe(0);
+    });
+  });
 });
 
 // A direct stream's cancel() is the "consumer went away" hook. The source's own


### PR DESCRIPTION
### Problem
- A `Bun.serve` `type: "direct"` stream whose synchronous `pull()` ends the response in chunked mode and then throws in the same call writes the chunked last-chunk twice. The wire carries `a␍␊xxxxxxxxxx␍␊0␍␊␍␊0␍␊␍␊` and the 5 surplus bytes sit in front of the next keep-alive response. A strict client parses `0` as that response's status line (the node keep-alive agent reports `HPE_INVALID_CONSTANT`).
- Three orderings hit it: `flush()` then `close()`, `flush()` then `end()`, and `close()` with more than the sink's high water mark buffered. The Content-Length path is unaffected.
- The cause is the order of two arms in `do_render_stream` (`src/runtime/server/RequestContext.rs:2170`). The thrown error was read first, so the already-responded arm never ran.

### Fix
- Check `resp.has_responded()` before the thrown-error arm. One arm now handles every stream that already ended the response, whether `pull()` returned or threw.
- Correct because the body is complete on the wire before the throw. `handle_reject()` does nothing once the response has responded, which left the request looking unanswered, and the handler tail (`should_render_missing()` in `src/runtime/server/mod.rs:1015`) then ended it a second time.
- A `pull()` that throws with an incomplete body is unchanged: the error is reported and the connection is reset.
- The throw is swallowed after a clean end, which is what a `pull()` promise that rejects after `close()` already does (`jsWebStreamsHandler_onReadDirectStreamPullRejected`). Both orderings now agree.
- Verified: `test/js/bun/http/serve-direct-readable-stream.test.ts` (3 new cases, all 3 fail without the diff). Also `test/js/web/streams/streams.test.js`, `serve-error-handler-stream`, `serve-stream-body-error`, `async-iterator-stream`, `serve-reused-response`, `serve-http2`, `serve-http2-lifecycle`, and the two stream-sink leak suites.

### Background
- A `type: "direct"` stream writes through a native sink (`HTTPServerWritable`). `controller.close()` and `controller.end()` both reach `end_from_js()`, which flushes the tail, calls uWS `end()`, and records `ended_response`.
- `do_render_stream` attaches the stream to that sink. A synchronous `pull()` runs to completion inside the attach call, so the response can be finished before the attach returns.
- A synchronous throw in `pull()` comes back from `assignToStream` as an `Exception` cell, not as a rejected promise (`GlobalObject::assignToStream`). That is the arm that ran too early.
- uWS `hasResponded()` is false only while `HTTP_RESPONSE_PENDING` is set. `markDone()` clears it when the terminating chunk or the last Content-Length byte goes out, so it is true exactly when nothing more may be written.

<details><summary>Notes</summary>

Wire bytes on `8f33aaa9` (debug build, shape `write(10) flush() close() throw`):

```
HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\na\r\nxxxxxxxxxx\r\n0\r\n\r\n0\r\n\r\nHTTP/1.1 200 OK...Content-Length: 2\r\n\r\nok
```

With the diff the first `0\r\n\r\n` is the only one and the second response starts right after it.

The second end came from the request-handler tail, not from the stream code: `should_render_missing()` tests `resp != null`, not aborted, not marked complete, not marked pending. The sink ends the response through uWS directly, so none of those flags change, and `render_missing()` called `ctx.end("")`. In chunked mode `internalEnd` then writes `0\r\n\r\n` again.

Order of events for the failing shape, from the debug log:

```
doRenderStream -> start(256) -> writeLatin1(10) -> flushFromJS -> endFromJS -> finalize
responded
returned an error        <- the arm that ran first
destroy()
shouldRenderMissing has response not aborted not marked complete not marked pending
end                      <- second 0\r\n\r\n
```

Shapes checked by hand against the debug build, before and after:

| `pull()` | before | after |
| --- | --- | --- |
| `write, flush, close, throw` | two last-chunks | one |
| `write(1000), close, throw` | two last-chunks | one |
| `write, flush, end, throw` | two last-chunks | one |
| `write, close, throw` (Content-Length) | one end, no bytes written twice | same |
| `write, flush, close, reject` | one | one |
| `throw` with nothing written | error reported, connection reset | same |
| `write, flush, throw` | error reported, connection reset | same |

`end()` plus a throw doubled on 1.4.2 too, so this is not a regression from #41894. There, `close()` plus a throw reset the connection instead, because `close()` dropped the buffered tail (bug 1 of #41894). #41894 routed `close()` onto the `end()` path, which already had this.

The hoisted arm also deinits the response body's stream reference and calls `stream.done()`, which the thrown-error arm did not. `done()` is a no-op for a JS-backed direct stream (it only cancels native Blob, File and Bytes sources).

Two failures in `test/js/bun/http/serve.test.ts` are environmental and fail the same way with the released binary: `should use correct error when using a root range port(#7187)` (the test runs as root) and `only serves /bun:info to loopback clients in development mode`.
</details>
