### PR TITLE
bundler: print an export named __proto__ as a computed object key

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1481,8 +1481,7 @@ impl Object {
     }
 }
 
-/// Flags for a string key that must print as an own property: `"__proto__"` is
-/// marked computed, since a plain `__proto__:` key sets the prototype instead.
+/// Flags for a string key that must stay an own property: `"__proto__"` prints computed.
 pub fn own_key_property_flags(key: &Expr) -> crate::flags::PropertySet {
     match &key.data {
         crate::expr::Data::EString(key_str) if key_str.eql_comptime(b"__proto__") => {

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1481,9 +1481,10 @@ impl Object {
     }
 }
 
-/// Data-file parsers (JSON/JSON5/TOML/YAML) define every key as an own
-/// property, so an own `"__proto__"` string key must be marked computed:
-/// a plain `"__proto__":` key in a printed object literal sets the prototype.
+/// Flags for a string key that must define an own property (data-file parsers,
+/// the linker's `__export(exports, { ... })` object): an own `"__proto__"` key
+/// must be marked computed, because a plain `"__proto__":` key in a printed
+/// object literal sets the prototype.
 pub fn own_key_property_flags(key: &Expr) -> crate::flags::PropertySet {
     match &key.data {
         crate::expr::Data::EString(key_str) if key_str.eql_comptime(b"__proto__") => {

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -1481,10 +1481,8 @@ impl Object {
     }
 }
 
-/// Flags for a string key that must define an own property (data-file parsers,
-/// the linker's `__export(exports, { ... })` object): an own `"__proto__"` key
-/// must be marked computed, because a plain `"__proto__":` key in a printed
-/// object literal sets the prototype.
+/// Flags for a string key that must print as an own property: `"__proto__"` is
+/// marked computed, since a plain `__proto__:` key sets the prototype instead.
 pub fn own_key_property_flags(key: &Expr) -> crate::flags::PropertySet {
     match &key.data {
         crate::expr::Data::EString(key_str) if key_str.eql_comptime(b"__proto__") => {

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -369,11 +369,11 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
                                     self.symbols[ref_.inner_index() as usize].original_name;
                                 // ImportScanner.recordExportedBinding → recordExport
                                 self.record_export(binding.loc, original_name.slice(), ref_)?;
+                                let key =
+                                    Expr::init(E::String::init(original_name.slice()), binding.loc);
                                 export_props.push(G::Property {
-                                    key: Some(Expr::init(
-                                        E::String::init(original_name.slice()),
-                                        binding.loc,
-                                    )),
+                                    flags: E::own_key_property_flags(&key),
+                                    key: Some(key),
                                     value: Some(Expr::init_identifier(ref_, binding.loc)),
                                     ..Default::default()
                                 });

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3638,6 +3638,7 @@ pub mod bv2_impl {
                             ..Default::default()
                         });
                         *client_item = G::Property {
+                            flags: E::own_key_property_flags(&export_name),
                             key: Some(export_name),
                             value: Some(server.new_expr(E::Object {
                                 properties: bun_ast::g::PropertyList::from_owned_slice(Box::new([

--- a/src/bundler/linker_context/doStep5.rs
+++ b/src/bundler/linker_context/doStep5.rs
@@ -557,16 +557,18 @@ impl LinkerContext<'_> {
                 stmts: stmts_eat1!(Stmt::allocate(arena, S::Return { value: Some(value) }, loc,)),
                 loc,
             };
+            // SAFETY: `alias` borrows the worker arena which outlives the
+            // link pass; `E::String::data: &'static [u8]` is the arena
+            // erasure used throughout the AST.
+            let key = Expr::allocate(
+                arena,
+                E::String::init(unsafe { bun_ptr::detach_lifetime(alias) }),
+                loc,
+            );
             properties.push(G::Property {
-                key: Some(Expr::allocate(
-                    arena,
-                    // TODO: test emoji work as expected (relevant for WASM exports)
-                    // SAFETY: `alias` borrows the worker arena which outlives the
-                    // link pass; `E::String::data: &'static [u8]` is the arena
-                    // erasure used throughout the AST.
-                    E::String::init(unsafe { bun_ptr::detach_lifetime(alias) }),
-                    loc,
-                )),
+                // An export may be named `__proto__`; as a plain key that would set the literal's prototype.
+                flags: E::own_key_property_flags(&key),
+                key: Some(key),
                 value: Some(Expr::allocate(
                     arena,
                     E::Arrow {
@@ -608,13 +610,15 @@ impl LinkerContext<'_> {
                     ),
                     ..Default::default()
                 });
+                // SAFETY: as for the getter key above.
+                let key = Expr::allocate(
+                    arena,
+                    E::String::init(unsafe { bun_ptr::detach_lifetime(alias) }),
+                    loc,
+                );
                 setter_properties.push(G::Property {
-                    key: Some(Expr::allocate(
-                        arena,
-                        // SAFETY: as for the getter key above.
-                        E::String::init(unsafe { bun_ptr::detach_lifetime(alias) }),
-                        loc,
-                    )),
+                    flags: E::own_key_property_flags(&key),
+                    key: Some(key),
                     value: Some(Expr::allocate(
                         arena,
                         E::Arrow {

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -460,6 +460,9 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                             // empty" invariant makes that drop a no-op today, but
                             // `ptr::write` enforces it structurally.
                             let key = prop.key;
+                            // Keeps `IsComputed` on a `"__proto__"` key; the value is no longer an
+                            // identifier of the same name once renamed, so no shorthand saves it.
+                            let flags = prop.flags;
                             let value_loc =
                                 prop.value.as_ref().expect("infallible: prop has value").loc;
                             // SAFETY: `prop` is a valid `&mut G::Property` slot;
@@ -469,6 +472,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                                 core::ptr::write(
                                     prop,
                                     G::Property {
+                                        flags,
                                         key,
                                         value: Some(Expr::init_identifier(export_ref, value_loc)),
                                         ..Default::default()

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -460,9 +460,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                             // empty" invariant makes that drop a no-op today, but
                             // `ptr::write` enforces it structurally.
                             let key = prop.key;
-                            // Keeps `IsComputed` on a `"__proto__"` key; the value is no longer an
-                            // identifier of the same name once renamed, so no shorthand saves it.
-                            let flags = prop.flags;
+                            let flags = prop.flags; // `IsComputed` for a `"__proto__"` key
                             let value_loc =
                                 prop.value.as_ref().expect("infallible: prop has value").loc;
                             // SAFETY: `prop` is a valid `&mut G::Property` slot;

--- a/src/js_parser/lower/lower_esm_exports_hmr.rs
+++ b/src/js_parser/lower/lower_esm_exports_hmr.rs
@@ -77,12 +77,14 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                             // if the symbol is not used, we don't need to preserve
                             // a binding in this scope. we can move it to the exports object.
                             if symbol.use_count_estimate == 0 && value.can_be_moved() {
+                                // SAFETY: arena-owned name slice valid for the parse.
+                                let key = Expr::init(
+                                    E::EString::init(symbol.original_name.slice()),
+                                    binding.loc,
+                                );
                                 self.export_props.push(G::Property {
-                                    key: Some(Expr::init(
-                                        // SAFETY: arena-owned name slice valid for the parse.
-                                        E::EString::init(symbol.original_name.slice()),
-                                        binding.loc,
-                                    )),
+                                    flags: E::own_key_property_flags(&key),
+                                    key: Some(key),
                                     value: Some(value),
                                     ..Default::default()
                                 });
@@ -257,16 +259,18 @@ impl<'a> ConvertESMExportsForHmr<'a> {
 
                 let class_name_ref = st.class.class_name.unwrap().ref_;
                 // Export as CommonJS
+                // SAFETY: arena-owned name slice valid for the parse.
+                let key = Expr::init(
+                    E::EString::init(
+                        p.symbols[class_name_ref.inner_index() as usize]
+                            .original_name
+                            .slice(),
+                    ),
+                    stmt.loc,
+                );
                 self.export_props.push(G::Property {
-                    key: Some(Expr::init(
-                        // SAFETY: arena-owned name slice valid for the parse.
-                        E::EString::init(
-                            p.symbols[class_name_ref.inner_index() as usize]
-                                .original_name
-                                .slice(),
-                        ),
-                        stmt.loc,
-                    )),
+                    flags: E::own_key_property_flags(&key),
+                    key: Some(key),
                     value: Some(Expr::init_identifier(class_name_ref, stmt.loc)),
                     ..Default::default()
                 });
@@ -350,12 +354,11 @@ impl<'a> ConvertESMExportsForHmr<'a> {
 
                 if let Some(alias) = &st.alias {
                     // 'export * as ns from' creates one named property.
+                    // SAFETY: arena-owned name slice valid for the parse.
+                    let key = Expr::init(E::EString::init(alias.original_name.slice()), stmt.loc);
                     self.export_props.push(G::Property {
-                        // SAFETY: arena-owned name slice valid for the parse.
-                        key: Some(Expr::init(
-                            E::EString::init(alias.original_name.slice()),
-                            stmt.loc,
-                        )),
+                        flags: E::own_key_property_flags(&key),
+                        key: Some(key),
                         value: Some(Expr::init_identifier(deduped.namespace_ref, stmt.loc)),
                         ..Default::default()
                     });
@@ -563,6 +566,10 @@ impl<'a> ConvertESMExportsForHmr<'a> {
         } else {
             Expr::init_identifier(ref_, loc)
         };
+        let key = Expr::init(
+            E::EString::init(export_symbol_name.unwrap_or(original_name).slice()),
+            loc,
+        );
         if is_live_binding_source
             || (kind == js_ast::symbol::Kind::Import && !self.is_in_node_modules)
             || has_been_assigned_to
@@ -576,10 +583,6 @@ impl<'a> ConvertESMExportsForHmr<'a> {
             // of importers. For local live bindings, these can just remember to
             // mutate the field in the exports object. Re-exports can just be
             // encoded into the module format, propagated in `replaceModules`
-            let key = Expr::init(
-                E::EString::init(export_symbol_name.unwrap_or(original_name).slice()),
-                loc,
-            );
 
             // This is technically incorrect in that we've marked this as a
             // top level symbol. but all we care about is preventing name
@@ -620,12 +623,10 @@ impl<'a> ConvertESMExportsForHmr<'a> {
             });
             // no setter is added since live bindings are read-only
         } else {
-            // 'abc,'
+            // 'abc,' (or 'alias: abc,'; an alias of `__proto__` must stay an own key)
             self.export_props.push(G::Property {
-                key: Some(Expr::init(
-                    E::EString::init(export_symbol_name.unwrap_or(original_name).slice()),
-                    loc,
-                )),
+                flags: E::own_key_property_flags(&key),
+                key: Some(key),
                 value: Some(id),
                 ..Default::default()
             });

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -232,6 +232,48 @@ devTest("export * as namespace", {
     await c.expectMessage("PASS");
   },
 });
+// The HMR transform lowers a module's exports to one object literal. An export named `__proto__`
+// must be an own key of that object: as a plain `__proto__:` key it would set (or, for a
+// primitive, silently drop) the prototype instead.
+devTest("exports named __proto__ are own keys", {
+  framework: minimalFramework,
+  files: {
+    // unused locally with a movable value: the binding moves into the exports object
+    "moved.ts": `
+      export const __proto__ = "moved";
+    `,
+    "aliased.ts": `
+      const p = { form: "aliased" };
+      export { p as __proto__ };
+    `,
+    "star.ts": `
+      export * as __proto__ from "./inner";
+      export const other = 1;
+    `,
+    "inner.ts": `
+      export const x = 1;
+    `,
+    "routes/index.ts": `
+      import * as moved from "../moved";
+      import * as aliased from "../aliased";
+      import * as star from "../star";
+      export default function (req, meta) {
+        return Response.json({
+          moved: [Object.keys(moved), moved["__proto__"]],
+          aliased: [Object.keys(aliased), aliased["__proto__"]],
+          star: [Object.keys(star).sort(), star["__proto__"].x],
+        });
+      }
+    `,
+  },
+  async test(dev) {
+    expect(await dev.fetch("/").json()).toEqual({
+      moved: [["__proto__"], "moved"],
+      aliased: [["__proto__"], { form: "aliased" }],
+      star: [["__proto__", "other"], 1],
+    });
+  },
+});
 devTest("ESM <-> CJS sync", {
   files: {
     "index.html": emptyHtmlFile({

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -188,6 +188,29 @@ describe("bundler", async () => {
     run: { stdout: '[true,true,null,"{\\"__proto__\\":{\\"x\\":1},\\"a\\":2}"]' },
   });
 
+  // A top-level key that is also imported by name becomes a variable, and the default object
+  // references it. Once the minifier renames that variable the property is no longer shorthand,
+  // so a `"__proto__"` key must keep its computed form.
+  itBundled("bun/loader-json-proto-key-imported-by-name", {
+    target: "bun",
+    minifyIdentifiers: true,
+    files: {
+      "/entry.ts": /* js */ `
+    import data, { __proto__ as proto, a } from './data.json';
+    const out = [
+      Object.getPrototypeOf(data) === Object.prototype,
+      Object.hasOwn(data, "__proto__"),
+      proto === data["__proto__"],
+      a,
+      JSON.stringify(data),
+    ];
+    console.write(JSON.stringify(out));
+  `,
+      "/data.json": `{"__proto__": {"x": 1}, "a": 2}`,
+    },
+    run: { stdout: '[true,true,true,2,"{\\"__proto__\\":{\\"x\\":1},\\"a\\":2}"]' },
+  });
+
   itBundled("bun/loader-toml-proto-key-is-own-property", {
     target: "bun",
     files: {

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -403,6 +403,41 @@ describe.concurrent("bundler", () => {
       file: "/test.js",
     },
   });
+  // An export named `__proto__` is an own property of the namespace like any other. In the
+  // `__export(exports, { ... })` object a plain `__proto__:` key would set the literal's prototype
+  // instead, so the key must be printed computed.
+  itBundled("default/ExportSpecialName", {
+    files: {
+      "/entry.mjs": `export const __proto__ = 123`,
+
+      "/test.js": /* js */ `
+        const assert = require("assert");
+        const lib = require("./out.js");
+        assert.deepStrictEqual(Object.keys(lib), ["__proto__"]);
+        assert.strictEqual(lib.__proto__, 123);
+      `,
+    },
+    format: "cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain(`["__proto__"]: () => __proto__`);
+    },
+    run: { file: "/test.js" },
+  });
+  itBundled("default/ExportSpecialNameBundle", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as ns from "./lib.mjs";
+        const key = (k) => k;
+        console.log(JSON.stringify(Object.keys(ns)), JSON.stringify(ns[key("__proto__")]), ns[key("a")]);
+      `,
+      "/lib.mjs": /* js */ `
+        const p = { proto: true };
+        export const a = 1;
+        export { p as __proto__ };
+      `,
+    },
+    run: { stdout: `["__proto__","a"] {"proto":true} 1` },
+  });
   itBundled("default/ExportInfiniteCycle1", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
### Problem
- An export named `__proto__` (`export { p as __proto__ }`, `export const __proto__ = 1`) is missing from the bundled module's namespace object. `Object.keys(ns)` prints `["__proto__","a"]` under `bun run` and Node, and `["a"]` from any `bun build` output (plain, `--compile`, with or without `--bytecode` or `--splitting`).
- The linker collects a module's exports into the object literal it passes to `__export(exports, { name: () => value })` (`src/bundler/linker_context/doStep5.rs:560`). The key was printed as a plain `__proto__:`, which sets the literal's prototype instead of defining a property, so `__export` never saw it. Three other places print a user-controlled export name as a plain key and lose it the same way: the dev server's HMR export lowering (`hmr.exports = { ... }`), the JSON/TOML/YAML default-object rewrite once `--minify` renames the variable out of shorthand, and the server-components manifest.

### Fix
- Every site that turns an export name into an object-literal key now takes its flags from `E::own_key_property_flags`, which marks a `"__proto__"` string key computed. The printer then writes `["__proto__"]: ...`, an own property. esbuild prints the linker case the same way (`TestExportSpecialName`). The data-file loaders already used this helper; its doc comment now names the new callers.
- Sites: the `__export`/`__exportCjs` keys in `doStep5.rs`; the four plain-key forms in `src/js_parser/lower/lower_esm_exports_hmr.rs` (a moved `const`, a class, `export * as ns`, `name: binding`; the getter form was already safe); the named-export rewrite in `generateCodeForFileInChunkJS.rs`, which now keeps the parser's flags; and the generated-module keys in `AstBuilder.rs` and the client manifest entry in `bundle_v2.rs`. The last two have no test harness (server components), the change there is the same one-line flag.
- Verified: `esbuild/default.test.ts` gains `default/ExportSpecialName` and `default/ExportSpecialNameBundle`; `bundler_loader.test.ts` gains `bun/loader-json-proto-key-imported-by-name` (`--minify`); `test/bake/dev/esm.test.ts` gains "exports named __proto__ are own keys". All four fail on stock bun and pass here. All of `esbuild/default.test.ts`, `bundler_edgecase.test.ts`, `bundler_cjs.test.ts`, `bundler_loader.test.ts` and `bake/dev/esm.test.ts` pass.

### Background
- For a file that other code reaches through `import * as ns`, `require()`, or as an entry point, the linker emits a namespace-export part: `var exports_x = {}; __export(exports_x, { a: () => a, ... })`. `__export` (`src/runtime.js`) defines one enumerable getter per key of that literal. The dev server does the equivalent per module with `hmr.exports = { ... }`.
- In an object literal, `__proto__: v` is the one plain key with special meaning: it calls `[[SetPrototypeOf]]` when `v` is an object and is dropped when `v` is a primitive. `["__proto__"]: v`, the shorthand `{ __proto__ }`, and methods or getters named `__proto__` define an own property instead.
