### PR TITLE
URLPattern: throw instead of aborting when a pattern string passes the string limit

### DIFF
--- a/src/jsc/bindings/webcore/URLPattern.cpp
+++ b/src/jsc/bindings/webcore/URLPattern.cpp
@@ -45,7 +45,7 @@ namespace WebCore {
 using namespace JSC;
 
 // https://urlpattern.spec.whatwg.org/#process-a-base-url-string
-static String processBaseURLString(StringView input, BaseURLStringType type)
+static ExceptionOr<String> processBaseURLString(StringView input, BaseURLStringType type)
 {
     if (type != BaseURLStringType::Pattern)
         return input.toString();
@@ -82,27 +82,50 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
         if (!baseURL.isValid())
             return Exception { ExceptionCode::TypeError, "Invalid baseURL."_s };
 
-        if (init.protocol.isNull())
-            result.protocol = processBaseURLString(baseURL.protocol(), type);
+        if (init.protocol.isNull()) {
+            auto protocolResult = processBaseURLString(baseURL.protocol(), type);
+
+            if (protocolResult.hasException())
+                return protocolResult.releaseException();
+
+            result.protocol = protocolResult.releaseReturnValue();
+        }
 
         if (type != BaseURLStringType::Pattern
             && init.protocol.isNull()
             && init.hostname.isNull()
             && init.port.isNull()
-            && init.username.isNull())
-            result.username = processBaseURLString(baseURL.user(), type);
+            && init.username.isNull()) {
+            auto usernameResult = processBaseURLString(baseURL.user(), type);
+
+            if (usernameResult.hasException())
+                return usernameResult.releaseException();
+
+            result.username = usernameResult.releaseReturnValue();
+        }
 
         if (type != BaseURLStringType::Pattern
             && init.protocol.isNull()
             && init.hostname.isNull()
             && init.port.isNull()
             && init.username.isNull()
-            && init.password.isNull())
-            result.password = processBaseURLString(baseURL.password(), type);
+            && init.password.isNull()) {
+            auto passwordResult = processBaseURLString(baseURL.password(), type);
+
+            if (passwordResult.hasException())
+                return passwordResult.releaseException();
+
+            result.password = passwordResult.releaseReturnValue();
+        }
 
         if (init.protocol.isNull()
             && init.hostname.isNull()) {
-            result.hostname = processBaseURLString(!baseURL.host().isNull() ? baseURL.host() : StringView { emptyString() }, type);
+            auto hostnameResult = processBaseURLString(!baseURL.host().isNull() ? baseURL.host() : StringView { emptyString() }, type);
+
+            if (hostnameResult.hasException())
+                return hostnameResult.releaseException();
+
+            result.hostname = hostnameResult.releaseReturnValue();
         }
 
         if (init.protocol.isNull()
@@ -116,7 +139,12 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
             && init.hostname.isNull()
             && init.port.isNull()
             && init.pathname.isNull()) {
-            result.pathname = processBaseURLString(baseURL.path(), type);
+            auto pathnameResult = processBaseURLString(baseURL.path(), type);
+
+            if (pathnameResult.hasException())
+                return pathnameResult.releaseException();
+
+            result.pathname = pathnameResult.releaseReturnValue();
         }
 
         if (init.protocol.isNull()
@@ -124,7 +152,12 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
             && init.port.isNull()
             && init.pathname.isNull()
             && init.search.isNull()) {
-            result.search = processBaseURLString(baseURL.hasQuery() ? baseURL.query() : StringView { emptyString() }, type);
+            auto searchResult = processBaseURLString(baseURL.hasQuery() ? baseURL.query() : StringView { emptyString() }, type);
+
+            if (searchResult.hasException())
+                return searchResult.releaseException();
+
+            result.search = searchResult.releaseReturnValue();
         }
 
         if (init.protocol.isNull()
@@ -133,7 +166,12 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
             && init.pathname.isNull()
             && init.search.isNull()
             && init.hash.isNull()) {
-            result.hash = processBaseURLString(baseURL.hasFragmentIdentifier() ? baseURL.fragmentIdentifier() : StringView { emptyString() }, type);
+            auto hashResult = processBaseURLString(baseURL.hasFragmentIdentifier() ? baseURL.fragmentIdentifier() : StringView { emptyString() }, type);
+
+            if (hashResult.hasException())
+                return hashResult.releaseException();
+
+            result.hash = hashResult.releaseReturnValue();
         }
     }
 
@@ -174,11 +212,24 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
         result.pathname = init.pathname;
 
         if (!baseURL.isNull() && !baseURL.hasOpaquePath() && !isAbsolutePathname(result.pathname, type)) {
-            auto baseURLPath = processBaseURLString(baseURL.path(), type);
+            auto baseURLPathResult = processBaseURLString(baseURL.path(), type);
+
+            if (baseURLPathResult.hasException())
+                return baseURLPathResult.releaseException();
+
+            auto baseURLPath = baseURLPathResult.releaseReturnValue();
             size_t slashIndex = baseURLPath.reverseFind('/');
 
-            if (slashIndex != notFound)
-                result.pathname = makeString(StringView { baseURLPath }.left(slashIndex + 1), result.pathname);
+            if (slashIndex != notFound) {
+                // The base path and the pathname are each below String::MaxLength,
+                // but their sum does not have to be.
+                auto joined = tryMakeString(StringView { baseURLPath }.left(slashIndex + 1), result.pathname);
+
+                if (joined.isNull()) [[unlikely]]
+                    return Exception { ExceptionCode::OutOfMemoryError };
+
+                result.pathname = WTF::move(joined);
+            }
         }
         auto pathResult = processPathname(result.pathname, result.protocol, type);
 

