### PR TITLE
bundler: fix the options.rs unit test build and type-check test targets in CI

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -116,15 +116,16 @@ export LLVM_VERSION_MAJOR=19
 
 ## rust-lints.yml Workflow
 
-Four independent jobs that each run one cargo command over the Rust workspace. They share `.github/actions/rust-lint-setup`, a composite action that installs LLVM from apt.llvm.org (configure resolves a clang even though nothing here compiles C++), Bun, optionally a pinned Rust toolchain plus components, runs `bun install`, then `bun scripts/build.ts --configure-only` and the ninja targets a job asks for: `clone-lolhtml clone-rust-argon2` (cargo cannot resolve the workspace until the vendored `lol_html` and `rust-argon2` path dependencies exist) and, for jobs that check `bun_runtime`/`bun_jsc`/`bun_core`, `codegen` (their `include!()`d sources under `build/debug/codegen`).
+Four independent jobs over the Rust workspace. They share `.github/actions/rust-lint-setup`, a composite action that installs LLVM from apt.llvm.org (configure resolves a clang even though nothing here compiles C++), Bun, optionally a pinned Rust toolchain plus components, runs `bun install`, then `bun scripts/build.ts --configure-only` and the ninja targets a job asks for: `clone-lolhtml clone-rust-argon2` (cargo cannot resolve the workspace until the vendored `lol_html` and `rust-argon2` path dependencies exist) and, for jobs that check `bun_runtime`/`bun_jsc`/`bun_core`, `codegen` (their `include!()`d sources under `build/debug/codegen`).
 
-| Job       | Check name            | Runs                                         | Blocking                       |
-| --------- | --------------------- | -------------------------------------------- | ------------------------------ |
-| `clippy`  | `cargo clippy`        | `bun run rust:clippy`                        | yes                            |
-| `miri`    | `cargo miri test`     | `bun run rust:miri` (`scripts/rust-miri.ts`) | yes                            |
-| `lolhtml` | `lol-html cargo test` | `cargo test` in `vendor/lolhtml`             | yes                            |
-| `mordant` | `mordant`             | `cargo dylint --all --workspace`             | advisory (`continue-on-error`) |
+| Job       | Check name            | Runs                                                                | Blocking                       |
+| --------- | --------------------- | ------------------------------------------------------------------- | ------------------------------ |
+| `clippy`  | `cargo clippy`        | `bun run rust:clippy`, then `cargo check --workspace --all-targets` | yes                            |
+| `miri`    | `cargo miri test`     | `bun run rust:miri` (`scripts/rust-miri.ts`)                        | yes                            |
+| `lolhtml` | `lol-html cargo test` | `cargo test` in `vendor/lolhtml`                                    | yes                            |
+| `mordant` | `mordant`             | `cargo dylint --all --workspace`                                    | advisory (`continue-on-error`) |
 
