### PR TITLE
js_parser: don't panic on an import clause with more than 65535 names

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4357,15 +4357,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let mut item_refs = ImportItemForNamespaceMap::new();
         // arena-owned `StoreSlice<ClauseItem>` valid for parser 'a.
-        let count_excluding_namespace = u16::try_from(stmt.items.len()).expect("int cast")
-            + u16::from(stmt.default_name.is_some());
+        let count_excluding_namespace =
+            stmt.items.len() + usize::from(stmt.default_name.is_some());
 
-        item_refs.ensure_unused_capacity(count_excluding_namespace as usize)?;
+        item_refs.ensure_unused_capacity(count_excluding_namespace)?;
         // Even though we allocate ahead of time here
         // we cannot use putAssumeCapacity because a symbol can have existing links
         // those may write to this hash table, so this estimate may be innaccurate
-        self.is_import_item
-            .reserve(count_excluding_namespace as usize);
+        self.is_import_item.reserve(count_excluding_namespace);
         let mut remap_count: u32 = 0;
         // Link the default item to the namespace
         if let Some(name_loc) = &mut stmt.default_name {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4357,8 +4357,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let mut item_refs = ImportItemForNamespaceMap::new();
         // arena-owned `StoreSlice<ClauseItem>` valid for parser 'a.
-        let count_excluding_namespace =
-            stmt.items.len() + usize::from(stmt.default_name.is_some());
+        let count_excluding_namespace = stmt.items.len() + usize::from(stmt.default_name.is_some());
 
         item_refs.ensure_unused_capacity(count_excluding_namespace)?;
         // Even though we allocate ahead of time here

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3105,6 +3105,22 @@ console.log(<div {...obj} key="after" />);`),
       expectPrinted_(`export * as "" from "m"`, `export * as "" from "m"`);
     });
 
+    it("import clause with more than 65535 names", () => {
+      // "a0000, a0001, ... affff": 65536 distinct names. Byte writes into one
+      // Buffer keep this fast on debug builds, where per-name string concat is slow.
+      const hex = Buffer.from("0123456789abcdef");
+      const names = Buffer.alloc(65536 * 7, "a0000, ");
+      for (let i = 0; i < 65536; i++) {
+        names[i * 7 + 1] = hex[i >> 12];
+        names[i * 7 + 2] = hex[(i >> 8) & 15];
+        names[i * 7 + 3] = hex[(i >> 4) & 15];
+        names[i * 7 + 4] = hex[i & 15];
+      }
+      const list = names.toString("latin1", 0, names.length - 2);
+      const out = new Bun.Transpiler({ loader: "js" }).transformSync("import def, {" + list + '} from "./m.js";');
+      expect(out).toBe("import def, { " + list + ' } from "./m.js";\n');
+    });
+
     it("string quote selection", () => {
       expectPrinted_(`console.log("\\n")`, "console.log(`\n`)");
       expectPrinted_(`console.log("\\"")`, `console.log('"')`);


### PR DESCRIPTION
### Problem
- An `import` clause with more than 65535 names crashes the parser: `panic: int cast: TryFromIntError(PosOverflow)` in `process_import_statement` (`src/js_parser/p.rs:4360`). Any full parse hits it: `bun run`, `bun build`, `Bun.Transpiler`.
- The cause is `u16::try_from(stmt.items.len()).expect("int cast") + u16::from(stmt.default_name.is_some())`. The item count comes from source text and has no 16-bit bound. With 65535 names plus a default import, the `+ 1` also overflows in debug builds.

### Fix
- Keep the count as `usize`. Its only two uses are capacity hints: `item_refs.ensure_unused_capacity(count)` and `self.is_import_item.reserve(count)`, which both take `usize`.
- No other site narrows a source-derived count this way. The remaining `u8`/`u16` casts in `js_parser` are over bounded values (regex flag letters, runtime import keys).
- Verified: `test/bundler/transpiler/transpiler.test.js` ("import clause with more than 65535 names") panics on 1.4.3 and passes with this change in about 1.1 s on the debug build. The whole file passes (236 tests).

### Background
- `process_import_statement` runs while the parser handles an `import` declaration. It declares a symbol for each imported name and records them in `is_import_item` and an `ImportItemForNamespaceMap` so later passes can rewrite property accesses on the namespace.
- The test builds the 65536 names (`a0000` through `affff`) with byte writes into one `Buffer`. Per-name string concatenation or `Array#join` of 65536 elements takes 1 to 2 seconds on a debug JavaScriptCore, which would put the test near the default 5 s timeout.
