### PR TITLE
Re-arm watches when a directory on the import path is replaced

### DIFF
--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -1070,8 +1070,7 @@ where
                             strings::paths::without_trailing_slash_windows_path(file_path),
                         );
 
-                        // A replaced directory below this one (`mv lib lib.old && mv
-                        // lib.new lib`): the watcher evicts the stale subtree, reload it.
+                        // A directory below this one was replaced: evict its stale subtree, reload.
                         {
                             let mut stale_dirs: Vec<Box<[u8]>> = Vec::new();
                             let mut stale_files: usize = 0;

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -1070,6 +1070,48 @@ where
                             strings::paths::without_trailing_slash_windows_path(file_path),
                         );
 
+                        // A directory below this one may have been replaced: renamed over
+                        // (`mv lib lib.old && mv lib.new lib`), or removed and created
+                        // again. Every watch at or below it is on the old inode, so no
+                        // later save under it would fire, and each reload's `add_file`
+                        // would keep matching the stale entries by hash. The watcher
+                        // evicts that subtree; reload what was loaded from it.
+                        {
+                            let mut stale_dirs: Vec<Box<[u8]>> = Vec::new();
+                            let mut stale_files: usize = 0;
+                            // SAFETY: see the File-arm `remove_at_index` call above;
+                            // this only queues evictions.
+                            unsafe {
+                                (*ctx).remove_entries_under_replaced_dirs(
+                                    event,
+                                    changed_files,
+                                    &mut |dir| stale_dirs.push(Box::from(dir)),
+                                    &mut |path, hash| {
+                                        record_changed_path(path);
+                                        current_task.append(hash);
+                                        stale_files += 1;
+                                    },
+                                )
+                            };
+                            for dir in &stale_dirs {
+                                let _ = self.ctx_mut().bust_dir_cache(dir);
+                                if self.verbose {
+                                    Self::debug(format_args!(
+                                        "Dir replaced: {}",
+                                        bstr::BStr::new(bun_paths::resolve_path::relative(
+                                            fs.top_level_dir,
+                                            dir,
+                                        ))
+                                    ));
+                                }
+                            }
+                            if !stale_dirs.is_empty() && stale_files == 0 {
+                                // The modules under it were evicted when they disappeared;
+                                // reload so that they resolve under the new directory.
+                                current_task.append(current_hash);
+                            }
+                        }
+
                         // The watched entrypoint has a per-file inotify watch on its inode.
                         // An atomic rename (`rename(tmp, entrypoint)`) or a rm+recreate over
                         // the entrypoint replaces that inode, so the kernel drops the

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -1083,7 +1083,7 @@ where
                             // this only queues evictions.
                             unsafe {
                                 (*ctx).remove_entries_under_replaced_dirs(
-                                    event,
+                                    *event,
                                     changed_files,
                                     &mut |dir| stale_dirs.push(Box::from(dir)),
                                     &mut |path, hash| {

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -1070,12 +1070,8 @@ where
                             strings::paths::without_trailing_slash_windows_path(file_path),
                         );
 
-                        // A directory below this one may have been replaced: renamed over
-                        // (`mv lib lib.old && mv lib.new lib`), or removed and created
-                        // again. Every watch at or below it is on the old inode, so no
-                        // later save under it would fire, and each reload's `add_file`
-                        // would keep matching the stale entries by hash. The watcher
-                        // evicts that subtree; reload what was loaded from it.
+                        // A replaced directory below this one (`mv lib lib.old && mv
+                        // lib.new lib`): the watcher evicts the stale subtree, reload it.
                         {
                             let mut stale_dirs: Vec<Box<[u8]>> = Vec::new();
                             let mut stale_files: usize = 0;
@@ -1106,8 +1102,7 @@ where
                                 }
                             }
                             if !stale_dirs.is_empty() && stale_files == 0 {
-                                // The modules under it were evicted when they disappeared;
-                                // reload so that they resolve under the new directory.
+                                // Its files were evicted when they vanished; still reload.
                                 current_task.append(current_hash);
                             }
                         }

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5837,10 +5837,11 @@ impl DevServer {
                     // happens and re-arms them, and its directories to the resolver
                     // cache bust.
                     self.bun_watcher.remove_entries_under_replaced_dirs(
-                        event,
+                        *event,
                         changed_files,
-                        // SAFETY: see `ev_ptr` above; call-scoped borrows.
+                        // SAFETY: see `ev_ptr` above; call-scoped borrow.
                         &mut |dir| unsafe { &mut *ev_ptr }.append_dir(dir, None),
+                        // SAFETY: see `ev_ptr` above; call-scoped borrow.
                         &mut |path, _| unsafe { &mut *ev_ptr }.append_file(path),
                     );
                 }

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5830,8 +5830,7 @@ impl DevServer {
                         unsafe { &mut *ev_ptr }.append_dir(file_path, None);
                     }
 
-                    // A replaced directory below this one: the watcher evicts the
-                    // stale subtree; rebundle its files, bust its directories.
+                    // A directory below this one was replaced: evict, rebundle, bust caches.
                     self.bun_watcher.remove_entries_under_replaced_dirs(
                         *event,
                         changed_files,

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5830,12 +5830,8 @@ impl DevServer {
                         unsafe { &mut *ev_ptr }.append_dir(file_path, None);
                     }
 
-                    // A directory below this one that was replaced (renamed over,
-                    // or removed and created again) leaves every watch at or below
-                    // it on the old inode. The watcher evicts that subtree; hand its
-                    // files to the incremental graph as changed so the next bundle
-                    // happens and re-arms them, and its directories to the resolver
-                    // cache bust.
+                    // A replaced directory below this one: the watcher evicts the
+                    // stale subtree; rebundle its files, bust its directories.
                     self.bun_watcher.remove_entries_under_replaced_dirs(
                         *event,
                         changed_files,

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5826,10 +5826,23 @@ impl DevServer {
                     }
                     #[cfg(not(any(target_os = "linux", target_os = "android")))]
                     {
-                        let _ = changed_files;
                         // SAFETY: see `ev_ptr` above; call-scoped borrow.
                         unsafe { &mut *ev_ptr }.append_dir(file_path, None);
                     }
+
+                    // A directory below this one that was replaced (renamed over,
+                    // or removed and created again) leaves every watch at or below
+                    // it on the old inode. The watcher evicts that subtree; hand its
+                    // files to the incremental graph as changed so the next bundle
+                    // happens and re-arms them, and its directories to the resolver
+                    // cache bust.
+                    self.bun_watcher.remove_entries_under_replaced_dirs(
+                        event,
+                        changed_files,
+                        // SAFETY: see `ev_ptr` above; call-scoped borrows.
+                        &mut |dir| unsafe { &mut *ev_ptr }.append_dir(dir, None),
+                        &mut |path, _| unsafe { &mut *ev_ptr }.append_file(path),
+                    );
                 }
             }
         }

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -182,9 +182,7 @@ impl INotifyWatcher {
         result
     }
 
-    /// Removes a watch added by `watch_path` / `watch_dir`. Errors are ignored:
-    /// the kernel already drops a watch on its own when the inode is deleted
-    /// (`EINVAL` then), and the caller has nothing to undo either way.
+    /// Removes a watch; `EINVAL` (already gone with its inode) is expected.
     pub(crate) fn unwatch(&mut self, wd: EventListIndex) {
         debug_assert!(self.loaded);
         let rc = bun_sys::linux::inotify_rm_watch(self.fd.native(), wd);

--- a/src/watcher/INotifyWatcher.rs
+++ b/src/watcher/INotifyWatcher.rs
@@ -182,6 +182,15 @@ impl INotifyWatcher {
         result
     }
 
+    /// Removes a watch added by `watch_path` / `watch_dir`. Errors are ignored:
+    /// the kernel already drops a watch on its own when the inode is deleted
+    /// (`EINVAL` then), and the caller has nothing to undo either way.
+    pub(crate) fn unwatch(&mut self, wd: EventListIndex) {
+        debug_assert!(self.loaded);
+        let rc = bun_sys::linux::inotify_rm_watch(self.fd.native(), wd);
+        bun_core::scoped_log!(watcher, "inotify_rm_watch({}, {}) = {}", self.fd, wd, rc);
+    }
+
     pub(crate) fn new(_root: &[u8]) -> crate::Result<Self> {
         use bun_sys::linux::IN;
 

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -227,6 +227,23 @@ impl Watcher {
         }
         let events = &mut self.watch_events[..event_count];
         let changed = &self.changed_filepaths[..changed_count];
+        // kqueue: a directory entry is registered for NOTE_WRITE | NOTE_RENAME |
+        // NOTE_DELETE, and the latter two (`Op::RENAME` / `Op::DELETE`) are
+        // about the directory's own vnode: its path no longer names it.
+        // Remember that, so that once the path exists again
+        // `remove_replaced_descendants` treats the directory as replaced even
+        // if the same inode was moved back. (inotify reports a child's
+        // deletion on the directory watch with the same op, so this is
+        // kqueue-only; inotify names the entry that reappears instead.)
+        #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+        for event in events.iter() {
+            let i = event.index as usize;
+            if event.op.intersects(Op::DELETE | Op::RENAME)
+                && self.watchlist.items_kind().get(i) == Some(&WatchItemKind::Directory)
+            {
+                self.watchlist.items_displaced_mut()[i] = true;
+            }
+        }
         WatcherTrace::write_events(&self.watchlist, events, changed);
         (self.on_file_update)(self.ctx, events, changed, &self.watchlist);
     }
