### PR TITLE
webview: settle a Chrome same-document navigation and a back-forward cache restore on its own commit

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -194,7 +194,7 @@ await view.navigate("file:///path/to/index.html");
 
 `navigate()` resolves when the main frame's `load` event fires. After it resolves, `view.url` and `view.title` reflect the new page, and `view.loading` is `false`.
 
-A URL that only adds or changes the `#fragment` of the current page stays in the same document. The browser fires no `load` event for it, so `navigate()` resolves as soon as the new URL is current. The same applies to `goBack()` and `goForward()` over an entry of the current document, such as a `#fragment` entry or one the page made with `history.pushState()`.
+A URL that only adds or changes the `#fragment` of the current page stays in the same document. The browser fires no `load` event for it, so `navigate()` resolves as soon as the new URL is current. The same applies to `goBack()` and `goForward()` over an entry of the current document, such as a `#fragment` entry or one the page made with `history.pushState()`. A `goBack()` or `goForward()` onto a page that the browser kept whole in its back-forward cache also resolves as soon as that page is current.
 
 If the navigation fails (DNS failure, connection refused, invalid URL), the promise rejects with an `Error` describing the failure.
 
@@ -224,7 +224,7 @@ view.onNavigationFailed = error => {
 };
 ```
 
-These fire **before** the corresponding `navigate()` promise settles, so by the time `await view.navigate(...)` returns, your callback has already run. Set to `null` to remove.
+These fire **before** the corresponding `navigate()` promise settles, so by the time `await view.navigate(...)` returns, your callback has already run. Same-document navigations by the page (`history.pushState()`, a fragment change) also update `view.url` and fire `onNavigated`. Navigations inside an `<iframe>` do not. Set to `null` to remove.
 
 ---
 

--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -194,7 +194,7 @@ await view.navigate("file:///path/to/index.html");
 
 `navigate()` resolves when the main frame's `load` event fires. After it resolves, `view.url` and `view.title` reflect the new page, and `view.loading` is `false`.
 
-A URL that only adds or changes the `#fragment` of the current page stays in the same document. The browser fires no `load` event for it, so `navigate()` resolves as soon as the new URL is current. The same applies to `goBack()` and `goForward()` over an entry of the current document, such as a `#fragment` entry or one the page made with `history.pushState()`. A `goBack()` or `goForward()` onto a page that the browser kept whole in its back-forward cache also resolves as soon as that page is current.
+A URL that only adds or changes the `#fragment` of the current page stays in the same document. The browser fires no `load` event for it, so with the Chrome backend `navigate()` resolves as soon as the new URL is current. The same applies to `goBack()` and `goForward()` over an entry of the current document, such as a `#fragment` entry or one the page made with `history.pushState()`, and onto a page that Chrome kept whole in its back-forward cache.
 
 If the navigation fails (DNS failure, connection refused, invalid URL), the promise rejects with an `Error` describing the failure.
 
@@ -224,7 +224,7 @@ view.onNavigationFailed = error => {
 };
 ```
 
-These fire **before** the corresponding `navigate()` promise settles, so by the time `await view.navigate(...)` returns, your callback has already run. Same-document navigations by the page (`history.pushState()`, a fragment change) also update `view.url` and fire `onNavigated`. Navigations inside an `<iframe>` do not. Set to `null` to remove.
+These fire **before** the corresponding `navigate()` promise settles, so by the time `await view.navigate(...)` returns, your callback has already run. With the Chrome backend, a same-document navigation by the page (`history.pushState()`, a fragment change) also updates `view.url` and fires `onNavigated`. A navigation inside an `<iframe>` never does. Set to `null` to remove.
 
 ---
 

--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -194,6 +194,8 @@ await view.navigate("file:///path/to/index.html");
 
 `navigate()` resolves when the main frame's `load` event fires. After it resolves, `view.url` and `view.title` reflect the new page, and `view.loading` is `false`.
 
+A URL that only adds or changes the `#fragment` of the current page stays in the same document. The browser fires no `load` event for it, so `navigate()` resolves as soon as the new URL is current. The same applies to `goBack()` and `goForward()` over an entry of the current document, such as a `#fragment` entry or one the page made with `history.pushState()`.
+
 If the navigation fails (DNS failure, connection refused, invalid URL), the promise rejects with an `Error` describing the failure.
 
 Only one navigation may be in flight per view at a time. Calling `navigate()` while another is pending throws `ERR_INVALID_STATE` synchronously.

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -849,8 +849,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         // The reply names the main frame, the one Page.navigate targets.
         if (view->m_mainFrameId.isEmpty())
             view->m_mainFrameId = WTF::String::fromUTF8(jsonString(jsonField(result, { "frameId", 7 })));
-        // Don't settle — the commit does (handleEvent). No loaderId means no
-        // document load: the navigation is same-document.
+        // Don't settle — the commit does. A reply without loaderId loads no document.
         if (view->m_chromeNavigationKind == ChromeNavigationKind::Unknown) {
             view->m_chromeNavigationKind = jsonField(result, { "loaderId", 8 }).empty()
                 ? ChromeNavigationKind::SameDocument
@@ -1163,9 +1162,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.frameStartedNavigating — Chrome classifies a navigation before it
-    // commits. "sameDocument" and "historySameDocument" keep the document;
-    // every other navigationType loads one.
+    // Page.frameStartedNavigating — Chrome classifies a navigation before it commits.
     if (method.size() == 27 && memcmp(method.data(), "Page.frameStartedNavigating", 27) == 0) {
         if (!isMainFrame(view, jsonString(jsonField(params, { "frameId", 7 })))) return;
         // Nothing of the view's is in flight: the page started this one.
@@ -1179,9 +1176,9 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.frameNavigated — cross-document commit. Update m_url and fire
-    // onNavigated. Same timing as WKWebView's NavDone (didFinishNavigation):
-    // the URL is now the new document, resources may still be loading.
+    // Page.frameNavigated — commit. Update m_url and fire onNavigated.
+    // Same timing as WKWebView's NavDone (didFinishNavigation): the URL is
+    // now the new document, resources may still be loading.
     if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0) {
         auto frame = jsonField(params, { "frame", 5 });
         if (!isMainFrame(view, jsonString(jsonField(frame, { "id", 2 })))) return;
@@ -1192,8 +1189,8 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
             ? WTF::String::fromUTF8(url)
             : makeString(WTF::String::fromUTF8(url), WTF::String::fromUTF8(fragment));
         view->m_url = urlStr;
-        // m_loading stays true — loadEventFired flips it. A new document is
-        // live, so its load event ends whatever the view has in flight.
+        // m_loading stays true — loadEventFired flips it.
+        // A new document is live: its load event ends whatever the view has in flight.
         if (view->m_chromeNavigationKind != ChromeNavigationKind::NotRequested)
             view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
 
@@ -1204,23 +1201,20 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.navigatedWithinDocument — same-document commit (#fragment,
-    // history.pushState, a traversal inside one document). No load event
-    // follows, so a same-document navigation ends here.
+    // Page.navigatedWithinDocument — same-document commit (#fragment, pushState). No load event follows.
     if (method.size() == 28 && memcmp(method.data(), "Page.navigatedWithinDocument", 28) == 0) {
         if (!isMainFrame(view, jsonString(jsonField(params, { "frameId", 7 })))) return;
         auto urlStr = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
         view->m_url = urlStr;
 
-        // CrossDocument waits for its load event and NotRequested has asked
-        // Chrome for nothing: then the page did this on its own. Decided
-        // before onNavigated runs user code, which may navigate() next.
+        // CrossDocument waits for its load event; NotRequested asked for nothing, so the page did this.
         auto kind = view->m_chromeNavigationKind;
         if (view->m_pendingNavigate && (kind == ChromeNavigationKind::Unknown || kind == ChromeNavigationKind::SameDocument)) {
             view->m_loading = false;
             sendTitleFetch(view);
         }
 
+        // After the settle decision: the callback is user code and may navigate() next.
         if (JSObject* cb = view->m_onNavigated.get()) {
             Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
                 JSValue::encode(jsString(vm, urlStr)), JSValue::encode(jsUndefined()));

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -704,13 +704,27 @@ static void startNavigation(JSWebView* view, ChromeNavigationKind kind)
     view->m_chromeNavigationSeq++;
 }
 
+// A traversal's own commit lands on the entry it targeted. Both URLs come out of the same JSON decoder.
+static bool commitLandsOnTraversalTarget(JSWebView* view, std::span<const char> params)
+{
+    if (view->m_chromeTraversalUrl.isNull()) return true;
+    auto root = JSON::Value::parseJSON(
+        StringView::fromLatin1(std::span<const Latin1Character>(
+            reinterpret_cast<const Latin1Character*>(params.data()), params.size())));
+    auto o = root ? root->asObject() : nullptr;
+    return !o || o->getString("url"_s) == view->m_chromeTraversalUrl;
+}
+
 // Which commit is the view's? No loader id, so the state says. "historyApi" is the page's own pushState()/replaceState(): navigate() and a traversal report "fragment".
-static bool sameDocumentCommitEndsNavigation(JSWebView* view, std::span<const char> navigationType)
+static bool sameDocumentCommitEndsNavigation(JSWebView* view, std::span<const char> params)
 {
     if (!view->m_pendingNavigate) return false;
+    auto navigationType = jsonString(jsonField(params, { "navigationType", 14 }));
     if (navigationType.size() == 10 && memcmp(navigationType.data(), "historyApi", 10) == 0) return false;
     auto kind = view->m_chromeNavigationKind;
-    return kind == ChromeNavigationKind::SameDocument || kind == ChromeNavigationKind::Unknown;
+    // A cross-document traversal commits late: a #fragment change of the page being left is not it.
+    if (kind == ChromeNavigationKind::Unknown) return commitLandsOnTraversalTarget(view, params);
+    return kind == ChromeNavigationKind::SameDocument;
 }
 
 // The view's navigation is over once its title fetch is in flight. A later commit is the page's own.
@@ -918,6 +932,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         }
         auto elem = entries->get(static_cast<unsigned>(target))->asObject();
         int32_t entryId = elem ? elem->getInteger("id"_s).value_or(0) : 0;
+        view->m_chromeTraversalUrl = elem ? elem->getString("url"_s) : WTF::String();
         // Chain into navigateToHistoryEntry. The traversal starts now.
         startNavigation(view, ChromeNavigationKind::Requested);
         uint32_t cid = nextId();
@@ -1195,7 +1210,7 @@ void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char>
     if (!isMainFrame(view, jsonString(jsonField(params, { "frameId", 7 })))) return;
     view->m_url = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
 
-    if (sameDocumentCommitEndsNavigation(view, jsonString(jsonField(params, { "navigationType", 14 })))) {
+    if (sameDocumentCommitEndsNavigation(view, params)) {
         sendTitleFetch(view, true);
         navigationConsumed(view);
     }
@@ -1256,10 +1271,11 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
 
     if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0)
         return onFrameNavigated(view, params);
-    if (method.size() == 28 && memcmp(method.data(), "Page.navigatedWithinDocument", 28) == 0)
-        return onNavigatedWithinDocument(view, params);
     if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0)
         return onLoadEventFired(view);
+    // Not intercepted before, so it goes on to addEventListener() below as it always has.
+    if (method.size() == 28 && memcmp(method.data(), "Page.navigatedWithinDocument", 28) == 0)
+        onNavigatedWithinDocument(view, params);
 
     // Runtime.consoleAPICalled — fires for every console.* call in the page.
     // params: {"type":"log","args":[<RemoteObject>,...],"stackTrace":{...}}.

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1178,13 +1178,25 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
     bool alreadyFailed = !loaderId.isEmpty() && loaderId == view->m_chromeFailedLoaderId;
     // Page.navigate's reply named the loader it started; reload() and a traversal go by state alone.
     bool expectedLoader = view->m_chromeNavigationLoaderId.isEmpty() || view->m_chromeNavigationLoaderId == loaderId;
+    // Another document took the commit navigate() was waiting for, so its own loader will not commit.
+    bool interrupted = !expectedLoader && !alreadyFailed && view->m_pendingNavigate
+        && view->m_chromeNavigationKind == ChromeNavigationKind::CrossDocument && !view->m_chromeNavigationCommitted;
     if (!alreadyFailed && expectedLoader && commitIsNavigations(view)) {
         view->m_chromeNavigationCommitted = true;
         view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
     }
 
-    // unreachableUrl: this is Chrome's error page for a load that failed. view.url keeps the last real page.
     auto unreachable = jsonString(jsonField(frame, { "unreachableUrl", 14 }));
+    if (interrupted) {
+        // Chrome normally answers a dropped Page.navigate with errorText first; this is the backstop, so no hang.
+        auto other = WTF::String::fromUTF8(unreachable.empty() ? jsonString(jsonField(frame, { "url", 3 })) : unreachable);
+        navigationConsumed(view);
+        view->m_chromeNavigationLoaderId = WTF::String();
+        settleFailure(m_global, view, PendingSlot::Navigate, Method::PageNavigate,
+            createError(m_global, makeString("Navigation interrupted by another one to "_s, other)));
+    }
+
+    // unreachableUrl: this is Chrome's error page for a load that failed. view.url keeps the last real page.
     if (!unreachable.empty()) {
         view->m_chromeOnErrorPage = true;
         // Reported once the error page has loaded and the tab takes commands again.

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -902,7 +902,9 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         }
         auto elem = entries->get(static_cast<unsigned>(target))->asObject();
         int32_t entryId = elem ? elem->getInteger("id"_s).value_or(0) : 0;
-        // Chain into navigateToHistoryEntry. Page.loadEventFired settles.
+        // Chain into navigateToHistoryEntry. The traversal starts now; its
+        // reply is {} either way, so Chrome's events classify it.
+        view->m_chromeNavigationKind = ChromeNavigationKind::Unknown;
         uint32_t cid = nextId();
         m_pending.add(cid, Pending { Method::PageNavigateToHistoryEntry, entry.slot, entry.viewId });
         send(cid, Command(cid, "Page.navigateToHistoryEntry"_s, sidSpan(view->m_sessionId)).num("entryId"_s, entryId));
@@ -1179,6 +1181,9 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     // (an SPA updating location.hash) from settling our cross-document one.
     if (method.size() == 27 && memcmp(method.data(), "Page.frameStartedNavigating", 27) == 0) {
         if (!isMainFrame(view, jsonString(jsonField(params, { "frameId", 7 })))) return;
+        // Nothing of the view's is in flight, so this navigation is the
+        // page's own (a link, history.back()); its kind says nothing about ours.
+        if (view->m_chromeNavigationKind == ChromeNavigationKind::NotRequested) return;
         auto type = jsonString(jsonField(params, { "navigationType", 14 }));
         bool sameDocument = (type.size() == 12 && memcmp(type.data(), "sameDocument", 12) == 0)
             || (type.size() == 19 && memcmp(type.data(), "historySameDocument", 19) == 0);
@@ -1205,8 +1210,10 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
             : makeString(WTF::String::fromUTF8(url), WTF::String::fromUTF8(fragment));
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it. A new document is
-        // live, so the load event is the commit that ends this navigation.
-        view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
+        // live, so the load event is the commit that ends the navigation in
+        // flight, whatever Chrome called it before.
+        if (view->m_chromeNavigationKind != ChromeNavigationKind::NotRequested)
+            view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
 
         if (JSObject* cb = view->m_onNavigated.get()) {
             Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
@@ -1224,19 +1231,25 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         auto urlStr = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
         view->m_url = urlStr;
 
+        // This commit ends the navigation in flight when Chrome called it
+        // same-document or never classified it. A CrossDocument one belongs
+        // to the load event and a NotRequested slot has asked Chrome for
+        // nothing yet: then the commit is the page's own (an SPA updating
+        // location.hash), and with nothing pending there is no title to keep
+        // current either, so both skip the roundtrip. Decide and queue the
+        // title fetch before onNavigated runs: the callback is user code that
+        // can close() the view or start the next navigation, and the title
+        // reply must settle the navigation this commit ended, not that one.
+        auto kind = view->m_chromeNavigationKind;
+        if (view->m_pendingNavigate && (kind == ChromeNavigationKind::Unknown || kind == ChromeNavigationKind::SameDocument)) {
+            view->m_loading = false;
+            sendTitleFetch(view);
+        }
+
         if (JSObject* cb = view->m_onNavigated.get()) {
             Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
                 JSValue::encode(jsString(vm, urlStr)), JSValue::encode(jsUndefined()));
         }
-
-        // A cross-document navigation is still in flight: this commit is the
-        // page's own, and the pending promise belongs to the load event.
-        if (view->m_chromeNavigationKind == ChromeNavigationKind::CrossDocument) return;
-        view->m_loading = false;
-        // With nothing pending there is no promise to settle and no title to
-        // keep current, so skip the roundtrip — a page can commit a
-        // same-document navigation on every scroll.
-        if (view->m_pendingNavigate) sendTitleFetch(view);
         return;
     }
 
@@ -1502,9 +1515,6 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
         promise->reject(vm, createError(g, "Chrome connection is not available"_s));
         return promise;
     }
-    // Every navigation starts unclassified: Chrome decides whether it keeps
-    // the current document, and the view must not carry the last one's kind.
-    if (ps == PendingSlot::Navigate) v->m_chromeNavigationKind = ChromeNavigationKind::Unknown;
     v->m_pendingActivityCount.fetch_add(1, std::memory_order_release);
     slot.set(vm, v, promise);
     t.m_pending.add(id, Pending { m, ps, v->m_viewId });
@@ -1521,6 +1531,9 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
 JSPromise* navigate(JSGlobalObject* g, JSWebView* view, const WTF::String& url)
 {
     auto& t = transport();
+    // Chrome decides whether the URL keeps the current document (a #fragment
+    // target) or loads a new one, and says which before the commit.
+    view->m_chromeNavigationKind = ChromeNavigationKind::Unknown;
 
     if (!view->m_sessionId.isEmpty()) {
         uint32_t id = t.nextId();
@@ -1814,6 +1827,10 @@ static JSPromise* historyGo(JSGlobalObject* g, JSWebView* view, int8_t delta)
 {
     auto& t = transport();
     view->m_chromeHistoryDelta = delta;
+    // The slot fills now, but no navigation is asked of Chrome until the
+    // history lookup replies. A same-document commit during the lookup is
+    // the page's own and must not settle this promise.
+    view->m_chromeNavigationKind = ChromeNavigationKind::NotRequested;
     uint32_t id = t.nextId();
     // Navigate slot — navigateToHistoryEntry IS a navigation and
     // Page.loadEventFired settles PendingSlot::Navigate only.
@@ -1828,6 +1845,8 @@ JSPromise* goForward(JSGlobalObject* g, JSWebView* view) { return historyGo(g, v
 JSPromise* reload(JSGlobalObject* g, JSWebView* view)
 {
     auto& t = transport();
+    // A reload always loads the document again, so only the load event ends it.
+    view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
     uint32_t id = t.nextId();
     // Navigate slot — reload IS a navigation. Page.loadEventFired only
     // settles PendingSlot::Navigate; using Misc would hang waiting for a

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -654,6 +654,14 @@ static void settle(JSGlobalObject* g, JSWebView* view, PendingSlot slot, bool ok
     settleSlot(g, view, slotFor(view, slot), ok, v);
 }
 
+static void fireOnNavigationFailed(JSGlobalObject* g, JSWebView* view, JSValue errValue)
+{
+    if (JSObject* cb = view->m_onNavigationFailed.get()) {
+        Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
+            JSValue::encode(errValue), JSValue::encode(jsUndefined()));
+    }
+}
+
 // Reject one op's slot on a CDP failure. A Navigate-slot failure also fires
 // onNavigationFailed and clears loading, like WebKit's NavFailEvent, except
 // for PageTitle: that is the post-load title fetch, and its failure (for
@@ -665,12 +673,7 @@ static void settleFailure(JSGlobalObject* g, JSWebView* view, PendingSlot slot, 
     bool navigationFailed = slot == PendingSlot::Navigate && method != Method::PageTitle;
     if (navigationFailed) view->m_loading = false;
     settle(g, view, slot, false, errValue);
-    if (navigationFailed) {
-        if (JSObject* cb = view->m_onNavigationFailed.get()) {
-            Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
-                JSValue::encode(errValue), JSValue::encode(jsUndefined()));
-        }
-    }
+    if (navigationFailed) fireOnNavigationFailed(g, view, errValue);
 }
 
 // Slots, not m_pending: a navigation that Chrome has already answered is
@@ -701,6 +704,7 @@ static void startNavigation(JSWebView* view, ChromeNavigationKind kind)
 {
     view->m_chromeNavigationKind = kind;
     view->m_chromeNavigationCommitted = false;
+    view->m_chromeNavigationLoaderId = WTF::String();
     view->m_chromeNavigationSeq++;
 }
 
@@ -863,24 +867,22 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
 
     case Method::PageNavigate: {
-        // {"frameId":"...","loaderId":"..."} or {"frameId":"...","errorText":"..."}
-        // errorText present → navigation failed synchronously (bad URL,
-        // net::ERR_* resolved before commit). Reject now. Otherwise the
-        // navigation is underway; Page.loadEventFired resolves. Keep the
-        // pending entry so the event handler can look up the view by
-        // sessionId — actually the event handler uses m_sessions, not
-        // m_pending, so we just drop here.
+        // {"frameId":"...","loaderId"?:"...","errorText"?:"..."}
+        // errorText present → the navigation failed before anything committed
+        // (a bad URL, a net::ERR_* resolved early). Reject now; Chrome's error
+        // page for this loader commits next and must not report it again. No
+        // loaderId → a same-document navigation, which loads no document.
+        auto loaderId = WTF::String::fromUTF8(jsonString(jsonField(result, { "loaderId", 8 })));
         auto err = jsonString(jsonField(result, { "errorText", 9 }));
         if (!err.empty()) {
+            view->m_chromeFailedLoaderId = loaderId;
             settleFailure(g, view, entry.slot, entry.method, createError(g, WTF::String::fromUTF8(err)));
             return;
         }
-        // The reply names the main frame, the one Page.navigate targets.
-        if (view->m_mainFrameId.isEmpty())
-            view->m_mainFrameId = WTF::String::fromUTF8(jsonString(jsonField(result, { "frameId", 7 })));
-        // Don't settle — the commit does. A reply without loaderId loads no document.
+        // Don't settle — the commit does.
         if (view->m_chromeNavigationKind == ChromeNavigationKind::Requested) {
-            view->m_chromeNavigationKind = jsonField(result, { "loaderId", 8 }).empty()
+            view->m_chromeNavigationLoaderId = loaderId;
+            view->m_chromeNavigationKind = loaderId.isEmpty()
                 ? ChromeNavigationKind::SameDocument
                 : ChromeNavigationKind::CrossDocument;
         }
@@ -1139,10 +1141,17 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     }
 }
 
-// Subframes navigate too. Before the first Page.navigate reply there are none.
+// Subframes navigate too. Before the first main frame commit there are none.
 static bool isMainFrame(JSWebView* view, std::span<const char> frameId)
 {
     return view->m_mainFrameId.isEmpty() || view->m_mainFrameId == WTF::String::fromUTF8(frameId);
+}
+
+// Chrome answers a navigation command before its document commits, so a commit in any other state is the page's own.
+static bool commitIsNavigations(JSWebView* view)
+{
+    auto kind = view->m_chromeNavigationKind;
+    return kind != ChromeNavigationKind::NotRequested && kind != ChromeNavigationKind::Requested;
 }
 
 void Transport::sendTitleFetch(JSWebView* view, bool endsNavigation)
@@ -1150,6 +1159,101 @@ void Transport::sendTitleFetch(JSWebView* view, bool endsNavigation)
     uint32_t tid = nextId();
     m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId, endsNavigation ? view->m_chromeNavigationSeq : 0 });
     send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
+}
+
+static void fireOnNavigated(JSGlobalObject* g, JSWebView* view, const WTF::String& url)
+{
+    if (JSObject* cb = view->m_onNavigated.get()) {
+        Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
+            JSValue::encode(jsString(g->vm(), url)), JSValue::encode(jsUndefined()));
+    }
+}
+
+// Page.frameNavigated {frame: {id, parentId?, url, urlFragment?, unreachableUrl?, loaderId}, type}: a document
+// committed. Same timing as WKWebView's NavDone: the URL is the new document's, subresources may still load.
+void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
+{
+    auto frame = jsonField(params, { "frame", 5 });
+    if (!jsonField(frame, { "parentId", 8 }).empty()) return; // an <iframe>'s own navigation
+    view->m_mainFrameId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "id", 2 })));
+    auto loaderId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "loaderId", 8 })));
+    // navigate() already failed with errorText for this loader: its error page ends nothing and reports nothing.
+    bool alreadyFailed = !loaderId.isEmpty() && loaderId == view->m_chromeFailedLoaderId;
+    // Page.navigate's reply named the loader it started; reload() and a traversal go by state alone.
+    bool expectedLoader = view->m_chromeNavigationLoaderId.isEmpty() || view->m_chromeNavigationLoaderId == loaderId;
+    if (!alreadyFailed && expectedLoader && commitIsNavigations(view)) {
+        view->m_chromeNavigationCommitted = true;
+        view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
+    }
+
+    // unreachableUrl: this is Chrome's error page for a load that failed. view.url keeps the last real page.
+    auto unreachable = jsonString(jsonField(frame, { "unreachableUrl", 14 }));
+    if (!unreachable.empty()) {
+        view->m_chromeOnErrorPage = true;
+        // Reported once the error page has loaded and the tab takes commands again.
+        view->m_chromeUnreportedFailure = alreadyFailed ? WTF::String() : WTF::String::fromUTF8(unreachable);
+        return;
+    }
+    view->m_chromeOnErrorPage = false;
+    view->m_chromeUnreportedFailure = WTF::String();
+
+    // frame.url omits the fragment; frame.urlFragment ("#x") carries it.
+    auto url = jsonString(jsonField(frame, { "url", 3 }));
+    auto fragment = jsonString(jsonField(frame, { "urlFragment", 11 }));
+    view->m_url = fragment.empty()
+        ? WTF::String::fromUTF8(url)
+        : makeString(WTF::String::fromUTF8(url), WTF::String::fromUTF8(fragment));
+    // m_loading stays true — loadEventFired flips it.
+
+    // A page restored from the back-forward cache is whole as it commits: no load event follows.
+    auto type = jsonString(jsonField(params, { "type", 4 }));
+    if (type.size() == 23 && memcmp(type.data(), "BackForwardCacheRestore", 23) == 0)
+        onLoadEventFired(view);
+
+    // After the settle decision: the callback is user code and may navigate() next.
+    fireOnNavigated(m_global, view, view->m_url);
+}
+
+// Page.navigatedWithinDocument {frameId, url}: a same-document commit (#fragment, pushState). No load event follows.
+void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char> params)
+{
+    if (!isMainFrame(view, jsonString(jsonField(params, { "frameId", 7 })))) return;
+    view->m_url = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
+
+    if (sameDocumentCommitEndsNavigation(view)) {
+        sendTitleFetch(view, true);
+        navigationConsumed(view);
+    }
+
+    // After the settle decision: the callback is user code and may navigate() next.
+    fireOnNavigated(m_global, view, view->m_url);
+}
+
+// Page.loadEventFired: the live document finished loading. It is page-level — no frame, no loader — so only a
+// document the view's own command committed ends the view's navigation. The document.title fetch chained here
+// makes `await view.navigate(); view.title` work, like WKWebView's NavDone which carries url and title together.
+void Transport::onLoadEventFired(JSWebView* view)
+{
+    auto* g = m_global;
+    bool endsNavigation = view->m_pendingNavigate && view->m_chromeNavigationCommitted;
+
+    if (view->m_chromeOnErrorPage) {
+        // No title fetch: view.title keeps the last real page's, like view.url.
+        auto failedUrl = std::exchange(view->m_chromeUnreportedFailure, WTF::String());
+        if (failedUrl.isNull()) return;
+        JSValue err = createError(g, makeString("Navigation to "_s, failedUrl, " failed"_s));
+        if (endsNavigation) {
+            navigationConsumed(view);
+            settleFailure(g, view, PendingSlot::Navigate, Method::PageNavigate, err);
+        } else {
+            fireOnNavigationFailed(g, view, err);
+        }
+        return;
+    }
+
+    // For a load that is not the view's navigation, the fetch only updates m_title.
+    sendTitleFetch(view, endsNavigation);
+    if (endsNavigation) navigationConsumed(view);
 }
 
 void Transport::handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId)
