### PR TITLE
shell: clamp a `> ${buf}` redirect to the target buffer's live length

### DIFF
--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -138,8 +138,7 @@ unsafe extern "C" {
     safe fn JSC__ArrayBuffer__deref(self_: &JSCArrayBuffer);
     // safe: by-value `JSValue`; no-op for non-buffer values.
     safe fn JSC__JSValue__unpinArrayBuffer(v: JSValue);
-    // safe: by-value `JSValue` plus two out-params the callee always fills
-    // (null/0 for a value with no live storage).
+    // safe: by-value `JSValue`; the callee always fills both out-params.
     safe fn JSC__JSValue__arrayBufferExtent(v: JSValue, out_ptr: &mut *mut u8, out_len: &mut usize);
 }
 
@@ -719,22 +718,16 @@ impl PinnedArrayBuffer {
         self.buffer.byte_slice_mut()
     }
 
-    /// [`slice_mut`](Self::slice_mut) with the byte range re-read from the JS
-    /// value first.
-    ///
-    /// A pin stops a detach but not a shrink: `ArrayBuffer.prototype.resize`
-    /// marks the pages it trims PROT_NONE, so a write through the range
-    /// captured at [`root`](Self::root) time faults. A writer that runs after
-    /// user JS (an async redirect target, for example) uses this instead.
+    /// [`slice_mut`](Self::slice_mut) for a writer that runs after user JS: a
+    /// pin stops a detach but not a `resize()`, so the range is re-read first.
     pub fn live_slice_mut(&mut self) -> &mut [u8] {
         self.refresh();
         self.slice_mut()
     }
 
