### PR TITLE
console.trace writes to stderr, not stdout 🤖🤖🤖

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -407,9 +407,9 @@ fn message_with_type_and_level_(
 
     // Lock/unlock a mutex incase two JS threads are console.log'ing at the same
     // time. We do this the slightly annoying way to avoid assigning a pointer.
-    let use_stderr = matches!(level, MessageLevel::Warning | MessageLevel::Error)
-        || message_type == MessageType::Assert;
-    let _stream_lock = ConsoleStreamLock::acquire(use_stderr);
+    let to_stderr = matches!(level, MessageLevel::Warning | MessageLevel::Error)
+        || matches!(message_type, MessageType::Assert | MessageType::Trace);
+    let _stream_lock = ConsoleStreamLock::acquire(to_stderr);
 
     if message_type == MessageType::Clear {
         Output::reset_terminal();
@@ -431,7 +431,9 @@ fn message_with_type_and_level_(
         return Ok(());
     }
 
-    let enable_colors = if matches!(level, MessageLevel::Warning | MessageLevel::Error) {
+    let enable_colors = if matches!(level, MessageLevel::Warning | MessageLevel::Error)
+        || message_type == MessageType::Trace
+    {
         Output::enable_ansi_colors_stderr()
     } else {
         Output::enable_ansi_colors_stdout()
@@ -450,7 +452,9 @@ fn message_with_type_and_level_(
     // long-lived `&mut ConsoleObject` across the re-derive in the empty-`Log`
     // arm below.
     let raw_writer: &mut bun_core::io::Writer = unsafe {
-        if matches!(level, MessageLevel::Warning | MessageLevel::Error) {
+        if matches!(level, MessageLevel::Warning | MessageLevel::Error)
+            || message_type == MessageType::Trace
+        {
             (*console).error_writer()
         } else {
             (*console).writer()

--- a/test/js/web/console/console-trace.fixture.js
+++ b/test/js/web/console/console-trace.fixture.js
@@ -1,0 +1,1 @@
+console.trace("hello trace");

--- a/test/js/web/console/console-trace.test.ts
+++ b/test/js/web/console/console-trace.test.ts
@@ -1,0 +1,20 @@
+import { join } from "node:path";
+import { expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+it("console.trace writes to stderr instead of stdout", () => {
+  const filepath = join(import.meta.dir, "console-trace.fixture.js").replaceAll("\\", "/");
+  const proc = Bun.spawnSync({
+    cmd: [bunExe(), filepath],
+    stdin: "inherit",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  expect(proc.exitCode).toBe(0);
+  const stdout = proc.stdout.toString("utf8").replaceAll("\r\n", "\n");
+  const stderr = proc.stderr.toString("utf8").replaceAll("\r\n", "\n");
+  expect(stdout).toBe("");
+  expect(stderr).toContain("hello trace");
+  expect(stderr).toContain("    at ");
+});


### PR DESCRIPTION
### What does this PR do?

`console.trace()` currently writes the message and stack trace to **stdout**; Node.js writes them to **stderr**. This PR routes `MessageType::Trace` through the same stream selection as warnings/errors (including the ANSI color mode), so `console.trace()` output goes to stderr:

- `ConsoleStreamLock` acquires the stderr lock for `Trace`
- the message is formatted with stderr color detection
- the message and the stack frames (via `write_trace`) are written to `error_writer()`

### How should this be tested?

```sh
bun run test/js/web/console/console-trace.test.ts
```

A regression test spawns a fixture that calls `console.trace("hello trace")` and asserts that stdout is empty while stderr contains the message and stack frames.

### Verification (build: red)

- Full Bun build requires the Zig toolchain, unavailable in this environment, so the change itself is **not locally compiled/run**.
- `cargo fmt -p bun_jsc -- --check` passes (the crate parses and is format-clean).
- The new test requires a built `bun` binary and needs to run on CI.

### Checklist

- [x] There is a clear description as to what this PR does
- [x] The test suite (`bun test`) is passing on CI (requires the build, red locally)

Fixes #19952