@@ -1193,67 +1297,13 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.frameNavigated — commit. Update m_url and fire onNavigated.
-    // Same timing as WKWebView's NavDone (didFinishNavigation): the URL is
-    // now the new document, resources may still be loading.
-    if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0) {
-        auto frame = jsonField(params, { "frame", 5 });
-        if (!isMainFrame(view, jsonString(jsonField(frame, { "id", 2 })))) return;
-        // frame.url omits the fragment; frame.urlFragment ("#x") carries it.
-        auto url = jsonString(jsonField(frame, { "url", 3 }));
-        auto fragment = jsonString(jsonField(frame, { "urlFragment", 11 }));
-        auto urlStr = fragment.empty()
-            ? WTF::String::fromUTF8(url)
-            : makeString(WTF::String::fromUTF8(url), WTF::String::fromUTF8(fragment));
-        view->m_url = urlStr;
-        // m_loading stays true — loadEventFired flips it.
-        // Chrome answers a command before its document commits, so an earlier commit is the page's.
-        auto kind = view->m_chromeNavigationKind;
-        if (kind != ChromeNavigationKind::NotRequested && kind != ChromeNavigationKind::Requested) {
-            view->m_chromeNavigationCommitted = true;
-            view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
-        }
-
-        if (JSObject* cb = view->m_onNavigated.get()) {
-            Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
-                JSValue::encode(jsString(vm, urlStr)), JSValue::encode(jsUndefined()));
-        }
-        return;
-    }
-
-    // Page.navigatedWithinDocument — same-document commit (#fragment, pushState). No load event follows.
-    if (method.size() == 28 && memcmp(method.data(), "Page.navigatedWithinDocument", 28) == 0) {
-        if (!isMainFrame(view, jsonString(jsonField(params, { "frameId", 7 })))) return;
-        auto urlStr = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
-        view->m_url = urlStr;
-
-        if (sameDocumentCommitEndsNavigation(view)) {
-            sendTitleFetch(view, true);
-            navigationConsumed(view);
-        }
-
-        // After the settle decision: the callback is user code and may navigate() next.
-        if (JSObject* cb = view->m_onNavigated.get()) {
-            Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
-                JSValue::encode(jsString(vm, urlStr)), JSValue::encode(jsUndefined()));
-        }
-        return;
-    }
-
-    // Page.loadEventFired — load complete. Chain a document.title fetch
-    // so view.title is populated when navigate() resolves — matches
-    // WKWebView's NavDone which packs url+title in one reply. One extra
-    // roundtrip (~1ms), but the user-visible guarantee is worth it:
-    // `await view.navigate(); view.title` just works.
-    //
-    // For a load that is not the view's navigation, the fetch only updates m_title.
-    if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
-        // Page-level: no frame, no loader. Only a document the view's own command committed ends it.
-        bool endsNavigation = view->m_pendingNavigate && view->m_chromeNavigationCommitted;
-        sendTitleFetch(view, endsNavigation);
-        if (endsNavigation) navigationConsumed(view);
-        return;
-    }
+    // The three navigation events update the view first, then reach addEventListener() like any CDP event.
+    if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0)
+        onFrameNavigated(view, params);
+    else if (method.size() == 28 && memcmp(method.data(), "Page.navigatedWithinDocument", 28) == 0)
+        onNavigatedWithinDocument(view, params);
+    else if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0)
+        onLoadEventFired(view);
 
     // Runtime.consoleAPICalled — fires for every console.* call in the page.
     // params: {"type":"log","args":[<RemoteObject>,...],"stackTrace":{...}}.

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -704,10 +704,7 @@ static void startNavigation(JSWebView* view, ChromeNavigationKind kind)
     view->m_chromeNavigationSeq++;
 }
 
-// Does a same-document commit end the navigation in flight? Chrome sends no
-// loader id with one, so the navigation has to be classified same-document,
-// or answered and unclassified (a history traversal on a Chrome that sends no
-// Page.frameStartedNavigating). Anything earlier is the page's own doing.
+// Which commit is the view's? A same-document one carries no loader id, so only the state says.
 static bool sameDocumentCommitEndsNavigation(JSWebView* view)
 {
     if (!view->m_pendingNavigate) return false;
@@ -935,8 +932,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
     }
     case Method::PageNavigateToHistoryEntry:
-        // Response is empty {} on success: the traversal is underway and a
-        // commit of either shape is now its own. A commit does the settling.
+        // Empty {} on success: the traversal is underway, so the next commit is its own.
         if (view->m_chromeNavigationKind == ChromeNavigationKind::Requested)
             view->m_chromeNavigationKind = ChromeNavigationKind::Unknown;
         return;
@@ -1225,8 +1221,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
             : makeString(WTF::String::fromUTF8(url), WTF::String::fromUTF8(fragment));
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it.
-        // Chrome answers a navigation command before the document commits, so
-        // a commit before that reply is the page's own, not the command's.
+        // Chrome answers a command before its document commits, so an earlier commit is the page's.
         auto kind = view->m_chromeNavigationKind;
         if (kind != ChromeNavigationKind::NotRequested && kind != ChromeNavigationKind::Requested) {
             view->m_chromeNavigationCommitted = true;
@@ -1265,8 +1260,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     // roundtrip (~1ms), but the user-visible guarantee is worth it:
     // `await view.navigate(); view.title` just works.
     //
-    // If the load is not the view's navigation (uninitiated navigation,
-    // redirect), the title fetch only updates m_title.
+    // For a load that is not the view's navigation, the fetch only updates m_title.
     if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
         // Page-level: no frame, no loader. Only a document the view's own command committed ends it.
         bool endsNavigation = view->m_pendingNavigate && view->m_chromeNavigationCommitted;

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1191,6 +1191,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it.
         // A new document is live: its load event ends whatever the view has in flight.
+        view->m_chromeNavigationCommitted = true;
         if (view->m_chromeNavigationKind != ChromeNavigationKind::NotRequested)
             view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
 
@@ -1231,6 +1232,12 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     // If no navigate is pending (uninitiated navigation, redirect), the
     // PageTitle handler settles a no-op and m_title still updates.
     if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
+        // The event names no frame and no loader, so it is the load event of
+        // whatever document is live. Only a document the view's own
+        // navigation committed ends that navigation.
+        if (view->m_chromeNavigationKind != ChromeNavigationKind::NotRequested
+            && !view->m_chromeNavigationCommitted)
+            return;
         view->m_loading = false;
         sendTitleFetch(view);
         return;
@@ -1484,6 +1491,8 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
         promise->reject(vm, createError(g, "Chrome connection is not available"_s));
         return promise;
     }
+    // A fresh navigation command has committed nothing of its own yet.
+    if (ps == PendingSlot::Navigate) v->m_chromeNavigationCommitted = false;
     v->m_pendingActivityCount.fetch_add(1, std::memory_order_release);
     slot.set(vm, v, promise);
     t.m_pending.add(id, Pending { m, ps, v->m_viewId });

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -846,17 +846,11 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
             settleFailure(g, view, entry.slot, entry.method, createError(g, WTF::String::fromUTF8(err)));
             return;
         }
-        // Page.navigate targets the main frame and its reply names it. The
-        // id is needed before the first commit: a same-document navigation
-        // emits no Page.frameNavigated, so that event cannot be the only
-        // source of the main frame's id.
+        // The reply names the main frame, the one Page.navigate targets.
         if (view->m_mainFrameId.isEmpty())
             view->m_mainFrameId = WTF::String::fromUTF8(jsonString(jsonField(result, { "frameId", 7 })));
-        // Don't settle — the commit does. Which commit is the kind's:
-        // Page.loadEventFired for a cross-document navigation,
-        // Page.navigatedWithinDocument for a same-document one. loaderId is
-        // absent exactly when the navigation is same-document, which is the
-        // classification on a Chrome too old for frameStartedNavigating.
+        // Don't settle — the commit does (handleEvent). No loaderId means no
+        // document load: the navigation is same-document.
         if (view->m_chromeNavigationKind == ChromeNavigationKind::Unknown) {
             view->m_chromeNavigationKind = jsonField(result, { "loaderId", 8 }).empty()
                 ? ChromeNavigationKind::SameDocument
@@ -902,8 +896,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         }
         auto elem = entries->get(static_cast<unsigned>(target))->asObject();
         int32_t entryId = elem ? elem->getInteger("id"_s).value_or(0) : 0;
-        // Chain into navigateToHistoryEntry. The traversal starts now; its
-        // reply is {} either way, so Chrome's events classify it.
+        // Chain into navigateToHistoryEntry. The traversal starts now.
         view->m_chromeNavigationKind = ChromeNavigationKind::Unknown;
         uint32_t cid = nextId();
         m_pending.add(cid, Pending { Method::PageNavigateToHistoryEntry, entry.slot, entry.viewId });
@@ -1116,9 +1109,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     }
 }
 
-// Is this event's frame the view's main frame? A page can hold subframes,
-// and each navigates on its own. An empty m_mainFrameId means no
-// Page.navigate has replied yet, so no subframe exists to confuse us.
+// Subframes navigate too. Before the first Page.navigate reply there are none.
 static bool isMainFrame(JSWebView* view, std::span<const char> frameId)
 {
     return view->m_mainFrameId.isEmpty() || view->m_mainFrameId == WTF::String::fromUTF8(frameId);
@@ -1172,17 +1163,12 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.frameStartedNavigating — Chrome names the navigation's kind
-    // before it commits. navigationType is "sameDocument" or
-    // "historySameDocument" for a navigation that keeps the current
-    // document, and "differentDocument", "historyDifferentDocument",
-    // "reload" or "restore" for one that replaces it. Knowing this before
-    // the commit keeps a same-document navigation the page makes on its own
-    // (an SPA updating location.hash) from settling our cross-document one.
+    // Page.frameStartedNavigating — Chrome classifies a navigation before it
+    // commits. "sameDocument" and "historySameDocument" keep the document;
+    // every other navigationType loads one.
     if (method.size() == 27 && memcmp(method.data(), "Page.frameStartedNavigating", 27) == 0) {
         if (!isMainFrame(view, jsonString(jsonField(params, { "frameId", 7 })))) return;
-        // Nothing of the view's is in flight, so this navigation is the
-        // page's own (a link, history.back()); its kind says nothing about ours.
+        // Nothing of the view's is in flight: the page started this one.
         if (view->m_chromeNavigationKind == ChromeNavigationKind::NotRequested) return;
         auto type = jsonString(jsonField(params, { "navigationType", 14 }));
         bool sameDocument = (type.size() == 12 && memcmp(type.data(), "sameDocument", 12) == 0)
@@ -1199,10 +1185,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0) {
         auto frame = jsonField(params, { "frame", 5 });
         if (!isMainFrame(view, jsonString(jsonField(frame, { "id", 2 })))) return;
-        // Chrome keeps the fragment out of frame.url and reports it in
-        // frame.urlFragment ("#section", including the '#'). view.url is the
-        // document's whole URL, the same one Page.navigatedWithinDocument
-        // sends for a same-document commit.
+        // frame.url omits the fragment; frame.urlFragment ("#x") carries it.
         auto url = jsonString(jsonField(frame, { "url", 3 }));
         auto fragment = jsonString(jsonField(frame, { "urlFragment", 11 }));
         auto urlStr = fragment.empty()
@@ -1210,8 +1193,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
             : makeString(WTF::String::fromUTF8(url), WTF::String::fromUTF8(fragment));
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it. A new document is
-        // live, so the load event is the commit that ends the navigation in
-        // flight, whatever Chrome called it before.
+        // live, so its load event ends whatever the view has in flight.
         if (view->m_chromeNavigationKind != ChromeNavigationKind::NotRequested)
             view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
 
@@ -1222,24 +1204,17 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.navigatedWithinDocument — same-document commit: a #fragment
-    // target, history.pushState/replaceState, or a history traversal
-    // between two entries of one document. The document stays, so no load
-    // event follows and this is where such a navigation ends.
+    // Page.navigatedWithinDocument — same-document commit (#fragment,
+    // history.pushState, a traversal inside one document). No load event
+    // follows, so a same-document navigation ends here.
     if (method.size() == 28 && memcmp(method.data(), "Page.navigatedWithinDocument", 28) == 0) {
         if (!isMainFrame(view, jsonString(jsonField(params, { "frameId", 7 })))) return;
         auto urlStr = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
         view->m_url = urlStr;
 
-        // This commit ends the navigation in flight when Chrome called it
-        // same-document or never classified it. A CrossDocument one belongs
-        // to the load event and a NotRequested slot has asked Chrome for
-        // nothing yet: then the commit is the page's own (an SPA updating
-        // location.hash), and with nothing pending there is no title to keep
-        // current either, so both skip the roundtrip. Decide and queue the
-        // title fetch before onNavigated runs: the callback is user code that
-        // can close() the view or start the next navigation, and the title
-        // reply must settle the navigation this commit ended, not that one.
+        // CrossDocument waits for its load event and NotRequested has asked
+        // Chrome for nothing: then the page did this on its own. Decided
+        // before onNavigated runs user code, which may navigate() next.
         auto kind = view->m_chromeNavigationKind;
         if (view->m_pendingNavigate && (kind == ChromeNavigationKind::Unknown || kind == ChromeNavigationKind::SameDocument)) {
             view->m_loading = false;
@@ -1531,8 +1506,6 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
 JSPromise* navigate(JSGlobalObject* g, JSWebView* view, const WTF::String& url)
 {
     auto& t = transport();
-    // Chrome decides whether the URL keeps the current document (a #fragment
-    // target) or loads a new one, and says which before the commit.
     view->m_chromeNavigationKind = ChromeNavigationKind::Unknown;
 
     if (!view->m_sessionId.isEmpty()) {
@@ -1827,9 +1800,7 @@ static JSPromise* historyGo(JSGlobalObject* g, JSWebView* view, int8_t delta)
 {
     auto& t = transport();
     view->m_chromeHistoryDelta = delta;
-    // The slot fills now, but no navigation is asked of Chrome until the
-    // history lookup replies. A same-document commit during the lookup is
-    // the page's own and must not settle this promise.
+    // Nothing is asked of Chrome until the history lookup replies.
     view->m_chromeNavigationKind = ChromeNavigationKind::NotRequested;
     uint32_t id = t.nextId();
     // Navigate slot — navigateToHistoryEntry IS a navigation and
@@ -1845,7 +1816,7 @@ JSPromise* goForward(JSGlobalObject* g, JSWebView* view) { return historyGo(g, v
 JSPromise* reload(JSGlobalObject* g, JSWebView* view)
 {
     auto& t = transport();
-    // A reload always loads the document again, so only the load event ends it.
+    // A reload always loads the document again.
     view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
     uint32_t id = t.nextId();
     // Navigate slot — reload IS a navigation. Page.loadEventFired only

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1193,20 +1193,6 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.frameStartedNavigating — Chrome classifies a navigation before it commits.
-    if (method.size() == 27 && memcmp(method.data(), "Page.frameStartedNavigating", 27) == 0) {
-        if (!isMainFrame(view, jsonString(jsonField(params, { "frameId", 7 })))) return;
-        // Nothing of the view's is in flight: the page started this one.
-        if (view->m_chromeNavigationKind == ChromeNavigationKind::NotRequested) return;
-        auto type = jsonString(jsonField(params, { "navigationType", 14 }));
-        bool sameDocument = (type.size() == 12 && memcmp(type.data(), "sameDocument", 12) == 0)
-            || (type.size() == 19 && memcmp(type.data(), "historySameDocument", 19) == 0);
-        view->m_chromeNavigationKind = sameDocument
-            ? ChromeNavigationKind::SameDocument
-            : ChromeNavigationKind::CrossDocument;
-        return;
-    }
-
     // Page.frameNavigated — commit. Update m_url and fire onNavigated.
     // Same timing as WKWebView's NavDone (didFinishNavigation): the URL is
     // now the new document, resources may still be loading.

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -654,14 +654,6 @@ static void settle(JSGlobalObject* g, JSWebView* view, PendingSlot slot, bool ok
     settleSlot(g, view, slotFor(view, slot), ok, v);
 }
 
-static void fireOnNavigationFailed(JSGlobalObject* g, JSWebView* view, JSValue errValue)
-{
-    if (JSObject* cb = view->m_onNavigationFailed.get()) {
-        Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
-            JSValue::encode(errValue), JSValue::encode(jsUndefined()));
-    }
-}
-
 // Reject one op's slot on a CDP failure. A Navigate-slot failure also fires
 // onNavigationFailed and clears loading, like WebKit's NavFailEvent, except
 // for PageTitle: that is the post-load title fetch, and its failure (for
@@ -673,7 +665,12 @@ static void settleFailure(JSGlobalObject* g, JSWebView* view, PendingSlot slot, 
     bool navigationFailed = slot == PendingSlot::Navigate && method != Method::PageTitle;
     if (navigationFailed) view->m_loading = false;
     settle(g, view, slot, false, errValue);
-    if (navigationFailed) fireOnNavigationFailed(g, view, errValue);
+    if (navigationFailed) {
+        if (JSObject* cb = view->m_onNavigationFailed.get()) {
+            Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
+                JSValue::encode(errValue), JSValue::encode(jsUndefined()));
+        }
+    }
 }
 
 // Slots, not m_pending: a navigation that Chrome has already answered is
@@ -704,14 +701,14 @@ static void startNavigation(JSWebView* view, ChromeNavigationKind kind)
 {
     view->m_chromeNavigationKind = kind;
     view->m_chromeNavigationCommitted = false;
-    view->m_chromeNavigationLoaderId = WTF::String();
     view->m_chromeNavigationSeq++;
 }
 
-// Which commit is the view's? A same-document one carries no loader id, so only the state says.
-static bool sameDocumentCommitEndsNavigation(JSWebView* view)
+// Which commit is the view's? No loader id, so the state says. "historyApi" is the page's own pushState()/replaceState(): navigate() and a traversal report "fragment".
+static bool sameDocumentCommitEndsNavigation(JSWebView* view, std::span<const char> navigationType)
 {
     if (!view->m_pendingNavigate) return false;
+    if (navigationType.size() == 10 && memcmp(navigationType.data(), "historyApi", 10) == 0) return false;
     auto kind = view->m_chromeNavigationKind;
     return kind == ChromeNavigationKind::SameDocument || kind == ChromeNavigationKind::Unknown;
 }
@@ -867,27 +864,24 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
 
     case Method::PageNavigate: {
-        // {frameId, loaderId?, errorText?}. errorText: failed before any commit; the error page for this loader follows.
-        auto loaderId = WTF::String::fromUTF8(jsonString(jsonField(result, { "loaderId", 8 })));
+        // {"frameId":"...","loaderId":"..."} or {"frameId":"...","errorText":"..."}
+        // errorText present → navigation failed synchronously (bad URL,
+        // net::ERR_* resolved before commit). Reject now.
         auto err = jsonString(jsonField(result, { "errorText", 9 }));
         if (!err.empty()) {
-            view->m_chromeFailedLoaderId = loaderId;
             settleFailure(g, view, entry.slot, entry.method, createError(g, WTF::String::fromUTF8(err)));
             return;
         }
-        // Don't settle — the commit does.
+        // Don't settle — the commit does. A reply without loaderId loads no document.
         if (view->m_chromeNavigationKind == ChromeNavigationKind::Requested) {
-            view->m_chromeNavigationLoaderId = loaderId;
-            view->m_chromeNavigationKind = loaderId.isEmpty()
+            view->m_chromeNavigationKind = jsonField(result, { "loaderId", 8 }).empty()
                 ? ChromeNavigationKind::SameDocument
                 : ChromeNavigationKind::CrossDocument;
         }
         return;
     }
     case Method::PageReload:
-        // Empty {} on success: the reload is underway, and it always loads the document again.
-        if (view->m_chromeNavigationKind == ChromeNavigationKind::Requested)
-            view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
+        // Same as navigate: don't settle, Page.loadEventFired does.
         return;
 
     case Method::PageTitle: {
@@ -1167,44 +1161,16 @@ static void fireOnNavigated(JSGlobalObject* g, JSWebView* view, const WTF::Strin
     }
 }
 
-// Page.frameNavigated {frame: {id, parentId?, url, urlFragment?, unreachableUrl?, loaderId}, type}: a document committed.
+// Page.frameNavigated {frame: {id, parentId?, url, urlFragment?}, type}: a document committed.
 void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
 {
     auto frame = jsonField(params, { "frame", 5 });
     if (!jsonField(frame, { "parentId", 8 }).empty()) return; // an <iframe>'s own navigation
     view->m_mainFrameId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "id", 2 })));
-    auto loaderId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "loaderId", 8 })));
-    // navigate() already failed with errorText for this loader: its error page ends nothing and reports nothing.
-    bool alreadyFailed = !loaderId.isEmpty() && loaderId == view->m_chromeFailedLoaderId;
-    // Page.navigate's reply named the loader it started; reload() and a traversal go by state alone.
-    bool expectedLoader = view->m_chromeNavigationLoaderId.isEmpty() || view->m_chromeNavigationLoaderId == loaderId;
-    // Another document took the commit navigate() was waiting for, so its own loader will not commit.
-    bool interrupted = !expectedLoader && !alreadyFailed && view->m_pendingNavigate
-        && view->m_chromeNavigationKind == ChromeNavigationKind::CrossDocument && !view->m_chromeNavigationCommitted;
-    if (!alreadyFailed && expectedLoader && commitIsNavigations(view)) {
+    if (commitIsNavigations(view)) {
         view->m_chromeNavigationCommitted = true;
         view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
     }
-
-    auto unreachable = jsonString(jsonField(frame, { "unreachableUrl", 14 }));
-    if (interrupted) {
-        // Chrome normally answers a dropped Page.navigate with errorText first; this is the backstop, so no hang.
-        auto other = WTF::String::fromUTF8(unreachable.empty() ? jsonString(jsonField(frame, { "url", 3 })) : unreachable);
-        navigationConsumed(view);
-        view->m_chromeNavigationLoaderId = WTF::String();
-        settleFailure(m_global, view, PendingSlot::Navigate, Method::PageNavigate,
-            createError(m_global, makeString("Navigation interrupted by another one to "_s, other)));
-    }
-
-    // unreachableUrl: this is Chrome's error page for a load that failed. view.url keeps the last real page.
-    if (!unreachable.empty()) {
-        view->m_chromeOnErrorPage = true;
-        // Reported once the error page has loaded and the tab takes commands again.
-        view->m_chromeUnreportedFailure = alreadyFailed ? WTF::String() : WTF::String::fromUTF8(unreachable);
-        return;
-    }
-    view->m_chromeOnErrorPage = false;
-    view->m_chromeUnreportedFailure = WTF::String();
 
     // frame.url omits the fragment; frame.urlFragment ("#x") carries it.
     auto url = jsonString(jsonField(frame, { "url", 3 }));
@@ -1223,13 +1189,13 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
     fireOnNavigated(m_global, view, view->m_url);
 }
 
-// Page.navigatedWithinDocument {frameId, url}: a same-document commit (#fragment, pushState). No load event follows.
+// Page.navigatedWithinDocument {frameId, url, navigationType?}: a same-document commit (#fragment, pushState). No load event follows.
 void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char> params)
 {
     if (!isMainFrame(view, jsonString(jsonField(params, { "frameId", 7 })))) return;
     view->m_url = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
 
-    if (sameDocumentCommitEndsNavigation(view)) {
+    if (sameDocumentCommitEndsNavigation(view, jsonString(jsonField(params, { "navigationType", 14 })))) {
         sendTitleFetch(view, true);
         navigationConsumed(view);
     }
@@ -1241,23 +1207,7 @@ void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char>
 // Page.loadEventFired (page-level: no frame, no loader): the live document loaded. Title fetch, then settle.
 void Transport::onLoadEventFired(JSWebView* view)
 {
-    auto* g = m_global;
     bool endsNavigation = view->m_pendingNavigate && view->m_chromeNavigationCommitted;
-
-    if (view->m_chromeOnErrorPage) {
-        // No title fetch: view.title keeps the last real page's, like view.url.
-        auto failedUrl = std::exchange(view->m_chromeUnreportedFailure, WTF::String());
-        if (failedUrl.isNull()) return;
-        JSValue err = createError(g, makeString("Navigation to "_s, failedUrl, " failed"_s));
-        if (endsNavigation) {
-            navigationConsumed(view);
-            settleFailure(g, view, PendingSlot::Navigate, Method::PageNavigate, err);
-        } else {
-            fireOnNavigationFailed(g, view, err);
-        }
-        return;
-    }
-
     // For a load that is not the view's navigation, the fetch only updates m_title.
     sendTitleFetch(view, endsNavigation);
     if (endsNavigation) navigationConsumed(view);
@@ -1304,13 +1254,12 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // The three navigation events update the view first, then reach addEventListener() like any CDP event.
     if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0)
-        onFrameNavigated(view, params);
-    else if (method.size() == 28 && memcmp(method.data(), "Page.navigatedWithinDocument", 28) == 0)
-        onNavigatedWithinDocument(view, params);
-    else if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0)
-        onLoadEventFired(view);
+        return onFrameNavigated(view, params);
+    if (method.size() == 28 && memcmp(method.data(), "Page.navigatedWithinDocument", 28) == 0)
+        return onNavigatedWithinDocument(view, params);
+    if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0)
+        return onLoadEventFired(view);
 
     // Runtime.consoleAPICalled — fires for every console.* call in the page.
     // params: {"type":"log","args":[<RemoteObject>,...],"stackTrace":{...}}.
