### PR TITLE
webview: type- and range-check Bun.WebView options and method arguments

### DIFF
--- a/src/runtime/webview/JSWebViewConstructor.cpp
+++ b/src/runtime/webview/JSWebViewConstructor.cpp
@@ -124,9 +124,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
     bool consoleIsGlobal = false;
     JSObject* consoleCallback = nullptr;
 
-    // Every option: undefined means the default; any other value must have
-    // the documented type (ERR_INVALID_ARG_TYPE) and range (ERR_OUT_OF_RANGE,
-    // reported with the value as passed).
+    // For every option, undefined means the default; anything else is type- and range-checked.
     JSValue options = callFrame->argument(0);
     if (!options.isUndefined() && (!options.isObject() || options.isCallable()))
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, options);
@@ -192,9 +190,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
             if (!parseBackendType(type.toWTFString(globalObject))) return {};
             RETURN_IF_EXCEPTION(scope, {});
 
-            // path/argv select spawn mode even when empty, so they can be
-            // checked against url (connect mode) below.
-            bool spawnOptionGiven = false;
+            bool spawnOptionGiven = false; // path/argv present (even empty): spawn mode
             JSValue path = beObj->get(globalObject, Identifier::fromString(vm, "path"_s));
             RETURN_IF_EXCEPTION(scope, {});
             if (path.isString()) {

--- a/src/runtime/webview/JSWebViewConstructor.cpp
+++ b/src/runtime/webview/JSWebViewConstructor.cpp
@@ -7,6 +7,7 @@
 #include "ZigGlobalObject.h"
 #include "ScriptExecutionContext.h"
 #include "ErrorCode.h"
+#include "NodeValidator.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/InternalFunction.h>
 #include <JavaScriptCore/FunctionPrototype.h>
@@ -123,22 +124,33 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
     bool consoleIsGlobal = false;
     JSObject* consoleCallback = nullptr;
 
+    // Every option: undefined means the default; any other value must have
+    // the documented type (ERR_INVALID_ARG_TYPE) and range (ERR_OUT_OF_RANGE,
+    // reported with the value as passed).
     JSValue options = callFrame->argument(0);
+    if (!options.isUndefined() && !options.isObject())
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, options);
     if (options.isObject()) {
         JSObject* opts = options.getObject();
         JSValue w = opts->get(globalObject, Identifier::fromString(vm, "width"_s));
         RETURN_IF_EXCEPTION(scope, {});
-        if (w.isNumber()) width = static_cast<uint32_t>(w.toUInt32(globalObject));
-        RETURN_IF_EXCEPTION(scope, {});
+        if (!w.isUndefined()) {
+            Bun::V::validateInteger(scope, globalObject, w, "width"_s, jsNumber(1), jsNumber(16384), &width);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
 
         JSValue h = opts->get(globalObject, Identifier::fromString(vm, "height"_s));
         RETURN_IF_EXCEPTION(scope, {});
-        if (h.isNumber()) height = static_cast<uint32_t>(h.toUInt32(globalObject));
-        RETURN_IF_EXCEPTION(scope, {});
+        if (!h.isUndefined()) {
+            Bun::V::validateInteger(scope, globalObject, h, "height"_s, jsNumber(1), jsNumber(16384), &height);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
 
         JSValue headless = opts->get(globalObject, Identifier::fromString(vm, "headless"_s));
         RETURN_IF_EXCEPTION(scope, {});
-        if (headless.isBoolean() && !headless.asBoolean()) {
+        if (!headless.isUndefined() && !headless.isBoolean())
+            return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options.headless"_s, "boolean"_s, headless);
+        if (headless.isFalse()) {
             return Bun::throwError(globalObject, scope, ErrorCode::ERR_METHOD_NOT_IMPLEMENTED,
                 "headless: false is not yet implemented"_s);
         }
@@ -166,6 +178,9 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
             WTF::String s = be.toWTFString(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
             if (!parseBackendType(s)) return {};
+        } else if (!be.isUndefined() && !be.isObject()) {
+            return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
+                "backend must be \"webkit\", \"chrome\", or an object with a type field"_s);
         } else if (be.isObject()) {
             JSObject* beObj = be.getObject();
             JSValue type = beObj->get(globalObject, Identifier::fromString(vm, "type"_s));
@@ -177,11 +192,17 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
             if (!parseBackendType(type.toWTFString(globalObject))) return {};
             RETURN_IF_EXCEPTION(scope, {});
 
+            // path/argv select spawn mode even when empty, so they can be
+            // checked against url (connect mode) below.
+            bool spawnOptionGiven = false;
             JSValue path = beObj->get(globalObject, Identifier::fromString(vm, "path"_s));
             RETURN_IF_EXCEPTION(scope, {});
             if (path.isString()) {
+                spawnOptionGiven = true;
                 chromePath = path.toWTFString(globalObject);
                 RETURN_IF_EXCEPTION(scope, {});
+                if (chromePath.contains(char16_t(0)))
+                    return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "backend.path"_s, path, "must be a string without null bytes"_s);
             } else if (!path.isUndefined()) {
                 return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
                     "backend.path must be a string"_s);
@@ -218,6 +239,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
             JSValue argvVal = beObj->get(globalObject, Identifier::fromString(vm, "argv"_s));
             RETURN_IF_EXCEPTION(scope, {});
             if (auto* arr = dynamicDowncast<JSArray>(argvVal)) {
+                spawnOptionGiven = true;
                 unsigned len = arr->length();
                 for (unsigned i = 0; i < len; ++i) {
                     JSValue item = arr->get(globalObject, i);
@@ -226,15 +248,18 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
                         return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
                             "backend.argv entries must be strings"_s);
                     }
-                    chromeArgv.append(item.toWTFString(globalObject));
+                    auto arg = item.toWTFString(globalObject);
                     RETURN_IF_EXCEPTION(scope, {});
+                    if (arg.contains(char16_t(0)))
+                        return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "backend.argv"_s, item, "must be a string without null bytes"_s);
+                    chromeArgv.append(WTF::move(arg));
                 }
             } else if (!argvVal.isUndefined()) {
                 return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
                     "backend.argv must be an array of strings"_s);
             }
 
