### PR TITLE
import() ignores a replaced Promise.prototype.then (WebKit bump for oven-sh/WebKit#608)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-608-4526f740";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/resolve/dynamic-import-then-tampered.test.ts
+++ b/test/js/bun/resolve/dynamic-import-then-tampered.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// ContinueDynamicImport settles the promise that import() returns only through
+// its PromiseCapability, so nothing on that path may look up "then" on a
+// %Promise%. A replaced Promise.prototype.then must not be able to decide what
+// import() resolves with, and a failed import() must still reject.
+test("import() settles with the loader's outcome when Promise.prototype.then is replaced", async () => {
+  using dir = tempDir("dyn-import-then-tampered", {
+    "dep.mjs": `export const dep = "from dependency";`,
+    "with-dep.mjs": `import { dep } from "./dep.mjs"; export const value = 42; export { dep };`,
+    "no-deps.mjs": `export const value = 43;`,
+    // A namespace that exports a callable "then" is a thenable per spec; that
+    // lookup happens on the namespace object, not on a promise, and must keep working.
+    "exports-then.mjs": `export function then(resolve) { resolve("from the namespace's then"); }`,
+    "main.mjs": `
+      const originalThen = Promise.prototype.then;
+      const results = {};
+      let pending = 0;
+      function track(label, promise) {
+        pending++;
+        const settle = (key, value) => {
+          results[label] = { [key]: value };
+          if (--pending === 0) {
+            Promise.prototype.then = originalThen;
+            console.log(JSON.stringify(results));
+          }
+        };
+        originalThen.call(
+          promise,
+          ns => settle("fulfilled", typeof ns === "object" ? { value: ns.value, dep: ns.dep } : ns),
+          e => settle("rejected", String(e?.message ?? e).split("\\n")[0]),
+        );
+      }
+
+      Promise.prototype.then = function (onFulfilled) {
+        onFulfilled("tampered");
+      };
+      track("withDep", import("./with-dep.mjs"));
+      track("noDeps", import("./no-deps.mjs"));
+      track("missing", import("./does-not-exist.mjs"));
+      track("exportsThen", import("./exports-then.mjs"));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(JSON.parse(stdout)).toEqual({
+    withDep: { fulfilled: { value: 42, dep: "from dependency" } },
+    noDeps: { fulfilled: { value: 43 } },
+    missing: { rejected: expect.stringContaining("Cannot find module") },
+    exportsThen: { fulfilled: "from the namespace's then" },
+  });
+  // The loader's own rejected promise for the missing module is consumed by
+  // import()'s promise, so it is not reported as unhandled a second time.
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- Once `Promise.prototype.then` is replaced, `import()` resolves with whatever the replacement passes on. With `Promise.prototype.then = f => f("tampered")` every pending `import()` fulfills with `"tampered"`, even one of a missing file, which must reject.
- The cause is the Bun-only tail of `globalFuncImportModule` in JavaScriptCore (`runtime/JSGlobalObjectFunctions.cpp`). It settled the fresh `import()` promise with `promise->resolve(importPromise)`, which reads and calls `then` on the loader's promise. [ContinueDynamicImport](https://tc39.es/ecma262/#sec-ContinueDynamicImport) uses the promise's capability only. Upstream dropped the same call in [311296@main](https://commits.webkit.org/311296@main).

### Fix
- oven-sh/WebKit#608 attaches the `PromiseResolveWithoutHandlerJob` reaction to the loader's promise directly: the reaction `resolve()`'s fast path attaches a microtask later for an untouched `%Promise%`. The common case loses one microtask hop.
- This PR pins that preview build and adds the test. Do not merge before oven-sh/WebKit#608 lands: the pin then moves to the merge commit's release.
- Self-reviewed: 1 concern raised, 0 addressed. `ShadowRealm.prototype.importValue` has the same call, but that code matches upstream and is left for upstream.
- Verified: `test/js/bun/resolve/dynamic-import-then-tampered.test.ts` fails on 1.4.3 and on a debug build at the current pin, passes with this pin. More in Notes.

### Background
- `JSPromise::resolve(value)` follows thenables: it looks up `value.then` and calls it when callable. `performPromiseThenWithInternalMicrotask` attaches a reaction without one.
- `require(esm)` runs loader-internal reactions synchronously through `VM::m_synchronousModuleQueue`. `JSPromise::pipeFrom()`'s job is one of them, so the fix avoids it: a `require()` that completes an in-flight `import()` would resume the awaiting module inside the `require()`.
- Node prints the same wrong value: this is spec conformance, not Node compatibility.

<details><summary>Notes</summary>

- Repro (three files): `dep.js: export var dep = "from dependency";`, `target.js: import { dep } from "./dep.js"; export var value = 42; export { dep };`, and
  ```js
  var originalThen = Promise.prototype.then;
  Promise.prototype.then = function (onFulfilled) { onFulfilled("tampered"); };
  originalThen.call(import("./target.js"), ns => { Promise.prototype.then = originalThen; console.log(typeof ns, ns && ns.value); });
  ```
  `bun main.mjs` prints `string undefined`; expected `object 42`. The loader's own rejection for a missing module also surfaced as an unhandled error (exit 1) even with a handler attached to the `import()` promise.
- Found through `JSTests/stress/module-loader-promise-then-tampered.js`, which fails on the fork's `jsc` shell. oven-sh/WebKit#608 adds a second stress test for the no-dependency and missing-module cases. On the preview shell both pass, and the other 156 `stress/module*`, `stress/import*` and `modules/` files give the same exit codes as the pinned shell.
- The fresh promise in `globalFuncImportModule` stays on purpose: `requestImportModule()` marks its promise as handled, so returning it directly (what upstream does) would hide unhandled `import()` rejections, and Bun's `node:vm` hook can hand back a promise that came from user code.
- A first variant used `pipeFrom()`. `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts` ("a user-defined getter can itself load the modules that import the export it backs") failed with it for the `require(esm)` reason in Background, and passes with the final change.
- Also green on a debug build with this pin: the rest of `test/js/bun/resolve/`, `test/js/node/vm/vm.test.ts`, `test/js/node/vm/sourcetextmodule-link-gc.test.ts`, `test/js/bun/plugin/plugins.test.ts`, `test/js/bun/jsc/shadow.test.js`, `test/js/node/module/node-module-module.test.js`, `esm-registry-concurrent-gc.test.ts`, and the node tests `test-vm-module-dynamic-import.js`, `test-vm-module-dynamic-import-promise.js`, `test-vm-module-dynamic-namespace.js`, `test-vm-module-import-meta.js`, `test-vm-no-dynamic-import-callback.js`. An unhandled `import()` rejection still exits 1 with `Cannot find module`; a handled one does not reach `unhandledRejection`.
- On the local debug+ASAN build, `load-same-js-file-a-lot.test.ts` "load the same empty JS file 2000 times" needs 11 s against its 5 s default timeout (its sibling carries a 20 s debug timeout), and several `test/cli/run/require-cache.test.ts` leak tests time out or trip the non-ASAN RSS threshold (the fixtures key ASAN off the `bun-asan` executable name), the `require()`-only variants included. Both are debug-build slowness, not behaviour changes.
- `ShadowRealmPrototype.cpp` `importInRealm` resolves its wrapper the same way (`promise->resolve(globalObject, vm, result)`). That file matches upstream WebKit, the `then` it would read is the shadow realm's own, and the proposal's ShadowRealmImportValue uses PerformPromiseThen, so it is an upstream conformance bug rather than a fork regression. Not changed here.
</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/resolve/dynamic-import-then-tampered.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/resolve/dynamic-import-then-tampered.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/resolve/dynamic-import-then-tampered.test.ts:
(pass) import() settles with the loader's outcome when Promise.prototype.then is replaced [483.19ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [3.48s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |  2 +-
 .../resolve/dynamic-import-then-tampered.test.ts   | 65 ++++++++++++++++++++++
 2 files changed, 66 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                  1      2      8
test/js/bun/resolve/dynamic-import-then-tampered.test.ts      0      2      8
```

</details>

<!-- robobun:evidence:end -->