### PR TITLE
Keep body stream bookkeeping independent of the body's source

### DIFF
--- a/src/js/internal/webstreams_adapters.ts
+++ b/src/js/internal/webstreams_adapters.ts
@@ -556,8 +556,7 @@ function newStreamReadableFromReadableStream(readableStream, options: Record<str
     throw $ERR_INVALID_ARG_VALUE("options.encoding", encoding);
   validateBoolean(objectMode, "options.objectMode");
 
-  // Node acquires the reader here, so a locked stream (another reader, a tee, a
-  // Body that was already read) fails now instead of on the first _read().
+  // Node acquires the reader at this point, so a locked stream throws here too.
   if (readableStream.locked) throw $ERR_INVALID_STATE_TypeError("ReadableStream is locked");
 
   const nativeStream = tryTransferToNativeReadable(readableStream, options);

--- a/src/js/internal/webstreams_adapters.ts
+++ b/src/js/internal/webstreams_adapters.ts
@@ -556,6 +556,10 @@ function newStreamReadableFromReadableStream(readableStream, options: Record<str
     throw $ERR_INVALID_ARG_VALUE("options.encoding", encoding);
   validateBoolean(objectMode, "options.objectMode");
 
+  // Node acquires the reader here, so a locked stream (another reader, a tee, a
+  // Body that was already read) fails now instead of on the first _read().
+  if (readableStream.locked) throw $ERR_INVALID_STATE_TypeError("ReadableStream is locked");
+
   const nativeStream = tryTransferToNativeReadable(readableStream, options);
 
   return (

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -632,6 +632,19 @@ static JSObject* createAlreadyUsedError(JSGlobalObject* globalObject)
     return Bun::createError(globalObject, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: ReadableStream has already been used"_s);
 }
 
+// Locked is checked before disturbed, except that a stream a Body consumer drained is both and
+// reports what happened to it rather than the lock it left behind. nullptr: usable.
+static JSObject* unusableStreamError(JSGlobalObject* globalObject, WebCore::JSReadableStream* stream)
+{
+    if (stream->m_consumedAsBody)
+        return createAlreadyUsedError(globalObject);
+    if (isReadableStreamLocked(stream))
+        return createLockedError(globalObject);
+    if (stream->m_disturbed)
+        return createAlreadyUsedError(globalObject);
+    return nullptr;
+}
+
 // The one shared `BunTextAccumulator` write arm (createTextStream.write, RSI:1411-1441).
 static JSValue textAccumulatorWrite(JSC::VM& vm, JSGlobalObject* globalObject, JSC::JSObject* owner, BunTextAccumulator& accumulator, JSValue chunk)
 {
@@ -1103,10 +1116,8 @@ JSValue readableStreamToText(JSGlobalObject* globalObject, WebCore::JSReadableSt
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (stream->m_bunMode == BunStreamMode::DirectPending)
         RELEASE_AND_RETURN(scope, readableStreamToTextDirect(globalObject, stream));
-    if (isReadableStreamLocked(stream))
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createLockedError(globalObject)));
-    if (stream->m_disturbed)
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createAlreadyUsedError(globalObject)));
+    if (auto* error = unusableStreamError(globalObject, stream))
+        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, error));
     JSValue fastPath = tryUseReadableStreamBufferedFastPath(globalObject, stream, builtinNames(vm).textPublicName());
     RETURN_IF_EXCEPTION(scope, {});
     if (fastPath)
@@ -1120,10 +1131,8 @@ JSValue readableStreamToArray(JSGlobalObject* globalObject, WebCore::JSReadableS
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (stream->m_bunMode == BunStreamMode::DirectPending)
         RELEASE_AND_RETURN(scope, readableStreamToArrayDirect(globalObject, stream));
-    if (isReadableStreamLocked(stream))
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createLockedError(globalObject)));
-    if (stream->m_disturbed)
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createAlreadyUsedError(globalObject)));
+    if (auto* error = unusableStreamError(globalObject, stream))
+        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, error));
     RELEASE_AND_RETURN(scope, readableStreamIntoArray(globalObject, stream));
 }
 
@@ -1197,10 +1206,8 @@ JSValue readableStreamToArrayBuffer(JSGlobalObject* globalObject, WebCore::JSRea
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (stream->m_bunMode == BunStreamMode::DirectPending)
         RELEASE_AND_RETURN(scope, consumeDirectStreamToArrayBuffer(globalObject, stream, /* asUint8Array */ false));
-    if (isReadableStreamLocked(stream))
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createLockedError(globalObject)));
-    if (stream->m_disturbed)
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createAlreadyUsedError(globalObject)));
+    if (auto* error = unusableStreamError(globalObject, stream))
+        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, error));
     JSValue fastPath = tryUseReadableStreamBufferedFastPath(globalObject, stream, builtinNames(vm).arrayBufferPublicName());
     RETURN_IF_EXCEPTION(scope, {});
     if (fastPath)
@@ -1216,10 +1223,8 @@ JSValue readableStreamToBytes(JSGlobalObject* globalObject, WebCore::JSReadableS
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (stream->m_bunMode == BunStreamMode::DirectPending)
         RELEASE_AND_RETURN(scope, consumeDirectStreamToArrayBuffer(globalObject, stream, /* asUint8Array */ true));
-    if (isReadableStreamLocked(stream))
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createLockedError(globalObject)));
-    if (stream->m_disturbed)
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createAlreadyUsedError(globalObject)));
+    if (auto* error = unusableStreamError(globalObject, stream))
+        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, error));
     JSValue fastPath = tryUseReadableStreamBufferedFastPath(globalObject, stream, builtinNames(vm).bytesPublicName());
     RETURN_IF_EXCEPTION(scope, {});
     if (fastPath)
@@ -1233,10 +1238,8 @@ JSValue readableStreamToJSON(JSGlobalObject* globalObject, WebCore::JSReadableSt
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (isReadableStreamLocked(stream))
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createLockedError(globalObject)));
-    if (stream->m_disturbed)
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createAlreadyUsedError(globalObject)));
+    if (auto* error = unusableStreamError(globalObject, stream))
+        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, error));
     JSValue fastPath = tryUseReadableStreamBufferedFastPath(globalObject, stream, builtinNames(vm).jsonPublicName());
     RETURN_IF_EXCEPTION(scope, {});
     if (fastPath)
@@ -1269,10 +1272,8 @@ JSValue readableStreamToBlob(JSGlobalObject* globalObject, WebCore::JSReadableSt
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (isReadableStreamLocked(stream))
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createLockedError(globalObject)));
-    if (stream->m_disturbed)
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createAlreadyUsedError(globalObject)));
+    if (auto* error = unusableStreamError(globalObject, stream))
+        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, error));
     JSValue fastPath = tryUseReadableStreamBufferedFastPath(globalObject, stream, builtinNames(vm).blobPublicName());
     RETURN_IF_EXCEPTION(scope, {});
     if (fastPath)
@@ -1294,10 +1295,8 @@ JSValue readableStreamToFormData(JSGlobalObject* globalObject, WebCore::JSReadab
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (isReadableStreamLocked(stream))
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createLockedError(globalObject)));
-    if (stream->m_disturbed)
-        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, createAlreadyUsedError(globalObject)));
+    if (auto* error = unusableStreamError(globalObject, stream))
+        RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, error));
     JSValue blobResult = readableStreamToBlob(globalObject, stream);
     RETURN_IF_EXCEPTION(scope, {});
     auto* blobPromise = dynamicDowncast<JSPromise>(blobResult);

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -632,8 +632,7 @@ static JSObject* createAlreadyUsedError(JSGlobalObject* globalObject)
     return Bun::createError(globalObject, Bun::ErrorCode::ERR_INVALID_STATE_TypeError, "Invalid state: ReadableStream has already been used"_s);
 }
 
