### PR TITLE
webview: report Chrome spawn and connect failures precisely, and let press() take one code point

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -109,7 +109,7 @@ When Bun needs to spawn Chrome, it searches in this order:
 4. Standard install locations (`/Applications/Google Chrome.app`, `~/Applications/...`, `/usr/bin/...`, `/snap/bin/...`; on Windows the `Application\*.exe` directories under `%ProgramFiles%`, `%ProgramFiles(x86)%`, and `%LOCALAPPDATA%`)
 5. Playwright's cache (`~/Library/Caches/ms-playwright`, `~/.cache/ms-playwright`, or `%LOCALAPPDATA%\ms-playwright`) for `chrome-headless-shell`
 
-If Bun finds none, the constructor throws.
+If Bun finds none, the constructor throws. If Bun finds (or is given) an executable but cannot start it, the constructor throws that system error instead, with `code` (`ENOENT`, `EACCES`, ...), `syscall`, and `path` set, the same shape `Bun.spawn` throws.
 
 <Note>
   Microsoft Edge refuses to start under the Windows `LocalSystem` account: it exits immediately and the first operation
@@ -140,7 +140,7 @@ new Bun.WebView({
 });
 ```
 
-If auto-detect finds a stale `DevToolsActivePort` file (Chrome crashed or restarted), the WebSocket connect fails and Bun transparently falls back to spawning its own Chrome. An explicit `url: "ws://..."` does **not** fall back — a failed connection throws.
+If auto-detect finds a stale `DevToolsActivePort` file (Chrome crashed or restarted), the WebSocket connect fails and Bun transparently falls back to spawning its own Chrome. An explicit `url: "ws://..."` does **not** fall back. The connection opens in the background, so the constructor still returns normally; if it cannot be established, the first operation you `await` rejects with `Failed to connect to Chrome at ws://...`.
 
 <Note>
   Passing `path` or `argv` implies spawn mode and skips auto-detect. `url: "ws://..."` cannot be combined with `path` or
@@ -369,7 +369,7 @@ await view.press("a", { modifiers: ["Meta"] }); // Cmd+A / Ctrl+A
 
 Named virtual keys: `Enter`, `Tab`, `Space`, `Backspace`, `Delete`, `Escape`, `ArrowLeft`, `ArrowRight`, `ArrowUp`, `ArrowDown`, `Home`, `End`, `PageUp`, `PageDown`.
 
-Any single character (for example, `"a"`) combined with `modifiers` sends a keyboard chord.
+Any other `key` must be a single character (one code point, so `"é"` and `"😀"` count). It sends a `keydown`/`keyup` pair for that character and, combined with `modifiers`, a keyboard chord.
 
 On the WebKit backend, most named keys (without modifiers) map to editing commands such as `DeleteBackward`, `MoveLeft`, and `InsertNewline`, and resolve after the page has applied them. `Escape`, `Space`, and any key with modifiers fall back to raw `keydown`/`keyup` events. These keys fire a `keydown` the page can observe, but there's no completion barrier. Follow with an `evaluate()` if you need to observe the effect.
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9716,8 +9716,9 @@ declare module "bun" {
      * keyDown/keyUp (no WebKit barrier exists for keyboard events — a
      * following `evaluate()` serializes).
      *
-     * A single character (e.g. `"a"`) combined with `modifiers` sends a
-     * chord like Cmd+A.
+     * Any other `key` must be a single character (one code point; `"é"`
+     * and `"😀"` count). Combined with `modifiers` it sends a chord like
+     * Cmd+A.
      */
     press(key: WebView.VirtualKey | (string & {}), options?: WebView.PressOptions): Promise<void>;
 

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -461,7 +461,10 @@ static void wsOnClose(void* ctx, unsigned short code)
         // false; rejectAllAndMarkDead's guard would short-circuit and
         // the pending promises would hang. Clear it so reject runs.
         t.m_dead = false;
-        spawnFailure = makeString("; spawning a new Chrome failed too: "_s, errorMessageOf(t.m_global, spawnError));
+        // No error object means no Chrome was found at all.
+        spawnFailure = makeString("; spawning a new Chrome failed too: "_s,
+            spawnError ? errorMessageOf(t.m_global, spawnError)
+                       : "no Chrome found (set BUN_CHROME_PATH, backend.path, or install Chrome/Chromium)"_s);
     }
 
     // rejectAllAndMarkDead settles every pending promise with an error.
@@ -1360,6 +1363,8 @@ void Transport::rejectAllAndMarkDead(const WTF::String& reason)
         if (!v) continue;
         rejectViewSlots(g, v, err);
         v->m_closed = true;
