### PR TITLE
Error the original body's stream after clone() when the body fails, instead of ending it

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4086,10 +4086,8 @@ where
 
                 let _exit = vm.enter_event_loop_scope();
 
-                // Reject through the body first, as the buffering branch below
-                // does: after `req.clone()` the body holds a tee branch that only
-                // this call reaches, and endRequestStreaming() (via
-                // this.endWithoutBody) would give it a generic ConnectionClosed.
+                // Reject the body first (it holds the tee branch after `req.clone()`) so
+                // endRequestStreaming() below doesn't substitute a generic ConnectionClosed.
                 if let Some(body) = this.request_body_mut() {
                     if matches!(body, Body::Value::Locked(_)) {
                         let _ = body.to_error_instance(

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4086,8 +4086,7 @@ where
 
                 let _exit = vm.enter_event_loop_scope();
 
-                // Reject the body first (it holds the tee branch after `req.clone()`) so
-                // endRequestStreaming() below doesn't substitute a generic ConnectionClosed.
+                // Body first (a tee branch after `req.clone()`), before endRequestStreaming()'s ConnectionClosed.
                 if let Some(body) = this.request_body_mut() {
                     if matches!(body, Body::Value::Locked(_)) {
                         let _ = body.to_error_instance(

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4086,6 +4086,21 @@ where
 
                 let _exit = vm.enter_event_loop_scope();
 
+                // Reject through the body first, as the buffering branch below
+                // does: after `req.clone()` the body holds a tee branch that only
+                // this call reaches, and endRequestStreaming() (via
+                // this.endWithoutBody) would give it a generic ConnectionClosed.
+                if let Some(body) = this.request_body_mut() {
+                    if matches!(body, Body::Value::Locked(_)) {
+                        let _ = body.to_error_instance(
+                            Body::ValueError::Message(BunString::static_(
+                                "Request body exceeded maxRequestBodySize",
+                            )),
+                            global_this,
+                        );
+                    }
+                }
+
                 // Release the strong stream ref like the `last` arm does, then
                 // error the stream so a pending or future read rejects instead
                 // of hanging forever.
@@ -4097,13 +4112,16 @@ where
                 if let Some(bytes) = readable.ptr.bytes() {
                     let source = bytes.parent_const();
                     source.producer.set(WebCore::streams::SourceHandle::None);
-                    let mut err = Body::ValueError::Message(BunString::static_(
-                        "Request body exceeded maxRequestBodySize",
-                    ));
-                    bytes.on_data(WebCore::streams::Result::Err(
-                        err.to_stream_error(global_this),
-                    ));
-                    err.reset();
+                    // False unless `to_error_instance` above reached this same stream through the body.
+                    if !bytes.has_received_last_chunk.get() {
+                        let mut err = Body::ValueError::Message(BunString::static_(
+                            "Request body exceeded maxRequestBodySize",
+                        ));
+                        bytes.on_data(WebCore::streams::Result::Err(
+                            err.to_stream_error(global_this),
+                        ));
+                        err.reset();
+                    }
                 }
 
                 // Route through the normal end path so this.resp is detached

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1369,7 +1369,9 @@ impl Value {
                 if let Some(bytes) = readable.ptr.bytes() {
                     bytes.on_data(streams::Result::Err(err_ref.to_stream_error(global)));
                 } else {
-                    readable.abort(global)?;
+                    // After `clone()` this is a tee branch. Cancelling it would end a
+                    // pending read with `{ done: true }` on a body that never finished.
+                    readable.error(global, err_ref.to_js(global))?;
                 }
             }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1369,8 +1369,7 @@ impl Value {
                 if let Some(bytes) = readable.ptr.bytes() {
                     bytes.on_data(streams::Result::Err(err_ref.to_stream_error(global)));
                 } else {
-                    // After `clone()` this is a tee branch. Cancelling it would end a
-                    // pending read with `{ done: true }` on a body that never finished.
+                    // e.g. a `clone()` tee branch; a cancel would end its reads with `{ done: true }`.
                     readable.error(global, err_ref.to_js(global))?;
                 }
             }

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1512,7 +1512,9 @@ describe("clone() of a body that fails mid-stream", () => {
     "fetch(): a reader on the %s response rejects when the server disconnects",
     async side => {
       const hangup = Promise.withResolvers<void>();
+      const accepted: net.Socket[] = [];
       const server = net.createServer(socket => {
+        accepted.push(socket);
         socket.on("error", () => {});
         socket.once("data", () => {
           socket.write(
@@ -1536,6 +1538,7 @@ describe("clone() of a body that fails mid-stream", () => {
           error: expect.stringContaining("The socket connection was closed unexpectedly"),
         });
       } finally {
+        for (const socket of accepted) socket.destroy();
         server.close();
       }
     },

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDirWithFiles } from "harness";
+import net from "node:net";
 import { join } from "node:path";
 
 test("Request with streaming body can be cloned", async () => {
@@ -1415,4 +1416,95 @@ describe("Bun.serve: clone() of an incoming request whose body nobody reads", ()
     for (let i = 0; i < 200 && state === "pending"; i++) state = await readState();
     expect(state).toBe("rejected: AbortError: The connection was closed.");
   });
+});
+
+// After `clone()` the body points at a tee branch instead of the native byte
+// stream. When the peer goes away mid-body, a read parked on either branch must
+// reject like a read on an un-cloned body does. The original's branch used to be
+// cancelled instead of errored, so its reader ended with `{ done: true }` on a
+// truncated body.
+describe("clone() of a body whose peer disconnects mid-stream", () => {
+  const announced = 64 * 1024;
+  const sent = 16 * 1024;
+  const payload = Buffer.alloc(sent, "a");
+
+  async function drain(body: ReadableStream<Uint8Array>, onBytes: (received: number) => void) {
+    const reader = body.getReader();
+    let received = 0;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) return { received, outcome: "done" };
+        received += value.byteLength;
+        onBytes(received);
+      }
+    } catch (e: any) {
+      return { received, outcome: "rejected", error: `${e?.name}: ${e?.message}` };
+    }
+  }
+
+  test.each(["original", "clone"] as const)(
+    "Bun.serve: a reader on the %s request rejects instead of ending early",
+    async side => {
+      const partial = Promise.withResolvers<void>();
+      const result = Promise.withResolvers<Awaited<ReturnType<typeof drain>>>();
+      await using server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        async fetch(req) {
+          const clone = req.clone();
+          const body = (side === "original" ? req : clone).body!;
+          result.resolve(await drain(body, received => received >= sent && partial.resolve()));
+          return new Response("k");
+        },
+      });
+      const client = net.connect(server.port, "127.0.0.1");
+      client.on("error", () => {});
+      client.write(
+        `POST / HTTP/1.1\r\nHost: example.com\r\nContent-Type: application/octet-stream\r\nContent-Length: ${announced}\r\n\r\n`,
+      );
+      client.write(payload);
+      // The handler holds every byte that was sent; now the client goes away.
+      await partial.promise;
+      client.destroy();
+      expect(await result.promise).toEqual({
+        received: sent,
+        outcome: "rejected",
+        error: "AbortError: The connection was closed.",
+      });
+    },
+  );
+
+  test.each(["original", "clone"] as const)(
+    "fetch(): a reader on the %s response rejects instead of ending early",
+    async side => {
+      const hangup = Promise.withResolvers<void>();
+      const server = net.createServer(socket => {
+        socket.on("error", () => {});
+        socket.once("data", () => {
+          socket.write(
+            `HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: ${announced}\r\n\r\n`,
+          );
+          socket.write(payload);
+          hangup.promise.then(() => socket.destroy());
+        });
+      });
+      const listening = Promise.withResolvers<void>();
+      server.listen(0, "127.0.0.1", () => listening.resolve());
+      await listening.promise;
+      try {
+        const res = await fetch(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}/`);
+        const clone = res.clone();
+        const body = (side === "original" ? res : clone).body!;
+        const result = await drain(body, received => received >= sent && hangup.resolve());
+        expect(result).toEqual({
+          received: sent,
+          outcome: "rejected",
+          error: expect.stringContaining("The socket connection was closed unexpectedly"),
+        });
+      } finally {
+        server.close();
+      }
+    },
+  );
 });

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1466,7 +1466,9 @@ describe("clone() of a body that fails mid-stream", () => {
     const client = net.connect(server.port, "127.0.0.1");
     try {
       client.on("error", () => {});
-      client.write(`POST / HTTP/1.1\r\nHost: example.com\r\nContent-Type: application/octet-stream\r\n${opts.framing}\r\n\r\n`);
+      client.write(
+        `POST / HTTP/1.1\r\nHost: example.com\r\nContent-Type: application/octet-stream\r\n${opts.framing}\r\n\r\n`,
+      );
       client.write(opts.firstPart);
       await partial.promise;
       opts.fail(client);

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1462,6 +1462,10 @@ describe("clone() of a body that fails mid-stream", () => {
         result.resolve(await drain(body, received => received >= sent && partial.resolve()));
         return new Response("k");
       },
+      error(err) {
+        result.reject(err);
+        return new Response("handler threw", { status: 500 });
+      },
     });
     const client = net.connect(server.port, "127.0.0.1");
     try {
@@ -1470,7 +1474,8 @@ describe("clone() of a body that fails mid-stream", () => {
         `POST / HTTP/1.1\r\nHost: example.com\r\nContent-Type: application/octet-stream\r\n${opts.framing}\r\n\r\n`,
       );
       client.write(opts.firstPart);
-      await partial.promise;
+      // A drain that ends before `sent` bytes arrived settles `result` instead.
+      await Promise.race([partial.promise, result.promise]);
       opts.fail(client);
       return await result.promise;
     } finally {

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1419,14 +1419,15 @@ describe("Bun.serve: clone() of an incoming request whose body nobody reads", ()
 });
 
 // After `clone()` the body points at a tee branch instead of the native byte
-// stream. When the peer goes away mid-body, a read parked on either branch must
-// reject like a read on an un-cloned body does. The original's branch used to be
-// cancelled instead of errored, so its reader ended with `{ done: true }` on a
-// truncated body.
-describe("clone() of a body whose peer disconnects mid-stream", () => {
+// stream. When the body fails mid-stream, a read parked on either branch must
+// reject with the error a read on an un-cloned body gets. The original's branch
+// used to be cancelled instead of errored, so its reader ended with
+// `{ done: true }` on a truncated body.
+describe("clone() of a body that fails mid-stream", () => {
   const announced = 64 * 1024;
   const sent = 16 * 1024;
   const payload = Buffer.alloc(sent, "a");
+  const chunkedPayload = Buffer.concat([Buffer.from(sent.toString(16) + "\r\n"), payload, Buffer.from("\r\n")]);
 
   async function drain(body: ReadableStream<Uint8Array>, onBytes: (received: number) => void) {
     const reader = body.getReader();
@@ -1443,40 +1444,70 @@ describe("clone() of a body whose peer disconnects mid-stream", () => {
     }
   }
 
-  test.each(["original", "clone"] as const)(
-    "Bun.serve: a reader on the %s request rejects instead of ending early",
-    async side => {
-      const partial = Promise.withResolvers<void>();
-      const result = Promise.withResolvers<Awaited<ReturnType<typeof drain>>>();
-      await using server = Bun.serve({
-        hostname: "127.0.0.1",
-        port: 0,
-        async fetch(req) {
-          const clone = req.clone();
-          const body = (side === "original" ? req : clone).body!;
-          result.resolve(await drain(body, received => received >= sent && partial.resolve()));
-          return new Response("k");
-        },
-      });
-      const client = net.connect(server.port, "127.0.0.1");
+  // POST a first body part to a handler that clones the request and drains one
+  // side. Once the handler holds those bytes, `fail(client)` breaks the body.
+  async function serveUpload(
+    side: "original" | "clone",
+    opts: { framing: string; firstPart: Buffer; maxRequestBodySize?: number; fail(client: net.Socket): void },
+  ) {
+    const partial = Promise.withResolvers<void>();
+    const result = Promise.withResolvers<Awaited<ReturnType<typeof drain>>>();
+    await using server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      maxRequestBodySize: opts.maxRequestBodySize,
+      async fetch(req) {
+        const clone = req.clone();
+        const body = (side === "original" ? req : clone).body!;
+        result.resolve(await drain(body, received => received >= sent && partial.resolve()));
+        return new Response("k");
+      },
+    });
+    const client = net.connect(server.port, "127.0.0.1");
+    try {
       client.on("error", () => {});
-      client.write(
-        `POST / HTTP/1.1\r\nHost: example.com\r\nContent-Type: application/octet-stream\r\nContent-Length: ${announced}\r\n\r\n`,
-      );
-      client.write(payload);
-      // The handler holds every byte that was sent; now the client goes away.
+      client.write(`POST / HTTP/1.1\r\nHost: example.com\r\nContent-Type: application/octet-stream\r\n${opts.framing}\r\n\r\n`);
+      client.write(opts.firstPart);
       await partial.promise;
+      opts.fail(client);
+      return await result.promise;
+    } finally {
       client.destroy();
-      expect(await result.promise).toEqual({
+    }
+  }
+
+  test.each(["original", "clone"] as const)(
+    "Bun.serve: a reader on the %s request rejects when the client disconnects",
+    async side => {
+      const result = await serveUpload(side, {
+        framing: `Content-Length: ${announced}`,
+        firstPart: payload,
+        fail: client => client.destroy(),
+      });
+      expect(result).toEqual({ received: sent, outcome: "rejected", error: "AbortError: The connection was closed." });
+    },
+  );
+
+  test.each(["original", "clone"] as const)(
+    "Bun.serve: a reader on the %s request rejects when a chunked body outgrows maxRequestBodySize",
+    async side => {
+      const result = await serveUpload(side, {
+        // No Content-Length, so only the streamed byte count can enforce the cap.
+        framing: "Transfer-Encoding: chunked",
+        firstPart: chunkedPayload,
+        maxRequestBodySize: sent + 1024,
+        fail: client => client.write(chunkedPayload),
+      });
+      expect(result).toEqual({
         received: sent,
         outcome: "rejected",
-        error: "AbortError: The connection was closed.",
+        error: "Error: Request body exceeded maxRequestBodySize",
       });
     },
   );
 
   test.each(["original", "clone"] as const)(
-    "fetch(): a reader on the %s response rejects instead of ending early",
+    "fetch(): a reader on the %s response rejects when the server disconnects",
     async side => {
       const hangup = Promise.withResolvers<void>();
       const server = net.createServer(socket => {


### PR DESCRIPTION
### Problem
- After `req.clone()` in `Bun.serve`, or `res.clone()` on a `fetch()` response, a reader on the original body ends with `{ done: true }` when the body fails mid-stream. 100 KB of an announced 160 KB reads as complete. The clone, and an un-cloned body, reject.
- Cause: `Body::Value::to_error_instance` (`src/runtime/webcore/Body.rs:1366`) errors a native `ByteStream` but cancels any other stream. After `clone()` the body holds a tee branch, and cancel closes it.

### Fix
- `to_error_instance` calls `ReadableStream::error()` with the body's error instead. Every caller is a producer that reports a failed body, so none wants a clean end.
- The streamed `maxRequestBodySize` arm in `RequestContext.rs` now rejects through the body first, as the buffering arm does. Otherwise the original's branch got `The connection was closed.` and the clone got `Request body exceeded maxRequestBodySize`.
- Self-reviewed: 2 concerns raised, 1 addressed (the parity fix above), 1 declined (see Notes).
- Verified: six new tests in `test/js/web/fetch/body-clone.test.ts`. The three original-side tests fail on main `b5ba14b6` and pass here. Neighbouring suites stay green (list in Notes).

### Background
- A streamed body is `Value::Locked` and holds a `ReadableStream`. For an incoming request or a fetch response its source is a native `ByteStream`.
- `clone()` tees that stream: the body keeps branch 1, the clone gets branch 2. When the body fails, the server or client errors the source. The tee forwards that to both branches, one microtask after `to_error_instance` ran on branch 1.
- `cancel()` is the consumer-side end: pending reads resolve `done: true`. `error()` is the producer-side failure: pending reads reject. The fetch abort listener already uses it (#35093).

<details><summary>Notes</summary>

- Found while re-checking the `req.clone()` abort work from #42017. That PR settles the native source so the clone's branch rejects. The original's branch still went through the `abort()` arm here.
- Callers of `to_error_instance`: `RequestContext::end_request_streaming` and the two `maxRequestBodySize` arms, `FetchTasklet` on failure, the fetch `AbortSignal` listener in `Response.rs`, `HTMLRewriter` `fail()`.
- Repro on main `b5ba14b6` (release and debug+ASAN), 102400 of 163840 bytes delivered, then the peer goes away. `Bun.serve` + `req.clone()`, reader on `req.body`: `done:true` at 102400. `fetch()` + `res.clone()`, reader on `res.body`: `done:true` at 102400. Reading the clone instead, or not cloning: rejects (`AbortError: The connection was closed.` / `ECONNRESET`). With the fix all of them reject. A `fetch()` aborted through its `AbortSignal` already rejected on both sides (the abort listener errors the branch itself).
- The six tests: serve client disconnect, serve chunked upload over `maxRequestBodySize`, fetch server disconnect, each for the original and the clone. The clone-side cells pass on main too and pin the symmetry.
- In the streamed cap arm the byte stream is errored through the held ref only when the body did not already reach it (`has_received_last_chunk`), the same guard `end_request_streaming` uses since #42017, so the un-cloned path does not see a second error.
- `HTMLRewriter`: `transform(res).clone()` with a failing input already rejected on both sides before this change, because `fail()` errors the output `ByteStream` directly and the tee forwards it. No change there.
- Declined review concern: rename `ReadableStream::abort()` (which cancels) at its three remaining callers. It stays. Those callers (`FetchTasklet::start_request_stream` on an already-aborted signal, `RequestContext::on_abort` for the response body, `FileSink::handle_reject_stream`) are consumers cancelling their source, which is what cancel is for.
- Erroring a tee branch from outside the tee is safe: `readableStreamDefaultControllerEnqueue`/`Close` check `CanCloseOrEnqueue` and `readableStreamDefaultControllerError` returns early on a non-readable stream, so the tee's later chunk, close, and error steps for that branch are no-ops. `ReadableStream__error` goes through `webStreamControllerError`, which is a no-op on a closed or errored stream.
- On the server disconnect path the original and the clone reject with two distinct `AbortError` objects (one from the body error, one from the source error through the tee). That was already true for a pending `.text()` on the original versus a read on the clone.
- Suites run on the debug+ASAN build: body-clone (85), html-rewriter (180), serve-body-leak (15), http-server-chunking (13), serve-http2-lifecycle (23), fetch-file-upload (11), fetch-abort-stream-body, body-mixin-errors, textstream-wpt, serve-pending-promise-abort-leak (27), regression/22353, `serve.test.ts -t "request body|streaming|abort|clone|maxRequestBodySize"`.
- Local-only failures seen while running neighbouring suites, identical on the unfixed release build in this container: `fetch.stream.test.ts` "Content-Length response works (multiple parts)" (5 s timeouts when the eight variants run concurrently under debug+ASAN, 0.8 s alone), `express-memory-leak.test.ts` (20 s budget, the body-less variant alone takes 19.9 s here), and `fetch.test.ts` "abort should work even if the socket was closed before the redirect" (connects to `[::]`, which this container's egress proxy refuses).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/body-clone.test.ts

<!-- robobun:evidence:end -->