### PR TITLE
bundler: declare UTF-8 in standalone HTML when the page has no charset

### DIFF
--- a/docs/bundler/standalone-html.mdx
+++ b/docs/bundler/standalone-html.mdx
@@ -39,6 +39,7 @@ You can distribute the page the same way you'd distribute a PDF: a single file y
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8" />
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
@@ -231,7 +232,8 @@ When you pass `--compile --target=browser` with an HTML entrypoint, Bun:
 4. Converts every relative asset reference into a base64 `data:` URI
 5. Inlines the bundled JS as `<script type="module">` before `</body>`
 6. Inlines the bundled CSS as `<style>` in `<head>`
-7. Outputs a single `.html` file with no external dependencies
+7. Adds `<meta charset="utf-8">` to `<head>` if the page does not declare an encoding, so browsers decode the inlined code as UTF-8
+8. Outputs a single `.html` file with no external dependencies
 
 ## Minification
 

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -180,6 +180,15 @@ pub(crate) trait HTMLProcessorHandler {
     fn on_html_tag(&mut self, _element: &mut Element<'_, '_>) -> bool {
         unreachable!()
     }
+
+    /// Whether to call `on_element` for every element. This registers a `*`
+    /// selector, which sends every tag through lol-html's full lexer.
+    fn visits_every_element(&self) -> bool {
+        false
+    }
+    fn on_element(&mut self, _element: &mut Element<'_, '_>) {
+        unreachable!()
+    }
 }
 
 impl<'a> HTMLProcessorHandler for HTMLScanner<'a> {
@@ -271,7 +280,7 @@ const TAG_HANDLERS: [TagHandler; 16] = [
     //     TagHandler::new("iframe[src]", "src", ImportKind::Url),
 ];
 
-const SELECTOR_CAP: usize = TAG_HANDLERS.len() + 3;
+const SELECTOR_CAP: usize = TAG_HANDLERS.len() + 4;
 
 #[inline]
 fn lol_err<E>(_: E) -> Error {
@@ -305,6 +314,8 @@ impl<T: HTMLProcessorHandler, const VISIT_DOCUMENT_TAGS: bool>
     HTMLProcessor<T, VISIT_DOCUMENT_TAGS>
 {
     pub(crate) fn run(this: &mut T, input: &[u8]) -> Result<(), Error> {
+        let visit_every_element = VISIT_DOCUMENT_TAGS && this.visits_every_element();
+
         // Every handler closure and the output sink capture this raw pointer
         // so one `&mut T` can service them all; `this` is not reborrowed
         // until the rewriter holding those closures is gone.
@@ -365,6 +376,17 @@ impl<T: HTMLProcessorHandler, const VISIT_DOCUMENT_TAGS: bool>
                 );
                 element_content_handlers.push(element_entry(tag, on_element)?);
             }
+        }
+
+        if visit_every_element {
+            let on_element: lol_html::ElementHandler<'_> = Box::new(
+                move |element: &mut Element<'_, '_>| -> lol_html::HandlerResult {
+                    // SAFETY: see `on_tag` above.
+                    unsafe { (*this_ptr).on_element(element) };
+                    Ok(())
+                },
+            );
+            element_content_handlers.push(element_entry("*", on_element)?);
         }
 
         let settings = lol_html::Settings {

--- a/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForHtmlChunk.rs
@@ -87,6 +87,12 @@ struct HTMLLoader<'a> {
     end_tag_indices: EndTagIndices,
     added_head_tags: bool,
     added_body_script: bool,
+    /// The document has a `<meta charset>` or its `http-equiv` form.
+    has_charset: bool,
+    /// Standalone mode: the offset in `output` of the first element past
+    /// `<html>`/`<head>`, else of `</head>`. A `<meta charset>` put there is
+    /// inside the head section, which is as far as browsers look for one.
+    charset_offset: Option<usize>,
 }
 
 /// `Element::set_attribute` takes `&str`, so non-UTF-8 `name`/`value` bytes
