### PR TITLE
WebAssembly.Exception.getArg: an index that is not an unsigned long is a TypeError (WebKit bump for oven-sh/WebKit#613)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-613-07a1e624";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/wasm/js-api.test.ts
+++ b/test/js/bun/wasm/js-api.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+
+// WebAssembly JS API conformance cases from a differential run against V8 and
+// SpiderMonkey. The getArg cases need oven-sh/WebKit#613. The Memory cases pin
+// behavior that JSC already has. Everything runs in-process.
+
+const pageSize = 64 * 1024;
+
+// (module
+//   (memory (import "imp" "memory") 1 3 shared?)
+//   (func (export "grow") (param i32) (result i32) local.get 0 memory.grow))
+function memoryGrowModule(shared: boolean) {
+  // prettier-ignore
+  return new WebAssembly.Module(new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    // type section: (func (param i32) (result i32))
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f,
+    // import section: imp.memory, limits {min 1, max 3, shared?}
+    0x02, 0x10, 0x01, 0x03, 0x69, 0x6d, 0x70, 0x06, 0x6d, 0x65, 0x6d, 0x6f, 0x72, 0x79, 0x02, shared ? 0x03 : 0x01, 0x01, 0x03,
+    // function section
+    0x03, 0x02, 0x01, 0x00,
+    // export section: "grow" = func 0
+    0x07, 0x08, 0x01, 0x04, 0x67, 0x72, 0x6f, 0x77, 0x00, 0x00,
+    // code section: local.get 0; memory.grow 0
+    0x0a, 0x08, 0x01, 0x06, 0x00, 0x20, 0x00, 0x40, 0x00, 0x0b,
+  ]));
+}
+
+// The error class is the point of these tests: report it by name so that a
+// failure reads "expected TypeError, received RangeError".
+function errorClassOf(fn: () => unknown): string {
+  try {
+    fn();
+  } catch (e) {
+    return (e as Error).constructor.name;
+  }
+  return "no exception";
+}
+
+describe("WebAssembly.Exception.prototype.getArg", () => {
+  const tag = new WebAssembly.Tag({ parameters: ["i32", "f64"] });
+  const exception = new WebAssembly.Exception(tag, [5, 6.5]);
+  const getArg = (index: unknown) => exception.getArg(tag, index as number);
+
+  // getArg(Tag exceptionTag, [EnforceRange] unsigned long index): a failed
+  // [EnforceRange] conversion is a TypeError, not a RangeError.
+  test.each([
+    -1,
+    -1.5,
+    2 ** 32,
+    2 ** 32 + 0.5,
+    2 ** 53,
+    Number.MAX_VALUE,
+    NaN,
+    Infinity,
+    -Infinity,
+    undefined,
+    "x",
+    {},
+  ])("index %p is a TypeError", index => {
+    expect(errorClassOf(() => getArg(index))).toBe("TypeError");
+  });
+
+  test("an index that converts is truncated toward zero", () => {
+    expect(getArg(0)).toBe(5);
+    expect(getArg(-0)).toBe(5);
+    expect(getArg(-0.5)).toBe(5);
+    expect(getArg(0.9)).toBe(5);
+    expect(getArg(null)).toBe(5);
+    expect(getArg(1)).toBe(6.5);
+    expect(getArg(1.99)).toBe(6.5);
+    expect(getArg("1")).toBe(6.5);
+    expect(getArg(true)).toBe(6.5);
+  });
+
+  test("a valid index past the payload is a RangeError", () => {
+    for (const index of [2, 2.5, 2 ** 31, 2 ** 32 - 1]) expect(errorClassOf(() => getArg(index))).toBe("RangeError");
+
+    const emptyTag = new WebAssembly.Tag({ parameters: [] });
+    const empty = new WebAssembly.Exception(emptyTag, []);
+    expect(errorClassOf(() => empty.getArg(emptyTag, 0))).toBe("RangeError");
+    // The conversion still comes first.
+    expect(errorClassOf(() => empty.getArg(emptyTag, -1))).toBe("TypeError");
+  });
+});
+
+describe("WebAssembly.Memory grow and the buffer object", () => {
+  // WebAssembly/threads#248: a non-shared memory detaches and replaces its
+  // ArrayBuffer on every successful grow, even by 0 pages. A shared memory
+  // hands out a new SharedArrayBuffer only when its length changed, and never
+  // detaches the old one. V8 main (crrev.com/c/7660970) and SpiderMonkey agree.
+  // Node 26 ships an older V8 that replaces the SharedArrayBuffer on grow(0).
+  for (const via of ["Memory.prototype.grow", "memory.grow instruction"] as const) {
+    const grower = (memory: WebAssembly.Memory, shared: boolean) =>
+      via === "Memory.prototype.grow"
+        ? (delta: number) => memory.grow(delta)
+        : (new WebAssembly.Instance(memoryGrowModule(shared), { imp: { memory } }).exports.grow as (
+            delta: number,
+          ) => number);
+
+    test(`non-shared memory, ${via}: grow(0) detaches and replaces the buffer`, () => {
+      const memory = new WebAssembly.Memory({ initial: 1, maximum: 3 });
+      const grow = grower(memory, false);
+      for (const delta of [0, 1, 0]) {
+        const before = memory.buffer;
+        const pagesBefore = before.byteLength / pageSize;
+        expect(grow(delta)).toBe(pagesBefore);
+        // Compare identities as booleans so that a failure does not print 64 KiB of zeros.
+        expect(memory.buffer === before).toBe(false);
+        expect(before.detached).toBe(true);
+        expect(memory.buffer).toBeInstanceOf(ArrayBuffer);
+        expect(memory.buffer.byteLength).toBe((pagesBefore + delta) * pageSize);
+      }
+    });
+
+    test(`shared memory, ${via}: grow(0) keeps the buffer, a real grow replaces it`, () => {
+      const memory = new WebAssembly.Memory({ initial: 1, maximum: 3, shared: true });
+      const grow = grower(memory, true);
+      const first = memory.buffer;
+      expect(first).toBeInstanceOf(SharedArrayBuffer);
+
+      expect(grow(0)).toBe(1);
+      expect(memory.buffer === first).toBe(true);
+
+      expect(grow(1)).toBe(1);
+      const second = memory.buffer;
+      expect(second === first).toBe(false);
+      expect(second).toBeInstanceOf(SharedArrayBuffer);
+      expect(second.byteLength).toBe(2 * pageSize);
+      // The old SharedArrayBuffer keeps its length and aliases the same block.
+      expect(first.byteLength).toBe(pageSize);
+      new Uint8Array(second)[0] = 7;
+      expect(new Uint8Array(first)[0]).toBe(7);
+
+      expect(grow(0)).toBe(2);
+      expect(memory.buffer === second).toBe(true);
+    });
+  }
+
+  test("growing one shared memory leaves another one's buffer alone", () => {
+    const a = new WebAssembly.Memory({ initial: 1, maximum: 2, shared: true });
+    const b = new WebAssembly.Memory({ initial: 1, maximum: 2, shared: true });
+    const bufferA = a.buffer;
+    const bufferB = b.buffer;
+    a.grow(1);
+    expect(a.buffer === bufferA).toBe(false);
+    expect(b.buffer === bufferB).toBe(true);
+  });
+});