+        // A view with nothing in flight has no promise to carry the reason.
+        v->m_closedReason = reason;
     }
     updateKeepAlive();
 }

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -80,11 +80,12 @@ namespace CDP {
 using namespace JSC;
 
 // Implemented in ChromeProcess.rs. Returns the parent's socketpair fd (0 on Windows, which keeps the pipes), -1 on failure.
+// On failure *errorOut receives an Error describing why (not thrown), or stays empty.
 // path overrides auto-detection; extraArgv (count entries, each NUL-
-// terminated) appends after core flags. All pointers nullable.
+// terminated) appends after core flags. All pointers nullable except errorOut.
 extern "C" int32_t Bun__Chrome__ensure(Zig::GlobalObject*, const char* userDataDir,
     const char* path, const char* const* extraArgv, uint32_t extraArgvLen,
-    bool stdoutInherit, bool stderrInherit);
+    bool stdoutInherit, bool stderrInherit, EncodedJSValue* errorOut);
 #if OS(WINDOWS)
 // Copies and queues one chunk; a failure arrives later as Bun__Chrome__onPipeClosed.
 extern "C" void Bun__Chrome__writePipe(const char* data, size_t len);
@@ -276,8 +277,9 @@ static constexpr us_socket_vtable_t s_cdpVTable = {
 
 bool Transport::ensureSpawned(Zig::GlobalObject* zig, const WTF::String& userDataDir,
     const WTF::String& path, const WTF::Vector<WTF::String>& extraArgv,
-    bool stdoutInherit, bool stderrInherit)
+    bool stdoutInherit, bool stderrInherit, JSValue& errorOut)
 {
+    errorOut = JSValue();
     if (m_mode != TransportMode::None && !m_dead) return true;
     if (m_dead) {
         m_dead = false;
@@ -300,13 +302,15 @@ bool Transport::ensureSpawned(Zig::GlobalObject* zig, const WTF::String& userDat
         argvC.append(s.utf8());
         argvPtrs.append(argvC.last().data());
     }
+    EncodedJSValue encodedError = JSValue::encode(JSValue());
     int32_t rc = Bun__Chrome__ensure(zig,
         dir.length() ? dir.data() : nullptr,
         pathC.length() ? pathC.data() : nullptr,
         argvPtrs.isEmpty() ? nullptr : argvPtrs.span().data(),
         static_cast<uint32_t>(argvPtrs.size()),
-        stdoutInherit, stderrInherit);
+        stdoutInherit, stderrInherit, &encodedError);
     if (rc < 0) {
+        errorOut = JSValue::decode(encodedError);
         m_dead = true;
         return false;
     }
@@ -400,11 +404,22 @@ static void wsOnMessage(void* ctx, std::span<const char> utf8)
     }
 }
 
