### PR TITLE
Date: local setters near the time value limits use the zone's own offset (WebKit bump for oven-sh/WebKit#615)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-614-3db1d92e";
+export const WEBKIT_VERSION = "4b9ff9959a04c70a4b0a2ae286fcfe16670e7fe1";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "dfd696443b9ba87c4f516d1c724f0abacdd8768a";
+export const WEBKIT_VERSION = "autobuild-preview-pr-614-3db1d92e";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "4b9ff9959a04c70a4b0a2ae286fcfe16670e7fe1";
+export const WEBKIT_VERSION = "autobuild-preview-pr-615-8030fb83";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -958,6 +958,7 @@ const JSC::GlobalObjectMethodTable& NodeVMGlobalObject::globalObjectMethodTable(
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // shouldInterruptScriptBeforeTimeout,
+        nullptr, // moduleTypeIsAllowed
         &moduleLoaderImportModule,
         nullptr, // moduleLoaderResolve
         nullptr, // moduleLoaderFetch

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -954,6 +954,7 @@ const JSC::GlobalObjectMethodTable& GlobalObject::globalObjectMethodTable()
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // &shouldInterruptScriptBeforeTimeout,
+        nullptr, // moduleTypeIsAllowed
         &moduleLoaderImportModule, // moduleLoaderImportModule
         &moduleLoaderResolve, // moduleLoaderResolve
         &moduleLoaderFetch, // moduleLoaderFetch
@@ -982,6 +983,7 @@ const JSC::GlobalObjectMethodTable& EvalGlobalObject::globalObjectMethodTable()
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // &shouldInterruptScriptBeforeTimeout,
+        nullptr, // moduleTypeIsAllowed
         &moduleLoaderImportModule, // moduleLoaderImportModule
         &moduleLoaderResolve, // moduleLoaderResolve
         &moduleLoaderFetch, // moduleLoaderFetch
@@ -1010,6 +1012,7 @@ const JSC::GlobalObjectMethodTable& StandaloneGlobalObject::globalObjectMethodTa
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // &shouldInterruptScriptBeforeTimeout,
+        nullptr, // moduleTypeIsAllowed
         &moduleLoaderImportModule, // moduleLoaderImportModule
         &StandaloneGlobalObject::moduleLoaderResolve,
         &StandaloneGlobalObject::moduleLoaderFetch,

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -218,6 +218,7 @@ const JSC::GlobalObjectMethodTable& GlobalObject::globalObjectMethodTable()
         INHERIT_HOOK_METHOD(shouldInterruptScript),
         INHERIT_HOOK_METHOD(javaScriptRuntimeFlags),
         INHERIT_HOOK_METHOD(shouldInterruptScriptBeforeTimeout),
+        INHERIT_HOOK_METHOD(moduleTypeIsAllowed),
         bakeModuleLoaderImportModule,
         bakeModuleLoaderResolve,
         bakeModuleLoaderFetch,

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -499,8 +499,8 @@ describe("bytecode cache portability", () => {
         "bun build --bytecode happy-dom/lib/index.js": {
           "js": "75d2ad2bc252c916f90f8ca85f53f0883ca46049c2700e3c1fe2337ec42d1142",
           "jsc": {
-            "bytes": 2337296,
-            "sha256": "28afc82679782e8effeb749b20556093facb376d7d1e92de50888230412ec0e2",
+            "bytes": 2337264,
+            "sha256": "49a83aca1ac5dcf9a7a20d64259fcb39aaec3a6c47afce6254cefb2bc89dde8e",
           },
         },
         "bun build --bytecode immutable/dist/immutable.es.js": {
@@ -513,8 +513,8 @@ describe("bytecode cache portability", () => {
         "bun build --bytecode libraries.js": {
           "js": "493bab674ff49b287f26be3f356a3ad6681afb0c7eeffaa590f10cdcd8b58724",
           "jsc": {
-            "bytes": 22009464,
-            "sha256": "3107a462fc955913d0c5b93633c450d3aa6b8cccf8e10ef763efdfee9da4cf6d",
+            "bytes": 22009352,
+            "sha256": "e53f7a300c80b6d6268023bf9ea8fd2996cb704f6624f8c68095bd47f1d7684b",
           },
         },
         "bun build --bytecode lodash/lodash.js": {
@@ -555,8 +555,8 @@ describe("bytecode cache portability", () => {
         "bun build --bytecode undici/index.js": {
           "js": "e1c4f1494711ecaae57a6d63dfb8ac6096629582f55cc42530ff5a156b70c9de",
           "jsc": {
-            "bytes": 874752,
-            "sha256": "80b3b63ecb885d41b285861b0a64e121f2586edb065ed170775bcf985df49db0",
+            "bytes": 874736,
+            "sha256": "20fc4d7f3f1deec97bbd18574f07e4c58426ba4a94596299640e2362b8fdfe66",
           },
         },
         "vm.Script big.js": {

--- a/test/js/bun/jsc/date-local-time-utc-conversion.test.ts
+++ b/test/js/bun/jsc/date-local-time-utc-conversion.test.ts
@@ -1,0 +1,153 @@
+import { afterAll, describe, expect, test } from "bun:test";
+
+// The local Date setters, the multi-argument Date constructor and Date.parse of
+// a string without a UTC offset compute TimeClip(UTC(local time value)). For a
+// Date within one UTC offset of either end of the time value range that local
+// time value is itself outside the range, and UTC() has to use the zone's
+// offset at that date for it (https://tc39.es/ecma262/#sec-utc-t: "The
+// algorithm must not limit t to the time value range"). JSC used to remap such
+// a local time to a year between 2008 and 2035 before it asked ICU for the
+// offset, so the result was off by the difference between the two offsets, or
+// NaN (oven-sh/WebKit#615).
+
+const originalTZ = process.env.TZ;
+afterAll(() => {
+  if (originalTZ === undefined) delete process.env.TZ;
+  else process.env.TZ = originalTZ;
+});
+
+const minTimeValue = -8.64e15; // -271821-04-20T00:00:00.000Z
+const maxTimeValue = 8.64e15; // +275760-09-13T00:00:00.000Z
+const msPerHour = 3600 * 1000;
+const msPerDay = 24 * msPerHour;
+
+const timeValuesNearTheLimits = [
+  minTimeValue,
+  minTimeValue + 1,
+  minTimeValue + msPerHour,
+  minTimeValue + msPerDay - 1,
+  minTimeValue + msPerDay,
+  maxTimeValue - msPerDay,
+  maxTimeValue - msPerDay + 1,
+  maxTimeValue - 5 * msPerHour,
+  maxTimeValue - 1,
+  maxTimeValue,
+];
+
+// Each zone with its getTimezoneOffset() at the epoch, to tell that the zone
+// change took effect. A zone west of Greenwich at its first (local mean time)
+// offset has the local time of the minimum time value below the range, a zone
+// east of it today has the local time of the maximum above it. Asia/Manila
+// (-15:56:08 until 1844, +8 today) has both.
+const timeZones = {
+  "America/New_York": 300,
+  "America/Los_Angeles": 480,
+  "America/St_Johns": 210,
+  "Pacific/Honolulu": 600,
+  "Europe/London": -60,
+  "Europe/Paris": -60,
+  "Asia/Kolkata": -330,
+  "Asia/Tokyo": -540,
+  "Australia/Lord_Howe": -600,
+  "Pacific/Kiritimati": 640,
+  "Pacific/Apia": 660,
+  "Asia/Manila": -480,
+  UTC: 0,
+};
+
+function setTimeZone(timeZone: keyof typeof timeZones) {
+  process.env.TZ = timeZone;
+  expect(new Date(0).getTimezoneOffset()).toBe(timeZones[timeZone]);
+}
+
+describe.each(Object.keys(timeZones) as (keyof typeof timeZones)[])("in %s", timeZone => {
+  test("rebuilding a Date near the time value limits from its local fields is the identity", () => {
+    setTimeZone(timeZone);
+    const results: Record<string, number> = {};
+    const expected: Record<string, number> = {};
+    for (const timeValue of timeValuesNearTheLimits) {
+      const date = new Date(timeValue);
+      const fields = [
+        date.getFullYear(),
+        date.getMonth(),
+        date.getDate(),
+        date.getHours(),
+        date.getMinutes(),
+        date.getSeconds(),
+        date.getMilliseconds(),
+      ] as const;
+      const check = (label: string, actual: number, want = timeValue) => {
+        results[`${timeValue}: ${label}`] = actual;
+        expected[`${timeValue}: ${label}`] = want;
+      };
+      check(`new Date(${fields.join(", ")})`, new Date(...fields).getTime());
+      check(`setMilliseconds(${fields[6]})`, new Date(timeValue).setMilliseconds(fields[6]));
+      check(`setSeconds(${fields[5]})`, new Date(timeValue).setSeconds(fields[5]));
+      check(`setMinutes(${fields[4]})`, new Date(timeValue).setMinutes(fields[4]));
+      check(`setHours(${fields[3]})`, new Date(timeValue).setHours(fields[3]));
+      check(`setDate(${fields[2]})`, new Date(timeValue).setDate(fields[2]));
+      check(`setMonth(${fields[1]})`, new Date(timeValue).setMonth(fields[1]));
+      check(`setFullYear(${fields[0]})`, new Date(timeValue).setFullYear(fields[0]));
+      check(`setFullYear(${fields.slice(0, 3).join(", ")})`, new Date(timeValue).setFullYear(...fields.slice(0, 3)));
+      check(`setHours(${fields.slice(3).join(", ")})`, new Date(timeValue).setHours(...fields.slice(3)));
+
+      // One millisecond further out is not a time value any more.
+      if (timeValue === minTimeValue) {
+        check(`setMilliseconds(${fields[6] - 1})`, new Date(timeValue).setMilliseconds(fields[6] - 1), NaN);
+        check(`new Date(..., ${fields[6] - 1})`, new Date(...fields.slice(0, 6), fields[6] - 1).getTime(), NaN);
+      }
+      if (timeValue === maxTimeValue) {
+        check(`setMilliseconds(${fields[6] + 1})`, new Date(timeValue).setMilliseconds(fields[6] + 1), NaN);
+        check(`new Date(..., ${fields[6] + 1})`, new Date(...fields.slice(0, 6), fields[6] + 1).getTime(), NaN);
+      }
+    }
+    expect(results).toEqual(expected);
+  });
+
+  test("a local time more than a day beyond either limit is an Invalid Date", () => {
+    setTimeZone(timeZone);
+    expect(new Date(275760, 8, 14, 0, 0, 0, 1).getTime()).toBeNaN();
+    expect(new Date(-271821, 3, 18, 23, 59, 59, 999).getTime()).toBeNaN();
+    expect(new Date(1970, 0, 1, 0, 0, 0, 1e300).getTime()).toBeNaN();
+    expect(new Date(1970, 0, 1, 0, 0, 0, -1e300).getTime()).toBeNaN();
+    expect(new Date(0).setMilliseconds(2 ** 70)).toBeNaN();
+  });
+
+  test("Date.parse with an explicit UTC offset only TimeClips the result", () => {
+    setTimeZone(timeZone);
+    expect(Date.parse("-271821-04-19T20:00:00-04:00")).toBe(minTimeValue);
+    expect(Date.parse("+275760-09-13T05:00:00+05:00")).toBe(maxTimeValue);
+    expect(Date.parse("+275760-09-13T05:00:00.001+05:00")).toBeNaN();
+  });
+});
+
+// America/New_York is at its local mean time, -4:56:02, before 1883-11-18, so
+// the minimum time value reads as -271821-04-19T19:03:58 local time there, and
+// that local time is below the time value range.
+test("America/New_York: local times around the minimum time value", () => {
+  setTimeZone("America/New_York");
+  expect(new Date(minTimeValue).getTimezoneOffset()).toBe(296);
+  expect(new Date(-271821, 3, 19, 19, 3, 58).getTime()).toBe(minTimeValue);
+  expect(new Date(-271821, 3, 19, 19, 3, 57, 999).getTime()).toBeNaN();
+  expect(new Date(-271821, 3, 19, 20, 3, 58).getTime()).toBe(minTimeValue + msPerHour);
+  expect(new Date(minTimeValue + msPerHour).setHours(19)).toBe(minTimeValue);
+  expect(new Date(minTimeValue + msPerHour).setHours(19, 3, 57, 999)).toBeNaN();
+  expect(Date.parse("-271821-04-19T19:03:58")).toBe(minTimeValue);
+  expect(Date.parse("-271821-04-19T19:03:57.999")).toBeNaN();
+});
+
+// East of Greenwich the maximum time value has a local time past
+// +275760-09-13T00:00:00.
+test.each(["Asia/Tokyo", "Pacific/Apia", "Pacific/Kiritimati"] as const)(
+  "%s: local times around the maximum time value",
+  timeZone => {
+    setTimeZone(timeZone);
+    const offset = -new Date(maxTimeValue).getTimezoneOffset() * 60 * 1000;
+    expect(offset).toBeGreaterThan(0);
+    expect(new Date(275760, 8, 13, 0, 0, 0, offset).getTime()).toBe(maxTimeValue);
+    expect(new Date(275760, 8, 13, 0, 0, 0, offset + 1).getTime()).toBeNaN();
+    expect(new Date(275760, 8, 13, 0, 0, 0, offset - 1).getTime()).toBe(maxTimeValue - 1);
+    expect(new Date(maxTimeValue - 5 * msPerHour).setHours(offset / msPerHour)).toBe(maxTimeValue);
+    expect(new Date(maxTimeValue - 5 * msPerHour).setHours(offset / msPerHour, 0, 0, 1)).toBeNaN();
+  },
+);

--- a/test/js/bun/jsc/webkit-upgrade-ccdcb8a026.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-ccdcb8a026.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// Coverage for the WebKit ccdcb8a026 sync (oven-sh/WebKit#614). Each case pins an
+// observable difference between the old and the new JavaScriptCore. The last case
+// exercises the GlobalObjectMethodTable::moduleTypeIsAllowed slot the range adds: a
+// host-defined import attribute type must still reach Bun's module loader.
+
+describe.concurrent("WebKit ccdcb8a026 upgrade", () => {
+  test("Array.prototype.toSpliced throws RangeError for a new length of 2^53 - 1 (c8c37314ee)", () => {
+    expect(() => Array.prototype.toSpliced.call({ length: Infinity }, 0, 0)).toThrow(RangeError);
+    // One past 2^53 - 1 is still the TypeError from step 10 of the spec algorithm.
+    expect(() => Array.prototype.toSpliced.call({ length: 2 ** 53 - 1 }, 0, 0, 1)).toThrow(TypeError);
+  });
+
+  test("Atomics.isLockFree uses ToIntegerOrInfinity instead of wrapping to int32 (41294576ac)", () => {
+    expect(Atomics.isLockFree(4)).toBe(true);
+    expect(Atomics.isLockFree(4294967297)).toBe(false);
+    expect(Atomics.isLockFree(2 ** 32 + 4)).toBe(false);
+  });
+
+  test("RegExp.escape keeps supplementary code points whose low 16 bits look like syntax characters (b44e00d2f0)", () => {
+    // U+2002A has 0x002A ('*') in its low 16 bits and U+20009 has 0x0009 (TAB).
+    expect(RegExp.escape("\u{2002A}")).toBe("\u{2002A}");
+    expect(RegExp.escape("\u{20009}")).toBe("\u{20009}");
+    expect(RegExp.escape("*")).toBe("\\*");
+  });
+
+  test("a strict async generator body does not tail-call its return expression (4fa7b55ae4)", async () => {
+    async function* g() {
+      "use strict";
+      return Promise.resolve(42);
+    }
+    const result = await g().next();
+    expect(result).toEqual({ value: 42, done: true });
+  });
+
+  test("host-defined import attribute types still load through Bun's module loader (64168e4d90)", async () => {
+    using dir = tempDir("wk-module-type", {
+      "data.toml": `name = "bun"\n`,
+      "note.txt": `hello`,
+      "entry.mjs": `
+        import data from "./data.toml" with { type: "toml" };
+        import note from "./note.txt" with { type: "text" };
+        const dynamic = await import("./data.toml", { with: { type: "toml" } });
+        process.stdout.write(JSON.stringify({ name: data.name, note, dynamic: dynamic.default.name }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ name: "bun", note: "hello", dynamic: "bun" });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Stacked on #42177 (WebKit upgrade to ccdcb8a026). Until that merges, the diff also shows its commits. Only the last commit belongs to this PR: `scripts/build/deps/webkit.ts` and `test/js/bun/jsc/date-local-time-utc-conversion.test.ts`.

### Problem
- Every local `Date` setter, the multi-argument `Date` constructor and `Date.parse` of an offset-less string give a shifted time value or `NaN` for a valid Date within one UTC offset of either end of the time value range (±8.64e15 ms). `TZ=America/New_York`: `d = new Date(-8.64e15 + 36e5); d.setHours(d.getHours())` moves `d` by 56 min 2 s and `new Date(-8.64e15).setMilliseconds(0)` is `NaN`. `TZ=Pacific/Apia`: every local setter on the last 13 hours of the range is `NaN`. Node 26 returns the identity, as the note on [UTC(t)](https://tc39.es/ecma262/#sec-utc-t) requires. `TZ=UTC` is not affected, and the getters were already right.
- The cause is in JSC: `DateCache::DSTCache::localTimeOffset()` (`vendor/WebKit/Source/JavaScriptCore/runtime/JSDateMath.cpp`) remapped a local time value outside the range to the same month and day in a year between 2008 and 2035 before it asked ICU for the offset, because its offset cache cannot hold a time outside the range. So New York got EDT -4:00 instead of its local mean time -4:56:02, and Apia got its 2008 offset -11:00 instead of +13:00.

### Fix
- Pin WebKit to `autobuild-preview-pr-615-8030fb83`, the preview build of oven-sh/WebKit#615. That is oven-sh/WebKit `main` (4b9ff9959a, the pin of #42177) plus one commit: `localTimeOffset()` asks ICU directly for a time outside the range, the V8 date parser path goes through the same guarded `localTimeToMS()` as the setters, and WTF's own parser no longer clips the local value before it subtracts the offset.
- The pin is a preview tag, not a merge commit. Do not merge before #42177 and oven-sh/WebKit#615 land. I then rebase on `main` and move the pin to the merged commit.
- Verified: `test/js/bun/jsc/date-local-time-utc-conversion.test.ts` (new, 43 tests). It round-trips the ten time values nearest the limits through the constructor and every local setter in 13 zones, and pins the New York, Tokyo, Apia and Kiritimati edge cases and the `Date.parse` forms. bun 1.4.3 fails 10 of the 43, `bun bd test` with this pin (debug + ASAN) passes all. `v8-date-parser.test.js`, `cron-local-time.test.ts`, the `setTimeZone` test in `bun-jsc.test.ts` and `test-datetime-change-notify.js` pass with the pin.

### Background
- A time value is UTC milliseconds in ±8.64e15 (20 April -271821 to 13 September 275760). A local setter decomposes `t + offset(t)` into fields, edits one, recomposes a local time value `l`, and stores `TimeClip(l - offset(l))`. For `t` near a limit, `l` is past it by up to the offset.
- JSC gets offsets from an ICU `UCalendar` behind a small interval cache ported from V8. For an instant before a zone's first rule ICU returns the zone's local mean time, which is why dates that old have offsets like -4:56:02. V8 asks ICU the same way, without the remap.
- The test switches zones with `process.env.TZ`, which bun applies to the running process, and restores the original value at the end.

<details><summary>Notes</summary>

- The first revision of this PR pinned `autobuild-preview-pr-615-c1a60940`, built on the previous WebKit pin (dfd696443b). oven-sh/WebKit#614 then merged with upstream 320788@main, which adds the same ±1-day narrowing guard that revision carried. oven-sh/WebKit#615 is now rebased on it and keeps only what upstream does not have. bun cannot build against a WebKit past #614 without the embedder changes of #42177 (`GlobalObjectMethodTable` gained a slot), so this branch sits on top of that PR.
- Against the jsc shell of WebKit `main` (4b9ff9959a), the JSC stress test of oven-sh/WebKit#615 fails in the same 8 zones (constructor and setters) as bun 1.4.3 does here, so the upgrade of #42177 alone does not fix this.
- `cron-parse.test.ts` "impossible day/month (Feb 30) returns null quickly" asserts a 50 ms wall clock bound and takes about 155 ms on a local debug + ASAN build (6 ms on release 1.4.3). The same run showed that `Bun.cron.parse("0 0 30 2 *", new Date(8.64e15 - 86400000 * 400), { tz: "UTC" })` does not return on a build with the #614 WebKit. That comes from upstream's change to `computeGregorianDateTime`, not from this PR, and is tracked separately for #42177.
- oven-sh/WebKit#615 has the JSC-side verification: the new `JSTests/stress/date-local-time-utc-conversion-at-time-value-limits.js` under four option sets, test262 `built-ins/Date`, `annexB/built-ins/Date`, `intl402/Date` and `intl402/DateTimeFormat` in six zones, the mozilla Date tests and the `JSTests/complex` time zone tests, all compared against the jsc shell of WebKit `main`.
- Source of the report: a seeded differential run of `Date` against Node 26 across seven non-UTC zones. Only the local-to-UTC direction differed, and only within 14 hours of either end of the range.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_bytecode_portable.test.ts

<!-- robobun:evidence:end -->