-            if (!chromeWsUrl.isEmpty() && (!chromePath.isEmpty() || !chromeArgv.isEmpty()))
+            if (!chromeWsUrl.isEmpty() && spawnOptionGiven)
                 return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_VALUE,
                     "backend.url (connect mode) cannot be combined with backend.path or backend.argv (spawn mode)"_s);
 
@@ -312,6 +337,8 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
             if (dir.isString()) {
                 persistDir = dir.toWTFString(globalObject);
                 RETURN_IF_EXCEPTION(scope, {});
+                if (persistDir.isEmpty() || persistDir.contains(char16_t(0)))
+                    return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "dataStore.directory"_s, dir, "must be a non-empty path without null bytes"_s);
             } else {
                 return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
                     "dataStore.directory must be a string"_s);
@@ -323,13 +350,11 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
                 return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_VALUE,
                     "dataStore must be \"ephemeral\" or { directory: string }"_s);
             }
+        } else if (!dataStore.isUndefined()) {
+            return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
+                "dataStore must be \"ephemeral\" or { directory: string }"_s);
         }
     }
-
-    if (width == 0 || width > 16384)
-        return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "width"_s, 1, 16384, jsNumber(width));
-    if (height == 0 || height > 16384)
-        return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "height"_s, 1, 16384, jsNumber(height));
 
     Structure* structure = zigGlobalObject->m_JSWebViewClassStructure.get(zigGlobalObject);
     JSValue newTarget = callFrame->newTarget();

--- a/src/runtime/webview/JSWebViewConstructor.cpp
+++ b/src/runtime/webview/JSWebViewConstructor.cpp
@@ -128,7 +128,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
     // the documented type (ERR_INVALID_ARG_TYPE) and range (ERR_OUT_OF_RANGE,
     // reported with the value as passed).
     JSValue options = callFrame->argument(0);
