### PR TITLE
node:http2: drop the connecting socket when a client session constructor throws

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -5656,6 +5656,7 @@ class ClientHttp2Session extends Http2Session {
     function onConnect() {
       // The parser's construction re-enters JS and can drain the tick queue, so a
       // connect that fires from that drain arrives before the constructor finished.
+      // A constructor that throws sets #parser to null, so this cannot re-arm forever.
       if (this.#parser === undefined) {
         process.nextTick(onConnect.bind(this));
         return;
@@ -5707,17 +5708,29 @@ class ClientHttp2Session extends Http2Session {
     const nativeSocket = socket._handle;
     this[kDeferWriteCallback] = deferWriteCallbackForSocket(nativeSocket);
 
-    if (options?.settings !== undefined) {
-      validateSettings(options.settings);
+    try {
+      if (options?.settings !== undefined) {
+        validateSettings(options.settings);
+      }
+      const nativeSettings = { ...options, ...options?.settings };
+      this.#localSettings = initialLocalSettings(nativeSettings);
+      this.#parser = new H2FrameParser({
+        native: nativeSocket,
+        context: this,
+        settings: nativeSettings,
+        handlers: ClientHttp2Session.#Handlers,
+      });
+    } catch (e) {
+      // Nothing can drive this connect: the caller gets the error, not a session.
+      this.#parser = null;
+      this[bunHTTP2Socket] = null;
+      try {
+        socket.destroy();
+      } catch {
+        // A createConnection socket whose destroy() throws must not replace `e`.
+      }
+      throw e;
     }
-    const nativeSettings = { ...options, ...options?.settings };
-    this.#localSettings = initialLocalSettings(nativeSettings);
-    this.#parser = new H2FrameParser({
-      native: nativeSocket,
-      context: this,
-      settings: nativeSettings,
-      handlers: ClientHttp2Session.#Handlers,
-    });
     socket.on("data", this.#onRead.bind(this));
     socket.on("drain", this.#onDrain.bind(this));
     socket.on("close", this.#onClose.bind(this));

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -5653,10 +5653,12 @@ class ClientHttp2Session extends Http2Session {
       this.#authority = needsBrackets ? `[${authorityHost}]:${port}` : `${authorityHost}:${port}`;
     }
 
+    // Set when the constructor throws: nobody holds this session.
+    let abandoned = false;
     function onConnect() {
+      if (abandoned) return;
       // The parser's construction re-enters JS and can drain the tick queue, so a
       // connect that fires from that drain arrives before the constructor finished.
-      // A constructor that throws sets #parser to null, so this cannot re-arm forever.
       if (this.#parser === undefined) {
         process.nextTick(onConnect.bind(this));
         return;
@@ -5704,11 +5706,10 @@ class ClientHttp2Session extends Http2Session {
       );
       this[bunHTTP2Socket] = socket;
     }
-    this.#encrypted = socket instanceof TLSSocket;
-    const nativeSocket = socket._handle;
-    this[kDeferWriteCallback] = deferWriteCallbackForSocket(nativeSocket);
-
     try {
+      this.#encrypted = socket instanceof TLSSocket;
+      const nativeSocket = socket._handle;
+      this[kDeferWriteCallback] = deferWriteCallbackForSocket(nativeSocket);
       if (options?.settings !== undefined) {
         validateSettings(options.settings);
       }
@@ -5721,8 +5722,7 @@ class ClientHttp2Session extends Http2Session {
         handlers: ClientHttp2Session.#Handlers,
       });
     } catch (e) {
-      // Nothing can drive this connect: the caller gets the error, not a session.
-      this.#parser = null;
+      abandoned = true;
       this[bunHTTP2Socket] = null;
       try {
         socket.destroy();

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6098,4 +6098,4 @@ it("a client session constructor that throws drops the socket it was connecting"
     stderr: "",
     exitCode: 0,
   });
-}, 45_000);
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6058,7 +6058,7 @@ it("a client session constructor that throws drops the socket it was connecting"
         req.setEncoding("utf8");
         req.on("data", chunk => (body += chunk));
         req.on("end", () => {
-          console.log(JSON.stringify({ thrown, reads, listenerCalls, body }));
+          console.log(JSON.stringify({ thrown, reads, listenerCalls, lateDestroyed: late.destroyed, body }));
           client.close();
           server.close();
         });
@@ -6092,6 +6092,7 @@ it("a client session constructor that throws drops the socket it was connecting"
       thrown: ["ERR_HTTP2_INVALID_SETTING_VALUE", "boom", "ERR_HTTP2_INVALID_SETTING_VALUE"],
       reads: 3,
       listenerCalls: 0,
+      lateDestroyed: true,
       body: "ok",
     },
     stderr: "",

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6013,89 +6013,92 @@ describe("frames issued from inside a user-supplied Duplex transport's _write", 
 // The client session starts the TCP connect before it reads the rest of its options, so a
 // throw from the constructor left a connecting socket that no session could ever drive. Its
 // connect callback then re-queued itself on process.nextTick forever: one thread at 100% CPU,
-// and no timer or I/O ran again. A constructor that throws now drops that socket, and the
-// connect that was in flight reaches neither the session nor the caller's listener.
-it("a client session constructor that throws drops the socket it was connecting", async () => {
-  const fixture = `
-    const http2 = require("node:http2");
-    const { Duplex } = require("node:stream");
-    const server = http2.createServer();
-    server.on("stream", stream => {
-      stream.respond({ ":status": 200 });
-      stream.end("ok");
-    });
-    server.listen(0, "127.0.0.1", () => {
-      const url = "http://127.0.0.1:" + server.address().port;
-      let reads = 0;
-      let listenerCalls = 0;
-      // A transport that reports 'connect' after it was destroyed. The session never
-      // reached the caller, so its connect listener must not run either.
-      const late = new Duplex({ read() {}, write(chunk, encoding, cb) { cb(); } });
-      late.connecting = true;
-      const cases = [
-        // validateSettings rejects the value, before the parser exists.
-        { settings: { initialWindowSize: -1 } },
-        // A getter that throws on the read after validateSettings' own two: the socket
-        // exists, the parser does not.
-        { settings: { get initialWindowSize() { if (++reads === 3) throw new Error("boom"); return 65535; } } },
-        { createConnection: () => late, settings: { initialWindowSize: -1 } },
-      ];
-      const thrown = [];
-      for (const options of cases) {
-        try {
-          http2.connect(url, options, () => listenerCalls++);
-          thrown.push("did not throw");
-        } catch (e) {
-          thrown.push(e.code || e.message);
-        }
+// and no timer or I/O ran again. The fixture runs on node v26.3.0 too, so it asserts what
+// both runtimes agree on: the error reaches the caller, the connect that was in flight
+// reaches neither the session nor the caller's listener, and the process stays usable.
+// (Where the error arrives differs. Bun throws from connect(), node emits 'error' on the
+// session it returns.)
+const connectThrowFixture = `
+  const http2 = require("node:http2");
+  const { Duplex } = require("node:stream");
+  const server = http2.createServer();
+  server.on("stream", stream => {
+    stream.respond({ ":status": 200 });
+    stream.end("ok");
+  });
+  server.listen(0, "127.0.0.1", () => {
+    const url = "http://127.0.0.1:" + server.address().port;
+    const codes = [];
+    let listenerCalls = 0;
+
+    function connectExpectingFailure(options) {
+      try {
+        const session = http2.connect(url, options, () => listenerCalls++);
+        session.on("error", e => codes.push(e.code));
+      } catch (e) {
+        codes.push(e.code);
       }
-      // A session that completes a request proves the event loop still runs. The process
-      // then has to exit on its own, so the dropped sockets hold nothing open.
-      const request = () => {
-        const client = http2.connect(url);
-        const req = client.request({ ":path": "/" });
-        let body = "";
-        req.setEncoding("utf8");
-        req.on("data", chunk => (body += chunk));
-        req.on("end", () => {
-          console.log(JSON.stringify({ thrown, reads, listenerCalls, lateDestroyed: late.destroyed, body }));
-          client.close();
-          server.close();
-        });
-        req.end();
-      };
-      setImmediate(() => {
-        late.connecting = false;
-        late.emit("connect");
-        setImmediate(request);
+    }
+
+    // A transport that reports 'connect' after the constructor gave up on it.
+    const late = new Duplex({ read() {}, write(chunk, encoding, cb) { cb(); } });
+    late.connecting = true;
+
+    connectExpectingFailure({ settings: { initialWindowSize: -1 } });
+    connectExpectingFailure({ createConnection: () => late, settings: { initialWindowSize: -1 } });
+
+    // A session that completes a request proves the event loop still runs. The process
+    // then has to exit on its own, so the failed connects hold nothing open.
+    const request = () => {
+      const client = http2.connect(url);
+      const req = client.request({ ":path": "/" });
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", chunk => (body += chunk));
+      req.on("end", () => {
+        console.log(JSON.stringify({ codes, listenerCalls, body }));
+        client.close();
+        server.close();
       });
+      req.end();
+    };
+    setImmediate(() => {
+      late.connecting = false;
+      late.emit("connect");
+      setImmediate(request);
     });
-  `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", fixture],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
   });
-  // The failure mode is a process that never exits, so bound the wait: the pipes close
-  // only once the child is gone.
-  const { promise: starved, resolve: giveUp } = Promise.withResolvers();
-  const watchdog = setTimeout(() => giveUp("the event loop is starved"), 15_000);
-  watchdog.unref?.();
-  const exitCode = await Promise.race([proc.exited, starved]);
-  clearTimeout(watchdog);
-  if (exitCode !== 0) proc.kill();
-  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
-  const printed = stdout.trim() ? JSON.parse(stdout) : stdout;
-  expect({ printed, stderr, exitCode }).toEqual({
-    printed: {
-      thrown: ["ERR_HTTP2_INVALID_SETTING_VALUE", "boom", "ERR_HTTP2_INVALID_SETTING_VALUE"],
-      reads: 3,
-      listenerCalls: 0,
-      lateDestroyed: true,
-      body: "ok",
+`;
+
+for (const runtime of [bunExe(), nodeExe()]) {
+  it.skipIf(!runtime)(
+    `a client session constructor that throws drops the socket it was connecting (${path.basename(runtime || "node")})`,
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [runtime, "-e", connectThrowFixture],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      // The failure mode is a process that never exits, so bound the wait: the pipes close
+      // only once the child is gone.
+      const { promise: starved, resolve: giveUp } = Promise.withResolvers();
+      const watchdog = setTimeout(() => giveUp("the event loop is starved"), 15_000);
+      watchdog.unref?.();
+      const exitCode = await Promise.race([proc.exited, starved]);
+      clearTimeout(watchdog);
+      if (exitCode !== 0) proc.kill();
+      const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
+      const printed = stdout.trim() ? JSON.parse(stdout) : stdout;
+      expect({ printed, stderr, exitCode }).toEqual({
+        printed: {
+          codes: ["ERR_HTTP2_INVALID_SETTING_VALUE", "ERR_HTTP2_INVALID_SETTING_VALUE"],
+          listenerCalls: 0,
+          body: "ok",
+        },
+        stderr: "",
+        exitCode: 0,
+      });
     },
-    stderr: "",
-    exitCode: 0,
-  });
-});
+  );
+}

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6013,10 +6013,12 @@ describe("frames issued from inside a user-supplied Duplex transport's _write", 
 // The client session starts the TCP connect before it reads the rest of its options, so a
 // throw from the constructor left a connecting socket that no session could ever drive. Its
 // connect callback then re-queued itself on process.nextTick forever: one thread at 100% CPU,
-// and no timer or I/O ran again. A constructor that throws now drops that socket.
+// and no timer or I/O ran again. A constructor that throws now drops that socket, and the
+// connect that was in flight reaches neither the session nor the caller's listener.
 it("a client session constructor that throws drops the socket it was connecting", async () => {
   const fixture = `
     const http2 = require("node:http2");
+    const { Duplex } = require("node:stream");
     const server = http2.createServer();
     server.on("stream", stream => {
       stream.respond({ ":status": 200 });
@@ -6025,17 +6027,23 @@ it("a client session constructor that throws drops the socket it was connecting"
     server.listen(0, "127.0.0.1", () => {
       const url = "http://127.0.0.1:" + server.address().port;
       let reads = 0;
+      let listenerCalls = 0;
+      // A transport that reports 'connect' after it was destroyed. The session never
+      // reached the caller, so its connect listener must not run either.
+      const late = new Duplex({ read() {}, write(chunk, encoding, cb) { cb(); } });
+      late.connecting = true;
       const cases = [
         // validateSettings rejects the value, before the parser exists.
         { settings: { initialWindowSize: -1 } },
         // A getter that throws on the read after validateSettings' own two: the socket
         // exists, the parser does not.
         { settings: { get initialWindowSize() { if (++reads === 3) throw new Error("boom"); return 65535; } } },
+        { createConnection: () => late, settings: { initialWindowSize: -1 } },
       ];
       const thrown = [];
       for (const options of cases) {
         try {
-          http2.connect(url, options);
+          http2.connect(url, options, () => listenerCalls++);
           thrown.push("did not throw");
         } catch (e) {
           thrown.push(e.code || e.message);
@@ -6043,17 +6051,24 @@ it("a client session constructor that throws drops the socket it was connecting"
       }
       // A session that completes a request proves the event loop still runs. The process
       // then has to exit on its own, so the dropped sockets hold nothing open.
-      const client = http2.connect(url);
-      const req = client.request({ ":path": "/" });
-      let body = "";
-      req.setEncoding("utf8");
-      req.on("data", chunk => (body += chunk));
-      req.on("end", () => {
-        console.log(JSON.stringify({ thrown, reads, body }));
-        client.close();
-        server.close();
+      const request = () => {
+        const client = http2.connect(url);
+        const req = client.request({ ":path": "/" });
+        let body = "";
+        req.setEncoding("utf8");
+        req.on("data", chunk => (body += chunk));
+        req.on("end", () => {
+          console.log(JSON.stringify({ thrown, reads, listenerCalls, body }));
+          client.close();
+          server.close();
+        });
+        req.end();
+      };
+      setImmediate(() => {
+        late.connecting = false;
+        late.emit("connect");
+        setImmediate(request);
       });
-      req.end();
     });
   `;
   await using proc = Bun.spawn({
@@ -6073,7 +6088,12 @@ it("a client session constructor that throws drops the socket it was connecting"
   const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
   const printed = stdout.trim() ? JSON.parse(stdout) : stdout;
   expect({ printed, stderr, exitCode }).toEqual({
-    printed: { thrown: ["ERR_HTTP2_INVALID_SETTING_VALUE", "boom"], reads: 3, body: "ok" },
+    printed: {
+      thrown: ["ERR_HTTP2_INVALID_SETTING_VALUE", "boom", "ERR_HTTP2_INVALID_SETTING_VALUE"],
+      reads: 3,
+      listenerCalls: 0,
+      body: "ok",
+    },
     stderr: "",
     exitCode: 0,
   });

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6009,3 +6009,72 @@ describe("frames issued from inside a user-supplied Duplex transport's _write", 
     },
   );
 });
+
+// The client session starts the TCP connect before it reads the rest of its options, so a
+// throw from the constructor left a connecting socket that no session could ever drive. Its
+// connect callback then re-queued itself on process.nextTick forever: one thread at 100% CPU,
+// and no timer or I/O ran again. A constructor that throws now drops that socket.
+it("a client session constructor that throws drops the socket it was connecting", async () => {
+  const fixture = `
+    const http2 = require("node:http2");
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const url = "http://127.0.0.1:" + server.address().port;
+      let reads = 0;
+      const cases = [
+        // validateSettings rejects the value, before the parser exists.
+        { settings: { initialWindowSize: -1 } },
+        // A getter that throws on the read after validateSettings' own two: the socket
+        // exists, the parser does not.
+        { settings: { get initialWindowSize() { if (++reads === 3) throw new Error("boom"); return 65535; } } },
+      ];
+      const thrown = [];
+      for (const options of cases) {
+        try {
+          http2.connect(url, options);
+          thrown.push("did not throw");
+        } catch (e) {
+          thrown.push(e.code || e.message);
+        }
+      }
+      // A session that completes a request proves the event loop still runs. The process
+      // then has to exit on its own, so the dropped sockets hold nothing open.
+      const client = http2.connect(url);
+      const req = client.request({ ":path": "/" });
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", chunk => (body += chunk));
+      req.on("end", () => {
+        console.log(JSON.stringify({ thrown, reads, body }));
+        client.close();
+        server.close();
+      });
+      req.end();
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  // The failure mode is a process that never exits, so bound the wait: the pipes close
+  // only once the child is gone.
+  const { promise: starved, resolve: giveUp } = Promise.withResolvers();
+  const watchdog = setTimeout(() => giveUp("the event loop is starved"), 15_000);
+  watchdog.unref?.();
+  const exitCode = await Promise.race([proc.exited, starved]);
+  clearTimeout(watchdog);
+  if (exitCode !== 0) proc.kill();
+  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
+  const printed = stdout.trim() ? JSON.parse(stdout) : stdout;
+  expect({ printed, stderr, exitCode }).toEqual({
+    printed: { thrown: ["ERR_HTTP2_INVALID_SETTING_VALUE", "boom"], reads: 3, body: "ok" },
+    stderr: "",
+    exitCode: 0,
+  });
+}, 45_000);


### PR DESCRIPTION
### Problem
- `http2.connect(url, { settings: { initialWindowSize: -1 } })` throws `ERR_HTTP2_INVALID_SETTING_VALUE`, and the process then spins at 100% CPU forever. No timer and no I/O runs again.
- The `ClientHttp2Session` constructor starts the TCP connect before it reads the rest of its options ([http2.ts:5692](https://github.com/oven-sh/bun/blob/robobun/70e51dc1/http2-connect-throw-socket/src/js/node/http2.ts#L5692)). The throw leaves a connecting socket and an unassigned `#parser`. When the socket connects, `onConnect` sees `#parser === undefined` and re-queues itself on `process.nextTick`, forever.
- Three inputs reach it: a value `validateSettings` rejects, a custom setting id only the native parser rejects (`customSettings: { "1e3": 5 }`), and a settings getter that throws on a read after validation.

### Fix
- Guard the window in which `#parser` is unassigned. On a throw, latch the session as abandoned, detach the socket, destroy it, then rethrow.
- The latch ends the loop, and it also keeps a transport that reports `'connect'` after `destroy()` from calling the caller's connect listener with a session the constructor never returned.
- Node does the same on its own failure path. Its `setupHandle` throw is caught at the connect event and destroys the socket.
- Verified: `test/js/node/http2/node-http2.test.js`. The new case runs one fixture under bun and under node v26.3.0 with the same expectations. Without this diff the bun run fails and the node run passes. Also all 256 vendored `test-http2-*.js` tests, the other 9 files in `test/js/node/http2/`, `serve-http2*.test.ts`, `fetch-http2-client.test.ts` and the `25589`, `26915`, `29073` regression tests.

### Background
- `H2FrameParser` is the native session object. `#parser` holds it. The constructor builds it last, because its construction re-enters JS.
- `onConnect` fires when the TCP or TLS connect completes. It drives the parser: flush the preface, then submit queued requests.
- The re-arm in `onConnect` comes from #34432. The parser's construction can drain the tick queue, so a connect can fire while the constructor is still on the stack. Waiting one tick was correct for that case. It had no end for a constructor that never finishes.
- A rejected `settings` value still throws from `connect()`. Node reports it as an `'error'` event on the session instead. That difference is out of scope here.

<details><summary>Notes</summary>

Measured on bun 1.4.2 release (3 of 3 runs) and on main 4ff91937708a (ASAN, 1 of 1): the repro prints the error, the 500 ms timer never fires, one thread sits at 100% CPU until killed. A `gdb` sample of that thread and `/proc/<pid>/utime` show the tick queue, not a native spin.

The three triggers, all on the released binary:

```js
// 1. validateSettings rejects the value
http2.connect(url, { settings: { initialWindowSize: -1 } });
// 2. validateSettings accepts the key (Number("1e3") is 1000), the native parser rejects it
http2.connect(url, { settings: { customSettings: { "1e3": 5 } } });
// 3. a getter that throws on the read after validateSettings' own two
let n = 0;
http2.connect(url, { settings: { get initialWindowSize() { if (++n === 3) throw new Error("boom"); return 65535; } } });
```

Case 2 is the `new H2FrameParser` throw that was recorded as inferred. It is reachable today. #41322 makes that key valid, so the test does not use it.

Case 3 throws at `{ ...options?.settings }`, between the socket and the parser. Any throw in that window had the same shape.

The test asserts only what bun and node v26.3.0 both do: the error reaches the caller with `ERR_HTTP2_INVALID_SETTING_VALUE`, the connect that was in flight never calls the caller's connect listener, a later request completes, and the process exits 0. Three earlier assertions were bun-only and are gone: the synchronous throw (node reports it on the session), the destroyed `createConnection` transport (node leaves a `Duplex` alive when it throws inline), and case 3 (node reads the settings object fewer times, so it never fails there).

The first revision set `#parser = null` instead of latching. That ended the re-arm, but `onConnect` then fell through to `this.#onConnect()` (which returns on the detached socket) and still called the caller's listener. A self-review found it with a `Duplex` transport that emits `'connect'` after `destroy()`. Node calls nothing there, and now neither does bun. The new test covers it.

Connecting to a closed port with a rejected setting used to exit 1 with an uncaught `ECONNREFUSED` from the orphaned socket. The socket is now destroyed before the connect fails, so the process exits 0.

A socket from `options.createConnection` is destroyed too, whether it is connecting, already connected, or a plain `Duplex`. Node destroys the user socket on its failure path as well. `destroy()` runs in its own try/catch so a user socket whose `destroy()` throws cannot replace the settings error. No `'error'` event escapes: the teardown runs before any listener of ours is attached, and a destroyed socket reports none.

Suites run on the debug (ASAN) build:

- `test/js/node/http2/` (10 files): 500 pass, 6 skip
- `test/js/node/test/parallel/test-http2-*.js` (256 files): all exit 0
- `serve-http2.test.ts`, `serve-http2-protocol.test.ts`, `serve-http2-lifecycle.test.ts`, `fetch-http2-client.test.ts`, `25589`, `26915`, `29073`: 392 pass
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (5f554969b)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [842.90ms]
(pass) node none > Client Basics > should be able to send a POST request [563.73ms]
(pass) node none > Client Basics > constants [19.31ms]
(pass) node none > Client Basics > getDefaultSettings [7.02ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [17.20ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.27ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.13ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [4.90ms]
(pass) node none > Client Basics > should be able to send data using end [589.65ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [578.66ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release without fix: 6 skipped
bun test v1.4.3-canary.1 (486c6c361)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [1.74ms]
(pass) node none > Client Basics > getDefaultSettings [0.16ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.27ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.11ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.03ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.07ms]
(pass) node none > Client Basics > is possible to abort request [3.15ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.72ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.62ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.53ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [50.59ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > close callback [43.06ms
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (5f554969b)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [831.65ms]
(pass) node none > Client Basics > should be able to send a POST request [554.28ms]
(pass) node none > Client Basics > constants [19.07ms]
(pass) node none > Client Basics > getDefaultSettings [7.29ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [17.20ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.33ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.20ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [4.88ms]
(pass) node none > Client Basics > should be able to send data using end [578.10ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [567.60ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 599ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/25] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/25] gen cpp.rs (cppbind)
[3/25] gen JS modules (bundle-modules)
Preprocess modules (8095ms)
Bundle modules (46ms)
Postprocesss modules (167ms)
Bundle Functions (576ms)
Generate Code (40ms)

[8.93s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/10] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                  | 41 +++++++++------
 test/js/node/http2/node-http2.test.js | 93 +++++++++++++++++++++++++++++++++++
 2 files changed, 120 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/node/http2.ts                       8     10     34
test/js/node/http2/node-http2.test.js      6     11     34
```

</details>

**root cause** · written by the author bot

The `ClientHttp2Session` constructor started the TCP connect before validating the `settings` option, so when `validateSettings` threw, the session was left with no parser while the socket kept connecting; once it connected, `onConnect` saw an undefined parser and rescheduled itself via `process.nextTick` indefinitely, starving timers and I/O at 100% CPU. The fix wraps the initialization so that any throw from the constructor marks the session as failed, clears the socket state, destroys the socket, and rethrows the original error, and `onConnect` no longer re-arms itself when the session w…

<!-- robobun:evidence:end -->