@@ -408,6 +425,10 @@ impl Watcher {
         let fds = slice.items_fd();
         let fds_len = fds.len();
         let mut last_item = NO_WATCH_ITEM;
+        // Watch registrations of evicted directory entries, released after the
+        // second pass once it is known that no surviving entry shares them.
+        #[cfg(not(windows))]
+        let mut evicted_dir_watches: Vec<EvictedDirWatch> = Vec::new();
 
         for &item in &self.evict_list[0..evict_list_i] {
             // catch duplicates, since the list is sorted, duplicates will appear right after each other
@@ -421,10 +442,25 @@ impl Watcher {
 
             #[cfg(not(windows))]
             {
-                // on mac and linux we can just close the file descriptor
-                // we don't need to call inotify_rm_watch on linux because it gets removed when the file descriptor is closed
-                if fds[item as usize].is_valid() {
-                    let _ = bun_sys::close(fds[item as usize]);
+                let kind = slice.items_kind()[item as usize];
+                let mut fd = fds[item as usize];
+                // A file's watch dies with its descriptor: the inode is already
+                // unlinked or replaced when a file is evicted, and inotify/kqueue
+                // drop the registration once the last reference goes. A directory
+                // fd that is not the watcher's (see `WatchItem::owns_fd`) stays
+                // open, so its registration is dropped explicitly below.
+                if fd.is_valid()
+                    && (kind == WatchItemKind::File || slice.items_owns_fd()[item as usize])
+                {
+                    let _ = bun_sys::close(fd);
+                    fd = Fd::INVALID;
+                }
+                if kind == WatchItemKind::Directory {
+                    evicted_dir_watches.push(EvictedDirWatch {
+                        fd,
+                        #[cfg(any(target_os = "linux", target_os = "android"))]
+                        eventlist_index: slice.items_eventlist_index()[item as usize],
+                    });
                 }
             }
             last_item = item;
@@ -458,6 +494,48 @@ impl Watcher {
         }
 
         self.evict_list_i = 0;
+
+        #[cfg(not(windows))]
+        for evicted in evicted_dir_watches {
+            self.release_directory_watch(evicted);
+        }
+    }
+
+    /// Drops the kernel registration of an evicted directory entry. Two
+    /// entries can share one (the same directory added with and without a
+    /// trailing slash hashes differently but is one inode, and kqueue keys
+    /// registrations by fd): when a surviving entry does, the registration is
+    /// kept, and on kqueue re-pointed at the survivor's index.
+    #[cfg(not(windows))]
+    fn release_directory_watch(&mut self, evicted: EvictedDirWatch) {
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            let shared = self
+                .watchlist
+                .items_eventlist_index()
+                .contains(&evicted.eventlist_index);
+            if !shared {
+                self.platform.unwatch(evicted.eventlist_index);
+            }
+            let _ = evicted.fd;
+        }
+        #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+        {
+            // Closed in `flush_evictions` (the watcher owned it): the vnode
+            // filter went with it.
+            if !evicted.fd.is_valid() {
+                return;
+            }
+            let survivor = self
+                .watchlist
+                .items_fd()
+                .iter()
+                .position(|fd| *fd == evicted.fd);
+            match survivor {
+                Some(index) => self.add_file_descriptor_to_kqueue_without_checks(evicted.fd, index),
+                None => self.remove_file_descriptor_from_kqueue(evicted.fd),
+            }
+        }
     }
 
     fn watch_loop(&mut self) -> sys::Result<()> {
@@ -508,6 +586,20 @@ impl Watcher {
         // Basically:
         // - We register the event here.
         // our while(true) loop above receives notification of changes to any of the events created here.
+        let _ = bun_sys::kevent(self.platform.fd, &[event], &mut [], None);
+    }
+
+    /// Undo `add_file_descriptor_to_kqueue_without_checks` for `fd` while
+    /// leaving the descriptor open. Does not propagate kevent errors (the
+    /// registration may already be gone if the vnode was revoked).
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    fn remove_file_descriptor_from_kqueue(&mut self, fd: Fd) {
+        use libc::{EV_DELETE, EVFILT_VNODE, kevent as KEvent};
+
+        let mut event: KEvent = bun_core::ffi::zeroed();
+        event.flags = EV_DELETE as _;
+        event.filter = EVFILT_VNODE as _;
+        event.ident = usize::try_from(fd.native()).expect("int cast");
         let _ = bun_sys::kevent(self.platform.fd, &[event], &mut [], None);
     }
 
@@ -577,8 +669,11 @@ impl Watcher {
             parent_hash,
             package_json,
             kind: WatchItemKind::File,
+            owns_fd: true,
             #[cfg(any(target_os = "linux", target_os = "android"))]
             eventlist_index,
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            displaced: false,
         });
         Ok(FdOwnership::Watcher)
     }
@@ -661,8 +756,11 @@ impl Watcher {
             parent_hash,
             kind: WatchItemKind::Directory,
             package_json: None,
+            owns_fd: !stored_fd.is_valid(),
             #[cfg(any(target_os = "linux", target_os = "android"))]
             eventlist_index,
+            #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+            displaced: false,
         });
         Ok((self.watchlist.len() - 1) as WatchItemIndex)
     }
