### PR TITLE
docs: cover a 0 return from a direct stream's write(), fix the WebView url option JSDoc

### DIFF
--- a/docs/runtime/streams.mdx
+++ b/docs/runtime/streams.mdx
@@ -81,7 +81,7 @@ When the stream is read through a reader (`getReader()`, `for await`, `pipeTo()`
 
 ### Handling backpressure
 
-`controller.write()` returns the number of bytes written, or a **pending `Promise<number>`** when the destination's internal buffer is full (for example, a slow HTTP client). The chunk is accepted either way. Once the destination has gone away (for example the HTTP client disconnected), `write()` returns `0`. The promise resolves once the destination has drained, so `await`ing the result is enough:
+`controller.write()` returns the number of bytes written, or a **pending `Promise<number>`** when the destination's internal buffer is full (for example, a slow HTTP client). The chunk is accepted either way. The promise resolves once the destination has drained, so `await`ing the result is enough to respect backpressure:
 
 ```ts
 const stream = new ReadableStream({
@@ -96,6 +96,21 @@ const stream = new ReadableStream({
 ```
 
 `await controller.flush(true)` is equivalent, and you can use it after a write returns a `Promise`.
+
+Once the destination has gone away, `write()` returns `0` (when an HTTP client disconnects, `Bun.serve` also calls the source's `cancel(reason)`). `await`ing a `0` does not pause anything, so a producer with no natural end must check for it and stop, or it spins without ever yielding to the event loop:
+
+```ts
+const stream = new ReadableStream({
+  type: "direct",
+  async pull(controller) {
+    while (true) {
+      const written = await controller.write(nextChunk());
+      if (written === 0) break; // the destination is gone
+    }
+    controller.close();
+  },
+});
+```
 
 When the stream is read from JavaScript (`getReader()`, `pipeTo()`, `for await`), the buffer is full once `highWaterMark` bytes (default 64 KiB) are waiting for the reader. Pass `{ highWaterMark }` as the second `ReadableStream` constructor argument to change it. `reader.cancel(reason)` calls the source's `cancel(reason)`.
 

--- a/docs/runtime/streams.mdx
+++ b/docs/runtime/streams.mdx
@@ -97,14 +97,16 @@ const stream = new ReadableStream({
 
 `await controller.flush(true)` is equivalent, and you can use it after a write returns a `Promise`.
 
-Once the destination has gone away, `write()` returns `0` (when an HTTP client disconnects, `Bun.serve` also calls the source's `cancel(reason)`). `await`ing a `0` does not pause anything, so a producer with no natural end must check for it and stop, or it spins without ever yielding to the event loop:
+Once the destination has gone away, `write()` returns `0` for every chunk (when an HTTP client disconnects, `Bun.serve` also calls the source's `cancel(reason)`). `await`ing a `0` does not pause anything, so a producer with no natural end must check for it and stop, or it spins without ever yielding to the event loop. An empty chunk also returns `0`, so skip those before you rely on the check:
 
 ```ts
 const stream = new ReadableStream({
   type: "direct",
   async pull(controller) {
     while (true) {
-      const written = await controller.write(nextChunk());
+      const chunk = await nextChunk();
+      if (chunk.length === 0) continue;
+      const written = await controller.write(chunk);
       if (written === 0) break; // the destination is gone
     }
     controller.close();

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9435,13 +9435,15 @@ declare module "bun" {
        */
       backend?: Backend;
       /**
-       * Initial URL to navigate to. The navigation starts before the
-       * constructor returns; `await view.navigate(otherUrl)` or any other
-       * operation waits for it to complete first.
+       * Initial URL to navigate to. Starts the same navigation
+       * `view.navigate(url)` on the next line would, before the
+       * constructor returns: {@link WebView.loading} is `true` and calling
+       * {@link WebView.navigate} throws `ERR_INVALID_STATE` until it
+       * settles. Other operations do not wait for it.
        *
-       * Starts the same navigation `view.navigate(url)` would, but its
-       * promise stays internal: a failure never surfaces as a rejection.
-       * Set {@link WebView.onNavigationFailed} to observe it.
+       * Its promise stays internal, so a failure never surfaces as a
+       * rejection. Set {@link WebView.onNavigated} and
+       * {@link WebView.onNavigationFailed} to observe the outcome.
        */
       url?: string;
       /** Capture page-side `console.*` calls. See {@link ConsoleCapture}. */


### PR DESCRIPTION
### Problem
- `docs/runtime/streams.mdx` ("Handling backpressure") says `await`ing `controller.write()` is enough. That holds for backpressure only. Once the destination is gone, `write()` returns `0`, and `await 0` never yields to the event loop. A producer with no natural end that only awaits spins forever: after a client abort, a `while` loop in `pull()` ran 45 million `write()` calls in 3 s and no timer fired until it stopped (bun 1.4.3).
- The JSDoc for `Bun.WebView`'s `url` option (`packages/bun-types/bun.d.ts`) says "`await view.navigate(otherUrl)` or any other operation waits for it to complete first". While that navigation is pending, `navigate()` throws `ERR_INVALID_STATE: a navigation is already pending`, and other operations do not wait for it. `docs/runtime/webview.mdx` already describes it correctly.

### Fix
- streams.mdx: keep the backpressure paragraph about the promise, then say what a `0` return means, that `Bun.serve` also calls the source's `cancel(reason)` on a disconnect, and show a loop that stops on `0`.
- bun.d.ts: describe the `url` option as the docs page does: same navigation as `navigate(url)`, `loading` is `true` and `navigate()` throws until it settles, the promise stays internal, observe it with `onNavigated` / `onNavigationFailed`.
- Verified against bun 1.4.3 with the Chrome backend: `navigate()` right after `new Bun.WebView({ url })` throws `ERR_INVALID_STATE`, `onNavigated` fires for the initial URL; for streams, `write()` returns `0` synchronously after the client aborts, a backpressure promise resolves to the chunk's byte count, and `cancel(reason)` runs with `AbortError: The connection was closed.`

### Background
- A `type: "direct"` `ReadableStream` hands `controller.write()` chunks straight to the native destination. The return value is the destination's answer: bytes taken, a promise while it is backed up, `0` once it is gone.
- `new Bun.WebView({ url })` starts a navigation whose promise no user code holds. Each view has one navigation slot, so a second `navigate()` while it is in flight throws instead of queueing.
