### PR TITLE
node:http: copy the HTTPParser input when a callback can unmap it

### DIFF
--- a/src/jsc/bindings/node/http/JSHTTPParserPrototype.cpp
+++ b/src/jsc/bindings/node/http/JSHTTPParserPrototype.cpp
@@ -134,12 +134,31 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPParser_execute, (JSGlobalObject * globalObject, C
             throwOutOfMemoryError(globalObject, scope);
             return {};
         }
-        if (!backingBuffer->isShared())
+
+        std::span<const uint8_t> input = buffer->span();
+
+        // llhttp reads these bytes for the whole run, and the parser's callbacks run user JS in
+        // the middle of it. A pin makes a transfer() copy instead of freeing the bytes, but it
+        // stops neither resize() on a resizable ArrayBuffer nor the detach that a
+        // WebAssembly.Memory grow() performs. Either one unmaps the bytes llhttp is still
+        // reading, so copy them into memory that lives for the whole call.
+        WTF::Vector<uint8_t> owned;
+        bool copied = !input.empty() && (backingBuffer->isResizableNonShared() || backingBuffer->isWasmMemory());
+        if (copied) {
+            if (!owned.tryAppend(input)) {
+                throwOutOfMemoryError(globalObject, scope);
+                return {};
+            }
+            input = owned.span();
+        }
+
+        bool pinned = !copied && !backingBuffer->isShared();
+        if (pinned)
             backingBuffer->pin();
 
-        JSValue result = parser->impl()->execute(globalObject, reinterpret_cast<const char*>(buffer->vector()), buffer->byteLength());
+        JSValue result = parser->impl()->execute(globalObject, reinterpret_cast<const char*>(input.data()), input.size());
 
-        if (!backingBuffer->isShared())
+        if (pinned)
             backingBuffer->unpin();
         RETURN_IF_EXCEPTION(scope, {});
 

