### PR TITLE
streams: ignore controller calls that follow end()/close() inside a direct stream's pull()

### DIFF
--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -1117,7 +1117,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectEndOfTickFlush, (JSGlobalOb
 }
 
 // The FIVE public own methods are JSBoundFunctions over these [bound-convention] targets.
-// Once m_closed is set they no-op: a late call from an in-flight pull() must not throw.
+// Once the source ended the stream they no-op: a late call from an in-flight pull() must not
+// throw, and a call that follows end()/close() inside the same pull() must not reach the sink
+// before the deferred close drains it.
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectWrite, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = getVM(globalObject);
@@ -1125,7 +1127,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectWrite, (JSGlobalObject *
     auto* controller = dynamicDowncast<JSDirectStreamController>(callFrame->argument(0));
     if (!controller) [[unlikely]]
         return JSValue::encode(jsUndefined());
-    if (controller->m_closed)
+    if (controller->sourceEnded())
         return JSValue::encode(jsNumber(0));
     JSDirectStreamController::StagedBytesScope stagedBytes(vm, controller);
     JSValue wrote = writeToDirectSink(globalObject, controller, callFrame->argument(1));
@@ -1151,7 +1153,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectClose, (JSGlobalObject *
 {
     auto& vm = getVM(globalObject);
     auto* controller = dynamicDowncast<JSDirectStreamController>(callFrame->argument(0));
-    if (!controller || controller->m_closed) [[unlikely]]
+    if (!controller || controller->sourceEnded()) [[unlikely]]
         return JSValue::encode(jsUndefined());
     return enterStreams(globalObject, [&] { controller->onClose(globalObject, callFrame->argument(1)); }, [&](JSValue error) {
         auto scope = DECLARE_THROW_SCOPE(vm);
@@ -1165,7 +1167,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectFlush, (JSGlobalObject *
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* controller = dynamicDowncast<JSDirectStreamController>(callFrame->argument(0));
-    if (!controller || controller->m_closed) [[unlikely]]
+    if (!controller || controller->sourceEnded()) [[unlikely]]
         return JSValue::encode(jsUndefined());
     controller->onFlush(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
@@ -1183,7 +1185,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectError, (JSGlobalObject *
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* controller = dynamicDowncast<JSDirectStreamController>(callFrame->argument(0));
-    if (!controller || controller->m_closed) [[unlikely]]
+    if (!controller || controller->sourceEnded()) [[unlikely]]
         return JSValue::encode(jsUndefined());
     controller->handleError(globalObject, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
@@ -105,6 +105,9 @@ public:
     // Once closed, the five methods are no-ops (there is NO "swap all 5 methods to a
     // throwing stub" trick).
     bool m_closed : 1 { false };
+    // The source already ended the stream: closed, or end()/close() ran inside pull() and
+    // completes when pull() returns. The five methods no-op from this point, not from m_closed.
+    bool sourceEnded() const { return m_closed || m_deferClose == 1; }
     // An async pull()'s returned promise has not yet settled; cleared by its settlement
     // reactions. m_pullAgain is set only when a NEW read arrives while m_pullInFlight
     // (edge-triggered, matching the spec default controller's [[pullAgain]]).

--- a/test/js/web/streams/direct-stream-contract.ts
+++ b/test/js/web/streams/direct-stream-contract.ts
@@ -125,6 +125,24 @@ export const shapes: Record<string, Shape> = {
         } catch {}
       }),
   },
+  "sync pull: write, close(), then write() and flush() in the same call": {
+    expect: { body: "hello world" },
+    make: t =>
+      direct(t, c => {
+        c.write("hello world");
+        c.close();
+        // The reader path reports 0 bytes, a native sink throws: neither delivers the chunk.
+        for (const late of [() => c.write(" ignored"), () => c.flush()]) {
+          try {
+            late();
+          } catch {}
+        }
+      }),
+  },
+  "sync pull: write, end(), then close(error) in the same call": {
+    expect: { body: "hello world" },
+    make: t => direct(t, c => (c.write("hello world"), c.end(), c.close(new Error("too late to matter")))),
+  },
   "end(value) is a clean close, unlike close(error)": {
     oneShotOnly: true,
     expect: { body: "hello world" },

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -3941,6 +3941,44 @@ describe("direct stream edge cases", () => {
         fileSink: { write: "throws", flush: "throws", end: undefined },
       });
     });
+
+    // close() inside the synchronous part of pull() completes when pull() returns. The calls
+    // that follow it in the same pull() must already see a closed controller.
+    test.each(["close", "end"])(
+      "after %s() in the same pull() call: write() reports 0 bytes, flush()/end()/close(error)/error() are no-ops",
+      async how => {
+        const after = {};
+        const t = tally();
+        const rs = direct(t, c => {
+          c.write("a");
+          c[how]();
+          const late = {
+            write: () => c.write("late"),
+            flush: () => c.flush(),
+            end: () => c.end(),
+            "close(error)": () => c.close(new Error("late")),
+            error: () => c.error(new Error("late")),
+          };
+          for (const [name, call] of Object.entries(late)) {
+            try {
+              const v = call();
+              after[name] = v instanceof Promise ? "promise" : v;
+            } catch (e) {
+              after[name] = "throws: " + e?.message;
+            }
+          }
+        });
+        const reader = rs.getReader();
+        const reads = [];
+        for (let r; !(r = await reader.read()).done; ) reads.push(txt(r.value));
+        expect({ reads, after, pulls: t.pulls, cancels: t.cancels.length }).toEqual({
+          reads: ["a"],
+          after: { write: 0, flush: undefined, end: undefined, "close(error)": undefined, error: undefined },
+          pulls: 1,
+          cancels: 0,
+        });
+      },
+    );
   });
 
   describe("ordering", () => {


### PR DESCRIPTION
### Problem
- A `type: "direct"` `ReadableStream` read from JavaScript delivers bytes written after `end()`. `pull(c) { c.write("A"); c.end(); c.write("LATE") }` reads as `"ALATE"` and the late `write()` returns `4`. In the same position `error(e)` fails the stream, and `close(error)` turns the clean close into a failure, which 1.4.3 did not.
- The cause is the deferred close in `JSDirectStreamController::onClose` (`src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp:856`). An `end()`/`close()` made while `pull()` is on the stack is recorded in `m_deferClose` and runs when `pull()` returns. `m_closed` stays unset until then, and the five controller methods (`:1128` on) checked only `m_closed`.

### Fix
- Add `sourceEnded()` (`m_closed || m_deferClose == 1`) and gate `write`, `end`, `close`, `flush`, `error` on it. `write()` returns `0`, the rest return `undefined`.
- Correct because the same calls already do this once `pull()` has yielded, and the native sinks (`Bun.serve`, `Bun.write`, `Bun.spawn` stdin) already deliver only what was written before `end()`. The deferral is unchanged.
- Verified: `test/js/web/streams/streams.test.js` (two new contract shapes across 14 consumers plus two reader-path tests, 20 of the 30 fail on main). Other suites in Notes.

### Background
- When JavaScript consumes a direct stream (`getReader()`, `for await`, `.text()`), its controller is `JSDirectStreamController`. It buffers `write()`s and hands them to reads as `Uint8Array`s.
- `onPull` runs the user's `pull()`, then registers the waiting read. A `close()` inside `pull()` is deferred past that registration so the final chunk has a read to land in.
- Native sinks (`HTTPResponseSink`, `FileSink`) are a different controller: `end()` completes at once and a later `write()` throws, on purpose (#41894).

<details><summary>Notes</summary>

Shapes checked by hand on a debug build of `e3b6d63dd7`, JS reader and `.text()` consumers, before and after:

| `pull()` (synchronous) | before | after |
| --- | --- | --- |
| `write("A"), end(), write("LATE")` | `"ALATE"`, write returns 4 | `"A"`, write returns 0 |
| `write("A"), close(), write("LATE")` | `"ALATE"` | `"A"` |
| `write("A"), end(), flush()` | `"A"` | `"A"` |
| `write("A"), end(), error(x)` | rejects with `x` | `"A"` |
| `write("A"), end(), close(err)` | rejects with `err` (1.4.3: `"A"`) | `"A"` |
| async: `write("A"), end(), write("LATE"), await` | `"ALATE"` | `"A"` |
| async: `write("A"), await, end(), write("LATE")` | `"A"`, write returns 0 | same |

The same shapes through `Bun.write(file)`, `Bun.spawn({ stdin })` and `Bun.serve` already produced `"hello world"` before the change (late `write()`/`flush()` throw there, `end()`/`close(err)` after close are no-ops), so the new contract cells in `serve-direct-readable-stream.test.ts` pass both ways. `.bytes()`, `readableStreamToBytes` and `readableStreamToArrayBuffer` also passed before: they consume through the native `ArrayBufferSink`, not `JSDirectStreamController`.

The `close(err)`-after-`end()` case changed with #41894: before it, `close(error)` on the reader path was a clean close, so the overwritten deferred reason made no difference. After it, the second call replaced the deferred `undefined` reason with the error and the stream failed.

**Intentionally not changed (same input family, other readers of the deferred state)**

`m_deferClose` / `m_deferFlush` are `int8_t` tri-states: `-1` while the `pull()` body is on the stack, `1` once a close / flush was requested inside it. Requesting one overwrites the `-1`, so the readers that ask "is the `pull()` body still running?" answer wrong after a `close()` or `flush()` inside that body. This PR only changes the five controller methods. The rest stays as is, each verified on the debug build:

- A re-entrant `reader.read()` issued inside `pull()` after `close()` passes the re-entrancy guard (`onPull`, `m_deferClose == -1`) and takes the final chunk; the read that triggered the `pull()` resolves `done`. With a close that is not deferred the triggering read gets the chunk. Fixing it changes what a refused re-entrant read resolves with, which is a pump change with its own tests.
- `reader.cancel()` inside `pull()` after `close()` runs the source's `cancel()` hook and not its `close()` hook (`cancelSteps` does not look at the deferred close). The chunk is dropped either way, because the cancel runs before the triggering read is registered.
- `flush()` then `write()` inside a synchronous `pull()` arms an end-of-tick flush job (`armEndOfTickFlush` tests `m_deferFlush == -1`), and `~StagedBytesScope` syncs the reported capacity mid-pull. Both are redundant there (`onPull` drains as soon as `pull()` returns), not wrong.
- A synchronous `pull()` that calls `end()` and then throws still errors the stream on the reader path (the throw is handled before the deferred close is replayed). `Bun.serve` completes the response in that case (#42115).

Splitting the tri-states into `inPullBody` / `closeRequested` / `flushRequested` bits would make those readers right by construction; `sourceEnded()` becomes `m_closed || closeRequested` under that split. Left out to keep this diff to the reported behavior.

Suites run locally on the debug ASAN build: `test/js/web/streams/streams.test.js` (549 pass), `test/js/bun/http/serve-direct-readable-stream.test.ts` (148 pass), `test/js/web/fetch/body-stream.test.ts`, `test/js/web/streams/readable-stream-terminal-barrier-release.test.ts`, `test/js/bun/spawn/spawn-stdin-readable-stream.test.ts`, `test/js/bun/io/bun-write.test.js`, `test/js/node/stream/node-stream.test.js`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/streams/streams.test.js

<!-- robobun:evidence:end -->