### PR TITLE
node:http2: report session.closed when the transport goes away

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4935,9 +4935,8 @@ class ClientHttp2Session extends Http2Session {
   #closed: boolean = false;
   // One-shot destroy latch (Node: "if (this.destroyed) return;" opens destroy()).
   #destroying: boolean = false;
-  /// closeCalled backs `session.closed`: node sets it in close() and in socketOnClose, so a
-  /// graceful close and a transport that went away both report it. A bare destroy() on a live
-  /// transport leaves it false while `session.destroyed` flips to true.
+  /// Backs `session.closed`: set by close() and by the socket's 'close' (node's socketOnClose
+  /// close()s the session). A bare destroy() leaves it false while `session.destroyed` flips.
   #closeCalled: boolean = false;
   /// connected indicates that the connection/socket is connected
   #connected: boolean = false;
@@ -5410,11 +5409,8 @@ class ClientHttp2Session extends Http2Session {
       parser.detach();
       this.#parser = null;
     }
-    // Node's socketOnClose marks the session closed before it destroys it, so a dead transport
-    // reports `closed` as well as `destroyed`. The latch is all close() would do here: its GOAWAY
-    // has no transport left to reach, and its deferred teardown is redundant next to the destroy
-    // below. An already-detached session (destroy() or a transport error ran first) keeps `closed`
-    // false - node's socketOnClose returns early once the socket no longer points at a session.
+    // Node's socketOnClose close()s a still-attached session before destroying it; only the latch
+    // matters here, since close()'s GOAWAY has no transport left to reach.
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js (socketOnClose)
     if (!this.destroyed) this.#closeCalled = true;
     this.destroy(err, NGHTTP2_NO_ERROR);

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4935,8 +4935,7 @@ class ClientHttp2Session extends Http2Session {
   #closed: boolean = false;
   // One-shot destroy latch (Node: "if (this.destroyed) return;" opens destroy()).
   #destroying: boolean = false;
-  /// Backs `session.closed`: set by close() and by the socket's 'close' (node's socketOnClose
-  /// close()s the session). A bare destroy() leaves it false while `session.destroyed` flips.
+  /// Backs `session.closed`: set by close() and by the socket's 'close' handler, never by a bare destroy().
   #closeCalled: boolean = false;
   /// connected indicates that the connection/socket is connected
   #connected: boolean = false;
@@ -5409,9 +5408,7 @@ class ClientHttp2Session extends Http2Session {
       parser.detach();
       this.#parser = null;
     }
-    // Node's socketOnClose close()s a still-attached session before destroying it; only the latch
-    // matters here, since close()'s GOAWAY has no transport left to reach.
-    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js (socketOnClose)
+    // Node's socketOnClose close()s a still-attached session first; with no transport only the latch matters.
     if (!this.destroyed) this.#closeCalled = true;
     this.destroy(err, NGHTTP2_NO_ERROR);
     this[bunHTTP2Socket] = null;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4935,8 +4935,9 @@ class ClientHttp2Session extends Http2Session {
   #closed: boolean = false;
   // One-shot destroy latch (Node: "if (this.destroyed) return;" opens destroy()).
   #destroying: boolean = false;
-  /// closeCalled tracks whether close() specifically was called: `session.closed` only reports a
-  /// graceful close() in node — destroy() leaves it false while `session.destroyed` flips to true.
+  /// closeCalled backs `session.closed`: node sets it in close() and in socketOnClose, so a
+  /// graceful close and a transport that went away both report it. A bare destroy() on a live
+  /// transport leaves it false while `session.destroyed` flips to true.
   #closeCalled: boolean = false;
   /// connected indicates that the connection/socket is connected
   #connected: boolean = false;
@@ -5409,6 +5410,13 @@ class ClientHttp2Session extends Http2Session {
       parser.detach();
       this.#parser = null;
     }
+    // Node's socketOnClose marks the session closed before it destroys it, so a dead transport
+    // reports `closed` as well as `destroyed`. The latch is all close() would do here: its GOAWAY
+    // has no transport left to reach, and its deferred teardown is redundant next to the destroy
+    // below. An already-detached session (destroy() or a transport error ran first) keeps `closed`
+    // false - node's socketOnClose returns early once the socket no longer points at a session.
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js (socketOnClose)
+    if (!this.destroyed) this.#closeCalled = true;
     this.destroy(err, NGHTTP2_NO_ERROR);
     this[bunHTTP2Socket] = null;
   }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6009,3 +6009,75 @@ describe("frames issued from inside a user-supplied Duplex transport's _write", 
     },
   );
 });
