### PR TITLE
WebAssembly: reject ill-typed unreachable code (WebKit bump for oven-sh/WebKit#611)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-611-86501bcc";
+export const WEBKIT_VERSION = "autobuild-preview-pr-611-e0871a4c";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "2e2aa2290fac856d6f451ceacb58f7f5b44dd057";
+export const WEBKIT_VERSION = "autobuild-preview-pr-611-86501bcc";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/webassembly/validate-unreachable-code.test.ts
+++ b/test/js/web/webassembly/validate-unreachable-code.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+
+// Code after `unreachable`, `br`, `br_table`, `return` or `throw` never runs, but the core spec
+// still types it: the block's operand stack becomes polymorphic at its bottom and every instruction
+// keeps its typing rules (spec test-suite unreached-invalid.wast). JSC used to decode such code
+// without typing it, so validate() was true and compilation succeeded for modules that V8 and the
+// reference interpreter reject. Fixed in oven-sh/WebKit#611.
+
+// One function of the given type whose body is `body`, plus whatever sections the body needs.
+function moduleWith({
+  params = [],
+  results = [],
+  body,
+  memory = false,
+  immutableGlobal = false,
+  callee = false,
+}: {
+  params?: number[];
+  results?: number[];
+  body: number[];
+  memory?: boolean;
+  immutableGlobal?: boolean;
+  callee?: boolean;
+}) {
+  const section = (id: number, payload: number[]) => [id, payload.length, ...payload];
+  const types = [0x60, params.length, ...params, results.length, ...results];
+  // Type 1, used by the callee: (i32) -> (i64).
+  const calleeType = [0x60, 1, i32, 1, i64];
+  const functionBody = [0 /* no locals */, ...body, end];
+  const calleeBody = [0, i64_const, 0, end];
+  return new Uint8Array([
+    ...[0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00],
+    ...section(1, callee ? [2, ...types, ...calleeType] : [1, ...types]),
+    ...section(3, callee ? [2, 0, 1] : [1, 0]),
+    ...(memory ? section(5, [1, 0, 1]) : []),
+    ...(immutableGlobal ? section(6, [1, i32, 0 /* const */, i32_const, 1, end]) : []),
+    ...section(
+      10,
+      callee
+        ? [2, functionBody.length, ...functionBody, calleeBody.length, ...calleeBody]
+        : [1, functionBody.length, ...functionBody],
+    ),
+  ]);
+}
+
+const [i32, i64, f32] = [0x7f, 0x7e, 0x7d];
+const [unreachable, block, if_, else_, end, br, br_table, return_, call, drop, select] = [
+  0x00, 0x02, 0x04, 0x05, 0x0b, 0x0c, 0x0e, 0x0f, 0x10, 0x1a, 0x1b,
+];
+const [global_set, i32_store, memory_grow, i32_const, i64_const, f32_const, i32_eqz, i32_add, void_] = [
+  0x24, 0x36, 0x40, 0x41, 0x42, 0x43, 0x45, 0x6a, 0x40,
+];
+const f32_zero = [f32_const, 0, 0, 0, 0];
+
+const invalid: [string, Uint8Array][] = [
+  ["unreachable; i64.const 1; i32.add", moduleWith({ body: [unreachable, i64_const, 1, i32_add, drop] })],
+  [
+    "() -> f32 whose dead code ends in an i32",
+    moduleWith({ results: [f32], body: [unreachable, i32_const, 1, i32_const, 2, i32_add] }),
+  ],
+  ["return; f32.const 0; i32.eqz", moduleWith({ body: [return_, ...f32_zero, i32_eqz, drop] })],
+  ["block; br 0; i64.const 1; i32.add", moduleWith({ body: [block, void_, br, 0, i64_const, 1, i32_add, drop, end] })],
+  [
+    "br_table; f32.const 0; i32.eqz",
+    moduleWith({ params: [i32], body: [block, void_, 0x20, 0, br_table, 1, 0, 1, ...f32_zero, i32_eqz, drop, end] }),
+  ],
+  [
+    "if (result i32) with an f32 arm and an i64 arm, entered from dead code",
+    moduleWith({ body: [unreachable, i32_const, 0, if_, i32, ...f32_zero, else_, i64_const, 0, end, drop] }),
+  ],
+  [
+    "global.set of an immutable global after unreachable",
+    moduleWith({ immutableGlobal: true, body: [unreachable, i32_const, 0, global_set, 0] }),
+  ],
+  [
+    "select with an i32 and an i64 operand",
+    moduleWith({ body: [unreachable, i32_const, 0, i64_const, 0, i32_const, 1, select, drop] }),
+  ],
+  ["a stray value at the end of a void block", moduleWith({ body: [block, void_, unreachable, i32_const, 0, end] })],
+  ["a stray value at the end of a void function", moduleWith({ body: [unreachable, i32_const, 0] })],
+  [
+    "i32.store of an i64",
+    moduleWith({ memory: true, body: [unreachable, i32_const, 0, i64_const, 0, i32_store, 2, 0] }),
+  ],
+  ["memory.grow of an f32", moduleWith({ memory: true, body: [unreachable, ...f32_zero, memory_grow, 0, drop] })],
+  [
+    "call with an f32 argument for an i32 parameter",
+    moduleWith({ callee: true, body: [unreachable, ...f32_zero, call, 1, drop] }),
+  ],
+  [
+    "call whose i64 result is used as an i32",
+    moduleWith({ callee: true, body: [unreachable, call, 1, i32_eqz, drop] }),
+  ],
+  [
+    "a block entered from dead code does not have a polymorphic stack",
+    moduleWith({ body: [unreachable, block, void_, drop, end] }),
+  ],
+];
+
+// The same shapes, typed correctly. Dead code may pop operands it never pushed.
+const valid: [string, Uint8Array][] = [
+  ["unreachable; i32.add with no operands", moduleWith({ results: [i32], body: [unreachable, i32_add] })],
+  ["unreachable; i32.const 1; i32.add", moduleWith({ body: [unreachable, i32_const, 1, i32_add, drop] })],
+  [
+    "() -> f32 whose dead code ends in an f32",
+    moduleWith({ results: [f32], body: [unreachable, i32_const, 1, drop, ...f32_zero] }),
+  ],
+  ["extra values before a br are fine", moduleWith({ body: [block, void_, i32_const, 1, i32_const, 2, br, 0, end] })],
+  [
+    "if (result i32) with i32 arms, entered from dead code",
+    moduleWith({ body: [unreachable, i32_const, 0, if_, i32, i32_const, 1, else_, i32_const, 2, end, drop] }),
+  ],
+  ["select with no operands", moduleWith({ results: [i32], body: [unreachable, select] })],
+  [
+    "i32.store and memory.grow with no operands",
+    moduleWith({ memory: true, results: [i32], body: [unreachable, i32_store, 2, 0, memory_grow, 0] }),
+  ],
+  [
+    "call with no operands whose i64 result is dropped",
+    moduleWith({ callee: true, body: [unreachable, call, 1, drop] }),
+  ],
+  [
+    "a block entered from dead code, ended by a br, has a polymorphic stack",
+    moduleWith({ body: [unreachable, block, void_, br, 0, drop, end] }),
+  ],
+];
+
+describe("WebAssembly validates unreachable code", () => {
+  test.each(invalid)("invalid: %s", (_, bytes) => {
+    expect(WebAssembly.validate(bytes)).toBe(false);
+    expect(() => new WebAssembly.Module(bytes)).toThrow(WebAssembly.CompileError);
+  });
+
+  test.each(valid)("valid: %s", (_, bytes) => {
+    expect(WebAssembly.validate(bytes)).toBe(true);
+    expect(new WebAssembly.Module(bytes)).toBeInstanceOf(WebAssembly.Module);
+  });
+
+  test("compile() and instantiate() reject too", async () => {
+    const bytes = invalid[0][1];
+    await expect(WebAssembly.compile(bytes)).rejects.toBeInstanceOf(WebAssembly.CompileError);
+    await expect(WebAssembly.instantiate(bytes)).rejects.toBeInstanceOf(WebAssembly.CompileError);
+  });
+});


### PR DESCRIPTION
### Problem
- `WebAssembly.validate()` returns `true`, and `new WebAssembly.Module()`, `compile()` and `instantiate()` succeed, for modules whose unreachable code is ill-typed: `unreachable; i64.const 1; i32.add`, `return; f32.const 0; i32.eqz`, a `global.set` of an immutable global after `unreachable`, an `if (result i32)` in dead code whose arms yield `f32` and `i64`. Node 26 (V8) and Chromium 148 reject every case with `CompileError` / `validate() === false`. Found by the differential fuzzer (ledger #45532, 68/68 divergent dead-code cells).
- The cause is in JSC: `FunctionParser::parseUnreachableExpression()` (`vendor/WebKit/Source/JavaScriptCore/wasm/WasmFunctionParser.h`) decoded the immediates of unreachable code but kept no operand types, so nothing after an unconditional `br`, `br_table`, `return`, `throw` or `unreachable` was type-checked.

### Fix
- Engine fix in oven-sh/WebKit#611: unreachable code gets the spec validation algorithm's type stack (polymorphic at the bottom of the block that became unreachable) and control frames, kept apart from the stacks the JIT tiers read, so generated code does not change. It carries WebKit/WebKit#70963 plus a commit that types GC, SIMD and atomic instructions the same way.
- This PR pins `WEBKIT_VERSION` to that PR's preview build `autobuild-preview-pr-611-e0871a4c`. The tag goes away when oven-sh/WebKit#611 merges, so the pin has to move to the merge commit's `autobuild-<sha>` release before this merges.
- Verified: `test/js/web/webassembly/validate-unreachable-code.test.ts` (new, 15 invalid and 9 valid modules plus `compile()` / `instantiate()`). With bun 1.4.3 (`USE_SYSTEM_BUN=1`) the 15 invalid cases and the `compile()` case fail and the 9 valid ones pass; with this pin all 25 pass under `bun bd test`, as do `test/js/bun/wasm/wasi.test.js`, `test/js/web/fetch/wasm-streaming.test.ts` and `test/js/bun/jsc-stress/jsc-stress.test.ts`.

### Background
- Wasm validation is a single pass over an operand type stack. After an instruction that cannot fall through, the spec empties the current block's stack and lets pops past its bottom produce a type that matches anything, but everything pushed afterwards is typed as usual and the block's `end` still checks its results. JSC skipped the typing entirely for that stretch of code; V8 and SpiderMonkey never did.
- This is conformance only. Ill-typed dead code generated no machine code and could not be reached, so memory safety was not involved.

<details><summary>Notes</summary>

- The gate's fail-before step restores `src/` and `packages/` only, and the fix lives in the WebKit pin under `scripts/`, so it cannot reproduce the failing side. Fail-before was checked by hand with `USE_SYSTEM_BUN=1 bun test test/js/web/webassembly/validate-unreachable-code.test.ts` (bun 1.4.3): 9 pass, 16 fail.
- The WebKit PR's own coverage: a 120-module JSTests file (stock JSC gets 71 wrong), V8's `unreachable-validation.js` mjsunit test (67 cases, previously skipped), the WPT `unreached-invalid.wast` baseline (116/244 to 244/244), the whole `JSTests/wasm.yaml` suite in every tier configuration, and 179 real-world `.wasm` binaries (JetStream 3 including Dart2wasm and Kotlin/Wasm GC modules, esbuild, swc, biome, lightningcss, duckdb, pglite, prisma, sql.js, tree-sitter and more) that validate identically before and after.
- One deliberate difference from the spec appendix, shared with V8 and SpiderMonkey: `ref.as_non_null` / `br_on_null` of a bottom operand stay bottom, so `unreachable; ref.as_non_null; i32.eqz` validates (WebAssembly/spec#2235).

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/webassembly/validate-unreachable-code.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/webassembly/validate-unreachable-code.test.ts
bun test v1.4.3 (f42e98025)

test/js/web/webassembly/validate-unreachable-code.test.ts:
(pass) WebAssembly validates unreachable code > invalid: unreachable; i64.const 1; i32.add [26.56ms]
(pass) WebAssembly validates unreachable code > invalid: () -> f32 whose dead code ends in an i32 [2.94ms]
(pass) WebAssembly validates unreachable code > invalid: return; f32.const 0; i32.eqz [2.58ms]
(pass) WebAssembly validates unreachable code > invalid: block; br 0; i64.const 1; i32.add [2.82ms]
(pass) WebAssembly validates unreachable code > invalid: br_table; f32.const 0; i32.eqz [3.16ms]
(pass) WebAssembly validates unreachable code > invalid: if (result i32) with an f32 arm and an i64 arm, entered from dead code [2.35ms]
(pass) WebAssembly validates unreachable code > invalid: global.set of an immutable global after unreachable [3.52ms]
(pass) WebAssembly validates unreachable code > invalid: select with an i32 and an i64 operand [2.71ms]
(pass) WebAssembly validates unreachable code > invalid: a stray value at the end of a void block [3.11ms]
(pass) WebAssembly validates unreachable code > invalid: a stray value at the end of a void function [2.43ms]
(pass) WebAssembly validates unreachable code > invalid: i32.store of an i64 [3.12ms]
(pass) WebAssembly validates unreachable code > invalid: memory.grow of an f32 [2.42ms]
(pass) WebAssembly validates unreachable code > invalid: call with an f32 argument for an i32 parameter [2.38ms]
(pass) WebAssembly validates unreachable code > invalid: call whose i64 result is used as an i32 [2.49ms]
(pass) WebAssembly validates unreachable code > invalid: a block entered from dead code does not have a polymorphic stack [2.75ms]
(pass) WebAssembly validates unreachable code > valid: unreachable; i32.add with no operands [4.00ms]
(pass) WebAssembly validates unreachable code > valid: unreac
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |   2 +-
 .../webassembly/validate-unreachable-code.test.ts  | 144 +++++++++++++++++++++
 2 files changed, 145 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                  1      1      7
…st/js/web/webassembly/validate-unreachable-code.test.ts      0      1      7
```

</details>

**root cause** · written by the author bot

JSC's function parser skipped operand type checking entirely once it entered unreachable code after `unreachable`, `br`, `br_table`, `return`, or `throw`, validating only index bounds and opcode decodability, so modules with ill-typed dead code were accepted by `WebAssembly.validate()` and compiled without error while V8 correctly rejected them. The fix makes the parser type-check concretely pushed operands in unreachable regions, honoring the polymorphic stack rules of the core spec section 3.3 while still enforcing operand types, control-stack arity, memory and global access, and call sig…

<!-- robobun:evidence:end -->