### PR TITLE
ShadowRealm: wrap the this value of a wrapped function call (WebKit bump for oven-sh/WebKit#594, behavior change)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-594-acf9aab2";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/shadow.test.js
+++ b/test/js/bun/jsc/shadow.test.js
@@ -1,4 +1,4 @@
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 
 it("shadow realm works", () => {
   const red = new ShadowRealm();
@@ -7,4 +7,297 @@ it("shadow realm works", () => {
   const result = red.evaluate("globalThis.someValue = 2;");
   expect(globalThis.someValue).toBe(1);
   expect(result).toBe(2);
+});
+
+// https://tc39.es/proposal-shadowrealm/#sec-ordinary-wrapped-function-call
+// OrdinaryWrappedFunctionCall passes |this| through GetWrappedValue, like an argument: a primitive crosses as is, a
+// callable is wrapped for the target realm, and any other object throws a TypeError from the caller's realm before the
+// target runs.
+describe("wrapped function this value", () => {
+  const realm = new ShadowRealm();
+  realm.evaluate(`globalThis.calls = 0`);
+  const callsInRealm = realm.evaluate(`() => globalThis.calls`);
+
+  const describeThisSource = `(function describeThis() {
+    "use strict";
+    globalThis.calls++;
+    if (this === undefined || this === null) return String(this);
+    if (typeof this === "function") return "function:" + (Object.getPrototypeOf(this) === Function.prototype) + ":" + this();
+    if (typeof this === "symbol") return "symbol:" + this.description;
+    return typeof this + ":" + String(this);
+  })`;
+
+  // A plain function target takes remoteFunctionCallForJSFunction (or the JIT thunk once the target has JIT code). The
+  // others take remoteFunctionCallGeneric.
+  const targets = {
+    "function": realm.evaluate(describeThisSource),
+    "proxy": realm.evaluate(`new Proxy(${describeThisSource}, {})`),
+    "proxy with an apply trap": realm.evaluate(
+      `new Proxy(${describeThisSource}, { apply(target, thisValue, args) { return Reflect.apply(target, thisValue, args); } })`,
+    ),
+    "bound function": realm.evaluate(`${describeThisSource}.bind("bound")`),
+  };
+
+  function outer() {
+    return "outer";
+  }
+
+  for (const [kind, wrapped] of Object.entries(targets)) {
+    const isBound = kind === "bound function";
+    describe(`${kind} target`, () => {
+      it("passes a primitive through", () => {
+        const seen = thisValue => [
+          wrapped.call(thisValue),
+          Reflect.apply(wrapped, thisValue, []),
+          wrapped.bind(thisValue)(),
+        ];
+        const before = callsInRealm();
+        const expected = isBound
+          ? Object.fromEntries(
+              [
+                "undefined",
+                "null",
+                "number",
+                "negative zero",
+                "string",
+                "boolean",
+                "bigint",
+                "symbol",
+                "well-known symbol",
+              ].map(k => [k, ["string:bound", "string:bound", "string:bound"]]),
+            )
+          : {
+              "undefined": ["undefined", "undefined", "undefined"],
+              "null": ["null", "null", "null"],
+              "number": ["number:5", "number:5", "number:5"],
+              "negative zero": ["number:0", "number:0", "number:0"],
+              "string": ["string:s", "string:s", "string:s"],
+              "boolean": ["boolean:true", "boolean:true", "boolean:true"],
+              "bigint": ["bigint:10", "bigint:10", "bigint:10"],
+              "symbol": ["symbol:d", "symbol:d", "symbol:d"],
+              "well-known symbol": ["symbol:Symbol.iterator", "symbol:Symbol.iterator", "symbol:Symbol.iterator"],
+            };
+        expect({
+          "undefined": seen(undefined),
+          "null": seen(null),
+          "number": seen(5),
+          "negative zero": seen(-0),
+          "string": seen("s"),
+          "boolean": seen(true),
+          "bigint": seen(10n),
+          "symbol": seen(Symbol("d")),
+          "well-known symbol": seen(Symbol.iterator),
+        }).toEqual(expected);
+        expect(callsInRealm()).toBe(before + 9 * 3);
+      });
+
+      it("wraps a callable for the target realm", () => {
+        expect([wrapped.call(outer), wrapped.apply(() => "arrow", []), wrapped.bind(outer)()]).toEqual(
+          isBound
+            ? ["string:bound", "string:bound", "string:bound"]
+            : ["function:true:outer", "function:true:arrow", "function:true:outer"],
+        );
+        if (!isBound) {
+          // The wrapped function itself: JSRemoteFunction::tryCreate unwraps it and wraps its target again, this time
+          // for the shadow realm, so the realm calls its own describeThis once more, with |this| undefined.
+          const before = callsInRealm();
+          expect(wrapped.call(wrapped)).toBe("function:true:undefined");
+          expect(callsInRealm()).toBe(before + 2);
+        }
+      });
+
+      it("throws a TypeError from the caller realm for any other object, before the target runs", () => {
+        for (const thisValue of [
+          {},
+          [],
+          new Proxy({}, {}),
+          new String("boxed"),
+          Object(Symbol("boxed")),
+          globalThis,
+          new Date(0),
+          /re/,
+        ]) {
+          const before = callsInRealm();
+          for (const call of [
+            () => wrapped.call(thisValue),
+            () => Reflect.apply(wrapped, thisValue, []),
+            () => wrapped.bind(thisValue)(),
+            () => ({ method: wrapped }).method(),
+          ]) {
+            let error;
+            try {
+              call();
+            } catch (e) {
+              error = e;
+            }
+            expect(error).toBeInstanceOf(TypeError);
+            expect(error.message).toBe("value passing between realms must be callable or primitive");
+          }
+          expect(callsInRealm()).toBe(before);
+        }
+      });
+    });
+  }
+
+  it("a sloppy-mode target sees its own global for undefined and null, and its own wrapper object for other primitives", () => {
+    const sloppy = realm.evaluate(`(function () {
+      if (this === globalThis) return "globalThis";
+      if (typeof this === "function") return "function:" + this();
+      return typeof this + ":" + (this instanceof Number || this instanceof String || this instanceof Symbol) + ":" + this.toString();
+    })`);
+    expect([
+      sloppy(),
+      sloppy.call(undefined),
+      sloppy.call(null),
+      sloppy.call(3),
+      sloppy.call("s"),
+      sloppy.call(Symbol("q")),
+      sloppy.call(outer),
+    ]).toEqual([
+      "globalThis",
+      "globalThis",
+      "globalThis",
+      "object:true:3",
+      "object:true:s",
+      "object:true:Symbol(q)",
+      "function:outer",
+    ]);
+    expect(() => sloppy.call({})).toThrow(TypeError);
+    // An arrow function target ignores |this|, but the wrapper cannot let an object through either.
+    const arrow = realm.evaluate(`() => "arrow"`);
+    expect([arrow.call(1), arrow.call(outer)]).toEqual(["arrow", "arrow"]);
+    expect(() => arrow.call({})).toThrow(TypeError);
+  });
+
+  it("works the same when the shadow realm calls a function of the incubating realm", () => {
+    let calls = 0;
+    function describeThis() {
+      "use strict";
+      calls++;
+      if (this === undefined || this === null) return String(this);
+      if (typeof this === "function")
+        return "function:" + (Object.getPrototypeOf(this) === Function.prototype) + ":" + this();
+      return typeof this + ":" + String(this);
+    }
+    const callWith = realm.evaluate(`(function callWith(f, kind) {
+      switch (kind) {
+      case "none": return f();
+      case "number": return f.call(42);
+      case "string": return Reflect.apply(f, "s", []);
+      case "callable": return f.call(() => "inner");
+      case "bound callable": return f.bind(function () { return "inner bound"; })();
+      default:
+        try {
+          if (kind === "object") f.call({});
+          else if (kind === "array") f.apply([], []);
+          else if (kind === "global") f.call(globalThis);
+          else ({ f }).f();
+        } catch (e) {
+          return "threw " + e.constructor.name + " of the shadow realm: " + (e instanceof TypeError) + ": " + e.message;
+        }
+        return "did not throw";
+      }
+    })`);
+    expect(
+      ["none", "number", "string", "callable", "bound callable"].map(kind => callWith(describeThis, kind)),
+    ).toEqual(["undefined", "number:42", "string:s", "function:true:inner", "function:true:inner bound"]);
+    const before = calls;
+    const threw =
+      "threw TypeError of the shadow realm: true: value passing between realms must be callable or primitive";
+    expect(["object", "array", "global", "method"].map(kind => callWith(describeThis, kind))).toEqual([
+      threw,
+      threw,
+      threw,
+      threw,
+    ]);
+    expect(calls).toBe(before);
+  });
+
+  // With the JIT on, only the first call of a plain function target goes through remoteFunctionCallForJSFunction. Once
+  // the target has code, the remoteFunctionCallGenerator thunk copies and wraps the arguments and |this| itself.
+  it("gets every argument count right on both call paths", () => {
+    const collect = realm.evaluate(`"use strict"; (function (...args) { return String(this) + "|" + args.join(",") })`);
+    const collectViaProxy = realm.evaluate(
+      `"use strict"; new Proxy(function (...args) { return String(this) + "|" + args.join(",") }, {})`,
+    );
+    const hundred = new Array(100).fill(9);
+    const expected = [
+      "undefined|",
+      "T|",
+      "T|1",
+      "T|1,2",
+      "T|1,2,3",
+      "T|1,2,3,4,5,6,7",
+      "undefined|1,2,3,4,5,6,7,8",
+      "T|" + hundred.join(","),
+      "function|1",
+      "TypeError",
+    ];
+    for (let i = 0; i < 200; i++) {
+      for (const f of [collect, collectViaProxy]) {
+        let objectThis;
+        try {
+          f.call({ i }, 1, 2);
+        } catch (e) {
+          objectThis = e.constructor.name;
+        }
+        const got = [
+          f(),
+          f.call("T"),
+          f.call("T", 1),
+          f.call("T", 1, 2),
+          f.call("T", 1, 2, 3),
+          f.call("T", 1, 2, 3, 4, 5, 6, 7),
+          f(1, 2, 3, 4, 5, 6, 7, 8),
+          f.apply("T", hundred),
+          f.call(outer, 1).replace(/^function[^|]*/, "function"),
+          objectThis,
+        ];
+        if (got.join("\n") !== expected.join("\n")) expect(got).toEqual(expected); // expect() in the loop is slow
+      }
+    }
+  });
+
+  // WrappedFunctionCreate reads the "length" and "name" of the callable it wraps, so the wrapping order is observable:
+  // each argument in order, then |this|.
+  it("wraps the arguments in order, then this", () => {
+    const log = [];
+    function observed(tag) {
+      const f = function () {
+        return tag;
+      };
+      Object.defineProperty(f, "name", {
+        get() {
+          log.push(tag + ".name");
+          return tag;
+        },
+      });
+      Object.defineProperty(f, "length", {
+        get() {
+          log.push(tag + ".length");
+          return 0;
+        },
+      });
+      return f;
+    }
+    const takesTwo = realm.evaluate(`(function (a, b) { "use strict"; return [this(), a(), b()].join() })`);
+    const takesTwoViaProxy = realm.evaluate(
+      `new Proxy(function (a, b) { "use strict"; return [this(), a(), b()].join() }, {})`,
+    );
+    // Past the first call, the plain function target takes the thunk.
+    for (let i = 0; i < 100; i++) {
+      for (const f of [takesTwo, takesTwoViaProxy]) {
+        log.length = 0;
+        const result = f.call(observed("this"), observed("a"), observed("b"));
+        if (result !== "this,a,b") expect(result).toBe("this,a,b");
+        if (log.join() !== "a.length,a.name,b.length,b.name,this.length,this.name")
+          expect(log).toEqual(["a.length", "a.name", "b.length", "b.name", "this.length", "this.name"]);
+
+        // When an argument cannot be wrapped, |this| is not looked at and the target does not run.
+        log.length = 0;
+        expect(() => f.call(observed("this"), observed("a"), {})).toThrow(TypeError);
+        if (log.join() !== "a.length,a.name") expect(log).toEqual(["a.length", "a.name"]);
+      }
+    }
+  });
 });


### PR DESCRIPTION
> **Behavior change, needs a decision.** With this change a ShadowRealm wrapped function called with a non-callable object as `this` throws a TypeError instead of running with `undefined`: `obj.wrapped()`, `this.wrapped()` in a class, `setTimeout(wrapped)`, `emitter.on(x, wrapped)`. That is the proposal text and what Node (`--experimental-shadow-realm`) and Firefox do. tc39/proposal-shadowrealm#328 is still open on exactly this, and upstream JSC picked `undefined` while it is. At least one project that runs on Bun calls `importValue`'d functions as methods (denoload's `this.jsonMetrics()`).

### Problem
- A ShadowRealm wrapped function drops the `this` value of the call. `wrapped.call(5)`, `wrapped.apply("s")`, `wrapped.bind(fn)()` and the realm-to-incubating direction all run the target with `undefined`. [OrdinaryWrappedFunctionCall](https://tc39.es/proposal-shadowrealm/#sec-ordinary-wrapped-function-call) step 8 is `GetWrappedValue(targetRealm, thisArgument)`: a primitive crosses as is, a callable is wrapped for the target realm, any other object throws a TypeError from the caller's realm before the target runs.
- The cause is in JavaScriptCore: `remoteFunctionCallForJSFunction` and `remoteFunctionCallGeneric` (`runtime/JSRemoteFunction.cpp`) and the `remoteFunctionCallGenerator` JIT thunk (`jit/ThunkGenerators.cpp`) call the target with `jsUndefined()`. Upstream WebKit has the same code.

### Fix
- Engine fix in oven-sh/WebKit#594. The two host functions and the thunk wrap `this` with `GetWrappedValue` after the arguments. The incoming value first goes through `JSValue::toThis(ECMAMode::strict())`, because an identifier call like `f()` carries the resolved scope object in the `this` slot and that means `undefined`. The thunk also wraps the arguments in order now (it went last to first), since wrapping a callable reads its `length` and `name` and the order is observable.
- `WEBKIT_VERSION` points at the preview build `autobuild-preview-pr-594-acf9aab2`. Move it to the merged `main` sha before this merges. The range from `2e2aa2290fac` also contains oven-sh/WebKit#561, oven-sh/WebKit#566 and oven-sh/WebKit#568, which are already on oven-sh/WebKit `main`.
- Verified: `test/js/bun/jsc/shadow.test.js` (16 new tests, 14 fail on the current pin) on a debug build against that WebKit branch. Also the `test-shadow-realm*` Node.js tests, `vm.test.ts -t ShadowRealm`, `test/regression/issue/29519.test.ts`, JSC's `shadow-realm*` stress tests under six JIT configurations, and the 64 test262 `built-ins/ShadowRealm` tests.

### Background
- A ShadowRealm is a second global object in the same VM. Only primitives and callables cross its boundary. A callable crosses as a *wrapped function* (`JSRemoteFunction` in JSC): calling it wraps each argument for the target's realm, calls the target there, and wraps the result for the caller's realm.
- JSC has two call paths for a wrapped function. A plain JS function target uses the `remoteFunctionCallForJSFunction` host function for its first call and the `remoteFunctionCallGenerator` JIT thunk after that. Any other callable (Proxy, bound function, host function) uses `remoteFunctionCallGeneric`. All three changed, and the test runs each case on each path.
- In JSC bytecode an identifier call `f()` does not pass `undefined` as `this`. It passes the scope object the name was resolved in, and the callee's `op_to_this` turns that into `undefined` (strict) or the global object (sloppy). A host function that forwards `this` somewhere visible has to do that itself with `JSValue::toThis()`, as `ProxyObject` does for an `apply` trap.

<details><summary>Notes</summary>

- Ledger item #45235 of the ShadowRealm callable-boundary census. The `importValue` item (#45236) is oven-sh/WebKit#612 with its own Bun PR and does not depend on this one.
- Wrapping order is observable through `length`/`name` getters on the callables being wrapped. The specification order is arguments in order, then `this`. V8 wraps `this` first. SpiderMonkey follows the specification. JSC's C++ paths now follow the specification and the thunk matches them.
- The TypeError for an object `this` reaches the caller in the caller's realm on every path because `sanitizeRemoteFunctionException` (`interpreter/Interpreter.cpp`) rewrites any exception that unwinds through a `JSRemoteFunction` frame.
- Self-reviewed: the review asked to split the `importValue` fix out (done, oven-sh/WebKit#612), to use an own-property check there (done), and to treat this half as an explicit behavior change that needs a maintainer decision (this note).

</details>