+
+// Node's socketOnClose marks the session closed before it destroys it, so a session whose
+// transport went away reports `closed` as well as `destroyed`. A destroy() on a live transport
+// reports only `destroyed` (node v26.3.0).
+describe.concurrent("session.closed after the transport goes away", () => {
+  const PREFACE = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
+  const EMPTY_SETTINGS = Buffer.from([0, 0, 0, 4, 0, 0, 0, 0, 0]);
+
+  // A TCP peer that sends its SETTINGS frame and reads everything the client sends, so a hang-up
+  // is a FIN and never an RST. It calls afterPreface with its socket once the client has written.
+  async function rawPeer(afterPreface) {
+    const server = net.createServer(socket => {
+      socket.on("error", () => {});
+      socket.once("data", () => afterPreface(socket));
+      socket.on("data", () => {});
+      socket.write(EMPTY_SETTINGS);
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    return server;
+  }
+
+  it("a client session reports closed when its peer hangs up", async () => {
+    const server = await rawPeer(socket => socket.end());
+    try {
+      const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+      client.on("error", () => {});
+      await new Promise(resolve => client.once("close", resolve));
+      expect({ closed: client.closed, destroyed: client.destroyed }).toEqual({ closed: true, destroyed: true });
+    } finally {
+      server.close();
+    }
+  });
+
+  it("a server session reports closed when its peer hangs up", async () => {
+    const server = http2.createServer();
+    const accepted = new Promise(resolve => server.on("session", resolve));
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const socket = net.connect(server.address().port, "127.0.0.1");
+    socket.on("error", () => {});
+    try {
+      socket.write(Buffer.concat([PREFACE, EMPTY_SETTINGS]));
+      const session = await accepted;
+      session.on("error", () => {});
+      const closed = new Promise(resolve => session.once("close", resolve));
+      socket.end();
+      await closed;
+      expect({ closed: session.closed, destroyed: session.destroyed }).toEqual({ closed: true, destroyed: true });
+    } finally {
+      socket.destroy();
+      server.close();
+    }
+  });
+
+  it("a client session destroyed while its transport is alive leaves closed false", async () => {
+    const server = await rawPeer(() => {});
+    try {
+      const socket = net.connect(server.address().port, "127.0.0.1");
+      socket.on("error", () => {});
+      const client = http2.connect(`http://127.0.0.1:${server.address().port}`, { createConnection: () => socket });
+      client.on("error", () => {});
+      await new Promise(resolve => client.once("remoteSettings", resolve));
+      const socketClosed = new Promise(resolve => socket.once("close", resolve));
+      client.destroy();
+      // The socket's own 'close' lands after the session is already detached. Node's socketOnClose
+      // returns early on a detached session, so that late teardown must not flip `closed`.
+      await socketClosed;
+      expect({ closed: client.closed, destroyed: client.destroyed }).toEqual({ closed: false, destroyed: true });
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6080,4 +6080,28 @@ describe.concurrent("session.closed after the transport goes away", () => {
       server.close();
     }
   });
+
+  it("a client session torn down by a transport error leaves closed false", async () => {
+    const server = await rawPeer(() => {});
+    try {
+      const socket = net.connect(server.address().port, "127.0.0.1");
+      socket.on("error", () => {});
+      const client = http2.connect(`http://127.0.0.1:${server.address().port}`, { createConnection: () => socket });
+      const errors = [];
+      client.on("error", err => errors.push(err.message));
+      await new Promise(resolve => client.once("remoteSettings", resolve));
+      const closed = new Promise(resolve => client.once("close", resolve));
+      // Node's socketOnError destroys the session with the error and detaches it, so the socket
+      // 'close' that follows finds no session to mark closed.
+      socket.destroy(new Error("transport blew up"));
+      await closed;
+      expect({ closed: client.closed, destroyed: client.destroyed, errors }).toEqual({
+        closed: false,
+        destroyed: true,
+        errors: ["transport blew up"],
+      });
+    } finally {
+      server.close();
+    }
+  });
 });


### PR DESCRIPTION
### Problem
- A `node:http2` client session reports `closed === false` after its transport goes away. Node reports `true` (`destroyed` is `true` in both). An h2c peer that sends SETTINGS and hangs up gives `{"closed":false,"destroyed":true}` on bun 1.4.3-canary.1 and `{"closed":true,"destroyed":true}` on node v26.3.0.
- `session.closed` reads the `#closeCalled` latch (`src/js/node/http2.ts:5472`), and only `close()` set it. Node's `socketOnClose` calls `session.close()` before it destroys the session. `ClientHttp2Session.#onClose` (`src/js/node/http2.ts:5403`) only destroyed.

### Fix
- Set the latch in the client session's socket `'close'` handler, before the existing destroy. Skip it when the session is already detached: a bare `destroy()` on a live transport and a transport error keep `closed` false, as node's `socketOnClose` does once the socket no longer points at a session.
- The handler sets the latch instead of calling `close()`: the GOAWAY has no transport left, the deferred teardown is redundant next to the destroy, and `close()` would trip a `destroy()` early-out for a socket that dies before connect and drop the session `'close'` event.
- Verified: `test/js/node/http2/node-http2.test.js` (four new tests, the client hang-up one fails on stock bun). Also the 261 vendored `test-http2-*.js` suites, the rest of `test/js/node/http2/`, `fetch-http2-client` and the grpc-js session tests.
- Self-reviewed: 4 concerns raised, 3 addressed (transport-error test, scope statement, #42175 interaction check). The fourth is a pre-existing hang in the same handler, described in Notes and left for its own change.

### Background
- `Http2Session#close()` is the graceful shutdown: send GOAWAY, let in-flight streams finish, then destroy. `destroy()` is the immediate teardown. Node reports them through `session.closed` and `session.destroyed`, independently.
- `socketOnClose` is node's handler for the session socket's `'close'` event (`lib/internal/http2/core.js`, v26.3.0). It cancels the streams, calls `session.close()`, then destroys the session. Bun's equivalent is the private `#onClose` on each session class.
- `ServerHttp2Session.#onClose` already calls `this.close()`, so only the client side changed. A new test covers the server path too.

<details>
<summary>Notes: session state after each teardown, node v26.3.0 vs bun</summary>

`{closed, destroyed}` read from the session's `'close'` event. The peer is a raw TCP socket that speaks the h2 preface.

```
                                        node v26.3.0      bun main          this branch
client: peer FIN                        true,  true       false, true       true,  true
client: peer RST                        false, true       false, true       false, true
client: peer GOAWAY(NO_ERROR) then FIN  true,  true       true,  true       true,  true
client: destroy(), live transport       false, true       false, true       false, true
server: peer FIN                        true,  true       true,  true       true,  true
server: peer RST                        false, true       false, true       false, true
server: destroy(), live transport       false, true       false, true       false, true
```

A client socket that dies before the session connects also reported `closed: false` and now reports `true`, which is what node reports for that case.

The detached-session guard is what keeps the `destroy()` rows at `false`: the socket's own `'close'` arrives after `destroy()` has already detached the session, and without the guard that late event would flip `closed` to `true`. The third new test asserts it by waiting for the socket's `'close'` before it reads the session state.

`test-http2-forget-closed-streams.js` takes about 70s under the debug+ASAN build, before and after the change.

**Scope.** This PR only aligns the `closed` getter. The client `#onClose` still differs from node's `socketOnClose` in two ways that this diff does not touch:

- A socket that closes before the session connects does not raise `ERR_SOCKET_CLOSED` on the session. `#onClose` derives it from `this.connecting`, which reads the socket, and bun's `net.Socket` already reports `connecting === false` by the time its `'close'` fires. Node still reports `true` there.
- `session.close()` while connecting, followed by a socket that closes without an `'error'` event, never emits the session `'close'` event (stock bun and this branch alike, node emits it). `#onClose` detaches the parser before it calls `destroy()`, and the client `destroy()` returns early on `#closed && !#connected && !#parser`. That early-out carries its own history (#32488), so removing it belongs in a separate change with its own CI signal.

**Interaction with #42175.** That PR stops the client `#onError` from detaching the socket before `destroy()`. `destroy()` itself still detaches it, so the `!this.destroyed` guard keeps `closed` false on the transport-error path either way. Checked by merging that branch locally and re-running the four new tests.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (5f554969b)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [857.96ms]
(pass) node none > Client Basics > should be able to send a POST request [593.70ms]
(pass) node none > Client Basics > constants [19.04ms]
(pass) node none > Client Basics > getDefaultSettings [7.27ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [18.08ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.50ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.30ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.16ms]
(pass) node none > Client Basics > should be able to send data using end [618.25ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [606.97ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release without fix: 1 failed, 6 skipped
bun test v1.4.3-canary.1 (5f554969b)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.91ms]
(pass) node none > Client Basics > getDefaultSettings [0.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.27ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.12ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.03ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.07ms]
(pass) node none > Client Basics > is possible to abort request [1.70ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.71ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.67ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [0.72ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [29.02ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (5f554969b)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [861.84ms]
(pass) node none > Client Basics > should be able to send a POST request [574.13ms]
(pass) node none > Client Basics > constants [19.27ms]
(pass) node none > Client Basics > getDefaultSettings [7.29ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [17.36ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.59ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.37ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.09ms]
(pass) node none > Client Basics > should be able to send data using end [598.84ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [588.06ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     04fb921122
  features     baseline

23 deps, 131 codegen, 1172 objects in 666ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (5f554969b)

Checked 22 installs across 61 packages (no changes) [10.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (5f554969b)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] gen bindgenv2
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (5f554969b)

Checked 111 installs across 104 packages (no changes) [12.00ms]
[7/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1216] fetch zlib
[zlib] up to date
[9/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 18ms

  react-refresh.js  4.81 KB  (entry point)

[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen JSBuffer.lut.h
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                  |  5 +-
 test/js/node/http2/node-http2.test.js | 96 +++++++++++++++++++++++++++++++++++
 2 files changed, 99 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/node/http2.ts                      13     10     19
test/js/node/http2/node-http2.test.js      4      1     18
```

</details>

<!-- robobun:evidence:end -->