### PR TITLE
runner: look the user up once, fall back to USER/HOME when os.userInfo() fails

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -845,7 +845,13 @@ async function runTests() {
       const absoluteTestPath = join(testsPath, testPath);
       const title = relative(cwd, absoluteTestPath).replaceAll(sep, "/");
       if (isNodeTest(testPath)) {
-        const testContent = readFileSync(absoluteTestPath, "utf-8");
+        let testContent = "";
+        try {
+          testContent = readFileSync(absoluteTestPath, "utf-8");
+        } catch {
+          // Gone since discovery (a wiped checkout). The step below fails on
+          // it with bun's own error instead of this throw ending the whole run.
+        }
         const flagsMatch = /^\/\/ Flags:[^\S\r\n]+(--[^\r\n]*)$/m.exec(testContent);
         const testFlags = flagsMatch
           ? flagsMatch[1].split(/\s+/).filter(flag => resolutionGatingFlags.has(flag.split("=")[0]))

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -848,9 +848,10 @@ async function runTests() {
         let testContent = "";
         try {
           testContent = readFileSync(absoluteTestPath, "utf-8");
-        } catch {
+        } catch (error) {
           // Gone since discovery (a wiped checkout). The step below fails on
           // it with bun's own error instead of this throw ending the whole run.
+          if (error?.code !== "ENOENT") throw error;
         }
         const flagsMatch = /^\/\/ Flags:[^\S\r\n]+(--[^\r\n]*)$/m.exec(testContent);
         const testFlags = flagsMatch

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -28,7 +28,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { availableParallelism, userInfo } from "node:os";
+import { availableParallelism } from "node:os";
 import { basename, dirname, extname, join, relative, sep } from "node:path";
 import { createInterface } from "node:readline";
 import { setTimeout as setTimeoutPromise } from "node:timers/promises";
@@ -54,6 +54,7 @@ import {
   getOs,
   getSecret,
   getShell,
+  getUserInfo,
   getWindowsExitReason,
   isAndroid,
   isBuildkite,
@@ -1762,7 +1763,7 @@ function getCombinedPath(execPath) {
 async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTimeout, env, stdout, stderr }) {
   const path = getCombinedPath(execPath);
   const tmpdirPath = mkdtempSync(join(tmpdir(), "buntmp-"));
-  const { username, homedir } = userInfo();
+  const { username, homedir } = getUserInfo();
   const shellPath = getShell();
   const bunEnv = {
     ...process.env,

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1609,11 +1609,42 @@ export function getHostname() {
 }
 
 /**
- * @returns {string}
+ * @typedef {object} UserInfo
+ * @property {string | undefined} username
+ * @property {string | undefined} homedir
+ */
+
+/** @type {UserInfo | undefined} */
+let cachedUserInfo;
+
+/**
+ * The user that runs this process, looked up once. `os.userInfo()` is a
+ * getpwuid_r() lookup that can fail at runtime: a macOS host that is shutting
+ * down answers ENOENT for its own uid once opendirectoryd is gone. The login
+ * session exported the same values, so a failed lookup falls back to them.
+ * @returns {UserInfo}
+ */
+export function getUserInfo() {
+  if (!cachedUserInfo) {
+    try {
+      const { username, homedir } = userInfo();
+      cachedUserInfo = { username, homedir };
+    } catch (error) {
+      cachedUserInfo = {
+        username: getEnv("USER", false) || getEnv("LOGNAME", false) || getEnv("USERNAME", false),
+        homedir: getEnv("HOME", false) || getEnv("USERPROFILE", false),
+      };
+      console.warn("os.userInfo() failed, using USER and HOME from the environment instead:", error);
+    }
+  }
+  return cachedUserInfo;
+}
+
+/**
+ * @returns {string | undefined}
  */
 export function getUsername() {
-  const { username } = userInfo();
-  return username;
+  return getUserInfo().username;
 }
 
 /**

--- a/test/internal/runner-user-info.test.ts
+++ b/test/internal/runner-user-info.test.ts
@@ -6,7 +6,7 @@
  * looks the user up once (getUserInfo() in scripts/utils.mjs) and falls back
  * to the environment when the lookup fails.
  *
- * This runs a copy of the runner under node, as CI does, over one test file.
+ * This runs a copy of the runner under node, as CI does, over two test files.
  * A --import preload replaces os.userInfo with one that throws and counts.
  */
 import { expect, test } from "bun:test";
@@ -28,6 +28,14 @@ const runnerFiles = [
 ];
 const node = nodeExe();
 
+/** A test file that prints the USER and HOME the runner gave its process. */
+const fixture = (file: string) => `
+  import { test } from "bun:test";
+  test("prints USER and HOME", () => {
+    console.error(JSON.stringify({ file: ${JSON.stringify(file)}, USER: process.env.USER, HOME: process.env.HOME }));
+  });
+`;
+
 test.skipIf(!node)("a failed passwd lookup does not end the run: USER and HOME come from the environment", async () => {
   using repo = tempDir("runner-user-info", {
     ...Object.fromEntries(runnerFiles.map(file => [file, readFileSync(join(repoRoot, file), "utf8")])),
@@ -44,16 +52,15 @@ test.skipIf(!node)("a failed passwd lookup does not end the run: USER and HOME c
       syncBuiltinESMExports();
       process.on("exit", () => console.error("os.userInfo() calls: " + calls));
     `,
-    "test/user-info.test.ts": `
-      import { test } from "bun:test";
-      test("prints the USER and HOME the runner set", () => {
-        console.error(JSON.stringify({ USER: process.env.USER, HOME: process.env.HOME }));
-      });
-    `,
+    // Two files, so that spawnBun runs twice and the call count below tells a
+    // cached lookup (1) from a per-file one (2).
+    "test/first.test.ts": fixture("first"),
+    "test/second.test.ts": fixture("second"),
     "home": {},
   });
   const root = String(repo);
   const home = join(root, "home");
+  const expected = (file: string) => JSON.stringify({ file, USER: "user-from-env", HOME: home });
 
   // The copy takes the runner's local code paths: no buildkite-agent, no
   // annotations, no retries. --quiet skips the `bun install` steps.
@@ -76,7 +83,8 @@ test.skipIf(!node)("a failed passwd lookup does not end the run: USER and HOME c
   const output = Bun.stripANSI(stdout + stderr);
 
   expect(output).toContain("os.userInfo() failed, using USER and HOME from the environment instead");
-  expect(output).toContain(JSON.stringify({ USER: "user-from-env", HOME: home }));
+  expect(output).toContain(expected("first"));
+  expect(output).toContain(expected("second"));
   expect(output).toContain("os.userInfo() calls: 1\n");
   expect(exitCode).toBe(0);
 });

--- a/test/internal/runner-user-info.test.ts
+++ b/test/internal/runner-user-info.test.ts
@@ -1,58 +1,82 @@
 /**
  * scripts/runner.node.mjs sets USER and HOME for every `bun test` it spawns.
- * It used to call os.userInfo() per test file for that, and the call throws
- * (`uv_os_get_passwd returned ENOENT`) on a macOS agent whose host has begun
- * to shut down, which ended the whole shard with exit 1 instead of one test.
- * getUserInfo() in scripts/utils.mjs does the lookup once and falls back to
- * the environment when it fails. The runner runs under node in CI, so this
- * does too: a --import preload replaces os.userInfo before utils.mjs loads.
+ * spawnBun used to call os.userInfo() per test file for that, and the call
+ * throws (`uv_os_get_passwd returned ENOENT`) on a macOS agent whose host has
+ * begun to shut down, which ended the whole shard with exit 1. The runner now
+ * looks the user up once (getUserInfo() in scripts/utils.mjs) and falls back
+ * to the environment when the lookup fails.
+ *
+ * This runs a copy of the runner under node, as CI does, over one test file.
+ * A --import preload replaces os.userInfo with one that throws and counts.
  */
 import { expect, test } from "bun:test";
-import { bunEnv, nodeExe, tempDir } from "harness";
+import { bunEnv, bunExe, nodeExe, tempDir } from "harness";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
-const utilsUrl = pathToFileURL(join(import.meta.dir, "..", "..", "scripts", "utils.mjs")).href;
+const repoRoot = join(import.meta.dir, "..", "..");
+// The runner, the modules it imports by relative path, and the LeakSanitizer
+// suppressions file it points the spawned `bun test` at.
+const runnerFiles = [
+  "scripts/runner.node.mjs",
+  "scripts/utils.mjs",
+  "scripts/p-limit.mjs",
+  "scripts/yocto-queue.mjs",
+  "test/docker/prestart-map.mjs",
+  "test/leaksan.supp",
+];
 const node = nodeExe();
 
-test.skipIf(!node)("getUserInfo() falls back to USER and HOME when the passwd lookup fails, once", async () => {
-  using dir = tempDir("runner-user-info", {
+test.skipIf(!node)("a failed passwd lookup does not end the run: USER and HOME come from the environment", async () => {
+  using repo = tempDir("runner-user-info", {
+    ...Object.fromEntries(runnerFiles.map(file => [file, readFileSync(join(repoRoot, file), "utf8")])),
     "preload.mjs": `
       import { syncBuiltinESMExports } from "node:module";
       import os from "node:os";
-      globalThis.userInfoCalls = 0;
+      let calls = 0;
       os.userInfo = () => {
-        globalThis.userInfoCalls++;
+        calls++;
         const error = new Error("A system error occurred: uv_os_get_passwd returned ENOENT (no such file or directory)");
         error.code = "ERR_SYSTEM_ERROR";
         throw error;
       };
       syncBuiltinESMExports();
+      process.on("exit", () => console.error("os.userInfo() calls: " + calls));
     `,
-    "main.mjs": `
-      import { getUserInfo, getUsername } from ${JSON.stringify(utilsUrl)};
-      const first = getUserInfo();
-      const second = getUserInfo();
-      const username = getUsername();
-      console.log(JSON.stringify({ first, cached: first === second, username, calls: globalThis.userInfoCalls }));
+    "test/user-info.test.ts": `
+      import { test } from "bun:test";
+      test("prints the USER and HOME the runner set", () => {
+        console.error(JSON.stringify({ USER: process.env.USER, HOME: process.env.HOME }));
+      });
     `,
+    "home": {},
   });
+  const root = String(repo);
+  const home = join(root, "home");
 
+  // The copy takes the runner's local code paths: no buildkite-agent, no
+  // annotations, no retries. --quiet skips the `bun install` steps.
+  const env: Record<string, string | undefined> = { ...bunEnv, USER: "user-from-env", HOME: home };
+  for (const name of ["CI", "BUILDKITE", "GITHUB_ACTIONS"]) delete env[name];
   await using proc = Bun.spawn({
-    cmd: [node!, `--import=${pathToFileURL(join(String(dir), "preload.mjs")).href}`, "main.mjs"],
-    cwd: String(dir),
-    env: { ...bunEnv, USER: "user-from-env", HOME: "/home/from/env" },
+    cmd: [
+      node!,
+      `--import=${pathToFileURL(join(root, "preload.mjs")).href}`,
+      join(root, "scripts", "runner.node.mjs"),
+      `--exec-path=${bunExe()}`,
+      "--quiet",
+    ],
+    cwd: root,
+    env,
     stdout: "pipe",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const output = Bun.stripANSI(stdout + stderr);
 
-  expect(stderr).toContain("os.userInfo() failed, using USER and HOME from the environment instead");
-  expect(JSON.parse(stdout)).toEqual({
-    first: { username: "user-from-env", homedir: "/home/from/env" },
-    cached: true,
-    username: "user-from-env",
-    calls: 1,
-  });
+  expect(output).toContain("os.userInfo() failed, using USER and HOME from the environment instead");
+  expect(output).toContain(JSON.stringify({ USER: "user-from-env", HOME: home }));
+  expect(output).toContain("os.userInfo() calls: 1\n");
   expect(exitCode).toBe(0);
 });

--- a/test/internal/runner-user-info.test.ts
+++ b/test/internal/runner-user-info.test.ts
@@ -1,90 +1,35 @@
 /**
- * scripts/runner.node.mjs sets USER and HOME for every `bun test` it spawns.
- * spawnBun used to call os.userInfo() per test file for that, and the call
- * throws (`uv_os_get_passwd returned ENOENT`) on a macOS agent whose host has
- * begun to shut down, which ended the whole shard with exit 1. The runner now
- * looks the user up once (getUserInfo() in scripts/utils.mjs) and falls back
+ * scripts/runner.node.mjs sets USER and HOME for every `bun test` it spawns
+ * from getUserInfo() in scripts/utils.mjs. spawnBun used to call os.userInfo()
+ * per test file instead, and that call throws (`uv_os_get_passwd returned
+ * ENOENT`) on a macOS agent whose host has begun to shut down, which ended the
+ * whole shard with exit 1. getUserInfo() looks the user up once and falls back
  * to the environment when the lookup fails.
- *
- * This runs a copy of the runner under node, as CI does, over two test files.
- * A --import preload replaces os.userInfo with one that throws and counts.
  */
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, nodeExe, tempDir } from "harness";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { expect, mock, test } from "bun:test";
+import * as os from "node:os";
+import { getUserInfo, getUsername } from "../../scripts/utils.mjs";
 
-const repoRoot = join(import.meta.dir, "..", "..");
-// The runner, the modules it imports by relative path, and the LeakSanitizer
-// suppressions file it points the spawned `bun test` at.
-const runnerFiles = [
-  "scripts/runner.node.mjs",
-  "scripts/utils.mjs",
-  "scripts/p-limit.mjs",
-  "scripts/yocto-queue.mjs",
-  "test/docker/prestart-map.mjs",
-  "test/leaksan.supp",
-];
-const node = nodeExe();
+test("getUserInfo() falls back to USER and HOME when os.userInfo() throws, and looks the user up once", () => {
+  const real = { ...os };
+  let calls = 0;
+  mock.module("node:os", () => ({
+    ...real,
+    userInfo: () => {
+      calls++;
+      throw new Error("A system error occurred: uv_os_get_passwd returned ENOENT (no such file or directory)");
+    },
+  }));
+  try {
+    const { env } = process;
+    const expected = { username: env.USER || env.LOGNAME || env.USERNAME, homedir: env.HOME || env.USERPROFILE };
 
-/** A test file that prints the USER and HOME the runner gave its process. */
-const fixture = (file: string) => `
-  import { test } from "bun:test";
-  test("prints USER and HOME", () => {
-    console.error(JSON.stringify({ file: ${JSON.stringify(file)}, USER: process.env.USER, HOME: process.env.HOME }));
-  });
-`;
-
-test.skipIf(!node)("a failed passwd lookup does not end the run: USER and HOME come from the environment", async () => {
-  using repo = tempDir("runner-user-info", {
-    ...Object.fromEntries(runnerFiles.map(file => [file, readFileSync(join(repoRoot, file), "utf8")])),
-    "preload.mjs": `
-      import { syncBuiltinESMExports } from "node:module";
-      import os from "node:os";
-      let calls = 0;
-      os.userInfo = () => {
-        calls++;
-        const error = new Error("A system error occurred: uv_os_get_passwd returned ENOENT (no such file or directory)");
-        error.code = "ERR_SYSTEM_ERROR";
-        throw error;
-      };
-      syncBuiltinESMExports();
-      process.on("exit", () => console.error("os.userInfo() calls: " + calls));
-    `,
-    // Two files, so that spawnBun runs twice and the call count below tells a
-    // cached lookup (1) from a per-file one (2).
-    "test/first.test.ts": fixture("first"),
-    "test/second.test.ts": fixture("second"),
-    "home": {},
-  });
-  const root = String(repo);
-  const home = join(root, "home");
-  const expected = (file: string) => JSON.stringify({ file, USER: "user-from-env", HOME: home });
-
-  // The copy takes the runner's local code paths: no buildkite-agent, no
-  // annotations, no retries. --quiet skips the `bun install` steps.
-  const env: Record<string, string | undefined> = { ...bunEnv, USER: "user-from-env", HOME: home };
-  for (const name of ["CI", "BUILDKITE", "GITHUB_ACTIONS"]) delete env[name];
-  await using proc = Bun.spawn({
-    cmd: [
-      node!,
-      `--import=${pathToFileURL(join(root, "preload.mjs")).href}`,
-      join(root, "scripts", "runner.node.mjs"),
-      `--exec-path=${bunExe()}`,
-      "--quiet",
-    ],
-    cwd: root,
-    env,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const output = Bun.stripANSI(stdout + stderr);
-
-  expect(output).toContain("os.userInfo() failed, using USER and HOME from the environment instead");
-  expect(output).toContain(expected("first"));
-  expect(output).toContain(expected("second"));
-  expect(output).toContain("os.userInfo() calls: 1\n");
-  expect(exitCode).toBe(0);
+    const first = getUserInfo();
+    expect(first).toEqual(expected);
+    expect(getUserInfo()).toBe(first);
+    expect(getUsername()).toBe(expected.username);
+    expect(calls).toBe(1);
+  } finally {
+    mock.module("node:os", () => real);
+  }
 });

--- a/test/internal/runner-user-info.test.ts
+++ b/test/internal/runner-user-info.test.ts
@@ -1,0 +1,58 @@
+/**
+ * scripts/runner.node.mjs sets USER and HOME for every `bun test` it spawns.
+ * It used to call os.userInfo() per test file for that, and the call throws
+ * (`uv_os_get_passwd returned ENOENT`) on a macOS agent whose host has begun
+ * to shut down, which ended the whole shard with exit 1 instead of one test.
+ * getUserInfo() in scripts/utils.mjs does the lookup once and falls back to
+ * the environment when it fails. The runner runs under node in CI, so this
+ * does too: a --import preload replaces os.userInfo before utils.mjs loads.
+ */
+import { expect, test } from "bun:test";
+import { bunEnv, nodeExe, tempDir } from "harness";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const utilsUrl = pathToFileURL(join(import.meta.dir, "..", "..", "scripts", "utils.mjs")).href;
+const node = nodeExe();
+
+test.skipIf(!node)("getUserInfo() falls back to USER and HOME when the passwd lookup fails, once", async () => {
+  using dir = tempDir("runner-user-info", {
+    "preload.mjs": `
+      import { syncBuiltinESMExports } from "node:module";
+      import os from "node:os";
+      globalThis.userInfoCalls = 0;
+      os.userInfo = () => {
+        globalThis.userInfoCalls++;
+        const error = new Error("A system error occurred: uv_os_get_passwd returned ENOENT (no such file or directory)");
+        error.code = "ERR_SYSTEM_ERROR";
+        throw error;
+      };
+      syncBuiltinESMExports();
+    `,
+    "main.mjs": `
+      import { getUserInfo, getUsername } from ${JSON.stringify(utilsUrl)};
+      const first = getUserInfo();
+      const second = getUserInfo();
+      const username = getUsername();
+      console.log(JSON.stringify({ first, cached: first === second, username, calls: globalThis.userInfoCalls }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [node!, `--import=${pathToFileURL(join(String(dir), "preload.mjs")).href}`, "main.mjs"],
+    cwd: String(dir),
+    env: { ...bunEnv, USER: "user-from-env", HOME: "/home/from/env" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("os.userInfo() failed, using USER and HOME from the environment instead");
+  expect(JSON.parse(stdout)).toEqual({
+    first: { username: "user-from-env", homedir: "/home/from/env" },
+    cached: true,
+    username: "user-from-env",
+    calls: 1,
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- Darwin shards die mid-run with `SystemError [ERR_SYSTEM_ERROR]: uv_os_get_passwd returned ENOENT` at `spawnBun` (`scripts/runner.node.mjs:1765`), which called `os.userInfo()` per test file. Builds 113713, 112842, 112537, 104623.
- The cause is the `com.buildkite.cleanup` LaunchDaemon from `scripts/agent.mjs:217-240` (#29672). At 06:27 local time it wipes `builds/*` on the bare minis and runs `shutdown -r now` under the running job. Once shutdown stops opendirectoryd, `getpwuid_r` finds no entry.
- The runner exits 1 before the agent dies. Buildkite records a test failure, which `getRetry()` does not retry.

### Fix
- `getUserInfo()` in `scripts/utils.mjs` calls `os.userInfo()` once and caches it. If the call throws, it uses `USER`/`LOGNAME`/`USERNAME` and `HOME`/`USERPROFILE` and warns. `spawnBun` and `getUsername()` use it.
- `runTests` read each node test file outside its step. A file that is gone now fails its step instead of ending the run. These are the two throws the wipe reaches.
- A shard that the reboot hits then ends as a lost agent, which CI retries. This is the interim with no deploy. #40349 fixes the reboot and needs `agent.mjs install` on each mini. Supersedes #40293.
- Verified: `test/internal/runner-user-info.test.ts`, and the runner under node with `os.userInfo` made to throw (Notes). Self-reviewed: 2 concerns raised, 2 addressed.

### Background
- `scripts/runner.node.mjs` is the CI test driver. It runs under node and spawns one `bun test` per file through `spawnBun`.
- `os.userInfo()` is libuv's `uv_os_get_passwd`, a `getpwuid_r` call. On macOS opendirectoryd serves it.
- `getRetry()` in `.buildkite/ci.mjs` retries a job whose agent dropped the connection (`exit_status: -1`).

@alii @dylan-conway: two calls are yours. Whether the runner keeps this once #40349 lands, and who redeploys the 13 minis.

<details><summary>Notes</summary>

**Timing.** Every darwin `test-bun` job that failed this way, with the host from the job's agent record and the finish time in UTC:

```
build   host                   exit  finished (UTC)
113713  darwin-arm64-crouton    1    2026-09-10 05:27:23
112537  darwin-arm64-breadstick 1    2026-09-08 05:27:26
112535  biscuit                 1    2026-09-08 05:27:16
104623  darwin-arm64-breadstick 1    2026-08-24 05:27:26
104622  darwin-arm64-crouton    1    2026-08-24 05:27:23
112842  darwin-x64-cornbread    1    2026-09-08 13:27:28
112842  darwin-x64-pita        -1    2026-09-08 13:27:22  (lost agent, retried, passed)
112835  darwin-x64-flatbread    1    2026-09-08 13:27:31
112835  darwin-x64-rye         -1    2026-09-08 13:31:00  (lost agent, retried, passed)
103586  darwin-x64-matzo        1    2026-08-22 13:27:36
103586  darwin-x64-bagel        1    2026-08-22 13:27:31
```

The agent name `darwin-aarch64-26.6.1-1` is shared by crouton, breadstick and biscuit, and `darwin-x64-14.8.9-1` by eight x64 minis, which is why the reports looked like one box failing twice at a time. The two `-1` rows are the same incident where the kill reached the agent before the runner reached its next `userInfo()` call. Those jobs were retried and the retries passed. That is the outcome this PR makes the normal one.

**On the host.** `ssh root@darwin-arm64-crouton`, 15 minutes after build 113713's shard died:

```
tz=IST+0100
$ last reboot | head -4
reboot time    Thu Sep 10 06:27
shutdown time  Thu Sep 10 06:27
reboot time    Wed Sep  9 06:27
shutdown time  Wed Sep  9 06:27
$ cat /Library/LaunchDaemons/com.buildkite.cleanup.plist
... rm -rf $BASE_PREFIX/{var,etc}/buildkite-agent/{builds,cache}/* /Users/administrator/Library/Services/buildkite-agent/{builds,cache}/* /tmp/* /var/tmp/* ...; { shutdown -r now || reboot; }
StartCalendarInterval Hour 6 Minute 27
```

In the job log the wipe shows first (`Test filter ".../abort.test.ts" had no matches` at 05:27:03, the file was gone), then the passwd failure at 05:27:23 when shutdown had stopped opendirectoryd.

**Runner repro without a Mac.** Copy `scripts/{runner.node,utils,p-limit,yocto-queue}.mjs`, `test/docker/prestart-map.mjs` and `test/leaksan.supp` into a directory with a `test/*.test.ts` file, then run the copy under node with a preload that replaces `os.userInfo` (through `module.syncBuiltinESMExports()`) with a function that throws:

```
env -u CI -u BUILDKITE node --import=file:///tmp/preload.mjs scripts/runner.node.mjs --exec-path=$(which bun) --quiet
```

With `scripts/` from main this exits 1 at the first test with the stack from the CI log (`at spawnBun (runner.node.mjs:1765:33)`, `at spawnBunTest (2007:48)`, `at runTest (696:24)`). With this branch `os.userInfo()` is called once, every file runs with `USER` and `HOME` from the environment, and the run ends normally. For the read site, add `test/js/node/test/parallel/test-gone.js` and a bun test that deletes it: main dies at `readFileSync ... at runOneTest (runner.node.mjs:847:29)` before the node test's step, this branch reports `test-gone.js - code 1` and runs the rest. The agent environment on the minis has `USER=administrator LOGNAME=administrator HOME=/Users/administrator`, the same values the passwd entry has.

**The test.** An earlier revision ran the copied runner under node from the test itself. That was cut back to an in-process check of `getUserInfo()` through `mock.module("node:os")`, in the style of `runner-junit.test.ts`, after a similar harness was removed from #40349 in review. The repro above covers the runner end to end.

**What remains.** `mkdtempSync` in `spawnBun` would throw if the temporary directory itself vanished. The wipe removes `/tmp/*`, not `/tmp`, so it does not.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/internal/runner-user-info.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/internal/runner-user-info.test.ts
bun test v1.4.3 (5f554969b)

test/internal/runner-user-info.test.ts:
os.userInfo() failed, using USER and HOME from the environment instead: warn: A system error occurred: uv_os_get_passwd returned ENOENT (no such file or directory)
      at userInfo (/workspace/bun/test/internal/runner-user-info.test.ts:20:17)
      at getUserInfo (/workspace/bun/scripts/utils.mjs:1630:37)
      at <anonymous> (/workspace/bun/test/internal/runner-user-info.test.ts:27:19)

(pass) getUserInfo() falls back to USER and HOME when os.userInfo() throws, and looks the user up once [16.15ms]

 1 pass
 0 fail
 4 expect() calls
Ran 1 test across 1 file. [2.69s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/runner.node.mjs                | 14 ++++++++++---
 scripts/utils.mjs                      | 37 +++++++++++++++++++++++++++++++---
 test/internal/runner-user-info.test.ts | 35 ++++++++++++++++++++++++++++++++
 3 files changed, 80 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
scripts/runner.node.mjs                     6      3     28
scripts/utils.mjs                           2      1     25
test/internal/runner-user-info.test.ts      4      7     18
```

</details>

<!-- robobun:evidence:end -->