-// Locked is checked before disturbed, except that a stream a Body consumer drained is both and
-// reports what happened to it rather than the lock it left behind. nullptr: usable.
+// nullptr when usable. A stream a Body drained is locked too, but "already used" is what happened to it.
 static JSObject* unusableStreamError(JSGlobalObject* globalObject, WebCore::JSReadableStream* stream)
 {
     if (stream->m_consumedAsBody)

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -57,10 +57,7 @@ public:
     // Bun: locked by a native/direct consumer WITHOUT a real reader object. Part of every
     // isReadableStreamLocked() check.
     bool m_lockedWithoutReader : 1 { false };
-    // Bun: a fetch Body consumer (text()/json()/blob()/..., or a native path that took the
-    // source's bytes directly) drained this stream. The reader the spec acquires for that is
-    // never released, so unlike m_lockedWithoutReader nothing clears this. Folded into
-    // nativeHandleDetached(), and through it into every isReadableStreamLocked() check.
+    // Bun: a Body consumer drained this stream. Its spec reader is never released: never cleared.
     bool m_consumedAsBody : 1 { false };
     // Set by jsFunctionTransferToNativeReadableStream.
     bool m_transferred : 1 { false };
@@ -118,8 +115,7 @@ public:
             return {};
         return m_nativePtr.get(); // may be empty
     }
