### PR TITLE
node:crypto: throw ERR_OUT_OF_RANGE for >2 GiB buffer arguments instead of aborting

### DIFF
--- a/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
@@ -139,45 +139,44 @@ KeyObject prepareKey(JSGlobalObject* globalObject, ThrowScope& scope, JSValue ke
         RETURN_IF_EXCEPTION(scope, {});
         auto* view = dynamicDowncast<JSC::JSArrayBufferView>(buffer);
 
-        Vector<uint8_t> copy;
-        copy.append(view->span());
-        return KeyObject::create(WTF::move(copy));
+        auto copy = copyArgumentBytes(globalObject, scope, view->span(), "key"_s);
+        if (!copy) return {};
+        return KeyObject::create(WTF::move(*copy));
     }
 
     // Handle ArrayBuffer types
     if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(key)) {
-        Vector<uint8_t> copy;
-        copy.append(view->span());
-        return KeyObject::create(WTF::move(copy));
+        auto copy = copyArgumentBytes(globalObject, scope, view->span(), "key"_s);
+        if (!copy) return {};
+        return KeyObject::create(WTF::move(*copy));
     }
 
     if (auto* buf = dynamicDowncast<JSC::JSArrayBuffer>(key)) {
-        auto* impl = buf->impl();
-        Vector<uint8_t> copy;
-        copy.append(impl->span());
-        return KeyObject::create(WTF::move(copy));
+        auto copy = copyArgumentBytes(globalObject, scope, buf->impl()->span(), "key"_s);
+        if (!copy) return {};
+        return KeyObject::create(WTF::move(*copy));
     }
 
     ERR::INVALID_ARG_TYPE(scope, globalObject, "ikm"_s, "string or an instance of SecretKeyObject, ArrayBuffer, TypedArray, DataView, or Buffer"_s, key);
     return {};
 }
 
-void copyBufferOrString(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, JSValue value, const WTF::ASCIILiteral& name, WTF::Vector<uint8_t>& buffer)
+std::optional<Vector<uint8_t>> copyBufferOrString(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, JSValue value, ASCIILiteral name)
 {
     if (value.isString()) {
         JSString* str = value.toString(lexicalGlobalObject);
-        RETURN_IF_EXCEPTION(scope, );
+        RETURN_IF_EXCEPTION(scope, std::nullopt);
         GCOwnedDataScope<WTF::StringView> view = str->view(lexicalGlobalObject);
-        RETURN_IF_EXCEPTION(scope, );
+        RETURN_IF_EXCEPTION(scope, std::nullopt);
         UTF8View utf8(view);
-        buffer.append(utf8.span());
-    } else if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
-        buffer.append(view->span());
-    } else if (auto* buf = dynamicDowncast<JSArrayBuffer>(value)) {
-        buffer.append(buf->impl()->span());
-    } else {
-        ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, name, "string, ArrayBuffer, TypedArray, Buffer"_s, value);
+        return copyArgumentBytes(lexicalGlobalObject, scope, utf8.bytes(), name);
     }
+    if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(value))
+        return copyArgumentBytes(lexicalGlobalObject, scope, view->span(), name);
+    if (auto* buf = dynamicDowncast<JSArrayBuffer>(value))
+        return copyArgumentBytes(lexicalGlobalObject, scope, buf->impl()->span(), name);
+    ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, name, "string, ArrayBuffer, TypedArray, Buffer"_s, value);
+    return std::nullopt;
 }
 
 std::optional<HkdfJobCtx> HkdfJobCtx::fromJS(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame, ThrowScope& scope, Mode mode)