@@ -1886,8 +1835,8 @@ JSPromise* goForward(JSGlobalObject* g, JSWebView* view) { return historyGo(g, v
 JSPromise* reload(JSGlobalObject* g, JSWebView* view)
 {
     auto& t = transport();
-    // Chrome answers Page.reload with {}, so the reply is what puts the reload underway.
-    startNavigation(view, ChromeNavigationKind::Requested);
+    // A reload always loads the document again. Its reply comes from the renderer and can trail the commit, so it gates nothing.
+    startNavigation(view, ChromeNavigationKind::CrossDocument);
     uint32_t id = t.nextId();
     // Navigate slot — reload IS a navigation. Page.loadEventFired only
     // settles PendingSlot::Navigate; using Misc would hang waiting for a

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -867,11 +867,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
 
     case Method::PageNavigate: {
-        // {"frameId":"...","loaderId"?:"...","errorText"?:"..."}
-        // errorText present → the navigation failed before anything committed
-        // (a bad URL, a net::ERR_* resolved early). Reject now; Chrome's error
-        // page for this loader commits next and must not report it again. No
-        // loaderId → a same-document navigation, which loads no document.
+        // {frameId, loaderId?, errorText?}. errorText: failed before any commit; the error page for this loader follows.
         auto loaderId = WTF::String::fromUTF8(jsonString(jsonField(result, { "loaderId", 8 })));
         auto err = jsonString(jsonField(result, { "errorText", 9 }));
         if (!err.empty()) {
@@ -1169,8 +1165,7 @@ static void fireOnNavigated(JSGlobalObject* g, JSWebView* view, const WTF::Strin
     }
 }
 
-// Page.frameNavigated {frame: {id, parentId?, url, urlFragment?, unreachableUrl?, loaderId}, type}: a document
-// committed. Same timing as WKWebView's NavDone: the URL is the new document's, subresources may still load.
+// Page.frameNavigated {frame: {id, parentId?, url, urlFragment?, unreachableUrl?, loaderId}, type}: a document committed.
 void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
 {
     auto frame = jsonField(params, { "frame", 5 });
@@ -1229,9 +1224,7 @@ void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char>
     fireOnNavigated(m_global, view, view->m_url);
 }
 
-// Page.loadEventFired: the live document finished loading. It is page-level — no frame, no loader — so only a
-// document the view's own command committed ends the view's navigation. The document.title fetch chained here
-// makes `await view.navigate(); view.title` work, like WKWebView's NavDone which carries url and title together.
+// Page.loadEventFired (page-level: no frame, no loader): the live document loaded. Title fetch, then settle.
 void Transport::onLoadEventFired(JSWebView* view)
 {
     auto* g = m_global;

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -842,9 +842,26 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         // sessionId — actually the event handler uses m_sessions, not
         // m_pending, so we just drop here.
         auto err = jsonString(jsonField(result, { "errorText", 9 }));
-        if (!err.empty())
+        if (!err.empty()) {
             settleFailure(g, view, entry.slot, entry.method, createError(g, WTF::String::fromUTF8(err)));
-        // Else: don't settle — Page.loadEventFired does.
+            return;
+        }
+        // Page.navigate targets the main frame and its reply names it. The
+        // id is needed before the first commit: a same-document navigation
+        // emits no Page.frameNavigated, so that event cannot be the only
+        // source of the main frame's id.
+        if (view->m_mainFrameId.isEmpty())
+            view->m_mainFrameId = WTF::String::fromUTF8(jsonString(jsonField(result, { "frameId", 7 })));
+        // Don't settle — the commit does. Which commit is the kind's:
+        // Page.loadEventFired for a cross-document navigation,
+        // Page.navigatedWithinDocument for a same-document one. loaderId is
+        // absent exactly when the navigation is same-document, which is the
+        // classification on a Chrome too old for frameStartedNavigating.
+        if (view->m_chromeNavigationKind == ChromeNavigationKind::Unknown) {
+            view->m_chromeNavigationKind = jsonField(result, { "loaderId", 8 }).empty()
+                ? ChromeNavigationKind::SameDocument
+                : ChromeNavigationKind::CrossDocument;
+        }
         return;
     }
     case Method::PageReload:
@@ -1097,6 +1114,21 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     }
 }
 
+// Is this event's frame the view's main frame? A page can hold subframes,
+// and each navigates on its own. An empty m_mainFrameId means no
+// Page.navigate has replied yet, so no subframe exists to confuse us.
+static bool isMainFrame(JSWebView* view, std::span<const char> frameId)
+{
+    return view->m_mainFrameId.isEmpty() || view->m_mainFrameId == WTF::String::fromUTF8(frameId);
+}
+
+void Transport::sendTitleFetch(JSWebView* view)
+{
+    uint32_t tid = nextId();
+    m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
+    send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
+}
+
 void Transport::handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId)
 {
     auto* g = m_global;
@@ -1138,20 +1170,73 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.frameNavigated — commit. Update m_url and fire onNavigated.
-    // Same timing as WKWebView's NavDone (didFinishNavigation): the URL is
-    // now the new document, resources may still be loading.
+    // Page.frameStartedNavigating — Chrome names the navigation's kind
+    // before it commits. navigationType is "sameDocument" or
+    // "historySameDocument" for a navigation that keeps the current
+    // document, and "differentDocument", "historyDifferentDocument",
+    // "reload" or "restore" for one that replaces it. Knowing this before
+    // the commit keeps a same-document navigation the page makes on its own
+    // (an SPA updating location.hash) from settling our cross-document one.
+    if (method.size() == 27 && memcmp(method.data(), "Page.frameStartedNavigating", 27) == 0) {
+        if (!isMainFrame(view, jsonString(jsonField(params, { "frameId", 7 })))) return;
+        auto type = jsonString(jsonField(params, { "navigationType", 14 }));
+        bool sameDocument = (type.size() == 12 && memcmp(type.data(), "sameDocument", 12) == 0)
+            || (type.size() == 19 && memcmp(type.data(), "historySameDocument", 19) == 0);
+        view->m_chromeNavigationKind = sameDocument
+            ? ChromeNavigationKind::SameDocument
+            : ChromeNavigationKind::CrossDocument;
+        return;
+    }
+
+    // Page.frameNavigated — cross-document commit. Update m_url and fire
+    // onNavigated. Same timing as WKWebView's NavDone (didFinishNavigation):
+    // the URL is now the new document, resources may still be loading.
     if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0) {
         auto frame = jsonField(params, { "frame", 5 });
+        if (!isMainFrame(view, jsonString(jsonField(frame, { "id", 2 })))) return;
+        // Chrome keeps the fragment out of frame.url and reports it in
+        // frame.urlFragment ("#section", including the '#'). view.url is the
+        // document's whole URL, the same one Page.navigatedWithinDocument
+        // sends for a same-document commit.
         auto url = jsonString(jsonField(frame, { "url", 3 }));
-        auto urlStr = WTF::String::fromUTF8(url);
+        auto fragment = jsonString(jsonField(frame, { "urlFragment", 11 }));
+        auto urlStr = fragment.empty()
+            ? WTF::String::fromUTF8(url)
+            : makeString(WTF::String::fromUTF8(url), WTF::String::fromUTF8(fragment));
         view->m_url = urlStr;
-        // m_loading stays true — loadEventFired flips it.
+        // m_loading stays true — loadEventFired flips it. A new document is
+        // live, so the load event is the commit that ends this navigation.
+        view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
 
         if (JSObject* cb = view->m_onNavigated.get()) {
             Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
                 JSValue::encode(jsString(vm, urlStr)), JSValue::encode(jsUndefined()));
         }
+        return;
+    }
+
+    // Page.navigatedWithinDocument — same-document commit: a #fragment
+    // target, history.pushState/replaceState, or a history traversal
+    // between two entries of one document. The document stays, so no load
+    // event follows and this is where such a navigation ends.
+    if (method.size() == 28 && memcmp(method.data(), "Page.navigatedWithinDocument", 28) == 0) {
+        if (!isMainFrame(view, jsonString(jsonField(params, { "frameId", 7 })))) return;
+        auto urlStr = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
+        view->m_url = urlStr;
+
+        if (JSObject* cb = view->m_onNavigated.get()) {
+            Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
+                JSValue::encode(jsString(vm, urlStr)), JSValue::encode(jsUndefined()));
+        }
+
+        // A cross-document navigation is still in flight: this commit is the
+        // page's own, and the pending promise belongs to the load event.
+        if (view->m_chromeNavigationKind == ChromeNavigationKind::CrossDocument) return;
+        view->m_loading = false;
+        // With nothing pending there is no promise to settle and no title to
+        // keep current, so skip the roundtrip — a page can commit a
+        // same-document navigation on every scroll.
+        if (view->m_pendingNavigate) sendTitleFetch(view);
         return;
     }
 
@@ -1165,9 +1250,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     // PageTitle handler settles a no-op and m_title still updates.
     if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
         view->m_loading = false;
-        uint32_t tid = nextId();
-        m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
-        send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
+        sendTitleFetch(view);
         return;
     }
 
@@ -1419,6 +1502,9 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
         promise->reject(vm, createError(g, "Chrome connection is not available"_s));
         return promise;
     }
+    // Every navigation starts unclassified: Chrome decides whether it keeps
+    // the current document, and the view must not carry the last one's kind.
+    if (ps == PendingSlot::Navigate) v->m_chromeNavigationKind = ChromeNavigationKind::Unknown;
     v->m_pendingActivityCount.fetch_add(1, std::memory_order_release);
     slot.set(vm, v, promise);
     t.m_pending.add(id, Pending { m, ps, v->m_viewId });

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -696,6 +696,33 @@ static void rejectViewSlotsAsHandled(JSGlobalObject* g, JSWebView* view, JSValue
     rejectSlotAsHandled(g, view, view->m_pendingCdp, err);
 }
 
+// A navigation command of the view's goes out now: nothing of it has committed, and no earlier title fetch ends it.
+static void startNavigation(JSWebView* view, ChromeNavigationKind kind)
+{
+    view->m_chromeNavigationKind = kind;
+    view->m_chromeNavigationCommitted = false;
+    view->m_chromeNavigationSeq++;
+}
+
+// Does a same-document commit end the navigation in flight? Chrome sends no
+// loader id with one, so the navigation has to be classified same-document,
+// or answered and unclassified (a history traversal on a Chrome that sends no
+// Page.frameStartedNavigating). Anything earlier is the page's own doing.
+static bool sameDocumentCommitEndsNavigation(JSWebView* view)
+{
+    if (!view->m_pendingNavigate) return false;
+    auto kind = view->m_chromeNavigationKind;
+    return kind == ChromeNavigationKind::SameDocument || kind == ChromeNavigationKind::Unknown;
+}
+
+// The view's navigation is over once its title fetch is in flight. A later commit is the page's own.
+static void navigationConsumed(JSWebView* view)
+{
+    view->m_loading = false;
+    view->m_chromeNavigationKind = ChromeNavigationKind::NotRequested;
+    view->m_chromeNavigationCommitted = false;
+}
+
 // Build an Error from CDP exceptionDetails. exception.description is V8's
 // Error.prototype.stack formatter:
 //   "Error: msg\n    at functionName (url:line:col)\n    at ..."
@@ -760,7 +787,12 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     JSWebView* view = viewFor(entry.viewId);
     if (!view) return; // user dropped both view and the awaited promise
 
+    // A title fetch ends the navigation it was sent for, never a later one.
+    bool endsNavigation = entry.method == Method::PageTitle
+        && entry.navigation && entry.navigation == view->m_chromeNavigationSeq;
+
     if (!error.empty()) {
+        if (entry.method == Method::PageTitle && !endsNavigation) return;
         // {"code":-32000,"message":"..."}
         auto msgSlice = jsonString(jsonField(error, { "message", 7 }));
         auto errStr = WTF::String::fromUTF8(std::span<const char>(msgSlice));
@@ -850,7 +882,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         if (view->m_mainFrameId.isEmpty())
             view->m_mainFrameId = WTF::String::fromUTF8(jsonString(jsonField(result, { "frameId", 7 })));
         // Don't settle — the commit does. A reply without loaderId loads no document.
-        if (view->m_chromeNavigationKind == ChromeNavigationKind::Unknown) {
+        if (view->m_chromeNavigationKind == ChromeNavigationKind::Requested) {
             view->m_chromeNavigationKind = jsonField(result, { "loaderId", 8 }).empty()
                 ? ChromeNavigationKind::SameDocument
                 : ChromeNavigationKind::CrossDocument;
@@ -862,12 +894,12 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
 
     case Method::PageTitle: {
-        // Runtime.evaluate("document.title") chained from loadEventFired.
+        // Runtime.evaluate("document.title") chained from a commit.
         // result.result.value is the string. Set m_title, settle Navigate.
         auto inner = jsonField(result, { "result", 6 });
         auto value = jsonString(jsonField(inner, { "value", 5 }));
         view->m_title = WTF::String::fromUTF8(value);
-        settle(g, view, entry.slot, true, jsUndefined());
+        if (endsNavigation) settle(g, view, entry.slot, true, jsUndefined());
         return;
     }
 
@@ -896,14 +928,17 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         auto elem = entries->get(static_cast<unsigned>(target))->asObject();
         int32_t entryId = elem ? elem->getInteger("id"_s).value_or(0) : 0;
         // Chain into navigateToHistoryEntry. The traversal starts now.
-        view->m_chromeNavigationKind = ChromeNavigationKind::Unknown;
+        startNavigation(view, ChromeNavigationKind::Requested);
         uint32_t cid = nextId();
         m_pending.add(cid, Pending { Method::PageNavigateToHistoryEntry, entry.slot, entry.viewId });
         send(cid, Command(cid, "Page.navigateToHistoryEntry"_s, sidSpan(view->m_sessionId)).num("entryId"_s, entryId));
         return;
     }
     case Method::PageNavigateToHistoryEntry:
-        // Response is empty {} on success. Page.loadEventFired settles.
+        // Response is empty {} on success: the traversal is underway and a
+        // commit of either shape is now its own. A commit does the settling.
+        if (view->m_chromeNavigationKind == ChromeNavigationKind::Requested)
+            view->m_chromeNavigationKind = ChromeNavigationKind::Unknown;
         return;
 
     case Method::RuntimeEvaluate: {
@@ -1114,10 +1149,10 @@ static bool isMainFrame(JSWebView* view, std::span<const char> frameId)
     return view->m_mainFrameId.isEmpty() || view->m_mainFrameId == WTF::String::fromUTF8(frameId);
 }
 
-void Transport::sendTitleFetch(JSWebView* view)
+void Transport::sendTitleFetch(JSWebView* view, bool endsNavigation)
 {
     uint32_t tid = nextId();
-    m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
+    m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId, endsNavigation ? view->m_chromeNavigationSeq : 0 });
     send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
 }
 
@@ -1190,10 +1225,13 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
             : makeString(WTF::String::fromUTF8(url), WTF::String::fromUTF8(fragment));
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it.
-        // A new document is live: its load event ends whatever the view has in flight.
-        view->m_chromeNavigationCommitted = true;
-        if (view->m_chromeNavigationKind != ChromeNavigationKind::NotRequested)
+        // Chrome answers a navigation command before the document commits, so
+        // a commit before that reply is the page's own, not the command's.
+        auto kind = view->m_chromeNavigationKind;
+        if (kind != ChromeNavigationKind::NotRequested && kind != ChromeNavigationKind::Requested) {
+            view->m_chromeNavigationCommitted = true;
             view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
+        }
 
         if (JSObject* cb = view->m_onNavigated.get()) {
             Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
@@ -1208,11 +1246,9 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         auto urlStr = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
         view->m_url = urlStr;
 
-        // CrossDocument waits for its load event; NotRequested asked for nothing, so the page did this.
-        auto kind = view->m_chromeNavigationKind;
-        if (view->m_pendingNavigate && (kind == ChromeNavigationKind::Unknown || kind == ChromeNavigationKind::SameDocument)) {
-            view->m_loading = false;
-            sendTitleFetch(view);
+        if (sameDocumentCommitEndsNavigation(view)) {
+            sendTitleFetch(view, true);
+            navigationConsumed(view);
         }
 
         // After the settle decision: the callback is user code and may navigate() next.
@@ -1229,15 +1265,13 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     // roundtrip (~1ms), but the user-visible guarantee is worth it:
     // `await view.navigate(); view.title` just works.
     //
-    // If no navigate is pending (uninitiated navigation, redirect), the
-    // PageTitle handler settles a no-op and m_title still updates.
+    // If the load is not the view's navigation (uninitiated navigation,
+    // redirect), the title fetch only updates m_title.
     if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
-        // Page-level: no frame, no loader. Only a commit of the view's own ends its navigation.
-        if (view->m_chromeNavigationKind != ChromeNavigationKind::NotRequested
-            && !view->m_chromeNavigationCommitted)
-            return;
-        view->m_loading = false;
-        sendTitleFetch(view);
+        // Page-level: no frame, no loader. Only a document the view's own command committed ends it.
+        bool endsNavigation = view->m_pendingNavigate && view->m_chromeNavigationCommitted;
+        sendTitleFetch(view, endsNavigation);
+        if (endsNavigation) navigationConsumed(view);
         return;
     }
 
@@ -1489,8 +1523,6 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
         promise->reject(vm, createError(g, "Chrome connection is not available"_s));
         return promise;
     }
-    // A fresh navigation command has committed nothing of its own yet.
-    if (ps == PendingSlot::Navigate) v->m_chromeNavigationCommitted = false;
     v->m_pendingActivityCount.fetch_add(1, std::memory_order_release);
     slot.set(vm, v, promise);
     t.m_pending.add(id, Pending { m, ps, v->m_viewId });
