### PR TITLE
webview: reject malformed Chrome replies instead of crashing

### DIFF
--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -603,8 +603,7 @@ static std::span<const char> sidSpan(const WTF::String& s)
     return { reinterpret_cast<const char*>(span.data()), span.size() };
 }
 
-// m_sessions keys must never be null Strings (StringHash derefs the impl);
-// fromUTF8 returns one for a missing field or invalid UTF-8. Empty = unusable.
+// Never null (a null String can't be an m_sessions key); empty = unusable.
 static WTF::String decodeSessionId(std::span<const char> utf8)
 {
     if (utf8.empty()) return WTF::emptyString();
@@ -1066,8 +1065,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
             settle(g, view, entry.slot, false, errorFromExceptionDetails(g, excDetails));
             return;
         }
-        // result.result.value = [cx, cy], the only shape kActionabilityIIFE
-        // returns. Anything else is a malformed reply.
+        // result.result.value = [cx, cy] from kActionabilityIIFE.
         auto inner = jsonField(result, { "result", 6 });
         auto value = jsonField(inner, { "value", 5 });
         auto root = value.empty() ? nullptr

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -603,11 +603,8 @@ static std::span<const char> sidSpan(const WTF::String& s)
     return { reinterpret_cast<const char*>(span.data()), span.size() };
 }
 
-// Every session id that reaches m_sessions goes through here, never through
-// String::fromUTF8 directly. fromUTF8 answers with a NULL String for a
-// missing field (jsonField returns a span with a null pointer) and for
-// invalid UTF-8, and a null String has no StringImpl for StringHash::hash to
-// read. The result is always hashable; empty means "no usable session id".
+// m_sessions keys must never be null Strings (StringHash derefs the impl);
+// fromUTF8 returns one for a missing field or invalid UTF-8. Empty = unusable.
 static WTF::String decodeSessionId(std::span<const char> utf8)
 {
     if (utf8.empty()) return WTF::emptyString();
@@ -803,8 +800,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         // {"sessionId":"<base64ish>"}
         auto session = decodeSessionId(jsonString(jsonField(result, { "sessionId", 9 })));
         if (session.isEmpty()) {
-            // Nothing addresses the page without a session id, so the load
-            // can never complete. Fail the navigation now.
+            // No session id, no way to address the page: the load can't finish.
             settleFailure(g, view, entry.slot, entry.method,
                 createError(g, "malformed attach response"_s));
             return;
@@ -1070,10 +1066,8 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
             settle(g, view, entry.slot, false, errorFromExceptionDetails(g, excDetails));
             return;
         }
-        // result.result.value = [cx, cy] — the only shape kActionabilityIIFE
-        // returns. WTF::JSON parses the two numbers to a C++ tree: no
-        // JSValue allocation for a pair we read once, and a reply that is
-        // not that pair fails the parse instead of the click.
+        // result.result.value = [cx, cy], the only shape kActionabilityIIFE
+        // returns. Anything else is a malformed reply.
         auto inner = jsonField(result, { "result", 6 });
         auto value = jsonField(inner, { "value", 5 });
         auto root = value.empty() ? nullptr
@@ -1083,8 +1077,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         auto point = root ? root->asArray() : nullptr;
         auto px = point && point->length() == 2 ? point->get(0)->asDouble() : std::nullopt;
         auto py = px ? point->get(1)->asDouble() : std::nullopt;
-        // "1e999" parses to infinity, which Command::num would put on the
-        // wire as a bare `Infinity` token.
+        // isfinite: "1e999" parses to infinity, which is not JSON on the wire.
         if (!py || !std::isfinite(*px) || !std::isfinite(*py)) {
             settle(g, view, entry.slot, false, createError(g, "malformed click response"_s));
             return;

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -857,8 +857,11 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         // sessionId — actually the event handler uses m_sessions, not
         // m_pending, so we just drop here.
         auto err = jsonString(jsonField(result, { "errorText", 9 }));
-        if (!err.empty())
-            settleFailure(g, view, entry.slot, entry.method, createError(g, WTF::String::fromUTF8(err)));
+        if (!err.empty()) {
+            auto errStr = WTF::String::fromUTF8(err); // null if not valid UTF-8
+            settleFailure(g, view, entry.slot, entry.method,
+                createError(g, errStr.isEmpty() ? "navigation failed"_s : errStr));
+        }
         // Else: don't settle — Page.loadEventFired does.
         return;
     }

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -603,13 +603,12 @@ static std::span<const char> sidSpan(const WTF::String& s)
     return { reinterpret_cast<const char*>(span.data()), span.size() };
 }
 
