### PR TITLE
test: tolerate one conservative-GC survivor in the aborted body stream check

### DIFF
--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -495,10 +495,10 @@ test.each(["sync", "async"])(
       await Bun.sleep(1);
       alive = streams.filter(ref => ref.deref() !== undefined).length;
     }
-    // Unfixed, every stream survives. One survivor is tolerated: the newest
-    // stream's address can linger in a native frame that is still live under
-    // this continuation (JSC::runInternalMicrotask, seen on x64 ASAN builds),
-    // where the conservative stack scan finds it.
+    // Unfixed, every stream survives. One survivor is tolerated on every build:
+    // the newest stream's address can linger in a native frame still live under
+    // this continuation (JSC::runInternalMicrotask), where the conservative
+    // stack scan finds it. Every run on x64 ASAN, rarely on release builds.
     expect(alive).toBeLessThanOrEqual(1);
   },
 );

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -490,12 +490,16 @@ test.each(["sync", "async"])(
     await stopAndAssertDrained(server);
 
     let alive = iterations;
-    for (let i = 0; i < 20 && alive > 0; i++) {
+    for (let i = 0; i < 20 && alive > 1; i++) {
       Bun.gc(true);
       await Bun.sleep(1);
       alive = streams.filter(ref => ref.deref() !== undefined).length;
     }
-    expect(alive).toBe(0);
+    // Unfixed, every stream survives. One survivor is tolerated: the newest
+    // stream's address can linger in a native frame that is still live under
+    // this continuation (JSC::runInternalMicrotask, seen on x64 ASAN builds),
+    // where the conservative stack scan finds it.
+    expect(alive).toBeLessThanOrEqual(1);
   },
 );
 

--- a/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
+++ b/test/js/bun/http/serve-pending-promise-abort-leak.test.ts
@@ -495,10 +495,9 @@ test.each(["sync", "async"])(
       await Bun.sleep(1);
       alive = streams.filter(ref => ref.deref() !== undefined).length;
     }
-    // Unfixed, every stream survives. One survivor is tolerated on every build:
-    // the newest stream's address can linger in a native frame still live under
-    // this continuation (JSC::runInternalMicrotask), where the conservative
-    // stack scan finds it. Every run on x64 ASAN, rarely on release builds.
+    // Unfixed, every stream survives. At most one may survive here: the newest
+    // stream's address can be left in a native frame that is still live under
+    // this continuation and act as a conservative root (proof in #42190).
     expect(alive).toBeLessThanOrEqual(1);
   },
 );


### PR DESCRIPTION
### Problem
- `test/js/bun/http/serve-pending-promise-abort-leak.test.ts`, both `releases the body stream it held` cases, fail on the `debian 13 x64-asan` lane: `expect(alive).toBe(0)`, `Received: 1`. Builds 113711, 113722, 113732, 113727 (3 of 3 attempts), and once on alpine x64 release (110257).
- It is not a leak. The survivor is always the last stream. A heap snapshot shows its cell with no incoming edge and no `roots` entry. At conservative root gathering, its address is on the main thread stack once: `rbp-0xa60` in the live `JSC::runInternalMicrotask` frame under the test's own `await` continuation.

### Fix
- Loop while more than one stream is alive and assert `alive <= 1`, on every build (a release lane hit it too). The leak that #41080 fixed kept every stream: with `release_body_stream` disabled in `finalize_without_deinit`, the test reports `Received: 8`.
- Verified: `release-asan` build, whole file, 3 runs each: 25 pass 2 fail before, 27 pass after. `bun bd test`: 27 pass.

### Background
- JSC scans the machine stack conservatively: a stack word that matches a cell address keeps that cell. `sanitizeStack` zeroes only dead stack below the stack pointer, so a stale value in a live caller frame survives each `Bun.gc(true)` from under it.
- An `await` continuation is a microtask and runs inside `runInternalMicrotask`. One drain earlier, the pump for the last response ran at that frame position and wrote the stream there.
- ASAN enlarges frames and stops slot reuse, so there the next call never overwrites that slot. Other builds usually do.

<details><summary>Notes</summary>

Main does not run the x64-asan test lane, so the failure only shows on PR builds.

Repro: `bun run build:asan`, then `./build/release-asan/bun-asan test test/js/bun/http/serve-pending-promise-abort-leak.test.ts`. The whole file fails 3 of 3 (25 pass, 2 fail). `-t "releases the body stream"` alone passes. `FOO=1` in the environment makes the whole file pass. The microtask that pumped the last response is what left the address in the frame: the stale code addresses around the slot are that response's teardown (see below).

Heap snapshot, taken with `generateHeapSnapshotForDebugging()` from `bun:jsc` after the 20 GC rounds, with each stream tagged by a property at creation so no `deref()` is needed to find it:

