### PR TITLE
Remove dead code from bun_collections, bun_io, and bun_react_compiler

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -130,7 +130,6 @@
 "unused_pub:src/bun_core/string/immutable.rs" = 6
 "unused_pub:src/bun_core/string/mod.rs" = 2
 "unused_pub:src/bun_core/util.rs" = 10
-"unused_pub:src/collections/StaticHashMap.rs" = 4
 "unused_pub:src/collections/vec_ext.rs" = 2
 "unused_pub:src/dotenv/env_loader.rs" = 1
 "unused_pub:src/errno/lib.rs" = 1
@@ -138,7 +137,7 @@
 "unused_pub:src/event_loop/SpawnSyncEventLoop.rs" = 1
 "unused_pub:src/glob/GlobWalker.rs" = 1
 "unused_pub:src/io/ParentDeathWatchdog.rs" = 1
-"unused_pub:src/io/PipeWriter.rs" = 2
+"unused_pub:src/io/PipeWriter.rs" = 1
 "unused_pub:src/jsc/bindgen.rs" = 6
 "unused_pub:src/jsc/host_fn.rs" = 1
 "unused_pub:src/jsc/lib.rs" = 1
@@ -154,7 +153,6 @@
 "unused_pub:src/paths/string_paths.rs" = 7
 "unused_pub:src/ptr/CowSlice.rs" = 1
 "unused_pub:src/ptr/ref_count.rs" = 2
-"unused_pub:src/react_compiler/hir/environment.rs" = 2
 "unused_pub:src/runtime/api/bun/h2/connection.rs" = 5
 "unused_pub:src/runtime/api/bun/h2/wire.rs" = 1
 "unused_pub:src/runtime/ipc.rs" = 3

--- a/src/collections/StaticHashMap.rs
+++ b/src/collections/StaticHashMap.rs
@@ -159,31 +159,6 @@ pub trait HashMapMixin<K: 'static, V: 'static, Ctx> {
     fn len_mut(&mut self) -> &mut usize;
     fn shift(&self) -> u8;
 
-    /// Full backing slice (capacity + overflow).
-    fn slice(&mut self) -> &mut [Entry<K, V>] {
-        // The storage carries its exact length; the assert checks it stays
-        // consistent with the `shift`-derived `capacity + overflow` size.
-        let capacity = 1u64 << (63 - self.shift() + 1);
-        let overflow = compute_overflow(capacity, self.shift());
-        debug_assert_eq!(
-            self.storage_mut().len(),
-            usize::try_from(capacity + overflow).expect("int cast")
-        );
-        self.storage_mut()
-    }
-
-    fn put_assume_capacity(&mut self, key: K, value: V)
-    where
-        K: Copy,
-        V: Copy + Default,
-        Ctx: HashContext<K>,
-    {
-        let result = self.get_or_put_assume_capacity(key);
-        if !result.found_existing {
-            *result.value_ptr = value;
-        }
-    }
-
     fn get_or_put_assume_capacity(&mut self, key: K) -> GetOrPutResult<'_, V>
     where
         K: Copy,
@@ -232,26 +207,6 @@ pub trait HashMapMixin<K: 'static, V: 'static, Ctx> {
         }
     }
 
-    fn get(&self, key: K) -> Option<V>
-    where
-        K: Copy,
-        V: Copy,
-        Ctx: HashContext<K>,
-    {
-        let hash = Ctx::ctx_hash(&key);
-        debug_assert!(hash != EMPTY_HASH);
-
-        for entry in &self.storage()[to_idx(hash >> self.shift())..] {
-            if entry.hash >= hash {
-                if !Ctx::ctx_eql(&entry.key, &key) {
-                    return None;
-                }
-                return Some(entry.value);
-            }
-        }
-        unreachable!()
-    }
-
     fn has_with_hash(&self, key_hash: u64) -> bool {
         debug_assert!(key_hash != EMPTY_HASH);
 
@@ -262,45 +217,6 @@ pub trait HashMapMixin<K: 'static, V: 'static, Ctx> {
         }
 
         false
-    }
-
-    fn delete(&mut self, key: K) -> Option<V>
-    where
-        K: Copy + Default,
-        V: Copy + Default,
-        Ctx: HashContext<K>,
-    {
-        let hash = Ctx::ctx_hash(&key);
-        debug_assert!(hash != EMPTY_HASH);
-
-        let shift = self.shift();
-        let mut i = to_idx(hash >> shift);
-        loop {
-            let entry = self.storage()[i];
-            if entry.hash >= hash {
-                if !Ctx::ctx_eql(&entry.key, &key) {
-                    return None;
-                }
-                break;
-            }
-            i += 1;
-        }
-
-        let value = self.storage()[i].value;
-
-        loop {
-            let next = self.storage()[i + 1];
-            let j = to_idx(next.hash >> shift);
-            if i < j || next.is_empty() {
-                break;
-            }
-            self.storage_mut()[i] = next;
-            i += 1;
-        }
-        self.storage_mut()[i] = Entry::empty();
-        *self.len_mut() -= 1;
-
-        Some(value)
     }
 }
 
