### PR TITLE
spawn: a direct stdin stream whose pull() throws no longer throws out of Bun.spawn()

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -752,11 +752,8 @@ JSValue readDirectStream(JSGlobalObject* globalObject, JSReadableStream* stream,
     ASSERT(!pullArgs.hasOverflowed());
     JSValue maybePromise = call(globalObject, pull, getCallData(pull), source->thisValue(), pullArgs);
     if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
-        // `pull` is a callback returning Promise<undefined>, so a synchronous throw is its rejection, handled as
-        // onReadDirectStreamPullRejected handles an async one: the sink has started and may hold bytes pull() wrote,
-        // so fail it from this side and hand the owner the rejection instead of returning to it abruptly. The owner
-        // reads the promise's state, as with close(error) below. A throw after pull() ended or closed the sink has
-        // nothing left to fail and falls through. A VM termination is not converted.
+        // A synchronous throw is pull()'s rejection: fail the sink and hand the owner a rejected promise it can read the
+        // state of, as onReadDirectStreamPullRejected does for an async pull(). A VM termination is not converted.
         JSValue reason = exception->value();
         TRY_CLEAR_EXCEPTION(scope, {});
         if (sinkController->wrapped()) {

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -751,15 +751,24 @@ JSValue readDirectStream(JSGlobalObject* globalObject, JSReadableStream* stream,
     pullArgs.append(sinkController);
     ASSERT(!pullArgs.hasOverflowed());
     JSValue maybePromise = call(globalObject, pull, getCallData(pull), source->thisValue(), pullArgs);
-    RETURN_IF_EXCEPTION(scope, {});
-
-    // Resolving without close()/end() ends the sink controller first; a sync return waits for close()/end().
-    if (auto* pullPromise = dynamicDowncast<JSPromise>(maybePromise)) {
+    if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
+        // `pull` is a callback returning Promise<undefined>, so a synchronous throw is its rejection, and the
+        // sink has started and may hold bytes pull() wrote: fail it from this side as the rejection handler of an
+        // async pull() does, then report it below like a sync close(error) instead of returning abruptly to the
+        // owner. A throw after pull() ended or closed the sink has nothing left to fail. A VM termination is not converted.
+        JSValue reason = exception->value();
+        TRY_CLEAR_EXCEPTION(scope, {});
+        if (sinkController->wrapped()) {
+            sinkController->close(globalObject, reason.toBoolean(globalObject) ? reason : JSValue(createError(globalObject, "pull() threw"_s)));
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+    } else if (auto* pullPromise = dynamicDowncast<JSPromise>(maybePromise)) {
+        // Resolving without close()/end() ends the sink controller first; a sync return waits for close()/end().
         auto* result = JSPromise::create(vm, globalObject->promiseStructure());
         pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onReadDirectStreamPullFulfilled(), runtime->onReadDirectStreamPullRejected(), result, sinkController);
         return result;
     }
-    // A sync pull() that called close(error): the owner hears it the way it hears an async one.
+    // A sync pull() that called close(error) or threw: the owner hears it the way it hears an async one.
     if (JSValue failed = sinkController->m_failReason.get()) {
         auto* rejected = promiseRejectedWith(globalObject, failed);
         RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -752,15 +752,19 @@ JSValue readDirectStream(JSGlobalObject* globalObject, JSReadableStream* stream,
     ASSERT(!pullArgs.hasOverflowed());
     JSValue maybePromise = call(globalObject, pull, getCallData(pull), source->thisValue(), pullArgs);
     if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
-        // `pull` is a callback returning Promise<undefined>, so a synchronous throw is its rejection, and the
-        // sink has started and may hold bytes pull() wrote: fail it from this side as the rejection handler of an
-        // async pull() does, then report it below like a sync close(error) instead of returning abruptly to the
-        // owner. A throw after pull() ended or closed the sink has nothing left to fail. A VM termination is not converted.
+        // `pull` is a callback returning Promise<undefined>, so a synchronous throw is its rejection, handled as
+        // onReadDirectStreamPullRejected handles an async one: the sink has started and may hold bytes pull() wrote,
+        // so fail it from this side and hand the owner the rejection instead of returning to it abruptly. The owner
+        // reads the promise's state, as with close(error) below. A throw after pull() ended or closed the sink has
+        // nothing left to fail and falls through. A VM termination is not converted.
         JSValue reason = exception->value();
         TRY_CLEAR_EXCEPTION(scope, {});
         if (sinkController->wrapped()) {
             sinkController->close(globalObject, reason.toBoolean(globalObject) ? reason : JSValue(createError(globalObject, "pull() threw"_s)));
             RETURN_IF_EXCEPTION(scope, {});
+            auto* rejected = promiseRejectedWith(globalObject, reason);
+            markPromiseAsHandled(vm, rejected);
+            return rejected;
         }
     } else if (auto* pullPromise = dynamicDowncast<JSPromise>(maybePromise)) {
         // Resolving without close()/end() ends the sink controller first; a sync return waits for close()/end().
@@ -768,7 +772,7 @@ JSValue readDirectStream(JSGlobalObject* globalObject, JSReadableStream* stream,
         pullPromise->performPromiseThenWithContext(vm, globalObject, runtime->onReadDirectStreamPullFulfilled(), runtime->onReadDirectStreamPullRejected(), result, sinkController);
         return result;
     }
-    // A sync pull() that called close(error) or threw: the owner hears it the way it hears an async one.
+    // A sync pull() that called close(error): the owner hears it the way it hears an async one.
     if (JSValue failed = sinkController->m_failReason.get()) {
         auto* rejected = promiseRejectedWith(globalObject, failed);
         RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -752,8 +752,7 @@ JSValue readDirectStream(JSGlobalObject* globalObject, JSReadableStream* stream,
     ASSERT(!pullArgs.hasOverflowed());
     JSValue maybePromise = call(globalObject, pull, getCallData(pull), source->thisValue(), pullArgs);
     if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
-        // A synchronous throw is pull()'s rejection: fail the sink and hand the owner a rejected promise it can read the
-        // state of, as onReadDirectStreamPullRejected does for an async pull(). A VM termination is not converted.
+        // A synchronous throw is pull()'s rejection: fail the sink and reject to the owner as onReadDirectStreamPullRejected does. A VM termination is not converted.
         JSValue reason = exception->value();
         TRY_CLEAR_EXCEPTION(scope, {});
         if (sinkController->wrapped()) {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1174,6 +1174,34 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       await expect(Bun.write(join(String(dir), "upfront.txt"), upfront)).rejects.toThrow("boom");
     });
 
+    // A synchronous throw from pull() is its rejection: it fails the sink and rejects the write, as the async
+    // throw above does. A falsy thrown value cannot fail a sink (close() reads it as a clean close), so the sink
+    // records a substitute Error and the write reports that.
+    it("a direct pull() that throws synchronously rejects the write and errors the stream", async () => {
+      using dir = tempDir("bun-write-direct-sync-throw", {});
+      const attempt = async thrown => {
+        const stream = new ReadableStream({
+          type: "direct",
+          pull(c) {
+            c.write("a");
+            throw thrown;
+          },
+        });
+        const result = await Bun.write(join(String(dir), "out.txt"), new Response(stream)).then(
+          written => "resolved " + written,
+          error => "rejected " + (error instanceof Error ? error.message : String(error)),
+        );
+        // directStreamOnClose released the sink's lock, so the terminal state is observable through a reader.
+        const state = await stream.getReader().closed.then(
+          () => "closed",
+          () => "errored",
+        );
+        return { result, state };
+      };
+      expect(await attempt(new Error("boom"))).toEqual({ result: "rejected boom", state: "errored" });
+      expect(await attempt(null)).toEqual({ result: "rejected pull() threw", state: "errored" });
+    });
+
     // The sink is released when the pump rejects; a controller collected after that must
     // already be detached. A subprocess, because that GC can be the one at process exit.
     it("survives a GC after a direct stream or a generator body fails", async () => {

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -8,6 +8,7 @@ import {
   expectMaxObjectTypeCount,
   isASAN,
   isDebug,
+  isLinux,
   isWindows,
   runFixtureMaxRSS,
   tempDir,
@@ -359,6 +360,123 @@ describe("spawn stdin ReadableStream", () => {
     expect(stdout.trim()).toBe("uncaught=0");
     expect(exitCode).toBe(0);
   });
+
+  // The child is already running when stdin is wired up, so an exception
+  // escaping spawn() here would lose the Subprocess handle (nothing to kill or
+  // await). A synchronous throw from a direct stream's pull() fails the stdin
+  // pipe instead: the bytes it flushed are delivered, stdin is closed, and the
+  // child sees EOF, as with `async pull() { throw }`. Where the error itself is
+  // then reported is not asserted here.
+  test("a direct ReadableStream whose pull() throws synchronously does not throw out of spawn()", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        process.on("unhandledRejection", () => {});
+        let child, threw = "nothing";
+        try {
+          child = Bun.spawn({
+            cmd: [process.execPath, "-e", "process.stdin.pipe(process.stdout)"],
+            stdin: new ReadableStream({
+              type: "direct",
+              pull(controller) {
+                controller.write("before throw|");
+                controller.flush();
+                throw new Error("sync pull boom");
+              },
+            }),
+            stdout: "pipe",
+          });
+        } catch (e) {
+          threw = e.message;
+        }
+        const [out, exitCode] = child ? await Promise.all([child.stdout.text(), child.exited]) : ["", "no child"];
+        console.log(JSON.stringify({ threw, returned: typeof child, out, exitCode }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({
+      threw: "nothing",
+      returned: "object",
+      out: "before throw|",
+      exitCode: 0,
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // The same exit without a user `throw`: the child exits before a synchronous
+  // pull() flushes, so the flush inside pull() fails with EPIPE. That error
+  // escaped spawn() too, and the child it lost was never reaped (one zombie
+  // per call). Linux-only: it reads /proc to see the child exit from inside
+  // pull(), where the Subprocess does not exist yet.
+  test.skipIf(!isLinux)(
+    "a write error inside a synchronous pull() does not throw out of spawn() or leave a zombie",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const fs = require("node:fs");
+          process.on("unhandledRejection", () => {});
+          // Child processes of this one by /proc state ("Z" = exited, not yet reaped).
+          function children() {
+            const states = { Z: 0, live: 0 };
+            for (const d of fs.readdirSync("/proc")) {
+              if (!/^\\d+$/.test(d)) continue;
+              let stat;
+              try { stat = fs.readFileSync("/proc/" + d + "/stat", "utf8"); } catch { continue; }
+              const [st, ppid] = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+              if (ppid === String(process.pid)) states[st === "Z" ? "Z" : "live"]++;
+            }
+            return states;
+          }
+          let child, threw = "nothing", sawExit = false;
+          try {
+            child = Bun.spawn({
+              cmd: ["true"],
+              stdin: new ReadableStream({
+                type: "direct",
+                pull(controller) {
+                  // spawn() has forked already; wait here until the child has exited
+                  // (zombie, or already reaped by a waiter thread) so its end of the
+                  // stdin pipe is closed and the flush below fails with EPIPE.
+                  const deadline = Date.now() + 30_000;
+                  while (!(sawExit = children().live === 0) && Date.now() < deadline) {}
+                  controller.write("x");
+                  controller.close();
+                },
+              }),
+            });
+          } catch (e) {
+            threw = e.code ?? e.message;
+          }
+          const exitCode = child ? await child.exited : "no child";
+          console.log(JSON.stringify({ sawExit, threw, returned: typeof child, exitCode, zombies: children().Z }));
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(JSON.parse(stdout)).toEqual({
+        sawExit: true,
+        threw: "nothing",
+        returned: "object",
+        exitCode: 0,
+        zombies: 0,
+      });
+      expect(exitCode).toBe(0);
+    },
+  );
 
   // The ReadableStream -> stdin FileSink pump intentionally does not await the
   // Promise FileSink.write() returns for writes it cannot complete synchronously

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1439,12 +1439,13 @@ it("throws when an ArrayBufferView is used for stdout or stderr", async () => {
   expect(exitCode).toBe(0);
 });
 
-it.skipIf(isWindows)("leaves a caller-supplied stdout fd open when stdin stream setup fails", async () => {
+it.skipIf(isWindows)("leaves a caller-supplied stdout fd open when the stdin stream's pull() throws", async () => {
   const file = join(tmp, "stdin-setup-failure.txt");
   const fixture = `
     const { openSync, fstatSync, writeSync, closeSync } = require("node:fs");
     const fd = openSync(process.env.OUT_FILE, "w");
     // The stdin sink invokes pull() synchronously while Bun.spawn wires up stdin.
+    // The throw fails only the stdin pump; the child still runs with the fd as stdout.
     const stream = new ReadableStream({
       type: "direct",
       pull() {
@@ -1452,11 +1453,13 @@ it.skipIf(isWindows)("leaves a caller-supplied stdout fd open when stdin stream 
       },
     });
     let message = "did not throw";
+    let child;
     try {
-      Bun.spawn({ cmd: [process.execPath, "-e", "0"], stdio: [stream, fd, "ignore"] });
+      child = Bun.spawn({ cmd: [process.execPath, "-e", "0"], stdio: [stream, fd, "ignore"] });
     } catch (err) {
       message = err.message;
     }
+    if (child) await child.exited;
     fstatSync(fd);
     writeSync(fd, "still-open");
     closeSync(fd);
@@ -1471,15 +1474,15 @@ it.skipIf(isWindows)("leaves a caller-supplied stdout fd open when stdin stream 
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("pull unavailable");
+  expect(stdout.trim()).toBe("did not throw");
   expect(readFileSync(file, "utf8")).toContain("still-open");
   expect(exitCode).toBe(0);
 });
 
-it.skipIf(isWindows)("leaves a Bun.file(fd) stdout open when stdin stream setup fails", async () => {
+it.skipIf(isWindows)("leaves a Bun.file(fd) stdout open when the stdin stream's pull() throws", async () => {
   // Bun.file(fd) as stdout is an fd-backed Blob; extract_blob lowers it to
-  // Stdio::Fd before spawn, so the error-path cleanup must recognise it as
-  // caller-owned via the Fd variant and leave it open.
+  // Stdio::Fd before spawn, so it stays caller-owned: neither the spawn nor
+  // the failed stdin pump may close it.
   const file = join(tmp, "stdin-setup-failure-blob.txt");
   const fixture = `
     const { openSync, fstatSync, writeSync, closeSync } = require("node:fs");
@@ -1492,11 +1495,13 @@ it.skipIf(isWindows)("leaves a Bun.file(fd) stdout open when stdin stream setup 
       },
     });
     let message = "did not throw";
+    let child;
     try {
-      Bun.spawn({ cmd: [process.execPath, "-e", "0"], stdio: [stream, Bun.file(fd), "ignore"] });
+      child = Bun.spawn({ cmd: [process.execPath, "-e", "0"], stdio: [stream, Bun.file(fd), "ignore"] });
     } catch (err) {
       message = err.message;
     }
+    if (child) await child.exited;
     fstatSync(fd);
     writeSync(fd, "still-open");
     closeSync(fd);
@@ -1511,7 +1516,7 @@ it.skipIf(isWindows)("leaves a Bun.file(fd) stdout open when stdin stream setup 
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(stdout.trim()).toBe("pull unavailable");
+  expect(stdout.trim()).toBe("did not throw");
   expect(readFileSync(file, "utf8")).toContain("still-open");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem
- `Bun.spawn({ stdin })` with a `type: "direct"` stream throws out of `Bun.spawn()` when the synchronous `pull()` throws, or when `c.close()` inside it hits `EPIPE` because the child already exited. The caller never gets the `Subprocess`, and the child is detached without being reaped (one zombie per call).
- The cause is `readDirectStream` (`src/jsc/bindings/webcore/streams/BunStreamSource.cpp:754`). A synchronous throw from `pull()` escapes as an exception, while a rejected `pull()` promise or a sync `close(error)` reaches the sink owner as a rejected pump promise. Of the six owners only spawn rethrows the exception.

### Fix
- On a synchronous throw, fail the sink controller with the thrown value and return an already-rejected, handled promise carrying it, as the rejection handler of an async `pull()` does. This is also how a sync `pull()` that called `close(error)` is reported since #42114. A throw after `pull()` already ended or closed the sink falls through to that existing tail.
- Spawn's `Rejected` arm closes stdin: `Bun.spawn` returns the `Subprocess`, the child reads EOF and is reaped. `Bun.write`, `Bun.serve`, `fetch`, S3 and HTMLRewriter keep their behaviour through their `Rejected` arms. A VM termination is still propagated.
- Verified: `test/js/bun/spawn/spawn-stdin-readable-stream.test.ts` (two new tests) and `test/js/bun/io/bun-write.test.js` (one new test); all three fail on 1.4.3 and main. The suites listed in Notes pass under ASAN. Self-reviewed: 9 concerns, 2 on shape addressed, the rest in Notes.

### Background
- A direct stream's `pull(controller)` writes straight into a sink controller. For a native sink, `readDirectStream` starts the sink, calls `pull()` once, synchronously, and gives the owner `undefined`, a promise, or an exception. For spawn this runs after `posix_spawn`, and an exception is rethrown by `spawn_maybe_sync`.
- `m_failReason` on the controller cell is the error that failed the sink. The promise built from it is marked handled because owners read its state instead of attaching a reaction.

<details><summary>Notes</summary>

- Rule choice. #41532 addresses the same input with the other rule: a pump failure known before `Bun.spawn` returns throws from it, after killing and reaping the child. This PR is neutral on that: the failure is now a synchronously `Rejected` pump promise, which is exactly what #41532's post-watch check reads, so if that rule is chosen it applies to this case too and #41532's `FileSink.rs` wrapping of the exception becomes redundant. If the other rule is chosen (never throw after the fork, surface the error on the Subprocess, #36236's direction), nothing here needs to change. The EPIPE face is an argument for the latter: with a throw, a well-behaved program gets `EPIPE` out of `Bun.spawn()` whenever the child exits without reading stdin (`true`, `head`, a fast failure), while `async pull()` with the same body returns the Subprocess and resolves `exited` with the real code.
- A throw after `pull()` already ended or closed the sink has nothing left to fail and takes the clean-close tail, as `onReadDirectStreamPullRejected` does for a detached controller.
- A falsy thrown value (`throw null`) cannot fail a sink, because `close()` reads a falsy reason as a clean close, so the sink is failed with a substitute `Error("pull() threw")` while the owner's promise carries the thrown value, mirroring the async handler's `"pull() rejected"`. `Bun.write` reports the sink's recorded error in both cases; the new Bun.write test pins that and the `Errored` end state of the stream.
- Where the rejection surfaces afterwards is unchanged: `FileSink::handle_reject_stream` drops it, as for every async stdin producer error today. The new tests install an `unhandledRejection` handler and do not assert on it or on stderr, so they hold under either routing.
- The `Writable::init` error arm (`js_bun_spawn_bindings.rs:1360`) still detaches instead of reaping. After this change it is reachable from internal failures only (sink `start()` failing, the `close(reason)` above throwing, a VM termination during `pull()`), not from a user `pull()`. Moving the stdin wiring after `watch()` would cover those too; #41532 already carries that restructuring.
- Two tests in `spawn.test.ts` used a throwing `pull()` as the trigger for "stdin setup fails" and asserted the throw. They now assert that spawn returns and the caller-owned stdout fd stays open.
- Consumers checked for the exception vs rejected-promise difference: `Blob.rs` (Bun.write, drains microtasks then reads `Rejected`), `RequestContext.rs` (serve, `unwrap(MarkHandled)`), `FetchTasklet.rs`, `s3/client.rs`, `html_rewriter.rs`, `FileSink.rs` (spawn). Each has a `Rejected` arm; only spawn's exception arm differed in outcome.
- Before/after with the thread's repro on a debug build: `spawn(direct) THREW: sync-boom | subprocess = undefined` → `spawn(direct) returned object, exited 0`; `Bun.write(direct)` and `text(direct)` still reject with `sync-boom`; serve still reports the error and resets the connection; a fetch upload still rejects with `sync-boom`; no unhandled rejection.
- The zombie test reads `/proc` from inside `pull()` to wait for the child to exit (the Subprocess does not exist yet there), so it is Linux-only. It also passes with `BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1`.
- Suites run under ASAN: `spawn-stdin-readable-stream*.test.ts`, `spawn.test.ts` (including its waiter-thread rerun), `serve-direct-readable-stream.test.ts`, `streams.test.js`, `body-stream.test.ts`, `bun-write.test.js`, `html-rewriter.test.js`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.test.ts, test/js/bun/spawn/spawn-stdin-readable-stream.test.ts, test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->