### PR TITLE
Copy WebAssembly.Memory bytes for native borrows that outlive the call

### DIFF
--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -162,19 +162,12 @@ impl ArrayBuffer {
         }
     }
 
-    /// True when a pin does not keep these bytes mapped, so a borrower that
-    /// reads or writes them after the call returns must copy them:
-    ///
-    /// - a resizable non-shared ArrayBuffer: `resize()` unmaps the trimmed pages.
-    /// - a non-shared `WebAssembly.Memory`: `grow()` on a bounds-checked memory
-    ///   allocates a new block, copies into it, and frees the old one. JSC
-    ///   detaches a wasm memory's buffer whatever its pin count ("We allow
-    ///   detaching wasm memory ArrayBuffers even though they are locked",
-    ///   `ArrayBuffer::detach`), and the detached contents hold the last ref on
-    ///   the block, so the pages go away under the borrow.
-    ///
-    /// A SharedArrayBuffer (including a shared wasm memory) only ever grows in
-    /// place, so a borrow of one stays valid and needs no copy.
+    /// True when a pin does not keep these bytes mapped: `resize()` unmaps a
+    /// resizable buffer's trimmed pages, and `grow()` on a bounds-checked
+    /// `WebAssembly.Memory` frees the old block, which JSC detaches whatever
+    /// the pin count ("We allow detaching wasm memory ArrayBuffers even though
+    /// they are locked", `ArrayBuffer::detach`). Only a shared one grows in
+    /// place. Copy these bytes for a borrow that outlives the call.
     pub fn pin_cannot_hold(&self) -> bool {
         !self.shared && (self.resizable || self.wasm_memory)
     }