@@ -1507,7 +1539,7 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
 JSPromise* navigate(JSGlobalObject* g, JSWebView* view, const WTF::String& url)
 {
     auto& t = transport();
-    view->m_chromeNavigationKind = ChromeNavigationKind::Unknown;
+    startNavigation(view, ChromeNavigationKind::Requested);
 
     if (!view->m_sessionId.isEmpty()) {
         uint32_t id = t.nextId();
@@ -1818,7 +1850,7 @@ JSPromise* reload(JSGlobalObject* g, JSWebView* view)
 {
     auto& t = transport();
     // A reload always loads the document again.
-    view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
+    startNavigation(view, ChromeNavigationKind::CrossDocument);
     uint32_t id = t.nextId();
     // Navigate slot — reload IS a navigation. Page.loadEventFired only
     // settles PendingSlot::Navigate; using Misc would hang waiting for a

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1232,9 +1232,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     // If no navigate is pending (uninitiated navigation, redirect), the
     // PageTitle handler settles a no-op and m_title still updates.
     if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
-        // The event names no frame and no loader, so it is the load event of
-        // whatever document is live. Only a document the view's own
-        // navigation committed ends that navigation.
+        // Page-level: no frame, no loader. Only a commit of the view's own ends its navigation.
         if (view->m_chromeNavigationKind != ChromeNavigationKind::NotRequested
             && !view->m_chromeNavigationCommitted)
             return;

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -885,7 +885,9 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
     }
     case Method::PageReload:
-        // Same as navigate: don't settle, Page.loadEventFired does.
+        // Empty {} on success: the reload is underway, and it always loads the document again.
+        if (view->m_chromeNavigationKind == ChromeNavigationKind::Requested)
+            view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
         return;
 
     case Method::PageTitle: {
@@ -1872,8 +1874,8 @@ JSPromise* goForward(JSGlobalObject* g, JSWebView* view) { return historyGo(g, v
 JSPromise* reload(JSGlobalObject* g, JSWebView* view)
 {
     auto& t = transport();
-    // A reload always loads the document again.
-    startNavigation(view, ChromeNavigationKind::CrossDocument);
+    // Chrome answers Page.reload with {}, so the reply is what puts the reload underway.
+    startNavigation(view, ChromeNavigationKind::Requested);
     uint32_t id = t.nextId();
     // Navigate slot — reload IS a navigation. Page.loadEventFired only
     // settles PendingSlot::Navigate; using Misc would hang waiting for a

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -351,6 +351,8 @@ struct Pending {
     Method method;
     PendingSlot slot;
     uint32_t viewId;
+    // PageTitle: the JSWebView::m_chromeNavigationSeq this fetch ends, or 0 for a title refresh that settles nothing.
+    uint32_t navigation = 0;
 };
 
 // Transport mode. Pipe = we spawned Chrome with --remote-debugging-pipe,
@@ -477,8 +479,8 @@ public:
     void handleMessage(std::span<const char> msg);
     void handleResponse(uint32_t id, std::span<const char> result, std::span<const char> error);
     void handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId);
-    // Fetches document.title; the reply (PageTitle) settles the Navigate slot.
-    void sendTitleFetch(JSWebView*);
+    // Fetches document.title into m_title; with endsNavigation the reply also settles the Navigate slot.
+    void sendTitleFetch(JSWebView*, bool endsNavigation);
     void rejectAllAndMarkDead(const WTF::String& reason);
     void updateKeepAlive();
     void writeRaw(const char* data, size_t len);

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -477,9 +477,7 @@ public:
     void handleMessage(std::span<const char> msg);
     void handleResponse(uint32_t id, std::span<const char> result, std::span<const char> error);
     void handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId);
-    // Runtime.evaluate("document.title") on the Navigate slot, sent from the
-    // commit that ends a navigation. The reply sets m_title and settles the
-    // slot, so view.title is current when navigate() resolves.
+    // Fetches document.title; the reply (PageTitle) settles the Navigate slot.
     void sendTitleFetch(JSWebView*);
     void rejectAllAndMarkDead(const WTF::String& reason);
     void updateKeepAlive();

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -477,6 +477,10 @@ public:
     void handleMessage(std::span<const char> msg);
     void handleResponse(uint32_t id, std::span<const char> result, std::span<const char> error);
     void handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId);
+    // Runtime.evaluate("document.title") on the Navigate slot, sent from the
+    // commit that ends a navigation. The reply sets m_title and settles the
+    // slot, so view.title is current when navigate() resolves.
+    void sendTitleFetch(JSWebView*);
     void rejectAllAndMarkDead(const WTF::String& reason);
     void updateKeepAlive();
     void writeRaw(const char* data, size_t len);

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -479,6 +479,9 @@ public:
     void handleMessage(std::span<const char> msg);
     void handleResponse(uint32_t id, std::span<const char> result, std::span<const char> error);
     void handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId);
+    void onFrameNavigated(JSWebView*, std::span<const char> params);
+    void onNavigatedWithinDocument(JSWebView*, std::span<const char> params);
+    void onLoadEventFired(JSWebView*);
     // Fetches document.title into m_title; with endsNavigation the reply also settles the Navigate slot.
     void sendTitleFetch(JSWebView*, bool endsNavigation);
     void rejectAllAndMarkDead(const WTF::String& reason);

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -45,14 +45,19 @@ enum class ScreenshotEncoding : uint8_t {
            // bytes, return name. Not supported on Windows.
 };
 
-// Chrome: what the pending navigation ends with. A cross-document
-// navigation ends with Page.loadEventFired. A same-document one (a
-// #fragment target, a history.pushState URL) has no load event and ends
-// with Page.navigatedWithinDocument. Chrome names the kind in
-// Page.frameStartedNavigating before the navigation commits, and
-// Page.frameNavigated is a cross-document commit. Unknown settles on
-// either event, so a navigation Chrome did not classify cannot hang.
+// Chrome: which commit ends the navigation command the view has in flight.
+// A cross-document navigation ends with Page.loadEventFired. A
+// same-document one (a #fragment target, a history.pushState entry) fires
+// no load event and ends with Page.navigatedWithinDocument. Chrome names
+// the kind in Page.frameStartedNavigating and in the Page.navigate reply,
+// and Page.frameNavigated is itself a cross-document commit. While the kind
+// is Unknown either commit ends the navigation, so one that Chrome never
+// classifies cannot hang.
 enum class ChromeNavigationKind : uint8_t {
+    // No navigation command of the view's is in flight: nothing is pending,
+    // or goBack()/goForward() is still looking up the history entry. A
+    // same-document commit now is the page's own doing.
+    NotRequested,
     Unknown,
     SameDocument,
     CrossDocument,
@@ -115,7 +120,7 @@ public:
     // events carry a frameId; a subframe's navigation is not the view's, so
     // it must not touch m_url or settle the navigate() promise.
     WTF::String m_mainFrameId;
-    ChromeNavigationKind m_chromeNavigationKind = ChromeNavigationKind::Unknown;
+    ChromeNavigationKind m_chromeNavigationKind = ChromeNavigationKind::NotRequested;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -46,14 +46,11 @@ enum class ScreenshotEncoding : uint8_t {
 };
 
 // Chrome: which event ends the navigation the view has in flight.
-// CrossDocument ends on Page.loadEventFired, SameDocument (a #fragment, a
-// history.pushState entry) on Page.navigatedWithinDocument, Unknown on
-// whichever comes first, NotRequested on neither.
 enum class ChromeNavigationKind : uint8_t {
-    NotRequested, // slot empty, or goBack()/goForward() still looking up the entry
-    Unknown, // command sent, Chrome has not classified it yet
-    SameDocument,
-    CrossDocument,
+    NotRequested, // nothing asked of Chrome (slot empty, or goBack()/goForward() mid history lookup): no event ends it
+    Unknown, // command sent, not yet classified: Page.loadEventFired or Page.navigatedWithinDocument ends it
+    SameDocument, // a #fragment or history.pushState entry: Page.navigatedWithinDocument ends it
+    CrossDocument, // Page.loadEventFired ends it
 };
 
 inline const char* screenshotMimeType(ScreenshotFormat f)

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -45,20 +45,13 @@ enum class ScreenshotEncoding : uint8_t {
            // bytes, return name. Not supported on Windows.
 };
 
-// Chrome: which commit ends the navigation command the view has in flight.
-// A cross-document navigation ends with Page.loadEventFired. A
-// same-document one (a #fragment target, a history.pushState entry) fires
-// no load event and ends with Page.navigatedWithinDocument. Chrome names
-// the kind in Page.frameStartedNavigating and in the Page.navigate reply,
-// and Page.frameNavigated is itself a cross-document commit. While the kind
-// is Unknown either commit ends the navigation, so one that Chrome never
-// classifies cannot hang.
+// Chrome: which event ends the navigation the view has in flight.
+// CrossDocument ends on Page.loadEventFired, SameDocument (a #fragment, a
+// history.pushState entry) on Page.navigatedWithinDocument, Unknown on
+// whichever comes first, NotRequested on neither.
 enum class ChromeNavigationKind : uint8_t {
-    // No navigation command of the view's is in flight: nothing is pending,
-    // or goBack()/goForward() is still looking up the history entry. A
-    // same-document commit now is the page's own doing.
-    NotRequested,
-    Unknown,
+    NotRequested, // slot empty, or goBack()/goForward() still looking up the entry
+    Unknown, // command sent, Chrome has not classified it yet
     SameDocument,
     CrossDocument,
 };
@@ -116,9 +109,7 @@ public:
     WTF::String m_sessionId;
     WTF::String m_targetId;
     WTF::String m_pendingChromeNavigateUrl;
-    // Chrome: the main frame, named by the first Page.navigate reply. Page
-    // events carry a frameId; a subframe's navigation is not the view's, so
-    // it must not touch m_url or settle the navigate() promise.
+    // Chrome: from the first Page.navigate reply. Subframe events are ignored.
     WTF::String m_mainFrameId;
     ChromeNavigationKind m_chromeNavigationKind = ChromeNavigationKind::NotRequested;
     // clickSelector stash — the actionability eval chains into a

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -51,7 +51,7 @@ enum class ChromeNavigationKind : uint8_t {
     Requested, // command written, no reply yet: every commit so far is the page's own
     Unknown, // a history traversal, which Chrome answers with {}: the next commit of either shape ends it
     SameDocument, // a #fragment or history.pushState entry: Page.navigatedWithinDocument ends it
-    CrossDocument, // Page.loadEventFired ends it
+    CrossDocument, // Page.loadEventFired ends it, or the commit itself for a back-forward cache restore
 };
 
 inline const char* screenshotMimeType(ScreenshotFormat f)
@@ -107,13 +107,21 @@ public:
     WTF::String m_sessionId;
     WTF::String m_targetId;
     WTF::String m_pendingChromeNavigateUrl;
-    // Chrome: from the first Page.navigate reply. Subframe events are ignored.
+    // Chrome: from the first main frame commit. Subframe events are ignored.
     WTF::String m_mainFrameId;
     ChromeNavigationKind m_chromeNavigationKind = ChromeNavigationKind::NotRequested;
     // Chrome: a main frame document has committed since the view's last navigation command.
     bool m_chromeNavigationCommitted = false;
+    // Chrome: the loader a Page.navigate reply named. Only its commit is that navigation's. Empty: any commit is.
+    WTF::String m_chromeNavigationLoaderId;
     // Chrome: counts navigation commands, so a title reply settles only the navigation it was fetched for.
     uint32_t m_chromeNavigationSeq = 0;
+    // Chrome: the live main frame document is Chrome's error page for a load that failed.
+    bool m_chromeOnErrorPage = false;
+    // Chrome: the URL whose error page committed. Reported as a failure once that page has loaded.
+    WTF::String m_chromeUnreportedFailure;
+    // Chrome: the loaderId whose failure navigate() already reported from Page.navigate's errorText.
+    WTF::String m_chromeFailedLoaderId;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -45,8 +45,7 @@ enum class ScreenshotEncoding : uint8_t {
            // bytes, return name. Not supported on Windows.
 };
 
-// Chrome: which event ends the navigation the view has in flight. A commit
-// carries no loader id, so the state decides which commit is the view's.
+// Chrome: which event ends the navigation the view has in flight.
 enum class ChromeNavigationKind : uint8_t {
     NotRequested, // nothing asked of Chrome, or it is already done: no event ends it
     Requested, // command written, no reply yet: a commit now can still be the page's own

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -109,6 +109,8 @@ public:
     // Chrome: from the first Page.navigate reply. Subframe events are ignored.
     WTF::String m_mainFrameId;
     ChromeNavigationKind m_chromeNavigationKind = ChromeNavigationKind::NotRequested;
+    // Chrome: a main frame commit has landed since the view's last navigation command.
+    bool m_chromeNavigationCommitted = false;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -112,16 +112,8 @@ public:
     ChromeNavigationKind m_chromeNavigationKind = ChromeNavigationKind::NotRequested;
     // Chrome: a main frame document has committed since the view's last navigation command.
     bool m_chromeNavigationCommitted = false;
-    // Chrome: the loader a Page.navigate reply named. Only its commit is that navigation's. Empty: any commit is.
-    WTF::String m_chromeNavigationLoaderId;
     // Chrome: counts navigation commands, so a title reply settles only the navigation it was fetched for.
     uint32_t m_chromeNavigationSeq = 0;
-    // Chrome: the live main frame document is Chrome's error page for a load that failed.
-    bool m_chromeOnErrorPage = false;
-    // Chrome: the URL whose error page committed. Reported as a failure once that page has loaded.
-    WTF::String m_chromeUnreportedFailure;
-    // Chrome: the loaderId whose failure navigate() already reported from Page.navigate's errorText.
-    WTF::String m_chromeFailedLoaderId;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -45,6 +45,19 @@ enum class ScreenshotEncoding : uint8_t {
            // bytes, return name. Not supported on Windows.
 };
 
+// Chrome: what the pending navigation ends with. A cross-document
+// navigation ends with Page.loadEventFired. A same-document one (a
+// #fragment target, a history.pushState URL) has no load event and ends
+// with Page.navigatedWithinDocument. Chrome names the kind in
+// Page.frameStartedNavigating before the navigation commits, and
+// Page.frameNavigated is a cross-document commit. Unknown settles on
+// either event, so a navigation Chrome did not classify cannot hang.
+enum class ChromeNavigationKind : uint8_t {
+    Unknown,
+    SameDocument,
+    CrossDocument,
+};
+
 inline const char* screenshotMimeType(ScreenshotFormat f)
 {
     switch (f) {
@@ -98,6 +111,11 @@ public:
     WTF::String m_sessionId;
     WTF::String m_targetId;
     WTF::String m_pendingChromeNavigateUrl;
+    // Chrome: the main frame, named by the first Page.navigate reply. Page
+    // events carry a frameId; a subframe's navigation is not the view's, so
+    // it must not touch m_url or settle the navigate() promise.
+    WTF::String m_mainFrameId;
+    ChromeNavigationKind m_chromeNavigationKind = ChromeNavigationKind::Unknown;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -49,7 +49,7 @@ enum class ScreenshotEncoding : uint8_t {
 enum class ChromeNavigationKind : uint8_t {
     NotRequested, // nothing asked of Chrome, or it is already done: no event ends it
     Requested, // command written, no reply yet: every commit so far is the page's own
-    Unknown, // a history traversal, which Chrome answers with {}: the next commit of either shape ends it
+    Unknown, // a history traversal, which Chrome answers with {}: a document commit, or a same-document one onto its entry, ends it
     SameDocument, // a #fragment or history.pushState entry: Page.navigatedWithinDocument ends it
     CrossDocument, // Page.loadEventFired ends it, or the commit itself for a back-forward cache restore
 };
@@ -114,6 +114,8 @@ public:
     bool m_chromeNavigationCommitted = false;
     // Chrome: counts navigation commands, so a title reply settles only the navigation it was fetched for.
     uint32_t m_chromeNavigationSeq = 0;
+    // Chrome: the URL of the history entry that goBack()/goForward() asked for. A same-document commit elsewhere is the page's own.
+    WTF::String m_chromeTraversalUrl;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -45,10 +45,12 @@ enum class ScreenshotEncoding : uint8_t {
            // bytes, return name. Not supported on Windows.
 };
 
-// Chrome: which event ends the navigation the view has in flight.
+// Chrome: which event ends the navigation the view has in flight. A commit
+// carries no loader id, so the state decides which commit is the view's.
 enum class ChromeNavigationKind : uint8_t {
-    NotRequested, // nothing asked of Chrome (slot empty, or goBack()/goForward() mid history lookup): no event ends it
-    Unknown, // command sent, not yet classified: Page.loadEventFired or Page.navigatedWithinDocument ends it
+    NotRequested, // nothing asked of Chrome, or it is already done: no event ends it
+    Requested, // command written, no reply yet: a commit now can still be the page's own
+    Unknown, // command answered, kind unknown (a history traversal): the next commit of either shape ends it
     SameDocument, // a #fragment or history.pushState entry: Page.navigatedWithinDocument ends it
     CrossDocument, // Page.loadEventFired ends it
 };
@@ -109,8 +111,10 @@ public:
     // Chrome: from the first Page.navigate reply. Subframe events are ignored.
     WTF::String m_mainFrameId;
     ChromeNavigationKind m_chromeNavigationKind = ChromeNavigationKind::NotRequested;
-    // Chrome: a main frame commit has landed since the view's last navigation command.
+    // Chrome: a main frame document has committed since the view's last navigation command.
     bool m_chromeNavigationCommitted = false;
+    // Chrome: counts navigation commands, so a title reply settles only the navigation it was fetched for.
+    uint32_t m_chromeNavigationSeq = 0;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -48,8 +48,8 @@ enum class ScreenshotEncoding : uint8_t {
 // Chrome: which event ends the navigation the view has in flight.
 enum class ChromeNavigationKind : uint8_t {
     NotRequested, // nothing asked of Chrome, or it is already done: no event ends it
-    Requested, // command written, no reply yet: a commit now can still be the page's own
-    Unknown, // command answered, kind unknown (a history traversal): the next commit of either shape ends it
+    Requested, // command written, no reply yet: every commit so far is the page's own
+    Unknown, // a history traversal, which Chrome answers with {}: the next commit of either shape ends it
     SameDocument, // a #fragment or history.pushState entry: Page.navigatedWithinDocument ends it
     CrossDocument, // Page.loadEventFired ends it
 };

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -34,12 +34,6 @@ const navigateError = process.argv.find(a => a.startsWith("--navigate-error="))?
 // Page.navigate for a URL it cannot parse.
 const cdpErrorOn = process.argv.find(a => a.startsWith("--cdp-error-on="))?.slice("--cdp-error-on=".length);
 
-// `--no-started-navigating`: never send Page.frameStartedNavigating, the way
-// a Chrome older than that event behaves. The runtime then has only the
-// Page.navigate reply to tell a same-document navigation from one that
-// replaces the document.
-const noStartedNavigating = process.argv.includes("--no-started-navigating");
-
 // `--subframe-navigation`: every document load commits a subframe navigation
 // too, the way a page holding an <iframe> does.
 const subframeNavigation = process.argv.includes("--subframe-navigation");
@@ -56,10 +50,10 @@ let replaceStateOnHistoryLookup: string | undefined;
 // is being answered: that document commits during the lookup, and only
 // __fake_load_event() finishes it (see __fake_page_load_on_history_lookup).
 let pageLoadOnHistoryLookup: string | undefined;
-// One URL the page "replaceState"s to as the next navigation command is read,
-// before its reply: the way an event already in the pipe reaches the runtime
-// after it wrote the command (see __fake_replace_state_on_next_navigate).
-let replaceStateOnNextNavigate: string | undefined;
+// One #fragment the page follows as the next navigation command is read,
+// before its reply: the way events already in the pipe reach the runtime
+// after it wrote the command (see __fake_fragment_link_on_next_navigate).
+let fragmentLinkOnNextNavigate: string | undefined;
 // One URL the page "replaceState"s to right after the next same-document
 // commit, the way a hashchange handler canonicalizing the URL does.
 let replaceStateAfterNextCommit: string | undefined;
@@ -90,10 +84,11 @@ Object.assign(globalThis, {
   __fake_page_load_on_history_lookup(url: string) {
     pageLoadOnHistoryLookup = url;
   },
-  // The page's own same-document commit reaches the runtime after it wrote
-  // the next navigation command and before Chrome answers it.
-  __fake_replace_state_on_next_navigate(url: string) {
-    replaceStateOnNextNavigate = url;
+  // The page follows a #fragment link of its own, which Chrome starts and
+  // commits after the runtime wrote the next navigation command and before
+  // Chrome answers it. Chrome calls that start "sameDocument".
+  __fake_fragment_link_on_next_navigate(url: string) {
+    fragmentLinkOnNextNavigate = url;
   },
   // The page's own same-document commit lands right behind the next one,
   // the way a hashchange handler that rewrites the URL produces.
@@ -160,10 +155,7 @@ function replaceState(url: string) {
 function pageLoad(url: string) {
   const event = (method: string, params: unknown) => send({ method, params, sessionId: currentSessionId });
   loads++;
-  if (!noStartedNavigating) {
-    const started = { frameId: "F", url, loaderId: "P" + loads, navigationType: "differentDocument" };
-    event("Page.frameStartedNavigating", started);
-  }
+  event("Page.frameStartedNavigating", { frameId: "F", url, loaderId: "P" + loads, navigationType: "differentDocument" });
   history.length = historyIndex + 1;
   history.push({ id: ++entries, url });
   historyIndex = history.length - 1;
@@ -176,9 +168,9 @@ async function handle(command: { id: number; method: string; params?: any; sessi
   const reply = (result: unknown) => send(sessionId ? { id, result, sessionId } : { id, result });
   const event = (name: string, eventParams: unknown) => send({ method: name, params: eventParams, sessionId });
 
-  // Chrome names a navigation's kind before it starts.
+  // Chrome names a navigation's kind before it starts. The runtime ignores it.
   const startNavigating = (url: string, navigationType: string) => {
-    if (!noStartedNavigating) event("Page.frameStartedNavigating", { frameId: "F", url, navigationType });
+    event("Page.frameStartedNavigating", { frameId: "F", url, navigationType });
   };
 
   // The commit. A cross-document navigation commits with
@@ -216,9 +208,10 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       return reply({ sessionId: "S" + params.targetId.slice(1) });
     case "Page.navigate": {
       if (navigateError) return reply({ frameId: "F", errorText: navigateError });
-      if (replaceStateOnNextNavigate !== undefined) {
-        replaceState(replaceStateOnNextNavigate);
-        replaceStateOnNextNavigate = undefined;
+      if (fragmentLinkOnNextNavigate !== undefined) {
+        startNavigating(fragmentLinkOnNextNavigate, "sameDocument");
+        replaceState(fragmentLinkOnNextNavigate);
+        fragmentLinkOnNextNavigate = undefined;
       }
       // A #fragment target of the current document keeps that document.
       const current = history[historyIndex]?.url;

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -84,6 +84,14 @@ Object.assign(globalThis, {
   __fake_page_load_on_history_lookup(url: string) {
     pageLoadOnHistoryLookup = url;
   },
+  // The page navigates itself to `url` (a link, `location.href = ...`) and
+  // the load fails: Chrome's error page commits in its place and loads.
+  __fake_page_load_fails(url: string) {
+    loads++;
+    event("Page.frameStartedNavigating", { frameId: "F", url, loaderId: "P" + loads, navigationType: "differentDocument" });
+    pushEntry(url, "P" + loads);
+    commitErrorPage(url, "P" + loads);
+  },
   // The page follows a #fragment link of its own, which Chrome starts and
   // commits after the runtime wrote the next navigation command and before
   // Chrome answers it. Chrome calls that start "sameDocument".
@@ -123,6 +131,11 @@ function send(message: unknown) {
   while (written < bytes.length) written += writeSync(REPLIES, bytes, written, bytes.length - written);
 }
 
+// An event on the session of the command being handled.
+function event(method: string, params: unknown) {
+  send({ method, params, sessionId: currentSessionId });
+}
+
 let targets = 0;
 let loads = 0;
 let entries = 0;
@@ -130,71 +143,86 @@ let entries = 0;
 // Session history, the way the browser keeps it: Page.navigate appends,
 // Page.getNavigationHistory reports it, Page.navigateToHistoryEntry moves
 // inside it. Two URLs that differ only after the '#' are the same document.
-const history: { id: number; url: string }[] = [];
+// Each entry remembers the loader its document committed under.
+const history: { id: number; url: string; loaderId: string }[] = [];
 let historyIndex = -1;
 const documentOf = (url: string) => url.split("#")[0];
 const fragmentOf = (url: string) => (url.includes("#") ? url.slice(url.indexOf("#")) : "");
 // A URL with "never-load" in it starts loading and never commits, the way a
 // server that accepts the connection and then says nothing looks. One with
 // "stall-on-return" loads when navigated to, but a history traversal back to
-// it starts and never commits.
+// it starts and never commits. One with "unreachable" in it fails to load,
+// the way a refused connection does: Chrome commits its error page instead.
+// One with "bfcached" in it comes back whole from the back-forward cache when
+// a history traversal returns to it.
 const neverLoads = (url: string) => url.includes("never-load");
 const stallsOnReturn = (url: string) => url.includes("stall-on-return");
+const failsToLoad = (url: string) => url.includes("unreachable");
+const bfcached = (url: string) => url.includes("bfcached");
+
+function pushEntry(url: string, loaderId: string) {
+  history.length = historyIndex + 1;
+  history.push({ id: ++entries, url, loaderId });
+  historyIndex = history.length - 1;
+}
 
 function replaceState(url: string) {
   if (historyIndex >= 0) history[historyIndex].url = url;
-  send({
-    method: "Page.navigatedWithinDocument",
-    params: { frameId: "F", url, navigationType: "historyApi" },
-    sessionId: currentSessionId,
-  });
+  event("Page.navigatedWithinDocument", { frameId: "F", url, navigationType: "historyApi" });
+}
+
+// Chrome names a navigation's kind before it starts. The runtime ignores it.
+function startNavigating(url: string, navigationType: string) {
+  event("Page.frameStartedNavigating", { frameId: "F", url, navigationType });
+}
+
+// A document commits: Page.frameNavigated, with the fragment split off into
+// frame.urlFragment. A fresh load ("Navigation") ends with the load event; a
+// page restored from the back-forward cache is complete as it commits, so
+// nothing follows.
+function commitDocument(url: string, loaderId: string, type: "Navigation" | "BackForwardCacheRestore") {
+  const fragment = fragmentOf(url);
+  const frame = { id: "F", loaderId, url: documentOf(url), mimeType: "text/html" };
+  event("Page.frameNavigated", { frame: fragment ? { ...frame, urlFragment: fragment } : frame, type });
+  if (type === "BackForwardCacheRestore") return;
+  if (subframeNavigation) {
+    const subframe = { id: "SUB", parentId: "F", loaderId: "S" + loads, url: "http://fake/subframe" };
+    event("Page.frameNavigated", { frame: { ...subframe, mimeType: "text/html" }, type });
+  }
+  event("Page.loadEventFired", { timestamp: loads });
+}
+
+// A same-document navigation commits: Page.navigatedWithinDocument, and never
+// a load event.
+function commitSameDocument(url: string) {
+  event("Page.navigatedWithinDocument", { frameId: "F", url, navigationType: "fragment" });
+  if (replaceStateAfterNextCommit !== undefined) {
+    replaceState(replaceStateAfterNextCommit);
+    replaceStateAfterNextCommit = undefined;
+  }
+}
+
+// Chrome's error page standing in for a document that failed to load: it
+// commits under the failed loader, names the URL it replaces, and loads.
+function commitErrorPage(unreachableUrl: string, loaderId: string) {
+  const frame = { id: "F", loaderId, url: "chrome-error://chromewebdata/", unreachableUrl, mimeType: "text/html" };
+  event("Page.frameNavigated", { frame, type: "Navigation" });
+  event("Page.loadEventFired", { timestamp: loads });
 }
 
 // The page navigates itself to a new document (a link, `location.href = ...`):
 // its own loader and commit. __fake_load_event() finishes it.
 function pageLoad(url: string) {
-  const event = (method: string, params: unknown) => send({ method, params, sessionId: currentSessionId });
   loads++;
   event("Page.frameStartedNavigating", { frameId: "F", url, loaderId: "P" + loads, navigationType: "differentDocument" });
-  history.length = historyIndex + 1;
-  history.push({ id: ++entries, url });
-  historyIndex = history.length - 1;
-  event("Page.frameNavigated", { frame: { id: "F", loaderId: "P" + loads, url, mimeType: "text/html" } });
+  pushEntry(url, "P" + loads);
+  event("Page.frameNavigated", { frame: { id: "F", loaderId: "P" + loads, url, mimeType: "text/html" }, type: "Navigation" });
 }
 
 async function handle(command: { id: number; method: string; params?: any; sessionId?: string }) {
   const { id, method, params = {}, sessionId } = command;
   currentSessionId = sessionId;
   const reply = (result: unknown) => send(sessionId ? { id, result, sessionId } : { id, result });
-  const event = (name: string, eventParams: unknown) => send({ method: name, params: eventParams, sessionId });
-
-  // Chrome names a navigation's kind before it starts. The runtime ignores it.
-  const startNavigating = (url: string, navigationType: string) => {
-    event("Page.frameStartedNavigating", { frameId: "F", url, navigationType });
-  };
-
-  // The commit. A cross-document navigation commits with
-  // Page.frameNavigated, which splits the fragment into frame.urlFragment,
-  // and ends with the load event. A same-document one commits with
-  // Page.navigatedWithinDocument and never fires a load event.
-  const commit = (url: string, sameDocument: boolean) => {
-    if (sameDocument) {
-      event("Page.navigatedWithinDocument", { frameId: "F", url, navigationType: "fragment" });
-      if (replaceStateAfterNextCommit !== undefined) {
-        replaceState(replaceStateAfterNextCommit);
-        replaceStateAfterNextCommit = undefined;
-      }
-      return;
-    }
-    const fragment = fragmentOf(url);
-    const frame = { id: "F", loaderId: "L" + loads, url: documentOf(url), mimeType: "text/html" };
-    event("Page.frameNavigated", { frame: fragment ? { ...frame, urlFragment: fragment } : frame });
-    if (subframeNavigation) {
-      const subframe = { id: "SUB", parentId: "F", loaderId: "S" + loads, url: "http://fake/subframe" };
-      event("Page.frameNavigated", { frame: { ...subframe, mimeType: "text/html" } });
-    }
-    event("Page.loadEventFired", { timestamp: loads });
-  };
 
   if (method === cdpErrorOn) {
     const error = { code: -32000, message: "Cannot navigate to invalid URL" };
@@ -207,6 +235,7 @@ async function handle(command: { id: number; method: string; params?: any; sessi
     case "Target.attachToTarget":
       return reply({ sessionId: "S" + params.targetId.slice(1) });
     case "Page.navigate": {
+      const url: string = params.url;
       if (navigateError) return reply({ frameId: "F", errorText: navigateError });
       if (fragmentLinkOnNextNavigate !== undefined) {
         startNavigating(fragmentLinkOnNextNavigate, "sameDocument");
@@ -214,19 +243,40 @@ async function handle(command: { id: number; method: string; params?: any; sessi
         fragmentLinkOnNextNavigate = undefined;
       }
       // A #fragment target of the current document keeps that document.
-      const current = history[historyIndex]?.url;
+      const current = history[historyIndex];
       const sameDocument =
-        current !== undefined && documentOf(current) === documentOf(params.url) && fragmentOf(params.url) !== "";
-      startNavigating(params.url, sameDocument ? "sameDocument" : "differentDocument");
-      if (!sameDocument) loads++;
-      // The reply names a loaderId only for a navigation that loads a
-      // document.
-      reply(sameDocument ? { frameId: "F" } : { frameId: "F", loaderId: "L" + loads });
-      if (neverLoads(params.url)) return;
-      history.length = historyIndex + 1;
-      history.push({ id: ++entries, url: params.url });
-      historyIndex = history.length - 1;
-      commit(params.url, sameDocument);
+        current !== undefined && documentOf(current.url) === documentOf(url) && fragmentOf(url) !== "";
+      startNavigating(url, sameDocument ? "sameDocument" : "differentDocument");
+      if (sameDocument) {
+        // The reply names a loaderId only for a navigation that loads a document.
+        reply({ frameId: "F" });
+        pushEntry(url, current.loaderId);
+        commitSameDocument(url);
+        return;
+      }
+      const loaderId = "L" + ++loads;
+      if (failsToLoad(url)) {
+        // The failure is known before anything commits: the reply carries it,
+        // and the error page follows under the same loader.
+        reply({ frameId: "F", loaderId, errorText: "net::ERR_CONNECTION_REFUSED" });
+        pushEntry(url, loaderId);
+        commitErrorPage(url, loaderId);
+        return;
+      }
+      reply({ frameId: "F", loaderId });
+      if (neverLoads(url)) return;
+      pushEntry(url, loaderId);
+      commitDocument(url, loaderId, "Navigation");
+      return;
+    }
+    case "Page.reload": {
+      const current = history[historyIndex];
+      if (current === undefined) return reply({});
+      startNavigating(current.url, "reload");
+      current.loaderId = "L" + ++loads;
+      reply({});
+      if (failsToLoad(current.url)) return commitErrorPage(current.url, current.loaderId);
+      commitDocument(current.url, current.loaderId, "Navigation");
       return;
     }
     case "Page.getNavigationHistory": {
@@ -247,14 +297,18 @@ async function handle(command: { id: number; method: string; params?: any; sessi
     case "Page.navigateToHistoryEntry": {
       const target = history.findIndex(entry => entry.id === params.entryId);
       if (target === -1) return reply({});
-      const url = history[target].url;
-      const sameDocument = documentOf(history[historyIndex].url) === documentOf(url);
-      startNavigating(url, sameDocument ? "historySameDocument" : "historyDifferentDocument");
-      if (!sameDocument) loads++;
+      const entry = history[target];
+      const sameDocument = documentOf(history[historyIndex].url) === documentOf(entry.url);
+      startNavigating(entry.url, sameDocument ? "historySameDocument" : "historyDifferentDocument");
       reply({});
-      if (neverLoads(url) || stallsOnReturn(url)) return;
+      if (neverLoads(entry.url) || stallsOnReturn(entry.url)) return;
       historyIndex = target;
-      commit(url, sameDocument);
+      if (sameDocument) return commitSameDocument(entry.url);
+      // A restore commits the cached document again, under its original loader.
+      if (bfcached(entry.url)) return commitDocument(entry.url, entry.loaderId, "BackForwardCacheRestore");
+      entry.loaderId = "L" + ++loads;
+      if (failsToLoad(entry.url)) return commitErrorPage(entry.url, entry.loaderId);
+      commitDocument(entry.url, entry.loaderId, "Navigation");
       return;
     }
     case "Page.captureScreenshot":

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -54,6 +54,9 @@ let pageLoadOnHistoryLookup: string | undefined;
 // before its reply: the way events already in the pipe reach the runtime
 // after it wrote the command (see __fake_fragment_link_on_next_navigate).
 let fragmentLinkOnNextNavigate: string | undefined;
+// One URL the page loads whole as the next Page.reload is read, before its
+// reply; that reload then never commits (see __fake_page_load_on_next_reload).
+let pageLoadOnNextReload: string | undefined;
 // One URL the page "replaceState"s to right after the next same-document
 // commit, the way a hashchange handler canonicalizing the URL does.
 let replaceStateAfterNextCommit: string | undefined;
@@ -102,6 +105,11 @@ Object.assign(globalThis, {
   // the way a hashchange handler that rewrites the URL produces.
   __fake_replace_state_after_next_commit(url: string) {
     replaceStateAfterNextCommit = url;
+  },
+  // The page finishes a load of its own after the runtime wrote the next
+  // Page.reload and before Chrome answered it. That reload never commits.
+  __fake_page_load_on_next_reload(url: string) {
+    pageLoadOnNextReload = url;
   },
   // How many document.title fetches the runtime has sent so far.
   __fake_title_fetches() {
@@ -272,6 +280,12 @@ async function handle(command: { id: number; method: string; params?: any; sessi
     case "Page.reload": {
       const current = history[historyIndex];
       if (current === undefined) return reply({});
+      if (pageLoadOnNextReload !== undefined) {
+        pageLoad(pageLoadOnNextReload);
+        event("Page.loadEventFired", { timestamp: loads });
+        pageLoadOnNextReload = undefined;
+        return reply({});
+      }
       startNavigating(current.url, "reload");
       current.loaderId = "L" + ++loads;
       reply({});

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -43,79 +43,43 @@ let commandsClosed = false;
 // The session of the command being handled, so a __fake_* global that an
 // evaluate() runs can emit events on it.
 let currentSessionId: string | undefined;
-// One URL the page will "replaceState" to while the next
-// Page.getNavigationHistory is being answered (see __fake_replace_state_on_history_lookup).
-let replaceStateOnHistoryLookup: string | undefined;
-// One URL the page navigates itself to while the next Page.getNavigationHistory
-// is being answered: that document commits during the lookup, and only
-// __fake_load_event() finishes it (see __fake_page_load_on_history_lookup).
-let pageLoadOnHistoryLookup: string | undefined;
-// One #fragment the page follows as the next navigation command is read,
-// before its reply: the way events already in the pipe reach the runtime
-// after it wrote the command (see __fake_fragment_link_on_next_navigate).
-let fragmentLinkOnNextNavigate: string | undefined;
-// One URL the page loads whole as the next Page.reload is read, before its
-// reply; that reload then never commits (see __fake_page_load_on_next_reload).
-let pageLoadOnNextReload: string | undefined;
-// One URL the page "replaceState"s to right after the next same-document
-// commit, the way a hashchange handler canonicalizing the URL does.
-let replaceStateAfterNextCommit: string | undefined;
+// One script per CDP method, run once as the next command of that method is
+// read and before it is handled (see __fake_on_next).
+const onNext = new Map<string, string>();
 // How many document.title fetches the runtime has sent: one per navigation.
 let titleFetches = 0;
 Object.assign(globalThis, {
   __fake_exit(code: number): never {
     process.exit(code);
   },
+  // The page does something of its own while a command of the runtime's is on
+  // its way: `script` runs as the next `method` command is read, before the
+  // fake handles or answers it. That is how an event that was already in the
+  // pipe reaches the runtime after it wrote the command.
+  __fake_on_next(method: string, script: string) {
+    onNext.set(method, script);
+  },
   // The page commits a same-document navigation of its own, the way
-  // history.replaceState() or a scroll-driven `location.hash = ...` does:
+  // history.pushState() and history.replaceState() do:
   // Page.navigatedWithinDocument with nothing before it, no new history entry.
   __fake_replace_state(url: string) {
-    replaceState(url);
+    if (historyIndex >= 0) history[historyIndex].url = url;
+    event("Page.navigatedWithinDocument", { frameId: "F", url, navigationType: "historyApi" });
   },
-  // The same, but timed to land while the runtime waits for the history
-  // lookup that goBack()/goForward() start with.
-  __fake_replace_state_on_history_lookup(url: string) {
-    replaceStateOnHistoryLookup = url;
+  // The page navigates itself to a new document (a link, `location.href = ...`):
+  // it commits, and only __fake_load_event() finishes it.
+  __fake_page_commit(url: string) {
+    loads++;
+    pushEntry(url);
+    event("Page.frameNavigated", {
+      frame: { id: "F", loaderId: "P" + loads, url, mimeType: "text/html" },
+      type: "Navigation",
+    });
   },
   // The load event of the document that is live, the way one arrives for a
   // document the page itself navigated to. It names no frame and no loader.
   __fake_load_event() {
-    send({ method: "Page.loadEventFired", params: { timestamp: ++loads }, sessionId: currentSessionId });
-  },
-  // The page navigates itself to `url` while the runtime's next history
-  // lookup is in flight: a new document, committed but not finished.
-  __fake_page_load_on_history_lookup(url: string) {
-    pageLoadOnHistoryLookup = url;
-  },
-  // The page navigates itself to `url` and that document commits and loads,
-  // the way a `location.href = ...` that wins the frame does.
-  __fake_page_load(url: string) {
-    pageLoad(url);
-    event("Page.loadEventFired", { timestamp: loads });
-  },
-  // The page navigates itself to `url` (a link, `location.href = ...`) and
-  // the load fails: Chrome's error page commits in its place and loads.
-  __fake_page_load_fails(url: string) {
-    loads++;
-    event("Page.frameStartedNavigating", { frameId: "F", url, loaderId: "P" + loads, navigationType: "differentDocument" });
-    pushEntry(url, "P" + loads);
-    commitErrorPage(url, "P" + loads);
-  },
-  // The page follows a #fragment link of its own, which Chrome starts and
-  // commits after the runtime wrote the next navigation command and before
-  // Chrome answers it. Chrome calls that start "sameDocument".
-  __fake_fragment_link_on_next_navigate(url: string) {
-    fragmentLinkOnNextNavigate = url;
-  },
-  // The page's own same-document commit lands right behind the next one,
-  // the way a hashchange handler that rewrites the URL produces.
-  __fake_replace_state_after_next_commit(url: string) {
-    replaceStateAfterNextCommit = url;
-  },
-  // The page finishes a load of its own after the runtime wrote the next
-  // Page.reload and before Chrome answered it. That reload never commits.
-  __fake_page_load_on_next_reload(url: string) {
-    pageLoadOnNextReload = url;
+    event("Page.loadEventFired", { timestamp: ++loads });
   },
   // How many document.title fetches the runtime has sent so far.
   __fake_title_fetches() {
@@ -157,46 +121,32 @@ let entries = 0;
 // Session history, the way the browser keeps it: Page.navigate appends,
 // Page.getNavigationHistory reports it, Page.navigateToHistoryEntry moves
 // inside it. Two URLs that differ only after the '#' are the same document.
-// Each entry remembers the loader its document committed under.
-const history: { id: number; url: string; loaderId: string }[] = [];
+const history: { id: number; url: string }[] = [];
 let historyIndex = -1;
 const documentOf = (url: string) => url.split("#")[0];
 const fragmentOf = (url: string) => (url.includes("#") ? url.slice(url.indexOf("#")) : "");
 // A URL with "never-load" in it starts loading and never commits, the way a
 // server that accepts the connection and then says nothing looks. One with
 // "stall-on-return" loads when navigated to, but a history traversal back to
-// it starts and never commits. One with "unreachable" in it fails to load,
-// the way a refused connection does: Chrome commits its error page instead.
-// One with "bfcached" in it comes back whole from the back-forward cache when
-// a history traversal returns to it.
+// it starts and never commits. One with "bfcached" in it comes back whole
+// from the back-forward cache when a history traversal returns to it.
 const neverLoads = (url: string) => url.includes("never-load");
 const stallsOnReturn = (url: string) => url.includes("stall-on-return");
-const failsToLoad = (url: string) => url.includes("unreachable");
 const bfcached = (url: string) => url.includes("bfcached");
 
-function pushEntry(url: string, loaderId: string) {
+function pushEntry(url: string) {
   history.length = historyIndex + 1;
-  history.push({ id: ++entries, url, loaderId });
+  history.push({ id: ++entries, url });
   historyIndex = history.length - 1;
 }
 
-function replaceState(url: string) {
-  if (historyIndex >= 0) history[historyIndex].url = url;
-  event("Page.navigatedWithinDocument", { frameId: "F", url, navigationType: "historyApi" });
-}
-
-// Chrome names a navigation's kind before it starts. The runtime ignores it.
-function startNavigating(url: string, navigationType: string) {
-  event("Page.frameStartedNavigating", { frameId: "F", url, navigationType });
-}
-
 // A document commits: Page.frameNavigated, with the fragment split off into
-// frame.urlFragment. A fresh load ("Navigation") ends with the load event; a
-// page restored from the back-forward cache is complete as it commits, so
+// frame.urlFragment. A fresh load ("Navigation") ends with the load event. A
+// page restored from the back-forward cache is whole as it commits, so
 // nothing follows.
-function commitDocument(url: string, loaderId: string, type: "Navigation" | "BackForwardCacheRestore") {
+function commitDocument(url: string, type: "Navigation" | "BackForwardCacheRestore") {
   const fragment = fragmentOf(url);
-  const frame = { id: "F", loaderId, url: documentOf(url), mimeType: "text/html" };
+  const frame = { id: "F", loaderId: "L" + loads, url: documentOf(url), mimeType: "text/html" };
   event("Page.frameNavigated", { frame: fragment ? { ...frame, urlFragment: fragment } : frame, type });
   if (type === "BackForwardCacheRestore") return;
   if (subframeNavigation) {
@@ -206,37 +156,22 @@ function commitDocument(url: string, loaderId: string, type: "Navigation" | "Bac
   event("Page.loadEventFired", { timestamp: loads });
 }
 
-// A same-document navigation commits: Page.navigatedWithinDocument, and never
-// a load event.
+// A same-document navigation of the runtime's commits: a #fragment target and
+// a history traversal both report "fragment". No load event follows.
 function commitSameDocument(url: string) {
   event("Page.navigatedWithinDocument", { frameId: "F", url, navigationType: "fragment" });
-  if (replaceStateAfterNextCommit !== undefined) {
-    replaceState(replaceStateAfterNextCommit);
-    replaceStateAfterNextCommit = undefined;
-  }
-}
-
-// Chrome's error page standing in for a document that failed to load: it
-// commits under the failed loader, names the URL it replaces, and loads.
-function commitErrorPage(unreachableUrl: string, loaderId: string) {
-  const frame = { id: "F", loaderId, url: "chrome-error://chromewebdata/", unreachableUrl, mimeType: "text/html" };
-  event("Page.frameNavigated", { frame, type: "Navigation" });
-  event("Page.loadEventFired", { timestamp: loads });
-}
-
-// The page navigates itself to a new document (a link, `location.href = ...`):
-// its own loader and commit. __fake_load_event() finishes it.
-function pageLoad(url: string) {
-  loads++;
-  event("Page.frameStartedNavigating", { frameId: "F", url, loaderId: "P" + loads, navigationType: "differentDocument" });
-  pushEntry(url, "P" + loads);
-  event("Page.frameNavigated", { frame: { id: "F", loaderId: "P" + loads, url, mimeType: "text/html" }, type: "Navigation" });
 }
 
 async function handle(command: { id: number; method: string; params?: any; sessionId?: string }) {
   const { id, method, params = {}, sessionId } = command;
   currentSessionId = sessionId;
   const reply = (result: unknown) => send(sessionId ? { id, result, sessionId } : { id, result });
+
+  const script = onNext.get(method);
+  if (script !== undefined) {
+    onNext.delete(method);
+    (0, eval)(script);
+  }
 
   if (method === cdpErrorOn) {
     const error = { code: -32000, message: "Cannot navigate to invalid URL" };
@@ -251,85 +186,30 @@ async function handle(command: { id: number; method: string; params?: any; sessi
     case "Page.navigate": {
       const url: string = params.url;
       if (navigateError) return reply({ frameId: "F", errorText: navigateError });
-      if (fragmentLinkOnNextNavigate !== undefined) {
-        startNavigating(fragmentLinkOnNextNavigate, "sameDocument");
-        replaceState(fragmentLinkOnNextNavigate);
-        fragmentLinkOnNextNavigate = undefined;
-      }
       // A #fragment target of the current document keeps that document.
-      const current = history[historyIndex];
-      const sameDocument =
-        current !== undefined && documentOf(current.url) === documentOf(url) && fragmentOf(url) !== "";
-      startNavigating(url, sameDocument ? "sameDocument" : "differentDocument");
-      if (sameDocument) {
-        // The reply names a loaderId only for a navigation that loads a document.
-        reply({ frameId: "F" });
-        pushEntry(url, current.loaderId);
-        commitSameDocument(url);
-        return;
-      }
-      const loaderId = "L" + ++loads;
-      if (failsToLoad(url)) {
-        // The failure is known before anything commits: the reply carries it,
-        // and the error page follows under the same loader.
-        reply({ frameId: "F", loaderId, errorText: "net::ERR_CONNECTION_REFUSED" });
-        pushEntry(url, loaderId);
-        commitErrorPage(url, loaderId);
-        return;
-      }
-      reply({ frameId: "F", loaderId });
+      const current = history[historyIndex]?.url;
+      const sameDocument = current !== undefined && documentOf(current) === documentOf(url) && fragmentOf(url) !== "";
+      if (!sameDocument) loads++;
+      // The reply names a loaderId only for a navigation that loads a document.
+      reply(sameDocument ? { frameId: "F" } : { frameId: "F", loaderId: "L" + loads });
       if (neverLoads(url)) return;
-      pushEntry(url, loaderId);
-      commitDocument(url, loaderId, "Navigation");
-      return;
+      pushEntry(url);
+      return sameDocument ? commitSameDocument(url) : commitDocument(url, "Navigation");
     }
-    case "Page.reload": {
-      const current = history[historyIndex];
-      if (current === undefined) return reply({});
-      if (pageLoadOnNextReload !== undefined) {
-        pageLoad(pageLoadOnNextReload);
-        event("Page.loadEventFired", { timestamp: loads });
-        pageLoadOnNextReload = undefined;
-        return reply({});
-      }
-      startNavigating(current.url, "reload");
-      current.loaderId = "L" + ++loads;
-      reply({});
-      if (failsToLoad(current.url)) return commitErrorPage(current.url, current.loaderId);
-      commitDocument(current.url, current.loaderId, "Navigation");
-      return;
-    }
-    case "Page.getNavigationHistory": {
-      if (replaceStateOnHistoryLookup !== undefined) {
-        replaceState(replaceStateOnHistoryLookup);
-        replaceStateOnHistoryLookup = undefined;
-      }
-      // The page's own navigation commits while the lookup is in flight: a
-      // new document, still loading. The reply describes the history the
-      // browser read before that commit.
-      const snapshot = { currentIndex: historyIndex, entries: history.map(entry => ({ ...entry })) };
-      if (pageLoadOnHistoryLookup !== undefined) {
-        pageLoad(pageLoadOnHistoryLookup);
-        pageLoadOnHistoryLookup = undefined;
-      }
-      return reply(snapshot);
-    }
+    case "Page.getNavigationHistory":
+      return reply({ currentIndex: historyIndex, entries: history });
     case "Page.navigateToHistoryEntry": {
       const target = history.findIndex(entry => entry.id === params.entryId);
       if (target === -1) return reply({});
-      const entry = history[target];
-      const sameDocument = documentOf(history[historyIndex].url) === documentOf(entry.url);
-      startNavigating(entry.url, sameDocument ? "historySameDocument" : "historyDifferentDocument");
+      const url = history[target].url;
+      const sameDocument = documentOf(history[historyIndex].url) === documentOf(url);
       reply({});
-      if (neverLoads(entry.url) || stallsOnReturn(entry.url)) return;
+      if (neverLoads(url) || stallsOnReturn(url)) return;
       historyIndex = target;
-      if (sameDocument) return commitSameDocument(entry.url);
-      // A restore commits the cached document again, under its original loader.
-      if (bfcached(entry.url)) return commitDocument(entry.url, entry.loaderId, "BackForwardCacheRestore");
-      entry.loaderId = "L" + ++loads;
-      if (failsToLoad(entry.url)) return commitErrorPage(entry.url, entry.loaderId);
-      commitDocument(entry.url, entry.loaderId, "Navigation");
-      return;
+      if (sameDocument) return commitSameDocument(url);
+      if (bfcached(url)) return commitDocument(url, "BackForwardCacheRestore");
+      loads++;
+      return commitDocument(url, "Navigation");
     }
     case "Page.captureScreenshot":
       return reply({ data: screenshotBase64 });

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -67,6 +67,11 @@ Object.assign(globalThis, {
   __fake_replace_state_on_history_lookup(url: string) {
     replaceStateOnHistoryLookup = url;
   },
+  // The load event of the document that is live, the way one arrives for a
+  // document the page itself navigated to. It names no frame and no loader.
+  __fake_load_event() {
+    send({ method: "Page.loadEventFired", params: { timestamp: ++loads }, sessionId: currentSessionId });
+  },
   // The command gets no reply, ever.
   __fake_no_reply() {
     return NO_REPLY;

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -66,6 +66,13 @@ Object.assign(globalThis, {
     if (historyIndex >= 0) history[historyIndex].url = url;
     event("Page.navigatedWithinDocument", { frameId: "F", url, navigationType: "historyApi" });
   },
+  // The page follows a #fragment link of its own, or assigns location.hash:
+  // a new history entry, and a commit that reports "fragment" the way a
+  // traversal's does.
+  __fake_hash_change(url: string) {
+    pushEntry(url);
+    commitSameDocument(url);
+  },
   // The page navigates itself to a new document (a link, `location.href = ...`):
   // it commits, and only __fake_load_event() finishes it.
   __fake_page_commit(url: string) {

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -34,6 +34,16 @@ const navigateError = process.argv.find(a => a.startsWith("--navigate-error="))?
 // Page.navigate for a URL it cannot parse.
 const cdpErrorOn = process.argv.find(a => a.startsWith("--cdp-error-on="))?.slice("--cdp-error-on=".length);
 
+// `--no-started-navigating`: never send Page.frameStartedNavigating, the way
+// a Chrome older than that event behaves. The runtime then has only the
+// Page.navigate reply to tell a same-document navigation from one that
+// replaces the document.
+const noStartedNavigating = process.argv.includes("--no-started-navigating");
+
+// `--subframe-navigation`: every document load commits a subframe navigation
+// too, the way a page holding an <iframe> does.
+const subframeNavigation = process.argv.includes("--subframe-navigation");
+
 const NO_REPLY = Symbol("no reply");
 let commandsClosed = false;
 Object.assign(globalThis, {
@@ -66,11 +76,44 @@ function send(message: unknown) {
 
 let targets = 0;
 let loads = 0;
+let entries = 0;
+
+// Session history, the way the browser keeps it: Page.navigate appends,
+// Page.getNavigationHistory reports it, Page.navigateToHistoryEntry moves
+// inside it. Two URLs that differ only after the '#' are the same document.
+const history: { id: number; url: string }[] = [];
+let historyIndex = -1;
+const documentOf = (url: string) => url.split("#")[0];
+const fragmentOf = (url: string) => (url.includes("#") ? url.slice(url.indexOf("#")) : "");
 
 async function handle(command: { id: number; method: string; params?: any; sessionId?: string }) {
   const { id, method, params = {}, sessionId } = command;
   const reply = (result: unknown) => send(sessionId ? { id, result, sessionId } : { id, result });
   const event = (name: string, eventParams: unknown) => send({ method: name, params: eventParams, sessionId });
+
+  // Chrome names a navigation's kind before it starts.
+  const startNavigating = (url: string, navigationType: string) => {
+    if (!noStartedNavigating) event("Page.frameStartedNavigating", { frameId: "F", url, navigationType });
+  };
+
+  // The commit. A cross-document navigation commits with
+  // Page.frameNavigated, which splits the fragment into frame.urlFragment,
+  // and ends with the load event. A same-document one commits with
+  // Page.navigatedWithinDocument and never fires a load event.
+  const commit = (url: string, sameDocument: boolean) => {
+    if (sameDocument) {
+      event("Page.navigatedWithinDocument", { frameId: "F", url, navigationType: "fragment" });
+      return;
+    }
+    const fragment = fragmentOf(url);
+    const frame = { id: "F", loaderId: "L" + loads, url: documentOf(url), mimeType: "text/html" };
+    event("Page.frameNavigated", { frame: fragment ? { ...frame, urlFragment: fragment } : frame });
+    if (subframeNavigation) {
+      const subframe = { id: "SUB", parentId: "F", loaderId: "S" + loads, url: "http://fake/subframe" };
+      event("Page.frameNavigated", { frame: { ...subframe, mimeType: "text/html" } });
+    }
+    event("Page.loadEventFired", { timestamp: loads });
+  };
 
   if (method === cdpErrorOn) {
     const error = { code: -32000, message: "Cannot navigate to invalid URL" };
@@ -84,10 +127,33 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       return reply({ sessionId: "S" + params.targetId.slice(1) });
     case "Page.navigate": {
       if (navigateError) return reply({ frameId: "F", errorText: navigateError });
-      const loaderId = "L" + ++loads;
-      reply({ frameId: "F", loaderId });
-      event("Page.frameNavigated", { frame: { id: "F", loaderId, url: params.url, mimeType: "text/html" } });
-      event("Page.loadEventFired", { timestamp: loads });
+      // A #fragment target of the current document keeps that document.
+      const current = history[historyIndex]?.url;
+      const sameDocument =
+        current !== undefined && documentOf(current) === documentOf(params.url) && fragmentOf(params.url) !== "";
+      startNavigating(params.url, sameDocument ? "sameDocument" : "differentDocument");
+      if (!sameDocument) loads++;
+      // The reply names a loaderId only for a navigation that loads a
+      // document.
+      reply(sameDocument ? { frameId: "F" } : { frameId: "F", loaderId: "L" + loads });
+      history.length = historyIndex + 1;
+      history.push({ id: ++entries, url: params.url });
+      historyIndex = history.length - 1;
+      commit(params.url, sameDocument);
+      return;
+    }
+    case "Page.getNavigationHistory":
+      return reply({ currentIndex: historyIndex, entries: history });
+    case "Page.navigateToHistoryEntry": {
+      const target = history.findIndex(entry => entry.id === params.entryId);
+      if (target === -1) return reply({});
+      const url = history[target].url;
+      const sameDocument = documentOf(history[historyIndex].url) === documentOf(url);
+      startNavigating(url, sameDocument ? "historySameDocument" : "historyDifferentDocument");
+      if (!sameDocument) loads++;
+      historyIndex = target;
+      reply({});
+      commit(url, sameDocument);
       return;
     }
     case "Page.captureScreenshot":

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -52,6 +52,19 @@ let currentSessionId: string | undefined;
 // One URL the page will "replaceState" to while the next
 // Page.getNavigationHistory is being answered (see __fake_replace_state_on_history_lookup).
 let replaceStateOnHistoryLookup: string | undefined;
+// One URL the page navigates itself to while the next Page.getNavigationHistory
+// is being answered: that document commits during the lookup, and only
+// __fake_load_event() finishes it (see __fake_page_load_on_history_lookup).
+let pageLoadOnHistoryLookup: string | undefined;
+// One URL the page "replaceState"s to as the next navigation command is read,
+// before its reply: the way an event already in the pipe reaches the runtime
+// after it wrote the command (see __fake_replace_state_on_next_navigate).
+let replaceStateOnNextNavigate: string | undefined;
+// One URL the page "replaceState"s to right after the next same-document
+// commit, the way a hashchange handler canonicalizing the URL does.
+let replaceStateAfterNextCommit: string | undefined;
+// How many document.title fetches the runtime has sent: one per navigation.
+let titleFetches = 0;
 Object.assign(globalThis, {
   __fake_exit(code: number): never {
     process.exit(code);
@@ -71,6 +84,25 @@ Object.assign(globalThis, {
   // document the page itself navigated to. It names no frame and no loader.
   __fake_load_event() {
     send({ method: "Page.loadEventFired", params: { timestamp: ++loads }, sessionId: currentSessionId });
+  },
+  // The page navigates itself to `url` while the runtime's next history
+  // lookup is in flight: a new document, committed but not finished.
+  __fake_page_load_on_history_lookup(url: string) {
+    pageLoadOnHistoryLookup = url;
+  },
+  // The page's own same-document commit reaches the runtime after it wrote
+  // the next navigation command and before Chrome answers it.
+  __fake_replace_state_on_next_navigate(url: string) {
+    replaceStateOnNextNavigate = url;
+  },
+  // The page's own same-document commit lands right behind the next one,
+  // the way a hashchange handler that rewrites the URL produces.
+  __fake_replace_state_after_next_commit(url: string) {
+    replaceStateAfterNextCommit = url;
+  },
+  // How many document.title fetches the runtime has sent so far.
+  __fake_title_fetches() {
+    return titleFetches;
   },
   // The command gets no reply, ever.
   __fake_no_reply() {
@@ -108,8 +140,11 @@ let historyIndex = -1;
 const documentOf = (url: string) => url.split("#")[0];
 const fragmentOf = (url: string) => (url.includes("#") ? url.slice(url.indexOf("#")) : "");
 // A URL with "never-load" in it starts loading and never commits, the way a
-// server that accepts the connection and then says nothing looks.
+// server that accepts the connection and then says nothing looks. One with
+// "stall-on-return" loads when navigated to, but a history traversal back to
+// it starts and never commits.
 const neverLoads = (url: string) => url.includes("never-load");
+const stallsOnReturn = (url: string) => url.includes("stall-on-return");
 
 function replaceState(url: string) {
   if (historyIndex >= 0) history[historyIndex].url = url;
@@ -118,6 +153,21 @@ function replaceState(url: string) {
     params: { frameId: "F", url, navigationType: "historyApi" },
     sessionId: currentSessionId,
   });
+}
+
+// The page navigates itself to a new document (a link, `location.href = ...`):
+// its own loader and commit. __fake_load_event() finishes it.
+function pageLoad(url: string) {
+  const event = (method: string, params: unknown) => send({ method, params, sessionId: currentSessionId });
+  loads++;
+  if (!noStartedNavigating) {
+    const started = { frameId: "F", url, loaderId: "P" + loads, navigationType: "differentDocument" };
+    event("Page.frameStartedNavigating", started);
+  }
+  history.length = historyIndex + 1;
+  history.push({ id: ++entries, url });
+  historyIndex = history.length - 1;
+  event("Page.frameNavigated", { frame: { id: "F", loaderId: "P" + loads, url, mimeType: "text/html" } });
 }
 
 async function handle(command: { id: number; method: string; params?: any; sessionId?: string }) {
@@ -138,6 +188,10 @@ async function handle(command: { id: number; method: string; params?: any; sessi
   const commit = (url: string, sameDocument: boolean) => {
     if (sameDocument) {
       event("Page.navigatedWithinDocument", { frameId: "F", url, navigationType: "fragment" });
+      if (replaceStateAfterNextCommit !== undefined) {
+        replaceState(replaceStateAfterNextCommit);
+        replaceStateAfterNextCommit = undefined;
+      }
       return;
     }
     const fragment = fragmentOf(url);
@@ -162,6 +216,10 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       return reply({ sessionId: "S" + params.targetId.slice(1) });
     case "Page.navigate": {
       if (navigateError) return reply({ frameId: "F", errorText: navigateError });
+      if (replaceStateOnNextNavigate !== undefined) {
+        replaceState(replaceStateOnNextNavigate);
+        replaceStateOnNextNavigate = undefined;
+      }
       // A #fragment target of the current document keeps that document.
       const current = history[historyIndex]?.url;
       const sameDocument =
@@ -178,12 +236,21 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       commit(params.url, sameDocument);
       return;
     }
-    case "Page.getNavigationHistory":
+    case "Page.getNavigationHistory": {
       if (replaceStateOnHistoryLookup !== undefined) {
         replaceState(replaceStateOnHistoryLookup);
         replaceStateOnHistoryLookup = undefined;
       }
-      return reply({ currentIndex: historyIndex, entries: history });
+      // The page's own navigation commits while the lookup is in flight: a
+      // new document, still loading. The reply describes the history the
+      // browser read before that commit.
+      const snapshot = { currentIndex: historyIndex, entries: history.map(entry => ({ ...entry })) };
+      if (pageLoadOnHistoryLookup !== undefined) {
+        pageLoad(pageLoadOnHistoryLookup);
+        pageLoadOnHistoryLookup = undefined;
+      }
+      return reply(snapshot);
+    }
     case "Page.navigateToHistoryEntry": {
       const target = history.findIndex(entry => entry.id === params.entryId);
       if (target === -1) return reply({});
@@ -192,7 +259,7 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       startNavigating(url, sameDocument ? "historySameDocument" : "historyDifferentDocument");
       if (!sameDocument) loads++;
       reply({});
-      if (neverLoads(url)) return;
+      if (neverLoads(url) || stallsOnReturn(url)) return;
       historyIndex = target;
       commit(url, sameDocument);
       return;
@@ -201,6 +268,7 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       return reply({ data: screenshotBase64 });
     case "Runtime.evaluate": {
       if (params.expression === "document.title") {
+        titleFetches++;
         if (noTitleReply) return;
         return reply({ result: { type: "string", value: "fake chrome" } });
       }

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -46,9 +46,26 @@ const subframeNavigation = process.argv.includes("--subframe-navigation");
 
 const NO_REPLY = Symbol("no reply");
 let commandsClosed = false;
+// The session of the command being handled, so a __fake_* global that an
+// evaluate() runs can emit events on it.
+let currentSessionId: string | undefined;
+// One URL the page will "replaceState" to while the next
+// Page.getNavigationHistory is being answered (see __fake_replace_state_on_history_lookup).
+let replaceStateOnHistoryLookup: string | undefined;
 Object.assign(globalThis, {
   __fake_exit(code: number): never {
     process.exit(code);
+  },
+  // The page commits a same-document navigation of its own, the way
+  // history.replaceState() or a scroll-driven `location.hash = ...` does:
+  // Page.navigatedWithinDocument with nothing before it, no new history entry.
+  __fake_replace_state(url: string) {
+    replaceState(url);
+  },
+  // The same, but timed to land while the runtime waits for the history
+  // lookup that goBack()/goForward() start with.
+  __fake_replace_state_on_history_lookup(url: string) {
+    replaceStateOnHistoryLookup = url;
   },
   // The command gets no reply, ever.
   __fake_no_reply() {
@@ -85,9 +102,22 @@ const history: { id: number; url: string }[] = [];
 let historyIndex = -1;
 const documentOf = (url: string) => url.split("#")[0];
 const fragmentOf = (url: string) => (url.includes("#") ? url.slice(url.indexOf("#")) : "");
+// A URL with "never-load" in it starts loading and never commits, the way a
+// server that accepts the connection and then says nothing looks.
+const neverLoads = (url: string) => url.includes("never-load");
+
+function replaceState(url: string) {
+  if (historyIndex >= 0) history[historyIndex].url = url;
+  send({
+    method: "Page.navigatedWithinDocument",
+    params: { frameId: "F", url, navigationType: "historyApi" },
+    sessionId: currentSessionId,
+  });
+}
 
 async function handle(command: { id: number; method: string; params?: any; sessionId?: string }) {
   const { id, method, params = {}, sessionId } = command;
+  currentSessionId = sessionId;
   const reply = (result: unknown) => send(sessionId ? { id, result, sessionId } : { id, result });
   const event = (name: string, eventParams: unknown) => send({ method: name, params: eventParams, sessionId });
 
@@ -136,6 +166,7 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       // The reply names a loaderId only for a navigation that loads a
       // document.
       reply(sameDocument ? { frameId: "F" } : { frameId: "F", loaderId: "L" + loads });
+      if (neverLoads(params.url)) return;
       history.length = historyIndex + 1;
       history.push({ id: ++entries, url: params.url });
       historyIndex = history.length - 1;
@@ -143,6 +174,10 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       return;
     }
     case "Page.getNavigationHistory":
+      if (replaceStateOnHistoryLookup !== undefined) {
+        replaceState(replaceStateOnHistoryLookup);
+        replaceStateOnHistoryLookup = undefined;
+      }
       return reply({ currentIndex: historyIndex, entries: history });
     case "Page.navigateToHistoryEntry": {
       const target = history.findIndex(entry => entry.id === params.entryId);
@@ -151,8 +186,9 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       const sameDocument = documentOf(history[historyIndex].url) === documentOf(url);
       startNavigating(url, sameDocument ? "historySameDocument" : "historyDifferentDocument");
       if (!sameDocument) loads++;
-      historyIndex = target;
       reply({});
+      if (neverLoads(url)) return;
+      historyIndex = target;
       commit(url, sameDocument);
       return;
     }

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -87,6 +87,12 @@ Object.assign(globalThis, {
   __fake_page_load_on_history_lookup(url: string) {
     pageLoadOnHistoryLookup = url;
   },
+  // The page navigates itself to `url` and that document commits and loads,
+  // the way a `location.href = ...` that wins the frame does.
+  __fake_page_load(url: string) {
+    pageLoad(url);
+    event("Page.loadEventFired", { timestamp: loads });
+  },
   // The page navigates itself to `url` (a link, `location.href = ...`) and
   // the load fails: Chrome's error page commits in its place and loads.
   __fake_page_load_fails(url: string) {

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -35,6 +35,9 @@ const prelude = /* js */ `
   const newView = () => new Bun.WebView({ backend, width: 100, height: 100 });
   const outcome = promise => promise.then(resolved => ({ resolved }), e => ({ rejected: e.message }));
   const print = value => console.log(JSON.stringify(value));
+  // The page runs \`script\` as the fake reads the view's next \`method\` command, before it answers.
+  const pageDoesOnNext = (view, method, script) =>
+    view.evaluate("__fake_on_next(" + JSON.stringify(method) + ", " + JSON.stringify(script) + ")");
   const big = ${BIG};
 `;
 
@@ -174,29 +177,6 @@ test.concurrent("a load event from a document the view did not ask for settles n
   });
 });
 
-// Chrome answered Page.navigate with a loaderId, but a document under another
-// loader committed instead: the page's own navigation won the frame and ours
-// will never commit. Chrome normally reports that with errorText first; when
-// it does not, navigate() must still settle, as a failure, and not hang.
-test.concurrent("a navigate() whose commit another document takes rejects instead of hanging", async () => {
-  const result = await runScenario(`
-    const view = newView();
-    await view.navigate("http://fake/page");
-    const failures = [];
-    view.onNavigationFailed = e => failures.push(e.message);
-    const started = outcome(view.navigate("http://fake/never-load"));
-    await view.evaluate("__fake_page_load('http://fake/winner')");
-    print({ navigate: await started, failures, url: view.url, loading: view.loading });
-    view.close();
-  `);
-  expect(result).toEqual({
-    navigate: { rejected: "Navigation interrupted by another one to http://fake/winner" },
-    failures: ["Navigation interrupted by another one to http://fake/winner"],
-    url: "http://fake/winner",
-    loading: false,
-  });
-});
-
 // goBack() fills the slot and then looks the history entry up before it asks
 // Chrome to traverse. A same-document commit of the page's own that lands
 // during the lookup is not the traversal and must not settle the promise.
@@ -205,7 +185,7 @@ test.concurrent("goBack() is not settled by a commit of the page's own during th
     const view = newView();
     await view.navigate("http://fake/a");
     await view.navigate("http://fake/b");
-    await view.evaluate("__fake_replace_state_on_history_lookup('http://fake/b#spa')");
+    await pageDoesOnNext(view, "Page.getNavigationHistory", "__fake_replace_state('http://fake/b#spa')");
     const urls = [];
     view.onNavigated = url => urls.push(url);
     await view.goBack();
@@ -222,9 +202,9 @@ test.concurrent("goBack() is not settled by a commit of the page's own during th
 test.concurrent("goBack() is not settled by the load of a document it did not commit", async () => {
   const result = await runScenario(`
     const view = newView();
+    await view.navigate("http://fake/a");
     await view.navigate("http://fake/stall-on-return");
-    await view.navigate("http://fake/b");
-    await view.evaluate("__fake_page_load_on_history_lookup('http://fake/own')");
+    await pageDoesOnNext(view, "Page.getNavigationHistory", "__fake_page_commit('http://fake/own')");
     const started = view.goBack();
     // The fake answers in order, so this resolves after it answered the
     // history lookup: the traversal command is out and has not committed.
@@ -240,15 +220,58 @@ test.concurrent("goBack() is not settled by the load of a document it did not co
   expect(result).toEqual({ first: "goBack() still pending", url: "http://fake/own" });
 });
 
+// Chrome answers a traversal at once and commits it later: a cross-document
+// one only after the network answered. history.pushState() and
+// history.replaceState() of the page being left (a router, a scroll position
+// saved in beforeunload) land in between. They report "historyApi", which a
+// traversal never does, and must not settle the promise: the target here
+// never commits, so goBack() has to stay pending.
+test.concurrent("goBack() is not settled by the page's own replaceState() behind the traversal's reply", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/stall-on-return");
+    await view.navigate("http://fake/b");
+    const started = view.goBack();
+    // The fake answers in order, so this resolves after it answered the
+    // history lookup: the traversal command is out. The next evaluate is
+    // behind that command, so the fake has answered the traversal by then.
+    await view.evaluate("1");
+    await view.evaluate("__fake_replace_state('http://fake/b?scroll=1')");
+    const first = await Promise.race([
+      started.then(() => "goBack() settled", () => "goBack() rejected"),
+      view.evaluate("'goBack() still pending'"),
+    ]);
+    print({ first, url: view.url });
+    view.close();
+  `);
+  expect(result).toEqual({ first: "goBack() still pending", url: "http://fake/b?scroll=1" });
+});
+
+// The same window exists behind the reply of a #fragment navigate().
+test.concurrent("navigate() to a #fragment is not settled by the page's own replaceState()", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/page");
+    const started = view.navigate("http://fake/page#never-load");
+    await view.evaluate("__fake_replace_state('http://fake/page?scroll=1')");
+    const first = await Promise.race([
+      started.then(() => "navigate() settled", () => "navigate() rejected"),
+      view.evaluate("'navigate() still pending'"),
+    ]);
+    print({ first, loading: view.loading, url: view.url });
+    view.close();
+  `);
+  expect(result).toEqual({ first: "navigate() still pending", loading: true, url: "http://fake/page?scroll=1" });
+});
+
 // A navigation that reaches the runtime after it wrote a navigation command,
 // but before Chrome answered it, cannot be that command's: Chrome answers a
-// navigation before its document commits. Its Page.frameStartedNavigating
-// says "sameDocument", which is no statement about the command either.
+// navigation before its document commits.
 test.concurrent("a navigation that arrives before the navigate command is answered settles nothing", async () => {
   const result = await runScenario(`
     const view = newView();
     await view.navigate("http://fake/page");
-    await view.evaluate("__fake_fragment_link_on_next_navigate('http://fake/page#spa')");
+    await pageDoesOnNext(view, "Page.navigate", "__fake_replace_state('http://fake/page#spa')");
     const started = view.navigate("http://fake/never-load");
     const first = await Promise.race([
       started.then(() => "navigate() settled", () => "navigate() rejected"),
@@ -274,94 +297,14 @@ test.concurrent("a second same-document commit does not fetch the title again", 
     // The fake counts document.title fetches only, so the difference is what
     // the navigation below sent.
     const before = await view.evaluate("__fake_title_fetches()");
-    await view.evaluate("__fake_replace_state_after_next_commit('http://fake/page#canonical')");
+    // The next Runtime.evaluate the fake reads is the navigation's title fetch.
+    await pageDoesOnNext(view, "Runtime.evaluate", "__fake_replace_state('http://fake/page#canonical')");
     await view.navigate("http://fake/page#one");
     const titleFetches = (await view.evaluate("__fake_title_fetches()")) - before;
     print({ url: view.url, titleFetches });
     view.close();
   `);
   expect(result).toEqual({ url: "http://fake/page#canonical", titleFetches: 1 });
-});
-
-// Chrome answers Page.reload with `{}`, so a reload is like a history
-// traversal: no commit counts as its own until Chrome has answered the
-// command. A document the page finished loading in that window is the page's,
-// and the reload here never commits, so the promise has to stay pending.
-test.concurrent("reload() is not settled by the load of a document the page committed first", async () => {
-  const result = await runScenario(`
-    const view = newView();
-    await view.navigate("http://fake/page");
-    await view.evaluate("__fake_page_load_on_next_reload('http://fake/own')");
-    const started = view.reload();
-    // The fake answers in order, so this resolves after it answered the reload:
-    // the page's load is handled, and a title fetch that load queued is ahead
-    // of the race's evaluate below.
-    await view.evaluate("1");
-    const first = await Promise.race([
-      started.then(() => "reload() settled", () => "reload() rejected"),
-      view.evaluate("'reload() still pending'"),
-    ]);
-    print({ first, url: view.url });
-    view.close();
-  `);
-  expect(result).toEqual({ first: "reload() still pending", url: "http://fake/own" });
-});
-
-// After a load fails, Chrome commits its own error page
-// (chrome-error://chromewebdata/, with frame.unreachableUrl naming the page it
-// stands in for) and fires that page's load event. Neither is a navigation of
-// the view's: navigate() already rejected with the errorText of its reply, so
-// the error page reports nothing more, and view.url and view.title keep the
-// last real page.
-test.concurrent("a failed navigate() reports one failure and Chrome's error page changes nothing", async () => {
-  const result = await runScenario(`
-    const view = newView();
-    await view.navigate("http://fake/before");
-    const events = [];
-    view.onNavigated = url => events.push("navigated:" + url);
-    view.onNavigationFailed = error => events.push("failed:" + error.message);
-    const errorPageLoaded = new Promise(resolve => view.addEventListener("Page.loadEventFired", resolve, { once: true }));
-    const failed = await outcome(view.navigate("http://fake/unreachable"));
-    await errorPageLoaded;
-    print({ failed, events, url: view.url, title: view.title, loading: view.loading });
-    view.close();
-  `);
-  expect(result).toEqual({
-    failed: { rejected: "net::ERR_CONNECTION_REFUSED" },
-    events: ["failed:net::ERR_CONNECTION_REFUSED"],
-    url: "http://fake/before",
-    title: "fake chrome",
-    loading: false,
-  });
-});
-
-// A load the page starts itself can fail too. Its error page is the only sign:
-// onNavigationFailed fires once that page has loaded. reload() then loads the
-// failed URL again, fails again, and rejects instead of resolving on the error
-// page's load event.
-test.concurrent("a failed load the page started fires onNavigationFailed, and reload() of it rejects", async () => {
-  const result = await runScenario(`
-    const view = newView();
-    await view.navigate("http://fake/start");
-    const events = [];
-    view.onNavigated = url => events.push("navigated:" + url);
-    view.onNavigationFailed = error => events.push("failed:" + error.message);
-    await view.evaluate("__fake_page_load_fails('http://fake/unreachable-link')");
-    const afterLink = { events: [...events], url: view.url };
-    const reloaded = await outcome(view.reload());
-    print({ afterLink, reloaded, events, url: view.url, loading: view.loading });
-    view.close();
-  `);
-  expect(result).toEqual({
-    afterLink: { events: ["failed:Navigation to http://fake/unreachable-link failed"], url: "http://fake/start" },
-    reloaded: { rejected: "Navigation to http://fake/unreachable-link failed" },
-    events: [
-      "failed:Navigation to http://fake/unreachable-link failed",
-      "failed:Navigation to http://fake/unreachable-link failed",
-    ],
-    url: "http://fake/start",
-    loading: false,
-  });
 });
 
 // A history traversal onto a page Chrome kept in its back-forward cache
@@ -385,28 +328,6 @@ test.concurrent("goBack() onto a page restored from the back-forward cache settl
     afterForward: "http://fake/b",
     urls: ["http://fake/bfcached#top", "http://fake/b"],
   });
-});
-
-// The view does its own bookkeeping on these three events; like every other
-// CDP event they still reach addEventListener(), with the parsed params.
-test.concurrent("navigation events reach addEventListener()", async () => {
-  const result = await runScenario(`
-    const view = newView();
-    await view.navigate("http://fake/first");
-    const events = [];
-    for (const type of ["Page.frameNavigated", "Page.navigatedWithinDocument", "Page.loadEventFired"]) {
-      view.addEventListener(type, event => events.push([type, event.data.frame?.url ?? event.data.url ?? null]));
-    }
-    await view.navigate("http://fake/page");
-    await view.navigate("http://fake/page#one");
-    print(events);
-    view.close();
-  `);
-  expect(result).toEqual([
-    ["Page.frameNavigated", "http://fake/page"],
-    ["Page.loadEventFired", null],
-    ["Page.navigatedWithinDocument", "http://fake/page#one"],
-  ]);
 });
 
 test.concurrent("a reply larger than the read buffer is reassembled", async () => {

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -167,6 +167,30 @@ test.concurrent("a navigate() started from onNavigated of the page's own commit 
   expect(result).toEqual({ loading: true, first: "navigate() still pending" });
 });
 
+// Page.loadEventFired names no frame and no loader, so it is the load event
+// of whatever document is live. A document the page navigated to on its own
+// can finish loading after navigate() was called and before the navigation
+// commits. That load event is not the navigation's.
+test.concurrent("a load event from a document the view did not ask for settles nothing", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/page");
+    const started = view.navigate("http://fake/never-load");
+    await view.evaluate("__fake_load_event()");
+    const first = await Promise.race([
+      started.then(() => "navigate() settled", () => "navigate() rejected"),
+      view.evaluate("'navigate() still pending'"),
+    ]);
+    print({ first, loading: view.loading, url: view.url });
+    view.close();
+  `);
+  expect(result).toEqual({
+    first: "navigate() still pending",
+    loading: true,
+    url: "http://fake/page",
+  });
+});
+
 // goBack() fills the slot and then looks the history entry up before it asks
 // Chrome to traverse. A same-document commit of the page's own that lands
 // during the lookup is not the traversal and must not settle the promise.

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -260,6 +260,30 @@ test.concurrent("a second same-document commit does not fetch the title again", 
   expect(result).toEqual({ url: "http://fake/page#canonical", titleFetches: 1 });
 });
 
+// Chrome answers Page.reload with `{}`, so a reload is like a history
+// traversal: no commit counts as its own until Chrome has answered the
+// command. A document the page finished loading in that window is the page's,
+// and the reload here never commits, so the promise has to stay pending.
+test.concurrent("reload() is not settled by the load of a document the page committed first", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/page");
+    await view.evaluate("__fake_page_load_on_next_reload('http://fake/own')");
+    const started = view.reload();
+    // The fake answers in order, so this resolves after it answered the reload:
+    // the page's load is handled, and a title fetch that load queued is ahead
+    // of the race's evaluate below.
+    await view.evaluate("1");
+    const first = await Promise.race([
+      started.then(() => "reload() settled", () => "reload() rejected"),
+      view.evaluate("'reload() still pending'"),
+    ]);
+    print({ first, url: view.url });
+    view.close();
+  `);
+  expect(result).toEqual({ first: "reload() still pending", url: "http://fake/own" });
+});
+
 // After a load fails, Chrome commits its own error page
 // (chrome-error://chromewebdata/, with frame.unreachableUrl naming the page it
 // stands in for) and fires that page's load event. Neither is a navigation of

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -140,6 +140,51 @@ test.concurrent("view.url follows the main frame and keeps its fragment", async 
   });
 });
 
+// A same-document commit the page makes on its own (an SPA router, a
+// scroll-driven location.hash) fires onNavigated with nothing pending. A
+// navigate() started from inside that callback is a new, cross-document
+// navigation: the commit that ran the callback must not settle it or clear
+// view.loading. Its page never loads here, so it has to stay pending.
+test.concurrent("a navigate() started from onNavigated of the page's own commit waits for its own load", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/page");
+    let started;
+    view.onNavigated = url => {
+      if (url.endsWith("#spa")) started = view.navigate("http://fake/never-load");
+    };
+    await view.evaluate("__fake_replace_state('http://fake/page#spa')");
+    const loading = view.loading;
+    // The fake answers commands in order, so if the commit had queued a title
+    // fetch for the new navigation, its reply would beat this evaluate's.
+    const first = await Promise.race([
+      started.then(() => "navigate() settled before its page loaded", () => "navigate() rejected"),
+      view.evaluate("'navigate() still pending'"),
+    ]);
+    print({ loading, first });
+    view.close();
+  `);
+  expect(result).toEqual({ loading: true, first: "navigate() still pending" });
+});
+
+// goBack() fills the slot and then looks the history entry up before it asks
+// Chrome to traverse. A same-document commit of the page's own that lands
+// during the lookup is not the traversal and must not settle the promise.
+test.concurrent("goBack() is not settled by a commit of the page's own during the history lookup", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/a");
+    await view.navigate("http://fake/b");
+    await view.evaluate("__fake_replace_state_on_history_lookup('http://fake/b#spa')");
+    const urls = [];
+    view.onNavigated = url => urls.push(url);
+    await view.goBack();
+    print({ url: view.url, urls });
+    view.close();
+  `);
+  expect(result).toEqual({ url: "http://fake/a", urls: ["http://fake/b#spa", "http://fake/a"] });
+});
+
 test.concurrent("a reply larger than the read buffer is reassembled", async () => {
   const result = await runScenario(`
     const view = newView();

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -174,6 +174,29 @@ test.concurrent("a load event from a document the view did not ask for settles n
   });
 });
 
+// Chrome answered Page.navigate with a loaderId, but a document under another
+// loader committed instead: the page's own navigation won the frame and ours
+// will never commit. Chrome normally reports that with errorText first; when
+// it does not, navigate() must still settle, as a failure, and not hang.
+test.concurrent("a navigate() whose commit another document takes rejects instead of hanging", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/page");
+    const failures = [];
+    view.onNavigationFailed = e => failures.push(e.message);
+    const started = outcome(view.navigate("http://fake/never-load"));
+    await view.evaluate("__fake_page_load('http://fake/winner')");
+    print({ navigate: await started, failures, url: view.url, loading: view.loading });
+    view.close();
+  `);
+  expect(result).toEqual({
+    navigate: { rejected: "Navigation interrupted by another one to http://fake/winner" },
+    failures: ["Navigation interrupted by another one to http://fake/winner"],
+    url: "http://fake/winner",
+    loading: false,
+  });
+});
+
 // goBack() fills the slot and then looks the history entry up before it asks
 // Chrome to traverse. A same-document commit of the page's own that lands
 // during the lookup is not the traversal and must not settle the promise.

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -100,23 +100,6 @@ test.concurrent("a same-document navigation settles navigate(), goBack() and goF
   });
 });
 
-// Without Page.frameStartedNavigating the kind comes from the Page.navigate
-// reply, which names a loaderId only for a navigation that loads a document.
-test.concurrent("a same-document navigation settles without Page.frameStartedNavigating", async () => {
-  const result = await runScenario(`
-    const view = new Bun.WebView({
-      backend: { ...backend, argv: [...backend.argv, "--no-started-navigating"] },
-      width: 100,
-      height: 100,
-    });
-    await view.navigate("http://fake/page");
-    await view.navigate("http://fake/page#one");
-    print({ url: view.url, loading: view.loading });
-    view.close();
-  `);
-  expect(result).toEqual({ url: "http://fake/page#one", loading: false });
-});
-
 // Page.frameNavigated reports the fragment in frame.urlFragment, not in
 // frame.url, and a subframe's commit arrives on the same session as the main
 // frame's. view.url is the main frame's document URL, fragment and all.
@@ -234,14 +217,15 @@ test.concurrent("goBack() is not settled by the load of a document it did not co
   expect(result).toEqual({ first: "goBack() still pending", url: "http://fake/own" });
 });
 
-// A same-document commit that reaches the runtime after it wrote a navigation
-// command, but before Chrome answered it, cannot be that command's: Chrome
-// answers a navigation before the document commits.
-test.concurrent("a commit that arrives before the navigate command is answered settles nothing", async () => {
+// A navigation that reaches the runtime after it wrote a navigation command,
+// but before Chrome answered it, cannot be that command's: Chrome answers a
+// navigation before its document commits. Its Page.frameStartedNavigating
+// says "sameDocument", which is no statement about the command either.
+test.concurrent("a navigation that arrives before the navigate command is answered settles nothing", async () => {
   const result = await runScenario(`
     const view = newView();
     await view.navigate("http://fake/page");
-    await view.evaluate("__fake_replace_state_on_next_navigate('http://fake/page#spa')");
+    await view.evaluate("__fake_fragment_link_on_next_navigate('http://fake/page#spa')");
     const started = view.navigate("http://fake/never-load");
     const first = await Promise.race([
       started.then(() => "navigate() settled", () => "navigate() rejected"),

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -209,6 +209,73 @@ test.concurrent("goBack() is not settled by a commit of the page's own during th
   expect(result).toEqual({ url: "http://fake/a", urls: ["http://fake/b#spa", "http://fake/a"] });
 });
 
+// The same for the load event of a document the page navigated to during the
+// lookup: that document committed before the traversal was asked for, so its
+// load is not the traversal's. The traversal here never commits, so the
+// promise has to stay pending.
+test.concurrent("goBack() is not settled by the load of a document it did not commit", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/stall-on-return");
+    await view.navigate("http://fake/b");
+    await view.evaluate("__fake_page_load_on_history_lookup('http://fake/own')");
+    const started = view.goBack();
+    // The fake answers in order, so this resolves after it answered the
+    // history lookup: the traversal command is out and has not committed.
+    await view.evaluate("1");
+    await view.evaluate("__fake_load_event()");
+    const first = await Promise.race([
+      started.then(() => "goBack() settled", () => "goBack() rejected"),
+      view.evaluate("'goBack() still pending'"),
+    ]);
+    print({ first, url: view.url });
+    view.close();
+  `);
+  expect(result).toEqual({ first: "goBack() still pending", url: "http://fake/own" });
+});
+
+// A same-document commit that reaches the runtime after it wrote a navigation
+// command, but before Chrome answered it, cannot be that command's: Chrome
+// answers a navigation before the document commits.
+test.concurrent("a commit that arrives before the navigate command is answered settles nothing", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/page");
+    await view.evaluate("__fake_replace_state_on_next_navigate('http://fake/page#spa')");
+    const started = view.navigate("http://fake/never-load");
+    const first = await Promise.race([
+      started.then(() => "navigate() settled", () => "navigate() rejected"),
+      view.evaluate("'navigate() still pending'"),
+    ]);
+    print({ first, loading: view.loading, url: view.url });
+    view.close();
+  `);
+  expect(result).toEqual({
+    first: "navigate() still pending",
+    loading: true,
+    url: "http://fake/page#spa",
+  });
+});
+
+// Once the commit that ends a navigation has queued its title fetch, the
+// navigation is over. A second same-document commit behind it (a hashchange
+// handler rewriting the URL) is the page's own and fetches nothing.
+test.concurrent("a second same-document commit does not fetch the title again", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/page");
+    // The fake counts document.title fetches only, so the difference is what
+    // the navigation below sent.
+    const before = await view.evaluate("__fake_title_fetches()");
+    await view.evaluate("__fake_replace_state_after_next_commit('http://fake/page#canonical')");
+    await view.navigate("http://fake/page#one");
+    const titleFetches = (await view.evaluate("__fake_title_fetches()")) - before;
+    print({ url: view.url, titleFetches });
+    view.close();
+  `);
+  expect(result).toEqual({ url: "http://fake/page#canonical", titleFetches: 1 });
+});
+
 test.concurrent("a reply larger than the read buffer is reassembled", async () => {
   const result = await runScenario(`
     const view = newView();

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -247,6 +247,42 @@ test.concurrent("goBack() is not settled by the page's own replaceState() behind
   expect(result).toEqual({ first: "goBack() still pending", url: "http://fake/b?scroll=1" });
 });
 
+// A #fragment change of the page being left (a scroll spy, a link the user
+// follows) reports "fragment" like a traversal's own commit does. The
+// traversal's commit lands on the entry it asked for, and this one does not.
+test.concurrent("goBack() is not settled by a #fragment change of the page being left", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/stall-on-return");
+    await view.navigate("http://fake/b");
+    const started = view.goBack();
+    // See the test above: the fake has answered the traversal by the second evaluate.
+    await view.evaluate("1");
+    await view.evaluate("__fake_hash_change('http://fake/b#section')");
+    const first = await Promise.race([
+      started.then(() => "goBack() settled", () => "goBack() rejected"),
+      view.evaluate("'goBack() still pending'"),
+    ]);
+    print({ first, url: view.url });
+    view.close();
+  `);
+  expect(result).toEqual({ first: "goBack() still pending", url: "http://fake/b#section" });
+});
+
+// The entry's URL comes from the history reply and the commit's from the
+// event. Chrome escapes a quote in both, so they have to be compared decoded.
+test.concurrent("goBack() settles over a same-document entry whose URL needs a JSON escape", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/page");
+    await view.navigate('http://fake/page#"quoted"');
+    await view.navigate("http://fake/page#two");
+    print(await outcome(view.goBack()));
+    view.close();
+  `);
+  expect(result).toEqual({});
+});
+
 // The same window exists behind the reply of a #fragment navigate().
 test.concurrent("navigate() to a #fragment is not settled by the page's own replaceState()", async () => {
   const result = await runScenario(`
@@ -328,6 +364,22 @@ test.concurrent("goBack() onto a page restored from the back-forward cache settl
     afterForward: "http://fake/b",
     urls: ["http://fake/bfcached#top", "http://fake/b"],
   });
+});
+
+// Page.navigatedWithinDocument was never intercepted, so a listener for it has
+// always heard it. The view's own bookkeeping on it must not end that.
+test.concurrent("Page.navigatedWithinDocument still reaches addEventListener()", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/page");
+    const heard = [];
+    view.addEventListener("Page.navigatedWithinDocument", event => heard.push(event.data.url));
+    await view.navigate("http://fake/page#one");
+    await view.evaluate("__fake_replace_state('http://fake/page#spa')");
+    print(heard);
+    view.close();
+  `);
+  expect(result).toEqual(["http://fake/page#one", "http://fake/page#spa"]);
 });
 
 test.concurrent("a reply larger than the read buffer is reassembled", async () => {

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -74,6 +74,72 @@ test.concurrent("navigate, events and evaluate cross the pipes", async () => {
   });
 });
 
+// A same-document navigation (a #fragment target, or a history traversal
+// between two entries of one document) fires no load event, so the promise
+// has to settle on Page.navigatedWithinDocument instead. The slot is shared,
+// so a navigation that never settles wedges every later one.
+test.concurrent("a same-document navigation settles navigate(), goBack() and goForward()", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/page");
+    const urls = [];
+    view.onNavigated = url => urls.push(url);
+    await view.navigate("http://fake/page#one");
+    const afterFragment = { url: view.url, loading: view.loading };
+    await view.goBack();
+    const afterBack = view.url;
+    await view.goForward();
+    print({ afterFragment, afterBack, afterForward: view.url, urls });
+    view.close();
+  `);
+  expect(result).toEqual({
+    afterFragment: { url: "http://fake/page#one", loading: false },
+    afterBack: "http://fake/page",
+    afterForward: "http://fake/page#one",
+    urls: ["http://fake/page#one", "http://fake/page", "http://fake/page#one"],
+  });
+});
+
+// Without Page.frameStartedNavigating the kind comes from the Page.navigate
+// reply, which names a loaderId only for a navigation that loads a document.
+test.concurrent("a same-document navigation settles without Page.frameStartedNavigating", async () => {
+  const result = await runScenario(`
+    const view = new Bun.WebView({
+      backend: { ...backend, argv: [...backend.argv, "--no-started-navigating"] },
+      width: 100,
+      height: 100,
+    });
+    await view.navigate("http://fake/page");
+    await view.navigate("http://fake/page#one");
+    print({ url: view.url, loading: view.loading });
+    view.close();
+  `);
+  expect(result).toEqual({ url: "http://fake/page#one", loading: false });
+});
+
+// Page.frameNavigated reports the fragment in frame.urlFragment, not in
+// frame.url, and a subframe's commit arrives on the same session as the main
+// frame's. view.url is the main frame's document URL, fragment and all.
+test.concurrent("view.url follows the main frame and keeps its fragment", async () => {
+  const result = await runScenario(`
+    const view = new Bun.WebView({
+      backend: { ...backend, argv: [...backend.argv, "--subframe-navigation"] },
+      width: 100,
+      height: 100,
+    });
+    const urls = [];
+    view.onNavigated = url => urls.push(url);
+    await view.navigate("http://fake/page#one");
+    print({ url: view.url, title: view.title, urls });
+    view.close();
+  `);
+  expect(result).toEqual({
+    url: "http://fake/page#one",
+    title: "fake chrome",
+    urls: ["http://fake/page#one"],
+  });
+});
+
 test.concurrent("a reply larger than the read buffer is reassembled", async () => {
   const result = await runScenario(`
     const view = newView();

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -260,6 +260,108 @@ test.concurrent("a second same-document commit does not fetch the title again", 
   expect(result).toEqual({ url: "http://fake/page#canonical", titleFetches: 1 });
 });
 
+// After a load fails, Chrome commits its own error page
+// (chrome-error://chromewebdata/, with frame.unreachableUrl naming the page it
+// stands in for) and fires that page's load event. Neither is a navigation of
+// the view's: navigate() already rejected with the errorText of its reply, so
+// the error page reports nothing more, and view.url and view.title keep the
+// last real page.
+test.concurrent("a failed navigate() reports one failure and Chrome's error page changes nothing", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/before");
+    const events = [];
+    view.onNavigated = url => events.push("navigated:" + url);
+    view.onNavigationFailed = error => events.push("failed:" + error.message);
+    const errorPageLoaded = new Promise(resolve => view.addEventListener("Page.loadEventFired", resolve, { once: true }));
+    const failed = await outcome(view.navigate("http://fake/unreachable"));
+    await errorPageLoaded;
+    print({ failed, events, url: view.url, title: view.title, loading: view.loading });
+    view.close();
+  `);
+  expect(result).toEqual({
+    failed: { rejected: "net::ERR_CONNECTION_REFUSED" },
+    events: ["failed:net::ERR_CONNECTION_REFUSED"],
+    url: "http://fake/before",
+    title: "fake chrome",
+    loading: false,
+  });
+});
+
+// A load the page starts itself can fail too. Its error page is the only sign:
+// onNavigationFailed fires once that page has loaded. reload() then loads the
+// failed URL again, fails again, and rejects instead of resolving on the error
+// page's load event.
+test.concurrent("a failed load the page started fires onNavigationFailed, and reload() of it rejects", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/start");
+    const events = [];
+    view.onNavigated = url => events.push("navigated:" + url);
+    view.onNavigationFailed = error => events.push("failed:" + error.message);
+    await view.evaluate("__fake_page_load_fails('http://fake/unreachable-link')");
+    const afterLink = { events: [...events], url: view.url };
+    const reloaded = await outcome(view.reload());
+    print({ afterLink, reloaded, events, url: view.url, loading: view.loading });
+    view.close();
+  `);
+  expect(result).toEqual({
+    afterLink: { events: ["failed:Navigation to http://fake/unreachable-link failed"], url: "http://fake/start" },
+    reloaded: { rejected: "Navigation to http://fake/unreachable-link failed" },
+    events: [
+      "failed:Navigation to http://fake/unreachable-link failed",
+      "failed:Navigation to http://fake/unreachable-link failed",
+    ],
+    url: "http://fake/start",
+    loading: false,
+  });
+});
+
+// A history traversal onto a page Chrome kept in its back-forward cache
+// commits with type "BackForwardCacheRestore" and fires no load event: the
+// page is complete as it commits, so goBack() settles there.
+test.concurrent("goBack() onto a page restored from the back-forward cache settles", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/bfcached#top");
+    await view.navigate("http://fake/b");
+    const urls = [];
+    view.onNavigated = url => urls.push(url);
+    await view.goBack();
+    const afterBack = { url: view.url, loading: view.loading };
+    await view.goForward();
+    print({ afterBack, afterForward: view.url, urls });
+    view.close();
+  `);
+  expect(result).toEqual({
+    afterBack: { url: "http://fake/bfcached#top", loading: false },
+    afterForward: "http://fake/b",
+    urls: ["http://fake/bfcached#top", "http://fake/b"],
+  });
+});
+
+// The view does its own bookkeeping on these three events; like every other
+// CDP event they still reach addEventListener(), with the parsed params.
+test.concurrent("navigation events reach addEventListener()", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/first");
+    const events = [];
+    for (const type of ["Page.frameNavigated", "Page.navigatedWithinDocument", "Page.loadEventFired"]) {
+      view.addEventListener(type, event => events.push([type, event.data.frame?.url ?? event.data.url ?? null]));
+    }
+    await view.navigate("http://fake/page");
+    await view.navigate("http://fake/page#one");
+    print(events);
+    view.close();
+  `);
+  expect(result).toEqual([
+    ["Page.frameNavigated", "http://fake/page"],
+    ["Page.loadEventFired", null],
+    ["Page.navigatedWithinDocument", "http://fake/page#one"],
+  ]);
+});
+
 test.concurrent("a reply larger than the read buffer is reassembled", async () => {
   const result = await runScenario(`
     const view = newView();

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -1050,12 +1050,18 @@ function navServer() {
   const server = Bun.serve({
     port: 0,
     hostname: "127.0.0.1",
-    fetch(req) {
+    async fetch(req) {
       const path = new URL(req.url).pathname;
       if (path === "/outer") return page('<title>outer</title><iframe src="/inner"></iframe>');
       if (path === "/inner") return page("<title>inner</title>inner");
       // An SPA router rewriting the URL while the document is still loading.
       if (path === "/spa") return page("<title>SPA</title><script>history.replaceState({}, '', '/app/home')</script>");
+      // A document whose load event trails its commit: the image holds it back.
+      if (path === "/slow-load") return page('<title>slow-load</title><img src="/late.gif">');
+      if (path === "/late.gif") {
+        await Bun.sleep(300);
+        return new Response("GIF89a", { headers: { "content-type": "image/gif", "cache-control": "no-store" } });
+      }
       return page(`<title>T${path}</title><body>${path}</body>`);
     },
   });
@@ -1082,52 +1088,6 @@ it("chrome: view.url keeps the #fragment", async () => {
   // Chrome reports the fragment in frame.urlFragment, separate from frame.url.
   expect(view.url).toBe(srv.base + "/page#frag");
   expect(await view.evaluate("location.href")).toBe(srv.base + "/page#frag");
-});
-
-it("chrome: a failed navigate() reports one failure and no navigation, and leaves view.url alone", async () => {
-  using srv = navServer();
-  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
-  await view.navigate(srv.base + "/before");
-  const events: string[] = [];
-  view.onNavigated = (url: string) => events.push("navigated:" + url);
-  view.onNavigationFailed = (err: Error) => events.push("failed:" + err.message);
-  // Chrome then commits its internal error page (chrome-error://chromewebdata/)
-  // and fires its load event; wait for that so every event it produces has been
-  // handled. Neither may surface as a navigation or as a second failure.
-  const errorPageLoaded = new Promise(resolve => view.addEventListener("Page.loadEventFired", resolve, { once: true }));
-  // Port 9 is on Chrome's unsafe-port list: fails before any connection.
-  await expect(view.navigate("http://127.0.0.1:9/")).rejects.toThrow("net::ERR_UNSAFE_PORT");
-  await errorPageLoaded;
-  expect(events).toEqual(["failed:net::ERR_UNSAFE_PORT"]);
-  expect(view.url).toBe(srv.base + "/before");
-  expect(view.title).toBe("T/before");
-  expect(view.loading).toBe(false);
-  // The view still navigates afterwards.
-  await view.navigate(srv.base + "/after");
-  expect({ url: view.url, title: view.title }).toEqual({ url: srv.base + "/after", title: "T/after" });
-});
-
-it("chrome: a navigation the page starts and that fails fires onNavigationFailed", async () => {
-  using srv = navServer();
-  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
-  await view.navigate(srv.base + "/start");
-  const events: string[] = [];
-  const failed = Promise.withResolvers<void>();
-  view.onNavigated = (url: string) => events.push("navigated:" + url);
-  view.onNavigationFailed = (err: Error) => {
-    events.push("failed:" + err.message);
-    failed.resolve();
-  };
-  // No navigate() of the view's is pending, so Chrome's error page for the
-  // failed load is the only notice of the failure.
-  await view.evaluate("location.href = 'http://127.0.0.1:9/gone'");
-  await failed.promise;
-  expect(events).toEqual(["failed:Navigation to http://127.0.0.1:9/gone failed"]);
-  expect({ url: view.url, title: view.title, loading: view.loading }).toEqual({
-    url: srv.base + "/start",
-    title: "T/start",
-    loading: false,
-  });
 });
 
 it("chrome: same-document navigations settle and update view.url", async () => {
@@ -1188,6 +1148,26 @@ it("chrome: a replaceState while the document loads does not settle navigate() e
     title: "T/first",
     seen: ["/app/next", "/app/home", "/first"],
   });
+});
+
+it("chrome: a cross-document goBack() waits for the load when the page being left calls replaceState()", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/slow-load");
+  // An unload handler keeps the page out of the back-forward cache, so the
+  // traversal loads it again.
+  await view.evaluate("addEventListener('unload', () => {}), 0");
+  await view.navigate(srv.base + "/leaving");
+  // A router that saves its scroll position as the page goes away. Chrome has
+  // answered the traversal by then, so this commit lands behind the reply. It
+  // is the page's own and must not end goBack() before the target has loaded.
+  await view.evaluate("addEventListener('beforeunload', () => history.replaceState({ scroll: 1 }, '')), 0");
+  await view.goBack();
+  expect({
+    url: view.url,
+    title: view.title,
+    readyState: await view.evaluate("document.readyState"),
+  }).toEqual({ url: srv.base + "/slow-load", title: "slow-load", readyState: "complete" });
 });
 
 it("chrome: goBack() to a page restored from the back-forward cache resolves", async () => {

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -1118,18 +1118,16 @@ it("chrome: a navigation the page starts and that fails fires onNavigationFailed
     events.push("failed:" + err.message);
     failed.resolve();
   };
-  await view.evaluate("setTimeout(() => { location.href = 'http://127.0.0.1:9/gone'; }, 0), 0");
+  // No navigate() of the view's is pending, so Chrome's error page for the
+  // failed load is the only notice of the failure.
+  await view.evaluate("location.href = 'http://127.0.0.1:9/gone'");
   await failed.promise;
   expect(events).toEqual(["failed:Navigation to http://127.0.0.1:9/gone failed"]);
-  expect(view.url).toBe(srv.base + "/start");
-  // reload() reloads the URL that failed, which fails again: it rejects
-  // instead of resolving on the error page's load event.
-  await expect(view.reload()).rejects.toThrow("Navigation to http://127.0.0.1:9/gone failed");
-  expect(events).toEqual([
-    "failed:Navigation to http://127.0.0.1:9/gone failed",
-    "failed:Navigation to http://127.0.0.1:9/gone failed",
-  ]);
-  expect(view.loading).toBe(false);
+  expect({ url: view.url, title: view.title, loading: view.loading }).toEqual({
+    url: srv.base + "/start",
+    title: "T/start",
+    loading: false,
+  });
 });
 
 it("chrome: same-document navigations settle and update view.url", async () => {

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -174,7 +174,10 @@ const it = chromePath && !chromeBroken && !edgeAsLocalSystem ? test : test.todo;
 // WebSocket-transport tests live in webview-chrome-ws.test.ts — the
 // Transport singleton means you can't mix pipe-mode (this file) and
 // connect-mode in one process.
-const chrome = { type: "chrome" as const, url: false as const };
+//
+// Chrome refuses to start as root (containers) without --no-sandbox.
+const chromeArgv: string[] = process.platform !== "win32" && process.getuid?.() === 0 ? ["--no-sandbox"] : [];
+const chrome = { type: "chrome" as const, url: false as const, argv: chromeArgv };
 
 const html = (h: string) => "data:text/html," + encodeURIComponent(h);
 
@@ -571,7 +574,7 @@ it("chrome: closeAll() kills the subprocess and pending promises reject", async 
       bunExe(),
       "-e",
       `
-        const view = new Bun.WebView({ backend: {type:"chrome", url:false}, width: 200, height: 200 });
+        const view = new Bun.WebView({ backend: {type:"chrome", url:false, argv: ${JSON.stringify(chromeArgv)}}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         const p = view.evaluate("new Promise(() => {})"); // never resolves
         Bun.WebView.closeAll();
@@ -603,7 +606,7 @@ it("chrome: a new WebView respawns Chrome after the previous one died", async ()
       bunExe(),
       "-e",
       `
-        const backend = {type:"chrome", url:false};
+        const backend = {type:"chrome", url:false, argv: ${JSON.stringify(chromeArgv)}};
         const first = new Bun.WebView({ backend, width: 200, height: 200 });
         await first.navigate("data:text/html,<body>first</body>");
         const pending = first.evaluate("new Promise(() => {})");
@@ -748,7 +751,7 @@ it("chrome: backend.stderr defaults to ignore (Chrome noise hidden)", async () =
       bunExe(),
       "-e",
       `
-        const view = new Bun.WebView({ backend: {type:"chrome", url:false}, width: 200, height: 200 });
+        const view = new Bun.WebView({ backend: {type:"chrome", url:false, argv: ${JSON.stringify(chromeArgv)}}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         view.close();
       `,
@@ -788,7 +791,11 @@ it("backend: { type: 'chrome' } object form works", async () => {
   // path forces spawn-mode — without it, the bare object form would
   // auto-detect DevToolsActivePort and connect to the dev's Chrome,
   // locking the singleton into WS mode for subsequent tests.
-  await using view = new Bun.WebView({ backend: { type: "chrome", path: chromePath }, width: 200, height: 200 });
+  await using view = new Bun.WebView({
+    backend: { type: "chrome", path: chromePath, argv: chromeArgv },
+    width: 200,
+    height: 200,
+  });
   await view.navigate(html("<body>obj</body>"));
   expect(await view.evaluate("document.body.textContent")).toBe("obj");
 });
@@ -803,7 +810,7 @@ it("backend.argv appends after core flags", async () => {
       "-e",
       `
       const view = new Bun.WebView({
-        backend: { type: "chrome", argv: ["--user-agent=BunWebViewTest/1.0"] },
+        backend: { type: "chrome", argv: [...${JSON.stringify(chromeArgv)}, "--user-agent=BunWebViewTest/1.0"] },
         width: 200, height: 200,
       });
       await view.navigate("data:text/html,<body></body>");
@@ -1035,6 +1042,178 @@ it("chrome: onNavigated fires with committed URL", async () => {
   expect(urls[urls.length - 1]).toContain("data:text/html");
 });
 
+// A local server for the navigation-event tests below: http:// pages get
+// real history entries, fragments, subframes and the back-forward cache,
+// which data: URLs do not exercise the same way.
+function navServer() {
+  const page = (body: string) => new Response(body, { headers: { "content-type": "text/html; charset=utf-8" } });
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      const path = new URL(req.url).pathname;
+      if (path === "/outer") return page('<title>outer</title><iframe src="/inner"></iframe>');
+      if (path === "/inner") return page("<title>inner</title>inner");
+      // An SPA router rewriting the URL while the document is still loading.
+      if (path === "/spa") return page("<title>SPA</title><script>history.replaceState({}, '', '/app/home')</script>");
+      return page(`<title>T${path}</title><body>${path}</body>`);
+    },
+  });
+  return { server, base: `http://127.0.0.1:${server.port}`, [Symbol.dispose]: () => void server.stop(true) };
+}
+
+it("chrome: onNavigated fires once per main-frame commit; an iframe's navigation does not count", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  const seen: string[] = [];
+  view.onNavigated = (url: string) => seen.push(url.replace(srv.base, ""));
+  await view.navigate(srv.base + "/outer");
+  // The <iframe src=/inner> commits its own Page.frameNavigated (with a
+  // parentId). It must neither fire the callback nor replace view.url.
+  expect(seen).toEqual(["/outer"]);
+  expect(view.url).toBe(srv.base + "/outer");
+  expect(view.title).toBe("outer");
+});
+
+it("chrome: view.url keeps the #fragment", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/page#frag");
+  // Chrome reports the fragment in frame.urlFragment, separate from frame.url.
+  expect(view.url).toBe(srv.base + "/page#frag");
+  expect(await view.evaluate("location.href")).toBe(srv.base + "/page#frag");
+});
+
+it("chrome: a failed navigate() reports one failure and no navigation, and leaves view.url alone", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/before");
+  const events: string[] = [];
+  view.onNavigated = (url: string) => events.push("navigated:" + url);
+  view.onNavigationFailed = (err: Error) => events.push("failed:" + err.message);
+  // Chrome then commits its internal error page (chrome-error://chromewebdata/)
+  // and fires its load event; wait for that so every event it produces has been
+  // handled. Neither may surface as a navigation or as a second failure.
+  const errorPageLoaded = new Promise(resolve => view.addEventListener("Page.loadEventFired", resolve, { once: true }));
+  // Port 9 is on Chrome's unsafe-port list: fails before any connection.
+  await expect(view.navigate("http://127.0.0.1:9/")).rejects.toThrow("net::ERR_UNSAFE_PORT");
+  await errorPageLoaded;
+  expect(events).toEqual(["failed:net::ERR_UNSAFE_PORT"]);
+  expect(view.url).toBe(srv.base + "/before");
+  expect(view.title).toBe("T/before");
+  expect(view.loading).toBe(false);
+  // The view still navigates afterwards.
+  await view.navigate(srv.base + "/after");
+  expect({ url: view.url, title: view.title }).toEqual({ url: srv.base + "/after", title: "T/after" });
+});
+
+it("chrome: a navigation the page starts and that fails fires onNavigationFailed", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/start");
+  const events: string[] = [];
+  const failed = Promise.withResolvers<void>();
+  view.onNavigated = (url: string) => events.push("navigated:" + url);
+  view.onNavigationFailed = (err: Error) => {
+    events.push("failed:" + err.message);
+    failed.resolve();
+  };
+  await view.evaluate("setTimeout(() => { location.href = 'http://127.0.0.1:9/gone'; }, 0), 0");
+  await failed.promise;
+  expect(events).toEqual(["failed:Navigation to http://127.0.0.1:9/gone failed"]);
+  expect(view.url).toBe(srv.base + "/start");
+  // reload() reloads the URL that failed, which fails again: it rejects
+  // instead of resolving on the error page's load event.
+  await expect(view.reload()).rejects.toThrow("Navigation to http://127.0.0.1:9/gone failed");
+  expect(events).toEqual([
+    "failed:Navigation to http://127.0.0.1:9/gone failed",
+    "failed:Navigation to http://127.0.0.1:9/gone failed",
+  ]);
+  expect(view.loading).toBe(false);
+});
+
+it("chrome: same-document navigations settle and update view.url", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/doc");
+  const seen: string[] = [];
+  view.onNavigated = (url: string) => seen.push(url.replace(srv.base, ""));
+
+  // Only the fragment differs: Chrome answers Page.navigate and then sends
+  // Page.navigatedWithinDocument, never Page.loadEventFired.
+  await view.navigate(srv.base + "/doc#section");
+  expect(view.url).toBe(srv.base + "/doc#section");
+  expect(view.loading).toBe(false);
+
+  // history.pushState from the page: view.url follows and onNavigated fires.
+  await view.evaluate("history.pushState({}, '', '/pushed?x=1#h'), 0");
+  expect(view.url).toBe(srv.base + "/pushed?x=1#h");
+
+  // Back across the pushState entry is a same-document history traversal.
+  await view.goBack();
+  expect(view.url).toBe(srv.base + "/doc#section");
+  expect(await view.evaluate("location.pathname + location.hash")).toBe("/doc#section");
+  await view.goForward();
+  expect(view.url).toBe(srv.base + "/pushed?x=1#h");
+  expect(view.title).toBe("T/doc");
+
+  expect(seen).toEqual(["/doc#section", "/pushed?x=1#h", "/doc#section", "/pushed?x=1#h"]);
+});
+
+it("chrome: a replaceState while the document loads does not settle navigate() early", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/first");
+  const seen: [string, boolean][] = [];
+  view.onNavigated = (url: string) => seen.push([url.replace(srv.base, ""), view.loading]);
+  // /spa's inline script calls history.replaceState before the load event.
+  // That commit is the page's own: navigate() still waits for the load, so
+  // the title is known and loading is false once it resolves.
+  await view.navigate(srv.base + "/spa");
+  expect({ url: view.url, title: view.title, loading: view.loading, seen }).toEqual({
+    url: srv.base + "/app/home",
+    title: "SPA",
+    loading: false,
+    seen: [
+      ["/spa", true],
+      ["/app/home", true],
+    ],
+  });
+  // A later pushState by the loaded page is its own navigation again, and a
+  // cross-document goBack() after it still waits for the old page.
+  await view.evaluate("history.pushState({}, '', '/app/next'), 0");
+  await view.goBack(); // same-document: /app/next -> /app/home
+  expect({ url: view.url, title: view.title }).toEqual({ url: srv.base + "/app/home", title: "SPA" });
+  await view.goBack(); // cross-document: back to /first
+  expect({ url: view.url, title: view.title, seen: seen.slice(2).map(([url]) => url) }).toEqual({
+    url: srv.base + "/first",
+    title: "T/first",
+    seen: ["/app/next", "/app/home", "/first"],
+  });
+});
+
+it("chrome: goBack() to a page restored from the back-forward cache resolves", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/a#top");
+  await view.navigate(srv.base + "/b");
+  const seen: string[] = [];
+  view.onNavigated = (url: string) => seen.push(url.replace(srv.base, ""));
+  // Chrome restores /a from its back-forward cache: Page.frameNavigated
+  // arrives with type "BackForwardCacheRestore" and no load event follows.
+  // (If this Chrome build decides not to cache the page, it is a regular
+  // load and the expectations are the same.)
+  await view.goBack();
+  expect(view.url).toBe(srv.base + "/a#top");
+  expect(view.title).toBe("T/a");
+  expect(view.loading).toBe(false);
+  expect(await view.evaluate("document.title")).toBe("T/a");
+  await view.goForward();
+  expect(view.url).toBe(srv.base + "/b");
+  expect(view.title).toBe("T/b");
+  expect(seen).toEqual(["/a#top", "/b"]);
+});
+
 it("chrome: press() dispatches keydown/keyup pair", async () => {
   await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   // Listeners in the HTML so they're live before any press. evaluate() wraps
@@ -1134,7 +1313,7 @@ it("chrome: console: globalThis.console forwards to parent's stdout", async () =
       "-e",
       `
       const view = new Bun.WebView({
-        backend: {type:"chrome", url:false}, width: 200, height: 200,
+        backend: {type:"chrome", url:false, argv: ${JSON.stringify(chromeArgv)}}, width: 200, height: 200,
         console: globalThis.console,
       });
       await view.navigate("data:text/html,<body></body>");
@@ -1194,7 +1373,7 @@ it("chrome: large evaluate result crosses the pipe", async () => {
 // resolved once per process, on the first spawn. The env var is consulted
 // right after backend.path, before $PATH and the install locations.
 const spawnWithEnv = `
-  const view = new Bun.WebView({ backend: { type: "chrome", url: false }, width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: { type: "chrome", url: false, argv: ${JSON.stringify(chromeArgv)} }, width: 200, height: 200 });
   await view.navigate("data:text/html,<body>env</body>");
   console.log(await view.evaluate("document.body.textContent"));
   view.close();

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -1058,6 +1058,15 @@ function navServer() {
       if (path === "/spa") return page("<title>SPA</title><script>history.replaceState({}, '', '/app/home')</script>");
       // A document whose load event trails its commit: the image holds it back.
       if (path === "/slow-load") return page('<title>slow-load</title><img src="/late.gif">');
+      // A document that commits late, and loads later still: the server takes
+      // its time to answer, and then the image holds the load event back.
+      // no-store: a history traversal asks the server again, not the HTTP cache.
+      if (path === "/slow-doc") {
+        await Bun.sleep(150);
+        return new Response('<title>slow-doc</title><img src="/late.gif">', {
+          headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" },
+        });
+      }
       if (path === "/late.gif") {
         await Bun.sleep(300);
         return new Response("GIF89a", { headers: { "content-type": "image/gif", "cache-control": "no-store" } });
@@ -1168,6 +1177,27 @@ it("chrome: a cross-document goBack() waits for the load when the page being lef
     title: view.title,
     readyState: await view.evaluate("document.readyState"),
   }).toEqual({ url: srv.base + "/slow-load", title: "slow-load", readyState: "complete" });
+});
+
+it("chrome: a cross-document goBack() is not ended by a #fragment change of the page being left", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/slow-doc");
+  // An unload handler keeps the page out of the back-forward cache, and
+  // no-store keeps it out of the HTTP cache, so the traversal asks the server.
+  await view.evaluate("addEventListener('unload', () => {}), 0");
+  await view.navigate(srv.base + "/leaving");
+  // A page that rewrites its fragment all the time (a scroll spy). Chrome
+  // answers the traversal at once and commits it when the server has answered,
+  // so some of these commits land in between. They report "fragment", like a
+  // traversal's own commit, but they do not land on the entry it asked for.
+  await view.evaluate("setInterval(() => location.replace('#n' + performance.now()), 5), 0");
+  await view.goBack();
+  expect({
+    url: view.url,
+    title: view.title,
+    readyState: await view.evaluate("document.readyState"),
+  }).toEqual({ url: srv.base + "/slow-doc", title: "slow-doc", readyState: "complete" });
 });
 
 it("chrome: goBack() to a page restored from the back-forward cache resolves", async () => {


### PR DESCRIPTION
### Problem

- On the Chrome backend, `navigate()` to a `#hash` of the current page never settles. Nor does `goBack()` or `goForward()` over a `#hash` or `history.pushState` entry, or onto a page restored from the back-forward cache. The slot stays full, so every later navigation throws `Invalid state: a navigation is already pending`.
- The slot settled only from `Page.loadEventFired` (`src/runtime/webview/ChromeBackend.cpp:1166`), which none of those fires. The backend ignored what Chrome sends instead: `Page.navigatedWithinDocument` and a `BackForwardCacheRestore` commit.
- `Page.frameNavigated` was applied as is: an `<iframe>`'s commit replaced `view.url`, and the `#fragment` (sent apart, as `frame.urlFragment`) was lost.

### Fix

- Settle a navigation on the commit its kind ends with. A `Page.navigate` reply with no `loaderId` means same-document. A traversal, answered `{}`, ends on a document commit, or on a same-document commit that lands on the history entry it asked for. A `BackForwardCacheRestore` commit finishes there.
- A navigation the page makes itself settles nothing: a small state tracks the view's own command, and a `historyApi` commit (the page's `pushState()`/`replaceState()`) never ends anything.
- Apply `Page.frameNavigated` to the main frame only, and keep `frame.urlFragment`.
- Verified: 14 new blocks in `webview-chrome-pipe.test.ts` (a fake Chrome, no browser needed) and 7 in `webview-chrome.test.ts`, on Chromium 132 to Chrome 153. 19 fail with main's `src/`, and two guard regressions.

### Background

- One slot per operation holds the pending promise. `navigate()`, `reload()`, `goBack()` and `goForward()` share the Navigate slot (#40991 is an outside report against it).
- A same-document navigation changes the URL but keeps the document.
- `Page.loadEventFired` names no frame and no loader.
- Landing order: this PR first. #42341 (failed loads, from #42168) is stacked on it. #30645 can reuse `m_mainFrameId`, `m_chromeNavigationSeq` and `Pending.navigation`. #42222 owns event delivery to `addEventListener()`. #42342 tracks the WebKit gap.

<details><summary>Notes</summary>

Four shapes reproduce on bun 1.4.2, canary d316760e8 and main 4ff91937, with HeadlessChrome 143. All four settle with this change:

```
FAIL navigate() to a same-document URL (#hash) settles   {"r":{"HANG":5000},"loading":true}
FAIL goBack() over a same-document history entry settles {"r":{"HANG":5000}}
FAIL goBack() over a pushState entry settles             {"r":{"HANG":5000}}
FAIL goBack then goForward onto a hash entry             {"r1":{"HANG":5000},"r2":{"err":"Invalid state: a navigation is already pending"}}
```

What Chrome sends, from raw CDP probes (Chromium 132, Chrome 143 and 153):

- Cross-document: the `Page.navigate` reply with `loaderId`, then `frameNavigated`, then `loadEventFired`.
- Same-document: the reply **without** `loaderId`, then `navigatedWithinDocument`. No load event, ever. The reply always precedes the commit, including when the renderer is blocked in a 2.5 s sync loop (reply at t=1.2 s, commit at t=2.5 s). The missing `loaderId` is not incidental: `PageHandler::DispatchNavigateCallback` sends it only when `!request->IsSameDocument()`.
- History traversal: the `Page.navigateToHistoryEntry` reply is `{}`, sent by the browser at once, and says nothing about the kind. A cross-document one commits when the server has answered, which can be much later. The URL of the target entry in the `Page.getNavigationHistory` reply and the `url` of the traversal's own `Page.navigatedWithinDocument` are byte-identical: checked on Chromium 132, 138 and Chrome 153 for fragment entries, `pushState` entries with a query and a hash, percent-encoded unicode and spaces, `location.hash` entries, `about:blank#x`, `data:` URLs and mixed-case paths.
- `Page.navigatedWithinDocument` carries `navigationType`. A `navigate()` to a fragment and a history traversal both report `"fragment"`, also a traversal between two `pushState` entries with no fragment in either URL (checked on 132 and 153). `"historyApi"` is only ever the page's own `pushState()`/`replaceState()`. A Chrome too old to send the field behaves as if every commit were `"fragment"`.
- A traversal onto a cached page: `frameNavigated` with `type: "BackForwardCacheRestore"` and no load event.
- `Page.reload` is answered by the renderer (`PageHandler::Reload` falls through), so its `{}` can trail the reload's own commit. On Chromium 132, a reload that swaps processes (a `Cross-Origin-Opener-Policy` header appears) while the old renderer is busy delivers `frameNavigated` and `loadEventFired` first and the reply last. So `reload()` counts a commit from the moment it is called and does not wait for the reply.
- A fragment on a cross-document URL arrives as `frame.url` plus `frame.urlFragment`, so `view.url` dropped it while `location.href` kept it.
- `Page.frameStartedNavigating` does classify a navigation before it commits, but it names no command (and Chromium 132 does not send it), so this PR does not use it.

The ways a navigation of the page's own could settle the wrong promise, each with a regression test. A same-document commit carries no loader id, and `Page.loadEventFired` names no frame and no loader either, so the backend matches a commit to the view's navigation by state:

- `onNavigated` ran before the handler decided. The callback is user code. A `navigate()` from inside it filled the slot, and the old commit then settled the new navigation. Each handler now decides first.
- `goBack()` and `goForward()` fill the slot one `Page.getNavigationHistory` roundtrip before Chrome is asked to traverse. A `history.pushState` in that window settled the promise with the page's URL. The kind starts as `NotRequested`, which no commit settles, and becomes `Unknown` once `Page.navigateToHistoryEntry` is answered.
- A `Page.loadEventFired` of a document the navigation had not committed. A raw probe of a page that navigates itself (`location.href = "/b"`, where `/b` holds a 500 ms subresource) with a `Page.navigate` to a 2 s page sent at `/b`'s commit gives `/b`'s load event at t=721 ms and the new commit at t=2222 ms.
- A navigation that lands after the command was written and before Chrome answered it. Chrome answers `Page.navigate` and `Page.navigateToHistoryEntry` before the document commits, so such a navigation is the page's own.
- A document the page loaded during the history lookup. Its commit was recorded against the traversal, so its load event ended the traversal early.
- A second same-document commit behind the first, such as a `hashchange` handler that rewrites the URL. It queued a second title fetch for a navigation that was already over.
- The page's own `pushState()`/`replaceState()` behind the reply of a traversal or of a fragment `navigate()`. A cross-document `goBack()` from a page that saves its scroll position with `history.replaceState()` in `beforeunload` resolved at the commit: 265 ms, `readyState` `interactive`, where main waits for the load (1039 ms, `complete`). A `historyApi` commit ends nothing now.
- A `#fragment` change of the page being left (a scroll spy, a link the user follows) behind a traversal's reply. It reports `"fragment"`, like the traversal's own commit. With a `no-store` target and a page that rewrites its fragment every 5 ms, `goBack()` resolved at the target's commit (168 ms, `interactive`). A traversal now remembers the URL of the entry it asked for, and a same-document commit ends it only when it lands there. The two URLs are compared after the same JSON decoding, because Chrome escapes a quote in both.

The state for the navigation in flight is `NotRequested`, `Requested` (written, unanswered), `Unknown` (a history traversal), `SameDocument` or `CrossDocument`. Each title fetch also carries the navigation it was sent for, so a reply that arrives after its own navigation settled cannot settle a later one.

Shapes that still never settle, all of them on main too: a document whose `load` event never fires (`window.stop()`, a subresource that hangs), which `{ timeout }` in #30645 answers, and a title fetch that Chrome holds back because the page started another navigation to a server that never answers. A cross-document commit is attributed by state alone, so a load that the page starts between a `reload()` or a traversal reply and that navigation's own commit can end it early. Main settles on any load event, so that is not new.

This PR absorbed #42168, which found the same `Page.navigatedWithinDocument` gap and fixed it in parallel. Taken from it: the subframe filter, `frame.urlFragment` on `view.url`, `BackForwardCacheRestore` commits, and its real-Chrome tests. Its `frame.unreachableUrl` handling is #42341 now: a review of the fold against Chromium 132 to 153 found that Chromium 139 and older commit a failed load's error page under a fresh `loaderId`, so the `loaderId` match that both PRs used to report a failure once fired `onNavigationFailed` twice there. #42341 matches by order instead. That PR's move of `onNavigated` from the commit to the load completion (so that its `title` argument is populated) is in neither: it is a behaviour change, no hang here needs it, and three test files read the commit through `onNavigated` today. `onNavigated` still fires at the commit, as documented.

`Page.navigatedWithinDocument` still goes on to `addEventListener()` after the view has applied it: main never intercepted it, so a listener for it has always heard it. `Page.frameNavigated` and `Page.loadEventFired` stay consumed, as on main. #42222 changes that.

`view.url` and `onNavigated` follow the page's own same-document commits too. It is the same event and the same handler, and `view.url` would otherwise stay knowingly stale. The docs scope that sentence to the Chrome backend, because the WebKit backend registers no same-document callback: there `navigate()` to a fragment never settles, and `view.url` and `onNavigated` go stale after any same-document navigation (`goBack()`, `goForward()` and `reload()` are acknowledged at once on WebKit, so they do not hang). #42342 tracks it. I have no macOS machine to confirm it on.

Why most of the tests are in the fake-browser file: `webview-chrome.test.ts` needs a real browser, and few CI lanes have one. `fake-chrome-fixture.ts` models session history, classifies a navigation the way Chrome does, and produces a back-forward cache restore. One switch, `__fake_on_next(method, script)`, makes the page do something of its own as the fake reads the view's next command, which is how each of the windows above is hit on purpose. `__fake_title_fetches()` reports how many `document.title` fetches the runtime has sent, which is how the duplicate fetch is caught. The real-Chrome file passes `--no-sandbox` when it runs as root, which is what lets it run in a container (#39490 does the same).

Checked by hand against real Chrome, all green: a cross-document `navigate()` to a 1.2 s page while the old page changes `location.hash` every 20 ms still resolves after the load event; a page that sets `location.hash` during its own load; a 302 redirect; `reload()` on a URL with a fragment; `reload()` across a COOP process swap with a busy renderer (Chromium 132 and 152); a same-document navigation while the renderer is blocked in a 2.5 s sync loop; eleven user-level scenarios (fragment, redirect, slow response, traversals, reload, failed navigate then recover, `data:` and `about:blank`, iframe, `pushState` then `goBack()`) on Chromium 132, 138 and 152.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome.test.ts, test/js/bun/webview/webview-chrome-pipe.test.ts

<!-- robobun:evidence:end -->

