### PR TITLE
webview: handle Chrome subframe, fragment, failed and same-document navigations

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -192,7 +192,7 @@ await view.navigate("data:text/html,<h1>hello</h1>");
 await view.navigate("file:///path/to/index.html");
 ```
 
-`navigate()` resolves when the main frame's `load` event fires. After it resolves, `view.url` and `view.title` reflect the new page, and `view.loading` is `false`.
+`navigate()` resolves when the main frame's `load` event fires, or as soon as the URL changes when only the `#fragment` differs from the current page (a same-document navigation). After it resolves, `view.url` and `view.title` reflect the new page, and `view.loading` is `false`.
 
 If the navigation fails (DNS failure, connection refused, invalid URL), the promise rejects with an `Error` describing the failure.
 
@@ -222,7 +222,7 @@ view.onNavigationFailed = error => {
 };
 ```
 
-These fire **before** the corresponding `navigate()` promise settles, so by the time `await view.navigate(...)` returns, your callback has already run. Set to `null` to remove.
+These fire **before** the corresponding `navigate()` promise settles, so by the time `await view.navigate(...)` returns, your callback has already run. Same-document navigations by the page (`history.pushState()`, fragment changes) also update `view.url` and fire `onNavigated`. Navigations inside `<iframe>`s do not. Set to `null` to remove.
 
 ---
 

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1115,7 +1115,6 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
 // Page.frameNavigated {frame: {parentId?, url, urlFragment?, unreachableUrl?, loaderId}, type}.
 void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
 {
-    auto* g = m_global;
     auto frame = jsonField(params, { "frame", 5 });
     if (!jsonField(frame, { "parentId", 8 }).empty()) return;
 
@@ -1124,14 +1123,14 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
     if (!unreachable.empty()) {
         view->m_chromeOnErrorPage = true;
         view->m_chromeDocumentLoading = false;
+        // Reported once the error page has loaded (the page answers commands again by then),
+        // unless navigate() already failed with errorText for this loaderId.
         auto loaderId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "loaderId", 8 })));
-        if (loaderId != view->m_chromeFailedLoaderId) {
-            settleFailure(g, view, PendingSlot::Navigate, Method::PageNavigate,
-                createError(g, makeString("Navigation to "_s, WTF::String::fromUTF8(unreachable), " failed"_s)));
-        }
+        if (loaderId != view->m_chromeFailedLoaderId) view->m_chromeUnreportedFailure = WTF::String::fromUTF8(unreachable);
         return;
     }
     view->m_chromeOnErrorPage = false;
+    view->m_chromeUnreportedFailure = WTF::String();
 
     // Chrome splits the fragment out of frame.url.
     auto url = jsonString(jsonField(frame, { "url", 3 }));
@@ -1232,10 +1231,12 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     else if (method.size() == 28 && memcmp(method.data(), "Page.navigatedWithinDocument", 28) == 0)
         onNavigatedWithinDocument(view, params);
     else if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
-        if (view->m_chromeOnErrorPage) // its failure was reported at commit
-            view->m_loading = false;
-        else
+        if (!view->m_chromeOnErrorPage)
             finishNavigation(view);
+        else if (auto failedUrl = std::exchange(view->m_chromeUnreportedFailure, WTF::String()); !failedUrl.isNull())
+            settleFailure(g, view, PendingSlot::Navigate, Method::PageNavigate, createError(g, makeString("Navigation to "_s, failedUrl, " failed"_s)));
+        else
+            view->m_loading = false;
     }
 
     // Runtime.consoleAPICalled — fires for every console.* call in the page.

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -843,8 +843,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
 
     case Method::PageNavigate: {
-        // {"frameId", "loaderId"?, "errorText"?}: errorText = failed before commit; no loaderId =
-        // same-document (settled by Page.navigatedWithinDocument or here, whichever is second).
+        // errorText: failed before commit. No loaderId: same-document, settled here or by its event.
         bool sameDocumentDone = std::exchange(view->m_chromeSameDocumentNavigated, false);
         auto err = jsonString(jsonField(result, { "errorText", 9 }));
         auto loaderId = jsonString(jsonField(result, { "loaderId", 8 }));
@@ -1112,16 +1111,14 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     }
 }
 
-// Page.frameNavigated {frame: {id, parentId?, url, urlFragment?, unreachableUrl?}, type}: a document
-// committed. Only the main frame counts; onNavigated and navigate() wait for its load.
+// Page.frameNavigated {frame: {parentId?, url, urlFragment?, unreachableUrl?, loaderId}, type}.
 void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
 {
     auto* g = m_global;
     auto frame = jsonField(params, { "frame", 5 });
     if (!jsonField(frame, { "parentId", 8 }).empty()) return;
 
-    // unreachableUrl: this commit is Chrome's error page for a failed load. A failure, not a
-    // new view.url; already reported if navigate()'s errorText named this loaderId.
+    // unreachableUrl: Chrome's error page for a failed load committed. Not a new view.url.
     auto unreachable = jsonString(jsonField(frame, { "unreachableUrl", 14 }));
     if (!unreachable.empty()) {
         view->m_chromeOnErrorPage = true;
@@ -1148,8 +1145,7 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
         view->m_chromeDocumentLoading = true;
 }
 
-// Page.navigatedWithinDocument {frameId, url}: fragment change, pushState/replaceState or history
-// traversal between such entries. The whole navigation: no commit or load event follows.
+// Page.navigatedWithinDocument {frameId, url}: fragment/pushState/traversal; no load event follows.
 void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char> params)
 {
     auto* g = m_global;
@@ -1340,8 +1336,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // view.addEventListener("Network.responseReceived", e => e.data.response): check
-    // hasEventListeners before the JSONParse, Chrome is chatty.
+    // view.addEventListener("<Domain.event>", e => e.data): skip the JSONParse without a listener.
     auto methodAtom = AtomString::fromUTF8(method);
     if (!view->wrapped().hasEventListeners(methodAtom)) return;
 

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1156,15 +1156,18 @@ void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char>
     view->m_url = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
     if (view->m_chromeDocumentLoading) return; // folded into that load's single onNavigated
     // An unanswered navigation command settles from its reply instead (see PageNavigate).
-    bool commandInFlight = false;
+    bool commandInFlight = false, titleFetchInFlight = false;
     for (auto& entry : m_pending.values()) {
-        if (entry.viewId == view->m_viewId && entry.slot == PendingSlot::Navigate && entry.method != Method::PageTitle) {
+        if (entry.viewId != view->m_viewId || entry.slot != PendingSlot::Navigate) continue;
+        if (entry.method != Method::PageTitle)
             commandInFlight = true;
-            break;
-        }
+        else if (entry.navGeneration == view->m_chromeNavGeneration)
+            titleFetchInFlight = true;
     }
     if (commandInFlight)
         view->m_chromeSameDocumentNavigated = true;
+    else if (titleFetchInFlight)
+        return; // that load's title reply settles and reports, with this URL
     else {
         view->m_loading = false;
         settle(g, view, PendingSlot::Navigate, true, jsUndefined());

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -774,7 +774,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
 
     if (!error.empty()) {
         // {"code":-32000,"message":"..."}
-        if (entry.method == Method::PageTitle && entry.navGeneration != view->m_chromeNavGeneration) return;
+        if (entry.method == Method::PageTitle && (entry.navGeneration != view->m_chromeNavGeneration || entry.docGeneration != view->m_chromeDocumentGeneration)) return;
         auto msgSlice = jsonString(jsonField(error, { "message", 7 }));
         auto errStr = WTF::String::fromUTF8(std::span<const char>(msgSlice));
         settleFailure(g, view, entry.slot, entry.method,
@@ -867,6 +867,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
 
     case Method::PageTitle: {
         // document.title after a load: set m_title, settle Navigate, then onNavigated (slot already free).
+        if (entry.docGeneration != view->m_chromeDocumentGeneration) return; // another document committed since
         auto inner = jsonField(result, { "result", 6 });
         auto value = jsonString(jsonField(inner, { "value", 5 }));
         view->m_title = WTF::String::fromUTF8(value);
@@ -1129,6 +1130,7 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
 {
     auto frame = jsonField(params, { "frame", 5 });
     if (!jsonField(frame, { "parentId", 8 }).empty()) return;
+    ++view->m_chromeDocumentGeneration;
 
     // unreachableUrl: Chrome's error page for a failed load committed. Not a new view.url.
     auto unreachable = jsonString(jsonField(frame, { "unreachableUrl", 14 }));
@@ -1158,7 +1160,7 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
     if (type.size() == 23 && memcmp(type.data(), "BackForwardCacheRestore", 23) == 0)
         finishNavigation(view);
     else
-        view->m_chromeDocumentLoading = true;
+        view->m_loading = view->m_chromeDocumentLoading = true;
 }
 
 // Page.navigatedWithinDocument {frameId, url}: fragment/pushState/traversal; no load event follows.
@@ -1193,7 +1195,7 @@ void Transport::finishNavigation(JSWebView* view)
     view->m_loading = false;
     view->m_chromeDocumentLoading = false;
     uint32_t tid = nextId();
-    m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId, view->m_chromeNavGeneration });
+    m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId, view->m_chromeNavGeneration, view->m_chromeDocumentGeneration });
     send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
 }
 

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1148,6 +1148,7 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
     auto unreachable = jsonString(jsonField(frame, { "unreachableUrl", 14 }));
     if (!unreachable.empty()) {
         view->m_chromeOnErrorPage = true;
+        view->m_chromeDocumentLoading = false;
         auto loaderId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "loaderId", 8 })));
         if (loaderId != view->m_chromeFailedLoaderId) {
             settleFailure(g, view, PendingSlot::Navigate, Method::PageNavigate,
@@ -1163,11 +1164,13 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
     view->m_url = makeString(WTF::String::fromUTF8(url), WTF::String::fromUTF8(fragment));
 
     // A back/forward entry restored from the back-forward cache is complete at
-    // commit: no load event follows. A regular commit keeps m_loading true
-    // until loadEventFired.
+    // commit: no load event follows. A regular commit is loading until
+    // loadEventFired.
     auto type = jsonString(jsonField(params, { "type", 4 }));
     if (type.size() == 23 && memcmp(type.data(), "BackForwardCacheRestore", 23) == 0)
         finishNavigation(view);
+    else
+        view->m_chromeDocumentLoading = true;
 }
 
 // Page.navigatedWithinDocument — fragment change, history.pushState /
@@ -1181,13 +1184,16 @@ void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char>
     auto frameId = WTF::String::fromUTF8(jsonString(jsonField(params, { "frameId", 7 })));
     if (frameId != view->m_targetId) return;
     view->m_url = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
+    // A document that is still loading (an SPA router calling replaceState on
+    // boot) is reported once, with this URL, when its load completes.
+    if (view->m_chromeDocumentLoading) return;
     // Settles a navigate()/goBack()/goForward() that Chrome has already
     // answered. While a navigation command is still unanswered, note the
     // event instead: that command's reply settles if it turns out to be a
     // same-document navigation, and its commit or load does otherwise.
     bool commandInFlight = false;
     for (auto& entry : m_pending.values()) {
-        if (entry.viewId == view->m_viewId && entry.slot == PendingSlot::Navigate) {
+        if (entry.viewId == view->m_viewId && entry.slot == PendingSlot::Navigate && entry.method != Method::PageTitle) {
             commandInFlight = true;
             break;
         }
@@ -1208,6 +1214,7 @@ void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char>
 void Transport::finishNavigation(JSWebView* view)
 {
     view->m_loading = false;
+    view->m_chromeDocumentLoading = false;
     uint32_t tid = nextId();
     m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
     send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
@@ -1519,6 +1526,7 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
     }
     v->m_pendingActivityCount.fetch_add(1, std::memory_order_release);
     slot.set(vm, v, promise);
+    if (ps == PendingSlot::Navigate) v->m_chromeSameDocumentNavigated = false;
     t.m_pending.add(id, Pending { m, ps, v->m_viewId });
     t.send(id, WTF::move(cmd));
     t.updateKeepAlive();

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1115,6 +1115,15 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     }
 }
 
+// A Navigate-slot command (navigate/reload/goBack/goForward or the attach chain) Chrome has not replied to.
+bool Transport::hasUnansweredNavigation(JSWebView* view)
+{
+    for (auto& entry : m_pending.values()) {
+        if (entry.viewId == view->m_viewId && entry.slot == PendingSlot::Navigate && entry.method != Method::PageTitle) return true;
+    }
+    return false;
+}
+
 // Page.frameNavigated {frame: {parentId?, url, urlFragment?, unreachableUrl?, loaderId}, type}.
 void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
 {
@@ -1131,6 +1140,9 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
         if (loaderId != view->m_chromeFailedLoaderId) {
             view->m_chromeUnreportedFailure = WTF::String::fromUTF8(unreachable);
             view->m_chromeUnreportedFailureGeneration = view->m_chromeNavGeneration;
+            // A navigation command Chrome has not answered yet did not produce this page (its
+            // reply would have come first), so the failure is not that command's to settle.
+            view->m_chromeUnreportedFailureSettles = !hasUnansweredNavigation(view);
         }
         return;
     }
@@ -1160,12 +1172,9 @@ void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char>
     view->m_url = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
     if (view->m_chromeDocumentLoading) return; // folded into that load's single onNavigated
     // An unanswered navigation command settles from its reply instead (see PageNavigate).
-    bool commandInFlight = false, titleFetchInFlight = false;
+    bool commandInFlight = hasUnansweredNavigation(view), titleFetchInFlight = false;
     for (auto& entry : m_pending.values()) {
-        if (entry.viewId != view->m_viewId || entry.slot != PendingSlot::Navigate) continue;
-        if (entry.method != Method::PageTitle)
-            commandInFlight = true;
-        else if (entry.navGeneration == view->m_chromeNavGeneration)
+        if (entry.viewId == view->m_viewId && entry.method == Method::PageTitle && entry.navGeneration == view->m_chromeNavGeneration)
             titleFetchInFlight = true;
     }
     if (commandInFlight)
@@ -1240,8 +1249,8 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
             finishNavigation(view);
         else if (auto failedUrl = std::exchange(view->m_chromeUnreportedFailure, WTF::String()); !failedUrl.isNull()) {
             JSValue err = createError(g, makeString("Navigation to "_s, failedUrl, " failed"_s));
-            // A navigation issued since that commit owns the slot now; it only hears the callback.
-            if (view->m_chromeUnreportedFailureGeneration == view->m_chromeNavGeneration)
+            // A navigation issued around that commit owns the slot now; it only hears the callback.
+            if (view->m_chromeUnreportedFailureSettles && view->m_chromeUnreportedFailureGeneration == view->m_chromeNavGeneration)
                 settleFailure(g, view, PendingSlot::Navigate, Method::PageNavigate, err);
             else
                 fireOnNavigationFailed(g, view, err);

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -771,6 +771,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
 
     if (!error.empty()) {
         // {"code":-32000,"message":"..."}
+        if (entry.method == Method::PageTitle && entry.navGeneration != view->m_chromeNavGeneration) return;
         auto msgSlice = jsonString(jsonField(error, { "message", 7 }));
         auto errStr = WTF::String::fromUTF8(std::span<const char>(msgSlice));
         settleFailure(g, view, entry.slot, entry.method,
@@ -866,7 +867,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         auto inner = jsonField(result, { "result", 6 });
         auto value = jsonString(jsonField(inner, { "value", 5 }));
         view->m_title = WTF::String::fromUTF8(value);
-        settle(g, view, entry.slot, true, jsUndefined());
+        if (entry.navGeneration == view->m_chromeNavGeneration) settle(g, view, entry.slot, true, jsUndefined());
         fireOnNavigated(g, view);
         return;
     }
@@ -1177,7 +1178,7 @@ void Transport::finishNavigation(JSWebView* view)
     view->m_loading = false;
     view->m_chromeDocumentLoading = false;
     uint32_t tid = nextId();
-    m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
+    m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId, view->m_chromeNavGeneration });
     send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
 }
 
@@ -1479,7 +1480,10 @@ static JSPromise* sendChromeOp(JSGlobalObject* g, JSWebView* v,
     }
     v->m_pendingActivityCount.fetch_add(1, std::memory_order_release);
     slot.set(vm, v, promise);
-    if (ps == PendingSlot::Navigate) v->m_chromeSameDocumentNavigated = false;
+    if (ps == PendingSlot::Navigate) {
+        v->m_chromeSameDocumentNavigated = false;
+        ++v->m_chromeNavGeneration;
+    }
     t.m_pending.add(id, Pending { m, ps, v->m_viewId });
     t.send(id, WTF::move(cmd));
     t.updateKeepAlive();

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -673,6 +673,15 @@ static void settleFailure(JSGlobalObject* g, JSWebView* view, PendingSlot slot, 
     }
 }
 
+static void fireOnNavigated(JSGlobalObject* g, JSWebView* view)
+{
+    JSObject* cb = view->m_onNavigated.get();
+    if (!cb) return;
+    auto& vm = g->vm();
+    Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
+        JSValue::encode(jsString(vm, view->m_url)), JSValue::encode(jsString(vm, view->m_title)));
+}
+
 // Slots, not m_pending: a navigation that Chrome has already answered is
 // waiting for Page.loadEventFired and exists only in its slot.
 static void rejectViewSlots(JSGlobalObject* g, JSWebView* view, JSValue err)
@@ -834,30 +843,43 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
 
     case Method::PageNavigate: {
-        // {"frameId":"...","loaderId":"..."} or {"frameId":"...","errorText":"..."}
-        // errorText present → navigation failed synchronously (bad URL,
-        // net::ERR_* resolved before commit). Reject now. Otherwise the
-        // navigation is underway; Page.loadEventFired resolves. Keep the
-        // pending entry so the event handler can look up the view by
-        // sessionId — actually the event handler uses m_sessions, not
-        // m_pending, so we just drop here.
+        // {"frameId", "loaderId"?, "errorText"?}. errorText → the navigation
+        // failed before commit (bad URL, net::ERR_*): reject now. A loaderId
+        // without errorText → a new document is loading and
+        // Page.loadEventFired resolves. No loaderId → same-document
+        // navigation (only the #fragment changed): nothing loads, and
+        // Page.navigatedWithinDocument is the whole navigation. That event
+        // and this reply arrive in either order; whichever comes second
+        // settles, so view.url is current once navigate() resolves.
+        bool sameDocumentDone = std::exchange(view->m_chromeSameDocumentNavigated, false);
         auto err = jsonString(jsonField(result, { "errorText", 9 }));
-        if (!err.empty())
+        auto loaderId = jsonString(jsonField(result, { "loaderId", 8 }));
+        if (!err.empty()) {
+            // Chrome may still commit an error page for this loaderId; its
+            // frameNavigated must not report the failure a second time.
+            view->m_chromeFailedLoaderId = WTF::String::fromUTF8(loaderId);
             settleFailure(g, view, entry.slot, entry.method, createError(g, WTF::String::fromUTF8(err)));
-        // Else: don't settle — Page.loadEventFired does.
+        } else if (loaderId.empty() && sameDocumentDone) {
+            view->m_loading = false;
+            settle(g, view, entry.slot, true, jsUndefined());
+        }
         return;
     }
     case Method::PageReload:
-        // Same as navigate: don't settle, Page.loadEventFired does.
+        // Always loads a document: Page.loadEventFired settles.
+        view->m_chromeSameDocumentNavigated = false;
         return;
 
     case Method::PageTitle: {
         // Runtime.evaluate("document.title") chained from loadEventFired.
-        // result.result.value is the string. Set m_title, settle Navigate.
+        // result.result.value is the string. Set m_title, settle Navigate,
+        // then run onNavigated: the slot is free again if the callback
+        // navigates, and it still runs before the awaiting code resumes.
         auto inner = jsonField(result, { "result", 6 });
         auto value = jsonString(jsonField(inner, { "value", 5 }));
         view->m_title = WTF::String::fromUTF8(value);
         settle(g, view, entry.slot, true, jsUndefined());
+        fireOnNavigated(g, view);
         return;
     }
 
@@ -892,7 +914,15 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
     }
     case Method::PageNavigateToHistoryEntry:
-        // Response is empty {} on success. Page.loadEventFired settles.
+        // Response is empty {} on success. A different-document entry loads
+        // (or is restored from the back-forward cache) and settles through
+        // frameNavigated/loadEventFired. An entry in the same document (one
+        // made by pushState, or only a #fragment away) settles through
+        // Page.navigatedWithinDocument, which may already have arrived.
+        if (std::exchange(view->m_chromeSameDocumentNavigated, false)) {
+            view->m_loading = false;
+            settle(g, view, entry.slot, true, jsUndefined());
+        }
         return;
 
     case Method::RuntimeEvaluate: {
@@ -1097,6 +1127,92 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     }
 }
 
+// Page.frameNavigated — a document committed in some frame of the page.
+// params.frame: {id, parentId?, url, urlFragment?, unreachableUrl?, ...},
+// params.type: "Navigation" | "BackForwardCacheRestore". Only the main frame
+// (no parentId) is the view's document. m_url updates here, at commit;
+// onNavigated and the navigate() promise wait for the load
+// (Page.loadEventFired → PageTitle), like WKWebView's didFinishNavigation.
+void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
+{
+    auto* g = m_global;
+    auto frame = jsonField(params, { "frame", 5 });
+    if (!jsonField(frame, { "parentId", 8 }).empty()) return;
+
+    // A failed load commits Chrome's error page (frame.url is
+    // chrome-error://chromewebdata/) and names the URL that failed. That is a
+    // failed navigation, not a new view.url. navigate() already reported its
+    // own failure from Page.navigate's errorText, keyed by the same loaderId;
+    // anything else (the page navigating itself, reload(), goBack()) is
+    // reported here.
+    auto unreachable = jsonString(jsonField(frame, { "unreachableUrl", 14 }));
+    if (!unreachable.empty()) {
+        view->m_chromeOnErrorPage = true;
+        auto loaderId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "loaderId", 8 })));
+        if (loaderId != view->m_chromeFailedLoaderId) {
+            settleFailure(g, view, PendingSlot::Navigate, Method::PageNavigate,
+                createError(g, makeString("Navigation to "_s, WTF::String::fromUTF8(unreachable), " failed"_s)));
+        }
+        return;
+    }
+    view->m_chromeOnErrorPage = false;
+
+    // Chrome splits the fragment out of frame.url.
+    auto url = jsonString(jsonField(frame, { "url", 3 }));
+    auto fragment = jsonString(jsonField(frame, { "urlFragment", 11 }));
+    view->m_url = makeString(WTF::String::fromUTF8(url), WTF::String::fromUTF8(fragment));
+
+    // A back/forward entry restored from the back-forward cache is complete at
+    // commit: no load event follows. A regular commit keeps m_loading true
+    // until loadEventFired.
+    auto type = jsonString(jsonField(params, { "type", 4 }));
+    if (type.size() == 23 && memcmp(type.data(), "BackForwardCacheRestore", 23) == 0)
+        finishNavigation(view);
+}
+
+// Page.navigatedWithinDocument — fragment change, history.pushState /
+// replaceState, or a back/forward between such entries. The document stays,
+// so no frameNavigated and no loadEventFired follow: this event is the whole
+// navigation. params: {frameId, url, navigationType}.
+void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char> params)
+{
+    auto* g = m_global;
+    // A page target's id is its main frame's id.
+    auto frameId = WTF::String::fromUTF8(jsonString(jsonField(params, { "frameId", 7 })));
+    if (frameId != view->m_targetId) return;
+    view->m_url = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
+    // Settles a navigate()/goBack()/goForward() that Chrome has already
+    // answered. While a navigation command is still unanswered, note the
+    // event instead: that command's reply settles if it turns out to be a
+    // same-document navigation, and its commit or load does otherwise.
+    bool commandInFlight = false;
+    for (auto& entry : m_pending.values()) {
+        if (entry.viewId == view->m_viewId && entry.slot == PendingSlot::Navigate) {
+            commandInFlight = true;
+            break;
+        }
+    }
+    if (commandInFlight)
+        view->m_chromeSameDocumentNavigated = true;
+    else {
+        view->m_loading = false;
+        settle(g, view, PendingSlot::Navigate, true, jsUndefined());
+    }
+    fireOnNavigated(g, view);
+}
+
+// The main frame finished loading (or was restored whole from the back-forward
+// cache). Fetch document.title; the PageTitle reply sets m_title, settles the
+// Navigate slot and fires onNavigated, so `await navigate(); view.title` works.
+// With no navigate pending (the page navigated itself) the settle is a no-op.
+void Transport::finishNavigation(JSWebView* view)
+{
+    view->m_loading = false;
+    uint32_t tid = nextId();
+    m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
+    send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
+}
+
 void Transport::handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId)
 {
     auto* g = m_global;
@@ -1138,37 +1254,19 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Page.frameNavigated — commit. Update m_url and fire onNavigated.
-    // Same timing as WKWebView's NavDone (didFinishNavigation): the URL is
-    // now the new document, resources may still be loading.
-    if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0) {
-        auto frame = jsonField(params, { "frame", 5 });
-        auto url = jsonString(jsonField(frame, { "url", 3 }));
-        auto urlStr = WTF::String::fromUTF8(url);
-        view->m_url = urlStr;
-        // m_loading stays true — loadEventFired flips it.
-
-        if (JSObject* cb = view->m_onNavigated.get()) {
-            Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
-                JSValue::encode(jsString(vm, urlStr)), JSValue::encode(jsUndefined()));
-        }
-        return;
-    }
-
-    // Page.loadEventFired — load complete. Chain a document.title fetch
-    // so view.title is populated when navigate() resolves — matches
-    // WKWebView's NavDone which packs url+title in one reply. One extra
-    // roundtrip (~1ms), but the user-visible guarantee is worth it:
-    // `await view.navigate(); view.title` just works.
-    //
-    // If no navigate is pending (uninitiated navigation, redirect), the
-    // PageTitle handler settles a no-op and m_title still updates.
-    if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
-        view->m_loading = false;
-        uint32_t tid = nextId();
-        m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
-        send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
-        return;
+    // Navigation events update the view first and then, like any other CDP
+    // event, reach addEventListener("Page.frameNavigated", ...) listeners.
+    if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0)
+        onFrameNavigated(view, params);
+    else if (method.size() == 28 && memcmp(method.data(), "Page.navigatedWithinDocument", 28) == 0)
+        onNavigatedWithinDocument(view, params);
+    else if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
+        // The main frame's load event. An error page finishing its load is not
+        // a navigation: its failure was reported at commit.
+        if (view->m_chromeOnErrorPage)
+            view->m_loading = false;
+        else
+            finishNavigation(view);
     }
 
     // Runtime.consoleAPICalled — fires for every console.* call in the page.
@@ -1273,11 +1371,11 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Unhandled CDP event — dispatch to the view's EventTarget if it has
-    // a listener for this method name. Check hasEventListeners first:
-    // Chrome is chatty (frameScheduledNavigation, lifecycleEvent, etc.)
-    // and most events won't have listeners; skipping the JSONParse saves
-    // an alloc per unwanted event. The listener was added via
+    // Dispatch to the view's EventTarget if it has a listener for this
+    // method name. Check hasEventListeners first: Chrome is chatty
+    // (frameScheduledNavigation, lifecycleEvent, etc.) and most events won't
+    // have listeners; skipping the JSONParse saves an alloc per unwanted
+    // event. The listener was added via
     // view.addEventListener("Network.responseReceived", e => e.data.response).
     auto methodAtom = AtomString::fromUTF8(method);
     if (!view->wrapped().hasEventListeners(methodAtom)) return;

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1123,8 +1123,7 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
     if (!unreachable.empty()) {
         view->m_chromeOnErrorPage = true;
         view->m_chromeDocumentLoading = false;
-        // Reported once the error page has loaded (the page answers commands again by then),
-        // unless navigate() already failed with errorText for this loaderId.
+        // Reported at the error page's load event, unless navigate()'s errorText already did.
         auto loaderId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "loaderId", 8 })));
         if (loaderId != view->m_chromeFailedLoaderId) view->m_chromeUnreportedFailure = WTF::String::fromUTF8(unreachable);
         return;

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -660,17 +660,20 @@ static void settle(JSGlobalObject* g, JSWebView* view, PendingSlot slot, bool ok
 // example a redirect destroying the context) is not a navigation failure.
 // The slot settles before the callback runs, so a retry with navigate()
 // from inside the callback sees an empty slot instead of ERR_INVALID_STATE.
+static void fireOnNavigationFailed(JSGlobalObject* g, JSWebView* view, JSValue errValue)
+{
+    if (JSObject* cb = view->m_onNavigationFailed.get()) {
+        Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
+            JSValue::encode(errValue), JSValue::encode(jsUndefined()));
+    }
+}
+
 static void settleFailure(JSGlobalObject* g, JSWebView* view, PendingSlot slot, Method method, JSValue errValue)
 {
     bool navigationFailed = slot == PendingSlot::Navigate && method != Method::PageTitle;
     if (navigationFailed) view->m_loading = false;
     settle(g, view, slot, false, errValue);
-    if (navigationFailed) {
-        if (JSObject* cb = view->m_onNavigationFailed.get()) {
-            Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
-                JSValue::encode(errValue), JSValue::encode(jsUndefined()));
-        }
-    }
+    if (navigationFailed) fireOnNavigationFailed(g, view, errValue);
 }
 
 static void fireOnNavigated(JSGlobalObject* g, JSWebView* view)
@@ -1125,7 +1128,10 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
         view->m_chromeDocumentLoading = false;
         // Reported at the error page's load event, unless navigate()'s errorText already did.
         auto loaderId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "loaderId", 8 })));
-        if (loaderId != view->m_chromeFailedLoaderId) view->m_chromeUnreportedFailure = WTF::String::fromUTF8(unreachable);
+        if (loaderId != view->m_chromeFailedLoaderId) {
+            view->m_chromeUnreportedFailure = WTF::String::fromUTF8(unreachable);
+            view->m_chromeUnreportedFailureGeneration = view->m_chromeNavGeneration;
+        }
         return;
     }
     view->m_chromeOnErrorPage = false;
@@ -1232,10 +1238,14 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     else if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
         if (!view->m_chromeOnErrorPage)
             finishNavigation(view);
-        else if (auto failedUrl = std::exchange(view->m_chromeUnreportedFailure, WTF::String()); !failedUrl.isNull())
-            settleFailure(g, view, PendingSlot::Navigate, Method::PageNavigate, createError(g, makeString("Navigation to "_s, failedUrl, " failed"_s)));
-        else
-            view->m_loading = false;
+        else if (auto failedUrl = std::exchange(view->m_chromeUnreportedFailure, WTF::String()); !failedUrl.isNull()) {
+            JSValue err = createError(g, makeString("Navigation to "_s, failedUrl, " failed"_s));
+            // A navigation issued since that commit owns the slot now; it only hears the callback.
+            if (view->m_chromeUnreportedFailureGeneration == view->m_chromeNavGeneration)
+                settleFailure(g, view, PendingSlot::Navigate, Method::PageNavigate, err);
+            else
+                fireOnNavigationFailed(g, view, err);
+        }
     }
 
     // Runtime.consoleAPICalled — fires for every console.* call in the page.

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1140,8 +1140,7 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
         if (loaderId != view->m_chromeFailedLoaderId) {
             view->m_chromeUnreportedFailure = WTF::String::fromUTF8(unreachable);
             view->m_chromeUnreportedFailureGeneration = view->m_chromeNavGeneration;
-            // A navigation command Chrome has not answered yet did not produce this page (its
-            // reply would have come first), so the failure is not that command's to settle.
+            // An unanswered command did not produce this page: CDP would have replied first.
             view->m_chromeUnreportedFailureSettles = !hasUnansweredNavigation(view);
         }
         return;

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -843,20 +843,12 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
 
     case Method::PageNavigate: {
-        // {"frameId", "loaderId"?, "errorText"?}. errorText → the navigation
-        // failed before commit (bad URL, net::ERR_*): reject now. A loaderId
-        // without errorText → a new document is loading and
-        // Page.loadEventFired resolves. No loaderId → same-document
-        // navigation (only the #fragment changed): nothing loads, and
-        // Page.navigatedWithinDocument is the whole navigation. That event
-        // and this reply arrive in either order; whichever comes second
-        // settles, so view.url is current once navigate() resolves.
+        // {"frameId", "loaderId"?, "errorText"?}: errorText = failed before commit; no loaderId =
+        // same-document (settled by Page.navigatedWithinDocument or here, whichever is second).
         bool sameDocumentDone = std::exchange(view->m_chromeSameDocumentNavigated, false);
         auto err = jsonString(jsonField(result, { "errorText", 9 }));
         auto loaderId = jsonString(jsonField(result, { "loaderId", 8 }));
         if (!err.empty()) {
-            // Chrome may still commit an error page for this loaderId; its
-            // frameNavigated must not report the failure a second time.
             view->m_chromeFailedLoaderId = WTF::String::fromUTF8(loaderId);
             settleFailure(g, view, entry.slot, entry.method, createError(g, WTF::String::fromUTF8(err)));
         } else if (loaderId.empty() && sameDocumentDone) {
@@ -871,10 +863,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
 
     case Method::PageTitle: {
-        // Runtime.evaluate("document.title") chained from loadEventFired.
-        // result.result.value is the string. Set m_title, settle Navigate,
-        // then run onNavigated: the slot is free again if the callback
-        // navigates, and it still runs before the awaiting code resumes.
+        // document.title after a load: set m_title, settle Navigate, then onNavigated (slot already free).
         auto inner = jsonField(result, { "result", 6 });
         auto value = jsonString(jsonField(inner, { "value", 5 }));
         view->m_title = WTF::String::fromUTF8(value);
@@ -914,11 +903,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
     }
     case Method::PageNavigateToHistoryEntry:
-        // Response is empty {} on success. A different-document entry loads
-        // (or is restored from the back-forward cache) and settles through
-        // frameNavigated/loadEventFired. An entry in the same document (one
-        // made by pushState, or only a #fragment away) settles through
-        // Page.navigatedWithinDocument, which may already have arrived.
+        // {} on success. Settled by the entry's load, bfcache restore, or same-document event.
         if (std::exchange(view->m_chromeSameDocumentNavigated, false)) {
             view->m_loading = false;
             settle(g, view, entry.slot, true, jsUndefined());
@@ -1127,24 +1112,16 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     }
 }
 
-// Page.frameNavigated — a document committed in some frame of the page.
-// params.frame: {id, parentId?, url, urlFragment?, unreachableUrl?, ...},
-// params.type: "Navigation" | "BackForwardCacheRestore". Only the main frame
-// (no parentId) is the view's document. m_url updates here, at commit;
-// onNavigated and the navigate() promise wait for the load
-// (Page.loadEventFired → PageTitle), like WKWebView's didFinishNavigation.
+// Page.frameNavigated {frame: {id, parentId?, url, urlFragment?, unreachableUrl?}, type}: a document
+// committed. Only the main frame counts; onNavigated and navigate() wait for its load.
 void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
 {
     auto* g = m_global;
     auto frame = jsonField(params, { "frame", 5 });
     if (!jsonField(frame, { "parentId", 8 }).empty()) return;
 
-    // A failed load commits Chrome's error page (frame.url is
-    // chrome-error://chromewebdata/) and names the URL that failed. That is a
-    // failed navigation, not a new view.url. navigate() already reported its
-    // own failure from Page.navigate's errorText, keyed by the same loaderId;
-    // anything else (the page navigating itself, reload(), goBack()) is
-    // reported here.
+    // unreachableUrl: this commit is Chrome's error page for a failed load. A failure, not a
+    // new view.url; already reported if navigate()'s errorText named this loaderId.
     auto unreachable = jsonString(jsonField(frame, { "unreachableUrl", 14 }));
     if (!unreachable.empty()) {
         view->m_chromeOnErrorPage = true;
@@ -1163,9 +1140,7 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
     auto fragment = jsonString(jsonField(frame, { "urlFragment", 11 }));
     view->m_url = makeString(WTF::String::fromUTF8(url), WTF::String::fromUTF8(fragment));
 
-    // A back/forward entry restored from the back-forward cache is complete at
-    // commit: no load event follows. A regular commit is loading until
-    // loadEventFired.
+    // A back-forward cache restore is complete at commit: no load event follows.
     auto type = jsonString(jsonField(params, { "type", 4 }));
     if (type.size() == 23 && memcmp(type.data(), "BackForwardCacheRestore", 23) == 0)
         finishNavigation(view);
@@ -1173,10 +1148,8 @@ void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
         view->m_chromeDocumentLoading = true;
 }
 
-// Page.navigatedWithinDocument — fragment change, history.pushState /
-// replaceState, or a back/forward between such entries. The document stays,
-// so no frameNavigated and no loadEventFired follow: this event is the whole
-// navigation. params: {frameId, url, navigationType}.
+// Page.navigatedWithinDocument {frameId, url}: fragment change, pushState/replaceState or history
+// traversal between such entries. The whole navigation: no commit or load event follows.
 void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char> params)
 {
     auto* g = m_global;
@@ -1184,13 +1157,8 @@ void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char>
     auto frameId = WTF::String::fromUTF8(jsonString(jsonField(params, { "frameId", 7 })));
     if (frameId != view->m_targetId) return;
     view->m_url = WTF::String::fromUTF8(jsonString(jsonField(params, { "url", 3 })));
-    // A document that is still loading (an SPA router calling replaceState on
-    // boot) is reported once, with this URL, when its load completes.
-    if (view->m_chromeDocumentLoading) return;
-    // Settles a navigate()/goBack()/goForward() that Chrome has already
-    // answered. While a navigation command is still unanswered, note the
-    // event instead: that command's reply settles if it turns out to be a
-    // same-document navigation, and its commit or load does otherwise.
+    if (view->m_chromeDocumentLoading) return; // folded into that load's single onNavigated
+    // An unanswered navigation command settles from its reply instead (see PageNavigate).
     bool commandInFlight = false;
     for (auto& entry : m_pending.values()) {
         if (entry.viewId == view->m_viewId && entry.slot == PendingSlot::Navigate && entry.method != Method::PageTitle) {
@@ -1207,10 +1175,7 @@ void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char>
     fireOnNavigated(g, view);
 }
 
-// The main frame finished loading (or was restored whole from the back-forward
-// cache). Fetch document.title; the PageTitle reply sets m_title, settles the
-// Navigate slot and fires onNavigated, so `await navigate(); view.title` works.
-// With no navigate pending (the page navigated itself) the settle is a no-op.
+// Main frame loaded (or restored): fetch document.title; its reply settles Navigate and fires onNavigated.
 void Transport::finishNavigation(JSWebView* view)
 {
     view->m_loading = false;
@@ -1261,16 +1226,13 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Navigation events update the view first and then, like any other CDP
-    // event, reach addEventListener("Page.frameNavigated", ...) listeners.
+    // Navigation events update the view, then reach addEventListener() like any CDP event.
     if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0)
         onFrameNavigated(view, params);
     else if (method.size() == 28 && memcmp(method.data(), "Page.navigatedWithinDocument", 28) == 0)
         onNavigatedWithinDocument(view, params);
     else if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
-        // The main frame's load event. An error page finishing its load is not
-        // a navigation: its failure was reported at commit.
-        if (view->m_chromeOnErrorPage)
+        if (view->m_chromeOnErrorPage) // its failure was reported at commit
             view->m_loading = false;
         else
             finishNavigation(view);
@@ -1378,12 +1340,8 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Dispatch to the view's EventTarget if it has a listener for this
-    // method name. Check hasEventListeners first: Chrome is chatty
-    // (frameScheduledNavigation, lifecycleEvent, etc.) and most events won't
-    // have listeners; skipping the JSONParse saves an alloc per unwanted
-    // event. The listener was added via
-    // view.addEventListener("Network.responseReceived", e => e.data.response).
+    // view.addEventListener("Network.responseReceived", e => e.data.response): check
+    // hasEventListeners before the JSONParse, Chrome is chatty.
     auto methodAtom = AtomString::fromUTF8(method);
     if (!view->wrapped().hasEventListeners(methodAtom)) return;
 

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -351,6 +351,9 @@ struct Pending {
     Method method;
     PendingSlot slot;
     uint32_t viewId;
+    // PageTitle: the view's m_chromeNavGeneration when the load finished. A
+    // navigation issued after that owns the slot, and this reply leaves it alone.
+    uint32_t navGeneration = 0;
 };
 
 // Transport mode. Pipe = we spawned Chrome with --remote-debugging-pipe,

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -351,9 +351,7 @@ struct Pending {
     Method method;
     PendingSlot slot;
     uint32_t viewId;
-    // PageTitle: the view's m_chromeNavGeneration when the load finished. A
-    // navigation issued after that owns the slot, and this reply leaves it alone.
-    uint32_t navGeneration = 0;
+    uint32_t navGeneration = 0; // PageTitle: m_chromeNavGeneration at load; stale replies do not settle
 };
 
 // Transport mode. Pipe = we spawned Chrome with --remote-debugging-pipe,

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -479,6 +479,7 @@ public:
     void handleResponse(uint32_t id, std::span<const char> result, std::span<const char> error);
     void handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId);
     void rejectAllAndMarkDead(const WTF::String& reason);
+    bool hasUnansweredNavigation(JSWebView*);
     void onFrameNavigated(JSWebView*, std::span<const char> params);
     void onNavigatedWithinDocument(JSWebView*, std::span<const char> params);
     void finishNavigation(JSWebView*);

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -352,6 +352,7 @@ struct Pending {
     PendingSlot slot;
     uint32_t viewId;
     uint32_t navGeneration = 0; // PageTitle: m_chromeNavGeneration at load; stale replies do not settle
+    uint32_t docGeneration = 0; // PageTitle: m_chromeDocumentGeneration at load; a newer commit drops the reply
 };
 
 // Transport mode. Pipe = we spawned Chrome with --remote-debugging-pipe,

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -478,6 +478,9 @@ public:
     void handleResponse(uint32_t id, std::span<const char> result, std::span<const char> error);
     void handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId);
     void rejectAllAndMarkDead(const WTF::String& reason);
+    void onFrameNavigated(JSWebView*, std::span<const char> params);
+    void onNavigatedWithinDocument(JSWebView*, std::span<const char> params);
+    void finishNavigation(JSWebView*);
     void updateKeepAlive();
     void writeRaw(const char* data, size_t len);
 

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -106,6 +106,8 @@ public:
     bool m_chromeDocumentLoading = false;
     // A same-document navigation happened while a navigation command was unanswered.
     bool m_chromeSameDocumentNavigated = false;
+    // Counts Navigate-slot commands issued, so a stale title reply can tell its slot was reused.
+    uint32_t m_chromeNavGeneration = 0;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -98,6 +98,14 @@ public:
     WTF::String m_sessionId;
     WTF::String m_targetId;
     WTF::String m_pendingChromeNavigateUrl;
+    // loaderId of the last Page.navigate that answered with errorText, so
+    // the error page Chrome then commits is not reported as a second failure.
+    WTF::String m_chromeFailedLoaderId;
+    // The committed main-frame document is Chrome's error page.
+    bool m_chromeOnErrorPage = false;
+    // Page.navigatedWithinDocument arrived while a navigation command was
+    // unanswered; that command's reply settles if it was same-document.
+    bool m_chromeSameDocumentNavigated = false;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -105,6 +105,7 @@ public:
     // The URL whose error page committed and whose failure is reported once that page loads.
     WTF::String m_chromeUnreportedFailure;
     uint32_t m_chromeUnreportedFailureGeneration = 0;
+    bool m_chromeUnreportedFailureSettles = false;
     // A main-frame document has committed and not fired its load event yet.
     bool m_chromeDocumentLoading = false;
     // A same-document navigation happened while a navigation command was unanswered.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -103,6 +103,8 @@ public:
     WTF::String m_chromeFailedLoaderId;
     // The committed main-frame document is Chrome's error page.
     bool m_chromeOnErrorPage = false;
+    // A main-frame document has committed and not fired its load event yet.
+    bool m_chromeDocumentLoading = false;
     // Page.navigatedWithinDocument arrived while a navigation command was
     // unanswered; that command's reply settles if it was same-document.
     bool m_chromeSameDocumentNavigated = false;

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -102,6 +102,8 @@ public:
     WTF::String m_chromeFailedLoaderId;
     // The committed main-frame document is Chrome's error page.
     bool m_chromeOnErrorPage = false;
+    // The URL whose error page committed and whose failure is reported once that page loads.
+    WTF::String m_chromeUnreportedFailure;
     // A main-frame document has committed and not fired its load event yet.
     bool m_chromeDocumentLoading = false;
     // A same-document navigation happened while a navigation command was unanswered.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -104,6 +104,7 @@ public:
     bool m_chromeOnErrorPage = false;
     // The URL whose error page committed and whose failure is reported once that page loads.
     WTF::String m_chromeUnreportedFailure;
+    uint32_t m_chromeUnreportedFailureGeneration = 0;
     // A main-frame document has committed and not fired its load event yet.
     bool m_chromeDocumentLoading = false;
     // A same-document navigation happened while a navigation command was unanswered.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -112,6 +112,8 @@ public:
     bool m_chromeSameDocumentNavigated = false;
     // Counts Navigate-slot commands issued, so a stale title reply can tell its slot was reused.
     uint32_t m_chromeNavGeneration = 0;
+    // Counts main-frame commits, so a title reply for a replaced document is dropped.
+    uint32_t m_chromeDocumentGeneration = 0;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -98,15 +98,13 @@ public:
     WTF::String m_sessionId;
     WTF::String m_targetId;
     WTF::String m_pendingChromeNavigateUrl;
-    // loaderId of the last Page.navigate that answered with errorText, so
-    // the error page Chrome then commits is not reported as a second failure.
+    // loaderId whose failure navigate() already reported (its error page commits later).
     WTF::String m_chromeFailedLoaderId;
     // The committed main-frame document is Chrome's error page.
     bool m_chromeOnErrorPage = false;
     // A main-frame document has committed and not fired its load event yet.
     bool m_chromeDocumentLoading = false;
-    // Page.navigatedWithinDocument arrived while a navigation command was
-    // unanswered; that command's reply settles if it was same-document.
+    // A same-document navigation happened while a navigation command was unanswered.
     bool m_chromeSameDocumentNavigated = false;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields

--- a/test/js/bun/webview/webview-chrome-disconnect.test.ts
+++ b/test/js/bun/webview/webview-chrome-disconnect.test.ts
@@ -128,12 +128,12 @@ test.concurrent.each([
 
     mock.completeLoads = false;
     const committed = Promise.withResolvers();
-    view.onNavigated = () => committed.resolve();
+    view.addEventListener("Page.frameNavigated", () => committed.resolve(), { once: true });
     let outcome = "pending";
     ${startOp}.then(() => (outcome = "resolved"), e => (outcome = "rejected: " + e.message));
-    // onNavigated fires on Page.frameNavigated, which the mock sends after
-    // the op's own reply, so by now the backend has consumed that reply and
-    // only the promise slot is waiting (for a load event that never comes).
+    // The mock sends Page.frameNavigated after the op's own reply, so by now
+    // the backend has consumed that reply and only the promise slot is
+    // waiting (for a load event that never comes).
     await committed.promise;
 
     // A request that is still waiting for its reply. It rejects as soon as
@@ -163,8 +163,8 @@ test.concurrent("a dropped connection rejects the committed navigation of every 
     mock.completeLoads = false;
     const committedA = Promise.withResolvers();
     const committedB = Promise.withResolvers();
-    a.onNavigated = () => committedA.resolve();
-    b.onNavigated = () => committedB.resolve();
+    a.addEventListener("Page.frameNavigated", () => committedA.resolve(), { once: true });
+    b.addEventListener("Page.frameNavigated", () => committedB.resolve(), { once: true });
     const nav = { a: "pending", b: "pending" };
     a.navigate("http://mock/a2").then(() => (nav.a = "resolved"), e => (nav.a = "rejected: " + e.message));
     b.navigate("http://mock/b2").then(() => (nav.b = "resolved"), e => (nav.b = "rejected: " + e.message));
@@ -205,7 +205,7 @@ test.concurrent.each([
 
     mock.completeLoads = false;
     const committed = Promise.withResolvers();
-    view.onNavigated = () => committed.resolve();
+    view.addEventListener("Page.frameNavigated", () => committed.resolve(), { once: true });
     const nav = view.navigate("http://mock/2").then(() => "resolved", e => "rejected: " + e.message);
     await committed.promise;
     const loadingBefore = view.loading;
@@ -258,8 +258,10 @@ const chromeInstalled =
             return new Response("<img src='/hang'>", { headers: { "content-type": "text/html" } });
           },
         });
+        // Page.frameNavigated is the commit; onNavigated would wait for the
+        // load that never finishes.
         const committed = Promise.withResolvers();
-        view.onNavigated = () => committed.resolve();
+        view.addEventListener("Page.frameNavigated", () => committed.resolve(), { once: true });
         let navigate = "pending";
         view.navigate(server.url.href).then(() => (navigate = "resolved"), e => (navigate = "rejected: " + e.message));
         await committed.promise;

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -199,8 +199,8 @@ test.concurrent("close() rejects a held navigate() catchably and a floating one 
 // The browser dying (instead of close()) rejects the same internal
 // constructor-url promise; that must be quiet too. A floating user promise
 // is the opposite: a crash is not a requested teardown, so its rejection
-// must stay loud. --no-title-reply keeps the Navigate slot pending past
-// onNavigated, like a real browser whose title fetch has not come back yet.
+// must stay loud. --no-title-reply keeps the Navigate slot pending past the
+// load event, like a real browser whose title fetch has not come back yet.
 test.concurrent(
   "a browser death is quiet for the constructor url promise and loud for a floating evaluate",
   async () => {
@@ -213,7 +213,7 @@ test.concurrent(
       height: 100,
       url: "http://fake/initial",
     });
-    await new Promise(resolve => { view.onNavigated = resolve; });
+    await new Promise(resolve => view.addEventListener("Page.loadEventFired", resolve, { once: true }));
     view.evaluate("__fake_exit(3)"); // floating: a crash rejection must stay loud
     const deadline = Date.now() + 5000;
     while (unhandled.length === 0 && Date.now() < deadline) await Bun.sleep(10);

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -174,7 +174,10 @@ const it = chromePath && !chromeBroken && !edgeAsLocalSystem ? test : test.todo;
 // WebSocket-transport tests live in webview-chrome-ws.test.ts — the
 // Transport singleton means you can't mix pipe-mode (this file) and
 // connect-mode in one process.
-const chrome = { type: "chrome" as const, url: false as const };
+//
+// Chrome refuses to start as root (containers) without --no-sandbox.
+const chromeArgv: string[] = process.platform !== "win32" && process.getuid?.() === 0 ? ["--no-sandbox"] : [];
+const chrome = { type: "chrome" as const, url: false as const, argv: chromeArgv };
 
 const html = (h: string) => "data:text/html," + encodeURIComponent(h);
 
@@ -571,7 +574,7 @@ it("chrome: closeAll() kills the subprocess and pending promises reject", async 
       bunExe(),
       "-e",
       `