-    /// Re-reads `ptr` and the lengths from the JS value. Only a resizable
-    /// buffer can change: a fixed-length one cannot move or shrink while it is
-    /// pinned, and a [`copy_if_resizable`](Self::copy_if_resizable) copy is
-    /// this value's own allocation.
+    /// Re-reads the range from the JS value. Skipped unless it can change: a
+    /// [`copy_if_resizable`](Self::copy_if_resizable) copy is this value's own
+    /// allocation.
     fn refresh(&mut self) {
         if !self.buffer.resizable || self.copy.is_some() {
             return;

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -719,17 +719,22 @@ impl PinnedArrayBuffer {
     }
 
     /// [`slice_mut`](Self::slice_mut) for a writer that runs after user JS: a
-    /// pin stops a detach but not a `resize()`, so the range is re-read first.
+    /// pin stops a `transfer()` but not a `resize()` or a
+    /// `WebAssembly.Memory.prototype.grow()`, so the range is re-read first.
     pub fn live_slice_mut(&mut self) -> &mut [u8] {
         self.refresh();
         self.slice_mut()
     }
 
-    /// Re-reads the range from the JS value. Skipped unless it can change: a
-    /// [`copy_if_resizable`](Self::copy_if_resizable) copy is this value's own
-    /// allocation.
+    /// Re-reads the range from the JS value, for every kind of buffer: a
+    /// `resize()` unmaps the pages it trims, and a `grow()` of a
+    /// bounds-checked `WebAssembly.Memory` frees the whole block and detaches
+    /// its fixed-length buffer, which JSC permits while the buffer is pinned
+    /// (`ArrayBuffer::detach`). Skipped for a
+    /// [`copy_if_resizable`](Self::copy_if_resizable) copy, which is this
+    /// value's own allocation.
     fn refresh(&mut self) {
-        if !self.buffer.resizable || self.copy.is_some() {
+        if self.copy.is_some() {
             return;
         }
         let mut ptr = ptr::null_mut();

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -138,6 +138,9 @@ unsafe extern "C" {
     safe fn JSC__ArrayBuffer__deref(self_: &JSCArrayBuffer);
     // safe: by-value `JSValue`; no-op for non-buffer values.
     safe fn JSC__JSValue__unpinArrayBuffer(v: JSValue);
+    // safe: by-value `JSValue` plus two out-params the callee always fills
+    // (null/0 for a value with no live storage).
+    safe fn JSC__JSValue__arrayBufferExtent(v: JSValue, out_ptr: &mut *mut u8, out_len: &mut usize);
 }
 
 impl JSValue {
@@ -714,6 +717,37 @@ impl PinnedArrayBuffer {
     pub fn slice_mut(&mut self) -> &mut [u8] {
         debug_assert!(self.copy.is_none(), "a read-only root is not writable");
         self.buffer.byte_slice_mut()
+    }
+
+    /// [`slice_mut`](Self::slice_mut) with the byte range re-read from the JS
+    /// value first.
+    ///
+    /// A pin stops a detach but not a shrink: `ArrayBuffer.prototype.resize`
+    /// marks the pages it trims PROT_NONE, so a write through the range
+    /// captured at [`root`](Self::root) time faults. A writer that runs after
+    /// user JS (an async redirect target, for example) uses this instead.
+    pub fn live_slice_mut(&mut self) -> &mut [u8] {
+        self.refresh();
+        self.slice_mut()
+    }
+
+    /// Re-reads `ptr` and the lengths from the JS value. Only a resizable
+    /// buffer can change: a fixed-length one cannot move or shrink while it is
+    /// pinned, and a [`copy_if_resizable`](Self::copy_if_resizable) copy is
+    /// this value's own allocation.
+    fn refresh(&mut self) {
+        if !self.buffer.resizable || self.copy.is_some() {
+            return;
+        }
+        let mut ptr = ptr::null_mut();
+        let mut byte_len = 0usize;
+        JSC__JSValue__arrayBufferExtent(self.buffer.value, &mut ptr, &mut byte_len);
+        self.buffer.ptr = ptr;
+        self.buffer.byte_len = byte_len;
+        self.buffer.len = match self.buffer.bytes_per_element() {
+            Some(size) => byte_len / size as usize,
+            None => byte_len,
+        };
     }
 
     /// VM-shutdown finalizer only: the heap sweep already deleted what `Drop`

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -726,26 +726,50 @@ impl PinnedArrayBuffer {
         self.slice_mut()
     }
 
-    /// Re-reads the range from the JS value, for every kind of buffer: a
-    /// `resize()` unmaps the pages it trims, and a `grow()` of a
-    /// bounds-checked `WebAssembly.Memory` frees the whole block and detaches
-    /// its fixed-length buffer, which JSC permits while the buffer is pinned
-    /// (`ArrayBuffer::detach`). Skipped for a
-    /// [`copy_if_resizable`](Self::copy_if_resizable) copy, which is this
-    /// value's own allocation.
-    fn refresh(&mut self) {
-        if self.copy.is_some() {
-            return;
+    /// [`slice`](ArrayBuffer::slice) for a reader that runs after user JS. The
+    /// `&self` form of [`live_slice_mut`](Self::live_slice_mut): it reads the
+    /// range without caching it.
+    pub fn live_slice(&self) -> &[u8] {
+        let Some((ptr, byte_len)) = self.live_extent() else {
+            return self.buffer.byte_slice();
+        };
+        if ptr.is_null() || byte_len == 0 {
+            return &[];
         }
-        let mut ptr = ptr::null_mut();
-        let mut byte_len = 0usize;
-        JSC__JSValue__arrayBufferExtent(self.buffer.value, &mut ptr, &mut byte_len);
+        // SAFETY: JSC reports the view's own range, and the pin plus the GC
+        // root hold the storage for as long as `self` lives.
+        unsafe { core::slice::from_raw_parts(ptr, byte_len) }
+    }
+
+    /// Re-reads the range from the JS value and caches it. See
+    /// [`live_extent`](Self::live_extent).
+    fn refresh(&mut self) {
+        let Some((ptr, byte_len)) = self.live_extent() else {
+            return;
+        };
         self.buffer.ptr = ptr;
         self.buffer.byte_len = byte_len;
         self.buffer.len = match self.buffer.bytes_per_element() {
             Some(size) => byte_len / size as usize,
             None => byte_len,
         };
+    }
+
+    /// The range JSC reports now, for every kind of buffer: a `resize()`
+    /// unmaps the pages it trims, and a `grow()` of a bounds-checked
+    /// `WebAssembly.Memory` frees the whole block and detaches its
+    /// fixed-length buffer, which JSC permits while the buffer is pinned
+    /// (`ArrayBuffer::detach`). `None` for a
+    /// [`copy_if_resizable`](Self::copy_if_resizable) copy, which is this
+    /// value's own allocation.
+    fn live_extent(&self) -> Option<(*mut u8, usize)> {
+        if self.copy.is_some() {
+            return None;
+        }
+        let mut ptr = ptr::null_mut();
+        let mut byte_len = 0usize;
+        JSC__JSValue__arrayBufferExtent(self.buffer.value, &mut ptr, &mut byte_len);
+        Some((ptr, byte_len))
     }
 
     /// VM-shutdown finalizer only: the heap sweep already deleted what `Drop`

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3619,13 +3619,10 @@ CPP_DECL void JSC__JSValue__unpinArrayBuffer(JSC::EncodedJSValue v)
         buf->unpin();
 }
 
-// Re-reads the live byte range of a pinned ArrayBuffer or view.
-//
-// A pin stops a detach, but it does not stop a resize. `ArrayBuffer::resize`
-// marks the pages it trims PROT_NONE, so the pointer and the length captured
-// when the pin was taken can name unmapped memory once JS has run again. A
-// borrower that outlives the call re-reads the range before each access.
-// Reports a null pointer and a zero length for a detached value.
+// The live byte range of `v` (null and 0 when detached). `pinArrayBuffer`
+// stops a detach but not a resize, and `ArrayBuffer::resize` marks the pages
+// it trims PROT_NONE, so a borrower that outlives the call re-reads the range
+// instead of keeping the one it got when it took the pin.
 CPP_DECL void JSC__JSValue__arrayBufferExtent(JSC::EncodedJSValue v, uint8_t** out_ptr, size_t* out_len)
 {
     auto value = JSC::JSValue::decode(v);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3619,6 +3619,34 @@ CPP_DECL void JSC__JSValue__unpinArrayBuffer(JSC::EncodedJSValue v)
         buf->unpin();
 }
 
+// Re-reads the live byte range of a pinned ArrayBuffer or view.
+//
+// A pin stops a detach, but it does not stop a resize. `ArrayBuffer::resize`
+// marks the pages it trims PROT_NONE, so the pointer and the length captured
+// when the pin was taken can name unmapped memory once JS has run again. A
+// borrower that outlives the call re-reads the range before each access.
+// Reports a null pointer and a zero length for a detached value.
+CPP_DECL void JSC__JSValue__arrayBufferExtent(JSC::EncodedJSValue v, uint8_t** out_ptr, size_t* out_len)
+{
+    auto value = JSC::JSValue::decode(v);
+    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
+        if (!view->isDetached()) {
+            *out_ptr = static_cast<uint8_t*>(view->vector());
+            *out_len = view->byteLength();
+            return;
+        }
+    } else if (auto* jb = dynamicDowncast<JSC::JSArrayBuffer>(value)) {
+        auto* buf = jb->impl();
+        if (buf && !buf->isDetached()) {
+            *out_ptr = static_cast<uint8_t*>(buf->data());
+            *out_len = buf->byteLength();
+            return;
+        }
+    }
+    *out_ptr = nullptr;
+    *out_len = 0;
+}
+
 // Borrow `v`'s byte storage for off-thread reading. Splits out only the
 // `FastTypedArray` case from `pinArrayBuffer`, because that's the one mode
 // where `possiblySharedBuffer()` actually COPIES data

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -350,11 +350,15 @@ impl BuiltinIO {
                 Ok(buf.len())
             }
             BuiltinIO::ArrayBuf { buf: arraybuf, i } => {
-                // `len = buf.len` stays usize so `i + len > byte_len` is
-                // computed at usize width and cannot overflow; only the
-                // stored cursor is u32.
+                // `live_slice_mut`, not `slice_mut`: the redirect target is
+                // pinned for the whole command, and user JS between two chunks
+                // can shrink a resizable backing store.
+                //
+                // `total` stays usize so `idx + write_len` is computed at usize
+                // width and cannot overflow; only the stored cursor is u32.
+                let dst_all = arraybuf.live_slice_mut();
                 let idx = *i as usize;
-                let total = arraybuf.byte_len;
+                let total = dst_all.len();
                 if idx >= total {
                     return Err(bun_sys::Error::from_code(
                         bun_sys::E::ENOSPC,
@@ -362,7 +366,7 @@ impl BuiltinIO {
                     ));
                 }
                 let write_len = (total - idx).min(buf.len());
-                let dst = &mut arraybuf.slice_mut()[idx..idx + write_len];
+                let dst = &mut dst_all[idx..idx + write_len];
                 dst.copy_from_slice(&buf[..write_len]);
                 *i = i.saturating_add(write_len as u32);
                 Ok(write_len)

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -350,12 +350,9 @@ impl BuiltinIO {
                 Ok(buf.len())
             }
             BuiltinIO::ArrayBuf { buf: arraybuf, i } => {
-                // `live_slice_mut`, not `slice_mut`: the redirect target is
-                // pinned for the whole command, and user JS between two chunks
-                // can shrink a resizable backing store.
-                //
-                // `total` stays usize so `idx + write_len` is computed at usize
-                // width and cannot overflow; only the stored cursor is u32.
+                // `live_slice_mut`: JS between two chunks can resize the
+                // target. `total` stays usize so `idx + write_len` is computed
+                // at usize width and cannot overflow; the cursor is u32.
                 let dst_all = arraybuf.live_slice_mut();
                 let idx = *i as usize;
                 let total = dst_all.len();

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1522,7 +1522,10 @@ impl BufferedOutput {
                 let _ = b.append_slice(bytes); // OOM/capacity: fire-and-forget
             }
             BufferedOutput::ArrayBuffer { buf, i } => {
-                let array_buf_slice = buf.slice_mut();
+                // `live_slice_mut`, not `slice_mut`: the redirect target is
+                // pinned for the whole command, and user JS between two chunks
+                // can shrink a resizable backing store.
+                let array_buf_slice = buf.live_slice_mut();
                 let idx = *i as usize;
                 // TODO: We should probably throw error here?
                 if idx >= array_buf_slice.len() {

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1509,10 +1509,17 @@ impl BufferedOutput {
         }
     }
 
+    /// What the command wrote, for a reader that tees it elsewhere. `2>&1
+    /// ${buf}` reaches this with an `ArrayBuffer`, so it re-reads the target's
+    /// range (`live_slice`) and stops at the cursor: the rest of the target is
+    /// the caller's own data, not output.
     pub(crate) fn slice(&self) -> &[u8] {
         match self {
             BufferedOutput::Bytelist(b) => b.slice(),
-            BufferedOutput::ArrayBuffer { buf, .. } => buf.slice(),
+            BufferedOutput::ArrayBuffer { buf, i } => {
+                let live = buf.live_slice();
+                &live[..(*i as usize).min(live.len())]
+            }
         }
     }
 

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1522,9 +1522,7 @@ impl BufferedOutput {
                 let _ = b.append_slice(bytes); // OOM/capacity: fire-and-forget
             }
             BufferedOutput::ArrayBuffer { buf, i } => {
-                // `live_slice_mut`, not `slice_mut`: the redirect target is
-                // pinned for the whole command, and user JS between two chunks
-                // can shrink a resizable backing store.
+                // `live_slice_mut`: JS between two chunks can resize the target.
                 let array_buf_slice = buf.live_slice_mut();
                 let idx = *i as usize;
                 // TODO: We should probably throw error here?

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3383,6 +3383,46 @@ test.skipIf(isWindows)(
   },
 );
 
+test.skipIf(isWindows)("a `2>&1 ${buf}` redirect tees only the bytes written, at the live length", async () => {
+  // `2>&1 ${buf}` is the one spelling that sets DUPLICATE_OUT with a buffer
+  // target. That inverts `redirects_elsewhere()` for stderr, so the command's
+  // close path tees the target through `BufferedOutput::slice()`. That reader
+  // has to re-read the range too, and stop at the cursor: the rest of the
+  // target holds the caller's own bytes, not output.
+  const ab = new ArrayBuffer(1 << 20, { maxByteLength: 1 << 21 });
+  const buffer = new Uint8Array(ab);
+  const gate = Promise.withResolvers<void>();
+  const childWaiting = Promise.withResolvers<void>();
+  await using server = Bun.serve({
+    port: 0,
+    async fetch() {
+      childWaiting.resolve();
+      await gate.promise;
+      return new Response("ok");
+    },
+  });
+  const childCode = `
+    process.stdout.write("hi");
+    await fetch(${JSON.stringify(String(server.url))});
+  `;
+  const promise = $`${BUN} -e ${childCode} 2>&1 ${buffer}`.env(bunEnv).quiet().nothrow();
+  const running = promise.then(o => o);
+
+  await Promise.race([
+    childWaiting.promise,
+    running.then(r => {
+      throw new Error(`command settled before the child connected (exit ${r.exitCode}): ${r.stderr}`);
+    }),
+  ]);
+  ab.resize(0);
+  gate.resolve();
+
+  const result = await running;
+  expect(ab.byteLength).toBe(0);
+  expect(result.stderr.toString()).toBe("");
+  expect(result.exitCode).toBe(0);
+});
+
 test("a builtin output redirect fills a target buffer that shrank to a shorter length", async () => {
   // A shrink to a length the command has not reached yet. The output must stop
   // at the new end of the buffer, and every byte up to it must be written.

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3421,6 +3421,42 @@ test("a builtin output redirect fills the capacity a target buffer gained", asyn
   expect(result.exitCode).toBe(1);
 });
 
+test("an output redirect stops when the target's WebAssembly.Memory grows", async () => {
+  // `WebAssembly.Memory.prototype.grow` in BoundsChecking mode allocates a new
+  // block, copies into it, frees the old one, and then detaches the buffer the
+  // target view was made from. JSC allows that detach while the buffer is
+  // pinned, so the range the command captured points at freed pages.
+  //
+  // The child needs two settings for a stale write to fault instead of landing
+  // in memory that is still mapped: `BUN_JSC_useWasmFastMemory=0` picks
+  // BoundsChecking over the signaling mode, which grows in place, and
+  // `Malloc=1` turns off the Gigacage, which recycles the freed block. The
+  // target spans the whole memory so that a stale write sweeps the freed
+  // mapping instead of a part of it that something else may have taken.
+  const child = `
+    const mem = new WebAssembly.Memory({ initial: 128, maximum: 132 });
+    const target = new Uint8Array(mem.buffer);
+    const promise = Bun.$\`yes > \${target}\`.quiet().nothrow();
+    const running = promise.then(o => o);
+    await Promise.resolve();
+    mem.grow(4);
+    const result = await running;
+    console.log(JSON.stringify({ exitCode: result.exitCode, stderr: result.stderr.toString() }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [BUN, "-e", child],
+    env: { ...bunEnv, BUN_JSC_useWasmFastMemory: "0", Malloc: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr }).toEqual({
+    stdout: JSON.stringify({ exitCode: 1, stderr: "yes: ENOSPC\n" }),
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
+});
+
 test("stdin redirect from a Uint8Array sends the bytes captured when the command starts", async () => {
   // `< ${buf}` snapshots the buffer's contents when the command starts and
   // streams them to the child's stdin across multiple event-loop turns.

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3365,7 +3365,14 @@ test.skipIf(isWindows)(
     const promise = $`${BUN} -e ${childCode} > ${buffer}`.env(bunEnv).quiet().nothrow();
     const running = promise.then(o => o);
 
-    await childWaiting.promise;
+    // If the child exits before it fetches, fail with its output instead of
+    // waiting on `childWaiting` until the test times out.
+    await Promise.race([
+      childWaiting.promise,
+      running.then(r => {
+        throw new Error(`command settled before the child connected (exit ${r.exitCode}): ${r.stderr}`);
+      }),
+    ]);
     ab.resize(0);
     gate.resolve();
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3376,6 +3376,44 @@ test.skipIf(isWindows)(
   },
 );
 
+test("a builtin output redirect fills a target buffer that shrank to a shorter length", async () => {
+  // A shrink to a length the command has not reached yet. The output must stop
+  // at the new end of the buffer, and every byte up to it must be written.
+  const SHRUNK = 1 << 16;
+  const ab = new ArrayBuffer(1 << 20, { maxByteLength: 1 << 21 });
+  const buffer = new Uint8Array(ab);
+  const promise = $`yes > ${buffer}`.env(bunEnv).quiet().nothrow();
+  const running = promise.then(o => o);
+  await Promise.resolve();
+  ab.resize(SHRUNK);
+
+  const result = await running;
+  expect(buffer.byteLength).toBe(SHRUNK);
+  // `yes` writes "y\n", so an untouched byte is still the zero it was created
+  // with.
+  expect(buffer.indexOf(0)).toBe(-1);
+  expect(result.stderr.toString()).toBe("yes: ENOSPC\n");
+  expect(result.exitCode).toBe(1);
+});
+
+test("a builtin output redirect fills the capacity a target buffer gained", async () => {
+  // The other direction: a grow commits pages past the length the command
+  // started with, and the output uses them.
+  const GROWN = 1 << 20;
+  const ab = new ArrayBuffer(1 << 16, { maxByteLength: GROWN });
+  const buffer = new Uint8Array(ab);
+  const promise = $`yes > ${buffer}`.env(bunEnv).quiet().nothrow();
+  const running = promise.then(o => o);
+  await Promise.resolve();
+  ab.resize(GROWN);
+
+  const result = await running;
+  expect(buffer.byteLength).toBe(GROWN);
+  expect(buffer.indexOf(0)).toBe(-1);
+  expect(result.stderr.toString()).toBe("yes: ENOSPC\n");
+  expect(result.exitCode).toBe(1);
+});
+
 test("stdin redirect from a Uint8Array sends the bytes captured when the command starts", async () => {
   // `< ${buf}` snapshots the buffer's contents when the command starts and
   // streams them to the child's stdin across multiple event-loop turns.

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3473,15 +3473,21 @@ test("an output redirect stops when the target's WebAssembly.Memory grows", asyn
   // `Malloc=1` turns off the Gigacage, which recycles the freed block. The
   // target spans the whole memory so that a stale write sweeps the freed
   // mapping instead of a part of it that something else may have taken.
+  //
+  // `wroteBeforeGrow` is the proof that the grow lands mid-command: `yes`
+  // writes its first batch while `.then()` starts the interpreter, the
+  // microtask below runs before the event loop picks up the next batch, and
+  // the `ENOSPC` therefore comes from a write after the grow.
   const child = `
     const mem = new WebAssembly.Memory({ initial: 128, maximum: 132 });
     const target = new Uint8Array(mem.buffer);
     const promise = Bun.$\`yes > \${target}\`.quiet().nothrow();
     const running = promise.then(o => o);
     await Promise.resolve();
+    const wroteBeforeGrow = target[0] === 0x79 && target[1] === 0x0a;
     mem.grow(4);
     const result = await running;
-    console.log(JSON.stringify({ exitCode: result.exitCode, stderr: result.stderr.toString() }));
+    console.log(JSON.stringify({ wroteBeforeGrow, exitCode: result.exitCode, stderr: result.stderr.toString() }));
   `;
   await using proc = Bun.spawn({
     cmd: [BUN, "-e", child],
@@ -3491,7 +3497,7 @@ test("an output redirect stops when the target's WebAssembly.Memory grows", asyn
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout: stdout.trim(), stderr }).toEqual({
-    stdout: JSON.stringify({ exitCode: 1, stderr: "yes: ENOSPC\n" }),
+    stdout: JSON.stringify({ wroteBeforeGrow: true, exitCode: 1, stderr: "yes: ENOSPC\n" }),
     stderr: "",
   });
   expect(exitCode).toBe(0);

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3318,6 +3318,64 @@ test.skipIf(isWindows)(
   },
 );
 
+test("a builtin output redirect clamps to the target buffer's live length after a resize", async () => {
+  // A pin stops a detach but not a resize: `ArrayBuffer.prototype.resize`
+  // unmaps the pages it trims. `yes` writes four chunks per event-loop turn,
+  // so the resize below lands between two batches, and the next batch must see
+  // the new length instead of the one captured when the command started.
+  const ab = new ArrayBuffer(1 << 20, { maxByteLength: 1 << 21 });
+  const buffer = new Uint8Array(ab);
+  const promise = $`yes > ${buffer}`.env(bunEnv).quiet().nothrow();
+  // Calling .then() starts the interpreter synchronously, so `yes` has already
+  // written its first batch and queued the next one.
+  const running = promise.then(o => o);
+  await Promise.resolve();
+  ab.resize(0);
+
+  const result = await running;
+  expect(ab.byteLength).toBe(0);
+  expect(result.stderr.toString()).toBe("yes: ENOSPC\n");
+  expect(result.exitCode).toBe(1);
+});
+
+test.skipIf(isWindows)(
+  "an external command output redirect clamps to the target buffer's live length after a resize",
+  async () => {
+    // Same hazard as the builtin case, on the subprocess pipe reader. The
+    // child writes, waits for the gated fetch below, then writes again, so the
+    // second chunk is guaranteed to arrive after the resize.
+    const ab = new ArrayBuffer(1 << 20, { maxByteLength: 1 << 21 });
+    const buffer = new Uint8Array(ab);
+    const gate = Promise.withResolvers<void>();
+    const childWaiting = Promise.withResolvers<void>();
+    await using server = Bun.serve({
+      port: 0,
+      async fetch() {
+        childWaiting.resolve();
+        await gate.promise;
+        return new Response("ok");
+      },
+    });
+    const childCode = `
+      const chunk = Buffer.alloc(1 << 16, 0x41);
+      process.stdout.write(chunk);
+      await fetch(${JSON.stringify(String(server.url))});
+      process.stdout.write(chunk);
+    `;
+    const promise = $`${BUN} -e ${childCode} > ${buffer}`.env(bunEnv).quiet().nothrow();
+    const running = promise.then(o => o);
+
+    await childWaiting.promise;
+    ab.resize(0);
+    gate.resolve();
+
+    const result = await running;
+    expect(ab.byteLength).toBe(0);
+    expect(result.stderr.toString()).toBe("");
+    expect(result.exitCode).toBe(0);
+  },
+);
+
 test("stdin redirect from a Uint8Array sends the bytes captured when the command starts", async () => {
   // `< ${buf}` snapshots the buffer's contents when the command starts and
   // streams them to the child's stdin across multiple event-loop turns.


### PR DESCRIPTION
### Problem

- `Bun.$` crashes the process when a `> ${buf}` redirect target loses its backing store while the command runs. An `ab.resize(0)` between two output chunks gives `panic(main thread): Segmentation fault`, 3 of 3 runs on 1.4.3. A `grow()` of the target's `WebAssembly.Memory` does the same. Both faces hit a builtin writer (`yes`) and an external command.
- The shell pins the buffer and keeps the pointer and the length it read when the command started: `BufferedOutput::append` (`src/runtime/shell/subproc.rs:1525`) and `BuiltinIO::write_no_io_to` (`src/runtime/shell/Builtin.rs:358`). A pin stops a `transfer()`. It stops neither a resize nor a wasm grow.

### Fix

- Add `PinnedArrayBuffer::live_slice_mut()`. It re-reads the view's byte range from the JS value, then returns the writable slice. The new binding `JSC__JSValue__arrayBufferExtent` reports `vector()` and `byteLength()`, which follow a resize and an auto-length view, and read null and 0 once the buffer is detached.
- Both shell write sites use it, for every kind of buffer. A target that shrank, or whose buffer is gone, stops the write: the builtin path reports `ENOSPC`, the subprocess path drops the rest. A target that grew gets the extra bytes.
- Both writers run on the JS thread, so the re-read cannot race the JS that changes the buffer.
- Verified: `test/js/bun/shell/bunshell.test.ts`, five new tests. All five fail on 1.4.3, and four of them crash it. Also all of `test/js/bun/shell/`.

### Background

- `PinnedArrayBuffer` is the pin plus GC root that the shell takes on a redirect target. It stores the pointer and the length read at pin time, and the command writes through them across many event-loop turns.
- A pin clears `ArrayBuffer::isDetachable()`, so `transfer()` copies instead of detaching. `resize()` ignores the pin: it calls `OSAllocator::protect` on the pages it trims, so a write there faults.
- A wasm grow in BoundsChecking mode allocates a new block, copies into it, frees the old one, then detaches the buffer. `ArrayBuffer::detach` permits that for a pinned wasm memory buffer, by design. Only the signaling mode grows in place.
- #40641 made the read side safe by copying the bytes (`copy_if_resizable`). A write target cannot copy, because the caller has to see the output in its own buffer, so it clamps instead.

<details><summary>Notes</summary>

Reproduction (released 1.4.3, SEGV 3 of 3 for each):

```js
// builtin writer
const ab = new ArrayBuffer(1 << 24, { maxByteLength: 1 << 25 });
const u8 = new Uint8Array(ab);
const p = Bun.$`yes > ${u8}`.quiet().nothrow();
const done = p.then(r => r); // Bun.$ is lazy: this starts the command and takes the pin
await Bun.sleep(0);
ab.resize(0);
await done;
```

`.then()` matters. Without it the pin is taken after the resize, the captured length is 0, and every write is skipped.

Why the faulting address is inside the buffer: `tryAllocateResizableMemory` reserves `maxByteLength` rounded up to the page size and protects everything past the initial length. `ArrayBuffer::resize` to a smaller length calls `OSAllocator::protect(memory + desiredSize, bytesToSubtract, false, false)`. The base pointer never moves, so the stale pointer still points at the reservation, and the write lands on a `PROT_NONE` page.

Test shape:

- The builtin test uses `yes`, which writes four 8 KB chunks per event-loop turn. `.then()` runs the first batch synchronously, the `await Promise.resolve()` drains the microtask queue before the loop picks up the next batch, so the `resize(0)` is always between two batches.
- The external-command test gates the child on a local `Bun.serve`: the child writes, fetches, then writes again. The parent resizes while the child waits, so the second chunk always arrives after the resize.

Suites run with the debug build: all of `test/js/bun/shell/`. The failures there (`fd leak > memleak_*`, `shell load > immediate exit`, the two `ls` permission cases) reproduce without this change. The leak tests pass under a release binary, so their 100 s timeouts are debug and ASAN build speed, and the `ls` permission cases need a non-root user.

The third site, found by review after the first two were fixed: `BufferedOutput::slice()` is the tee a command's close path runs, and it read the range captured at pin time. An earlier note here claimed no reader reaches it for a buffer target. That was wrong. `2>&1 ${buf}` is the one spelling that sets `DUPLICATE_OUT` with a buffer target, which inverts `redirects_elsewhere()` for stderr and reaches the tee. It also copied the whole target instead of the written prefix: 5 bytes of output memcpy'd 8 MiB. The patched build still SEGV'd on that spelling until the last commit, which re-reads the range there (`live_slice`) and stops at the cursor.

`refresh` / `live_extent` / `JSC__JSValue__arrayBufferExtent` are meant to be the one place that asks JSC for a pinned value's current range. #42203 fixes the same hazard for `fs.read` into a wasm-memory view and adds its own `write_back`. Whichever lands second should call this primitive rather than add a second one.

The wasm face, and why it needs two env settings. Reproduction (released 1.4.3, crash 20 of 20):

```js
// BUN_JSC_useWasmFastMemory=0 Malloc=1 bun wasmgrow.js
const mem = new WebAssembly.Memory({ initial: 128, maximum: 132 });
const target = new Uint8Array(mem.buffer);
const p = Bun.$`yes > ${target}`.quiet().nothrow();
const running = p.then(o => o);
await Promise.resolve();
mem.grow(4);
console.log((await running).exitCode);
```

`BUN_JSC_useWasmFastMemory=0` picks BoundsChecking, which reallocates on a grow. The signaling mode grows in place, so the stale pointer stays valid there and the bug is invisible. `Malloc=1` turns off the Gigacage: the freed block is then unmapped instead of returned to a cage free list that keeps it mapped. With the default settings the same script prints `1` and exits 0, which is why a fuzz pass over the release binary does not see this face.

The target view spans the whole memory on purpose. A 1 MiB view over an 8 MiB memory crashed only about half the time, because a stale write of 32 KB can land in a part of the freed hole that something else has taken. A view over the whole memory crashed 20 of 20.

Frames on the debug ASAN build, before the second commit (`WRITE of size 8192`, the first write after the grow):

```
__asan_memcpy
core::slice::copy_from_slice_impl::<u8>
<bun_runtime::shell::builtin::BuiltinIO>::write_no_io_to  src/runtime/shell/Builtin.rs:367
<bun_runtime::shell::builtins::yes::Yes>::write_no_io_loop  src/runtime/shell/builtin/yes.rs:105
<bun_runtime::shell::builtins::yes::YesTask>::run_from_main_thread  src/runtime/shell/builtin/yes.rs:245
bun_runtime::dispatch::run_task  src/runtime/dispatch.rs:333
```

`yes` writes four 8 KB chunks per event-loop turn, so 32768 bytes land before the `grow()` and the rest after it. That count is the same for a file and for `-e`.

The subprocess door has the same wasm face: `sh -c 'sleep 0.3; head -c 200000 /dev/zero' > ${viewOverWasmMemory}` with a `grow()` at 100 ms crashes 3 of 3 on 1.4.3. It is not a separate test, because both doors reach the target through `live_slice_mut`, and the subprocess door already has a resize test with a deterministic gate.

Checked the other two ways a pinned target can change under a deferred writer. A `transfer()` of a pinned buffer copies and leaves the source attached, so it is safe. A growable `SharedArrayBuffer` never detaches and keeps its reservation, and the re-read picks up the new length.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->