### PR TITLE
terminal: release the wrapper after PTY EOF leaves input unflushed

### DIFF
--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -141,20 +141,16 @@ pub struct Terminal {
     /// Reader for receiving data from the terminal
     reader: JsCell<IOReader>,
 
-    /// The JS wrapper. Strong from creation until no further callback can
-    /// fire (PTY EOF with no drain pending, close, or dispose), because the
-    /// wrapper's cached slots are the only GC root of the callbacks; weak
-    /// afterwards so the wrapper can be collected.
+    /// The JS wrapper, which roots the callbacks in its cached slots. Strong
+    /// until no callback can fire, then weak (`maybe_downgrade_after_eof`).
     this_value: JsCell<JsRef>,
 
     /// State flags
     flags: Cell<Flags>,
 
-    /// The streaming writer has accepted bytes it hasn't flushed to the fd
-    /// yet. Set by `write()` from `has_pending_data()`; cleared when
-    /// `on_write` observes `Drained` (POSIX fires the `drain` callback there,
-    /// Windows from `on_writable`) or `EndOfFile`. Also gates the post-EOF
-    /// downgrade in `maybe_downgrade_after_eof`.
+    /// The writer holds bytes it has not flushed to the fd yet, so a `drain`
+    /// is still owed. Gates the post-EOF downgrade in
+    /// `maybe_downgrade_after_eof`.
     writer_has_buffered: Cell<bool>,
 
     /// This PTY's own raw-mode state (mode + saved termios), so one terminal
@@ -1441,9 +1437,8 @@ impl Terminal {
             return Ok(JSValue::js_number(0.0));
         }
 
-        // The PTY already hung up (see `on_reader_finished`): nothing can read
-        // this input, and handing it to the finished writer would re-root the
-        // wrapper below for a drain that never comes.
+        // The write side is gone, so queuing these bytes would only re-root the
+        // wrapper below for a drain that cannot come.
         if self.flags.get().contains(Flags::WRITER_DONE) {
             return Ok(JSValue::js_number(input_len as f64));
         }
@@ -1777,9 +1772,9 @@ impl Terminal {
         let _ = amount;
         match status {
             WriteStatus::Pending => {}
-            // POSIX: `PosixStreamingWriter` never dispatches `on_ready`; detect
-            // the buffered→drained transition here instead. Windows fires the
-            // drain callback from `on_writable`, so only record the state.
+            // `PosixStreamingWriter` never dispatches `on_ready`, so POSIX
+            // fires `drain` off this transition. Windows fires it from
+            // `on_writable` and only records the state here.
             WriteStatus::Drained => {
                 let had_buffered = self.writer_has_buffered.replace(false);
                 #[cfg(unix)]
@@ -1789,8 +1784,7 @@ impl Terminal {
                 #[cfg(not(unix))]
                 let _ = had_buffered;
             }
-            // The writer dropped whatever it still had queued and closed its
-            // fd: no drain will follow, so stop holding the wrapper for one.
+            // The writer closed its fd, so no drain can follow.
             WriteStatus::EndOfFile => {
                 self.writer_has_buffered.set(false);
                 self.maybe_downgrade_after_eof();
@@ -1820,27 +1814,7 @@ impl Terminal {
         }
         self.update_flags(|f| f.insert(Flags::READER_DONE));
         #[cfg(unix)]
-        {
-            // EOF closes the reader on its own. A read error (Linux reports the
-            // last slave close as EIO, not EOF) leaves it open with its poll
-            // armed, and late echo of queued input would still reach `data`
-            // after `exit`. Close it so `exit` is the last callback.
-            if !self.reader.get().is_done() {
-                self.reader.with_mut(|r| r.close());
-                self.read_fd.set(Fd::INVALID);
-            }
-            // Every slave fd is gone, so input still queued in the writer can
-            // never be read. A pty master does not report that as a write
-            // error (Linux keeps answering EAGAIN), so the writer would wait
-            // for a drain that cannot come: its poll stays armed on a permanent
-            // POLLHUP and the pending drain keeps the wrapper rooted. `end()`
-            // closes write_fd and the poll, then dispatches `on_writer_close`,
-            // which sets WRITER_DONE before the downgrade check below.
-            if !self.flags.get().contains(Flags::WRITER_DONE) {
-                self.writer.with_mut(|w| w.end());
-                self.write_fd.set(Fd::INVALID);
-            }
-        }
+        self.finish_io_after_eof();
         // EOF from master - downgrade to weak ref to allow GC.
         // Skip JS interactions if already finalized (happens when close() is called during finalize)
         if !self.flags.get().contains(Flags::FINALIZED) {
@@ -1850,11 +1824,29 @@ impl Terminal {
         self.deref_();
     }
 
-    /// Downgrade `this_value` once no further callback can fire: reader hit
-    /// EOF *and* the writer has no buffered data awaiting a `drain` dispatch.
-    /// The wrapper's cached callback slots are the only GC root of the
-    /// callbacks, so downgrading with a drain still pending lets GC collect
-    /// the wrapper before `on_writer_ready` dispatches through it.
+    /// Finish both ends of the PTY once the reader is done, so `exit` is the
+    /// last callback. A pty master reports neither side's hangup the way a
+    /// pipe does: Linux answers a write with EAGAIN instead of EPIPE, and a
+    /// read with EIO instead of EOF. Left alone, the writer waits for a drain
+    /// that cannot come and the reader delivers echo after `exit`.
+    #[cfg(unix)]
+    fn finish_io_after_eof(&self) {
+        // EOF closes the reader itself, a read error does not.
+        if !self.reader.get().is_done() {
+            self.reader.with_mut(|r| r.close());
+            self.read_fd.set(Fd::INVALID);
+        }
+        // `end()` dispatches `on_writer_close`, which sets `WRITER_DONE`.
+        if !self.flags.get().contains(Flags::WRITER_DONE) {
+            self.writer.with_mut(|w| w.end());
+            self.write_fd.set(Fd::INVALID);
+        }
+    }
+
+    /// Downgrade `this_value` once no further callback can fire: the reader is
+    /// done and no `drain` is owed. Downgrading with a drain pending would let
+    /// GC collect the wrapper, and with it the callbacks it roots, before
+    /// `on_writer_ready` dispatches through it.
     ///
     /// Reads only `Cell` fields, never `self.writer`: callers include
     /// writer-parent callbacks that run while a writer borrow is live.

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -151,8 +151,8 @@ pub struct Terminal {
 
     /// The streaming writer has accepted bytes it hasn't flushed to the fd
     /// yet. Set by `write()` from `has_pending_data()`; cleared when
-    /// `on_write` observes `Drained` so POSIX can fire the `drain` callback
-    /// (Windows fires it from `on_writable`). Also gates the post-EOF
+    /// `on_write` observes `Drained` (POSIX fires the `drain` callback there,
+    /// Windows from `on_writable`) or `EndOfFile`. Also gates the post-EOF
     /// downgrade in `maybe_downgrade_after_eof`.
     writer_has_buffered: Cell<bool>,
 
@@ -1441,6 +1441,13 @@ impl Terminal {
             return Ok(JSValue::js_number(0.0));
         }
 
+        // The PTY already hung up (see `on_reader_finished`): nothing can read
+        // this input, and handing it to the finished writer would re-root the
+        // wrapper below for a drain that never comes.
+        if self.flags.get().contains(Flags::WRITER_DONE) {
+            return Ok(JSValue::js_number(input_len as f64));
+        }
+
         // Suppress drain firing from the synchronous on_write calls that
         // StreamingWriter::write() makes while we still hold the `with_mut`
         // borrow; it is restored from `has_pending_data()` immediately after.
@@ -1768,17 +1775,26 @@ impl Terminal {
     fn on_write(&self, amount: usize, status: WriteStatus) {
         bun_output::scoped_log!(Terminal, "onWrite: {} bytes", amount);
         let _ = amount;
-        // POSIX: `PosixStreamingWriter` never dispatches `on_ready`; detect the
-        // buffered→drained transition here instead. Windows fires the drain
-        // callback from `on_writable`, so only record the drained state (a
-        // stale flag would block `maybe_downgrade_after_eof` forever).
-        #[cfg(unix)]
-        if status == WriteStatus::Drained && self.writer_has_buffered.replace(false) {
-            self.on_writer_ready();
-        }
-        #[cfg(not(unix))]
-        if matches!(status, WriteStatus::Drained | WriteStatus::EndOfFile) {
-            self.writer_has_buffered.set(false);
+        match status {
+            WriteStatus::Pending => {}
+            // POSIX: `PosixStreamingWriter` never dispatches `on_ready`; detect
+            // the buffered→drained transition here instead. Windows fires the
+            // drain callback from `on_writable`, so only record the state.
+            WriteStatus::Drained => {
+                let had_buffered = self.writer_has_buffered.replace(false);
+                #[cfg(unix)]
+                if had_buffered {
+                    self.on_writer_ready();
+                }
+                #[cfg(not(unix))]
+                let _ = had_buffered;
+            }
+            // The writer dropped whatever it still had queued and closed its
+            // fd: no drain will follow, so stop holding the wrapper for one.
+            WriteStatus::EndOfFile => {
+                self.writer_has_buffered.set(false);
+                self.maybe_downgrade_after_eof();
+            }
         }
     }
 
@@ -1806,6 +1822,18 @@ impl Terminal {
             f.insert(Flags::READER_DONE);
             f.remove(Flags::CONNECTED);
         });
+        // Reader EOF means every slave fd is gone, so input still queued in the
+        // writer can never be read. A pty master does not report that as a
+        // write error (Linux keeps answering EAGAIN), so the writer would wait
+        // for a drain that cannot come: its poll stays armed on a permanent
+        // POLLHUP and the pending drain keeps the wrapper rooted. End it here
+        // instead. `end()` closes write_fd and the poll, then dispatches
+        // `on_writer_close`, which sets WRITER_DONE before the check below.
+        #[cfg(unix)]
+        if !self.flags.get().contains(Flags::WRITER_DONE) {
+            self.writer.with_mut(|w| w.end());
+            self.write_fd.set(Fd::INVALID);
+        }
         // EOF from master - downgrade to weak ref to allow GC.
         // Skip JS interactions if already finalized (happens when close() is called during finalize)
         if !self.flags.get().contains(Flags::FINALIZED) {
@@ -1876,8 +1904,12 @@ impl Terminal {
             return true;
         }
 
-        // First data received - upgrade to strong ref (connected)
-        if !self.flags.get().contains(Flags::CONNECTED) {
+        // First data received - upgrade to strong ref (connected). Not after
+        // the reader finished: the `exit` callback has already run and nothing
+        // downgrades again, so a chunk the poll delivers after EOF (a queued
+        // read that follows an EIO) would root the wrapper for good.
+        let flags = self.flags.get();
+        if !flags.contains(Flags::CONNECTED) && !flags.contains(Flags::READER_DONE) {
             self.update_flags(|f| f.insert(Flags::CONNECTED));
             let global = self.global();
             self.this_value.with_mut(|v| v.upgrade(global));

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -141,9 +141,10 @@ pub struct Terminal {
     /// Reader for receiving data from the terminal
     reader: JsCell<IOReader>,
 
-    /// This value reference for GC tracking
-    /// - weak: allows GC when idle
-    /// - strong: prevents GC when actively connected
+    /// The JS wrapper. Strong from creation until no further callback can
+    /// fire (PTY EOF with no drain pending, close, or dispose), because the
+    /// wrapper's cached slots are the only GC root of the callbacks; weak
+    /// afterwards so the wrapper can be collected.
     this_value: JsCell<JsRef>,
 
     /// State flags
@@ -169,13 +170,12 @@ bitflags::bitflags! {
         const FINALIZED      = 1 << 1;
         const RAW_MODE       = 1 << 2;
         const READER_STARTED = 1 << 3;
-        const CONNECTED      = 1 << 4;
-        const READER_DONE    = 1 << 5;
-        const WRITER_DONE    = 1 << 6;
+        const READER_DONE    = 1 << 4;
+        const WRITER_DONE    = 1 << 5;
         /// Set once an inline-created terminal is attached to a spawn; blocks
         /// reuse. Windows: the ConDrv `\Reference` handle is released at spawn.
         /// POSIX: slave_fd is held until first exit (`drain_and_close_slave_fd`).
-        const INLINE_SPAWNED = 1 << 7;
+        const INLINE_SPAWNED = 1 << 6;
     }
 }
 
@@ -1818,21 +1818,28 @@ impl Terminal {
         if self.flags.get().contains(Flags::READER_DONE) {
             return;
         }
-        self.update_flags(|f| {
-            f.insert(Flags::READER_DONE);
-            f.remove(Flags::CONNECTED);
-        });
-        // Reader EOF means every slave fd is gone, so input still queued in the
-        // writer can never be read. A pty master does not report that as a
-        // write error (Linux keeps answering EAGAIN), so the writer would wait
-        // for a drain that cannot come: its poll stays armed on a permanent
-        // POLLHUP and the pending drain keeps the wrapper rooted. End it here
-        // instead. `end()` closes write_fd and the poll, then dispatches
-        // `on_writer_close`, which sets WRITER_DONE before the check below.
+        self.update_flags(|f| f.insert(Flags::READER_DONE));
         #[cfg(unix)]
-        if !self.flags.get().contains(Flags::WRITER_DONE) {
-            self.writer.with_mut(|w| w.end());
-            self.write_fd.set(Fd::INVALID);
+        {
+            // EOF closes the reader on its own. A read error (Linux reports the
+            // last slave close as EIO, not EOF) leaves it open with its poll
+            // armed, and late echo of queued input would still reach `data`
+            // after `exit`. Close it so `exit` is the last callback.
+            if !self.reader.get().is_done() {
+                self.reader.with_mut(|r| r.close());
+                self.read_fd.set(Fd::INVALID);
+            }
+            // Every slave fd is gone, so input still queued in the writer can
+            // never be read. A pty master does not report that as a write
+            // error (Linux keeps answering EAGAIN), so the writer would wait
+            // for a drain that cannot come: its poll stays armed on a permanent
+            // POLLHUP and the pending drain keeps the wrapper rooted. `end()`
+            // closes write_fd and the poll, then dispatches `on_writer_close`,
+            // which sets WRITER_DONE before the downgrade check below.
+            if !self.flags.get().contains(Flags::WRITER_DONE) {
+                self.writer.with_mut(|w| w.end());
+                self.write_fd.set(Fd::INVALID);
+            }
         }
         // EOF from master - downgrade to weak ref to allow GC.
         // Skip JS interactions if already finalized (happens when close() is called during finalize)
@@ -1902,17 +1909,6 @@ impl Terminal {
 
         if self.flags.get().contains(Flags::FINALIZED) {
             return true;
-        }
-
-        // First data received - upgrade to strong ref (connected). Not after
-        // the reader finished: the `exit` callback has already run and nothing
-        // downgrades again, so a chunk the poll delivers after EOF (a queued
-        // read that follows an EIO) would root the wrapper for good.
-        let flags = self.flags.get();
-        if !flags.contains(Flags::CONNECTED) && !flags.contains(Flags::READER_DONE) {
-            self.update_flags(|f| f.insert(Flags::CONNECTED));
-            let global = self.global();
-            self.this_value.with_mut(|v| v.upgrade(global));
         }
 
         let Some(this_jsvalue) = self.this_value.get().try_get() else {

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -172,6 +172,9 @@ bitflags::bitflags! {
         /// reuse. Windows: the ConDrv `\Reference` handle is released at spawn.
         /// POSIX: slave_fd is held until first exit (`drain_and_close_slave_fd`).
         const INLINE_SPAWNED = 1 << 6;
+        /// The `exit` callback has run (or was skipped). The wrapper stays
+        /// strong until then; see `maybe_downgrade_after_eof`.
+        const EXIT_DISPATCHED = 1 << 7;
     }
 }
 
@@ -1815,12 +1818,14 @@ impl Terminal {
         self.update_flags(|f| f.insert(Flags::READER_DONE));
         #[cfg(unix)]
         self.finish_io_after_eof();
-        // EOF from master - downgrade to weak ref to allow GC.
         // Skip JS interactions if already finalized (happens when close() is called during finalize)
         if !self.flags.get().contains(Flags::FINALIZED) {
-            self.maybe_downgrade_after_eof();
             self.call_exit_callback(exit_code, None);
         }
+        // The wrapper stayed strong for `exit`; only a pending `drain` needs
+        // it from here on.
+        self.update_flags(|f| f.insert(Flags::EXIT_DISPATCHED));
+        self.maybe_downgrade_after_eof();
         self.deref_();
     }
 
@@ -1843,16 +1848,16 @@ impl Terminal {
         }
     }
 
-    /// Downgrade `this_value` once no further callback can fire: the reader is
-    /// done and no `drain` is owed. Downgrading with a drain pending would let
-    /// GC collect the wrapper, and with it the callbacks it roots, before
-    /// `on_writer_ready` dispatches through it.
+    /// Downgrade `this_value` once no further callback can fire: `exit` has
+    /// been dispatched and no `drain` is owed. Downgrading earlier would let
+    /// GC collect the wrapper, and with it the callbacks it roots, before the
+    /// last dispatch goes through it.
     ///
     /// Reads only `Cell` fields, never `self.writer`: callers include
     /// writer-parent callbacks that run while a writer borrow is live.
     fn maybe_downgrade_after_eof(&self) {
         let flags = self.flags.get();
-        if !flags.contains(Flags::READER_DONE) || flags.contains(Flags::FINALIZED) {
+        if !flags.contains(Flags::EXIT_DISPATCHED) || flags.contains(Flags::FINALIZED) {
             return;
         }
         if !flags.contains(Flags::WRITER_DONE) && self.writer_has_buffered.get() {

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -767,65 +767,73 @@ describe("Bun.Terminal", () => {
       expect(drainCount).toBeGreaterThan(0);
     });
 
-    // After PTY EOF the wrapper used to be downgraded to a weak ref while
-    // buffered input the child never read was still flushing, so a GC in that
-    // window collected the wrapper together with the callbacks it roots: the
-    // pending drain dispatch was then lost (or, before a sweep, invoked a
-    // collected function). The wrapper must stay strongly held until the
-    // writer goes idle. Ten fresh processes, sequentially, because collection
-    // under conservative stack scanning is probabilistic per process (roughly
-    // half hit the window on an unfixed build; concurrent children skew the
-    // race uniformly, so sequential keeps the attempts independent). Each
-    // child bounds its wait at 20s and the loop stops at the first loss.
-    // Linux-only: the repro window depends on how the kernel drains PTY input
-    // after exit; the code under test is shared.
-    test.skipIf(!isLinux)(
-      "drain still fires when GC runs while unread input is buffered after the child exits",
-      async () => {
-        const childSrc = [
-          "const sleep = ms => new Promise(r => setTimeout(r, ms));",
-          "let sink;",
-          "function churn() { for (let i = 0; i < 500; i++) sink = { i, a: new Array(32).fill(i) }; }",
-          "let resolveDrain;",
-          "const drained = new Promise(r => (resolveDrain = r));",
-          "let proc = Bun.spawn(['sh', '-c', 'exit 0'], {",
-          "  terminal: { data() {}, exit() {}, drain() { resolveDrain('drain'); } },",
-          "});",
-          "const big = Buffer.alloc(65536, 97);",
-          "for (let i = 0; i < 16; i++) proc.terminal.write(big);",
-          "const exited = proc.exited;",
-          "proc = null;",
-          "await exited;",
-          "for (let i = 0; i < 4; i++) { churn(); await sleep(0); Bun.gc(true); }",
-          "const timer = setTimeout(() => resolveDrain('lost'), 20000);",
-          "const result = await drained;",
-          "clearTimeout(timer);",
-          "console.log(result);",
-        ].join("\n");
+    // Input the child never read can never drain once the last slave fd is
+    // gone, because a pty master answers EAGAIN instead of EPIPE. The writer
+    // used to wait for that drain forever, which kept the wrapper (and the
+    // callbacks it roots) alive for the rest of the process and kept its poll
+    // re-arming on a permanent POLLHUP. PTY EOF now ends the writer, so `exit`
+    // is the last callback and the wrapper becomes collectable. The children
+    // alternate two queue shapes: complete lines (the line discipline stops
+    // accepting once its line buffer is full) and one unterminated line (the
+    // kernel keeps discarding it, so an unfixed build fires a late `drain`).
+    test.skipIf(isWindows)("terminal is released after the child exits with input it never read", async () => {
+      const childSrc = /* js */ `
+        const N = 4;
+        let collected = 0;
+        const registry = new FinalizationRegistry(() => collected++);
+        let exits = 0;
+        let drainsAfterExit = 0;
 
-        const run = async () => {
-          await using proc = Bun.spawn({
-            cmd: [bunExe(), "-e", childSrc],
-            env: bunEnv,
-            stderr: "pipe",
+        async function one(i) {
+          const { promise: ptyClosed, resolve } = Promise.withResolvers();
+          let exited = false;
+          let proc = Bun.spawn(["sh", "-c", "exit 0"], {
+            terminal: {
+              data() {},
+              exit() {
+                exited = true;
+                exits++;
+                resolve();
+              },
+              drain() {
+                if (exited) drainsAfterExit++;
+              },
+            },
           });
-          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-          return { stdout: stdout.trim(), stderr, exitCode };
-        };
-
-        const results = [];
-        for (let i = 0; i < 10; i++) {
-          const r = await run();
-          results.push(r);
-          if (r.stdout !== "drain") break;
+          registry.register(proc.terminal, i);
+          const big = Buffer.alloc(65536, i % 2 === 0 ? "echo\\n" : "a");
+          for (let j = 0; j < 32; j++) proc.terminal.write(big);
+          const procExited = proc.exited;
+          proc = null;
+          await procExited;
+          await ptyClosed;
         }
-        expect(results.map(r => r.stdout)).toEqual(Array(results.length).fill("drain"));
-        expect(results.map(r => r.stderr)).toEqual(Array(results.length).fill(""));
-        expect(results.map(r => r.exitCode)).toEqual(Array(results.length).fill(0));
-        expect(results.length).toBe(10);
-      },
-      90_000,
-    );
+
+        for (let i = 0; i < N; i++) await one(i);
+
+        let sink;
+        function churn() {
+          for (let i = 0; i < 500; i++) sink = { i, a: new Array(32).fill(i) };
+        }
+        for (let i = 0; i < 200 && collected < N; i++) {
+          churn();
+          Bun.gc(true);
+          await new Promise(r => setImmediate(r));
+        }
+        console.log(JSON.stringify({ exits, collected, drainsAfterExit }));
+      `;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", childSrc],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({ exits: 4, collected: 4, drainsAfterExit: 0 });
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe.concurrent("subprocess interaction", () => {

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -770,57 +770,74 @@ describe("Bun.Terminal", () => {
     // Input the child never read can never drain once the last slave fd is
     // gone, because a pty master answers EAGAIN instead of EPIPE. The writer
     // used to wait for that drain forever, which kept the wrapper (and the
-    // callbacks it roots) alive for the rest of the process and kept its poll
-    // re-arming on a permanent POLLHUP. PTY EOF now ends the writer, so `exit`
-    // is the last callback and the wrapper becomes collectable. The children
-    // alternate two queue shapes: complete lines (the line discipline stops
-    // accepting once its line buffer is full) and one unterminated line (the
-    // kernel keeps discarding it, so an unfixed build fires a late `drain`).
+    // callbacks it roots) alive with its three pty fds for the rest of the
+    // process, and kept its poll re-arming on a permanent POLLHUP. PTY EOF now
+    // ends the writer and closes the reader, so `exit` is the last callback,
+    // a later write() is dropped instead of queued, and the wrapper becomes
+    // collectable. The children alternate two queue shapes: complete lines
+    // (the line discipline stops accepting once its line buffer is full) and
+    // one unterminated line (the kernel keeps discarding it, so an unfixed
+    // build delivers late echo and a late `drain` after `exit`).
     test.skipIf(isWindows)("terminal is released after the child exits with input it never read", async () => {
       const childSrc = /* js */ `
+        const { readdirSync } = require("node:fs");
+        const openFds = () => readdirSync("/dev/fd").length;
         const N = 4;
         let collected = 0;
         const registry = new FinalizationRegistry(() => collected++);
         let exits = 0;
-        let drainsAfterExit = 0;
+        let callbacksAfterExit = 0;
+        const big = { lines: Buffer.alloc(65536, "echo\\n"), unterminated: Buffer.alloc(65536, "a") };
 
         async function one(i) {
           const { promise: ptyClosed, resolve } = Promise.withResolvers();
           let exited = false;
           let proc = Bun.spawn(["sh", "-c", "exit 0"], {
             terminal: {
-              data() {},
+              data() {
+                if (exited) callbacksAfterExit++;
+              },
               exit() {
                 exited = true;
                 exits++;
                 resolve();
               },
               drain() {
-                if (exited) drainsAfterExit++;
+                if (exited) callbacksAfterExit++;
               },
             },
           });
-          registry.register(proc.terminal, i);
-          const big = Buffer.alloc(65536, i % 2 === 0 ? "echo\\n" : "a");
-          for (let j = 0; j < 32; j++) proc.terminal.write(big);
+          let terminal = proc.terminal;
+          registry.register(terminal, i);
+          const input = i % 2 === 0 ? big.lines : big.unterminated;
+          for (let j = 0; j < 32; j++) terminal.write(input);
           const procExited = proc.exited;
           proc = null;
           await procExited;
           await ptyClosed;
+          // After PTY EOF a write is accepted and dropped; it must not queue
+          // (and so re-root the wrapper) behind input that can never drain.
+          for (let j = 0; j < 32; j++) terminal.write(input);
+          terminal = null;
         }
 
+        const fdsBefore = openFds();
         for (let i = 0; i < N; i++) await one(i);
 
         let sink;
         function churn() {
           for (let i = 0; i < 500; i++) sink = { i, a: new Array(32).fill(i) };
         }
-        for (let i = 0; i < 200 && collected < N; i++) {
+        // Collection runs the finalizer, which hands the remaining pty fds to
+        // a close thread; poll both conditions rather than a delay.
+        let fdsAfter = openFds();
+        for (let i = 0; i < 50 && (collected < N || fdsAfter > fdsBefore); i++) {
           churn();
           Bun.gc(true);
           await new Promise(r => setImmediate(r));
+          fdsAfter = openFds();
         }
-        console.log(JSON.stringify({ exits, collected, drainsAfterExit }));
+        console.log(JSON.stringify({ exits, collected, callbacksAfterExit, leakedFds: Math.max(0, fdsAfter - fdsBefore) }));
       `;
 
       await using proc = Bun.spawn({
@@ -831,7 +848,7 @@ describe("Bun.Terminal", () => {
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual({ exits: 4, collected: 4, drainsAfterExit: 0 });
+      expect(JSON.parse(stdout)).toEqual({ exits: 4, collected: 4, callbacksAfterExit: 0, leakedFds: 0 });
       expect(exitCode).toBe(0);
     });
   });

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -821,6 +821,9 @@ describe("Bun.Terminal", () => {
           terminal = null;
         }
 
+        // Spawn once first so any fd the spawn machinery opens lazily and
+        // keeps is part of the baseline.
+        await Bun.spawn(["sh", "-c", "exit 0"], { stdio: ["ignore", "ignore", "ignore"] }).exited;
         const fdsBefore = openFds();
         for (let i = 0; i < N; i++) await one(i);
 

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -768,9 +768,9 @@ describe("Bun.Terminal", () => {
     });
 
     // Input the child never read can never drain once the last slave fd is
-    // gone, because a pty master answers EAGAIN instead of EPIPE. The writer
-    // used to wait for that drain forever, which kept the wrapper (and the
-    // callbacks it roots) alive with its three pty fds for the rest of the
+    // gone, because a Linux pty master answers EAGAIN instead of EPIPE. The
+    // writer used to wait for that drain forever, which kept the wrapper (and
+    // the callbacks it roots) alive with its three pty fds for the rest of the
     // process, and kept its poll re-arming on a permanent POLLHUP. PTY EOF now
     // ends the writer and closes the reader, so `exit` is the last callback,
     // a later write() is dropped instead of queued, and the wrapper becomes
@@ -778,7 +778,11 @@ describe("Bun.Terminal", () => {
     // (the line discipline stops accepting once its line buffer is full) and
     // one unterminated line (the kernel keeps discarding it, so an unfixed
     // build delivers late echo and a late `drain` after `exit`).
-    test.skipIf(isWindows)("terminal is released after the child exits with input it never read", async () => {
+    // Linux-only: macOS fails the same write with EIO, which the writer
+    // reports as an error and which closes the whole terminal, so the queue
+    // never gets stuck and a post-EOF write throws there instead. The code
+    // under test is shared.
+    test.skipIf(!isLinux)("terminal is released after the child exits with input it never read", async () => {
       const childSrc = /* js */ `
         const { readdirSync } = require("node:fs");
         const openFds = () => readdirSync("/dev/fd").length;


### PR DESCRIPTION
### Problem
- Since #36962 (v1.4.0), a POSIX `Bun.spawn({ terminal })` whose child exits with `terminal.write()` input still queued never releases the `Terminal` or its callbacks. It keeps three pty fds until process exit, spins on `POLLHUP` (2.6 s CPU per 2 s idle), and queues every later write in memory.
- At reader EOF every slave fd is gone, so the queue can never drain: a pty master answers `EAGAIN`, not `EPIPE`. `writer_has_buffered` stayed set and `maybe_downgrade_after_eof` (`Terminal.rs:1826` on main) never downgraded. Late echo after the `EIO` also re-upgraded `this_value` in `on_read_chunk`.
### Fix
- On POSIX `on_reader_finished` ends the writer and closes the reader: `WRITER_DONE` is set before the downgrade check, `exit` is the last callback, and a later `write()` returns without queuing.
- The `CONNECTED` flag and its upgrade are deleted: `this_value` is strong until EOF, so the upgrade only fired on that late echo. The downgrade now waits for a new `EXIT_DISPATCHED` flag, set after the `exit` callback returns, instead of `READER_DONE`, so the wrapper stays strong through its last dispatch.
- Behaviour change: no `drain` or `data` after `exit`. The #36962 test that expected a late `drain` is replaced: that drain came only from the kernel discarding an unterminated line.
- Verified: the new `terminal.test.ts` block (collection, fd count, late callbacks) fails on 1.4.3 and passes 10 of 10. Also all of `test/js/bun/terminal/` and `spawn.test.ts`.
### Background
- `Terminal` holds its wrapper in a `JsRef`, strong while a callback can fire, because the wrapper's cached slots are the callbacks' only GC root.
- A `BufferedReader` and a `PosixStreamingWriter` drive the pty master. The writer queues what `write(2)` refuses and waits for `POLLOUT`.
- At child exit bun closes its slave fd, the master reads `EIO` (Linux) or EOF (macOS), and `exit` fires.

<details><summary>Notes</summary>

Reproduction on released bun (1.4.3-canary.1, Linux x64, kernel 7.0):

```js
let proc = Bun.spawn(["sh", "-c", "exit 0"], { terminal: { data() {}, exit() {}, drain() {} } });
const big = Buffer.alloc(65536, "a\n");
for (let i = 0; i < 32; i++) proc.terminal.write(big);   // ~2 MB the child never reads
await proc.exited;
```

- Leak: with a `FinalizationRegistry` on `proc.terminal` and a `Bun.gc(true)` loop, 0 of 5 wrappers are collected. Without the `write()` calls, 5 of 5.
- Fds: `/dev/fd` grows by 3 per terminal (master plus the reader and writer dups) and never shrinks. With the fix it returns to the baseline once the wrappers are collected.
- Spin: `process.cpuUsage()` over 2 s of idle after `proc.exited` reports 2603 ms of CPU. Without the write, 3 ms. With the fix, 39 ms.
- Post-exit writes: 64 MB of `terminal.write()` after `proc.exited` grows RSS by 178 MB on 1.4.3 (256 MB grows it by 491 MB). With the fix, 3 to 4 MB.
- Size: there is no clean threshold. The wrapper leaks whenever part of the input is still queued in the writer at EOF (8 KB of lines was enough here, 12 KB happened to fit) and, at any size, whenever echo arrives after the `EIO` (seen with 1 KB). With an unterminated line the kernel keeps discarding input, so an unfixed build drains after a few hundred ms, fires a late `drain`, and then releases the wrapper; with complete lines the queue is stuck for good.

Why the reader is closed too: on Linux the master read fails with `EIO` as soon as the last slave fd closes, but the slave's line discipline keeps processing input that was already queued and echoes it back, so later reads return data again. The reader's poll stayed armed after the error, delivered those chunks to `data` after `exit`, and the old `CONNECTED` branch re-rooted the wrapper on the first one. EOF (the macOS path) already closes the reader inside `BufferedReader`; the error path now matches it.

Why the writer is ended in `Terminal` and not in `PosixPipeWriter::on_poll`: a first version made `on_poll` report `EndOfFile` when a short write met `POLLHUP`, for every posix writer. With the terminal change in place the pty case no longer reaches that branch (measured: the spin is gone with the terminal change alone), and pipes and sockets fail with `EPIPE` or `ECONNRESET` there instead, so the generic change had no reachable case and was dropped.

`write()` after PTY EOF returns the byte length and drops the bytes. Before this change the same call also returned the byte length but queued the bytes in the writer forever (the RSS numbers above), so the return value is unchanged and the memory growth is gone. Throwing was rejected because `terminal.closed` is still `false` in that state.

Windows is unchanged: its writer already reports close when the conhost input pipe breaks, and the test is skipped there because it spawns `sh`.

`test/js/bun/spawn/spawn-pipe-leak.test.ts` fails the same way in my container on `main` and on this branch (three 500-process leak tests time out at 30 s on a debug ASAN build), so it is not a regression from this diff.

Self-reviewed: the review asked for the fd assertion, the post-exit write coverage, the regression origin and the measured consequences in this body, and deletion of the dead `CONNECTED` state instead of a guard. All done. An RSS assertion was not added: the post-exit writes in the test already fail the collection and fd checks on a build without the `write()` guard (verified by removing it), and RSS bounds are noisy under ASAN.

`cargo check -p bun_runtime` is clean for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/terminal/terminal.test.ts

<!-- robobun:evidence:end -->