-        const view = new Bun.WebView({ backend: {type:"chrome", url:false}, width: 200, height: 200 });
+        const view = new Bun.WebView({ backend: {type:"chrome", url:false, argv: ${JSON.stringify(chromeArgv)}}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         const p = view.evaluate("new Promise(() => {})"); // never resolves
         Bun.WebView.closeAll();
@@ -603,7 +606,7 @@ it("chrome: a new WebView respawns Chrome after the previous one died", async ()
       bunExe(),
       "-e",
       `
-        const backend = {type:"chrome", url:false};
+        const backend = {type:"chrome", url:false, argv: ${JSON.stringify(chromeArgv)}};
         const first = new Bun.WebView({ backend, width: 200, height: 200 });
         await first.navigate("data:text/html,<body>first</body>");
         const pending = first.evaluate("new Promise(() => {})");
@@ -748,7 +751,7 @@ it("chrome: backend.stderr defaults to ignore (Chrome noise hidden)", async () =
       bunExe(),
       "-e",
       `
-        const view = new Bun.WebView({ backend: {type:"chrome", url:false}, width: 200, height: 200 });
+        const view = new Bun.WebView({ backend: {type:"chrome", url:false, argv: ${JSON.stringify(chromeArgv)}}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         view.close();
       `,
@@ -788,7 +791,11 @@ it("backend: { type: 'chrome' } object form works", async () => {
   // path forces spawn-mode — without it, the bare object form would
   // auto-detect DevToolsActivePort and connect to the dev's Chrome,
   // locking the singleton into WS mode for subsequent tests.
-  await using view = new Bun.WebView({ backend: { type: "chrome", path: chromePath }, width: 200, height: 200 });
+  await using view = new Bun.WebView({
+    backend: { type: "chrome", path: chromePath, argv: chromeArgv },
+    width: 200,
+    height: 200,
+  });
   await view.navigate(html("<body>obj</body>"));
   expect(await view.evaluate("document.body.textContent")).toBe("obj");
 });
@@ -803,7 +810,7 @@ it("backend.argv appends after core flags", async () => {
       "-e",
       `
       const view = new Bun.WebView({
-        backend: { type: "chrome", argv: ["--user-agent=BunWebViewTest/1.0"] },
+        backend: { type: "chrome", argv: [...${JSON.stringify(chromeArgv)}, "--user-agent=BunWebViewTest/1.0"] },
         width: 200, height: 200,
       });
       await view.navigate("data:text/html,<body></body>");
@@ -1029,10 +1036,150 @@ it("chrome: onNavigated fires with committed URL", async () => {
   view.onNavigated = (url: string) => urls.push(url);
   const url = html("<body>test</body>");
   await view.navigate(url);
-  // Page.frameNavigated fires before loadEventFired; the callback runs
-  // inside onData before the promise microtask.
+  // The callback runs when the load completes, inside onData, before the
+  // navigate() promise's microtask.
   expect(urls.length).toBeGreaterThanOrEqual(1);
   expect(urls[urls.length - 1]).toContain("data:text/html");
+});
+
+// A local server for the navigation-event tests below: http:// pages get
+// real history entries, fragments, subframes and the back-forward cache,
+// which data: URLs do not exercise the same way.
+function navServer() {
+  const page = (body: string) => new Response(body, { headers: { "content-type": "text/html; charset=utf-8" } });
+  const server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req) {
+      const path = new URL(req.url).pathname;
+      if (path === "/outer") return page('<title>outer</title><iframe src="/inner"></iframe>');
+      if (path === "/inner") return page("<title>inner</title>inner");
+      return page(`<title>T${path}</title><body>${path}</body>`);
+    },
+  });
+  return { server, base: `http://127.0.0.1:${server.port}`, [Symbol.dispose]: () => void server.stop(true) };
+}
+
+it("chrome: onNavigated receives (url, title) once per main-frame load; subframes do not count", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  const seen: [string, string][] = [];
+  view.onNavigated = (url: string, title: string) => seen.push([url.replace(srv.base, ""), title]);
+  await view.navigate(srv.base + "/outer");
+  // The <iframe src=/inner> commits its own Page.frameNavigated (with a
+  // parentId). It must neither fire the callback nor replace view.url.
+  expect(seen).toEqual([["/outer", "outer"]]);
+  expect(view.url).toBe(srv.base + "/outer");
+  expect(view.title).toBe("outer");
+});
+
+it("chrome: view.url keeps the #fragment", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/page#frag");
+  // Chrome reports the fragment in frame.urlFragment, separate from frame.url.
+  expect(view.url).toBe(srv.base + "/page#frag");
+  expect(await view.evaluate("location.href")).toBe(srv.base + "/page#frag");
+});
+
+it("chrome: a failed navigate() reports one failure and no navigation, and leaves view.url alone", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/before");
+  const events: string[] = [];
+  view.onNavigated = (url: string) => events.push("navigated:" + url);
+  view.onNavigationFailed = (err: Error) => events.push("failed:" + err.message);
+  // Port 9 is on Chrome's unsafe-port list: fails before any connection.
+  await expect(view.navigate("http://127.0.0.1:9/")).rejects.toThrow("net::ERR_UNSAFE_PORT");
+  // Chrome then commits its internal error page (chrome-error://chromewebdata/)
+  // and fires its load event. Round-trip an evaluate so those events have
+  // arrived: neither may surface as a navigation or as a second failure.
+  await view.evaluate("1");
+  expect(events).toEqual(["failed:net::ERR_UNSAFE_PORT"]);
+  expect(view.url).toBe(srv.base + "/before");
+  expect(view.title).toBe("T/before");
+  expect(view.loading).toBe(false);
+});
+
+it("chrome: a navigation the page starts and that fails fires onNavigationFailed", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/start");
+  const events: string[] = [];
+  const failed = Promise.withResolvers<void>();
+  view.onNavigated = (url: string) => events.push("navigated:" + url);
+  view.onNavigationFailed = (err: Error) => {
+    events.push("failed:" + err.message);
+    failed.resolve();
+  };
+  await view.evaluate("setTimeout(() => { location.href = 'http://127.0.0.1:9/gone'; }, 0), 0");
+  await failed.promise;
+  expect(events).toEqual(["failed:Navigation to http://127.0.0.1:9/gone failed"]);
+  expect(view.url).toBe(srv.base + "/start");
+  // reload() reloads the URL that failed, which fails again: it rejects
+  // instead of resolving on the error page's load event.
+  await expect(view.reload()).rejects.toThrow("Navigation to http://127.0.0.1:9/gone failed");
+  expect(events).toEqual([
+    "failed:Navigation to http://127.0.0.1:9/gone failed",
+    "failed:Navigation to http://127.0.0.1:9/gone failed",
+  ]);
+});
+
+it("chrome: same-document navigations settle and update view.url", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/doc");
+  const seen: [string, string][] = [];
+  view.onNavigated = (url: string, title: string) => seen.push([url.replace(srv.base, ""), title]);
+
+  // Only the fragment differs: Chrome answers Page.navigate and then sends
+  // Page.navigatedWithinDocument, never Page.loadEventFired.
+  await view.navigate(srv.base + "/doc#section");
+  expect(view.url).toBe(srv.base + "/doc#section");
+  expect(view.loading).toBe(false);
+
+  // history.pushState from the page: view.url follows and onNavigated fires.
+  await view.evaluate("history.pushState({}, '', '/pushed?x=1#h'), 0");
+  expect(view.url).toBe(srv.base + "/pushed?x=1#h");
+
+  // Back across the pushState entry is a same-document history traversal.
+  await view.goBack();
+  expect(view.url).toBe(srv.base + "/doc#section");
+  expect(await view.evaluate("location.pathname + location.hash")).toBe("/doc#section");
+  await view.goForward();
+  expect(view.url).toBe(srv.base + "/pushed?x=1#h");
+
+  expect(seen).toEqual([
+    ["/doc#section", "T/doc"],
+    ["/pushed?x=1#h", "T/doc"],
+    ["/doc#section", "T/doc"],
+    ["/pushed?x=1#h", "T/doc"],
+  ]);
+});
+
+it("chrome: goBack() to a page restored from the back-forward cache resolves", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/a#top");
+  await view.navigate(srv.base + "/b");
+  const seen: [string, string][] = [];
+  view.onNavigated = (url: string, title: string) => seen.push([url.replace(srv.base, ""), title]);
+  // Chrome restores /a from its back-forward cache: Page.frameNavigated
+  // arrives with type "BackForwardCacheRestore" and no load event follows.
+  // (If this Chrome build decides not to cache the page, it is a regular
+  // load and the expectations are the same.)
+  await view.goBack();
+  expect(view.url).toBe(srv.base + "/a#top");
+  expect(view.title).toBe("T/a");
+  expect(view.loading).toBe(false);
+  expect(await view.evaluate("document.title")).toBe("T/a");
+  await view.goForward();
+  expect(view.url).toBe(srv.base + "/b");
+  expect(view.title).toBe("T/b");
+  expect(seen).toEqual([
+    ["/a#top", "T/a"],
+    ["/b", "T/b"],
+  ]);
 });
 
 it("chrome: press() dispatches keydown/keyup pair", async () => {
@@ -1134,7 +1281,7 @@ it("chrome: console: globalThis.console forwards to parent's stdout", async () =
       "-e",
       `
       const view = new Bun.WebView({
-        backend: {type:"chrome", url:false}, width: 200, height: 200,
+        backend: {type:"chrome", url:false, argv: ${JSON.stringify(chromeArgv)}}, width: 200, height: 200,
         console: globalThis.console,
       });
       await view.navigate("data:text/html,<body></body>");
@@ -1194,7 +1341,7 @@ it("chrome: large evaluate result crosses the pipe", async () => {
 // resolved once per process, on the first spawn. The env var is consulted
 // right after backend.path, before $PATH and the install locations.
 const spawnWithEnv = `
-  const view = new Bun.WebView({ backend: { type: "chrome", url: false }, width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: { type: "chrome", url: false, argv: ${JSON.stringify(chromeArgv)} }, width: 200, height: 200 });
   await view.navigate("data:text/html,<body>env</body>");
   console.log(await view.evaluate("document.body.textContent"));
   view.close();

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -1054,6 +1054,8 @@ function navServer() {
       const path = new URL(req.url).pathname;
       if (path === "/outer") return page('<title>outer</title><iframe src="/inner"></iframe>');
       if (path === "/inner") return page("<title>inner</title>inner");
+      // An SPA router rewriting the URL while the document is still loading.
+      if (path === "/spa") return page("<title>SPA</title><script>history.replaceState({}, '', '/app/home')</script>");
       return page(`<title>T${path}</title><body>${path}</body>`);
     },
   });
@@ -1155,6 +1157,38 @@ it("chrome: same-document navigations settle and update view.url", async () => {
     ["/doc#section", "T/doc"],
     ["/pushed?x=1#h", "T/doc"],
   ]);
+});
+
+it("chrome: a replaceState while the document loads is part of that load, not an early settle", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/first");
+  const seen: [string, string, boolean][] = [];
+  view.onNavigated = (url: string, title: string) => seen.push([url.replace(srv.base, ""), title, view.loading]);
+  // /spa's inline script calls history.replaceState before the load event.
+  // navigate() must still wait for the load (title known, loading false) and
+  // report the navigation once, with the rewritten URL.
+  await view.navigate(srv.base + "/spa");
+  expect({ url: view.url, title: view.title, loading: view.loading, seen }).toEqual({
+    url: srv.base + "/app/home",
+    title: "SPA",
+    loading: false,
+    seen: [["/app/home", "SPA", false]],
+  });
+  // A later pushState by the loaded page is its own navigation again, and a
+  // cross-document goBack() after it still waits for the old page to load.
+  await view.evaluate("history.pushState({}, '', '/app/next'), 0");
+  await view.goBack(); // same-document: /app/next -> /app/home
+  await view.goBack(); // cross-document: back to /first
+  expect({ url: view.url, title: view.title, seen: seen.slice(1) }).toEqual({
+    url: srv.base + "/first",
+    title: "T/first",
+    seen: [
+      ["/app/next", "SPA", false],
+      ["/app/home", "SPA", false],
+      ["/first", "T/first", false],
+    ],
+  });
 });
 
 it("chrome: goBack() to a page restored from the back-forward cache resolves", async () => {

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -1091,12 +1091,13 @@ it("chrome: a failed navigate() reports one failure and no navigation, and leave
   const events: string[] = [];
   view.onNavigated = (url: string) => events.push("navigated:" + url);
   view.onNavigationFailed = (err: Error) => events.push("failed:" + err.message);
+  // Chrome then commits its internal error page (chrome-error://chromewebdata/)
+  // and fires its load event; wait for that so every event it produces has been
+  // handled. Neither may surface as a navigation or as a second failure.
+  const errorPageLoaded = new Promise(resolve => view.addEventListener("Page.loadEventFired", resolve, { once: true }));
   // Port 9 is on Chrome's unsafe-port list: fails before any connection.
   await expect(view.navigate("http://127.0.0.1:9/")).rejects.toThrow("net::ERR_UNSAFE_PORT");
-  // Chrome then commits its internal error page (chrome-error://chromewebdata/)
-  // and fires its load event. Round-trip an evaluate so those events have
-  // arrived: neither may surface as a navigation or as a second failure.
-  await view.evaluate("1");
+  await errorPageLoaded;
   expect(events).toEqual(["failed:net::ERR_UNSAFE_PORT"]);
   expect(view.url).toBe(srv.base + "/before");
   expect(view.title).toBe("T/before");


### PR DESCRIPTION
### Problem
- The Chrome backend applied every `Page.frameNavigated` to the view as is. An `<iframe>`'s commit replaced `view.url`; the `#fragment` (which Chrome sends separately as `frame.urlFragment`) was dropped; after a failed load, Chrome's error-page commit fired `onNavigated("chrome-error://chromewebdata/")` and became `view.url`; and `onNavigated(url, title)` always received `title === undefined` because it ran at commit, before the title exists.
- It also settled a navigation only on `Page.loadEventFired`, which never comes for a same-document navigation or a back-forward-cache restore. So `navigate()` to a URL that differs only in its fragment, `goBack()` across a `history.pushState()` entry, and `goBack()` to a cached http page never resolved, and a page-side `pushState()` left `view.url` stale.
- Cause: `Transport::handleEvent` in `src/runtime/webview/ChromeBackend.cpp` read only `frame.url` from `Page.frameNavigated` (no `parentId`, `urlFragment`, `unreachableUrl` or `type` check) and had no handler for `Page.navigatedWithinDocument`.

### Fix
- `onFrameNavigated`: ignore frames with a `parentId`; set `view.url = frame.url + frame.urlFragment`; treat a commit with `unreachableUrl` as a failure (fire `onNavigationFailed` and reject a pending `reload()`/`goBack()`, unless `navigate()` already reported that `loaderId` from `Page.navigate`'s `errorText`), leaving `view.url`/`view.title` alone and skipping the error page's load event; finish a `BackForwardCacheRestore` commit at once. `onNavigatedWithinDocument` (main frame only): update `view.url`, fire `onNavigated`, and settle a pending `navigate()`/`goBack()`/`goForward()`; when the command's reply has not arrived yet, the reply settles instead (a `Page.navigate` reply without `loaderId` is a same-document navigation).
- `onNavigated(url, title)` now runs when the load completes, right after the title fetch and still before `navigate()` resolves, as documented and as the WebKit backend does. `Page.frameNavigated`, `Page.navigatedWithinDocument` and `Page.loadEventFired` now also reach `addEventListener()` listeners like every other CDP event; that is how a caller observes the commit itself (the mock-transport tests switch to it).
- Verified: `test/js/bun/webview/webview-chrome.test.ts` (six new tests against a local server: subframe + title, fragment, failed `navigate()`, page-initiated failure + `reload()`, same-document `navigate()`/`pushState`/`goBack()`/`goForward()`, bfcache `goBack()`; all six fail or hang on stock 1.4.3). `webview-chrome-disconnect.test.ts` and `webview-chrome-pipe.test.ts` pass with their commit signal moved to `Page.frameNavigated`.

### Background
- CDP sends `Page.frameNavigated {frame, type}` when a document commits in any frame of the page. `frame.parentId` is set for subframes. `frame.urlFragment` carries the `#fragment`, which `frame.url` omits. `frame.unreachableUrl` is set when the commit is Chrome's error page for a load that failed. `type` is `Navigation` or `BackForwardCacheRestore`; a restore is a complete page and no load event follows.
- `Page.navigatedWithinDocument {frameId, url, navigationType}` is the only event for a same-document navigation (fragment change, `pushState`/`replaceState`, or history traversal between such entries). A page target's id equals its main frame's id, which is how the main frame is recognised here.
- `Page.navigate` replies `{frameId, loaderId?, errorText?}`: `errorText` for a failure before commit, and no `loaderId` for a same-document navigation. The backend keeps one pending "Navigate slot" promise per view; before this change only the `document.title` fetch chained from `Page.loadEventFired` resolved it.

<details><summary>Notes</summary>

- Reported as ledger item 45813 (cases A, B, C, pushState, title). The three hangs were found while tracing the same handler with a raw CDP probe against Chrome 143: for `Page.navigate` to `url#frag` on the same document Chrome sends `frameStartedNavigating(sameDocument)`, the reply (no `loaderId`), then `navigatedWithinDocument`; for `navigateToHistoryEntry` across a pushState entry the same; for a cross-document history entry on an http page, `frameNavigated` with `type: "BackForwardCacheRestore"` and no `loadEventFired`.
- The subframe check is the same one #30645 carries inside its larger change; the two will merge trivially.
- A same-document navigation while a new main-frame document is still loading (an SPA router calling `replaceState` on boot) only updates `view.url`; the load settles `navigate()` and its `onNavigated` reports the rewritten URL once. What remains open: the old document calling `pushState` in the short window between a cross-document command's reply and its commit settles that command early. Puppeteer's lifecycle watcher has the same race.
- The Chrome test file passes `--no-sandbox` when it runs as root (containers), as #42163 does, so the file runs in that environment.

</details>
