### PR TITLE
webview: attach the Chrome session on the first operation, not only on navigate

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -455,7 +455,7 @@ When using `backend: "chrome"`, you can drop down to raw [CDP](https://chromedev
 
 ```ts
 const view = new Bun.WebView({ backend: "chrome" });
-await view.navigate("https://example.com"); // required: sets up the CDP session
+await view.navigate("https://example.com"); // the first awaited operation sets up the CDP session
 
 await view.cdp("Emulation.setUserAgentOverride", {
   userAgent: "MyBot/1.0",

--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -33,7 +33,7 @@ const view = new Bun.WebView({
 });
 ```
 
-The constructor is synchronous — it returns immediately and spawns the browser subprocess in the background. The first operation you `await` (such as `navigate()` or `evaluate()`) waits for the browser to be ready.
+The constructor is synchronous — it returns immediately and spawns the browser subprocess in the background. The first operation you `await` (such as `navigate()` or `evaluate()`) waits for the browser to be ready. Before any navigation, the page is `about:blank`: `evaluate()` runs there, and `screenshot()` captures it.
 
 If you pass `url`, the view begins navigating before the constructor returns, the same way `view.navigate(url)` on the next line would. One difference: the constructor keeps the navigation's promise internal, so a failure never surfaces as a rejection. Set `onNavigationFailed` to observe it.
 
@@ -471,7 +471,7 @@ await view.cdp("DOM.focus", { nodeId });
 
 `cdp(method, params?)` returns the `result` object from the CDP response. If Chrome returns an error (unknown method, bad params), the promise rejects with its `error.message`.
 
-Commands are scoped to this view's session (they target this tab). You must `await navigate(...)` at least once before calling `cdp()` — the first navigation establishes the session. Calling `cdp()` before that throws `ERR_INVALID_STATE`.
+Commands are scoped to this view's session (they target this tab). You must `await` one other operation, such as `navigate()` or `evaluate()`, before calling `cdp()` — the first operation establishes the session. Calling `cdp()` before that throws `ERR_INVALID_STATE`.
 
 `params` must be a JSON-serializable object; omit it for commands that take no parameters. One `cdp()` call may be in flight at a time per view.
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9612,8 +9612,10 @@ declare module "bun" {
      * tab). Returns the decoded `result` object from the CDP response, or
      * rejects with the `error.message` if Chrome reports a protocol error.
      *
-     * Call `await view.navigate(...)` at least once before using `cdp()` —
-     * the first navigate sets up the CDP session.
+     * `await` one other operation (such as `view.navigate(...)` or
+     * `view.evaluate(...)`) before using `cdp()` — the first operation on a
+     * view sets up the CDP session, and `cdp()` throws `ERR_INVALID_STATE`
+     * until one has.
      *
      * @param method Domain-qualified method name, e.g.
      *   `"Runtime.evaluate"`, `"DOM.querySelector"`,

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -644,8 +644,6 @@ static WriteBarrier<JSPromise>& slotFor(JSWebView* view, PendingSlot s)
     case PendingSlot::Cdp:
         return view->m_pendingCdp;
     case PendingSlot::Attach:
-        // The attach chain settles no slot: its failures go through
-        // failDeferred, and its successes chain to the next command.
         break;
     }
     ASSERT_NOT_REACHED();
@@ -701,18 +699,15 @@ static void rejectViewSlotsAsHandled(JSGlobalObject* g, JSWebView* view, JSValue
 }
 
 // --- Attach chain + parked commands ----------------------------------------