+- `clippy` lints the default targets only (lib and bin): test code was never held to the clippy lint set. Its second step, `cargo check --workspace --all-targets`, type-checks `#[cfg(test)]` code, `tests/` and `benches/` so they keep compiling. Nothing else builds them except the crates `rust:miri` runs.
 - `clippy`, `miri` and `lolhtml` pin `RUSTUP_TOOLCHAIN` at the workflow level (kept in sync with `channel` in `rust-toolchain.toml`) so rustup does not install that file's cross-target list; the action installs the toolchain with `--profile minimal` plus the components the job names (`clippy`, `miri rust-src`, none).
 - `lolhtml` exists because the vendored lol-html is a fork (oven-sh/lol-html, `bun` branch) whose own test suite is the only thing guarding the fork's invariants. It used to trigger only on `scripts/build/deps/lolhtml.ts`; it now shares the workflow's wider path filter.
 - `mordant` runs the [mordant](https://github.com/scarletindustries/mordant) dylint pack. It sets `RUSTUP_TOOLCHAIN: stable` instead: mordant is built with, and lints us using, the nightly named in its own rust-toolchain file, which dylint fetches on demand, so the outer cargo only needs to exist. Because that nightly is older than ours, the job passes `-A unknown_lints` through `DYLINT_RUSTFLAGS`. Two caches cover the slow parts: `~/.cargo/bin/{cargo-dylint,dylint-link}` keyed on `DYLINT_VERSION`, and `~/.dylint_drivers` + `target/dylint/libraries` keyed on `DYLINT_VERSION` plus the pinned mordant rev read out of `Cargo.toml`. It is skipped on `merge_group`.

--- a/.github/workflows/rust-lints.yml
+++ b/.github/workflows/rust-lints.yml
@@ -63,6 +63,15 @@ jobs:
           BUN_CODEGEN_DIR: ${{ github.workspace }}/build/debug/codegen
         run: bun run rust:clippy
 
+      - name: cargo check --all-targets
+        # Clippy above covers the default targets only (lib and bin). This
+        # type-checks what it skips (`#[cfg(test)]` code, `tests/`, `benches/`)
+        # so that code keeps compiling: the miri job builds a few crates'
+        # tests, nothing builds the rest.
+        env:
+          BUN_CODEGEN_DIR: ${{ github.workspace }}/build/debug/codegen
+        run: cargo check --workspace --all-targets --keep-going
+
   miri:
     name: cargo miri test
     runs-on: ubuntu-latest

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -42,6 +42,7 @@ const MIRI_CRATES = [
   "bun_paths",
   "bun_hash",
   "bun_base64",
+  "bun_bundler",
   "bun_clap",
   "bun_dispatch",
   "bun_errno",

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2319,7 +2319,8 @@ fn write_sanitized_parent_dirs_rewrites_every_dotdot_segment() {
 fn path_template_print_tolerates_malformed_brackets() {
     fn run(template: &[u8]) -> Vec<u8> {
         let mut out = Vec::new();
-        path_template_print(&mut out, template, b"D", b"N", b"E", Some(0), b"T", false).unwrap();
+        let hash = Some(bun_core::fmt::ContentHash::short(0));
+        path_template_print(&mut out, template, b"D", b"N", b"E", hash, b"T", false).unwrap();
         out
     }
     // Unterminated known placeholder: used to slice one past the end.


### PR DESCRIPTION
### Problem
- `cargo check --workspace --all-targets` fails on main with one error: `src/bundler/options.rs:2322: error[E0308]: mismatched types: expected ContentHash, found integer`.
- The unit test `path_template_print_tolerates_malformed_brackets` passes `Some(0)` as the hash. Since #41317 that parameter is `Option<bun_core::fmt::ContentHash>`. CI never builds this test target: `cargo clippy` checks the default targets only, and `rust:miri` does not list `bun_bundler`.

### Fix
- Pass `ContentHash::short(0)`. No assertion in the test prints a hash, so the value does not matter.
- Add `bun_bundler` to `MIRI_CRATES` in `scripts/rust-miri.ts`. Its three unit tests pass under Tree Borrows and need only the configure-time codegen files, which the miri job has.
- Add a `cargo check --workspace --all-targets` step to the `cargo clippy` job. It type-checks `#[cfg(test)]` code, `tests/` and `benches/` in every crate, so the next error of this kind fails CI.
- Verified: `cargo check --workspace --all-targets` (one error before, none after) and `bun run rust:miri` (17 crates pass), also in a fresh worktree set up like the CI jobs.

### Background
- `path_template_print` renders output name templates such as `[dir]/[name]-[hash].[ext]`. `ContentHash` (`src/bun_core/fmt.rs`) is a hash value plus the width that `[hashN]` asks for.
- A workspace crate's test binary does not link on its own: it lacks the C and C++ symbols that only the full `bun` link provides (`highway_index_of_char` here). Miri interprets MIR and never links, so `rust:miri` is where these unit tests can run.
- `cargo check` and `cargo clippy` without `--all-targets` build lib and bin targets only. `#[cfg(test)]` code is not type-checked.

<details><summary>Notes</summary>

- #41957 changes the same test line in the same way, as part of a behaviour change to `[ext]`. The hunk here is byte-identical, so the two do not conflict whichever merges first.
- `cargo clippy --all-targets` was the first idea for the guard. It reports over 100 lint errors in test and bench code across ten crates (`undocumented_unsafe_blocks`, `disallowed_methods`, ...). Test code was never held to the workspace lint set, so that is a separate cleanup. Plain `cargo check --all-targets` is clean today.
- CI cost, measured on an 8-core container in a fresh worktree after `--configure-only` and `ninja codegen clone-lolhtml clone-rust-argon2`: the new check step takes 1m58s from a cold target dir (it downloads the bench dev-dependencies: criterion, quick-xml, roxmltree, xml-rs). In the miri job, `bun_bundler` and its dependencies add about 30 s to the `--no-run` build with only the configure-time codegen files present. Its tests run in under 1 s. `bun_collections` stays the long pole of that job.
- #37592 and #37599 also touch `rust-lints.yml` and `rust-miri.ts` (native `cargo test` for the miri crate set). They do not build `bun_bundler`'s tests or check test targets workspace-wide.
- There is no `bun test` file for this change: it is a Rust `#[cfg(test)]` function plus CI configuration. The `cargo clippy` and `cargo miri test` checks on this PR are the proof.

</details>