@@ -213,6 +219,36 @@ impl<'a> HTMLProcessorHandler for HTMLLoader<'a> {
     fn on_body_tag(&mut self, element: &mut Element<'_, '_>) -> bool {
         self.register_end_tag_handler(element, Self::end_body_tag_handler)
     }
+
+    fn visits_every_element(&self) -> bool {
+        self.declares_charset()
+    }
+
+    fn on_element(&mut self, element: &mut Element<'_, '_>) {
+        if self.has_charset {
+            return;
+        }
+        let tag = element.tag_name();
+        if tag == "html" || tag == "head" {
+            return;
+        }
+        if self.charset_offset.is_none() {
+            // lol-html has written everything ahead of this tag to `output`.
+            self.charset_offset = Some(self.output.len());
+        }
+        if tag == "meta" {
+            self.has_charset = element.has_attribute("charset")
+                || matches!(
+                    (element.get_attribute("http-equiv"), element.get_attribute("content")),
+                    (Some(http_equiv), Some(content))
+                        if http_equiv.trim_ascii().eq_ignore_ascii_case("content-type")
+                            && strings::contains_case_insensitive_ascii(
+                                content.as_bytes(),
+                                b"charset",
+                            )
+                );
+        }
+    }
 }
 
 /// An `HTMLLoader` end-tag callback. It receives the loader as an erased
@@ -275,6 +311,25 @@ impl<'a> HTMLLoader<'a> {
         ))
     }
 
