### PR TITLE
webview: re-check that the view is open after argument conversion in click/press/scroll/scrollTo/resize

### DIFF
--- a/src/runtime/webview/JSWebViewConstructor.cpp
+++ b/src/runtime/webview/JSWebViewConstructor.cpp
@@ -382,7 +382,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
     if (consoleCallback) view->m_onConsole.set(vm, view, consoleCallback);
     // Navigate promise lands in m_pendingNavigate; the user's first await
     // (including the next navigate()) serializes behind it. If it rejects
-    // (bad URL), the next op's checkSlot sees the slot cleared and proceeds.
+    // (bad URL), the next op's checkReady sees the slot cleared and proceeds.
     // No user code ever holds this promise; handled, so a rejection cannot
     // surface as unhandledRejection.
     if (!initialUrl.isEmpty()) {

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -143,10 +143,16 @@ static JSWebView* unwrapThis(JSGlobalObject* globalObject, ThrowScope& scope, Ca
     return thisObject;
 }
 
-// Slot-empty check + INVALID_STATE. Separate from unwrapThis because each
-// method uses a different slot.
-static bool checkSlot(JSGlobalObject* g, ThrowScope& scope, const WriteBarrier<JSPromise>& slot, ASCIILiteral what)
+// Last guard before dispatch, run after all argument conversion: a getter,
+// valueOf(), toString() or toJSON() on an argument can call view.close() or
+// start another operation on this view after unwrapThis() passed. A command
+// sent for a closed view gets a reply that finds no view to settle.
+static bool checkReady(JSGlobalObject* g, ThrowScope& scope, JSWebView* view, const WriteBarrier<JSPromise>& slot, ASCIILiteral what)
 {
+    if (view->m_closed) {
+        Bun::throwError(g, scope, ErrorCode::ERR_INVALID_STATE, "WebView is closed"_s);
+        return false;
+    }
     if (slot) {
         Bun::ERR::INVALID_STATE(scope, g, makeString(what, " is already pending"_s));
         return false;
@@ -222,7 +228,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncNavigate, (JSGlobalObject * globalObj
     WTF::String url = urlArg.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    if (!checkSlot(globalObject, scope, thisObject->m_pendingNavigate, "a navigation"_s)) return {};
+    if (!checkReady(globalObject, scope, thisObject, thisObject->m_pendingNavigate, "a navigation"_s)) return {};
     return JSValue::encode(thisObject->navigate(globalObject, url));
 }
 
@@ -239,7 +245,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncEvaluate, (JSGlobalObject * globalObj
     WTF::String script = scriptArg.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    if (!checkSlot(globalObject, scope, thisObject->m_pendingEval, "an evaluate()"_s)) return {};
+    if (!checkReady(globalObject, scope, thisObject, thisObject->m_pendingEval, "an evaluate()"_s)) return {};
     return JSValue::encode(thisObject->evaluate(globalObject, script));
 }
 
@@ -324,12 +330,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScreenshot, (JSGlobalObject * globalO
                 "encoding must be a string"_s);
     }
 
-    // checkSlot after option parsing: opts->get() can invoke Proxy getters
-    // that call view.close() between the guard and the screenshot() send.
-    if (!checkSlot(globalObject, scope, thisObject->m_pendingScreenshot, "a screenshot()"_s)) return {};
-    if (thisObject->m_closed)
-        return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE, "WebView is closed"_s);
-
+    if (!checkReady(globalObject, scope, thisObject, thisObject->m_pendingScreenshot, "a screenshot()"_s)) return {};
     thisObject->m_screenshotEncoding = encoding;
     return JSValue::encode(thisObject->screenshot(globalObject, format, quality));
 }
@@ -393,11 +394,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncCdp, (JSGlobalObject * globalObject, 
                 "params must be a JSON-serializable object"_s);
     }
 
-    // Same TOCTOU as screenshot: JSONStringify can call a user-supplied
-    // .toJSON() that closes the view between the earlier guards and send.
-    if (thisObject->m_closed)
-        return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE, "WebView is closed"_s);
-    if (!checkSlot(globalObject, scope, thisObject->m_pendingCdp, "a cdp()"_s)) return {};
+    if (!checkReady(globalObject, scope, thisObject, thisObject->m_pendingCdp, "a cdp()"_s)) return {};
     return JSValue::encode(thisObject->cdp(globalObject, method, paramsJson));
 }
 