```
[diag] kind=sync alive indices: 7
[diag] ReadableStream-class nodes in snapshot: 3; total nodes 15182; total roots 446
[diag] index 7: ReadableStream#450 cell=0x7bb7b1d10700 roots=[] incoming=[]
[diag] cell 0x7bb7b1d10700: 1 hit(s) in [stack]: 0x7ffd3e0c91d0 (top-0xae30)
```

The async case is the same (index 7, `roots=[] incoming=[]`, one stack hit at the same stack address).

Stack word, from gdb as the parent (`startup-with-shell off`, `LINES`/`COLUMNS` unset, suspend signals passed through), with a breakpoint on `JSC::MachineThreads::gatherConservativeRoots` armed by the test right before one more `Bun.gc(true)` from the same continuation. Frame-pointer walk of the main thread at that point, newest first (GC frames 0 to 16 elided):

```
#17 JSC__VM__runGC + 324
#18 bun_runtime::hw_exports::bindgen_bunobject_dispatch_gc + 234
#19 bindgen_BunObject_jsGc + 696
#20 0x7283b20141b8 (JIT)
#21 op_call_ignore_result_return_location
#22 llint_call_javascript + 6
#23 JSC::asyncFunctionGeneratorBodyCall(...)            rbp=0x7ffcc6f06db0
#24 JSC::runInternalMicrotask(...)                      rbp=0x7ffcc6f07cd0
#25 JSC::MicrotaskQueue::drainWithUseCallOnEachMicrotask(...) + 1500
#26 JSC::VM::drainMicrotasks() + 2166
#27 Bun::jsFunctionDrainMicrotaskQueue(...) + 42
#28-#30 JS (processTicksAndRejections), llint_call_javascript
#31-#34 JSC::Interpreter::executeCall / JSC::call
#35 Bun::JSNextTickQueue::drain(...) + 1272
#36 Zig::GlobalObject::drainMicrotasks() + 853
#37 bun_jsc::event_loop::EventLoop::drain_microtasks_with_global
#38 bun_jsc::event_loop::EventLoop::exit
#39 bun_runtime::timer::...::TimerObjectInternals::fire      (the Bun.sleep(1) timer)
#40 __bun_fire_timer
#41 bun_runtime::timer::All::drain_timers
#42 bun_runtime::jsc_hooks::auto_tick
...
victim 0x7283f3d10700: 1 aligned hit(s) in live stack [rsp=0x7ffcc6f00dd0, top=0x7ffcc6f13000): 0x7ffcc6f07270
  hit 0x7ffcc6f07270 lies in frame #24 (JSC::runInternalMicrotask): rbp=0x7ffcc6f07cd0, slot = rbp-0xa60
```

Stale code addresses next to that slot (symbolized): `WebCore::JSReadableHTTPResponseSinkController__endImpl`, `RequestContext::end_request_streaming`, `uWS::HttpContext<false>::onClose`, `us_internal_socket_close_raw`, a return address inside `JSC::runInternalMicrotask`, and `__interceptor_free` / `__sanitizer::BufferedStackTrace::UnwindImpl`. That is the teardown of the last aborted response.

#41409 adds a retainer report to this test and lists the file as flaky because the cause was not known then. This is the answer that report was meant to find. #40539 rewrites the file for speed and does not touch this assertion's meaning.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/serve-pending-promise-abort-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/serve-pending-promise-abort-leak.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/http/serve-pending-promise-abort-leak.test.ts:
(pass) RequestContext is freed when client aborts before Promise<Response> settles (http2: false) [2636.71ms]
(pass) RequestContext is freed when client aborts before Promise<Response> settles (http2: true) [2174.72ms]
(pass) Promise<Response> still works normally when not aborted [34.15ms]
(pass) resolve() inside abort handler is handled safely [33.72ms]
(pass) streaming 413 detaches the response so a late resolve/reject is a no-op [7332.69ms]
(pass) chunked request body consumed as a ReadableStream is capped at maxRequestBodySize [481.38ms]
(pass) client abort frees the context even while the resolve function stays reachable [42.78ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending req.text() read [51.95ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending for await (req.body) read [39.60ms]
(pass) client abort while a direct stream pull() is parked frees the context and rejects a pending req.textStream() read [39.15ms]
(pass) pendingRequests drops when the client aborts a parked direct-stream pull(), and the late pull() settle is a no-op [109.16ms]
(pass) client abort of a streaming Response releases the body stream it held (sync handler) [123.05ms]
(pass) client abort of a streaming Response releases the body stream it held (async handler) [100.93ms]
(pass) releasing a parked pull() after the abort tore down the context and the server is a no-op (stop-then-abort) [349.74ms]
(pass) releasing a parked pull() after the abort tore down the context and the server is a no-op (abort-then-stop) [338.88ms]
(pass) async server.upgrade() frees the context while the handler promise stays parked [68.48ms]
(pass) 413 on a chunked upload frees th
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/serve-pending-promise-abort-leak.test.ts | 7 +++++--
 1 file changed, 5 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…st/js/bun/http/serve-pending-promise-abort-leak.test.ts      5      4     14
```

</details>

<!-- robobun:evidence:end -->