+// Own "message" data property of an Error we built ourselves; no getters run.
+static WTF::String errorMessageOf(JSGlobalObject* g, JSValue error)
+{
+    auto* object = error ? error.getObject() : nullptr;
+    if (!object) return "unknown error"_s;
+    JSValue message = object->getDirect(g->vm(), g->vm().propertyNames->message);
+    if (!message || !message.isString()) return "unknown error"_s;
+    return asString(message)->tryGetValue();
+}
+
 static void wsOnClose(void* ctx, unsigned short code)
 {
     auto& t = *static_cast<Transport*>(ctx);
     bool neverOpened = !t.m_wsOpen;
     bool wasAutoDetected = std::exchange(t.m_wasAutoDetected, false);
+    WTF::String url = t.m_ws ? t.m_ws->url().string() : WTF::String();
     t.m_wsOpen = false;
     t.m_ws = nullptr;
 
@@ -421,13 +436,15 @@ static void wsOnClose(void* ctx, unsigned short code)
     // first spawn's onOpen path (socket adoption) drains the same way.
     // But m_wsPending stores the NON-NUL-terminated body. The pipe needs
     // the NUL. We write each body + NUL manually after spawn.
+    WTF::String spawnFailure;
     if (wasAutoDetected && neverOpened) {
         t.m_mode = TransportMode::None;
         // m_wsPending survives — we replay it below after spawn. Don't
         // let ensureSpawned's m_dead-reset clear it.
         auto pending = std::exchange(t.m_wsPending, {});
+        JSValue spawnError;
         if (t.ensureSpawned(t.m_global, t.m_fallbackUserDataDir, {}, {},
-                t.m_fallbackStdoutInherit, t.m_fallbackStderrInherit)) {
+                t.m_fallbackStdoutInherit, t.m_fallbackStderrInherit, spawnError)) {
             // Replay over the pipe. Same cancellation check as wsOnOpen
             // — skip ids close() already removed. Append the NUL
             // terminator the pipe protocol needs.
@@ -444,12 +461,15 @@ static void wsOnClose(void* ctx, unsigned short code)
         // false; rejectAllAndMarkDead's guard would short-circuit and
         // the pending promises would hang. Clear it so reject runs.
         t.m_dead = false;
+        spawnFailure = makeString("; spawning a new Chrome failed too: "_s, errorMessageOf(t.m_global, spawnError));
     }
 
     // rejectAllAndMarkDead settles every pending promise with an error.
     // If onOpen never fired (connect failure), m_pending holds the first
     // navigate's Target.createTarget — it rejects with this message.
-    t.rejectAllAndMarkDead(makeString("Chrome WebSocket closed (code "_s, code, ')'));
+    t.rejectAllAndMarkDead(neverOpened
+            ? makeString("Failed to connect to Chrome at "_s, url, spawnFailure)
+            : makeString("Chrome WebSocket closed (code "_s, code, ')'));
 }
 
 bool Transport::ensureConnected(Zig::GlobalObject* zig, const WTF::String& wsUrl, bool autoDetected,

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -372,16 +372,16 @@ enum class TransportMode : uint8_t {
 
 class Transport {
 public:
-    // Lazy-spawn Chrome. Returns false on spawn failure; caller throws.
+    // Lazy-spawn Chrome. Returns false on failure; errorOut then holds the reason when the spawner gave one.
     // path overrides auto-detection (BUN_CHROME_PATH > path > app bundles >
     // playwright cache). extraArgv appends after the core flags so user
     // flags can override built-ins. stdoutInherit/stderrInherit route
     // Chrome's output (chatty on stderr — GCM/updater/font-config noise).
     // Spawn args apply only on the FIRST call — subsequent views share the
     // one Chrome, so mismatched args across views get the first-call's.
-    bool ensureSpawned(Zig::GlobalObject*, const WTF::String& userDataDir = {},
-        const WTF::String& path = {}, const WTF::Vector<WTF::String>& extraArgv = {},
-        bool stdoutInherit = false, bool stderrInherit = false);
+    bool ensureSpawned(Zig::GlobalObject*, const WTF::String& userDataDir,
+        const WTF::String& path, const WTF::Vector<WTF::String>& extraArgv,
+        bool stdoutInherit, bool stderrInherit, JSC::JSValue& errorOut);
 
     // Connect to an already-running Chrome's DevTools endpoint. wsUrl is
     // a full ws:// URL (from DevToolsActivePort or user-supplied). Same

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -28,8 +28,8 @@ use std::io::Write as _;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use bun_core::ZStr;
 use bun_core::{self, ZBox, env_var, getenv_z, strings, zstr};
-use bun_jsc::JSGlobalObject;
 use bun_jsc::virtual_machine::VirtualMachine;
+use bun_jsc::{JSGlobalObject, JSValue};
 #[cfg(windows)]
 use bun_libuv_sys::{UvHandle as _, UvStream as _};
 use bun_output::{declare_scope, scoped_log};
@@ -45,6 +45,7 @@ use bun_sys::ReturnCodeExt as _;
 #[cfg(windows)]
 use bun_sys::windows::libuv as uv;
 use bun_sys::{self, Fd, FdExt as _};
+use bun_sys_jsc::ErrorJsc as _;
 use bun_which::which;
 
 declare_scope!(Chrome, hidden);
@@ -115,11 +116,12 @@ extern "C" fn Bun__Chrome__retire() {
 }
 
 /// Returns the parent's socketpair fd (POSIX, owned by usockets from then on), 0 (Windows), or -1 on failure.
+/// On failure `*error_out` gets an Error when there is more to say than "no Chrome found".
 ///
 /// # Safety
 /// `user_data_dir` and `path` must each be null or point to a valid
 /// NUL-terminated string. `extra_argv` must be null or point to
-/// `extra_argv_len` valid NUL-terminated string pointers.
+/// `extra_argv_len` valid NUL-terminated string pointers. `error_out` is writable.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Bun__Chrome__ensure(
     global: &JSGlobalObject,
@@ -129,6 +131,7 @@ unsafe extern "C" fn Bun__Chrome__ensure(
     extra_argv_len: u32,
     stdout_inherit: bool,
     stderr_inherit: bool,
+    error_out: *mut JSValue,
 ) -> i32 {
     {
         if !INSTANCE.load(Ordering::Relaxed).is_null() {
@@ -154,7 +157,7 @@ unsafe extern "C" fn Bun__Chrome__ensure(
             // SAFETY: caller passes a valid NUL-terminated string when non-null; null is handled above.
             Some(unsafe { bun_core::ffi::cstr(path) })
         };
-        match spawn(
+        let error = match spawn(
             vm,
             user_data_dir,
             path,
@@ -162,12 +165,23 @@ unsafe extern "C" fn Bun__Chrome__ensure(
             stdout_inherit,
             stderr_inherit,
         ) {
-            Ok(rc) => rc,
+            Ok(Ok(rc)) => return rc,
+            Ok(Err(exec_error)) => {
+                scoped_log!(Chrome, "spawn failed: {}", exec_error);
+                exec_error.to_js(global).unwrap_or_default()
+            }
+            Err(crate::Error::ChromeNotFound) => {
+                scoped_log!(Chrome, "spawn failed: no Chrome found");
+                return -1;
+            }
             Err(err) => {
                 scoped_log!(Chrome, "spawn failed: {}", err.name());
-                -1
+                global.create_error_instance(format_args!("Failed to start Chrome: {err}"))
             }
-        }
+        };
+        // SAFETY: caller contract; `error_out` points to a live JSValue slot.
+        unsafe { *error_out = error };
+        -1
     }
 }
 
@@ -476,7 +490,7 @@ fn find_playwright_shell() -> Option<ZBox> {
     None
 }
 
-/// Returns `Bun__Chrome__ensure`'s success value.
+/// Returns `Bun__Chrome__ensure`'s success value; the inner error is the chosen binary failing to start.
 fn spawn(
     vm: *mut VirtualMachine,
     user_data_dir: Option<&CStr>,
@@ -484,7 +498,7 @@ fn spawn(
     extra_argv: &[*const c_char],
     stdout_inherit: bool,
     stderr_inherit: bool,
-) -> crate::Result<i32> {
+) -> crate::Result<bun_sys::Result<i32>> {
     {
         let chrome = find_chrome(explicit_path).ok_or(crate::Error::ChromeNotFound)?;
         scoped_log!(
@@ -601,14 +615,17 @@ fn spawn(
         // SAFETY: `argv`/`env` are local null-terminated C-string arrays with
         // argv[0] non-null; valid for this call.
         let spawned =
-            unsafe { bun_spawn::spawn_process(&opts, argv.as_ptr(), env.as_ptr().cast()) }??;
+            match unsafe { bun_spawn::spawn_process(&opts, argv.as_ptr(), env.as_ptr().cast()) }? {
+                Ok(spawned) => spawned,
+                Err(err) => return Ok(Err(err.with_path(chrome.as_bytes()))),
+            };
         #[cfg(windows)]
         let mut spawned = spawned;
 
         // Keeping our copies of the child's ends would mask Chrome's death (no EOF).
         endpoints.close_child_ends();
 
-        endpoints.attach(spawned.to_process_handle(event_loop))
+        Ok(Ok(endpoints.attach(spawned.to_process_handle(event_loop))?))
     }
 }
 

--- a/src/runtime/webview/JSWebView.cpp
+++ b/src/runtime/webview/JSWebView.cpp
@@ -340,10 +340,12 @@ extern "C" size_t Bun__Chrome__autoDetect(char* out, size_t cap);
 JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
     uint32_t width, uint32_t height, const WTF::String& userDataDir,
     const WTF::String& path, const WTF::Vector<WTF::String>& extraArgv,
-    bool stdoutInherit, bool stderrInherit, const WTF::String& wsUrl, bool skipAutoDetect)
+    bool stdoutInherit, bool stderrInherit, const WTF::String& wsUrl, bool skipAutoDetect,
+    JSValue& errorOut)
 {
     auto* zig = defaultGlobalObject(g);
     auto& t = CDP::transport();
+    errorOut = JSValue();
 
     // Transport selection, in priority order:
     //   1. url: "ws://..." → connect (autoDetected=false → no fallback)
@@ -358,7 +360,7 @@ JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
     if (!wsUrl.isEmpty()) {
         ok = t.ensureConnected(zig, wsUrl, /* autoDetected */ false);
     } else if (skipAutoDetect || !path.isEmpty() || !extraArgv.isEmpty()) {
-        ok = t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit);
+        ok = t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit, errorOut);
     } else {
         // Auto-detect. DevToolsActivePort URL caps at
         // ws://127.0.0.1:65535/devtools/browser/<36-char-uuid> ≈ 70B.
@@ -369,7 +371,7 @@ JSWebView* JSWebView::createChrome(JSGlobalObject* g, Structure* structure,
                 WTF::String::fromUTF8(std::span<const char>(buf, len)),
                 /* autoDetected */ true, userDataDir, stdoutInherit, stderrInherit);
         } else {
-            ok = t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit);
+            ok = t.ensureSpawned(zig, userDataDir, path, extraArgv, stdoutInherit, stderrInherit, errorOut);
         }
     }
     if (!ok) return nullptr;

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -189,14 +189,14 @@ public:
     // Target.createTarget that the first navigate() sends. path overrides
     // auto-detection; extraArgv appends to the built-in flags. Works on
     // all platforms where Chrome runs (not just Darwin). Returns nullptr
-    // if Chrome spawn failed.
+    // if Chrome spawn failed (errorOut may then hold the reason).
     // wsUrl: connect to an existing Chrome's WebSocket debugger endpoint
     // instead of spawning. Empty → spawn with --remote-debugging-pipe.
     static JSWebView* createChrome(JSC::JSGlobalObject*, JSC::Structure*,
         uint32_t width, uint32_t height, const WTF::String& userDataDir,
         const WTF::String& path, const WTF::Vector<WTF::String>& extraArgv,
-        bool stdoutInherit, bool stderrInherit, const WTF::String& wsUrl = {},
-        bool skipAutoDetect = false);
+        bool stdoutInherit, bool stderrInherit, const WTF::String& wsUrl,
+        bool skipAutoDetect, JSC::JSValue& errorOut);
 
     void finishCreation(JSC::VM&);
     static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue prototype);

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -83,6 +83,8 @@ public:
     // does Target.createTarget. WebKit: held in the child.
     uint32_t m_width = 0, m_height = 0;
     bool m_closed = false;
+    // Why the transport closed the view; empty when the user closed it.
+    WTF::String m_closedReason;
     // Updated from NavDone replies / Page.frameNavigated — the getters are
     // synchronous but the real values live in the child.
     WTF::String m_url;

--- a/src/runtime/webview/JSWebViewConstructor.cpp
+++ b/src/runtime/webview/JSWebViewConstructor.cpp
@@ -348,10 +348,16 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
                 "Bun.WebView with backend \"chrome\" is only available on the main thread"_s);
         }
         Bun__Feature__webview_chrome += 1;
