### PR TITLE
Upgrade WebKit to ccdcb8a026

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-614-3db1d92e";
+export const WEBKIT_VERSION = "4b9ff9959a04c70a4b0a2ae286fcfe16670e7fe1";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "dfd696443b9ba87c4f516d1c724f0abacdd8768a";
+export const WEBKIT_VERSION = "autobuild-preview-pr-614-3db1d92e";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -958,6 +958,7 @@ const JSC::GlobalObjectMethodTable& NodeVMGlobalObject::globalObjectMethodTable(
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // shouldInterruptScriptBeforeTimeout,
+        nullptr, // moduleTypeIsAllowed
         &moduleLoaderImportModule,
         nullptr, // moduleLoaderResolve
         nullptr, // moduleLoaderFetch

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -954,6 +954,7 @@ const JSC::GlobalObjectMethodTable& GlobalObject::globalObjectMethodTable()
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // &shouldInterruptScriptBeforeTimeout,
+        nullptr, // moduleTypeIsAllowed
         &moduleLoaderImportModule, // moduleLoaderImportModule
         &moduleLoaderResolve, // moduleLoaderResolve
         &moduleLoaderFetch, // moduleLoaderFetch
@@ -982,6 +983,7 @@ const JSC::GlobalObjectMethodTable& EvalGlobalObject::globalObjectMethodTable()
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // &shouldInterruptScriptBeforeTimeout,
+        nullptr, // moduleTypeIsAllowed
         &moduleLoaderImportModule, // moduleLoaderImportModule
         &moduleLoaderResolve, // moduleLoaderResolve
         &moduleLoaderFetch, // moduleLoaderFetch
@@ -1010,6 +1012,7 @@ const JSC::GlobalObjectMethodTable& StandaloneGlobalObject::globalObjectMethodTa
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // &shouldInterruptScriptBeforeTimeout,
+        nullptr, // moduleTypeIsAllowed
         &moduleLoaderImportModule, // moduleLoaderImportModule
         &StandaloneGlobalObject::moduleLoaderResolve,
         &StandaloneGlobalObject::moduleLoaderFetch,

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -218,6 +218,7 @@ const JSC::GlobalObjectMethodTable& GlobalObject::globalObjectMethodTable()
         INHERIT_HOOK_METHOD(shouldInterruptScript),
         INHERIT_HOOK_METHOD(javaScriptRuntimeFlags),
         INHERIT_HOOK_METHOD(shouldInterruptScriptBeforeTimeout),
+        INHERIT_HOOK_METHOD(moduleTypeIsAllowed),
         bakeModuleLoaderImportModule,
         bakeModuleLoaderResolve,
         bakeModuleLoaderFetch,

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -499,8 +499,8 @@ describe("bytecode cache portability", () => {
         "bun build --bytecode happy-dom/lib/index.js": {
           "js": "75d2ad2bc252c916f90f8ca85f53f0883ca46049c2700e3c1fe2337ec42d1142",
           "jsc": {
-            "bytes": 2337296,
-            "sha256": "28afc82679782e8effeb749b20556093facb376d7d1e92de50888230412ec0e2",
+            "bytes": 2337264,
+            "sha256": "49a83aca1ac5dcf9a7a20d64259fcb39aaec3a6c47afce6254cefb2bc89dde8e",
           },
         },
         "bun build --bytecode immutable/dist/immutable.es.js": {
@@ -513,8 +513,8 @@ describe("bytecode cache portability", () => {
         "bun build --bytecode libraries.js": {
           "js": "493bab674ff49b287f26be3f356a3ad6681afb0c7eeffaa590f10cdcd8b58724",
           "jsc": {
-            "bytes": 22009464,
-            "sha256": "3107a462fc955913d0c5b93633c450d3aa6b8cccf8e10ef763efdfee9da4cf6d",
+            "bytes": 22009352,
+            "sha256": "e53f7a300c80b6d6268023bf9ea8fd2996cb704f6624f8c68095bd47f1d7684b",
           },
         },
         "bun build --bytecode lodash/lodash.js": {
@@ -555,8 +555,8 @@ describe("bytecode cache portability", () => {
         "bun build --bytecode undici/index.js": {
           "js": "e1c4f1494711ecaae57a6d63dfb8ac6096629582f55cc42530ff5a156b70c9de",
           "jsc": {
-            "bytes": 874752,
-            "sha256": "80b3b63ecb885d41b285861b0a64e121f2586edb065ed170775bcf985df49db0",
+            "bytes": 874736,
+            "sha256": "20fc4d7f3f1deec97bbd18574f07e4c58426ba4a94596299640e2362b8fdfe66",
           },
         },
         "vm.Script big.js": {

--- a/test/js/bun/jsc/webkit-upgrade-ccdcb8a026.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-ccdcb8a026.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Coverage for the WebKit ccdcb8a026 sync (oven-sh/WebKit#614). Each case pins an
+// observable difference between the old and the new JavaScriptCore. The last case
+// exercises the GlobalObjectMethodTable::moduleTypeIsAllowed slot the range adds: a
+// host-defined import attribute type must still reach Bun's module loader.
+
+describe.concurrent("WebKit ccdcb8a026 upgrade", () => {
+  test("Array.prototype.toSpliced throws RangeError for a new length of 2^53 - 1 (c8c37314ee)", () => {
+    expect(() => Array.prototype.toSpliced.call({ length: Infinity }, 0, 0)).toThrow(RangeError);
+    // One past 2^53 - 1 is still the TypeError from step 10 of the spec algorithm.
+    expect(() => Array.prototype.toSpliced.call({ length: 2 ** 53 - 1 }, 0, 0, 1)).toThrow(TypeError);
+  });
+
+  test("Atomics.isLockFree uses ToIntegerOrInfinity instead of wrapping to int32 (41294576ac)", () => {
+    expect(Atomics.isLockFree(4)).toBe(true);
+    expect(Atomics.isLockFree(4294967297)).toBe(false);
+    expect(Atomics.isLockFree(2 ** 32 + 4)).toBe(false);
+  });
+
+  test("RegExp.escape keeps supplementary code points whose low 16 bits look like syntax characters (b44e00d2f0)", () => {
+    // U+2002A has 0x002A ('*') in its low 16 bits and U+20009 has 0x0009 (TAB).
+    expect(RegExp.escape("\u{2002A}")).toBe("\u{2002A}");
+    expect(RegExp.escape("\u{20009}")).toBe("\u{20009}");
+    expect(RegExp.escape("*")).toBe("\\*");
+  });
+
+  test("a strict async generator body does not tail-call its return expression (4fa7b55ae4)", async () => {
+    async function* g() {
+      "use strict";
+      return Promise.resolve(42);
+    }
+    const result = await g().next();
+    expect(result).toEqual({ value: 42, done: true });
+  });
+
+  test("host-defined import attribute types still load through Bun's module loader (64168e4d90)", async () => {
+    using dir = tempDir("wk-module-type", {
+      "data.toml": `name = "bun"\n`,
+      "note.txt": `hello`,
+      "entry.mjs": `
+        import data from "./data.toml" with { type: "toml" };
+        import note from "./note.txt" with { type: "text" };
+        const dynamic = await import("./data.toml", { with: { type: "toml" } });
+        process.stdout.write(JSON.stringify({ name: data.name, note, dynamic: dynamic.default.name }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ name: "bun", note: "hello", dynamic: "bun" });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
# WebKit upgrade: upstream changes

Range: `0d58b764f3..ccdcb8a026` (320 upstream commits, 71 touch JavaScriptCore, WTF, bmalloc or cmake). Fork PR: oven-sh/WebKit#614.

`WEBKIT_VERSION` is `4b9ff9959a04c70a4b0a2ae286fcfe16670e7fe1`, the merge commit of oven-sh/WebKit#614 on the fork's main (release `autobuild-4b9ff9959a04c70a4b0a2ae286fcfe16670e7fe1`, 42 tarballs). Its tree is identical to the preview build `autobuild-preview-pr-614-3db1d92e` that the earlier CI runs on this PR used.

## Notes for Bun

- Upstream `64168e4d90` inserts `bool (*moduleTypeIsAllowed)(ScriptFetchParameters::Type)` into `GlobalObjectMethodTable` ahead of `moduleLoaderImportModule`. Bun's five positional initializers (`ZigGlobalObject.cpp` x3, `NodeVM.cpp`, `BakeGlobalObject.cpp`) get a `nullptr` slot (Bake inherits the parent's). With no hook the fork's `JSModuleLoader` keeps allowing `ScriptFetchParameters::HostDefined`, so `with { type: "toml" }`, `"text"`, `"file"` and the rest still reach Bun's loader. This is the only Bun source change the range needs.
- Several commits in the range are the fork's own patches landed upstream in another shape (Karatsuba, `Object.values`, the memset-vs-marker fix, `RegExpTestInline` with a Yarr frame). oven-sh/WebKit#614 describes which shape the merge kept. Three Yarr refactors (`956f6fb496`, `549955d997`, `6279ebe3bd`) are not taken because they assume upstream's RegExp JIT rather than the fork's. Their tests pass on the fork's engine.
- `wtf/text/CString.h` (`5f14e32e57`): `String::latin1()`, `ascii()` and `tryGetUTF8()` now return typed `Latin1CString` / `ASCIICString` / `UTF8CString`. Bun's current callers compile unchanged, new code that wants a `const char*` should use `characters()` or `byteCast<char>(span())`.
- `wtf/RunLoop.h` (`19cfe1ed98`): `releaseAssertIsCurrent()` is gone and `assertIsCurrent()` is a RELEASE_ASSERT in every build type.
- `JSType.h` did not change. The WebCore bindings generator did not change. The release tarball names did not change.
- New test `test/js/bun/jsc/webkit-upgrade-ccdcb8a026.test.ts` pins four engine fixes from the range (`toSpliced` RangeError, `Atomics.isLockFree`, `RegExp.escape` on supplementary code points, no tail call out of an async generator body) plus the host-defined import-attribute path. Four of its five cases fail on the current pin.
- Verified locally on Linux x64 with `bun run build:local` against the merged tree and `bun bd` against the preview debug-asan tarball: `test/js/bun/jsc/`, `test/js/bun/resolve/{toml,yaml}`, `import-defer`, `test/js/node/vm/vm.test.ts`, `sourcetextmodule-link-gc`, `test/js/web/atomics`, `test/js/web/url/url.test.ts`, `test/js/node/path/`, `test/js/node/buffer.test.js`, `test/js/bun/util/{escapeRegExp,stringWidth,escapeHTML}`, `test/js/web/workers/worker.test.ts`, `test/js/web/timers/setTimeout.test.js`. No failures other than the three `setTimeout doesn't leak ...` cases, which fail the same way on the current pin under a debug ASAN build (the fixture widens its RSS threshold only for a binary named `bun-asan`).

## Needs an embedder-side change

- `64168e4d90` `GlobalObjectMethodTable` (`runtime/GlobalObjectMethodTable.h`) gains `bool (*moduleTypeIsAllowed)(ScriptFetchParameters::Type)` between `shouldInterruptScriptBeforeTimeout` and `moduleLoaderImportModule`, so every positional initializer of the table needs a new entry (upstream `jsc.cpp` and `JSGlobalObject::baseGlobalObjectMethodTable` pass `nullptr`). `JSModuleLoader::importModule` and `hostLoadImportedModule` always allow `None`, `JavaScript`, `WebAssembly`, `JSON` and `Text`, and for any other `ScriptFetchParameters::Type` they ask the hook and reject with TypeError "Module type not supported by environment" when it is null or returns false. https://bugs.webkit.org/show_bug.cgi?id=323170
- `5f14e32e57` `wtf/text/CString.h` adds `CStringWithEncoding<CharacterType>` with aliases `UTF8CString`, `Latin1CString`, `ASCIICString`. `String::ascii()` returns `ASCIICString`, `String::latin1()` returns `Latin1CString`, `String/StringView/StringImpl::tryGetUTF8()` return `std::expected<UTF8CString, UTF8ConversionError>`. Their `data()`/`span()` are typed (`const char8_t*`, `const Latin1Character*`), so callers that passed `latin1().data()` or `tryGetUTF8()->data()` to a `const char*` API must use `characters()`, `byteCast<char>(span())`, or bind to `const CString&`. `utf8()` still returns plain `CString`. https://bugs.webkit.org/show_bug.cgi?id=323408
- `19cfe1ed98` `assertIsCurrent(const RunLoop&)` in `wtf/RunLoop.h` is now `RELEASE_ASSERT(runLoop.isCurrent())` in all build types and `releaseAssertIsCurrent()` is removed. https://bugs.webkit.org/show_bug.cgi?id=323572

## Runtime and builtins

- `cbd15fc88b` (already in the fork, whose copy is kept) `JSBigInt` multiplication uses Karatsuba (ported from V8 and Go) when the smaller operand has at least 44 digits. 1000x1000-digit products are about 2.7x faster, 4000x4000 about 4.8x. https://bugs.webkit.org/show_bug.cgi?id=323244
- `f52d0e486a` `JSBigInt.cpp` hoists `std::span` bounds checks out of hot loops with explicit `RELEASE_ASSERT` preconditions and `size_t` indices (some private `JSBigInt.h` signatures change). Performance only. https://bugs.webkit.org/show_bug.cgi?id=323699
- `c8c37314ee` `Array.prototype.toSpliced` throws TypeError only when the new length exceeds 2^53 - 1. A new length of exactly 2^53 - 1 (an array-like with `length = Infinity`) now reaches ArrayCreate and throws RangeError as the spec requires. https://bugs.webkit.org/show_bug.cgi?id=320830
- `f37e633649` The `Object.values` fast path counts properties first and writes values directly into the result array's contiguous storage instead of staging them in a `MarkedArgumentBuffer`, 2.3x to 3.2x faster for objects with more than 8 properties. https://bugs.webkit.org/show_bug.cgi?id=323406
- `ae97aa471a` `JSArray::fastCopyWithin` no longer bails to the slow path when an Int32, Double or Contiguous array contains holes (holes move as raw bits), removing the linear `containsHole` scan. `copyWithin` is about 2x faster without holes and about 45x with holes. https://bugs.webkit.org/show_bug.cgi?id=323593
- `4fa7b55ae4` A strict-mode call spelled `eval(...)` in tail position becomes a real tail call when the callee is not the built-in eval (test262 `tco-non-eval-*`). Also fixes a pre-existing `useTailCalls` bug: generator, async function and async generator bodies no longer get tail calls, so a strict async generator that does `return someCall()` awaits the returned promise instead of resolving `{ value: <promise>, done: true }`. https://bugs.webkit.org/show_bug.cgi?id=323597
- `41294576ac` `Atomics.isLockFree` applies ToIntegerOrInfinity instead of ToInt32, so `Atomics.isLockFree(4294967297)` returns false instead of wrapping to 1. https://bugs.webkit.org/show_bug.cgi?id=323323
- `d5ba0ecec9` `JSDateMath.cpp` skips the double to int64 narrowing for local-time values outside the ECMAScript time range plus one day. Results were already NaN through TimeClip, this removes the undefined conversion UBSan reported. https://bugs.webkit.org/show_bug.cgi?id=323443
- `b6afe0d39e` `StackFrame::toString` truncates a `data:` source URL to 1024 characters (never splitting a `%XX` escape) when building `Error.stack`. https://bugs.webkit.org/show_bug.cgi?id=323636
- `566279d48d` C++ `toInt32(double)` in `runtime/MathCommon.h` uses `truncateDoubleToInt64` plus a new `toInt32AfterFailedTruncation(double)` on x86_64. The `ToIntMode` enum and the `Mode` template parameter of `toIntImpl` are removed. https://bugs.webkit.org/show_bug.cgi?id=323591

## RegExp (Yarr)

- `34141654c7` `RegExp` stores the pattern's minimum match length (`RegExp::minimumSize()`, `offsetOfMinimumSize()`). `RegExp::matchInline` fails fast when the remaining input is shorter, and DFG/FTL `RegExpTest` emit the same check inline for non-global, non-sticky RegExps, about 5x on a path-to-regexp style router benchmark. https://bugs.webkit.org/show_bug.cgi?id=322689
- `fea77037ca` Follow-up: the inline minimum-length filter is taken only when `lastIndex` is an Int32, so a `lastIndex` with a `valueOf` keeps its observable read after tier-up. https://bugs.webkit.org/show_bug.cgi?id=323501
- `83683abb03` `RegExpTestInline` (the Yarr matcher emitted directly into DFG/FTL code for a constant RegExp on 8-bit strings) now handles patterns that need Yarr frame slots (quantifiers, alternation) and patterns with the `u` or `v` flag, by reserving the Yarr frame in the DFG/FTL outgoing-argument area (`Graph::m_parameterSlots`). `Yarr::jitCompileInlinedTest` gains a `reservedFrameSizeInBytes` parameter and `argumentCountForStackSize` is removed from `runtime/StackAlignment.h`. About 1.6x to 1.7x on the microbenchmarks. https://bugs.webkit.org/show_bug.cgi?id=322949
- `111d7edcec` Fixes a DFG/FTL compiler-thread crash on a null `YarrCodeBlock` when `VM::deleteAllCode()` clears RegExp code between strength reduction and `RegExpTestInline` code generation. Adds `RegExp::getRegExpJITCodeBlockConcurrently()`. https://bugs.webkit.org/show_bug.cgi?id=323583
- `eb64f293d8` `RegExp::ensureRegExpJITCode()` moves out of line and issues `WTF::storeStoreFence()` before publishing `m_regExpJITCode`, which compiler threads read concurrently. https://bugs.webkit.org/show_bug.cgi?id=323796
- `d5531cc083` DFG strength reduction no longer folds a `NewRegExpUntyped` with constant pattern and flags into `NewRegExp` when the resulting `RegExp` is invalid, and `RegExpCache::lookupOrCreate` does not cache invalid RegExps. `RegExp` refreshes `m_atom`, `m_specificPattern`, `m_numSubpatterns` and named-capture data from the parsed pattern on every compile through a new `updateMetadataFromPattern()`. Landed first on a Safari security branch (stale captures). https://bugs.webkit.org/show_bug.cgi?id=316723
- `956f6fb496` (not taken, see above) The Yarr interpreter matches lookbehinds from a match-order copy of the disjunction like upstream's JIT does, deleting every Backward-specific matcher. Fixes interpreter-only `/u` lookbehind bugs upstream: `/(?<=[\u{1F600}a])b/u` on "x😀b", `/(?<=\u{1F600}{2})x/u` on "😀😀x", `/(?<=$.*)/su` and `/(?<=\uD83D)/u` matching inside a surrogate pair. The fork's interpreter already passes these tests. https://bugs.webkit.org/show_bug.cgi?id=322692
- `549955d997` (not taken) `YarrPatternConstructor` stores the terms of lookbehind alternatives in match order, so both upstream tiers use the pattern directly and `copyDisjunctionInMatchOrder()` is removed. https://bugs.webkit.org/show_bug.cgi?id=323421
- `6279ebe3bd` (not taken) Built-in character classes are built once per process and shared by every `YarrPattern` as `const CharacterClass*`. The fork has had the equivalent since #588. https://bugs.webkit.org/show_bug.cgi?id=323731
- `b44e00d2f0` `RegExp.escape` no longer escapes a supplementary code point whose low 16 bits equal a syntax character, punctuator, whitespace or control character (U+2002A used to come out as `\` followed by U+2002A). https://bugs.webkit.org/show_bug.cgi?id=323642
- `1a29b8cfcf` (already in the fork) In `/v` mode an escaped hyphen after a class set operand (`/[[a]\-]/v`, `/[\q{ab}\-]/v`) no longer throws SyntaxError. https://bugs.webkit.org/show_bug.cgi?id=323496

## JIT (Baseline, DFG, FTL, B3)

- `0d6cf47c3b` DFG/FTL `ArrayIndexOf`/`ArrayIncludes` on Int32 and Double arrays call a vectorized operation (new `operationArrayIndexOfDouble`, `operationArrayIncludesDouble`) once at least 32 elements remain, 2.4x to 3.3x faster on long arrays. In WTF, `findDouble` is rebuilt on a shared `find64BitLaneImpl`, `findDoubleAlignedImpl` is removed, and `SIMD::splat<double>` is added. https://bugs.webkit.org/show_bug.cgi?id=323192
- `8e7f96f9a5` On x86_64, DFG/FTL double to int32 conversion truncates with 64-bit `cvttsd2siq` and keeps the low 32 bits, so doubles outside the int32 range no longer call `operationToInt32SensibleSlow`, 3.1x on the microbenchmark. Adds `MacroAssemblerX86_64::branchTruncateDoubleToInt32ViaInt64`. https://bugs.webkit.org/show_bug.cgi?id=323498
- `e6507c8f6a` `CodeBlock::finishCreation` pre-invalidates the `WatchpointSet` of `ResolvedClosureVar` `put_to_scope` targets inside generator, async function and async generator bodies. Fixes DFG code returning stale constant-folded values of captured variables after `deleteAllCode` re-creates a suspended generator's CodeBlock, at the cost of no longer constant-folding such variables. https://bugs.webkit.org/show_bug.cgi?id=313499
- `db10a0f616` Fixes stale get/put inline caches when a custom accessor or custom value with no backing property (for example from a static property table) on an already-flattened dictionary object is shadowed by a real property. `PropertySlot::setCacheableCustom`, `PutPropertySlot::setCustomValue` and `setCustomAccessor` gain a trailing `PropertyOffset offset = invalidOffset` parameter. https://bugs.webkit.org/show_bug.cgi?id=319303
- `e2f1a867ae` DFG node creation moves `CodeOrigin`/`NodeOrigin` instead of copying, saving a malloc/free per node when the bytecode index does not fit the packed form. https://bugs.webkit.org/show_bug.cgi?id=323490
- `b091600bca` `ARM64Assembler.h`, `X86Assembler.h` and `RISCV64Assembler.h` declare `RegisterID`, `SPRegisterID` and `FPRegisterID`/`XMMRegisterID` as named enums instead of `typedef enum`. https://bugs.webkit.org/show_bug.cgi?id=323455
- `ce4906cf9b` `B3Validate` converts SIMD lane types with `simdB3ScalarType()` from `B3Type.h`. Internal cleanup. https://bugs.webkit.org/show_bug.cgi?id=314639

## WebAssembly

- `10d4d20f5b` B3 `LowerToAir` no longer folds a `Shl` into the `WasmAddress` scaled-index form when the Shl's child is a locked value. On ARM64 the fold could address memory through an undefined index register while the bounds check tested the correct pointer (OMG miscompile from 320441@main). https://bugs.webkit.org/show_bug.cgi?id=323582
- `6ae2e2fec9` The validator accepts `(ref none)` and `(ref null none)` operands for `i31.get_s` and `i31.get_u`, fixing rejection of Binaryen output that canonicalizes `ref.null i31` to `ref.null none`. https://bugs.webkit.org/show_bug.cgi?id=322836
- `1b46b20806` Extended constant expressions for globals record `maxStackHeight` during validation and reuse it at evaluation, and GC array/struct initialization skips storing values equal to the zero fill. Faster instantiation for modules with many GC globals. https://bugs.webkit.org/show_bug.cgi?id=323465
- `54c30c45be` ARM64 `i8x16/i16x8/i32x4.bitmask` in BBQ and B3 load the lane-bit mask from a shared constant (`vectorBitmaskTower` in `jit/SIMDInfo.h`). https://bugs.webkit.org/show_bug.cgi?id=323350
- `0ddad2a1c1` The wasm-to-wasm tail-call restore-frame copy loop uses ARM64 post-index `loadPair64`/`storePair64`. https://bugs.webkit.org/show_bug.cgi?id=323374
- `ca158eb19b` The Wasm debugger stub supports the instance-scoped `qWasmGlobal` packet form and advertises `qWasmInstance+`, and `qWasmLocal` errors on unparsable fields instead of reading local 0. https://bugs.webkit.org/show_bug.cgi?id=323123

## GC and memory

- `ccdcb8a026` `JSArray::setLength`, `JSArray::shiftCountWithAnyIndexingType` and `JSObject::increaseVectorLength` clear vacated Contiguous slots with `gcSafeZeroMemory()` (and `increaseVectorLength` fences before publishing the new vector length) instead of a `WriteBarrier::clear()` loop that compilers lower to libc `memset`. With musl, whose memset uses sub-8-byte edge stores, the concurrent marker could read a torn JSValue. This is the upstream form of the fork's #564. https://bugs.webkit.org/show_bug.cgi?id=323639
- `366915db5c` `SlotVisitor::drainFromShared` decrements `Heap::m_numberOfWaitingParallelMarkers` through a scope exit, fixing early-return paths that left the counter unbalanced. https://bugs.webkit.org/show_bug.cgi?id=323491
- `4577b17ad8` Removes dead `Heap::isPagedOut()`, `MarkedSpace::isPagedOut()`, `BlockDirectory::updatePercentageOfPagedOutPages()` and the JSC option `customFullGCCallbackBailThreshold`. https://bugs.webkit.org/show_bug.cgi?id=323689
- `a0042af348` ARM64 LLInt `sanitizeStackForVM` zero-fills large stack regions with a `dc zva` cache-line loop when `DCZID_EL0` reads 4. https://bugs.webkit.org/show_bug.cgi?id=323368

## WTF and bmalloc

- `249ede976f` New `wtf/SpinBackoff.h` (mirrored in `bmalloc/SpinBackoff.h`) centralizes spin-then-yield logic and is adopted by `LockAlgorithm::lockSlow`, `WordLock`, `bmalloc::Mutex`, `JSLock::grabAllLocks` and `Heap::resumeThePeriphery`. On non-Darwin POSIX `Thread::yield()` now does a 1ns `nanosleep` instead of `sched_yield()`, and Linux lock slow paths spin with `pause` backoff before parking. Reported perf neutral. https://bugs.webkit.org/show_bug.cgi?id=321012
- `c0121e11c1` libpas: when bmalloc routes allocations to the system heap (`Malloc=1`, sanitizers, valgrind), non-`try` allocators crash on allocation failure like the normal path, `try` variants return null, and `try_reallocate` variants set `errno` to `ENOMEM`. https://bugs.webkit.org/show_bug.cgi?id=323456
- `b982ebd314`, `6f13897892`, `0f31212799` `wtf/ThreadAssertions.h` gains `assertIsOwnerThread(lock, ownerThread)`, `releaseOwnerThreadAssertion(lock)` and the `WTF_DECLARE_OWNER_THREAD_ASSERTIONS` macro, for state written under a lock but read unlocked on its owner thread. Adoption is WebCore-only. https://bugs.webkit.org/show_bug.cgi?id=323596
- `f2535d35a0` Adds `WTF_GUARDED_BY_LOCK`/`WTF_REQUIRES_LOCK` annotations to lock-protected members across JSC and WTF headers (`Heap`, `JSRunLoopTimer::Manager`, `RegExpCache::m_weakCache`, `RunLoop::m_registeredTimers`, `Inspector::RemoteConnectionToTarget`, `PerfLog`, `ProfilerDatabase`, Wasm callee groups and thunks). The actual race fixes in the commit are WebCore/WebKit only. https://bugs.webkit.org/show_bug.cgi?id=323492
- `da79705ade` `WTF::Vector` gains `moveTo(oldPosition, newPosition)`. https://bugs.webkit.org/show_bug.cgi?id=322891
- `3856a28580` Windows `WTF::memoryFootprint()` computes the private working set with `QueryWorkingSetEx` over `VirtualQuery` regions in fixed batches, with a hardened `QueryWorkingSet` fallback. Fixes a crash under Wine where the old code sized a retry buffer from uninitialized memory. https://bugs.webkit.org/show_bug.cgi?id=323559
- `7e1a50ea08`, `79282f6ac8`, `d0088e0c11` Swift interop annotations on `Vector`, `HashMap`, `Variant`, `RetainPtr` and `UniqueRef` (`SWIFT_COPYABLE_IF`, `SWIFT_ESCAPABLE`), plus the non-Swift fallback macro fix. No C++ semantic change. https://bugs.webkit.org/show_bug.cgi?id=323454

## Build system and platform

- `72ec90eba3` Non-unified CMake builds route ARC `.mm` sources into the `${framework}_ARC_SOURCES` object library through a new `generate-unified-source-bundles.py --print-arc-sources` mode (Cocoa only in effect). https://bugs.webkit.org/show_bug.cgi?id=323139
- `1bcccddc7c` `WebKitMacros.cmake` passes `-clang-target ${CMAKE_Swift_COMPILER_TARGET}` to swiftc when generating Swift/C++ interop headers. Swift targets only. https://bugs.webkit.org/show_bug.cgi?id=323370
- `56d21bcfd6` `ENABLE_WEBGPU_SWIFT` becomes a regular `WEBKIT_OPTION_DEFINE` (default OFF, ON in `OptionsCocoa.cmake`). https://bugs.webkit.org/show_bug.cgi?id=323430
- `34aca645c7` The CMake `SWIFT_NINJA_TRACE` option nests `swiftc_job_recorder.py` under `swiftc-wrapper.py` and errors out on Windows. https://bugs.webkit.org/show_bug.cgi?id=323380
- `dfc530cd33` Removes the `ENABLE_TEXT_AUTOSIZING` flag from `wtf/PlatformEnable.h` and the cmake feature lists. No JSC effect. https://bugs.webkit.org/show_bug.cgi?id=322941

## Reverted within the range

- `fe81aba198` "[JSC] Unify allocators" was reverted by `ce29fcc8c7`, and its follow-up `03c6c95044` "[JSC] Move BlockDirectory for-stealing list to AlignedMemoryAllocator" by `10f4e9581e`, both for a 0.3% Speedometer 3 regression. Net effect none. https://bugs.webkit.org/show_bug.cgi?id=323629

## WebCore-only or no effect on JSC embedders

`6f6d92eda1`, `fcef99916e`, `edc74c3eeb`, `ab7189f839`, `194d557d4f`, `2391a5cb88`, `3e12766ced`, `4b78955e0d`, `3821585ac8`, `67c93bbc4b`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_bytecode_portable.test.ts

<!-- robobun:evidence:end -->