### PR TITLE
ImportMetaObject: hold import.meta.path as a JSString, drop the WTF::String member and the destructor

### DIFF
--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -69,23 +69,19 @@ ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* globalObject, JS
     RELEASE_AND_RETURN(scope, create(globalObject, keyString));
 }
 
-// True when URL::fileURLWithFileSystemPath(path).fileSystemPath() gives back `path` unchanged, which
-// is the case for what the resolver produces: a normalized absolute path in the platform's own syntax.
+// True when URL::fileURLWithFileSystemPath(path).fileSystemPath() == path: a normalized absolute path.
 static bool isFileSystemPathInURLForm(const WTF::String& path)
 {
 #if OS(WINDOWS)
-    // `C:\dir\file`. Forward slashes come back as backslashes (the standalone executable's
-    // `B:/~BUN/root/...`), and a UNC or rooted path takes a different shape.
+    // `C:\...` only. `B:/~BUN/...` (standalone) comes back with backslashes, UNC paths change shape.
     if (path.length() < 3 || !isASCIIAlpha(path[0]) || path[1] != ':' || path[2] != '\\')
         return false;
     if (path.find('/') != notFound)
         return false;
-    // The URL parser collapses `.` and `..` segments.
     return !path.contains("\\.\\"_s) && !path.contains("\\..\\"_s) && !path.endsWith("\\."_s) && !path.endsWith("\\.."_s);
 #else
     if (!path.startsWith('/'))
         return false;
-    // The URL parser collapses `.` and `..` segments.
     return !path.contains("/./"_s) && !path.contains("/../"_s) && !path.endsWith("/."_s) && !path.endsWith("/.."_s);
 #endif
 }

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -25,7 +25,6 @@
 #include <JavaScriptCore/HeapAnalyzer.h>
 #include <JavaScriptCore/CallData.h>
 
-#include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
@@ -38,7 +37,6 @@
 #include "JSBufferEncodingType.h"
 #include <JavaScriptCore/JSBase.h>
 
-#include "JSDOMURL.h"
 #include <JavaScriptCore/JSNativeStdFunction.h>
 #include <JavaScriptCore/LazyProperty.h>
 #include <JavaScriptCore/LazyPropertyInlines.h>
@@ -55,50 +53,69 @@ namespace Zig {
 using namespace JSC;
 using namespace WebCore;
 
-ImportMetaObject* ImportMetaObject::create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const WTF::String& url)
+ImportMetaObject* ImportMetaObject::create(JSC::VM& vm, JSC::Structure* structure, JSString* path, JSString* url)
 {
-    ImportMetaObject* ptr = new (NotNull, JSC::allocateCell<ImportMetaObject>(vm)) ImportMetaObject(vm, structure, url);
-    ptr->finishCreation(vm);
+    ImportMetaObject* ptr = new (NotNull, JSC::allocateCell<ImportMetaObject>(vm)) ImportMetaObject(vm, structure);
+    ptr->finishCreation(vm, path, url);
     return ptr;
 }
 
-ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* globalObject, const WTF::String& url)
+ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* globalObject, JSValue key)
 {
     VM& vm = globalObject->vm();
-    Zig::GlobalObject* zigGlobalObject = uncheckedDowncast<Zig::GlobalObject>(globalObject);
-    bool isBake = url.startsWith("bake:"_s);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSString* keyString = key.toString(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    RELEASE_AND_RETURN(scope, create(globalObject, keyString));
+}
 
-    // Get the appropriate structure
-    Structure* structure = isBake
+// True when URL::fileURLWithFileSystemPath(path).fileSystemPath() gives back `path` unchanged, which
+// is the case for what the resolver produces: an absolute path in the platform's own syntax.
+static bool isFileSystemPathInURLForm(const WTF::String& path)
+{
+#if OS(WINDOWS)
+    // `C:\dir\file`. Forward slashes come back as backslashes (the standalone executable's
+    // `B:/~BUN/root/...`), and a UNC or rooted path takes a different shape.
+    if (path.length() < 3 || !isASCIIAlpha(path[0]) || path[1] != ':' || path[2] != '\\')
+        return false;
+    return path.find('/') == notFound;
+#else
+    return path.startsWith('/');
+#endif
+}
+
+ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* globalObject, JSString* key)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Resolves a rope in place, so that m_path never is one.
+    auto keyString = key->value(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    size_t queryStart = keyString->find('?');
+    if (queryStart == notFound && isFileSystemPathInURLForm(keyString)) {
+        RELEASE_AND_RETURN(scope, create(vm, uncheckedDowncast<Zig::GlobalObject>(globalObject)->ImportMetaObjectStructure(), key, nullptr));
+    }
+
+    StringView keyView = keyString;
+    URL url = URL::fileURLWithFileSystemPath(queryStart == notFound ? keyView : keyView.left(queryStart));
+    if (queryStart != notFound)
+        url.setQuery(keyView.substring(queryStart + 1));
+    RELEASE_AND_RETURN(scope, createFromURL(globalObject, url));
+}
+
+ImportMetaObject* ImportMetaObject::createFromURL(JSC::JSGlobalObject* globalObject, const WTF::URL& url)
+{
+    VM& vm = globalObject->vm();
+    auto* zigGlobalObject = uncheckedDowncast<Zig::GlobalObject>(globalObject);
+
+    Structure* structure = url.protocolIs("bake"_s)
         ? zigGlobalObject->ImportMetaBakeObjectStructure()
         : zigGlobalObject->ImportMetaObjectStructure();
+    WTF::String path = url.protocolIsFile() ? url.fileSystemPath() : url.path().toString();
 
-    return create(vm, globalObject, structure, url);
-}
-
-ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* globalObject, JSValue specifierOrURL)
-{
-    if (WebCore::DOMURL* url = WebCoreCast<WebCore::JSDOMURL, WebCore::DOMURL>(JSValue::encode(specifierOrURL))) {
-        return create(globalObject, url->href().string());
-    }
-
-    WTF::String specifier = specifierOrURL.toWTFString(globalObject);
-    ASSERT(specifier);
-    return ImportMetaObject::createFromSpecifier(globalObject, specifier);
-}
-
-ImportMetaObject* ImportMetaObject::createFromSpecifier(JSC::JSGlobalObject* globalObject, const String& specifier)
-{
-    auto index = specifier.find('?');
-    URL url;
-    if (index != notFound) {
-        StringView view = specifier;
-        url = URL::fileURLWithFileSystemPath(view.substring(0, index));
-        url.setQuery(view.substring(index + 1));
-    } else {
-        url = URL::fileURLWithFileSystemPath(specifier);
-    }
-    return create(globalObject, url.string());
+    return create(vm, structure, jsString(vm, WTF::move(path)), jsString(vm, url.string()));
 }
 
 extern "C" JSC::EncodedJSValue functionImportMeta__resolveSync(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
@@ -470,7 +487,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_path, (JSGlobalObject * global
     if (!thisObject) [[unlikely]]
         return JSValue::encode(jsUndefined());
 
-    return JSValue::encode(thisObject->pathProperty.getInitializedOnMainThread(thisObject));
+    return JSValue::encode(thisObject->path());
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_require, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, PropertyName propertyName))
@@ -524,7 +541,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsImportMetaObjectGetter_main, (JSGlobalObject * lexica
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSValue path = thisObject->pathProperty.getInitializedOnMainThread(thisObject);
+    JSValue path = thisObject->path();
     JSValue bunMain = JSValue::decode(BunObject_getter_main(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
     bool isMain = JSValue::strictEqual(globalObject, path, bunMain);
@@ -620,87 +637,47 @@ JSC::Structure* ImportMetaObject::createStructure(JSC::VM& vm, JSC::JSGlobalObje
     return Bun::createClassStructure(vm, globalObject, prototype, JSC::TypeInfo(ObjectType, StructureFlags), ImportMetaObject::info());
 }
 
-void ImportMetaObject::finishCreation(VM& vm)
+void ImportMetaObject::finishCreation(VM& vm, JSString* path, JSString* url)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
+    ASSERT(!path->isRope());
+    m_path.set(vm, this, path);
 
     this->requireProperty.initLater([](const JSC::LazyProperty<JSC::JSObject, JSC::JSCell>::Initializer& init) {
         auto scope = DECLARE_THROW_SCOPE(init.vm);
         ImportMetaObject* meta = uncheckedDowncast<ImportMetaObject>(init.owner);
-
-        WTF::URL url = isAbsolutePath(meta->url) ? WTF::URL::fileURLWithFileSystemPath(meta->url) : WTF::URL(meta->url);
-        WTF::String path;
-
-        if (url.isValid()) {
-            if (url.protocolIsFile()) {
-                path = url.fileSystemPath();
-            } else {
-                path = url.path().toString();
-            }
-        } else {
-            path = meta->url;
-        }
-
-        auto* object = Bun::JSCommonJSModule::createBoundRequireFunction(init.vm, meta->globalObject(), path);
+        auto* object = Bun::JSCommonJSModule::createBoundRequireFunction(init.vm, meta->globalObject(), meta->path());
         RETURN_IF_EXCEPTION(scope, );
         ASSERT(object);
         init.set(uncheckedDowncast<JSFunction>(object));
     });
-    this->urlProperty.initLater([](const JSC::LazyProperty<JSC::JSObject, JSC::JSString>::Initializer& init) {
-        ImportMetaObject* meta = uncheckedDowncast<ImportMetaObject>(init.owner);
-        init.set(jsString(init.vm, meta->url));
-    });
+    if (url) {
+        this->urlProperty.set(vm, this, url);
+    } else {
+        this->urlProperty.initLater([](const JSC::LazyProperty<JSC::JSObject, JSC::JSString>::Initializer& init) {
+            ImportMetaObject* meta = uncheckedDowncast<ImportMetaObject>(init.owner);
+            auto path = meta->path()->tryGetValue();
+            init.set(jsString(init.vm, WTF::URL::fileURLWithFileSystemPath(path).string()));
+        });
+    }
     this->dirProperty.initLater([](const JSC::LazyProperty<JSC::JSObject, JSC::JSString>::Initializer& init) {
         ImportMetaObject* meta = uncheckedDowncast<ImportMetaObject>(init.owner);
+        auto path = meta->path()->tryGetValue();
 
-        WTF::URL url(meta->url);
-        WTF::String dirname;
-
-        if (url.protocolIsFile()) {
-            dirname = url.fileSystemPath();
-        } else {
-            dirname = url.path().toString();
+        size_t end = path->endsWith(PLATFORM_SEP) ? path->length() - 1 : path->reverseFind(PLATFORM_SEP);
+        if (end == notFound) {
+            init.set(meta->path());
+            return;
         }
-
-        if (dirname.endsWith(PLATFORM_SEP_s)) {
-            dirname = dirname.substring(0, dirname.length() - 1);
-        } else if (dirname.contains(PLATFORM_SEP)) {
-            dirname = dirname.substring(0, dirname.reverseFind(PLATFORM_SEP));
-        }
-
-        init.set(jsString(init.vm, dirname));
+        init.set(jsSubstringOfResolved(init.vm, meta->path(), 0, end));
     });
     this->fileProperty.initLater([](const JSC::LazyProperty<JSC::JSObject, JSC::JSString>::Initializer& init) {
         ImportMetaObject* meta = uncheckedDowncast<ImportMetaObject>(init.owner);
+        auto path = meta->path()->tryGetValue();
 
-        WTF::URL url(meta->url);
-        WTF::String path;
-
-        if (url.protocolIsFile()) {
-            path = url.fileSystemPath();
-        } else {
-            path = url.path().toString();
-        }
-
-        WTF::String filename;
-        if (path.endsWith(PLATFORM_SEP_s)) {
-            filename = path.substring(path.reverseFind(PLATFORM_SEP, path.length() - 2) + 1);
-        } else {
-            filename = path.substring(path.reverseFind(PLATFORM_SEP) + 1);
-        }
-
-        init.set(jsString(init.vm, filename));
-    });
-    this->pathProperty.initLater([](const JSC::LazyProperty<JSC::JSObject, JSC::JSString>::Initializer& init) {
-        ImportMetaObject* meta = uncheckedDowncast<ImportMetaObject>(init.owner);
-
-        WTF::URL url(meta->url);
-        if (url.protocolIsFile()) {
-            init.set(jsString(init.vm, url.fileSystemPath()));
-        } else {
-            init.set(jsString(init.vm, url.path()));
-        }
+        size_t start = (path->endsWith(PLATFORM_SEP) ? path->reverseFind(PLATFORM_SEP, path->length() - 2) : path->reverseFind(PLATFORM_SEP)) + 1;
+        init.set(jsSubstringOfResolved(init.vm, meta->path(), start, path->length() - start));
     });
 }
 
@@ -711,11 +688,11 @@ void ImportMetaObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(fn, info());
     Base::visitChildren(fn, visitor);
 
+    visitor.append(fn->m_path);
     fn->requireProperty.visit(visitor);
     fn->urlProperty.visit(visitor);
     fn->dirProperty.visit(visitor);
     fn->fileProperty.visit(visitor);
-    fn->pathProperty.visit(visitor);
 }
 
 DEFINE_VISIT_CHILDREN(ImportMetaObject);

--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -70,7 +70,7 @@ ImportMetaObject* ImportMetaObject::create(JSC::JSGlobalObject* globalObject, JS
 }
 
 // True when URL::fileURLWithFileSystemPath(path).fileSystemPath() gives back `path` unchanged, which
-// is the case for what the resolver produces: an absolute path in the platform's own syntax.
+// is the case for what the resolver produces: a normalized absolute path in the platform's own syntax.
 static bool isFileSystemPathInURLForm(const WTF::String& path)
 {
 #if OS(WINDOWS)
@@ -78,9 +78,15 @@ static bool isFileSystemPathInURLForm(const WTF::String& path)
     // `B:/~BUN/root/...`), and a UNC or rooted path takes a different shape.
     if (path.length() < 3 || !isASCIIAlpha(path[0]) || path[1] != ':' || path[2] != '\\')
         return false;
-    return path.find('/') == notFound;
+    if (path.find('/') != notFound)
+        return false;
+    // The URL parser collapses `.` and `..` segments.
+    return !path.contains("\\.\\"_s) && !path.contains("\\..\\"_s) && !path.endsWith("\\."_s) && !path.endsWith("\\.."_s);
 #else
-    return path.startsWith('/');
+    if (!path.startsWith('/'))
+        return false;
+    // The URL parser collapses `.` and `..` segments.
+    return !path.contains("/./"_s) && !path.contains("/../"_s) && !path.endsWith("/."_s) && !path.endsWith("/.."_s);
 #endif
 }
 

--- a/src/jsc/bindings/ImportMetaObject.h
+++ b/src/jsc/bindings/ImportMetaObject.h
@@ -28,8 +28,10 @@ public:
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetPrototype;
 
-    /// `key` is a module registry key or a CommonJS filename: the absolute path of the
-    /// module as the resolver produced it, with the `?query` of the import (if any) appended.
+    /// `key` is a module registry key or a CommonJS filename. For a file that is its absolute
+    /// path as the resolver produced it, with the `?query` of the import (if any) appended, and
+    /// that JSString becomes `import.meta.path` as is. Any other key (one with a query, a plugin's
+    /// virtual module id, `data:`, `blob:`, `vm:module(n)`) goes through a `file:` URL round trip.
     ///
     /// Caveats of that format: the `?` is not a literal `?` in a file name but the start of
     /// the query string, and nothing is URL encoded despite that. So a module with a `?` in

--- a/src/jsc/bindings/ImportMetaObject.h
+++ b/src/jsc/bindings/ImportMetaObject.h
@@ -28,20 +28,11 @@ public:
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetPrototype;
 
-    /// `key` is a module registry key or a CommonJS filename. For a file that is its absolute
-    /// path as the resolver produced it, with the `?query` of the import (if any) appended, and
-    /// that JSString becomes `import.meta.path` as is. Any other key (one with a query, a plugin's
-    /// virtual module id, `data:`, `blob:`, `vm:module(n)`) goes through a `file:` URL round trip.
-    ///
-    /// Caveats of that format: the `?` is not a literal `?` in a file name but the start of
-    /// the query string, and nothing is URL encoded despite that. So a module with a `?` in
-    /// its file name cannot be represented. Fixing this means making the module resolver
-    /// operate on URLs, see https://github.com/oven-sh/bun/issues/8640 and
-    /// https://github.com/oven-sh/bun/pull/9399.
+    /// `key` is a module registry key or a CommonJS filename: normally an absolute path, where a `?`
+    /// starts the import's query string (https://github.com/oven-sh/bun/issues/8640).
     static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, JSValue key);
     static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, JSString* key);