--- a/src/jsc/bindings/node/http/JSHTTPParserPrototype.cpp
+++ b/src/jsc/bindings/node/http/JSHTTPParserPrototype.cpp
@@ -137,11 +137,7 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPParser_execute, (JSGlobalObject * globalObject, C
 
         std::span<const uint8_t> input = buffer->span();
 
-        // llhttp reads these bytes for the whole run, and the parser's callbacks run user JS in
-        // the middle of it. A pin makes a transfer() copy instead of freeing the bytes, but it
-        // stops neither resize() on a resizable ArrayBuffer nor the detach that a
-        // WebAssembly.Memory grow() performs. Either one unmaps the bytes llhttp is still
-        // reading, so copy them into memory that lives for the whole call.
+        // A pin stops transfer(), not resize() or a WebAssembly.Memory grow(), which a callback can call.
         WTF::Vector<uint8_t> owned;
         bool copied = !input.empty() && (backingBuffer->isResizableNonShared() || backingBuffer->isWasmMemory());
         if (copied) {

--- a/test/js/node/http/node-http-parser.test.ts
+++ b/test/js/node/http/node-http-parser.test.ts
@@ -193,6 +193,10 @@ describe("HTTPParser.prototype.execute", () => {
   const chunkSize = `${payloadSize.toString(16)}\r\n`.length + payloadSize + "\r\n".length;
   // A resizable ArrayBuffer of its own, or one WebAssembly.Memory page.
   const inputSizes = { resizable: 1024 * 1024, wasm: 64 * 1024 };
+  // A signaling wasm memory reserves its maximum up front and commits pages in place as it grows,
+  // which leaves the input mapped. Only a bounds checked memory releases the block it grew out of,
+  // so the wasm case asks JSC for that mode instead of counting on a full signaling memory pool.
+  const modeEnv = { resizable: bunEnv, wasm: { ...bunEnv, BUN_JSC_useWasmFastMemory: "0" } };
 
   const fixture = (mode: keyof typeof inputSizes) => `
     const { HTTPParser } = process.binding("http_parser");
@@ -205,12 +209,9 @@ describe("HTTPParser.prototype.execute", () => {
       // resize() decommits the trimmed pages.
       mutate = () => buffer.resize(0);
     } else {
-      // Fill the signaling memory pool first so that the next memory is bounds checked. A bounds
-      // checked memory can move its bytes when it grows.
-      globalThis.hold = Array.from({ length: 12 }, () => new WebAssembly.Memory({ initial: 1, maximum: 2 }));
       const memory = new WebAssembly.Memory({ initial: 1, maximum: 2 });
       bytes = new Uint8Array(memory.buffer);
-      // grow() detaches the old buffer and releases its block.
+      // grow() detaches the old buffer and releases the block it held.
       mutate = () => memory.grow(1);
     }
 
@@ -260,7 +261,7 @@ describe("HTTPParser.prototype.execute", () => {
     async mode => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", fixture(mode)],
-        env: bunEnv,
+        env: modeEnv[mode],
         stderr: "pipe",
       });
 

--- a/test/js/node/http/node-http-parser.test.ts
+++ b/test/js/node/http/node-http-parser.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 const { HTTPParser, ConnectionsList, methods, allMethods } = process.binding("http_parser");
 const { parsers } = require("node:_http_common");
 
@@ -182,6 +183,107 @@ describe("HTTPParser.prototype.execute", () => {
     expect(bodyChunks.join("")).toBe("hello world");
     expect(executed).toBe(inputLength);
   });
+
+  // A callback can shrink a resizable ArrayBuffer, or grow a WebAssembly.Memory, while llhttp is
+  // still scanning the input. Both unmap the input bytes, which a pin does not stop, so each case
+  // runs in a child process: the parse must finish on bytes that stay mapped.
+  const head = "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n";
+  const tail = "0\r\n\r\n";
+  const payloadSize = 1024;
+  const chunkSize = `${payloadSize.toString(16)}\r\n`.length + payloadSize + "\r\n".length;
+  // A resizable ArrayBuffer of its own, or one WebAssembly.Memory page.
+  const inputSizes = { resizable: 1024 * 1024, wasm: 64 * 1024 };
+
+  const fixture = (mode: keyof typeof inputSizes) => `
+    const { HTTPParser } = process.binding("http_parser");
+
+    let bytes, mutate;
+    if (${JSON.stringify(mode)} === "resizable") {
+      const size = ${inputSizes.resizable};
+      const buffer = new ArrayBuffer(size, { maxByteLength: size });
+      bytes = new Uint8Array(buffer);
+      // resize() decommits the trimmed pages.
+      mutate = () => buffer.resize(0);
+    } else {
+      // Fill the signaling memory pool first so that the next memory is bounds checked. A bounds
+      // checked memory can move its bytes when it grows.
+      globalThis.hold = Array.from({ length: 12 }, () => new WebAssembly.Memory({ initial: 1, maximum: 2 }));
+      const memory = new WebAssembly.Memory({ initial: 1, maximum: 2 });
+      bytes = new Uint8Array(memory.buffer);
+      // grow() detaches the old buffer and releases its block.
+      mutate = () => memory.grow(1);
+    }
+
+    const payload = Buffer.alloc(${payloadSize}, 0x61);
+    const chunk = Buffer.concat([Buffer.from(${JSON.stringify(`${payloadSize.toString(16)}\r\n`)}), payload, Buffer.from("\\r\\n")]);
+    const head = Buffer.from(${JSON.stringify(head)});
+    const tail = Buffer.from(${JSON.stringify(tail)});
+
+    bytes.set(head, 0);
+    let end = head.byteLength;
+    while (end + chunk.byteLength + tail.byteLength <= bytes.byteLength) {
+      bytes.set(chunk, end);
+      end += chunk.byteLength;
+    }
+    bytes.set(tail, end);
+    end += tail.byteLength;
+
+    const parser = new HTTPParser();
+    parser.initialize(HTTPParser.REQUEST, {});
+
+    let mutated = false;
+    let bodyBytes = 0;
+    let bodyMatches = true;
+    let complete = false;
+    let currentBuffer = -1;
+    parser[HTTPParser.kOnHeadersComplete] = () => 0;
+    parser[HTTPParser.kOnBody] = received => {
+      bodyBytes += received.byteLength;
+      if (!received.equals(payload.subarray(0, received.byteLength))) bodyMatches = false;
+      if (!mutated) {
+        mutated = true;
+        mutate();
+        // getCurrentBuffer() copies out of the same bytes llhttp is reading.
+        currentBuffer = parser.getCurrentBuffer().byteLength;
+      }
+    };
+    parser[HTTPParser.kOnMessageComplete] = () => {
+      complete = true;
+    };
+
+    const executed = parser.execute(bytes.subarray(0, end));
+    console.log(JSON.stringify({ executed, bodyBytes, bodyMatches, complete, mutated, currentBuffer: currentBuffer === end }));
+  `;
+
+  test.each(Object.keys(inputSizes) as (keyof typeof inputSizes)[])(
+    "finishes the parse when a callback unmaps the input (%s)",
+    async mode => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture(mode)],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      const chunks = Math.floor((inputSizes[mode] - head.length - tail.length) / chunkSize);
+
+      // `executed` covers the whole request, so llhttp read every chunk that follows the callback
+      // which unmapped the input, and each one held the bytes the request was built with.
+      expect({ stdout: JSON.parse(stdout.trim() || "null"), stderr }).toEqual({
+        stdout: {
+          executed: head.length + chunks * chunkSize + tail.length,
+          bodyBytes: chunks * payloadSize,
+          bodyMatches: true,
+          complete: true,
+          mutated: true,
+          currentBuffer: true,
+        },
+        stderr: "",
+      });
+      expect(exitCode).toBe(0);
+    },
+  );
 
   test("rejects re-entrant execute, even after a nested finish()", async () => {
     const parser = new HTTPParser();


### PR DESCRIPTION
### Problem

- `HTTPParser.prototype.execute(view)` (`process.binding("http_parser")`, the parser behind `node:_http_common`) crashes the main thread when a parser callback releases the input: `SEGV READ` in `llhttp__internal__run` (`llhttp.c:1362`), under `Bun::HTTPParser::execute`.
- `jsHTTPParser_execute` gives llhttp the view's raw pointer and length for the whole run (`JSHTTPParserPrototype.cpp:140`). `kOnHeadersComplete` and `kOnBody` run user JS in the middle of that run.
- The `pin()` above it only makes `ArrayBuffer.prototype.transfer()` copy. It stops neither `resize()` on a resizable ArrayBuffer nor the detach that `WebAssembly.Memory.prototype.grow()` performs.

### Fix

- Copy the input into a `WTF::Vector<uint8_t>` that lives for the whole call when the backing buffer is a resizable non-shared ArrayBuffer or a `WebAssembly.Memory`. Every other buffer keeps the pin and is read in place, so a socket read still does not copy.
- One copy covers every borrow of those bytes in a run: llhttp's own cursor, the header and URL spans that `save()` copies at the end, and `getCurrentBuffer()`.
- Those two kinds are the ones JSC can release while the buffer is pinned. A growable SharedArrayBuffer grows in place and keeps its pointer, so it is read in place.
- Verified: `test/js/node/http/node-http-parser.test.ts`, two new cases (resizable and wasm), each fails on stock bun. Also ran all of `test/js/node/http` and the node `test-http-parser` tests. Self-reviewed: 6 concerns, all about a wider scope, answered in the notes.

### Background

- llhttp is a C parser. It scans the caller's bytes and calls back per message part. A callback runs user JS, then llhttp keeps reading from the same pointer.
- A pin on a JSC `ArrayBuffer` blocks a detach only. `isDetachable()` is read by `transferTo`, not by `resize()` and not by the wasm grow path.
- A resizable ArrayBuffer decommits its trimmed pages, so a read after `resize(0)` faults. A bounds-checked `WebAssembly.Memory` can move its bytes when it grows.

<details><summary>Notes</summary>

Reproduction (both cases are in the new test):

```js
const { HTTPParser } = process.binding("http_parser");
const size = 1024 * 1024;
const buffer = new ArrayBuffer(size, { maxByteLength: size });
const bytes = new Uint8Array(buffer);
// a chunked POST that fills `bytes`
const parser = new HTTPParser();
parser.initialize(HTTPParser.REQUEST, {});
parser[HTTPParser.kOnHeadersComplete] = () => 0;
parser[HTTPParser.kOnBody] = () => buffer.resize(0); // llhttp keeps scanning the trimmed pages
parser.execute(bytes);
```

Verification:

- `bun bd` (debug, ASAN), resizable: `AddressSanitizer: SEGV on unknown address`, `READ`, `#0 llhttp__internal__run llhttp.c:1362`.
- Local release build (1.4.3-canary), resizable: `panic(main thread): Segmentation fault`, 4/4 runs.
- Local release build, wasm: no crash, but the parse walks the released block and returns `HPE_STRICT: Expected LF after chunk data` after the first body callback, 2/2 runs.
- With `src/` reverted to the base commit, `bun bd test test/js/node/http/node-http-parser.test.ts` fails the resizable case. With the fix, all 22 tests in the file pass.
- `bun bd test test/js/node/http`: 356 pass. The one failure (`node-http-syscall-fault.test.ts`, "queued drain", a subprocess test with a 5 s timeout) fails the same way with `src/` reverted, so it is not from this change.

Why copy instead of re-reading the live extent after each callback: llhttp resumes from its own saved pointer as soon as a callback returns, and the parser holds more borrows of the same bytes than that cursor. `m_url`, `m_statusMessage` and the header `StringPtr` entries point into the input until `save()` copies them at the end of `execute()`, and `getCurrentBuffer()` memcpys out of `m_currentBufferData` while a callback runs. A copy with the same lifetime as the call fixes all of them at once. A `getCurrentBuffer()` call in a callback that follows `resize(0)` segfaults on stock bun too, and the new test asserts its length.

Same shape as existing code for this hazard: `PinnedArrayBuffer::copy_if_resizable` in `src/jsc/array_buffer.rs` ("a pin stops a detach but not a shrink, which unmaps pages") and the changeset copy in `src/jsc/bindings/sqlite/NodeSqlite.cpp`, where SQLite streams from a buffer while its callbacks re-enter JS.

The copy is conditional on purpose. `node:_http_common` calls `execute()` with a plain socket `Buffer` on every read, so an unconditional copy would memcpy every HTTP read.

Scope. This PR fixes the llhttp borrow only. #42192 is the umbrella pass for this class and lists this file as not covered by it. Two same-class sites stay open and are not in this diff: `Bun.markdown.{html,ansi,render,react}` (`src/runtime/api/MarkdownObject.rs:68`, which uses the pin-only `PinnedArrayBuffer::pin` while its render callbacks run user JS per element), and `Transpiler.scan` / `transformSync`. When the second of #42192 and this PR lands, the `isResizableNonShared() || isWasmMemory()` test is worth hoisting into one named helper next to `pinStorage()` in `bindings.cpp`, so the three current spellings of it (here, `copy_if_resizable` in `src/jsc/array_buffer.rs`, and #42192's) become one.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http-parser.test.ts
bun test v1.4.3 (5f554969b)

test/js/node/http/node-http-parser.test.ts:
(pass) method lists > contain M-SEARCH, not a malformed token [14.13ms]
(pass) method lists > contain no whitespace in any method token [16.95ms]
(pass) HTTPParser.prototype.close > does not double free [1.89ms]
(pass) HTTPParser.prototype.close > does not segfault calling other methods after close [5.15ms]
(pass) HTTPParser before initialize() > execute() and finish() throw instead of running over uninitialised state [262.98ms]
(pass) HTTPParser.prototype.finish > reports bytesParsed of 0 when finish() fails after a paused parse [4.64ms]
(pass) HTTPParser.prototype.finish > returns error for invalid state [9.33ms]
(pass) HTTPParser.prototype.finish > basic [1.99ms]
(pass) HTTPParser.prototype.execute > keeps the input buffer attached when a callback transfers it mid-parse [12.04ms]
269 | 
270 |       const chunks = Math.floor((inputSizes[mode] - head.length - tail.length) / chunkSize);
271 | 
272 |       // `executed` cov
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (5f554969b)

test/js/node/http/node-http-parser.test.ts:
(pass) method lists > contain M-SEARCH, not a malformed token [0.02ms]
(pass) method lists > contain no whitespace in any method token [0.10ms]
(pass) HTTPParser.prototype.close > does not double free [0.02ms]
(pass) HTTPParser.prototype.close > does not segfault calling other methods after close [0.04ms]
(pass) HTTPParser before initialize() > execute() and finish() throw instead of running over uninitialised state [4.42ms]
(pass) HTTPParser.prototype.finish > reports bytesParsed of 0 when finish() fails after a paused parse [0.08ms]
(pass) HTTPParser.prototype.finish > returns error for invalid state [0.14ms]
(pass) HTTPParser.prototype.finish > basic [0.02ms]
(pass) HTTPParser.prototype.execute > keeps the input buffer attached when a callback transfers it mid-parse [0.18ms]
269 | 
270 |       const chunks = Math.floor((inputSizes[mode] - head.length - tail.length) / chunkSize);
271 | 
272 |       // `executed` covers the whole request, so llhttp read every chunk that follows the callback
273 |       // which unmapped the input, and each one held the bytes the request was built with
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http-parser.test.ts
bun test v1.4.3 (5f554969b)

test/js/node/http/node-http-parser.test.ts:
(pass) method lists > contain M-SEARCH, not a malformed token [2.22ms]
(pass) method lists > contain no whitespace in any method token [28.64ms]
(pass) HTTPParser.prototype.close > does not double free [2.99ms]
(pass) HTTPParser.prototype.close > does not segfault calling other methods after close [4.75ms]
(pass) HTTPParser before initialize() > execute() and finish() throw instead of running over uninitialised state [273.83ms]
(pass) HTTPParser.prototype.finish > reports bytesParsed of 0 when finish() fails after a paused parse [4.53ms]
(pass) HTTPParser.prototype.finish > returns error for invalid state [9.05ms]
(pass) HTTPParser.prototype.finish > basic [1.93ms]
(pass) HTTPParser.prototype.execute > keeps the input buffer attached when a callback transfers it mid-parse [12.08ms]
(pass) HTTPParser.prototype.execute > finishes the parse when a callback unmaps the input (resizable) [454.38ms]
(pass) HTTPParser.prototype.ex
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f244f258ec
  features     baseline

23 deps, 131 codegen, 1172 objects in 657ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (5f554969b)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (5f554969b)

Checked 1 install across 2 packages (no changes) [5.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] fetch zlib
[zlib] up to date
[5/1244] gen bindgenv2
[6/1244] gen .bind.ts → GeneratedBindings.cpp
[7/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (5f554969b)

Checked 111 installs across 104 packages (no changes) [3.00ms]
[8/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 12ms

  react-refresh.js  4.81 KB  (entry point)

[9/1244] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[10/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1217] fetch tinycc
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../bindings/node/http/JSHTTPParserPrototype.cpp   |  21 ++++-
 test/js/node/http/node-http-parser.test.ts         | 103 +++++++++++++++++++++
 2 files changed, 121 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/jsc/bindings/node/http/JSHTTPParserPrototype.cpp      2      5     22
test/js/node/http/node-http-parser.test.ts                2      8     22
```

</details>

<!-- robobun:evidence:end -->