### PR TITLE
css: print the vendor prefix on downleveled :any-link, :read-only, :read-write, :placeholder-shown and :autofill

### DIFF
--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -1001,7 +1001,7 @@ pub(crate) mod serialize {
             d.write_char(b':')?;
             // If the printer has a vendor prefix override, use that.
             let vp = if !d.vendor_prefix.is_empty() {
-                (d.vendor_prefix | prefix).or_none()
+                (d.vendor_prefix & prefix).or_none()
             } else {
                 prefix
             };
@@ -1056,7 +1056,7 @@ pub(crate) mod serialize {
                     *prefix
                 };
                 vp.to_css(dest)?;
-                if vp.contains(VendorPrefix::WEBKIT) || vp.contains(VendorPrefix::MOZ) {
+                if vp == VendorPrefix::WEBKIT || vp == VendorPrefix::MOZ {
                     dest.write_str(b"full-screen")?;
                 } else {
                     dest.write_str(b"fullscreen")?;
@@ -1205,7 +1205,7 @@ pub(crate) mod serialize {
             }
             PseudoElement::Placeholder(prefix) => {
                 let vp = write_prefix(dest, *prefix)?;
-                if vp.contains(VendorPrefix::WEBKIT) || vp.contains(VendorPrefix::MS) {
+                if vp == VendorPrefix::WEBKIT || vp == VendorPrefix::MS {
                     dest.write_str(b"input-placeholder")?;
                 } else {
                     dest.write_str(b"placeholder")?;
@@ -1214,9 +1214,9 @@ pub(crate) mod serialize {
             PseudoElement::Backdrop(prefix) => write_prefixed(dest, *prefix, b"backdrop")?,
             PseudoElement::FileSelectorButton(prefix) => {
                 let vp = write_prefix(dest, *prefix)?;
-                if vp.contains(VendorPrefix::WEBKIT) {
+                if vp == VendorPrefix::WEBKIT {
                     dest.write_str(b"file-upload-button")?;
-                } else if vp.contains(VendorPrefix::MS) {
+                } else if vp == VendorPrefix::MS {
                     dest.write_str(b"browse")?;
                 } else {
                     dest.write_str(b"file-selector-button")?;

--- a/test/bundler/css/prefixed-pseudo-class.test.ts
+++ b/test/bundler/css/prefixed-pseudo-class.test.ts
@@ -1,0 +1,31 @@
+import { describe } from "bun:test";
+import { itBundled } from "../expectBundled";
+
+describe("css", () => {
+  // The default browser targets include engines that only match `:autofill`
+  // as `:-webkit-autofill`, so the rule is printed once per prefix.
+  itBundled("css/prefixed-pseudo-class-default-targets", {
+    files: {
+      "index.css": /* css */ `
+        input:autofill {
+          color: red;
+        }
+      `,
+    },
+    outdir: "/out",
+    entryPoints: ["/index.css"],
+    onAfterBundle(api) {
+      api.expectFile("/out/index.css").toMatchInlineSnapshot(`
+        "/* index.css */
+        input:-webkit-autofill {
+          color: red;
+        }
+
+        input:autofill {
+          color: red;
+        }
+        "
+      `);
+    },
+  });
+});

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -5693,6 +5693,204 @@ describe("css tests", () => {
       },
     );
 
+    // A pseudo-class that a target only supports behind a vendor prefix is
+    // printed once per needed prefix, each copy with its own prefix.
+    prefix_test(
+      ".foo:any-link {color:red}",
+      `
+      .foo:-webkit-any-link {
+        color: red;
+      }
+
+      .foo:-moz-any-link {
+        color: red;
+      }
+
+      .foo:any-link {
+        color: red;
+      }
+      `,
+      {
+        chrome: 50 << 16,
+        firefox: 40 << 16,
+      },
+    );
+    prefix_test(
+      ".foo:read-only {color:red}",
+      `
+      .foo:-moz-read-only {
+        color: red;
+      }
+
+      .foo:read-only {
+        color: red;
+      }
+      `,
+      {
+        firefox: 36 << 16,
+      },
+    );
+    prefix_test(
+      ".foo:read-write {color:red}",
+      `
+      .foo:-moz-read-write {
+        color: red;
+      }
+
+      .foo:read-write {
+        color: red;
+      }
+      `,
+      {
+        firefox: 36 << 16,
+      },
+    );
+    prefix_test(
+      ".foo:placeholder-shown {color:red}",
+      `
+      .foo:-moz-placeholder-shown {
+        color: red;
+      }
+
+      .foo:placeholder-shown {
+        color: red;
+      }
+      `,
+      {
+        firefox: 40 << 16,
+      },
+    );
+    prefix_test(
+      ".foo:autofill {color:red}",
+      `
+      .foo:-webkit-autofill {
+        color: red;
+      }
+
+      .foo:autofill {
+        color: red;
+      }
+      `,
+      {
+        chrome: 103 << 16,
+      },
+    );
+    prefix_test(
+      ".foo:placeholder-shown .bar {color:red} .foo:autofill .baz {color:red}",
+      `
+      .foo:placeholder-shown .bar {
+        color: red;
+      }
+
+      .foo:-webkit-autofill .baz {
+        color: red;
+      }
+
+      .foo:autofill .baz {
+        color: red;
+      }
+      `,
+      {
+        chrome: 103 << 16,
+      },
+    );
+    prefix_test(
+      ".foo:placeholder-shown .bar,.foo:autofill .baz{color:red}",
+      `
+      :-webkit-any(.foo:placeholder-shown .bar, .foo:-webkit-autofill .baz) {
+        color: red;
+      }
+
+      :is(.foo:placeholder-shown .bar, .foo:autofill .baz) {
+        color: red;
+      }
+      `,
+      {
+        chrome: 103 << 16,
+      },
+    );
+    // Targets that support the unprefixed form print it once.
+    prefix_test(
+      ".foo:any-link {color:red}",
+      `
+      .foo:any-link {
+        color: red;
+      }
+      `,
+      {
+        chrome: 87 << 16,
+        firefox: 78 << 16,
+        safari: 14 << 16,
+      },
+    );
+    // With nesting compiled away, a nested rule that runs its own prefix passes
+    // leaves the printer outside any pass. A sibling printed after it carries
+    // the parent's whole prefix set and must print the unprefixed name.
+    prefix_test(
+      ".a:fullscreen { color: red; & .b:autofill { color: green } & .c { color: blue } }",
+      `
+      .a:-webkit-full-screen {
+        color: red;
+      }
+
+      .a:-webkit-full-screen .c {
+        color: #00f;
+      }
+
+      .a:fullscreen {
+        color: red;
+      }
+
+      .a:-webkit-full-screen .b:-webkit-autofill {
+        color: green;
+      }
+
+      .a:fullscreen .b:autofill {
+        color: green;
+      }
+
+      .a:fullscreen .c {
+        color: #00f;
+      }
+      `,
+      {
+        chrome: 87 << 16,
+        safari: 14 << 16,
+      },
+    );
+    prefix_test(
+      ".a::file-selector-button { color: red; &:is(:hover, :focus-visible) { color: green } &:active { color: blue } }",
+      `
+      .a::-webkit-file-upload-button {
+        color: red;
+      }
+
+      .a::-webkit-file-upload-button:active {
+        color: #00f;
+      }
+
+      .a::file-selector-button {
+        color: red;
+      }
+
+      .a::-webkit-file-upload-button:-webkit-any(:hover, :focus-visible) {
+        color: green;
+      }
+
+      .a::file-selector-button:is(:hover, :focus-visible) {
+        color: green;
+      }
+
+      .a::file-selector-button:active {
+        color: #00f;
+      }
+      `,
+      {
+        chrome: 87 << 16,
+        safari: 14 << 16,
+      },
+    );
+
     minify_test(".foo::cue {color: red}", ".foo::cue{color:red}");
     minify_test(".foo::cue-region {color: red}", ".foo::cue-region{color:red}");
     minify_test(".foo::cue(b) {color: red}", ".foo::cue(b){color:red}");


### PR DESCRIPTION
### Problem
- Some targets need a prefixed `:any-link`, `:read-only`, `:read-write`, `:placeholder-shown` or `:autofill`. The rule is then printed once per prefix, but every copy is unprefixed. Default-target `bun build` turns `.q:autofill {}` into two `.q:autofill {}` rules and no `.q:-webkit-autofill`.
- Cause: `write_prefixed` in `serialize_pseudo_class` (`src/css/selectors/selector.rs:1004`) combines the pass prefix with the component's prefix set using `|`. The result has several bits, and `VendorPrefix::to_css` prints nothing for that.
- The `:fullscreen`, `::placeholder` and `::file-selector-button` arms pick the legacy name with `contains()`. A downleveled component printed outside a pass carries its whole set. So `.a:fullscreen { & .b:autofill {} & .c {} }` ends in `.a:full-screen .c` once nesting is compiled away.

### Fix
- Use `&` in `write_prefixed` and `==` in the three arms, as lightningcss does. Each pass prints only its own prefix. Outside a pass the standard name is printed.
- Verified: `test/js/bun/css/css.test.ts` (10 new cases, 9 fail on 1.4.3) and `test/bundler/css/prefixed-pseudo-class.test.ts` (fails on 1.4.3). Also ran `test/js/bun/css/`, `test/bundler/css/` and `test/bundler/esbuild/css.test.ts`.
- #42106 has the same `&` change as its first commit, under a larger rework. If this lands first, that commit drops on rebase.
- Self-reviewed: 7 concerns raised, 4 addressed, 3 declined in Notes.

### Background
- `VendorPrefix` is a bit set (`WEBKIT`, `MOZ`, `MS`, `O`, `NONE`). A parsed `:autofill` carries `NONE`. For old targets `get_necessary_prefixes` widens it, for example to `WEBKIT | NONE`.
- A style rule that needs several prefixes is serialized once per prefix. Each pass sets `Printer::vendor_prefix` to that one prefix.

<details><summary>Notes</summary>

- Chrome < 110 and Safari < 15 only match `:-webkit-autofill`, so the default-target output lost the style there and duplicated the rule everywhere else.
- The Zig port had the same `or` and `contains`, so this was never correct in Bun. It is not a regression.
- `VendorPrefix::to_css` is at `src/css/css_parser.rs:137`. `or_none()` (`src/css/lib.rs:257`) returns `NONE` for an empty set and the set unchanged otherwise. `get_necessary_prefixes` is in `src/css/selectors/parser.rs`. The upstream code is the `write_prefixed!` macro and the `Fullscreen`, `Placeholder` and `FileSelectorButton` arms in lightningcss `src/selector.rs`.
- How a component gets printed outside a pass: `StyleRule::to_css` (`src/css/rules/style.rs:155`) resets `Printer::vendor_prefix` to empty after its passes instead of restoring the parent's value. lightningcss does the same. With nesting compiled away, a nested rule that runs its own passes (`& .b:autofill`) therefore leaves the printer outside any pass, and a later sibling (`& .c`) re-prints the parent's downleveled `:fullscreen` with its whole set. With `==` that prints `:fullscreen`, which is right because nested rules with their own passes are only emitted in the parent's final, unprefixed pass (#31642). Restoring instead of resetting would diverge from upstream and is left to #42106, which reworks the passes.
- An explicitly prefixed pseudo-class in a list that also gets an unprefixed pass (for example `.a:placeholder-shown .x, .b:-webkit-autofill .y`) prints the same before and after this change: `NONE | WEBKIT` printed nothing, and `(NONE & WEBKIT).or_none()` prints nothing. lightningcss prints the same. #42100 and #42106 change that behaviour on purpose, so this PR adds no test that pins it.
- Probe cases compared against lightningcss 1.30.2 (`transform` with the same targets), all byte for byte identical after the fix: `:any-link` (chrome 50 + firefox 40, and the default targets), `:read-only` / `:read-write` (chrome 30 + firefox 40, firefox 36), `:placeholder-shown` (firefox 40, default targets), `:autofill` (chrome 80, chrome 103, default targets), `.foo:-moz-read-only {} .foo:read-only {}` (firefox 36 and 85), and the three `.foo:placeholder-shown .bar` / `.foo:autofill .baz` cases from lightningcss `test_merge_rules` (chrome 103).
- Review concerns declined: port all of lightningcss `test_merge_rules` (about 60 cases, most unrelated to prefixes), and add a `debug_assert` for multi-bit values in `VendorPrefix::to_css` (it would fire on the reset path above until that changes). Both are follow-ups. The third asked to keep two explicit-prefix test pins. They pass on 1.4.3 and conflict with #42100 and #42106, so they were dropped.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/css/prefixed-pseudo-class.test.ts test/js/bun/css/css.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/css/prefixed-pseudo-class.test.ts:
13 |       `,
14 |     },
15 |     outdir: "/out",
16 |     entryPoints: ["/index.css"],
17 |     onAfterBundle(api) {
18 |       api.expectFile("/out/index.css").toMatchInlineSnapshot(`
                                            ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "/* index.css */
- input:-webkit-autofill {
+ input:autofill {
    color: red;
  }
  
  input:autofill {
    color: red;
  }
  "
  

- Expected  - 1
+ Received  + 1

      at onAfterBundle (/workspace/bun/test/bundler/css/prefixed-pseudo-class.test.ts:18:40)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1658:13)
(fail) css > css/prefixed-pseudo-class-default-targets [469.94ms]

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexro
... (truncated)

release without fix: 10 failed, 67 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/css/prefixed-pseudo-class.test.ts:
13 |       `,
14 |     },
15 |     outdir: "/out",
16 |     entryPoints: ["/index.css"],
17 |     onAfterBundle(api) {
18 |       api.expectFile("/out/index.css").toMatchInlineSnapshot(`
                                            ^
error: expect(received).toMatchInlineSnapshot(expected)

  
  "/* index.css */
- input:-webkit-autofill {
+ input:autofill {
    color: red;
  }
  
  input:autofill {
    color: red;
  }
  "
  

- Expected  - 1
+ Received  + 1

      at onAfterBundle (/workspace/bun/test/bundler/css/prefixed-pseudo-class.test.ts:18:40)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1658:13)
(fail) css > css/prefixed-pseudo-class-default-targets [13.49ms]

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.09ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/css/prefixed-pseudo-class.test.ts test/js/bun/css/css.test.ts
bun test v1.4.3 (f42e98025)

test/bundler/css/prefixed-pseudo-class.test.ts:
(pass) css > css/prefixed-pseudo-class-default-targets [492.68ms]

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [2.94ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.10ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [13.05ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  b
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 592ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/127] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/127] gen cpp.rs (cppbind)
[3/127] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 7 sinks, 84 exported symbols
Generating /workspace/bun/build/release/codegen/JSSink.lut.h from /workspace/bun/build/release/codegen/JSSink.lut.txt
[4/127] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRou
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/selectors/selector.rs                  |  10 +-
 test/bundler/css/prefixed-pseudo-class.test.ts |  31 ++++
 test/js/bun/css/css.test.ts                    | 198 +++++++++++++++++++++++++
 3 files changed, 234 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/css/selectors/selector.rs                       4      4     15
test/bundler/css/prefixed-pseudo-class.test.ts      0      1      4
test/js/bun/css/css.test.ts                         3      5     12
```

</details>

<!-- robobun:evidence:end -->