+        JSValue spawnError;
         JSWebView* view = JSWebView::createChrome(globalObject, structure, width, height,
             persistDir, chromePath, chromeArgv, stdoutInherit, stderrInherit, chromeWsUrl,
-            chromeSkipAutoDetect);
+            chromeSkipAutoDetect, spawnError);
         if (!view) {
+            RETURN_IF_EXCEPTION(scope, {});
+            if (spawnError) {
+                scope.throwException(globalObject, spawnError);
+                return {};
+            }
             return Bun::throwError(globalObject, scope, ErrorCode::ERR_DLOPEN_FAILED,
                 chromeWsUrl.isEmpty()
                     ? "Failed to spawn Chrome (set BUN_CHROME_PATH, backend.path, or install Chrome/Chromium)"_s

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -513,8 +513,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncPress, (JSGlobalObject * globalObject
     }
 
     VirtualKey vk = virtualKeyFromName(key);
-    // One code point: one BMP unit, or one surrogate pair (an emoji). A lone
-    // surrogate is half a character and has no key to send.
+    // One code point: one BMP unit, or one surrogate pair (an emoji).
     bool singleCodePoint = (key.length() == 1 && !U16_IS_SURROGATE(key[0]))
         || (key.length() == 2 && U16_IS_LEAD(key[0]) && U16_IS_TRAIL(key[1]));
     if (vk == VirtualKey::Character && !singleCodePoint) {

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -513,8 +513,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncPress, (JSGlobalObject * globalObject
     }
 
     VirtualKey vk = virtualKeyFromName(key);
-    // One code point: a lone BMP unit, or one surrogate pair (an emoji).
-    bool singleCodePoint = key.length() == 1
+    // One code point: one BMP unit, or one surrogate pair (an emoji). A lone
+    // surrogate is half a character and has no key to send.
+    bool singleCodePoint = (key.length() == 1 && !U16_IS_SURROGATE(key[0]))
         || (key.length() == 2 && U16_IS_LEAD(key[0]) && U16_IS_TRAIL(key[1]));
     if (vk == VirtualKey::Character && !singleCodePoint) {
         return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "key"_s, keyArg,

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -137,7 +137,11 @@ static JSWebView* unwrapThis(JSGlobalObject* globalObject, ThrowScope& scope, Ca
         return nullptr;
     }
     if (thisObject->m_closed) {
-        Bun::ERR::INVALID_STATE(scope, globalObject, makeString("WebView."_s, method, ": view is closed"_s));
+        const auto& reason = thisObject->m_closedReason;
+        Bun::ERR::INVALID_STATE(scope, globalObject,
+            reason.isEmpty()
+                ? makeString("WebView."_s, method, ": view is closed"_s)
+                : makeString("WebView."_s, method, ": "_s, reason));
         return nullptr;
     }
     return thisObject;

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -509,7 +509,10 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncPress, (JSGlobalObject * globalObject
     }
 
     VirtualKey vk = virtualKeyFromName(key);
-    if (vk == VirtualKey::Character && key.length() != 1) {
+    // One code point: a lone BMP unit, or one surrogate pair (an emoji).
+    bool singleCodePoint = key.length() == 1
+        || (key.length() == 2 && U16_IS_LEAD(key[0]) && U16_IS_TRAIL(key[1]));
+    if (vk == VirtualKey::Character && !singleCodePoint) {
         return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "key"_s, keyArg,
             "must be a virtual key name (Enter, Tab, Escape, Arrow*, etc.) or a single character"_s);
     }

--- a/src/runtime/webview/WebKitBackend.cpp
+++ b/src/runtime/webview/WebKitBackend.cpp
@@ -481,6 +481,8 @@ void HostClient::rejectAllAndMarkDead(const WTF::String& reason)
         settleSlot(g, v, v->m_pendingScreenshot, false, err);
         settleSlot(g, v, v->m_pendingMisc, false, err);
         v->m_closed = true;
+        // A view with nothing in flight has no promise to carry the reason.
+        v->m_closedReason = reason;
     }
     viewsById.clear();
     updateKeepAlive();

--- a/test/js/bun/webview/webview-chrome-disconnect.test.ts
+++ b/test/js/bun/webview/webview-chrome-disconnect.test.ts
@@ -186,6 +186,35 @@ test.concurrent("a dropped connection rejects the committed navigation of every 
   });
 });
 