-
-    /// For a module whose key is a URL and not a file path (`bake://server-runtime.js`).
+    /// For a key that is a URL and not a path (`bake://server-runtime.js`).
     static ImportMetaObject* createFromURL(JSC::JSGlobalObject* globalObject, const WTF::URL& url);
 
     DECLARE_INFO;
@@ -59,8 +50,7 @@ public:
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
     static JSValue getPrototype(JSObject*, JSC::JSGlobalObject* globalObject);
 
-    /// `import.meta.path`: the file system path of the module, without the query string.
-    /// Never a rope. `url`, `dir`, `file` and `require` derive from it on first access.
+    /// `import.meta.path`. Never a rope.
     JSString* path() const { return m_path.get(); }
 
     LazyProperty<JSObject, JSCell> requireProperty;
@@ -69,7 +59,7 @@ public:
     LazyProperty<JSObject, JSString> fileProperty;
 
 private:
-    /// `url` may be null, in which case it is `URL::fileURLWithFileSystemPath(path)` computed on first access.
+    /// A null `url` means `URL::fileURLWithFileSystemPath(path)`, computed on first access.
     static ImportMetaObject* create(JSC::VM& vm, JSC::Structure* structure, JSString* path, JSString* url);
 
     ImportMetaObject(JSC::VM& vm, JSC::Structure* structure)