+    /// Standalone mode inlines the bundle as `<script>`/`<style>` text, which a
+    /// browser decodes with the document's encoding, and that falls back to
+    /// windows-1252 when the document declares none. The external module
+    /// script of the source page was UTF-8 regardless, so the page may well
+    /// lack a declaration. The file written here is UTF-8, so say so.
+    fn declares_charset(&self) -> bool {
+        self.compile_to_standalone_html && self.linker.dev_server.is_none()
+    }
+
+    /// Runs after the rewrite, once the whole document was seen.
+    fn declare_charset(&mut self) {
+        if !self.declares_charset() || self.has_charset {
+            return;
+        }
+        let at = self.charset_offset.unwrap_or(self.output.len());
+        self.output
+            .splice(at..at, b"<meta charset=\"utf-8\">".iter().copied());
+    }
+
     fn get_head_tags(&self) -> Vec<String> {
         let mut array: Vec<String> = Vec::with_capacity(2);
         if self.compile_to_standalone_html {
@@ -321,6 +376,9 @@ impl<'a> HTMLLoader<'a> {
         // SAFETY: `opaque_this` is the erased `&mut HTMLLoader` from `register_end_tag_handler`.
         let this: &mut Self = unsafe { &mut *opaque_this.cast::<Self>() };
         if this.linker.dev_server.is_none() {
+            // An empty `<head>`: the declaration goes ahead of `</head>` and
+            // of the `<style>` added next.
+            this.charset_offset.get_or_insert(this.output.len());
             this.add_head_tags(end);
         } else {
             this.end_tag_indices.head = Some(u32::try_from(this.output.len()).expect("int cast"));
@@ -404,6 +462,8 @@ fn generate_compile_result_for_html_chunk_impl<'a>(
         },
         added_head_tags: false,
         added_body_script: false,
+        has_charset: false,
+        charset_offset: None,
     };
 
     HTMLProcessor::<HTMLLoader, true>::run(&mut html_loader, contents)
@@ -433,6 +493,7 @@ fn generate_compile_result_for_html_chunk_impl<'a>(
         }
     } else {
         'brk: {
+            html_loader.declare_charset();
             if !html_loader.added_head_tags || !html_loader.added_body_script {
                 // Cold path: the document is missing all of the head, body, and html elements.
                 if !html_loader.added_head_tags {

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -522,6 +522,94 @@ console.log(message);`,
     expect(html).toContain("</script>");
   });
 
+  // A browser decodes inline <script>/<style> text with the document's
+  // encoding, which falls back to windows-1252 when nothing declares one. The
+  // external module script the source page used was always UTF-8.
+  describe("charset declaration", () => {
+    const app = { "app.js": `document.title = "héllo ✓";`, "style.css": `body::after { content: "✓"; }` };
+    // Browsers stop looking for a declaration at the first body content once
+    // they are 1024 bytes in, so it has to land ahead of this.
+    const filler = `<p>${Buffer.alloc(1500, "a").toString()}</p>`;
+
+    async function buildStandalone(dir: string) {
+      const result = await Bun.build({ entrypoints: [`${dir}/index.html`], compile: true, target: "browser" });
+      expect(result.success).toBe(true);
+      expect(result.outputs.length).toBe(1);
+      return await result.outputs[0].text();
+    }
+
+    test.each([
+      [
+        "at the start of <head>",
+        `<!DOCTYPE html>\n<html>\n<head><title>x</title><link rel="stylesheet" href="./style.css"></head>\n<body>${filler}<script src="./app.js"></script></body>\n</html>`,
+        `<!DOCTYPE html>\n<html>\n<head><meta charset="utf-8"><title>x</title></head>`,
+      ],
+      [
+        "into an empty <head>",
+        `<!DOCTYPE html><html><head></head><body>${filler}<script src="./app.js"></script></body></html>`,
+        `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body><p>`,
+      ],
+      [
+        "ahead of <body> when there is no <head>",
+        `<!DOCTYPE html><html lang="en"><body><script src="./app.js"></script>${filler}</body></html>`,
+        `<!DOCTYPE html><html lang="en"><meta charset="utf-8"><body><p>`,
+      ],
+      [
+        "ahead of the first element when the tags are implied",
+        `<!DOCTYPE html><title>x</title><link rel="stylesheet" href="./style.css">${filler}<script src="./app.js"></script>`,
+        `<!DOCTYPE html><meta charset="utf-8"><title>x</title><p>`,
+      ],
+      [
+        "at the start of a fragment",
+        `<div id="app">${filler}</div><link rel="stylesheet" href="./style.css"><script src="./app.js"></script>`,
+        `<meta charset="utf-8"><div id="app"><p>`,
+      ],
+    ])("a document that declares no encoding gets <meta charset> %s", async (_, source, expected) => {
+      using dir = tempDir("compile-browser-charset-added", { ...app, "index.html": source });
+      const html = await buildStandalone(String(dir));
+      expect(html.replace(/<style>.*?<\/style>/s, "")).toStartWith(expected);
+      expect(html.match(/<meta/g)).toEqual(["<meta"]);
+      expect(html).toContain(`"héllo ✓"`);
+      if (source.includes("style.css")) {
+        expect(html.indexOf('<meta charset="utf-8">')).toBeLessThan(html.indexOf("<style>"));
+        expect(html).toContain(`content: "✓"`);
+      }
+    });
+
+    test.each([
+      `<meta charset="UTF-8" />`,
+      `<meta charset=windows-1252>`,
+      `<meta http-equiv="Content-Type" content="text/html; charset=utf-8">`,
+    ])("keeps %s as the only declaration", async declaration => {
+      using dir = tempDir("compile-browser-charset-declared", {
+        ...app,
+        "index.html": `<!DOCTYPE html>
+<html>
+<head>${declaration}<link rel="stylesheet" href="./style.css"></head>
+<body><script src="./app.js"></script></body>
+</html>`,
+      });
+      const html = await buildStandalone(String(dir));
+      expect(html).toContain(declaration);
+      expect(html.match(/<meta/gi)).toEqual(["<meta"]);
+    });
+
+    test("a <meta http-equiv> that is not a Content-Type with a charset does not count", async () => {
+      using dir = tempDir("compile-browser-charset-other-meta", {
+        ...app,
+        "index.html": `<!DOCTYPE html>
+<html>
+<head><meta http-equiv="Content-Type" content="text/html"><meta name="viewport" content="width=device-width"></head>
+<body><script src="./app.js"></script></body>
+</html>`,
+      });
+      const html = await buildStandalone(String(dir));
+      expect(html).toContain(
+        '<head><meta charset="utf-8"><meta http-equiv="Content-Type" content="text/html"><meta name="viewport" content="width=device-width"></head>',
+      );
+    });
+  });
+
   // https://github.com/oven-sh/bun/issues/32114
   describe.concurrent("sourcemaps", () => {
     const fixture = {


### PR DESCRIPTION
### Problem
- `bun build --compile --target=browser ./index.html` inlines the bundle as `<script type="module">` and `<style>` text. When the page has no `<meta charset>`, browsers decode inline text as windows-1252, so non-ASCII literals are mojibake: `"héllo ✓".length` is 10 in Chrome 152, not 7. The source page is fine: external module scripts are UTF-8.
- `src/bundler/linker_context/generateCompileResultForHtmlChunk.rs` makes the script inline but never declares the encoding of the UTF-8 file it writes.

### Fix
- In standalone mode, `HTMLLoader` visits every element (a `*` hook in `HTMLProcessor`, this mode only). It records the output offset of the first element past `<html>`/`<head>`, else of `</head>`, and whether the page declares a charset. If not, it splices `<meta charset="utf-8">` in at that offset.
- Correct because the file is UTF-8 by construction, and the offset is inside the head section for any page shape, which is where browsers look. A page with its own declaration is untouched. So are the dev server and the regular build.
- Verified: `test/bundler/standalone.test.ts` (nine new tests, stock bun fails six) and five page shapes in headless Chrome 152.
- Self-reviewed: 4 concerns raised, 4 addressed.

### Background
- Standalone HTML rewrites the page with lol-html in one streaming pass.
- lol-html flushes all input ahead of a tag before it calls its handler, so `output.len()` in a handler is that tag's offset. The dev server path uses this already.
- With no BOM, `Content-Type` charset, or `<meta>`, browsers fall back to a locale default, windows-1252 for most.

<details><summary>Notes</summary>

- A `<meta charset>` or a `<meta http-equiv="Content-Type">` whose `content` has a charset counts as a declaration. `content="text/html"` alone does not. Any `<meta charset=…>` value counts, including a non-UTF-8 one: the author's declaration wins.
- Bun serves the same page as `text/html;charset=utf-8` from the dev server and `Bun.serve`, so the file written to disk was the one place with no declaration.
- Output for each shape (Chrome 152 reports `UTF-8`, standards mode unchanged):
  - `<html><head><title>…` becomes `<head><meta charset="utf-8"><title>…`
  - `<html><head></head>` becomes `<head><meta charset="utf-8"></head>`
  - `<html lang="en"><body>…` becomes `<html lang="en"><meta charset="utf-8"><body>…` (valid: the head tags are optional)
  - `<!DOCTYPE html><title>x</title>…` becomes `<!DOCTYPE html><meta charset="utf-8"><title>x</title>…`
  - a fragment `<div id="app">…` becomes `<meta charset="utf-8"><div id="app">…`
- Also ran: `bundler_html.test.ts`, `html-import-manifest.test.ts`, `bundler_html_server.test.ts`, `test/bake/dev/html.test.ts`.
- An earlier revision inserted the tag before `</head>`, ahead of `<body>`, or at the end in the fallback path. A page with more than 1 KB of markup and no `<head>`/`<body>` tags then got the tag too late for Chrome, which stops looking at the first body element once past 1024 bytes. The offset splice removes that case.
- Probes in Chrome 152: a `<meta charset>` 1.5 KB into `<head>` works. One after `</body>`, or after 1.5 KB of body content, does not. A `<meta>` loses to a conflicting `Content-Type` charset from the server. A BOM would win there, but a BOM breaks a page that a server includes into another one (quirks mode), and it is invisible, so the tag is the better default.
- A UTF-8 BOM in the source page does not survive into the output, so it does not count as a declaration.
- The Quick start page in `docs/bundler/standalone-html.mdx` now has `<meta charset="utf-8">`, and "How it works" lists the new step.
- Self-review concerns, all addressed: placement for pages without `<head>`/`<body>` tags, a test that pinned the regular build's output, the Quick start snippet, and wording that read as if external CSS were immune.
- Not in this PR: in the regular build the CSS chunk stays an external `<link>`, and an external stylesheet with no `@charset` or BOM also inherits an undeclared page's encoding. The CSS printer drops `@charset` and prints escapes such as `\2713` as raw UTF-8, so that case exists there. It belongs to the CSS printer or the regular HTML build, not to this change.
- #41954 (CSP meta rewrite) and #42013 touch the same file. This change does not depend on either.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/standalone.test.ts

<!-- robobun:evidence:end -->