+// An explicit backend.url never falls back to spawning (only an auto-detected
+// one does). The WebSocket connects in the background, so the constructor
+// cannot throw for it; the first awaited operation rejects, naming the URL.
+test.concurrent(
+  "an explicit backend.url that refuses the upgrade rejects the first operation with the URL",
+  async () => {
+    const result = await runScenario(`
+    // Answers every request with a plain 404, so the upgrade never completes.
+    const server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response(null, { status: 404 }) });
+    const url = "ws://127.0.0.1:" + server.port + "/devtools/browser/nope";
+    let constructed;
+    try {
+      var view = new Bun.WebView({ backend: { type: "chrome", url }, width: 100, height: 100 });
+      constructed = true;
+    } catch (e) {
+      constructed = "threw: " + e.message;
+    }
+    const navigate = await view.navigate("http://mock/1").then(() => "resolved", e => "rejected: " + e.message);
+    console.log(JSON.stringify({ constructed, navigate: navigate.replace(url, "<url>"), loading: view.loading }));
+    server.stop(true);
+  `);
+    expect(result).toEqual({
+      constructed: true,
+      navigate: "rejected: Failed to connect to Chrome at <url>",
+      loading: false,
+    });
+  },
+);
+
 // The connection stays up but the view's own page goes away. The promise
 // was already rejected on these paths; they also have to clear loading.
 test.concurrent.each([

--- a/test/js/bun/webview/webview-chrome-disconnect.test.ts
+++ b/test/js/bun/webview/webview-chrome-disconnect.test.ts
@@ -215,6 +215,38 @@ test.concurrent(
   },
 );
 
+// Nothing is in flight when that connection dies, so no promise carries the
+// reason. Every later call reports it, instead of a bare "view is closed".
+test.concurrent("a connection that dies with nothing pending names itself on later calls", async () => {
+  const result = await runScenario(`
+    const server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response(null, { status: 404 }) });
+    const url = "ws://127.0.0.1:" + server.port + "/devtools/browser/nope";
+    const view = new Bun.WebView({ backend: { type: "chrome", url }, width: 100, height: 100 });
+
+    // Poll until the view has been closed by the failed connection. Until
+    // then navigate() is accepted and rejects asynchronously; once closed it
+    // throws synchronously, which is the state under test.
+    const attempt = () => {
+      try {
+        return view.navigate("http://mock/1").then(() => "resolved", e => "rejected: " + e.message);
+      } catch (e) {
+        return "threw: " + e.message;
+      }
+    };
+    let closed;
+    for (;;) {
+      closed = await attempt();
+      if (closed.startsWith("threw: ")) break;
+    }
+    const next = await attempt();
+    console.log(JSON.stringify({ closed: closed.replace(url, "<url>"), next: next.replace(url, "<url>") }));
+    server.stop(true);
+  `);
+  // Both report the endpoint, not a bare "view is closed".
+  const named = "threw: Invalid state: WebView.navigate: Failed to connect to Chrome at <url>";
+  expect(result).toEqual({ closed: named, next: named });
+});
+
 // The connection stays up but the view's own page goes away. The promise
 // was already rejected on these paths; they also have to clear loading.
 test.concurrent.each([

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -1085,9 +1085,12 @@ it("chrome: press() accepts a character outside the BMP", async () => {
   // One code point, two UTF-16 units.
   await view.press("😀");
   expect(await view.evaluate("[document.getElementById('i').value, __keys]")).toEqual(["😀", ["😀"]]);
-  // Two code points is still not a single character.
+  // Two code points is still not a single character, and half of one is not
+  // a character at all.
   expect(() => view.press("ab")).toThrow(/single character/);
   expect(() => view.press("👍🏽")).toThrow(/single character/);
+  expect(() => view.press("\uD83D")).toThrow(/single character/);
+  expect(() => view.press("\uDE00")).toThrow(/single character/);
 });
 
 it("chrome: goBack/goForward navigates history", async () => {

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -1071,6 +1071,25 @@ it("chrome: press() with modifiers", async () => {
   expect(await view.evaluate("__ev")).toEqual({ key: "ArrowLeft", shift: true, ctrl: true });
 });
 
+it("chrome: press() accepts a character outside the BMP", async () => {
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(
+    html(`
+    <body><input id=i><script>
+      window.__keys = [];
+      addEventListener('keydown', e => __keys.push(e.key));
+    </script></body>
+  `),
+  );
+  await view.click("#i");
+  // One code point, two UTF-16 units.
+  await view.press("😀");
+  expect(await view.evaluate("[document.getElementById('i').value, __keys]")).toEqual(["😀", ["😀"]]);
+  // Two code points is still not a single character.
+  expect(() => view.press("ab")).toThrow(/single character/);
+  expect(() => view.press("👍🏽")).toThrow(/single character/);
+});
+
 it("chrome: goBack/goForward navigates history", async () => {
   await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   await view.navigate(html("<body>A</body>"));
@@ -1205,15 +1224,57 @@ it("BUN_CHROME_PATH wins over auto-detection", async () => {
   // `it` gate), so the only way the constructor can fail here is by honoring
   // the env var.
   using dir = tempDir("bun-chrome-path", {});
+  const missing = join(String(dir), "not-a-browser");
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", spawnWithEnv],
-    env: { ...bunEnv, BUN_CHROME_PATH: join(String(dir), "not-a-browser") },
+    env: { ...bunEnv, BUN_CHROME_PATH: missing },
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("");
-  expect(stderr).toContain("Failed to spawn Chrome");
+  expect(stderr).toContain("ENOENT");
+  expect(stderr).toContain(missing);
   expect(exitCode).toBe(1);
+});
+
+// No browser needed: the constructor is handed something it cannot start. The
+// error is the spawn's own system error (errno, syscall, path), the same shape
+// Bun.spawn throws, instead of one fixed "Failed to spawn Chrome" for all.
+test.concurrent("a backend.path that cannot be spawned throws the system error for that path", async () => {
+  using dir = tempDir("bun-chrome-spawn-error", { "not-executable": "" });
+  const construct = (path: string) => `
+    try {
+      new Bun.WebView({ backend: { type: "chrome", path: ${JSON.stringify(path)} }, width: 200, height: 200 });
+      console.log("constructed");
+    } catch (e) {
+      console.log(JSON.stringify({ code: e.code, syscall: e.syscall, path: e.path, errno: typeof e.errno }));
+    }
+  `;
+  const run = async (path: string) => {
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", construct(path)], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  };
+
+  const missing = join(String(dir), "does-not-exist");
+  expect(await run(missing)).toEqual({
+    code: "ENOENT",
+    syscall: expect.stringMatching(/spawn/),
+    path: missing,
+    errno: "number",
+  });
+
+  if (process.platform !== "win32") {
+    const notExecutable = join(String(dir), "not-executable");
+    expect(await run(notExecutable)).toEqual({
+      code: "EACCES",
+      syscall: expect.stringMatching(/spawn/),
+      path: notExecutable,
+      errno: "number",
+    });
+  }
 });
 
 it("BUN_CHROME_PATH is used as the executable", async () => {

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -1140,6 +1140,10 @@ it("views orphaned by a host death are closed, even after a new view respawns th
       busy: "ERR_INVALID_STATE",
       idle: "ERR_INVALID_STATE",
       blank: "ERR_INVALID_STATE",
+      // The view kept the reason, so the call it refuses can name it.
+      idleMessage: expect.stringMatching(
+        /^Invalid state: WebView\.evaluate: WebView host process (died|killed by signal \d+|exited)$/,
+      ),
     },
     freshBody: "fresh",
     afterRespawn: {
@@ -1149,9 +1153,6 @@ it("views orphaned by a host death are closed, even after a new view respawns th
       click: "ERR_INVALID_STATE",
       idle: "ERR_INVALID_STATE",
       blank: "ERR_INVALID_STATE",
-      idleMessage: expect.stringMatching(
-        /^Invalid state: WebView\.evaluate: WebView host process (died|killed by signal \d+|exited)$/,
-      ),
     },
   });
   expect(exitCode, stderr).toBe(0);

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -1069,6 +1069,15 @@ it("views orphaned by a host death are closed, even after a new view respawns th
             return e.code;
           }
         };
+        // The view kept the reason the host died of, for the calls it refuses.
+        const reason = fn => {
+          try {
+            fn().catch(() => {});
+            return "returned a promise";
+          } catch (e) {
+            return e.message;
+          }
+        };
 
         const busy = open();
         const idle = open();
@@ -1083,6 +1092,7 @@ it("views orphaned by a host death are closed, even after a new view respawns th
           busy: probe(() => busy.evaluate("1")),
           idle: probe(() => idle.evaluate("1")),
           blank: probe(() => blank.navigate(html("<body>blank</body>"))),
+          idleMessage: reason(() => idle.evaluate("1")),
         };
 
         // The client is marked dead as soon as the event loop sees the
@@ -1139,6 +1149,9 @@ it("views orphaned by a host death are closed, even after a new view respawns th
       click: "ERR_INVALID_STATE",
       idle: "ERR_INVALID_STATE",
       blank: "ERR_INVALID_STATE",
+      idleMessage: expect.stringMatching(
+        /^Invalid state: WebView\.evaluate: WebView host process (died|killed by signal \d+|exited)$/,
+      ),
     },
   });
   expect(exitCode, stderr).toBe(0);


### PR DESCRIPTION
### Problem
- Every Chrome spawn failure throws `ERR_DLOPEN_FAILED` with one fixed text and no path: a `backend.path` or `BUN_CHROME_PATH` that does not exist, is not executable, or is not a binary all read "Failed to spawn Chrome (set BUN_CHROME_PATH, ...)".
- The docs say an explicit `backend.url` that fails to connect makes the constructor throw. The connect is asynchronous, so the constructor returned and the first operation rejected with `Chrome WebSocket closed (code 1006)`.
- `press("😀")` threw "must be ... a single character": the check counted UTF-16 units.

### Fix
- `Bun__Chrome__ensure` (`ChromeProcess.rs`) hands the spawn's `bun_sys::Error`, with the path, back through a new out-parameter; the constructor throws it as the same `SystemError` shape `Bun.spawn` uses (`code`, `errno`, `syscall`, `path`). "No Chrome found" keeps `ERR_DLOPEN_FAILED` and its hint.
- `wsOnClose` tells a connect that never opened (`Failed to connect to Chrome at <url>`, plus the fallback spawn's reason when auto-detect also failed to spawn) from a drop after open (unchanged message). A transport death also stores its reason on each view it closes, so a call made after it says why instead of `view is closed`. The docs describe the asynchronous failure.
- `press()` accepts one code point (a lone unit or one surrogate pair).
- Verified: `webview-chrome.test.ts` (the spawn error test needs no browser; `press`; `BUN_CHROME_PATH`), `webview-chrome-disconnect.test.ts` (2 blocks, no browser). All fail on 1.4.3; the Chrome suites pass against Chrome 153.

### Background
- The Chrome backend spawns one browser per process from Rust (`ChromeProcess.rs`) and returns a pipe fd to the C++ transport; until now a failure came back as a bare `-1`.
- `backend.url` connects to a running Chrome's DevTools WebSocket instead. Only an auto-detected URL (a stale `DevToolsActivePort` file) falls back to spawning.

<details><summary>Notes</summary>

From a docs-vs-backend pass over `docs/runtime/webview.mdx` (items 2, 6 and 7 of seven). The other items are in separate PRs: evaluate() error fidelity and the trailing-comment wrapper (#42221), and the Chrome event/history/dialog behaviours (#42222). They do not depend on each other.

- A setup failure before the spawn (socketpair, temp profile dir) now reads `Failed to start Chrome: <reason>` instead of the not-found hint. The `INSTANCE`-still-set case (previous Chrome not yet reaped, see #40176) is unchanged and still produces the generic text the existing retry loops match.
- `ENOEXEC` prints as "unknown error" in the message because the errno name table has no text for it; the `code` is right. Not touched here.
- Review follow-ups. A terminal close used to lose its reason when no operation was pending: the view was marked closed and the next call said `view is closed`. `JSWebView::m_closedReason` carries it, and every later call repeats it. A fallback spawn that finds no Chrome at all reports that hint rather than `unknown error` (it returns no error object, by design, so the constructor keeps throwing `ERR_DLOPEN_FAILED` for the same case).
- `press()`: a grapheme cluster of several code points (`👍🏽`) is still rejected; CDP's `Input.dispatchKeyEvent` and `NSEvent` take one key.

</details>
