### PR TITLE
Convert JS numbers to i64 in Rust instead of a C++ static_cast

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -216,7 +216,6 @@ declare function $cancel(): TODO;
 declare function $close(): TODO;
 declare function $code(): TODO;
 declare function $createFIFO(): TODO;
-declare function $createUninitializedArrayBuffer(size: number): ArrayBuffer;
 declare function $data(): TODO;
 declare function $decode(): TODO;
 declare function $dirname(): TODO;

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -64,7 +64,6 @@ using namespace JSC;
     macro(createCommonJSModule) \
     macro(createFIFO) \
     macro(createInternalModuleById) \
-    macro(createUninitializedArrayBuffer) \
     macro(ctimeMs) \
     macro(data) \
     macro(decode) \

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -776,15 +776,13 @@ impl JSValue {
         }
         JSC__JSValue__toInt32(self)
     }
+    /// Numbers convert as `f64 as i64` (NaN → 0, saturating). Heap BigInt → its low 64 bits.
     pub fn to_int64(self) -> i64 {
         if self.is_int32() {
             return self.as_int32() as i64;
         }
         if let Some(num) = self.get_number() {
-            if num.is_nan() {
-                return 0;
-            }
-            return num as i64; // saturating truncation
+            return num as i64;
         }
         JSC__JSValue__toInt64(self)
     }