-// Never null (a null String can't be an m_sessions key); empty = unusable.
-static WTF::String decodeSessionId(std::span<const char> utf8)
+// Session ids are ASCII (sidSpan relies on it). Never null; empty = unusable.
+static WTF::String decodeSessionId(std::span<const char> bytes)
 {
-    if (utf8.empty()) return WTF::emptyString();
-    auto decoded = WTF::String::fromUTF8(utf8);
-    if (decoded.isNull()) return WTF::emptyString();
-    return decoded;
+    auto chars = byteCast<Latin1Character>(bytes);
+    if (chars.empty() || !charactersAreAllASCII(chars)) return WTF::emptyString();
+    return WTF::String(chars);
 }
 
 // Bun click button → CDP button enum string. CDP's Input.dispatchMouseEvent

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -602,6 +602,19 @@ static std::span<const char> sidSpan(const WTF::String& s)
     return { reinterpret_cast<const char*>(span.data()), span.size() };
 }
 
+// Every session id that reaches m_sessions goes through here, never through
+// String::fromUTF8 directly. fromUTF8 answers with a NULL String for a
+// missing field (jsonField returns a span with a null pointer) and for
+// invalid UTF-8, and a null String has no StringImpl for StringHash::hash to
+// read. The result is always hashable; empty means "no usable session id".
+static WTF::String decodeSessionId(std::span<const char> utf8)
+{
+    if (utf8.empty()) return WTF::emptyString();
+    auto decoded = WTF::String::fromUTF8(utf8);
+    if (decoded.isNull()) return WTF::emptyString();
+    return decoded;
+}
+
 // Bun click button → CDP button enum string. CDP's Input.dispatchMouseEvent
 // takes a string: "none", "left", "middle", "right".
 static constexpr ASCIILiteral cdpButton(uint8_t b)
@@ -787,8 +800,15 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     }
     case Method::TargetAttachToTarget: {
         // {"sessionId":"<base64ish>"}
-        auto sid = jsonString(jsonField(result, { "sessionId", 9 }));
-        view->m_sessionId = WTF::String::fromUTF8(sid);
+        auto session = decodeSessionId(jsonString(jsonField(result, { "sessionId", 9 })));
+        if (session.isEmpty()) {
+            // Nothing addresses the page without a session id, so the load
+            // can never complete. Fail the navigation now.
+            settleFailure(g, view, entry.slot, entry.method,
+                createError(g, "malformed attach response"_s));
+            return;
+        }
+        view->m_sessionId = WTF::move(session);
         // Route events to this view via its viewId — m_views holds the one
         // Weak per view. A view with a slot set is rooted via the owner
         // predicate reading m_pendingActivityCount.
@@ -1049,22 +1069,25 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
             settle(g, view, entry.slot, false, errorFromExceptionDetails(g, excDetails));
             return;
         }
-        // result.result.value = [cx, cy]. jsonField gives us the array
-        // slice "[<cx>,<cy>]"; scan for the comma.
+        // result.result.value = [cx, cy] — the only shape kActionabilityIIFE
+        // returns. WTF::JSON parses the two numbers to a C++ tree: no
+        // JSValue allocation for a pair we read once, and a reply that is
+        // not that pair fails the parse instead of the click.
         auto inner = jsonField(result, { "result", 6 });
         auto value = jsonField(inner, { "value", 5 });
-        // Skip leading '['
-        const char* p = value.data();
-        const char* end = p + value.size();
-        while (p < end && (*p == '[' || *p == ' '))
-            ++p;
-        // Parse cx (float until comma)
-        char* ep;
-        float cx = strtof(p, &ep);
-        p = ep;
-        while (p < end && (*p == ',' || *p == ' '))
-            ++p;
-        float cy = strtof(p, nullptr);
+        auto root = value.empty() ? nullptr
+                                  : JSON::Value::parseJSON(
+                                        StringView::fromLatin1(std::span<const Latin1Character>(
+                                            reinterpret_cast<const Latin1Character*>(value.data()), value.size())));
+        auto point = root ? root->asArray() : nullptr;
+        auto px = point && point->length() == 2 ? point->get(0)->asDouble() : std::nullopt;
+        auto py = px ? point->get(1)->asDouble() : std::nullopt;
+        if (!py) {
+            settle(g, view, entry.slot, false, createError(g, "malformed click response"_s));
+            return;
+        }
+        float cx = static_cast<float>(*px);
+        float cy = static_cast<float>(*py);
 
         // Chain into dispatchMouseEvent. Same down+up pair as Ops::click.
         auto ss = view->m_sessionId.utf8();