--- a/src/jsc/bindings/ImportMetaObject.h
+++ b/src/jsc/bindings/ImportMetaObject.h
@@ -28,8 +28,7 @@ public:
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetPrototype;
 
-    /// `key` is a module registry key or a CommonJS filename: normally an absolute path, where a `?`
-    /// starts the import's query string (https://github.com/oven-sh/bun/issues/8640).
+    /// `key` is a module registry key or a CommonJS filename. A `?` in it starts the import's query string (#8640).
     static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, JSValue key);
     static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, JSString* key);
     /// For a key that is a URL and not a path (`bake://server-runtime.js`).

--- a/src/jsc/bindings/ImportMetaObject.h
+++ b/src/jsc/bindings/ImportMetaObject.h
@@ -2,6 +2,8 @@
 
 #include "root.h"
 
+#include <wtf/URL.h>
+
 #include "BunBuiltinNames.h"
 #include "BunClientData.h"
 #include "ZigGlobalObject.h"
@@ -20,41 +22,25 @@ namespace Zig {
 using namespace JSC;
 using namespace WebCore;
 
-class ImportMetaObject final : public JSC::JSDestructibleObject {
+class ImportMetaObject final : public JSC::JSNonFinalObject {
 public:
-    using Base = JSC::JSDestructibleObject;
+    using Base = JSC::JSNonFinalObject;
 
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetPrototype;
 
-    static void destroy(JSC::JSCell* cell)
-    {
-        static_cast<ImportMetaObject*>(cell)->ImportMetaObject::~ImportMetaObject();
-    }
+    /// `key` is a module registry key or a CommonJS filename: the absolute path of the
+    /// module as the resolver produced it, with the `?query` of the import (if any) appended.
+    ///
+    /// Caveats of that format: the `?` is not a literal `?` in a file name but the start of
+    /// the query string, and nothing is URL encoded despite that. So a module with a `?` in
+    /// its file name cannot be represented. Fixing this means making the module resolver
+    /// operate on URLs, see https://github.com/oven-sh/bun/issues/8640 and
+    /// https://github.com/oven-sh/bun/pull/9399.
+    static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, JSValue key);
+    static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, JSString* key);
 
-    /// Must be called with a valid url string (for `import.meta.url`)
-    static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, const String& url);
-
-    /// Creates an ImportMetaObject from a specifier or URL JSValue
-    /// - URL object -> use that url
-    /// - string -> see the below method for how the string is processed
-    /// - other -> assertion failure
-    static ImportMetaObject* create(JSC::JSGlobalObject* globalObject, JSValue specifierOrURL);
-
-    /// TODO:
-    /// The rules for this function's input is a bit weird. `specifier` is an import path specifier aka a file path.
-    ///
-    /// - Should be an absolute path or name of a plugin module
-    /// - A '?' is handled not as a literal '?' in a file, but rather as the query string
-    /// - The string is not URL encoded, despite having a query string.
-    ///
-    /// caveat: It is impossible to have a module with a `?` in it's file name.
-    ///
-    /// Fixing this means adjusting a lot of how the module resolver works to operate and handle URL
-    /// escaping, see https://github.com/oven-sh/bun/issues/8640 for more details.
-    ///
-    /// The above rules get a best estimate bandage to solve the problems
-    /// stated in https://github.com/oven-sh/bun/pull/9399
-    static ImportMetaObject* createFromSpecifier(JSC::JSGlobalObject* globalObject, const String& specifier);
+    /// For a module whose key is a URL and not a file path (`bake://server-runtime.js`).
+    static ImportMetaObject* createFromURL(JSC::JSGlobalObject* globalObject, const WTF::URL& url);
 
     DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;
