### PR TITLE
Date setters: range-check year + floor(month / 12), not each argument (WebKit bump for oven-sh/WebKit#616)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "dfd696443b9ba87c4f516d1c724f0abacdd8768a";
+export const WEBKIT_VERSION = "autobuild-preview-pr-616-5e00ef59";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/date-setters-year-month-range.test.ts
+++ b/test/js/bun/jsc/date-setters-year-month-range.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+// Date.prototype.set{FullYear,Month,UTCFullYear,UTCMonth} build their result with
+// MakeDay(year, month, date), which range-checks year + floor(month / 12) and never year or month
+// alone (https://tc39.es/ecma262/#sec-makeday). JSC used to return NaN as soon as |year| or
+// |month / 12| alone exceeded 275760, while Date.UTC and the Date constructor in the same engine
+// (and V8) returned the date. oven-sh/WebKit#616.
+
+const startOfYear275760 = 8639977881600000; // 275760 is the last year with representable time values.
+const minTimeValue = -8.64e15; // -271821-04-20T00:00:00Z
+
+describe("Date setters range-check year + floor(month / 12), not each argument", () => {
+  test("UTC setters give what Date.UTC gives for the same fields", () => {
+    expect(Date.UTC(275760, 0, 1)).toBe(startOfYear275760);
+    expect(new Date(0).setUTCFullYear(275761, -12, 1)).toBe(startOfYear275760);
+    expect(new Date(0).setUTCFullYear(275761, -12)).toBe(startOfYear275760);
+    expect(new Date(0).setUTCFullYear(300000, -300000, 1)).toBe(Date.UTC(275000, 0, 1));
+    expect(new Date(0).setUTCFullYear(-300000, 12 * 302000)).toBe(Date.UTC(2000, 0, 1));
+    expect(new Date(NaN).setUTCFullYear(-271821, 3600000)).toBe(Date.UTC(28179, 0, 1));
+    expect(new Date(Date.UTC(-1, 0, 1)).setUTCMonth(12 * 275761)).toBe(startOfYear275760);
+    expect(new Date(Date.UTC(-271821, 3, 20)).setUTCMonth(3 + 12 * (275760 + 271821))).toBe(Date.UTC(275760, 3, 20));
+    expect(new Date(startOfYear275760).setUTCMonth(3 - 12 * (275760 + 271821), 20)).toBe(minTimeValue);
+
+    // The day count is part of the same sum: the start of 275761 is out of range, 200 days earlier is not.
+    expect(new Date(0).setUTCFullYear(275761, 0, -200)).toBe(Date.UTC(275760, 0, 166));
+    expect(new Date(0).setUTCFullYear(-271822, 0, 500)).toBe(Date.UTC(-271821, 0, 135));
+
+    // Exact to the millisecond even when |days * msPerDay| exceeds 2^53.
+    expect(new Date(946688523001).setUTCFullYear(300000, 0, -108842264)).toBe(946688523001);
+    expect(new Date(8.64e15 - 999).setUTCDate(-199000000)).toBe(Date.UTC(275760, 8, -199000000, 23, 59, 59, 1));
+    expect(new Date(8.64e15 - 999).setUTCDate(-199000000)).toBe(-8553601036800999);
+
+    const date = new Date(0);
+    expect(date.setUTCFullYear(275761, -12, 1)).toBe(startOfYear275760);
+    expect(date.toISOString()).toBe("+275760-01-01T00:00:00.000Z");
+    expect(date.setUTCMonth(9)).toBeNaN(); // October 275760 is past the last time value.
+    expect(date.getTime()).toBeNaN();
+  });
+
+  test("local time setters give what the Date constructor gives", () => {
+    expect(new Date(2000, 0, 1).setFullYear(300000, -300000, 1)).toBe(new Date(275000, 0, 1).getTime());
+    expect(new Date(2000, 0, 1).setFullYear(275761, -12)).toBe(new Date(275760, 0, 1).getTime());
+    expect(new Date(-1000, 0, 1).setMonth(12 * 276000 + 5, 6)).toBe(new Date(275000, 5, 6).getTime());
+    expect(new Date(2000, 0, 1, 1, 2, 3, 457).setFullYear(300000, 0, -108842264)).toBe(
+      new Date(300000, 0, -108842264, 1, 2, 3, 457).getTime(),
+    );
+    expect(Number.isFinite(new Date(275000, 5, 6).getTime())).toBe(true);
+  });
+
+  test("still NaN when the combined year is out of range or an argument is not finite", () => {
+    expect(new Date(0).setUTCFullYear(275761, 0, 1)).toBeNaN();
+    expect(new Date(0).setUTCFullYear(275760, 12)).toBeNaN();
+    expect(new Date(0).setUTCFullYear(-271822, 0, 1)).toBeNaN();
+    expect(new Date(0).setUTCMonth(12 * 275760)).toBeNaN();
+    // A year or month count beyond int32 does not wrap around.
+    expect(new Date(0).setUTCFullYear(2 ** 31 + 2000)).toBeNaN();
+    expect(new Date(0).setUTCFullYear(2 ** 32 + 2000)).toBeNaN();
+    expect(new Date(0).setUTCFullYear(2000, 12 * 2 ** 32)).toBeNaN();
+    expect(new Date(0).setUTCMonth(12 * 2 ** 32)).toBeNaN();
+    expect(new Date(0).setFullYear(2 ** 32 + 2000)).toBeNaN();
+    expect(new Date(0).setMonth(12 * 2 ** 32)).toBeNaN();
+    expect(new Date(0).setYear(2 ** 32 + 2000)).toBeNaN();
+    expect(new Date(0).setYear(275761)).toBeNaN();
+    expect(new Date(0).setUTCFullYear(500000, -12 * (500000 - 2000))).toBe(Date.UTC(2000, 0, 1));
+    expect(new Date(0).setUTCFullYear(-9007197107257351, 108086391056891980, 784353026671)).toBeNaN();
+    expect(Date.UTC(-9007197107257351, 108086391056891980, 784353026671)).toBeNaN();
+
+    expect(new Date(0).setUTCFullYear(Infinity, -Infinity)).toBeNaN();
+    expect(new Date(0).setUTCFullYear(-Infinity, Infinity, 1)).toBeNaN();
+    expect(new Date(0).setUTCFullYear(2000, Infinity, -Infinity)).toBeNaN();
+    expect(new Date(0).setUTCMonth(NaN, 1)).toBeNaN();
+    expect(new Date(0).setFullYear(Infinity, -Infinity)).toBeNaN();
+  });
+});


### PR DESCRIPTION
### Problem
- The Date year/month setters return `NaN` once the year argument alone (or month / 12 alone) is outside ±275760, even when the date is valid: `new Date(0).setUTCFullYear(275761, -12, 1)` is `NaN`, while `Date.UTC(275761, -12, 1)` is `8639977881600000`. Node returns the date.
- The cause is in JSC: `fillStructuresUsingDateArgs()` (`runtime/DatePrototype.cpp`) bounds `years` and `months / 12` separately and stores them as `int`, while [MakeDay](https://tc39.es/ecma262/#sec-makeday) range-checks only `year + floor(month / 12)`.

### Fix
- Pin WebKit to `autobuild-preview-pr-616-5e00ef59`, the preview build of oven-sh/WebKit#616. With it the setters hold their arguments as doubles and build the result through the same `makeDay` / `makeTime` / `makeDate` path as the Date constructor and `Date.UTC`, so they give exactly what those give for the same fields.
- The pin is a preview tag. Do not merge before oven-sh/WebKit#616 lands. I move the pin to the merged commit then. The preview is the current pin (`dfd696443b`) plus that one commit.
- Verified: `test/js/bun/jsc/date-setters-year-month-range.test.ts` (new, 3 tests). `USE_SYSTEM_BUN=1` (bun 1.4.3) fails all 3, `bun bd test` with this pin passes all 3. Also ran `test/js/web/intl` and `test/js/bun/jsc/temporal-global.test.ts`. oven-sh/WebKit#616 lists the JSC-side runs.

### Background
- A time value is milliseconds from the epoch, at most ±8.64e15 (years -271821 to 275760). Anything beyond becomes `NaN` (TimeClip).
- MakeDay normalises first (`ym = year + floor(month / 12)`, `mn = month mod 12`), then adds `date - 1` days. A month of -12 or a negative day count can pull an out-of-range year back in, and only the final value decides.
- Upstream WebKit added the per-argument bound (295562@main) so that `toInt32()` of a huge year cannot wrap into range. `makeDay()` adds in doubles before it requires an int32, so the bound is not needed for that.

<details><summary>Notes</summary>

- Other ledger cases, now equal to Node: `new Date(0).setFullYear(300000, -300000, 1)` = `new Date(300000, -300000, 1)`, `new Date(Date.UTC(-1, 0, 1)).setUTCMonth(12 * 275761)` = 8639977881600000, `new Date(NaN).setUTCFullYear(-271821, 3600000)` = 827076182400000. Controls unchanged: `setUTCFullYear(275760, -12, 1)` = 8639946345600000, `setUTCFullYear(275761, 0, 1)` = NaN.
- The WebKit change also stops pre-multiplying the day argument into the milliseconds, so `new Date(8.64e15 - 999).setUTCDate(-199000000)` is `-8553601036800999` like `Date.UTC(275760, 8, -199000000, 23, 59, 59, 1)` and Node, not `-8553601036801000`. The test covers that.
- JSC accepts any normalised year that fits an int32 and lets TimeClip decide, as its `Date.UTC` always has. V8 caps |year| at 1e6 and |month| at 1e7 first. The test stays inside both.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/date-setters-year-month-range.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc/date-setters-year-month-range.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/jsc/date-setters-year-month-range.test.ts:
(pass) Date setters range-check year + floor(month / 12), not each argument > UTC setters give what Date.UTC gives for the same fields [17.37ms]
(pass) Date setters range-check year + floor(month / 12), not each argument > local time setters give what the Date constructor gives [177.27ms]
(pass) Date setters range-check year + floor(month / 12), not each argument > still NaN when the combined year is out of range or an argument is not finite [10.61ms]

 3 pass
 0 fail
 43 expect() calls
Ran 3 tests across 1 file. [2.25s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |  2 +-
 .../bun/jsc/date-setters-year-month-range.test.ts  | 74 ++++++++++++++++++++++
 2 files changed, 75 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
scripts/build/deps/webkit.ts                               1      1      5
test/js/bun/jsc/date-setters-year-month-range.test.ts      0      1      5
```

</details>

<!-- robobun:evidence:end -->