### PR TITLE
node:http2: destroy the transport when a transport error destroys a client session

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -5413,13 +5413,17 @@ class ClientHttp2Session extends Http2Session {
     this[bunHTTP2Socket] = null;
   }
   #onError(error: Error) {
-    // See the client session's #onError: Node's socketOnError is a no-op once
+    // See the server session's #onError: Node's socketOnError is a no-op once
     // the session has been detached from the socket, so a transport error that
     // races our own teardown is not re-reported.
     if (this.destroyed) {
       return;
     }
-    this[bunHTTP2Socket] = null;
+    // Keep the socket attached: destroy() ends and destroys it, and it only
+    // detaches afterwards. Detaching here left destroy() with no socket to
+    // tear down, so a transport that reports an error without destroying
+    // itself (emit('error'), autoDestroy:false, a wrapper that forwards the
+    // error) stayed open and leaked the connection.
     if (this.#closed) {
       this.destroy();
       return;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4699,9 +4699,7 @@ class ServerHttp2Session extends Http2Session {
   }
 
   destroy(error: Error | number | undefined = NGHTTP2_NO_ERROR, code?: number) {
-    // Idempotent, like Node's destroy(). A latch rather than the `destroyed` getter: the socket
-    // only detaches at the end of the teardown, and destroy() is re-entered from inside it (a
-    // stream's 'error' listener, the 'goaway' emit).
+    // Idempotent like Node's. Latched, not `destroyed`: destroy() is re-entered before the socket detaches.
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js (Http2Session#destroy)
     if (this.#destroying) {
       return;
@@ -5767,9 +5765,7 @@ class ClientHttp2Session extends Http2Session {
   }
 
   destroy(error?: Error | number, code?: number) {
-    // Idempotent, like Node's destroy(). A latch rather than the `destroyed` getter: the socket
-    // only detaches at the end of the teardown, and destroy() is re-entered from inside it (a
-    // stream's 'error' listener, the 'goaway' emit).
+    // Idempotent like Node's. Latched, not `destroyed`: destroy() is re-entered before the socket detaches.
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js (Http2Session#destroy)
     if (this.#destroying) {
       return;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4699,15 +4699,9 @@ class ServerHttp2Session extends Http2Session {
   }
 
   destroy(error: Error | number | undefined = NGHTTP2_NO_ERROR, code?: number) {
-    // Node's destroy() is idempotent - "if (this.destroyed) return;" is its
-    // first line - so a second destroy (e.g. the received-GOAWAY handler
-    // destroying with a session error after a socket error's destroy already
-    // ran re-entrantly out of the 'goaway' emit) never re-runs the teardown or
-    // re-emits 'error' on a session whose one-shot listeners are consumed.
-    // Guard on a latch, not the destroyed getter: that getter reads "socket
-    // detached", which only happens at the end of the teardown, so a destroy()
-    // re-entered from inside it (a stream's 'error' listener, the 'goaway'
-    // emit) would otherwise run the teardown twice.
+    // Idempotent, like Node's destroy(). A latch rather than the `destroyed` getter: the socket
+    // only detaches at the end of the teardown, and destroy() is re-entered from inside it (a
+    // stream's 'error' listener, the 'goaway' emit).
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js (Http2Session#destroy)
     if (this.#destroying) {
       return;
@@ -5773,15 +5767,9 @@ class ClientHttp2Session extends Http2Session {
   }
 
   destroy(error?: Error | number, code?: number) {
-    // Node's destroy() is idempotent - "if (this.destroyed) return;" is its
-    // first line - so a second destroy (e.g. the received-GOAWAY handler
-    // destroying with a session error after a socket error's destroy already
-    // ran re-entrantly out of the 'goaway' emit) never re-runs the teardown or
-    // re-emits 'error' on a session whose one-shot listeners are consumed.
-    // Guard on a latch, not the destroyed getter: that getter reads "socket
-    // detached", which only happens at the end of the teardown, so a destroy()
-    // re-entered from inside it (a stream's 'error' listener, the 'goaway'
-    // emit) would otherwise run the teardown twice.
+    // Idempotent, like Node's destroy(). A latch rather than the `destroyed` getter: the socket
+    // only detaches at the end of the teardown, and destroy() is re-entered from inside it (a
+    // stream's 'error' listener, the 'goaway' emit).
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js (Http2Session#destroy)
     if (this.#destroying) {
       return;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4705,8 +4705,9 @@ class ServerHttp2Session extends Http2Session {
     // ran re-entrantly out of the 'goaway' emit) never re-runs the teardown or
     // re-emits 'error' on a session whose one-shot listeners are consumed.
     // Guard on a latch, not the destroyed getter: that getter reads "socket
-    // detached", which #onError sets before calling in here, and the
-    // error-carrying destroy must still run once.
+    // detached", which only happens at the end of the teardown, so a destroy()
+    // re-entered from inside it (a stream's 'error' listener, the 'goaway'
+    // emit) would otherwise run the teardown twice.
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js (Http2Session#destroy)
     if (this.#destroying) {
       return;
@@ -5419,11 +5420,7 @@ class ClientHttp2Session extends Http2Session {
     if (this.destroyed) {
       return;
     }
-    // Keep the socket attached: destroy() ends and destroys it, and it only
-    // detaches afterwards. Detaching here left destroy() with no socket to
-    // tear down, so a transport that reports an error without destroying
-    // itself (emit('error'), autoDestroy:false, a wrapper that forwards the
-    // error) stayed open and leaked the connection.
+    // The socket stays attached so destroy() can end and destroy it.
     if (this.#closed) {
       this.destroy();
       return;
@@ -5782,8 +5779,9 @@ class ClientHttp2Session extends Http2Session {
     // ran re-entrantly out of the 'goaway' emit) never re-runs the teardown or
     // re-emits 'error' on a session whose one-shot listeners are consumed.
     // Guard on a latch, not the destroyed getter: that getter reads "socket
-    // detached", which #onError sets before calling in here, and the
-    // error-carrying destroy must still run once.
+    // detached", which only happens at the end of the teardown, so a destroy()
+    // re-entered from inside it (a stream's 'error' listener, the 'goaway'
+    // emit) would otherwise run the teardown twice.
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js (Http2Session#destroy)
     if (this.#destroying) {
       return;

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6009,3 +6009,60 @@ describe("frames issued from inside a user-supplied Duplex transport's _write", 
     },
   );
 });
+
+it("destroys the transport when a transport 'error' tears the client session down", async () => {
+  // Node's socketOnError hands a transport error to session.destroy(error), and that teardown
+  // ends and then destroys the socket. So a transport that reports an error without destroying
+  // itself (emit('error'), an autoDestroy:false stream, a wrapper that forwards errors) is still
+  // closed by the session. Bun detached the socket from the session first, which left the
+  // teardown with no socket to close: the connection, and its fd, stayed open for the life of the
+  // process.
+  function frame(type, flags) {
+    const header = Buffer.alloc(9);
+    header[3] = type;
+    header[4] = flags;
+    return header;
+  }
+  let connectionsOpen = 0;
+  const { promise: peerClosed, resolve: resolvePeerClosed } = Promise.withResolvers();
+  const server = net.createServer(connection => {
+    connectionsOpen++;
+    connection.on("close", () => {
+      connectionsOpen--;
+      resolvePeerClosed();
+    });
+    connection.on("error", () => {});
+    // The smallest usable server preface: an empty SETTINGS frame, then an ACK of the client's.
+    connection.write(frame(4, 0));
+    connection.once("data", () => connection.write(frame(4, 1)));
+  });
+  try {
+    const port = await new Promise(resolve => server.listen(0, "127.0.0.1", () => resolve(server.address().port)));
+    let transport;
+    const session = http2.connect(`http://127.0.0.1:${port}`, {
+      createConnection: () => (transport = net.connect(port, "127.0.0.1")),
+    });
+    const sessionError = new Promise(resolve => session.once("error", resolve));
+    const sessionClosed = new Promise(resolve => session.once("close", resolve));
+    await new Promise(resolve => session.once("connect", resolve));
+    expect(connectionsOpen).toBe(1);
+
+    transport.emit("error", Object.assign(new Error("transport failed"), { code: "EFAIL" }));
+
+    expect((await sessionError).message).toBe("transport failed");
+    await sessionClosed;
+    expect(session.destroyed).toBe(true);
+
+    // The socket teardown is end() -> 'finish' -> destroy(), so it lands a few turns after the
+    // session's 'close'.
+    for (let tick = 0; tick < 200 && !transport.destroyed; tick++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    expect(transport.destroyed).toBe(true);
+    // The peer observes the connection going away.
+    await peerClosed;
+    expect(connectionsOpen).toBe(0);
+  } finally {
+    server.close();
+  }
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6024,6 +6024,7 @@ it("destroys the transport when a transport 'error' tears the client session dow
     return header;
   }
   let connectionsOpen = 0;
+  const { promise: peerConnected, resolve: resolvePeerConnected } = Promise.withResolvers();
   const { promise: peerClosed, resolve: resolvePeerClosed } = Promise.withResolvers();
   const server = net.createServer(connection => {
     connectionsOpen++;
@@ -6035,21 +6036,34 @@ it("destroys the transport when a transport 'error' tears the client session dow
     // The smallest usable server preface: an empty SETTINGS frame, then an ACK of the client's.
     connection.write(frame(4, 0));
     connection.once("data", () => connection.write(frame(4, 1)));
+    resolvePeerConnected();
   });
+  let transport;
+  let session;
   try {
-    const port = await new Promise(resolve => server.listen(0, "127.0.0.1", () => resolve(server.address().port)));
-    let transport;
-    const session = http2.connect(`http://127.0.0.1:${port}`, {
+    const port = await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+    });
+    session = http2.connect(`http://127.0.0.1:${port}`, {
       createConnection: () => (transport = net.connect(port, "127.0.0.1")),
     });
+    const injected = Object.assign(new Error("transport failed"), { code: "EFAIL" });
     const sessionError = new Promise(resolve => session.once("error", resolve));
     const sessionClosed = new Promise(resolve => session.once("close", resolve));
-    await new Promise(resolve => session.once("connect", resolve));
+    // The client's 'connect' can land before the server has accepted (it did on macOS), so wait
+    // for both ends before counting connections. A session that dies first fails the wait.
+    const connected = new Promise((resolve, reject) => {
+      session.once("connect", resolve);
+      sessionError.then(reject);
+      sessionClosed.then(() => reject(new Error("session closed before 'connect'")));
+    });
+    await Promise.all([connected, peerConnected]);
     expect(connectionsOpen).toBe(1);
 
-    transport.emit("error", Object.assign(new Error("transport failed"), { code: "EFAIL" }));
+    transport.emit("error", injected);
 
-    expect((await sessionError).message).toBe("transport failed");
+    expect(await sessionError).toBe(injected);
     await sessionClosed;
     expect(session.destroyed).toBe(true);
 
@@ -6063,6 +6077,10 @@ it("destroys the transport when a transport 'error' tears the client session dow
     await peerClosed;
     expect(connectionsOpen).toBe(0);
   } finally {
+    // server.close() does not drop a live connection, so release the client end too (a failing
+    // run has just shown it is still open).
+    transport?.destroy();
+    session?.destroy();
     server.close();
   }
 });


### PR DESCRIPTION
### Problem
- A `node:http2` client session that takes a transport error destroys itself and leaves the transport open. The peer never sees a close. 100 sessions leak 100 connections and 200 fds. Node destroys the transport and leaks nothing.
- Cause: `ClientHttp2Session#onError` (`src/js/node/http2.ts:5422` on main) sets `this[bunHTTP2Socket] = null` before `this.destroy(error)`. The socket step inside `destroy()` (GOAWAY, `end()`, then `destroy()`) finds no socket and does nothing.
- Reached by any transport that reports an error without destroying itself: `emit('error')`, `autoDestroy:false`, a wrapper that forwards an inner error. A `net.Socket` that errors natively destroys itself, which hides the leak.

### Fix
- Remove the early detach. The session keeps the socket through `destroy()` and drops it after the teardown, as `#onClose` and the server session already do.
- Correct because `destroy()` owns the socket teardown, as in Node: `socketOnError` calls `session.destroy(error)` with the socket attached, and `finishSessionClose` ends and destroys it. An already destroyed socket is unaffected: `end()` is a no-op and the delayed destroy checks `socket.destroyed`.
- Self-reviewed: 2 concerns, 0 blocking. Reach is narrow (custom transports only). A Node-style destroyed flag is a follow-up (see Notes).
- Verified: `test/js/node/http2/node-http2.test.js` (new test, stock bun fails it), all of `test/js/node/http2/`, and the 278 vendored `test-http2-*` files.

### Background
- An `Http2Session` runs over a transport: a socket it dials, or whatever `options.createConnection` returns. The session holds it under `bunHTTP2Socket`, and `session.destroyed` reads that reference.
- `#onError` handles the transport's `'error'` and calls `destroy()`, which sends the GOAWAY, ends the socket, destroys it a turn later, then drops the reference.

<details><summary>Notes</summary>

Repro (loopback, `/proc` for the fd count): 100 client sessions over `createConnection: () => net.connect()`, each transport emits one `'error'` after the session connects. The far end is a raw TCP server that speaks an empty SETTINGS frame plus an ACK.

```
bun 1.4.2 and main @4ff91937:
  {"sessionsClosed":100,"last":{"sessionDestroyed":true,"transportDestroyed":false},
   "serverSideConnectionsStillOpen":100,"fdsBefore":10,"fdsAfter":210}
node v26.3.0:
  {"sessionsClosed":100,"last":{"sessionDestroyed":true,"transportDestroyed":true},
   "serverSideConnectionsStillOpen":0,"fdsBefore":23,"fdsAfter":23}
with this change:
  {"sessionsClosed":100,"last":{"sessionDestroyed":true,"transportDestroyed":false},
   "serverSideConnectionsStillOpen":0,"fdsBefore":10,"fdsAfter":10}
```

`last.transportDestroyed` is read when the session emits `'close'`. It is still `false` there because bun emits the session's `'close'` on the next tick, while node emits it from the socket's own `'close'` listener. The transport is destroyed a few turns later, which is what the new test waits for. #38195 moves the session's `'close'` behind the socket's.

The error path now also puts the final GOAWAY on the wire before the FIN, as Node's best-effort `nghttp2_session_terminate_session` does.

The early detach came in with the 2024 "H2 fixes" batch (#14606). No commit argues for it, and the only text that referenced it was the `destroy()` latch comment, now corrected. The `#destroying` latch itself is unchanged: `destroy()` is re-entered from inside its own teardown (stream `'error'` listeners, the `'goaway'` emit) before the socket detaches, so it cannot key off the `destroyed` getter.

Follow-up, not in this PR: `session.destroyed` means "socket detached" in bun and "destroy() ran" in node (a state flag). A flag would make the getter total during the teardown window. It would not close this leak on its own, so it is a separate change.

Related, and not covered by this change:
- #38195 rewrites the socket step inside `destroy()` (a `destroy()` with no `close()` must hard-destroy the socket, not only `end()` it). The error path here never reached that step, so the two changes compose in either merge order: with both, a transport error ends and destroys the socket and the session reports itself closed afterwards.
- An unobserved `ECONNRESET` (no `'error'` listener on the session) still takes the graceful branch of `destroy()`, which only calls `end()`. That branch is #38195's subject.

The server session's `#onError` does not detach, and a synthetic error on an accepted socket already destroys it (checked on main), so no server-side change was needed.

Test hardening after the first CI run: the macOS lanes saw the client's `'connect'` before the server's accept callback, so the test now waits for both ends before it counts connections. The connect wait also rejects on an early session `'error'` or `'close'`, and `finally` destroys the transport and session so a failing run releases the connection it just proved open.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (5f554969b)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [852.31ms]
(pass) node none > Client Basics > should be able to send a POST request [578.14ms]
(pass) node none > Client Basics > constants [18.55ms]
(pass) node none > Client Basics > getDefaultSettings [6.86ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [17.85ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.36ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.05ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [4.90ms]
(pass) node none > Client Basics > should be able to send data using end [600.74ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [589.52ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release without fix: 1 failed, 6 skipped
bun test v1.4.3-canary.1 (5f554969b)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.84ms]
(pass) node none > Client Basics > getDefaultSettings [0.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.29ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.12ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.03ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.07ms]
(pass) node none > Client Basics > is possible to abort request [1.72ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.70ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.67ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [0.74ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [29.29ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (5f554969b)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [866.40ms]
(pass) node none > Client Basics > should be able to send a POST request [582.68ms]
(pass) node none > Client Basics > constants [19.02ms]
(pass) node none > Client Basics > getDefaultSettings [7.25ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [18.17ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.83ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.27ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.09ms]
(pass) node none > Client Basics > should be able to send data using end [609.01ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [598.26ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e6018304f6
  features     baseline

23 deps, 131 codegen, 1172 objects in 881ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (5f554969b)

Checked 22 installs across 61 packages (no changes) [6.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (5f554969b)

Checked 1 install across 2 packages (no changes) [8.00ms]
[3/1244] fetch zlib
[zlib] up to date
[4/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1217] gen ErrorCode+*.h
[6/1217] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (5f554969b)

Checked 111 installs across 104 packages (no changes) [17.00ms]
[7/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[8/1217] gen .bind.ts → GeneratedBindings.cpp
[9/1217] fetch tinycc
[tinycc] up to date
[10/1216] gen bindgenv2
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                  | 22 ++--------
 test/js/node/http2/node-http2.test.js | 75 +++++++++++++++++++++++++++++++++++
 2 files changed, 79 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/node/http2.ts                      12      7     20
test/js/node/http2/node-http2.test.js      4      4     20
```

</details>

**root cause** · written by the author bot

The client HTTP/2 session's transport 'error' handler set its internal socket reference to null before calling destroy(), and because destroy() only performs its GOAWAY, end, and socket-destroy step when that reference is still set, the teardown was skipped and any transport that reported an error without destroying itself stayed open, leaking the connection and its file descriptor. The fix removes that premature detach so destroy() runs with the socket still attached and ends and destroys it, matching the server session's error path and Node's behavior. A regression test confirms the sessi…

<!-- robobun:evidence:end -->