@@ -315,9 +231,8 @@ mod tests {
     /// xoshiro256++ with the state seeded by splitmix64. `AutoHashContext`
     /// routes through `bun_wyhash::auto_hash` (mum-mix). The 100%-load probe
     /// bound of the static test was validated for this hash by exact
-    /// simulation of all 128 seeds: max slot index touched (incl. delete's
-    /// `i + 1` backshift read) is 548 of 632, with no 64-bit hash collisions
-    /// among any seed's 512 keys.
+    /// simulation of all 128 seeds: max slot index touched is 548 of 632,
+    /// with no 64-bit hash collisions among any seed's 512 keys.
     struct Xoshiro256PlusPlus {
         s: [u64; 4],
     }
@@ -354,16 +269,16 @@ mod tests {
     }
 
     #[test]
-    fn static_hash_map_put_get_delete_grow() {
+    fn static_hash_map_put_get_grow() {
         const CAP: usize = 512;
         const SLOTS: usize = static_slots(CAP);
-        // Boxed: ~15 KB of entries is fine on the heap, gratuitous on the stack.
-        let mut map: Box<StaticHashMap<usize, usize, AutoContext, CAP, SLOTS>> =
-            Box::new(Default::default());
 
-        // Miri is ~100× slower; 2 seeds still cover the put/get/delete cycle.
+        // Miri is ~100× slower; 2 seeds still cover the put/get cycle.
         const SEEDS: u64 = if cfg!(miri) { 2 } else { 128 };
         for seed in 0..SEEDS {
+            // Boxed: ~15 KB of entries is fine on the heap, gratuitous on the stack.
+            let mut map: Box<StaticHashMap<usize, usize, AutoContext, CAP, SLOTS>> =
+                Box::new(Default::default());
             let mut rng = Xoshiro256PlusPlus::init(seed);
 
             let keys: Vec<usize> = (0..512).map(|_| rng.next() as usize).collect();
@@ -371,12 +286,12 @@ mod tests {
             assert_eq!(map.shift, 55);
 
             for (i, &key) in keys.iter().enumerate() {
-                map.put_assume_capacity(key, i);
+                *map.get_or_put_assume_capacity(key).value_ptr = i;
             }
             assert_eq!(map.len, keys.len());
 
             let mut it: u64 = 0;
-            for entry in map.slice().iter() {
+            for entry in map.entries.iter() {
                 if !entry.is_empty() {
                     assert!(it <= entry.hash, "Unsorted");
                     it = entry.hash;
@@ -384,11 +299,12 @@ mod tests {
             }
 
             for (i, &key) in keys.iter().enumerate() {
-                assert_eq!(map.get(key).unwrap(), i);
+                let existing = map.get_or_put_assume_capacity(key);
+                assert!(existing.found_existing);
+                assert_eq!(*existing.value_ptr, i);
+                assert!(map.has_with_hash(<AutoContext as HashContext<usize>>::ctx_hash(&key)));
             }
-            for (i, &key) in keys.iter().enumerate() {
-                assert_eq!(map.delete(key).unwrap(), i);
-            }
+            assert_eq!(map.len, keys.len());
         }
     }
 }

--- a/src/collections/StaticHashMap.rs
+++ b/src/collections/StaticHashMap.rs
@@ -231,8 +231,7 @@ mod tests {
     /// xoshiro256++ with the state seeded by splitmix64. `AutoHashContext`
     /// routes through `bun_wyhash::auto_hash` (mum-mix). The 100%-load probe
     /// bound of the static test was validated for this hash by exact
-    /// simulation of all 128 seeds: max slot index touched is 548 of 632,
-    /// with no 64-bit hash collisions among any seed's 512 keys.
+    /// simulation of all 128 seeds: max slot 548 of 632, no 64-bit hash collisions.
     struct Xoshiro256PlusPlus {
         s: [u64; 4],
     }

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -589,9 +589,6 @@ pub trait PosixStreamingWriterParent {
     unsafe fn on_error(this: *mut Self, err: sys::Error);
     /// # Safety
     /// `this` must point to a live `Self`.
-    unsafe fn on_ready(_this: *mut Self) {}
-    /// # Safety
-    /// `this` must point to a live `Self`.
     unsafe fn on_close(this: *mut Self);
     /// # Safety
     /// `this` must point to a live `Self`.
@@ -2646,11 +2643,6 @@ macro_rules! impl_streaming_writer_parent {
                 unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_error(err)) }
             }
             #[inline]
-            unsafe fn on_ready(this: *mut Self) {
-                // SAFETY: see on_write.
-                unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_ready()) }
-            }
-            #[inline]
             unsafe fn on_close(this: *mut Self) {
                 // SAFETY: see on_write.
                 unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_close()) }
@@ -2698,7 +2690,6 @@ macro_rules! impl_streaming_writer_parent {
 
         #[cfg(windows)]
         impl $($gen)* $crate::pipe_writer::WindowsStreamingWriterParent for $Ty {
-            // Same body as POSIX `on_ready`.
             const HAS_ON_WRITABLE: bool = true;
             #[inline]
             unsafe fn on_write(this: *mut Self, amount: usize, status: $crate::WriteStatus) {

--- a/src/react_compiler/hir/environment.rs
+++ b/src/react_compiler/hir/environment.rs
@@ -123,10 +123,6 @@ pub struct OutlinedFunctionEntry {
 }
 
 impl Environment {
-    pub fn new() -> Self {
-        Self::with_config(EnvironmentConfig::default())
-    }
-
     /// Create a new Environment with the given configuration.
     ///
     /// Initializes the shape and global registries, registers custom hooks,
@@ -557,45 +553,6 @@ impl Environment {
         None
     }
 
-    /// Get the type of a named property on a receiver type.
-    /// Ported from TS `getPropertyType`.
-    pub fn get_property_type(
-        &mut self,
-        receiver: &Type,
-        property: &[u8],
-    ) -> Result<Option<Type>, CompilerDiagnostic> {
-        let shape_id = match receiver {
-            Type::Object { shape_id } | Type::Function { shape_id, .. } => shape_id.as_deref(),
-            _ => None,
-        };
-        if let Some(shape_id) = shape_id {
-            let shape = self
-                .shapes
-                .get(shape_id)
-                .ok_or_else(|| shape_not_found(shape_id))?;
-            if let Some(ty) = core::str::from_utf8(property)
-                .ok()
-                .and_then(|k| shape.properties.get(k))
-            {
-                return Ok(Some(ty.clone()));
-            }
-            // Fall through to wildcard
-            if let Some(ty) = shape.properties.get("*") {
-                return Ok(Some(ty.clone()));
-            }
-            // If property name looks like a hook, return custom hook type
-            if is_hook_name(property) {
-                return Ok(Some(self.get_custom_hook_type()));
-            }
-            return Ok(None);
-        }
-        // No shape ID — if property looks like a hook, return custom hook type
-        if is_hook_name(property) {
-            return Ok(Some(self.get_custom_hook_type()));
-        }
-        Ok(None)
-    }
-
     /// Get the function signature for a function type.
     /// Ported from TS `getFunctionSignature`.
     pub fn get_function_signature(
@@ -911,7 +868,7 @@ mod tests {
 
     #[test]
     fn test_environment_has_globals() {
-        let env = Environment::new();
+        let env = Environment::with_config(EnvironmentConfig::default());
         assert!(env.globals().contains_key("useState"));
         assert!(env.globals().contains_key("useEffect"));
         assert!(env.globals().contains_key("useRef"));
@@ -923,23 +880,26 @@ mod tests {
 
     #[test]
     fn test_get_property_type_array() {
-        let mut env = Environment::new();
+        let env = Environment::with_config(EnvironmentConfig::default());
         let array_type = Type::Object {
             shape_id: Some("BuiltInArray"),
         };
-        let map_type = env.get_property_type(&array_type, b"map").unwrap();
+        let map_type = Environment::get_property_type_from_shapes(&env.shapes, &array_type, b"map");
         assert!(map_type.is_some());
-        let push_type = env.get_property_type(&array_type, b"push").unwrap();
+        let push_type =
+            Environment::get_property_type_from_shapes(&env.shapes, &array_type, b"push");
         assert!(push_type.is_some());
-        let nonexistent = env
-            .get_property_type(&array_type, b"nonExistentMethod")
-            .unwrap();
+        let nonexistent = Environment::get_property_type_from_shapes(
+            &env.shapes,
+            &array_type,
+            b"nonExistentMethod",
+        );
         assert!(nonexistent.is_none());
     }
 
     #[test]
     fn test_get_function_signature() {
-        let env = Environment::new();
+        let env = Environment::with_config(EnvironmentConfig::default());
         let use_state_type = env.globals().get("useState").unwrap();
         let sig = env.get_function_signature(use_state_type).unwrap();
         assert!(sig.is_some());
@@ -950,7 +910,7 @@ mod tests {
 
     #[test]
     fn test_get_global_declaration() {
-        let mut env = Environment::new();
+        let mut env = Environment::with_config(EnvironmentConfig::default());
         // Global binding
         let binding = NonLocalBinding {
             ref_: bun_ast::Ref::NONE,

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -1768,7 +1768,7 @@ impl Terminal {
     fn on_write(&self, amount: usize, status: WriteStatus) {
         bun_output::scoped_log!(Terminal, "onWrite: {} bytes", amount);
         let _ = amount;
-        // POSIX: `PosixStreamingWriter` never dispatches `on_ready`; detect the
+        // POSIX: `PosixStreamingWriter` has no writable callback; detect the
         // buffered→drained transition here instead. Windows fires the drain
         // callback from `on_writable`, so only record the drained state (a
         // stale flag would block `maybe_downgrade_after_eof` forever).
@@ -2008,9 +2008,6 @@ impl bun_io::pipe_writer::PosixStreamingWriterParent for Terminal {
     }
     unsafe fn on_error(this: *mut Self, err: sys::Error) {
         Self::from_parent_ptr(this).on_writer_error(&err);
-    }
-    unsafe fn on_ready(this: *mut Self) {
-        Self::from_parent_ptr(this).on_writer_ready();
     }
     unsafe fn on_close(this: *mut Self) {
         Self::from_parent_ptr(this).on_writer_close();

--- a/src/runtime/image/backend_coregraphics.rs
+++ b/src/runtime/image/backend_coregraphics.rs
@@ -47,7 +47,6 @@ impl BackendError {
     /// `codecs.rs` (`Ok(None)` = BackendUnavailable → fall through to the
     /// pure-Rust codec path).
     #[inline]
-    #[allow(dead_code)]
     pub(crate) fn split<T>(r: Result<T, Self>) -> Result<Option<T>, codecs::Error> {
         match r {
             Ok(v) => Ok(Some(v)),
@@ -72,7 +71,6 @@ unsafe extern "C" {
         out: *mut u8, // nullable
     ) -> i32;
 
-    #[allow(dead_code)]
     fn bun_coregraphics_encode(
         rgba: *const u8,
         width: u32,
@@ -168,7 +166,6 @@ pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, B
     })
 }
 
-#[allow(dead_code)]
 pub(crate) fn encode(
     rgba: &[u8],
     width: u32,
@@ -225,7 +222,6 @@ pub(crate) fn encode(
 // .or_else(|_| fallback.x())`.
 
 unsafe extern "C" {
-    #[allow(dead_code)]
     fn bun_coregraphics_scale(
         src: *const u8,
         sw: u32,
@@ -234,7 +230,6 @@ unsafe extern "C" {
         dw: u32,
         dh: u32,
     ) -> i32;
-    #[allow(dead_code)]
     fn bun_coregraphics_rotate90(
         src: *const u8,
         w: u32,
@@ -242,7 +237,6 @@ unsafe extern "C" {
         dst: *mut u8,
         quarters: u32,
     ) -> i32;
-    #[allow(dead_code)]
     fn bun_coregraphics_reflect(
         src: *const u8,
         w: u32,
@@ -255,7 +249,6 @@ unsafe extern "C" {
 /// vImageScale's default kernel is Lanczos-3 (the HQ flag widens to L5), so
 /// we only take this path for the `.lanczos3` default — explicit non-Lanczos
 /// filters fall through to the Highway kernel which honours them exactly.
-#[allow(dead_code)]
 pub(crate) fn scale(
     src: &[u8],
     sw: u32,
@@ -276,7 +269,6 @@ pub(crate) fn scale(
     Ok(out)
 }
 
-#[allow(dead_code)]
 pub(crate) fn rotate(src: &[u8], w: u32, h: u32, quarters: u32) -> Result<Vec<u8>, BackendError> {
     // PERF: zero-fill alloc — profile if hot.
     let mut out = vec![0u8; (w as usize) * (h as usize) * 4];
@@ -288,7 +280,6 @@ pub(crate) fn rotate(src: &[u8], w: u32, h: u32, quarters: u32) -> Result<Vec<u8
     Ok(out)
 }
 
-#[allow(dead_code)]
 pub(crate) fn flip(src: &[u8], w: u32, h: u32, horizontal: bool) -> Result<Vec<u8>, BackendError> {
     // PERF: zero-fill alloc — profile if hot.
     let mut out = vec![0u8; (w as usize) * (h as usize) * 4];
@@ -307,13 +298,11 @@ pub(crate) fn flip(src: &[u8], w: u32, h: u32, horizontal: bool) -> Result<Vec<u
 // before constructing the Image — the heavy decode still goes to WorkPool).
 
 unsafe extern "C" {
-    #[allow(dead_code)]
     fn bun_coregraphics_clipboard(out: *mut u8, out_len: *mut usize, probe_only: i32) -> i32;
 }
 
 /// `None` ⇔ no image on the pasteboard. Returned bytes are an opaque container
 /// (PNG/TIFF/HEIC/…); feed straight to `new Bun.Image(…)`.
-#[allow(dead_code)]
 pub(crate) fn clipboard() -> Result<Option<Vec<u8>>, BackendError> {
     let mut len: usize = 0;
     // SAFETY: out=null + probe_only=0 → shim fills len with required byte count.
@@ -333,7 +322,6 @@ pub(crate) fn clipboard() -> Result<Option<Vec<u8>>, BackendError> {
     Ok(Some(out))
 }
 
-#[allow(dead_code)]
 pub(crate) fn has_clipboard_image() -> bool {
     let mut len: usize = 0;
     // SAFETY: out=null + probe_only=1 → shim only checks for image presence.
@@ -343,10 +331,8 @@ pub(crate) fn has_clipboard_image() -> bool {
 }
 
 unsafe extern "C" {
-    #[allow(dead_code)]
     fn bun_coregraphics_clipboard_change_count() -> i64;
 }
-#[allow(dead_code)]
 pub(crate) fn clipboard_change_count() -> i64 {
     // SAFETY: pure getter, no preconditions.
     unsafe { bun_coregraphics_clipboard_change_count() }

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -482,11 +482,13 @@ impl FileSink {
         }
     }
 
-    /// Serves both POSIX `on_ready` and the Windows `on_writable` slot.
+    /// Serves the Windows `on_writable` slot. POSIX resumes a pending pull
+    /// from `on_write` instead.
     ///
     /// # Safety
     /// `this` must be the canonical live `*mut FileSink` (see
     /// [`on_attached_process_exit`](Self::on_attached_process_exit)).
+    #[cfg(windows)]
     pub unsafe fn on_ready(this: *mut FileSink) {
         bun_core::scoped_log!(FileSink, "onReady()");
         // SAFETY: caller contract — `this` is live; only `source` is reborrowed.

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -482,8 +482,7 @@ impl FileSink {
         }
     }
 
-    /// Serves the Windows `on_writable` slot. POSIX resumes a pending pull
-    /// from `on_write` instead.
+    /// Windows `on_writable` slot. POSIX resumes a pending pull in `on_write`.
     ///
     /// # Safety
     /// `this` must be the canonical live `*mut FileSink` (see

--- a/test/internal/source-lints/dead-code-escape-limits.json
+++ b/test/internal/source-lints/dead-code-escape-limits.json
@@ -17,7 +17,6 @@
   "src/patch/lib.rs": 2,
   "src/runtime/api/bun/Terminal.rs": 1,
   "src/runtime/cli/test/ChangedFilesFilter.rs": 1,
-  "src/runtime/image/backend_coregraphics.rs": 14,
   "src/runtime/image/codecs.rs": 1,
   "src/runtime/node/node_fs.rs": 2,
   "src/runtime/shell/subproc.rs": 1,


### PR DESCRIPTION
### Problem
- A few `pub` Rust items have no caller on any platform outside of unit tests. `dead_code` does not see them because they are `pub`, and the Linux-only `unused_pub` lint cannot tell them apart from items that Windows or macOS code uses.
- `PosixStreamingWriterParent::on_ready` (`src/io/PipeWriter.rs`) is a trait slot that `PosixStreamingWriter` never dispatches. Both parents (FileSink, Terminal) already detect the drained transition in `on_write`.

### Fix
- `bun_collections::static_hash_map::HashMapMixin`: remove `slice`, `put_assume_capacity`, `get`, `delete`. The one implementor is `StaticHashMap`; the one external user (`install/lockfile.rs`) calls only `get_or_put_assume_capacity` and `has_with_hash`. The unit test now goes through those.
- `bun_react_compiler::hir::environment::Environment`: remove `new` and `get_property_type`. Production code uses `with_config` and the private `get_property_type_from_shapes`; the unit tests now call those.
- `bun_io`: remove `PosixStreamingWriterParent::on_ready`, the POSIX arm of `impl_streaming_writer_parent!` that forwarded it, and the `Terminal` override. `FileSink::on_ready` now only backs the Windows `on_writable` slot, so it is `#[cfg(windows)]`. `mordant-baseline.toml` drops the entries these removals clear.
- `src/runtime/image/backend_coregraphics.rs`: remove 14 stale `#[allow(dead_code)]` escapes. The module is compiled only under `cfg(target_os = "macos")` and every item is reachable there in dev and release, so the escapes suppress nothing. `test/internal/source-lints/dead-code-escape-limits.json` is regenerated to match.
- Verified: `cargo check -p bun_runtime` on linux-x64, `bun scripts/rust-check-all.ts x86_64-pc-windows-msvc aarch64-apple-darwin` (plus `x86_64-apple-darwin` and `--release` for the CoreGraphics file), `dead-code-escapes.test.ts` (fails on the base tree, passes here), `cargo test -p bun_collections static_hash_map`, `bun bd`, then `terminal.test.ts`, `spawn-stdin-readable-stream-integration.test.ts`, `bun-write.test.js`, and the trusted-dependency tests in `bun-install-lifecycle-scripts.test.ts`.

### Background
- `StaticHashMap` is a fixed-capacity Robin Hood table (port of rheia's `hash_map.zig`). Bun uses one instance: the default trusted-dependencies set in the lockfile.
- `impl_streaming_writer_parent!` stamps the POSIX and Windows parent vtables for a streaming pipe writer from one list of handler names. Only the Windows writer has a writable callback (`on_writable`); the `on_ready = ...` argument still feeds that.

<details><summary>Notes</summary>

How the candidates were found: the `unused_pub` findings recorded in `mordant-baseline.toml` (416 items) were each checked for references under every `cfg` (windows, macos, freebsd, test, `bun_codegen_embed`). Almost all of them are live on another platform, which is why they stay in the baseline. The items above are the ones with no caller anywhere. Every removal was also checked against the diffs of the open dead-code PRs so nothing here duplicates them.

Other scans that came back empty or already covered by open PRs: Rust files outside every module tree, `macro_rules!` with no invocation, trait methods with no call site, enum variants and struct fields never named, Cargo dependencies never imported, internal JS modules never required, unused exports of `src/js/internal/*`, builtins in `src/js/builtins/*` with no C++ or JS reference, C++ `extern "C"` definitions with no Rust or WebKit caller, and a `-Wunused-function -Wunused-member-function -Wunused-template` pass over every non-vendor C++ translation unit (the build passes `-Wno-unused-function`, so these are normally silent). The last two found about 70 symbols, all of which #40232, #40294, #40367, #40492 or #40915 already remove.

Probably dead, left alone on purpose:
- `Connection::{begin_header_block, encode_header, send_header_block, send_data, send_push_promise}` in `src/runtime/api/bun/h2/connection.rs` are test-only today, but the module is marked as an in-progress rewrite with `#![allow(dead_code)]`.
- `JsClass::estimated_size` default body: no generated thunk can reach it (the trait is not in scope in `generated_classes.rs`), but its doc describes it as the intended fallback.
- `bun_jsc::host_fn::host_fn_this_value`: no generated caller today, but `generate-classes.ts` still emits it for a `passThis` class without `sharedThis`.
- `bun_sys::O::{NOATIME, DSYNC, SYMLINK, NOFOLLOW_ANY}`, `bun_sys::posix::{R_OK, POLL_OUT}`: unused on every platform, kept for flag-table completeness.

</details>