-    // The native handle must not be started or handed out any more: it moved to a node:stream
-    // Readable, a Body consumer already took its bytes, or it was detached outright.
+    // Transferred to a node:stream Readable, drained as a Body, or detached: the handle is off limits.
     bool nativeHandleDetached() const
     {
         return m_transferred || m_consumedAsBody || (m_nativePtr.get().isInt32() && m_nativePtr.get().asInt32() == -1);

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -57,6 +57,11 @@ public:
     // Bun: locked by a native/direct consumer WITHOUT a real reader object. Part of every
     // isReadableStreamLocked() check.
     bool m_lockedWithoutReader : 1 { false };
+    // Bun: a fetch Body consumer (text()/json()/blob()/..., or a native path that took the
+    // source's bytes directly) drained this stream. The reader the spec acquires for that is
+    // never released, so unlike m_lockedWithoutReader nothing clears this. Part of every
+    // isReadableStreamLocked() check.
+    bool m_consumedAsBody : 1 { false };
     // Set by jsFunctionTransferToNativeReadableStream.
     bool m_transferred : 1 { false };
     // `typeof rawHighWaterMark === "number"` at construction time.

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -59,8 +59,8 @@ public:
     bool m_lockedWithoutReader : 1 { false };
     // Bun: a fetch Body consumer (text()/json()/blob()/..., or a native path that took the
     // source's bytes directly) drained this stream. The reader the spec acquires for that is
-    // never released, so unlike m_lockedWithoutReader nothing clears this. Part of every
-    // isReadableStreamLocked() check.
+    // never released, so unlike m_lockedWithoutReader nothing clears this. Folded into
+    // nativeHandleDetached(), and through it into every isReadableStreamLocked() check.
     bool m_consumedAsBody : 1 { false };
     // Set by jsFunctionTransferToNativeReadableStream.
     bool m_transferred : 1 { false };
@@ -108,7 +108,7 @@ public:
     // The value the old `$bunNativePtr` DOMAttribute getter returned.
     JSC::JSValue nativePtrForJS() const
     {
-        if (m_transferred)
+        if (nativeHandleDetached())
             return JSC::jsNumber(-1);
         // A text-mode native stream's handle wraps a raw byte source; hide it
         // from JS-side native-transfer fast paths (Readable.fromWeb) so they
@@ -118,9 +118,11 @@ public:
             return {};
         return m_nativePtr.get(); // may be empty
     }
+    // The native handle must not be started or handed out any more: it moved to a node:stream
+    // Readable, a Body consumer already took its bytes, or it was detached outright.
     bool nativeHandleDetached() const
     {
-        return m_transferred || (m_nativePtr.get().isInt32() && m_nativePtr.get().asInt32() == -1);
+        return m_transferred || m_consumedAsBody || (m_nativePtr.get().isInt32() && m_nativePtr.get().asInt32() == -1);
     }
 
 private:

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -158,7 +158,7 @@ void initializeReadableStream(JSReadableStream* stream)
 // IsReadableStreamLocked(stream), widened by Bun's reader-less lock states.
 bool isReadableStreamLocked(JSReadableStream* stream)
 {
-    return !!stream->m_reader || stream->m_lockedWithoutReader || stream->nativeHandleDetached();
+    return !!stream->m_reader || stream->m_lockedWithoutReader || stream->m_consumedAsBody || stream->nativeHandleDetached();
 }
 
 // ReadableStreamHasDefaultReader(stream)

--- a/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
+++ b/src/jsc/bindings/webcore/streams/ReadableStreamOperations.cpp
@@ -158,7 +158,7 @@ void initializeReadableStream(JSReadableStream* stream)
 // IsReadableStreamLocked(stream), widened by Bun's reader-less lock states.
 bool isReadableStreamLocked(JSReadableStream* stream)
 {
-    return !!stream->m_reader || stream->m_lockedWithoutReader || stream->m_consumedAsBody || stream->nativeHandleDetached();
+    return !!stream->m_reader || stream->m_lockedWithoutReader || stream->nativeHandleDetached();
 }
 
 // ReadableStreamHasDefaultReader(stream)

--- a/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
@@ -182,17 +182,14 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void ReadableStream__error(JSC::EncodedJSV
     Bun::WebStreams::webStreamControllerError(globalObject, stream, JSValue::decode(reason));
 }
 
-// Closed before anything read from or locked it. ReadableStream{Default,Byte}ControllerClose
-// only moves the stream to Closed once the queue is empty, so such a stream never yields a byte.
+// Closed with nothing ever read or attached: the queue was empty at close, so no byte can come out.
 extern "C" bool ReadableStream__isClosedUnread(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*)
 {
     auto* stream = dynamicDowncast<JSReadableStream>(JSValue::decode(possibleReadableStream));
     return stream && stream->m_state == ReadableStreamState::Closed && !stream->m_disturbed && !isReadableStreamLocked(stream);
 }
 
-// A fetch Body consumer took this stream's contents (through a Bun.readableStreamTo* pump or
-// fast path that has already started, or by lifting the native source's bytes directly). The
-// spec reader for that is never released: keep the stream disturbed and locked from here on.
+// A Body consumer took this stream's contents; its spec reader is never released.
 extern "C" void ReadableStream__markConsumedAsBody(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*)
 {
     auto* stream = dynamicDowncast<JSReadableStream>(JSValue::decode(possibleReadableStream));

--- a/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
@@ -182,13 +182,24 @@ extern "C" [[ZIG_EXPORT(check_slow)]] void ReadableStream__error(JSC::EncodedJSV
     Bun::WebStreams::webStreamControllerError(globalObject, stream, JSValue::decode(reason));
 }
 
-extern "C" void ReadableStream__detach(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject* globalObject)
+// Closed before anything read from or locked it. ReadableStream{Default,Byte}ControllerClose
+// only moves the stream to Closed once the queue is empty, so such a stream never yields a byte.
+extern "C" bool ReadableStream__isClosedUnread(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*)
+{
+    auto* stream = dynamicDowncast<JSReadableStream>(JSValue::decode(possibleReadableStream));
+    return stream && stream->m_state == ReadableStreamState::Closed && !stream->m_disturbed && !isReadableStreamLocked(stream);
+}
+
+// A fetch Body consumer took this stream's contents (through a Bun.readableStreamTo* pump or
+// fast path that has already started, or by lifting the native source's bytes directly). The
+// spec reader for that is never released: keep the stream disturbed and locked from here on.
+extern "C" void ReadableStream__markConsumedAsBody(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*)
 {
     auto* stream = dynamicDowncast<JSReadableStream>(JSValue::decode(possibleReadableStream));
     if (!stream) [[unlikely]]
         return;
-    stream->m_nativePtr.set(globalObject->vm(), stream, jsNumber(-1));
     stream->m_disturbed = true;
+    stream->m_consumedAsBody = true;
 }
 
 // A native sink (fetch body / S3 / FileSink) has attached directly without a reader.

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -719,7 +719,8 @@ bool ReadableStream__isLocked(JSC::EncodedJSValue possibleReadableStream, Zig::G
 void ReadableStream__cancel(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*); // userJS: yes
 // NO sentinel guard (reachable on a NativeSink-controlled stream).
 void ReadableStream__cancelWithReason(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*, JSC::EncodedJSValue reason); // userJS: yes
-void ReadableStream__detach(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*); // userJS: no
+bool ReadableStream__isClosedUnread(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*); // userJS: no
+void ReadableStream__markConsumedAsBody(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*); // userJS: no
 JSC::EncodedJSValue ReadableStream__empty(Zig::GlobalObject*); // userJS: no
 JSC::EncodedJSValue ReadableStream__used(Zig::GlobalObject*); // userJS: no
 JSC::EncodedJSValue ReadableStream__errored(Zig::GlobalObject*, JSC::EncodedJSValue reason); // userJS: no

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -436,6 +436,11 @@ impl PendingValue {
                         _ => unreachable!(),
                     };
                     self.readable.deinit();
+                    if promise.is_ok() {
+                        // The consumer has its reader (or already finished); from here on the
+                        // stream belongs to this body read even after that reader is released.
+                        readable.mark_consumed_as_body(global_this);
+                    }
                     // The ReadableStream within is expected to keep this Promise alive.
                     // If you try to protect() this, it will leak memory because the other end of the ReadableStream won't call it.
                     // See https://github.com/oven-sh/bun/issues/13678
@@ -777,43 +782,35 @@ impl Value {
     pub(crate) fn to_readable_stream(&mut self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         jsc::mark_binding();
 
-        match self {
-            Value::Used => ReadableStream::used(global_this),
-            Value::Empty => ReadableStream::empty(global_this),
-            Value::Null => Ok(JSValue::NULL),
+        // Once handed out, the stream *is* the body: `.body` returns it again,
+        // `bodyUsed` follows it, and every reader goes through it.
+        let stream = match self {
+            Value::Used => return ReadableStream::used(global_this),
+            Value::Null => return Ok(JSValue::NULL),
+            Value::Locked(locked) => {
+                if let Some(readable) = locked.readable.get() {
+                    return Ok(readable.value);
+                }
+                return self.locked_to_native_stream(global_this, false);
+            }
+            Value::Empty => ReadableStream::empty(global_this)?,
             Value::InternalBlob(_) | Value::Blob(_) | Value::WTFStringImpl(_) => {
                 // `deinit` must run on every exit incl. `?` paths.
                 let blob = scopeguard::guard(self.use_(), |mut b| b.deinit());
                 blob.resolve_size();
                 let blob_size = blob.size.get();
-                let value = ReadableStream::from_blob_copy_ref(global_this, &blob, blob_size)?;
-
-                let stream = ReadableStream::from_js_direct(value).unwrap();
-                *self = Value::Locked(PendingValue {
-                    readable: webcore::readable_stream::Strong::init(stream, global_this),
-                    ..PendingValue::new(global_this)
-                });
-                Ok(value)
-            }
-            Value::Locked(locked) => {
-                if let Some(readable) = locked.readable.get() {
-                    return Ok(readable.value);
-                }
-                self.locked_to_native_stream(global_this, false)
+                ReadableStream::from_blob_copy_ref(global_this, &blob, blob_size)?
             }
             Value::Error(err) => {
                 let reason = err.to_js(global_this);
-                let value = ReadableStream::errored(global_this, reason)?;
-                // As for a blob above: this stream is the body from here on, so `.body` hands it
-                // out again, `bodyUsed` follows it, and the promise readers reject through it.
-                let stream = ReadableStream::from_js_direct(value).unwrap();
-                *self = Value::Locked(PendingValue {
-                    readable: webcore::readable_stream::Strong::init(stream, global_this),
-                    ..PendingValue::new(global_this)
-                });
-                Ok(value)
+                ReadableStream::errored(global_this, reason)?
             }
-        }
+        };
+        *self = Value::from_readable_stream_without_lock_check(
+            ReadableStream::from_js_direct(stream).unwrap(),
+            global_this,
+        );
+        Ok(stream)
     }
 
     /// `Body.textStream()`: a `ReadableStream<string>` of the body's UTF-8
@@ -1034,18 +1031,9 @@ impl Value {
                 )));
             }
 
-            match readable.ptr {
-                webcore::readable_stream::Source::Blob(blob) => {
-                    // SAFETY: `Source::Blob` holds a live *mut ByteBlobLoader for the
-                    // lifetime of the ReadableStream JS wrapper.
-                    let result = unsafe { (*blob).to_any_blob(global_this) }
-                        .map_or(Value::Empty, Value::from);
-                    readable.force_detach(global_this);
-                    return Ok(result);
-                }
-                _ => {}
-            }
-
+            // The stream object itself becomes the body, whatever backs it. A
+            // native-backed one is still lifted back into a blob, but only when
+            // something consumes the body (`to_blob_if_possible`).
             return Ok(Value::from_readable_stream_without_lock_check(
                 readable,
                 global_this,
@@ -1231,8 +1219,13 @@ impl Value {
                 wtf_ref.deref();
                 new_blob
             }
+            // A zero-length body is spent by a read like any other (`use_as_any_blob` agrees).
             // `Blob::default()` leaves `global_this` null which matches the
             // don't-care contract here.
+            Value::Empty => {
+                *self = Value::Used;
+                Blob::default()
+            }
             _ => Blob::default(),
         }
     }
@@ -1766,8 +1759,8 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
 
         if matches!(value, Value::Locked(_)) {
             if let Some(readable) = self.get_body_readable_stream() {
-                if readable.is_disturbed(global_object) {
-                    return Ok(handle_body_already_used(global_object));
+                if let Some(rejected) = handle_body_stream_unusable(&readable, global_object) {
+                    return Ok(rejected);
                 }
                 let value = self.get_body_value();
                 if let Value::Locked(locked) = value {
@@ -1877,7 +1870,7 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
     /// disturbed or locked. <https://fetch.spec.whatwg.org/#body-unusable>
     fn throw_if_body_unusable(&self, global_object: &JSGlobalObject) -> JsResult<()> {
         let unusable =
-            self.body_stream_check(global_object, |s, g| s.is_disturbed(g) || s.is_locked(g));
+            self.body_stream_check(global_object, ReadableStream::is_disturbed_or_locked);
         if unusable {
             return Err(global_object
                 .err(
@@ -1900,8 +1893,8 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
 
         if matches!(value, Value::Locked(_)) {
             if let Some(readable) = self.get_body_readable_stream() {
-                if readable.is_disturbed(global_object) {
-                    return Ok(handle_body_already_used(global_object));
+                if let Some(rejected) = handle_body_stream_unusable(&readable, global_object) {
+                    return Ok(rejected);
                 }
                 let value = self.get_body_value();
                 value.to_blob_if_possible();
@@ -1950,8 +1943,8 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
 
         if matches!(value, Value::Locked(_)) {
             if let Some(readable) = self.get_body_readable_stream() {
-                if readable.is_disturbed(global_object) {
-                    return Ok(handle_body_already_used(global_object));
+                if let Some(rejected) = handle_body_stream_unusable(&readable, global_object) {
+                    return Ok(rejected);
                 }
                 let value = self.get_body_value();
                 value.to_blob_if_possible();
@@ -2005,8 +1998,8 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
 
         if matches!(value, Value::Locked(_)) {
             if let Some(readable) = self.get_body_readable_stream() {
-                if readable.is_disturbed(global_object) {
-                    return Ok(handle_body_already_used(global_object));
+                if let Some(rejected) = handle_body_stream_unusable(&readable, global_object) {
+                    return Ok(rejected);
                 }
                 let value = self.get_body_value();
                 value.to_blob_if_possible();
@@ -2056,8 +2049,8 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
 
         if matches!(value, Value::Locked(_)) {
             if let Some(readable) = self.get_body_readable_stream() {
-                if readable.is_disturbed(global_object) {
-                    return Ok(handle_body_already_used(global_object));
+                if let Some(rejected) = handle_body_stream_unusable(&readable, global_object) {
+                    return Ok(rejected);
                 }
                 let value = self.get_body_value();
                 value.to_blob_if_possible();
@@ -2156,11 +2149,11 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
                 let Value::Locked(locked) = value else {
                     unreachable!()
                 };
-                if !locked.action.is_none()
-                    || ((!this_value.is_empty() && readable.is_disturbed(global_object))
-                        || (this_value.is_empty() && readable.is_disturbed(global_object)))
-                {
+                if !locked.action.is_none() {
                     return Ok(handle_body_already_used(global_object));
+                }
+                if let Some(rejected) = handle_body_stream_unusable(&readable, global_object) {
+                    return Ok(rejected);
                 }
                 value.to_blob_if_possible();
                 if let Value::Locked(locked) = value {
@@ -2222,6 +2215,29 @@ fn handle_body_already_used(global_object: &JSGlobalObject) -> JSValue {
             format_args!("Body already used"),
         )
         .reject()
+}
+
+/// A body whose stream is disturbed or locked is "unusable" and every reader
+/// rejects with a TypeError before touching it.
+/// <https://fetch.spec.whatwg.org/#body-unusable>
+fn handle_body_stream_unusable(
+    readable: &ReadableStream,
+    global_object: &JSGlobalObject,
+) -> Option<JSValue> {
+    if readable.is_disturbed(global_object) {
+        return Some(handle_body_already_used(global_object));
+    }
+    if readable.is_locked(global_object) {
+        return Some(
+            global_object
+                .err(
+                    jsc::ErrorCode::INVALID_STATE_TypeError,
+                    format_args!("Invalid state: ReadableStream is locked"),
+                )
+                .reject(),
+        );
+    }
+    None
 }
 
 /// If the body already failed, reject the read with that error. Every body

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -371,8 +371,8 @@ impl PendingValue {
     }
 
     /// [`Self::to_any_blob`] for `clone()`: the stream is the wrapper's cached
-    /// `.body` when there is one, and it is detached afterwards so a reference
-    /// the caller still holds reads as locked, the state a tee leaves it in.
+    /// `.body` when there is one. `to_any_blob` leaves a reference the caller
+    /// still holds reading as locked, the state a tee leaves it in.
     fn take_blob_from_unread_stream(
         &mut self,
         global: &JSGlobalObject,
@@ -393,7 +393,6 @@ impl PendingValue {
             }
         }
         let blob = stream.to_any_blob(global)?;
-        stream.force_detach(global);
         self.readable.deinit();
         Some(blob)
     }
@@ -437,8 +436,7 @@ impl PendingValue {
                     };
                     self.readable.deinit();
                     if promise.is_ok() {
-                        // The consumer has its reader (or already finished); from here on the
-                        // stream belongs to this body read even after that reader is released.
+                        // The consumer holds its reader now; keep the lock once it lets go.
                         readable.mark_consumed_as_body(global_this);
                     }
                     // The ReadableStream within is expected to keep this Promise alive.
@@ -745,11 +743,7 @@ impl Value {
         }
     }
 
-    /// [`Self::to_blob_if_possible`] for an upload: a payload that is already
-    /// in memory behind an unread stream is lifted out so it goes out with a
-    /// Content-Length, but a file-backed stream keeps streaming, since its
-    /// length may not be knowable up front (FIFO, device) and reading it
-    /// belongs off this thread.
+    /// [`Self::to_blob_if_possible`], except a file-backed stream keeps streaming (a FIFO has no length).
     pub(crate) fn to_blob_if_in_memory(&mut self) {
         let Value::Locked(locked) = self else {
             return;
@@ -800,8 +794,7 @@ impl Value {
     pub(crate) fn to_readable_stream(&mut self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         jsc::mark_binding();
 
-        // Once handed out, the stream *is* the body: `.body` returns it again,
-        // `bodyUsed` follows it, and every reader goes through it.
+        // From here on the stream is the body: `.body`, `bodyUsed` and every reader go through it.
         let stream = match self {
             Value::Used => return ReadableStream::used(global_this),
             Value::Null => return Ok(JSValue::NULL),
@@ -1049,9 +1042,7 @@ impl Value {
                 )));
             }
 
-            // The stream object itself becomes the body, whatever backs it. A
-            // native-backed one is still lifted back into a blob, but only when
-            // something consumes the body (`to_blob_if_possible`).
+            // Adopt the stream whatever backs it; `to_blob_if_possible` lifts a native payload out later.
             return Ok(Value::from_readable_stream_without_lock_check(
                 readable,
                 global_this,
@@ -2235,9 +2226,7 @@ fn handle_body_already_used(global_object: &JSGlobalObject) -> JSValue {
         .reject()
 }
 
-/// A body whose stream is disturbed or locked is "unusable" and every reader
-/// rejects with a TypeError before touching it.
-/// <https://fetch.spec.whatwg.org/#body-unusable>
+/// <https://fetch.spec.whatwg.org/#body-unusable>: a disturbed or locked stream rejects every reader.
 fn handle_body_stream_unusable(
     readable: &ReadableStream,
     global_object: &JSGlobalObject,

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -745,6 +745,24 @@ impl Value {
         }
     }
 
+    /// [`Self::to_blob_if_possible`] for an upload: a payload that is already
+    /// in memory behind an unread stream is lifted out so it goes out with a
+    /// Content-Length, but a file-backed stream keeps streaming, since its
+    /// length may not be knowable up front (FIFO, device) and reading it
+    /// belongs off this thread.
+    pub(crate) fn to_blob_if_in_memory(&mut self) {
+        let Value::Locked(locked) = self else {
+            return;
+        };
+        let file_backed = locked
+            .readable
+            .get()
+            .is_some_and(|r| matches!(r.ptr, webcore::readable_stream::Source::File(_)));
+        if !file_backed {
+            self.to_blob_if_possible();
+        }
+    }
+
     pub(crate) fn size(&mut self) -> blob::SizeType {
         match self {
             Value::Blob(b) => b.get_size_for_bindings() as blob::SizeType,

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -370,9 +370,7 @@ impl PendingValue {
         None
     }
 
-    /// [`Self::to_any_blob`] for `clone()`: the stream is the wrapper's cached
-    /// `.body` when there is one. `to_any_blob` leaves a reference the caller
-    /// still holds reading as locked, the state a tee leaves it in.
+    /// [`Self::to_any_blob`] for `clone()`, going through the wrapper's cached `.body` when there is one.
     fn take_blob_from_unread_stream(
         &mut self,
         global: &JSGlobalObject,

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -191,10 +191,7 @@ impl ReadableStream {
         });
     }
 
-    /// Lift the whole body out of a stream nothing has read from yet, so the
-    /// caller can skip the stream machinery. On success the stream is spent:
-    /// its native source is cancelled and the JS object reads as a consumed
-    /// body (disturbed and locked) from then on.
+    /// Lift the whole payload out of an unread stream. On success the stream is spent (disturbed, locked).
     pub fn to_any_blob(&mut self, global_this: &JSGlobalObject) -> Option<webcore::blob::Any> {
         if self.is_disturbed(global_this) || self.is_locked(global_this) {
             return None;
@@ -234,12 +231,10 @@ impl ReadableStream {
                 // we can avoid streaming it and convert it to a Blob
                 bytes.to_any_blob()?
             }
-            // A stream that closed before anything read from it never yields a byte.
+            // A stream that closed before anything read from it never yields a byte; give back the
+            // store-less empty Blob that `new Response(new Blob([]))` holds.
             Source::JavaScript if ReadableStream__isClosedUnread(self.value, global_this) => {
-                webcore::blob::Any::InternalBlob(webcore::InternalBlob {
-                    bytes: Vec::new(),
-                    was_string: false,
-                })
+                webcore::blob::Any::Blob(Blob::init_empty(global_this))
             }
             Source::JavaScript | Source::Invalid => return None,
         };
@@ -299,10 +294,7 @@ impl ReadableStream {
         result
     }
 
-    /// A Body consumer (`text()`/`json()`/`blob()`/..., or a native path that
-    /// took the source's bytes via [`Self::to_any_blob`]) owns this stream now.
-    /// The fetch spec never releases the reader it acquires for that, so the
-    /// stream stays disturbed and locked for good.
+    /// A Body consumer owns this stream now; it stays disturbed and locked (the spec reader is never released).
     pub(crate) fn mark_consumed_as_body(&self, global_object: &JSGlobalObject) {
         ReadableStream__markConsumedAsBody(self.value, global_object);
     }
@@ -414,8 +406,7 @@ impl ReadableStream {
         ReadableStream__isLocked(self.value, global_object)
     }
 
-    /// Fetch's "body is unusable": its stream is disturbed or locked.
-    /// <https://fetch.spec.whatwg.org/#body-unusable>
+    /// Fetch's "body is unusable" (<https://fetch.spec.whatwg.org/#body-unusable>).
     pub fn is_disturbed_or_locked(&self, global_object: &JSGlobalObject) -> bool {
         self.is_disturbed(global_object) || self.is_locked(global_object)
     }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -137,12 +137,16 @@ unsafe extern "C" {
         possible_readable_stream: JSValue,
         global_object: &JSGlobalObject,
     ) -> bool;
+    safe fn ReadableStream__isClosedUnread(
+        possible_readable_stream: JSValue,
+        global_object: &JSGlobalObject,
+    ) -> bool;
     safe fn ReadableStream__empty(global: &JSGlobalObject) -> JSValue;
     safe fn ReadableStream__used(global: &JSGlobalObject) -> JSValue;
     safe fn ReadableStream__errored(global: &JSGlobalObject, reason: JSValue) -> JSValue;
     safe fn ReadableStream__fromDecodedText(global: &JSGlobalObject, string: JSValue) -> JSValue;
     safe fn ReadableStream__textDecodeFrom(global: &JSGlobalObject, source: JSValue) -> JSValue;
-    safe fn ReadableStream__detach(stream: JSValue, global: &JSGlobalObject);
+    safe fn ReadableStream__markConsumedAsBody(stream: JSValue, global: &JSGlobalObject);
     safe fn ReadableStream__lockNative(stream: JSValue, global: &JSGlobalObject);
     /// BunStreamSource.cpp: queue the adapter's close on the microtask queue.
     safe fn Bun__NativeStreamSourceAdapter__onClose(global: &JSGlobalObject, adapter: JSValue);
@@ -187,56 +191,62 @@ impl ReadableStream {
         });
     }
 
+    /// Lift the whole body out of a stream nothing has read from yet, so the
+    /// caller can skip the stream machinery. On success the stream is spent:
+    /// its native source is cancelled and the JS object reads as a consumed
+    /// body (disturbed and locked) from then on.
     pub fn to_any_blob(&mut self, global_this: &JSGlobalObject) -> Option<webcore::blob::Any> {
-        if self.is_disturbed(global_this) {
+        if self.is_disturbed(global_this) || self.is_locked(global_this) {
             return None;
         }
 
         self.reload_tag();
 
-        match self.ptr {
+        let blob = match self.ptr {
             Source::Blob(blobby) => {
                 // SAFETY: ptr came from ReadableStreamTag__tagged; valid while stream alive.
                 let blobby = unsafe { &mut *blobby };
-                if let Some(blob) = blobby.to_any_blob(global_this) {
-                    self.done();
-                    return Some(blob);
-                }
+                blobby.to_any_blob(global_this)?
             }
             Source::File(_) => {
                 // BACKREF: see `Source::file()` — payload valid while stream alive.
                 // R-2: `lazy`/`started` are `JsCell`/`Cell`; shared borrow suffices.
                 let blobby = self.ptr.file().expect("matched File");
-                if let webcore::file_reader::Lazy::Blob(store) = blobby.lazy.get() {
-                    let blob = Blob::init_with_store(store.clone(), global_this);
-                    // The window `from_blob_copy_ref` moved onto the reader.
-                    if let Some(offset) = blobby.start_offset {
-                        blob.offset.set(offset as webcore::blob::SizeType);
-                    }
-                    if let Some(size) = blobby.max_size {
-                        blob.size.set(size as webcore::blob::SizeType);
-                    }
-                    // it should be lazy, file shouldn't have opened yet.
-                    debug_assert!(!blobby.started.get());
-                    self.done();
-                    return Some(webcore::blob::Any::Blob(blob));
+                let webcore::file_reader::Lazy::Blob(store) = blobby.lazy.get() else {
+                    return None;
+                };
+                let blob = Blob::init_with_store(store.clone(), global_this);
+                // The window `from_blob_copy_ref` moved onto the reader.
+                if let Some(offset) = blobby.start_offset {
+                    blob.offset.set(offset as webcore::blob::SizeType);
                 }
+                if let Some(size) = blobby.max_size {
+                    blob.size.set(size as webcore::blob::SizeType);
+                }
+                // it should be lazy, file shouldn't have opened yet.
+                debug_assert!(!blobby.started.get());
+                webcore::blob::Any::Blob(blob)
             }
             Source::Bytes(_) => {
                 // BACKREF: see `Source::bytes()` — payload valid while stream alive.
                 let bytes = self.ptr.bytes().expect("matched Bytes");
                 // If we've received the complete body by the time this function is called
                 // we can avoid streaming it and convert it to a Blob
-                if let Some(blob) = bytes.to_any_blob() {
-                    self.done();
-                    return Some(blob);
-                }
-                return None;
+                bytes.to_any_blob()?
             }
-            _ => {}
-        }
+            // A stream that closed before anything read from it never yields a byte.
+            Source::JavaScript if ReadableStream__isClosedUnread(self.value, global_this) => {
+                webcore::blob::Any::InternalBlob(webcore::InternalBlob {
+                    bytes: Vec::new(),
+                    was_string: false,
+                })
+            }
+            Source::JavaScript | Source::Invalid => return None,
+        };
 
-        None
+        self.done();
+        self.mark_consumed_as_body(global_this);
+        Some(blob)
     }
 
     pub fn done(&self) {
@@ -289,9 +299,12 @@ impl ReadableStream {
         result
     }
 
-    pub(crate) fn force_detach(&self, global_object: &JSGlobalObject) {
-        // SAFETY: FFI call; value is a valid ReadableStream JSValue.
-        ReadableStream__detach(self.value, global_object);
+    /// A Body consumer (`text()`/`json()`/`blob()`/..., or a native path that
+    /// took the source's bytes via [`Self::to_any_blob`]) owns this stream now.
+    /// The fetch spec never releases the reader it acquires for that, so the
+    /// stream stays disturbed and locked for good.
+    pub(crate) fn mark_consumed_as_body(&self, global_object: &JSGlobalObject) {
+        ReadableStream__markConsumedAsBody(self.value, global_object);
     }
 
     /// Mark the stream disturbed + locked-without-reader. Called by native
@@ -399,6 +412,12 @@ impl ReadableStream {
     pub fn is_locked(&self, global_object: &JSGlobalObject) -> bool {
         // SAFETY: FFI call; value is a valid ReadableStream JSValue.
         ReadableStream__isLocked(self.value, global_object)
+    }
+
+    /// Fetch's "body is unusable": its stream is disturbed or locked.
+    /// <https://fetch.spec.whatwg.org/#body-unusable>
+    pub fn is_disturbed_or_locked(&self, global_object: &JSGlobalObject) -> bool {
+        self.is_disturbed(global_object) || self.is_locked(global_object)
     }
 
     /// A pure `dynamicDowncast<JSReadableStream>` type test: no tagging, no conversion.

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -231,8 +231,7 @@ impl ReadableStream {
                 // we can avoid streaming it and convert it to a Blob
                 bytes.to_any_blob()?
             }
-            // A stream that closed before anything read from it never yields a byte; give back the
-            // store-less empty Blob that `new Response(new Blob([]))` holds.
+            // Closed before anything read from it: the same store-less empty Blob `new Blob([])` gives.
             Source::JavaScript if ReadableStream__isClosedUnread(self.value, global_this) => {
                 webcore::blob::Any::Blob(Blob::init_empty(global_this))
             }

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -983,7 +983,7 @@ impl Response {
                     status_code: 302,
                     ..Default::default()
                 }),
-                body: JsCell::new(Body::new(BodyValue::Empty)),
+                body: JsCell::new(Body::new(BodyValue::Null)),
                 ..Default::default()
             };
 
@@ -1039,7 +1039,7 @@ impl Response {
                 status_code: 0,
                 ..Default::default()
             }),
-            body: JsCell::new(Body::new(BodyValue::Empty)),
+            body: JsCell::new(Body::new(BodyValue::Null)),
             ..Default::default()
         }));
 
@@ -1075,7 +1075,7 @@ impl Response {
                             status_code: 302,
                             ..Default::default()
                         }),
-                        body: JsCell::new(Body::new(BodyValue::Empty)),
+                        body: JsCell::new(Body::new(BodyValue::Null)),
                         js_ref: JsCell::new(JsRef::init_weak(js_this)),
                         ..Default::default()
                     };

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1025,6 +1025,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                     .throw());
             }
 
+            body_value.to_blob_if_in_memory();
             if matches!(*body_value, BodyValue::Locked(_)) {
                 if let Some(readable) = req.get_body_readable_stream() {
                     if readable.is_disturbed(global_this) || readable.is_locked(global_this) {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -213,6 +213,7 @@ impl HTTPRequestBody {
                 )
                 .throw());
         }
+        body_value.to_blob_if_in_memory();
         if let BodyValue::Locked(locked) = &mut body_value {
             if locked.readable.has() {
                 // `BodyValue` now has `Drop` (H3), so we cannot move

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -2,6 +2,7 @@ import { file, spawn, version, type Socket } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, exampleSite, tempDir } from "harness";
 import net from "net";
+import { Readable } from "node:stream";
 
 const exampleServer = exampleSite("http");
 
@@ -1721,8 +1722,84 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
           });
         }
       });
+
+      // A consumed body's stream is locked for every other consumer too,
+      // including the node:stream adapter's native fast path.
+      test("Readable.fromWeb() refuses a consumed body's stream", async () => {
+        for (const [, init] of sources) {
+          const owner = make(init());
+          const stream = owner.body!;
+          await owner.text();
+          expect(() => Readable.fromWeb(stream)).toThrow(
+            expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_STATE" }),
+          );
+        }
+      });
     });
   }
+
+  // A null body is not a zero-length body: nothing can use it up.
+  test("Response.redirect() and Response.error() have a null body", async () => {
+    for (const response of [Response.redirect("http://a/"), Response.error()]) {
+      expect(await response.text()).toBe("");
+      expect({
+        body: response.body,
+        bodyUsed: response.bodyUsed,
+        again: await response.text(),
+        clone: errorName(() => response.clone()),
+      }).toEqual({ body: null, bodyUsed: false, again: "", clone: "ok" });
+    }
+  });
+
+  // fetch() lifts a payload that is already in memory back out of an unread
+  // body stream and uploads it with a Content-Length; a JS stream still streams.
+  test("fetch() uploads an in-memory body behind a stream with a Content-Length", async () => {
+    const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+    const server = net.createServer(socket => {
+      let head = "";
+      socket.setEncoding("latin1");
+      socket.on("data", chunk => {
+        if (head.includes("\r\n\r\n")) return;
+        head += chunk;
+        if (!head.includes("\r\n\r\n")) return;
+        const lower = head.slice(0, head.indexOf("\r\n\r\n")).toLowerCase();
+        const framing = lower.includes("transfer-encoding: chunked")
+          ? "chunked"
+          : (lower.match(/content-length: \d+/)?.[0] ?? "none");
+        socket.end(`HTTP/1.1 200 OK\r\nContent-Length: ${framing.length}\r\nConnection: close\r\n\r\n${framing}`);
+      });
+    });
+    server.listen(0, "127.0.0.1", onListening);
+    await listening;
+    try {
+      const url = `http://127.0.0.1:${(server.address() as net.AddressInfo).port}/`;
+      const post = (body: BodyInit) => ({ method: "POST", body, duplex: "half" }) as RequestInit;
+      const touched = (body: BodyInit) => {
+        const request = new Request(url, post(body));
+        request.body;
+        return request;
+      };
+      const framing = async (input: Request | RequestInit) =>
+        (await fetch(...((input instanceof Request ? [input] : [url, input]) as [any]))).text();
+      expect({
+        responseStream: await framing(post(new Response("x").body!)),
+        requestAroundStream: await framing(new Request(url, post(new Response("xy").body!))),
+        blobStream: await framing(post(new Blob(["abcd"]).stream())),
+        touchedString: await framing(touched("xyz")),
+        touchedEmpty: await framing(touched("")),
+        jsStream: await framing(post(jsStream("q"))),
+      }).toEqual({
+        responseStream: "content-length: 1",
+        requestAroundStream: "content-length: 2",
+        blobStream: "content-length: 4",
+        touchedString: "content-length: 3",
+        touchedEmpty: "content-length: 0",
+        jsStream: "chunked",
+      });
+    } finally {
+      server.close();
+    }
+  });
 
   // The re-wrap idiom keeps the blob fast path on the wire: the server lifts
   // the payload back out of the adopted stream and frames it with a

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1534,3 +1534,227 @@ describe.concurrent("a fetch() Response that cannot have a body", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// A body's ReadableStream is one object no matter whether the body started out
+// as a string, a Blob, a typed array, a JS ReadableStream, or zero bytes, so the
+// disturbed/locked bookkeeping on it must not depend on what backs the body or
+// on which mixin method reads it. Every expectation below is what undici does.
+describe("body stream bookkeeping does not depend on the body's source", () => {
+  const jsStream = (chunk: string) =>
+    new ReadableStream({
+      start(c) {
+        c.enqueue(new TextEncoder().encode(chunk));
+        c.close();
+      },
+    });
+  const sources: [string, () => BodyInit, string][] = [
+    ["string", () => "payload", "payload"],
+    ["Blob", () => new Blob(["payload"]), "payload"],
+    ["Uint8Array", () => new TextEncoder().encode("payload"), "payload"],
+    ["URLSearchParams", () => new URLSearchParams("a=1"), "a=1"],
+    ["ReadableStream", () => jsStream("payload"), "payload"],
+    ['""', () => "", ""],
+    ["Uint8Array(0)", () => new Uint8Array(0), ""],
+    ["Blob([])", () => new Blob([]), ""],
+  ];
+  const owners: [string, (body: BodyInit, headers?: HeadersInit) => Request | Response][] = [
+    // `duplex` is what undici wants for a stream body; Bun accepts and ignores it.
+    [
+      "Request",
+      (body, headers) => new Request("http://a/", { method: "POST", body, headers, duplex: "half" } as RequestInit),
+    ],
+    ["Response", (body, headers) => new Response(body, { headers })],
+  ];
+  const errorName = (fn: () => unknown) => {
+    try {
+      fn();
+      return "ok";
+    } catch (e) {
+      return (e as Error).constructor.name;
+    }
+  };
+  const settled = (p: Promise<unknown>) => p.then(String, e => (e as Error).constructor.name);
+
+  for (const [ownerName, make] of owners) {
+    describe(ownerName, () => {
+      // https://fetch.spec.whatwg.org/#concept-bodyinit-extract: a ReadableStream
+      // init is adopted as the new body's stream. Nothing reads it until the new
+      // body is read, and reading the new body is what uses up the old one.
+      describe("new (stream) adopts another body's stream without reading it", () => {
+        for (const [name, init, content] of sources) {
+          test(name, async () => {
+            const from = make(init());
+            const stream = from.body!;
+            const to = make(stream);
+            expect({
+              same: to.body === stream,
+              locked: stream.locked,
+              fromUsed: from.bodyUsed,
+              toUsed: to.bodyUsed,
+              fromClone: errorName(() => from.clone()),
+            }).toEqual({ same: true, locked: false, fromUsed: false, toUsed: false, fromClone: "ok" });
+            // from.clone() teed the stream: `from` now reads one branch and the
+            // tee's reader holds the original, which is still `to`'s body.
+            expect(stream.locked).toBe(true);
+            expect(await settled(to.text())).toBe("TypeError");
+
+            const from2 = make(init());
+            const stream2 = from2.body!;
+            const to2 = make(stream2);
+            expect(await to2.text()).toBe(content);
+            expect({ locked: stream2.locked, fromUsed: from2.bodyUsed, toUsed: to2.bodyUsed }).toEqual({
+              locked: true,
+              fromUsed: true,
+              toUsed: true,
+            });
+            expect(await settled(from2.text())).toBe("TypeError");
+            expect(errorName(() => from2.clone())).toBe("TypeError");
+          });
+        }
+      });
+
+      // Consuming a body acquires a reader on its stream and never releases it.
+      describe("a consumed body's stream stays locked", () => {
+        for (const [name, init] of sources) {
+          const methods = ["text", "json", "arrayBuffer", "bytes", "blob"] as const;
+          for (const method of name === "URLSearchParams" ? ([...methods, "formData"] as const) : methods) {
+            test(`${name} .body then ${method}()`, async () => {
+              const owner = make(init());
+              const stream = owner.body!;
+              // json() rejects on most of these payloads; the body is read either way.
+              await owner[method]().catch(() => {});
+              expect({
+                same: owner.body === stream,
+                locked: stream.locked,
+                bodyUsed: owner.bodyUsed,
+                getReader: errorName(() => stream.getReader()),
+                rewrap: errorName(() => make(stream)),
+                again: await settled(owner[method]()),
+                clone: errorName(() => owner.clone()),
+              }).toEqual({
+                same: true,
+                locked: true,
+                bodyUsed: true,
+                getReader: "TypeError",
+                rewrap: "TypeError",
+                again: "TypeError",
+                clone: "TypeError",
+              });
+            });
+          }
+        }
+        for (const method of ["text", "json", "arrayBuffer", "bytes", "blob"] as const) {
+          test(`${method}() then .body`, async () => {
+            const owner = make("[1]");
+            await owner[method]();
+            const stream = owner.body!;
+            expect({
+              locked: stream.locked,
+              bodyUsed: owner.bodyUsed,
+              getReader: errorName(() => stream.getReader()),
+            }).toEqual({ locked: true, bodyUsed: true, getReader: "TypeError" });
+          });
+        }
+        test("when the stream errors instead of closing", async () => {
+          const stream = new ReadableStream({
+            pull(c) {
+              c.error(new Error("boom"));
+            },
+          });
+          const owner = make(stream);
+          expect(await settled(owner.text())).toBe("Error");
+          expect({
+            locked: stream.locked,
+            bodyUsed: owner.bodyUsed,
+            getReader: errorName(() => stream.getReader()),
+          }).toEqual({ locked: true, bodyUsed: true, getReader: "TypeError" });
+        });
+      });
+
+      // A zero-length body is a body: reading it, through a mixin method or
+      // through its stream, uses it up.
+      describe("a zero-length body is used up like any other", () => {
+        for (const [name, init] of sources.filter(([, , content]) => content === "")) {
+          test(`${name}: blob()`, async () => {
+            const owner = make(init());
+            expect((await owner.blob()).size).toBe(0);
+            expect({
+              bodyUsed: owner.bodyUsed,
+              text: await settled(owner.text()),
+              clone: errorName(() => owner.clone()),
+            }).toEqual({ bodyUsed: true, text: "TypeError", clone: "TypeError" });
+          });
+          test(`${name}: draining .body with a reader`, async () => {
+            const owner = make(init());
+            const reader = owner.body!.getReader();
+            expect(await reader.read()).toEqual({ done: true, value: undefined });
+            reader.releaseLock();
+            expect({ text: await settled(owner.text()), bodyUsed: owner.bodyUsed }).toEqual({
+              text: "TypeError",
+              bodyUsed: true,
+            });
+          });
+          test(`${name}: piping .body through a TransformStream`, async () => {
+            const owner = make(init());
+            const piped = owner.body!.pipeThrough(new TransformStream());
+            expect({ text: await settled(owner.text()), bodyUsed: owner.bodyUsed }).toEqual({
+              text: "TypeError",
+              bodyUsed: true,
+            });
+            expect(await new Response(piped).text()).toBe("");
+          });
+          test(`${name}: .body then text()`, async () => {
+            const owner = make(init());
+            const stream = owner.body!;
+            expect(await owner.text()).toBe("");
+            expect({ locked: stream.locked, bodyUsed: owner.bodyUsed }).toEqual({ locked: true, bodyUsed: true });
+          });
+          test(`${name}: .body then blob() keeps the Content-Type`, async () => {
+            const owner = make(init(), { "content-type": "text/x-custom" });
+            owner.body;
+            const blob = await owner.blob();
+            expect({ size: blob.size, type: blob.type, bodyUsed: owner.bodyUsed }).toEqual({
+              size: 0,
+              type: "text/x-custom",
+              bodyUsed: true,
+            });
+          });
+        }
+      });
+    });
+  }
+
+  // The re-wrap idiom keeps the blob fast path on the wire: the server lifts
+  // the payload back out of the adopted stream and frames it with a
+  // Content-Length instead of chunking it.
+  test("Bun.serve sends a re-wrapped blob-backed body with a Content-Length", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const path = new URL(req.url).pathname;
+        const inner =
+          path === "/blob"
+            ? new Response(new Blob(["payload"]))
+            : path === "/empty"
+              ? new Response("")
+              : new Response("payload", { headers: { "x-inner": "1" } });
+        return new Response(inner.body, inner);
+      },
+    });
+    for (const path of ["/string", "/blob", "/empty"]) {
+      const { promise, resolve } = Promise.withResolvers<string>();
+      let raw = "";
+      const socket = net.connect(server.port, "127.0.0.1", () =>
+        socket.write(`GET ${path} HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n`),
+      );
+      socket.setEncoding("latin1");
+      socket.on("data", chunk => (raw += chunk));
+      socket.on("close", () => resolve(raw));
+      const response = await promise;
+      const expected = path === "/empty" ? "" : "payload";
+      expect(response.toLowerCase()).toContain(`content-length: ${expected.length}\r\n`);
+      expect(response.toLowerCase()).not.toContain("transfer-encoding");
+      expect(response.endsWith(`\r\n\r\n${expected}`)).toBe(true);
+    }
+  });
+});

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1760,6 +1760,7 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
     const server = net.createServer(socket => {
       let head = "";
       socket.setEncoding("latin1");
+      socket.on("error", () => socket.destroy());
       socket.on("data", chunk => {
         if (head.includes("\r\n\r\n")) return;
         head += chunk;
@@ -1821,13 +1822,14 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
       },
     });
     for (const path of ["/string", "/blob", "/empty"]) {
-      const { promise, resolve } = Promise.withResolvers<string>();
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
       let raw = "";
       const socket = net.connect(server.port, "127.0.0.1", () =>
         socket.write(`GET ${path} HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\n`),
       );
       socket.setEncoding("latin1");
       socket.on("data", chunk => (raw += chunk));
+      socket.on("error", reject);
       socket.on("close", () => resolve(raw));
       const response = await promise;
       const expected = path === "/empty" ? "" : "payload";

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1725,14 +1725,16 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
 
       // A consumed body's stream is locked for every other consumer too,
       // including the node:stream adapter's native fast path.
-      test("Readable.fromWeb() refuses a consumed body's stream", async () => {
-        for (const [, init] of sources) {
-          const owner = make(init());
-          const stream = owner.body!;
-          await owner.text();
-          expect(() => Readable.fromWeb(stream)).toThrow(
-            expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_STATE" }),
-          );
+      describe("Readable.fromWeb() refuses a consumed body's stream", () => {
+        for (const [name, init] of sources) {
+          test(name, async () => {
+            const owner = make(init());
+            const stream = owner.body!;
+            await owner.text();
+            expect(() => Readable.fromWeb(stream)).toThrow(
+              expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_STATE" }),
+            );
+          });
         }
       });
     });

--- a/test/js/web/streams/readable-stream-blob-consumed.test.ts
+++ b/test/js/web/streams/readable-stream-blob-consumed.test.ts
@@ -3,8 +3,11 @@ import { expect, test } from "bun:test";
 test("ReadableStream.blob() after body consumed does not crash", async () => {
   const r = new Response("Hello World");
   const body = r.body!;
-  // Consume the body through the Response API, detaching the blob store
+  // Consume the body through the Response API, detaching the blob store. The
+  // stream is that body's stream, so it is left disturbed and locked, as if the
+  // read had gone through a reader that is never released.
   await r.arrayBuffer();
+  expect(body.locked).toBe(true);
   // Calling blob() on the stream whose store is now null should return a
   // rejected promise (not crash or throw synchronously)
   const promise = body.blob();
@@ -13,6 +16,8 @@ test("ReadableStream.blob() after body consumed does not crash", async () => {
     await promise;
     expect.unreachable();
   } catch (e: any) {
-    expect(e.code).toBe("ERR_BODY_ALREADY_USED");
+    expect(e).toBeInstanceOf(TypeError);
+    expect(e.code).toBe("ERR_INVALID_STATE");
+    expect(e.message).toContain("locked");
   }
 });

--- a/test/js/web/streams/readable-stream-blob-consumed.test.ts
+++ b/test/js/web/streams/readable-stream-blob-consumed.test.ts
@@ -18,6 +18,6 @@ test("ReadableStream.blob() after body consumed does not crash", async () => {
   } catch (e: any) {
     expect(e).toBeInstanceOf(TypeError);
     expect(e.code).toBe("ERR_INVALID_STATE");
-    expect(e.message).toContain("locked");
+    expect(e.message).toContain("already been used");
   }
 });


### PR DESCRIPTION
### Problem
- `new Response(p.body, p)` adopted a JS-backed stream but pulled the Blob out of a blob-backed one (`Value::from_js`): `p` came out locked and used, and `r.body !== p.body`.
- After `text()`/`json()`/`blob()`/... the body's stream was unlocked and `getReader()` worked. undici and Chromium keep it locked.
- Zero-length string/`Uint8Array` bodies were never used up: `blob()` left `bodyUsed` false, and `.body` handed out a stream the body did not track.

### Fix
- `Value::from_js` adopts every stream. `to_blob_if_possible` still lifts a blob/file-backed stream back into a blob when the body is consumed, served, or uploaded, so the Content-Length framing stays.
- New `m_consumedAsBody` bit on `JSReadableStream`, part of `nativeHandleDetached()` and so of `isReadableStreamLocked()`. `set_promise` sets it once the consumer has started, `to_any_blob` after taking a native source's bytes. `Bun.readableStreamToText()` is unchanged.
- `.body` on `Empty` stores its stream like the other arms, `use_()` marks `Empty` used, `to_any_blob` turns a closed never-read stream into an empty blob, the getters reject a locked stream up front, and `Response.redirect()`/`error()` get a null body.
- Verified: `test/js/web/fetch/body.test.ts` (145 new cases, 128 fail on 1.4.3, all checked against node v26.3.0), plus the suites in Notes. Self-reviewed: 4 concerns, 3 addressed, the #33461 overlap is noted below.

### Background
- A body is a `Body::Value`: string, `Blob`, bytes, `Empty`, `Null`, or `Locked` (a stream). Reading `.body` makes a non-null body `Locked`.
- Blob- and file-backed streams keep a native source. Until something reads them, `to_any_blob` can take the payload back without running the stream. The fetch spec reads a body through a reader it never releases, so a consumed body's stream stays disturbed and locked.

<details><summary>Notes</summary>

- Ledger members: #44053 (eager transfer), #44054 and #44171 (unlocked after consume, JS-stream close and error paths), #44055 (zero-length bodies). Not in this PR: #44057 is covered by #33499, and the "`getReader()` alone marks a native body used" cascade (#921) by #33461. #44059, #44060 and #44061 are separate mechanisms.
- Overlap with #33461: both touch the body getter prologues, `ReadableStream::to_any_blob`'s guard and `Value::from_js`. If this lands first, #33461 keeps its `m_nativeSourceMaterialized` gating and drops its getter and `from_js` hunks on rebase. `to_any_blob` then wants `is_native_source_consumed || is_locked` as its guard.
- `ReadableStream__detach`/`force_detach` had no other caller and is removed. `m_consumedAsBody` takes over both halves of what the `-1` handle sentinel did there: the stream reads as locked, and its native handle is neither started by `getReader()` nor handed to `Readable.fromWeb()`'s fast path. Unlike the sentinel it leaves `m_nativePtr` alone, so the handle stays rooted while an async consumer runs.
- `Readable.fromWeb()` now throws `ERR_INVALID_STATE` for any locked stream before it does anything else, as Node does (Node acquires the reader at that point). Before, a locked native-backed stream had its handle taken anyway.
- `ReadableStream__isClosedUnread`: `ReadableStream{Default,Byte}ControllerClose` only moves a stream to `Closed` once its queue is empty, so `Closed && !disturbed && !locked` means the stream can never yield a byte. This keeps a touched empty body (`new Response(""); r.body`) framing and typing exactly like an untouched one, and `new Response(new Blob([]))` takes the same path.
- A locked (not disturbed) body stream now rejects from the getter with `TypeError: Invalid state: ReadableStream is locked`, the same error the C++ helper produced before, and no longer records a pending read first. For JS-stream bodies `getReader(); releaseLock(); await r.text()` works and `bodyUsed` stays false while only locked, as in undici. Native-backed bodies still mark themselves disturbed on `getReader()`; that is #33461's subject.
- `fetch()` upload framing: a blob/bytes-backed or closed-empty stream body goes out with a Content-Length (as 1.4.3 did for the blob case through the eager transfer, and as undici does for bodies whose source it knows). A file-backed stream keeps streaming chunked, as today, because its length may not be knowable (FIFO, device). A JS stream streams chunked.
- `Response.redirect()`, `Response.error()` and the S3 `new Response(s3file)` redirect used `Value::Empty`. The spec body is null. With `Empty` now tracked like any other body they would have become visibly one-shot, so they are `Value::Null` here (the same three-line change sits in #33125).
- `Bun.readableStreamToText()` and the other helpers on a stream a Body already consumed reject with `ERR_INVALID_STATE` "ReadableStream has already been used" (a stream held by someone else's reader still says "is locked"). `test/js/web/streams/readable-stream-blob-consumed.test.ts` asserted `ERR_BODY_ALREADY_USED` from the old blob-loader path and is updated; its point (no crash, a rejected promise) is unchanged.
- Rebased onto #42053: its `take_blob_from_unread_stream` used `force_detach`; `to_any_blob` now marks the stream consumed itself.
- Suites run on the debug build: `body.test.ts`, `body-stream.test.ts` (9086), `body-clone`, `body-mixin-errors`, `body-async-iterator`, `body-stream-excess`, `serve.test.ts`, `bun-server`, `bun-serve-static`, `bun-serve-file`, `bun-serve-body-json-async`, `serve-if-none-match`, `proxy.test.ts`, `cookie.test.ts`, `html-rewriter.test.js`, `bun-write.test.js`, `spawn-stdin-readable-stream`, `streams.test.js`, `readable-stream-blob-consumed`, `native-source-onclose-leak`, `sync-pull-fast-path`, `request.test.ts`, `response.test.ts`, `client-fetch`, `content-length`, `fetch.stream`, `fetch.test.ts`, `fetch-abort-stream-body`, `fetch-keepalive`, `fetch-backpressure`, `node-stream.test.js`, `direct-readable-stream`, the node `test-readable-from-web-*` files, regression 07001 and 09555. The failures left in `fetch.test.ts`/`serve.test.ts`/`bun-server`/`fetch-backpressure` are environment-only here (IPv6, running as root, no internet or S3 egress, ASAN timeouts, and the ASAN RSS bound in "bounds memory when a handler forwards req.body") and reproduce with `origin/main`'s `src/`.

</details>