@@ -836,10 +834,12 @@ impl JSValue {
     pub fn coerce_to_i32(self, global: &JSGlobalObject) -> JsResult<i32> {
         host_fn::from_js_host_call_generic(global, || JSC__JSValue__coerceToInt32(self, global))
     }
-    /// `JSValue.coerceToInt64` — full ToNumber → Int64 path
-    /// (may throw via `valueOf`/`toString`).
+    /// [`to_int64`](Self::to_int64) after `ToNumber` for other values (may throw via `valueOf`).
     pub fn coerce_to_int64(self, global: &JSGlobalObject) -> JsResult<i64> {
-        host_fn::from_js_host_call_generic(global, || JSC__JSValue__coerceToInt64(self, global))
+        if self.is_number() || self.is_big_int() {
+            return Ok(self.to_int64());
+        }
+        Ok(self.to_number(global)? as i64)
     }
     /// Generic coercion. Per-type helpers are
     /// `coerce_to_i32` / `coerce_f64` etc.; this fronts the i32 path.
@@ -1912,20 +1912,7 @@ impl CoerceTo for i32 {
 }
 impl CoerceTo for i64 {
     fn coerce_from(v: JSValue, global: &JSGlobalObject) -> JsResult<i64> {
-        if v.is_int32() {
-            return Ok(v.as_int32() as i64);
-        }
-        if let Some(num) = v.get_number() {
-            return Ok(if num.is_nan() { 0 } else { num as i64 });
-        }
-        if v.is_big_int() {
-            return v.coerce_to_int64(global);
-        }
-        // `JSC__JSValue__coerceToInt64` falls through to 32-bit `toInt32` for
-        // non-number, non-BigInt cells (strings wrap at 2^31). Go through full
-        // ToNumber here so string inputs above 2^31 round-trip to i64.
-        let num = v.to_number(global)?;
-        Ok(if num.is_nan() { 0 } else { num as i64 })
+        v.coerce_to_int64(global)
     }
 }
 /// No coercion: `get_optional::<JSValue>` is `get` with `null` filtered out.
@@ -2006,7 +1993,6 @@ unsafe extern "C" {
     safe fn JSC__JSValue__isBigInt(this: JSValue) -> bool;
     safe fn JSC__JSValue__isCallable(this: JSValue) -> bool;
     safe fn JSC__JSValue__coerceToInt32(this: JSValue, global: &JSGlobalObject) -> i32;
-    safe fn JSC__JSValue__coerceToInt64(this: JSValue, global: &JSGlobalObject) -> i64;
     safe fn JSC__JSValue__fastGet(this: JSValue, global: &JSGlobalObject, builtin: u8) -> JSValue;
     safe fn JSC__JSValue__jsonStringify(
         this: JSValue,

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1608,22 +1608,6 @@ extern "C" JSC::EncodedJSValue Bun__createTypedArrayForCopy(JSC::JSGlobalObject*
     return {};
 }
 
-JSC_DECLARE_HOST_FUNCTION(functionCreateUninitializedArrayBuffer);
-JSC_DEFINE_HOST_FUNCTION(functionCreateUninitializedArrayBuffer,
-    (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
-{
-    size_t len = static_cast<size_t>(JSC__JSValue__toInt64(JSC::JSValue::encode(callFrame->argument(0))));
-    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    auto arrayBuffer = JSC::ArrayBuffer::tryCreateUninitialized(len, 1);
-
-    if (!arrayBuffer) [[unlikely]] {
-        JSC::throwOutOfMemoryError(globalObject, scope);
-        return {};
-    }
-
-    RELEASE_AND_RETURN(scope, JSValue::encode(JSC::JSArrayBuffer::create(globalObject->vm(), globalObject->arrayBufferStructure(JSC::ArrayBufferSharingMode::Default), WTF::move(arrayBuffer))));
-}
-
 static inline JSC::EncodedJSValue jsFunctionAddEventListenerBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, Zig::GlobalObject* castedThis)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
@@ -2892,7 +2876,6 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
 
     putDirectBuiltinFunction(vm, this, builtinNames.overridableRequirePrivateName(), commonJSOverridableRequireCodeGenerator(vm), 0);
 
-    putDirectNativeFunction(vm, this, builtinNames.createUninitializedArrayBufferPrivateName(), 1, functionCreateUninitializedArrayBuffer, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNativeFunction(vm, this, builtinNames.resolveSyncPrivateName(), 1, functionImportMeta__resolveSyncPrivate, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNativeFunction(vm, this, builtinNames.createInternalModuleByIdPrivateName(), 1, InternalModuleRegistry::jsCreateInternalModuleById, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4302,18 +4302,15 @@ JSC::EncodedJSValue JSC__JSValue__jsNumberFromUint64(uint64_t arg0)
     return JSC::JSValue::encode(JSC::jsNumber(arg0));
 }
 
+// BigInt only: JSValue::to_int64 (Rust) and JSVALUE_TO_INT64 (FFI.h) convert numbers themselves.
 [[ZIG_EXPORT(nothrow)]] int64_t JSC__JSValue__toInt64(JSC::EncodedJSValue val)
 {
     JSC::JSValue value = JSC::JSValue::decode(val);
-    ASSERT(value.isHeapBigInt() || value.isNumber());
-    if (value.isHeapBigInt()) {
-        if (auto* heapBigInt = value.asHeapBigInt()) {
-            return heapBigInt->toBigInt64(heapBigInt);
-        }
+    ASSERT(value.isBigInt());
+    if (value.isBigInt()) {
+        return JSC::JSBigInt::toBigInt64(value);
     }
-    if (value.isInt32())
-        return value.asInt32();
-    return static_cast<int64_t>(value.asDouble());
+    return 0;
 }
 
 uint8_t JSC__JSValue__asBigIntCompare(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue JSValue1)
@@ -4734,25 +4731,6 @@ CPP_DECL double Bun__JSValue__toNumber(JSC::EncodedJSValue JSValue0, JSC::JSGlob
     if (value.isCell() && value.isHeapBigInt()) {
         return static_cast<int32_t>(value.toBigInt64(arg1));
     }
-    return value.toInt32(arg1);
-}
-
-[[ZIG_EXPORT(check_slow)]] int64_t JSC__JSValue__coerceToInt64(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1)
-{
-    JSValue value = JSValue::decode(JSValue0);
-    if (value.isCell() && value.isHeapBigInt()) {
-        return value.toBigInt64(arg1);
-    }
-
-    if (value.isDouble()) {
-        int64_t result = tryConvertToInt52(value.asDouble());
-        if (result != JSValue::notInt52) {
-            return result;
-        }
-
-        return static_cast<int64_t>(value.asDouble());
-    }
-
     return value.toInt32(arg1);
 }
 

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -184,7 +184,6 @@ CPP_DECL JSC::JSPromise* JSC__JSValue__asInternalPromise(JSC::EncodedJSValue JSV
 CPP_DECL JSC::JSPromise* JSC__JSValue__asPromise(JSC::EncodedJSValue JSValue0);
 CPP_DECL JSC::JSString* JSC__JSValue__asString(JSC::EncodedJSValue JSValue0);
 CPP_DECL int32_t JSC__JSValue__coerceToInt32(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
-CPP_DECL int64_t JSC__JSValue__coerceToInt64(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__createEmptyArray(JSC::JSGlobalObject* arg0, size_t arg1);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__createEmptyObject(JSC::JSGlobalObject* arg0, size_t arg1);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__createInternalPromise(JSC::JSGlobalObject* arg0);

--- a/test/js/bun/util/index-of-line.test.ts
+++ b/test/js/bun/util/index-of-line.test.ts
@@ -18,6 +18,32 @@ test("indexOfLine handles non-number offset", () => {
   expect(indexOfLine(buf, "2")).toBe(5); // "2" coerces to 2, newline is at 5
 });
 
+test("indexOfLine offset outside the int64 range saturates instead of wrapping", () => {
+  const buf = new Uint8Array([104, 101, 108, 108, 111, 10, 119, 111, 114, 108, 100]); // "hello\nworld"
+  const found = (offset: unknown) => [offset, indexOfLine(buf, offset as number)];
+
+  // At or past the end there is nothing to find, however large the offset.
+  // Strings and BigInts take the same path (no 32-bit wrap for "4294967296").
+  const pastEnd = [buf.length, 2 ** 31, 2 ** 53, 2 ** 63, 2 ** 64, 1e300, Number.MAX_VALUE, Infinity, "4294967296", 6n];
+  expect(pastEnd.map(found)).toEqual(pastEnd.map(offset => [offset, -1]));
+
+  // Negative offsets clamp to the start, however small. NaN is 0.
+  const beforeStart = [
+    -1,
+    -0.5,
+    -(2 ** 31),
+    -(2 ** 53),
+    -(2 ** 63),
+    -(2 ** 64),
+    -1e300,
+    -Infinity,
+    NaN,
+    "-4294967296",
+    -1n,
+  ];
+  expect(beforeStart.map(found)).toEqual(beforeStart.map(offset => [offset, 5]));
+});
+
 test("indexOfLine", () => {
   const source = `
         const a = 1;


### PR DESCRIPTION
### Problem
- `Bun.indexOfLine(buf, Infinity)` (also `1e300`, `2 ** 63`) scans from offset 0 on x86_64. On arm64 it returns -1. `new Response("", { status: "4294967496" })` is accepted as 200.
- The cause is `JSC__JSValue__coerceToInt64` (`src/jsc/bindings/bindings.cpp`), behind every `JSValue::coerce_to_int64` call. It cast doubles with `static_cast<int64_t>`, undefined behavior for NaN, +/-Infinity and `|x| >= 2^63` (x86_64 gives INT64_MIN, arm64 saturates). It sent strings through `toInt32`, which wraps at 2^32.

### Fix
- Convert in Rust. `coerce_to_int64` now uses `to_int64` (`f64 as i64`) for numbers and BigInts, and `ToNumber` then `as i64` for the rest. `CoerceTo for i64` already did this and now delegates to it. The C++ export is deleted.
- Correct because Rust defines `f64 as i64` as saturating with NaN as 0. rustc emits one `fcvtzs` on aarch64 and `cvttsd2si` plus two `cmov` on x86_64: no UB, one result on every architecture.
- `JSC__JSValue__toInt64` keeps only its BigInt branch. Its callers (`JSValue::to_int64`, `FFI.h`) convert numbers themselves. Its one number caller, `$createUninitializedArrayBuffer`, is unused since #31339 and is removed.
- Verified: `test/js/bun/util/index-of-line.test.ts` (fails 6 of 21 offsets on stock x64, passes with the fix), plus the suites in Notes. Self-reviewed, then reworked to this shape on review.

### Background
- `JSValue::to_int64` (Rust) already converted numbers with `as i64`. `coerce_to_int64` was the one wrapper that still shipped numbers to C++. Callers: `Bun.indexOfLine`, `Response` `status`, `Bun.spawn` `maxBuffer`, `Bun.mmap`.
- A C++ double-to-int64 cast whose result does not fit is undefined behavior, which LLVM exploits (oven-sh/WebKit#609, #244). Rust's `as` is defined.

<details><summary>Notes</summary>

- First revision hoisted a saturating C++ helper into `helpers.h`. Review asked for the conversion to live in Rust instead, which also removes an FFI round trip for the common number case. `f64 as i64` codegen checked with `rustc -O --emit asm` on the repo toolchain (1.99 nightly): aarch64 `fcvtzs x0, d0; ret`, x86_64 `cvttsd2si` + `ucomisd`/`cmovbe` (upper clamp) + `ucomisd`/`cmovnp` (NaN to 0).
- Behavior change for numbers is x86_64 only, and only for NaN, +/-Infinity and `|x| >= 2^63`. arm64 already produced these results (its `fcvtzs` saturates and maps NaN to 0). On x64 the new test fails before for `2**63`, `2**64`, `1e300`, `Number.MAX_VALUE`, `Infinity`.
- Behavior change for strings and objects with `valueOf` is on every architecture: they now go through `ToNumber` and the same saturating conversion instead of `ToInt32`. `Bun.indexOfLine(buf, "4294967296")` was offset 0, is now past the end. `new Response("", { status: "4294967496" })` was 200, now throws the RangeError. `http.maxHeaderSize = "4294967296"` was rejected as non-positive, is now accepted. The new test covers `"4294967296"`, `"-4294967296"`, `6n`, `-1n`.
- Per-caller effect on x64 for out-of-range numbers: `indexOfLine` huge offset now returns -1. `Response` status error message now prints INT64_MAX / 0 instead of INT64_MIN (still throws). `http.maxHeaderSize = Infinity` (or `2 ** 63`) is now accepted as a huge limit instead of throwing "must be non-negative" (matches arm64). `spawn maxBuffer: 1e300` becomes an INT64_MAX limit instead of being ignored (no visible difference). `setMaxSendFragment(Infinity)` still returns false. `exportKeyingMaterial(Infinity, ...)` now fails in `Buffer` allocation with ERR_OUT_OF_RANGE instead of "Expected length to be a positive number". `Bun.mmap({ size: Infinity })` now fails in `mmap(2)` instead of "size must be a non-negative integer".
- `JSC__JSValue__toInt64` with a value that is neither number nor BigInt (reachable through an FFI `i64` argument given a string) used to reinterpret the cell bits as a double in release builds. It now returns 0. The debug `ASSERT` is unchanged in strength.
- Suites run with the debug build, all pass: `test/js/bun/util/index-of-line.test.ts`, `test/js/node/buffer.test.js`, `test/js/bun/util/mmap.test.js`, `test/js/bun/spawn/spawn-maxbuf.test.ts`, `test/js/node/http/node-http-maxHeaderSize.test.ts`, `test/js/web/fetch/response.test.ts`, `test/js/web/fetch/blob.test.ts`, `test/js/node/tls/node-tls-connect.test.ts`, `test/js/bun/perf_hooks/histogram.test.ts`, `test/js/bun/jsc/bun-jsc.test.ts`, `test/js/bun/util/inspect.test.js`, `test/js/bun/test/expect.test.js`, `test/js/bun/ffi/ffi.test.js` (147 pass; the one FTL ptr-argument stress test times out at 5 s in this debug ASAN container with or without the change, it is allocation-bound).
- Sibling casts checked and intentionally left alone: `JSCookie.cpp` `getExpiresValue` (NaN/Infinity rejected first, INT64_MIN is `Cookie::emptyExpiresAtValue`, the real invariant is the ECMAScript time range, open as #32267), perf_hooks `Histogram` (already `truncateDoubleToInt64` from #29746, wants `validateInteger` for consistency), `Bun__msToGregorianDateTimeInZone` (only caller rejects NaN and `|ms| > MAX_ECMASCRIPT_TIME` first), `v8::Integer::Value` (int32/uint32 by construction), `napi_get_value_int64` (already clamps), `FFI.h` `JSVALUE_TO_INT64` (C compiled by TinyCC at runtime).
- `JSBuffer.cpp`'s `toIntegerValue` (v8 `IntegerValue` semantics for `parseArrayIndex`) stays where it is: that double comes from `toNumber()` inside C++.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/index-of-line.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/util/index-of-line.test.ts:
(pass) indexOfLine handles non-number offset [11.24ms]
23 |   const found = (offset: unknown) => [offset, indexOfLine(buf, offset as number)];
24 | 
25 |   // At or past the end there is nothing to find, however large the offset.
26 |   // Strings and BigInts take the same path (no 32-bit wrap for "4294967296").
27 |   const pastEnd = [buf.length, 2 ** 31, 2 ** 53, 2 ** 63, 2 ** 64, 1e300, Number.MAX_VALUE, Infinity, "4294967296", 6n];
28 |   expect(pastEnd.map(found)).toEqual(pastEnd.map(offset => [offset, -1]));
                                  ^
error: expect(received).toEqual(expected)

  [
    [
      11,
      -1,
    ],
    [
      2147483648,
      -1,
    ],
    [
      9007199254740992,
      -1,
    ],
    [
      9223372036854776000,
-     -1,
+     5,
    ],
    [
      18446744073709552000,
-     -1,
+     5,
    ],
    [
      1e+300,
-     -1,
+     5,
    ],
    [
      1.7976931348623157e+308,
-     -1,
+     5,
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (5f554969b)

test/js/bun/util/index-of-line.test.ts:
(pass) indexOfLine handles non-number offset [0.08ms]
23 |   const found = (offset: unknown) => [offset, indexOfLine(buf, offset as number)];
24 | 
25 |   // At or past the end there is nothing to find, however large the offset.
26 |   // Strings and BigInts take the same path (no 32-bit wrap for "4294967296").
27 |   const pastEnd = [buf.length, 2 ** 31, 2 ** 53, 2 ** 63, 2 ** 64, 1e300, Number.MAX_VALUE, Infinity, "4294967296", 6n];
28 |   expect(pastEnd.map(found)).toEqual(pastEnd.map(offset => [offset, -1]));
                                  ^
error: expect(received).toEqual(expected)

  [
    [
      11,
      -1,
    ],
    [
      2147483648,
      -1,
    ],
    [
      9007199254740992,
      -1,
    ],
    [
      9223372036854776000,
-     -1,
+     5,
    ],
    [
      18446744073709552000,
-     -1,
+     5,
    ],
    [
      1e+300,
-     -1,
+     5,
    ],
    [
      1.7976931348623157e+308,
-     -1,
+     5,
    ],
    [
      Infinity,
-     -1,
+     5,
    ],
    [
      "4294967296",
-     -1,
+     5,
    ],
    [
      6n,
      -1,
    ],
  ]

- Expected  - 6
+
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/index-of-line.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/util/index-of-line.test.ts:
(pass) indexOfLine handles non-number offset [12.69ms]
(pass) indexOfLine offset outside the int64 range saturates instead of wrapping [20.33ms]

       const a = 1;

       const b = 2;

       😋const c = 3; // handles unicode

       😋 Get Emoji — All Emojis to ✂️

       const b = 2;

       const c = 3;
(pass) indexOfLine [9.69ms]
(pass) indexOfLine is linear on large input with a non-ASCII byte [263.74ms]
(pass) indexOfLine returns -1 when the offset's valueOf transfers the buffer via structuredClone [11.21ms]
(pass) indexOfLine returns -1 when the offset's valueOf transfers the buffer via ArrayBuffer.prototype.transfer [4.36ms]
(pass) indexOfLine skips multi-byte sequences correctly [2.77ms]
(pass) indexOfLine with invalid UTF-8 [ 240, 10 ] at offset 0 > returns 1 [1.66ms]
(pass) indexOfLine with invalid UTF-8 [ 226, 130, 10 ] at offset 0 > returns 2 [0.28ms]
(pass) indexOfLine with invalid UTF-8 [ 195, 10, 65, 1
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     a72b37201a
  features     baseline

23 deps, 131 codegen, 1172 objects in 590ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (5f554969b)

Checked 22 installs across 61 packages (no changes) [2.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (5f554969b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (5f554969b)

Checked 111 installs across 104 packages (no changes) [2.00ms]
[5/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 4ms

  react-refresh.js  4.81 KB  (entry point)

[6/1244] gen bindgenv2
[7/1244] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 22ms
[8/1244] fetch zlib
[zlib] up to date
[9/1244] gen bake.{client,server,error}.js
-> bake.c
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins.d.ts                   |  1 -
 src/js/builtins/BunBuiltinNames.h      |  1 -
 src/jsc/JSValue.rs                     | 30 ++++++++----------------------
 src/jsc/bindings/ZigGlobalObject.cpp   | 17 -----------------
 src/jsc/bindings/bindings.cpp          | 32 +++++---------------------------
 src/jsc/bindings/headers.h             |  1 -
 test/js/bun/util/index-of-line.test.ts | 26 ++++++++++++++++++++++++++
 7 files changed, 39 insertions(+), 69 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/js/builtins.d.ts                        1      1     13
src/js/builtins/BunBuiltinNames.h           1      1     13
src/jsc/JSValue.rs                          4      6     12
src/jsc/bindings/ZigGlobalObject.cpp        2      2     13
src/jsc/bindings/bindings.cpp               4      6     12
src/jsc/bindings/headers.h                  1      1     12
test/js/bun/util/index-of-line.test.ts      2      2     12
```

</details>

<!-- robobun:evidence:end -->