### PR TITLE
json5: parse hex numbers wider than 64 bits as the nearest double instead of throwing

### DIFF
--- a/src/parsers/json5.rs
+++ b/src/parsers/json5.rs
@@ -882,10 +882,11 @@ impl<'a> JSON5Parser<'a> {
             return Err(ParseError::InvalidHexNumber);
         }
 
-        // scanner pre-filters to is_ascii_hexdigit → `_`/sign unreachable
-        let value = bun_core::fmt::parse_int::<u64>(&self.source[hex_start..self.pos], 16)
-            .map_err(|_| ParseError::InvalidHexNumber)?;
-        Ok(value as f64)
+        // A HexIntegerLiteral is a Number of any magnitude: the nearest double, as for a JS literal.
+        Ok(bun_core::fmt::parse_power_of_two_radix_digits(
+            &self.source[hex_start..self.pos],
+            16,
+        ))
     }
 
     fn scan_identifier(&mut self) -> Result<&'a [u8], ParseError> {

--- a/test/js/bun/json5/json5.test.ts
+++ b/test/js/bun/json5/json5.test.ts
@@ -302,6 +302,45 @@ describe("numbers - additional", () => {
     // 0xFFFFFFFFFFFFFFFF = u64 max
     expect(JSON5.parse("0xFFFFFFFFFFFFFFFF")).toEqual(18446744073709551615);
   });
+
+  // A JSON5 hex number is an ES HexIntegerLiteral: a Number of any magnitude,
+  // rounded to the nearest double (json5 does `Number("0x...")`).
+  test("hex number wider than 64 bits", () => {
+    expect(JSON5.parse("0x1ffffffffffffffff")).toBe(2 ** 65);
+    expect(JSON5.parse("0xfffffffffffffffff")).toBe(2 ** 68);
+    expect(JSON5.parse("0xFFFFFFFFFFFFFFFFFF")).toBe(2 ** 72);
+    expect(JSON5.parse("+0x1" + "0".repeat(30))).toBe(2 ** 120);
+    expect(JSON5.parse("-0x1" + "0".repeat(30))).toBe(-(2 ** 120));
+    expect(JSON5.parse("{a: [0x1" + "0".repeat(255) + ", -0x1" + "0".repeat(256) + "]}")).toEqual({
+      a: [2 ** 1020, -Infinity],
+    });
+    // Number.MAX_VALUE is 0xfffffffffffff8 followed by 242 zeros; half an ulp more rounds to Infinity
+    expect(JSON5.parse("0xfffffffffffff8" + "0".repeat(242))).toBe(Number.MAX_VALUE);
+    expect(JSON5.parse("0xfffffffffffffb" + "f".repeat(242))).toBe(Number.MAX_VALUE);
+    expect(JSON5.parse("0xfffffffffffffc" + "0".repeat(242))).toBe(Infinity);
+  });
+
+  test("hex number above 2^53 rounds once, ties to even", () => {
+    // 2^53 + 1 ties down to the even neighbour, 2^53 + 3 ties up to it
+    expect(JSON5.parse("0x20000000000001")).toBe(9007199254740992);
+    expect(JSON5.parse("0x20000000000003")).toBe(9007199254740996);
+    // 2^64 + 2^11 is a tie and goes to even (down); one more unit anywhere below breaks the tie upward
+    expect(JSON5.parse("0x10000000000000800")).toBe(18446744073709551616);
+    expect(JSON5.parse("0x10000000000000801")).toBe(18446744073709555712);
+    for (const digits of [
+      "97b89d834f82bbef",
+      "fffffffffffffbff",
+      "1fffffffffffffff",
+      "20000000000000fff",
+      "123456789abcdef0123",
+      "80000000000004000001",
+      "100000000000008" + "0".repeat(40) + "1",
+      "ffffffffffffffffffffffff",
+    ]) {
+      expect(JSON5.parse("0x" + digits)).toBe(Number(BigInt("0x" + digits)));
+      expect(JSON5.parse("-0X00" + digits.toUpperCase())).toBe(-Number(BigInt("0x" + digits)));
+    }
+  });
 });
 
 describe("objects - additional", () => {
@@ -705,11 +744,6 @@ describe("error messages", () => {
     expect(() => JSON5.parse("0x")).toThrow("Invalid hex number");
     expect(() => JSON5.parse("0X")).toThrow("Invalid hex number");
     expect(() => JSON5.parse("0xGG")).toThrow("Invalid hex number");
-  });
-
-  // -- Hex number too large --
-  test("hex number too large", () => {
-    expect(() => JSON5.parse("0xFFFFFFFFFFFFFFFFFF")).toThrow("Invalid hex number");
   });
 });
 


