### PR TITLE
test: run the node:test fixture spawns concurrently and assert exact reports

### DIFF
--- a/test/js/node/test_runner/fixtures/02-hooks.js
+++ b/test/js/node/test_runner/fixtures/02-hooks.js
@@ -130,7 +130,8 @@ describe("execution order", () => {
 });
 
 after(() => {
-  console.log("%AFTER%");
+  // node-test.test.ts compares these lines against 02-hooks.json as well.
+  for (const entry of order) console.log(entry);
   Bun.jest("/").expect(order).toEqual(node);
   assert.deepEqual(order, node);
 });

--- a/test/js/node/test_runner/fixtures/05-test-in-test.js
+++ b/test/js/node/test_runner/fixtures/05-test-in-test.js
@@ -26,6 +26,7 @@ test("t.test() runs subtests inline and returns a promise", async t => {
   });
 
   t.after(() => {
+    console.log("subtest order: " + order.join(", "));
     // The unawaited subtest must have completed before the parent finished.
     assert.deepStrictEqual(order, ["awaited", "unawaited", "inner"]);
   });

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -1,347 +1,545 @@
-import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
+import hookOrder from "./fixtures/02-hooks.json";
 
-describe("node:test", () => {
-  // These three drive the largest fixtures (01-harness has 32 node:test cases);
-  // a debug+ASAN `bun test` child takes several seconds to start, so give them
-  // headroom and let them spawn in parallel instead of serially.
-  test.concurrent(
-    "should run basic tests",
-    async () => {
-      const { exitCode, stderr } = await runTests(["01-harness.js"]);
-      expect({ exitCode, stderr }).toMatchObject({
-        exitCode: 0,
-        stderr: expect.stringContaining("0 fail"),
-      });
-    },
-    30_000,
-  );
+const fixturesDir = join(import.meta.dirname, "fixtures");
 
-  test.concurrent(
-    "should run hooks in the right order",
-    async () => {
-      const { exitCode, stderr } = await runTests(["02-hooks.js"]);
-      expect({ exitCode, stderr }).toMatchObject({
-        exitCode: 0,
-        stderr: expect.stringContaining("0 fail"),
-      });
-    },
-    30_000,
-  );
+// `report` lines for the two fixtures that more than one test runs.
+const harnessReport = [
+  "01-harness.js:",
+  "(pass) test() is a function",
+  "(pass) describe() is a function",
+  "(pass) TestContext > <exists>",
+  "(pass) TestContext > name",
+  "(pass) TestContext > filePath",
+  "(pass) TestContext > signal",
+  "(pass) TestContext > assert",
+  "(pass) TestContext > diagnostic()",
+  "(pass) TestContext > before()",
+  "(pass) TestContext > after()",
+  "(pass) TestContext > beforeEach()",
+  "(pass) TestContext > afterEach()",
+  "(pass) TestContext > test()",
+  "(pass) before() is a function",
+  "(pass) after() is a function",
+  "(pass) beforeEach() is a function",
+  "(pass) afterEach() is a function",
+  "(pass) test > test()",
+  "(pass) test > it()",
+  "(pass) test > skip()",
+  "(pass) test > todo()",
+  "(pass) test > only()",
+  "(pass) test > describe()",
+  "(pass) test > suite()",
+  "(pass) describe > <exists>",
+  "(pass) describe > skip()",
+  "(pass) describe > todo()",
+  "(pass) describe > only()",
+  "(pass) describe 1 > name is correct",
+  "(pass) describe 1 > fullName is correct",
+  "(pass) describe 1 > describe 2 > name is correct",
+  "(pass) describe 1 > describe 2 > fullName is correct",
+];
+const hooksReport = [
+  "02-hooks.js:",
+  "(pass) execution order > test 1",
+  "(pass) execution order > describe 1 > test 2",
+  "(pass) execution order > describe 1 > describe 2 > test 3",
+];
+
+// Every test in here spawns its own child process over read-only fixtures.
+describe.concurrent("node:test", () => {
+  test("should run basic tests", async () => {
+    const { report, summary, exitCode } = await runTests(["01-harness.js"]);
+    expect(report).toEqual(harnessReport);
+    expect(summary).toEqual({ pass: 32, fail: 0, tests: 32, files: 1 });
+    expect(exitCode).toBe(0);
+  });
+
+  test("should run hooks in the right order", async () => {
+    const { stdoutLines, report, summary, exitCode } = await runTests(["02-hooks.js"]);
+    // The fixture's last after() prints every hook and test it recorded, in order.
+    expect(stdoutLines).toEqual(hookOrder.node);
+    expect(report).toEqual(hooksReport);
+    expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
+    expect(exitCode).toBe(0);
+  });
 
   test("should run tests with different variations", async () => {
-    const { exitCode, stderr } = await runTests(["03-test-variations.js"]);
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["03-test-variations.js"]);
+    expect(report).toEqual([
+      "03-test-variations.js:",
+      "(pass) <anonymous>",
+      "(pass) test with name and callback",
+      "(pass) test with name, options, and callback",
+      "(pass) <anonymous>",
+      "(pass) testWithFunctionName",
+      "(pass) <anonymous>",
+      "(pass) describe with name and callback > nested test",
+      "(pass) describe with name, options, and callback > nested test",
+      "(skip) skipped test",
+      "(skip) skipped test with options",
+      "(todo) todo test",
+      "(todo) todo test with options",
+    ]);
+    expect(summary).toEqual({ pass: 8, skip: 2, todo: 2, fail: 0, tests: 12, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should run async tests", async () => {
-    const { exitCode, stderr } = await runTests(["04-async-tests.js"]);
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["04-async-tests.js"]);
+    expect(report).toEqual([
+      "04-async-tests.js:",
+      "(pass) test with an async function",
+      "(pass) test with an async function that delays",
+      "(pass) nested tests > nested test with an async function",
+      "(pass) nested tests > nested test with an async function that delays",
+    ]);
+    expect(summary).toEqual({ pass: 4, fail: 0, tests: 4, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
-  test.concurrent(
-    "should run all tests from multiple files",
-    async () => {
-      const { exitCode, stderr } = await runTests(["01-harness.js", "02-hooks.js"]);
-      expect({ exitCode, stderr }).toMatchObject({
-        exitCode: 0,
-        // 32 from 01-harness + 3 from 02-hooks
-        stderr: expect.stringContaining("35 pass"),
-      });
-    },
-    30_000,
-  );
+  test("should run all tests from multiple files", async () => {
+    const { stdoutLines, report, summary, exitCode } = await runTests(["01-harness.js", "02-hooks.js"]);
+    expect(stdoutLines).toEqual(hookOrder.node);
+    expect(report).toEqual([...harnessReport, ...hooksReport]);
+    expect(summary).toEqual({ pass: 35, fail: 0, tests: 35, files: 2 });
+    expect(exitCode).toBe(0);
+  });
 
   test("should run test() and describe() called inside another test() as subtests", async () => {
-    const { exitCode, stderr } = await runTests(["05-test-in-test.js"]);
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { stdoutLines, report, summary, exitCode } = await runTests(["05-test-in-test.js"]);
+    // Printed from a t.after() hook, so this also proves the hook ran.
+    expect(stdoutLines).toEqual(["subtest order: awaited, unawaited, inner"]);
+    expect(report).toEqual([
+      "05-test-in-test.js:",
+      "(pass) t.test() runs subtests inline and returns a promise",
+      "(pass) test() and describe() called inside a running test become subtests",
+    ]);
+    expect(summary).toEqual({ pass: 2, fail: 0, tests: 2, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should run before hooks created on a running test once and validate hook options", async () => {
-    const { exitCode, stderr } = await runTests(["06-hook-semantics.js"]);
-    expect(stderr).toContain("4 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["06-hook-semantics.js"]);
+    expect(report).toEqual([
+      "06-hook-semantics.js:",
+      "(pass) t.before() registered on a running test runs exactly once",
+      "(pass) before() registered inside a running test runs exactly once",
+      "(pass) hook options are validated",
+      "(pass) mock once registries never call user-patched Map.prototype methods",
+    ]);
+    expect(summary).toEqual({ pass: 4, fail: 0, tests: 4, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should fail tests whose hooks, bodies, or inline suite callbacks fail", async () => {
-    const { exitCode, stdout, stderr } = await runTests(["07-failing-hooks.js"]);
+    const { stdoutLines, report, summary, exitCode } = await runTests(["07-failing-hooks.js"]);
     // The subtest after the failing before hook must not run its body (Node).
-    expect(stdout).toContain("SUB_BODY_RAN=false");
-    expect(stderr).toContain("0 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 1,
-      stderr: expect.stringContaining("10 fail"),
-    });
+    expect(stdoutLines).toEqual(["SUB_BODY_RAN=false"]);
+    // Each (fail) line is preceded by the error(s) that failed it.
+    expect(report).toEqual([
+      "07-failing-hooks.js:",
+      "error: test failed",
+      "(fail) a test body that rejects with undefined fails",
+      "error: passed a callback but also returned a Promise",
+      "(fail) an async function with a done callback fails",
+      "error: callback invoked multiple times",
+      "(fail) a done callback invoked twice fails",
+      "error: passed a callback but also returned a Promise",
+      "(fail) a done callback called from a returned promise still fails",
+      "error: 1 subtest failed",
+      "error: after hook boom",
+      "(fail) an inline suite whose after hook fails fails the test",
+      "error: passed a callback but also returned a Promise",
+      "(fail) an async before hook with a done callback fails the test",
+      "error: 1 subtest failed",
+      "error: async describe boom",
+      "(fail) an async inline describe callback rejection fails the test",
+      "error: 1 subtest failed",
+      "error: inline suite before hook failed",
+      "(fail) an inline suite whose before hook fails fails the test",
+      "error: test timed out after 1ms",
+      "(fail) a before hook that exceeds its timeout fails the test",
+      "error: boom",
+      "(fail) a subtest created after its parent before hook failed does not run",
+    ]);
+    expect(summary).toEqual({ pass: 0, fail: 10, tests: 10, files: 1 });
+    expect(exitCode).toBe(1);
   });
 
   test("should support done callbacks in tests and hooks", async () => {
-    const { exitCode, stderr } = await runTests(["10-done-callbacks.js"]);
-    expect(stderr).toContain("2 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["10-done-callbacks.js"]);
+    expect(report).toEqual([
+      "10-done-callbacks.js:",
+      "(pass) file-level hooks with done callbacks ran first",
+      "(pass) t.beforeEach with a done callback applies to subtests",
+    ]);
+    expect(summary).toEqual({ pass: 2, fail: 0, tests: 2, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
+  const runtimeTodoReport = [
+    "12-runtime-todo-and-mock-timers.js:",
+    "(todo) a runtime t.todo() suppresses a later failure",
+    "(skip) a runtime t.skip() suppresses a later failure",
+    "(pass) an inline describe.todo() with a failing child does not fail the test",
+    "(pass) an inline describe with todo: true and a failing child does not fail the test",
+    "(pass) t.waitFor uses real timers while mock timers are enabled",
+  ];
+
   test("should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers", async () => {
-    const { exitCode, stderr } = await runTests(["12-runtime-todo-and-mock-timers.js"]);
-    expect(stderr).toContain("3 pass");
-    expect(stderr).toContain("1 skip");
-    expect(stderr).toContain("1 todo");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["12-runtime-todo-and-mock-timers.js"]);
+    expect(report).toEqual(runtimeTodoReport);
+    expect(summary).toEqual({ pass: 3, skip: 1, todo: 1, fail: 0, tests: 5, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should count runtime t.todo()/t.skip() as todo/skip under --concurrent too", async () => {
     // markCurrentResult's microtask-drain fallback could not name a sequence
     // inside a concurrent group, so the skip/todo mark was dropped and both
     // tests were reported as pass.
-    const { exitCode, stderr } = await runTests(["12-runtime-todo-and-mock-timers.js"], {}, ["--concurrent"]);
-    expect(stderr).toContain("3 pass");
-    expect(stderr).toContain("1 skip");
-    expect(stderr).toContain("1 todo");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
+    const { report, summary, exitCode } = await runTests(["12-runtime-todo-and-mock-timers.js"], {
+      args: ["--concurrent"],
     });
+    // --concurrent reports tests in completion order.
+    expect(report.toSorted()).toEqual(runtimeTodoReport.toSorted());
+    expect(summary).toEqual({ pass: 3, skip: 1, todo: 1, fail: 0, tests: 5, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should run todo bodies under --todo instead of registering an empty function", async () => {
-    const { exitCode, stderr } = await runTests(["13-todo-bodies.js"], {}, ["--todo"]);
-    expect(stderr).toContain("2 todo");
-    expect(stderr).toContain("1 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["13-todo-bodies.js"], { args: ["--todo"] });
+    // The errors prove that both todo bodies ran.
+    expect(report).toEqual([
+      "13-todo-bodies.js:",
+      "error: expected todo failure",
+      "(todo) a todo body runs and may fail",
+      "error: expected todo failure too",
+      "(todo) a todo option body runs and may fail",
+      "(pass) sibling test still passes",
+    ]);
+    expect(summary).toEqual({ pass: 1, todo: 2, fail: 0, tests: 3, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should forward Infinity and finite timeouts so they override the runner default", async () => {
-    const { exitCode, stderr } = await runTests(["11-timeout-overrides.js"], {}, ["--timeout", "100"]);
-    expect(stderr).toContain("2 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
+    const { report, summary, exitCode } = await runTests(["11-timeout-overrides.js"], {
+      args: ["--timeout", "100"],
     });
+    expect(report).toEqual([
+      "11-timeout-overrides.js:",
+      "(pass) an Infinity timeout overrides the runner default",
+      "(pass) a finite timeout larger than the runner default is honored",
+    ]);
+    expect(summary).toEqual({ pass: 2, fail: 0, tests: 2, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should not leak file-level beforeEach hooks across files in one process", async () => {
-    const { exitCode, stderr } = await runTests(["14-root-hooks-a.js", "14-root-hooks-b.js"]);
-    expect(stderr).toContain("4 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["14-root-hooks-a.js", "14-root-hooks-b.js"]);
+    expect(report).toEqual([
+      "14-root-hooks-a.js:",
+      "(pass) file A runs its own file-level beforeEach and sees its own registrations",
+      "14-root-hooks-b.js:",
+      "(pass) first test in file B",
+      "(pass) file A's file-level beforeEach and custom assertion did not leak into file B",
+      "(pass) module-scope registrations from this file survive and capture the true original",
+    ]);
+    expect(summary).toEqual({ pass: 4, fail: 0, tests: 4, files: 2 });
+    expect(exitCode).toBe(0);
   });
 
   test("should treat only as a no-op instead of using bun:test's CI-banned only()", async () => {
     // bun:test's only() only throws when CI is set; pin the precondition.
-    const { exitCode, stderr } = await runTests(["08-only-no-op.js"], { CI: "1" });
-    expect(stderr).toContain("4 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["08-only-no-op.js"], { env: { CI: "1" } });
+    expect(report).toEqual([
+      "08-only-no-op.js:",
+      "(pass) only-marked test runs",
+      "(pass) sibling of an only-marked test also runs",
+      "(pass) only-marked suite runs > test inside an only-marked suite",
+      "(pass) only is a no-op without --test-only",
+    ]);
+    expect(summary).toEqual({ pass: 4, fail: 0, tests: 4, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should serialize inline suites and await async describe callbacks like node", async () => {
-    const { exitCode, stderr } = await runTests(["09-inline-suites.js"]);
-    expect(stderr).toContain("3 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["09-inline-suites.js"]);
+    expect(report).toEqual([
+      "09-inline-suites.js:",
+      "(pass) inline suite children run after previously scheduled subtests",
+      "(pass) an async inline describe callback is awaited before the suite finishes",
+      "(pass) early inline-suite child waits for the async describe callback to settle",
+    ]);
+    expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should expose the body outcome to afterEach and workerId to the context", async () => {
-    const { exitCode, stderr } = await runTests(["15-outcome-in-hooks.js"]);
-    expect(stderr).toContain("3 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["15-outcome-in-hooks.js"]);
+    expect(report).toEqual([
+      "15-outcome-in-hooks.js:",
+      "(pass) afterEach sees passed=true, error=null for a passing subtest",
+      "(pass) afterEach sees passed=false and the thrown error for a failing subtest",
+      "(pass) workerId reads NODE_TEST_WORKER_ID",
+    ]);
+    expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should capture plan at first t.assert access and resolve subtests started after their parent finished", async () => {
-    const { exitCode, stderr } = await runTests(["16-plan-and-late-subtest.js"]);
-    expect(stderr).toContain("2 pass");
-    expect(stderr).toContain("1 todo");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["16-plan-and-late-subtest.js"]);
+    expect(report).toEqual([
+      "16-plan-and-late-subtest.js:",
+      "(todo) plan capture at first t.assert access > assert-before-plan",
+      "(pass) plan capture at first t.assert access > verify assert-before-plan failed with 0/2",
+      "(pass) late subtest after parent finished",
+    ]);
+    expect(summary).toEqual({ pass: 2, todo: 1, fail: 0, tests: 3, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should bound plan({wait:true}) by the test's own timeout instead of hanging", async () => {
-    const { exitCode, stderr } = await runTests(["16b-plan-wait-timeout.js"]);
-    expect(stderr).toContain("test timed out after 100ms");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 1,
-      stderr: expect.stringContaining("1 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["16b-plan-wait-timeout.js"]);
+    expect(report).toEqual([
+      "16b-plan-wait-timeout.js:",
+      "error: test timed out after 100ms",
+      "(fail) wait:true bounded by test timeout",
+    ]);
+    expect(summary).toEqual({ pass: 0, fail: 1, tests: 1, files: 1 });
+    expect(exitCode).toBe(1);
   });
 
   test("should fail the parent when a t.test() that fulfills plan({wait}) throws", async () => {
-    const { exitCode, stderr } = await runTests(["24-plan-wait-late-subtest.js"]);
-    // The error message from makeTestFailure — must not be satisfied by the
-    // fixture's own source lines echoed in the failure context.
-    expect(stderr).toContain("error: 1 subtest failed");
-    expect(stderr).toContain("boom");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 1,
-      stderr: expect.stringContaining("1 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["24-plan-wait-late-subtest.js"]);
+    // "1 subtest failed" is makeTestFailure's message for the parent, "boom"
+    // is the subtest's own error.
+    expect(report).toEqual(["24-plan-wait-late-subtest.js:", "error: 1 subtest failed", "error: boom", "(fail) p"]);
+    expect(summary).toEqual({ pass: 0, fail: 1, tests: 1, files: 1 });
+    expect(exitCode).toBe(1);
   });
 
   test("should treat a failing expectFailure test as a pass", async () => {
-    const { exitCode, stderr } = await runTests(["25-expect-failure.js"]);
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["25-expect-failure.js"]);
+    expect(report).toEqual([
+      "25-expect-failure.js:",
+      "(pass) a failing body is the expected outcome",
+      "(pass) a label is allowed in place of true",
+      "(pass) a RegExp validates the error",
+      "(pass) an object may carry both label and match",
+    ]);
+    expect(summary).toEqual({ pass: 4, fail: 0, tests: 4, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should fail an expectFailure test that passes", async () => {
-    const { exitCode, stderr } = await runTests(["27-expect-failure-but-passes.js"]);
-    expect(stderr).toContain("test was expected to fail but passed");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 1,
-      stderr: expect.stringContaining("1 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["27-expect-failure-but-passes.js"]);
+    expect(report).toEqual([
+      "27-expect-failure-but-passes.js:",
+      "error: test was expected to fail but passed",
+      "(fail) passes unexpectedly",
+    ]);
+    expect(summary).toEqual({ pass: 0, fail: 1, tests: 1, files: 1 });
+    expect(exitCode).toBe(1);
   });
 
   test("should fail an expectFailure test whose error does not match the validator", async () => {
-    const { exitCode, stderr } = await runTests(["29-expect-failure-mismatch.js"]);
-    expect(stderr).toContain("the error did not match the expected validation");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 1,
-      stderr: expect.stringContaining("1 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["29-expect-failure-mismatch.js"]);
+    // The second error is the thrown one, echoed as the `actual` of the
+    // validator's AssertionError.
+    expect(report).toEqual([
+      "29-expect-failure-mismatch.js:",
+      "error: The test failed, but the error did not match the expected validation",
+      "error: a different message entirely",
+      "(fail) the thrown error does not satisfy the validator",
+    ]);
+    expect(summary).toEqual({ pass: 0, fail: 1, tests: 1, files: 1 });
+    expect(exitCode).toBe(1);
   });
 
   test("should inherit expectFailure into subtests", async () => {
     // Matches node v26.3.0: the subtest inherits the expectation and passes, so
     // the parent is the one that fails for not failing.
-    const { exitCode, stderr } = await runTests(["28-expect-failure-inherited.js"]);
-    expect(stderr).toContain("test was expected to fail but passed");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 1,
-      stderr: expect.stringContaining("1 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["28-expect-failure-inherited.js"]);
+    expect(report).toEqual([
+      "28-expect-failure-inherited.js:",
+      "error: test was expected to fail but passed",
+      "(fail) expectFailure is inherited by subtests",
+    ]);
+    expect(summary).toEqual({ pass: 0, fail: 1, tests: 1, files: 1 });
+    expect(exitCode).toBe(1);
   });
 
   test("should not run a skipped suite's callback", async () => {
-    const { exitCode, stdout, stderr } = await runTests(["26-skipped-suite-body.js"]);
-    expect(stdout).not.toContain("[suite body ran: skip-only]");
-    // { skip: true, todo: true } is a skip in Node, so this body is skipped too.
-    expect(stdout).not.toContain("[suite body ran: both-flags]");
-    // A todo suite's callback does run.
-    expect(stdout).toContain("[suite body ran: pending-only]");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { stdoutLines, report, summary, exitCode } = await runTests(["26-skipped-suite-body.js"]);
+    // Neither the { skip: true } body nor the { skip: true, todo: true } body
+    // may print ({ skip, todo } is a skip in Node). A todo suite's callback does run.
+    expect(stdoutLines).toEqual(["[suite body ran: pending-only]"]);
+    expect(report).toEqual(["26-skipped-suite-body.js:", "(pass) sanity"]);
+    expect(summary).toEqual({ pass: 1, fail: 0, tests: 1, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should reset the module-level mock tracker between --rerun-each iterations", async () => {
     // ESM entry: --rerun-each currently only re-evaluates ESM entry files.
-    const { exitCode, stderr } = await runTests(["17-rerun-mock-reset.mjs"], {}, ["--rerun-each=3"]);
-    expect(stderr).toContain("3 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["17-rerun-mock-reset.mjs"], { args: ["--rerun-each=3"] });
+    expect(report).toEqual([
+      "17-rerun-mock-reset.mjs: (run #1)",
+      "(pass) module-scope mock.method captured the real original across reruns",
+      "17-rerun-mock-reset.mjs: (run #2)",
+      "(pass) module-scope mock.method captured the real original across reruns",
+      "17-rerun-mock-reset.mjs: (run #3)",
+      "(pass) module-scope mock.method captured the real original across reruns",
+    ]);
+    expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should keep node's zero-delay mock interval semantics", async () => {
-    const { exitCode, stderr } = await runTests(["18-mock-timers-interval-zero.js"]);
-    expect(stderr).toContain("3 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["18-mock-timers-interval-zero.js"]);
+    expect(report).toEqual([
+      "18-mock-timers-interval-zero.js:",
+      "(pass) setInterval(fn, 0) re-fires within one tick until cleared",
+      "(pass) runAll() drains a zero-delay interval that clears itself",
+      "(pass) setTimeout(fn, 0) still fires once on tick(0)",
+    ]);
+    expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should apply the plan option before beforeEach so a hook cannot snapshot a null plan", async () => {
-    const { exitCode, stderr } = await runTests(["19-plan-option-order.js"]);
-    expect(stderr).toContain("3 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["19-plan-option-order.js"]);
+    expect(report).toEqual([
+      "19-plan-option-order.js:",
+      "(pass) the plan option survives a beforeEach that touches t.assert",
+      "(pass) the plan option is already set inside beforeEach",
+      "(pass) a zero plan option installs no plan",
+    ]);
+    expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should enforce a hook-level signal and install t.assert.ok separately", async () => {
-    const { exitCode, stderr } = await runTests(["20-hook-signal-and-assert-ok.js"]);
-    expect(stderr).toContain("2 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["20-hook-signal-and-assert-ok.js"]);
+    expect(report).toEqual([
+      "20-hook-signal-and-assert-ok.js:",
+      "(pass) a hook-level signal aborts the hook and fails the owning subtest",
+      "(pass) t.assert.ok is installed separately and still counts toward the plan",
+    ]);
+    expect(summary).toEqual({ pass: 2, fail: 0, tests: 2, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should let a registered ok assertion override the built-in one", async () => {
-    const { exitCode, stderr } = await runTests(["21-register-ok.js"]);
-    expect(stderr).toContain("2 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["21-register-ok.js"]);
+    expect(report).toEqual([
+      "21-register-ok.js:",
+      "(pass) a registered ok overrides the built-in one",
+      "(pass) a registered ok still counts toward the plan",
+    ]);
+    expect(summary).toEqual({ pass: 2, fail: 0, tests: 2, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should gate a nested inline subtest on every ancestor suite's before hooks", async () => {
-    const { exitCode, stderr } = await runTests(["22-nested-suite-before.js"]);
-    expect(stderr).toContain("3 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
-    });
+    const { report, summary, exitCode } = await runTests(["22-nested-suite-before.js"]);
+    expect(report).toEqual([
+      "22-nested-suite-before.js:",
+      "(pass) a nested test is gated on the outer suite's async before hook",
+      "(pass) a nested test is gated on the owning test's before hook too",
+      "(pass) an outer suite's throwing before hook fails the test without running x",
+    ]);
+    expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
+    expect(exitCode).toBe(0);
   });
 
   test("should resolve the promise of a test that a name pattern filters out", async () => {
-    const { exitCode, stderr } = await runTests(["23-filtered-test-promise.js"], {}, ["-t", "should resolve"]);
-    expect(stderr).not.toContain("timed out");
-    expect(stderr).toContain("1 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 0,
-      stderr: expect.stringContaining("0 fail"),
+    const { report, summary, exitCode } = await runTests(["23-filtered-test-promise.js"], {
+      args: ["-t", "should resolve"],
     });
+    // If that promise never settled, the awaiting test would time out and
+    // `report` would carry the timeout error and a (fail) line instead.
+    expect(report).toEqual([
+      "23-filtered-test-promise.js:",
+      "(pass) should resolve the promise of a name-pattern-filtered test",
+    ]);
+    expect(summary).toEqual({ pass: 1, "filtered out": 1, fail: 0, tests: 1, files: 1 });
+    expect(exitCode).toBe(0);
+  });
+
+  test("mock.property/mock.method survive a polluted Object.prototype", async () => {
+    // The defineProperty descriptors must carry __proto__:null so an inherited
+    // `value` on Object.prototype does not turn the accessor descriptor into a
+    // TypeError (nodejs/node lib/internal/test_runner/mock/mock.js does this).
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          Object.prototype.value = 1;
+          const { mock } = require("node:test");
+          const obj = { x: 1, get p() { return 5; } };
+          mock.property(obj, "x");
+          mock.getter(obj, "p");
+          console.log("ok");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({ stdout: "ok", exitCode: 0 });
   });
 });
 
-async function runTests(filenames: string[], env: Record<string, string> = {}, args: string[] = []) {
-  const testPaths = filenames.map(filename => join(import.meta.dirname, "fixtures", filename));
-  const {
-    exited,
-    stdout: stdoutStream,
-    stderr: stderrStream,
-  } = spawn({
-    cmd: [bunExe(), "test", ...args, ...testPaths],
+/**
+ * Runs `bun test` over the given fixtures in one child process and parses what
+ * it printed into the parts that do not depend on timings or source locations:
+ *
+ * - `stdoutLines`: what the fixtures themselves printed.
+ * - `report`: each file header, `error: ...` message and `(pass|fail|skip|todo)`
+ *   result line from stderr, in order. An error precedes the result it failed.
+ * - `summary`: the pass/skip/todo/fail/error counters bun printed at the end,
+ *   keyed by their label, plus the totals from `Ran N tests across M files`.
+ */
+async function runTests(filenames: string[], options: { args?: string[]; env?: Record<string, string> } = {}) {
+  const { args = [], env = {} } = options;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", ...args, ...filenames.map(filename => join(fixturesDir, filename))],
+    // Keeps the file headers bun prints down to the bare fixture name, and
+    // keeps the repo's bunfig.toml preload out of the child.
+    cwd: fixturesDir,
     env: { ...bunEnv, ...env },
+    stdout: "pipe",
     stderr: "pipe",
   });
-  const [exitCode, stdout, stderr] = await Promise.all([
-    exited,
-    new Response(stdoutStream).text(),
-    new Response(stderrStream).text(),
-  ]);
-  return { exitCode, stdout, stderr };
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const stdoutLines = stdout.split(/\r?\n/).filter(line => line !== "" && !line.startsWith("bun test v"));
+
+  const report: string[] = [];
+  for (const line of stderr.split(/\r?\n/)) {
+    if (/^[\w.-]+\.m?js:( \(run #\d+\))?$/.test(line) || line.startsWith("error: ")) {
+      report.push(line);
+    } else if (/^\((pass|fail|skip|todo)\) /.test(line)) {
+      report.push(line.replace(/\s\[[\d.]+\s?m?s\]$/, ""));
+    }
+  }
+
+  const summary: Record<string, number> = {};
+  for (const [, count, label] of stderr.matchAll(/^ +(\d+) (pass|skip|todo|fail|filtered out|errors?)\r?$/gm)) {
+    summary[label] = Number(count);
+  }
+  const ran = stderr.match(/^Ran (\d+) tests? across (\d+) files?\. /m);
+  if (ran) {
+    summary.tests = Number(ran[1]);
+    summary.files = Number(ran[2]);
+  }
+
+  return { exitCode, stdoutLines, report, summary };
 }
 
 describe("node:test mock", () => {
@@ -496,28 +694,4 @@ test("the call record is pushed after the implementation runs, like node", () =>
   expect(inside).toBe(0);
   expect(f.mock.callCount()).toBe(1);
   mock.reset();
-});
-
-test("mock.property/mock.method survive a polluted Object.prototype", async () => {
-  // The defineProperty descriptors must carry __proto__:null so an inherited
-  // `value` on Object.prototype does not turn the accessor descriptor into a
-  // TypeError (nodejs/node lib/internal/test_runner/mock/mock.js does this).
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
-        Object.prototype.value = 1;
-        const { mock } = require("node:test");
-        const obj = { x: 1, get p() { return 5; } };
-        mock.property(obj, "x");
-        mock.getter(obj, "p");
-        console.log("ok");
-      `,
-    ],
-    env: bunEnv,
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({ stdout: "ok", exitCode: 0 });
 });

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -48,26 +48,26 @@ const hooksReport = [
   "(pass) execution order > describe 1 > describe 2 > test 3",
 ];
 
-// Every test in here spawns its own child process over read-only fixtures.
+// Every test in here spawns its own `bun test` child over read-only fixtures.
 describe.concurrent("node:test", () => {
   test("should run basic tests", async () => {
-    const { report, summary, exitCode } = await runTests(["01-harness.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["01-harness.js"]);
     expect(report).toEqual(harnessReport);
     expect(summary).toEqual({ pass: 32, fail: 0, tests: 32, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should run hooks in the right order", async () => {
-    const { stdoutLines, report, summary, exitCode } = await runTests(["02-hooks.js"]);
+    const { stdoutLines, report, summary, exitCode, stderr } = await runTests(["02-hooks.js"]);
     // The fixture's last after() prints every hook and test it recorded, in order.
     expect(stdoutLines).toEqual(hookOrder.node);
     expect(report).toEqual(hooksReport);
     expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should run tests with different variations", async () => {
-    const { report, summary, exitCode } = await runTests(["03-test-variations.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["03-test-variations.js"]);
     expect(report).toEqual([
       "03-test-variations.js:",
       "(pass) <anonymous>",
@@ -84,11 +84,11 @@ describe.concurrent("node:test", () => {
       "(todo) todo test with options",
     ]);
     expect(summary).toEqual({ pass: 8, skip: 2, todo: 2, fail: 0, tests: 12, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should run async tests", async () => {
-    const { report, summary, exitCode } = await runTests(["04-async-tests.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["04-async-tests.js"]);
     expect(report).toEqual([
       "04-async-tests.js:",
       "(pass) test with an async function",
@@ -97,19 +97,19 @@ describe.concurrent("node:test", () => {
       "(pass) nested tests > nested test with an async function that delays",
     ]);
     expect(summary).toEqual({ pass: 4, fail: 0, tests: 4, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should run all tests from multiple files", async () => {
-    const { stdoutLines, report, summary, exitCode } = await runTests(["01-harness.js", "02-hooks.js"]);
+    const { stdoutLines, report, summary, exitCode, stderr } = await runTests(["01-harness.js", "02-hooks.js"]);
     expect(stdoutLines).toEqual(hookOrder.node);
     expect(report).toEqual([...harnessReport, ...hooksReport]);
     expect(summary).toEqual({ pass: 35, fail: 0, tests: 35, files: 2 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should run test() and describe() called inside another test() as subtests", async () => {
-    const { stdoutLines, report, summary, exitCode } = await runTests(["05-test-in-test.js"]);
+    const { stdoutLines, report, summary, exitCode, stderr } = await runTests(["05-test-in-test.js"]);
     // Printed from a t.after() hook, so this also proves the hook ran.
     expect(stdoutLines).toEqual(["subtest order: awaited, unawaited, inner"]);
     expect(report).toEqual([
@@ -118,11 +118,11 @@ describe.concurrent("node:test", () => {
       "(pass) test() and describe() called inside a running test become subtests",
     ]);
     expect(summary).toEqual({ pass: 2, fail: 0, tests: 2, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should run before hooks created on a running test once and validate hook options", async () => {
-    const { report, summary, exitCode } = await runTests(["06-hook-semantics.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["06-hook-semantics.js"]);
     expect(report).toEqual([
       "06-hook-semantics.js:",
       "(pass) t.before() registered on a running test runs exactly once",
@@ -131,11 +131,11 @@ describe.concurrent("node:test", () => {
       "(pass) mock once registries never call user-patched Map.prototype methods",
     ]);
     expect(summary).toEqual({ pass: 4, fail: 0, tests: 4, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should fail tests whose hooks, bodies, or inline suite callbacks fail", async () => {
-    const { stdoutLines, report, summary, exitCode } = await runTests(["07-failing-hooks.js"]);
+    const { stdoutLines, report, summary, exitCode, stderr } = await runTests(["07-failing-hooks.js"]);
     // The subtest after the failing before hook must not run its body (Node).
     expect(stdoutLines).toEqual(["SUB_BODY_RAN=false"]);
     // Each (fail) line is preceded by the error(s) that failed it.
@@ -166,18 +166,18 @@ describe.concurrent("node:test", () => {
       "(fail) a subtest created after its parent before hook failed does not run",
     ]);
     expect(summary).toEqual({ pass: 0, fail: 10, tests: 10, files: 1 });
-    expect(exitCode).toBe(1);
+    expect(exitCode, stderr).toBe(1);
   });
 
   test("should support done callbacks in tests and hooks", async () => {
-    const { report, summary, exitCode } = await runTests(["10-done-callbacks.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["10-done-callbacks.js"]);
     expect(report).toEqual([
       "10-done-callbacks.js:",
       "(pass) file-level hooks with done callbacks ran first",
       "(pass) t.beforeEach with a done callback applies to subtests",
     ]);
     expect(summary).toEqual({ pass: 2, fail: 0, tests: 2, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   const runtimeTodoReport = [
@@ -190,27 +190,27 @@ describe.concurrent("node:test", () => {
   ];
 
   test("should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers", async () => {
-    const { report, summary, exitCode } = await runTests(["12-runtime-todo-and-mock-timers.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["12-runtime-todo-and-mock-timers.js"]);
     expect(report).toEqual(runtimeTodoReport);
     expect(summary).toEqual({ pass: 3, skip: 1, todo: 1, fail: 0, tests: 5, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should count runtime t.todo()/t.skip() as todo/skip under --concurrent too", async () => {
     // markCurrentResult's microtask-drain fallback could not name a sequence
     // inside a concurrent group, so the skip/todo mark was dropped and both
     // tests were reported as pass.
-    const { report, summary, exitCode } = await runTests(["12-runtime-todo-and-mock-timers.js"], {
-      args: ["--concurrent"],
-    });
+    const { report, summary, exitCode, stderr } = await runTests(["12-runtime-todo-and-mock-timers.js"], {}, [
+      "--concurrent",
+    ]);
     // --concurrent reports tests in completion order.
     expect(report.toSorted()).toEqual(runtimeTodoReport.toSorted());
     expect(summary).toEqual({ pass: 3, skip: 1, todo: 1, fail: 0, tests: 5, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should run todo bodies under --todo instead of registering an empty function", async () => {
-    const { report, summary, exitCode } = await runTests(["13-todo-bodies.js"], { args: ["--todo"] });
+    const { report, summary, exitCode, stderr } = await runTests(["13-todo-bodies.js"], {}, ["--todo"]);
     // The errors prove that both todo bodies ran.
     expect(report).toEqual([
       "13-todo-bodies.js:",
@@ -221,24 +221,22 @@ describe.concurrent("node:test", () => {
       "(pass) sibling test still passes",
     ]);
     expect(summary).toEqual({ pass: 1, todo: 2, fail: 0, tests: 3, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should forward Infinity and finite timeouts so they override the runner default", async () => {
-    const { report, summary, exitCode } = await runTests(["11-timeout-overrides.js"], {
-      args: ["--timeout", "100"],
-    });
+    const { report, summary, exitCode, stderr } = await runTests(["11-timeout-overrides.js"], {}, ["--timeout", "100"]);
     expect(report).toEqual([
       "11-timeout-overrides.js:",
       "(pass) an Infinity timeout overrides the runner default",
       "(pass) a finite timeout larger than the runner default is honored",
     ]);
     expect(summary).toEqual({ pass: 2, fail: 0, tests: 2, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should not leak file-level beforeEach hooks across files in one process", async () => {
-    const { report, summary, exitCode } = await runTests(["14-root-hooks-a.js", "14-root-hooks-b.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["14-root-hooks-a.js", "14-root-hooks-b.js"]);
     expect(report).toEqual([
       "14-root-hooks-a.js:",
       "(pass) file A runs its own file-level beforeEach and sees its own registrations",
@@ -248,12 +246,12 @@ describe.concurrent("node:test", () => {
       "(pass) module-scope registrations from this file survive and capture the true original",
     ]);
     expect(summary).toEqual({ pass: 4, fail: 0, tests: 4, files: 2 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should treat only as a no-op instead of using bun:test's CI-banned only()", async () => {
     // bun:test's only() only throws when CI is set; pin the precondition.
-    const { report, summary, exitCode } = await runTests(["08-only-no-op.js"], { env: { CI: "1" } });
+    const { report, summary, exitCode, stderr } = await runTests(["08-only-no-op.js"], { CI: "1" });
     expect(report).toEqual([
       "08-only-no-op.js:",
       "(pass) only-marked test runs",
@@ -262,11 +260,11 @@ describe.concurrent("node:test", () => {
       "(pass) only is a no-op without --test-only",
     ]);
     expect(summary).toEqual({ pass: 4, fail: 0, tests: 4, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should serialize inline suites and await async describe callbacks like node", async () => {
-    const { report, summary, exitCode } = await runTests(["09-inline-suites.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["09-inline-suites.js"]);
     expect(report).toEqual([
       "09-inline-suites.js:",
       "(pass) inline suite children run after previously scheduled subtests",
@@ -274,11 +272,11 @@ describe.concurrent("node:test", () => {
       "(pass) early inline-suite child waits for the async describe callback to settle",
     ]);
     expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should expose the body outcome to afterEach and workerId to the context", async () => {
-    const { report, summary, exitCode } = await runTests(["15-outcome-in-hooks.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["15-outcome-in-hooks.js"]);
     expect(report).toEqual([
       "15-outcome-in-hooks.js:",
       "(pass) afterEach sees passed=true, error=null for a passing subtest",
@@ -286,11 +284,11 @@ describe.concurrent("node:test", () => {
       "(pass) workerId reads NODE_TEST_WORKER_ID",
     ]);
     expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should capture plan at first t.assert access and resolve subtests started after their parent finished", async () => {
-    const { report, summary, exitCode } = await runTests(["16-plan-and-late-subtest.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["16-plan-and-late-subtest.js"]);
     expect(report).toEqual([
       "16-plan-and-late-subtest.js:",
       "(todo) plan capture at first t.assert access > assert-before-plan",
@@ -298,31 +296,31 @@ describe.concurrent("node:test", () => {
       "(pass) late subtest after parent finished",
     ]);
     expect(summary).toEqual({ pass: 2, todo: 1, fail: 0, tests: 3, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should bound plan({wait:true}) by the test's own timeout instead of hanging", async () => {
-    const { report, summary, exitCode } = await runTests(["16b-plan-wait-timeout.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["16b-plan-wait-timeout.js"]);
     expect(report).toEqual([
       "16b-plan-wait-timeout.js:",
       "error: test timed out after 100ms",
       "(fail) wait:true bounded by test timeout",
     ]);
     expect(summary).toEqual({ pass: 0, fail: 1, tests: 1, files: 1 });
-    expect(exitCode).toBe(1);
+    expect(exitCode, stderr).toBe(1);
   });
 
   test("should fail the parent when a t.test() that fulfills plan({wait}) throws", async () => {
-    const { report, summary, exitCode } = await runTests(["24-plan-wait-late-subtest.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["24-plan-wait-late-subtest.js"]);
     // "1 subtest failed" is makeTestFailure's message for the parent, "boom"
     // is the subtest's own error.
     expect(report).toEqual(["24-plan-wait-late-subtest.js:", "error: 1 subtest failed", "error: boom", "(fail) p"]);
     expect(summary).toEqual({ pass: 0, fail: 1, tests: 1, files: 1 });
-    expect(exitCode).toBe(1);
+    expect(exitCode, stderr).toBe(1);
   });
 
   test("should treat a failing expectFailure test as a pass", async () => {
-    const { report, summary, exitCode } = await runTests(["25-expect-failure.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["25-expect-failure.js"]);
     expect(report).toEqual([
       "25-expect-failure.js:",
       "(pass) a failing body is the expected outcome",
@@ -331,60 +329,61 @@ describe.concurrent("node:test", () => {
       "(pass) an object may carry both label and match",
     ]);
     expect(summary).toEqual({ pass: 4, fail: 0, tests: 4, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should fail an expectFailure test that passes", async () => {
-    const { report, summary, exitCode } = await runTests(["27-expect-failure-but-passes.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["27-expect-failure-but-passes.js"]);
     expect(report).toEqual([
       "27-expect-failure-but-passes.js:",
       "error: test was expected to fail but passed",
       "(fail) passes unexpectedly",
     ]);
     expect(summary).toEqual({ pass: 0, fail: 1, tests: 1, files: 1 });
-    expect(exitCode).toBe(1);
+    expect(exitCode, stderr).toBe(1);
   });
 
   test("should fail an expectFailure test whose error does not match the validator", async () => {
-    const { report, summary, exitCode } = await runTests(["29-expect-failure-mismatch.js"]);
-    // The second error is the thrown one, echoed as the `actual` of the
-    // validator's AssertionError.
+    const { report, summary, exitCode, stderr } = await runTests(["29-expect-failure-mismatch.js"]);
+    // The validator's AssertionError follows, and its `actual` echoes the
+    // thrown error.
     expect(report).toEqual([
       "29-expect-failure-mismatch.js:",
       "error: The test failed, but the error did not match the expected validation",
+      "AssertionError: The input did not match the regular expression /expected message/. Input:",
       "error: a different message entirely",
       "(fail) the thrown error does not satisfy the validator",
     ]);
     expect(summary).toEqual({ pass: 0, fail: 1, tests: 1, files: 1 });
-    expect(exitCode).toBe(1);
+    expect(exitCode, stderr).toBe(1);
   });
 
   test("should inherit expectFailure into subtests", async () => {
     // Matches node v26.3.0: the subtest inherits the expectation and passes, so
     // the parent is the one that fails for not failing.
-    const { report, summary, exitCode } = await runTests(["28-expect-failure-inherited.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["28-expect-failure-inherited.js"]);
     expect(report).toEqual([
       "28-expect-failure-inherited.js:",
       "error: test was expected to fail but passed",
       "(fail) expectFailure is inherited by subtests",
     ]);
     expect(summary).toEqual({ pass: 0, fail: 1, tests: 1, files: 1 });
-    expect(exitCode).toBe(1);
+    expect(exitCode, stderr).toBe(1);
   });
 
   test("should not run a skipped suite's callback", async () => {
-    const { stdoutLines, report, summary, exitCode } = await runTests(["26-skipped-suite-body.js"]);
+    const { stdoutLines, report, summary, exitCode, stderr } = await runTests(["26-skipped-suite-body.js"]);
     // Neither the { skip: true } body nor the { skip: true, todo: true } body
     // may print ({ skip, todo } is a skip in Node). A todo suite's callback does run.
     expect(stdoutLines).toEqual(["[suite body ran: pending-only]"]);
     expect(report).toEqual(["26-skipped-suite-body.js:", "(pass) sanity"]);
     expect(summary).toEqual({ pass: 1, fail: 0, tests: 1, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should reset the module-level mock tracker between --rerun-each iterations", async () => {
     // ESM entry: --rerun-each currently only re-evaluates ESM entry files.
-    const { report, summary, exitCode } = await runTests(["17-rerun-mock-reset.mjs"], { args: ["--rerun-each=3"] });
+    const { report, summary, exitCode, stderr } = await runTests(["17-rerun-mock-reset.mjs"], {}, ["--rerun-each=3"]);
     expect(report).toEqual([
       "17-rerun-mock-reset.mjs: (run #1)",
       "(pass) module-scope mock.method captured the real original across reruns",
@@ -394,11 +393,11 @@ describe.concurrent("node:test", () => {
       "(pass) module-scope mock.method captured the real original across reruns",
     ]);
     expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should keep node's zero-delay mock interval semantics", async () => {
-    const { report, summary, exitCode } = await runTests(["18-mock-timers-interval-zero.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["18-mock-timers-interval-zero.js"]);
     expect(report).toEqual([
       "18-mock-timers-interval-zero.js:",
       "(pass) setInterval(fn, 0) re-fires within one tick until cleared",
@@ -406,11 +405,11 @@ describe.concurrent("node:test", () => {
       "(pass) setTimeout(fn, 0) still fires once on tick(0)",
     ]);
     expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should apply the plan option before beforeEach so a hook cannot snapshot a null plan", async () => {
-    const { report, summary, exitCode } = await runTests(["19-plan-option-order.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["19-plan-option-order.js"]);
     expect(report).toEqual([
       "19-plan-option-order.js:",
       "(pass) the plan option survives a beforeEach that touches t.assert",
@@ -418,33 +417,33 @@ describe.concurrent("node:test", () => {
       "(pass) a zero plan option installs no plan",
     ]);
     expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should enforce a hook-level signal and install t.assert.ok separately", async () => {
-    const { report, summary, exitCode } = await runTests(["20-hook-signal-and-assert-ok.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["20-hook-signal-and-assert-ok.js"]);
     expect(report).toEqual([
       "20-hook-signal-and-assert-ok.js:",
       "(pass) a hook-level signal aborts the hook and fails the owning subtest",
       "(pass) t.assert.ok is installed separately and still counts toward the plan",
     ]);
     expect(summary).toEqual({ pass: 2, fail: 0, tests: 2, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should let a registered ok assertion override the built-in one", async () => {
-    const { report, summary, exitCode } = await runTests(["21-register-ok.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["21-register-ok.js"]);
     expect(report).toEqual([
       "21-register-ok.js:",
       "(pass) a registered ok overrides the built-in one",
       "(pass) a registered ok still counts toward the plan",
     ]);
     expect(summary).toEqual({ pass: 2, fail: 0, tests: 2, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should gate a nested inline subtest on every ancestor suite's before hooks", async () => {
-    const { report, summary, exitCode } = await runTests(["22-nested-suite-before.js"]);
+    const { report, summary, exitCode, stderr } = await runTests(["22-nested-suite-before.js"]);
     expect(report).toEqual([
       "22-nested-suite-before.js:",
       "(pass) a nested test is gated on the outer suite's async before hook",
@@ -452,13 +451,14 @@ describe.concurrent("node:test", () => {
       "(pass) an outer suite's throwing before hook fails the test without running x",
     ]);
     expect(summary).toEqual({ pass: 3, fail: 0, tests: 3, files: 1 });
-    expect(exitCode).toBe(0);
+    expect(exitCode, stderr).toBe(0);
   });
 
   test("should resolve the promise of a test that a name pattern filters out", async () => {
-    const { report, summary, exitCode } = await runTests(["23-filtered-test-promise.js"], {
-      args: ["-t", "should resolve"],
-    });
+    const { report, summary, exitCode, stderr } = await runTests(["23-filtered-test-promise.js"], {}, [
+      "-t",
+      "should resolve",
+    ]);
     // If that promise never settled, the awaiting test would time out and
     // `report` would carry the timeout error and a (fail) line instead.
     expect(report).toEqual([
@@ -466,47 +466,23 @@ describe.concurrent("node:test", () => {
       "(pass) should resolve the promise of a name-pattern-filtered test",
     ]);
     expect(summary).toEqual({ pass: 1, "filtered out": 1, fail: 0, tests: 1, files: 1 });
-    expect(exitCode).toBe(0);
-  });
-
-  test("mock.property/mock.method survive a polluted Object.prototype", async () => {
-    // The defineProperty descriptors must carry __proto__:null so an inherited
-    // `value` on Object.prototype does not turn the accessor descriptor into a
-    // TypeError (nodejs/node lib/internal/test_runner/mock/mock.js does this).
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          Object.prototype.value = 1;
-          const { mock } = require("node:test");
-          const obj = { x: 1, get p() { return 5; } };
-          mock.property(obj, "x");
-          mock.getter(obj, "p");
-          console.log("ok");
-        `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({ stdout: "ok", exitCode: 0 });
+    expect(exitCode, stderr).toBe(0);
   });
 });
 
 /**
- * Runs `bun test` over the given fixtures in one child process and parses what
- * it printed into the parts that do not depend on timings or source locations:
+ * Runs `bun test` over the given fixtures in one child process. Next to the raw
+ * `stdout`/`stderr` it returns the parts of them that do not depend on timings
+ * or source locations:
  *
  * - `stdoutLines`: what the fixtures themselves printed.
- * - `report`: each file header, `error: ...` message and `(pass|fail|skip|todo)`
- *   result line from stderr, in order. An error precedes the result it failed.
+ * - `report`: each file header, `error: ...` / `SomeError: ...` message,
+ *   unhandled-error banner and `(pass|fail|skip|todo)` result line from stderr,
+ *   in order. An error precedes the result it failed.
  * - `summary`: the pass/skip/todo/fail/error counters bun printed at the end,
  *   keyed by their label, plus the totals from `Ran N tests across M files`.
  */
-async function runTests(filenames: string[], options: { args?: string[]; env?: Record<string, string> } = {}) {
-  const { args = [], env = {} } = options;
+async function runTests(filenames: string[], env: Record<string, string> = {}, args: string[] = []) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", ...args, ...filenames.map(filename => join(fixturesDir, filename))],
     // Keeps the file headers bun prints down to the bare fixture name, and
@@ -522,7 +498,11 @@ async function runTests(filenames: string[], options: { args?: string[]; env?: R
 
   const report: string[] = [];
   for (const line of stderr.split(/\r?\n/)) {
-    if (/^[\w.-]+\.m?js:( \(run #\d+\))?$/.test(line) || line.startsWith("error: ")) {
+    if (
+      /^[\w.-]+\.m?js:( \(run #\d+\))?$/.test(line) ||
+      /^([A-Z]\w*)?[Ee]rror: /.test(line) ||
+      line.startsWith("# Unhandled error")
+    ) {
       report.push(line);
     } else if (/^\((pass|fail|skip|todo)\) /.test(line)) {
       report.push(line.replace(/\s\[[\d.]+\s?m?s\]$/, ""));
@@ -539,7 +519,7 @@ async function runTests(filenames: string[], options: { args?: string[]; env?: R
     summary.files = Number(ran[2]);
   }
 
-  return { exitCode, stdoutLines, report, summary };
+  return { exitCode, stdout, stderr, stdoutLines, report, summary };
 }
 
 describe("node:test mock", () => {
@@ -694,4 +674,28 @@ test("the call record is pushed after the implementation runs, like node", () =>
   expect(inside).toBe(0);
   expect(f.mock.callCount()).toBe(1);
   mock.reset();
+});
+
+test("mock.property/mock.method survive a polluted Object.prototype", async () => {
+  // The defineProperty descriptors must carry __proto__:null so an inherited
+  // `value` on Object.prototype does not turn the accessor descriptor into a
+  // TypeError (nodejs/node lib/internal/test_runner/mock/mock.js does this).
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        Object.prototype.value = 1;
+        const { mock } = require("node:test");
+        const obj = { x: 1, get p() { return 5; } };
+        mock.property(obj, "x");
+        mock.getter(obj, "p");
+        console.log("ok");
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({ stdout: "ok", exitCode: 0 });
 });


### PR DESCRIPTION
### Problem
- `test/js/node/test_runner/node-test.test.ts` took 12 s on the debian 13 x64-asan lane. About 30 of its tests spawned a `bun test <fixture>` child, one at a time.
- Most tests asserted only `exitCode` and a `"0 fail"` or `"N pass"` substring. That passes when a fixture registers no tests or prints an unexpected error.

### Fix
- The `node:test` describe is `describe.concurrent`, without explicit timeouts. An ASAN build caps concurrent tests at 5, so the children do not pile up.
- `runTests` spawns with `await using` and the fixtures directory as `cwd`, so the children skip the repo `bunfig.toml` preload (a quarter of a debug child's time). Its signature and raw output stay for the other open changes to this file.
- `runTests` also returns `stdoutLines`, `report` (each file header, error message and `(pass|fail|skip|todo)` line, in order) and `summary` (the printed counters). Every fixture run asserts all three with `toEqual`.
- Verified: `bun bd test` on this file (debug+ASAN) went from 69.73 s to 14.54, 14.76 and 14.54 s in three runs, 45 pass each. Release: 1.95 s to 0.75 s. Self-reviewed: 4 concerns raised, 2 addressed, 2 are follow-ups outside this file.

### Background
- Each fixture is a `node:test` file that runs under `bun test` in a child. Hooks, `assert.register()` and module-scope mocks are scoped per file, and several fixtures check that isolation. So each test keeps its own child.
- `bun test` reads `bunfig.toml` from its working directory only. At the repo root it names `test/preload.ts`.

<details><summary>Notes</summary>

Assertion changes per fixture:

- Exact ordered `(pass|fail|skip|todo)` lines and exact summary counts (`pass`, `skip`, `todo`, `fail`, `filtered out`, plus `tests` and `files` from `Ran N tests across M files`) for every fixture run: 01, 02, 03, 04, 01+02, 05, 06, 07, 08, 09, 10, 11, 12 (serial and `--concurrent`), 13, 14a+14b, 15, 16, 16b, 17 (per `--rerun-each` run), 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29. Any `error:` / `SomeError:` line, unhandled-error banner or `N error` counter that a passing fixture did not print before fails the comparison.
- Exact failure messages, each paired with the `(fail)` line it precedes: 07 (all ten, for example `passed a callback but also returned a Promise`, `callback invoked multiple times`, `test timed out after 1ms`), 16b (`test timed out after 100ms`), 24 (`1 subtest failed` then `boom`), 27 and 28 (`test was expected to fail but passed`), 29 (`The test failed, but the error did not match the expected validation` and the validator's `AssertionError`), 13 (the two todo bodies' errors, which proves the bodies ran under `--todo`).
- Exact stdout: 02-hooks now prints the recorded hook order from its last `after()` and the test compares it with `02-hooks.json` (alone and in the two-file run). 05-test-in-test prints the subtest order from its `t.after()` hook, so the test also proves that hook ran. 07 (`SUB_BODY_RAN=false`) and 26 (only the todo suite body prints) compare the whole stdout instead of `toContain` / `not.toContain`.
- `bun test` prints concurrent tests in completion order, so the one `--concurrent` fixture run (12) compares its `report` sorted.

Timings on this machine (8 cores), `bun bd test test/js/node/test_runner/node-test.test.ts` (debug+ASAN): before 69.73 s, after 14.54 s / 14.76 s / 14.54 s. `USE_SYSTEM_BUN=1 bun test` (release): before 1.95 s, after 0.75 s. A debug child took about 2.05 s with the repo preload and 1.47 s without it. The slowest single test under debug+ASAN takes about 2 s, under the 5 s default.

Stability: five extra release runs and two debug runs under eight CPU-burning processes all passed. Fixtures with timers (07's 1 ms hook timeout against a 200 ms settle, 11's 300 ms sleeps against a 3000 ms timeout, 12's `waitFor`, 16b's 100 ms timeout) compare outcomes, not durations.

Review follow-ups left out on purpose, both outside this file: the ASAN-only cap of 5 concurrent tests (`src/options_types/context.rs`) could also apply to plain debug builds, and `test/preload.ts` could import a lighter module than the whole harness.

Nothing under `src/` changed. No fixture writes to disk, so the concurrent children share nothing but read-only files.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 2 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/test_runner/node-test.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/test_runner/node-test.test.ts
bun test v1.4.3 (f42e98025)

test/js/node/test_runner/node-test.test.ts:
(pass) node:test > should run async tests [1538.57ms]
(pass) node:test > should run tests with different variations [1567.93ms]
(pass) node:test > should run hooks in the right order [1723.21ms]
(pass) node:test > should run basic tests [1786.76ms]
(pass) node:test > should run all tests from multiple files [1960.10ms]
(pass) node:test > should run test() and describe() called inside another test() as subtests [1627.35ms]
(pass) node:test > should run before hooks created on a running test once and validate hook options [1618.16ms]
(pass) node:test > should support done callbacks in tests and hooks [1589.94ms]
(pass) node:test > should fail tests whose hooks, bodies, or inline suite callbacks fail [1688.84ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip and keep runner timers real under mock timers [1685.01ms]
(pass) node:test > should run todo bodies under --todo instead of registering an empty function [1515.91ms]
(pass) node:test > should count runtime t.todo()/t.skip() as todo/skip under --concurrent too [1770.31ms]
(pass) node:test > should not leak file-level beforeEach hooks across files in one process [1577.63ms]
(pass) node:test > should treat only as a no-op instead of using bun:test's CI-banned only() [1456.45ms]
(pass) node:test > should forward Infinity and finite timeouts so they override the runner default [2025.80ms]
(pass) node:test > should serialize inline suites and await async describe callbacks like node [1571.67ms]
(pass) node:test > should expose the body outcome to afterEach and workerId to the context [1505.39ms]
(pass) node:test > should capture plan at first t.assert access and resolve subtests started after their parent finished [1556.73ms]
(pass) node:test > should bound plan({wait:true}) by the test's own t
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/test_runner/fixtures/02-hooks.js      |   3 +-
 .../node/test_runner/fixtures/05-test-in-test.js   |   1 +
 test/js/node/test_runner/node-test.test.ts         | 662 +++++++++++++--------
 3 files changed, 423 insertions(+), 243 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
test/js/node/test_runner/fixtures/02-hooks.js             2      2     30
test/js/node/test_runner/fixtures/05-test-in-test.js      1      1     29
test/js/node/test_runner/node-test.test.ts                8     12     29
```

</details>

<!-- robobun:evidence:end -->