--- a/src/jsc/bindings/webcore/URLPattern.cpp
+++ b/src/jsc/bindings/webcore/URLPattern.cpp
@@ -221,8 +221,6 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
             size_t slashIndex = baseURLPath.reverseFind('/');
 
             if (slashIndex != notFound) {
-                // The base path and the pathname are each below String::MaxLength,
-                // but their sum does not have to be.
                 auto joined = tryMakeString(StringView { baseURLPath }.left(slashIndex + 1), result.pathname);
 
                 if (joined.isNull()) [[unlikely]]

--- a/src/jsc/bindings/webcore/URLPattern.cpp
+++ b/src/jsc/bindings/webcore/URLPattern.cpp
@@ -223,7 +223,7 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
             if (slashIndex != notFound) {
                 auto joined = tryMakeString(StringView { baseURLPath }.left(slashIndex + 1), result.pathname);
 
-                if (joined.isNull()) [[unlikely]]
+                if (joined.isNull() || exceedsStringLimit(joined.length())) [[unlikely]]
                     return Exception { ExceptionCode::OutOfMemoryError };
 
                 result.pathname = WTF::move(joined);

--- a/src/jsc/bindings/webcore/URLPattern.cpp
+++ b/src/jsc/bindings/webcore/URLPattern.cpp
@@ -223,7 +223,7 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
             if (slashIndex != notFound) {
                 auto joined = tryMakeString(StringView { baseURLPath }.left(slashIndex + 1), result.pathname);
 
-                if (joined.isNull() || exceedsStringLimit(joined.length())) [[unlikely]]
+                if (joined.isNull()) [[unlikely]]
                     return Exception { ExceptionCode::OutOfMemoryError };
 
                 result.pathname = WTF::move(joined);

--- a/src/jsc/bindings/webcore/URLPatternCanonical.cpp
+++ b/src/jsc/bindings/webcore/URLPatternCanonical.cpp
@@ -29,6 +29,7 @@
 #include "ExceptionOr.h"
 #include "URLDecomposition.h"
 #include "URLPattern.h"
+#include "helpers.h"
 #include <wtf/URL.h>
 #include <wtf/URLParser.h>
 #include <wtf/text/MakeString.h>
@@ -36,6 +37,11 @@
 namespace WebCore {
 
 static constexpr auto dummyURLCharacters { "https://w/"_s };
+
+bool exceedsStringLimit(size_t length)
+{
+    return length > Bun__stringSyntheticAllocationLimit || length > String::MaxLength;
+}
 
 static bool isValidIPv6HostCodePoint(auto codepoint)
 {
@@ -78,7 +84,12 @@ ExceptionOr<String> canonicalizeProtocol(StringView value, BaseURLStringType val
     if (valueType == BaseURLStringType::Pattern)
         return strippedValue.toString();
 
-    URL dummyURL(makeString(strippedValue, "://w/"_s));
+    auto dummyURLString = tryMakeString(strippedValue, "://w/"_s);
+
+    if (dummyURLString.isNull() || exceedsStringLimit(dummyURLString.length())) [[unlikely]]
+        return Exception { ExceptionCode::OutOfMemoryError };
+
+    URL dummyURL(WTF::move(dummyURLString));
 
     if (!dummyURL.isValid())
         return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL protocol string."_s };
@@ -177,7 +188,12 @@ ExceptionOr<String> canonicalizeOpaquePathname(StringView value)
     if (value.isEmpty())
         return value.toString();
 
-    URL dummyURL(makeString("a:"_s, value));
+    auto dummyURLString = tryMakeString("a:"_s, value);
+
+    if (dummyURLString.isNull() || exceedsStringLimit(dummyURLString.length())) [[unlikely]]
+        return Exception { ExceptionCode::OutOfMemoryError };
+
+    URL dummyURL(WTF::move(dummyURLString));
 
     if (!dummyURL.isValid())
         return Exception { ExceptionCode::TypeError, "Invalid input to canonicalize a URL opaque path string."_s };
@@ -192,7 +208,10 @@ ExceptionOr<String> canonicalizePathname(StringView pathnameValue)
         return pathnameValue.toString();
 
     bool hasLeadingSlash = pathnameValue[0] == '/';
-    String maybeAddSlashPrefix = hasLeadingSlash ? pathnameValue.toString() : makeString("/-"_s, pathnameValue);
+    String maybeAddSlashPrefix = hasLeadingSlash ? pathnameValue.toString() : tryMakeString("/-"_s, pathnameValue);
+
+    if (maybeAddSlashPrefix.isNull() || exceedsStringLimit(maybeAddSlashPrefix.length())) [[unlikely]]
+        return Exception { ExceptionCode::OutOfMemoryError };
 
     // FIXME: Set state override to State::PathStart after URLParser supports state override.
     URL dummyURL(dummyURLCharacters);

--- a/src/jsc/bindings/webcore/URLPatternCanonical.h
+++ b/src/jsc/bindings/webcore/URLPatternCanonical.h
@@ -44,6 +44,11 @@ enum class EncodingCallbackType : uint8_t { Protocol,
     Search,
     Hash };
 
+// True when a string of this length cannot be built. The limit is String::MaxLength, or the
+// lower one setSyntheticAllocationLimitForTesting sets, which is how the tests reach these
+// paths without a 2 GB allocation.
+bool exceedsStringLimit(size_t length);
+
 bool isAbsolutePathname(StringView input, BaseURLStringType inputType);
 ExceptionOr<String> canonicalizeProtocol(StringView, BaseURLStringType valueType);
 String canonicalizeUsername(StringView value, BaseURLStringType valueType);

--- a/src/jsc/bindings/webcore/URLPatternCanonical.h
+++ b/src/jsc/bindings/webcore/URLPatternCanonical.h
@@ -44,9 +44,7 @@ enum class EncodingCallbackType : uint8_t { Protocol,
     Search,
     Hash };
 
-// True when a string of this length cannot be built. The limit is String::MaxLength, or the
-// lower one setSyntheticAllocationLimitForTesting sets, which is how the tests reach these
-// paths without a 2 GB allocation.
+// String::MaxLength, or the lower limit setSyntheticAllocationLimitForTesting sets.
 bool exceedsStringLimit(size_t length);
 
 bool isAbsolutePathname(StringView input, BaseURLStringType inputType);

--- a/src/jsc/bindings/webcore/URLPatternComponent.cpp
+++ b/src/jsc/bindings/webcore/URLPatternComponent.cpp
@@ -53,7 +53,10 @@ ExceptionOr<URLPatternComponent> URLPatternComponent::compile(Ref<JSC::VM> vm, S
         return maybePartList.releaseException();
     Vector<Part> partList = maybePartList.releaseReturnValue();
 
-    auto [regularExpressionString, nameList] = generateRegexAndNameList(partList, options);
+    auto maybeRegexAndNameList = generateRegexAndNameList(partList, options);
+    if (maybeRegexAndNameList.hasException())
+        return maybeRegexAndNameList.releaseException();
+    auto [regularExpressionString, nameList] = maybeRegexAndNameList.releaseReturnValue();
 
     OptionSet<JSC::Yarr::Flags> flags = { JSC::Yarr::Flags::UnicodeSets };
     if (options.ignoreCase)

--- a/src/jsc/bindings/webcore/URLPatternComponent.cpp
+++ b/src/jsc/bindings/webcore/URLPatternComponent.cpp
@@ -63,7 +63,10 @@ ExceptionOr<URLPatternComponent> URLPatternComponent::compile(Ref<JSC::VM> vm, S
     if (!regularExpression->isValid())
         return Exception { ExceptionCode::TypeError, "Unable to create RegExp object regular expression from provided URLPattern string."_s };
 
-    String patternString = generatePatternString(partList, options);
+    auto maybePatternString = generatePatternString(partList, options);
+    if (maybePatternString.hasException())
+        return maybePatternString.releaseException();
+    String patternString = maybePatternString.releaseReturnValue();
 
     bool hasRegexGroups = partList.containsIf([](auto& part) {
         return part.type == PartType::Regexp;

--- a/src/jsc/bindings/webcore/URLPatternParser.cpp
+++ b/src/jsc/bindings/webcore/URLPatternParser.cpp
@@ -306,9 +306,7 @@ ExceptionOr<Vector<Part>> URLPatternParser::parse(StringView patternStringInput,
     return tokenParser.takePartList();
 }
 
-// Shared by the regexp and pattern escapers. With an OverflowPolicy::RecordOverflow builder
-// the loop stops at the character that passes String::MaxLength and the caller checks
-// hasOverflowed(), so `characters` can have any length the caller was handed.
+// Shared by the regexp and pattern escapers. The loop stops at the character that overflows.
 template<typename CharacterType, std::size_t setSize>
 static void appendWithBackslashEscapes(StringBuilder& result, std::span<const CharacterType> characters, const std::array<CharacterType, setSize>& escapeSet)
 {
@@ -567,7 +565,7 @@ ExceptionOr<String> escapePatternString(StringView input)
     StringBuilder result { OverflowPolicy::RecordOverflow };
     appendEscapedPatternString(result, input);
 
-    if (result.hasOverflowed() || exceedsStringLimit(result.length())) [[unlikely]]
+    if (result.hasOverflowed()) [[unlikely]]
         return Exception { ExceptionCode::OutOfMemoryError };
 
     return String { result.toString() };

--- a/src/jsc/bindings/webcore/URLPatternParser.cpp
+++ b/src/jsc/bindings/webcore/URLPatternParser.cpp
@@ -526,22 +526,17 @@ static void appendEscapedPatternStringForCharacters(StringBuilder& result, std::
     if (result.hasOverflowed()) [[unlikely]]
         return;
 
-    // An escape adds a character, so the result is never shorter than the input.
-    // A capacity above String::MaxLength cannot be reserved, and the appends
-    // below record that overflow.
-    auto requiredCapacity = static_cast<uint64_t>(result.length()) + characters.size();
-    if (requiredCapacity <= String::MaxLength)
-        result.reserveCapacity(static_cast<unsigned>(requiredCapacity));
+    // The result is at least this long. A capacity past String::MaxLength records the overflow here.
+    result.reserveCapacity(saturatingSum<unsigned>(result.length(), static_cast<unsigned>(characters.size())));
 
     for (auto character : characters) {
+        if (result.hasOverflowed()) [[unlikely]]
+            return;
+
         if (std::ranges::find(escapeCharacters, character) != escapeCharacters.end())
             result.append('\\');
 
         result.append(character);
-
-        // The rest of the input cannot change the outcome, and it can be long.
-        if (result.hasOverflowed()) [[unlikely]]
-            return;
     }
 }
 

--- a/src/jsc/bindings/webcore/URLPatternParser.cpp
+++ b/src/jsc/bindings/webcore/URLPatternParser.cpp
@@ -306,39 +306,58 @@ ExceptionOr<Vector<Part>> URLPatternParser::parse(StringView patternStringInput,
     return tokenParser.takePartList();
 }
 
-// https://urlpattern.spec.whatwg.org/#generate-a-segment-wildcard-regexp
-String generateSegmentWildcardRegexp(const URLPatternStringOptions& options)
+// Shared by the regexp and pattern escapers. With an OverflowPolicy::RecordOverflow builder
+// the loop stops at the character that passes String::MaxLength and the caller checks
+// hasOverflowed(), so `characters` can have any length the caller was handed.
+template<typename CharacterType, std::size_t setSize>
+static void appendWithBackslashEscapes(StringBuilder& result, std::span<const CharacterType> characters, const std::array<CharacterType, setSize>& escapeSet)
 {
-    return makeString("[^"_s, escapeRegexString(options.delimiterCodepoint), "]+?"_s);
-}
+    if (result.hasOverflowed()) [[unlikely]]
+        return;
 
-template<typename CharacterType>
-static String escapeRegexStringForCharacters(std::span<const CharacterType> characters)
-{
-    static constexpr auto regexEscapeCharacters = std::to_array<const CharacterType>({ '.', '+', '*', '?', '^', '$', '{', '}', '(', ')', '[', ']', '|', '/', '\\' }); // NOLINT
-
-    StringBuilder result;
-    result.reserveCapacity(characters.size());
+    if (result.isEmpty())
+        result.reserveCapacity(static_cast<unsigned>(characters.size()));
 
     for (auto character : characters) {
-        if (std::ranges::find(regexEscapeCharacters, character) != regexEscapeCharacters.end())
+        if (result.hasOverflowed()) [[unlikely]]
+            return;
+
+        if (std::ranges::find(escapeSet, character) != escapeSet.end())
             result.append('\\');
 
         result.append(character);
     }
+}
 
-    return result.toString();
+template<typename CharacterType>
+static void appendEscapedRegexStringForCharacters(StringBuilder& result, std::span<const CharacterType> characters)
+{
+    static constexpr auto regexEscapeCharacters = std::to_array<const CharacterType>({ '.', '+', '*', '?', '^', '$', '{', '}', '(', ')', '[', ']', '|', '/', '\\' }); // NOLINT
+
+    appendWithBackslashEscapes(result, characters, regexEscapeCharacters);
 }
 
 // https://urlpattern.spec.whatwg.org/#escape-a-regexp-string
-String escapeRegexString(StringView input)
+static void appendEscapedRegexString(StringBuilder& result, StringView input)
 {
     // FIXME: Ensure input only contains ASCII based on spec after the parser (or tokenizer) knows to filter non-ASCII input.
 
     if (input.is8Bit())
-        return escapeRegexStringForCharacters(input.span8());
+        appendEscapedRegexStringForCharacters(result, input.span8());
+    else
+        appendEscapedRegexStringForCharacters(result, input.span16());
+}
 
-    return escapeRegexStringForCharacters(input.span16());
+// https://urlpattern.spec.whatwg.org/#generate-a-segment-wildcard-regexp
+String generateSegmentWildcardRegexp(const URLPatternStringOptions& options)
+{
+    // delimiterCodepoint is empty or one code point, chosen per component, so this cannot overflow.
+    StringBuilder result;
+    result.append("[^"_s);
+    appendEscapedRegexString(result, options.delimiterCodepoint);
+    result.append("]+?"_s);
+
+    return result.toString();
 }
 
 // https://urlpattern.spec.whatwg.org/#convert-a-modifier-to-a-string
@@ -357,9 +376,9 @@ ASCIILiteral convertModifierToString(Modifier modifier)
 }
 
 // https://urlpattern.spec.whatwg.org/#generate-a-regular-expression-and-name-list
-std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& partList, const URLPatternStringOptions& options)
+ExceptionOr<std::pair<String, Vector<String>>> generateRegexAndNameList(const Vector<Part>& partList, const URLPatternStringOptions& options)
 {
-    StringBuilder result;
+    StringBuilder result { OverflowPolicy::RecordOverflow };
     result.append('^');
 
     Vector<String> nameList;
@@ -367,9 +386,12 @@ std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& p
     for (auto& part : partList) {
         if (part.type == PartType::FixedText) {
             if (part.modifier == Modifier::None)
-                result.append(escapeRegexString(part.value));
-            else
-                result.append("(?:"_s, escapeRegexString(part.value), ')', convertModifierToString(part.modifier));
+                appendEscapedRegexString(result, part.value);
+            else {
+                result.append("(?:"_s);
+                appendEscapedRegexString(result, part.value);
+                result.append(')', convertModifierToString(part.modifier));
+            }
 
             continue;
         }
@@ -397,7 +419,11 @@ std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& p
         }
 
         if (part.modifier == Modifier::None || part.modifier == Modifier::Optional) {
-            result.append("(?:"_s, escapeRegexString(part.prefix), '(', regexpValue, ')', escapeRegexString(part.suffix), ')', convertModifierToString(part.modifier));
+            result.append("(?:"_s);
+            appendEscapedRegexString(result, part.prefix);
+            result.append('(', regexpValue, ')');
+            appendEscapedRegexString(result, part.suffix);
+            result.append(')', convertModifierToString(part.modifier));
 
             continue;
         }
@@ -405,18 +431,14 @@ std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& p
         ASSERT(part.modifier == Modifier::ZeroOrMore || part.modifier == Modifier::OneOrMore);
         ASSERT(!part.prefix.isEmpty() || !part.suffix.isEmpty());
 
-        result.append("(?:"_s,
-            escapeRegexString(part.prefix),
-            "((?:"_s,
-            regexpValue,
-            ")(?:"_s,
-            escapeRegexString(part.suffix),
-            escapeRegexString(part.prefix),
-            "(?:"_s,
-            regexpValue,
-            "))*)"_s,
-            escapeRegexString(part.suffix),
-            ')');
+        result.append("(?:"_s);
+        appendEscapedRegexString(result, part.prefix);
+        result.append("((?:"_s, regexpValue, ")(?:"_s);
+        appendEscapedRegexString(result, part.suffix);
+        appendEscapedRegexString(result, part.prefix);
+        result.append("(?:"_s, regexpValue, "))*)"_s);
+        appendEscapedRegexString(result, part.suffix);
+        result.append(')');
 
         if (part.modifier == Modifier::ZeroOrMore)
             result.append('?');
@@ -424,7 +446,10 @@ std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& p
 
     result.append('$');
 
-    return { result.toString(), WTF::move(nameList) };
+    if (result.hasOverflowed() || exceedsStringLimit(result.length())) [[unlikely]]
+        return Exception { ExceptionCode::OutOfMemoryError };
+
+    return std::pair { String { result.toString() }, WTF::move(nameList) };
 }
 
 static void appendEscapedPatternString(StringBuilder&, StringView);
@@ -512,7 +537,7 @@ ExceptionOr<String> generatePatternString(const Vector<Part>& partList, const UR
         result.append(convertModifierToString(part.modifier));
     }
 
-    if (result.hasOverflowed()) [[unlikely]]
+    if (result.hasOverflowed() || exceedsStringLimit(result.length())) [[unlikely]]
         return Exception { ExceptionCode::OutOfMemoryError };
 
     return String { result.toString() };
@@ -523,21 +548,7 @@ static void appendEscapedPatternStringForCharacters(StringBuilder& result, std::
 {
     static constexpr auto escapeCharacters = std::to_array<const CharacterType>({ '+', '*', '?', ':', '(', ')', '\\', '{', '}' }); // NOLINT
 
-    if (result.hasOverflowed()) [[unlikely]]
-        return;
-
-    // The result is at least this long. A capacity past String::MaxLength records the overflow here.
-    result.reserveCapacity(saturatingSum<unsigned>(result.length(), static_cast<unsigned>(characters.size())));
-
-    for (auto character : characters) {
-        if (result.hasOverflowed()) [[unlikely]]
-            return;
-
-        if (std::ranges::find(escapeCharacters, character) != escapeCharacters.end())
-            result.append('\\');
-
-        result.append(character);
-    }
+    appendWithBackslashEscapes(result, characters, escapeCharacters);
 }
 
 // https://urlpattern.spec.whatwg.org/#escape-a-pattern-string
@@ -556,7 +567,7 @@ ExceptionOr<String> escapePatternString(StringView input)
     StringBuilder result { OverflowPolicy::RecordOverflow };
     appendEscapedPatternString(result, input);
 
-    if (result.hasOverflowed()) [[unlikely]]
+    if (result.hasOverflowed() || exceedsStringLimit(result.length())) [[unlikely]]
         return Exception { ExceptionCode::OutOfMemoryError };
 
     return String { result.toString() };

--- a/src/jsc/bindings/webcore/URLPatternParser.cpp
+++ b/src/jsc/bindings/webcore/URLPatternParser.cpp
@@ -538,6 +538,10 @@ static void appendEscapedPatternStringForCharacters(StringBuilder& result, std::
             result.append('\\');
 
         result.append(character);
+
+        // The rest of the input cannot change the outcome, and it can be long.
+        if (result.hasOverflowed()) [[unlikely]]
+            return;
     }
 }
 

--- a/src/jsc/bindings/webcore/URLPatternParser.cpp
+++ b/src/jsc/bindings/webcore/URLPatternParser.cpp
@@ -427,10 +427,12 @@ std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& p
     return { result.toString(), WTF::move(nameList) };
 }
 
+static void appendEscapedPatternString(StringBuilder&, StringView);
+
 // https://urlpattern.spec.whatwg.org/#generate-a-pattern-string
-String generatePatternString(const Vector<Part>& partList, const URLPatternStringOptions& options)
+ExceptionOr<String> generatePatternString(const Vector<Part>& partList, const URLPatternStringOptions& options)
 {
-    StringBuilder result;
+    StringBuilder result { OverflowPolicy::RecordOverflow };
 
     for (size_t index = 0; index < partList.size(); ++index) {
         auto& part = partList[index];
@@ -445,11 +447,13 @@ String generatePatternString(const Vector<Part>& partList, const URLPatternStrin
 
         if (part.type == PartType::FixedText) {
             if (part.modifier == Modifier::None) {
-                result.append(escapePatternString(part.value));
+                appendEscapedPatternString(result, part.value);
 
                 continue;
             }
-            result.append('{', escapePatternString(part.value), '}', convertModifierToString(part.modifier));
+            result.append('{');
+            appendEscapedPatternString(result, part.value);
+            result.append('}', convertModifierToString(part.modifier));
 
             continue;
         }
@@ -479,7 +483,7 @@ String generatePatternString(const Vector<Part>& partList, const URLPatternStrin
         if (needsGrouping)
             result.append('{');
 
-        result.append(escapePatternString(part.prefix));
+        appendEscapedPatternString(result, part.prefix);
 
         if (hasCustomName)
             result.append(':', part.name);
@@ -500,7 +504,7 @@ String generatePatternString(const Vector<Part>& partList, const URLPatternStrin
         if (part.type == PartType::SegmentWildcard && hasCustomName && !part.suffix.isEmpty() && isValidNameCodepoint(*StringView(part.suffix).codePoints().begin(), IsFirst::Yes))
             result.append('\\');
 
-        result.append(escapePatternString(part.suffix));
+        appendEscapedPatternString(result, part.suffix);
 
         if (needsGrouping)
             result.append('}');
@@ -508,16 +512,26 @@ String generatePatternString(const Vector<Part>& partList, const URLPatternStrin
         result.append(convertModifierToString(part.modifier));
     }
 
-    return result.toString();
+    if (result.hasOverflowed()) [[unlikely]]
+        return Exception { ExceptionCode::OutOfMemoryError };
+
+    return String { result.toString() };
 }
 
 template<typename CharacterType>
-static String escapePatternStringForCharacters(std::span<const CharacterType> characters)
+static void appendEscapedPatternStringForCharacters(StringBuilder& result, std::span<const CharacterType> characters)
 {
     static constexpr auto escapeCharacters = std::to_array<const CharacterType>({ '+', '*', '?', ':', '(', ')', '\\', '{', '}' }); // NOLINT
 
-    StringBuilder result;
-    result.reserveCapacity(characters.size());
+    if (result.hasOverflowed()) [[unlikely]]
+        return;
+
+    // An escape adds a character, so the result is never shorter than the input.
+    // A capacity above String::MaxLength cannot be reserved, and the appends
+    // below record that overflow.
+    auto requiredCapacity = static_cast<uint64_t>(result.length()) + characters.size();
+    if (requiredCapacity <= String::MaxLength)
+        result.reserveCapacity(static_cast<unsigned>(requiredCapacity));
 
     for (auto character : characters) {
         if (std::ranges::find(escapeCharacters, character) != escapeCharacters.end())
@@ -525,19 +539,28 @@ static String escapePatternStringForCharacters(std::span<const CharacterType> ch
 
         result.append(character);
     }
-
-    return result.toString();
 }
 
 // https://urlpattern.spec.whatwg.org/#escape-a-pattern-string
-String escapePatternString(StringView input)
+static void appendEscapedPatternString(StringBuilder& result, StringView input)
 {
     // FIXME: Ensure input only contains ASCII based on spec after the parser (or tokenizer) knows to filter non-ASCII input.
 
     if (input.is8Bit())
-        return escapePatternStringForCharacters(input.span8());
+        appendEscapedPatternStringForCharacters(result, input.span8());
+    else
+        appendEscapedPatternStringForCharacters(result, input.span16());
+}
 
-    return escapePatternStringForCharacters(input.span16());
+ExceptionOr<String> escapePatternString(StringView input)
+{
+    StringBuilder result { OverflowPolicy::RecordOverflow };
+    appendEscapedPatternString(result, input);
+
+    if (result.hasOverflowed()) [[unlikely]]
+        return Exception { ExceptionCode::OutOfMemoryError };
+
+    return String { result.toString() };
 }
 
 // https://urlpattern.spec.whatwg.org/#is-a-valid-name-code-point

--- a/src/jsc/bindings/webcore/URLPatternParser.h
+++ b/src/jsc/bindings/webcore/URLPatternParser.h
@@ -102,10 +102,7 @@ String generateSegmentWildcardRegexp(const URLPatternStringOptions&);
 String escapeRegexString(StringView);
 ASCIILiteral convertModifierToString(Modifier);
 std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& partList, const URLPatternStringOptions&);
-
-// Both fail with an OutOfMemoryError when the string they build would be longer
-// than String::MaxLength. An escape adds a character, so an input below that
-// limit can escape to a result above it.
+// OutOfMemoryError when the result would pass String::MaxLength (escaping can double the input).
 ExceptionOr<String> generatePatternString(const Vector<Part>& partList, const URLPatternStringOptions&);
 ExceptionOr<String> escapePatternString(StringView input);
 bool isValidNameCodepoint(char32_t codepoint, URLPatternUtilities::IsFirst);

--- a/src/jsc/bindings/webcore/URLPatternParser.h
+++ b/src/jsc/bindings/webcore/URLPatternParser.h
@@ -102,8 +102,12 @@ String generateSegmentWildcardRegexp(const URLPatternStringOptions&);
 String escapeRegexString(StringView);
 ASCIILiteral convertModifierToString(Modifier);
 std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& partList, const URLPatternStringOptions&);
-String generatePatternString(const Vector<Part>& partList, const URLPatternStringOptions&);
-String escapePatternString(StringView input);
+
+// Both fail with an OutOfMemoryError when the string they build would be longer
+// than String::MaxLength. An escape adds a character, so an input below that
+// limit can escape to a result above it.
+ExceptionOr<String> generatePatternString(const Vector<Part>& partList, const URLPatternStringOptions&);
+ExceptionOr<String> escapePatternString(StringView input);
 bool isValidNameCodepoint(char32_t codepoint, URLPatternUtilities::IsFirst);
 
 } // namespace URLPatternUtilities

--- a/src/jsc/bindings/webcore/URLPatternParser.h
+++ b/src/jsc/bindings/webcore/URLPatternParser.h
@@ -99,10 +99,9 @@ private:
 
 // FIXME: Consider moving functions to somewhere generic, perhaps refactor Part to its own class.
 String generateSegmentWildcardRegexp(const URLPatternStringOptions&);
-String escapeRegexString(StringView);
 ASCIILiteral convertModifierToString(Modifier);
-std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& partList, const URLPatternStringOptions&);
-// OutOfMemoryError when the result would pass String::MaxLength (escaping can double the input).
+// These three report OutOfMemoryError when the string they build would pass String::MaxLength.
+ExceptionOr<std::pair<String, Vector<String>>> generateRegexAndNameList(const Vector<Part>& partList, const URLPatternStringOptions&);
 ExceptionOr<String> generatePatternString(const Vector<Part>& partList, const URLPatternStringOptions&);
 ExceptionOr<String> escapePatternString(StringView input);
 bool isValidNameCodepoint(char32_t codepoint, URLPatternUtilities::IsFirst);

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -1,7 +1,7 @@
 // Test data from Web Platform Tests
 // https://github.com/web-platform-tests/wpt/blob/master/LICENSE.md
 import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 import { totalmem } from "node:os";
 import testData from "./urlpatterntestdata.json";
@@ -212,65 +212,64 @@ describe("URLPattern", () => {
 });
 
 // URLPattern builds a pattern string, a regular expression and a canonical URL
-// from input the caller sizes. Escaping adds a character per escaped character,
-// and the base path is joined onto a relative pathname, so an input below the
-// 2147483647 character string limit produces a result above it. Every one of
-// those must throw a catchable error, not abort.
+// from input the caller sizes, so an input below the 2147483647 character string
+// limit produces a result above it. Each of those must report an error, not abort.
 //
-// setSyntheticAllocationLimitForTesting lowers the limit the code checks, which
-// reaches each site with kilobytes instead of gigabytes.
+// setSyntheticAllocationLimitForTesting lowers the limit these five sites check,
+// which reaches them with 1 MiB. The base path escaper and the pathname join are
+// not here: everything they produce flows into the regexp generator, so under a
+// lowered limit no input can tell their check from its check. The real-limit
+// tests below cover those two.
 describe("string above the synthetic string length limit", () => {
   const limit = 1024 * 1024;
-  const long = "x".repeat(limit);
+  // Built here, before beforeEach lowers the limit.
+  const long = Buffer.alloc(limit, "x").toString();
+  const overHalf = Buffer.alloc(limit / 2 + 16, "x").toString();
+  const outOfMemory = new RangeError("Out of memory");
+  let previousLimit = 0;
 
-  function withLimit(fn: () => void) {
-    const previousLimit = setSyntheticAllocationLimitForTesting(limit);
-    try {
-      expect(fn).toThrow(new RangeError("Out of memory"));
-    } finally {
-      setSyntheticAllocationLimitForTesting(previousLimit);
-    }
-  }
-
-  test("a base path that escapes past the limit", () => {
-    const escapes = "(".repeat(limit / 2 + 16);
-    withLimit(() => new URLPattern({ baseURL: "https://e.com/" + escapes }));
+  beforeEach(() => {
+    previousLimit = setSyntheticAllocationLimitForTesting(limit);
   });
 
-  test("a base path joined with a relative pathname past the limit", () => {
-    withLimit(() => new URLPattern({ pathname: long, baseURL: "https://e.com/" + long + "/" }));
+  afterEach(() => {
+    setSyntheticAllocationLimitForTesting(previousLimit);
   });
 
+  // The callbacks return nothing. If one returned a pattern that wrongly got built,
+  // toThrow would format it, which itself passes the lowered limit and throws
+  // "Out of memory", and the test would pass for the wrong reason.
   test("a generated regular expression past the limit", () => {
-    // The group's value is repeated in the regexp, so half the limit is enough.
-    withLimit(() => new URLPattern({ pathname: "{a(" + "x".repeat(limit / 2 + 16) + ")b}*" }));
+    // The group's value is written twice into the regexp, so half the limit is enough.
+    expect(() => {
+      new URLPattern({ pathname: "{a(" + overHalf + ")b}*" });
+    }).toThrow(outOfMemory);
+  });
+
+  test("a generated pattern string past the limit", () => {
+    // A group's name is in the pattern string and not in the regexp, so only the
+    // pattern string passes the limit.
+    expect(() => {
+      new URLPattern({ pathname: ":" + long });
+    }).toThrow(outOfMemory);
   });
 
   // match() turns a URLPatternInit it cannot process into no match, per the
   // spec, so these report the failure as false and null instead of throwing.
-  function noMatch(fn: () => unknown, expected: unknown) {
-    const previousLimit = setSyntheticAllocationLimitForTesting(limit);
-    try {
-      expect(fn()).toEqual(expected);
-    } finally {
-      setSyntheticAllocationLimitForTesting(previousLimit);
-    }
-  }
-
   test("a protocol that canonicalizes past the limit", () => {
     const pattern = new URLPattern({ protocol: "*" });
-    noMatch(() => pattern.test({ protocol: long }), false);
-    noMatch(() => pattern.exec({ protocol: long }), null);
+    expect(pattern.test({ protocol: long })).toBe(false);
+    expect(pattern.exec({ protocol: long })).toBe(null);
   });
 
   test("a pathname that canonicalizes past the limit", () => {
     const pattern = new URLPattern({ pathname: "*" });
-    noMatch(() => pattern.test({ pathname: long }), false);
+    expect(pattern.test({ pathname: long })).toBe(false);
   });
 
   test("an opaque pathname that canonicalizes past the limit", () => {
     const pattern = new URLPattern({ pathname: "*" });
-    noMatch(() => pattern.test({ protocol: "data", pathname: long }), false);
+    expect(pattern.test({ protocol: "data", pathname: long })).toBe(false);
   });
 });
 

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -229,7 +229,9 @@ describe("pattern string above the string length limit", () => {
   const threw = { stdout: "RangeError Out of memory", stderr: "", exitCode: 0 };
 
   // The child holds a pathname of about 2.1 GB, so it needs more than the
-  // default per-test timeout on a loaded machine.
+  // default per-test timeout on a loaded machine. repeat() builds that string
+  // in 1.7 s in a debug ASAN build. Buffer.alloc(n, "b").toString() takes
+  // 3.2 s there and holds the 2.1 GB buffer and the 2.1 GB string at once.
   test.skipIf(totalmem() < 8 * 1024 ** 3)(
     "the base path joined with a relative pathname throws",
     async () => {

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -1,5 +1,6 @@
 // Test data from Web Platform Tests
 // https://github.com/web-platform-tests/wpt/blob/master/LICENSE.md
+import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug } from "harness";
 import { totalmem } from "node:os";
@@ -210,10 +211,70 @@ describe("URLPattern", () => {
   });
 });
 
-// The constructor builds each component pattern from the baseURL. Escaping adds
-// a character per escaped character, and a relative pathname is joined onto the
-// base path, so an input below the 2147483647 character string limit produces a
-// result above it. Both cases must throw a catchable error, not abort.
+// URLPattern builds a pattern string, a regular expression and a canonical URL
+// from input the caller sizes. Escaping adds a character per escaped character,
+// and the base path is joined onto a relative pathname, so an input below the
+// 2147483647 character string limit produces a result above it. Every one of
+// those must throw a catchable error, not abort.
+//
+// setSyntheticAllocationLimitForTesting lowers the limit the code checks, which
+// reaches each site with kilobytes instead of gigabytes.
+describe("string above the synthetic string length limit", () => {
+  const limit = 1024 * 1024;
+  const long = "x".repeat(limit);
+
+  function withLimit(fn: () => void) {
+    const previousLimit = setSyntheticAllocationLimitForTesting(limit);
+    try {
+      expect(fn).toThrow(new RangeError("Out of memory"));
+    } finally {
+      setSyntheticAllocationLimitForTesting(previousLimit);
+    }
+  }
+
+  test("a base path that escapes past the limit", () => {
+    const escapes = "(".repeat(limit / 2 + 16);
+    withLimit(() => new URLPattern({ baseURL: "https://e.com/" + escapes }));
+  });
+
+  test("a base path joined with a relative pathname past the limit", () => {
+    withLimit(() => new URLPattern({ pathname: long, baseURL: "https://e.com/" + long + "/" }));
+  });
+
+  test("a generated regular expression past the limit", () => {
+    // The group's value is repeated in the regexp, so half the limit is enough.
+    withLimit(() => new URLPattern({ pathname: "{a(" + "x".repeat(limit / 2 + 16) + ")b}*" }));
+  });
+
+  // match() turns a URLPatternInit it cannot process into no match, per the
+  // spec, so these report the failure as false and null instead of throwing.
+  function noMatch(fn: () => unknown, expected: unknown) {
+    const previousLimit = setSyntheticAllocationLimitForTesting(limit);
+    try {
+      expect(fn()).toEqual(expected);
+    } finally {
+      setSyntheticAllocationLimitForTesting(previousLimit);
+    }
+  }
+
+  test("a protocol that canonicalizes past the limit", () => {
+    const pattern = new URLPattern({ protocol: "*" });
+    noMatch(() => pattern.test({ protocol: long }), false);
+    noMatch(() => pattern.exec({ protocol: long }), null);
+  });
+
+  test("a pathname that canonicalizes past the limit", () => {
+    const pattern = new URLPattern({ pathname: "*" });
+    noMatch(() => pattern.test({ pathname: long }), false);
+  });
+
+  test("an opaque pathname that canonicalizes past the limit", () => {
+    const pattern = new URLPattern({ pathname: "*" });
+    noMatch(() => pattern.test({ protocol: "data", pathname: long }), false);
+  });
+});
+
+// The same two sites at the real limit, which no synthetic limit can stand in for.
 describe("pattern string above the string length limit", () => {
   async function run(script: string) {
     await using proc = Bun.spawn({

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -1,6 +1,8 @@
 // Test data from Web Platform Tests
 // https://github.com/web-platform-tests/wpt/blob/master/LICENSE.md
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { totalmem } from "node:os";
 import testData from "./urlpatterntestdata.json";
 
 const kComponents = ["protocol", "username", "password", "hostname", "port", "pathname", "search", "hash"] as const;
@@ -206,4 +208,64 @@ describe("URLPattern", () => {
       expect(new URLPattern({ pathname: "/a/:foo/:baz([a-z]+)?/b/*" }).hasRegExpGroups).toBe(true);
     });
   });
+});
+
+// The constructor builds each component pattern from the baseURL. Escaping adds
+// a character per escaped character, and a relative pathname is joined onto the
+// base path, so an input below the 2147483647 character string limit produces a
+// result above it. Both cases must throw a catchable error, not abort.
+describe("pattern string above the string length limit", () => {
+  async function run(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode };
+  }
+
+  const threw = { stdout: "RangeError Out of memory", stderr: "", exitCode: 0 };
+
+  // The child holds a pathname of about 2.1 GB, so it needs more than the
+  // default per-test timeout on a loaded machine.
+  test.skipIf(totalmem() < 8 * 1024 ** 3)(
+    "the base path joined with a relative pathname throws",
+    async () => {
+      expect(
+        await run(`
+          const basePath = "/" + "x".repeat(1 << 20) + "/";
+          const pathname = "b".repeat(2 ** 31 - (1 << 19));
+          try {
+            new URLPattern({ pathname, baseURL: "https://e.com" + basePath });
+            console.log("no error");
+          } catch (e) {
+            console.log(e.name, e.message);
+          }
+        `),
+      ).toEqual(threw);
+    },
+    60_000,
+  );
+
+  // The child commits about 6 GB, and escaping 2^30 characters takes minutes in
+  // a debug or ASAN build.
+  test.skipIf(isDebug || isASAN || totalmem() < 16 * 1024 ** 3)(
+    "a base path that escapes past the limit throws",
+    async () => {
+      expect(
+        await run(`
+          const path = "(".repeat(2 ** 30 + 16);
+          try {
+            new URLPattern({ baseURL: "https://e.com/" + path });
+            console.log("no error");
+          } catch (e) {
+            console.log(e.name, e.message);
+          }
+        `),
+      ).toEqual(threw);
+    },
+    120_000,
+  );
 });

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -228,10 +228,8 @@ describe("pattern string above the string length limit", () => {
 
   const threw = { stdout: "RangeError Out of memory", stderr: "", exitCode: 0 };
 
-  // The child holds a pathname of about 2.1 GB, so it needs more than the
-  // default per-test timeout on a loaded machine. repeat() builds that string
-  // in 1.7 s in a debug ASAN build. Buffer.alloc(n, "b").toString() takes
-  // 3.2 s there and holds the 2.1 GB buffer and the 2.1 GB string at once.
+  // The child holds a 2.1 GB pathname. repeat() is faster than Buffer.alloc().toString()
+  // at this size even in a debug build, and it needs half the memory.
   test.skipIf(totalmem() < 8 * 1024 ** 3)(
     "the base path joined with a relative pathname throws",
     async () => {


### PR DESCRIPTION
### Problem
- Several places in URLPattern build a string from a length the caller controls, with a `StringBuilder` or a `makeString` that calls `CRASH()` on overflow. Each exits 134 with `panic(main thread): abort() called` and no catchable error. Measured on the released build (1.4.3):

```js
new URLPattern({ baseURL: "https://e.com/" + "(".repeat(2 ** 30 + 16) });        // escapePatternString
new URLPattern({ pathname: "b".repeat(2 ** 31 - (1 << 19)), baseURL: "https://e.com/x/" }); // the pathname join
new URLPattern({ pathname: "{a(" + "x".repeat(2 ** 30) + ")b}*" });              // generateRegexAndNameList
new URLPattern({ protocol: "*" }).test({ protocol: "h".repeat(2147483645) });    // canonicalizeProtocol
```

- Escaping adds a character per escaped character, a group's value is written twice into the generated regular expression, and the base path is joined onto a relative pathname. So an input below the 2147483647 character `String` limit produces a result above it.

### Fix
- `escapePatternString`, `generatePatternString` and `generateRegexAndNameList` build with `OverflowPolicy::RecordOverflow` and return `ExceptionOr`. An overflow becomes `ExceptionCode::OutOfMemoryError`, which the bindings throw as `RangeError: Out of memory`. The two escapers share one append helper that stops at the character that overflows.
- The pathname join and the three canonicalizers use `tryMakeString`. `processBaseURLString` returns `ExceptionOr<String>` and `processInit` propagates it, as it already does for `canonicalizeProtocol`. On the `exec()` and `test()` path `match()` turns that into no match, the same as any other input it cannot process.
- The two generators and the three canonicalizers also check `Bun__stringSyntheticAllocationLimit`, the limit `setSyntheticAllocationLimitForTesting` lowers, so their tests need 1 MiB.
- Verified: `test/js/web/urlpattern/urlpattern.test.ts`, 7 new tests, all 7 fail on the released build. Five run on every lane in under 200 ms. The 408 existing tests there and `test/js/node/test/parallel/test-urlpattern.js` pass. Self-reviewed, see Notes.

### Background
- A `WTF::String` holds at most `String::MaxLength` (2147483647) characters. A default `StringBuilder` calls `CRASH()` when it needs more. With `OverflowPolicy::RecordOverflow` it sets a flag, ignores further appends, and `hasOverflowed()` reports it. `toString()` asserts no overflow, so the caller checks first. `makeString` crashes the same way on its `CheckedInt32` sum, `tryMakeString` returns a null `String`.
- `ExceptionOr<T>` is WebCore's result type. `URLPattern::create` returns it, and the generated binding throws the `Exception`. `OutOfMemoryError` maps to a `RangeError` with the message `Out of memory`, which bun throws elsewhere for a result above the string limit.
- `Bun__stringSyntheticAllocationLimit` is the process-wide string length cap (`helpers.h`). It defaults above `String::MaxLength`, and `bun:internal-for-testing` can lower it to 1 MiB, which is how the streams and fs limit tests work.

<details><summary>Notes</summary>

- Before and after, for the four repros above: exit 134 on the released build, then `RangeError: Out of memory` for the first three and `false` for the fourth. The debug ASAN build agrees. Each repro reports a different crash hash, which is how I confirmed they are separate sites.
- Tests. Five lower the synthetic limit to 1 MiB and run in process: the regexp generator, the pattern string generator, and the protocol, pathname and opaque-pathname canonicalizers. Each of those checks changes an observable result (a constructor that throws or does not, `test()` that returns `false` or `true`), and each test fails when its check is removed.
- The base path escaper and the pathname join have no synthetic check, on purpose. Everything they produce flows into the regexp generator, which is at least as long, so under a lowered limit no input can tell their check from its check. I had both checks and both tests. Removing the checks left the tests green, so both went. Those two sites keep their real guards (`hasOverflowed()`, a null `tryMakeString`) and two real-limit tests: the join needs a 2.1 GB pathname (skipped below 8 GB of RAM, 60 s timeout), and the escaper needs 2^30 escapable characters, because the escaped result is at most twice the input. That child commits about 6 GB and its loop takes 6.5 minutes in a debug or ASAN build, so it is skipped there and below 16 GB. On the previous revision (build 113807) the join test ran on x64-asan, both windows lanes and both alpine lanes, and both ran on darwin aarch64 and x64.
- The synthetic test callbacks return nothing. A callback that returns the pattern makes `toThrow` format it when it does not throw, and under the lowered limit that formatting throws `Out of memory` itself. One test passed on the released build that way.
- The first version of this PR fixed only the first two sites, and I said the regexp generator was unreachable because the tokenizer caps the input. That was wrong: the tokenizer emits one `Token` per code point for plain text, but a regexp group is one token, so `{a(<1 GB>)b}*` reaches the regexp generator with a 1 GB part value and the `ZeroOrMore` branch writes it twice. The review that raised it was right, and the case is fixed and tested.
- Two aborts on oversized URLPattern input are out of scope here and reported separately. #42220 fixes the tokenizer's `Vector<Token>` capacity cap (about 51 M characters of plain text). The `URL` `pathname` setter aborts for a value within about 15 characters of the string limit, which `canonicalizePathname` reaches through `dummyURL.setPath`. `new URL()` with the same size already throws.
- `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1` is clean on the whole test file and on the throwing repros.
- Review: five rounds. Fixed from them: stop the escape loop at the overflowing character, widen to the regexp generator and the three canonicalizers, replace most of the multi-GB proof with synthetic-limit tests, and drop the two synthetic checks no test could isolate. Declined: `Buffer.alloc().toString()` for the 2 GB test string (measured slower and twice the memory at that size, the 1 MiB strings use it) and gating the join test on debug (it is the one that proves that site on the ASAN lane).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/urlpattern/urlpattern.test.ts
bun test v1.4.3 (5f554969b)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [52.52ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [9.91ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [7.67ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [8.27ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [13.36ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [10.21ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [12.57ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/
... (truncated)

release without fix: 7 FAILED
bun test v1.4.3-canary.1 (5f554969b)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [0.55ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [0.04ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [0.03ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [0.04ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [0.34ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [0.09ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [0.07ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] [0.02ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] [0.05ms]
(pass) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/urlpattern/urlpattern.test.ts
bun test v1.4.3 (5f554969b)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [40.75ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [6.66ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [6.49ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [6.87ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [10.93ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [8.05ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [11.63ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/b
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f15794a3f7
  features     baseline

23 deps, 131 codegen, 1172 objects in 844ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (5f554969b)

Checked 22 installs across 61 packages (no changes) [18.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (5f554969b)

Checked 1 install across 2 packages (no changes) [11.00ms]
[5/1244] fetch zlib
[zlib] up to date
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (5f554969b)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[10/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 7ms

  react-refresh.js  4.81 KB  (entry point)

[11/1216] gen ProcessBindingH
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/URLPattern.cpp          |  77 +++++++++---
 src/jsc/bindings/webcore/URLPatternCanonical.cpp |  25 +++-
 src/jsc/bindings/webcore/URLPatternCanonical.h   |   3 +
 src/jsc/bindings/webcore/URLPatternComponent.cpp |  10 +-
 src/jsc/bindings/webcore/URLPatternParser.cpp    | 145 ++++++++++++++---------
 src/jsc/bindings/webcore/URLPatternParser.h      |   8 +-
 test/js/web/urlpattern/urlpattern.test.ts        | 124 ++++++++++++++++++-
 7 files changed, 311 insertions(+), 81 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/jsc/bindings/webcore/URLPattern.cpp               1      7     23
src/jsc/bindings/webcore/URLPatternCanonical.cpp      2      4     23
src/jsc/bindings/webcore/URLPatternCanonical.h        1      3     23
src/jsc/bindings/webcore/URLPatternComponent.cpp      2      3     23
src/jsc/bindings/webcore/URLPatternParser.cpp         6     18     23
src/jsc/bindings/webcore/URLPatternParser.h           2      4     23
test/js/web/urlpattern/urlpattern.test.ts             8     15     23
```

</details>

<!-- robobun:evidence:end -->