### PR TITLE
webview: delete the temporary Chrome profile directory once its browser is gone

### DIFF
--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -586,7 +586,7 @@ fn kill_and_wait(pid: bun_spawn::PidT) {
         return;
     }
     TerminateProcess(handle, 1);
-    w::WaitForSingleObject(handle, 5000);
+    w::kernel32::WaitForSingleObject(handle, 5000);
     // SAFETY: `handle` came from OpenProcess above.
     unsafe { w::CloseHandle(handle) };
 }

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -512,8 +512,7 @@ fn delete_profile_dir(dir: &[u8]) {
     }
 }
 
-/// `<profile>/SingletonSocket` links into a second temp directory that a killed
-/// Chrome never removes: delete that socket, its cookie, then the directory if empty.
+/// `<profile>/SingletonSocket` links into a second temp dir a killed Chrome never removes.
 #[cfg(unix)]
 fn delete_singleton_socket(profile_dir: &[u8]) {
     let mut link_buf = path_buffer_pool::get();
@@ -553,8 +552,7 @@ extern "C" fn delete_temp_profiles_at_exit() {
     }
 }
 
-/// `pid` is running or an unreaped child of ours, so it cannot have been reused.
-/// Returns whether the process is known to be gone.
+/// `pid` is running or our unreaped child (never reused); returns whether it is gone.
 #[cfg(unix)]
 fn kill_and_wait(pid: bun_spawn::PidT) -> bool {
     // SAFETY: plain syscalls on a pid; no memory is passed.

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -478,37 +478,50 @@ fn find_playwright_shell() -> Option<ZBox> {
     None
 }
 
-/// A temp-dir `--user-data-dir` made for a Chrome without `dataStore`, and its browser.
+/// A temp-dir `--user-data-dir` made for a Chrome without `dataStore`.
 struct TempProfile {
-    pid: bun_spawn::PidT,
+    /// The browser to kill before `dir` can go at exit; `None` once it is gone.
+    pid: Option<bun_spawn::PidT>,
     dir: Box<[u8]>,
 }
 
-/// Profiles whose browser has not been reaped yet; see [`delete_temp_profiles_at_exit`].
+/// Profiles not deleted yet; see [`delete_temp_profiles_at_exit`].
 static TEMP_PROFILES: bun_core::Mutex<Vec<TempProfile>> = bun_core::Mutex::new(Vec::new());
 
-fn register_temp_profile(pid: bun_spawn::PidT, dir: Box<[u8]>) {
+fn register_temp_profile(pid: Option<bun_spawn::PidT>, dir: Box<[u8]>) {
     TEMP_PROFILES.lock().push(TempProfile { pid, dir });
     bun_core::add_exit_callback(delete_temp_profiles_at_exit);
 }
 
-/// The browser with this pid has exited: its profile directory is ours to delete.
-fn delete_temp_profile_of(pid: bun_spawn::PidT) {
-    let profile = {
-        let mut profiles = TEMP_PROFILES.lock();
-        let Some(i) = profiles.iter().position(|p| p.pid == pid) else {
-            return;
-        };
-        profiles.swap_remove(i)
-    };
-    delete_profile_dir(&profile.dir);
+fn take_temp_profile(pid: bun_spawn::PidT) -> Option<Box<[u8]>> {
+    let mut profiles = TEMP_PROFILES.lock();
+    let i = profiles.iter().position(|p| p.pid == Some(pid))?;
+    Some(profiles.swap_remove(i).dir)
 }
 
-fn delete_profile_dir(dir: &[u8]) {
+/// The browser with this pid has exited: its profile directory is ours to delete.
+fn delete_temp_profile_of(pid: bun_spawn::PidT) {
+    if let Some(dir) = take_temp_profile(pid) {
+        delete_profile_dir(dir);
+    }
+}
+
+/// Tries again at exit if this attempt fails (on Windows a straggling child can still hold a file).
+fn delete_profile_dir(dir: Box<[u8]>) {
+    if !try_delete_profile_dir(&dir) {
+        register_temp_profile(None, dir);
+    }
+}
+
+fn try_delete_profile_dir(dir: &[u8]) -> bool {
     #[cfg(unix)]
     delete_singleton_socket(dir);
-    if let Err(err) = bun_sys::delete_tree_absolute(dir) {
-        scoped_log!(Chrome, "could not delete {}: {}", bstr::BStr::new(dir), err);
+    match bun_sys::delete_tree_absolute(dir) {
+        Ok(()) => true,
+        Err(err) => {
+            scoped_log!(Chrome, "could not delete {}: {}", bstr::BStr::new(dir), err);
+            false
+        }
     }
 }
 
@@ -546,8 +559,8 @@ fn delete_singleton_socket(profile_dir: &[u8]) {
 extern "C" fn delete_temp_profiles_at_exit() {
     let profiles = core::mem::take(&mut *TEMP_PROFILES.lock());
     for profile in profiles {
-        if kill_and_wait(profile.pid) {
-            delete_profile_dir(&profile.dir);
+        if profile.pid.is_none_or(kill_and_wait) {
+            try_delete_profile_dir(&profile.dir);
         }
     }
 }
@@ -653,7 +666,7 @@ fn spawn(
         };
         let temp_dir = scopeguard::guard(temp_dir, |dir| {
             if let Some(dir) = dir {
-                delete_profile_dir(&dir);
+                delete_profile_dir(dir);
             }
         });
 
@@ -733,12 +746,19 @@ fn spawn(
         let process = spawned.to_process_handle(event_loop);
         let pid = process.process_mut().pid;
         if let Some(dir) = scopeguard::ScopeGuard::into_inner(temp_dir) {
-            register_temp_profile(pid, dir);
+            register_temp_profile(Some(pid), dir);
         }
         let attached = endpoints.attach(process);
         if attached.is_err() {
-            // Unwatched from here on and its pid may be reused: forget it now, never kill by pid later.
-            delete_temp_profile_of(pid);
+            // No exit handler will run for this browser: reap it here, while the pid is still ours.
+            let gone = kill_and_wait(pid);
+            if let Some(dir) = take_temp_profile(pid) {
+                if gone {
+                    delete_profile_dir(dir);
+                } else {
+                    register_temp_profile(None, dir);
+                }
+            }
         }
         attached
     }

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -575,10 +575,11 @@ fn kill_and_wait(pid: bun_spawn::PidT) -> bool {
     const PROCESS_TERMINATE: w::DWORD = 0x0001;
     const SYNCHRONIZE: w::DWORD = 0x0010_0000;
     const WAIT_OBJECT_0: w::DWORD = 0;
-    // SAFETY: FFI; a pid that no longer exists yields a null handle.
+    const ERROR_INVALID_PARAMETER: w::DWORD = 87;
+    // SAFETY: FFI; ERROR_INVALID_PARAMETER means no process has this pid any more.
     let handle = unsafe { w::OpenProcess(PROCESS_TERMINATE | SYNCHRONIZE, 0, pid as w::DWORD) };
     if handle.is_null() {
-        return true;
+        return w::GetLastError() == ERROR_INVALID_PARAMETER;
     }
     // Fails if the process already exited, which the wait then reports.
     TerminateProcess(handle, 1);
@@ -735,9 +736,7 @@ fn spawn(
         }
         let attached = endpoints.attach(process);
         if attached.is_err() {
-            // No exit handler will report this browser, and once its handle is
-            // dropped the pid may be reused: forget it now instead of killing
-            // whatever owns the pid at exit.
+            // Unwatched from here on and its pid may be reused: forget it now, never kill by pid later.
             delete_temp_profile_of(pid);
         }
         attached

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -560,7 +560,7 @@ fn kill_and_wait(pid: bun_spawn::PidT) -> bool {
         libc::kill(pid, libc::SIGKILL);
         let mut status = 0;
         // Returns once the child is reaped here, or fails with ECHILD if it already was.
-        while libc::waitpid(pid, &mut status, 0) == -1 && bun_sys::last_errno() == libc::EINTR {}
+        while libc::waitpid(pid, &raw mut status, 0) == -1 && bun_sys::last_errno() == libc::EINTR {}
     }
     true
 }

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -478,17 +478,13 @@ fn find_playwright_shell() -> Option<ZBox> {
     None
 }
 
-/// A `--user-data-dir` this process created under the temp dir for a Chrome
-/// spawned without `dataStore` ("ephemeral" storage), and the browser using it.
+/// A temp-dir `--user-data-dir` made for a Chrome without `dataStore`, and its browser.
 struct TempProfile {
     pid: bun_spawn::PidT,
     dir: Box<[u8]>,
 }
 
-/// Profiles whose browser has not been reaped yet. [`ChromeProcess::on_exit`]
-/// deletes a profile once its browser is gone; [`delete_temp_profiles_at_exit`]
-/// handles a browser that is still running when Bun exits (the common case:
-/// nothing reaps the browser that `dispatch_on_exit` kills).
+/// Profiles whose browser has not been reaped yet; see [`delete_temp_profiles_at_exit`].
 static TEMP_PROFILES: bun_core::Mutex<Vec<TempProfile>> = bun_core::Mutex::new(Vec::new());
 
 fn register_temp_profile(pid: bun_spawn::PidT, dir: Box<[u8]>) {
@@ -516,10 +512,8 @@ fn delete_profile_dir(dir: &[u8]) {
     }
 }
 
-/// `<profile>/SingletonSocket` is a symlink to a socket in a second directory
-/// Chrome creates under the temp dir (next to the profile, not inside it) and
-/// removes only on a clean shutdown, which a killed browser never gets. Remove
-/// that socket and its cookie, then the directory if that leaves it empty.
+/// `<profile>/SingletonSocket` links into a second temp directory that a killed
+/// Chrome never removes: delete that socket, its cookie, then the directory if empty.
 #[cfg(unix)]
 fn delete_singleton_socket(profile_dir: &[u8]) {
     let mut link_buf = path_buffer_pool::get();
@@ -549,30 +543,32 @@ fn delete_singleton_socket(profile_dir: &[u8]) {
     let _ = bun_sys::rmdir(dir);
 }
 
-/// Chrome keeps files in the profile open (and on Windows, locked) for as long
-/// as it runs, so make sure each browser is dead before deleting its directory.
+/// A running Chrome holds (on Windows, locks) profile files: kill it before deleting.
 extern "C" fn delete_temp_profiles_at_exit() {
     let profiles = core::mem::take(&mut *TEMP_PROFILES.lock());
     for profile in profiles {
-        kill_and_wait(profile.pid);
-        delete_profile_dir(&profile.dir);
+        if kill_and_wait(profile.pid) {
+            delete_profile_dir(&profile.dir);
+        }
     }
 }
 
-/// SIGKILL `pid` (a child of ours that is running or not yet reaped, so the pid
-/// cannot have been reused) and wait until it is gone.
+/// `pid` is running or an unreaped child of ours, so it cannot have been reused.
+/// Returns whether the process is known to be gone.
 #[cfg(unix)]
-fn kill_and_wait(pid: bun_spawn::PidT) {
+fn kill_and_wait(pid: bun_spawn::PidT) -> bool {
     // SAFETY: plain syscalls on a pid; no memory is passed.
     unsafe {
         libc::kill(pid, libc::SIGKILL);
         let mut status = 0;
+        // Returns once the child is reaped here, or fails with ECHILD if it already was.
         while libc::waitpid(pid, &mut status, 0) == -1 && bun_sys::last_errno() == libc::EINTR {}
     }
+    true
 }
 
 #[cfg(windows)]
-fn kill_and_wait(pid: bun_spawn::PidT) {
+fn kill_and_wait(pid: bun_spawn::PidT) -> bool {
     use bun_sys::windows as w;
     unsafe extern "system" {
         // Opaque kernel HANDLE, validated by the kernel; no memory-safety preconditions.
@@ -580,15 +576,18 @@ fn kill_and_wait(pid: bun_spawn::PidT) {
     }
     const PROCESS_TERMINATE: w::DWORD = 0x0001;
     const SYNCHRONIZE: w::DWORD = 0x0010_0000;
-    // SAFETY: FFI; a stale pid yields a null handle, which is checked.
+    const WAIT_OBJECT_0: w::DWORD = 0;
+    // SAFETY: FFI; a pid that no longer exists yields a null handle.
     let handle = unsafe { w::OpenProcess(PROCESS_TERMINATE | SYNCHRONIZE, 0, pid as w::DWORD) };
     if handle.is_null() {
-        return;
+        return true;
     }
+    // Fails if the process already exited, which the wait then reports.
     TerminateProcess(handle, 1);
-    w::kernel32::WaitForSingleObject(handle, 5000);
+    let gone = w::kernel32::WaitForSingleObject(handle, 5000) == WAIT_OBJECT_0;
     // SAFETY: `handle` came from OpenProcess above.
     unsafe { w::CloseHandle(handle) };
+    gone
 }
 
 /// Returns `Bun__Chrome__ensure`'s success value.
@@ -626,9 +625,7 @@ fn spawn(
         // layout every headless harness uses. Without it, ProcessSingleton locks
         // the default profile (~/Library/Application Support/Google/Chrome) and
         // aborts if a real Chrome is already running.
-        // With no `dataStore` directory the profile is a fresh directory under
-        // the temp dir, deleted again once this browser is gone (or right here
-        // if it never starts).
+        // No `dataStore`: a fresh temp profile, deleted with this browser (or below if it never starts).
         let mut temp_dir: Option<Box<[u8]>> = None;
         let data_dir: ZBox = if let Some(d) = user_data_dir {
             let d = d.to_bytes();

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -25,7 +25,7 @@ use core::sync::atomic::AtomicU32;
 use core::sync::atomic::{AtomicPtr, Ordering};
 use std::io::Write as _;
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(unix)]
 use bun_core::ZStr;
 use bun_core::{self, ZBox, env_var, getenv_z, strings, zstr};
 use bun_jsc::JSGlobalObject;
@@ -188,6 +188,8 @@ impl ChromeProcess {
         let mut chrome = unsafe { bun_core::heap::take(this) };
         debug_assert_eq!(process, chrome.process.as_ptr());
         chrome.close_transport();
+        // SAFETY: `process` is the live argument of this exit callback.
+        delete_temp_profile_of(unsafe { (*process).pid });
         if chrome.retired {
             return;
         }
@@ -476,6 +478,119 @@ fn find_playwright_shell() -> Option<ZBox> {
     None
 }
 
+/// A `--user-data-dir` this process created under the temp dir for a Chrome
+/// spawned without `dataStore` ("ephemeral" storage), and the browser using it.
+struct TempProfile {
+    pid: bun_spawn::PidT,
+    dir: Box<[u8]>,
+}
+
+/// Profiles whose browser has not been reaped yet. [`ChromeProcess::on_exit`]
+/// deletes a profile once its browser is gone; [`delete_temp_profiles_at_exit`]
+/// handles a browser that is still running when Bun exits (the common case:
+/// nothing reaps the browser that `dispatch_on_exit` kills).
+static TEMP_PROFILES: bun_core::Mutex<Vec<TempProfile>> = bun_core::Mutex::new(Vec::new());
+
+fn register_temp_profile(pid: bun_spawn::PidT, dir: Box<[u8]>) {
+    TEMP_PROFILES.lock().push(TempProfile { pid, dir });
+    bun_core::add_exit_callback(delete_temp_profiles_at_exit);
+}
+
+/// The browser with this pid has exited: its profile directory is ours to delete.
+fn delete_temp_profile_of(pid: bun_spawn::PidT) {
+    let profile = {
+        let mut profiles = TEMP_PROFILES.lock();
+        let Some(i) = profiles.iter().position(|p| p.pid == pid) else {
+            return;
+        };
+        profiles.swap_remove(i)
+    };
+    delete_profile_dir(&profile.dir);
+}
+
+fn delete_profile_dir(dir: &[u8]) {
+    #[cfg(unix)]
+    delete_singleton_socket(dir);
+    if let Err(err) = bun_sys::delete_tree_absolute(dir) {
+        scoped_log!(Chrome, "could not delete {}: {}", bstr::BStr::new(dir), err);
+    }
+}
+
+/// `<profile>/SingletonSocket` is a symlink to a socket in a second directory
+/// Chrome creates under the temp dir (next to the profile, not inside it) and
+/// removes only on a clean shutdown, which a killed browser never gets. Remove
+/// that socket and its cookie, then the directory if that leaves it empty.
+#[cfg(unix)]
+fn delete_singleton_socket(profile_dir: &[u8]) {
+    let mut link_buf = path_buffer_pool::get();
+    let link = resolve_path::join_string_buf_z::<platform::Auto>(
+        &mut link_buf[..],
+        &[profile_dir, b"SingletonSocket".as_slice()],
+    );
+    let mut target_buf = path_buffer_pool::get();
+    let Ok(len) = bun_sys::readlink(link, &mut target_buf[..]) else {
+        return;
+    };
+    let socket = ZStr::from_buf(&target_buf[..], len);
+    let Some(socket_dir) = bun_paths::dirname(socket.as_bytes()) else {
+        return;
+    };
+    if !socket.as_bytes().starts_with(b"/") || socket_dir == profile_dir {
+        return;
+    }
+    let _ = bun_sys::unlink(socket);
+    let mut buf = path_buffer_pool::get();
+    let cookie = resolve_path::join_string_buf_z::<platform::Auto>(
+        &mut buf[..],
+        &[socket_dir, b"SingletonCookie".as_slice()],
+    );
+    let _ = bun_sys::unlink(cookie);
+    let dir = resolve_path::join_string_buf_z::<platform::Auto>(&mut buf[..], &[socket_dir]);
+    let _ = bun_sys::rmdir(dir);
+}
+
+/// Chrome keeps files in the profile open (and on Windows, locked) for as long
+/// as it runs, so make sure each browser is dead before deleting its directory.
+extern "C" fn delete_temp_profiles_at_exit() {
+    let profiles = core::mem::take(&mut *TEMP_PROFILES.lock());
+    for profile in profiles {
+        kill_and_wait(profile.pid);
+        delete_profile_dir(&profile.dir);
+    }
+}
+
+/// SIGKILL `pid` (a child of ours that is running or not yet reaped, so the pid
+/// cannot have been reused) and wait until it is gone.
+#[cfg(unix)]
+fn kill_and_wait(pid: bun_spawn::PidT) {
+    // SAFETY: plain syscalls on a pid; no memory is passed.
+    unsafe {
+        libc::kill(pid, libc::SIGKILL);
+        let mut status = 0;
+        while libc::waitpid(pid, &mut status, 0) == -1 && bun_sys::last_errno() == libc::EINTR {}
+    }
+}
+
+#[cfg(windows)]
+fn kill_and_wait(pid: bun_spawn::PidT) {
+    use bun_sys::windows as w;
+    unsafe extern "system" {
+        // Opaque kernel HANDLE, validated by the kernel; no memory-safety preconditions.
+        safe fn TerminateProcess(h: w::HANDLE, code: u32) -> w::BOOL;
+    }
+    const PROCESS_TERMINATE: w::DWORD = 0x0001;
+    const SYNCHRONIZE: w::DWORD = 0x0010_0000;
+    // SAFETY: FFI; a stale pid yields a null handle, which is checked.
+    let handle = unsafe { w::OpenProcess(PROCESS_TERMINATE | SYNCHRONIZE, 0, pid as w::DWORD) };
+    if handle.is_null() {
+        return;
+    }
+    TerminateProcess(handle, 1);
+    w::WaitForSingleObject(handle, 5000);
+    // SAFETY: `handle` came from OpenProcess above.
+    unsafe { w::CloseHandle(handle) };
+}
+
 /// Returns `Bun__Chrome__ensure`'s success value.
 fn spawn(
     vm: *mut VirtualMachine,
@@ -511,6 +626,10 @@ fn spawn(
         // layout every headless harness uses. Without it, ProcessSingleton locks
         // the default profile (~/Library/Application Support/Google/Chrome) and
         // aborts if a real Chrome is already running.
+        // With no `dataStore` directory the profile is a fresh directory under
+        // the temp dir, deleted again once this browser is gone (or right here
+        // if it never starts).
+        let mut temp_dir: Option<Box<[u8]>> = None;
         let data_dir: ZBox = if let Some(d) = user_data_dir {
             let d = d.to_bytes();
             let mut v = Vec::with_capacity(16 + d.len());
@@ -529,11 +648,17 @@ fn spawn(
             let dir =
                 resolve_path::join_string_buf_z::<platform::Auto>(&mut dir_buf[..], &dir_parts);
             bun_sys::mkdir(dir, 0o700)?;
+            temp_dir = Some(Box::from(dir.as_bytes()));
             let mut v = Vec::with_capacity(16 + dir.len());
             v.extend_from_slice(b"--user-data-dir=");
             v.extend_from_slice(&dir[..]);
             ZBox::from_vec(v)
         };
+        let temp_dir = scopeguard::guard(temp_dir, |dir| {
+            if let Some(dir) = dir {
+                delete_profile_dir(&dir);
+            }
+        });
 
         let mut argv: Vec<*const c_char> = vec![
             chrome.as_ptr(),
@@ -608,7 +733,11 @@ fn spawn(
         // Keeping our copies of the child's ends would mask Chrome's death (no EOF).
         endpoints.close_child_ends();
 
-        endpoints.attach(spawned.to_process_handle(event_loop))
+        let process = spawned.to_process_handle(event_loop);
+        if let Some(dir) = scopeguard::ScopeGuard::into_inner(temp_dir) {
+            register_temp_profile(process.process_mut().pid, dir);
+        }
+        endpoints.attach(process)
     }
 }
 

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -560,7 +560,8 @@ fn kill_and_wait(pid: bun_spawn::PidT) -> bool {
         libc::kill(pid, libc::SIGKILL);
         let mut status = 0;
         // Returns once the child is reaped here, or fails with ECHILD if it already was.
-        while libc::waitpid(pid, &raw mut status, 0) == -1 && bun_sys::last_errno() == libc::EINTR {}
+        while libc::waitpid(pid, &raw mut status, 0) == -1 && bun_sys::last_errno() == libc::EINTR {
+        }
     }
     true
 }

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -729,10 +729,18 @@ fn spawn(
         endpoints.close_child_ends();
 
         let process = spawned.to_process_handle(event_loop);
+        let pid = process.process_mut().pid;
         if let Some(dir) = scopeguard::ScopeGuard::into_inner(temp_dir) {
-            register_temp_profile(process.process_mut().pid, dir);
+            register_temp_profile(pid, dir);
         }
-        endpoints.attach(process)
+        let attached = endpoints.attach(process);
+        if attached.is_err() {
+            // No exit handler will report this browser, and once its handle is
+            // dropped the pid may be reused: forget it now instead of killing
+            // whatever owns the pid at exit.
+            delete_temp_profile_of(pid);
+        }
+        attached
     }
 }
 

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -397,7 +397,7 @@ test.concurrent("the temporary profile directory is deleted with its browser", a
   using tmp = tempDir("webview-chrome-profile", {});
   const profileDirs = (dir: string) => readdirSync(dir).filter(name => name.endsWith(".bun-chrome"));
   const probe = /* js */ `
-    const { readdirSync } = require("node:fs");
+    import { readdirSync } from "node:fs";
     const profileDirs = () => readdirSync(process.env.BUN_TMPDIR).filter(name => name.endsWith(".bun-chrome"));
   `;
 

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -11,6 +11,7 @@
 // { resolved } or { rejected: message }.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 const fixture = join(import.meta.dir, "fake-chrome-fixture.ts");
@@ -38,10 +39,10 @@ const prelude = /* js */ `
   const big = ${BIG};
 `;
 
-async function runScenario(body: string): Promise<unknown> {
+async function runScenario(body: string, env: Record<string, string> = {}): Promise<unknown> {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", prelude + body],
-    env: bunEnv,
+    env: { ...bunEnv, ...env },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -386,6 +387,55 @@ test.concurrent("bun test --isolate retires the transport with the file that spa
   ]);
   expect(stderr).toContain(" 2 pass");
   expect(exitCode).toBe(0);
+});
+
+// Without a dataStore directory, each browser gets a fresh --user-data-dir
+// under the temp dir (BUN_TMPDIR here). It is deleted once that browser is
+// gone: when the browser dies while Bun keeps running, and at exit for a
+// browser that is still up then (the usual case; close() does not stop it).
+test.concurrent("the temporary profile directory is deleted with its browser", async () => {
+  using tmp = tempDir("webview-chrome-profile", {});
+  const profileDirs = (dir: string) => readdirSync(dir).filter(name => name.endsWith(".bun-chrome"));
+  const probe = /* js */ `
+    const { readdirSync } = require("node:fs");
+    const profileDirs = () => readdirSync(process.env.BUN_TMPDIR).filter(name => name.endsWith(".bun-chrome"));
+  `;
+
+  // Still running at exit.
+  const atExit = await runScenario(
+    probe +
+      `
+    const view = newView();
+    await view.navigate("http://fake/");
+    print({ whileRunning: profileDirs().length });
+    view.close();
+  `,
+    { BUN_TMPDIR: String(tmp) },
+  );
+  expect({ result: atExit, afterExit: profileDirs(String(tmp)) }).toEqual({
+    result: { whileRunning: 1 },
+    afterExit: [],
+  });
+
+  // Dies while Bun keeps running: gone as soon as the exit has been reaped,
+  // which is also when its pending operations reject.
+  const reaped = await runScenario(
+    probe +
+      `
+    const view = newView();
+    await view.navigate("http://fake/");
+    const whileRunning = profileDirs().length;
+    await outcome(view.evaluate("__fake_exit(0)"));
+    let afterDeath = profileDirs();
+    for (const deadline = Date.now() + 5000; afterDeath.length && Date.now() < deadline; ) {
+      await Bun.sleep(10);
+      afterDeath = profileDirs();
+    }
+    print({ whileRunning, afterDeath });
+  `,
+    { BUN_TMPDIR: String(tmp) },
+  );
+  expect(reaped).toEqual({ whileRunning: 1, afterDeath: [] });
 });
 
 // On POSIX fd 3 and fd 4 are one socket, so losing a single direction is not


### PR DESCRIPTION
### Problem
- Every process that opens a Chrome-backend `Bun.WebView` without `dataStore` leaves `$TMPDIR/.<16 hex>-<seq>.bun-chrome` behind (1 to 5 MB once used). The docs call this storage ephemeral; in practice it is an on-disk `--user-data-dir` that outlives the process. It also stayed when the spawn failed after the directory was made.
- Cause: `spawn()` in `src/runtime/webview/ChromeProcess.rs` created the directory with `bun_sys::mkdir` and kept no record of it. Nothing in `on_exit` (browser reaped), `Bun__Chrome__kill` (process exit, `closeAll()`) or the spawn error path removed it.

### Fix
- Record each temporary profile with the pid of the browser that uses it. Delete it when that browser is reaped (`ChromeProcess::on_exit`), from an exit callback for a browser still running at exit (after SIGKILL/`TerminateProcess` and a wait, because Chrome keeps profile files open, and locked on Windows), and through a scope guard when the spawn fails.
- On POSIX, also remove the `ProcessSingleton` socket directory (`$TMPDIR/com.google.Chrome.XXXXXX`, reached through the profile's `SingletonSocket` symlink) that a killed Chrome never cleans up: unlink that socket and its cookie, then `rmdir`, so nothing but Chrome's own two entries is ever touched.
- A user-supplied `dataStore: { directory }` is never registered, so it is never deleted.
- Verified: `test/js/bun/webview/webview-chrome-pipe.test.ts` (`the temporary profile directory is deleted with its browser`, fake browser, runs on every platform: covers exit-time and reap-time deletion; fails on stock 1.4.3). With real Chrome 143 the ledger repro, a `closeAll()` + respawn run, and a browser that exits at once all leave an empty `$TMPDIR`.

### Background
- The Chrome backend spawns one browser per process with `--remote-debugging-pipe` and a `--user-data-dir`; `dataStore: { directory }` supplies that directory, otherwise a fresh one is made under `RealFS::tmpdir_path()` (`BUN_TMPDIR`, else the platform temp dir).
- The browser is reaped through `bun_spawn`'s exit handler (`ChromeProcess::on_exit`) while the event loop runs. At process exit `dispatch_on_exit` only SIGKILLs it (`Bun__Chrome__kill`) and never reaps, so exit-time cleanup runs from `bun_core::add_exit_callback`, which `Bun__onExit` calls after that kill.
- Chrome's `ProcessSingleton` puts its socket in a separate temp directory and symlinks `<profile>/SingletonSocket` to it; Chrome removes it only on a clean shutdown.

<details><summary>Notes</summary>

- Reported as ledger item 45817.
- The exit-time wait is a blocking `waitpid` after `SIGKILL` (POSIX) or `WaitForSingleObject(…, 5000)` after `TerminateProcess` (Windows). The pid cannot have been recycled: an entry is removed as soon as its browser is reaped, so a listed pid is either running or an unreaped child.
- If the transport cannot attach to a freshly spawned browser (no exit handler will run for it), `spawn()` kills and reaps it on the spot, while the pid is still ours, then deletes the profile. A deletion that fails (on Windows a straggling child can still hold a file) keeps the path with no pid and runs once more at exit.
- Not covered: a second directory is only leaked if a retired browser (`bun test --isolate`) has not been reaped by exit; it is still deleted if the reap happens first, which is the normal order.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome-pipe.test.ts

<!-- robobun:evidence:end -->