@@ -925,17 +1023,204 @@ impl Watcher {
 
         debug_assert!(index != NO_WATCH_ITEM);
 
-        self.evict_list[self.evict_list_i as usize] = index;
-        self.evict_list_i += 1;
+        self.queue_eviction(index);
 
         if kind == WatchItemKind::Directory {
             for &parent in parents {
                 if parent == hash {
-                    self.evict_list[self.evict_list_i as usize] = parent as WatchItemIndex;
-                    self.evict_list_i += 1;
+                    self.queue_eviction(parent as WatchItemIndex);
                 }
             }
         }
+    }
+
+    /// Returns `false` when `evict_list` is full; the entry then stays in the
+    /// watchlist until a later `flush_evictions` makes room.
+    fn queue_eviction(&mut self, index: WatchItemIndex) -> bool {
+        let i = self.evict_list_i as usize;
+        if i >= self.evict_list.len() {
+            return false;
+        }
+        self.evict_list[i] = index;
+        self.evict_list_i += 1;
+        true
+    }
+
+    /// Directory-event hook for `WatcherContext::on_file_update`: detects that a
+    /// directory *below* the one `event` is for was replaced, and queues the
+    /// eviction (see `flush_evictions`) of every watchlist entry at or below
+    /// the replaced path.
+    ///
+    /// A directory that is renamed over (`mv lib lib.old && mv lib.new lib`),
+    /// or removed and created again, is a new inode at the same path. inotify
+    /// and kqueue watch inodes, so every registration at or below that path
+    /// keeps observing the old tree (or nothing), and `add_file` /
+    /// `add_directory` would keep matching the stale entries by path hash
+    /// instead of watching the new ones. With the entries evicted, the reload
+    /// the caller schedules re-arms fresh watches.
+    ///
+    /// inotify names the created or moved-in entries (`names`), so each
+    /// `<dir>/<name>` that is a prefix of watched paths is a replaced subtree.
+    /// kqueue has no names: on a write to the directory, every watched
+    /// directory below it is compared by inode instead (see
+    /// `remove_replaced_descendants`). Windows matches events by path and
+    /// needs none of this.
+    ///
+    /// `stale_dir` receives each directory path whose resolver caches are now
+    /// wrong (the replaced path itself and every evicted directory entry, no
+    /// trailing slash); `stale_file` each evicted file entry with its hash.
+    /// Same contract as `remove_at_index::<false>`: the caller holds
+    /// `self.mutex`. Returns the number of entries queued.
+    pub fn remove_entries_under_replaced_dirs(
+        &mut self,
+        event: &WatchEvent,
+        names: &[ChangedFilePath],
+        stale_dir: &mut dyn FnMut(&[u8]),
+        stale_file: &mut dyn FnMut(&[u8], HashType),
+    ) -> usize {
+        let mut each = |kind: WatchItemKind, path: &[u8], hash: HashType| match kind {
+            WatchItemKind::Directory => stale_dir(strings::trim_right(path, &[b'/'])),
+            WatchItemKind::File => stale_file(path, hash),
+        };
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            if !event.op.intersects(Op::CREATE | Op::MOVE_TO) {
+                return 0;
+            }
+            let slice = self.watchlist.slice();
+            let Some(dir) = slice.items_file_path().get(event.index as usize) else {
+                return 0;
+            };
+            let dir = strings::trim_right(dir, &[b'/']);
+            let mut child = bun_paths::path_buffer_pool::get();
+            let mut queued = 0;
+            for name in event.names(names).iter().flatten() {
+                let name = name.as_bytes();
+                let len = dir.len() + 1 + name.len();
+                if name.is_empty() || len > child.len() {
+                    continue;
+                }
+                child[..dir.len()].copy_from_slice(dir);
+                child[dir.len()] = b'/';
+                child[dir.len() + 1..len].copy_from_slice(name);
+                let evicted = self.remove_path_and_descendants(&child[..len], &mut each);
+                if evicted > 0 {
+                    // Reported even when the path itself is not an entry: the
+                    // resolver caches intermediate directories it never watches.
+                    (each)(WatchItemKind::Directory, &child[..len], 0);
+                    queued += evicted;
+                }
+            }
+            queued
+        }
+        #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+        {
+            let _ = names;
+            if !event.op.contains(Op::WRITE) {
+                return 0;
+            }
+            self.remove_replaced_descendants(event.index, &mut each)
+        }
+        #[cfg(windows)]
+        {
+            let _ = (event, names, &mut each);
+            0
+        }
+    }
+
+    /// Queues eviction of every entry whose path is `dir_path` or lies below
+    /// it, skipping entries already queued, and reports each one to `each`.
+    #[cfg(not(windows))]
+    fn remove_path_and_descendants(
+        &mut self,
+        dir_path: &[u8],
+        each: &mut dyn FnMut(WatchItemKind, &[u8], HashType),
+    ) -> usize {
+        use bun_paths::resolve_path::{ParentEqual, is_parent_or_equal};
+
+        let slice = self.watchlist.slice();
+        let paths = slice.items_file_path();
+        let kinds = slice.items_kind();
+        let hashes = slice.items_hash();
+        let mut queued = 0;
+        for i in 0..slice.len() {
+            if is_parent_or_equal(dir_path, &paths[i]) == ParentEqual::Unrelated
+                || self.evict_list[..self.evict_list_i as usize].contains(&(i as WatchItemIndex))
+            {
+                continue;
+            }
+            if !self.queue_eviction(i as WatchItemIndex) {
+                break;
+            }
+            each(kinds[i], &paths[i], hashes[i]);
+            queued += 1;
+        }
+        queued
+    }
+
+    /// kqueue reports only that *something* in the directory at `parent`
+    /// changed. Finds every watched directory below it whose path now names a
+    /// different inode than the one its fd holds (or names anything again
+    /// once its vnode was `displaced`), and evicts that subtree through
+    /// `remove_path_and_descendants`. A directory whose path does not exist at
+    /// the moment is left alone: the parent receives another write event when
+    /// something reappears under that name.
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    fn remove_replaced_descendants(
+        &mut self,
+        parent: WatchItemIndex,
+        each: &mut dyn FnMut(WatchItemKind, &[u8], HashType),
+    ) -> usize {
+        use bun_paths::resolve_path::{ParentEqual, is_parent_or_equal};
+
+        let slice = self.watchlist.slice();
+        let paths = slice.items_file_path();
+        let kinds = slice.items_kind();
+        let fds = slice.items_fd();
+        let Some(parent_path) = paths.get(parent as usize) else {
+            return 0;
+        };
+
+        let mut replaced: Vec<&[u8]> = Vec::new();
+        let mut zbuf = bun_paths::path_buffer_pool::get();
+        for i in 0..slice.len() {
+            if kinds[i] != WatchItemKind::Directory || !fds[i].is_valid() {
+                continue;
+            }
+            let path: &[u8] = &paths[i];
+            if is_parent_or_equal(parent_path, path) != ParentEqual::Parent
+                || path.len() >= zbuf.len()
+                || replaced
+                    .iter()
+                    .any(|r| is_parent_or_equal(r, path) != ParentEqual::Unrelated)
+            {
+                continue;
+            }
+            zbuf[..path.len()].copy_from_slice(path);
+            zbuf[path.len()] = 0;
+            let z = ZStr::from_buf(&zbuf[..], path.len());
+            let Ok(by_path) = bun_sys::stat(z) else {
+                continue;
+            };
+            if !slice.items_displaced()[i] {
+                let Ok(by_fd) = bun_sys::fstat(fds[i]) else {
+                    continue;
+                };
+                if by_path.st_ino == by_fd.st_ino && by_path.st_dev == by_fd.st_dev {
+                    continue;
+                }
+            }
+            // A replaced ancestor's eviction covers this one.
+            replaced.retain(|r| is_parent_or_equal(path, r) == ParentEqual::Unrelated);
+            replaced.push(path);
+        }
+        drop(zbuf);
+
+        let mut queued = 0;
+        for path in replaced {
+            queued += self.remove_path_and_descendants(path, each);
+        }
+        queued
     }
 
     pub fn get_resolve_watcher(&mut self) -> AnyResolveWatcher {
@@ -1051,14 +1336,34 @@ pub struct WatchItem {
     pub parent_hash: u32,
     pub kind: WatchItemKind,
     pub package_json: Option<&'static PackageJSON>,
+    /// Whether `flush_evictions` may close `fd`. Files: always (`add_file`
+    /// hands the descriptor over, see [`FdOwnership`]). Directories: only when
+    /// the watcher opened it itself; otherwise it is the resolver's cached
+    /// directory handle, or the dev server's, and theirs to close.
+    pub owns_fd: bool,
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub eventlist_index: platform::EventListIndex,
+    /// kqueue: this directory's vnode reported NOTE_RENAME or NOTE_DELETE, so
+    /// `file_path` no longer names it. See `dispatch_file_updates` and
+    /// `remove_replaced_descendants`.
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    pub displaced: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum WatchItemKind {
     File,
     Directory,
+}
+
+/// What `flush_evictions` needs to drop the kernel registration of an evicted
+/// directory entry after the entry itself is gone from the watchlist.
+#[cfg(not(windows))]
+struct EvictedDirWatch {
+    /// `Fd::INVALID` when `flush_evictions` closed it.
+    fd: Fd,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    eventlist_index: platform::EventListIndex,
 }
 
 /// Who owns the `fd` passed to [`Watcher::add_file`] after it returns.
@@ -1085,8 +1390,13 @@ pub trait WatchItemColumns {
     fn items_fd_mut(&mut self) -> &mut [Fd];
     fn items_parent_hash(&self) -> &[u32];
     fn items_kind(&self) -> &[WatchItemKind];
+    fn items_owns_fd(&self) -> &[bool];
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn items_eventlist_index(&self) -> &[platform::EventListIndex];
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    fn items_displaced(&self) -> &[bool];
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    fn items_displaced_mut(&mut self) -> &mut [bool];
 }
 
 impl WatchItemColumns for WatchList {
@@ -1108,9 +1418,20 @@ impl WatchItemColumns for WatchList {
     fn items_kind(&self) -> &[WatchItemKind] {
         self.items::<"kind", WatchItemKind>()
     }
+    fn items_owns_fd(&self) -> &[bool] {
+        self.items::<"owns_fd", bool>()
+    }
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn items_eventlist_index(&self) -> &[platform::EventListIndex] {
         self.items::<"eventlist_index", platform::EventListIndex>()
+    }
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    fn items_displaced(&self) -> &[bool] {
+        self.items::<"displaced", bool>()
+    }
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    fn items_displaced_mut(&mut self) -> &mut [bool] {
+        self.items_mut::<"displaced", bool>()
     }
 }
 
@@ -1133,8 +1454,19 @@ impl WatchItemColumns for bun_collections::multi_array_list::Slice<WatchItem> {
     fn items_kind(&self) -> &[WatchItemKind] {
         self.items::<"kind", WatchItemKind>()
     }
+    fn items_owns_fd(&self) -> &[bool] {
+        self.items::<"owns_fd", bool>()
+    }
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn items_eventlist_index(&self) -> &[platform::EventListIndex] {
         self.items::<"eventlist_index", platform::EventListIndex>()
+    }
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    fn items_displaced(&self) -> &[bool] {
+        self.items::<"displaced", bool>()
+    }
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    fn items_displaced_mut(&mut self) -> &mut [bool] {
+        self.items_mut::<"displaced", bool>()
     }
 }

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -227,14 +227,8 @@ impl Watcher {
         }
         let events = &mut self.watch_events[..event_count];
         let changed = &self.changed_filepaths[..changed_count];
-        // kqueue: a directory entry is registered for NOTE_WRITE | NOTE_RENAME |
-        // NOTE_DELETE, and the latter two (`Op::RENAME` / `Op::DELETE`) are
-        // about the directory's own vnode: its path no longer names it.
-        // Remember that, so that once the path exists again
-        // `remove_replaced_descendants` treats the directory as replaced even
-        // if the same inode was moved back. (inotify reports a child's
-        // deletion on the directory watch with the same op, so this is
-        // kqueue-only; inotify names the entry that reappears instead.)
+        // kqueue: NOTE_RENAME / NOTE_DELETE on a directory entry are about its
+        // own vnode, so its path no longer names it (see `WatchItem::displaced`).
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
         for event in events.iter() {
             let i = event.index as usize;
@@ -425,8 +419,6 @@ impl Watcher {
         let fds = slice.items_fd();
         let fds_len = fds.len();
         let mut last_item = NO_WATCH_ITEM;
-        // Watch registrations of evicted directory entries, released after the
-        // second pass once it is known that no surviving entry shares them.
         #[cfg(not(windows))]
         let mut evicted_dir_watches: Vec<EvictedDirWatch> = Vec::new();
 
@@ -444,11 +436,9 @@ impl Watcher {
             {
                 let kind = slice.items_kind()[item as usize];
                 let mut fd = fds[item as usize];
-                // A file's watch dies with its descriptor: the inode is already
-                // unlinked or replaced when a file is evicted, and inotify/kqueue
-                // drop the registration once the last reference goes. A directory
-                // fd that is not the watcher's (see `WatchItem::owns_fd`) stays
-                // open, so its registration is dropped explicitly below.
+                // An evicted file is unlinked or replaced, so closing its fd ends
+                // the watch too. A directory fd that stays open (see
+                // `WatchItem::owns_fd`) has its registration dropped after pass 2.
                 if fd.is_valid()
                     && (kind == WatchItemKind::File || slice.items_owns_fd()[item as usize])
                 {
@@ -501,11 +491,9 @@ impl Watcher {
         }
     }
 
-    /// Drops the kernel registration of an evicted directory entry. Two
-    /// entries can share one (the same directory added with and without a
-    /// trailing slash hashes differently but is one inode, and kqueue keys
-    /// registrations by fd): when a surviving entry does, the registration is
-    /// kept, and on kqueue re-pointed at the survivor's index.
+    /// Drops the kernel registration of an evicted directory entry, unless a
+    /// surviving entry shares it (same inode under another path, e.g. with and
+    /// without a trailing slash); on kqueue that one is re-pointed instead.
     #[cfg(not(windows))]
     fn release_directory_watch(&mut self, evicted: &EvictedDirWatch) {
         #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -521,8 +509,7 @@ impl Watcher {
         }
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
         {
-            // Closed in `flush_evictions` (the watcher owned it): the vnode
-            // filter went with it.
+            // Closed by `flush_evictions`; the vnode filter went with it.
             if !evicted.fd.is_valid() {
                 return;
             }
@@ -589,9 +576,7 @@ impl Watcher {
         let _ = bun_sys::kevent(self.platform.fd, &[event], &mut [], None);
     }
 
-    /// Undo `add_file_descriptor_to_kqueue_without_checks` for `fd` while
-    /// leaving the descriptor open. Does not propagate kevent errors (the
-    /// registration may already be gone if the vnode was revoked).
+    /// Undoes `add_file_descriptor_to_kqueue_without_checks`; leaves `fd` open.
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     fn remove_file_descriptor_from_kqueue(&mut self, fd: Fd) {
         use libc::{EV_DELETE, EVFILT_VNODE, kevent as KEvent};
@@ -1034,8 +1019,7 @@ impl Watcher {
         }
     }
 
-    /// Returns `false` when `evict_list` is full; the entry then stays in the
-    /// watchlist until a later `flush_evictions` makes room.
+    /// `false` when `evict_list` is full; the entry stays until a later flush.
     fn queue_eviction(&mut self, index: WatchItemIndex) -> bool {
         let i = self.evict_list_i as usize;
         if i >= self.evict_list.len() {
@@ -1046,31 +1030,17 @@ impl Watcher {
         true
     }
 
-    /// Directory-event hook for `WatcherContext::on_file_update`: detects that a
-    /// directory *below* the one `event` is for was replaced, and queues the
-    /// eviction (see `flush_evictions`) of every watchlist entry at or below
-    /// the replaced path.
+    /// For a directory `event` inside `on_file_update`: when a directory below
+    /// it was replaced (renamed over, or removed and created again: a new inode
+    /// at a path whose watches still point at the old one), queues the
+    /// eviction of every entry at or below that path so the caller's reload
+    /// re-arms them. inotify: each created or moved-in `<dir>/<name>` that
+    /// prefixes watched paths. kqueue (no names): each watched directory below
+    /// whose inode no longer matches its path. Windows matches by path: no-op.
     ///
-    /// A directory that is renamed over (`mv lib lib.old && mv lib.new lib`),
-    /// or removed and created again, is a new inode at the same path. inotify
-    /// and kqueue watch inodes, so every registration at or below that path
-    /// keeps observing the old tree (or nothing), and `add_file` /
-    /// `add_directory` would keep matching the stale entries by path hash
-    /// instead of watching the new ones. With the entries evicted, the reload
-    /// the caller schedules re-arms fresh watches.
-    ///
-    /// inotify names the created or moved-in entries (`names`), so each
-    /// `<dir>/<name>` that is a prefix of watched paths is a replaced subtree.
-    /// kqueue has no names: on a write to the directory, every watched
-    /// directory below it is compared by inode instead (see
-    /// `remove_replaced_descendants`). Windows matches events by path and
-    /// needs none of this.
-    ///
-    /// `stale_dir` receives each directory path whose resolver caches are now
-    /// wrong (the replaced path itself and every evicted directory entry, no
-    /// trailing slash); `stale_file` each evicted file entry with its hash.
-    /// Same contract as `remove_at_index::<false>`: the caller holds
-    /// `self.mutex`. Returns the number of entries queued.
+    /// `stale_dir` gets each directory path to bust (replaced path and evicted
+    /// directory entries, no trailing slash), `stale_file` each evicted file.
+    /// Caller holds `self.mutex`. Returns the number of entries queued.
     pub fn remove_entries_under_replaced_dirs(
         &mut self,
         event: WatchEvent,
@@ -1105,8 +1075,7 @@ impl Watcher {
                 child[dir.len() + 1..len].copy_from_slice(name);
                 let evicted = self.remove_path_and_descendants(&child[..len], &mut each);
                 if evicted > 0 {
-                    // Reported even when the path itself is not an entry: the
-                    // resolver caches intermediate directories it never watches.
+                    // Not necessarily an entry itself; the resolver may cache it.
                     (each)(WatchItemKind::Directory, &child[..len], 0);
                     queued += evicted;
                 }
@@ -1152,10 +1121,9 @@ impl Watcher {
             if !self.queue_eviction(i as WatchItemIndex) {
                 break;
             }
-            // The old file usually still exists under the directory's new name,
-            // so closing its fd in `flush_evictions` does not end the inotify
-            // watch the way it does for an unlinked file. Drop it here, unless
-            // another entry (the same inode under a second path) still uses it.
+            // The old file usually still exists (under the directory's old
+            // name), so closing its fd will not end the watch; drop it unless
+            // another entry shares it.
             #[cfg(any(target_os = "linux", target_os = "android"))]
             if kinds[i] == WatchItemKind::File {
                 let wds = slice.items_eventlist_index();
@@ -1175,13 +1143,9 @@ impl Watcher {
         queued
     }
 
-    /// kqueue reports only that *something* in the directory at `parent`
-    /// changed. Finds every watched directory below it whose path now names a
-    /// different inode than the one its fd holds (or names anything again
-    /// once its vnode was `displaced`), and evicts that subtree through
-    /// `remove_path_and_descendants`. A directory whose path does not exist at
-    /// the moment is left alone: the parent receives another write event when
-    /// something reappears under that name.
+    /// Evicts the subtree of every watched directory below `parent` whose path
+    /// now names another inode than its fd (or anything, once `displaced`). A
+    /// path that does not exist yet is skipped; its return writes `parent` again.
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     fn remove_replaced_descendants(
         &mut self,
@@ -1353,16 +1317,14 @@ pub struct WatchItem {
     pub parent_hash: u32,
     pub kind: WatchItemKind,
     pub package_json: Option<&'static PackageJSON>,
-    /// Whether `flush_evictions` may close `fd`. Files: always (`add_file`
-    /// hands the descriptor over, see [`FdOwnership`]). Directories: only when
-    /// the watcher opened it itself; otherwise it is the resolver's cached
-    /// directory handle, or the dev server's, and theirs to close.
+    /// Whether `flush_evictions` may close `fd`: every file (see [`FdOwnership`]),
+    /// and a directory only when the watcher opened it itself rather than
+    /// borrowing the resolver's or the dev server's handle.
     pub owns_fd: bool,
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub eventlist_index: platform::EventListIndex,
-    /// kqueue: this directory's vnode reported NOTE_RENAME or NOTE_DELETE, so
-    /// `file_path` no longer names it. See `dispatch_file_updates` and
-    /// `remove_replaced_descendants`.
+    /// kqueue: the directory's vnode was renamed or deleted, so `file_path` no
+    /// longer names it; it counts as replaced once the path exists again.
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     pub displaced: bool,
 }
@@ -1373,8 +1335,7 @@ pub enum WatchItemKind {
     Directory,
 }
 
-/// What `flush_evictions` needs to drop the kernel registration of an evicted
-/// directory entry after the entry itself is gone from the watchlist.
+/// An evicted directory entry's registration, dropped after the swap-removes.
 #[cfg(not(windows))]
 struct EvictedDirWatch {
     /// `Fd::INVALID` when `flush_evictions` closed it.

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -44,7 +44,6 @@ pub type Event = WatchEvent;
 pub type WatchList = MultiArrayList<WatchItem>;
 pub type HashType = u32;
 pub type WatchItemIndex = u16;
-pub const MAX_EVICTION_COUNT: usize = 8096;
 
 const NO_WATCH_ITEM: WatchItemIndex = WatchItemIndex::MAX;
 
@@ -121,8 +120,8 @@ pub struct Watcher {
     /// thread) after the loop exits.
     pub(crate) close_descriptors: bun_core::AtomicCell<bool>,
 
-    pub(crate) evict_list: [WatchItemIndex; MAX_EVICTION_COUNT],
-    pub(crate) evict_list_i: WatchItemIndex,
+    /// Indices queued by `remove_at_index` and friends, drained by `flush_evictions`.
+    pub(crate) evict_list: Vec<WatchItemIndex>,
 
     /// Scratch snapshot of `watchlist.eventlist_index` used by
     /// `watch_loop_cycle`; owned by the watcher thread.
@@ -201,8 +200,7 @@ impl Watcher {
             thread: None,
             running: bun_core::AtomicCell::new(true),
             close_descriptors: bun_core::AtomicCell::new(false),
-            evict_list: [0; MAX_EVICTION_COUNT],
-            evict_list_i: 0,
+            evict_list: Vec::new(),
             #[cfg(any(target_os = "linux", target_os = "android"))]
             eventlist_index_scratch: Vec::new(),
             thread_lock: ThreadLock::init_unlocked(),
@@ -227,8 +225,7 @@ impl Watcher {
         }
         let events = &mut self.watch_events[..event_count];
         let changed = &self.changed_filepaths[..changed_count];
-        // kqueue: NOTE_RENAME / NOTE_DELETE on a directory entry are about its
-        // own vnode, so its path no longer names it (see `WatchItem::displaced`).
+        // kqueue: RENAME/DELETE on a directory entry concern its own vnode (`WatchItem::displaced`).
         #[cfg(any(target_os = "macos", target_os = "freebsd"))]
         for event in events.iter() {
             let i = event.index as usize;
@@ -388,7 +385,7 @@ impl Watcher {
     }
 
     pub fn flush_evictions(&mut self) {
-        if self.evict_list_i == 0 {
+        if self.evict_list.is_empty() {
             return;
         }
         // The close+swap_remove below must be serialized against the JS
@@ -407,7 +404,7 @@ impl Watcher {
             self.mutex.is_held_by_current_thread(),
             "flush_evictions: caller must hold self.mutex (platform watcher holds it around on_file_update)",
         );
-        let evict_list_i = self.evict_list_i as usize;
+        let evict_list_i = self.evict_list.len();
 
         // swapRemove messes up the order
         // But, it only messes up the order if any elements in the list appear after the item being removed
@@ -436,9 +433,7 @@ impl Watcher {
             {
                 let kind = slice.items_kind()[item as usize];
                 let mut fd = fds[item as usize];
-                // An evicted file is unlinked or replaced, so closing its fd ends
-                // the watch too. A directory fd that stays open (see
-                // `WatchItem::owns_fd`) has its registration dropped after pass 2.
+                // Closing an evicted file's fd ends its watch; open directory fds are released after pass 2.
                 if fd.is_valid()
                     && (kind == WatchItemKind::File || slice.items_owns_fd()[item as usize])
                 {
@@ -483,7 +478,7 @@ impl Watcher {
             last_item = item;
         }
 
-        self.evict_list_i = 0;
+        self.evict_list.clear();
 
         #[cfg(not(windows))]
         for evicted in &evicted_dir_watches {
@@ -491,9 +486,7 @@ impl Watcher {
         }
     }
 
-    /// Drops the kernel registration of an evicted directory entry, unless a
-    /// surviving entry shares it (same inode under another path, e.g. with and
-    /// without a trailing slash); on kqueue that one is re-pointed instead.
+    /// Drops an evicted directory's kernel registration unless a surviving entry shares it.
     #[cfg(not(windows))]
     fn release_directory_watch(&mut self, evicted: &EvictedDirWatch) {
         #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -1019,28 +1012,17 @@ impl Watcher {
         }
     }
 
-    /// `false` when `evict_list` is full; the entry stays until a later flush.
-    fn queue_eviction(&mut self, index: WatchItemIndex) -> bool {
-        let i = self.evict_list_i as usize;
-        if i >= self.evict_list.len() {
-            return false;
-        }
-        self.evict_list[i] = index;
-        self.evict_list_i += 1;
-        true
+    fn queue_eviction(&mut self, index: WatchItemIndex) {
+        self.evict_list.push(index);
     }
 
-    /// For a directory `event` inside `on_file_update`: when a directory below
-    /// it was replaced (renamed over, or removed and created again: a new inode
-    /// at a path whose watches still point at the old one), queues the
-    /// eviction of every entry at or below that path so the caller's reload
-    /// re-arms them. inotify: each created or moved-in `<dir>/<name>` that
-    /// prefixes watched paths. kqueue (no names): each watched directory below
-    /// whose inode no longer matches its path. Windows matches by path: no-op.
-    ///
-    /// `stale_dir` gets each directory path to bust (replaced path and evicted
-    /// directory entries, no trailing slash), `stale_file` each evicted file.
-    /// Caller holds `self.mutex`. Returns the number of entries queued.
+    /// For a directory `event` in `on_file_update`: a directory below it that was replaced (new
+    /// inode at a path whose watches still hold the old one) gets every entry at or below it
+    /// queued for eviction, so the caller's reload re-arms them. inotify: each created or moved-in
+    /// `<dir>/<name>` that prefixes watched paths; kqueue: each watched directory below whose
+    /// inode no longer matches its path; Windows (path-based): nothing. `stale_dir` gets each
+    /// directory to bust (no trailing slash), `stale_file` each evicted file. Caller holds
+    /// `self.mutex`. Returns the number of entries queued.
     pub fn remove_entries_under_replaced_dirs(
         &mut self,
         event: WatchEvent,
@@ -1114,24 +1096,17 @@ impl Watcher {
         let mut queued = 0;
         for i in 0..slice.len() {
             if is_parent_or_equal(dir_path, &paths[i]) == ParentEqual::Unrelated
-                || self.evict_list[..self.evict_list_i as usize].contains(&(i as WatchItemIndex))
+                || self.evict_list.contains(&(i as WatchItemIndex))
             {
                 continue;
             }
-            if !self.queue_eviction(i as WatchItemIndex) {
-                break;
-            }
-            // The old file usually still exists (under the directory's old
-            // name), so closing its fd will not end the watch; drop it unless
-            // another entry shares it.
+            self.queue_eviction(i as WatchItemIndex);
+            // The old inode usually survives (under the old directory name), so drop its watch here.
             #[cfg(any(target_os = "linux", target_os = "android"))]
             if kinds[i] == WatchItemKind::File {
                 let wds = slice.items_eventlist_index();
                 let shared = (0..slice.len()).any(|j| {
-                    j != i
-                        && wds[j] == wds[i]
-                        && !self.evict_list[..self.evict_list_i as usize]
-                            .contains(&(j as WatchItemIndex))
+                    j != i && wds[j] == wds[i] && !self.evict_list.contains(&(j as WatchItemIndex))
                 });
                 if !shared {
                     self.platform.unwatch(wds[i]);
@@ -1143,9 +1118,8 @@ impl Watcher {
         queued
     }
 
-    /// Evicts the subtree of every watched directory below `parent` whose path
-    /// now names another inode than its fd (or anything, once `displaced`). A
-    /// path that does not exist yet is skipped; its return writes `parent` again.
+    /// Evicts the subtree of each watched directory below `parent` whose path now names another
+    /// inode than its fd (or exists again after `displaced`); a missing path is left for later.
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     fn remove_replaced_descendants(
         &mut self,
@@ -1317,14 +1291,12 @@ pub struct WatchItem {
     pub parent_hash: u32,
     pub kind: WatchItemKind,
     pub package_json: Option<&'static PackageJSON>,
-    /// Whether `flush_evictions` may close `fd`: every file (see [`FdOwnership`]),
-    /// and a directory only when the watcher opened it itself rather than
-    /// borrowing the resolver's or the dev server's handle.
+    /// `flush_evictions` may close `fd`: always for files ([`FdOwnership`]), for a directory only
+    /// when the watcher opened it (not the resolver's or the dev server's handle).
     pub owns_fd: bool,
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub eventlist_index: platform::EventListIndex,
-    /// kqueue: the directory's vnode was renamed or deleted, so `file_path` no
-    /// longer names it; it counts as replaced once the path exists again.
+    /// kqueue: the directory's vnode was renamed or deleted; replaced once the path exists again.
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     pub displaced: bool,
 }

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -496,7 +496,7 @@ impl Watcher {
         self.evict_list_i = 0;
 
         #[cfg(not(windows))]
-        for evicted in evicted_dir_watches {
+        for evicted in &evicted_dir_watches {
             self.release_directory_watch(evicted);
         }
     }
@@ -507,7 +507,7 @@ impl Watcher {
     /// registrations by fd): when a surviving entry does, the registration is
     /// kept, and on kqueue re-pointed at the survivor's index.
     #[cfg(not(windows))]
-    fn release_directory_watch(&mut self, evicted: EvictedDirWatch) {
+    fn release_directory_watch(&mut self, evicted: &EvictedDirWatch) {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             let shared = self
@@ -1073,13 +1073,13 @@ impl Watcher {
     /// `self.mutex`. Returns the number of entries queued.
     pub fn remove_entries_under_replaced_dirs(
         &mut self,
-        event: &WatchEvent,
+        event: WatchEvent,
         names: &[ChangedFilePath],
         stale_dir: &mut dyn FnMut(&[u8]),
         stale_file: &mut dyn FnMut(&[u8], HashType),
     ) -> usize {
         let mut each = |kind: WatchItemKind, path: &[u8], hash: HashType| match kind {
-            WatchItemKind::Directory => stale_dir(strings::trim_right(path, &[b'/'])),
+            WatchItemKind::Directory => stale_dir(strings::trim_right(path, b"/")),
             WatchItemKind::File => stale_file(path, hash),
         };
         #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -1091,7 +1091,7 @@ impl Watcher {
             let Some(dir) = slice.items_file_path().get(event.index as usize) else {
                 return 0;
             };
-            let dir = strings::trim_right(dir, &[b'/']);
+            let dir = strings::trim_right(dir, b"/");
             let mut child = bun_paths::path_buffer_pool::get();
             let mut queued = 0;
             for name in event.names(names).iter().flatten() {
@@ -1151,6 +1151,23 @@ impl Watcher {
             }
             if !self.queue_eviction(i as WatchItemIndex) {
                 break;
+            }
+            // The old file usually still exists under the directory's new name,
+            // so closing its fd in `flush_evictions` does not end the inotify
+            // watch the way it does for an unlinked file. Drop it here, unless
+            // another entry (the same inode under a second path) still uses it.
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            if kinds[i] == WatchItemKind::File {
+                let wds = slice.items_eventlist_index();
+                let shared = (0..slice.len()).any(|j| {
+                    j != i
+                        && wds[j] == wds[i]
+                        && !self.evict_list[..self.evict_list_i as usize]
+                            .contains(&(j as WatchItemIndex))
+                });
+                if !shared {
+                    self.platform.unwatch(wds[i]);
+                }
             }
             each(kinds[i], &paths[i], hashes[i]);
             queued += 1;

--- a/src/watcher/lib.rs
+++ b/src/watcher/lib.rs
@@ -35,7 +35,7 @@ pub use error::{Error, Result};
 
 pub use WatchItemKind as Kind;
 pub use watcher_impl::{
-    AnyResolveWatcher, ChangedFilePath, Event, FdOwnership, HashType, MAX_COUNT,
-    MAX_EVICTION_COUNT, Op, PackageJSON, REQUIRES_FILE_DESCRIPTORS, WATCH_OPEN_FLAGS, WatchEvent,
-    WatchItem, WatchItemColumns, WatchItemIndex, WatchItemKind, WatchList, Watcher, WatcherContext,
+    AnyResolveWatcher, ChangedFilePath, Event, FdOwnership, HashType, MAX_COUNT, Op, PackageJSON,
+    REQUIRES_FILE_DESCRIPTORS, WATCH_OPEN_FLAGS, WatchEvent, WatchItem, WatchItemColumns,
+    WatchItemIndex, WatchItemKind, WatchList, Watcher, WatcherContext,
 };

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -528,6 +528,9 @@ devTest("hmr forwards every merged inotify sub-path from a directory batch", {
   },
 });
 devTest("directory of an imported module replaced by another directory", {
+  // Windows: the running process holds the directory open, so the rename itself
+  // fails with EPERM; its watcher matches events by path anyway.
+  skip: ["win32"],
   files: {
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -527,6 +527,51 @@ devTest("hmr forwards every merged inotify sub-path from a directory batch", {
     }
   },
 });
+devTest("directory of an imported module replaced by another directory", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { V } from "./lib/dep";
+      console.log(V);
+      import.meta.hot.accept();
+    `,
+    "lib/dep.ts": `
+      export const V = "a0";
+    `,
+    "lib.new/dep.ts": `
+      export const V = "b0";
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("a0");
+
+    // `mv lib lib.old && mv lib.new lib`. On Linux and macOS the watches on
+    // `lib/` and `lib/dep.ts` are inode watches on the old directory, so the
+    // dev server has to treat the moved-in directory as a change to every
+    // module below it and watch the new directory from then on.
+    {
+      await using _wait = await dev.batchChanges();
+      renameSync(dev.join("lib"), dev.join("lib.old"));
+      renameSync(dev.join("lib.new"), dev.join("lib"));
+    }
+    await c.expectMessage("b0");
+
+    // A later in-place save under the new directory is seen...
+    await dev.write("lib/dep.ts", `export const V = "b1";\n`);
+    await c.expectMessage("b1");
+
+    // ...and so is a later atomic save (write temp + rename over).
+    {
+      await using _wait = await dev.batchChanges();
+      writeFileSync(dev.join("lib/.dep.ts.tmp"), `export const V = "b2";\n`);
+      renameSync(dev.join("lib/.dep.ts.tmp"), dev.join("lib/dep.ts"));
+    }
+    await c.expectMessage("b2");
+  },
+});
 devTest("hot update frames are not delivered to application websocket topics", {
   files: {
     "index.html": emptyHtmlFile({

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
-import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import { copyFileSync, cpSync, mkdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -775,4 +775,126 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
     // TODO: bun has a memory leak when --hot is used on very large files
   },
   longTimeout,
+);
+
+// The tests below replace the DIRECTORY that holds an imported module. On
+// Linux and macOS the watches on that directory and on the files in it are
+// inode watches, so after the replacement they observe the old directory (or
+// nothing). `--hot` has to reload with the new contents and re-arm the
+// watches, or every later save under the new directory is invisible.
+function hotDirFixture() {
+  const dir = tempDir("hot-dir-replaced", {
+    "app.mjs": `import { V } from "./lib/dep.js";\nconsole.log("[dep] " + V);\n`,
+    "lib/dep.js": `export const V = "a0";\n`,
+  });
+  const root = String(dir);
+  const runner = spawn({
+    cmd: [bunExe(), "--hot", "--no-clear-screen", "app.mjs"],
+    env: bunEnv,
+    cwd: root,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const waiter = (stream: ReadableStream<Uint8Array>, name: string) => {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let output = "";
+    // Resolves once `needle` has been printed after everything seen so far.
+    return async (needle: string) => {
+      const from = output.length;
+      while (!output.slice(from).includes(needle)) {
+        const { value: chunk, done } = await reader.read();
+        if (done)
+          throw new Error(
+            `--hot exited while waiting for ${JSON.stringify(needle)} on ${name}: ${JSON.stringify(output)}`,
+          );
+        output += decoder.decode(chunk, { stream: true });
+      }
+    };
+  };
+  const nextStdout = waiter(runner.stdout, "stdout");
+  const nextStderr = waiter(runner.stderr, "stderr");
+  const next = (value: string) => nextStdout(`[dep] ${value}\n`);
+  const writeDep = (where: string, value: string) =>
+    writeFileSync(join(root, where, "dep.js"), `export const V = "${value}";\n`);
+  return {
+    root,
+    runner,
+    next,
+    nextStderr,
+    writeDep,
+    // A later in-place save and a later atomic save (write temp + rename over)
+    // in the replaced directory must both still reload.
+    async expectLaterSavesReload(prefix: string) {
+      writeDep("lib", `${prefix}1`);
+      await next(`${prefix}1`);
+      writeFileSync(join(root, "lib", ".dep.js.tmp"), `export const V = "${prefix}2";\n`);
+      renameSync(join(root, "lib", ".dep.js.tmp"), join(root, "lib", "dep.js"));
+      await next(`${prefix}2`);
+    },
+    [Symbol.dispose]() {
+      runner.kill(9);
+      dir[Symbol.dispose]();
+    },
+  };
+}
+
+it(
+  "should hot reload when the directory of an import is renamed over, and keep watching it",
+  async () => {
+    using hot = hotDirFixture();
+    await hot.next("a0");
+
+    // mv lib lib.old && mv lib.new lib
+    mkdirSync(join(hot.root, "lib.new"));
+    hot.writeDep("lib.new", "b0");
+    renameSync(join(hot.root, "lib"), join(hot.root, "lib.old"));
+    renameSync(join(hot.root, "lib.new"), join(hot.root, "lib"));
+    await hot.next("b0");
+
+    await hot.expectLaterSavesReload("b");
+  },
+  timeout,
+);
+
+it(
+  "should hot reload when the directory of an import is removed and created again, and keep watching it",
+  async () => {
+    using hot = hotDirFixture();
+    await hot.next("a0");
+
+    // The removal reloads once and that reload fails to resolve `./lib/dep.js`;
+    // the error goes to stderr and is expected.
+    rmSync(join(hot.root, "lib"), { recursive: true, force: true });
+    // Recreate it with the module already inside, the way a checkout or a
+    // copy of a prepared tree does.
+    mkdirSync(join(hot.root, "lib.new"));
+    hot.writeDep("lib.new", "c0");
+    renameSync(join(hot.root, "lib.new"), join(hot.root, "lib"));
+    await hot.next("c0");
+
+    await hot.expectLaterSavesReload("c");
+  },
+  timeout,
+);
+
+it(
+  "should hot reload when the directory of an import is renamed away and back",
+  async () => {
+    using hot = hotDirFixture();
+    await hot.next("a0");
+
+    renameSync(join(hot.root, "lib"), join(hot.root, "lib.away"));
+    // The moved file is still watched (same inode), so saving it reloads, and
+    // that reload cannot resolve `./lib/dep.js` while the directory is away.
+    hot.writeDep("lib.away", "d0");
+    await hot.nextStderr(`Cannot find module './lib/dep.js'`);
+    // Moving the directory back has to recover from that on its own.
+    renameSync(join(hot.root, "lib.away"), join(hot.root, "lib"));
+    await hot.next("d0");
+
+    await hot.expectLaterSavesReload("d");
+  },
+  timeout,
 );

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -781,7 +781,9 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
 // Linux and macOS the watches on that directory and on the files in it are
 // inode watches, so after the replacement they observe the old directory (or
 // nothing). `--hot` has to reload with the new contents and re-arm the
-// watches, or every later save under the new directory is invisible.
+// watches, or every later save under the new directory is invisible. Windows
+// is skipped: the running process holds the directory open, so the rename
+// itself fails with EPERM, and its watcher matches events by path anyway.
 function hotDirFixture() {
   const dir = tempDir("hot-dir-replaced", {
     "app.mjs": `import { V } from "./lib/dep.js";\nconsole.log("[dep] " + V);\n`,
@@ -840,7 +842,7 @@ function hotDirFixture() {
   };
 }
 
-it(
+it.skipIf(isWindows)(
   "should hot reload when the directory of an import is renamed over, and keep watching it",
   async () => {
     using hot = hotDirFixture();
@@ -858,7 +860,7 @@ it(
   timeout,
 );
 
-it(
+it.skipIf(isWindows)(
   "should hot reload when the directory of an import is removed and created again, and keep watching it",
   async () => {
     using hot = hotDirFixture();
@@ -879,7 +881,7 @@ it(
   timeout,
 );
 
-it(
+it.skipIf(isWindows)(
   "should hot reload when the directory of an import is renamed away and back",
   async () => {
     using hot = hotDirFixture();

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -470,31 +470,41 @@ it.skipIf(isWindows)(
 // same name (`mv lib lib.old && mv lib.new lib`). On Linux and macOS the
 // watches below it are inode watches on the old directory, so without
 // treating the replacement as a change the process keeps running the old
-// module and never sees a save under the new directory again.
-it("--watch reruns when the directory of an import is renamed over", async () => {
-  using dir = tempDir("watch-dir-replaced", {
-    "app.js": `import { V } from "./lib/dep.js";\nconsole.log("[dep] " + V);\nsetInterval(() => {}, 1000);\n`,
-    "lib/dep.js": `export const V = "a0";\n`,
-    "lib.new/dep.js": `export const V = "b0";\n`,
-  });
-  const root = String(dir);
+// module and never sees a save under the new directory again. Windows is
+// skipped: the running process holds the directory open, so the rename itself
+// fails with EPERM, and its watcher matches events by path anyway.
+it.skipIf(isWindows)(
+  "--watch reruns when the directory of an import is renamed over",
+  async () => {
+    using dir = tempDir("watch-dir-replaced", {
+      "app.js": `import { V } from "./lib/dep.js";\nconsole.log("[dep] " + V);\nsetInterval(() => {}, 1000);\n`,
+      "lib/dep.js": `export const V = "a0";\n`,
+      "lib.new/dep.js": `export const V = "b0";\n`,
+    });
+    const root = String(dir);
 
-  watchee = spawn({
-    cmd: [bunExe(), "--watch", "--no-clear-screen", "app.js"],
-    cwd: root,
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "inherit",
-    stdin: "ignore",
-  });
-  const { waitFor } = stdoutWaiter(watchee);
+    watchee = spawn({
+      cmd: [bunExe(), "--watch", "--no-clear-screen", "app.js"],
+      cwd: root,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
+    const { waitFor } = stdoutWaiter(watchee);
 
-  await waitFor("[dep] a0\n");
-  renameSync(join(root, "lib"), join(root, "lib.old"));
-  renameSync(join(root, "lib.new"), join(root, "lib"));
-  await waitFor("[dep] b0\n");
+    await waitFor("[dep] a0\n");
+    renameSync(join(root, "lib"), join(root, "lib.old"));
+    renameSync(join(root, "lib.new"), join(root, "lib"));
+    await waitFor("[dep] b0\n");
 
-  // The rerun process watches the new directory: a later save in it reruns too.
-  writeFileSync(join(root, "lib", "dep.js"), `export const V = "b1";\n`);
-  await waitFor("[dep] b1\n");
-}, 30000);
+    // The rerun process watches the new directory: a later save in it reruns too.
+    writeFileSync(join(root, "lib", "dep.js"), `export const V = "b1";\n`);
+    await waitFor("[dep] b1\n");
+
+    // Stop the child before `dir` is removed on scope exit.
+    watchee.kill("SIGKILL");
+    await watchee.exited;
+  },
+  30000,
+);

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -2,7 +2,7 @@ import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterEach, expect, it } from "bun:test";
 import { bunEnv, bunExe, isBroken, isLinux, isWindows, tempDir, tmpdirSync } from "harness";
-import { readdirSync, rmSync } from "node:fs";
+import { readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 let watchee: Subprocess;
@@ -465,3 +465,36 @@ it.skipIf(isWindows)(
   },
   30000,
 );
+
+// The directory holding an import is replaced by another directory of the
+// same name (`mv lib lib.old && mv lib.new lib`). On Linux and macOS the
+// watches below it are inode watches on the old directory, so without
+// treating the replacement as a change the process keeps running the old
+// module and never sees a save under the new directory again.
+it("--watch reruns when the directory of an import is renamed over", async () => {
+  using dir = tempDir("watch-dir-replaced", {
+    "app.js": `import { V } from "./lib/dep.js";\nconsole.log("[dep] " + V);\nsetInterval(() => {}, 1000);\n`,
+    "lib/dep.js": `export const V = "a0";\n`,
+    "lib.new/dep.js": `export const V = "b0";\n`,
+  });
+  const root = String(dir);
+
+  watchee = spawn({
+    cmd: [bunExe(), "--watch", "--no-clear-screen", "app.js"],
+    cwd: root,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+    stdin: "ignore",
+  });
+  const { waitFor } = stdoutWaiter(watchee);
+
+  await waitFor("[dep] a0\n");
+  renameSync(join(root, "lib"), join(root, "lib.old"));
+  renameSync(join(root, "lib.new"), join(root, "lib"));
+  await waitFor("[dep] b0\n");
+
+  // The rerun process watches the new directory: a later save in it reruns too.
+  writeFileSync(join(root, "lib", "dep.js"), `export const V = "b1";\n`);
+  await waitFor("[dep] b1\n");
+}, 30000);


### PR DESCRIPTION
### Problem
- Linux and macOS, `--hot` / `--watch` / `bun build --watch` / dev server: replace the directory of an imported module (`mv lib lib.old && mv lib.new lib`, or `rm -rf lib` and regenerate). No reload, and every later save under the new directory is ignored.
- inotify and kqueue watch inodes. The entries under `lib/` kept the old ones, a moved-in directory name matched nothing in `on_file_update` (`hot_reloader.rs`), and each reload's `Watcher::add_file` found the stale entries by path hash, so no new watch was armed.

### Fix
- `Watcher::remove_entries_under_replaced_dirs`: a created or moved-in name that prefixes watched paths (inotify) evicts every entry at or below it. kqueue has no names, so on a directory write each watched directory below it is compared by inode instead. The hot reloader busts the resolver cache and reloads the evicted files, the dev server hands them to its incremental graph, and the reload re-arms the watches.
- `flush_evictions` closes a directory entry's fd only when the watcher opened it (`owns_fd`), and otherwise drops only the kernel registration. Evicted files under a replaced directory have their inotify watch dropped too.
- Verified: 5 new tests (`test/cli/hot/hot.test.ts`, `test/cli/watch/watch.test.ts`, `test/bake/dev/hot.test.ts`) fail on bun 1.4.3 and pass here, as do those suites in full. Self-reviewed: re-cut to the watcher-level core as the review asked (see notes).

### Background
- An inotify watch is added by path but bound to the inode, and its directory events name the changed entry. A kqueue watch is a vnode filter on an open fd and gives only flags. Neither follows a path to a new inode.
- `on_file_update` runs on the watcher thread. Queued evictions are applied by `flush_evictions` before the reload task is posted. A `--hot` reload re-imports everything through `add_file`, which also watches each module's directory.

<details><summary>Notes</summary>

- Shapes covered by the new tests: directory renamed over, directory removed and created again with its files, directory renamed away and back after a failed reload, `--watch` directory renamed over, dev server directory renamed over plus later in-place and atomic saves.
- Not in this PR: an imported *file* that comes back only after the failed reload already ran (deleted and recreated later, or its name briefly a directory or dangling symlink), and the `rm -rf lib`, `mkdir lib`, and later a write of `lib/dep.js` order. Those need a memory of the missing path. #41461 adds that at the resolver/watcher level for `--hot`, `--watch` and `bun build --watch`, and this change stacks with it. The self-review asked to keep that out of here rather than add a second mechanism.
- Windows is not affected: `ReadDirectoryChangesW` watches the project root recursively and events are matched by path. `remove_entries_under_replaced_dirs` is a no-op there, and the new tests are skipped there because the running process holds the directory open, so the rename itself fails with EPERM.
- kqueue: a `displaced` flag is set on a directory entry when its own vnode reports `NOTE_RENAME`/`NOTE_DELETE`, so a same-inode move-back also counts as replaced once the path exists again. The descendant check costs one `stat` (plus one `fstat`) per watched directory below the directory that reported a write. Directory vnodes report writes on entry create, remove and rename, not on file content writes. I could not run the macOS lanes locally. CI covers them.
- fd ownership rule: a file entry's fd is the watcher's (`add_file` returns `FdOwnership::Watcher`) and is closed on eviction as before. A directory entry's fd is the watcher's only when `append_directory_assume_capacity` opened it itself. Usually it is the resolver's cached handle (`store_fd`) or the dev server `DirectoryWatchStore`'s, which closes its own. Kernel registrations of evicted directories are dropped with `inotify_rm_watch` / `EV_DELETE` unless a surviving entry shares them (the same directory can be in the list with and without a trailing slash). On kqueue a shared registration is re-pointed at the survivor's index.
- The inotify path also evicts and reloads a watched file whose own name is created or renamed over in the batch. The existing lookup through the resolver's directory-entry cache does the same when the cache has the entry. Evictions and reload hashes are deduplicated, so the overlap is harmless.
- `evict_list` is a growable `Vec` now, so a replaced directory with many watched descendants is evicted in full.
- The shell repro from the report (swap, rename away and back, `rm -rf lib` then `mkdir lib && echo ... > lib/dep.js`) reloads on the change and keeps seeing in-place and atomic saves. The inotify watch count stays at 4 throughout.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/watch/watch.test.ts, test/cli/hot/hot.test.ts, test/bake/dev/hot.test.ts

<!-- robobun:evidence:end -->