@@ -1110,8 +1133,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     if (sessionId.empty()) {
         if (method.size() != 25 || memcmp(method.data(), "Target.detachedFromTarget", 25) != 0)
             return;
-        auto sid = jsonString(jsonField(params, { "sessionId", 9 }));
-        auto sidStr = WTF::String::fromUTF8(sid);
+        auto sidStr = decodeSessionId(jsonString(jsonField(params, { "sessionId", 9 })));
         auto it = m_sessions.find(sidStr);
         if (it == m_sessions.end()) return;
         uint32_t vid = it->value;
@@ -1126,7 +1148,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         updateKeepAlive();
         return;
     }
-    auto sidStr = WTF::String::fromUTF8(sessionId);
+    auto sidStr = decodeSessionId(sessionId);
     auto it = m_sessions.find(sidStr);
     if (it == m_sessions.end()) return;
     JSWebView* view = viewFor(it->value);

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -25,6 +25,7 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/Base64.h>
 
+#include <cmath>
 #include <errno.h>
 #include <mutex>
 #include <stdio.h>
@@ -1082,12 +1083,14 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         auto point = root ? root->asArray() : nullptr;
         auto px = point && point->length() == 2 ? point->get(0)->asDouble() : std::nullopt;
         auto py = px ? point->get(1)->asDouble() : std::nullopt;
