### PR TITLE
js_parser: fold enum members nested in an earlier namespace into enum initializers

### DIFF
--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1012,6 +1012,10 @@ impl<'a> Parser<'a> {
                         }
                         // An enum above can only see the constants declared before it.
                         js_ast::StmtData::SLocal(local) => p.record_ts_enum_constants(&local),
+                        // The enums inside are visited with the namespace's part, after this loop.
+                        js_ast::StmtData::SNamespace(namespace) => {
+                            p.compute_enum_values_inside_namespace(namespace.stmts.slice())
+                        }
                         _ => {}
                     }
                 }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1536,6 +1536,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
                         // An enum above can only see the constants declared before it.
                         StmtData::SLocal(local) => p.record_ts_enum_constants(&local),
+                        // The enums inside are visited with the namespace, after this loop.
+                        StmtData::SNamespace(namespace) => {
+                            p.compute_enum_values_inside_namespace(namespace.stmts.slice())
+                        }
                         _ => {}
                     }
                 }

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2437,9 +2437,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// What `ref_` names when that is an enum, a namespace, or a member of one. A member of
-    /// another block of the same enum or namespace is reached through this block's closure
-    /// argument (see `find_symbol`), as in `handle_identifier`.
+    /// The enum, namespace, or member that `ref_` names; a sibling block's member goes through `namespace_alias`.
     fn ts_member_data_of_symbol(&self, ref_: Ref) -> Option<js_ast::ts::Data> {
         if let Some(alias) = &self.symbols[ref_.inner_index() as usize].namespace_alias {
             let js_ast::ts::Data::Namespace(map) =
@@ -2452,16 +2450,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.ref_to_ts_namespace_member.get(&ref_).copied()
     }
 
-    /// `visit_stmts` visits the enums of a statement list ahead of its other statements, so
-    /// that their member values are known everywhere in the list. Enums nested in a namespace
-    /// of that list are only visited with the namespace, but the list can reference them too:
-    ///
-    ///   namespace NS { export enum Inner { X = 1 } }
-    ///   enum Outer { A = NS.Inner.X, B }
-    ///
-    /// `B` only gets a value if `NS.Inner.X` is known when `Outer` is visited. So compute the
-    /// value of each constant member of the enums inside the namespace from its unvisited
-    /// initializer first, by the rules of `s_enum`, which stores the same values again later.
+    /// Stores the constant members of the enums in an unvisited namespace body, for the enums `visit_stmts` pre-visits.
     pub(crate) fn compute_enum_values_inside_namespace(&mut self, stmts: &[Stmt]) {
         for stmt in stmts {
             match stmt.data {
@@ -2517,8 +2506,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
         }
-        // `s_enum` adds these one member at a time, so that a member after the initializer
-        // stays a property access there, as it does in an enum that is not nested.
+        // `s_enum` adds these back one member at a time, so that a later member stays a property access.
         for ref_ in members_so_far {
             self.ref_to_ts_namespace_member.remove(&ref_);
         }

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2461,7 +2461,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ///
     /// `B` only gets a value if `NS.Inner.X` is known when `Outer` is visited. So compute the
     /// value of each constant member of the enums inside the namespace from its unvisited
-    /// initializer first. The visit of those enums stores the same values again.
+    /// initializer first, by the rules of `s_enum`, which stores the same values again later.
     pub(crate) fn compute_enum_values_inside_namespace(&mut self, stmts: &[Stmt]) {
         for stmt in stmts {
             match stmt.data {
@@ -2488,38 +2488,39 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let old_scope = self.current_scope;
         self.current_scope = scope;
 
+        // An initializer can reference the members before it by name.
+        let mut members_so_far: smallvec::SmallVec<[Ref; 16]> = smallvec::SmallVec::new();
         let mut next_numeric_value: Option<f64> = Some(0.0);
         for value in data.values.slice() {
-            let name: &[u8] = value.name.slice();
-            let current = (*exported_members).get(name).unwrap().data;
-            let known = match current {
-                // Computed by an earlier call.
-                js_ast::ts::Data::EnumNumber(_) | js_ast::ts::Data::EnumString(_) => Some(current),
-                _ => match value.value {
-                    Some(initializer) => match self.eval_ts_constant_expression(&initializer) {
-                        Some(TSConstantValue::Number(number)) => {
-                            Some(js_ast::ts::Data::EnumNumber(number))
-                        }
-                        Some(TSConstantValue::String(str_)) => {
-                            Some(js_ast::ts::Data::EnumString(str_))
-                        }
-                        None => None,
-                    },
-                    None => next_numeric_value.map(js_ast::ts::Data::EnumNumber),
+            let known = match value.value {
+                Some(initializer) => match self.eval_ts_constant_expression(&initializer) {
+                    Some(TSConstantValue::Number(number)) => {
+                        Some(js_ast::ts::Data::EnumNumber(number))
+                    }
+                    Some(TSConstantValue::String(str_)) => Some(js_ast::ts::Data::EnumString(str_)),
+                    None => None,
                 },
+                None => next_numeric_value.map(js_ast::ts::Data::EnumNumber),
             };
             next_numeric_value = match known {
                 Some(js_ast::ts::Data::EnumNumber(number)) => Some(number + 1.0),
                 _ => None,
             };
-            if let Some(known) = known
-                && matches!(current, js_ast::ts::Data::EnumProperty)
-            {
-                exported_members.get_ptr_mut(name).unwrap().data = known;
+            if let Some(known) = known {
+                exported_members
+                    .get_ptr_mut(value.name.slice())
+                    .unwrap()
+                    .data = known;
                 if value.ref_.is_valid() {
                     self.ref_to_ts_namespace_member.insert(value.ref_, known);
+                    members_so_far.push(value.ref_);
                 }
             }
+        }
+        // `s_enum` adds these one member at a time, so that a member after the initializer
+        // stays a property access there, as it does in an enum that is not nested.
+        for ref_ in members_so_far {
+            self.ref_to_ts_namespace_member.remove(&ref_);
         }
 
         self.current_scope = old_scope;

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -59,6 +59,21 @@ fn ts_namespace_member_value(data: js_ast::ts::Data) -> Option<TSConstantValue> 
     }
 }
 
+/// The enum, namespace, or member that `ref_` names; a sibling block's member goes through `namespace_alias`.
+fn ts_member_data_of_symbol(
+    symbols: &[js_ast::Symbol],
+    members: &bun_collections::HashMap<Ref, js_ast::ts::Data>,
+    ref_: Ref,
+) -> Option<js_ast::ts::Data> {
+    if let Some(alias) = &symbols[ref_.inner_index() as usize].namespace_alias {
+        let js_ast::ts::Data::Namespace(map) = *members.get(&alias.namespace_ref)? else {
+            return None;
+        };
+        return Some((*map).get(alias.alias.slice())?.data);
+    }
+    members.get(&ref_).copied()
+}
+
 /// An unbound `Infinity` or `NaN`, which tsc folds too.
 fn ts_global_constant(name: &[u8]) -> Option<TSConstantValue> {
     match name {
@@ -2366,7 +2381,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if let Some(&value) = self.ts_enum_constants.get(&result.r#ref) {
                     return Some(value);
                 }
-                ts_namespace_member_value(self.ts_member_data_of_symbol(result.r#ref)?)
+                ts_namespace_member_value(ts_member_data_of_symbol(
+                    &self.symbols,
+                    &self.ref_to_ts_namespace_member,
+                    result.r#ref,
+                )?)
             }
             js_ast::ExprData::EDot(dot) => {
                 if dot.optional_chain.is_some() {
@@ -2423,7 +2442,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if result.is_inside_with_scope || result.r#ref.is_empty() {
             return None;
         }
-        let mut data = self.ts_member_data_of_symbol(result.r#ref)?;
+        let mut data = ts_member_data_of_symbol(
+            &self.symbols,
+            &self.ref_to_ts_namespace_member,
+            result.r#ref,
+        )?;
         // The innermost member was pushed last.
         for member_name in member_names.iter().rev() {
             let js_ast::ts::Data::Namespace(map) = data else {
@@ -2435,19 +2458,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             js_ast::ts::Data::Namespace(map) => Some(map),
             _ => None,
         }
-    }
-
-    /// The enum, namespace, or member that `ref_` names; a sibling block's member goes through `namespace_alias`.
-    fn ts_member_data_of_symbol(&self, ref_: Ref) -> Option<js_ast::ts::Data> {
-        if let Some(alias) = &self.symbols[ref_.inner_index() as usize].namespace_alias {
-            let js_ast::ts::Data::Namespace(map) =
-                *self.ref_to_ts_namespace_member.get(&alias.namespace_ref)?
-            else {
-                return None;
-            };
-            return Some((*map).get(alias.alias.slice())?.data);
-        }
-        self.ref_to_ts_namespace_member.get(&ref_).copied()
     }
 
     /// Stores the constant members of the enums in an unvisited namespace body, for the enums `visit_stmts` pre-visits.

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -2366,7 +2366,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if let Some(&value) = self.ts_enum_constants.get(&result.r#ref) {
                     return Some(value);
                 }
-                ts_namespace_member_value(*self.ref_to_ts_namespace_member.get(&result.r#ref)?)
+                ts_namespace_member_value(self.ts_member_data_of_symbol(result.r#ref)?)
             }
             js_ast::ExprData::EDot(dot) => {
                 if dot.optional_chain.is_some() {
@@ -2423,7 +2423,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if result.is_inside_with_scope || result.r#ref.is_empty() {
             return None;
         }
-        let mut data = *self.ref_to_ts_namespace_member.get(&result.r#ref)?;
+        let mut data = self.ts_member_data_of_symbol(result.r#ref)?;
         // The innermost member was pushed last.
         for member_name in member_names.iter().rev() {
             let js_ast::ts::Data::Namespace(map) = data else {
@@ -2435,6 +2435,94 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             js_ast::ts::Data::Namespace(map) => Some(map),
             _ => None,
         }
+    }
+
+    /// What `ref_` names when that is an enum, a namespace, or a member of one. A member of
+    /// another block of the same enum or namespace is reached through this block's closure
+    /// argument (see `find_symbol`), as in `handle_identifier`.
+    fn ts_member_data_of_symbol(&self, ref_: Ref) -> Option<js_ast::ts::Data> {
+        if let Some(alias) = &self.symbols[ref_.inner_index() as usize].namespace_alias {
+            let js_ast::ts::Data::Namespace(map) =
+                *self.ref_to_ts_namespace_member.get(&alias.namespace_ref)?
+            else {
+                return None;
+            };
+            return Some((*map).get(alias.alias.slice())?.data);
+        }
+        self.ref_to_ts_namespace_member.get(&ref_).copied()
+    }
+
+    /// `visit_stmts` visits the enums of a statement list ahead of its other statements, so
+    /// that their member values are known everywhere in the list. Enums nested in a namespace
+    /// of that list are only visited with the namespace, but the list can reference them too:
+    ///
+    ///   namespace NS { export enum Inner { X = 1 } }
+    ///   enum Outer { A = NS.Inner.X, B }
+    ///
+    /// `B` only gets a value if `NS.Inner.X` is known when `Outer` is visited. So compute the
+    /// value of each constant member of the enums inside the namespace from its unvisited
+    /// initializer first. The visit of those enums stores the same values again.
+    pub(crate) fn compute_enum_values_inside_namespace(&mut self, stmts: &[Stmt]) {
+        for stmt in stmts {
+            match stmt.data {
+                StmtData::SEnum(data) => self.compute_enum_values_ahead_of_visit(stmt.loc, &data),
+                StmtData::SNamespace(namespace) => {
+                    if self.stack_check.is_safe_to_recurse() {
+                        self.compute_enum_values_inside_namespace(namespace.stmts.slice());
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn compute_enum_values_ahead_of_visit(&mut self, loc: bun_ast::Loc, data: &S::Enum) {
+        // The first scope recorded for an enum statement is its own.
+        let scope = super::scopes_for_enum_at(&self.scopes_in_order_for_enum, loc)[0].scope_ref();
+        let Some(ts_namespace) = scope.ts_namespace else {
+            return;
+        };
+        let mut exported_members = ts_namespace.exported_members;
+
+        // Identifiers in an initializer resolve from inside the enum.
+        let old_scope = self.current_scope;
+        self.current_scope = scope;
+
+        let mut next_numeric_value: Option<f64> = Some(0.0);
+        for value in data.values.slice() {
+            let name: &[u8] = value.name.slice();
+            let current = (*exported_members).get(name).unwrap().data;
+            let known = match current {
+                // Computed by an earlier call.
+                js_ast::ts::Data::EnumNumber(_) | js_ast::ts::Data::EnumString(_) => Some(current),
+                _ => match value.value {
+                    Some(initializer) => match self.eval_ts_constant_expression(&initializer) {
+                        Some(TSConstantValue::Number(number)) => {
+                            Some(js_ast::ts::Data::EnumNumber(number))
+                        }
+                        Some(TSConstantValue::String(str_)) => {
+                            Some(js_ast::ts::Data::EnumString(str_))
+                        }
+                        None => None,
+                    },
+                    None => next_numeric_value.map(js_ast::ts::Data::EnumNumber),
+                },
+            };
+            next_numeric_value = match known {
+                Some(js_ast::ts::Data::EnumNumber(number)) => Some(number + 1.0),
+                _ => None,
+            };
+            if let Some(known) = known
+                && matches!(current, js_ast::ts::Data::EnumProperty)
+            {
+                exported_members.get_ptr_mut(name).unwrap().data = known;
+                if value.ref_.is_valid() {
+                    self.ref_to_ts_namespace_member.insert(value.ref_, known);
+                }
+            }
+        }
+
+        self.current_scope = old_scope;
     }
 
     fn s_enum(

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -58,7 +58,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
 /// Version 30: TypeScript enum initializers fold references to `const` variables.
-const EXPECTED_VERSION: u32 = 30;
+/// Version 31: TypeScript enum initializers fold members of enums nested in an earlier namespace.
+const EXPECTED_VERSION: u32 = 31;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -2589,4 +2589,48 @@ describe("bundler", () => {
       `,
     },
   });
+  itBundled("ts/EnumReferencesEnumInsideEarlierNamespace", {
+    files: {
+      "/entry.ts": /* ts */ `
+        namespace NS {
+          export enum Inner { X = 3, S = "s" }
+          export namespace Deep {
+            enum Hidden { H = 100 }
+            export enum Flags { A = 1 << 0, B = 1 << 4, AB = A | B, H = Hidden.H }
+          }
+          export enum Merged { P = 200 }
+          export enum Merged { Q = P + 1, R }
+        }
+        enum Outer { A = NS.Inner.X, B, C = NS.Deep.Flags.AB, D, E = NS["Deep"].Flags["H"], F = NS.Merged.R, G, S = NS.Inner.S }
+        namespace Later {
+          export namespace L { export enum Z { Q = 7 } }
+          export enum D { A = L.Z.Q, B }
+        }
+        console.log(JSON.stringify([Outer, Later.D]));
+        export { Outer };
+      `,
+      "/other.ts": /* ts */ `
+        import { Outer } from "./entry";
+        console.log(JSON.stringify([Outer.B, Outer.G, Outer.S]));
+      `,
+    },
+    entryPoints: ["/entry.ts", "/other.ts"],
+    run: [
+      {
+        file: "/out/entry.js",
+        stdout:
+          '[{"3":"A","4":"B","17":"C","18":"D","100":"E","202":"F","203":"G","A":3,"B":4,"C":17,"D":18,"E":100,"F":202,"G":203,"S":"s"},{"7":"A","8":"B","A":7,"B":8}]',
+      },
+      {
+        file: "/out/other.js",
+        stdout:
+          '[{"3":"A","4":"B","17":"C","18":"D","100":"E","202":"F","203":"G","A":3,"B":4,"C":17,"D":18,"E":100,"F":202,"G":203,"S":"s"},{"7":"A","8":"B","A":7,"B":8}]\n[4,203,"s"]',
+      },
+    ],
+    onAfterBundle(api) {
+      // The values are known at bundle time, so the uses in the other module are inlined.
+      const other = api.readFile("/out/other.js");
+      expect(other).not.toMatch(/Outer\.[BGS]/);
+    },
+  });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2231,6 +2231,100 @@ export default class {
       expect(stdout).toBe('["m2","_m2"]\n');
       expect(exitCode).toBe(0);
     });
+
+    // The enums of a statement list are visited before its other statements, so
+    // an enum nested in a namespace is visited after the enums that follow the
+    // namespace. Its constant members must still be known to them, like in tsc.
+    describe("enum initializers that reference an enum inside an earlier namespace", () => {
+      const exp = ts.expectPrinted_;
+
+      it("numeric member continues auto-increment", () => {
+        exp(
+          "namespace M { export enum Z { Q = 3 } }\nenum D { A = M.Z.Q, B }",
+          'var M;\n((M) => {\n  let Z;\n  ((Z) => {\n    Z[Z["Q"] = 3] = "Q";\n  })(Z = M.Z ||= {});\n})(M ||= {});\nvar D;\n((D) => {\n  D[D["A"] = 3] = "A";\n  D[D["B"] = 4] = "B";\n})(D ||= {})',
+        );
+      });
+
+      it("nested namespaces, index access, string members", () => {
+        exp(
+          'namespace A { export namespace B { export enum Z { Q = 1 << 2, S = "s" } } }\nenum D { X = A.B.Z.Q | 1, Y, Z = A.B.Z.S, W = A["B"].Z["Q"] }',
+          'var A;\n((A) => {\n  let B;\n  ((B) => {\n    let Z;\n    ((Z) => {\n      Z[Z["Q"] = 4] = "Q";\n      Z["S"] = "s";\n    })(Z = B.Z ||= {});\n  })(B = A.B ||= {});\n})(A ||= {});\nvar D;\n((D) => {\n  D[D["X"] = 5] = "X";\n  D[D["Y"] = 6] = "Y";\n  D["Z"] = "s";\n  D[D["W"] = 4] = "W";\n})(D ||= {})',
+        );
+      });
+
+      it("constant expressions over earlier members, unary operators, template literals", () => {
+        exp(
+          "namespace M { export enum Z { A = 2, N = -(A ** 3), C = ~A, T = `v${N}` } }\nenum D { N = M.Z.N, C = M.Z.C, T = M.Z.T }",
+          'var M;\n((M) => {\n  let Z;\n  ((Z) => {\n    Z[Z["A"] = 2] = "A";\n    Z[Z["N"] = -8] = "N";\n    Z[Z["C"] = -3] = "C";\n    Z["T"] = "v-8";\n  })(Z = M.Z ||= {});\n})(M ||= {});\nvar D;\n((D) => {\n  D[D["N"] = -8] = "N";\n  D[D["C"] = -3] = "C";\n  D["T"] = "v-8";\n})(D ||= {})',
+        );
+      });
+
+      it("an enum inside a namespace sees an enum inside a nested namespace before it", () => {
+        exp(
+          "namespace O {\n  export namespace I { export enum Z { Q = 7 } }\n  export enum D { A = I.Z.Q, B }\n}",
+          'var O;\n((O) => {\n  let I;\n  ((I) => {\n    let Z;\n    ((Z) => {\n      Z[Z["Q"] = 7] = "Q";\n    })(Z = I.Z ||= {});\n  })(I = O.I ||= {});\n  let D;\n  ((D) => {\n    D[D["A"] = 7] = "A";\n    D[D["B"] = 8] = "B";\n  })(D = O.D ||= {});\n})(O ||= {})',
+        );
+      });
+
+      it("names resolve from the scope of the nested enum", () => {
+        // The inner `G` shadows the outer one inside `M`.
+        exp(
+          "enum G { X = 1 }\nnamespace M { enum G { X = 50 } export enum Z { A = G.X, B } }\nenum D { V = M.Z.B }",
+          'var G;\n((G) => {\n  G[G["X"] = 1] = "X";\n})(G ||= {});\nvar M;\n((M) => {\n  let G;\n  ((G) => {\n    G[G["X"] = 50] = "X";\n  })(G ||= {});\n  let Z;\n  ((Z) => {\n    Z[Z["A"] = 50] = "A";\n    Z[Z["B"] = 51] = "B";\n  })(Z = M.Z ||= {});\n})(M ||= {});\nvar D;\n((D) => {\n  D[D["V"] = 51] = "V";\n})(D ||= {})',
+        );
+      });
+
+      it("members that are not constant are left alone", () => {
+        exp(
+          "namespace M { export enum Z { Q = f(), R = 2, S } }\nenum D { A = M.Z.R, B = M.Z.S, C = M.Z.Q }",
+          'var M;\n((M) => {\n  let Z;\n  ((Z) => {\n    Z[Z["Q"] = f()] = "Q";\n    Z[Z["R"] = 2] = "R";\n    Z[Z["S"] = 3] = "S";\n  })(Z = M.Z ||= {});\n})(M ||= {});\nvar D;\n((D) => {\n  D[D["A"] = 2] = "A";\n  D[D["B"] = 3] = "B";\n  D[D["C"] = M.Z.Q] = "C";\n})(D ||= {})',
+        );
+      });
+
+      it("a namespace after the enum is not consulted", () => {
+        // tsc reports an error for a reference to an enum member declared later.
+        exp(
+          "enum D { A = M.Z.Q, B }\nnamespace M { export enum Z { Q = 3 } }",
+          'var D;\n((D) => {\n  D[D["A"] = M.Z.Q] = "A";\n  D[D["B"] = undefined] = "B";\n})(D ||= {});\nvar M;\n((M) => {\n  let Z;\n  ((Z) => {\n    Z[Z["Q"] = 3] = "Q";\n  })(Z = M.Z ||= {});\n})(M ||= {})',
+        );
+      });
+
+      it("a const declared before the namespace", () => {
+        exp(
+          "const k = 2;\nnamespace M { export enum Z { Q = k * 10, R } }\nenum D { A = M.Z.R, B }",
+          'const k = 2;\nvar M;\n((M) => {\n  let Z;\n  ((Z) => {\n    Z[Z["Q"] = 20] = "Q";\n    Z[Z["R"] = 21] = "R";\n  })(Z = M.Z ||= {});\n})(M ||= {});\nvar D;\n((D) => {\n  D[D["A"] = 21] = "A";\n  D[D["B"] = 22] = "B";\n})(D ||= {})',
+        );
+      });
+
+      it("a second block of the same enum sees the members of the first", () => {
+        exp(
+          "namespace M { export enum Z { A = 1 } export enum Z { B = A + 1, C } }\nenum D { X = M.Z.C, Y }",
+          'var M;\n((M) => {\n  let Z;\n  ((Z) => {\n    Z[Z["A"] = 1] = "A";\n  })(Z = M.Z ||= {});\n  ((Z) => {\n    Z[Z["B"] = 2] = "B";\n    Z[Z["C"] = 3] = "C";\n  })(Z = M.Z ||= {});\n})(M ||= {});\nvar D;\n((D) => {\n  D[D["X"] = 3] = "X";\n  D[D["Y"] = 4] = "Y";\n})(D ||= {})',
+        );
+      });
+
+      it("statements before the namespace see the values too, as with top-level enums", () => {
+        exp(
+          "export function f() {\n  return M.Z.Q;\n}\nnamespace M { export enum Z { Q = 1 } }",
+          'export function f() {\n  return 1 /* Q */;\n}\nvar M;\n((M) => {\n  let Z;\n  ((Z) => {\n    Z[Z["Q"] = 1] = "Q";\n  })(Z = M.Z ||= {});\n})(M ||= {})',
+        );
+      });
+
+      it("a folded string member is stored flat", () => {
+        // Each inlined use copies the member's node; a rope would be shared and appended to.
+        ts.expectPrintedMin_(
+          'namespace M { export enum Z { S = "a" + "b" } }\nenum D { B = M.Z.S }\nconsole.log(`${D.B}x`, `${D.B}y`, `${M.Z.S}z`);',
+          'var M;\n((M) => {\n  let Z;\n  ((Z) => Z.S = "ab")(Z = M.Z ||= {});\n})(M ||= {});\nvar D;\n((D) => D.B = "ab")(D ||= {});\nconsole.log("abx", "aby", "abz")',
+        );
+      });
+
+      it("const enum members are inlined with the computed value", () => {
+        const out = ts.parsedMin(
+          "namespace M { export const enum Z { Q = 3 } }\nconst enum D { A = M.Z.Q, B }\nconsole.log(D.B);",
+        );
+        expect(out.split("\n").at(-1)).toBe("console.log(4 /* B */)");
+      });
+    });
   });
 
   describe("exports.replace", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2289,6 +2289,13 @@ export default class {
         );
       });
 
+      it("a member that references a later member stays a property access, as at top level", () => {
+        exp(
+          "namespace M { export enum Z { A = B, B = 5, C } }\nenum D { X = M.Z.C, Y = M.Z.A }",
+          'var M;\n((M) => {\n  let Z;\n  ((Z) => {\n    Z[Z["A"] = Z.B] = "A";\n    Z[Z["B"] = 5] = "B";\n    Z[Z["C"] = 6] = "C";\n  })(Z = M.Z ||= {});\n})(M ||= {});\nvar D;\n((D) => {\n  D[D["X"] = 6] = "X";\n  D[D["Y"] = M.Z.A] = "Y";\n})(D ||= {})',
+        );
+      });
+
       it("a const declared before the namespace", () => {
         exp(
           "const k = 2;\nnamespace M { export enum Z { Q = k * 10, R } }\nenum D { A = M.Z.R, B }",


### PR DESCRIPTION
Stacked on #42004: the base branch is that PR's branch, and this reuses its `eval_ts_constant_expression`.

### Problem
- `namespace M { export enum Z { Q = 3 } } enum D { A = M.Z.Q, B }` emits `D[D["B"] = undefined] = "B"`. tsc emits `A = 3, B = 4`. esbuild 0.28.2 has the same gap.
- Cause: the enum pre-visit in `visit_stmts` (`src/js_parser/visit/mod.rs`, twin in `parse_entry.rs`) visits the enums of a statement list first, but not enums nested in a namespace of that list. `D` is visited before `M`, while `M.Z.Q` is still `EnumProperty`.

### Fix
- When either pre-visit loop passes a namespace, `compute_enum_values_inside_namespace` evaluates the constant members of the enums inside it with `eval_ts_constant_expression` and stores them in the member maps, where the visit looks them up. Names resolve from the enum's own scope.
- The evaluator reaches a member of another block of the same enum through the block's closure argument (`ts_member_data_of_symbol`), as `handle_identifier` does.
- No statement is visited out of order. The later visit of the nested enums stores the same values again.
- Verified: `test/bundler/transpiler/transpiler.test.js` (13 new cases) and `test/bundler/esbuild/ts.test.ts` (1 new case), both fail on the base branch. Self-reviewed: restructured onto #42004 as asked, 4 more concerns addressed (Notes).

### Background
- A member without an initializer continues from the previous member only when that value is a known number (`next_numeric_value` in `s_enum`).
- Each enum and namespace has a `TSNamespaceMemberMap`. A member is `EnumProperty` after parsing and becomes `EnumNumber` or `EnumString` when `s_enum` folds its initializer. `M.Z.Q` is inlined by walking these maps.
- `eval_ts_constant_expression` (#42004) evaluates an unvisited expression by tsc's rules and binds names with `find_symbol` from `current_scope`. The walk sets `current_scope` to the enum's scope first.

<details><summary>Notes</summary>

- Review concerns addressed: one evaluator instead of a second one (stacked on #42004); the `const` to nested enum to later enum case works and has a test; string members computed ahead of the visit are flat (the evaluator never builds ropes) and a test reads one through two template literals; the values do not depend on whether an unrelated enum follows the namespace, because every namespace the loop passes is walked, not only those before an enum.
- A consequence of the last point: statements before the namespace in the same list see the values too. `function f() { return M.Z.Q } namespace M { export enum Z { Q = 1 } }` now returns `1 /* Q */`. Top-level enums already behave this way (`ts/EnumUseBeforeDeclare`). A test pins it.
- A reference to a namespace that comes after the enum is left alone (tsc reports TS2651 there). A test pins that.
- `const`s declared inside the namespace body are not known to this early walk (they are recorded when the namespace body is visited, with its scope current). The nested enum's own output still folds them. Only an enum outside the namespace that reads such a member keeps the property access.
- Not in this change: a bare reference to an exported enum of a sibling block of the same namespace (`namespace M { export enum Z { Q = 3 } } namespace M { export enum Y { P = Z.Q, R } }`). bun does not register the namespace closure argument in `ref_to_ts_namespace_member` (esbuild does), and the `Namespace` arm of the alias path in `handle_identifier` does not record the usage of the argument as esbuild does, so enabling it is its own change.
- `RuntimeTranspilerCache` version goes to 31 on top of #42004's 30. main took 30 in #41973 since, so both numbers move up by one when #42004 rebases.
- Cost: one statement-kind scan of each namespace body per enclosing list, plus one evaluation of each nested enum initializer, only in files that contain an enum. A 200 KB file of 300 namespaces with 30-member enums takes the same time within noise on the debug build.
- Also ran: the rest of `transpiler.test.js` and `esbuild/ts.test.ts`, `bundler_edgecase`, `bundler_decorator_metadata`, `decorator-metadata`, `ts-enum-redecl-panic`, `regression/issue/10887`. `cargo clippy -p bun_js_parser` is clean.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 3 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 failed, 39 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/esbuild/ts.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (4ff919377)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.80ms]
(pass) Bun.Transpiler > normalizes \r\n [8.14ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.63ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [8.91ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.86ms]
(pass) Bun.Transpiler > property access inlining > works [3.42ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.93ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [58.71ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [24.39ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [307.05ms]
(pass) Bun.Transpiler > property access i
... (truncated)

release without fix: 23 failed, 39 skipped
bun test v1.4.3-canary.1 (4ff919377)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.11ms]
(pass) Bun.Transpiler > normalizes \r\n [0.16ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.08ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.11ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.04ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [0.77ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.29ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [8.33ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.42ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.06ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 39 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/esbuild/ts.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (4ff919377)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.49ms]
(pass) Bun.Transpiler > normalizes \r\n [6.18ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.38ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [9.28ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.93ms]
(pass) Bun.Transpiler > property access inlining > works [4.40ms]
(pass) Bun.Transpiler > property access inlining > works nested [5.51ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [69.06ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [28.73ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [393.08ms]
(pass) Bun.Transpiler > property access i
... (truncated)

release with fix: 39 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 701ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_js
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/parse_entry.rs         |   4 ++
 src/js_parser/visit/mod.rs                 |   4 ++
 src/js_parser/visit/visit_stmt.rs          |  91 +++++++++++++++++++++++++-
 src/jsc/RuntimeTranspilerCache.rs          |   3 +-
 test/bundler/esbuild/ts.test.ts            |  44 +++++++++++++
 test/bundler/transpiler/transpiler.test.js | 101 +++++++++++++++++++++++++++++
 6 files changed, 244 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/parse/parse_entry.rs              2      2     26
src/js_parser/visit/mod.rs                      2      2     26
src/js_parser/visit/visit_stmt.rs               8     13     26
src/jsc/RuntimeTranspilerCache.rs               2      2     26
test/bundler/esbuild/ts.test.ts                 1      2     11
test/bundler/transpiler/transpiler.test.js      3      3     21
```

</details>

<!-- robobun:evidence:end -->