### PR TITLE
Pin the storage of a typed array that has no ArrayBuffer before an off-thread borrow

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -925,15 +925,13 @@ impl JSValue {
     /// source attached rather than throwing. See `JSC__JSValue__pinArrayBuffer`
     /// in bindings.cpp for why. Release the pin with `ArrayBuffer::unpin`.
     pub fn as_pinned_arraybuffer(self, global: &JSGlobalObject) -> Option<ArrayBuffer> {
-        let kind = JSC__JSValue__pinArrayBuffer(self);
-        if kind == 0 {
+        if !JSC__JSValue__pinArrayBuffer(self) {
             return None;
         }
         let mut buffer = self.as_array_buffer(global);
         match &mut buffer {
-            Some(buffer) => buffer.pinned = kind == 1,
-            None if kind == 1 => self.unpin_array_buffer(),
-            None => {}
+            Some(buffer) => buffer.pinned = true,
+            None => self.unpin_array_buffer(),
         }
         buffer
     }
@@ -2109,8 +2107,8 @@ unsafe extern "C" {
         global: &JSGlobalObject,
         out: &mut ArrayBuffer,
     ) -> bool;
-    /// 0 = nothing to pin, 1 = pinned an ArrayBuffer (unpin later), 2 = held a bufferless view (nothing to unpin).
-    safe fn JSC__JSValue__pinArrayBuffer(this: JSValue) -> u8;
+    /// `true` = pinned the storage's ArrayBuffer, adopting one for a bufferless view (unpin later).
+    safe fn JSC__JSValue__pinArrayBuffer(this: JSValue) -> bool;
     safe fn JSC__JSValue__asPromise(this: JSValue) -> *mut JSPromise;
     safe fn JSC__JSValue__asInternalPromise(this: JSValue) -> *mut JSInternalPromise;
     safe fn Bun__attachAsyncStackFromPromise(

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -31,7 +31,7 @@ pub struct ArrayBuffer {
     /// True for resizable ArrayBuffer or growable SharedArrayBuffer — borrowing
     /// a slice from one is unsafe (it can shrink/reallocate underneath you).
     pub resizable: bool,
-    /// Set by [`JSValue::as_pinned_arraybuffer`] when an ArrayBuffer was actually pinned (as opposed to a bufferless view merely held); [`ArrayBuffer::unpin`] is a no-op otherwise.
+    /// Set by [`JSValue::as_pinned_arraybuffer`] when an ArrayBuffer was actually pinned; [`ArrayBuffer::unpin`] is a no-op otherwise.
     pub pinned: bool,
 }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3586,7 +3586,7 @@ static bool pinStorage(JSC::JSValue value)
             return false;
         buf = view->possiblySharedBuffer();
     }
-    if (!buf)
+    if (!buf || buf->isDetached())
         return false;
     if (!buf->isShared())
         buf->pin();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3571,42 +3571,36 @@ bool JSC__JSValue__asArrayBuffer(
 // independent copy, and leave `ab` attached; the bytes being read never move.
 //
 // A view with no ArrayBuffer yet (`Buffer.allocUnsafeSlow`, `new Uint8Array(n)`
-// past fastSizeLimit: OversizeTypedArray) is held, not adopted: materializing
-// an ArrayBuffer just to pin it registers the bytes with the heap a second
-// time and, because ArrayBuffers are only reclaimed by full collections,
-// turns every threadpool fs/zlib/crypto op over a fresh Buffer into full-GC
-// pressure. Such a view cannot be detached without JS first touching
-// `.buffer`; if it does so mid-op the new ArrayBuffer is unpinned and a
-// `transfer()` moves (does not free) the storage — the same window Node has.
-// The caller keeps the returned kind and only calls unpin for `Pinned`; a
-// held view is kept alive by the caller's own root, and nothing here needs
-// undoing for it.
-enum class PinKind : uint8_t { None = 0,
-    Pinned = 1,
-    Held = 2 };
-static PinKind pinStorage(JSC::JSValue value)
+// past fastSizeLimit: OversizeTypedArray) is adopted first, because a pin needs
+// an ArrayBuffer to live on: `possiblySharedBuffer()` wraps the storage where it
+// already is (`ArrayBuffer::createAdopted`, no byte copy). Holding such a view
+// without adopting it does not keep the storage alive. JS reaches the same bytes
+// through `view.buffer`, which materializes an ArrayBuffer no pin covers, and a
+// transfer of that buffer moves the storage into a fresh ArrayBufferContents.
+// When nothing references the new owner, `Heap::sweepArrayBuffers` frees the
+// bytes while the borrower still reads them. Adoption costs one ArrayBuffer per
+// borrow, and only a full collection reclaims it.
+static bool pinStorage(JSC::JSValue value)
 {
     JSC::ArrayBuffer* buf = nullptr;
     if (auto* jb = dynamicDowncast<JSC::JSArrayBuffer>(value))
         buf = jb->impl();
     else if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
         if (view->isDetached())
-            return PinKind::None;
-        if (!view->hasArrayBuffer() && view->mode() == JSC::OversizeTypedArray)
-            return PinKind::Held;
+            return false;
         buf = view->possiblySharedBuffer();
     }
     if (!buf)
-        return PinKind::None;
+        return false;
     if (!buf->isShared())
         buf->pin();
-    return PinKind::Pinned;
+    return true;
 }
-CPP_DECL uint8_t JSC__JSValue__pinArrayBuffer(JSC::EncodedJSValue v)
+CPP_DECL bool JSC__JSValue__pinArrayBuffer(JSC::EncodedJSValue v)
 {
-    return static_cast<uint8_t>(pinStorage(JSC::JSValue::decode(v)));
+    return pinStorage(JSC::JSValue::decode(v));
 }
-// Only for a value `pinStorage` answered `Pinned` for: that buffer still exists (pinned buffers are not detached).
+// Only for a value `pinStorage` answered true for: that buffer still exists (pinned buffers are not detached).
 CPP_DECL void JSC__JSValue__unpinArrayBuffer(JSC::EncodedJSValue v)
 {
     auto value = JSC::JSValue::decode(v);
@@ -3623,16 +3617,13 @@ CPP_DECL void JSC__JSValue__unpinArrayBuffer(JSC::EncodedJSValue v)
 // `FastTypedArray` case from `pinArrayBuffer`, because that's the one mode
 // where `possiblySharedBuffer()` actually COPIES data
 // (`ArrayBuffer::tryCreate(span())`) — and it's ≤ fastSizeLimit elements, so
-// the caller dupes instead. Every other mode goes through `pinStorage` (pin an
-// existing ArrayBuffer, hold an OversizeTypedArray without adopting it).
+// the caller dupes instead. Every other mode goes through `pinStorage`.
 //
 //   0  Detached/null — nothing to read.
 //   1  `FastTypedArray` — ≤ fastSizeLimit elements, GC-movable. Caller
 //      should dupe `out_ptr[0..out_len]`; no unpin.
-//   2  Pinned an existing ArrayBuffer; caller MUST `unpinArrayBuffer(v)`
-//      when done.
-//   3  Held: a bufferless OversizeTypedArray; nothing to unpin, caller roots
-//      the value for the duration as it already does for 2.
+//   2  Pinned the storage: an existing ArrayBuffer, or one adopted for a
+//      bufferless view. Caller MUST `unpinArrayBuffer(v)` when done.
 //
 // `out_ptr`/`out_len` describe the VIEW's byte range (offset+length).
 CPP_DECL int32_t JSC__JSValue__borrowBytesForOffThread(JSC::EncodedJSValue v, const uint8_t** out_ptr, size_t* out_len)
@@ -3645,11 +3636,10 @@ CPP_DECL int32_t JSC__JSValue__borrowBytesForOffThread(JSC::EncodedJSValue v, co
             *out_len = view->byteLength();
             return 1;
         }
-        auto kind = pinStorage(view);
-        if (kind == PinKind::None) return 0;
+        if (!pinStorage(view)) return 0;
         *out_ptr = static_cast<const uint8_t*>(view->vector());
         *out_len = view->byteLength();
-        return kind == PinKind::Held ? 3 : 2;
+        return 2;
     }
     if (auto* jb = dynamicDowncast<JSC::JSArrayBuffer>(value)) {
         auto* buf = jb->impl();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3570,16 +3570,12 @@ bool JSC__JSValue__asArrayBuffer(
 // `port.postMessage(v, [ab])` each return normally, give the destination an
 // independent copy, and leave `ab` attached; the bytes being read never move.
 //
-// A view with no ArrayBuffer yet (`Buffer.allocUnsafeSlow`, `new Uint8Array(n)`
-// past fastSizeLimit: OversizeTypedArray) is adopted first, because a pin needs
-// an ArrayBuffer to live on: `possiblySharedBuffer()` wraps the storage where it
-// already is (`ArrayBuffer::createAdopted`, no byte copy). Holding such a view
-// without adopting it does not keep the storage alive. JS reaches the same bytes
-// through `view.buffer`, which materializes an ArrayBuffer no pin covers, and a
-// transfer of that buffer moves the storage into a fresh ArrayBufferContents.
-// When nothing references the new owner, `Heap::sweepArrayBuffers` frees the
-// bytes while the borrower still reads them. Adoption costs one ArrayBuffer per
-// borrow, and only a full collection reclaims it.
+// A pin needs an ArrayBuffer to live on, so a view that has none yet
+// (OversizeTypedArray) is adopted first: `possiblySharedBuffer()` wraps the
+// storage where it already is (`createAdopted`, no byte copy). Holding such a
+// view instead does not keep its storage alive: `view.buffer` makes an
+// ArrayBuffer no pin covers, a transfer re-homes the storage, and
+// `Heap::sweepArrayBuffers` frees it under the borrower.
 static bool pinStorage(JSC::JSValue value)
 {
     JSC::ArrayBuffer* buf = nullptr;

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -130,9 +130,8 @@ pub enum Source {
 unsafe extern "C" {
     fn JSC__JSValue__unpinArrayBuffer(v: JSValue);
     /// 0 = detached/null, 1 = FastTypedArray (≤~1 KB, GC-movable — dupe),
-    /// 2 = pinned an existing ArrayBuffer (caller must unpin). 3 = held a
-    /// bufferless OversizeTypedArray: valid for the op, nothing to unpin (the
-    /// caller roots the value as it does for 2).
+    /// 2 = pinned the storage, adopting an ArrayBuffer for a bufferless view
+    /// (caller must unpin).
     fn JSC__JSValue__borrowBytesForOffThread(
         v: JSValue,
         out_ptr: *mut *const u8,
@@ -717,14 +716,11 @@ impl Image {
                 let Some(v) = js::source_js_get_cached(this_value) else {
                     return Err(PinError::Detached);
                 };
-                // Classify the storage mode WITHOUT promoting it. A fresh
-                // `new Uint8Array(N)` (the common path — `await res.bytes()`,
-                // `Buffer.from(file)`) is `OversizeTypedArray`: bytes in
-                // fastMalloc, no JSArrayBuffer wrapper, can't be detached or
-                // moved. Calling `possiblySharedBuffer()` on that would
-                // `slowDownAndWasteMemory()` → copy + allocate a wrapper for
-                // every input. The classifier returns the slice directly and
-                // tells us whether anything actually needs pinning.
+                // Classify the storage mode and pin what the worker reads. A
+                // fresh `new Uint8Array(N)` (the common path — `await
+                // res.bytes()`, `Buffer.from(file)`) is `OversizeTypedArray`:
+                // bytes in fastMalloc, no JSArrayBuffer wrapper yet. The helper
+                // adopts one in place so the pin has somewhere to live.
                 let mut ptr: *const u8 = core::ptr::null();
                 let mut len: usize = 0;
                 // SAFETY: FFI call; out-params are valid pointers to locals.
@@ -751,14 +747,11 @@ impl Image {
                             ))
                         }
                     }
-                    // 2: Wasteful/DataView/JSArrayBuffer, pinned by the helper (unpin when done).
-                    // 3: OversizeTypedArray held without adopting an ArrayBuffer; nothing to unpin.
-                    kind @ (2 | 3) => {
+                    // Oversize/Wasteful/DataView/JSArrayBuffer, pinned by the helper (unpin when done).
+                    2 => {
                         if len == 0 {
-                            if kind == 2 {
-                                // SAFETY: helper pinned `v`; unpin before erroring.
-                                unsafe { JSC__JSValue__unpinArrayBuffer(v) };
-                            }
+                            // SAFETY: helper pinned `v`; unpin before erroring.
+                            unsafe { JSC__JSValue__unpinArrayBuffer(v) };
                             Err(PinError::Detached)
                         } else {
                             // SAFETY: pinned until the returned `Pin` drops (with the job's
@@ -769,7 +762,7 @@ impl Image {
                                     bytes: bun_ptr::RawSlice::new(bytes),
                                     ..Default::default()
                                 },
-                                if kind == 2 { Pin(v) } else { Pin::NONE },
+                                Pin(v),
                             ))
                         }
                     }

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -716,11 +716,9 @@ impl Image {
                 let Some(v) = js::source_js_get_cached(this_value) else {
                     return Err(PinError::Detached);
                 };
-                // Classify the storage mode and pin what the worker reads. A
-                // fresh `new Uint8Array(N)` (the common path — `await
-                // res.bytes()`, `Buffer.from(file)`) is `OversizeTypedArray`:
-                // bytes in fastMalloc, no JSArrayBuffer wrapper yet. The helper
-                // adopts one in place so the pin has somewhere to live.
+                // Classify the storage mode and pin what the worker reads. The
+                // common input (`await res.bytes()`, `Buffer.from(file)`) has
+                // no ArrayBuffer yet, so the helper adopts one in place.
                 let mut ptr: *const u8 = core::ptr::null();
                 let mut len: usize = 0;
                 // SAFETY: FFI call; out-params are valid pointers to locals.

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -87,7 +87,7 @@ mod _impl {
         // TODO: Strong self-ref on the wrapper → JsRef per PORTING.md §JSC (Strong back-ref to own wrapper leaks)
         pub this_value: JsCell<StrongOptional>, // Strong.Optional — empty-initialised
         pub write_in_progress: Cell<bool>,
-        /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's. A held bufferless view sets neither.
+        /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's.
         pub pinned_buffers: Cell<u8>,
         pub pending_close: Cell<bool>,
         pub closed: Cell<bool>,

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -44,7 +44,7 @@ mod _impl {
         pub poll_ref: JsCell<CountedKeepAlive>,
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
         pub write_in_progress: Cell<bool>,
-        /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's. A held bufferless view sets neither.
+        /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's.
         pub pinned_buffers: Cell<u8>,
         pub pending_close: Cell<bool>,
         pub closed: Cell<bool>,

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -47,7 +47,7 @@ mod _impl {
         pub poll_ref: JsCell<CountedKeepAlive>,
         pub this_value: JsCell<StrongOptional>, // jsc.Strong.Optional
         pub write_in_progress: Cell<bool>,
-        /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's. A held bufferless view sets neither.
+        /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's.
         pub pinned_buffers: Cell<u8>,
         pub pending_close: Cell<bool>,
         pub closed: Cell<bool>,

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2074,8 +2074,8 @@ impl NodeHTTPResponse {
                             ab.unpin();
                             None
                         }
-                        Some(ab) if ab.pinned => Some(input_value),
-                        Some(_) | None => Some(JSValue::ZERO),
+                        Some(_) => Some(input_value),
+                        None => Some(JSValue::ZERO),
                     }
                 } else {
                     Some(JSValue::ZERO)

--- a/src/sql_jsc/mysql/MySQLValue.rs
+++ b/src/sql_jsc/mysql/MySQLValue.rs
@@ -352,15 +352,15 @@ impl Value {
                         // collect it (and free the backing store despite
                         // the pin) if user JS drops the last reference from
                         // a later parameter.
-                        kind @ (2 | 3) => {
+                        2 => {
                             roots.append(value);
                             Ok(Value::Bytes(Bytes {
-                                // SAFETY: backing storage is pinned or held (bufferless view) and
-                                // rooted via `roots`; slice stays valid until Bytes::drop unpins.
+                                // SAFETY: backing storage is pinned and rooted via
+                                // `roots`; slice stays valid until Bytes::drop unpins.
                                 slice: Utf8Bytes::Borrowed(unsafe {
                                     core::slice::from_raw_parts(ptr, len)
                                 }),
-                                pinned: if kind == 2 { value } else { JSValue::ZERO },
+                                pinned: value,
                             }))
                         }
                         _ => unreachable!(),
@@ -809,8 +809,8 @@ unsafe extern "C" {
     /// No caller-side preconditions → `safe fn`.
     safe fn JSC__JSValue__unpinArrayBuffer(v: JSValue);
     /// 0 = detached/null, 1 = FastTypedArray (GC-movable — caller should dupe;
-    /// no unpin needed), 2 = pinned an existing ArrayBuffer (caller must
-    /// `unpinArrayBuffer`), 3 = held a bufferless OversizeTypedArray (nothing to unpin; root it as for 2).
+    /// no unpin needed), 2 = pinned the storage, adopting an ArrayBuffer for a
+    /// bufferless view (caller must `unpinArrayBuffer`).
     /// Out-params are `&mut` (same ABI as `*mut`), so the only obligation left
     /// is on the *returned* slice, not the call itself → `safe fn`.
     safe fn JSC__JSValue__borrowBytesForOffThread(

--- a/test/js/bun/image/image-adversarial.test.ts
+++ b/test/js/bun/image/image-adversarial.test.ts
@@ -10,7 +10,7 @@
 // Kept in its own file so the happy-path image.test.ts stays readable.
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, gcTick, isASAN, rss, tempDir } from "harness";
+import { bunEnv, bunExe, gcTick, isASAN, isWindows, rss, tempDir } from "harness";
 import { join } from "node:path";
 import zlib from "node:zlib";
 
@@ -720,7 +720,8 @@ describe("hostile option objects", () => {
     // Heap::sweepArrayBuffers frees it, and the pool thread reads the freed
     // block: an ASAN heap-use-after-free, or a decode error / wrong image on a
     // build without ASAN. `Malloc=1` routes the Gigacage through system malloc
-    // so ASAN sees the free.
+    // so ASAN sees the free. Windows is left alone: bmalloc's SystemHeap is
+    // unimplemented there and `Malloc=1` would RELEASE_BASSERT.
     using dir = tempDir("image-oversize-transfer", {
       "repro.ts": `
         import zlib from "node:zlib";
@@ -761,7 +762,7 @@ describe("hostile option objects", () => {
     const rounds = 3;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "repro.ts", String(rounds)],
-      env: { ...bunEnv, Malloc: "1" },
+      env: { ...bunEnv, ...(isWindows ? {} : { Malloc: "1" }) },
       cwd: String(dir),
       stderr: "pipe",
     });

--- a/test/js/bun/image/image-adversarial.test.ts
+++ b/test/js/bun/image/image-adversarial.test.ts
@@ -10,7 +10,7 @@
 // Kept in its own file so the happy-path image.test.ts stays readable.
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { gcTick, isASAN, rss, tempDir } from "harness";
+import { bunEnv, bunExe, gcTick, isASAN, rss, tempDir } from "harness";
 import { join } from "node:path";
 import zlib from "node:zlib";
 
@@ -77,6 +77,9 @@ function makePng(
 }
 
 const tinyPng = makePng(2, 2, (x, y) => [x * 255, y * 255, 128, 255]);
+/// Past JSC's fastSizeLimit (1000 elements), so a `new Uint8Array(kilobytePng)`
+/// is an OversizeTypedArray: its bytes sit in fastMalloc with no ArrayBuffer.
+const kilobytePng = makePng(32, 32, (x, y) => [(x * 7 + y * 13) & 255, (x * 31) & 255, (y * 17) & 255, 255]);
 
 /// Decode any image to RGBA via Bun.Image→PNG, then walk the PNG ourselves
 /// (filter de-prediction included) so assertions are against ground truth,
@@ -692,6 +695,80 @@ describe("hostile option objects", () => {
     // After resolve the pin is released; now transfer() actually detaches.
     a.buffer.transfer();
     expect(a.byteLength).toBe(0);
+  });
+
+  test("a view that never had a `.buffer` is pinned too, so the same transfer copies", async () => {
+    // Same as above without the subarray(): subarray() materializes the
+    // ArrayBuffer, so that test only ever reached the already-has-a-buffer
+    // path. A view handed straight to the constructor is still
+    // OversizeTypedArray when the borrow happens, and the helper has to adopt
+    // an ArrayBuffer for it before a pin has anywhere to live.
+    const a = new Uint8Array(kilobytePng); // > fastSizeLimit elements, no .buffer touched
+    const p = new Bun.Image(a).png().bytes();
+    const moved = a.buffer.transfer();
+    expect(moved.byteLength).toBe(kilobytePng.length);
+    expect(a.byteLength).toBe(kilobytePng.length); // pinned: `a` keeps its bytes
+    expect((await p)[0]).toBe(0x89);
+    a.buffer.transfer();
+    expect(a.byteLength).toBe(0); // pin released with the task
+  });
+
+  test("transfer + GC under a decode does not free the bytes the pool thread reads", async () => {
+    // The same sequence in a loop, with a decode long enough to still be
+    // running when the collection happens. Without the pin, `.buffer` +
+    // transfer moves the storage to an ArrayBuffer nothing references,
+    // Heap::sweepArrayBuffers frees it, and the pool thread reads the freed
+    // block: an ASAN heap-use-after-free, or a decode error / wrong image on a
+    // build without ASAN. `Malloc=1` routes the Gigacage through system malloc
+    // so ASAN sees the free.
+    using dir = tempDir("image-oversize-transfer", {
+      "repro.ts": `
+        import zlib from "node:zlib";
+        const be32 = (n: number) => { const b = Buffer.alloc(4); b.writeUInt32BE(n >>> 0); return b; };
+        const chunk = (t: string, d: Buffer) =>
+          Buffer.concat([be32(d.length), Buffer.from(t), d,
+            be32(zlib.crc32(Buffer.concat([Buffer.from(t), d])) >>> 0)]);
+        const w = 900, h = 700, stride = w * 4 + 1;
+        const raw = Buffer.alloc(stride * h);
+        // Noise, so the JPEG below stays large and its decode outlives the
+        // collection. One 64 KB tile (the getRandomValues limit), repeated.
+        const tile = new Uint8Array(65536);
+        crypto.getRandomValues(tile);
+        for (let off = 0; off < raw.length; off += tile.length) raw.set(tile.subarray(0, Math.min(tile.length, raw.length - off)), off);
+        for (let y = 0; y < h; y++) raw[y * stride] = 0; // filter byte: none
+        const png = Buffer.concat([
+          Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+          chunk("IHDR", Buffer.concat([be32(w), be32(h), Buffer.from([8, 6, 0, 0, 0])])),
+          chunk("IDAT", zlib.deflateSync(raw)),
+          chunk("IEND", Buffer.alloc(0)),
+        ]);
+        const jpeg = Buffer.from(await new Bun.Image(png).jpeg({ quality: 90 }).bytes());
+        const want = Bun.hash(await new Bun.Image(new Uint8Array(jpeg)).bytes());
+        const rounds = Number(process.argv[2]);
+        let ok = 0, wrong = 0, rejected = 0;
+        for (let i = 0; i < rounds; i++) {
+          const input = new Uint8Array(jpeg);       // OversizeTypedArray: no ArrayBuffer yet
+          const decode = new Bun.Image(input).bytes(); // the pool thread reads input's storage
+          const ab = input.buffer;                  // an ArrayBuffer over the same storage
+          structuredClone(ab, { transfer: [ab] });  // storage moves to an unreferenced owner
+          Bun.gc(true);                             // ... which this collection sweeps
+          for (let k = 0; k < 8; k++) new Uint8Array(jpeg.length).fill(0xee); // reuse the block
+          await decode.then(r => { Bun.hash(r) === want ? ok++ : wrong++; }, () => { rejected++; });
+        }
+        console.log(JSON.stringify({ ok, wrong, rejected }));
+      `,
+    });
+    const rounds = 3;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "repro.ts", String(rounds)],
+      env: { ...bunEnv, Malloc: "1" },
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe(JSON.stringify({ ok: rounds, wrong: 0, rejected: 0 }));
+    expect(exitCode).toBe(0);
   });
 
   test("SharedArrayBuffer input is refused (cross-thread mutation surface)", () => {

--- a/test/js/bun/util/zstd.test.ts
+++ b/test/js/bun/util/zstd.test.ts
@@ -750,6 +750,29 @@ describe.concurrent("async compression of a resizable ArrayBuffer that shrinks a
       "same\n",
     );
   });
+
+  // A view allocated by length owns its bytes directly: it has no ArrayBuffer
+  // until JS asks for one. The borrow adopts one so it has something to pin,
+  // and the pin makes the transfer below copy. Without it the transfer moves
+  // the storage to an owner nothing references and the pool thread reads the
+  // freed block.
+  it("a by-length typed array keeps its bytes when the caller transfers them mid-compress", async () => {
+    await runInChild(
+      /* js */ `
+      const N = 256 * 1024;
+      const u8 = new Uint8Array(N).fill(0x41);
+      const promise = Bun.zstdCompress(u8);
+      u8.buffer.transfer(0);
+      const out = Buffer.from(Bun.zstdDecompressSync(await promise));
+      console.log(JSON.stringify({
+        byteLength: u8.byteLength,
+        decompressed: out.length,
+        allA: out.every(b => b === 0x41),
+      }));
+    `,
+      JSON.stringify({ byteLength: 256 * 1024, decompressed: 256 * 1024, allA: true }) + "\n",
+    );
+  });
 });
 
 describe.concurrent("Zstandard HTTP compression", () => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6681,11 +6681,15 @@ it("a by-length path argument keeps its bytes while an async call is pending", a
   // view holding a file name has the same hazard: without the pin the
   // transfer below frees the name under the pool thread, which then opens
   // whatever landed in the freed block. The path is padded with "/." segments
-  // so that every byte of the view is part of the name.
+  // so that every byte of the view is part of the name. The length sits
+  // between JSC's 1000-element fastSizeLimit (above it, so the view has no
+  // ArrayBuffer) and macOS's 1024-byte MAX_PATH_BYTES (below it, so the call
+  // reaches the pool instead of failing with ENAMETOOLONG).
+  const N = 1020;
   const script = `
     const fs = require("node:fs");
     const cwd = process.cwd();
-    const N = 3000;
+    const N = ${N};
     const name = n => {
       const pad = N - cwd.length - 1 - n.length;
       const u = new Uint8Array(N);
@@ -6717,7 +6721,7 @@ it("a by-length path argument keeps its bytes while an async call is pending", a
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stderr).toBe("");
-  expect(JSON.parse(stdout.trim())).toEqual({ byteLength: 3000, contents: "AAAA" });
+  expect(JSON.parse(stdout.trim())).toEqual({ byteLength: N, contents: "AAAA" });
   expect(exitCode).toBe(0);
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6671,6 +6671,56 @@ it("fs.read keeps filling the caller's view when its ArrayBuffer is transferred 
   expect(exitCode).toBe(0);
 });
 
+it("a by-length path argument keeps its bytes while an async call is pending", async () => {
+  using dir = tempDir("fs-path-transfer-oversize", {
+    "a.txt": "AAAA",
+    "b.txt": "BBBBBB",
+  });
+
+  // The path is borrowed the same way the data buffers are, so a by-length
+  // view holding a file name has the same hazard: without the pin the
+  // transfer below frees the name under the pool thread, which then opens
+  // whatever landed in the freed block. The path is padded with "/." segments
+  // so that every byte of the view is part of the name.
+  const script = `
+    const fs = require("node:fs");
+    const cwd = process.cwd();
+    const N = 3000;
+    const name = n => {
+      const pad = N - cwd.length - 1 - n.length;
+      const u = new Uint8Array(N);
+      u.set(new TextEncoder().encode(cwd + (pad & 1 ? "/" : "") + "/.".repeat(pad >> 1) + "/" + n));
+      return u;
+    };
+    (async () => {
+      for (let i = 0; i < 400; i++) fs.stat(cwd, () => {}); // park the pool
+      const p = name("a.txt");
+      const pending = fs.promises.readFile(p, "latin1");
+      try {
+        p.buffer.transfer(0);
+      } catch {}
+      globalThis.keep = Array.from({ length: 64 }, () => name("b.txt"));
+      console.log(JSON.stringify({ byteLength: p.byteLength, contents: await pending }));
+    })().catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({ byteLength: 3000, contents: "AAAA" });
+  expect(exitCode).toBe(0);
+});
+
 it("fs.read keeps filling a by-length view when its storage is transferred while the read is pending", async () => {
   using dir = tempDir("fs-read-transfer-oversize", {
     "data.bin": Buffer.alloc(65536, 0x61).toString(),

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6687,22 +6687,21 @@ it("a by-length path argument keeps its bytes while an async call is pending", a
   // reaches the pool instead of failing with ENAMETOOLONG).
   const N = 1020;
   const script = `
-    const fs = require("node:fs");
+    import fs from "node:fs";
     const cwd = process.cwd();
     const N = ${N};
     const name = n => {
       const pad = N - cwd.length - 1 - n.length;
       const u = new Uint8Array(N);
-      u.set(new TextEncoder().encode(cwd + (pad & 1 ? "/" : "") + "/.".repeat(pad >> 1) + "/" + n));
+      const dots = Buffer.alloc((pad >> 1) * 2, "/.").toString();
+      u.set(new TextEncoder().encode(cwd + (pad & 1 ? "/" : "") + dots + "/" + n));
       return u;
     };
     (async () => {
       for (let i = 0; i < 400; i++) fs.stat(cwd, () => {}); // park the pool
       const p = name("a.txt");
       const pending = fs.promises.readFile(p, "latin1");
-      try {
-        p.buffer.transfer(0);
-      } catch {}
+      p.buffer.transfer(0); // pinned: this copies, so the view keeps its bytes
       globalThis.keep = Array.from({ length: 64 }, () => name("b.txt"));
       console.log(JSON.stringify({ byteLength: p.byteLength, contents: await pending }));
     })().catch(err => {
@@ -6736,17 +6735,15 @@ it("fs.read keeps filling a by-length view when its storage is transferred while
   // ArrayBuffer nothing pins, the transfer moves the storage to an owner
   // nothing references, and the pool thread writes into freed memory.
   const script = `
-    const fs = require("node:fs");
-    const path = require("node:path");
+    import fs from "node:fs";
+    import path from "node:path";
     (async () => {
       const fd = fs.openSync(path.join(process.cwd(), "data.bin"), "r");
       const view = new Uint8Array(65536);
       const pending = new Promise((resolve, reject) => {
         fs.read(fd, view, 0, 65536, 0, (err, bytesRead) => (err ? reject(err) : resolve(bytesRead)));
       });
-      try {
-        view.buffer.transfer();
-      } catch {}
+      view.buffer.transfer(); // pinned: this copies, so the read keeps its destination
       const bytesRead = await pending;
       fs.closeSync(fd);
       console.log(

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6671,6 +6671,63 @@ it("fs.read keeps filling the caller's view when its ArrayBuffer is transferred 
   expect(exitCode).toBe(0);
 });
 
+it("fs.read keeps filling a by-length view when its storage is transferred while the read is pending", async () => {
+  using dir = tempDir("fs-read-transfer-oversize", {
+    "data.bin": Buffer.alloc(65536, 0x61).toString(),
+  });
+
+  // Same as the test above, with the destination allocated by length. Such a
+  // view owns its bytes directly and has no ArrayBuffer, so the borrow has to
+  // adopt one before it can pin it. Without the pin, `view.buffer` makes an
+  // ArrayBuffer nothing pins, the transfer moves the storage to an owner
+  // nothing references, and the pool thread writes into freed memory.
+  const script = `
+    const fs = require("node:fs");
+    const path = require("node:path");
+    (async () => {
+      const fd = fs.openSync(path.join(process.cwd(), "data.bin"), "r");
+      const view = new Uint8Array(65536);
+      const pending = new Promise((resolve, reject) => {
+        fs.read(fd, view, 0, 65536, 0, (err, bytesRead) => (err ? reject(err) : resolve(bytesRead)));
+      });
+      try {
+        view.buffer.transfer();
+      } catch {}
+      const bytesRead = await pending;
+      fs.closeSync(fd);
+      console.log(
+        JSON.stringify({
+          bytesRead,
+          viewByteLength: view.byteLength,
+          first: view[0] ?? null,
+          last: view[65535] ?? null,
+        }),
+      );
+    })().catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({
+    bytesRead: 65536,
+    viewByteLength: 65536,
+    first: 0x61,
+    last: 0x61,
+  });
+  expect(exitCode).toBe(0);
+});
+
 it("writevSync does not write bytes from a buffer detached by an index getter during argument conversion", () => {
   using dir = tempDir("fs-writev-detach", {});
   const file = join(String(dir), "out.bin");

--- a/test/js/node/http/node-http-pinned-write.test.ts
+++ b/test/js/node/http/node-http-pinned-write.test.ts
@@ -108,15 +108,16 @@ describe("node:http large Buffer writes are sent zero-copy", () => {
     },
   );
 
-  // A plain Buffer has no ArrayBuffer until `.buffer` is touched, and the
-  // pending write holds it without materializing one (doing so registers the
-  // bytes with the GC a second time). transfer() mid-write therefore detaches,
-  // as in Node, but it moves the storage rather than freeing it, so the bytes
-  // still to be written reach the client intact.
-  test.skipIf(isWindows)("a plain Buffer transferred while its write is pending still arrives intact", async () => {
+  // A plain Buffer has no ArrayBuffer until `.buffer` is touched. The pending
+  // write adopts one so its pin has somewhere to live, so transfer() mid-write
+  // copies and leaves the Buffer attached, as in the case above. Holding the
+  // view without a pin instead let transfer() move the storage to an object
+  // nothing references, and the next full collection freed it mid-write.
+  test.skipIf(isWindows)("a plain Buffer is pinned while its write is pending, then released on drain", async () => {
     const payload = makePayload(CHUNK_SIZE);
     const expectedHash = sha1(payload);
     let detachedWhilePending: boolean | undefined;
+    let detachedAfterDrain: boolean | undefined;
     let moved: ArrayBuffer | undefined;
     let handlerError: unknown;
     const serverReady = Promise.withResolvers<void>();
@@ -129,6 +130,8 @@ describe("node:http large Buffer writes are sent zero-copy", () => {
         detachedWhilePending = payload.buffer.detached;
         serverReady.resolve();
         await once(res, "drain");
+        payload.buffer.transfer();
+        detachedAfterDrain = payload.buffer.detached;
         res.end();
       } catch (e) {
         handlerError = e;
@@ -154,7 +157,8 @@ describe("node:http large Buffer writes are sent zero-copy", () => {
     const body = received.subarray(received.indexOf("\r\n\r\n") + 4);
     expect(body.length).toBe(CHUNK_SIZE);
     expect(sha1(body)).toBe(expectedHash);
-    expect(detachedWhilePending).toBe(true);
+    expect(detachedWhilePending).toBe(false);
+    expect(detachedAfterDrain).toBe(true);
     expect(moved?.byteLength).toBe(CHUNK_SIZE);
   });
 


### PR DESCRIPTION
### Problem

- A native borrow of a typed array's bytes can read or write memory that the collector already freed. ASAN, from a `Bun.Image` decode: `heap-use-after-free READ` in `decode_mcu_fast` (`vendor/libjpeg-turbo/src/jdhuff.c:704`) on `Bun Pool 0` under `PipelineTask::run`, freed by the main thread through `Gigacage::free` <- `~ArrayBufferContents` <- `Heap::sweepArrayBuffers`.
- The cause is the `Held` arm of `pinStorage` (`src/jsc/bindings/bindings.cpp:3584`). A view allocated by length (`new Uint8Array(n)` past 1000 elements, `Buffer.allocUnsafeSlow`) owns its bytes with no ArrayBuffer, so that arm reports success and pins nothing. JS then reads `view.buffer`, which makes an ArrayBuffer over the same bytes that no pin covers, transfers it to an object nothing references, and the next full collection frees the bytes under the worker.
- Every async borrow reaches that arm: `Bun.Image`, `Bun.zstdCompress`, `fs.read`, `res.write(buffer)` in `node:http`, zlib, crypto, the shell, MySQL binds.

### Fix

- `pinStorage` adopts an ArrayBuffer for such a view and pins that. `possiblySharedBuffer()` wraps the bytes where they already are (`ArrayBuffer::createAdopted`), so the adoption copies nothing.
- This is correct because the pin is what turns a steal into a copy. `ArrayBuffer::transferTo` takes its `copyTo` path for an undetachable buffer, so the view keeps its bytes for the whole borrow. A by-length `Buffer` now behaves like one built on an explicit `ArrayBuffer`.
- Cost: an adopted ArrayBuffer is reclaimed only by a full collection. 256 MB through `fs.createReadStream`, debug + ASAN build, counting JSC `FullCollection` lines with `BUN_JSC_logGC=1`: 0 full collections and 2.52 s before, 24 and 3.77 s after. That is the case #38886 optimized. `zlib` sync and async are unchanged (17 full collections either way).
- Verified: `test/js/bun/image/image-adversarial.test.ts` (2 new), `test/js/node/fs/fs.test.ts` (2 new: a read destination and a path argument), `test/js/bun/util/zstd.test.ts` (1 new), `test/js/node/http/node-http-pinned-write.test.ts` (1 updated: it asserted the old behaviour). Each one fails on the unfixed build. Also the whole of `test/js/bun/image/`, `test/js/node/fs/fs.test.ts`, `test/js/node/zlib/`, `test/js/workerd/html-rewriter.test.js`.

### Background

- A typed array past JSC's `fastSizeLimit` (1000 elements) with no `.buffer` touched yet is an `OversizeTypedArray`. Its bytes are a Gigacage block the view itself owns, and JSC frees them when the view dies, in an eden collection.
- `view.buffer` changes that owner. `slowDownAndWasteMemory()` hands the block to an `ArrayBuffer` (`createAdopted`), and from then on only `Heap::sweepArrayBuffers`, which runs in a full collection, frees it.
- `ArrayBuffer::pin()` clears `isDetachable()`. A transfer of a pinned buffer copies the bytes into the destination, reports success, and leaves the source attached. That is how every other borrow mode already survives a mid-op `transfer()`.
- Holding a view without a pin cannot be made safe by timing. Every holder is an async op, so JS always gets a turn between the borrow and the release.

<details><summary>Notes</summary>

**Fail-before oracle, no sanitizer needed.** While the op is in flight, `view.buffer.transfer()` must leave `view.byteLength` at N. On the unfixed build it is 0, because the transfer detaches. That is what three of the four tests assert. The fourth spawns a child with `Malloc=1` (so the Gigacage goes through system malloc and ASAN sees the free) and decodes a 900x700 JPEG while the storage is transferred and collected: the unfixed debug build aborts with the stack above, and a release build returns a decode error or a wrong image (55 of 60 rounds on 1.4.3-canary).

**Reach beyond `Bun.Image`.** The same single line serves `JSValue::as_pinned_arraybuffer`, which backs `PinnedArrayBuffer::root`: `fs.read` writes into the freed block instead of reading it, and `Bun.zstdCompress` and `fs.promises.writeFile` compress or write whatever now sits there. The borrowed bytes can also be a file name, not only data: an async `node:fs` call holding its path in a by-length view reads the freed name and can open a different file.

**Alternatives considered.**
- Copy the bytes instead of adopting: wrong for a write destination such as the `fs.read` buffer, and the image path takes inputs of tens of MB.
- Pin at the moment JS materializes `.buffer`: there is no hook outside WebKit. `slowDownAndWasteMemory` would have to copy, not adopt, for a view with a live borrow.
- Keep a reference to the storage instead of pinning: `transferTo` moves `ArrayBufferContents`, so a `Ref` on the source buffer does not keep the bytes.
- Skip the pin for borrows that never cross a JS turn (sync calls): sound, but `PinnedArrayBuffer::pin` is also used for borrows that outlive the call (a `Blob` store), so it needs a separate entry point. Left out of this change.

**Measurement detail.** `fs.createReadStream` over a 256 MB file, reading to the end, on this container's debug + ASAN build. Full collection counts are allocation-driven, so they carry over to a release build; the wall-clock numbers do not. The destination buffer is `Buffer.allocUnsafeSlow(64K)`, a bare oversize view, which is why this path pays and zlib (whose input already has an ArrayBuffer) does not.

**Test runs.** Green: `test/js/bun/image/` (230), `test/js/node/fs/fs.test.ts` (566), `test/js/bun/util/zstd.test.ts` with `test/js/workerd/html-rewriter.test.js` (280), `test/js/node/http/node-http-pinned-write.test.ts` (10), `test/js/bun/shell/shell-pipe-read-fault.test.ts`, `test/js/sql/sql-mysql-bind-blob-borrow.test.ts`. Red before and after this change, confirmed on `main` in the same container: the `beforeAll` hook of `test/js/node/zlib/leak.test.ts` (10 000 sync deflates inside the default 5 s hook timeout), `Absolute memory usage remains relatively constant when reading and writing to a pipe` in `test/js/web/streams/streams-leak.test.ts` (15 000 rounds of 500 KB, also a 5 s timeout), and two in `test/js/node/child_process/child_process.test.ts`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/http/node-http-pinned-write.test.ts, test/js/node/fs/fs.test.ts, test/js/bun/image/image-adversarial.test.ts

<!-- robobun:evidence:end -->