@@ -71,23 +57,30 @@ public:
     static void analyzeHeap(JSCell*, JSC::HeapAnalyzer&);
     static JSValue getPrototype(JSObject*, JSC::JSGlobalObject* globalObject);
 
-    WTF::String url;
+    /// `import.meta.path`: the file system path of the module, without the query string.
+    /// Never a rope. `url`, `dir`, `file` and `require` derive from it on first access.
+    JSString* path() const { return m_path.get(); }
+
     LazyProperty<JSObject, JSCell> requireProperty;
-    LazyProperty<JSObject, JSString> dirProperty;
     LazyProperty<JSObject, JSString> urlProperty;
+    LazyProperty<JSObject, JSString> dirProperty;
     LazyProperty<JSObject, JSString> fileProperty;
-    LazyProperty<JSObject, JSString> pathProperty;
 
 private:
-    static ImportMetaObject* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, const WTF::String& url);
+    /// `url` may be null, in which case it is `URL::fileURLWithFileSystemPath(path)` computed on first access.
+    static ImportMetaObject* create(JSC::VM& vm, JSC::Structure* structure, JSString* path, JSString* url);
 
-    ImportMetaObject(JSC::VM& vm, JSC::Structure* structure, const WTF::String& url)
+    ImportMetaObject(JSC::VM& vm, JSC::Structure* structure)
         : Base(vm, structure)
