### PR TITLE
ShadowRealm: importValue resolves an export whose value is undefined (WebKit bump for oven-sh/WebKit#612)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-612-43d09378";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/shadow.test.js
+++ b/test/js/bun/jsc/shadow.test.js
@@ -1,4 +1,6 @@
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
+import { tempDir } from "harness";
+import { join } from "node:path";
 
 it("shadow realm works", () => {
   const red = new ShadowRealm();
@@ -7,4 +9,39 @@ it("shadow realm works", () => {
   const result = red.evaluate("globalThis.someValue = 2;");
   expect(globalThis.someValue).toBe(1);
   expect(result).toBe(2);
+});
+
+describe("importValue", () => {
+  // https://tc39.es/proposal-shadowrealm/#sec-export-getter-functions checks HasOwnProperty(exports, name), then reads
+  // the value. An export whose value is undefined exists.
+  it("resolves an export whose value is undefined", async () => {
+    using dir = tempDir("shadow-realm-import-value", {
+      "mod.mjs": `
+        export const undefinedValue = undefined;
+        export let notYet;
+        export function setNotYet(v) { notYet = v; }
+        export const nullValue = null;
+      `,
+    });
+    const mod = join(String(dir), "mod.mjs");
+    const realm = new ShadowRealm();
+    expect(await realm.importValue(mod, "undefinedValue")).toBe(undefined);
+    expect(await realm.importValue(mod, "nullValue")).toBe(null);
+    // A live binding that is still undefined reads its current value each time.
+    expect(await realm.importValue(mod, "notYet")).toBe(undefined);
+    (await realm.importValue(mod, "setNotYet"))("now");
+    expect(await realm.importValue(mod, "notYet")).toBe("now");
+    // A name that is not exported still rejects. That includes names an ordinary object would inherit, and __esModule,
+    // which Bun's module namespace objects inherit from their prototype: the check is HasOwnProperty.
+    for (const name of ["missing", "toString", "__proto__", "constructor", "then", "__esModule"]) {
+      let error;
+      try {
+        await realm.importValue(mod, name);
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeInstanceOf(TypeError);
+      expect(error.message).toBe("%ShadowRealm%.importValue requires |exportName| to exist in the |specifier|");
+    }
+  });
 });


### PR DESCRIPTION
### Problem
- `realm.importValue(specifier, "v")` rejects with `%ShadowRealm%.importValue requires |exportName| to exist in the |specifier|` when the module has `export const v = undefined`, or an `export let v` that it assigns later. Node (`--experimental-shadow-realm`) resolves `undefined`.
- The cause is in JavaScriptCore's `importValue` builtin (`Source/JavaScriptCore/builtins/ShadowRealmPrototype.js`): it read the export and treated the value `undefined` as a missing name. The proposal's [ExportGetter](https://tc39.es/proposal-shadowrealm/#sec-export-getter-functions) checks `HasOwnProperty(exports, name)` and then reads the value.

### Fix
- Engine fix in oven-sh/WebKit#612: check the name with `@Object.@hasOwn(module, exportName)`, then read and wrap it. For a module namespace object that is a lookup in the export list. It stays an own-property check, so `importValue(m, "__esModule")` still rejects even though Bun's namespace objects inherit an `__esModule` accessor.
- `WEBKIT_VERSION` points at the preview build `autobuild-preview-pr-612-43d09378`. Move it to the merged `main` sha before this merges. The range from `2e2aa2290fac` also contains oven-sh/WebKit#561, oven-sh/WebKit#566 and oven-sh/WebKit#568, which are already on oven-sh/WebKit `main`.
- Verified: `test/js/bun/jsc/shadow.test.js` (`importValue > resolves an export whose value is undefined`, fails on the current pin) on a debug build against that WebKit branch. Also JSC's `shadow-realm-import-value.js` stress test and the test262 `built-ins/ShadowRealm` tests on a Debug+ASAN `jsc`.

### Background
- `ShadowRealm.prototype.importValue(specifier, name)` imports a module inside the shadow realm and resolves with one of its exports, wrapped for the caller: a primitive as is, a callable as a wrapped function, anything else rejects. The namespace object never crosses the boundary, so this lookup is the only place the export name is checked.
- The wrapped-function `this` value fix from the same area is separate: oven-sh/WebKit#594, with its own Bun branch. It changes behavior (an object receiver throws) and waits for a decision.

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/shadow.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/shadow.test.js
bun test v1.4.3 (f42e98025)

test/js/bun/jsc/shadow.test.js:
(pass) shadow realm works [44.37ms]
(pass) importValue > resolves an export whose value is undefined [88.62ms]

 2 pass
 0 fail
 18 expect() calls
Ran 2 tests across 1 file. [2.01s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts   |  2 +-
 test/js/bun/jsc/shadow.test.js | 39 ++++++++++++++++++++++++++++++++++++++-
 2 files changed, 39 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
scripts/build/deps/webkit.ts        0      0     16
test/js/bun/jsc/shadow.test.js      2      2     15
```

</details>

<!-- robobun:evidence:end -->