### PR DESCRIPTION
### Problem
- `WebAssembly.Exception.prototype.getArg(tag, index)` throws `RangeError: Expect an integer argument in the range: [0, 2^32 - 1]` when `index` is `-1`, `2 ** 32`, `NaN`, `undefined` or anything else that is not an unsigned long. Node 26 and Chromium throw `TypeError`. The spec IDL is `[EnforceRange] unsigned long index` (WebAssembly/exception-handling#257), and a failed `[EnforceRange]` conversion is a `TypeError`.
- The cause is in JSC: `WebAssemblyExceptionPrototype.cpp` asks its conversion helper for a `RangeError`. Upstream WebKit 282520@main did that to pass a WPT test that predates exception-handling#257 (V8 and Firefox mark that WPT subtest as an expected failure).

### Fix
- Pin WebKit to `autobuild-preview-pr-613-07a1e624`, the preview build of oven-sh/WebKit#613, which makes `getArg` throw `TypeError` for a failed index conversion and keeps `RangeError` for an index past the payload.
- The pin is a preview tag, not a merge commit. Do not merge before oven-sh/WebKit#613 lands. I move the pin to the merged commit then. The preview also carries oven-sh/WebKit#561, #566 and #568, which are on WebKit `main` past the current pin.
- Verified: `test/js/bun/wasm/js-api.test.ts` (new, 19 tests). bun 1.4.3 fails the 13 `getArg` error-class cases, `bun bd test` with this pin (debug + ASAN) passes all 19. `test/js/bun/wasm/wasi.test.js` and `test/js/web/workers/structured-clone.test.ts` pass with the pin.

### Background
- WebIDL `[EnforceRange] unsigned long`: `NaN` and the infinities throw `TypeError`, then the integer part must be in `[0, 2^32 - 1]` or it throws `TypeError`. So `getArg(tag, -0.5)` and `getArg(tag, 0.9)` read argument 0.
- The same test file pins the `WebAssembly.Memory` buffer rules that bun already follows and that the same differential run questioned: a non-shared memory detaches and replaces its `ArrayBuffer` on every grow, even `grow(0)`, while a shared memory hands out a new `SharedArrayBuffer` only when its length changed. V8 `main` (crrev.com/c/7660970), SpiderMonkey and WebAssembly/threads#248 agree. Node 26 ships an older V8 that replaces the `SharedArrayBuffer` on `grow(0)`.

<details><summary>Notes</summary>

- oven-sh/WebKit#613 has the JSC-side verification: the new `JSTests/wasm/js-api/exception-getarg-index-enforce-range.js` in all 13 wasm modes, the full `JSTests/wasm.yaml` run (17940 runs), and a Debug+ASan run with exception-check validation.
- Source for the Node and Chromium comparison: a WebAssembly JS-API differential run against node v26.3.0 and Chromium 148.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/wasm/js-api.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/wasm/js-api.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/wasm/js-api.test.ts:
(pass) WebAssembly.Exception.prototype.getArg > index -1 is a TypeError [8.56ms]
(pass) WebAssembly.Exception.prototype.getArg > index -1.5 is a TypeError [0.67ms]
(pass) WebAssembly.Exception.prototype.getArg > index 4294967296 is a TypeError [0.46ms]
(pass) WebAssembly.Exception.prototype.getArg > index 4294967296.5 is a TypeError [0.36ms]
(pass) WebAssembly.Exception.prototype.getArg > index 9007199254740992 is a TypeError [0.42ms]
(pass) WebAssembly.Exception.prototype.getArg > index 1.7976931348623157e+308 is a TypeError [0.62ms]
(pass) WebAssembly.Exception.prototype.getArg > index NaN is a TypeError [0.38ms]
(pass) WebAssembly.Exception.prototype.getArg > index Infinity is a TypeError [0.36ms]
(pass) WebAssembly.Exception.prototype.getArg > index -Infinity is a TypeError [0.56ms]
(pass) WebAssembly.Exception.prototype.getArg > index undefined is a TypeError [0.32ms]
(pass) WebAssembly.Exception.prototype.getArg > index "x" is a TypeError [0.32ms]
(pass) WebAssembly.Exception.prototype.getArg > index {} is a TypeError [0.62ms]
(pass) WebAssembly.Exception.prototype.getArg > an index that converts is truncated toward zero [3.33ms]
(pass) WebAssembly.Exception.prototype.getArg > a valid index past the payload is a RangeError [8.79ms]
(pass) WebAssembly.Memory grow and the buffer object > non-shared memory, Memory.prototype.grow: grow(0) detaches and replaces the buffer [9.88ms]
(pass) WebAssembly.Memory grow and the buffer object > shared memory, Memory.prototype.grow: grow(0) keeps the buffer, a real grow replaces it [5.98ms]
(pass) WebAssembly.Memory grow and the buffer object > non-shared memory, memory.grow instruction: grow(0) detaches and replaces the buffer [13.25ms]
(pass) WebAssembly.Memory grow and the buffer object > shared memory, memory.grow instruction: grow(0) keeps
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts    |   2 +-
 test/js/bun/wasm/js-api.test.ts | 149 ++++++++++++++++++++++++++++++++++++++++
 2 files changed, 150 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
scripts/build/deps/webkit.ts         0      0     13
test/js/bun/wasm/js-api.test.ts      2      1     12
```

</details>

<!-- robobun:evidence:end -->