-// Every Page.*, Runtime.*, Input.* and Emulation.* command has to carry a
-// sessionId: those domains exist per target, not on the browser endpoint.
-// A view gets its session from Target.createTarget → Target.attachToTarget
-// → Page.enable, so the first operation on a view starts that chain and
-// waits for it.
+// Page.*, Runtime.*, Input.* and Emulation.* exist per target, not on the
+// browser endpoint, so every one of their commands needs the view's
+// sessionId. The first operation on a view starts the chain that produces
+// it and waits, and so does anything issued while the chain runs.
 
 void Transport::sendToView(JSWebView* view, uint32_t cdpId, Command&& cmd)
 {
-    // The gate is the whole chain, not the session id alone.
     // Target.attachToTarget fills in m_sessionId one reply before
-    // Page.enable drains the queue, and a command written in that
-    // window would reach Chrome ahead of the ones already parked.
+    // Page.enable drains the queue, so the gate is the whole chain.
     if (!view->m_chromeAttaching && !view->m_sessionId.isEmpty()) {
         send(cdpId, WTF::move(cmd), sidSpan(view->m_sessionId));
         return;
@@ -757,11 +752,10 @@ void Transport::failDeferred(JSWebView* view, JSValue error)
 {
     auto* g = m_global;
     uint32_t vid = view->m_viewId;
-    // Take the queue out before settling anything. settleFailure calls
-    // into JS (onNavigationFailed), and a navigate() retry from that
-    // callback parks a command and starts a fresh chain. Iterating the
-    // live queue would reject that retry with this error too, and a
-    // callback that always retries would never finish the loop.
+    // settleFailure runs onNavigationFailed, which may retry navigate().
+    // The retry parks a command and starts a new chain, so take the queue
+    // out and clear the flag first: a live loop would reject the retry
+    // with this error too, forever if the callback always retries.
     WTF::Vector<DeferredCmd> parked;
     for (size_t i = 0; i < m_deferred.size();) {
         if (m_deferred[i].viewId != vid) {
@@ -771,13 +765,10 @@ void Transport::failDeferred(JSWebView* view, JSValue error)
         parked.append(WTF::move(m_deferred[i]));
         m_deferred.removeAt(i);
     }
-    // Cleared before the callbacks run, so a retry starts a new chain
-    // instead of parking behind the one that just failed.
     view->m_chromeAttaching = false;
     for (auto& entry : parked) {
-        // id 0 is the untracked half of a pair (click's mousePressed). It
-        // owns no slot, and 0 is the HashMap's empty key, so looking it
-        // up asserts. The tracked half carries the rejection.
+        // The untracked half of a pair owns no slot, and 0 is the
+        // HashMap's empty key, so a lookup would assert.
         if (!entry.id) continue;
         auto it = m_pending.find(entry.id);
         if (it == m_pending.end()) continue; // cancelled by close()
@@ -874,11 +865,9 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
 
     switch (entry.method) {
     // --- Attach chain --------------------------------------------------
-    // The first operation on a view sends Target.createTarget; each
-    // response chains into the next command. None of them settles a user
-    // promise: the operations that started the chain, and any issued
-    // while it ran, are parked in m_deferred and written by the last
-    // step. A failure at any stage rejects all of them (failDeferred).
+    // Each response chains into the next command and settles no user
+    // promise. The last step writes what m_deferred holds; a failure at
+    // any step rejects all of it.
     case Method::TargetCreateTarget: {
         // {"targetId":"<hex>"}
         auto tid = jsonString(jsonField(result, { "targetId", 8 }));
@@ -906,9 +895,9 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
     }
     case Method::PageEnable: {
-        // Runtime.enable (for consoleAPICalled later) — fire-and-forget,
-        // untracked. Chrome processes commands in order per session, so
-        // it takes effect before anything drained below.
+        // Runtime.enable (for consoleAPICalled later) — untracked. One
+        // session processes its commands in order, so it takes effect
+        // before anything the drain writes.
         uint32_t rid = nextId();
         send(0, Command(rid, "Runtime.enable"_s), sidSpan(view->m_sessionId));
 
@@ -1605,9 +1594,7 @@ JSPromise* click(JSGlobalObject* g, JSWebView* view, float x, float y, uint8_t b
     int32_t mods = cdpModifiers(modifiers);
 
     // Pressed — untracked. Chrome replies but we don't need the ack; the
-    // Released event's reply confirms both were processed. Parked with
-    // id 0 when the view is still attaching: the pair stays in order and
-    // neither half can be cancelled on its own.
+    // Released event's reply confirms both were processed.
     uint32_t idDown = t.nextId();
     t.sendToView(view, 0, Command(idDown, "Input.dispatchMouseEvent"_s).raw("type"_s, "\"mousePressed\""_s).num("x"_s, x).num("y"_s, y).raw("button"_s, btn).num("clickCount"_s, static_cast<int32_t>(clickCount)).num("modifiers"_s, mods));
     // Released — tracked, resolves the promise.
@@ -1819,14 +1806,12 @@ void close(JSWebView* view)
 {
     auto& t = transport();
     if (auto* g = t.m_global) rejectViewSlotsAsHandled(g, view, createError(g, "WebView closed"_s));
-    // Prune m_pending entries for this view — the attach chain
-    // (TargetCreateTarget → TargetAttachToTarget → PageEnable) chains to
-    // the next command on each reply. If close() lands mid-chain, the
-    // next reply would continue on a closed view: m_sessions.add
-    // re-registers it, and the commands parked behind the chain reach
-    // the tab after dispose. removeIf breaks the chain at the next
-    // reply — handleResponse's find(id)==end() early-return drops it —
-    // and dropDeferred forgets what was parked.
+    // Prune m_pending entries for this view — each attach-chain reply
+    // sends the next command, so a close() mid-chain would otherwise
+    // re-register the session and let the parked commands reach the tab
+    // after dispose. removeIf breaks the chain at the next reply
+    // (handleResponse's find(id)==end() drops it); dropDeferred forgets
+    // what was parked.
     t.m_pending.removeIf([vid = view->m_viewId](auto& pair) {
         return pair.value.viewId == vid;
     });

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -766,6 +766,17 @@ void Transport::failDeferred(JSWebView* view, JSValue error)
         m_deferred.removeAt(i);
     }
     view->m_chromeAttaching = false;
+    // A chain that got past Target.attachToTarget leaves a session
+    // Page.enable never reached, and such a session sends no load event.
+    // Forget it and close its tab so the next operation attaches again.
+    if (!view->m_sessionId.isEmpty()) {
+        m_sessions.remove(view->m_sessionId);
+        view->m_sessionId = WTF::String();
+    }
+    if (!view->m_targetId.isEmpty()) {
+        send(0, Command(nextId(), "Target.closeTarget"_s).str("targetId"_s, view->m_targetId));
+        view->m_targetId = WTF::String();
+    }
     for (auto& entry : parked) {
         // The untracked half of a pair owns no slot, and 0 is the
         // HashMap's empty key, so a lookup would assert.

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -709,7 +709,11 @@ static void rejectViewSlotsAsHandled(JSGlobalObject* g, JSWebView* view, JSValue
 
 void Transport::sendToView(JSWebView* view, uint32_t cdpId, Command&& cmd)
 {
-    if (!view->m_sessionId.isEmpty()) {
+    // The gate is the whole chain, not the session id alone.
+    // Target.attachToTarget fills in m_sessionId one reply before
+    // Page.enable drains the queue, and a command written in that
+    // window would reach Chrome ahead of the ones already parked.
+    if (!view->m_chromeAttaching && !view->m_sessionId.isEmpty()) {
         send(cdpId, WTF::move(cmd), sidSpan(view->m_sessionId));
         return;
     }
@@ -753,23 +757,33 @@ void Transport::failDeferred(JSWebView* view, JSValue error)
 {
     auto* g = m_global;
     uint32_t vid = view->m_viewId;
-    view->m_chromeAttaching = false;
+    // Take the queue out before settling anything. settleFailure calls
+    // into JS (onNavigationFailed), and a navigate() retry from that
+    // callback parks a command and starts a fresh chain. Iterating the
+    // live queue would reject that retry with this error too, and a
+    // callback that always retries would never finish the loop.
+    WTF::Vector<DeferredCmd> parked;
     for (size_t i = 0; i < m_deferred.size();) {
         if (m_deferred[i].viewId != vid) {
             ++i;
             continue;
         }
-        uint32_t id = m_deferred[i].id;
+        parked.append(WTF::move(m_deferred[i]));
         m_deferred.removeAt(i);
+    }
+    // Cleared before the callbacks run, so a retry starts a new chain
+    // instead of parking behind the one that just failed.
+    view->m_chromeAttaching = false;
+    for (auto& entry : parked) {
         // id 0 is the untracked half of a pair (click's mousePressed). It
         // owns no slot, and 0 is the HashMap's empty key, so looking it
         // up asserts. The tracked half carries the rejection.
-        if (!id) continue;
-        auto it = m_pending.find(id);
+        if (!entry.id) continue;
+        auto it = m_pending.find(entry.id);
         if (it == m_pending.end()) continue; // cancelled by close()
-        auto entry = it->value;
+        auto pending = it->value;
         m_pending.remove(it);
-        settleFailure(g, view, entry.slot, entry.method, error);
+        settleFailure(g, view, pending.slot, pending.method, error);
     }
     updateKeepAlive();
 }

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -340,7 +340,7 @@ bool Transport::ensureSpawned(Zig::GlobalObject* zig, const WTF::String& userDat
 #endif
 }
 
-void Transport::send(uint32_t cdpId, Command&& cmd)
+void Transport::send(uint32_t cdpId, Command&& cmd, std::span<const char> sessionId)
 {
     if (m_mode == TransportMode::WebSocket) {
         // WS text frame per CDP message — the framing IS the delimiter.
@@ -349,7 +349,7 @@ void Transport::send(uint32_t cdpId, Command&& cmd)
         // m_pending (view closed before open = don't create its target).
         // sendTextNative is a no-op when m_state != OPEN, so queuing is
         // mandatory here or commands silently drop.
-        auto body = cmd.finishToString();
+        auto body = cmd.finishToString(sessionId);
         if (m_wsOpen) {
             m_ws->sendTextNative(body);
         } else {
@@ -357,7 +357,7 @@ void Transport::send(uint32_t cdpId, Command&& cmd)
         }
         return;
     }
-    cmd.finishAndWrite([this](const char* d, size_t n) { writeRaw(d, n); });
+    cmd.finishAndWrite([this](const char* d, size_t n) { writeRaw(d, n); }, sessionId);
 }
 
 // --- WebSocket transport ----------------------------------------------------
@@ -643,6 +643,10 @@ static WriteBarrier<JSPromise>& slotFor(JSWebView* view, PendingSlot s)
         return view->m_pendingMisc;
     case PendingSlot::Cdp:
         return view->m_pendingCdp;
+    case PendingSlot::Attach:
+        // The attach chain settles no slot: its failures go through
+        // failDeferred, and its successes chain to the next command.
+        break;
     }
     ASSERT_NOT_REACHED();
     return view->m_pendingMisc;
@@ -694,6 +698,85 @@ static void rejectViewSlotsAsHandled(JSGlobalObject* g, JSWebView* view, JSValue
     rejectSlotAsHandled(g, view, view->m_pendingScreenshot, err);
     rejectSlotAsHandled(g, view, view->m_pendingMisc, err);
     rejectSlotAsHandled(g, view, view->m_pendingCdp, err);
+}
+
+// --- Attach chain + parked commands ----------------------------------------
+// Every Page.*, Runtime.*, Input.* and Emulation.* command has to carry a
+// sessionId: those domains exist per target, not on the browser endpoint.
+// A view gets its session from Target.createTarget → Target.attachToTarget
+// → Page.enable, so the first operation on a view starts that chain and
+// waits for it.
+
+void Transport::sendToView(JSWebView* view, uint32_t cdpId, Command&& cmd)
+{
+    if (!view->m_sessionId.isEmpty()) {
+        send(cdpId, WTF::move(cmd), sidSpan(view->m_sessionId));
+        return;
+    }
+    m_deferred.append(DeferredCmd { view->m_viewId, cdpId, WTF::move(cmd) });
+    if (!std::exchange(view->m_chromeAttaching, true)) beginAttach(view);
+}
+
+void Transport::beginAttach(JSWebView* view)
+{
+    // newWindow:true is required for width/height — without it Chrome
+    // reuses an existing window and rejects position params. Headless has
+    // no visible window either way; "new window" just means "new top-level
+    // browsing context".
+    uint32_t id = nextId();
+    m_pending.add(id, Pending { Method::TargetCreateTarget, PendingSlot::Attach, view->m_viewId });
+    send(id,
+        Command(id, "Target.createTarget"_s)
+            .str("url"_s, "about:blank"_s)
+            .boolean("newWindow"_s, true)
+            .num("width"_s, static_cast<int32_t>(view->m_width))
+            .num("height"_s, static_cast<int32_t>(view->m_height)));
+}
+
+void Transport::drainDeferred(JSWebView* view)
+{
+    auto sid = sidSpan(view->m_sessionId);
+    uint32_t vid = view->m_viewId;
+    for (size_t i = 0; i < m_deferred.size();) {
+        if (m_deferred[i].viewId != vid) {
+            ++i;
+            continue;
+        }
+        auto parked = WTF::move(m_deferred[i]);
+        m_deferred.removeAt(i);
+        if (parked.id && !m_pending.contains(parked.id)) continue; // cancelled
+        send(parked.id, WTF::move(parked.cmd), sid);
+    }
+}
+
+void Transport::failDeferred(JSWebView* view, JSValue error)
+{
+    auto* g = m_global;
+    uint32_t vid = view->m_viewId;
+    view->m_chromeAttaching = false;
+    for (size_t i = 0; i < m_deferred.size();) {
+        if (m_deferred[i].viewId != vid) {
+            ++i;
+            continue;
+        }
+        uint32_t id = m_deferred[i].id;
+        m_deferred.removeAt(i);
+        // id 0 is the untracked half of a pair (click's mousePressed). It
+        // owns no slot, and 0 is the HashMap's empty key, so looking it
+        // up asserts. The tracked half carries the rejection.
+        if (!id) continue;
+        auto it = m_pending.find(id);
+        if (it == m_pending.end()) continue; // cancelled by close()
+        auto entry = it->value;
+        m_pending.remove(it);
+        settleFailure(g, view, entry.slot, entry.method, error);
+    }
+    updateKeepAlive();
+}
+
+void Transport::dropDeferred(uint32_t viewId)
+{
+    m_deferred.removeAllMatching([viewId](auto& parked) { return parked.viewId == viewId; });
 }
 
 // Build an Error from CDP exceptionDetails. exception.description is V8's
@@ -764,24 +847,30 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         // {"code":-32000,"message":"..."}
         auto msgSlice = jsonString(jsonField(error, { "message", 7 }));
         auto errStr = WTF::String::fromUTF8(std::span<const char>(msgSlice));
-        settleFailure(g, view, entry.slot, entry.method,
-            createError(g, errStr.isEmpty() ? "CDP error"_s : errStr));
+        JSValue errValue = createError(g, errStr.isEmpty() ? "CDP error"_s : errStr);
+        // An attach-chain failure belongs to no single slot: every
+        // operation parked behind it fails with it.
+        if (entry.slot == PendingSlot::Attach) {
+            failDeferred(view, errValue);
+            return;
+        }
+        settleFailure(g, view, entry.slot, entry.method, errValue);
         return;
     }
 
     switch (entry.method) {
     // --- Attach chain --------------------------------------------------
-    // First navigate() sends Target.createTarget; each response chains
-    // into the next command by re-adding to m_pending with WTFMove'd
-    // Weak. The chain carries entry.slot (= Navigate) so errors at any
-    // stage reject the right promise. The promise RESOLVES on
-    // Page.loadEventFired — not on any response in this chain.
+    // The first operation on a view sends Target.createTarget; each
+    // response chains into the next command. None of them settles a user
+    // promise: the operations that started the chain, and any issued
+    // while it ran, are parked in m_deferred and written by the last
+    // step. A failure at any stage rejects all of them (failDeferred).
     case Method::TargetCreateTarget: {
         // {"targetId":"<hex>"}
         auto tid = jsonString(jsonField(result, { "targetId", 8 }));
         view->m_targetId = WTF::String::fromUTF8(tid);
         uint32_t cid = nextId();
-        m_pending.add(cid, Pending { Method::TargetAttachToTarget, entry.slot, entry.viewId });
+        m_pending.add(cid, Pending { Method::TargetAttachToTarget, PendingSlot::Attach, entry.viewId });
         send(cid, Command(cid, "Target.attachToTarget"_s).str("targetId"_s, view->m_targetId).boolean("flatten"_s, true));
         return;
     }
@@ -797,32 +886,20 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
 
         // Page.enable lets us receive frameNavigated / loadEventFired.
         // sessionId now available — the remaining chain goes to the page.
-        auto ss = view->m_sessionId.utf8();
-        std::span<const char> sidSpan(ss.data(), ss.length());
         uint32_t cid = nextId();
-        m_pending.add(cid, Pending { Method::PageEnable, entry.slot, entry.viewId });
-        send(cid, Command(cid, "Page.enable"_s, sidSpan));
+        m_pending.add(cid, Pending { Method::PageEnable, PendingSlot::Attach, entry.viewId });
+        send(cid, Command(cid, "Page.enable"_s), sidSpan(view->m_sessionId));
         return;
     }
     case Method::PageEnable: {
-        // Chain into Runtime.enable (for consoleAPICalled later) then
-        // Page.navigate to the stashed url.
-        auto ss = view->m_sessionId.utf8();
-        std::span<const char> sidSpan(ss.data(), ss.length());
-
-        // Runtime.enable — fire-and-forget, untracked. We don't need to
-        // wait for its reply before navigating.
+        // Runtime.enable (for consoleAPICalled later) — fire-and-forget,
+        // untracked. Chrome processes commands in order per session, so
+        // it takes effect before anything drained below.
         uint32_t rid = nextId();
-        send(0, Command(rid, "Runtime.enable"_s, sidSpan));
+        send(0, Command(rid, "Runtime.enable"_s), sidSpan(view->m_sessionId));
 
-        // Page.navigate with the url stashed by the first navigate() call.
-        // The response confirms the navigation STARTED; Page.loadEventFired
-        // confirms completion. We keep the pending entry alive for the
-        // response so errorText rejects the right slot.
-        uint32_t cid = nextId();
-        m_pending.add(cid, Pending { Method::PageNavigate, entry.slot, entry.viewId });
-        send(cid, Command(cid, "Page.navigate"_s, sidSpan).str("url"_s, view->m_pendingChromeNavigateUrl));
-        view->m_pendingChromeNavigateUrl = WTF::String();
+        view->m_chromeAttaching = false;
+        drainDeferred(view);
         return;
     }
     case Method::RuntimeEnable:
@@ -888,7 +965,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         // Chain into navigateToHistoryEntry. Page.loadEventFired settles.
         uint32_t cid = nextId();
         m_pending.add(cid, Pending { Method::PageNavigateToHistoryEntry, entry.slot, entry.viewId });
-        send(cid, Command(cid, "Page.navigateToHistoryEntry"_s, sidSpan(view->m_sessionId)).num("entryId"_s, entryId));
+        send(cid, Command(cid, "Page.navigateToHistoryEntry"_s).num("entryId"_s, entryId), sidSpan(view->m_sessionId));
         return;
     }
     case Method::PageNavigateToHistoryEntry:
@@ -1067,19 +1144,17 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         float cy = strtof(p, nullptr);
 
         // Chain into dispatchMouseEvent. Same down+up pair as Ops::click.
-        auto ss = view->m_sessionId.utf8();
-        std::span<const char> sid(ss.data(), ss.length());
-
+        auto sid = sidSpan(view->m_sessionId);
         auto btn = cdpButton(view->m_selButton);
         int32_t mods = cdpModifiers(view->m_selModifiers);
 
         // Pressed — untracked fire-and-forget.
         uint32_t idDown = nextId();
-        send(0, Command(idDown, "Input.dispatchMouseEvent"_s, sid).raw("type"_s, "\"mousePressed\""_s).num("x"_s, cx).num("y"_s, cy).raw("button"_s, btn).num("clickCount"_s, static_cast<int32_t>(view->m_selClickCount)).num("modifiers"_s, mods));
+        send(0, Command(idDown, "Input.dispatchMouseEvent"_s).raw("type"_s, "\"mousePressed\""_s).num("x"_s, cx).num("y"_s, cy).raw("button"_s, btn).num("clickCount"_s, static_cast<int32_t>(view->m_selClickCount)).num("modifiers"_s, mods), sid);
         // Released — tracked, resolves the slot.
         uint32_t idUp = nextId();
         m_pending.add(idUp, Pending { Method::InputDispatchMouseEvent, entry.slot, entry.viewId });
-        send(idUp, Command(idUp, "Input.dispatchMouseEvent"_s, sid).raw("type"_s, "\"mouseReleased\""_s).num("x"_s, cx).num("y"_s, cy).raw("button"_s, btn).num("clickCount"_s, static_cast<int32_t>(view->m_selClickCount)).num("modifiers"_s, mods));
+        send(idUp, Command(idUp, "Input.dispatchMouseEvent"_s).raw("type"_s, "\"mouseReleased\""_s).num("x"_s, cx).num("y"_s, cy).raw("button"_s, btn).num("clickCount"_s, static_cast<int32_t>(view->m_selClickCount)).num("modifiers"_s, mods), sid);
         return;
     }
 
@@ -1118,6 +1193,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         m_sessions.remove(it);
         JSWebView* view = viewFor(vid);
         m_views.remove(vid);
+        dropDeferred(vid);
         if (!view) return;
         rejectViewSlots(g, view, createError(g, "page detached (crashed or closed)"_s));
         // Erase stale m_pending entries — replies won't come.
@@ -1167,7 +1243,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         view->m_loading = false;
         uint32_t tid = nextId();
         m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
-        send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
+        send(tid, Command(tid, "Runtime.evaluate"_s).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true), sidSpan(view->m_sessionId));
         return;
     }
 
@@ -1328,6 +1404,7 @@ void Transport::rejectAllAndMarkDead(const WTF::String& reason)
     m_mode = TransportMode::None;
     m_wsOpen = false;
     m_wsPending.clear();
+    m_deferred.clear();
     m_pending.clear();
     m_sessions.clear();
     // ~JSWebView() (a GC while settling) removes from m_views; iterate a local.
@@ -1402,8 +1479,8 @@ namespace Ops {
 
 // Allocate promise, store in slot, add to Transport pending map, send frame.
 // Caller guarantees the slot is empty and m_closed == false. Command is
-// moved in; t.send() calls finishAndWrite which zero-copies to the pipe
-// when the body is all-ASCII.
+// moved in; sendToView stamps the session id and writes, or parks the
+// command until the view's attach chain produces one.
 static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
     WriteBarrier<JSPromise>& slot, PendingSlot ps, Method m,
     uint32_t id, Command&& cmd)
@@ -1422,47 +1499,21 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
     v->m_pendingActivityCount.fetch_add(1, std::memory_order_release);
     slot.set(vm, v, promise);
     t.m_pending.add(id, Pending { m, ps, v->m_viewId });
-    t.send(id, WTF::move(cmd));
+    t.sendToView(v, id, WTF::move(cmd));
     t.updateKeepAlive();
     return promise;
 }
 
-// The first navigate() kicks off the attach chain: Target.createTarget
-// (browser-level, no sessionId) → Target.attachToTarget → Page.enable →
-// Page.navigate(url). Each response chains into the next command; the
-// Navigate slot promise resolves on Page.loadEventFired, not on any
-// response. Subsequent navigates skip straight to Page.navigate.
+// Page.navigate. The response confirms the navigation STARTED;
+// Page.loadEventFired resolves the promise. On a view that has not
+// attached yet this parks behind the attach chain, like every other op.
 JSPromise* navigate(JSGlobalObject* g, JSWebView* view, const WTF::String& url)
 {
     auto& t = transport();
-
-    if (!view->m_sessionId.isEmpty()) {
-        uint32_t id = t.nextId();
-        return sendChromeOp(g, view, view->m_pendingNavigate, PendingSlot::Navigate,
-            Method::PageNavigate, id,
-            Command(id, "Page.navigate"_s, sidSpan(view->m_sessionId))
-                .str("url"_s, url));
-    }
-
-    // First navigate: start the chain. Stash url; the PageEnable response
-    // handler in Transport::handleResponse reads it and sends Page.navigate.
-    // The Navigate slot promise is created now; it resolves much later on
-    // Page.loadEventFired. The chain carries the same Weak<view> forward
-    // so the pending activity count keeps this object rooted the whole time.
-    //
-    // newWindow:true is required for width/height — without it Chrome
-    // reuses an existing window and rejects position params. Headless has
-    // no visible window either way; "new window" just means "new top-level
-    // browsing context".
-    view->m_pendingChromeNavigateUrl = url;
     uint32_t id = t.nextId();
     return sendChromeOp(g, view, view->m_pendingNavigate, PendingSlot::Navigate,
-        Method::TargetCreateTarget, id,
-        Command(id, "Target.createTarget"_s)
-            .str("url"_s, "about:blank"_s)
-            .boolean("newWindow"_s, true)
-            .num("width"_s, static_cast<int32_t>(view->m_width))
-            .num("height"_s, static_cast<int32_t>(view->m_height)));
+        Method::PageNavigate, id,
+        Command(id, "Page.navigate"_s).str("url"_s, url));
 }
 
 // Runtime.evaluate with returnByValue + awaitPromise. Chrome JSON-serializes
@@ -1478,7 +1529,7 @@ JSPromise* evaluate(JSGlobalObject* g, JSWebView* view, const WTF::String& scrip
     auto body = makeString("(async()=>{return await ("_s, script, ")})()"_s);
     return sendChromeOp(g, view, view->m_pendingEval, PendingSlot::Evaluate,
         Method::RuntimeEvaluate, id,
-        Command(id, "Runtime.evaluate"_s, sidSpan(view->m_sessionId))
+        Command(id, "Runtime.evaluate"_s)
             .str("expression"_s, body)
             .boolean("returnByValue"_s, true)
             .boolean("awaitPromise"_s, true));
@@ -1493,18 +1544,16 @@ JSPromise* evaluate(JSGlobalObject* g, JSWebView* view, const WTF::String& scrip
 // Response handler JSONParse's the result object and settles with the
 // decoded JSValue — caller gets the same object shape CDP documents.
 //
-// Scoped to the view's sessionId, so commands target THIS tab. Browser-
-// level commands (Target.*, Browser.*) need the sessionId omitted —
-// if m_sessionId is empty (first-navigate chain not yet complete) we send
-// browser-level. For explicit browser-level after attach, the user can
-// construct a second WebView or await Bun-side Target APIs (v2).
+// Scoped to the view's sessionId, so commands target THIS tab. The
+// prototype guard (m_sessionId empty → ERR_INVALID_STATE) means this
+// never parks: the user has already run an operation that attached.
 JSPromise* cdp(JSGlobalObject* g, JSWebView* view, const WTF::String& method, const WTF::String& paramsJson)
 {
     auto& t = transport();
     uint32_t id = t.nextId();
     return sendChromeOp(g, view, view->m_pendingCdp, PendingSlot::Cdp,
         Method::UserRaw, id,
-        Command(Command::RawTag {}, id, method, sidSpan(view->m_sessionId), paramsJson));
+        Command(Command::RawTag {}, id, method, paramsJson));
 }
 
 JSPromise* screenshot(JSGlobalObject* g, JSWebView* view, ScreenshotFormat format, uint8_t quality)
@@ -1523,7 +1572,7 @@ JSPromise* screenshot(JSGlobalObject* g, JSWebView* view, ScreenshotFormat forma
                                                            : "\"png\""_s;
     return sendChromeOp(g, view, view->m_pendingScreenshot, PendingSlot::Screenshot,
         Method::PageCaptureScreenshot, id,
-        Command(id, "Page.captureScreenshot"_s, sidSpan(view->m_sessionId))
+        Command(id, "Page.captureScreenshot"_s)
             .raw("format"_s, fmtLit)
             .num("quality"_s, static_cast<int32_t>(quality)));
 }
@@ -1538,19 +1587,20 @@ JSPromise* screenshot(JSGlobalObject* g, JSWebView* view, ScreenshotFormat forma
 JSPromise* click(JSGlobalObject* g, JSWebView* view, float x, float y, uint8_t button, uint8_t modifiers, uint8_t clickCount)
 {
     auto& t = transport();
-    auto sid = sidSpan(view->m_sessionId);
     auto btn = cdpButton(button);
     int32_t mods = cdpModifiers(modifiers);
 
     // Pressed — untracked. Chrome replies but we don't need the ack; the
-    // Released event's reply confirms both were processed.
+    // Released event's reply confirms both were processed. Parked with
+    // id 0 when the view is still attaching: the pair stays in order and
+    // neither half can be cancelled on its own.
     uint32_t idDown = t.nextId();
-    t.send(0, Command(idDown, "Input.dispatchMouseEvent"_s, sid).raw("type"_s, "\"mousePressed\""_s).num("x"_s, x).num("y"_s, y).raw("button"_s, btn).num("clickCount"_s, static_cast<int32_t>(clickCount)).num("modifiers"_s, mods));
+    t.sendToView(view, 0, Command(idDown, "Input.dispatchMouseEvent"_s).raw("type"_s, "\"mousePressed\""_s).num("x"_s, x).num("y"_s, y).raw("button"_s, btn).num("clickCount"_s, static_cast<int32_t>(clickCount)).num("modifiers"_s, mods));
     // Released — tracked, resolves the promise.
     uint32_t idUp = t.nextId();
     return sendChromeOp(g, view, view->m_pendingMisc, PendingSlot::Misc,
         Method::InputDispatchMouseEvent, idUp,
-        Command(idUp, "Input.dispatchMouseEvent"_s, sid)
+        Command(idUp, "Input.dispatchMouseEvent"_s)
             .raw("type"_s, "\"mouseReleased\""_s)
             .num("x"_s, x)
             .num("y"_s, y)
@@ -1581,7 +1631,7 @@ JSPromise* clickSelector(JSGlobalObject* g, JSWebView* view, const WTF::String& 
     uint32_t id = t.nextId();
     return sendChromeOp(g, view, view->m_pendingMisc, PendingSlot::Misc,
         Method::ClickSelectorEval, id,
-        Command(id, "Runtime.evaluate"_s, sidSpan(view->m_sessionId))
+        Command(id, "Runtime.evaluate"_s)
             .str("expression"_s, sb.toString())
             .boolean("returnByValue"_s, true)
             .boolean("awaitPromise"_s, true));
@@ -1602,7 +1652,7 @@ JSPromise* scrollTo(JSGlobalObject* g, JSWebView* view, const WTF::String& selec
     uint32_t id = t.nextId();
     return sendChromeOp(g, view, view->m_pendingMisc, PendingSlot::Misc,
         Method::ScrollToSelectorEval, id,
-        Command(id, "Runtime.evaluate"_s, sidSpan(view->m_sessionId))
+        Command(id, "Runtime.evaluate"_s)
             .str("expression"_s, sb.toString())
             .boolean("returnByValue"_s, true)
             .boolean("awaitPromise"_s, true));
@@ -1616,7 +1666,7 @@ JSPromise* type(JSGlobalObject* g, JSWebView* view, const WTF::String& text)
     // InsertText does — inserts text at the caret without keydown events.
     return sendChromeOp(g, view, view->m_pendingMisc, PendingSlot::Misc,
         Method::InputInsertText, id,
-        Command(id, "Input.insertText"_s, sidSpan(view->m_sessionId))
+        Command(id, "Input.insertText"_s)
             .str("text"_s, text));
 }
 
@@ -1656,7 +1706,6 @@ static const CDPKeyInfo& cdpKeyInfo(uint8_t k)
 JSPromise* press(JSGlobalObject* g, JSWebView* view, uint8_t key, uint8_t modifiers, const WTF::String& character)
 {
     auto& t = transport();
-    auto sid = sidSpan(view->m_sessionId);
     int32_t mods = cdpModifiers(modifiers);
     const auto& info = cdpKeyInfo(key);
 
@@ -1677,12 +1726,12 @@ JSPromise* press(JSGlobalObject* g, JSWebView* view, uint8_t key, uint8_t modifi
     // fired if text present) by the time we get the reply. No _doAfter*
     // dance like WKWebView's press().
     uint32_t idDown = t.nextId();
-    t.send(0, Command(idDown, "Input.dispatchKeyEvent"_s, sid).raw("type"_s, hasText ? "\"keyDown\""_s : "\"rawKeyDown\""_s).str("key"_s, keyStr).str("text"_s, textStr).num("windowsVirtualKeyCode"_s, info.vk).num("modifiers"_s, mods));
+    t.sendToView(view, 0, Command(idDown, "Input.dispatchKeyEvent"_s).raw("type"_s, hasText ? "\"keyDown\""_s : "\"rawKeyDown\""_s).str("key"_s, keyStr).str("text"_s, textStr).num("windowsVirtualKeyCode"_s, info.vk).num("modifiers"_s, mods));
     // keyUp — tracked, resolves the promise.
     uint32_t idUp = t.nextId();
     return sendChromeOp(g, view, view->m_pendingMisc, PendingSlot::Misc,
         Method::InputDispatchKeyEvent, idUp,
-        Command(idUp, "Input.dispatchKeyEvent"_s, sid)
+        Command(idUp, "Input.dispatchKeyEvent"_s)
             .raw("type"_s, "\"keyUp\""_s)
             .str("key"_s, keyStr)
             .num("windowsVirtualKeyCode"_s, info.vk)
@@ -1697,7 +1746,7 @@ JSPromise* scroll(JSGlobalObject* g, JSWebView* view, double dx, double dy)
     // reply means the scroll was processed.
     return sendChromeOp(g, view, view->m_pendingMisc, PendingSlot::Misc,
         Method::InputDispatchMouseEvent, id,
-        Command(id, "Input.dispatchMouseEvent"_s, sidSpan(view->m_sessionId))
+        Command(id, "Input.dispatchMouseEvent"_s)
             .raw("type"_s, "\"mouseWheel\""_s)
             .num("x"_s, view->m_width / 2.0)
             .num("y"_s, view->m_height / 2.0)
@@ -1713,7 +1762,7 @@ JSPromise* resize(JSGlobalObject* g, JSWebView* view, uint32_t width, uint32_t h
     uint32_t id = t.nextId();
     return sendChromeOp(g, view, view->m_pendingMisc, PendingSlot::Misc,
         Method::EmulationSetDeviceMetricsOverride, id,
-        Command(id, "Emulation.setDeviceMetricsOverride"_s, sidSpan(view->m_sessionId))
+        Command(id, "Emulation.setDeviceMetricsOverride"_s)
             .num("width"_s, static_cast<int32_t>(width))
             .num("height"_s, static_cast<int32_t>(height))
             .num("deviceScaleFactor"_s, 1)
@@ -1733,7 +1782,7 @@ static JSPromise* historyGo(JSGlobalObject* g, JSWebView* view, int8_t delta)
     // Page.loadEventFired settles PendingSlot::Navigate only.
     return sendChromeOp(g, view, view->m_pendingNavigate, PendingSlot::Navigate,
         Method::PageGetNavigationHistory, id,
-        Command(id, "Page.getNavigationHistory"_s, sidSpan(view->m_sessionId)));
+        Command(id, "Page.getNavigationHistory"_s));
 }
 
 JSPromise* goBack(JSGlobalObject* g, JSWebView* view) { return historyGo(g, view, -1); }
@@ -1749,7 +1798,7 @@ JSPromise* reload(JSGlobalObject* g, JSWebView* view)
     // Op::Reload Ack is synchronous.
     return sendChromeOp(g, view, view->m_pendingNavigate, PendingSlot::Navigate,
         Method::PageReload, id,
-        Command(id, "Page.reload"_s, sidSpan(view->m_sessionId)));
+        Command(id, "Page.reload"_s));
 }
 
 void close(JSWebView* view)
@@ -1757,16 +1806,17 @@ void close(JSWebView* view)
     auto& t = transport();
     if (auto* g = t.m_global) rejectViewSlotsAsHandled(g, view, createError(g, "WebView closed"_s));
     // Prune m_pending entries for this view — the attach chain
-    // (TargetCreateTarget → TargetAttachToTarget → PageEnable →
-    // PageNavigate) holds Weak<view> per step and each step chains to the
-    // next on reply. If close() lands mid-chain, the next reply would
-    // continue on a closed view: m_sessions.add re-registers it,
-    // PageEnable sends Page.navigate, the tab navigates after dispose.
-    // removeIf breaks the chain at the next reply — handleResponse's
-    // find(id)==end() early-return drops it.
+    // (TargetCreateTarget → TargetAttachToTarget → PageEnable) chains to
+    // the next command on each reply. If close() lands mid-chain, the
+    // next reply would continue on a closed view: m_sessions.add
+    // re-registers it, and the commands parked behind the chain reach
+    // the tab after dispose. removeIf breaks the chain at the next
+    // reply — handleResponse's find(id)==end() early-return drops it —
+    // and dropDeferred forgets what was parked.
     t.m_pending.removeIf([vid = view->m_viewId](auto& pair) {
         return pair.value.viewId == vid;
     });
+    t.dropDeferred(view->m_viewId);
     // Target.closeTarget — fire-and-forget. targetId is stashed at
     // TargetCreateTarget's reply (before sessionId) so it's populated
     // earlier in the chain. Chrome tears down the tab; we ignore the

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1559,8 +1559,9 @@ JSPromise* evaluate(JSGlobalObject* g, JSWebView* view, const WTF::String& scrip
 // decoded JSValue — caller gets the same object shape CDP documents.
 //
 // Scoped to the view's sessionId, so commands target THIS tab. The
-// prototype guard (m_sessionId empty → ERR_INVALID_STATE) means this
-// never parks: the user has already run an operation that attached.
+// prototype guard (m_sessionId empty → ERR_INVALID_STATE) lets this
+// through once Target.attachToTarget has answered; if Page.enable has
+// not, it parks like any other op and goes out in order.
 JSPromise* cdp(JSGlobalObject* g, JSWebView* view, const WTF::String& method, const WTF::String& paramsJson)
 {
     auto& t = transport();

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -74,18 +74,15 @@ std::span<const char> jsonString(std::span<const char> field);
 // StringBuilder::appendQuotedJSONString is the one escape hatch — it's
 // WTF's own JSON string quoter (handles control chars, quotes, backslash,
 // non-BMP). Every user-controlled string goes through it.
+//
+// The session id is NOT a constructor argument: it is stamped at finish
+// time. A command built before its view attached has no session id yet,
+// and Transport parks it until the attach chain produces one.
 class Command {
 public:
-    Command(uint32_t id, ASCIILiteral method, std::span<const char> sessionId = {})
+    Command(uint32_t id, ASCIILiteral method)
     {
-        m_sb.append("{\"id\":"_s, id, ",\"method\":\""_s, method, "\""_s);
-        if (!sessionId.empty()) {
-            m_sb.append(",\"sessionId\":\""_s);
-            m_sb.append(std::span<const Latin1Character>(
-                reinterpret_cast<const Latin1Character*>(sessionId.data()), sessionId.size()));
-            m_sb.append('"');
-        }
-        m_sb.append(",\"params\":{"_s);
+        m_sb.append("{\"id\":"_s, id, ",\"method\":\""_s, method, "\""_s, ",\"params\":{"_s);
     }
 
     // Raw passthrough — user-provided method string and pre-serialized
@@ -93,26 +90,14 @@ public:
     // method goes through appendQuotedJSONString (a user can pass
     // `Page.navigate"` with a stray quote — the method string IS user input
     // for this entry point). paramsJson is trusted JSON — it came from
-    // JSON.stringify which guarantees well-formed output. The builder's
-    // finishAndWrite appends the closing }} so paramsJson must be the inner
-    // object without the outer braces; we write it verbatim and skip the
-    // normal str()/num() comma machinery.
+    // JSON.stringify which guarantees well-formed output. It is the
+    // complete params object, so set m_paramsRaw: finish() then skips the
+    // implicit params brace and the normal str()/num() comma machinery.
     struct RawTag {};
-    Command(RawTag, uint32_t id, const WTF::String& method, std::span<const char> sessionId, const WTF::String& paramsJson)
+    Command(RawTag, uint32_t id, const WTF::String& method, const WTF::String& paramsJson)
     {
         m_sb.append("{\"id\":"_s, id, ",\"method\":"_s);
         m_sb.appendQuotedJSONString(method);
-        if (!sessionId.empty()) {
-            m_sb.append(",\"sessionId\":\""_s);
-            m_sb.append(std::span<const Latin1Character>(
-                reinterpret_cast<const Latin1Character*>(sessionId.data()), sessionId.size()));
-            m_sb.append('"');
-        }
-        // paramsJson is an object or {} — the user passed `params` or
-        // nothing. JSON.stringify already handled escapes/encoding. We
-        // write `,"params":` then the verbatim JSON, then cheat: set
-        // m_paramsRaw so finishAndWrite appends a single } (the frame
-        // close) instead of }} (frame close + our implicit params brace).
         m_sb.append(",\"params\":"_s);
         m_sb.append(paramsJson);
         m_paramsRaw = true;
@@ -180,19 +165,16 @@ public:
     // into the String if nothing else holds a ref — zero-copy for the
     // 8-bit-ASCII case (our templates are ASCII, user strings go
     // through appendQuotedJSONString which produces ASCII escapes).
-    WTF::String finishToString()
+    WTF::String finishToString(std::span<const char> sessionId)
     {
-        m_sb.append(m_paramsRaw ? "}"_s : "}}"_s);
+        finish(sessionId);
         return m_sb.toString();
     }
 
     template<typename Sink> // void(const char*, size_t)
-    void finishAndWrite(Sink&& sink)
+    void finishAndWrite(Sink&& sink, std::span<const char> sessionId)
     {
-        // RawTag constructor already wrote the complete params object;
-        // only the outer frame brace remains. Normal path needs both the
-        // params brace and the frame brace.
-        m_sb.append(m_paramsRaw ? "}"_s : "}}"_s);
+        finish(sessionId);
         if (m_sb.is8Bit()) [[likely]] {
             auto s = m_sb.span8();
             // OR-accumulate: all bytes < 0x80 → no high bit → valid ASCII.
@@ -213,6 +195,21 @@ public:
     }
 
 private:
+    // Close the params object, then the frame. The session id goes last:
+    // CDP reads JSON, where key order carries no meaning, so a command
+    // built before its session existed can still be routed to it.
+    void finish(std::span<const char> sessionId)
+    {
+        if (!m_paramsRaw) m_sb.append('}');
+        if (!sessionId.empty()) {
+            m_sb.append(",\"sessionId\":\""_s);
+            m_sb.append(std::span<const Latin1Character>(
+                reinterpret_cast<const Latin1Character*>(sessionId.data()), sessionId.size()));
+            m_sb.append('"');
+        }
+        m_sb.append('}');
+    }
+
     void comma()
     {
         if (m_hasParam) m_sb.append(',');
@@ -229,9 +226,9 @@ private:
 // the method string. Adding a method means adding a tag + a handler arm.
 //
 // TargetCreateTarget + TargetAttachToTarget + PageEnable form an internal
-// chain kicked off by the first navigate() on a view. Their responses
-// don't settle a user promise; the last one (PageEnable) sends the actual
-// Page.navigate and the promise resolves on Page.loadEventFired.
+// chain kicked off by the first operation on a view. Their responses
+// don't settle a user promise; the last one (PageEnable) writes every
+// command parked while the chain ran.
 enum class Method : uint8_t {
     // Internal attach chain — responses chain into the next command.
     TargetCreateTarget,
@@ -341,6 +338,10 @@ enum class PendingSlot : uint8_t {
     // resize/goBack/etc. Still one-at-a-time (slot model, not id-keyed
     // promise map) — lift in v2 when/if someone needs burst CDP.
     Cdp,
+    // The attach chain's own commands. They settle no user promise, so
+    // this names no barrier. A chain failure rejects every parked
+    // operation instead (Transport::failDeferred).
+    Attach,
 };
 
 // Per-CDP-id pending entry. viewId indirects through Transport::m_views
@@ -409,7 +410,14 @@ public:
     // Pipe mode: NUL-delimited via writeRaw. WebSocket mode: one text
     // frame via sendTextNative, or queue with its CDP id pre-open so
     // close() can cancel (m_pending.removeIf erases the id, drain skips).
-    void send(uint32_t cdpId, Command&& cmd);
+    // An empty sessionId makes it a browser-level command (Target.*).
+    void send(uint32_t cdpId, Command&& cmd, std::span<const char> sessionId = {});
+
+    // Write a command that belongs to one view's CDP session. Before the
+    // session exists (no operation has run yet) the frame cannot be
+    // built: park it and start the attach chain. drainDeferred stamps the
+    // session id on every parked command once the chain completes.
+    void sendToView(JSWebView*, uint32_t cdpId, Command&& cmd);
 
     // Both transports' receive path: parses complete NUL-delimited messages
     // out of rx, dispatches each to handleMessage.
@@ -442,6 +450,21 @@ public:
         WTF::String body;
     };
     WTF::Vector<WsPendingCmd> m_wsPending;
+    // Commands parked while a view's attach chain runs. Every operation
+    // needs the view's session id, which only Target.attachToTarget can
+    // provide, so the ones issued before it answers wait here in the
+    // order the user made them. At most one per slot per attaching view.
+    //
+    // id is the CDP id the command carries, or 0 for the untracked half
+    // of a pair (click's mousePressed). Nonzero ids that Ops::close()
+    // already erased from m_pending are dropped instead of sent, the
+    // same cancellation check wsOnOpen's drain does.
+    struct DeferredCmd {
+        uint32_t viewId;
+        uint32_t id;
+        Command cmd;
+    };
+    WTF::Vector<DeferredCmd> m_deferred;
     bool m_wsOpen = false;
     // True when ensureConnected was called from auto-detect (the
     // constructor read DevToolsActivePort) — gates the stale-file
@@ -480,6 +503,19 @@ public:
     void rejectAllAndMarkDead(const WTF::String& reason);
     void updateKeepAlive();
     void writeRaw(const char* data, size_t len);
+
+    // Target.createTarget → Target.attachToTarget → Page.enable. Started
+    // by the first operation on a view, once.
+    void beginAttach(JSWebView*);
+    // Write every command parked for this view, in issue order, now that
+    // it has a session id.
+    void drainDeferred(JSWebView*);
+    // The attach chain failed: reject each parked operation's slot with
+    // the CDP error, so the user sees the failure instead of a promise
+    // that never settles.
+    void failDeferred(JSWebView*, JSC::JSValue error);
+    // Forget a view's parked commands (close, detach, transport death).
+    void dropDeferred(uint32_t viewId);
 
     // Resolve viewId → JSWebView* through m_views. Null if the view was
     // collected (user dropped both the view and its awaited promise —

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -413,10 +413,8 @@ public:
     // An empty sessionId makes it a browser-level command (Target.*).
     void send(uint32_t cdpId, Command&& cmd, std::span<const char> sessionId = {});
 
-    // Write a command that belongs to one view's CDP session. Before the
-    // session exists (no operation has run yet) the frame cannot be
-    // built: park it and start the attach chain. drainDeferred stamps the
-    // session id on every parked command once the chain completes.
+    // Write a command that belongs to one view's CDP session, or park it
+    // and start the attach chain when the view has no session yet.
     void sendToView(JSWebView*, uint32_t cdpId, Command&& cmd);
 
     // Both transports' receive path: parses complete NUL-delimited messages
@@ -450,15 +448,12 @@ public:
         WTF::String body;
     };
     WTF::Vector<WsPendingCmd> m_wsPending;
-    // Commands parked while a view's attach chain runs. Every operation
-    // needs the view's session id, which only Target.attachToTarget can
-    // provide, so the ones issued before it answers wait here in the
-    // order the user made them. At most one per slot per attaching view.
+    // Commands parked while a view's attach chain runs, in the order the
+    // user issued them. At most one per slot per attaching view.
     //
-    // id is the CDP id the command carries, or 0 for the untracked half
-    // of a pair (click's mousePressed). Nonzero ids that Ops::close()
-    // already erased from m_pending are dropped instead of sent, the
-    // same cancellation check wsOnOpen's drain does.
+    // id is the command's CDP id, or 0 for the untracked half of a pair
+    // (click's mousePressed). A nonzero id that Ops::close() erased from
+    // m_pending is dropped instead of sent, like wsOnOpen's drain.
     struct DeferredCmd {
         uint32_t viewId;
         uint32_t id;
@@ -504,15 +499,14 @@ public:
     void updateKeepAlive();
     void writeRaw(const char* data, size_t len);
 
-    // Target.createTarget → Target.attachToTarget → Page.enable. Started
-    // by the first operation on a view, once.
+    // Target.createTarget → Target.attachToTarget → Page.enable, once
+    // per view.
     void beginAttach(JSWebView*);
-    // Write every command parked for this view, in issue order, now that
-    // it has a session id.
+    // Write what the view parked, in issue order, now that it has a
+    // session id.
     void drainDeferred(JSWebView*);
-    // The attach chain failed: reject each parked operation's slot with
-    // the CDP error, so the user sees the failure instead of a promise
-    // that never settles.
+    // The chain failed: reject each parked operation's slot with the CDP
+    // error instead of leaving its promise unsettled.
     void failDeferred(JSWebView*, JSC::JSValue error);
     // Forget a view's parked commands (close, detach, transport death).
     void dropDeferred(uint32_t viewId);

--- a/src/runtime/webview/JSWebView.cpp
+++ b/src/runtime/webview/JSWebView.cpp
@@ -132,7 +132,10 @@ JSWebView::~JSWebView()
             auto it = t.m_sessions.find(m_sessionId);
             if (it != t.m_sessions.end() && it->value == m_viewId) t.m_sessions.remove(it);
         }
-        if (m_viewId) t.m_views.remove(m_viewId);
+        if (m_viewId) {
+            t.m_views.remove(m_viewId);
+            t.dropDeferred(m_viewId);
+        }
         t.updateKeepAlive();
         return;
     }
@@ -383,9 +386,9 @@ JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
     // dereferences through this — m_pending and m_sessions hold just the
     // viewId, not their own Weaks. Mirrors WebKit's HostClient::viewsById.
     view->m_viewId = t.registerView(view);
-    // Target.createTarget deferred to first navigate() — keeps the constructor
-    // synchronous and the attach chain owned by the navigate promise (which
-    // resolves on Page.loadEventFired, so one await covers the whole sequence).
+    // Target.createTarget is deferred to the first operation — the
+    // constructor stays synchronous, and a view nobody uses opens no tab
+    // and keeps no event-loop reference.
     return view;
 }
 

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -90,14 +90,14 @@ public:
     bool m_loading = false;
 
     // Chrome session state. Empty until the Target.createTarget →
-    // Target.attachToTarget → Page.enable chain completes (driven by the
-    // first navigate()). sessionId routes commands; targetId is for
-    // Target.closeTarget. The chain stashes the navigate URL here so the
-    // final step can send Page.navigate; subsequent navigates read
-    // m_sessionId directly and skip the chain.
+    // Target.attachToTarget → Page.enable chain completes (started by the
+    // first operation on this view). sessionId routes commands; targetId
+    // is for Target.closeTarget. Operations issued while the chain runs
+    // wait in Transport::m_deferred; m_chromeAttaching keeps the chain
+    // from being started twice.
     WTF::String m_sessionId;
     WTF::String m_targetId;
-    WTF::String m_pendingChromeNavigateUrl;
+    bool m_chromeAttaching = false;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -360,14 +360,12 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncCdp, (JSGlobalObject * globalObject, 
         return Bun::throwError(globalObject, scope, ErrorCode::ERR_METHOD_NOT_IMPLEMENTED,
             "WebView.cdp() requires backend: \"chrome\""_s);
 
-    // Must have attached (first navigate() completes the target→session
-    // chain). Before attach there's no sessionId; a browser-level CDP
-    // command here would reach the wrong target. The user can `await
-    // navigate(...)` first to get a session, or use Bun.WebView.chrome()
-    // for browser-level commands (v2).
+    // The raw escape hatch asks for a session up front instead of starting
+    // the attach chain itself: the first awaited operation of any kind
+    // (navigate(), evaluate(), ...) produces one.
     if (thisObject->m_sessionId.isEmpty())
         return Bun::ERR::INVALID_STATE(scope, globalObject,
-            "WebView.cdp(): no session - await navigate() first"_s);
+            "WebView.cdp(): no session yet - await another operation (such as navigate()) first"_s);
 
     JSValue methodArg = callFrame->argument(0);
     if (!methodArg.isString())

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -80,7 +80,11 @@ function send(message: unknown) {
 
 let targets = 0;
 let loads = 0;
+// The last page any session committed, in command arrival order: what
+// __fake_url() reports. Each session's own current page, which is what
+// Page.reload loads again, is in committedUrl.
 let lastUrl = "about:blank";
+const committedUrl = new Map<string, string>();
 // Chrome sends a domain's events only to sessions that enabled it, so a
 // session whose Page.enable failed gets no frameNavigated and no
 // loadEventFired.
@@ -92,6 +96,7 @@ async function handle(command: { id: number; method: string; params?: any; sessi
   const event = (name: string, eventParams: unknown) => send({ method: name, params: eventParams, sessionId });
   const committed = (url: string) => {
     lastUrl = url;
+    committedUrl.set(sessionId!, url);
     const loaderId = "L" + ++loads;
     if (!pageEnabled.has(sessionId!)) return loaderId;
     event("Page.frameNavigated", { frame: { id: "F", loaderId, url, mimeType: "text/html" } });
@@ -125,7 +130,7 @@ async function handle(command: { id: number; method: string; params?: any; sessi
     }
     case "Page.reload": {
       reply({});
-      committed(lastUrl);
+      committed(committedUrl.get(sessionId!) ?? "about:blank");
       return;
     }
     case "Page.enable": {

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -34,11 +34,25 @@ const navigateError = process.argv.find(a => a.startsWith("--navigate-error="))?
 // Page.navigate for a URL it cannot parse.
 const cdpErrorOn = process.argv.find(a => a.startsWith("--cdp-error-on="))?.slice("--cdp-error-on=".length);
 
+// `--cdp-error-once=<method>`: the same, for the first call only. A retry
+// of whatever failed then gets through.
+let cdpErrorOnce = process.argv.find(a => a.startsWith("--cdp-error-once="))?.slice("--cdp-error-once=".length);
+
+// `--event-before-page-enable`: emit a session event just before the
+// Page.enable reply, so the runtime runs a listener while the attach
+// chain has a sessionId but has not finished.
+const eventBeforePageEnable = process.argv.includes("--event-before-page-enable");
+
 const NO_REPLY = Symbol("no reply");
 let commandsClosed = false;
 Object.assign(globalThis, {
   __fake_exit(code: number): never {
     process.exit(code);
+  },
+  // The page the last Page.navigate committed, as this process saw the
+  // commands arrive. Tells a test where its evaluate landed in the order.
+  __fake_url() {
+    return lastUrl;
   },
   // The command gets no reply, ever.
   __fake_no_reply() {
@@ -80,7 +94,8 @@ async function handle(command: { id: number; method: string; params?: any; sessi
     return loaderId;
   };
 
-  if (method === cdpErrorOn) {
+  if (method === cdpErrorOn || method === cdpErrorOnce) {
+    if (method === cdpErrorOnce) cdpErrorOnce = undefined;
     const error = { code: -32000, message: "Cannot navigate to invalid URL" };
     return send(sessionId ? { id, error, sessionId } : { id, error });
   }
@@ -108,6 +123,13 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       committed(lastUrl);
       return;
     }
+    case "Page.enable": {
+      // The event reaches the runtime while the view has a sessionId and
+      // an unfinished attach chain: anything a listener starts there has
+      // to queue behind what the user asked for first.
+      if (eventBeforePageEnable) event("Page.frameStartedLoading", { frameId: "F" });
+      return reply({});
+    }
     case "Page.captureScreenshot":
       return reply({ data: screenshotBase64 });
     case "Runtime.evaluate": {
@@ -129,7 +151,7 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       return reply({ result: { type: typeof value, value } });
     }
     default:
-      // Page.enable, Runtime.enable, Target.closeTarget, Input.*: nothing to say.
+      // Runtime.enable, Target.closeTarget, Input.*: nothing to say.
       return reply({});
   }
 }

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -81,6 +81,10 @@ function send(message: unknown) {
 let targets = 0;
 let loads = 0;
 let lastUrl = "about:blank";
+// Chrome sends a domain's events only to sessions that enabled it, so a
+// session whose Page.enable failed gets no frameNavigated and no
+// loadEventFired.
+const pageEnabled = new Set<string>();
 
 async function handle(command: { id: number; method: string; params?: any; sessionId?: string }) {
   const { id, method, params = {}, sessionId } = command;
@@ -89,6 +93,7 @@ async function handle(command: { id: number; method: string; params?: any; sessi
   const committed = (url: string) => {
     lastUrl = url;
     const loaderId = "L" + ++loads;
+    if (!pageEnabled.has(sessionId!)) return loaderId;
     event("Page.frameNavigated", { frame: { id: "F", loaderId, url, mimeType: "text/html" } });
     event("Page.loadEventFired", { timestamp: loads });
     return loaderId;
@@ -124,6 +129,7 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       return;
     }
     case "Page.enable": {
+      pageEnabled.add(sessionId!);
       // The event reaches the runtime while the view has a sessionId and
       // an unfinished attach chain: anything a listener starts there has
       // to queue behind what the user asked for first.

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -66,15 +66,30 @@ function send(message: unknown) {
 
 let targets = 0;
 let loads = 0;
+let lastUrl = "about:blank";
 
 async function handle(command: { id: number; method: string; params?: any; sessionId?: string }) {
   const { id, method, params = {}, sessionId } = command;
   const reply = (result: unknown) => send(sessionId ? { id, result, sessionId } : { id, result });
   const event = (name: string, eventParams: unknown) => send({ method: name, params: eventParams, sessionId });
+  const committed = (url: string) => {
+    lastUrl = url;
+    const loaderId = "L" + ++loads;
+    event("Page.frameNavigated", { frame: { id: "F", loaderId, url, mimeType: "text/html" } });
+    event("Page.loadEventFired", { timestamp: loads });
+    return loaderId;
+  };
 
   if (method === cdpErrorOn) {
     const error = { code: -32000, message: "Cannot navigate to invalid URL" };
     return send(sessionId ? { id, error, sessionId } : { id, error });
+  }
+
+  // The browser endpoint carries Target.* and Browser.* only. Every other
+  // domain lives on a target's session, so Chrome answers a command that
+  // arrives with no sessionId the same way it answers an unknown method.
+  if (!sessionId && !method.startsWith("Target.") && !method.startsWith("Browser.")) {
+    return send({ id, error: { code: -32601, message: `'${method}' wasn't found` } });
   }
 
   switch (method) {
@@ -84,10 +99,13 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       return reply({ sessionId: "S" + params.targetId.slice(1) });
     case "Page.navigate": {
       if (navigateError) return reply({ frameId: "F", errorText: navigateError });
-      const loaderId = "L" + ++loads;
-      reply({ frameId: "F", loaderId });
-      event("Page.frameNavigated", { frame: { id: "F", loaderId, url: params.url, mimeType: "text/html" } });
-      event("Page.loadEventFired", { timestamp: loads });
+      reply({ frameId: "F", loaderId: "L" + (loads + 1) });
+      committed(params.url);
+      return;
+    }
+    case "Page.reload": {
+      reply({});
+      committed(lastUrl);
       return;
     }
     case "Page.captureScreenshot":

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -74,6 +74,119 @@ test.concurrent("navigate, events and evaluate cross the pipes", async () => {
   });
 });
 
+// A view has no CDP session until Target.createTarget → attachToTarget →
+// Page.enable has run, and every Page.*, Runtime.*, Input.* and
+// Emulation.* command needs one. The operation that finds no session
+// starts that chain and waits for it, whichever operation it is. Sending
+// the command without a session id would reach the browser endpoint,
+// where those domains do not exist, and Chrome would answer
+// "'Runtime.evaluate' wasn't found".
+test.concurrent("the first operation attaches the view instead of going to the browser endpoint", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    // No navigate() first: this evaluate has to attach the view itself.
+    const value = await view.evaluate("6 * 7");
+    const navigated = await outcome(view.navigate("http://fake/after"));
+    print({ value, navigated, url: view.url, title: view.title });
+    view.close();
+  `);
+  expect(result).toEqual({
+    value: 42,
+    navigated: {}, // resolves undefined
+    url: "http://fake/after",
+    title: "fake chrome",
+  });
+});
+
+test.concurrent("every operation kind works as the first one on a view", async () => {
+  const result = await runScenario(`
+    // JSON keeps no undefined, so name the void resolution.
+    const settled = promise => promise.then(value => (value === undefined ? "resolved" : value), e => "rejected: " + e.message);
+    const first = {
+      evaluate: view => view.evaluate("'ok'"),
+      screenshot: view => view.screenshot({ encoding: "base64" }).then(shot => shot.length > 0),
+      click: view => view.click(5, 5),
+      type: view => view.type("hello"),
+      press: view => view.press("Enter"),
+      scroll: view => view.scroll(0, 10),
+      resize: view => view.resize(120, 90),
+      reload: view => view.reload(),
+      goBack: view => view.goBack(),
+      navigate: view => view.navigate("http://fake/first"),
+    };
+    const results = {};
+    for (const [name, run] of Object.entries(first)) {
+      const view = newView();
+      results[name] = await settled(run(view));
+      view.close();
+    }
+    print(results);
+  `);
+  expect(result).toEqual({
+    evaluate: "ok",
+    screenshot: true,
+    click: "resolved",
+    type: "resolved",
+    press: "resolved",
+    scroll: "resolved",
+    resize: "resolved",
+    reload: "resolved",
+    goBack: "resolved",
+    navigate: "resolved",
+  });
+});
+
+// One chain serves every operation issued while it runs: they wait for
+// the session instead of each starting an attach of their own.
+test.concurrent("operations issued while the view attaches all complete", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    const settled = await Promise.all([
+      outcome(view.evaluate("'during'")),
+      outcome(view.navigate("http://fake/during")),
+      outcome(view.resize(300, 200)),
+    ]);
+    print({ settled, url: view.url, title: view.title });
+    view.close();
+  `);
+  expect(result).toEqual({
+    settled: [{ resolved: "during" }, {}, {}],
+    url: "http://fake/during",
+    title: "fake chrome",
+  });
+});
+
+// The attach chain settles no promise of its own, so a failure in it has
+// to reach every operation parked behind it. "Cannot navigate to invalid
+// URL" is the fake's one canned protocol error, here on attachToTarget.
+test.concurrent("an attach failure rejects every operation waiting on it", async () => {
+  const result = await runScenario(`
+    const view = new Bun.WebView({
+      backend: { ...backend, argv: [...backend.argv, "--cdp-error-on=Target.attachToTarget"] },
+      width: 100,
+      height: 100,
+    });
+    // click() parks two commands, and only the second one owns a slot.
+    const failed = await Promise.all([
+      outcome(view.evaluate("1")),
+      outcome(view.navigate("http://fake/nope")),
+      outcome(view.screenshot()),
+      outcome(view.click(5, 5)),
+    ]);
+    print({ failed, loading: view.loading });
+    view.close();
+  `);
+  expect(result).toEqual({
+    failed: [
+      { rejected: "Cannot navigate to invalid URL" },
+      { rejected: "Cannot navigate to invalid URL" },
+      { rejected: "Cannot navigate to invalid URL" },
+      { rejected: "Cannot navigate to invalid URL" },
+    ],
+    loading: false,
+  });
+});
+
 test.concurrent("a reply larger than the read buffer is reassembled", async () => {
   const result = await runScenario(`
     const view = newView();

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -243,6 +243,32 @@ test.concurrent("navigate() retried from onNavigationFailed after an attach fail
   });
 });
 
+// A chain that fails after Target.attachToTarget leaves a session that
+// Page.enable never reached. Chrome sends that session no load event, so
+// the failure has to forget it: otherwise the next operation takes the
+// attached path on it and its promise never settles. The fake fails
+// Page.enable once and, like Chrome, only emits Page events to sessions
+// that enabled the domain.
+test.concurrent("an operation after a Page.enable failure attaches a new session", async () => {
+  const result = await runScenario(`
+    const view = new Bun.WebView({
+      backend: { ...backend, argv: [...backend.argv, "--cdp-error-once=Page.enable"] },
+      width: 100,
+      height: 100,
+    });
+    const failed = await outcome(view.navigate("http://fake/first"));
+    const retried = await outcome(view.navigate("http://fake/retry"));
+    print({ failed, retried, url: view.url, title: view.title });
+    view.close();
+  `);
+  expect(result).toEqual({
+    failed: { rejected: "Cannot navigate to invalid URL" },
+    retried: {}, // resolves undefined
+    url: "http://fake/retry",
+    title: "fake chrome",
+  });
+});
+
 test.concurrent("a reply larger than the read buffer is reassembled", async () => {
   const result = await runScenario(`
     const view = newView();

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -160,7 +160,7 @@ test.concurrent("operations issued while the view attaches all complete", async 
 // user never sees a promise for. The next operation has to wait behind
 // it like behind an explicit navigate(): the fake reports which page it
 // had committed when the evaluate reached it.
-test.concurrent("an operation right after new Bun.WebView({ url }) waits behind the constructor navigation", async () => {
+test.concurrent("an operation after new Bun.WebView({ url }) waits behind that navigation", async () => {
   const result = await runScenario(`
     const view = new Bun.WebView({ backend, width: 100, height: 100, url: "http://fake/ctor" });
     const urlWhenTheEvaluateRan = await outcome(view.evaluate("__fake_url()"));

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -156,6 +156,32 @@ test.concurrent("operations issued while the view attaches all complete", async 
   });
 });
 
+// Target.attachToTarget answers one reply before Page.enable, so there
+// is a window where the view has a session id and an unfinished chain.
+// An operation started in that window still goes out behind the ones
+// already waiting. The fake emits an event in exactly that window and
+// reports, from its own process, which command it saw first.
+test.concurrent("an operation started while the chain finishes stays behind the parked ones", async () => {
+  const result = await runScenario(`
+    const view = new Bun.WebView({
+      backend: { ...backend, argv: [...backend.argv, "--event-before-page-enable"] },
+      width: 100,
+      height: 100,
+    });
+    let inWindow;
+    view.addEventListener("Page.frameStartedLoading", () => {
+      inWindow ??= view.evaluate("__fake_url()");
+    });
+    const navigated = await outcome(view.navigate("http://fake/first"));
+    print({ navigated, urlWhenTheEvaluateRan: await inWindow });
+    view.close();
+  `);
+  expect(result).toEqual({
+    navigated: {}, // resolves undefined
+    urlWhenTheEvaluateRan: "http://fake/first",
+  });
+});
+
 // The attach chain settles no promise of its own, so a failure in it has
 // to reach every operation parked behind it. "Cannot navigate to invalid
 // URL" is the fake's one canned protocol error, here on attachToTarget.
@@ -184,6 +210,36 @@ test.concurrent("an attach failure rejects every operation waiting on it", async
       { rejected: "Cannot navigate to invalid URL" },
     ],
     loading: false,
+  });
+});
+
+// onNavigationFailed runs from inside the failure handling, and a
+// navigate() from it is documented to work. The retry has to start a
+// fresh attach chain, not collect the failure that is being delivered.
+test.concurrent("navigate() retried from onNavigationFailed after an attach failure attaches", async () => {
+  const result = await runScenario(`
+    // The fake fails the first Target.attachToTarget only, so the retry's
+    // chain completes.
+    const view = new Bun.WebView({
+      backend: { ...backend, argv: [...backend.argv, "--cdp-error-once=Target.attachToTarget"] },
+      width: 100,
+      height: 100,
+    });
+    const failures = [];
+    const { promise, resolve } = Promise.withResolvers();
+    view.onNavigationFailed = error => {
+      failures.push(error.message);
+      if (failures.length > 1) return resolve("the retry failed too");
+      view.navigate("http://fake/retry").then(() => resolve("the retry attached"), e => resolve("rejected: " + e.message));
+    };
+    view.navigate("http://fake/first").catch(() => {});
+    print({ outcome: await promise, failures, url: view.url });
+    view.close();
+  `);
+  expect(result).toEqual({
+    outcome: "the retry attached",
+    failures: ["Cannot navigate to invalid URL"],
+    url: "http://fake/retry",
   });
 });
 

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -156,6 +156,23 @@ test.concurrent("operations issued while the view attaches all complete", async 
   });
 });
 
+// The constructor's `url` navigation is the chain-starting operation a
+// user never sees a promise for. The next operation has to wait behind
+// it like behind an explicit navigate(): the fake reports which page it
+// had committed when the evaluate reached it.
+test.concurrent("an operation right after new Bun.WebView({ url }) waits behind the constructor navigation", async () => {
+  const result = await runScenario(`
+    const view = new Bun.WebView({ backend, width: 100, height: 100, url: "http://fake/ctor" });
+    const urlWhenTheEvaluateRan = await outcome(view.evaluate("__fake_url()"));
+    print({ urlWhenTheEvaluateRan, url: view.url });
+    view.close();
+  `);
+  expect(result).toEqual({
+    urlWhenTheEvaluateRan: { resolved: "http://fake/ctor" },
+    url: "http://fake/ctor",
+  });
+});
+
 // Target.attachToTarget answers one reply before Page.enable, so there
 // is a window where the view has a session id and an unfinished chain.
 // An operation started in that window still goes out behind the ones


### PR DESCRIPTION
### Problem
- `Bun.WebView` with the Chrome backend rejects every operation that runs before the first `navigate()` completes, with a raw protocol error: `evaluate()` gives `'Runtime.evaluate' wasn't found`, `screenshot()` gives `'Page.captureScreenshot' wasn't found`, and `click`, `type`, `press`, `scroll`, `resize`, `reload` and `goBack` each name their own CDP method. `reload()` and `goBack()` also fire `onNavigationFailed`.
- The docs say the opposite (`docs/runtime/webview.mdx`, "Creating a view"): "The first operation you `await` (such as `navigate()` or `evaluate()`) waits for the browser to be ready." The WebKit backend does that today.
- The cause is in `CDP::Ops` (`src/runtime/webview/ChromeBackend.cpp`). Only `navigate()` started the `Target.createTarget` to `Target.attachToTarget` to `Page.enable` chain that produces the view's session id. Every other operation built its command with an empty session id, so it went to the browser endpoint, where the `Page`, `Runtime`, `Input` and `Emulation` domains do not exist.

### Fix
- Any operation now starts the attach chain, and the chain carries no user promise of its own. Commands issued before the session exists wait in `Transport::m_deferred` in issue order, and `Page.enable`'s reply writes each one with the session id.
- The park gate is the whole chain, not the session id: `Target.attachToTarget` answers one reply earlier, and a command written in that window would overtake the parked ones.
- A chain failure rejects every parked operation (`failDeferred`), from a copy of the queue, because `onNavigationFailed` can retry `navigate()` from inside the settle. The failure also forgets the half-built session and closes its target, so the retry attaches from scratch instead of waiting forever on a session that never enabled the `Page` domain.
- The session id is no longer a `Command` constructor argument. `finish()` stamps it as the frame's last key, which is what lets a command be built before its session exists. CDP reads JSON, where key order carries no meaning.
- Verified: `test/js/bun/webview/webview-chrome-pipe.test.ts` (8 new cases, browser-free). Also all of `test/js/bun/webview/` against Chrome 142 on Linux, 90 pass. Self-reviewed: 4 concerns raised, 4 addressed (stale "await navigate() first" wording in the `cdp()` guard, its JSDoc, the docs example, and one comment).

### Background
- CDP has two endpoint levels. The browser endpoint serves `Target.*` and `Browser.*`. Everything that acts on a page needs a `sessionId` from `Target.attachToTarget`.
- A view keeps its id in `JSWebView::m_sessionId`, empty until the chain completes. The chain is deferred to the first operation so that the constructor stays synchronous, and so that a view nobody uses opens no tab.
- Chrome delivers a domain's events only to sessions that enabled it. A navigation settles on `Page.loadEventFired`, so a session whose `Page.enable` failed can never settle one.
- One promise slot per operation kind means at most one parked command per kind per view, plus the untracked half of `click` and `press` (each sends a press and a release).

<details><summary>Notes</summary>

Reproduction, on Linux with Chrome 142, `bun 1.4.2`, canary `d316760e8` and `main` at `4ff91937`: every operation below rejects before this change and resolves after it.

```js
const backend = { type: "chrome", url: false, argv: ["--no-sandbox"] };
const view = new Bun.WebView({ backend });
await view.evaluate("1 + 1"); // "'Runtime.evaluate' wasn't found"
```

Three defects in the first version were found in review and fixed, each with its own regression test:

1. `sendToView` gated on the session id alone, so an operation started between the `Target.attachToTarget` reply and the `Page.enable` reply overtook the parked ones (b6f5a01 to a373cfd).
2. `failDeferred` iterated the live queue while `settleFailure` re-entered JS, so a `navigate()` retry from `onNavigationFailed` was rejected with the old error, and a callback that always retries never finished the loop (a373cfd).
3. A chain that failed after `Target.attachToTarget` left the session id on the view. The next operation took the attached path on it and never settled, because that session never enabled the `Page` domain (e335989).

What did not change:

- `cdp()` keeps its documented `ERR_INVALID_STATE` guard ("no session - await navigate() first"). It is the raw escape hatch, where the user decides the target of each command, so it still asks for one explicit operation first. The doc sentence now says that any operation establishes the session, not only `navigate()`.
- `new Bun.WebView({ url })` still exposes no promise for the constructor's navigation, and an immediate `navigate()` still throws `ERR_INVALID_STATE` ("a navigation is already pending"). `onNavigated` and `onNavigationFailed` remain the signals, as documented. Making that navigation awaitable is an API question, not part of this fix.
- Ordering for the normal path: the chain still sends `Page.enable`, then `Runtime.enable`, then the navigate, in the same places as before.

Tests added to `webview-chrome-pipe.test.ts`, which drives `fake-chrome-fixture.ts` instead of a real browser, so they run on every CI lane:

1. the first operation attaches the view instead of going to the browser endpoint
2. every operation kind works as the first one on a view (10 kinds, one fresh view each)
3. operations issued while the view attaches all complete
4. an operation started while the chain finishes stays behind the parked ones
5. an attach failure rejects every operation waiting on it, including `click`, whose first command owns no slot
6. `navigate()` retried from `onNavigationFailed` after an attach failure attaches
7. an operation after a `Page.enable` failure attaches a new session
8. an operation after `new Bun.WebView({ url })` waits behind that navigation (the second line of the original report; the fake reports which page it had committed when the `evaluate` reached it)

The fixture gained three behaviours of real Chrome that these tests need: it answers a session-scoped method that arrives with no `sessionId` with `{"error":{"code":-32601,"message":"'<method>' wasn't found"}}`, it sends `Page` events only to sessions that enabled the domain, and it answers `Page.reload`. Without the first one it answered every command regardless, so these tests would pass on an unfixed build. Three switches are new: `--cdp-error-once`, `--event-before-page-enable`, and the `__fake_url()` probe.

One bug found while writing case 5: `m_pending.find(0)` for the untracked half of a pair hits WTF's `RELEASE_ASSERT(isValidKey(...))`, because 0 is the HashMap's empty key. `failDeferred` skips id 0.

`#39075` (open) fixes a different, pre-existing bug in the same functions: a `close()` that lands while `Target.createTarget` is in flight drops the reply, so the tab it created is never closed. This PR does not widen that window; it changes which operation opens it (any first operation, not only `navigate()`). The two will conflict textually in `Ops::close` and the `TargetCreateTarget` arm, not in intent.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome-pipe.test.ts

<!-- robobun:evidence:end -->