### PR TITLE
Free a global object's SubtleCrypto together with the global

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2470,7 +2470,7 @@ void GlobalObject::finishCreation(VM& vm)
              auto& global = *static_cast<Zig::GlobalObject*>(init.owner);
 
              if (!global.m_subtleCrypto) {
-                 global.m_subtleCrypto = &WebCore::SubtleCrypto::create(global.scriptExecutionContext()).leakRef();
+                 global.m_subtleCrypto = WebCore::SubtleCrypto::create(global.scriptExecutionContext());
              }
 
              init.set(toJS<IDLInterface<SubtleCrypto>>(*init.owner, global, global.m_subtleCrypto).getObject());

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -809,7 +809,7 @@ public:
 
 private:
     DOMGuardedObjectSet m_guardedObjects WTF_GUARDED_BY_LOCK(m_gcLock);
-    WebCore::SubtleCrypto* m_subtleCrypto = nullptr;
+    RefPtr<WebCore::SubtleCrypto> m_subtleCrypto;
 
     Bun::WriteBarrierList<JSC::JSPromise> m_aboutToBeNotifiedRejectedPromises;
 

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -1,7 +1,9 @@
 import { spawnSync } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 import { createSecretKey } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 // This is consistent with what Node.js does, probably for polyfills to continue to work.
 it("crypto.subtle setter should not throw", () => {
@@ -1451,5 +1453,52 @@ describe("exception scope discipline", () => {
       uncheckedScopes: [],
       exitCode: 0,
     });
+  });
+});
+
+// Every global object creates its own native SubtleCrypto behind `crypto.subtle`. It must be
+// freed together with the global: at exit for the main global (BUN_DESTRUCT_VM_ON_EXIT), and on
+// a live VM when a ShadowRealm's global is collected. The object is fastMalloc'd, so LeakSanitizer
+// only sees it with Malloc=1.
+describe.skipIf(!isASAN)("SubtleCrypto is freed with its global", () => {
+  const repoSuppressions = join(import.meta.dirname, "../../../leaksan.supp");
+
+  async function expectNoLeak(script: string, suppressions = repoSuppressions) {
+    await using proc = Bun.spawn({
+      // From setImmediate: allocations made during module evaluation match blanket entries in
+      // leaksan.supp and would go unreported.
+      cmd: [bunExe(), "-e", `setImmediate(() => { ${script}; console.log("done"); });`],
+      env: {
+        ...bunEnv,
+        Malloc: "1",
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${suppressions}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "done\n", stderr: "", exitCode: 0 });
+  }
+
+  it.concurrent("main global", async () => {
+    await expectNoLeak(`globalThis.crypto.subtle`);
+  });
+
+  it.concurrent("ShadowRealm globals", async () => {
+    // A realm global's console client is a separate leak; suppress it here so that this test
+    // only covers SubtleCrypto.
+    using dir = tempDir("subtle-crypto-lsan", {
+      "leaksan.supp":
+        readFileSync(repoSuppressions, "utf8") + "\nleak:Zig::GlobalObject::deriveShadowRealmGlobalObject\n",
+    });
+    await expectNoLeak(
+      `for (let i = 0; i < 4; i++) {
+        if (new ShadowRealm().evaluate("typeof crypto.subtle") !== "object") throw new Error("no crypto.subtle");
+      }
+      Bun.gc(true)`,
+      join(String(dir), "leaksan.supp"),
+    );
   });
 });

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -1459,7 +1459,8 @@ describe("exception scope discipline", () => {
 // Every global object creates its own native SubtleCrypto behind `crypto.subtle`. It must be
 // freed together with the global: at exit for the main global (BUN_DESTRUCT_VM_ON_EXIT), and on
 // a live VM when a ShadowRealm's global is collected. The object is fastMalloc'd, so LeakSanitizer
-// only sees it with Malloc=1.
+// only sees it with Malloc=1. LSan symbolizes the (suppressed) leak stacks against the debug binary,
+// which alone takes seconds, hence the explicit per-test timeout.
 describe.skipIf(!isASAN)("SubtleCrypto is freed with its global", () => {
   const repoSuppressions = join(import.meta.dirname, "../../../leaksan.supp");
 
@@ -1482,23 +1483,31 @@ describe.skipIf(!isASAN)("SubtleCrypto is freed with its global", () => {
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "done\n", stderr: "", exitCode: 0 });
   }
 
-  it.concurrent("main global", async () => {
-    await expectNoLeak(`globalThis.crypto.subtle`);
-  });
+  it.concurrent(
+    "main global",
+    async () => {
+      await expectNoLeak(`globalThis.crypto.subtle`);
+    },
+    30_000,
+  );
 
-  it.concurrent("ShadowRealm globals", async () => {
-    // A realm global's console client is a separate leak; suppress it here so that this test
-    // only covers SubtleCrypto.
-    using dir = tempDir("subtle-crypto-lsan", {
-      "leaksan.supp":
-        readFileSync(repoSuppressions, "utf8") + "\nleak:Zig::GlobalObject::deriveShadowRealmGlobalObject\n",
-    });
-    await expectNoLeak(
-      `for (let i = 0; i < 4; i++) {
-        if (new ShadowRealm().evaluate("typeof crypto.subtle") !== "object") throw new Error("no crypto.subtle");
-      }
-      Bun.gc(true)`,
-      join(String(dir), "leaksan.supp"),
-    );
-  });
+  it.concurrent(
+    "ShadowRealm globals",
+    async () => {
+      // A realm global's console client is a separate leak; suppress it here so that this test
+      // only covers SubtleCrypto.
+      using dir = tempDir("subtle-crypto-lsan", {
+        "leaksan.supp":
+          readFileSync(repoSuppressions, "utf8") + "\nleak:Zig::GlobalObject::deriveShadowRealmGlobalObject\n",
+      });
+      await expectNoLeak(
+        `for (let i = 0; i < 4; i++) {
+          if (new ShadowRealm().evaluate("typeof crypto.subtle") !== "object") throw new Error("no crypto.subtle");
+        }
+        Bun.gc(true)`,
+        join(String(dir), "leaksan.supp"),
+      );
+    },
+    30_000,
+  );
 });


### PR DESCRIPTION
### Problem
- Every `Zig::GlobalObject` that touches `crypto.subtle` leaks its `WebCore::SubtleCrypto` when the global is destroyed (ShadowRealm, retired `bun test --isolate`, worker and main globals). With `Malloc=1`, LSan reports `Direct leak of 88 byte(s)` in `WTF::RefCounted<WebCore::SubtleCrypto>::operator new`.
- Cause: the lazy initializer (`src/jsc/bindings/ZigGlobalObject.cpp:2473`) stores `&SubtleCrypto::create(...).leakRef()` in a raw pointer and nothing derefs it. 22818e6806 removed the old `delete m_subtleCrypto` from `~GlobalObject` (the JS wrapper still held a ref).

### Fix
- Hold it as `RefPtr<WebCore::SubtleCrypto>`, like `m_performance` (`Performance` has the same shape: RefCounted plus `ContextDestructionObserver`).
- Correct because the `JSSubtleCrypto` wrapper takes its own `Ref`: the object is freed once the wrapper is finalized and the global is destroyed, in either order. In-flight operations hold only a `WeakPtr<SubtleCrypto>` and treat a dead one as a no-op.
- Verified: `test/js/web/crypto/web-crypto.test.ts` ("SubtleCrypto is freed with its global", both cases fail on the unfixed ASAN build), the rest of that file, and the suites listed in Notes.
- Self-reviewed: 1 concern raised (local timeout headroom of the LSan rows), addressed with a per-test timeout.

### Background
- `crypto.subtle` is a `LazyProperty` on each `Zig::GlobalObject`. The first access creates the native `SubtleCrypto` and its wrapper.
- A ShadowRealm or retired `bun test --isolate` global is an ordinary GC cell: `~GlobalObject` runs on a live VM. Worker and main globals die at VM teardown.
- `SubtleCrypto` is fastMalloc'd, so LSan only sees it when `Malloc=1` routes bmalloc to the system allocator. `BUN_DESTRUCT_VM_ON_EXIT=1` destroys the VM at exit, which frees what the main global owns.

<details><summary>Notes</summary>

- Other suites run on the fixed build: `test-shadow-realm*.js`, `test/js/bun/jsc/shadow.test.js`, `test/cli/test/isolation.test.ts`, `test/js/web/workers/worker-late-completion.test.ts`, the `pool` family of `worker-terminate-funnels.test.ts`.
- The ShadowRealm test case appends one LSan suppression, `leak:Zig::GlobalObject::deriveShadowRealmGlobalObject`, to a copy of `test/leaksan.supp`. A realm global also leaks its `Bun::ConsoleObject` (created in `setConsole()` from `deriveShadowRealmGlobalObject`). That is a separate leak with its own PR (#38395). The main global's console client is already covered by the existing `leak:Zig__GlobalObject__create` entry. The `SubtleCrypto` allocation stack goes through `ShadowRealm.prototype.evaluate`, not through `deriveShadowRealmGlobalObject`, so the extra entry cannot hide it.
- The test accesses `crypto.subtle` from `setImmediate`: allocations made during module evaluation sit under `Bun::evaluateCommonJSModuleOnce` / `JSC::JSModuleLoader::evaluateNonVirtual`, which `test/leaksan.supp` suppresses wholesale.
- Unfixed debug ASAN build, `Malloc=1 BUN_DESTRUCT_VM_ON_EXIT=1 detect_leaks=1`, main global only: `101 byte(s) leaked in 3 allocation(s)` (SubtleCrypto 88 B, PhonyWorkQueue 12 B, a `WTF::Lock`). With 8 realms: 9 SubtleCrypto direct leaks. Fixed build: both cases exit 0 with empty stderr.
- Destruction order: `~GlobalObject` derefs the `ScriptExecutionContext` in its body. If that destroys the context, `~ScriptExecutionContext` calls `contextDestroyed()` on the `SubtleCrypto`, which clears its `WeakPtr` to the context. The `RefPtr` member is destroyed after the body, so `~ContextDestructionObserver` then sees a null context and does nothing. If the wrapper dies last instead, the same holds. `m_performance` already relies on this order.
- Pending operations: a global can be collected while one of its `SubtleCrypto` operations is still on the work pool (checked with `heapStats().objectTypeCounts.GlobalObject` during a pending RSA-4096 `generateKey`). `~SubtleCrypto` then drops the pending `DeferredPromise`s, whose `Weak<>` handles to the dead global are already cleared. The completion's `postTaskTo` finds no context and is released unrun, as before. Probes under ASAN with and without `Malloc=1`: 36 realms dropped mid-`digest`/`generateKey` across GC cycles, and 6 workers that `process.exit()` or are terminated mid-operation. No reports.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.30ms]
(pass) Web Crypto > keeps event loop alive [337.63ms]
(pass) Web Crypto > has globals [2.94ms]
(pass) Web Crypto > should encrypt and decrypt [14.02ms]
(pass) Web Crypto > should verify and sign [35.93ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [14.76ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [9.78ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [10.10ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2491.23ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [301.61ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [61.93m
... (truncated)

release without fix: 2 skipped
bun test v1.4.3-canary.1 (fb01724ee)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [0.04ms]
(pass) Web Crypto > keeps event loop alive [7.15ms]
(pass) Web Crypto > has globals [0.05ms]
(pass) Web Crypto > should encrypt and decrypt [0.56ms]
(pass) Web Crypto > should verify and sign [0.80ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [0.27ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [0.20ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [0.17ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [26.38ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [6.50ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [6.78ms]
(pass) Ed25519 > generateKey > should return CryptoKeys without namedCurve in algorithm field [0.16ms]
(pass) Ed25519 > importKey > rejects a 64-byte JWK d whose trailin
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/crypto/web-crypto.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/crypto/web-crypto.test.ts:
(pass) crypto.subtle setter should not throw [3.23ms]
(pass) Web Crypto > keeps event loop alive [329.51ms]
(pass) Web Crypto > has globals [3.14ms]
(pass) Web Crypto > should encrypt and decrypt [15.57ms]
(pass) Web Crypto > should verify and sign [37.31ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are not valid JSON [16.32ms]
(pass) Web Crypto > unwrapKey JWK error handling > rejects when wrapped bytes are valid JSON but not a valid JWK [11.01ms]
(pass) Web Crypto > unwrapKey JWK error handling > settles when JsonWebKey dictionary conversion itself throws [10.92ms]
(pass) Web Crypto > unwrapKey JWK error handling > does not leak DeferredPromise in m_pendingPromises on JWK parse errors [2478.52ms]
(pass) oversized inputs > rejects >2 GiB inputs instead of aborting [310.03ms]
(pass) RSA-PSS saltLength > rejects values that do not fit in an int instead of treating them as the -1/-2 selectors [63.15
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 753ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/138] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/138] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ZigGlobalObject.cpp  |  2 +-
 src/jsc/bindings/ZigGlobalObject.h    |  2 +-
 test/js/web/crypto/web-crypto.test.ts | 60 ++++++++++++++++++++++++++++++++++-
 3 files changed, 61 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/bindings/ZigGlobalObject.cpp       4      1     14
src/jsc/bindings/ZigGlobalObject.h         1      1     13
test/js/web/crypto/web-crypto.test.ts      3      4     13
```

</details>

<!-- robobun:evidence:end -->