@@ -196,20 +195,18 @@ std::optional<HkdfJobCtx> HkdfJobCtx::fromJS(JSGlobalObject* lexicalGlobalObject
     KeyObject keyObject = prepareKey(lexicalGlobalObject, scope, keyValue);
     RETURN_IF_EXCEPTION(scope, std::nullopt);
 
-    WTF::Vector<uint8_t> salt;
-    copyBufferOrString(lexicalGlobalObject, scope, saltValue, "salt"_s, salt);
-    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    auto salt = copyBufferOrString(lexicalGlobalObject, scope, saltValue, "salt"_s);
+    if (!salt) return std::nullopt;
 
-    WTF::Vector<uint8_t> info;
-    copyBufferOrString(lexicalGlobalObject, scope, infoValue, "info"_s, info);
-    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    auto info = copyBufferOrString(lexicalGlobalObject, scope, infoValue, "info"_s);
+    if (!info) return std::nullopt;
 
     int32_t length = 0;
     V::validateInteger(scope, lexicalGlobalObject, lengthValue, "length"_s, jsNumber(0), jsNumber(Bun::Buffer::kMaxLength), &length);
     RETURN_IF_EXCEPTION(scope, std::nullopt);
 
-    if (info.size() > 1024) {
-        ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "info"_s, "must not contain more than 1024 bytes"_s, jsNumber(info.size()));
+    if (info->size() > 1024) {
+        ERR::OUT_OF_RANGE(scope, lexicalGlobalObject, "info"_s, "must not contain more than 1024 bytes"_s, jsNumber(info->size()));
         return std::nullopt;
     }
 
@@ -226,7 +223,7 @@ std::optional<HkdfJobCtx> HkdfJobCtx::fromJS(JSGlobalObject* lexicalGlobalObject
         return std::nullopt;
     }
 
-    return HkdfJobCtx(hash, length, WTF::move(keyObject), WTF::move(info), WTF::move(salt));
+    return HkdfJobCtx(hash, length, WTF::move(keyObject), WTF::move(*info), WTF::move(*salt));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsHkdf, (JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))