### PR DESCRIPTION
Stacked on #42112, which adds the helper this uses. Merge that first.

### Problem
- `Bun.JSON5.parse("0x1ffffffffffffffff")` throws `SyntaxError: JSON5 Parse error: Invalid hex number`. The `json5` package and the JS literal give 36893488147419103000 (2^65). A JSON5 hex number is an ES5 `HexIntegerLiteral`: a Number of any magnitude.
- `scan_hex_number()` (`src/parsers/json5.rs:886`) parsed the digits with `parse_int::<u64>` and mapped the overflow to `InvalidHexNumber`, so 2^64 or more was rejected. The `.json5` loader shares the parser.

### Fix
- `scan_hex_number()` hands the digit run to `bun_core::fmt::parse_power_of_two_radix_digits(digits, 16)` from #42112. That is the JSC function behind `parseInt` and hex literals, which #42112 makes round once, half to even. JSON5 hex then matches `eval("0x…")` by construction.
- Values below 2^64 do not change: the old `u64 as f64` cast also rounded once.
- The test `error messages > hex number too large` pinned the throw. Two tests in the same file replace it.
- Verified: `test/js/bun/json5/json5.test.ts` (both new tests fail on 1.4.3 and on #42112 alone), all of `test/js/bun/json5/`, the `json5` loader cases, and #42112's radix test. Self-reviewed: 1 concern (a second helper beside #42112's), addressed by stacking on it.

### Background
- JSON5 numbers are ES5 `NumericLiteral`s, so a hex number has no digit limit. ECMA-262 converts the exact value to the nearest double, ties to even ([RoundMVResult](https://tc39.es/ecma262/#sec-roundmvresult)). The `json5` package does `Number("0x...")`.
- A double holds 53 significant bits. In a power-of-two radix each digit is an exact group of bits, so the nearest double needs only integer shifts and one rounding (oven-sh/WebKit#597).

<details><summary>Notes</summary>

- Checked `Bun.JSON5.parse("0x" + digits)` against `Number(BigInt("0x" + digits))` for 52,772 inputs (random digit strings of 1 to 300 digits, a tie-biased 53 to 80-bit band, `2^k ± small` with zero and non-zero tails, the `Number.MAX_VALUE` / `Infinity` boundary), plus the negated form of each: 0 mismatches. JSC's `Number(BigInt)` agrees with V8's on 20,000 random inputs, so it is a sound reference.
- `json5@2.2.3` on node gives the same values as the new tests for the headline inputs, including `Infinity` for `0xfffffffffffffc` followed by 242 zeros and `Number.MAX_VALUE` for `0xfffffffffffff8` followed by 242 zeros.
- JSON5 decimals already go through `WTF::parseDouble`, so routing hex through JSC follows the same pattern.
- Expected values in the tests avoid hex literals above 2^53 and use `2 ** n`, decimal literals, or `Number(BigInt(...))`.
- A first version of this change added a pure-Rust helper to `bun_core::fmt` with the same algorithm. Review pointed out that #42112 adds a helper with the same contract for the lexer and the JSONC parser, so this PR uses that one instead of adding a second.
- `Bun.YAML.parse` returns a string for a `0x` scalar wider than 64 bits (`src/parsers/yaml.rs`). That is a schema-resolution question for the YAML parser and is not changed here.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/json5/json5.test.ts

<!-- robobun:evidence:end -->