### PR TITLE
node:module: reject a _resolveFilename override result that contains a null byte

### DIFF
--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -246,6 +246,13 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
                         RETURN_IF_EXCEPTION(scope, {});
                         auto str = string->value(globalObject);
                         RETURN_IF_EXCEPTION(scope, {});
+                        // The override replaces the resolver, which rejects a null byte. require()
+                        // opens this string as a path, and a null byte truncates the C string, so
+                        // reject it here the way node's loader does.
+                        if (str->contains('\0')) [[unlikely]] {
+                            Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "path"_s, string, "must be a string, Uint8Array, or URL without null bytes"_s);
+                            return {};
+                        }
                         WTF::String prefixed = Bun::isUnprefixedNodeBuiltin(str);
                         if (!prefixed.isNull()) {
                             return JSValue::encode(jsString(vm, prefixed));

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -655,6 +655,46 @@ console.log("survived", require("./late.js"));`,
     expect(exitCode).toBe(0);
   });
 
+  test("Overridden _resolveFilename returning a path with a null byte makes require() throw", async () => {
+    using dir = tempDir("resolve-filename-null-byte", {
+      "x.js": `module.exports = "loaded:" + __filename;`,
+      "main.cjs": `
+        const path = require("node:path");
+        const { Module } = require("node:module");
+        const real = path.join(__dirname, "x.js");
+        Module._resolveFilename = () => real + "\\u0000IGNORED";
+        const out = {};
+        try {
+          out.require = "loaded " + require("anything");
+        } catch (e) {
+          out.require = e.code;
+          out.requireMessageMentionsNullBytes = e.message.includes("without null bytes");
+        }
+        // Node returns the override's value from require.resolve() unchanged.
+        try {
+          out.resolveKeepsNullByte = require.resolve("anything").endsWith("\\u0000IGNORED");
+        } catch (e) {
+          out.resolveKeepsNullByte = e.code;
+        }
+        console.log(JSON.stringify(out));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(String(dir), "main.cjs")],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // Node v26.3.0 prints this exact object.
+    expect(JSON.parse(stdout)).toEqual({
+      require: "ERR_INVALID_ARG_VALUE",
+      requireMessageMentionsNullBytes: true,
+      resolveKeepsNullByte: true,
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test("Overridden _resolveFilename receives a parent Module for createRequire from ESM", async () => {
     using dir = tempDir("resolve-filename-args-esm", {
       "real.cjs": "module.exports = 'REAL';",


### PR DESCRIPTION
### Problem
- An override of `Module._resolveFilename` that returns a path with a null byte is used as a filesystem path with no check. `require()` opens the truncated path and loads that file, and `__filename` keeps the untruncated string. An assert build panics first: `ZStr::as_cstr: interior NUL would truncate the C view` (`src/bun_core/util.rs:181`, reached from `openat` in the CommonJS fetch path).
- The cause is `functionImportMeta__resolveSyncPrivate` (`src/jsc/bindings/ImportMetaObject.cpp:244`). When the override is set, it returns the override's result as the resolved filename. The normal resolver, which is what rejects a null byte, never runs.
- Node throws from its loader instead: `TypeError [ERR_INVALID_ARG_VALUE]: The argument 'path' must be a string, Uint8Array, or URL without null bytes.`

### Fix
- Check the string the override returned for a null byte and throw `ERR_INVALID_ARG_VALUE` with node's message.
- The check covers the `require()` path only. `require.resolve()` returns the override's value unchanged, which is what node does, because node validates in `fs`, not in the hook.
- This is correct because the override is the one resolver result that skips the path validation every other producer gets. `require()`, `createRequire()(id)` and `Module._load` all reach this one native function, so one check covers them.
- Verified: `test/js/node/module/node-module-module.test.js` ("Overridden _resolveFilename returning a path with a null byte makes require() throw"). The child's expected output comes from node v26.3.0. The released binary prints the loaded module instead, and the debug build panics. Also ran `module-resolve-filename-paths.test.js`, `test/js/bun/resolve/import-meta.test.js` and `require-extensions.test.ts`.

### Background
- `Module._resolveFilename` is node's hook that turns a request into a filename. Bun keeps the override on the global object and calls it from the native require path in place of its own resolver.
- A resolved filename reaches the loader, which opens it through a C string. A null byte ends a C string, so the OS opens a shorter path than the string says.
- Bun's own resolver already rejects such a path. `require(realPath + "\0x")` without the override reports `MODULE_NOT_FOUND`, and that path is unchanged.

<details><summary>Notes</summary>

Repro on the released binary (1.4.3):

```js
const fs = require("node:fs"), path = require("node:path"), os = require("node:os");
const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rf-")), real = path.join(dir, "x.js");
fs.writeFileSync(real, 'module.exports = "loaded:" + __filename;');
require("node:module")._resolveFilename = () => real + "\0IGNORED";
console.log(JSON.stringify(require("anything")));
```

- bun 1.4.3: `"loaded:/tmp/rf-xxxx/x.js\^@IGNORED"` (the file at the truncated path is loaded).
- bun debug build before this change: `panic: ZStr::as_cstr: interior NUL would truncate the C view`, stack `as_cstr <- openat <- bun_sys::open_file <- Fs::read_file_with_allocator <- Transpiler::parse... <- transpile_source_code_inner <- Bun__transpileFile <- fetchCommonJSModuleNonBuiltin <- jsFunctionRequireCommonJS`.
- node v26.3.0 and this change: `TypeError [ERR_INVALID_ARG_VALUE]: The argument 'path' must be a string, Uint8Array, or URL without null bytes. Received '/tmp/rf-xxxx/x.js\x00IGNORED'`.

Other return values from the override were checked and need no change: `{}`, a symbol, `42`, `undefined` and a revoked proxy all fail cleanly today.

A `Bun.plugin` `onResolve` hook that returns a path with a null byte does not panic and does not load a truncated file. It returns an empty module. That path is separate from this one and is not changed here.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->