### PR TITLE
Intl.DurationFormat: show the fraction of a numeric sub-second unit when its carrier is zero (WebKit bump for oven-sh/WebKit#599)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-599-79e4c286";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -290,6 +290,140 @@ describe("Intl.RelativeTimeFormat", () => {
 });
 
 // ---------------------------------------------------------------------------
+// DurationFormat — a "numeric" sub-second unit is the decimal fraction of the
+// unit before it. The expectations are built from NumberFormat and ListFormat
+// the way ECMA-402 PartitionDurationFormatPattern builds them, so they hold on
+// any ICU; the digital and numeric cases have no unit text and use literals.
+// ---------------------------------------------------------------------------
+
+describe("Intl.DurationFormat", () => {
+  const unit = (value: number, unit: string, unitDisplay: "long" | "short" | "narrow" = "short") =>
+    new Intl.NumberFormat("en", {
+      style: "unit",
+      unit,
+      unitDisplay,
+      maximumFractionDigits: 9,
+      roundingMode: "trunc",
+    }).format(value);
+  const list = (parts: string[], style: "long" | "short" | "narrow" = "short") =>
+    new Intl.ListFormat("en", { type: "unit", style }).format(parts);
+
+  test("fraction of a sub-second unit is shown when the unit that carries it is zero", () => {
+    const df = new Intl.DurationFormat("en", { milliseconds: "numeric" });
+    expect(df.format({ milliseconds: 250 })).toBe(unit(0.25, "second"));
+    expect(df.format({ hours: 3, milliseconds: 250 })).toBe(list([unit(3, "hour"), unit(0.25, "second")]));
+    expect(df.format({ microseconds: 500 })).toBe(unit(0.0005, "second"));
+    expect(df.format({ nanoseconds: 1 })).toBe(unit(0.000000001, "second"));
+    // Unchanged: a non-zero carrier, and a zero duration.
+    expect(df.format({ seconds: 1, milliseconds: 500 })).toBe(unit(1.5, "second"));
+    expect(df.format({ milliseconds: 0 })).toBe("");
+    expect(df.format({ hours: 3 })).toBe(unit(3, "hour"));
+
+    expect(df.formatToParts({ milliseconds: 999 }).map(p => [p.type, p.value])).toEqual(
+      new Intl.NumberFormat("en", { style: "unit", unit: "second", unitDisplay: "short", maximumFractionDigits: 9 })
+        .formatToParts(0.999)
+        .map(p => [p.type, p.value]),
+    );
+
+    for (const style of ["long", "short", "narrow"] as const) {
+      expect(new Intl.DurationFormat("en", { style, milliseconds: "numeric" }).format({ milliseconds: 250 })).toBe(
+        unit(0.25, "second", style),
+      );
+      expect(
+        new Intl.DurationFormat("en", { style, milliseconds: "numeric" }).format({ minutes: 2, microseconds: 300 }),
+      ).toBe(list([unit(2, "minute", style), unit(0.0003, "second", style)], style));
+    }
+    expect(new Intl.DurationFormat("en", { style: "digital", milliseconds: "numeric" }).format({ milliseconds: 250 })).toBe(
+      "0:00:00.25",
+    );
+
+    const micro = new Intl.DurationFormat("en", { microseconds: "numeric" });
+    expect(micro.format({ microseconds: 55 })).toBe(unit(0.055, "millisecond"));
+    expect(micro.format({ seconds: 3, microseconds: 55 })).toBe(list([unit(3, "second"), unit(0.055, "millisecond")]));
+    const nano = new Intl.DurationFormat("en", { nanoseconds: "numeric" });
+    expect(nano.format({ nanoseconds: 7 })).toBe(unit(0.007, "microsecond"));
+    expect(nano.format({ hours: 1, nanoseconds: 7 })).toBe(list([unit(1, "hour"), unit(0.007, "microsecond")]));
+
+    // fractionalDigits truncates what is shown; the display test is on the exact value.
+    const twoDigits = new Intl.DurationFormat("en", { milliseconds: "numeric", fractionalDigits: 2 });
+    expect(twoDigits.format({ milliseconds: 5 })).toBe(
+      new Intl.NumberFormat("en", {
+        style: "unit",
+        unit: "second",
+        unitDisplay: "short",
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+        roundingMode: "trunc",
+      }).format(0.005),
+    );
+    expect(twoDigits.format({ seconds: 0 })).toBe("");
+  });
+
+  test("a carrier with integer part zero keeps the sign of the fraction", () => {
+    expect(new Intl.DurationFormat("en", { milliseconds: "numeric" }).format({ milliseconds: -250 })).toBe(
+      unit(-0.25, "second"),
+    );
+    expect(
+      new Intl.DurationFormat("en", { milliseconds: "numeric" }).format({ hours: -3, milliseconds: -250 }),
+    ).toBe(list([unit(-3, "hour"), unit(0.25, "second")]));
+    expect(new Intl.DurationFormat("en", { microseconds: "numeric" }).format({ microseconds: -55 })).toBe(
+      unit(-0.055, "millisecond"),
+    );
+    expect(new Intl.DurationFormat("en", { seconds: "numeric" }).format({ milliseconds: -250 })).toBe("-0.25");
+    expect(new Intl.DurationFormat("en", { seconds: "numeric" }).format({ milliseconds: 250 })).toBe("0.25");
+    expect(new Intl.DurationFormat("en", { seconds: "2-digit" }).format({ milliseconds: -250 })).toBe("-00.25");
+    expect(new Intl.DurationFormat("en", { style: "digital" }).format({ milliseconds: -250 })).toBe("-0:00:00.25");
+    expect(
+      new Intl.DurationFormat("en", { seconds: "numeric" })
+        .formatToParts({ milliseconds: -250 })
+        .map(p => [p.type, p.value, p.unit]),
+    ).toEqual([
+      ["minusSign", "-", "second"],
+      ["integer", "0", "second"],
+      ["decimal", ".", "second"],
+      ["fraction", "25", "second"],
+    ]);
+  });
+
+  test('"numeric" on a sub-second unit defaults its display to "auto" and rejects "always"', () => {
+    const resolved = new Intl.DurationFormat("en", { milliseconds: "numeric" }).resolvedOptions();
+    expect({
+      milliseconds: resolved.milliseconds,
+      millisecondsDisplay: resolved.millisecondsDisplay,
+      microseconds: resolved.microseconds,
+      microsecondsDisplay: resolved.microsecondsDisplay,
+      nanoseconds: resolved.nanoseconds,
+      nanosecondsDisplay: resolved.nanosecondsDisplay,
+    }).toEqual({
+      milliseconds: "numeric",
+      millisecondsDisplay: "auto",
+      microseconds: "numeric",
+      microsecondsDisplay: "auto",
+      nanoseconds: "numeric",
+      nanosecondsDisplay: "auto",
+    });
+    expect(new Intl.DurationFormat("en", { microseconds: "numeric" }).resolvedOptions().microsecondsDisplay).toBe("auto");
+    expect(new Intl.DurationFormat("en", { nanoseconds: "numeric" }).resolvedOptions().nanosecondsDisplay).toBe("auto");
+    // Numeric seconds are not a fraction of anything and keep "always"; so does a sub-second unit in a text style.
+    expect(new Intl.DurationFormat("en", { seconds: "numeric" }).resolvedOptions().secondsDisplay).toBe("always");
+    expect(new Intl.DurationFormat("en", { milliseconds: "short" }).resolvedOptions().millisecondsDisplay).toBe("always");
+
+    for (const options of [
+      { milliseconds: "numeric", millisecondsDisplay: "always" },
+      { microseconds: "numeric", microsecondsDisplay: "always" },
+      { nanoseconds: "numeric", nanosecondsDisplay: "always" },
+      { milliseconds: "numeric", nanosecondsDisplay: "always" },
+      { seconds: "numeric", millisecondsDisplay: "always" },
+      { style: "digital", millisecondsDisplay: "always" },
+    ] as const) {
+      expect(() => new Intl.DurationFormat("en", options)).toThrow(RangeError);
+    }
+    expect(() => new Intl.DurationFormat("en", { milliseconds: "numeric", millisecondsDisplay: "auto" })).not.toThrow();
+    expect(() => new Intl.DurationFormat("en", { milliseconds: "short", millisecondsDisplay: "always" })).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // String / URL paths through ICU — raw
 // ---------------------------------------------------------------------------
 

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -333,9 +333,9 @@ describe("Intl.DurationFormat", () => {
         new Intl.DurationFormat("en", { style, milliseconds: "numeric" }).format({ minutes: 2, microseconds: 300 }),
       ).toBe(list([unit(2, "minute", style), unit(0.0003, "second", style)], style));
     }
-    expect(new Intl.DurationFormat("en", { style: "digital", milliseconds: "numeric" }).format({ milliseconds: 250 })).toBe(
-      "0:00:00.25",
-    );
+    expect(
+      new Intl.DurationFormat("en", { style: "digital", milliseconds: "numeric" }).format({ milliseconds: 250 }),
+    ).toBe("0:00:00.25");
 
     const micro = new Intl.DurationFormat("en", { microseconds: "numeric" });
     expect(micro.format({ microseconds: 55 })).toBe(unit(0.055, "millisecond"));
@@ -363,9 +363,9 @@ describe("Intl.DurationFormat", () => {
     expect(new Intl.DurationFormat("en", { milliseconds: "numeric" }).format({ milliseconds: -250 })).toBe(
       unit(-0.25, "second"),
     );
-    expect(
-      new Intl.DurationFormat("en", { milliseconds: "numeric" }).format({ hours: -3, milliseconds: -250 }),
-    ).toBe(list([unit(-3, "hour"), unit(0.25, "second")]));
+    expect(new Intl.DurationFormat("en", { milliseconds: "numeric" }).format({ hours: -3, milliseconds: -250 })).toBe(
+      list([unit(-3, "hour"), unit(0.25, "second")]),
+    );
     expect(new Intl.DurationFormat("en", { microseconds: "numeric" }).format({ microseconds: -55 })).toBe(
       unit(-0.055, "millisecond"),
     );
@@ -402,11 +402,15 @@ describe("Intl.DurationFormat", () => {
       nanoseconds: "numeric",
       nanosecondsDisplay: "auto",
     });
-    expect(new Intl.DurationFormat("en", { microseconds: "numeric" }).resolvedOptions().microsecondsDisplay).toBe("auto");
+    expect(new Intl.DurationFormat("en", { microseconds: "numeric" }).resolvedOptions().microsecondsDisplay).toBe(
+      "auto",
+    );
     expect(new Intl.DurationFormat("en", { nanoseconds: "numeric" }).resolvedOptions().nanosecondsDisplay).toBe("auto");
     // Numeric seconds are not a fraction of anything and keep "always"; so does a sub-second unit in a text style.
     expect(new Intl.DurationFormat("en", { seconds: "numeric" }).resolvedOptions().secondsDisplay).toBe("always");
-    expect(new Intl.DurationFormat("en", { milliseconds: "short" }).resolvedOptions().millisecondsDisplay).toBe("always");
+    expect(new Intl.DurationFormat("en", { milliseconds: "short" }).resolvedOptions().millisecondsDisplay).toBe(
+      "always",
+    );
 
     for (const options of [
       { milliseconds: "numeric", millisecondsDisplay: "always" },

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -325,14 +325,6 @@ describe("Intl.DurationFormat", () => {
         .map(p => [p.type, p.value]),
     );
 
-    for (const style of ["long", "short", "narrow"] as const) {
-      expect(new Intl.DurationFormat("en", { style, milliseconds: "numeric" }).format({ milliseconds: 250 })).toBe(
-        unit(0.25, "second", style),
-      );
-      expect(
-        new Intl.DurationFormat("en", { style, milliseconds: "numeric" }).format({ minutes: 2, microseconds: 300 }),
-      ).toBe(list([unit(2, "minute", style), unit(0.0003, "second", style)], style));
-    }
     expect(
       new Intl.DurationFormat("en", { style: "digital", milliseconds: "numeric" }).format({ milliseconds: 250 }),
     ).toBe("0:00:00.25");
@@ -357,6 +349,14 @@ describe("Intl.DurationFormat", () => {
       }).format(0.005),
     );
     expect(twoDigits.format({ seconds: 0 })).toBe("");
+  });
+
+  test.each(["long", "short", "narrow"] as const)("zero carrier with base style %s", style => {
+    const df = new Intl.DurationFormat("en", { style, milliseconds: "numeric" });
+    expect(df.format({ milliseconds: 250 })).toBe(unit(0.25, "second", style));
+    expect(df.format({ minutes: 2, microseconds: 300 })).toBe(
+      list([unit(2, "minute", style), unit(0.0003, "second", style)], style),
+    );
   });
 
   test("a carrier with integer part zero keeps the sign of the fraction", () => {


### PR DESCRIPTION
### Problem
- `Intl.DurationFormat` with a sub-second unit in `"numeric"` style drops the fraction when the unit that carries it is 0. `new Intl.DurationFormat("en", { milliseconds: "numeric" }).format({ milliseconds: 250 })` returns `""` (node, spec: `"0.25 sec"`). Every locale and base style is affected.
- Cause: `collectElements()` in JavaScriptCore's `IntlDurationFormat.cpp` tests the carrier's own integer field for zero, not the `Int128` total that holds the fraction. Same path: `buildDecimalFormat()` loses the sign of a value in (-1, 0), and `millisecondsDisplay` resolves to `"always"` where the spec says `"auto"`.

### Fix
- Pin WebKit to `autobuild-preview-pr-599-79e4c286`, the preview build of oven-sh/WebKit#599. It reads the total for the zero and sign tests, keeps the sign, and implements the fractional display default and its RangeError as V8 and SpiderMonkey do.
- The pin is a preview tag. Do not merge before oven-sh/WebKit#599 lands. I move the pin to the merge commit's release then.
- Self-reviewed: the concerns were about packaging (fold with oven-sh/WebKit#375, a different default in the same function), none about the hunks. Kept separate: the two compose in either order.
- Verified: `test/js/web/intl/intl.test.ts`. The six new `Intl.DurationFormat` tests fail on 1.4.3. The file is green on a debug build with this pin.

### Background
- ECMA-402 calls `"numeric"` on a sub-second unit the `"fractional"` style: the unit is not printed, its value joins the previous unit as a decimal fraction (`1.5 sec`).
- [PartitionDurationFormatPattern](https://tc39.es/ecma402/#sec-partitiondurationformatpattern) step 4.h adds that fraction first and only then applies `"auto"` (skip a unit whose value is 0).
- JSC keeps the folded value as an exact `Int128` nanosecond count. The display test never read it.

<details><summary>Notes</summary>

- Source: a DurationFormat differential run (bun 1.4.2 and canary vs node v26.3.0, same ICU 78.3 on both sides, so not ICU drift). 23 of 1,116 generated cells diverged on this.
- More symptoms: `{ hours: 3, milliseconds: 250 }` gave `"3 hr"`; `formatToParts({ milliseconds: 999 })` returned no parts; `{ microseconds: "numeric" }` and `{ nanoseconds: "numeric" }` carriers behaved the same way; `new Intl.DurationFormat("en", { seconds: "numeric" }).format({ milliseconds: -250 })` printed `"0.25"`; `millisecondsDisplay: "always"` on a fractional unit was accepted and ignored instead of throwing.
- The test expectations with unit text are built from `Intl.NumberFormat` (style `unit`) and `Intl.ListFormat` (type `unit`), the same way the spec composes the output, so they hold on macOS's system ICU too. Digital and numeric outputs have no unit text and use literals.
- A sweep of 18 option bags x 23 durations x 5 locales (9,010 cells) against node 26.3.0 on a local JSC build with the patch: 5,950 cells that differed now match, 0 regress. What still differs is the minutes/seconds display default after a numeric hour (oven-sh/WebKit#375, #36364) and V8 joining a text-style hour to numeric seconds with `:`.
- test262 `intl402/DurationFormat` (110 files) passes before and after; it only covers a non-zero carrier, which is why no suite caught this.
- The preview build is WebKit `main` (10350ddde9fe) plus the one commit; #42059 already builds bun against that base.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/intl/intl.test.ts

<!-- robobun:evidence:end -->