-    if (!options.isUndefined() && !options.isObject())
+    if (!options.isUndefined() && (!options.isObject() || options.isCallable()))
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, options);
     if (options.isObject()) {
         JSObject* opts = options.getObject();
@@ -262,6 +262,9 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(constructWebView, __attribute__((minsiz
             if (!chromeWsUrl.isEmpty() && spawnOptionGiven)
                 return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_VALUE,
                     "backend.url (connect mode) cannot be combined with backend.path or backend.argv (spawn mode)"_s);
+            if (backend != WebViewBackend::Chrome && spawnOptionGiven)
+                return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_VALUE,
+                    "backend.path and backend.argv require type: \"chrome\""_s);
 
             // stdout/stderr: "inherit" | "ignore" — whether the subprocess's
             // streams flow to Bun's. Chrome is chatty on stderr (GCM

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -439,7 +439,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncClick, (JSGlobalObject * globalObject
     uint32_t timeout = 30000;
     auto parseOpts = [&](JSValue opts) -> bool {
         if (opts.isUndefined()) return true;
-        if (!opts.isObject()) {
+        if (!opts.isObject() || opts.isCallable()) {
             Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, opts);
             return false;
         }
@@ -497,10 +497,11 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncClick, (JSGlobalObject * globalObject
             "click() takes a selector string or x and y coordinates (numbers)"_s);
     if (!arg1.isNumber())
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "y"_s, "number"_s, arg1);
+    // The wire format carries float coordinates.
     double x = arg0.asNumber();
     double y = arg1.asNumber();
-    if (!std::isfinite(x) || !std::isfinite(y))
-        return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "x/y"_s, jsNumber(std::isfinite(x) ? y : x), "must be finite"_s);
+    if (!std::isfinite(static_cast<float>(x)) || !std::isfinite(static_cast<float>(y)))
+        return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "x/y"_s, jsNumber(std::isfinite(static_cast<float>(x)) ? y : x), "must be finite"_s);
     if (!parseOpts(callFrame->argument(2))) return {};
 
     if (!checkSlot(globalObject, scope, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
@@ -540,7 +541,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncPress, (JSGlobalObject * globalObject
 
     uint8_t mods = 0;
     JSValue opts = callFrame->argument(1);
-    if (!opts.isUndefined() && !opts.isObject())
+    if (!opts.isUndefined() && (!opts.isObject() || opts.isCallable()))
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, opts);
     if (opts.isObject()) {
         JSValue m = opts.getObject()->get(globalObject, Identifier::fromString(vm, "modifiers"_s));
@@ -603,7 +604,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScrollTo, (JSGlobalObject * globalObj
     uint32_t timeout = 30000;
     uint8_t block = 1; // center
     JSValue opts = callFrame->argument(1);
-    if (!opts.isUndefined() && !opts.isObject())
+    if (!opts.isUndefined() && (!opts.isObject() || opts.isCallable()))
         return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, opts);
     if (opts.isObject()) {
         JSObject* o = opts.getObject();

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -580,6 +580,12 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScroll, (JSGlobalObject * globalObjec
     if (!std::isfinite(dx) || !std::isfinite(dy))
         return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "dx/dy"_s,
             jsNumber(std::isfinite(dx) ? dy : dx), "must be finite"_s);
+    // The WebKit host hands the deltas to CGEvent as int32.
+    constexpr double minDelta = std::numeric_limits<int32_t>::min(), maxDelta = std::numeric_limits<int32_t>::max();
+    if (dx < minDelta || dx > maxDelta)
+        return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "dx"_s, minDelta, maxDelta, callFrame->argument(0));
+    if (dy < minDelta || dy > maxDelta)
+        return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "dy"_s, minDelta, maxDelta, callFrame->argument(1));
 
     if (!checkSlot(globalObject, scope, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
     return JSValue::encode(thisObject->scroll(globalObject, dx, dy));

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -155,8 +155,7 @@ static bool checkSlot(JSGlobalObject* g, ThrowScope& scope, const WriteBarrier<J
     return true;
 }
 
-// options.modifiers: undefined, or an array of modifier names. Throws on
-// anything else so a typo is not a silently unmodified click.
+// options.modifiers: undefined or an array of modifier names; anything else throws.
 static uint8_t parseModifiers(JSGlobalObject* g, ThrowScope& scope, JSValue v)
 {
     using namespace WebViewProto;
@@ -189,8 +188,7 @@ static uint8_t parseModifiers(JSGlobalObject* g, ThrowScope& scope, JSValue v)
     return mods;
 }
 
-// options.timeout: undefined (keep the default) or a finite number of
-// milliseconds >= 0.
+// options.timeout: undefined (keep the default) or a finite millisecond count >= 0.
 static bool parseTimeout(JSGlobalObject* g, ThrowScope& scope, JSValue v, uint32_t& timeout)
 {
     if (v.isUndefined()) return true;

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -274,6 +274,8 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScreenshot, (JSGlobalObject * globalO
     uint8_t quality = 80; // CDP default for jpeg/webp. Ignored for png.
 
     JSValue optsVal = callFrame->argument(0);
+    if (!optsVal.isUndefined() && (!optsVal.isObject() || optsVal.isCallable()))
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, optsVal);
     if (optsVal.isObject()) {
         JSObject* opts = optsVal.getObject();
         JSValue fmtVal = opts->get(globalObject, Identifier::fromString(vm, "format"_s));
@@ -566,10 +568,12 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScroll, (JSGlobalObject * globalObjec
     auto* thisObject = unwrapThis(globalObject, scope, callFrame, "scroll"_s);
     RETURN_IF_EXCEPTION(scope, {});
 
-    double dx = callFrame->argument(0).toNumber(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-    double dy = callFrame->argument(1).toNumber(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
+    if (!callFrame->argument(0).isNumber())
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "dx"_s, "number"_s, callFrame->argument(0));
+    if (!callFrame->argument(1).isNumber())
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "dy"_s, "number"_s, callFrame->argument(1));
+    double dx = callFrame->argument(0).asNumber();
+    double dy = callFrame->argument(1).asNumber();
     // NaN/Inf permanently poison the m_pendingScrollDx/Dy accumulators
     // in the host (NaN + anything = NaN), and static_cast<int32_t>(NaN)
     // at the CGEvent call site is UB.

--- a/src/runtime/webview/JSWebViewPrototype.cpp
+++ b/src/runtime/webview/JSWebViewPrototype.cpp
@@ -6,6 +6,7 @@
 #include "JSWebView.h"
 #include "ZigGlobalObject.h"
 #include "ErrorCode.h"
+#include "NodeValidator.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
@@ -154,18 +155,23 @@ static bool checkSlot(JSGlobalObject* g, ThrowScope& scope, const WriteBarrier<J
     return true;
 }
 
+// options.modifiers: undefined, or an array of modifier names. Throws on
+// anything else so a typo is not a silently unmodified click.
 static uint8_t parseModifiers(JSGlobalObject* g, ThrowScope& scope, JSValue v)
 {
     using namespace WebViewProto;
-    if (!v.isObject()) return 0;
+    if (v.isUndefined()) return 0;
     auto* arr = dynamicDowncast<JSArray>(v);
-    if (!arr) return 0;
+    if (!arr) {
+        Bun::ERR::INVALID_ARG_TYPE_INSTANCE(scope, g, "options.modifiers"_s, "Array"_s, v);
+        return 0;
+    }
     uint8_t mods = 0;
     unsigned len = arr->length();
     for (unsigned i = 0; i < len; ++i) {
         JSValue item = arr->get(g, i);
         RETURN_IF_EXCEPTION(scope, 0);
-        WTF::String s = item.toWTFString(g);
+        WTF::String s = item.isString() ? item.toWTFString(g) : WTF::String();
         RETURN_IF_EXCEPTION(scope, 0);
         if (s == "Shift"_s || s == "shift"_s)
             mods |= ModShift;
@@ -175,8 +181,23 @@ static uint8_t parseModifiers(JSGlobalObject* g, ThrowScope& scope, JSValue v)
             mods |= ModAlt;
         else if (s == "Meta"_s || s == "meta"_s || s == "Cmd"_s || s == "cmd"_s || s == "Command"_s || s == "command"_s)
             mods |= ModMeta;
+        else {
+            Bun::ERR::INVALID_ARG_VALUE(scope, g, "options.modifiers"_s, item, "must be \"Shift\", \"Control\", \"Alt\", or \"Meta\""_s);
+            return 0;
+        }
     }
     return mods;
+}
+
+// options.timeout: undefined (keep the default) or a finite number of
+// milliseconds >= 0.
+static bool parseTimeout(JSGlobalObject* g, ThrowScope& scope, JSValue v, uint32_t& timeout)
+{
+    if (v.isUndefined()) return true;
+    Bun::V::validateNumber(scope, g, v, "options.timeout"_s, jsNumber(0), jsNumber(std::numeric_limits<uint32_t>::max()));
+    RETURN_IF_EXCEPTION(scope, false);
+    timeout = static_cast<uint32_t>(v.asNumber());
+    return true;
 }
 
 // JS string name → wire tag. Order must match ipc_protocol.h's enum; the
@@ -417,17 +438,27 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncClick, (JSGlobalObject * globalObject
     uint8_t button = 0, mods = 0, clickCount = 1;
     uint32_t timeout = 30000;
     auto parseOpts = [&](JSValue opts) -> bool {
-        if (!opts.isObject()) return true;
+        if (opts.isUndefined()) return true;
+        if (!opts.isObject()) {
+            Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, opts);
+            return false;
+        }
         JSObject* o = opts.getObject();
         JSValue b = o->get(globalObject, Identifier::fromString(vm, "button"_s));
         RETURN_IF_EXCEPTION(scope, false);
-        if (b.isString()) {
-            WTF::String bs = b.toWTFString(globalObject);
+        if (!b.isUndefined()) {
+            WTF::String bs = b.isString() ? b.toWTFString(globalObject) : WTF::String();
             RETURN_IF_EXCEPTION(scope, false);
-            if (bs == "right"_s)
+            if (bs == "left"_s)
+                button = 0;
+            else if (bs == "right"_s)
                 button = 1;
             else if (bs == "middle"_s)
                 button = 2;
+            else {
+                Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "options.button"_s, b, "must be \"left\", \"right\", or \"middle\""_s);
+                return false;
+            }
         }
         JSValue m = o->get(globalObject, Identifier::fromString(vm, "modifiers"_s));
         RETURN_IF_EXCEPTION(scope, false);
@@ -435,13 +466,15 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncClick, (JSGlobalObject * globalObject
         RETURN_IF_EXCEPTION(scope, false);
         JSValue cc = o->get(globalObject, Identifier::fromString(vm, "clickCount"_s));
         RETURN_IF_EXCEPTION(scope, false);
-        if (cc.isNumber()) clickCount = static_cast<uint8_t>(std::clamp(cc.toInt32(globalObject), 1, 3));
-        RETURN_IF_EXCEPTION(scope, false);
+        if (!cc.isUndefined()) {
+            uint32_t count = 1;
+            Bun::V::validateInteger(scope, globalObject, cc, "options.clickCount"_s, jsNumber(1), jsNumber(3), &count);
+            RETURN_IF_EXCEPTION(scope, false);
+            clickCount = static_cast<uint8_t>(count);
+        }
         JSValue t = o->get(globalObject, Identifier::fromString(vm, "timeout"_s));
         RETURN_IF_EXCEPTION(scope, false);
-        if (t.isNumber()) timeout = static_cast<uint32_t>(std::max(0.0, t.toNumber(globalObject)));
-        RETURN_IF_EXCEPTION(scope, false);
-        return true;
+        return parseTimeout(globalObject, scope, t, timeout);
     };
 
     // click(selector, opts?) — rAF-polled actionability check page-side
@@ -458,10 +491,16 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncClick, (JSGlobalObject * globalObject
     }
 
     // click(x, y, opts?)
-    double x = arg0.toNumber(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-    double y = callFrame->argument(1).toNumber(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
+    JSValue arg1 = callFrame->argument(1);
+    if (!arg0.isNumber())
+        return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE,
+            "click() takes a selector string or x and y coordinates (numbers)"_s);
+    if (!arg1.isNumber())
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "y"_s, "number"_s, arg1);
+    double x = arg0.asNumber();
+    double y = arg1.asNumber();
+    if (!std::isfinite(x) || !std::isfinite(y))
+        return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "x/y"_s, jsNumber(std::isfinite(x) ? y : x), "must be finite"_s);
     if (!parseOpts(callFrame->argument(2))) return {};
 
     if (!checkSlot(globalObject, scope, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
@@ -501,6 +540,8 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncPress, (JSGlobalObject * globalObject
 
     uint8_t mods = 0;
     JSValue opts = callFrame->argument(1);
+    if (!opts.isUndefined() && !opts.isObject())
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, opts);
     if (opts.isObject()) {
         JSValue m = opts.getObject()->get(globalObject, Identifier::fromString(vm, "modifiers"_s));
         RETURN_IF_EXCEPTION(scope, {});
@@ -562,16 +603,17 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScrollTo, (JSGlobalObject * globalObj
     uint32_t timeout = 30000;
     uint8_t block = 1; // center
     JSValue opts = callFrame->argument(1);
+    if (!opts.isUndefined() && !opts.isObject())
+        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, opts);
     if (opts.isObject()) {
         JSObject* o = opts.getObject();
         JSValue t = o->get(globalObject, Identifier::fromString(vm, "timeout"_s));
         RETURN_IF_EXCEPTION(scope, {});
-        if (t.isNumber()) timeout = static_cast<uint32_t>(std::max(0.0, t.toNumber(globalObject)));
-        RETURN_IF_EXCEPTION(scope, {});
+        if (!parseTimeout(globalObject, scope, t, timeout)) return {};
         JSValue b = o->get(globalObject, Identifier::fromString(vm, "block"_s));
         RETURN_IF_EXCEPTION(scope, {});
-        if (b.isString()) {
-            WTF::String bs = b.toWTFString(globalObject);
+        if (!b.isUndefined()) {
+            WTF::String bs = b.isString() ? b.toWTFString(globalObject) : WTF::String();
             RETURN_IF_EXCEPTION(scope, {});
             if (bs == "start"_s)
                 block = 0;
@@ -582,7 +624,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncScrollTo, (JSGlobalObject * globalObj
             else if (bs == "nearest"_s)
                 block = 3;
             else
-                return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "block"_s, b,
+                return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "options.block"_s, b,
                     "must be \"start\", \"center\", \"end\", or \"nearest\""_s);
         }
     }
@@ -598,14 +640,11 @@ JSC_DEFINE_HOST_FUNCTION(jsWebViewProtoFuncResize, (JSGlobalObject * globalObjec
     auto* thisObject = unwrapThis(globalObject, scope, callFrame, "resize"_s);
     RETURN_IF_EXCEPTION(scope, {});
 
-    uint32_t w = callFrame->argument(0).toUInt32(globalObject);
+    uint32_t w = 0, h = 0;
+    Bun::V::validateInteger(scope, globalObject, callFrame->argument(0), "width"_s, jsNumber(1), jsNumber(16384), &w);
     RETURN_IF_EXCEPTION(scope, {});
-    uint32_t h = callFrame->argument(1).toUInt32(globalObject);
+    Bun::V::validateInteger(scope, globalObject, callFrame->argument(1), "height"_s, jsNumber(1), jsNumber(16384), &h);
     RETURN_IF_EXCEPTION(scope, {});
-    if (w == 0 || w > 16384)
-        return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "width"_s, 1, 16384, jsNumber(w));
-    if (h == 0 || h > 16384)
-        return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "height"_s, 1, 16384, jsNumber(h));
 
     if (!checkSlot(globalObject, scope, thisObject->m_pendingMisc, "a simple operation"_s)) return {};
     return JSValue::encode(thisObject->resize(globalObject, w, h));

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -830,6 +830,7 @@ test("constructor options are type- and range-checked", () => {
   expect(ctor("http://example.com/")).toBe(
     `ERR_INVALID_ARG_TYPE: The "options" argument must be of type object. Received type string ('http://example.com/')`,
   );
+  expect(ctor(() => {})).toStartWith(`ERR_INVALID_ARG_TYPE: The "options" argument must be of type object.`);
   expect(ctor({ backend: 42 })).toStartWith("ERR_INVALID_ARG_TYPE: backend must be");
   expect(ctor({ backend: null })).toStartWith("ERR_INVALID_ARG_TYPE: backend must be");
   expect(ctor({ backend: spawn, dataStore: 5 })).toStartWith("ERR_INVALID_ARG_TYPE: dataStore must be");
@@ -851,9 +852,12 @@ test("constructor options are type- and range-checked", () => {
   );
 
   // An argv (even empty) or path asks for a spawned browser; url asks for an
-  // existing one.
+  // existing one; neither means anything to the WebKit backend.
   expect(ctor({ backend: { type: "chrome", url: "ws://127.0.0.1:1/devtools/browser/x", argv: [] } })).toMatch(
     /connect mode.*cannot be combined.*spawn/,
+  );
+  expect(ctor({ backend: { type: "webkit", argv: ["--flag"] } })).toBe(
+    `ERR_INVALID_ARG_VALUE: backend.path and backend.argv require type: "chrome"`,
   );
 });
 
@@ -907,7 +911,11 @@ it("chrome: method arguments are type- and range-checked", async () => {
     `ERR_INVALID_ARG_TYPE: The "y" argument must be of type number. Received undefined`,
   );
   expect(code(() => v.click(1, NaN))).toBe(`ERR_INVALID_ARG_VALUE: The argument 'x/y' must be finite. Received NaN`);
+  // Coordinates travel as floats; a double beyond float range would arrive as Infinity.
+  expect(code(() => v.click(Number.MAX_VALUE, 0))).toStartWith(`ERR_INVALID_ARG_VALUE: The argument 'x/y' must be finite.`);
   expect(code(() => v.click(1, 2, "opts"))).toStartWith("ERR_INVALID_ARG_TYPE:");
+  expect(code(() => v.click(1, 2, () => {}))).toStartWith("ERR_INVALID_ARG_TYPE:");
+  expect(code(() => v.scrollTo("#a", () => {}))).toStartWith("ERR_INVALID_ARG_TYPE:");
 
   expect(code(() => v.scrollTo("#a", { block: 5 }))).toBe(
     `ERR_INVALID_ARG_VALUE: The property 'options.block' must be "start", "center", "end", or "nearest". Received 5`,

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -928,6 +928,7 @@ it("chrome: method arguments are type- and range-checked", async () => {
   expect(code(() => v.scroll(0, null))).toBe(
     `ERR_INVALID_ARG_TYPE: The "dy" argument must be of type number. Received null`,
   );
+  expect(code(() => v.scroll(1e100, 0))).toStartWith(`ERR_OUT_OF_RANGE: The value of "dx" is out of range.`);
   expect(code(() => v.scrollTo("#a", { block: 5 }))).toBe(
     `ERR_INVALID_ARG_VALUE: The property 'options.block' must be "start", "center", "end", or "nearest". Received 5`,
   );

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -174,7 +174,10 @@ const it = chromePath && !chromeBroken && !edgeAsLocalSystem ? test : test.todo;
 // WebSocket-transport tests live in webview-chrome-ws.test.ts — the
 // Transport singleton means you can't mix pipe-mode (this file) and
 // connect-mode in one process.
-const chrome = { type: "chrome" as const, url: false as const };
+//
+// Chrome refuses to start as root (containers) without --no-sandbox.
+const chromeArgv: string[] = process.platform !== "win32" && process.getuid?.() === 0 ? ["--no-sandbox"] : [];
+const chrome = { type: "chrome" as const, url: false as const, argv: chromeArgv };
 
 const html = (h: string) => "data:text/html," + encodeURIComponent(h);
 
@@ -571,7 +574,7 @@ it("chrome: closeAll() kills the subprocess and pending promises reject", async 
       bunExe(),
       "-e",
       `
-        const view = new Bun.WebView({ backend: {type:"chrome", url:false}, width: 200, height: 200 });
+        const view = new Bun.WebView({ backend: {type:"chrome", url:false, argv: ${JSON.stringify(chromeArgv)}}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         const p = view.evaluate("new Promise(() => {})"); // never resolves
         Bun.WebView.closeAll();
@@ -603,7 +606,7 @@ it("chrome: a new WebView respawns Chrome after the previous one died", async ()
       bunExe(),
       "-e",
       `
-        const backend = {type:"chrome", url:false};
+        const backend = {type:"chrome", url:false, argv: ${JSON.stringify(chromeArgv)}};
         const first = new Bun.WebView({ backend, width: 200, height: 200 });
         await first.navigate("data:text/html,<body>first</body>");
         const pending = first.evaluate("new Promise(() => {})");
@@ -748,7 +751,7 @@ it("chrome: backend.stderr defaults to ignore (Chrome noise hidden)", async () =
       bunExe(),
       "-e",
       `
-        const view = new Bun.WebView({ backend: {type:"chrome", url:false}, width: 200, height: 200 });
+        const view = new Bun.WebView({ backend: {type:"chrome", url:false, argv: ${JSON.stringify(chromeArgv)}}, width: 200, height: 200 });
         await view.navigate("data:text/html,<body>test</body>");
         view.close();
       `,
@@ -784,11 +787,152 @@ test("backend option validates", () => {
   );
 });
 
+// The constructor validates every option before it spawns anything, so none of
+// these need a browser. undefined means the default; any other value must have
+// the documented type and range, and the error reports the value as passed.
+test("constructor options are type- and range-checked", () => {
+  const code = (fn: () => unknown) => {
+    try {
+      fn();
+    } catch (e) {
+      return `${(e as NodeJS.ErrnoException).code}: ${(e as Error).message}`;
+    }
+    return "did not throw";
+  };
+  const ctor = (opts: unknown) => code(() => new (Bun.WebView as any)(opts));
+  const spawn = { type: "chrome", url: false };
+
+  // width/height: previously converted with ToUint32 before the range check
+  // (2**32 + 5 became a 5px viewport, "100" and null became the default).
+  expect(ctor({ backend: spawn, width: 2 ** 32 + 5 })).toBe(
+    `ERR_OUT_OF_RANGE: The value of "width" is out of range. It must be >= 1 && <= 16384. Received 4_294_967_301`,
+  );
+  expect(ctor({ backend: spawn, width: -1 })).toBe(
+    `ERR_OUT_OF_RANGE: The value of "width" is out of range. It must be >= 1 && <= 16384. Received -1`,
+  );
+  expect(ctor({ backend: spawn, height: 0.5 })).toBe(
+    `ERR_OUT_OF_RANGE: The value of "height" is out of range. It must be an integer. Received 0.5`,
+  );
+  expect(ctor({ backend: spawn, height: NaN })).toBe(
+    `ERR_OUT_OF_RANGE: The value of "height" is out of range. It must be an integer. Received NaN`,
+  );
+  expect(ctor({ backend: spawn, width: "100" })).toBe(
+    `ERR_INVALID_ARG_TYPE: The "width" argument must be of type number. Received type string ('100')`,
+  );
+  expect(ctor({ backend: spawn, width: null })).toBe(
+    `ERR_INVALID_ARG_TYPE: The "width" argument must be of type number. Received null`,
+  );
+  expect(ctor({ backend: spawn, height: 600n })).toBe(
+    `ERR_INVALID_ARG_TYPE: The "height" argument must be of type number. Received type bigint (600n)`,
+  );
+
+  // Wrong-typed options used to fall back to their defaults silently.
+  expect(ctor("http://example.com/")).toBe(
+    `ERR_INVALID_ARG_TYPE: The "options" argument must be of type object. Received type string ('http://example.com/')`,
+  );
+  expect(ctor({ backend: 42 })).toStartWith("ERR_INVALID_ARG_TYPE: backend must be");
+  expect(ctor({ backend: null })).toStartWith("ERR_INVALID_ARG_TYPE: backend must be");
+  expect(ctor({ backend: spawn, dataStore: 5 })).toStartWith("ERR_INVALID_ARG_TYPE: dataStore must be");
+  expect(ctor({ backend: spawn, dataStore: null })).toStartWith("ERR_INVALID_ARG_TYPE: dataStore must be");
+  expect(ctor({ backend: spawn, headless: "no" })).toBe(
+    `ERR_INVALID_ARG_TYPE: The "options.headless" property must be of type boolean. Received type string ('no')`,
+  );
+
+  // Strings that end up as C strings must not be cut short by a NUL byte.
+  expect(ctor({ backend: spawn, dataStore: { directory: "/tmp/a\0b" } })).toStartWith(
+    `ERR_INVALID_ARG_VALUE: The property 'dataStore.directory' must be a non-empty path without null bytes.`,
+  );
+  expect(ctor({ backend: spawn, dataStore: { directory: "" } })).toStartWith("ERR_INVALID_ARG_VALUE:");
+  expect(ctor({ backend: { type: "chrome", url: false, argv: ["--a\0b"] } })).toStartWith(
+    `ERR_INVALID_ARG_VALUE: The property 'backend.argv' must be a string without null bytes.`,
+  );
+  expect(ctor({ backend: { type: "chrome", path: "/usr/bin/x\0y" } })).toStartWith(
+    `ERR_INVALID_ARG_VALUE: The property 'backend.path' must be a string without null bytes.`,
+  );
+
+  // An argv (even empty) or path asks for a spawned browser; url asks for an
+  // existing one.
+  expect(ctor({ backend: { type: "chrome", url: "ws://127.0.0.1:1/devtools/browser/x", argv: [] } })).toMatch(
+    /connect mode.*cannot be combined.*spawn/,
+  );
+});
+
+it("chrome: method arguments are type- and range-checked", async () => {
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  const code = (fn: () => unknown) => {
+    try {
+      fn();
+    } catch (e) {
+      return `${(e as NodeJS.ErrnoException).code}: ${(e as Error).message}`;
+    }
+    return "did not throw";
+  };
+  const v = view as any;
+
+  expect(code(() => v.resize(2 ** 32 + 7, 100))).toBe(
+    `ERR_OUT_OF_RANGE: The value of "width" is out of range. It must be >= 1 && <= 16384. Received 4_294_967_303`,
+  );
+  expect(code(() => v.resize("800", 600))).toBe(
+    `ERR_INVALID_ARG_TYPE: The "width" argument must be of type number. Received type string ('800')`,
+  );
+  expect(code(() => v.resize(800, 600.5))).toBe(
+    `ERR_OUT_OF_RANGE: The value of "height" is out of range. It must be an integer. Received 600.5`,
+  );
+
+  expect(code(() => v.click("#a", { timeout: "300" }))).toBe(
+    `ERR_INVALID_ARG_TYPE: The "options.timeout" property must be of type number. Received type string ('300')`,
+  );
+  expect(code(() => v.click("#a", { timeout: -1 }))).toStartWith(
+    `ERR_OUT_OF_RANGE: The value of "options.timeout" is out of range.`,
+  );
+  expect(code(() => v.click("#a", { clickCount: "2" }))).toBe(
+    `ERR_INVALID_ARG_TYPE: The "options.clickCount" property must be of type number. Received type string ('2')`,
+  );
+  expect(code(() => v.click("#a", { clickCount: 4 }))).toBe(
+    `ERR_OUT_OF_RANGE: The value of "options.clickCount" is out of range. It must be >= 1 && <= 3. Received 4`,
+  );
+  expect(code(() => v.click("#a", { button: "bogus" }))).toBe(
+    `ERR_INVALID_ARG_VALUE: The property 'options.button' must be "left", "right", or "middle". Received 'bogus'`,
+  );
+  expect(code(() => v.click("#a", { button: 1 }))).toStartWith("ERR_INVALID_ARG_VALUE:");
+  expect(code(() => v.click("#a", { modifiers: "Shift" }))).toBe(
+    `ERR_INVALID_ARG_TYPE: The "options.modifiers" argument must be an instance of Array. Received type string ('Shift')`,
+  );
+  expect(code(() => v.click("#a", { modifiers: { 0: "Shift", length: 1 } }))).toStartWith("ERR_INVALID_ARG_TYPE:");
+  expect(code(() => v.click("#a", { modifiers: ["Hyper"] }))).toBe(
+    `ERR_INVALID_ARG_VALUE: The property 'options.modifiers' must be "Shift", "Control", "Alt", or "Meta". Received 'Hyper'`,
+  );
+  expect(code(() => v.click())).toStartWith("ERR_INVALID_ARG_TYPE:");
+  expect(code(() => v.click(1))).toBe(
+    `ERR_INVALID_ARG_TYPE: The "y" argument must be of type number. Received undefined`,
+  );
+  expect(code(() => v.click(1, NaN))).toBe(`ERR_INVALID_ARG_VALUE: The argument 'x/y' must be finite. Received NaN`);
+  expect(code(() => v.click(1, 2, "opts"))).toStartWith("ERR_INVALID_ARG_TYPE:");
+
+  expect(code(() => v.scrollTo("#a", { block: 5 }))).toBe(
+    `ERR_INVALID_ARG_VALUE: The property 'options.block' must be "start", "center", "end", or "nearest". Received 5`,
+  );
+  expect(code(() => v.scrollTo("#a", { timeout: Infinity }))).toStartWith("ERR_OUT_OF_RANGE:");
+  expect(code(() => v.press("a", { modifiers: 5 }))).toStartWith("ERR_INVALID_ARG_TYPE:");
+  expect(code(() => v.press("a", "Shift"))).toStartWith("ERR_INVALID_ARG_TYPE:");
+
+  // The accepted shapes still work.
+  await view.navigate(html("<div id=a style='width:40px;height:40px'></div>"));
+  await view.click("#a", { button: "left", modifiers: ["Shift", "meta"], clickCount: 2, timeout: 1000.5 });
+  await view.click(1, 2);
+  await view.scrollTo("#a", { block: "nearest", timeout: 500 });
+  await view.resize(300, 200);
+});
+
 it("backend: { type: 'chrome' } object form works", async () => {
   // path forces spawn-mode — without it, the bare object form would
   // auto-detect DevToolsActivePort and connect to the dev's Chrome,
   // locking the singleton into WS mode for subsequent tests.
-  await using view = new Bun.WebView({ backend: { type: "chrome", path: chromePath }, width: 200, height: 200 });
+  await using view = new Bun.WebView({
+    backend: { type: "chrome", path: chromePath, argv: chromeArgv },
+    width: 200,
+    height: 200,
+  });
   await view.navigate(html("<body>obj</body>"));
   expect(await view.evaluate("document.body.textContent")).toBe("obj");
 });
@@ -803,7 +947,7 @@ it("backend.argv appends after core flags", async () => {
       "-e",
       `
       const view = new Bun.WebView({
-        backend: { type: "chrome", argv: ["--user-agent=BunWebViewTest/1.0"] },
+        backend: { type: "chrome", argv: [...${JSON.stringify(chromeArgv)}, "--user-agent=BunWebViewTest/1.0"] },
         width: 200, height: 200,
       });
       await view.navigate("data:text/html,<body></body>");
@@ -1134,7 +1278,7 @@ it("chrome: console: globalThis.console forwards to parent's stdout", async () =
       "-e",
       `
       const view = new Bun.WebView({
-        backend: {type:"chrome", url:false}, width: 200, height: 200,
+        backend: {type:"chrome", url:false, argv: ${JSON.stringify(chromeArgv)}}, width: 200, height: 200,
         console: globalThis.console,
       });
       await view.navigate("data:text/html,<body></body>");
@@ -1194,7 +1338,7 @@ it("chrome: large evaluate result crosses the pipe", async () => {
 // resolved once per process, on the first spawn. The env var is consulted
 // right after backend.path, before $PATH and the install locations.
 const spawnWithEnv = `
-  const view = new Bun.WebView({ backend: { type: "chrome", url: false }, width: 200, height: 200 });
+  const view = new Bun.WebView({ backend: { type: "chrome", url: false, argv: ${JSON.stringify(chromeArgv)} }, width: 200, height: 200 });
   await view.navigate("data:text/html,<body>env</body>");
   console.log(await view.evaluate("document.body.textContent"));
   view.close();

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -912,7 +912,9 @@ it("chrome: method arguments are type- and range-checked", async () => {
   );
   expect(code(() => v.click(1, NaN))).toBe(`ERR_INVALID_ARG_VALUE: The argument 'x/y' must be finite. Received NaN`);
   // Coordinates travel as floats; a double beyond float range would arrive as Infinity.
-  expect(code(() => v.click(Number.MAX_VALUE, 0))).toStartWith(`ERR_INVALID_ARG_VALUE: The argument 'x/y' must be finite.`);
+  expect(code(() => v.click(Number.MAX_VALUE, 0))).toStartWith(
+    `ERR_INVALID_ARG_VALUE: The argument 'x/y' must be finite.`,
+  );
   expect(code(() => v.click(1, 2, "opts"))).toStartWith("ERR_INVALID_ARG_TYPE:");
   expect(code(() => v.click(1, 2, () => {}))).toStartWith("ERR_INVALID_ARG_TYPE:");
   expect(code(() => v.scrollTo("#a", () => {}))).toStartWith("ERR_INVALID_ARG_TYPE:");

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -919,6 +919,15 @@ it("chrome: method arguments are type- and range-checked", async () => {
   expect(code(() => v.click(1, 2, () => {}))).toStartWith("ERR_INVALID_ARG_TYPE:");
   expect(code(() => v.scrollTo("#a", () => {}))).toStartWith("ERR_INVALID_ARG_TYPE:");
 
+  expect(code(() => v.screenshot("png"))).toBe(
+    `ERR_INVALID_ARG_TYPE: The "options" argument must be of type object. Received type string ('png')`,
+  );
+  expect(code(() => v.scroll("100", 0))).toBe(
+    `ERR_INVALID_ARG_TYPE: The "dx" argument must be of type number. Received type string ('100')`,
+  );
+  expect(code(() => v.scroll(0, null))).toBe(
+    `ERR_INVALID_ARG_TYPE: The "dy" argument must be of type number. Received null`,
+  );
   expect(code(() => v.scrollTo("#a", { block: 5 }))).toBe(
     `ERR_INVALID_ARG_VALUE: The property 'options.block' must be "start", "center", "end", or "nearest". Received 5`,
   );


### PR DESCRIPTION
### Problem
- `new Bun.WebView({ width: 2 ** 32 + 5 })` produced a 5px viewport and `resize(2 ** 32 + 7, 100)` a 7px one: sizes went through `ToUint32` before the `1..16384` range check, so the check saw the wrapped value (`-1` reported "Received 4294967295", `-4294967295` passed as `1`).
- Wrong-typed options were silently replaced by defaults instead of throwing: `width: "100"`/`null`/`800n`, `backend: 42`, `dataStore: 5`, `new Bun.WebView("http://x/")`, `headless: "no"`, `click(sel, { timeout: "300", clickCount: 0, button: "bogus", modifiers: "Shift" })`, `scrollTo(sel, { block: 5 })`, `press(key, 5)`, `screenshot("png")`, `scroll("100", 0)`. A NUL byte truncated `backend.path`, `backend.argv` entries and `dataStore.directory`, and `backend.url` was accepted next to an (empty) `backend.argv`.
- Cause: `constructWebView` (`src/runtime/webview/JSWebViewConstructor.cpp`) and the `click`/`press`/`scrollTo`/`resize` host functions (`JSWebViewPrototype.cpp`) read options with `isNumber() ? toUInt32()` / `isString() ?` patterns that skip anything of another type.

### Fix
- Use the shared Node-style validators (`Bun::V::validateInteger` / `validateNumber`, `Bun::ERR::INVALID_ARG_TYPE` / `INVALID_ARG_VALUE`) the way the constructor already did for `backend.type`, `path`, `argv` and `console`: `undefined` keeps the default, anything else must have the documented type and range, and `ERR_OUT_OF_RANGE` reports the value as passed.
- Enum-like strings (`button`, `block`, modifier names) outside their set throw `ERR_INVALID_ARG_VALUE`; `modifiers` must be an `Array`; options bags must be non-callable objects; strings that become C strings reject NUL; `path`/`argv` count as spawn mode even when empty, so they cannot be combined with `url`, and they require `type: "chrome"`.
- No accepted input changes meaning: every value that was valid before parses to the same result (`timeout` stays a fractional-milliseconds number, truncated as before).
- Verified: `test/js/bun/webview/webview-chrome.test.ts` (new `constructor options are type- and range-checked`, which needs no browser, and `chrome: method arguments are type- and range-checked`; both fail on stock 1.4.3, 60/60 pass with the change). `webview.test.ts`'s existing range expectations are unchanged.

### Background
- `Bun::V::validateInteger(scope, global, value, name, min, max, &out)` (`src/jsc/bindings/NodeValidator.h`) is the C++ port of Node's `validateInteger`: `ERR_INVALID_ARG_TYPE` for non-numbers, `ERR_OUT_OF_RANGE` ("must be an integer" / ">= min && <= max") otherwise, with Node's message format. `Bun::ERR::*` in `ErrorCode.h` build the same messages for one-off checks.
- `JSValue::toUInt32` is ECMAScript `ToUint32`: it wraps modulo 2^32 and maps `NaN`/`Infinity` to 0, which is why the old range check could not see the original value.
- The Chrome test file now passes `--no-sandbox` when it runs as root (containers), as #42163 and #42168 do, so the file runs there.

<details><summary>Notes</summary>

- Reported as ledger item 45820. Every case in that report is covered by the two tests, plus `click()` coordinates (`click()` / `click(1)` / `click(1, NaN)` used to send NaN coordinates to the browser).
- Error-message names follow the existing ones in these files (`"width"`, `"height"`, `"quality"`) and use `options.<name>` for nested method options, matching how `ERR_INVALID_ARG_TYPE` renders "property" for dotted names.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome.test.ts

<!-- robobun:evidence:end -->