-        , url(url)
     {
     }
 
-    void finishCreation(JSC::VM&);
+    void finishCreation(JSC::VM&, JSString* path, JSString* url);
+
+    WriteBarrier<JSString> m_path;
 };
+
+// Swept without a destructor, so every member must be GC-managed or plain data.
+static_assert(std::is_trivially_destructible_v<ImportMetaObject>);
 
 }

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1659,20 +1659,20 @@ std::optional<JSC::SourceCode> createCommonJSModule(
 
 JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, const WTF::String& pathString)
 {
-    ASSERT(!pathString.startsWith("file://"_s));
+    return createBoundRequireFunction(vm, lexicalGlobalObject, JSC::jsStringWithCache(vm, pathString));
+}
 
+JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, JSString* filename)
+{
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSString* filename = JSC::jsStringWithCache(vm, pathString);
-    auto index = pathString.reverseFind(PLATFORM_SEP, pathString.length());
-    JSString* dirname;
-    if (index != WTF::notFound) {
-        dirname = JSC::jsSubstring(globalObject, filename, 0, index);
-        RETURN_IF_EXCEPTION(scope, nullptr);
-    } else {
-        dirname = jsEmptyString(vm);
-    }
+    auto pathString = filename->value(lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    ASSERT(!pathString->startsWith("file://"_s));
+
+    auto index = pathString->reverseFind(PLATFORM_SEP);
+    JSString* dirname = index != WTF::notFound ? JSC::jsSubstringOfResolved(vm, filename, 0, index) : jsEmptyString(vm);
 
     auto moduleObject = Bun::JSCommonJSModule::create(
         vm,

--- a/src/jsc/bindings/JSCommonJSModule.h
+++ b/src/jsc/bindings/JSCommonJSModule.h
@@ -111,6 +111,7 @@ public:
         JSValue exportsObject, bool hasEvaluated, JSValue parent);
 
     static JSObject* createBoundRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, const WTF::String& pathString);
+    static JSObject* createBoundRequireFunction(VM& vm, JSGlobalObject* lexicalGlobalObject, JSString* filename);
 
     void toSyntheticSource(JSC::JSGlobalObject* globalObject,
         const JSC::Identifier& moduleKey,

--- a/src/runtime/bake/BakeSourceProvider.cpp
+++ b/src/runtime/bake/BakeSourceProvider.cpp
@@ -49,7 +49,7 @@ extern "C" JSC::EncodedJSValue BakeLoadInitialServerCode(JSC::JSGlobalObject* gl
 
   JSC::MarkedArgumentBuffer args;
   args.append(JSC::jsBoolean(separateSSRGraph)); // separateSSRGraph
-  args.append(Zig::ImportMetaObject::create(global, "bake://server-runtime.js"_s)); // importMeta
+  args.append(Zig::ImportMetaObject::createFromURL(global, WTF::URL("bake://server-runtime.js"_s))); // importMeta
 
   RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSC::profiledCall(global, JSC::ProfilingReason::API, fn, callData, JSC::jsUndefined(), args)));
 }