--- a/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoSignJob.cpp
@@ -286,8 +286,8 @@ std::optional<SignJobCtx> SignJobCtx::fromJS(JSGlobalObject* globalObject, Throw
     auto dataView = getArrayBufferOrView2(globalObject, scope, dataValue, "data"_s, jsUndefined());
     RETURN_IF_EXCEPTION(scope, {});
 
-    Vector<uint8_t> data;
-    data.append(std::span { dataView->data(), dataView->size() });
+    auto data = copyArgumentBytes(globalObject, scope, std::span { dataView->data(), dataView->size() }, "data"_s);
+    if (!data) return std::nullopt;
 
     if (mode == Mode::Sign) {
         if (keyValue.pureToBoolean() == TriState::False) {
@@ -321,7 +321,9 @@ std::optional<SignJobCtx> SignJobCtx::fromJS(JSGlobalObject* globalObject, Throw
     if (mode == Mode::Verify) {
         auto signatureView = getArrayBufferOrView2(globalObject, scope, signatureValue, "signature"_s, jsUndefined(), true);
         RETURN_IF_EXCEPTION(scope, {});
-        signatureData.append(std::span { signatureView->data(), signatureView->size() });
+        auto copy = copyArgumentBytes(globalObject, scope, std::span { signatureView->data(), signatureView->size() }, "signature"_s);
+        if (!copy) return std::nullopt;
+        signatureData = WTF::move(*copy);
     }
 
     auto prepareResult = mode == Mode::Verify
@@ -432,7 +434,7 @@ std::optional<SignJobCtx> SignJobCtx::fromJS(JSGlobalObject* globalObject, Throw
         return SignJobCtx(
             mode,
             keyObject.data(),
-            WTF::move(data),
+            WTF::move(*data),
             digest,
             padding,
             pssSaltLength,
@@ -444,7 +446,7 @@ std::optional<SignJobCtx> SignJobCtx::fromJS(JSGlobalObject* globalObject, Throw
     return SignJobCtx(
         mode,
         keyObject.data(),
-        WTF::move(data),
+        WTF::move(*data),
         digest,
         padding,
         pssSaltLength,

--- a/src/jsc/bindings/node/crypto/CryptoUtil.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoUtil.cpp
@@ -787,6 +787,16 @@ std::optional<std::span<const uint8_t>> getBuffer(JSC::JSValue maybeBuffer)
     return std::nullopt;
 }
 
+std::optional<Vector<uint8_t>> copyArgumentBytes(JSGlobalObject* globalObject, ThrowScope& scope, std::span<const uint8_t> bytes, ASCIILiteral argName)
+{
+    static_assert(WTF::isValidCapacityForVector<uint8_t>(INT32_MAX));
+    if (bytes.size() > INT32_MAX) [[unlikely]] {
+        throwError(globalObject, scope, ErrorCode::ERR_OUT_OF_RANGE, makeString(argName, " is too big"_s));
+        return std::nullopt;
+    }
+    return Vector<uint8_t>(bytes);
+}
+
 bool isStringOrBuffer(JSValue value)
 {
     if (value.isString()) {

--- a/src/jsc/bindings/node/crypto/CryptoUtil.h
+++ b/src/jsc/bindings/node/crypto/CryptoUtil.h
@@ -65,8 +65,7 @@ JSC::JSArrayBufferView* getArrayBufferOrView(JSGlobalObject* globalObject, Throw
 JSC::JSArrayBufferView* getArrayBufferOrView(JSGlobalObject* globalObject, ThrowScope& scope, JSValue value, ASCIILiteral argName, BufferEncodingType encoding);
 bool isKeyValidForCurve(const EC_GROUP* group, const ncrypto::BignumPointer& privateKey);
 std::optional<std::span<const uint8_t>> getBuffer(JSC::JSValue maybeBuffer);
-// Copies caller-provided bytes. Past INT32_MAX bytes (Node's limit for these arguments,
-// and the most a WTF::Vector holds) it throws ERR_OUT_OF_RANGE "<argName> is too big".
+// Throws ERR_OUT_OF_RANGE "<argName> is too big" past INT32_MAX bytes, like Node.
 std::optional<WTF::Vector<uint8_t>> copyArgumentBytes(JSGlobalObject* globalObject, ThrowScope& scope, std::span<const uint8_t> bytes, ASCIILiteral argName);
 
 // For output encoding

--- a/src/jsc/bindings/node/crypto/CryptoUtil.h
+++ b/src/jsc/bindings/node/crypto/CryptoUtil.h
@@ -65,6 +65,9 @@ JSC::JSArrayBufferView* getArrayBufferOrView(JSGlobalObject* globalObject, Throw
 JSC::JSArrayBufferView* getArrayBufferOrView(JSGlobalObject* globalObject, ThrowScope& scope, JSValue value, ASCIILiteral argName, BufferEncodingType encoding);
 bool isKeyValidForCurve(const EC_GROUP* group, const ncrypto::BignumPointer& privateKey);
 std::optional<std::span<const uint8_t>> getBuffer(JSC::JSValue maybeBuffer);
+// Copies caller-provided bytes. Past INT32_MAX bytes (Node's limit for these arguments,
+// and the most a WTF::Vector holds) it throws ERR_OUT_OF_RANGE "<argName> is too big".
+std::optional<WTF::Vector<uint8_t>> copyArgumentBytes(JSGlobalObject* globalObject, ThrowScope& scope, std::span<const uint8_t> bytes, ASCIILiteral argName);
 
 // For output encoding
 void parsePublicKeyEncoding(JSGlobalObject*, ThrowScope&, JSObject* enc, JSValue keyTypeValue, WTF::StringView objName, ncrypto::EVPKeyPointer::PublicKeyEncodingConfig&);

--- a/src/jsc/bindings/node/crypto/JSCipher.cpp
+++ b/src/jsc/bindings/node/crypto/JSCipher.cpp
@@ -115,7 +115,8 @@ JSValue rsaFunction(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* ca
             // detach a borrowed label buffer, so copy the bytes instead of holding a view.
             auto view = getArrayBufferOrView2(lexicalGlobalObject, scope, oaepLabelValue, "options.oaepLabel"_s, encodingValue);
             RETURN_IF_EXCEPTION(scope, {});
-            oaepLabel = WTF::Vector<uint8_t>(std::span<const uint8_t> { view->data(), view->size() });
+            oaepLabel = copyArgumentBytes(lexicalGlobalObject, scope, std::span { view->data(), view->size() }, "oaepLabel"_s);
+            if (!oaepLabel) return {};
         }
     }
 

--- a/src/jsc/bindings/node/crypto/JSCipherConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSCipherConstructor.cpp
@@ -144,10 +144,6 @@ JSC_DEFINE_HOST_FUNCTION(constructCipher, (JSC::JSGlobalObject * globalObject, J
     WTF::String cipherString = cipherValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    if (keyData.size() > INT_MAX) [[unlikely]] {
-        return ERR::OUT_OF_RANGE(scope, globalObject, "key is too big"_s, 0, INT_MAX, jsNumber(keyData.size()));
-    }
-
     int32_t ivLen = 0;
     if (ivView) {
         if (ivView->byteLength() > INT_MAX) [[unlikely]] {

--- a/src/jsc/bindings/node/crypto/KeyObject.cpp
+++ b/src/jsc/bindings/node/crypto/KeyObject.cpp
@@ -2131,24 +2131,23 @@ KeyObject KeyObject::prepareSecretKey(JSGlobalObject* globalObject, ThrowScope& 
             return {};
         }
 
-        Vector<uint8_t> copy;
-        copy.append(view->span());
-        return create(WTF::move(copy));
+        auto copy = copyArgumentBytes(globalObject, scope, view->span(), "key"_s);
+        if (!copy) return {};
+        return create(WTF::move(*copy));
     }
 
     // TODO(dylan-conway): avoid copying by keeping the buffer alive
     if (auto* view = dynamicDowncast<JSArrayBufferView>(keyValue)) {
-        Vector<uint8_t> copy;
-        copy.append(view->span());
-        return create(WTF::move(copy));
+        auto copy = copyArgumentBytes(globalObject, scope, view->span(), "key"_s);
+        if (!copy) return {};
+        return create(WTF::move(*copy));
     }
 
     // TODO(dylan-conway): avoid copying by keeping the buffer alive
     if (auto* arrayBuffer = dynamicDowncast<JSArrayBuffer>(keyValue)) {
-        auto* impl = arrayBuffer->impl();
-        Vector<uint8_t> copy;
-        copy.append(impl->span());
-        return create(WTF::move(copy));
+        auto copy = copyArgumentBytes(globalObject, scope, arrayBuffer->impl()->span(), "key"_s);
+        if (!copy) return {};
+        return create(WTF::move(*copy));
     }
 
     if (bufferOnly) {

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -1053,6 +1053,71 @@ it("cipher.setAAD on a non-authenticated cipher throws ERR_CRYPTO_INVALID_STATE"
   });
 });
 
+// node:crypto copies key/data/salt/info/signature/oaepLabel arguments into a
+// WTF::Vector<uint8_t>, which cannot hold more than INT32_MAX bytes and crashes the
+// process past that. Node rejects the same arguments with ERR_OUT_OF_RANGE
+// "<name> is too big" (createSecretKey is the one Node accepts). Runs in a subprocess
+// so an unfixed build's abort does not take out the runner; the 2 GiB buffer is never
+// written, so RSS stays small.
+it("node:crypto rejects >2 GiB buffer arguments with ERR_OUT_OF_RANGE instead of aborting", async () => {
+  const script = `
+    const crypto = require("node:crypto");
+    let big;
+    try {
+      big = new Uint8Array(2 ** 31);
+    } catch {
+      console.log("SKIP");
+      process.exit(0);
+    }
+    const { publicKey, privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
+    const results = {};
+    const record = (label, fn) => {
+      try {
+        fn();
+        results[label] = "returned";
+      } catch (e) {
+        results[label] = e.code + ": " + e.message;
+      }
+    };
+    record("createSecretKey", () => crypto.createSecretKey(big));
+    record("createSecretKey ArrayBuffer", () => crypto.createSecretKey(big.buffer));
+    record("createHmac", () => crypto.createHmac("sha256", big));
+    record("createCipheriv", () => crypto.createCipheriv("aes-128-gcm", big, Buffer.alloc(12)));
+    record("hkdfSync ikm", () => crypto.hkdfSync("sha256", big, "salt", "info", 16));
+    record("hkdfSync ikm ArrayBuffer", () => crypto.hkdfSync("sha256", big.buffer, "salt", "info", 16));
+    record("hkdfSync salt", () => crypto.hkdfSync("sha256", "key", big, "info", 16));
+    record("hkdfSync info", () => crypto.hkdfSync("sha256", "key", "salt", big, 16));
+    record("sign data", () => crypto.sign("sha256", big, privateKey));
+    record("verify signature", () => crypto.verify("sha256", Buffer.from("x"), publicKey, big));
+    record("publicEncrypt oaepLabel", () =>
+      crypto.publicEncrypt({ key: publicKey, padding: crypto.constants.RSA_PKCS1_OAEP_PADDING, oaepLabel: big }, Buffer.alloc(16)),
+    );
+    // Normal-sized inputs keep working in the same process.
+    results["small hmac"] = crypto.createHmac("sha256", big.subarray(0, 32)).update("x").digest("hex").length;
+    console.log(JSON.stringify(results));
+  `;
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  if (stdout.trim() !== "SKIP") {
+    expect(JSON.parse(stdout)).toEqual({
+      "createSecretKey": "ERR_OUT_OF_RANGE: key is too big",
+      "createSecretKey ArrayBuffer": "ERR_OUT_OF_RANGE: key is too big",
+      "createHmac": "ERR_OUT_OF_RANGE: key is too big",
+      "createCipheriv": "ERR_OUT_OF_RANGE: key is too big",
+      "hkdfSync ikm": "ERR_OUT_OF_RANGE: key is too big",
+      "hkdfSync ikm ArrayBuffer": "ERR_OUT_OF_RANGE: key is too big",
+      "hkdfSync salt": "ERR_OUT_OF_RANGE: salt is too big",
+      "hkdfSync info": "ERR_OUT_OF_RANGE: info is too big",
+      "sign data": "ERR_OUT_OF_RANGE: data is too big",
+      "verify signature": "ERR_OUT_OF_RANGE: signature is too big",
+      "publicEncrypt oaepLabel": "ERR_OUT_OF_RANGE: oaepLabel is too big",
+      "small hmac": 64,
+    });
+  }
+  expect(exitCode).toBe(0);
+});
+
 it("generatePrime(Sync) should return an ArrayBuffer", async () => {
   const prime = crypto.generatePrimeSync(512);
   expect(prime).toBeInstanceOf(ArrayBuffer);

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -1061,7 +1061,7 @@ it("cipher.setAAD on a non-authenticated cipher throws ERR_CRYPTO_INVALID_STATE"
 // written, so RSS stays small.
 it("node:crypto rejects >2 GiB buffer arguments with ERR_OUT_OF_RANGE instead of aborting", async () => {
   const script = `
-    const crypto = require("node:crypto");
+    import crypto from "node:crypto";
     let big;
     try {
       big = new Uint8Array(2 ** 31);


### PR DESCRIPTION
### Problem
- `require("node:crypto").createSecretKey(Buffer.allocUnsafe(2 ** 31))` aborts the process (`panic(main thread): abort() called`, rc 134). `2 ** 31 - 1` works. The same 2 GiB buffer aborts `createHmac`, `createCipheriv`, `hkdfSync` (ikm, salt, info), `crypto.sign` (data), `crypto.verify` (signature) and `publicEncrypt`/`privateDecrypt` (`oaepLabel`).
- Each of these copies the caller's bytes with an infallible `Vector<uint8_t>::append` (`KeyObject::prepareSecretKey`, `src/jsc/bindings/node/crypto/KeyObject.cpp:2134`; `CryptoHkdf.cpp` `prepareKey` and `copyBufferOrString`; `CryptoSignJob.cpp:290,324`; `JSCipher.cpp:118`). `WTF::Vector` stores its size as `unsigned` and `isValidCapacityForVector` caps it at `INT32_MAX` bytes, so `reserveCapacity<FailureAction::Crash>` calls `CRASH()` for 2^31.

### Fix
- Add `copyArgumentBytes(globalObject, scope, bytes, argName)` to `CryptoUtil`. Above `INT32_MAX` bytes it throws `ERR_OUT_OF_RANGE` with the message `"<argName> is too big"` and copies nothing. Every caller-sized copy listed above goes through it.
- This is what Node does for the same arguments: `key is too big`, `salt is too big`, `data is too big`, `signature is too big`, `oaepLabel is too big` are Node's own `ERR_OUT_OF_RANGE` messages at the same `INT32_MAX` bound. The one divergence is `createSecretKey`, which Node accepts at 2 GiB. Bun now throws `key is too big` there instead of aborting.
- The `key.size() > INT_MAX` check in the `Cipheriv` constructor ran after the copy had already crashed, and a `Vector` can never exceed that size, so it is removed.
- Verified: `test/js/node/crypto/node-crypto.test.js` (new subprocess test, aborts on 1.4.3, passes with the fix). Also `crypto.key-objects`, `crypto.hmac`, `crypto-rsa`, `hkdf-callback-null`, `sign-jwk-ieee-p1363` and 12 vendored `test-crypto-{hkdf,sign-verify,key-objects,hmac,cipheriv-decipheriv,rsa-dsa,...}.js` pass.

### Background
- `WTF::Vector<T>` keeps `m_size`/`m_capacity` as 32-bit `unsigned`. `append`/`reserveCapacity` default to `FailureAction::Crash`, so a capacity past `(UINT_MAX >> 1) / sizeof(T)` is a deliberate `CRASH()`, not an allocation failure. A `static_assert` ties the new check to that limit.
- A JS `ArrayBuffer` can be up to 4 GiB, so any binding that copies a user buffer into a `Vector` needs a bound first. The WebCrypto entry points already have one (`test/js/web/crypto/web-crypto.test.ts`, "oversized inputs"); this is the node:crypto side.
- Node's C++ uses `ArrayBufferOrViewContents::CheckSizeInt32()` for these arguments and throws `THROW_ERR_OUT_OF_RANGE(env, "<name> is too big")`, which is where the messages come from.

<details><summary>Notes</summary>

Doors checked on bun 1.4.3 vs node 26.3.0 with one `Buffer.allocUnsafe(2 ** 31)`:

```
                              bun 1.4.3     node 26.3.0                          bun with fix
createSecretKey(b)            abort 134     ok                                   ERR_OUT_OF_RANGE key is too big
createHmac("sha256", b)       abort 134     Error error:00000000:lib(0)          ERR_OUT_OF_RANGE key is too big
createCipheriv(gcm, b, iv)    abort 134     ERR_OUT_OF_RANGE key is too big      same as node
hkdfSync(_, b, ...)           abort 134     ERR_OUT_OF_RANGE key is too big      same as node
hkdfSync(_, _, b, ...)        abort 134     ERR_OUT_OF_RANGE salt is too big     same as node
hkdfSync(_, _, _, b, _)       abort 134     ERR_OUT_OF_RANGE (info > 1024 bytes) ERR_OUT_OF_RANGE info is too big
sign("sha256", b, key)        abort 134     ERR_OUT_OF_RANGE data is too big     same as node
verify(_, _, key, b)          abort 134     ERR_OUT_OF_RANGE signature is too big same as node
publicEncrypt({oaepLabel: b}) abort 134     ERR_OUT_OF_RANGE oaepLabel is too big same as node
subtle.digest / importKey     OperationError (already bounded)
createHash().update(b)        ok (no copy)
```

For `info`, Node validates the 1024-byte HKDF limit in JS before the size check, so its message differs above 2 GiB. Bun keeps the 1024-byte check after the copy, so a 2 GiB `info` reports `info is too big`. Both are `ERR_OUT_OF_RANGE`.

The string paths (`createSecretKey("...")`, hkdf string salt/info) also go through the helper. A JS string cannot reach 2^31 UTF-8 bytes in practice, but the copy is the same statement.

All doors were also run under `BUN_JSC_validateExceptionChecks=1` on the debug build with no unchecked-exception assertions.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 3 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.3 (5f554969b)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [5.44ms]
(pass) crypto.randomInt should return a number [2.59ms]
(pass) crypto.randomInt with no arguments [4.54ms]
(pass) crypto.randomInt with one argument [3.12ms]
(pass) crypto.randomInt with a callback [45.62ms]
(pass) createHash > rsa-md5 - "Hello World" [8.96ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [5.52ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [1.07ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.94ms]
(pass) createHash > rsa-sha1 - "Hello World" [9.85ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.50ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.72ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.75ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.50ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.91ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.73ms]
(pass) createH
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (5f554969b)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [0.11ms]
(pass) crypto.randomInt should return a number [0.03ms]
(pass) crypto.randomInt with no arguments [0.07ms]
(pass) crypto.randomInt with one argument [0.02ms]
(pass) crypto.randomInt with a callback [0.57ms]
(pass) createHash > rsa-md5 - "Hello World" [0.13ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [0.05ms]
(pass) createHash > rsa-ripemd160 - "Hello World"
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary
(pass) createHash > rsa-sha1 - "Hello World" [0.11ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [0.02ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.01ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary
(pass) createHash > rsa-sha224 - "Hello World" [0.03ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary
(pass) createHash > rsa-sha256 - "Hello World" [0.01ms]
(pass) createHash > rsa-sha256 - "Hello World" -> binary
(pass) createHash > rsa-sha3-224 - "Hello World"
(pass) createHash > rsa-sha3-224 - "Hello World" -> binary
(pass) createHash > rsa-sha3-256 - "Hello World"

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.3 (5f554969b)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [7.59ms]
(pass) crypto.randomInt should return a number [3.76ms]
(pass) crypto.randomInt with no arguments [6.60ms]
(pass) crypto.randomInt with one argument [3.78ms]
(pass) crypto.randomInt with a callback [65.64ms]
(pass) createHash > rsa-md5 - "Hello World" [12.88ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [7.96ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [1.23ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [1.29ms]
(pass) createHash > rsa-sha1 - "Hello World" [12.95ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.92ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [1.07ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [1.10ms]
(pass) createHash > rsa-sha224 - "Hello World" [3.90ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [1.37ms]
(pass) createHash > rsa-sha256 - "Hello World" [2.61ms]
(pass) creat
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
rustup spent 37s installing the pinned toolchain (nightly-2026-07-20); it was missing or incomplete on this machine
[configured] bun-profile → bun (stripped) in 37615ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/141] gen cpp.rs (cppbind)
[2/141] gen JS modules (bundle-modules)
Preprocess modules (9507ms)
Bundle modules (101ms)
Postprocesss modules (1042ms)
Bundle Functions (666ms)
Generate Code (39ms)

[11.36s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/141] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_output_tags v0.0.0 (/workspace/bun/src/bun_output_tags)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_dispatch v0.0.0 (/workspace/bun/src/dispatch)
[1m[92m   Compiling[0m bun_jsc_macros v0.0.0 (/workspace/bun/src/jsc_macro
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/node/crypto/CryptoHkdf.cpp        | 55 +++++++++---------
 src/jsc/bindings/node/crypto/CryptoSignJob.cpp     | 12 ++--
 src/jsc/bindings/node/crypto/CryptoUtil.cpp        | 10 ++++
 src/jsc/bindings/node/crypto/CryptoUtil.h          |  2 +
 src/jsc/bindings/node/crypto/JSCipher.cpp          |  3 +-
 .../bindings/node/crypto/JSCipherConstructor.cpp   |  4 --
 src/jsc/bindings/node/crypto/KeyObject.cpp         | 19 +++----
 test/js/node/crypto/node-crypto.test.js            | 65 ++++++++++++++++++++++
 8 files changed, 121 insertions(+), 49 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/jsc/bindings/node/crypto/CryptoHkdf.cpp               2      5     12
src/jsc/bindings/node/crypto/CryptoSignJob.cpp            2      3     12
src/jsc/bindings/node/crypto/CryptoUtil.cpp               2      1     11
src/jsc/bindings/node/crypto/CryptoUtil.h                 2      2     11
src/jsc/bindings/node/crypto/JSCipher.cpp                 1      1     12
src/jsc/bindings/node/crypto/JSCipherConstructor.cpp      1      1     11
src/jsc/bindings/node/crypto/KeyObject.cpp                1      1     11
test/js/node/crypto/node-crypto.test.js                   3      3     11
```

</details>

<!-- robobun:evidence:end -->