@@ -666,10 +659,9 @@ impl ArrayBuffer {
 
 /// A JS ArrayBuffer/view whose backing store is pinned (cannot be detached or
 /// moved) for as long as this value lives; [`root`](Self::root) additionally
-/// GC-roots the cell. `Drop` releases what was taken, which reads the cell, so
-/// it has to run on the JS thread and outside a heap sweep. Every value is
-/// constructed and dropped inside one host call: a value a `Blob` store keeps
-/// is copied out first ([`PathLike::thread_isolated_copy`]).
+/// GC-roots the cell. `Drop` reads the cell, so it runs on the JS thread and
+/// outside a heap sweep: a value a `Blob` store keeps is copied out first
+/// ([`PathLike::thread_isolated_copy`]).
 pub struct PinnedArrayBuffer {
     buffer: ArrayBuffer,
     rooted: bool,
@@ -711,10 +703,9 @@ impl PinnedArrayBuffer {
         this.copy_if_pin_cannot_hold(global).then_some(this)
     }
 
-    /// Copies the bytes when the pin does not keep them mapped
-    /// ([`ArrayBuffer::pin_cannot_hold`]), so that a read of them after the
-    /// call returns cannot fault or see another object's memory. `false` if the
-    /// copy cannot be allocated.
+    /// Copies the bytes the pin does not keep mapped
+    /// ([`ArrayBuffer::pin_cannot_hold`]). `false` if the copy cannot be
+    /// allocated.
     pub fn copy_if_pin_cannot_hold(&mut self, global: &JSGlobalObject) -> bool {
         if !self.buffer.pin_cannot_hold() || self.buffer.byte_len == 0 || self.copy.is_some() {
             return true;

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -666,9 +666,10 @@ impl ArrayBuffer {
 
 /// A JS ArrayBuffer/view whose backing store is pinned (cannot be detached or
 /// moved) for as long as this value lives; [`root`](Self::root) additionally
-/// GC-roots the cell. `Drop` releases what was taken. Constructed on the JS
-/// thread; a `root()`ed value is dropped there too, while a `pin()`-only value
-/// held by a `Blob` store drops wherever the store's last ref goes.
+/// GC-roots the cell. `Drop` releases what was taken, which reads the cell, so
+/// it has to run on the JS thread and outside a heap sweep. Every value is
+/// constructed and dropped inside one host call: a value a `Blob` store keeps
+/// is copied out first ([`PathLike::thread_isolated_copy`]).
 pub struct PinnedArrayBuffer {
     buffer: ArrayBuffer,
     rooted: bool,
@@ -762,8 +763,8 @@ impl Drop for PinnedArrayBuffer {
     }
 }
 
-// SAFETY: a pin and GC protection on a heap cell; constructed on the JS thread,
-// and a rooted value is dropped there (a pin-only one may drop with its `Blob` store).
+// SAFETY: a pin and GC protection on a heap cell; constructed and dropped on
+// the JS thread.
 unsafe impl crate::job::JsAffine for PinnedArrayBuffer {}
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -31,6 +31,8 @@ pub struct ArrayBuffer {
     /// True for resizable ArrayBuffer or growable SharedArrayBuffer — borrowing
     /// a slice from one is unsafe (it can shrink/reallocate underneath you).
     pub resizable: bool,
+    /// True when the bytes belong to a `WebAssembly.Memory`. See [`pin_cannot_hold`](Self::pin_cannot_hold).
+    pub wasm_memory: bool,
     /// Set by [`JSValue::as_pinned_arraybuffer`] when an ArrayBuffer was actually pinned (as opposed to a bufferless view merely held); [`ArrayBuffer::unpin`] is a no-op otherwise.
     pub pinned: bool,
 }
@@ -45,6 +47,7 @@ impl Default for ArrayBuffer {
             typed_array_type: JSType::Cell,
             shared: false,
             resizable: false,
+            wasm_memory: false,
             pinned: false,
         }
     }
@@ -157,6 +160,23 @@ impl ArrayBuffer {
         if self.pinned {
             self.value.unpin_array_buffer();
         }
+    }
+
+    /// True when a pin does not keep these bytes mapped, so a borrower that
+    /// reads or writes them after the call returns must copy them:
+    ///
+    /// - a resizable non-shared ArrayBuffer: `resize()` unmaps the trimmed pages.
+    /// - a non-shared `WebAssembly.Memory`: `grow()` on a bounds-checked memory
+    ///   allocates a new block, copies into it, and frees the old one. JSC
+    ///   detaches a wasm memory's buffer whatever its pin count ("We allow
+    ///   detaching wasm memory ArrayBuffers even though they are locked",
+    ///   `ArrayBuffer::detach`), and the detached contents hold the last ref on
+    ///   the block, so the pages go away under the borrow.
+    ///
+    /// A SharedArrayBuffer (including a shared wasm memory) only ever grows in
+    /// place, so a borrow of one stays valid and needs no copy.
+    pub fn pin_cannot_hold(&self) -> bool {
+        !self.shared && (self.resizable || self.wasm_memory)
     }
 
     // require('buffer').kMaxLength.
@@ -300,6 +320,7 @@ impl ArrayBuffer {
         typed_array_type: JSType::Uint8Array,
         shared: false,
         resizable: false,
+        wasm_memory: false,
         pinned: false,
     };
 
@@ -651,7 +672,7 @@ impl ArrayBuffer {
 pub struct PinnedArrayBuffer {
     buffer: ArrayBuffer,
     rooted: bool,
-    /// The bytes `buffer.ptr` points at when [`copy_if_resizable`](Self::copy_if_resizable) took a copy.
+    /// The bytes `buffer.ptr` points at when [`copy_if_pin_cannot_hold`](Self::copy_if_pin_cannot_hold) took a copy.
     copy: Option<Vec<u8>>,
 }
 
@@ -683,19 +704,18 @@ impl PinnedArrayBuffer {
         Some(this)
     }
 
-    /// [`root`](Self::root) for a job that reads the bytes itself: see [`copy_if_resizable`](Self::copy_if_resizable).
+    /// [`root`](Self::root) for a job that reads the bytes itself: see [`copy_if_pin_cannot_hold`](Self::copy_if_pin_cannot_hold).
     pub fn root_read_only(global: &JSGlobalObject, value: JSValue) -> Option<Self> {
         let mut this = Self::root(global, value)?;
-        this.copy_if_resizable(global).then_some(this)
+        this.copy_if_pin_cannot_hold(global).then_some(this)
     }
 
-    /// A pin stops a detach but not a shrink, which unmaps pages: a resizable non-shared buffer is copied so a later read of the bytes in user space cannot fault (a syscall reader gets `EFAULT` and needs no copy). `false` if the copy cannot be allocated.
-    pub fn copy_if_resizable(&mut self, global: &JSGlobalObject) -> bool {
-        if !self.buffer.resizable
-            || self.buffer.shared
-            || self.buffer.byte_len == 0
-            || self.copy.is_some()
-        {
+    /// Copies the bytes when the pin does not keep them mapped
+    /// ([`ArrayBuffer::pin_cannot_hold`]), so that a read of them after the
+    /// call returns cannot fault or see another object's memory. `false` if the
+    /// copy cannot be allocated.
+    pub fn copy_if_pin_cannot_hold(&mut self, global: &JSGlobalObject) -> bool {
+        if !self.buffer.pin_cannot_hold() || self.buffer.byte_len == 0 || self.copy.is_some() {
             return true;
         }
         let bytes = self.buffer.byte_slice();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3476,6 +3476,19 @@ JSC::EncodedJSValue JSC__JSValue__values(JSC::JSGlobalObject* globalObject, JSC:
     return JSValue::encode(JSC::objectValues(vm, globalObject, value));
 }
 
+// True when the view's bytes belong to a `WebAssembly.Memory`. Only a view
+// that already has an ArrayBuffer can be one (a memory hands out its buffer),
+// so a Fast/Oversize view answers false without materializing anything; for
+// the other modes `possiblySharedBuffer()` is the buffer the butterfly already
+// holds.
+static bool viewIsWasmMemory(JSC::JSArrayBufferView* view)
+{
+    if (!view->hasArrayBuffer())
+        return false;
+    JSC::ArrayBuffer* buffer = view->possiblySharedBuffer();
+    return buffer && buffer->isWasmMemory();
+}
+
 bool JSC__JSValue__asArrayBuffer(
     JSC::EncodedJSValue encodedValue,
     JSC::JSGlobalObject* globalObject,
@@ -3511,6 +3524,7 @@ bool JSC__JSValue__asArrayBuffer(
         out->cell_type = type;
         out->shared = view->isShared();
         out->resizable = view->isResizableOrGrowableShared();
+        out->wasm_memory = viewIsWasmMemory(view);
         break;
     }
     case JSC::JSType::ArrayBufferType: {
@@ -3521,6 +3535,7 @@ bool JSC__JSValue__asArrayBuffer(
         out->cell_type = JSC::JSType::ArrayBufferType;
         out->shared = buffer->isShared();
         out->resizable = buffer->isResizableOrGrowableShared();
+        out->wasm_memory = buffer->isWasmMemory();
         break;
     }
     case JSC::JSType::ObjectType:
@@ -3532,6 +3547,7 @@ bool JSC__JSValue__asArrayBuffer(
             out->cell_type = view->type();
             out->shared = view->isShared();
             out->resizable = view->isResizableOrGrowableShared();
+            out->wasm_memory = viewIsWasmMemory(view);
         } else if (JSC::JSArrayBuffer* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(value)) {
             JSC::ArrayBuffer* buffer = jsBuffer->impl();
             if (!buffer)
@@ -3542,6 +3558,7 @@ bool JSC__JSValue__asArrayBuffer(
             out->cell_type = JSC::JSType::ArrayBufferType;
             out->shared = buffer->isShared();
             out->resizable = buffer->isResizableOrGrowableShared();
+            out->wasm_memory = buffer->isWasmMemory();
         } else {
             return false;
         }
@@ -7133,5 +7150,6 @@ extern "C" void JSC__ArrayBuffer__asBunArrayBuffer(JSC::ArrayBuffer* self, Bun__
     out->cell_type = JSC::JSType::ArrayBufferType;
     out->shared = self->isShared();
     out->resizable = self->isResizableOrGrowableShared();
+    out->wasm_memory = self->isWasmMemory();
     out->pinned = false;
 }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3476,11 +3476,9 @@ JSC::EncodedJSValue JSC__JSValue__values(JSC::JSGlobalObject* globalObject, JSC:
     return JSValue::encode(JSC::objectValues(vm, globalObject, value));
 }
 
-// True when the view's bytes belong to a `WebAssembly.Memory`. Only a view
-// that already has an ArrayBuffer can be one (a memory hands out its buffer),
-// so a Fast/Oversize view answers false without materializing anything; for
-// the other modes `possiblySharedBuffer()` is the buffer the butterfly already
-// holds.
+// True when the view's bytes belong to a `WebAssembly.Memory`. A memory hands
+// out its buffer, so only a view that already has one can be backed by it and
+// nothing is materialized here.
 static bool viewIsWasmMemory(JSC::JSArrayBufferView* view)
 {
     if (!view->hasArrayBuffer())

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -367,6 +367,7 @@ typedef struct {
     uint8_t cell_type;
     bool shared;
     bool resizable;
+    bool wasm_memory;
     bool pinned;
 } Bun__ArrayBuffer;
 

--- a/src/jsc/node_path.rs
+++ b/src/jsc/node_path.rs
@@ -82,11 +82,10 @@ impl<'a> PathLike<'a> {
 }
 
 impl PathLike<'static> {
-    /// For a path a `Blob` store keeps (dropped on any thread): a JS-backed
-    /// string becomes a private copy never handed to JS, and a buffer's bytes
-    /// are copied here, on the JS thread. The store then owns its path, so
-    /// reading it cannot see a detached buffer's freed storage, and releasing
-    /// it touches no JS cell from a heap sweep or another thread.
+    /// For a path a `Blob` store keeps: a JS-backed string becomes a private
+    /// copy never handed to JS, and a buffer's bytes are copied here, on the JS
+    /// thread. The store owns its path, so it keeps no pin to release from a
+    /// heap sweep and cannot read a detached buffer's freed storage.
     pub fn thread_isolated_copy(self) -> Self {
         match self {
             Self::String(s) | Self::ThreadIsolatedString(s) => {

--- a/src/jsc/node_path.rs
+++ b/src/jsc/node_path.rs
@@ -83,17 +83,16 @@ impl<'a> PathLike<'a> {
 
 impl PathLike<'static> {
     /// For a path a `Blob` store keeps (dropped on any thread): a JS-backed
-    /// string becomes a private copy never handed to JS; a buffer stays
-    /// pinned and is GC-protected for good.
+    /// string becomes a private copy never handed to JS, and a buffer's bytes
+    /// are copied here, on the JS thread. The store then owns its path, so
+    /// reading it cannot see a detached buffer's freed storage, and releasing
+    /// it touches no JS cell from a heap sweep or another thread.
     pub fn thread_isolated_copy(self) -> Self {
         match self {
             Self::String(s) | Self::ThreadIsolatedString(s) => {
                 Self::ThreadIsolatedString(s.thread_isolated_copy())
             }
-            Self::Buffer(b) => {
-                b.value.protect();
-                Self::Buffer(b)
-            }
+            Self::Buffer(b) => Self::Utf8(Utf8Bytes::Owned(b.slice().to_vec())),
             Self::Utf8(s) => Self::Utf8(s),
         }
     }

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -394,12 +394,14 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
                 )
                 .throw());
         }
-        if out_buf.resizable && !out_buf.shared {
+        // The pool thread writes the output after this call returns; storage a
+        // pin does not keep mapped until then cannot take it.
+        if out_buf.pin_cannot_hold() {
             return Err(global_this
                 .err(
                     ErrorCode::INVALID_ARG_VALUE,
                     format_args!(
-                        "The \"out\" argument must not be backed by a resizable ArrayBuffer"
+                        "The \"out\" argument must not be backed by a resizable ArrayBuffer or a WebAssembly.Memory"
                     ),
                 )
                 .throw());
@@ -418,6 +420,12 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
             };
             Some(buf)
         };
+        let Some(mut out_buf) = arguments[4].as_pinned_arraybuffer(global_this) else {
+            if let Some(buf) = &in_buf {
+                buf.unpin();
+            }
+            return Err(global_this.throw_out_of_memory());
+        };
         let mut in_: Option<&[u8]> = in_buf
             .as_ref()
             .map(|b| &b.byte_slice()[in_off as usize..in_off as usize + in_len as usize]);
@@ -429,16 +437,11 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         {
             let Some(copied) = Self::copy_input(this, chunk) else {
                 buf.unpin();
+                out_buf.unpin();
                 return Err(global_this.throw_out_of_memory());
             };
             in_ = Some(copied);
         }
-        let Some(mut out_buf) = arguments[4].as_pinned_arraybuffer(global_this) else {
-            if let Some(buf) = &in_buf {
-                buf.unpin();
-            }
-            return Err(global_this.throw_out_of_memory());
-        };
         this.pinned_buffers().set(
             u8::from(in_buf.as_ref().is_some_and(|b| b.pinned)) | (u8::from(out_buf.pinned) << 1),
         );

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -394,8 +394,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
                 )
                 .throw());
         }
-        // The pool thread writes the output after this call returns; storage a
-        // pin does not keep mapped until then cannot take it.
+        // The pool thread writes into `out` after this call returns.
         if out_buf.pin_cannot_hold() {
             return Err(global_this
                 .err(
@@ -429,9 +428,8 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         let mut in_: Option<&[u8]> = in_buf
             .as_ref()
             .map(|b| &b.byte_slice()[in_off as usize..in_off as usize + in_len as usize]);
-        // The pool thread reads the input after this call returns, and a pin does
-        // not keep every kind of storage mapped until then
-        // (`ArrayBuffer::pin_cannot_hold`). Read a copy of the chunk instead.
+        // The pool thread reads the input after this call returns, so read a
+        // copy of storage the pin does not keep mapped.
         if let (Some(chunk), Some(buf)) = (in_, in_buf.as_ref())
             && buf.pin_cannot_hold()
         {
@@ -512,8 +510,8 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         ticket.post(ConcurrentTask::create(Task::init(this)));
     }
 
-    /// Copies an input chunk the caller's pin does not keep mapped into the
-    /// stream's own buffer. `None` if the copy cannot be allocated.
+    /// Copies an input chunk into the stream's own buffer. `None` if the copy
+    /// cannot be allocated.
     fn copy_input<'a>(this: &'a T, chunk: &[u8]) -> Option<&'a [u8]> {
         this.input_copy().with_mut(|copy| {
             copy.clear();

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -239,6 +239,8 @@ pub(crate) trait CompressionStreamImpl:
     fn task(&self) -> &JsCell<WorkPoolTask>;
     fn write_in_progress(&self) -> &Cell<bool>;
     fn pinned_buffers(&self) -> &Cell<u8>;
+    /// Scratch for [`CompressionStream::copy_input`]; empty while no copy is live.
+    fn input_copy(&self) -> &JsCell<Vec<u8>>;
     fn pending_close(&self) -> &Cell<bool>;
     fn closed(&self) -> &Cell<bool>;
 
@@ -416,9 +418,21 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
             };
             Some(buf)
         };
-        let in_: Option<&[u8]> = in_buf
+        let mut in_: Option<&[u8]> = in_buf
             .as_ref()
             .map(|b| &b.byte_slice()[in_off as usize..in_off as usize + in_len as usize]);
+        // The pool thread reads the input after this call returns, and a pin does
+        // not keep every kind of storage mapped until then
+        // (`ArrayBuffer::pin_cannot_hold`). Read a copy of the chunk instead.
+        if let (Some(chunk), Some(buf)) = (in_, in_buf.as_ref())
+            && buf.pin_cannot_hold()
+        {
+            let Some(copied) = Self::copy_input(this, chunk) else {
+                buf.unpin();
+                return Err(global_this.throw_out_of_memory());
+            };
+            in_ = Some(copied);
+        }
         let Some(mut out_buf) = arguments[4].as_pinned_arraybuffer(global_this) else {
             if let Some(buf) = &in_buf {
                 buf.unpin();
@@ -495,7 +509,23 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         ticket.post(ConcurrentTask::create(Task::init(this)));
     }
 
-    /// Releases the pins `write()` took; the cached slots keep rooting the values either way.
+    /// Copies an input chunk the caller's pin does not keep mapped into the
+    /// stream's own buffer. `None` if the copy cannot be allocated.
+    fn copy_input<'a>(this: &'a T, chunk: &[u8]) -> Option<&'a [u8]> {
+        this.input_copy().with_mut(|copy| {
+            copy.clear();
+            if copy.try_reserve_exact(chunk.len()).is_err() {
+                return None;
+            }
+            copy.extend_from_slice(chunk);
+            // SAFETY: the bytes live in `this.input_copy`. Only `write()` and the
+            // completion touch it, and a second `write()` is refused while this
+            // one is in progress, so they outlive the job that reads them.
+            Some(unsafe { core::slice::from_raw_parts(copy.as_ptr(), copy.len()) })
+        })
+    }
+
+    /// Releases the pins `write()` took and the input copy it made; the cached slots keep rooting the values either way.
     fn unpin_pending_buffers(this: &T, this_value: JSValue) {
         let pinned = this.pinned_buffers().replace(0);
         if pinned & 1 != 0 {
@@ -508,6 +538,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
                 value.unpin_array_buffer();
             }
         }
+        this.input_copy().set(Vec::new());
     }
 
     /// VM teardown, JS thread, heap alive: a completion that was queued but
@@ -1016,6 +1047,7 @@ macro_rules! __impl_compression_stream {
             #[inline] fn task(&self) -> &::bun_jsc::JsCell<::bun_jsc::WorkPoolTask> { &self.task }
             #[inline] fn write_in_progress(&self) -> &::core::cell::Cell<bool> { &self.write_in_progress }
             #[inline] fn pinned_buffers(&self) -> &::core::cell::Cell<u8> { &self.pinned_buffers }
+            #[inline] fn input_copy(&self) -> &::bun_jsc::JsCell<::std::vec::Vec<u8>> { &self.input_copy }
             #[inline] fn pending_close(&self) -> &::core::cell::Cell<bool> { &self.pending_close }
             #[inline] fn closed(&self) -> &::core::cell::Cell<bool> { &self.closed }
 

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -342,9 +342,8 @@ impl StringOrBuffer<'static> {
     }
 
     /// `value` is ArrayBuffer-like (the caller checked): borrowed for `Sync`,
-    /// pinned and GC-rooted for `Async`. An `Async` parse is read after the
-    /// call returns, so storage the pin does not keep mapped is copied
-    /// ([`PinnedArrayBuffer::root_read_only`]).
+    /// pinned, GC-rooted and copied where a pin cannot hold the bytes for
+    /// `Async` ([`PinnedArrayBuffer::root_read_only`]).
     pub(crate) fn buffer_from_js(
         global: &JSGlobalObject,
         value: JSValue,

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -342,7 +342,9 @@ impl StringOrBuffer<'static> {
     }
 
     /// `value` is ArrayBuffer-like (the caller checked): borrowed for `Sync`,
-    /// pinned and GC-rooted for `Async`.
+    /// pinned and GC-rooted for `Async`. An `Async` parse is read after the
+    /// call returns, so storage the pin does not keep mapped is copied
+    /// ([`PinnedArrayBuffer::root_read_only`]).
     pub(crate) fn buffer_from_js(
         global: &JSGlobalObject,
         value: JSValue,
@@ -351,7 +353,7 @@ impl StringOrBuffer<'static> {
         if flavor == Flavor::Sync {
             return Ok(Self::Buffer(Buffer::from_array_buffer(global, value)));
         }
-        match PinnedArrayBuffer::root(global, value) {
+        match PinnedArrayBuffer::root_read_only(global, value) {
             Some(buffer) => Ok(Self::PinnedBuffer(buffer)),
             None => Err(global.throw_out_of_memory()),
         }
@@ -454,19 +456,13 @@ impl StringOrBuffer<'static> {
         Self::from_js_maybe_async(global, value, Flavor::Sync, StringObjects::Allow)
     }
 
-    /// [`from_js`](Self::from_js) for a work-pool job that reads the bytes itself: strings thread-isolated, buffers pinned and GC-rooted, a resizable buffer copied ([`PinnedArrayBuffer::copy_if_resizable`]).
+    /// [`from_js`](Self::from_js) for a work-pool job that reads the bytes itself: strings thread-isolated, buffers pinned and GC-rooted (see [`buffer_from_js`](Self::buffer_from_js)).
     #[inline]
     pub(crate) fn from_js_async(
         global: &JSGlobalObject,
         value: JSValue,
     ) -> JsResult<Option<ThreadIsolated<Self>>> {
-        let mut parsed =
-            Self::from_js_maybe_async(global, value, Flavor::Async, StringObjects::Allow)?;
-        if let Some(Self::PinnedBuffer(buffer)) = &mut parsed
-            && !buffer.copy_if_resizable(global)
-        {
-            return Err(global.throw_out_of_memory());
-        }
+        let parsed = Self::from_js_maybe_async(global, value, Flavor::Async, StringObjects::Allow)?;
         // SAFETY: parsed with `Flavor::Async`.
         Ok(parsed.map(|v| unsafe { ThreadIsolated::new(v) }))
     }
@@ -1111,8 +1107,8 @@ impl PathLikeExt for PathLike<'_> {
                     PinnedArrayBuffer::pin(ctx, arg)
                 }
                 .ok_or_else(|| ctx.throw_out_of_memory())?;
-                // Read after this call (pool thread, a later argument's getter, a `Blob` store): a shrink in between unmaps the pages.
-                if !buffer.copy_if_resizable(ctx) {
+                // Read after this call (pool thread, a later argument's getter, a `Blob` store): a shrink or a wasm-memory grow in between frees the pages.
+                if !buffer.copy_if_pin_cannot_hold(ctx) {
                     return Err(ctx.throw_out_of_memory());
                 }
                 Valid::path_buffer(buffer.slice(), ctx)?;

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -89,8 +89,7 @@ mod _impl {
         pub write_in_progress: Cell<bool>,
         /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's. A held bufferless view sets neither.
         pub pinned_buffers: Cell<u8>,
-        /// Input bytes copied by `write()` when the caller's pin does not keep
-        /// the caller's storage mapped; empty otherwise.
+        /// What `write()` copies for storage a pin cannot hold; else empty.
         pub input_copy: JsCell<Vec<u8>>,
         pub pending_close: Cell<bool>,
         pub closed: Cell<bool>,

--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -89,6 +89,9 @@ mod _impl {
         pub write_in_progress: Cell<bool>,
         /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's. A held bufferless view sets neither.
         pub pinned_buffers: Cell<u8>,
+        /// Input bytes copied by `write()` when the caller's pin does not keep
+        /// the caller's storage mapped; empty otherwise.
+        pub input_copy: JsCell<Vec<u8>>,
         pub pending_close: Cell<bool>,
         pub closed: Cell<bool>,
         pub task: JsCell<WorkPoolTask>,
@@ -152,6 +155,7 @@ mod _impl {
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
                 pinned_buffers: Cell::new(0),
+                input_copy: JsCell::new(Vec::new()),
                 pending_close: Cell::new(false),
                 closed: Cell::new(false),
                 // .callback = undefined — overwritten before WorkPool::schedule()

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -46,8 +46,7 @@ mod _impl {
         pub write_in_progress: Cell<bool>,
         /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's. A held bufferless view sets neither.
         pub pinned_buffers: Cell<u8>,
-        /// Input bytes copied by `write()` when the caller's pin does not keep
-        /// the caller's storage mapped; empty otherwise.
+        /// What `write()` copies for storage a pin cannot hold; else empty.
         pub input_copy: JsCell<Vec<u8>>,
         pub pending_close: Cell<bool>,
         pub closed: Cell<bool>,

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -46,6 +46,9 @@ mod _impl {
         pub write_in_progress: Cell<bool>,
         /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's. A held bufferless view sets neither.
         pub pinned_buffers: Cell<u8>,
+        /// Input bytes copied by `write()` when the caller's pin does not keep
+        /// the caller's storage mapped; empty otherwise.
+        pub input_copy: JsCell<Vec<u8>>,
         pub pending_close: Cell<bool>,
         pub closed: Cell<bool>,
         pub task: JsCell<WorkPoolTask>,
@@ -101,6 +104,7 @@ mod _impl {
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
                 pinned_buffers: Cell::new(0),
+                input_copy: JsCell::new(Vec::new()),
                 pending_close: Cell::new(false),
                 closed: Cell::new(false),
                 task: JsCell::new(WorkPoolTask {

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -49,8 +49,7 @@ mod _impl {
         pub write_in_progress: Cell<bool>,
         /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's. A held bufferless view sets neither.
         pub pinned_buffers: Cell<u8>,
-        /// Input bytes copied by `write()` when the caller's pin does not keep
-        /// the caller's storage mapped; empty otherwise.
+        /// What `write()` copies for storage a pin cannot hold; else empty.
         pub input_copy: JsCell<Vec<u8>>,
         pub pending_close: Cell<bool>,
         pub closed: Cell<bool>,

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -49,6 +49,9 @@ mod _impl {
         pub write_in_progress: Cell<bool>,
         /// bit 0: the pending input's ArrayBuffer is pinned; bit 1: the pending output's. A held bufferless view sets neither.
         pub pinned_buffers: Cell<u8>,
+        /// Input bytes copied by `write()` when the caller's pin does not keep
+        /// the caller's storage mapped; empty otherwise.
+        pub input_copy: JsCell<Vec<u8>>,
         pub pending_close: Cell<bool>,
         pub closed: Cell<bool>,
         pub task: JsCell<WorkPoolTask>,
@@ -115,6 +118,7 @@ mod _impl {
                 this_value: JsCell::new(StrongOptional::empty()),
                 write_in_progress: Cell::new(false),
                 pinned_buffers: Cell::new(0),
+                input_copy: JsCell::new(Vec::new()),
                 pending_close: Cell::new(false),
                 closed: Cell::new(false),
                 // WorkPoolTask { callback: undefined } — callback is overwritten by

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2066,11 +2066,12 @@ impl NodeHTTPResponse {
                     bytes_len
                 );
                 // For buffers, pin so `transfer()` copies instead of detaching.
-                // Resizable (non-shared) buffers are spilled: `resize()` mprotect()s
-                // trimmed pages PROT_NONE and `pin()` doesn't prevent it.
+                // Storage a pin does not keep mapped is spilled instead
+                // (copied into backpressure now): see
+                // `ArrayBuffer::pin_cannot_hold`.
                 let pinned_value = if is_buffer && input_value.is_cell() {
                     match input_value.as_pinned_arraybuffer(global_object) {
-                        Some(ab) if ab.resizable && !ab.shared => {
+                        Some(ab) if ab.pin_cannot_hold() => {
                             ab.unpin();
                             None
                         }

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2066,9 +2066,8 @@ impl NodeHTTPResponse {
                     bytes_len
                 );
                 // For buffers, pin so `transfer()` copies instead of detaching.
-                // Storage a pin does not keep mapped is spilled instead
-                // (copied into backpressure now): see
-                // `ArrayBuffer::pin_cannot_hold`.
+                // Storage `ArrayBuffer::pin_cannot_hold` names is spilled
+                // into backpressure here instead.
                 let pinned_value = if is_buffer && input_value.is_cell() {
                     match input_value.as_pinned_arraybuffer(global_object) {
                         Some(ab) if ab.pin_cannot_hold() => {

--- a/test/js/node/crypto/scrypt.test.ts
+++ b/test/js/node/crypto/scrypt.test.ts
@@ -93,7 +93,7 @@ test("scrypt copies a password over a WebAssembly.Memory that grows after the ca
       bunExe(),
       "-e",
       /* js */ `
-      const { scrypt, scryptSync } = require("node:crypto");
+      import { scrypt, scryptSync } from "node:crypto";
       const PAGES = 128; // 8 MB
       const newMemory = () => new WebAssembly.Memory({ initial: PAGES, maximum: PAGES + 4 });
 

--- a/test/js/node/crypto/scrypt.test.ts
+++ b/test/js/node/crypto/scrypt.test.ts
@@ -78,6 +78,59 @@ test("scrypt async does not leak callback/buffers when output allocation fails",
   expect(exitCode).toBe(0);
 });
 
+// `WebAssembly.Memory` hands out an ArrayBuffer over its own block. Once the
+// process holds more fast memories than the platform reserves slots for, the
+// next one is bounds-checked, and `grow()` on a bounds-checked memory allocates
+// a new block, copies into it, and frees the old one. JSC detaches the old
+// buffer whatever its pin count, so the pin `scrypt` takes on the password does
+// not keep those pages mapped for the pool thread.
+//
+// Run in a child: on an unfixed build the pool thread reads another object's
+// memory (wrong key) or faults.
+test("scrypt copies a password over a WebAssembly.Memory that grows after the call", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      /* js */ `
+      const { scrypt, scryptSync } = require("node:crypto");
+      const PAGES = 128; // 8 MB
+      const newMemory = () => new WebAssembly.Memory({ initial: PAGES, maximum: PAGES + 4 });
+
+      // Use up the fast-memory slots so that \`mem\` is bounds-checked.
+      const fast = Array.from({ length: 10 }, () => new WebAssembly.Memory({ initial: 1, maximum: 2 }));
+      const mem = newMemory();
+      const password = new Uint8Array(mem.buffer).fill(7);
+      const options = { N: 1024, r: 1, p: 1 };
+      const expected = scryptSync(Buffer.from(password), "salt", 32, options).toString("hex");
+
+      const { promise, resolve } = Promise.withResolvers();
+      scrypt(password, "salt", 32, options, (err, key) => resolve(err ? String(err) : key.toString("hex")));
+      mem.grow(2);
+      // Claim the freed block, so that reading it cannot see the caller's bytes.
+      const claim = Array.from({ length: 2 }, () => {
+        const memory = newMemory();
+        new Uint8Array(memory.buffer).fill(0xee);
+        return memory;
+      });
+
+      console.log(JSON.stringify({ detachedAfterGrow: password.byteLength === 0, keyMatches: (await promise) === expected }));
+    `,
+    ],
+    // `Malloc=1` makes WebKit use system malloc, so the freed block is
+    // unmapped instead of kept in bmalloc's cache: the unfixed build faults
+    // instead of reading stale bytes.
+    env: { ...bunEnv, Malloc: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout.trim()).toBe(JSON.stringify({ detachedAfterGrow: true, keyMatches: true }));
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+}, 30_000); // An 8 MB password through a debug build under system malloc: the default 5 s is not enough.
+
 test("scryptSync reads its buffers only after every argument has been coerced", () => {
   const passwordBytes = new Uint8Array(64).fill(97);
   const key = scryptSync(passwordBytes, "salt", 16, {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6868,6 +6868,78 @@ it("Bun.file keeps a path over a WebAssembly.Memory that grows after the call", 
   expect(exitCode).toBe(0);
 });
 
+// `fs.write` to a fifo whose reader drains it one pipe buffer at a time: the pool thread is still
+// inside `write(2)` when the memory grows, so it ships whatever takes the freed block's address.
+// The bytes the reader gets are the oracle, no crash needed.
+it.skipIf(isWindows)(
+  "fs.write sends the bytes the caller passed when a WebAssembly.Memory grows mid-write",
+  async () => {
+    using dir = tempDir("fs-write-wasm", {});
+    const fifoPath = join(String(dir), "w.fifo");
+    mkfifo(fifoPath);
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import fs from "node:fs";
+        const PAGES = 128;
+        const TOTAL = PAGES * 65536;
+        const newMemory = () => new WebAssembly.Memory({ initial: PAGES, maximum: PAGES + 8 });
+
+        // Use up the fast-memory slots so that \`mem\` is bounds-checked.
+        const fast = Array.from({ length: 10 }, () => new WebAssembly.Memory({ initial: 1, maximum: 2 }));
+        const mem = newMemory();
+        const view = new Uint8Array(mem.buffer).fill(0x41);
+
+        // O_RDWR keeps the open from blocking and lets this process drain the fifo itself.
+        const fd = fs.openSync(process.env.FIFO_PATH, fs.constants.O_RDWR);
+        const written = Promise.withResolvers();
+        fs.write(fd, view, 0, TOTAL, null, (err, n) => written.resolve(err ? err.code : n));
+
+        const chunk = Buffer.alloc(65536);
+        const expected = Buffer.alloc(65536, 0x41);
+        const read = () =>
+          new Promise((resolve, reject) =>
+            fs.read(fd, chunk, 0, chunk.length, null, (err, n) => (err ? reject(err) : resolve(n))),
+          );
+
+        // One pipe buffer: the pool thread is inside write(2) for the rest.
+        let drained = await read();
+        let foreignChunks = 0;
+        mem.grow(2);
+        // Claim the freed block, so that reading it cannot see the caller's bytes.
+        const claim = Array.from({ length: 4 }, () => {
+          const memory = newMemory();
+          new Uint8Array(memory.buffer).fill(0xee);
+          return memory;
+        });
+
+        while (drained < TOTAL) {
+          const n = await read();
+          if (!n) break;
+          if (Buffer.compare(chunk.subarray(0, n), expected.subarray(0, n)) !== 0) foreignChunks++;
+          drained += n;
+        }
+        console.log(JSON.stringify({ drained, foreignChunks, written: await written.promise }));
+        process.exit(0);
+      `,
+      ],
+      env: { ...bunEnv, FIFO_PATH: fifoPath },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe(JSON.stringify({ drained: 8388608, foreignChunks: 0, written: 8388608 }));
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    // 8 MB through a 64 KB pipe on a debug build: the default 5 s is not enough.
+  },
+  30_000,
+);
+
 // A sync call reads the path after the option getters ran. It reads the bytes captured at call time
 // when a getter shrinks the buffer.
 it("sync fs calls read a Buffer path captured at call time when an option getter shrinks its resizable ArrayBuffer", async () => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6826,6 +6826,48 @@ it("fs.promises.stat reads a Buffer path captured at call time when its resizabl
   expect(exitCode).toBe(0);
 });
 
+// `Bun.file(view)` keeps the path bytes and re-reads them on every later call. A pin does not keep a
+// bounds-checked `WebAssembly.Memory`'s block mapped: `grow()` allocates a new block, copies into it
+// and frees the old one, and JSC detaches the old buffer whatever its pin count.
+it("Bun.file keeps a path over a WebAssembly.Memory that grows after the call", async () => {
+  using dir = tempDir("bun-file-wasm-path", { "hello.txt": "hello" });
+  // The unfixed build segfaults on the main thread, so this runs in a child process.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        // Use up the fast-memory slots so that \`mem\` is bounds-checked.
+        const fast = Array.from({ length: 12 }, () => new WebAssembly.Memory({ initial: 1, maximum: 2 }));
+        const mem = new WebAssembly.Memory({ initial: 1, maximum: 16 });
+        const encoded = new TextEncoder().encode(process.cwd() + "/hello.txt");
+        new Uint8Array(mem.buffer).set(encoded);
+
+        const file = Bun.file(new Uint8Array(mem.buffer, 0, encoded.length));
+        mem.grow(1);
+        // Claim the freed block, so that reading it cannot see the path bytes.
+        const claim = Array.from({ length: 2 }, () => {
+          const memory = new WebAssembly.Memory({ initial: 1, maximum: 16 });
+          new Uint8Array(memory.buffer).fill(0xee);
+          return memory;
+        });
+
+        console.log(JSON.stringify({ text: await file.text(), exists: await file.exists() }));
+      `,
+    ],
+    // `Malloc=1` makes WebKit use system malloc, so the freed block is unmapped instead of kept in
+    // bmalloc's cache: the unfixed build faults instead of reading stale bytes.
+    env: { ...bunEnv, Malloc: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout.trim()).toBe(JSON.stringify({ text: "hello", exists: true }));
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 // A sync call reads the path after the option getters ran. It reads the bytes captured at call time
 // when a getter shrinks the buffer.
 it("sync fs calls read a Buffer path captured at call time when an option getter shrinks its resizable ArrayBuffer", async () => {

--- a/test/js/node/http/node-http-pinned-write.test.ts
+++ b/test/js/node/http/node-http-pinned-write.test.ts
@@ -396,6 +396,98 @@ describe("node:http large Buffer writes are sent zero-copy", () => {
     expect(exitCode).toBe(0);
   });
 
+  // `WebAssembly.Memory` hands out an ArrayBuffer over its own block. Once the
+  // process holds more fast memories than the platform reserves slots for, the
+  // next one is bounds-checked, and `grow()` on a bounds-checked memory
+  // allocates a new block, copies into it, and frees the old one. JSC detaches
+  // the old buffer whatever its pin count, so a pinned tail over one of those
+  // points at freed pages.
+  //
+  // 32 MB: the loopback send + receive buffers absorb several MB, so a smaller
+  // body can leave no tail to spill.
+  const WASM_PAGES = 512;
+  const wasmMemoryChild = /* js */ `
+    const http = require("node:http");
+    const net = require("node:net");
+    const { once } = require("node:events");
+    const PAGES = ${WASM_PAGES}; // 32 MB
+    const newMemory = () => new WebAssembly.Memory({ initial: PAGES, maximum: PAGES + 4 });
+
+    // Use up the fast-memory slots so that \`mem\` is bounds-checked.
+    const fast = Array.from({ length: 10 }, () => new WebAssembly.Memory({ initial: 1, maximum: 2 }));
+    const mem = newMemory();
+    const payload = new Uint8Array(mem.buffer).fill(7);
+    const CHUNK_SIZE = payload.byteLength;
+
+    let detachedAfterGrow;
+    const wrote = Promise.withResolvers();
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, {
+        "Content-Type": "application/octet-stream",
+        "Content-Length": String(CHUNK_SIZE),
+      });
+      res.write(payload);
+      mem.grow(2);
+      detachedAfterGrow = payload.byteLength === 0;
+      // Claim the freed block, so that reading it cannot see the caller's bytes.
+      globalThis.claim = Array.from({ length: 2 }, () => {
+        const memory = newMemory();
+        new Uint8Array(memory.buffer).fill(0xee);
+        return memory;
+      });
+      wrote.resolve();
+      res.end(); // spills the pending tail
+    });
+    await once(server.listen(0), "listening");
+
+    const socket = net.connect(server.address().port, "127.0.0.1");
+    await once(socket, "connect");
+    socket.pause();
+    socket.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
+    await wrote.promise;
+
+    const chunks = [];
+    socket.on("data", c => chunks.push(c));
+    const closed = once(socket, "close");
+    socket.resume();
+    await closed;
+
+    const received = Buffer.concat(chunks);
+    const body = received.subarray(received.indexOf("\\r\\n\\r\\n") + 4);
+    const expected = Buffer.alloc(CHUNK_SIZE, 7);
+    console.log(JSON.stringify({
+      detachedAfterGrow,
+      bodyLength: body.length,
+      bodyMatches: Buffer.compare(body, expected) === 0,
+    }));
+    server.close();
+  `;
+
+  test.skipIf(isWindows)(
+    "a WebAssembly.Memory that grows after write() is copied, not held by reference",
+    async () => {
+      // Run in a child so a fault on the spill is observed as exit != 0.
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", wasmMemoryChild],
+        // `Malloc=1` makes WebKit use system malloc, so the freed block is
+        // unmapped instead of kept in bmalloc's cache: the unfixed build
+        // faults instead of reading stale bytes.
+        env: { ...bunEnv, Malloc: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr }).toEqual({
+        stdout: JSON.stringify({ detachedAfterGrow: true, bodyLength: WASM_PAGES * 64 * 1024, bodyMatches: true }),
+        stderr: expect.any(String),
+      });
+      expect(exitCode).toBe(0);
+    },
+    // A 32 MB body through a debug build: the default 5 s is not enough.
+    30_000,
+  );
+
   test("a second write before drain releases the pin on the first buffer", async () => {
     let detachedAfterSecondWrite: boolean | undefined;
     const total = CHUNK_SIZE + 1024;

--- a/test/js/node/zlib/zlib-handle-bounds-check.test.ts
+++ b/test/js/node/zlib/zlib-handle-bounds-check.test.ts
@@ -466,7 +466,8 @@ describe.concurrent("zlib native handle argument validation", () => {
          catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
       ),
     ).toEqual({
-      stdout: 'threw ERR_INVALID_ARG_VALUE: The "out" argument must not be backed by a resizable ArrayBuffer',
+      stdout:
+        'threw ERR_INVALID_ARG_VALUE: The "out" argument must not be backed by a resizable ArrayBuffer or a WebAssembly.Memory',
       exitCode: 0,
     });
   });

--- a/test/js/node/zlib/zlib-reset-race.test.ts
+++ b/test/js/node/zlib/zlib-reset-race.test.ts
@@ -186,7 +186,8 @@ const resizableWriteFixture = (which: "in" | "out") => /* js */ `
 
 test("async write() rejects an output buffer backed by a resizable ArrayBuffer for zlib, brotli, and zstd", async () => {
   const { stdout, exitCode } = await run(resizableWriteFixture("out"));
-  const expected = 'threw ERR_INVALID_ARG_VALUE: The "out" argument must not be backed by a resizable ArrayBuffer';
+  const expected =
+    'threw ERR_INVALID_ARG_VALUE: The "out" argument must not be backed by a resizable ArrayBuffer or a WebAssembly.Memory';
   expect(stdout.trim()).toBe([expected, expected, expected].join("\n"));
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -860,6 +860,67 @@ describe("input over a WebAssembly.Memory that grows after the call", () => {
     expect(exitCode).toBe(0);
     // An 8 MB input through a debug build under system malloc: the default 5 s is not enough.
   }, 30_000);
+
+  // The stream APIs reach the same native write as the one-shots above.
+  it("createZstdCompress().write() compresses the bytes the caller passed", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        /* js */ `
+        const { createZstdCompress, zstdDecompressSync, constants } = require("node:zlib");
+        const { randomFillSync } = require("node:crypto");
+        const PAGES = 128; // 8 MB
+        const newMemory = () => new WebAssembly.Memory({ initial: PAGES, maximum: PAGES + 4 });
+
+        // Use up the fast-memory slots so that \`mem\` is bounds-checked.
+        const fast = Array.from({ length: 10 }, () => new WebAssembly.Memory({ initial: 1, maximum: 2 }));
+        const mem = newMemory();
+        const input = new Uint8Array(mem.buffer);
+        // Incompressible input at a high level: the job is still reading when the block is freed.
+        randomFillSync(input);
+        const original = Buffer.from(input);
+
+        const stream = createZstdCompress({
+          chunkSize: 12 << 20,
+          params: { [constants.ZSTD_c_compressionLevel]: 12 },
+        });
+        const chunks = [];
+        stream.on("data", chunk => chunks.push(chunk));
+        const ended = new Promise(resolve => stream.on("end", resolve));
+
+        stream.write(input);
+        stream.end();
+        mem.grow(2);
+        // Claim the freed block, so that reading it cannot see the caller's bytes.
+        const claim = Array.from({ length: 4 }, () => {
+          const memory = newMemory();
+          new Uint8Array(memory.buffer).fill(0xee);
+          return memory;
+        });
+
+        await ended;
+        const out = Buffer.concat(chunks);
+        console.log(JSON.stringify({
+          detachedAfterGrow: input.byteLength === 0,
+          roundTripMatches: Buffer.compare(zstdDecompressSync(out), original) === 0,
+        }));
+      `,
+      ],
+      // `Malloc=1` makes WebKit use system malloc, so the freed block is
+      // unmapped instead of kept in bmalloc's cache: the unfixed build faults
+      // instead of reading stale bytes.
+      env: { ...bunEnv, Malloc: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe(JSON.stringify({ detachedAfterGrow: true, roundTripMatches: true }));
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    // An 8 MB input through a debug build under system malloc: the default 5 s is not enough.
+  }, 30_000);
 });
 
 describe("crc32", () => {

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -1,6 +1,6 @@
 import { deflateSync, gunzipSync, gzipSync, inflateSync } from "bun";
 import { describe, expect, it } from "bun:test";
-import { tmpdirSync } from "harness";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 import * as buffer from "node:buffer";
 import { randomFillSync } from "node:crypto";
 import * as fs from "node:fs";
@@ -799,6 +799,67 @@ describe("dictionary buffer lifetime", () => {
 
     expect(Buffer.concat(chunks).toString()).toBe(input.toString());
   });
+});
+
+// `WebAssembly.Memory` hands out an ArrayBuffer over its own block. Once the
+// process holds more fast memories than the platform reserves slots for, the
+// next one is bounds-checked, and `grow()` on a bounds-checked memory allocates
+// a new block, copies into it, and frees the old one. JSC detaches the old
+// buffer whatever its pin count, so the pin the async write takes on the input
+// does not keep those pages mapped for the pool thread.
+//
+// Run in a child: on an unfixed build the pool thread compresses another
+// object's memory or faults.
+describe("input over a WebAssembly.Memory that grows after the call", () => {
+  it("zstdCompress compresses the bytes the caller passed", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        /* js */ `
+        const { zstdCompress, zstdDecompressSync, constants } = require("node:zlib");
+        const { randomFillSync } = require("node:crypto");
+        const PAGES = 128; // 8 MB
+        const newMemory = () => new WebAssembly.Memory({ initial: PAGES, maximum: PAGES + 4 });
+
+        // Use up the fast-memory slots so that \`mem\` is bounds-checked.
+        const fast = Array.from({ length: 10 }, () => new WebAssembly.Memory({ initial: 1, maximum: 2 }));
+        const mem = newMemory();
+        const input = new Uint8Array(mem.buffer);
+        // Incompressible input at a high level: the job is still reading when the block is freed.
+        randomFillSync(input);
+        const original = Buffer.from(input);
+
+        const { promise, resolve } = Promise.withResolvers();
+        const options = { chunkSize: 12 << 20, params: { [constants.ZSTD_c_compressionLevel]: 12 } };
+        zstdCompress(input, options, (err, out) =>
+          resolve(err ? String(err) : Buffer.compare(zstdDecompressSync(out), original) === 0),
+        );
+        mem.grow(2);
+        // Claim the freed block, so that reading it cannot see the caller's bytes.
+        const claim = Array.from({ length: 4 }, () => {
+          const memory = newMemory();
+          new Uint8Array(memory.buffer).fill(0xee);
+          return memory;
+        });
+
+        console.log(JSON.stringify({ detachedAfterGrow: input.byteLength === 0, roundTripMatches: await promise }));
+      `,
+      ],
+      // `Malloc=1` makes WebKit use system malloc, so the freed block is
+      // unmapped instead of kept in bmalloc's cache: the unfixed build faults
+      // instead of reading stale bytes.
+      env: { ...bunEnv, Malloc: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe(JSON.stringify({ detachedAfterGrow: true, roundTripMatches: true }));
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    // An 8 MB input through a debug build under system malloc: the default 5 s is not enough.
+  }, 30_000);
 });
 
 describe("crc32", () => {

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -817,8 +817,8 @@ describe("input over a WebAssembly.Memory that grows after the call", () => {
         bunExe(),
         "-e",
         /* js */ `
-        const { zstdCompress, zstdDecompressSync, constants } = require("node:zlib");
-        const { randomFillSync } = require("node:crypto");
+        import { zstdCompress, zstdDecompressSync, constants } from "node:zlib";
+        import { randomFillSync } from "node:crypto";
         const PAGES = 128; // 8 MB
         const newMemory = () => new WebAssembly.Memory({ initial: PAGES, maximum: PAGES + 4 });
 
@@ -868,8 +868,8 @@ describe("input over a WebAssembly.Memory that grows after the call", () => {
         bunExe(),
         "-e",
         /* js */ `
-        const { createZstdCompress, zstdDecompressSync, constants } = require("node:zlib");
-        const { randomFillSync } = require("node:crypto");
+        import { createZstdCompress, zstdDecompressSync, constants } from "node:zlib";
+        import { randomFillSync } from "node:crypto";
         const PAGES = 128; // 8 MB
         const newMemory = () => new WebAssembly.Memory({ initial: PAGES, maximum: PAGES + 4 });
 


### PR DESCRIPTION
### Problem

- A native job that borrows a `WebAssembly.Memory`'s bytes reads freed pages once the memory grows. On the pool thread `crypto.scrypt` faults in `sha256_block_data_order_hw` and `zlib.zstdCompress` faults in `memcpy <- ZSTD_limitCopy`. On the main thread a `node:http` pending write faults in `uWS::BackPressure::append`, and `Bun.file(pathView)` answers `ENOENT` for a file that exists.
- A pin does not hold that storage. `grow()` on a bounds-checked memory allocates a new block, copies into it, and frees the old one: `JSWebAssemblyMemory::growSuccessCallback` calls `ArrayBuffer::detach()`, which releases the contents whatever the pin count ("We allow detaching wasm memory ArrayBuffers even though they are locked", WebKit `ArrayBuffer.cpp`), and those contents hold the last ref on the block.
- A memory is bounds-checked once the process holds more fast memories than the platform reserves slots for (8, or 3 without a large Gigacage), so an app with a handful of wasm modules hands out such buffers.

### Fix

- `Bun__ArrayBuffer` now reports `wasm_memory`, and `ArrayBuffer::pin_cannot_hold()` is true for a non-shared wasm memory or a resizable non-shared buffer. `PinnedArrayBuffer::copy_if_resizable` becomes `copy_if_pin_cannot_hold` and copies for both (`src/jsc/array_buffer.rs:166`).
- `StringOrBuffer::buffer_from_js` copies in its async arm, so every parse for a work-pool job is covered (`fs.write`, `fs.writeFile`, `crypto.pbkdf2`, `crypto.scrypt`, `Bun.zstdCompress`) instead of only the `from_js_async` callers. `PathLike` picks up the wider rule for the async fs family, and a `Blob` store now copies a path buffer's bytes instead of keeping the buffer pinned for good.
- The `node:zlib` async write copies the input chunk into the stream, which covers the one-shots and `createGzip()`/`createZstdCompress()`. A `node:http` pending zero-copy write spills into backpressure instead of holding such a buffer by reference.
- Correct because a SharedArrayBuffer and a fast (signal-handling) memory grow in place, so only a non-shared memory needs the copy. The ArrayBuffer does not say which mode the memory uses, so every non-shared wasm borrow copies.
- Verified: `test/js/node/crypto/scrypt.test.ts`, `test/js/node/zlib/zlib.test.js`, `test/js/node/http/node-http-pinned-write.test.ts`, `test/js/node/fs/fs.test.ts` (6 new cells, each fails on unfixed `src/`). Also all of `test/js/node/zlib/` and `test/js/node/fs/fs.test.ts` together (1038 tests), plus `test/js/bun/util/zstd.test.ts`, `test/js/node/crypto/pbkdf2.test.ts` and `test/js/bun/io/bun-write.test.js`.

### Background

- A pin (`ArrayBuffer::pin()`) clears `isDetachable()`. It makes `transfer()` copy instead of detach, so a borrow keeps reading the same bytes. It does not own the storage, and wasm memory is the documented exception to the detach rule.
- `WebAssembly.Memory` hands out an ArrayBuffer over the block the memory owns. A fast memory reserves a huge address range and only maps more of it on `grow()`, so the base pointer never moves. A bounds-checked memory has no reservation, so `grow()` moves the block.
- `PinnedArrayBuffer` is the borrow helper for a value whose bytes are read after the call returns (a work-pool job, a `Blob` store). It pins, GC-roots, and now copies when the pin cannot hold the bytes.
- The `node:http` pending zero-copy write holds the unsent tail of a large `res.write()` by reference instead of copying it into the uWS backpressure buffer. `res.end()` spills that tail.

<details><summary>Notes</summary>

Not covered by this change, and still live:

- `fs.read` / `fs.readv` / `FileHandle.read` into a view over such a memory. That is the write direction: the pool thread writes into the old block, so the fix needs a scratch buffer plus a copy-back on the JS thread once the call completes.
- `fs.writev`, which does not parse through `StringOrBuffer`. `VectorArrayBuffer::from_js` pins each span and keeps a raw iovec, and one parse serves both `writev` and `readv`, so a copy there needs the direction threaded through first.
- The shell's `> ${view}` redirect, for the same reason as `fs.read`.
- `HTTPParser.execute(view)`, which pins in C++ (`src/jsc/bindings/node/http/JSHTTPParserPrototype.cpp`).
- `JSC__JSValue__borrowBytesForOffThread` (`Bun.Image`, MySQL binds). #38289 copies there.

Two of the six cells were added after a coverage check pointed out that `fs.write` and the zlib stream face were covered by construction only. Both compare bytes rather than waiting for a crash. On unfixed `src/` the `fs.write` cell receives 923 chunks that are not the caller's bytes (the callback still reports success, `n` = 8388608), and the `createZstdCompress().write()` cell kills the child.

Two findings from the first round of review are in the second commit. The `node:zlib` async write rejected only a resizable output buffer, and the pool thread writes into that buffer after the call returns, so the test is now `pin_cannot_hold()` as well (the message gains "or a `WebAssembly.Memory`"; the output buffer is not reachable from the public API, which allocates it internally). The output buffer is also pinned before the input copy is taken, so no error path can leave a copy behind.

The `Blob` store fix came out of the x64-asan lane. A store kept its path as a pinned buffer and protected the cell for good, so a collected `Bun.file(pathBuffer)` released that pin from a heap sweep: `ASSERTION FAILED: vm().currentThreadIsHoldingAPILock() => vm().heap.mutatorState() != MutatorState::Sweeping`, `JSCell.cpp(179)`. It reproduces on the base commit with a plain `Buffer` path and no wasm at all. `thread_isolated_copy` now copies the bytes on the JS thread, as `Clone` already did, which also stops leaking one protected cell per call.

The tests spawn their child with `Malloc=1`. Without it WebKit keeps the freed block in bmalloc's cache, so the unfixed build reads stale-but-intact bytes and the test passes when it must fail. Each child also allocates same-shaped memories right after `grow()` to claim the freed block, which turns a crash-or-not race into a byte comparison.

Costs: `JSC__JSValue__asArrayBuffer` adds two loads for a view that already has an ArrayBuffer (`hasArrayBuffer()` then the buffer's flag), and nothing for a Fast or Oversize view. An async borrow of a wasm-backed view now copies the bytes, including for a fast memory that would not have moved. Node copies KDF inputs for the same reason.

`pin_cannot_hold()` also makes the `node:http` write path and the fs/`Bun.file` path family handle `mem.toResizableBuffer()`, which reports `resizable` and `wasm_memory` at once.

This makes #40554 (copy the password and salt by hand in the KDFs) unnecessary: the same inputs are copied one level down, in the parse every async `StringOrBuffer` goes through.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/http/node-http-pinned-write.test.ts, test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->
