### PR TITLE
webview: settle a Chrome view's pending work when its renderer crashes

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -528,14 +528,20 @@ If the browser subprocess dies unexpectedly (crash, OOM-kill, `SIGKILL`), every 
 
 ### Renderer death
 
-On the Chrome backend, one tab's renderer process can die while the browser keeps running. Pending promises on that view reject with `Error("page crashed (renderer process died)")`, and the view's [operation slots](#concurrency-model) are freed. The view stays open: the next `navigate()` makes Chrome create a new renderer for it.
+On the Chrome backend, one tab's renderer process can die while the browser keeps running (an OOM kill, a `SIGKILL`, a renderer bug). Pending promises on that view reject with `Error("page crashed (renderer process died)")`, and the view's [operation slots](#concurrency-model) are freed.
 
-Chrome reports this as the CDP event `Inspector.targetCrashed`, which the view also dispatches to `addEventListener`:
+The view stays open, but Chrome has no renderer for it until a navigation makes a new one. Until then:
+
+- `navigate()` works. It gives the view a new renderer, and the view is usable again.
+- Every other method rejects at once with `Error("page crashed (renderer process died), navigate() to recover")`.
+- `cdp()` is the exception. It stays a raw passthrough, so Chrome answers it on its own terms: most commands wait for the next navigation and then fail with `"Target crashed"`.
+
+Chrome reports the death as the CDP event `Inspector.targetCrashed`, which the view also dispatches to `addEventListener`:
 
 ```ts
-view.addEventListener("Inspector.targetCrashed", () => {
+view.addEventListener("Inspector.targetCrashed", async () => {
   console.log("the page crashed, reloading");
-  view.navigate(view.url);
+  await view.navigate(view.url);
 });
 ```
 

--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -532,9 +532,9 @@ On the Chrome backend, one tab's renderer process can die while the browser keep
 
 The view stays open, but it has no renderer until a navigation gives it a new one:
 
-- `navigate()`, `reload()`, `goBack()` and `goForward()` work. Once one of them commits a document, the view is usable again.
-- Until then, Bun rejects every other method at once with `Error("page crashed (renderer process died), reload() or navigate() to recover")` instead of sending it to a renderer that cannot answer.
-- `cdp()` is the exception. It stays a raw passthrough, so Chrome answers on its own terms: browser-handled commands work, most page commands wait for the next navigation and then fail with `"Target crashed"`.
+- `navigate()`, `reload()`, `goBack()` and `goForward()` work. Once one of them commits a document, the view is usable again. `close()` works too.
+- Until then, Bun rejects the operations that need the page (`evaluate()`, `screenshot()`, `click()`, `type()`, `press()`, `scroll()`, `scrollTo()`, `resize()`) at once with `Error("page crashed (renderer process died), reload() or navigate() to recover")` instead of sending them to a renderer that cannot answer.
+- `cdp()` stays a raw passthrough, so Chrome answers on its own terms: browser-handled commands work, most page commands wait for the next navigation and then fail with `"Target crashed"`.
 
 Chrome reports the death as the CDP event `Inspector.targetCrashed`, which the view also dispatches to `addEventListener`:
 

--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -526,6 +526,19 @@ The browser subprocess does **not** keep Bun's event loop alive on its own. An o
 
 If the browser subprocess dies unexpectedly (crash, OOM-kill, `SIGKILL`), every pending promise on every view rejects with an error describing how it died (`"Chrome killed by signal 9"`, `"WebView host process died"`). Further operations on those views throw.
 
+### Renderer death
+
+On the Chrome backend, one tab's renderer process can die while the browser keeps running. Pending promises on that view reject with `Error("page crashed (renderer process died)")`, and the view's [operation slots](#concurrency-model) are freed. The view stays open: the next `navigate()` makes Chrome create a new renderer for it.
+
+Chrome reports this as the CDP event `Inspector.targetCrashed`, which the view also dispatches to `addEventListener`:
+
+```ts
+view.addEventListener("Inspector.targetCrashed", () => {
+  console.log("the page crashed, reloading");
+  view.navigate(view.url);
+});
+```
+
 ---
 
 ## Concurrency model

--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -530,18 +530,18 @@ If the browser subprocess dies unexpectedly (crash, OOM-kill, `SIGKILL`), every 
 
 On the Chrome backend, one tab's renderer process can die while the browser keeps running (an OOM kill, a `SIGKILL`, a renderer bug). Pending promises on that view reject with `Error("page crashed (renderer process died)")`, and the view's [operation slots](#concurrency-model) are freed.
 
-The view stays open, but Chrome has no renderer for it until a navigation makes a new one. Until then:
+The view stays open, but it has no renderer until a navigation gives it a new one:
 
-- `navigate()` works. It gives the view a new renderer, and the view is usable again.
-- Every other method rejects at once with `Error("page crashed (renderer process died), navigate() to recover")`.
-- `cdp()` is the exception. It stays a raw passthrough, so Chrome answers it on its own terms: most commands wait for the next navigation and then fail with `"Target crashed"`.
+- `navigate()`, `reload()`, `goBack()` and `goForward()` work. Once one of them commits a document, the view is usable again.
+- Until then, Bun rejects every other method at once with `Error("page crashed (renderer process died), reload() or navigate() to recover")` instead of sending it to a renderer that cannot answer.
+- `cdp()` is the exception. It stays a raw passthrough, so Chrome answers on its own terms: browser-handled commands work, most page commands wait for the next navigation and then fail with `"Target crashed"`.
 
 Chrome reports the death as the CDP event `Inspector.targetCrashed`, which the view also dispatches to `addEventListener`:
 
 ```ts
 view.addEventListener("Inspector.targetCrashed", async () => {
   console.log("the page crashed, reloading");
-  await view.navigate(view.url);
+  await view.reload();
 });
 ```
 

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -685,6 +685,15 @@ static void rejectViewSlots(JSGlobalObject* g, JSWebView* view, JSValue err)
     settleSlot(g, view, view->m_pendingCdp, false, err);
 }
 
+// A page death the user did not ask for: reject the view's slots and forget the ids Chrome still owes it.
+void Transport::failPendingWork(JSWebView* view, JSValue err)
+{
+    rejectViewSlots(m_global, view, err);
+    uint32_t vid = view->m_viewId;
+    m_pending.removeIf([vid](auto& kv) { return kv.value.viewId == vid; });
+    updateKeepAlive();
+}
+
 // close() variant of rejectViewSlots: see rejectSlotAsHandled (JSWebView.h).
 static void rejectViewSlotsAsHandled(JSGlobalObject* g, JSWebView* view, JSValue err)
 {
@@ -1103,7 +1112,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     auto& vm = g->vm();
 
     // Target.detachedFromTarget — fires when an attached session's target
-    // dies (renderer crash, OOM, kill). params: {sessionId, targetId}.
+    // is destroyed (tab closed from outside, context gone). params: {sessionId, targetId}.
     // Browser-level (no sessionId on the envelope). close() handles user-
     // initiated closes eagerly; this is the only notification for external
     // death. Without it, pending evaluates on the dead view hang forever.
@@ -1119,11 +1128,8 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         JSWebView* view = viewFor(vid);
         m_views.remove(vid);
         if (!view) return;
-        rejectViewSlots(g, view, createError(g, "page detached (crashed or closed)"_s));
-        // Erase stale m_pending entries — replies won't come.
-        m_pending.removeIf([vid](auto& kv) { return kv.value.viewId == vid; });
         view->m_closed = true;
-        updateKeepAlive();
+        failPendingWork(view, createError(g, "page detached (crashed or closed)"_s));
         return;
     }
     auto sidStr = WTF::String::fromUTF8(sessionId);
@@ -1278,11 +1284,8 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     // Renderer died, session stays attached: the detach path above never fires.
     if (method.size() == 23 && memcmp(method.data(), "Inspector.targetCrashed", 23) == 0) {
         view->m_crashed = true;
-        // Settled before the dispatch below, so a listener can navigate().
-        rejectViewSlots(g, view, createError(g, "page crashed (renderer process died)"_s));
-        uint32_t vid = view->m_viewId;
-        m_pending.removeIf([vid](auto& kv) { return kv.value.viewId == vid; });
-        updateKeepAlive();
+        // Settled before the dispatch below, so a listener can reload().
+        failPendingWork(view, createError(g, "page crashed (renderer process died)"_s));
     }
 
     // Unhandled CDP event — dispatch to the view's EventTarget if it has
@@ -1419,11 +1422,11 @@ static JSPromise* rejectedPromise(JSGlobalObject* g, const WTF::String& message)
     return promise;
 }
 
-// Chrome holds a crashed session's page commands until a navigate recreates the renderer.
+// Chrome holds (or, for Emulation.*, wedges on) a crashed tab's page commands until a navigation recreates the renderer.
 static JSPromise* refuseIfCrashed(JSGlobalObject* g, JSWebView* v)
 {
     if (!v->m_crashed) return nullptr;
-    return rejectedPromise(g, "page crashed (renderer process died), navigate() to recover"_s);
+    return rejectedPromise(g, "page crashed (renderer process died), reload() or navigate() to recover"_s);
 }
 
 // Allocate promise, store in slot, add to Transport pending map, send frame.
@@ -1442,8 +1445,8 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
     // m_wsOpen here — send() queues until onOpen fires.
     if (t.m_dead || t.m_mode == TransportMode::None)
         return rejectedPromise(g, "Chrome connection is not available"_s);
-    // navigate() recovers the view; cdp() keeps Chrome's raw semantics.
-    if (m != Method::PageNavigate && m != Method::UserRaw) {
+    // Any navigation recovers a crashed view; cdp() keeps Chrome's raw semantics.
+    if (ps != PendingSlot::Navigate && ps != PendingSlot::Cdp) {
         if (auto* refused = refuseIfCrashed(g, v)) return refused;
     }
     auto* promise = JSPromise::create(vm, g->promiseStructure());

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1742,6 +1742,8 @@ JSPromise* scroll(JSGlobalObject* g, JSWebView* view, double dx, double dy)
 
 JSPromise* resize(JSGlobalObject* g, JSWebView* view, uint32_t width, uint32_t height)
 {
+    // Before the stored size below diverges from a viewport nothing resized.
+    if (auto* refused = refuseIfCrashed(g, view)) return refused;
     auto& t = transport();
     view->m_width = width;
     view->m_height = height;

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1275,21 +1275,10 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Inspector.targetCrashed — the tab's renderer process died (crash, OOM
-    // kill, SIGKILL). Chrome keeps the session attached, so the view stays
-    // open and Target.detachedFromTarget (the whole-tab case above) never
-    // fires. Until a Page.navigate creates a new renderer, Chrome queues
-    // every page-handled command on this session, including the ones the
-    // dead renderer already owed, and answers them with "Target crashed"
-    // only once that navigation happens. So: settle what is pending now,
-    // and have sendChromeOp refuse page ops while m_crashed is set instead
-    // of letting them hang on a navigation that may never come.
-    //
-    // Reject before the EventTarget dispatch below so a listener can call
-    // navigate() from inside its handler, like settleFailure does for
-    // onNavigationFailed.
+    // Renderer died, session stays attached: the detach path above never fires.
     if (method.size() == 23 && memcmp(method.data(), "Inspector.targetCrashed", 23) == 0) {
         view->m_crashed = true;
+        // Settled before the dispatch below, so a listener can navigate().
         rejectViewSlots(g, view, createError(g, "page crashed (renderer process died)"_s));
         uint32_t vid = view->m_viewId;
         m_pending.removeIf([vid](auto& kv) { return kv.value.viewId == vid; });
@@ -1430,8 +1419,7 @@ static JSPromise* rejectedPromise(JSGlobalObject* g, const WTF::String& message)
     return promise;
 }
 
-// See Inspector.targetCrashed in handleEvent: Chrome would queue the op
-// behind a navigation that may never come.
+// Chrome holds a crashed session's page commands until a navigate recreates the renderer.
 static JSPromise* refuseIfCrashed(JSGlobalObject* g, JSWebView* v)
 {
     if (!v->m_crashed) return nullptr;
@@ -1454,9 +1442,7 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
     // m_wsOpen here — send() queues until onOpen fires.
     if (t.m_dead || t.m_mode == TransportMode::None)
         return rejectedPromise(g, "Chrome connection is not available"_s);
-    // Page.navigate is answered by the browser and is what recovers a
-    // crashed view; cdp() is the raw escape hatch and keeps Chrome's own
-    // semantics. Everything else waits on the renderer.
+    // navigate() recovers the view; cdp() keeps Chrome's raw semantics.
     if (m != Method::PageNavigate && m != Method::UserRaw) {
         if (auto* refused = refuseIfCrashed(g, v)) return refused;
     }

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1273,6 +1273,26 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
+    // Inspector.targetCrashed — the tab's renderer process died (crash, OOM
+    // kill, SIGKILL). Chrome keeps the session attached and re-creates the
+    // renderer on the next navigation, so the view stays open, but it never
+    // answers the commands the dead renderer owed: without this the pending
+    // promises hang and their slots stay taken for the life of the view.
+    // Target.detachedFromTarget does not fire for this — that is the
+    // whole-tab case, handled above.
+    //
+    // Reject before the EventTarget dispatch below so a listener can start
+    // a new operation from inside its handler, like settleFailure does for
+    // onNavigationFailed.
+    if (method.size() == 23 && memcmp(method.data(), "Inspector.targetCrashed", 23) == 0) {
+        rejectViewSlots(g, view, createError(g, "page crashed (renderer process died)"_s));
+        // Chrome answers these ids with "Target crashed" only if the view is
+        // navigated again; drop them now so the slots are free either way.
+        uint32_t vid = view->m_viewId;
+        m_pending.removeIf([vid](auto& kv) { return kv.value.viewId == vid; });
+        updateKeepAlive();
+    }
+
     // Unhandled CDP event — dispatch to the view's EventTarget if it has
     // a listener for this method name. Check hasEventListeners first:
     // Chrome is chatty (frameScheduledNavigation, lifecycleEvent, etc.)

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1147,6 +1147,8 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         auto urlStr = WTF::String::fromUTF8(url);
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it.
+        // A document committed, so a live renderer exists again.
+        view->m_crashed = false;
 
         if (JSObject* cb = view->m_onNavigated.get()) {
             Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
@@ -1274,20 +1276,21 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     }
 
     // Inspector.targetCrashed — the tab's renderer process died (crash, OOM
-    // kill, SIGKILL). Chrome keeps the session attached and re-creates the
-    // renderer on the next navigation, so the view stays open, but it never
-    // answers the commands the dead renderer owed: without this the pending
-    // promises hang and their slots stay taken for the life of the view.
-    // Target.detachedFromTarget does not fire for this — that is the
-    // whole-tab case, handled above.
+    // kill, SIGKILL). Chrome keeps the session attached, so the view stays
+    // open and Target.detachedFromTarget (the whole-tab case above) never
+    // fires. Until a Page.navigate creates a new renderer, Chrome queues
+    // every page-handled command on this session, including the ones the
+    // dead renderer already owed, and answers them with "Target crashed"
+    // only once that navigation happens. So: settle what is pending now,
+    // and have sendChromeOp refuse page ops while m_crashed is set instead
+    // of letting them hang on a navigation that may never come.
     //
-    // Reject before the EventTarget dispatch below so a listener can start
-    // a new operation from inside its handler, like settleFailure does for
+    // Reject before the EventTarget dispatch below so a listener can call
+    // navigate() from inside its handler, like settleFailure does for
     // onNavigationFailed.
     if (method.size() == 23 && memcmp(method.data(), "Inspector.targetCrashed", 23) == 0) {
+        view->m_crashed = true;
         rejectViewSlots(g, view, createError(g, "page crashed (renderer process died)"_s));
-        // Chrome answers these ids with "Target crashed" only if the view is
-        // navigated again; drop them now so the slots are free either way.
         uint32_t vid = view->m_viewId;
         m_pending.removeIf([vid](auto& kv) { return kv.value.viewId == vid; });
         updateKeepAlive();
@@ -1420,6 +1423,21 @@ void Transport::retireGlobal(Zig::GlobalObject* global)
 
 namespace Ops {
 
+static JSPromise* rejectedPromise(JSGlobalObject* g, const WTF::String& message)
+{
+    auto* promise = JSPromise::create(g->vm(), g->promiseStructure());
+    promise->reject(g->vm(), createError(g, message));
+    return promise;
+}
+
+// See Inspector.targetCrashed in handleEvent: Chrome would queue the op
+// behind a navigation that may never come.
+static JSPromise* refuseIfCrashed(JSGlobalObject* g, JSWebView* v)
+{
+    if (!v->m_crashed) return nullptr;
+    return rejectedPromise(g, "page crashed (renderer process died), navigate() to recover"_s);
+}
+
 // Allocate promise, store in slot, add to Transport pending map, send frame.
 // Caller guarantees the slot is empty and m_closed == false. Command is
 // moved in; t.send() calls finishAndWrite which zero-copies to the pipe
@@ -1430,15 +1448,19 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
 {
     auto& vm = g->vm();
     auto& t = transport();
-    auto* promise = JSPromise::create(vm, g->promiseStructure());
     // Unreachable: the constructor spawned or connected, and the paths that
     // kill or release the transport afterwards (rejectAllAndMarkDead,
     // updateKeepAlive) leave no open view behind. WebSocket mode doesn't need
     // m_wsOpen here — send() queues until onOpen fires.
-    if (t.m_dead || t.m_mode == TransportMode::None) {
-        promise->reject(vm, createError(g, "Chrome connection is not available"_s));
-        return promise;
+    if (t.m_dead || t.m_mode == TransportMode::None)
+        return rejectedPromise(g, "Chrome connection is not available"_s);
+    // Page.navigate is answered by the browser and is what recovers a
+    // crashed view; cdp() is the raw escape hatch and keeps Chrome's own
+    // semantics. Everything else waits on the renderer.
+    if (m != Method::PageNavigate && m != Method::UserRaw) {
+        if (auto* refused = refuseIfCrashed(g, v)) return refused;
     }
+    auto* promise = JSPromise::create(vm, g->promiseStructure());
     v->m_pendingActivityCount.fetch_add(1, std::memory_order_release);
     slot.set(vm, v, promise);
     t.m_pending.add(id, Pending { m, ps, v->m_viewId });
@@ -1557,6 +1579,8 @@ JSPromise* screenshot(JSGlobalObject* g, JSWebView* view, ScreenshotFormat forma
 // Chrome sends a reply we ignore). Both frames go in one write().
 JSPromise* click(JSGlobalObject* g, JSWebView* view, float x, float y, uint8_t button, uint8_t modifiers, uint8_t clickCount)
 {
+    // Before the untracked mousePressed below reaches a dead renderer.
+    if (auto* refused = refuseIfCrashed(g, view)) return refused;
     auto& t = transport();
     auto sid = sidSpan(view->m_sessionId);
     auto btn = cdpButton(button);
@@ -1675,6 +1699,8 @@ static const CDPKeyInfo& cdpKeyInfo(uint8_t k)
 
 JSPromise* press(JSGlobalObject* g, JSWebView* view, uint8_t key, uint8_t modifiers, const WTF::String& character)
 {
+    // Before the untracked keyDown below reaches a dead renderer.
+    if (auto* refused = refuseIfCrashed(g, view)) return refused;
     auto& t = transport();
     auto sid = sidSpan(view->m_sessionId);
     int32_t mods = cdpModifiers(modifiers);

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -477,6 +477,7 @@ public:
     void handleMessage(std::span<const char> msg);
     void handleResponse(uint32_t id, std::span<const char> result, std::span<const char> error);
     void handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId);
+    void failPendingWork(JSWebView*, JSC::JSValue err);
     void rejectAllAndMarkDead(const WTF::String& reason);
     void updateKeepAlive();
     void writeRaw(const char* data, size_t len);

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -88,9 +88,7 @@ public:
     WTF::String m_url;
     WTF::String m_title;
     bool m_loading = false;
-    // Chrome: the tab's renderer died (Inspector.targetCrashed) and no
-    // document has committed since. Chrome queues page commands in this
-    // state, so CDP::Ops refuses them; Page.frameNavigated clears it.
+    // Chrome: renderer dead since Inspector.targetCrashed, no document yet.
     bool m_crashed = false;
 
     // Chrome session state. Empty until the Target.createTarget →

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -88,6 +88,10 @@ public:
     WTF::String m_url;
     WTF::String m_title;
     bool m_loading = false;
+    // Chrome: the tab's renderer died (Inspector.targetCrashed) and no
+    // document has committed since. Chrome queues page commands in this
+    // state, so CDP::Ops refuses them; Page.frameNavigated clears it.
+    bool m_crashed = false;
 
     // Chrome session state. Empty until the Target.createTarget →
     // Target.attachToTarget → Page.enable chain completes (driven by the

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -67,14 +67,19 @@ function send(message: unknown) {
 
 let targets = 0;
 let loads = 0;
+// Last committed URL per session, for Page.reload.
+const urls = new Map<string, string>();
 
 // Sessions whose renderer Page.crash killed, with the ids of the commands
-// Chrome would be holding for the dead renderer. What real Chrome does: the
-// session stays attached; commands the renderer handles get no reply until a
-// Page.navigate creates a new renderer, and are then failed with "Target
-// crashed"; Page.captureScreenshot and Input.* fail at once; Page.navigate
-// itself is handled by the browser and works.
+// Chrome would be holding for the dead renderer. What real Chrome (153) does:
+// the session stays attached; Target.* and the navigation commands are the
+// browser's and keep working, and a navigation gives the tab a new renderer;
+// until then, commands the renderer answers get no reply, and once it exists
+// again they are failed with "Target crashed"; Page.captureScreenshot and
+// Input.* fail at once. (Emulation.* hangs the whole browser connection for
+// good there; here it is only held.)
 const crashedSessions = new Map<string, number[]>();
+const browserHandled = /^(Target\.|Page\.(navigate|reload|getNavigationHistory|navigateToHistoryEntry|crash)$)/;
 
 async function handle(command: { id: number; method: string; params?: any; sessionId?: string }) {
   const { id, method, params = {}, sessionId } = command;
@@ -84,11 +89,26 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       sessionId ? { id: failedId, error: { code, message }, sessionId } : { id: failedId, error: { code, message } },
     );
   const event = (name: string, eventParams: unknown) => send({ method: name, params: eventParams, sessionId });
+  // A document commits and finishes loading. If the renderer was dead, this
+  // is also where the new one takes over and the held commands are failed.
+  const load = (url: string) => {
+    const loaderId = "L" + ++loads;
+    const held = crashedSessions.get(sessionId!);
+    if (held) {
+      crashedSessions.delete(sessionId!);
+      for (const heldId of held) fail(heldId, -32000, "Target crashed");
+      event("Inspector.targetReloadedAfterCrash", {});
+    }
+    urls.set(sessionId!, url);
+    event("Page.frameNavigated", { frame: { id: "F", loaderId, url, mimeType: "text/html" } });
+    event("Page.loadEventFired", { timestamp: loads });
+    return loaderId;
+  };
 
   if (method === cdpErrorOn) return fail(id, -32000, "Cannot navigate to invalid URL");
 
   const held = sessionId === undefined ? undefined : crashedSessions.get(sessionId);
-  if (held && method !== "Page.navigate" && !method.startsWith("Target.")) {
+  if (held && !browserHandled.test(method)) {
     if (method === "Page.captureScreenshot" || method.startsWith("Input.")) return fail(id, -32603, "Internal error");
     held.push(id);
     return;
@@ -101,17 +121,14 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       return reply({ sessionId: "S" + params.targetId.slice(1) });
     case "Page.navigate": {
       if (navigateError) return reply({ frameId: "F", errorText: navigateError });
-      const loaderId = "L" + ++loads;
-      reply({ frameId: "F", loaderId });
-      if (held) {
-        crashedSessions.delete(sessionId!);
-        for (const heldId of held) fail(heldId, -32000, "Target crashed");
-        event("Inspector.targetReloadedAfterCrash", {});
-      }
-      event("Page.frameNavigated", { frame: { id: "F", loaderId, url: params.url, mimeType: "text/html" } });
-      event("Page.loadEventFired", { timestamp: loads });
+      reply({ frameId: "F", loaderId: "L" + (loads + 1) });
+      load(params.url);
       return;
     }
+    case "Page.reload":
+      reply({});
+      load(urls.get(sessionId!) ?? "about:blank");
+      return;
     case "Page.captureScreenshot":
       return reply({ data: screenshotBase64 });
     case "Page.crash":

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -92,6 +92,13 @@ async function handle(command: { id: number; method: string; params?: any; sessi
     }
     case "Page.captureScreenshot":
       return reply({ data: screenshotBase64 });
+    case "Page.crash":
+      // Real Chrome kills the tab's renderer process, reports the death on
+      // the view's session, and never answers this command or anything else
+      // the dead renderer owed. The session stays attached: a later
+      // Page.navigate gets a new renderer.
+      event("Inspector.targetCrashed", {});
+      return;
     case "Runtime.evaluate": {
       if (params.expression === "document.title") {
         if (noTitleReply) return;

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -3,9 +3,10 @@
 // and this file speaks the --remote-debugging-pipe protocol back to it:
 // NUL-delimited CDP JSON, commands arriving on fd 3, replies and events
 // leaving on fd 4. It implements just enough of CDP for navigate(),
-// evaluate() and screenshot(). evaluate() runs the expression in this
-// process, which is how the tests move chosen payloads across the pipes and
-// how they make the fake browser misbehave on cue (the __fake_* globals).
+// evaluate(), screenshot() and a renderer crash (Page.crash). evaluate()
+// runs the expression in this process, which is how the tests move chosen
+// payloads across the pipes and how they make the fake browser misbehave on
+// cue (the __fake_* globals).
 import { closeSync, readSync, writeSync } from "node:fs";
 
 const COMMANDS = 3;
@@ -67,14 +68,30 @@ function send(message: unknown) {
 let targets = 0;
 let loads = 0;
 
+// Sessions whose renderer Page.crash killed, with the ids of the commands
+// Chrome would be holding for the dead renderer. What real Chrome does: the
+// session stays attached; commands the renderer handles get no reply until a
+// Page.navigate creates a new renderer, and are then failed with "Target
+// crashed"; Page.captureScreenshot and Input.* fail at once; Page.navigate
+// itself is handled by the browser and works.
+const crashedSessions = new Map<string, number[]>();
+
 async function handle(command: { id: number; method: string; params?: any; sessionId?: string }) {
   const { id, method, params = {}, sessionId } = command;
   const reply = (result: unknown) => send(sessionId ? { id, result, sessionId } : { id, result });
+  const fail = (failedId: number, code: number, message: string) =>
+    send(
+      sessionId ? { id: failedId, error: { code, message }, sessionId } : { id: failedId, error: { code, message } },
+    );
   const event = (name: string, eventParams: unknown) => send({ method: name, params: eventParams, sessionId });
 
-  if (method === cdpErrorOn) {
-    const error = { code: -32000, message: "Cannot navigate to invalid URL" };
-    return send(sessionId ? { id, error, sessionId } : { id, error });
+  if (method === cdpErrorOn) return fail(id, -32000, "Cannot navigate to invalid URL");
+
+  const held = sessionId === undefined ? undefined : crashedSessions.get(sessionId);
+  if (held && method !== "Page.navigate" && !method.startsWith("Target.")) {
+    if (method === "Page.captureScreenshot" || method.startsWith("Input.")) return fail(id, -32603, "Internal error");
+    held.push(id);
+    return;
   }
 
   switch (method) {
@@ -86,6 +103,11 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       if (navigateError) return reply({ frameId: "F", errorText: navigateError });
       const loaderId = "L" + ++loads;
       reply({ frameId: "F", loaderId });
+      if (held) {
+        crashedSessions.delete(sessionId!);
+        for (const heldId of held) fail(heldId, -32000, "Target crashed");
+        event("Inspector.targetReloadedAfterCrash", {});
+      }
       event("Page.frameNavigated", { frame: { id: "F", loaderId, url: params.url, mimeType: "text/html" } });
       event("Page.loadEventFired", { timestamp: loads });
       return;
@@ -93,10 +115,8 @@ async function handle(command: { id: number; method: string; params?: any; sessi
     case "Page.captureScreenshot":
       return reply({ data: screenshotBase64 });
     case "Page.crash":
-      // Real Chrome kills the tab's renderer process, reports the death on
-      // the view's session, and never answers this command or anything else
-      // the dead renderer owed. The session stays attached: a later
-      // Page.navigate gets a new renderer.
+      // The renderer dies before it could answer this.
+      crashedSessions.set(sessionId!, [id]);
       event("Inspector.targetCrashed", {});
       return;
     case "Runtime.evaluate": {

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -3,10 +3,10 @@
 // and this file speaks the --remote-debugging-pipe protocol back to it:
 // NUL-delimited CDP JSON, commands arriving on fd 3, replies and events
 // leaving on fd 4. It implements just enough of CDP for navigate(),
-// evaluate(), screenshot() and a renderer crash (Page.crash). evaluate()
-// runs the expression in this process, which is how the tests move chosen
-// payloads across the pipes and how they make the fake browser misbehave on
-// cue (the __fake_* globals).
+// reload(), goBack()/goForward(), evaluate(), screenshot() and a renderer
+// crash (Page.crash). evaluate() runs the expression in this process, which
+// is how the tests move chosen payloads across the pipes and how they make
+// the fake browser misbehave on cue (the __fake_* globals).
 import { closeSync, readSync, writeSync } from "node:fs";
 
 const COMMANDS = 3;
@@ -67,8 +67,17 @@ function send(message: unknown) {
 
 let targets = 0;
 let loads = 0;
-// Last committed URL per session, for Page.reload.
-const urls = new Map<string, string>();
+let entryIds = 0;
+// Session history for Page.reload and the Page.getNavigationHistory +
+// Page.navigateToHistoryEntry pair behind goBack()/goForward(). A new tab
+// starts at about:blank, as in Chrome.
+type History = { entries: { id: number; url: string }[]; index: number };
+const histories = new Map<string, History>();
+function historyOf(sessionId: string): History {
+  let h = histories.get(sessionId);
+  if (!h) histories.set(sessionId, (h = { entries: [{ id: ++entryIds, url: "about:blank" }], index: 0 }));
+  return h;
+}
 
 // Sessions whose renderer Page.crash killed, with the ids of the commands
 // Chrome would be holding for the dead renderer. What real Chrome (153) does:
@@ -99,7 +108,6 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       for (const heldId of held) fail(heldId, -32000, "Target crashed");
       event("Inspector.targetReloadedAfterCrash", {});
     }
-    urls.set(sessionId!, url);
     event("Page.frameNavigated", { frame: { id: "F", loaderId, url, mimeType: "text/html" } });
     event("Page.loadEventFired", { timestamp: loads });
     return loaderId;
@@ -121,14 +129,32 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       return reply({ sessionId: "S" + params.targetId.slice(1) });
     case "Page.navigate": {
       if (navigateError) return reply({ frameId: "F", errorText: navigateError });
+      const h = historyOf(sessionId!);
+      h.entries.splice(h.index + 1, Infinity, { id: ++entryIds, url: params.url });
+      h.index = h.entries.length - 1;
       reply({ frameId: "F", loaderId: "L" + (loads + 1) });
       load(params.url);
       return;
     }
-    case "Page.reload":
+    case "Page.reload": {
+      const h = historyOf(sessionId!);
       reply({});
-      load(urls.get(sessionId!) ?? "about:blank");
+      load(h.entries[h.index].url);
       return;
+    }
+    case "Page.getNavigationHistory": {
+      const h = historyOf(sessionId!);
+      return reply({ currentIndex: h.index, entries: h.entries });
+    }
+    case "Page.navigateToHistoryEntry": {
+      const h = historyOf(sessionId!);
+      const index = h.entries.findIndex(e => e.id === params.entryId);
+      if (index === -1) return fail(id, -32000, "No entry with passed id");
+      h.index = index;
+      reply({});
+      load(h.entries[index].url);
+      return;
+    }
     case "Page.captureScreenshot":
       return reply({ data: screenshotBase64 });
     case "Page.crash":
@@ -155,6 +181,8 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       return reply({ result: { type: typeof value, value } });
     }
     default:
+      // Input.* is recorded where a later evaluate("__fake_last_input") finds it.
+      if (method.startsWith("Input.")) Object.assign(globalThis, { __fake_last_input: { method, ...params } });
       // Page.enable, Runtime.enable, Target.closeTarget, Input.*: nothing to say.
       return reply({});
   }

--- a/test/js/bun/webview/webview-chrome-disconnect.test.ts
+++ b/test/js/bun/webview/webview-chrome-disconnect.test.ts
@@ -197,6 +197,9 @@ test.concurrent.each([
     `mock.emit("Target.detachedFromTarget", { sessionId: "S1", targetId: "T1" })`,
     "page detached (crashed or closed)",
   ],
+  // The tab's renderer process dies. Chrome reports it on the view's own
+  // session, not at browser level, and keeps the session attached.
+  ["Inspector.targetCrashed", `mock.emit("Inspector.targetCrashed", {}, "S1")`, "page crashed (renderer process died)"],
 ])("%s during a load rejects navigate() and clears loading", async (_, takePageAway, reason) => {
   const result = await runScenario(`
     const mock = startMockCDP();

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -338,16 +338,21 @@ test.concurrent("onNavigationFailed can retry navigate() immediately", async () 
 
 // A tab's renderer process can die while the browser keeps running (OOM kill,
 // SIGKILL, Page.crash). Chrome reports it with Inspector.targetCrashed on the
-// view's session and never answers what the dead renderer owed, so the view
-// has to settle that work itself. The statuses are read inside the listener,
-// which runs after the rejections, so the check needs no timer.
-test.concurrent("a renderer crash rejects the view's pending work and frees its slots", async () => {
+// view's session, keeps the session attached, and holds every command the
+// page has to answer, the ones already in flight included, until a
+// Page.navigate gives the tab a new renderer. So the view has to settle the
+// pending work itself, and refuse page operations until then rather than let
+// them wait for a navigation that may never come. cdp() stays raw.
+test.concurrent("a renderer crash rejects the view's pending work and navigate() recovers it", async () => {
   const result = await runScenario(`
     const view = newView();
     await view.navigate("http://fake/");
     const hungEvaluate = view.evaluate("__fake_no_reply()");
     const hungCdp = view.cdp("Page.crash");
-    const held = [outcome(hungEvaluate), outcome(hungCdp)];
+    hungEvaluate.catch(() => {}); // held, so the crash rejection is not loud here
+    hungCdp.catch(() => {});
+    // The listener runs after the rejections, so the statuses are final here
+    // and the check needs no timer.
     const report = await new Promise(resolve => {
       view.addEventListener("Inspector.targetCrashed", () => resolve({
         evaluateStatus: Bun.peek.status(hungEvaluate),
@@ -356,25 +361,37 @@ test.concurrent("a renderer crash rejects the view's pending work and frees its 
     });
     // Awaiting a slot the crash left pending would never return, so report
     // that instead of hanging.
-    const reason = (status, held) => status === "pending" ? { pending: true } : held;
-    report.evaluate = await reason(report.evaluateStatus, held[0]);
-    report.cdp = await reason(report.cdpStatus, held[1]);
-    // Both slots are free again, and the view still works. A taken slot
-    // throws ERR_INVALID_STATE from the call itself, not from its promise.
-    const begin = call => { try { return outcome(call()); } catch (e) { return { threw: e.message }; } };
-    report.nextEvaluate = await begin(() => view.evaluate("'alive'"));
-    report.nextCdp = await begin(() => view.cdp("Page.enable"));
+    const settledNow = p => Bun.peek.status(p) === "pending" ? { pending: true } : outcome(p);
+    // A taken slot throws ERR_INVALID_STATE from the call, not its promise.
+    const begin = call => { try { return call(); } catch (e) { return Promise.reject(new Error("threw " + e.message)); } };
+    report.evaluate = await settledNow(hungEvaluate);
+    report.cdp = await settledNow(hungCdp);
+
+    // While the renderer is dead, a page operation is refused on the spot
+    // instead of waiting on a navigation that may never come.
+    report.evaluateWhileCrashed = await settledNow(begin(() => view.evaluate("'too early'")));
+    report.reloadWhileCrashed = await settledNow(begin(() => view.reload()));
+    // cdp() keeps Chrome's own semantics: the browser holds the command and
+    // fails it with "Target crashed" once the navigation recreates the tab.
+    const cdpWhileCrashed = outcome(begin(() => view.cdp("DOM.getDocument")));
+    report.recovery = await outcome(begin(() => view.navigate("http://fake/again")));
+    report.cdpWhileCrashed = await cdpWhileCrashed;
+    report.evaluateAfter = await outcome(begin(() => view.evaluate("'alive'")));
     view.close();
     print(report);
   `);
   const crashed = { rejected: "page crashed (renderer process died)" };
+  const refused = { rejected: "page crashed (renderer process died), navigate() to recover" };
   expect(result).toEqual({
     evaluateStatus: "rejected",
     cdpStatus: "rejected",
     evaluate: crashed,
     cdp: crashed,
-    nextEvaluate: { resolved: "alive" },
-    nextCdp: { resolved: {} },
+    evaluateWhileCrashed: refused,
+    reloadWhileCrashed: refused,
+    recovery: {},
+    cdpWhileCrashed: { rejected: "Target crashed" },
+    evaluateAfter: { resolved: "alive" },
   });
 });
 

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -377,6 +377,11 @@ test.concurrent("a renderer crash rejects the view's pending work and a reload()
     report.reload = await outcome(begin(() => view.reload()));
     report.cdpWhileCrashed = await cdpWhileCrashed;
     report.after = await outcome(begin(() => view.evaluate("'alive at ' + " + JSON.stringify(view.url))));
+    // The refused resize() left the view's own idea of its size alone:
+    // scroll() still aims its wheel event at the centre of the 100x100 view.
+    await view.scroll(0, 10);
+    const { x, y } = await view.evaluate("__fake_last_input");
+    report.scrollCentre = [x, y];
     view.close();
     print(report);
   `);
@@ -392,7 +397,26 @@ test.concurrent("a renderer crash rejects the view's pending work and a reload()
     reload: {},
     cdpWhileCrashed: { rejected: "Target crashed" },
     after: { resolved: "alive at http://fake/crashed-and-reloaded" },
+    scrollCentre: [50, 50],
   });
+});
+
+// History navigation is a navigation too: Chrome answers
+// Page.getNavigationHistory from the browser while the renderer is dead, and
+// Page.navigateToHistoryEntry recreates it. So goBack() must not be refused.
+test.concurrent("goBack() recovers a crashed view too", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/one");
+    await view.navigate("http://fake/two");
+    const crashed = new Promise(resolve => view.addEventListener("Inspector.targetCrashed", resolve));
+    view.cdp("Page.crash").catch(() => {});
+    await crashed;
+    const back = await outcome(view.goBack());
+    print({ back, url: view.url, value: await outcome(view.evaluate("'alive'")) });
+    view.close();
+  `);
+  expect(result).toEqual({ back: {}, url: "http://fake/one", value: { resolved: "alive" } });
 });
 
 // The crash rejection is not a requested teardown, so a pending operation

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -338,15 +338,16 @@ test.concurrent("onNavigationFailed can retry navigate() immediately", async () 
 
 // A tab's renderer process can die while the browser keeps running (OOM kill,
 // SIGKILL, Page.crash). Chrome reports it with Inspector.targetCrashed on the
-// view's session, keeps the session attached, and holds every command the
-// page has to answer, the ones already in flight included, until a
-// Page.navigate gives the tab a new renderer. So the view has to settle the
-// pending work itself, and refuse page operations until then rather than let
-// them wait for a navigation that may never come. cdp() stays raw.
-test.concurrent("a renderer crash rejects the view's pending work and navigate() recovers it", async () => {
+// view's session and keeps the session attached. A navigation (navigate,
+// reload, history) gives the tab a new renderer; until then Chrome holds every
+// command the page has to answer, the ones already in flight included. So the
+// view settles the pending work itself and refuses page operations until a
+// navigation commits, rather than let them wait for one that may never come.
+// cdp() stays raw.
+test.concurrent("a renderer crash rejects the view's pending work and a reload() recovers it", async () => {
   const result = await runScenario(`
     const view = newView();
-    await view.navigate("http://fake/");
+    await view.navigate("http://fake/crashed-and-reloaded");
     const hungEvaluate = view.evaluate("__fake_no_reply()");
     const hungCdp = view.cdp("Page.crash");
     hungEvaluate.catch(() => {}); // held, so the crash rejection is not loud here
@@ -360,38 +361,37 @@ test.concurrent("a renderer crash rejects the view's pending work and navigate()
       }));
     });
     // Awaiting a slot the crash left pending would never return, so report
-    // that instead of hanging.
-    const settledNow = p => Bun.peek.status(p) === "pending" ? { pending: true } : outcome(p);
+    // that instead of hanging (and keep whatever it settles with later quiet).
+    const settledNow = p => Bun.peek.status(p) === "pending" ? (p.catch(() => {}), { pending: true }) : outcome(p);
     // A taken slot throws ERR_INVALID_STATE from the call, not its promise.
     const begin = call => { try { return call(); } catch (e) { return Promise.reject(new Error("threw " + e.message)); } };
     report.evaluate = await settledNow(hungEvaluate);
     report.cdp = await settledNow(hungCdp);
 
-    // While the renderer is dead, a page operation is refused on the spot
-    // instead of waiting on a navigation that may never come.
+    // While the renderer is dead, a page operation is refused on the spot.
     report.evaluateWhileCrashed = await settledNow(begin(() => view.evaluate("'too early'")));
-    report.reloadWhileCrashed = await settledNow(begin(() => view.reload()));
+    report.resizeWhileCrashed = await settledNow(begin(() => view.resize(120, 120)));
     // cdp() keeps Chrome's own semantics: the browser holds the command and
-    // fails it with "Target crashed" once the navigation recreates the tab.
+    // fails it with "Target crashed" once a navigation recreates the renderer.
     const cdpWhileCrashed = outcome(begin(() => view.cdp("DOM.getDocument")));
-    report.recovery = await outcome(begin(() => view.navigate("http://fake/again")));
+    report.reload = await outcome(begin(() => view.reload()));
     report.cdpWhileCrashed = await cdpWhileCrashed;
-    report.evaluateAfter = await outcome(begin(() => view.evaluate("'alive'")));
+    report.after = await outcome(begin(() => view.evaluate("'alive at ' + " + JSON.stringify(view.url))));
     view.close();
     print(report);
   `);
   const crashed = { rejected: "page crashed (renderer process died)" };
-  const refused = { rejected: "page crashed (renderer process died), navigate() to recover" };
+  const refused = { rejected: "page crashed (renderer process died), reload() or navigate() to recover" };
   expect(result).toEqual({
     evaluateStatus: "rejected",
     cdpStatus: "rejected",
     evaluate: crashed,
     cdp: crashed,
     evaluateWhileCrashed: refused,
-    reloadWhileCrashed: refused,
-    recovery: {},
+    resizeWhileCrashed: refused,
+    reload: {},
     cdpWhileCrashed: { rejected: "Target crashed" },
-    evaluateAfter: { resolved: "alive" },
+    after: { resolved: "alive at http://fake/crashed-and-reloaded" },
   });
 });
 

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -336,6 +336,71 @@ test.concurrent("onNavigationFailed can retry navigate() immediately", async () 
   expect(result).toBe("retry was accepted and failed too");
 });
 
+// A tab's renderer process can die while the browser keeps running (OOM kill,
+// SIGKILL, Page.crash). Chrome reports it with Inspector.targetCrashed on the
+// view's session and never answers what the dead renderer owed, so the view
+// has to settle that work itself. The statuses are read inside the listener,
+// which runs after the rejections, so the check needs no timer.
+test.concurrent("a renderer crash rejects the view's pending work and frees its slots", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/");
+    const hungEvaluate = view.evaluate("__fake_no_reply()");
+    const hungCdp = view.cdp("Page.crash");
+    const held = [outcome(hungEvaluate), outcome(hungCdp)];
+    const report = await new Promise(resolve => {
+      view.addEventListener("Inspector.targetCrashed", () => resolve({
+        evaluateStatus: Bun.peek.status(hungEvaluate),
+        cdpStatus: Bun.peek.status(hungCdp),
+      }));
+    });
+    // Awaiting a slot the crash left pending would never return, so report
+    // that instead of hanging.
+    const reason = (status, held) => status === "pending" ? { pending: true } : held;
+    report.evaluate = await reason(report.evaluateStatus, held[0]);
+    report.cdp = await reason(report.cdpStatus, held[1]);
+    // Both slots are free again, and the view still works. A taken slot
+    // throws ERR_INVALID_STATE from the call itself, not from its promise.
+    const begin = call => { try { return outcome(call()); } catch (e) { return { threw: e.message }; } };
+    report.nextEvaluate = await begin(() => view.evaluate("'alive'"));
+    report.nextCdp = await begin(() => view.cdp("Page.enable"));
+    view.close();
+    print(report);
+  `);
+  const crashed = { rejected: "page crashed (renderer process died)" };
+  expect(result).toEqual({
+    evaluateStatus: "rejected",
+    cdpStatus: "rejected",
+    evaluate: crashed,
+    cdp: crashed,
+    nextEvaluate: { resolved: "alive" },
+    nextCdp: { resolved: {} },
+  });
+});
+
+// The crash rejection is not a requested teardown, so a pending operation
+// nothing holds has to surface as an unhandled rejection, the way a browser
+// death does.
+test.concurrent("a floating operation killed by a renderer crash stays loud", async () => {
+  const result = await runScenario(`
+    const unhandled = [];
+    process.on("unhandledRejection", e => unhandled.push(e.message));
+    const view = newView();
+    await view.navigate("http://fake/");
+    view.evaluate("__fake_no_reply()"); // floating: nobody handles it
+    view.cdp("Page.crash").catch(() => {});
+    // Bounded so the scenario still reports when the report never comes.
+    const deadline = Date.now() + 2000;
+    while (unhandled.length === 0 && Date.now() < deadline) await Bun.sleep(10);
+    // Nothing announces "no second report is coming"; this is a bounded
+    // window for one to appear.
+    await Bun.sleep(50);
+    view.close();
+    print(unhandled);
+  `);
+  expect(result).toEqual(["page crashed (renderer process died)"]);
+});
+
 // `bun test --isolate` replaces the global object between files. The transport
 // is bound to the global that spawned the browser, so it has to go with that
 // file: its open views are closed, their pending promises rejected, and the

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -537,6 +537,33 @@ it("chrome: close() rejects pending promises", async () => {
   await expect(p).rejects.toThrow(/closed/);
 });
 
+// Page.crash kills the tab's renderer the same way an OOM kill or a SIGKILL
+// of that process does. The browser lives on, so only this view is affected:
+// Chrome sends Inspector.targetCrashed on its session, never answers the work
+// the dead renderer owed, and gives the view a new renderer on the next
+// navigate.
+it("chrome: a renderer crash rejects the view's pending work and keeps the view usable", async () => {
+  const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  try {
+    await view.navigate(html("<title>before</title>"));
+    // Both reject in the same turn, so both need a handler before the
+    // first await, or the second one reports as an unhandled rejection.
+    const settled = await Promise.allSettled([view.evaluate("new Promise(() => {})"), view.cdp("Page.crash")]);
+    expect(settled.map(s => s.status)).toEqual(["rejected", "rejected"]);
+    expect(settled.map(s => (s as PromiseRejectedResult).reason.message)).toEqual([
+      "page crashed (renderer process died)",
+      "page crashed (renderer process died)",
+    ]);
+    // The slots are free and the view is not closed: a navigate gets a new
+    // renderer, and evaluate() works in it.
+    await view.navigate(html("<title>after</title>"));
+    expect(view.title).toBe("after");
+    expect(await view.evaluate("document.title")).toBe("after");
+  } finally {
+    view.close();
+  }
+});
+
 it("chrome: two views have independent sessions", async () => {
   const a = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   const b = new Bun.WebView({ backend: chrome, width: 200, height: 200 });

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -539,23 +539,29 @@ it("chrome: close() rejects pending promises", async () => {
 
 // Page.crash kills the tab's renderer the same way an OOM kill or a SIGKILL
 // of that process does. The browser lives on, so only this view is affected:
-// Chrome sends Inspector.targetCrashed on its session, never answers the work
-// the dead renderer owed, and gives the view a new renderer on the next
-// navigate.
-it("chrome: a renderer crash rejects the view's pending work and keeps the view usable", async () => {
+// Chrome sends Inspector.targetCrashed on its session, holds every command
+// the page has to answer until a navigation recreates the renderer, and
+// gives the view that new renderer on the next navigate.
+it("chrome: a renderer crash rejects the view's pending work and navigate() recovers it", async () => {
   const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  const message = (e: unknown) => (e as Error).message;
   try {
     await view.navigate(html("<title>before</title>"));
     // Both reject in the same turn, so both need a handler before the
     // first await, or the second one reports as an unhandled rejection.
     const settled = await Promise.allSettled([view.evaluate("new Promise(() => {})"), view.cdp("Page.crash")]);
     expect(settled.map(s => s.status)).toEqual(["rejected", "rejected"]);
-    expect(settled.map(s => (s as PromiseRejectedResult).reason.message)).toEqual([
+    expect(settled.map(s => message((s as PromiseRejectedResult).reason))).toEqual([
       "page crashed (renderer process died)",
       "page crashed (renderer process died)",
     ]);
-    // The slots are free and the view is not closed: a navigate gets a new
-    // renderer, and evaluate() works in it.
+    // The slots are free, and a page operation fails fast while the renderer
+    // is gone rather than waiting on a navigation that may never come.
+    expect(await view.evaluate("1").then(() => null, message)).toBe(
+      "page crashed (renderer process died), navigate() to recover",
+    );
+    // The view is not closed: a navigate gets a new renderer, and evaluate()
+    // works in it again.
     await view.navigate(html("<title>after</title>"));
     expect(view.title).toBe("after");
     expect(await view.evaluate("document.title")).toBe("after");

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -539,14 +539,16 @@ it("chrome: close() rejects pending promises", async () => {
 
 // Page.crash kills the tab's renderer the same way an OOM kill or a SIGKILL
 // of that process does. The browser lives on, so only this view is affected:
-// Chrome sends Inspector.targetCrashed on its session, holds every command
-// the page has to answer until a navigation recreates the renderer, and
-// gives the view that new renderer on the next navigate.
-it("chrome: a renderer crash rejects the view's pending work and navigate() recovers it", async () => {
+// Chrome sends Inspector.targetCrashed on its session and holds every command
+// the page has to answer until a navigation of any kind recreates the
+// renderer. The view stays open throughout.
+it("chrome: a renderer crash rejects the view's pending work, and reload() or goBack() recovers it", async () => {
   const view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   const message = (e: unknown) => (e as Error).message;
+  const refused = "page crashed (renderer process died), reload() or navigate() to recover";
   try {
-    await view.navigate(html("<title>before</title>"));
+    await view.navigate(html("<title>first</title>"));
+    await view.navigate(html("<title>second</title>"));
     // Both reject in the same turn, so both need a handler before the
     // first await, or the second one reports as an unhandled rejection.
     const settled = await Promise.allSettled([view.evaluate("new Promise(() => {})"), view.cdp("Page.crash")]);
@@ -557,14 +559,20 @@ it("chrome: a renderer crash rejects the view's pending work and navigate() reco
     ]);
     // The slots are free, and a page operation fails fast while the renderer
     // is gone rather than waiting on a navigation that may never come.
-    expect(await view.evaluate("1").then(() => null, message)).toBe(
-      "page crashed (renderer process died), navigate() to recover",
-    );
-    // The view is not closed: a navigate gets a new renderer, and evaluate()
-    // works in it again.
-    await view.navigate(html("<title>after</title>"));
-    expect(view.title).toBe("after");
-    expect(await view.evaluate("document.title")).toBe("after");
+    // resize() in particular: Chrome 153 wedges the whole DevTools connection
+    // on an Emulation command sent to a crashed tab.
+    expect(await view.evaluate("1").then(() => null, message)).toBe(refused);
+    expect(await view.resize(300, 300).then(() => null, message)).toBe(refused);
+    // reload() is a navigation: it gets the tab a new renderer.
+    await view.reload();
+    expect(view.title).toBe("second");
+    expect(await view.evaluate("document.title")).toBe("second");
+    // So is goBack().
+    await view.cdp("Page.crash").catch(() => {});
+    expect(await view.evaluate("1").then(() => null, message)).toBe(refused);
+    await view.goBack();
+    expect(view.title).toBe("first");
+    expect(await view.evaluate("document.title")).toBe("first");
   } finally {
     view.close();
   }


### PR DESCRIPTION
### Problem

- When a Chrome view's renderer process dies, its pending `evaluate()` and `cdp()` promises never settle and both slots stay taken: every later call throws `Invalid state: an evaluate() is already pending`.
- `Transport::handleEvent` (`ChromeBackend.cpp:1110`) rejects a view's slots only on `Target.detachedFromTarget`. For a renderer death Chrome sends `Inspector.targetCrashed` on the view's session instead.
- Chrome then holds every page command until a navigation recreates the renderer. An `Emulation.*` command in that state wedges the whole DevTools connection.

### Fix

- On `Inspector.targetCrashed`, reject the view's slots and drop its pending ids (`Transport::failPendingWork`, shared with the detach path), before the `EventTarget` dispatch so a listener can `reload()`.
- Mark the view crashed until a document commits. While set, `navigate()`, `reload()`, `goBack()`, `goForward()` and raw `cdp()` go through and everything else rejects at once. Any navigation recovers the view.
- Self-reviewed: 2 concerns, both addressed (the first gate wrongly refused `reload()` and history navigation). The review preferred the gate as a follow-up PR. I kept it: without it a retried `evaluate()` hangs until some navigation, and one `resize()` hangs every view in the process.
- Verified: new tests in `webview-chrome-pipe.test.ts` (3), `webview-chrome-disconnect.test.ts` (1), `webview-chrome.test.ts` (1, real Chrome). All but the `goBack()` pipe test fail on stock bun (that one guards against refusing history navigation). Ran all of `test/js/bun/webview/`.

### Background

- Each view has one promise slot per operation kind (`navigate`, `evaluate`, `screenshot`, `cdp`, misc). A second call on a taken slot throws `ERR_INVALID_STATE`.
- One Chrome process serves every view. Each view is a CDP target with its own session id; `handleEvent` routes events by it.
- A renderer is the per-tab process that runs the page. It can die alone (OOM kill, `Page.crash`) while the browser lives on.

<details><summary>Notes</summary>

Reproduction, before the fix (real headless Chrome):

```
pending evaluate(): STILL PENDING after 5000 ms
cdp("Page.crash"):   STILL PENDING after 100 ms
Inspector.targetCrashed events seen by addEventListener: 1
evaluate() afterwards: Invalid state: an evaluate() is already pending
cdp() afterwards:      Invalid state: a cdp() is already pending
navigate() afterwards: resolved undefined
```

After the fix both report `rejected: page crashed (renderer process died)`, and the later calls no longer throw.

What raw CDP probes against Chrome 153 show for a crashed session, one fresh tab per scenario:

- `Inspector.targetCrashed` arrives with empty `params` on the view's session. The browser-level `Target.detachedFromTarget` never fires.
- `Runtime.evaluate`, `DOM.*` and the like get no reply for as long as nothing navigates. Once a navigation recreates the renderer, Chrome fails each of them with `-32000 Target crashed` and emits `Inspector.targetReloadedAfterCrash`.
- `Page.navigate`, `Page.reload` and `Page.navigateToHistoryEntry` all recreate the renderer, and `Page.getNavigationHistory` is answered by the browser while crashed. So every operation on the view's navigation slot recovers it.
- `Page.captureScreenshot` and `Input.*` fail at once with `-32603 Internal error`.
- `Emulation.setDeviceMetricsOverride` (what `resize()` sends) never gets a reply, and after it nothing else does either: not a `Page.navigate` on that session, not `Browser.getVersion` on the root session. The gate keeps `resize()` away from a crashed tab for this reason above all.

An earlier revision of this PR claimed `Page.reload` cannot recover a crashed tab. That probe had sent the `Emulation` command first, which is what actually hung the session. The per-scenario probe corrected it.

So the view tracks the crash in `m_crashed`, set on `Inspector.targetCrashed` and cleared on `Page.frameNavigated`. `sendChromeOp` refuses everything outside the `Navigate` and `Cdp` slots while it is set. `click()` and `press()` take the check before their untracked first frame, and `resize()` before it stores the new size, so a refused resize does not leave `scroll()` aiming at the wrong centre.

Test notes:

- `fake-chrome-fixture.ts` models the crashed session: `Target.*` and the navigation commands stay answered, page commands are held by id and failed with `Target crashed` when a navigation brings the renderer back, screenshot and input fail with `-32603`. It also learned `Page.reload` and session history (`Page.getNavigationHistory`, `Page.navigateToHistoryEntry`), so a third pipe test covers `goBack()` recovery without a browser.
- The pipe test reads `Bun.peek.status()` on both promises from inside the crash listener. The listener runs after the rejections, so that assertion needs no timer. It then checks that `evaluate()` and `resize()` are refused, that a raw `cdp("DOM.getDocument")` is failed by the browser with `Target crashed` once `reload()` recovers the view, and that `evaluate()` works again afterwards.
- The real-Chrome test crashes the tab twice and recovers once with `reload()` and once with `goBack()`.
- A crash is not a requested teardown, so the rejections stay loud. A second pipe test asserts that a floating operation killed by a crash still reports through `unhandledRejection`, the way a browser death does.
- Suites run: `webview-chrome-pipe.test.ts` (17 pass), `webview-chrome-disconnect.test.ts` (8 pass), `webview-chrome-ws.test.ts` (5 todo, no Chrome endpoint here), `webview-chrome.test.ts` (59 pass, with a `--no-sandbox` wrapper because this container runs as root).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome.test.ts, test/js/bun/webview/webview-chrome-pipe.test.ts, test/js/bun/webview/webview-chrome-disconnect.test.ts

<!-- robobun:evidence:end -->