@@ -453,7 +450,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncClick, (JSGlobalObject * globalObject
             return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "selector"_s, arg0, "must not be empty"_s);
         }
         if (!parseOpts(callFrame->argument(1))) return {};
-        if (!checkSlot(globalObject, scope, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
+        if (!checkReady(globalObject, scope, thisObject, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
         return JSValue::encode(thisObject->clickSelector(globalObject, selector, timeout, button, mods, clickCount));
     }
 
@@ -464,7 +461,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncClick, (JSGlobalObject * globalObject
     RETURN_IF_EXCEPTION(scope, {});
     if (!parseOpts(callFrame->argument(2))) return {};
 
-    if (!checkSlot(globalObject, scope, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
+    if (!checkReady(globalObject, scope, thisObject, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
     return JSValue::encode(thisObject->click(globalObject,
         static_cast<float>(x), static_cast<float>(y), button, mods, clickCount));
 }
@@ -482,7 +479,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncType, (JSGlobalObject * globalObject,
     WTF::String text = textArg.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    if (!checkSlot(globalObject, scope, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
+    if (!checkReady(globalObject, scope, thisObject, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
     return JSValue::encode(thisObject->type(globalObject, text));
 }
 
@@ -514,7 +511,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncPress, (JSGlobalObject * globalObject
             "must be a virtual key name (Enter, Tab, Escape, Arrow*, etc.) or a single character"_s);
     }
 
-    if (!checkSlot(globalObject, scope, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
+    if (!checkReady(globalObject, scope, thisObject, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
     return JSValue::encode(thisObject->press(globalObject, vk, mods,
         vk == VirtualKey::Character ? key : WTF::String()));
 }
@@ -537,7 +534,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScroll, (JSGlobalObject * globalObjec
         return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "dx/dy"_s,
             jsNumber(std::isfinite(dx) ? dy : dx), "must be finite"_s);
 
-    if (!checkSlot(globalObject, scope, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
+    if (!checkReady(globalObject, scope, thisObject, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
     return JSValue::encode(thisObject->scroll(globalObject, dx, dy));
 }
 
@@ -587,7 +584,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScrollTo, (JSGlobalObject * globalObj
         }
     }
 
-    if (!checkSlot(globalObject, scope, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
+    if (!checkReady(globalObject, scope, thisObject, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
     return JSValue::encode(thisObject->scrollTo(globalObject, selector, timeout, block));
 }
 
@@ -607,7 +604,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncResize, (JSGlobalObject * globalObjec
     if (h == 0 || h > 16384)
         return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "height"_s, 1, 16384, jsNumber(h));
 
-    if (!checkSlot(globalObject, scope, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
+    if (!checkReady(globalObject, scope, thisObject, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
     return JSValue::encode(thisObject->resize(globalObject, w, h));
 }
 
@@ -626,7 +623,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncBack, (JSGlobalObject * globalObject,
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = unwrapThis(globalObject, scope, callFrame, "goBack"_s);
     RETURN_IF_EXCEPTION(scope, {});
-    if (!checkSlot(globalObject, scope, navSlot(thisObject), "a navigation"_s)) return {};
+    if (!checkReady(globalObject, scope, thisObject, navSlot(thisObject), "a navigation"_s)) return {};
     return JSValue::encode(thisObject->goBack(globalObject));
 }
 
@@ -636,7 +633,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncForward, (JSGlobalObject * globalObje
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = unwrapThis(globalObject, scope, callFrame, "goForward"_s);
     RETURN_IF_EXCEPTION(scope, {});
-    if (!checkSlot(globalObject, scope, navSlot(thisObject), "a navigation"_s)) return {};
+    if (!checkReady(globalObject, scope, thisObject, navSlot(thisObject), "a navigation"_s)) return {};
     return JSValue::encode(thisObject->goForward(globalObject));
 }
 
@@ -646,7 +643,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncReload, (JSGlobalObject * globalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* thisObject = unwrapThis(globalObject, scope, callFrame, "reload"_s);
     RETURN_IF_EXCEPTION(scope, {});
-    if (!checkSlot(globalObject, scope, navSlot(thisObject), "a navigation"_s)) return {};
+    if (!checkReady(globalObject, scope, thisObject, navSlot(thisObject), "a navigation"_s)) return {};
     return JSValue::encode(thisObject->reload(globalObject));
 }
 

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -143,8 +143,7 @@ static JSWebView* unwrapThis(JSGlobalObject* globalObject, ThrowScope& scope, Ca
     return thisObject;
 }
 
-// Call after all argument conversion: user code it runs (valueOf, getters,
-// toJSON) can close the view or start another operation on it.
+// Call after argument conversion: user code there (valueOf, getters, toJSON) can close the view or start another operation on it.
 static bool checkReady(JSGlobalObject* g, ThrowScope& scope, JSWebView* view, const WriteBarrier<JSPromise>& slot, ASCIILiteral what)
 {
     if (view->m_closed) {

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -143,10 +143,8 @@ static JSWebView* unwrapThis(JSGlobalObject* globalObject, ThrowScope& scope, Ca
     return thisObject;
 }
 
-// Last guard before dispatch, run after all argument conversion: a getter,
-// valueOf(), toString() or toJSON() on an argument can call view.close() or
-// start another operation on this view after unwrapThis() passed. A command
-// sent for a closed view gets a reply that finds no view to settle.
+// Call after all argument conversion: user code it runs (valueOf, getters,
+// toJSON) can close the view or start another operation on it.
 static bool checkReady(JSGlobalObject* g, ThrowScope& scope, JSWebView* view, const WriteBarrier<JSPromise>& slot, ASCIILiteral what)
 {
     if (view->m_closed) {

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -196,6 +196,58 @@ test.concurrent("close() rejects a held navigate() catchably and a floating one 
   expect(result).toEqual({ heldOutcome: { rejected: "WebView closed" }, unhandled: [] });
 });
 
+// Converting an argument can run user code (valueOf, toString, toJSON, an
+// options getter) that closes the view after the method's first closed-check.
+// Every method must check again before it sends: a command sent for a closed
+// view gets a reply nothing can route, so its promise would never settle.
+test.concurrent("close() during argument conversion makes the call throw instead of hang", async () => {
+  const result = await runScenario(`
+    const closing = (view, value) => ({
+      valueOf() { view.close(); return value; },
+      toString() { view.close(); return String(value); },
+    });
+    const shapes = {
+      "click(x, _)": view => view.click(closing(view, 5), 5),
+      "click(_, y)": view => view.click(5, closing(view, 5)),
+      "click(x, y, options)": view => view.click(5, 5, { get button() { view.close(); return "left"; } }),
+      "click(x, y, { modifiers })": view => view.click(5, 5, { modifiers: [closing(view, "Shift")] }),
+      "click(selector, options)": view => view.click("#b", { get timeout() { view.close(); return 100; } }),
+      "press(key, options)": view => view.press("Enter", { get modifiers() { view.close(); return []; } }),
+      "scroll(dx, _)": view => view.scroll(closing(view, 5), 5),
+      "scrollTo(selector, options)": view => view.scrollTo("#b", { get block() { view.close(); return "center"; } }),
+      "resize(width, _)": view => view.resize(closing(view, 50), 50),
+      "screenshot(options)": view => view.screenshot({ get format() { view.close(); return "png"; } }),
+      "cdp(method, params)": view => view.cdp("Runtime.evaluate", { toJSON() { view.close(); return {}; } }),
+    };
+    const results = {};
+    for (const [name, call] of Object.entries(shapes)) {
+      const view = newView();
+      await view.navigate("http://fake/");
+      try {
+        call(view);
+        results[name] = "returned";
+      } catch (e) {
+        results[name] = e.code + ": " + e.message;
+      }
+    }
+    print(results);
+  `);
+  const closed = "ERR_INVALID_STATE: WebView is closed";
+  expect(result).toEqual({
+    "click(x, _)": closed,
+    "click(_, y)": closed,
+    "click(x, y, options)": closed,
+    "click(x, y, { modifiers })": closed,
+    "click(selector, options)": closed,
+    "press(key, options)": closed,
+    "scroll(dx, _)": closed,
+    "scrollTo(selector, options)": closed,
+    "resize(width, _)": closed,
+    "screenshot(options)": closed,
+    "cdp(method, params)": closed,
+  });
+});
+
 // The browser dying (instead of close()) rejects the same internal
 // constructor-url promise; that must be quiet too. A floating user promise
 // is the opposite: a crash is not a requested teardown, so its rejection

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -180,7 +180,7 @@ it("url constructor option fires navigate()", async () => {
   // page has loaded.
   await using view = new Bun.WebView({ width: 200, height: 200, url: html("<h1 id=t>from-ctor</h1>") });
   // No explicit navigate() — the constructor fired it. evaluate() will
-  // wait for the pending navigate to complete (checkSlot serializes).
+  // wait for the pending navigate to complete (checkReady serializes).
   // Actually — evaluate uses m_pendingEval, not m_pendingNavigate, so
   // they don't serialize against each other on the JS side. The child
   // processes the Create+Navigate+Evaluate frames in order from the same


### PR DESCRIPTION
### Problem
- `Bun.WebView`: if user code that runs while `click()`, `press()`, `scroll()`, `scrollTo()` or `resize()` convert their arguments (a `valueOf()`, a `modifiers` entry's `toString()`, an options getter) calls `view.close()`, the returned promise never settles. `screenshot()` and `cdp()` in the same position throw `WebView is closed`.
- The cause is in `src/runtime/webview/JSWebViewPrototype.cpp`. These five methods checked `m_closed` only in `unwrapThis()`, before `toNumber()`/`toUInt32()`/`JSObject::get()` ran. `close()` removes the view from the transport's routing table (`CDP::Ops::close`, `WK::Ops::close`). The command sent after that gets a reply that `handleResponse` cannot route (`viewFor()` is null), so nothing settles the slot and `m_pendingActivityCount` never returns to zero.

### Fix
- Rename the shared pre-dispatch guard `checkSlot` to `checkReady` and make it check `m_closed` before the slot. Every method already calls it as the last step before sending, after all argument conversion.
- Delete the two ad-hoc `m_closed` re-checks in `screenshot()` and `cdp()`. The helper now does the same thing with the same error (`ERR_INVALID_STATE`, `WebView is closed`), so their behavior is unchanged.
- Correct because the guard now runs after the last call that can enter user code in every method, on both backends. The early check in `unwrapThis()` stays: it avoids running any conversion on a view that is already closed.
- Verified: `test/js/bun/webview/webview-chrome-pipe.test.ts` (new test, 11 shapes, runs against the fake-Chrome fixture so it needs no browser; stock bun fails 9 of 11). Also ran `webview-chrome.test.ts` (58 pass), `webview-chrome-disconnect.test.ts` and `webview-chrome-ws.test.ts` against Chrome 143 with the debug build.

### Background
- Each `WebView` method validates its arguments in `JSWebViewPrototype.cpp`, then calls an instance method that builds the wire command and stores the returned promise in a per-operation `WriteBarrier<JSPromise>` slot (`m_pendingMisc` for the input methods).
- Replies are routed by request id to a view id, then through the transport's `m_views` (Chrome) or `viewsById` (WebKit) weak map. `close()` rejects the view's slots and erases it from that map, so a reply for a closed view is dropped by design.
- `m_pendingActivityCount` is what keeps a view with an in-flight operation alive for the GC. A slot that is set but never settled pins the view.

<details><summary>Notes</summary>

- Reproduces on 1.4.2, canary `5f554969b` and main with real Chrome and with `test/js/bun/webview/fake-chrome-fixture.ts`. With the fake, the unfixed build returns a pending promise for all nine input shapes; with the fix each call throws synchronously, like every other argument error in these methods.
- `navigate()`, `evaluate()` and `type()` only call `toWTFString()` on a value already checked with `isString()`, and `goBack()`/`goForward()`/`reload()` take no arguments, so they could not hit this today. They go through the same helper now, which also covers #30645 (it adds option parsing to the navigation methods and carried its own copies of the re-check).
- A re-entrant call that starts another operation on the same view during conversion was already handled: the slot check ran after conversion. Only the closed check was missing.
- #39075 is a different path (`close()` while `Target.createTarget` is in flight).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview.test.ts, test/js/bun/webview/webview-chrome-pipe.test.ts

<!-- robobun:evidence:end -->