--- a/test/js/bun/resolve/import-meta.test.js
+++ b/test/js/bun/resolve/import-meta.test.js
@@ -347,6 +347,40 @@ it("import.meta is correct in a module that was required with a query param", as
   expect(cjs.file).toBe("other-cjs.js");
 });
 
+it("import.meta of a virtual module whose id is a path with . and .. segments is normalized like its url", async () => {
+  // The registry key of a build.module() virtual module is the id verbatim. import.meta.path and
+  // import.meta.url must still describe the same file.
+  const id = [import.meta.dir, ".", "sub", "..", "import-meta-virtual.mjs"].join(sep);
+  const bare = "import-meta-virtual-bare";
+  Bun.plugin({
+    name: "import-meta-virtual",
+    setup(build) {
+      for (const specifier of [id, bare]) {
+        build.module(specifier, () => ({
+          contents: `export default { path: import.meta.path, dir: import.meta.dir, file: import.meta.file, url: import.meta.url };`,
+          loader: "js",
+        }));
+      }
+    },
+  });
+  try {
+    const { default: dotted } = await import(id);
+    expect(dotted).toEqual({
+      path: join(import.meta.dir, "import-meta-virtual.mjs"),
+      dir: import.meta.dir,
+      file: "import-meta-virtual.mjs",
+      url: new URL("./import-meta-virtual.mjs", import.meta.url).href,
+    });
+    expect(Bun.fileURLToPath(dotted.url)).toBe(dotted.path);
+
+    const { default: plain } = await import(bare);
+    expect(plain.file).toBe(bare);
+    expect(plain.url).toBe("file:///" + bare);
+  } finally {
+    Bun.plugin.clearAll();
+  }
+});
+
 it("import.meta of a collected module does not leak its url", async () => {
   // 200 module records with a 512 KB url each: 100 MiB when every one leaks.
   await expectRssDeltaBelow(["--smol", join(import.meta.dir, "import-meta-url-leak-fixture.mjs"), "200"], {


### PR DESCRIPTION
### Problem
- `Zig::ImportMetaObject` kept the module's URL as a `WTF::String url` member. #42023 made the class a `JSDestructibleObject` so that string is freed, which puts every `import.meta` object in a destructible subspace and runs `destroy()` on sweep.
- The URL was built from the module key at creation, and `path`, `dir`, `file` each parsed it back with `WTF::URL` and copied a new string on first access. The key the loader passes in (`src/jsc/bindings/ZigGlobalObject.cpp:3947`) already is the module's absolute path as a `JSString`.

### Fix
- `ImportMetaObject` is a `JSNonFinalObject` again. It holds `WriteBarrier<JSString> m_path`, set at creation to the key `JSString` itself when the key is a normalized absolute path with no `?query` (the common case, no allocation). `url` stays lazy, derived from the path. `dir` and `file` are substrings of the same `JSString`. `require` takes the `JSString` through a new `createBoundRequireFunction(VM&, JSGlobalObject*, JSString*)` overload.
- Every other key (`?query`, `.`/`..` segments, a plugin's virtual module id, `B:/~BUN/...` on Windows, `bake://`) takes the same file URL round trip as before in `createFromURL`, which sets `path` and `url` eagerly. So `import.meta` values are byte-identical to main.
- `static_assert(std::is_trivially_destructible_v<ImportMetaObject>)` keeps a member with a destructor from coming back.
- Verified: `test/js/bun/resolve/import-meta.test.js` (one new case for a dot-segment virtual module id, plus the RSS test from #42023), the resolve, plugin, `node:module`, `node:vm` and standalone `compile/*` suites, on Linux x64 (debug ASAN) and Windows x64. Self-reviewed: 3 concerns raised, 3 addressed.

### Background
- JSC creates one `import.meta` object per module record that references `import.meta`, through the `moduleLoaderCreateImportMetaProperties` hook. It passes the registry key as `identifierToJSValue(vm, moduleKey())`, a fresh `JSString` over the key's atom. CommonJS modules pass their `filename` `JSString`.
- In Bun the registry key is the resolver's output: an absolute path (`/a/b.js`, `C:\a\b.js`), with the import's `?query` appended when there is one. `import.meta.path` drops the query, `import.meta.url` keeps it.
- A cell in a non-destructible `IsoSubspace` is swept without any call, so it must not own heap memory. `WriteBarrier` and `LazyProperty` members are plain words that `visitChildren` reports to the GC.

<details><summary>Notes</summary>

- The fast path condition is `isFileSystemPathInURLForm`: POSIX `path[0] == '/'`, Windows `X:\` prefix with no `/`, and on both no `.` or `..` segment. For those, `URL::fileURLWithFileSystemPath(p).fileSystemPath() == p`: Bun's WebKit escapes `% # ? [ ] ^ | ~`, space, controls and (on POSIX) `\` in `escapeFilePathWithoutCopying` and `fileSystemPath()` decodes them back; on Windows the parser turns `\` into `/` and `fileSystemPathWindows` turns them back; the parser collapses dot segments, which is why those keys (possible from `build.module()` ids or an overridden `Module._resolveFilename`, never from the resolver) take the slow path. What remains different in theory: a file name that ends in a raw C0 control byte, or holds a lone surrogate.
- `B:/~BUN/root/x` (Windows standalone) must keep coming out as `B:\~BUN\root\x`: `compile/pathToFileURLWorks` asserts `fileURLToPath(import.meta.url) === import.meta.path`. That is why forward slashes take the slow path on Windows.
- `create(JSGlobalObject*, JSString*)` calls `key->value(globalObject)` first, which resolves a rope in place, so `m_path` is never a rope and the lazy initializers can use `tryGetValue()` and `jsSubstringOfResolved` without an exception path.
- The `JSDOMURL` branch in the old `create(JSValue)` had no producer (the loader passes a string or, for JSC's own entry-point keys that Bun does not use, a Symbol) and is gone.
- `import.meta.path` for `bake://server-runtime.js` is `""` on main too (`URL::path()` of an authority-only URL). The bake runtime only calls `import.meta.bakeBuiltin(import.meta.resolve("node:..."))`, so that is left as is.
- Output of `import.meta.{path,dir,file,url}` compared against the release binary for: a normal file, a `?query` import, an absolute forward-slash specifier on Windows, `build.module()` ids (bare, and absolute with `./` and `../` segments). Identical. Also ran the property reads under `BUN_JSC_collectContinuously=1` across 80 module loads, and a bake dev server route that imports node builtins.
- Full list of suites run: `import-meta.test.js`, `import-query.test.ts`, `import-meta-resolve.test.mjs`, `resolve.test.ts`, `plugins.test.ts`, `node-module-module.test.js`, `test-vm-module-import-meta.js`, `bundler_compile.test.ts` (`pathToFileURLWorks`, `EmbeddedResolvePrecedence`, `ImportMetaMain`).

</details>
