### PR TITLE
webview: pass --do-not-de-elevate to Chrome

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -156,8 +156,10 @@ When spawning, Bun passes a minimal flag set:
 --no-default-browser-check --disable-gpu --disable-extensions
 --disable-background-networking --disable-background-timer-throttling
 --disable-backgrounding-occluded-windows --disable-renderer-backgrounding
---disable-ipc-flooding-protection --no-startup-window
+--disable-ipc-flooding-protection --no-startup-window --do-not-de-elevate
 ```
+
+`--do-not-de-elevate` stops Chrome on Windows from relaunching itself de-elevated when Bun runs as Administrator. The relaunched process would not inherit the debugging pipe. Other platforms ignore the switch.
 
 Append your own with `argv` — Chrome resolves duplicate switches last-wins, so you can override any default:
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9316,8 +9316,11 @@ declare module "bun" {
      * call's `path`/`argv`/`dataStore.directory` win; subsequent views reuse
      * the same Chrome instance via `Target.createTarget`.
      *
-     * Default flags: `--remote-debugging-pipe --headless --no-first-run
-     * --no-default-browser-check --disable-gpu --user-data-dir=<temp>`.
+     * Default flags: `--user-data-dir=<temp> --remote-debugging-pipe --headless
+     * --no-first-run --no-default-browser-check --disable-gpu --disable-extensions
+     * --disable-background-networking --disable-background-timer-throttling
+     * --disable-backgrounding-occluded-windows --disable-renderer-backgrounding
+     * --disable-ipc-flooding-protection --no-startup-window --do-not-de-elevate`.
      */
     type Backend =
       | "webkit"

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -561,6 +561,13 @@ fn spawn(
             // No startup window — targets are Target.createTarget'd, not the
             // default about:blank. Saves one tab and the visual-complete wait.
             c"--no-startup-window".as_ptr(),
+            // Chrome on Windows relaunches itself de-elevated when the parent
+            // runs as Administrator (ChromeBrowserMainPartsWin::MaybeAutoDeElevate)
+            // and the original process exits. The relaunched process does not
+            // inherit the pipe handles we pass via STARTUPINFO.lpReserved2, so
+            // the transport sees EOF before the first CDP message. This switch
+            // suppresses the relaunch; other platforms ignore it.
+            c"--do-not-de-elevate".as_ptr(),
         ];
         // User extras last so they can override built-in flags (Chrome's
         // CommandLine last-wins for duplicate switches). Memory is the caller's

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -561,12 +561,8 @@ fn spawn(
             // No startup window — targets are Target.createTarget'd, not the
             // default about:blank. Saves one tab and the visual-complete wait.
             c"--no-startup-window".as_ptr(),
-            // Chrome on Windows relaunches itself de-elevated when the parent
-            // runs as Administrator (ChromeBrowserMainPartsWin::MaybeAutoDeElevate)
-            // and the original process exits. The relaunched process does not
-            // inherit the pipe handles we pass via STARTUPINFO.lpReserved2, so
-            // the transport sees EOF before the first CDP message. This switch
-            // suppresses the relaunch; other platforms ignore it.
+            // An elevated parent on Windows makes Chrome relaunch itself
+            // de-elevated, and the relaunch loses the pipe handles (#42147).
             c"--do-not-de-elevate".as_ptr(),
         ];
         // User extras last so they can override built-in flags (Chrome's

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -126,6 +126,20 @@ test.concurrent("many views interleave their commands on the one transport", asy
   });
 });
 
+// Chrome on Windows relaunches itself de-elevated when the parent runs as
+// Administrator, and the relaunched process does not inherit the pipe handles
+// (#42147). --do-not-de-elevate suppresses that. The fake sees the switches
+// the runtime puts before the script path as execArgv.
+test.concurrent("the default switches suppress Chrome's auto de-elevation", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/");
+    print(await view.evaluate("process.execArgv"));
+    view.close();
+  `);
+  expect(result).toContain("--do-not-de-elevate");
+});
+
 test.concurrent("an expression that throws rejects", async () => {
   const result = await runScenario(`
     const view = newView();


### PR DESCRIPTION
### Problem
- `new Bun.WebView()` fails with `Chrome process closed the pipe` on Windows when the parent process is elevated (runs as Administrator). The same script works from a non-elevated process.
- The cause is Chrome's auto de-elevation. `ChromeBrowserMainPartsWin::MaybeAutoDeElevate` relaunches Chrome as a medium-integrity process and exits the original. The relaunched process gets a fresh `STARTUPINFO`, so it does not receive the two pipe handles Bun passes through `lpReserved2` (fd 3 and fd 4 for `DevToolsPipeHandler`). Bun holds the original process, which exits before the first CDP message.

### Fix
- Add `--do-not-de-elevate` to the default Chrome argv in `src/runtime/webview/ChromeProcess.rs`. Chrome skips the relaunch when this switch is present.
- The switch is passed on every platform. Chrome ignores switches it does not know, so Linux and macOS behaviour does not change. User `backend.argv` still comes last and can override it.
- Verified: `test/js/bun/webview/webview-chrome-pipe.test.ts` (new test asserts the fake Chrome sees the switch in `process.execArgv`; stock bun fails it). Also ran `webview-chrome-disconnect.test.ts`.

### Background
- `Bun.WebView` spawns Chrome with `--remote-debugging-pipe`. Chrome reads CDP commands from fd 3 and writes replies to fd 4. On Windows those fds are inherited handles in `STARTUPINFO.lpReserved2`.
- `MaybeAutoDeElevate` runs in `PreEarlyInitialization` when the process token has `TokenElevationTypeFull`. It returns early only for `--enable-automation` or `--do-not-de-elevate`. `--headless` does not suppress it.
- The tests spawn `fake-chrome-fixture.ts` with bun in Chrome's place. Bun keeps the switches that precede the script path in `process.execArgv`, so the fixture can report the argv it received.

<details><summary>Notes</summary>

- The reporter's verbose Chrome log shows the relaunch: `RunDeElevated: Started process, PID: 60608` and `Windows.AutoDeElevateResult recorded 1 samples`. The reporter confirmed `argv: ['--do-not-de-elevate']` fixes it on Chrome 152, Chromium 151 and Edge.
- An elevated end-to-end run is not possible in CI. The Windows agents run in session 0 with no shell window, and `base::win::RunDeElevated` fails there with `ERROR_ACCESS_DENIED`, so Chrome stays elevated and the bug does not fire.
- Not addressed here: after a failed first spawn, later `new Bun.WebView()` calls in the same process report `Failed to spawn Chrome (...)` instead of the original error. That is a separate reporting issue in `Bun__Chrome__ensure`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome-pipe.test.ts

<!-- robobun:evidence:end -->