### PR TITLE
streams: error a Bun.file() stream whose open fails instead of throwing from its first consumer

### DIFF
--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -428,10 +428,8 @@ void materializeNativeSource(JSGlobalObject* globalObject, JSReadableStream* str
     ASSERT(!startArgs.hasOverflowed());
     JSValue startResult = invokeMethod(vm, globalObject, handle, builtinNames(vm).startPublicName(), startArgs);
     if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
-        // The source cannot start (open() → ENOENT/EISDIR, dup() failure, ...). As with a rejected
-        // pull, the stream errors with that reason and the consumer that materialized it observes it
-        // through the stream rather than as a throw. The handle never produced and never will, so the
-        // errored stream stops advertising it (Readable.fromWeb would otherwise adopt a dead source).
+        // The source failed to start (open() → ENOENT, EISDIR, ...): error the stream, as a rejected
+        // pull does, and drop the dead handle so nothing adopts it later.
         TRY_CLEAR_EXCEPTION(scope, );
         stream->m_nativePtr.clear();
         auto* controller = WebCore::JSReadableStreamDefaultController::create(vm, WebCore::getDOMStructure<WebCore::JSReadableStreamDefaultController>(vm, *domGlobalObject));

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -427,7 +427,19 @@ void materializeNativeSource(JSGlobalObject* globalObject, JSReadableStream* str
     startArgs.append(jsNumber(static_cast<double>(autoAllocateChunkSize)));
     ASSERT(!startArgs.hasOverflowed());
     JSValue startResult = invokeMethod(vm, globalObject, handle, builtinNames(vm).startPublicName(), startArgs);
-    RETURN_IF_EXCEPTION(scope, );
+    if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
+        // The source cannot start (open() → ENOENT/EISDIR, dup() failure, ...). As with a rejected
+        // pull, the stream errors with that reason and the consumer that materialized it observes it
+        // through the stream rather than as a throw. The handle never produced and never will, so the
+        // errored stream stops advertising it (Readable.fromWeb would otherwise adopt a dead source).
+        TRY_CLEAR_EXCEPTION(scope, );
+        stream->m_nativePtr.clear();
+        auto* controller = WebCore::JSReadableStreamDefaultController::create(vm, WebCore::getDOMStructure<WebCore::JSReadableStreamDefaultController>(vm, *domGlobalObject));
+        controller->m_algorithms.kind = SourceKind::Nothing;
+        setUpReadableStreamDefaultController(globalObject, stream, controller, jsUndefined(), 1);
+        RETURN_IF_EXCEPTION(scope, );
+        RELEASE_AND_RETURN(scope, readableStreamDefaultControllerError(globalObject, controller, exception->value()));
+    }
 
     double chunkSize = 0;
     JSValue drainValue;

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -428,8 +428,7 @@ void materializeNativeSource(JSGlobalObject* globalObject, JSReadableStream* str
     ASSERT(!startArgs.hasOverflowed());
     JSValue startResult = invokeMethod(vm, globalObject, handle, builtinNames(vm).startPublicName(), startArgs);
     if (JSC::Exception* exception = scope.exception()) [[unlikely]] {
-        // The source failed to start (open() → ENOENT, EISDIR, ...): error the stream, as a rejected
-        // pull does, and drop the dead handle so nothing adopts it later.
+        // open() failed (ENOENT, EISDIR, ...): error the stream like a rejected pull, drop the dead handle.
         TRY_CLEAR_EXCEPTION(scope, );
         stream->m_nativePtr.clear();
         auto* controller = WebCore::JSReadableStreamDefaultController::create(vm, WebCore::getDOMStructure<WebCore::JSReadableStreamDefaultController>(vm, *domGlobalObject));

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2132,66 +2132,64 @@ describe("ReadableStream for a File that fails to open", () => {
       : { directory: [() => file(import.meta.dir).stream(), expect.objectContaining({ code: "EISDIR" })] }),
   };
 
-  for (const [label, [makeStream, expected]] of Object.entries(doors)) {
-    describe(label, () => {
-      it("getReader() returns a reader whose read() rejects", async () => {
-        const stream = makeStream();
-        const reader = stream.getReader();
-        expect(stream.locked).toBe(true);
-        await expect(reader.read()).rejects.toEqual(expected);
-        await expect(reader.closed).rejects.toEqual(expected);
-        // Later consumers see the same error instead of a read that never settles.
-        reader.releaseLock();
-        const second = stream.getReader();
-        await expect(second.read()).rejects.toEqual(expected);
-        second.releaseLock();
-        await expect(Array.fromAsync(stream)).rejects.toEqual(expected);
-      });
-
-      it("tee() returns two errored branches", async () => {
-        const [a, b] = makeStream().tee();
-        await expect(a.getReader().read()).rejects.toEqual(expected);
-        await expect(b.getReader().read()).rejects.toEqual(expected);
-      });
-
-      it("promise-returning consumers reject instead of throwing", async () => {
-        let result;
-        expect(() => {
-          result = makeStream().text();
-        }).not.toThrow();
-        await expect(result).rejects.toEqual(expected);
-        expect(() => {
-          result = makeStream().pipeTo(new WritableStream());
-        }).not.toThrow();
-        await expect(result).rejects.toEqual(expected);
-        expect(() => {
-          result = makeStream().pipeThrough(new TransformStream()).getReader().read();
-        }).not.toThrow();
-        await expect(result).rejects.toEqual(expected);
-        expect(() => {
-          result = new Response(makeStream()).bytes();
-        }).not.toThrow();
-        await expect(result).rejects.toEqual(expected);
-        expect(() => {
-          result = readableStreamToArrayBuffer(makeStream());
-        }).not.toThrow();
-        await expect(result).rejects.toEqual(expected);
-      });
-
-      it("Readable.fromWeb() after the failed start emits the error", async () => {
-        const stream = makeStream();
-        stream.getReader().releaseLock();
-        const readable = Readable.fromWeb(stream);
-        const { promise, resolve, reject } = Promise.withResolvers();
-        readable
-          .on("error", resolve)
-          .on("end", () => reject(new Error("ended without an error")))
-          .on("close", () => reject(new Error("closed without an error")));
-        readable.resume();
-        expect(await promise).toEqual(expected);
-      });
+  describe.each(Object.entries(doors))("%s", (label, [makeStream, expected]) => {
+    it("getReader() returns a reader whose read() rejects", async () => {
+      const stream = makeStream();
+      const reader = stream.getReader();
+      expect(stream.locked).toBe(true);
+      await expect(reader.read()).rejects.toEqual(expected);
+      await expect(reader.closed).rejects.toEqual(expected);
+      // Later consumers see the same error instead of a read that never settles.
+      reader.releaseLock();
+      const second = stream.getReader();
+      await expect(second.read()).rejects.toEqual(expected);
+      second.releaseLock();
+      await expect(Array.fromAsync(stream)).rejects.toEqual(expected);
     });
-  }
+
+    it("tee() returns two errored branches", async () => {
+      const [a, b] = makeStream().tee();
+      await expect(a.getReader().read()).rejects.toEqual(expected);
+      await expect(b.getReader().read()).rejects.toEqual(expected);
+    });
+
+    it("promise-returning consumers reject instead of throwing", async () => {
+      let result;
+      expect(() => {
+        result = makeStream().text();
+      }).not.toThrow();
+      await expect(result).rejects.toEqual(expected);
+      expect(() => {
+        result = makeStream().pipeTo(new WritableStream());
+      }).not.toThrow();
+      await expect(result).rejects.toEqual(expected);
+      expect(() => {
+        result = makeStream().pipeThrough(new TransformStream()).getReader().read();
+      }).not.toThrow();
+      await expect(result).rejects.toEqual(expected);
+      expect(() => {
+        result = new Response(makeStream()).bytes();
+      }).not.toThrow();
+      await expect(result).rejects.toEqual(expected);
+      expect(() => {
+        result = readableStreamToArrayBuffer(makeStream());
+      }).not.toThrow();
+      await expect(result).rejects.toEqual(expected);
+    });
+
+    it("Readable.fromWeb() after the failed start emits the error", async () => {
+      const stream = makeStream();
+      stream.getReader().releaseLock();
+      const readable = Readable.fromWeb(stream);
+      const { promise, resolve, reject } = Promise.withResolvers();
+      readable
+        .on("error", resolve)
+        .on("end", () => reject(new Error("ended without an error")))
+        .on("close", () => reject(new Error("closed without an error")));
+      readable.resume();
+      expect(await promise).toEqual(expected);
+    });
+  });
 });
 
 it("ReadableStream for empty blob closes immediately", async () => {

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2101,14 +2101,67 @@ it("ReadableStream for File", async () => {
   expect(output).toBe(input);
 });
 
-it("ReadableStream for File errors", async () => {
-  try {
-    var blob = file(import.meta.dir + "/fetch.js.txt.notfound");
-    blob.stream().getReader();
-    throw new Error("should not reach here");
-  } catch (e) {
-    expect(e.code).toBe("ENOENT");
-    expect(e.syscall).toBe("open");
+describe("ReadableStream for a File that fails to open", () => {
+  // The native file source opens the file when the stream is first consumed. A failure
+  // there errors the stream: consumers do not throw synchronously, and every read settles.
+  const missing = import.meta.dir + "/fetch.js.txt.notfound";
+  const enoent = expect.objectContaining({ code: "ENOENT", syscall: "open" });
+  const streams = {
+    "Bun.file().stream()": () => file(missing).stream(),
+    "new Response(Bun.file()).body": () => new Response(file(missing)).body,
+    "new Request({ body: Bun.file() }).body": () =>
+      new Request("http://example.com/", { method: "POST", body: file(missing) }).body,
+  };
+
+  for (const [label, makeStream] of Object.entries(streams)) {
+    describe(label, () => {
+      it("getReader() returns a reader whose read() rejects", async () => {
+        const stream = makeStream();
+        const reader = stream.getReader();
+        expect(stream.locked).toBe(true);
+        await expect(reader.read()).rejects.toEqual(enoent);
+        await expect(reader.closed).rejects.toEqual(enoent);
+        // A second consumer sees the same error instead of a read that never settles.
+        reader.releaseLock();
+        await expect(stream.getReader().read()).rejects.toEqual(enoent);
+      });
+
+      it("tee() returns two errored branches", async () => {
+        const [a, b] = makeStream().tee();
+        await expect(a.getReader().read()).rejects.toEqual(enoent);
+        await expect(b.getReader().read()).rejects.toEqual(enoent);
+      });
+
+      it("promise-returning consumers reject instead of throwing", async () => {
+        let result;
+        expect(() => {
+          result = makeStream().text();
+        }).not.toThrow();
+        await expect(result).rejects.toEqual(enoent);
+        expect(() => {
+          result = makeStream().pipeTo(new WritableStream());
+        }).not.toThrow();
+        await expect(result).rejects.toEqual(enoent);
+        expect(() => {
+          result = new Response(makeStream()).bytes();
+        }).not.toThrow();
+        await expect(result).rejects.toEqual(enoent);
+        expect(() => {
+          result = readableStreamToArrayBuffer(makeStream());
+        }).not.toThrow();
+        await expect(result).rejects.toEqual(enoent);
+      });
+
+      it("Readable.fromWeb() after the failed start emits the error", async () => {
+        const stream = makeStream();
+        stream.getReader().releaseLock();
+        const readable = Readable.fromWeb(stream);
+        const { promise, resolve, reject } = Promise.withResolvers();
+        readable.on("error", resolve).on("end", () => reject(new Error("ended without an error")));
+        readable.resume();
+        expect(await promise).toEqual(enoent);
+      });
+    });
   }
 });
 

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2104,32 +2104,55 @@ it("ReadableStream for File", async () => {
 describe("ReadableStream for a File that fails to open", () => {
   // The native file source opens the file when the stream is first consumed. A failure
   // there errors the stream: consumers do not throw synchronously, and every read settles.
-  const missing = import.meta.dir + "/fetch.js.txt.notfound";
+  const missing = join(import.meta.dir, "fetch.js.txt.notfound");
   const enoent = expect.objectContaining({ code: "ENOENT", syscall: "open" });
-  const streams = {
-    "Bun.file().stream()": () => file(missing).stream(),
-    "new Response(Bun.file()).body": () => new Response(file(missing)).body,
-    "new Request({ body: Bun.file() }).body": () =>
-      new Request("http://example.com/", { method: "POST", body: file(missing) }).body,
+  const unlinkDir = tmpdirSync();
+  let unlinkCount = 0;
+  // label => [makeStream, expected error]
+  const doors = {
+    "Bun.file(missing).stream()": [() => file(missing).stream(), enoent],
+    "Bun.file(missing).slice().stream()": [() => file(missing).slice(0, 10).stream(), enoent],
+    "new Response(Bun.file(missing)).body": [() => new Response(file(missing)).body, enoent],
+    "new Request({ body: Bun.file(missing) }).body": [
+      () => new Request("http://example.com/", { method: "POST", body: file(missing) }).body,
+      enoent,
+    ],
+    "file unlinked after .stream()": [
+      () => {
+        const path = join(unlinkDir, "unlinked-" + unlinkCount++);
+        writeFileSync(path, "gone before the first read");
+        const stream = file(path).stream();
+        unlinkSync(path);
+        return stream;
+      },
+      enoent,
+    ],
+    // open() succeeds, the fstat() after it reports a directory.
+    ...(isWindows
+      ? {}
+      : { directory: [() => file(import.meta.dir).stream(), expect.objectContaining({ code: "EISDIR" })] }),
   };
 
-  for (const [label, makeStream] of Object.entries(streams)) {
+  for (const [label, [makeStream, expected]] of Object.entries(doors)) {
     describe(label, () => {
       it("getReader() returns a reader whose read() rejects", async () => {
         const stream = makeStream();
         const reader = stream.getReader();
         expect(stream.locked).toBe(true);
-        await expect(reader.read()).rejects.toEqual(enoent);
-        await expect(reader.closed).rejects.toEqual(enoent);
-        // A second consumer sees the same error instead of a read that never settles.
+        await expect(reader.read()).rejects.toEqual(expected);
+        await expect(reader.closed).rejects.toEqual(expected);
+        // Later consumers see the same error instead of a read that never settles.
         reader.releaseLock();
-        await expect(stream.getReader().read()).rejects.toEqual(enoent);
+        const second = stream.getReader();
+        await expect(second.read()).rejects.toEqual(expected);
+        second.releaseLock();
+        await expect(Array.fromAsync(stream)).rejects.toEqual(expected);
       });
 
       it("tee() returns two errored branches", async () => {
         const [a, b] = makeStream().tee();
-        await expect(a.getReader().read()).rejects.toEqual(enoent);
-        await expect(b.getReader().read()).rejects.toEqual(enoent);
+        await expect(a.getReader().read()).rejects.toEqual(expected);
+        await expect(b.getReader().read()).rejects.toEqual(expected);
       });
 
       it("promise-returning consumers reject instead of throwing", async () => {
@@ -2137,19 +2160,23 @@ describe("ReadableStream for a File that fails to open", () => {
         expect(() => {
           result = makeStream().text();
         }).not.toThrow();
-        await expect(result).rejects.toEqual(enoent);
+        await expect(result).rejects.toEqual(expected);
         expect(() => {
           result = makeStream().pipeTo(new WritableStream());
         }).not.toThrow();
-        await expect(result).rejects.toEqual(enoent);
+        await expect(result).rejects.toEqual(expected);
+        expect(() => {
+          result = makeStream().pipeThrough(new TransformStream()).getReader().read();
+        }).not.toThrow();
+        await expect(result).rejects.toEqual(expected);
         expect(() => {
           result = new Response(makeStream()).bytes();
         }).not.toThrow();
-        await expect(result).rejects.toEqual(enoent);
+        await expect(result).rejects.toEqual(expected);
         expect(() => {
           result = readableStreamToArrayBuffer(makeStream());
         }).not.toThrow();
-        await expect(result).rejects.toEqual(enoent);
+        await expect(result).rejects.toEqual(expected);
       });
 
       it("Readable.fromWeb() after the failed start emits the error", async () => {
@@ -2159,7 +2186,7 @@ describe("ReadableStream for a File that fails to open", () => {
         const { promise, resolve, reject } = Promise.withResolvers();
         readable.on("error", resolve).on("end", () => reject(new Error("ended without an error")));
         readable.resume();
-        expect(await promise).toEqual(enoent);
+        expect(await promise).toEqual(expected);
       });
     });
   }

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2106,8 +2106,6 @@ describe("ReadableStream for a File that fails to open", () => {
   // there errors the stream: consumers do not throw synchronously, and every read settles.
   const missing = join(import.meta.dir, "fetch.js.txt.notfound");
   const enoent = expect.objectContaining({ code: "ENOENT", syscall: "open" });
-  const unlinkDir = tmpdirSync();
-  let unlinkCount = 0;
   // label => [makeStream, expected error]
   const doors = {
     "Bun.file(missing).stream()": [() => file(missing).stream(), enoent],
@@ -2119,12 +2117,11 @@ describe("ReadableStream for a File that fails to open", () => {
       () => new Request("http://example.com/", { method: "POST", body: file(missing) }).body,
       enoent,
     ],
-    "file unlinked after .stream()": [
+    "file removed after .stream()": [
       () => {
-        const path = join(unlinkDir, "unlinked-" + unlinkCount++);
-        writeFileSync(path, "gone before the first read");
-        const stream = file(path).stream();
-        unlinkSync(path);
+        const dir = tempDir("file-stream-open-fail", { "gone.txt": "gone before the first read" });
+        const stream = file(join(String(dir), "gone.txt")).stream();
+        dir[Symbol.dispose]();
         return stream;
       },
       enoent,
@@ -2186,7 +2183,10 @@ describe("ReadableStream for a File that fails to open", () => {
         stream.getReader().releaseLock();
         const readable = Readable.fromWeb(stream);
         const { promise, resolve, reject } = Promise.withResolvers();
-        readable.on("error", resolve).on("end", () => reject(new Error("ended without an error")));
+        readable
+          .on("error", resolve)
+          .on("end", () => reject(new Error("ended without an error")))
+          .on("close", () => reject(new Error("closed without an error")));
         readable.resume();
         expect(await promise).toEqual(expected);
       });

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -2113,6 +2113,8 @@ describe("ReadableStream for a File that fails to open", () => {
     "Bun.file(missing).stream()": [() => file(missing).stream(), enoent],
     "Bun.file(missing).slice().stream()": [() => file(missing).slice(0, 10).stream(), enoent],
     "new Response(Bun.file(missing)).body": [() => new Response(file(missing)).body, enoent],
+    // The text-mode native source takes the same start path.
+    "new Response(Bun.file(missing)).textStream()": [() => new Response(file(missing)).textStream(), enoent],
     "new Request({ body: Bun.file(missing) }).body": [
       () => new Request("http://example.com/", { method: "POST", body: file(missing) }).body,
       enoent,


### PR DESCRIPTION
### Problem
- A stream over `Bun.file(path)` opens the file on first use. When that fails (`ENOENT: no such file or directory, open '<path>'`, also `EISDIR`, `EBADF`), the first consumer throws it synchronously: `getReader()`, `tee()`, `pipeThrough()`, even the promise-returning `stream.text()`. The stream stays `"readable"` with no controller, so a later `getReader().read()`, `tee()` or `pipeTo()` never settles.
- Cause: `materializeNativeSource` (`src/jsc/bindings/webcore/streams/BunStreamSource.cpp:429`) lets the exception from the handle's `start()` (`FileReader::on_start` → `Start::Err`) escape after it flipped `m_bunMode`/`m_disturbed` and before a controller existed. Found by an automated sweep, no linked issue.

### Fix
- Catch the `start()` exception (termination still propagates), clear the handle slot, install a `SourceKind::Nothing` controller, error it with the thrown value. Same shape as `nativeSourcePullRejected`.
- Consumers now see the `SystemError` through the stream, as in Node: `read()`/`closed` reject, `tee()` branches error, `Readable.fromWeb()` emits `error` instead of pulling a never-opened fd.
- Behavior change: `getReader()` here no longer throws. This inverts the 2022 test "ReadableStream for File errors". A `Bun.serve` handler that caught the throw to answer 404 now gets what any errored body gets (reset, logged error).
- Verified: `test/js/web/streams/streams.test.js` "ReadableStream for a File that fails to open", 28 cases, all fail on 1.4.3.

### Background
- Streams from `Bun.file()`, `Blob` and bodies start lazy (`BunStreamMode::NativePending`) with the Rust source's handle in `m_nativePtr`. The first consumer runs `materializeNativeSource`: `handle.start()`, then a controller over the handle.
- `FileReader::on_start` (`src/runtime/webcore/FileReader.rs`) does the `open()`/`fstat()`. So open errors surface at first consumption.
- `new Response(Bun.file(missing)).text()` (no `.body` access) builds no stream and already rejected `ENOENT`.

<details><summary>Notes</summary>

Other suites run on the debug build: `body-stream`, `body`, `body-clone`, `stream-fast-path`, `bun-serve-file`, `bun-file`, `node-stream`, `spawn-stdin-readable-stream`, and all of `streams.test.js`.

Consumer matrix on stock 1.4.3 vs this branch (missing file):

| consumer | 1.4.3 | this branch |
| --- | --- | --- |
| `stream.text()` / `Bun.readableStreamToText(s)` | sync throw ENOENT | rejects ENOENT |
| `new Response(stream).text()` | sync throw | rejects |
| `new Response(stream).bytes()`, `pipeTo()` | rejects, stream left dead | rejects, stream errored |
| `getReader()` then `read()` | `getReader()` throws | `read()` and `closed` reject |
| second `getReader().read()` / `tee()` / `pipeTo()` / `for await` after the throw | never settles | rejects with the same error |
| `tee()` | throws | two errored branches |
| `pipeThrough()` | sync throw | readable side errors |
| `Readable.fromWeb(s)` after the failed first use | release: neither `error` nor `end`; debug: `assertion failed: fd == CWD \|\| fd == ABS \|\| fd >= 0` in rustix from `FileReader::on_pull` | `error` event ENOENT |

Doors covered by the test: missing path, `.slice()` of it, `Response.body`, `Response.textStream()`, `Request.body`, a file unlinked between `.stream()` and first use, and (POSIX) a directory (`EISDIR` from the `fstat` after a successful `open`). An `EBADF` door (closed fd) behaves the same but is left out of the test because the fd number can be reused by another thread between `closeSync` and the `dup()`.

Why clear `m_nativePtr` rather than set the `-1` "detached" sentinel: `isReadableStreamLocked()` treats a detached handle as locked, and the errored stream must stay consumable (`releaseLock()` then a new reader). With the slot cleared, `$bunNativePtr` reads `undefined`, so `Readable.fromWeb()` takes the reader path, and `ReadableStreamTag` sees a plain JS stream.

Related, tracked separately and not changed here: a healthy file stream that was already materialized (reader acquired and released, or partially read) still advertises its handle, so `Readable.fromWeb()` adopts it and drops the chunks queued in the web stream. `Bun.spawn({ stdin: Bun.file(missing) })` creates the missing file (`O_RDONLY|O_CREAT`).

For a handler that wants a 404 for a missing file: `if (!(await Bun.file(p).exists()))`, or return `new Response(Bun.file(p))` and handle `ENOENT` in `error()`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/streams/streams.test.js

<!-- robobun:evidence:end -->