-        if (!py) {
+        // "1e999" parses to infinity, which Command::num would put on the
+        // wire as a bare `Infinity` token.
+        if (!py || !std::isfinite(*px) || !std::isfinite(*py)) {
             settle(g, view, entry.slot, false, createError(g, "malformed click response"_s));
             return;
         }
-        float cx = static_cast<float>(*px);
-        float cy = static_cast<float>(*py);
+        double cx = *px;
+        double cy = *py;
 
         // Chain into dispatchMouseEvent. Same down+up pair as Ops::click.
         auto ss = view->m_sessionId.utf8();

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -40,6 +40,7 @@ const cdpErrorOn = process.argv.find(a => a.startsWith("--cdp-error-on="))?.slic
 //   attach-no-session-id   Target.attachToTarget answers {}
 //   attach-bad-utf8        ... answers a sessionId that is not valid UTF-8
 //   click-no-value         the click(selector) check answers without result.value
+//   click-huge-value       ... answers a position too large for a double (1e999)
 //   detach-no-session-id   Target.detachedFromTarget arrives with params {}
 //   event-bad-utf8         a page event arrives with an invalid UTF-8 sessionId
 const malformed = process.argv.find(a => a.startsWith("--malformed="))?.slice("--malformed=".length);
@@ -143,6 +144,12 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       // process cannot run it; answer the [cx, cy] the page would return.
       if (params.expression.includes("elementFromPoint")) {
         if (malformed === "click-no-value") return reply({ result: { type: "undefined" } });
+        // JSON.stringify cannot write 1e999 (it is Infinity, which encodes
+        // as null), so the literal goes in by hand.
+        if (malformed === "click-huge-value") {
+          const frame = JSON.stringify({ id, result: { result: { type: "object", value: "HUGE" } }, sessionId });
+          return sendBytes(Buffer.from(frame.replace('"HUGE"', "[1e999,0]") + "\0"));
+        }
         return reply({ result: { type: "object", value: [12, 34] } });
       }
       let value: unknown;

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -44,12 +44,12 @@ const cdpErrorOn = process.argv.find(a => a.startsWith("--cdp-error-on="))?.slic
 //   click-huge-value       ... answers a position too large for a double (1e999)
 //   detach-no-session-id   Target.detachedFromTarget arrives with params {}
 //   event-bad-utf8         a page event arrives with an invalid UTF-8 sessionId
+//   navigate-bad-utf8      Page.navigate answers an errorText that is not valid UTF-8
 const malformed = process.argv.find(a => a.startsWith("--malformed="))?.slice("--malformed=".length);
 
-// Stands in for a session id until sendInvalidSessionId() overwrites its
-// first byte. JSON.stringify cannot emit invalid UTF-8, so the byte goes in
-// after the encode.
-const BAD_SESSION_ID = "not-utf8";
+// Placeholder that sendWithInvalidUtf8() corrupts after the encode, since
+// JSON.stringify cannot emit invalid UTF-8 itself.
+const BAD_UTF8 = "not-utf8";
 
 const NO_REPLY = Symbol("no reply");
 let commandsClosed = false;
@@ -90,11 +90,11 @@ function send(message: unknown) {
   sendBytes(Buffer.from(JSON.stringify(message) + "\0"));
 }
 
-// The message with BAD_SESSION_ID wherever it appears turned into bytes that
-// are not valid UTF-8: 0xff is never a legal UTF-8 byte.
-function sendInvalidSessionId(message: unknown) {
+// The message with the first byte of BAD_UTF8 overwritten by 0xff, which is
+// never a legal UTF-8 byte.
+function sendWithInvalidUtf8(message: unknown) {
   const bytes = Buffer.from(JSON.stringify(message) + "\0");
-  bytes[bytes.indexOf(BAD_SESSION_ID)] = 0xff;
+  bytes[bytes.indexOf(BAD_UTF8)] = 0xff;
   sendBytes(bytes);
 }
 
@@ -116,11 +116,14 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       return reply({ targetId: "T" + ++targets });
     case "Target.attachToTarget":
       if (malformed === "attach-no-session-id") return reply({});
-      if (malformed === "attach-bad-utf8") return sendInvalidSessionId({ id, result: { sessionId: BAD_SESSION_ID } });
+      if (malformed === "attach-bad-utf8") return sendWithInvalidUtf8({ id, result: { sessionId: BAD_UTF8 } });
       if (malformed === "attach-non-ascii") return reply({ sessionId: "S\u0100" });
       return reply({ sessionId: "S" + params.targetId.slice(1) });
     case "Page.navigate": {
       if (navigateError) return reply({ frameId: "F", errorText: navigateError });
+      if (malformed === "navigate-bad-utf8") {
+        return sendWithInvalidUtf8({ id, result: { frameId: "F", errorText: BAD_UTF8 }, sessionId });
+      }
       const loaderId = "L" + ++loads;
       reply({ frameId: "F", loaderId });
       event("Page.frameNavigated", { frame: { id: "F", loaderId, url: params.url, mimeType: "text/html" } });
@@ -128,7 +131,7 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       // One stray event per load, addressed to a session nothing can name.
       if (malformed === "detach-no-session-id") send({ method: "Target.detachedFromTarget", params: {} });
       if (malformed === "event-bad-utf8") {
-        sendInvalidSessionId({ method: "Page.loadEventFired", params: {}, sessionId: BAD_SESSION_ID });
+        sendWithInvalidUtf8({ method: "Page.loadEventFired", params: {}, sessionId: BAD_UTF8 });
       }
       return;
     }

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -39,6 +39,7 @@ const cdpErrorOn = process.argv.find(a => a.startsWith("--cdp-error-on="))?.slic
 // produces these. One kind per run:
 //   attach-no-session-id   Target.attachToTarget answers {}
 //   attach-bad-utf8        ... answers a sessionId that is not valid UTF-8
+//   attach-non-ascii       ... answers a sessionId that is valid UTF-8 but not ASCII
 //   click-no-value         the click(selector) check answers without result.value
 //   click-huge-value       ... answers a position too large for a double (1e999)
 //   detach-no-session-id   Target.detachedFromTarget arrives with params {}
@@ -116,6 +117,7 @@ async function handle(command: { id: number; method: string; params?: any; sessi
     case "Target.attachToTarget":
       if (malformed === "attach-no-session-id") return reply({});
       if (malformed === "attach-bad-utf8") return sendInvalidSessionId({ id, result: { sessionId: BAD_SESSION_ID } });
+      if (malformed === "attach-non-ascii") return reply({ sessionId: "S\u0100" });
       return reply({ sessionId: "S" + params.targetId.slice(1) });
     case "Page.navigate": {
       if (navigateError) return reply({ frameId: "F", errorText: navigateError });

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -34,6 +34,21 @@ const navigateError = process.argv.find(a => a.startsWith("--navigate-error="))?
 // Page.navigate for a URL it cannot parse.
 const cdpErrorOn = process.argv.find(a => a.startsWith("--cdp-error-on="))?.slice("--cdp-error-on=".length);
 
+// `--malformed=<kind>`: leave out a field, or corrupt one, that real Chrome
+// always fills in. Only a broken or hostile executable at backend.path
+// produces these. One kind per run:
+//   attach-no-session-id   Target.attachToTarget answers {}
+//   attach-bad-utf8        ... answers a sessionId that is not valid UTF-8
+//   click-no-value         the click(selector) check answers without result.value
+//   detach-no-session-id   Target.detachedFromTarget arrives with params {}
+//   event-bad-utf8         a page event arrives with an invalid UTF-8 sessionId
+const malformed = process.argv.find(a => a.startsWith("--malformed="))?.slice("--malformed=".length);
+
+// Stands in for a session id until sendInvalidSessionId() overwrites its
+// first byte. JSON.stringify cannot emit invalid UTF-8, so the byte goes in
+// after the encode.
+const BAD_SESSION_ID = "not-utf8";
+
 const NO_REPLY = Symbol("no reply");
 let commandsClosed = false;
 Object.assign(globalThis, {
@@ -56,12 +71,29 @@ Object.assign(globalThis, {
     closeSync(COMMANDS);
     setInterval(() => {}, 2 ** 30);
   },
+  // Every Input.dispatchMouseEvent this process has seen, in order.
+  __fake_mouse_events() {
+    return mouseEvents;
+  },
 });
 
-function send(message: unknown) {
-  const bytes = Buffer.from(JSON.stringify(message) + "\0");
+const mouseEvents: { type: string; x: number; y: number }[] = [];
+
+function sendBytes(bytes: Buffer) {
   let written = 0;
   while (written < bytes.length) written += writeSync(REPLIES, bytes, written, bytes.length - written);
+}
+
+function send(message: unknown) {
+  sendBytes(Buffer.from(JSON.stringify(message) + "\0"));
+}
+
+// The message with BAD_SESSION_ID wherever it appears turned into bytes that
+// are not valid UTF-8: 0xff is never a legal UTF-8 byte.
+function sendInvalidSessionId(message: unknown) {
+  const bytes = Buffer.from(JSON.stringify(message) + "\0");
+  bytes[bytes.indexOf(BAD_SESSION_ID)] = 0xff;
+  sendBytes(bytes);
 }
 
 let targets = 0;
@@ -81,6 +113,8 @@ async function handle(command: { id: number; method: string; params?: any; sessi
     case "Target.createTarget":
       return reply({ targetId: "T" + ++targets });
     case "Target.attachToTarget":
+      if (malformed === "attach-no-session-id") return reply({});
+      if (malformed === "attach-bad-utf8") return sendInvalidSessionId({ id, result: { sessionId: BAD_SESSION_ID } });
       return reply({ sessionId: "S" + params.targetId.slice(1) });
     case "Page.navigate": {
       if (navigateError) return reply({ frameId: "F", errorText: navigateError });
@@ -88,14 +122,28 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       reply({ frameId: "F", loaderId });
       event("Page.frameNavigated", { frame: { id: "F", loaderId, url: params.url, mimeType: "text/html" } });
       event("Page.loadEventFired", { timestamp: loads });
+      // One stray event per load, addressed to a session nothing can name.
+      if (malformed === "detach-no-session-id") send({ method: "Target.detachedFromTarget", params: {} });
+      if (malformed === "event-bad-utf8") {
+        sendInvalidSessionId({ method: "Page.loadEventFired", params: {}, sessionId: BAD_SESSION_ID });
+      }
       return;
     }
     case "Page.captureScreenshot":
       return reply({ data: screenshotBase64 });
+    case "Input.dispatchMouseEvent":
+      mouseEvents.push({ type: params.type, x: params.x, y: params.y });
+      return reply({});
     case "Runtime.evaluate": {
       if (params.expression === "document.title") {
         if (noTitleReply) return;
         return reply({ result: { type: "string", value: "fake chrome" } });
+      }
+      // The click(selector) actionability check. It needs a DOM, so this
+      // process cannot run it; answer the [cx, cy] the page would return.
+      if (params.expression.includes("elementFromPoint")) {
+        if (malformed === "click-no-value") return reply({ result: { type: "undefined" } });
+        return reply({ result: { type: "object", value: [12, 34] } });
       }
       let value: unknown;
       try {

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -255,6 +255,30 @@ test.concurrent("a navigation that Chrome fails with errorText rejects and fires
   });
 });
 
+// An errorText that does not decode still fails the navigation, with a
+// generic message in place of the text. It used to reach createError() as an
+// empty string, which debug builds assert against.
+test.concurrent("a navigation errorText that is not valid UTF-8 rejects with a generic message", async () => {
+  const result = await runScenario(`
+    const view = new Bun.WebView({
+      backend: { ...backend, argv: [...backend.argv, "--malformed=navigate-bad-utf8"] },
+      width: 100,
+      height: 100,
+    });
+    let failedMessage;
+    view.onNavigationFailed = e => { failedMessage = e.message; };
+    const held = await outcome(view.navigate("http://fake/"));
+    const loadingAfterFail = view.loading;
+    view.close();
+    print({ held, failedMessage, loadingAfterFail });
+  `);
+  expect(result).toEqual({
+    held: { rejected: "navigation failed" },
+    failedMessage: "navigation failed",
+    loadingAfterFail: false,
+  });
+});
+
 // A CDP protocol error ({"error":{"code":-32000}}) can fail a navigation at
 // any stage: the attach chain, or Page.navigate itself (real Chrome answers
 // "Cannot navigate to invalid URL" this way). The constructor url has no

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -336,6 +336,79 @@ test.concurrent("onNavigationFailed can retry navigate() immediately", async () 
   expect(result).toBe("retry was accepted and failed too");
 });
 
+// The browser addresses a page by the sessionId that Target.attachToTarget
+// hands back. Without a usable one the page is unreachable, so the load can
+// never finish. The reply handler used to store the sessionId whatever came
+// back and route the rest of the chain with it.
+for (const kind of ["attach-no-session-id", "attach-bad-utf8"]) {
+  test.concurrent(`an attach reply with no usable sessionId fails the navigation (${kind})`, async () => {
+    const result = await runScenario(`
+      const view = new Bun.WebView({
+        backend: { ...backend, argv: [...backend.argv, "--malformed=${kind}"] },
+        width: 100,
+        height: 100,
+      });
+      const held = await outcome(view.navigate("http://fake/"));
+      const loadingAfterFail = view.loading;
+      view.close();
+      print({ held, loadingAfterFail });
+    `);
+    expect(result).toEqual({ held: { rejected: "malformed attach response" }, loadingAfterFail: false });
+  });
+}
+
+// An event names its page with a sessionId too. One that names no page the
+// transport knows is dropped, and the views it was not addressed to keep
+// working.
+for (const kind of ["detach-no-session-id", "event-bad-utf8"]) {
+  test.concurrent(`an event with no usable sessionId is ignored (${kind})`, async () => {
+    const result = await runScenario(`
+      const view = new Bun.WebView({
+        backend: { ...backend, argv: [...backend.argv, "--malformed=${kind}"] },
+        width: 100,
+        height: 100,
+      });
+      await view.navigate("http://fake/");
+      print({ url: view.url, value: await view.evaluate("6 * 7") });
+      view.close();
+    `);
+    expect(result).toEqual({ url: "http://fake/", value: 42 });
+  });
+}
+
+// click(selector) waits for the element page-side and gets its center back as
+// [cx, cy]. Those two numbers go straight into Input.dispatchMouseEvent.
+test.concurrent("click(selector) sends the position the page reported", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/");
+    await view.click("#target", { timeout: 100 });
+    print(await view.evaluate("__fake_mouse_events()"));
+    view.close();
+  `);
+  expect(result).toEqual([
+    { type: "mousePressed", x: 12, y: 34 },
+    { type: "mouseReleased", x: 12, y: 34 },
+  ]);
+});
+
+// The same reply without result.value. The handler used to read the position
+// with strtof() straight off the pointer jsonField returns, which is null
+// when the field is absent.
+test.concurrent("a click reply with no position rejects", async () => {
+  const result = await runScenario(`
+    const view = new Bun.WebView({
+      backend: { ...backend, argv: [...backend.argv, "--malformed=click-no-value"] },
+      width: 100,
+      height: 100,
+    });
+    await view.navigate("http://fake/");
+    print(await outcome(view.click("#target", { timeout: 100 })));
+    view.close();
+  `);
+  expect(result).toEqual({ rejected: "malformed click response" });
+});
+
 // `bun test --isolate` replaces the global object between files. The transport
 // is bound to the global that spawned the browser, so it has to go with that
 // file: its open views are closed, their pending promises rejected, and the

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -337,10 +337,10 @@ test.concurrent("onNavigationFailed can retry navigate() immediately", async () 
 });
 
 // The browser addresses a page by the sessionId that Target.attachToTarget
-// hands back. Without a usable one the page is unreachable, so the load can
-// never finish. The reply handler used to store the sessionId whatever came
-// back and route the rest of the chain with it.
-for (const kind of ["attach-no-session-id", "attach-bad-utf8"]) {
+// hands back, and CDP session ids are ASCII. Without a usable one the page is
+// unreachable, so the load can never finish. The reply handler used to store
+// the sessionId whatever came back and route the rest of the chain with it.
+for (const kind of ["attach-no-session-id", "attach-bad-utf8", "attach-non-ascii"]) {
   test.concurrent(`an attach reply with no usable sessionId fails the navigation (${kind})`, async () => {
     const result = await runScenario(`
       const view = new Bun.WebView({

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -392,22 +392,25 @@ test.concurrent("click(selector) sends the position the page reported", async ()
   ]);
 });
 
-// The same reply without result.value. The handler used to read the position
-// with strtof() straight off the pointer jsonField returns, which is null
-// when the field is absent.
-test.concurrent("a click reply with no position rejects", async () => {
-  const result = await runScenario(`
-    const view = new Bun.WebView({
-      backend: { ...backend, argv: [...backend.argv, "--malformed=click-no-value"] },
-      width: 100,
-      height: 100,
-    });
-    await view.navigate("http://fake/");
-    print(await outcome(view.click("#target", { timeout: 100 })));
-    view.close();
-  `);
-  expect(result).toEqual({ rejected: "malformed click response" });
-});
+// The same reply without result.value, or with a position that is not two
+// finite numbers. The handler used to read the position with strtof()
+// straight off the pointer jsonField returns, which is null when the field
+// is absent.
+for (const kind of ["click-no-value", "click-huge-value"]) {
+  test.concurrent(`a click reply with no usable position rejects (${kind})`, async () => {
+    const result = await runScenario(`
+      const view = new Bun.WebView({
+        backend: { ...backend, argv: [...backend.argv, "--malformed=${kind}"] },
+        width: 100,
+        height: 100,
+      });
+      await view.navigate("http://fake/");
+      print(await outcome(view.click("#target", { timeout: 100 })));
+      view.close();
+    `);
+    expect(result).toEqual({ rejected: "malformed click response" });
+  });
+}
 
 // `bun test --isolate` replaces the global object between files. The transport
 // is bound to the global that spawned the browser, so it has to go with that


### PR DESCRIPTION
### Problem

- Malformed CDP replies from the executable at `backend.path` crash bun: `panic: Segmentation fault at address 0x10` inside `WTF::StringHash::hash`, `Segmentation fault at address 0x0` inside `strtof`, and on debug builds `ASSERTION FAILED: s.is8Bit()` (`sidSpan`) and `ASSERTION FAILED: !message.isEmpty()` (`JSC::createError`). Robustness only: real Chromium never sends these.
- `String::fromUTF8` returns a null `WTF::String` for a missing field and for invalid UTF-8. A null `m_sessions` key crashes at `ChromeBackend.cpp:795`, `:1115` and `:1130`. A null `errorText` reaches `createError`. A non-ASCII session id becomes a 16-bit String that the command builder writes as Latin-1 bytes.
- `click(selector)` read its position with `strtof()` on the pointer `jsonField` returns, which is null when `result.value` is absent (`:1063`).

### Fix

- `decodeSessionId()` decodes every session id the transport reads. CDP session ids are ASCII, so anything missing or not ASCII comes back empty, never null.
- An attach reply with no usable session id fails the navigation (`malformed attach response`), and a later `navigate()` restarts the attach chain. An event for no known session is dropped. An `errorText` that does not decode rejects with `navigation failed`.
- The click position parses through `WTF::JSON` and stays a `double`. Anything but two finite numbers rejects (`malformed click response`).
- Verified: `test/js/bun/webview/webview-chrome-pipe.test.ts`, 9 new blocks, 8 fail on stock bun. Self-reviewed: 1 code concern fixed (the `errorText` shape), 3 follow-ups left out (see Notes). Bot review: 3 fixed, 1 declined in the comments.

### Background

- The chrome backend speaks CDP to a browser it spawns: NUL-delimited JSON on fd 3 and fd 4.
- CDP addresses a page by the `sessionId` from `Target.attachToTarget`. `m_sessions` maps it to a view and routes every page event. `sidSpan()` hands it to the command builder as 8-bit bytes.
- A null `WTF::String` has no `StringImpl`, and `StringHash::hash` is `key.impl()->hash()`.
- `click(selector)` polls a page-side check through `Runtime.evaluate`, which answers the element center as `[cx, cy]`.

<details><summary>Notes</summary>

#### The shapes

| reply or event | old result |
| --- | --- |
| `Target.attachToTarget` answers `{}` | `m_sessions.add(<null String>)`, SIGSEGV at 0x10 |
| `Target.attachToTarget` answers a `sessionId` that is not valid UTF-8 | the same |
| `Target.attachToTarget` answers a `sessionId` that is valid UTF-8 but not ASCII | navigation hangs (the id goes out double-encoded, so no event matches). `evaluate()` meanwhile hits `ASSERT(s.is8Bit())` in `sidSpan()` on debug builds |
| `Target.detachedFromTarget` arrives with `params: {}` | `m_sessions.find(<null String>)`, SIGSEGV at 0x10 |
| a page event arrives with a `sessionId` that is not valid UTF-8 | the same |
| the `click(selector)` check answers `{"result":{"type":"undefined"}}` | `strtof(nullptr)`, SIGSEGV at 0x0 |
| the `click(selector)` check answers `[1e999,0]` | `strtof` gives infinity, and `"x":Infinity` goes on the wire (not JSON) |
| `Page.navigate` answers an `errorText` that is not valid UTF-8 | `createError(g, <null String>)`: `.message === ""` on release, `ASSERT(!message.isEmpty())` on debug |

The first two attach shapes and the `type: undefined` click shape come from a fuzz sweep of malformed replies. The detach and event shapes are the same root cause, found by reading the three `m_sessions` call sites. The non-ASCII, `1e999` and `errorText` shapes came out of review. About 118 other malformed-reply shapes (garbage, partial frames, wrong types, duplicate and foreign ids, invalid UTF-8 in other fields) produced no report in the sweep. That claim covers crashes on bounded input only: the sweep's oracle was a sanitizer report or a fatal signal, so hangs and resource exhaustion were out of its scope.

#### Left for follow-ups

Three things the review raised that this PR does not take on, to keep it to the crash class: a seeded `--malformed=fuzz:<seed>` mode for the fixture so new reply handlers get swept automatically; `jsonId` and `jsonField` assume Chrome's no-whitespace encoder, so a proxy that pretty-prints would see hangs rather than crashes; and `m_rx` has no cap in pipe mode, so a peer that never sends a NUL grows it without bound.

#### Why `fromUTF8` returns null twice over

`StringImpl::create(std::span<const char8_t>)` returns `nullptr` when the span's data pointer is null, and again when `simdutf::convert_utf8_to_utf16` writes nothing. `jsonField` returns `{}` for a field it does not find, so a missing field takes the first path and invalid UTF-8 takes the second. An empty span with a live pointer (the field is `""`) returns `StringImpl::empty()`, which is why the `""` case never crashed. `decodeSessionId()` no longer calls `fromUTF8` at all: after the ASCII check the bytes construct an 8-bit String directly.

#### Test fixture

`fake-chrome-fixture.ts` takes `--malformed=<kind>` with one kind per run. `JSON.stringify` cannot emit invalid UTF-8, so the fixture writes the placeholder `not-utf8` and overwrites its first byte with `0xff` after the encode. `0xff` is never a legal UTF-8 byte. It cannot emit `1e999` either (that is `Infinity`, which encodes as `null`), so that literal is spliced in the same way.

The fixture also answers the `click(selector)` actionability check now, with a fixed `[12, 34]`. That check needs a DOM, which the fixture process does not have. One new test reads back the `Input.dispatchMouseEvent` frames and asserts both carry `x: 12, y: 34`, so the new parse is covered on the happy path too. That block passes with and without the fix.

#### Unchanged on the failure path

A failed attach leaves `m_pendingChromeNavigateUrl` set and leaves the tab that `Target.createTarget` opened. Both already happen when Chrome answers `Target.attachToTarget` with a CDP protocol error (the `error` branch at the top of `handleResponse`), and when `Page.enable` fails. Tab cleanup after a failed attach chain is one behavior for all three exits and overlaps with #39075, so this PR leaves it alone.

#### Locale

`strtof` reads the decimal separator from the C locale. `WTF::JSON` does not. The replacement removes that dependency as a side effect.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome-pipe.test.ts

<!-- robobun:evidence:end -->