### PR TITLE
node:http2: count a frame written after the transport closed as sent

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4292,9 +4292,10 @@ class ServerHttp2Session extends Http2Session {
       if (!self) return;
       self.destroy();
     },
-    write(self: ServerHttp2Session, buffer: Buffer) {
+    write(self: ServerHttp2Session, buffer: Buffer, transportClosed: boolean) {
       if (!self) return -1;
       const socket = self[bunHTTP2Socket];
+      if (transportClosed) return writeToClosedTransport(socket);
       if (socket && !socket.writableEnded && self.#connected) {
         // redirect writes to socket
         return socket.write(buffer) ? 1 : 0;
@@ -4899,6 +4900,12 @@ function destroySelfOnEnd(this: Http2Stream) {
 function streamCancel(stream: Http2Stream) {
   stream.close(NGHTTP2_CANCEL);
 }
+function writeToClosedTransport(socket: TLSSocket | Socket | null) {
+  // allowHalfOpen keeps the socket open past 'end', and nothing else ends it once its handle closed.
+  if (socket?.allowHalfOpen && !socket.writableEnded) socket.end();
+  // Sent, like node's Http2Session::ClearOutgoing: a frame for a closed transport completes.
+  return 1;
+}
 
 // After the socket is gone a graceful close can never complete — the parser
 // is detached, so the stream's writable side has nothing left to flush
@@ -5330,9 +5337,10 @@ class ClientHttp2Session extends Http2Session {
         }
       }
     },
-    write(self: ClientHttp2Session, buffer: Buffer) {
+    write(self: ClientHttp2Session, buffer: Buffer, transportClosed: boolean) {
       if (!self) return -1;
       const socket = self[bunHTTP2Socket];
+      if (transportClosed) return writeToClosedTransport(socket);
       if (socket && !socket.writableEnded && self.#connected) {
         // redirect writes to socket
         return socket.write(buffer) ? 1 : 0;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -98,11 +98,8 @@ const MAX_PAYLOAD_SIZE_WITHOUT_FRAME: usize = 16384 - FrameHeader::BYTE_SIZE - 1
 /// holds on them.
 #[derive(Default, Clone, Copy)]
 enum BunSocket {
-    /// No native socket: `_write` hands the bytes to the `onWrite` handler.
     #[default]
     None,
-    /// The native socket closed: `_write` drops the bytes, there is no transport.
-    Closed,
     Tls(bun_ptr::BackRef<TLSSocket>),
     TlsWriteonly(bun_ptr::BackRef<TLSSocket>),
     Tcp(bun_ptr::BackRef<TCPSocket>),
@@ -114,12 +111,16 @@ enum BunSocket {
 /// that slot is taken, takes a ref on the socket (`*Writeonly`); `detach` /
 /// `Drop` undo whichever one it was. Readers take a [`BunSocket`] snapshot.
 #[derive(Default)]
-struct NativeSocket(Cell<BunSocket>);
+struct NativeSocket {
+    socket: Cell<BunSocket>,
+    /// The attached socket closed. Sticky until `attach`; `onWrite` tells the session.
+    closed: Cell<bool>,
+}
 
 impl NativeSocket {
     #[inline]
     fn get(&self) -> BunSocket {
-        self.0.get()
+        self.socket.get()
     }
 
     /// `attach_native_callback` stores `h2` (a ref on the parser) in the
@@ -131,12 +132,13 @@ impl NativeSocket {
         socket: *mut crate::socket::NewSocket<SSL>,
         h2: RefPtr<H2FrameParser>,
     ) {
-        debug_assert!(matches!(self.0.get(), BunSocket::None | BunSocket::Closed));
+        debug_assert!(matches!(self.socket.get(), BunSocket::None));
+        self.closed.set(false);
         // BACKREF: `socket` is the live `m_ctx` borrowed from the JS wrapper
         // rooted by the caller's `socket_js`.
         let socket_nn = NonNull::new(socket).expect("NewSocket m_ctx");
         let socket = bun_ptr::BackRef::from(socket_nn);
-        self.0
+        self.socket
             .set(if socket.attach_native_callback(NativeCallbacks::H2(h2)) {
                 if SSL {
                     BunSocket::Tls(bun_ptr::BackRef::from(socket_nn.cast::<TLSSocket>()))
@@ -154,35 +156,22 @@ impl NativeSocket {
             });
     }
 
-    /// Releases whatever `attach` took. `Closed` is sticky: only `attach` clears it.
     fn detach(&self) {
-        // Each arm sets the cell before its release call: that call re-enters here.
-        match self.0.get() {
-            BunSocket::Tcp(socket) => {
-                self.0.set(BunSocket::None);
-                socket.detach_native_callback();
-            }
-            BunSocket::Tls(socket) => {
-                self.0.set(BunSocket::None);
-                socket.detach_native_callback();
-            }
+        match self.socket.replace(BunSocket::None) {
+            BunSocket::Tcp(socket) => socket.detach_native_callback(),
+            BunSocket::Tls(socket) => socket.detach_native_callback(),
             // The ref `attach` took.
-            BunSocket::TcpWriteonly(socket) => {
-                self.0.set(BunSocket::None);
-                TCPSocket::deref(socket.get());
-            }
-            BunSocket::TlsWriteonly(socket) => {
-                self.0.set(BunSocket::None);
-                TLSSocket::deref(socket.get());
-            }
-            BunSocket::None | BunSocket::Closed => {}
+            BunSocket::TcpWriteonly(socket) => TCPSocket::deref(socket.get()),
+            BunSocket::TlsWriteonly(socket) => TLSSocket::deref(socket.get()),
+            BunSocket::None => {}
         }
     }
 
-    /// `detach`, then `Closed`: a write after the close must not fall back to JS.
-    fn mark_closed(&self) {
-        self.detach();
-        self.0.set(BunSocket::Closed);
+    /// The socket released the parser. `detach` gets here too, but with nothing attached.
+    fn note_socket_closed(&self) {
+        if !matches!(self.socket.get(), BunSocket::None) {
+            self.closed.set(true);
+        }
     }
 }
 
@@ -2424,18 +2413,25 @@ impl H2FrameParser {
         );
     }
 
-    pub(crate) fn call(&self, event: JSH2FrameParser::Gc, value: JSValue) -> JSValue {
+    /// `onWrite(context, bytes, transportClosed)`. The flag is true once the native socket closed.
+    fn call_on_write(&self, bytes: JSValue) -> JSValue {
         let Some(this_value) = self.strong_this.get().try_get() else {
             return JSValue::ZERO;
         };
         let Some(ctx_value) = JSH2FrameParser::Gc::context.get(this_value) else {
             return JSValue::ZERO;
         };
-        value.ensure_still_alive();
+        bytes.ensure_still_alive();
         let _dispatch = self.enter_dispatch();
-        self.handlers
-            .get()
-            .call_event_handler_with_result(event, this_value, &[ctx_value, value])
+        self.handlers.get().call_event_handler_with_result(
+            JSH2FrameParser::Gc::onWrite,
+            this_value,
+            &[
+                ctx_value,
+                bytes,
+                JSValue::from(self.native_socket.closed.get()),
+            ],
+        )
     }
 
     pub(crate) fn dispatch_write_callback(&self, callback: JSValue) {
@@ -2713,8 +2709,6 @@ impl H2FrameParser {
             BunSocket::TcpWriteonly(socket) | BunSocket::Tcp(socket) => {
                 self.generic_flush(socket.get())
             }
-            // The transport closed: the buffered bytes can never reach the peer.
-            BunSocket::Closed => return written,
             BunSocket::None => {
                 // consider that backpressure is gone and flush data queue
                 self.has_nonnative_backpressure.set(false);
@@ -2733,7 +2727,7 @@ impl H2FrameParser {
                         return 0;
                     };
                     self.js_socket_flushing.set(true);
-                    let result = self.call(JSH2FrameParser::Gc::onWrite, output_value);
+                    let result = self.call_on_write(output_value);
                     self.js_socket_flushing.set(false);
 
                     // Same contract as _write: -1 dropped, 0 queued by the socket, else sent.
@@ -2790,15 +2784,6 @@ impl H2FrameParser {
             BunSocket::TcpWriteonly(socket) | BunSocket::Tcp(socket) => {
                 self.generic_write(socket.get(), bytes)
             }
-            BunSocket::Closed => {
-                bun_output::scoped_log!(
-                    H2FrameParser,
-                    "_write dropped {} (transport closed)",
-                    bytes.len()
-                );
-                // Sent, not queued: a transport that is gone never drains.
-                true
-            }
             BunSocket::None => {
                 let global = self.global();
                 if self.has_nonnative_backpressure.get() {
@@ -2815,7 +2800,7 @@ impl H2FrameParser {
                     .to_js(bytes, &self.handlers.get().global())
                 {
                     Ok(output_value) => {
-                        let result = self.call(JSH2FrameParser::Gc::onWrite, output_value);
+                        let result = self.call_on_write(output_value);
                         if result.is_number() {
                             result.to_int32()
                         } else {
@@ -2859,8 +2844,6 @@ impl H2FrameParser {
     fn transport_write_runs_js(&self) -> bool {
         match self.native_socket.get() {
             BunSocket::None => true,
-            // `_write` drops the bytes without calling anything.
-            BunSocket::Closed => false,
             BunSocket::Tls(s) | BunSocket::TlsWriteonly(s) => matches!(
                 s.get().socket.get().socket,
                 bun_uws::InternalSocket::UpgradedDuplex(_)
@@ -3020,7 +3003,7 @@ impl H2FrameParser {
             BunSocket::Tcp(socket) | BunSocket::TcpWriteonly(socket) => {
                 Self::close_socket_for_dead_transport::<false>(socket.get());
             }
-            BunSocket::None | BunSocket::Closed => {}
+            BunSocket::None => {}
         }
     }
 
@@ -3223,10 +3206,6 @@ impl H2FrameParser {
 
     pub(crate) fn write(&self, mut bytes: &[u8]) -> bool {
         bun_output::scoped_log!(H2FrameParser, "write {}", bytes.len());
-        if matches!(self.native_socket.get(), BunSocket::Closed) {
-            // Nothing to cork for: `_write` has no transport to hand them to.
-            return self._write(bytes);
-        }
         if !ENABLE_AUTO_CORK {
             return self._write(bytes);
         }
@@ -7550,9 +7529,11 @@ impl H2FrameParser {
 
     pub(crate) fn on_native_close(&self) {
         bun_output::scoped_log!(H2FrameParser, "onNativeClose");
-        // mark_closed can drop the socket's last ref (Writeonly deref): hold a +1.
+        // detach_native_socket can drop the socket's last ref (Writeonly deref),
+        // so match on_native_read/on_native_writable and hold our own +1.
         let _keepalive = self.keepalive();
-        self.native_socket.mark_closed();
+        self.native_socket.note_socket_closed();
+        self.detach_native_socket();
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -156,8 +156,7 @@ impl NativeSocket {
 
     /// Releases whatever `attach` took. `Closed` is sticky: only `attach` clears it.
     fn detach(&self) {
-        // Each arm sets the cell before its release call, which re-enters through
-        // `NewSocket::detach_native_callback`.
+        // Each arm sets the cell before its release call: that call re-enters here.
         match self.0.get() {
             BunSocket::Tcp(socket) => {
                 self.0.set(BunSocket::None);
@@ -180,8 +179,7 @@ impl NativeSocket {
         }
     }
 
-    /// The socket's close dispatch detached this parser. `Closed`, not the `None`
-    /// `detach` leaves: a frame written after the close must not go out through JS.
+    /// `detach`, then `Closed`: a write after the close must not fall back to JS.
     fn mark_closed(&self) {
         self.detach();
         self.0.set(BunSocket::Closed);

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -98,8 +98,15 @@ const MAX_PAYLOAD_SIZE_WITHOUT_FRAME: usize = 16384 - FrameHeader::BYTE_SIZE - 1
 /// holds on them.
 #[derive(Default, Clone, Copy)]
 enum BunSocket {
+    /// No native socket: the bytes go out through the `onWrite` handler, which
+    /// writes them to the session's JS transport (a `Duplex`, a socket that is
+    /// still connecting).
     #[default]
     None,
+    /// The native socket this parser was attached to has closed. Frames
+    /// serialized after that have no transport, so `_write` drops them instead
+    /// of taking the `None` route back into JS.
+    Closed,
     Tls(bun_ptr::BackRef<TLSSocket>),
     TlsWriteonly(bun_ptr::BackRef<TLSSocket>),
     Tcp(bun_ptr::BackRef<TCPSocket>),
@@ -128,7 +135,10 @@ impl NativeSocket {
         socket: *mut crate::socket::NewSocket<SSL>,
         h2: RefPtr<H2FrameParser>,
     ) {
-        debug_assert!(matches!(self.0.get(), BunSocket::None));
+        debug_assert!(matches!(
+            self.0.get(),
+            BunSocket::None | BunSocket::Closed
+        ));
         // BACKREF: `socket` is the live `m_ctx` borrowed from the JS wrapper
         // rooted by the caller's `socket_js`.
         let socket_nn = NonNull::new(socket).expect("NewSocket m_ctx");
@@ -151,15 +161,41 @@ impl NativeSocket {
             });
     }
 
+    /// Releases whatever `attach` took. The state the cell is left in is set
+    /// before the release call, which can re-enter through
+    /// `NewSocket::detach_native_callback`. `Closed` is sticky: only a new
+    /// `attach` clears it.
     fn detach(&self) {
-        match self.0.replace(BunSocket::None) {
-            BunSocket::Tcp(socket) => socket.detach_native_callback(),
-            BunSocket::Tls(socket) => socket.detach_native_callback(),
+        match self.0.get() {
+            BunSocket::Tcp(socket) => {
+                self.0.set(BunSocket::None);
+                socket.detach_native_callback();
+            }
+            BunSocket::Tls(socket) => {
+                self.0.set(BunSocket::None);
+                socket.detach_native_callback();
+            }
             // The ref `attach` took.
-            BunSocket::TcpWriteonly(socket) => TCPSocket::deref(socket.get()),
-            BunSocket::TlsWriteonly(socket) => TLSSocket::deref(socket.get()),
-            BunSocket::None => {}
+            BunSocket::TcpWriteonly(socket) => {
+                self.0.set(BunSocket::None);
+                TCPSocket::deref(socket.get());
+            }
+            BunSocket::TlsWriteonly(socket) => {
+                self.0.set(BunSocket::None);
+                TLSSocket::deref(socket.get());
+            }
+            BunSocket::None | BunSocket::Closed => {}
         }
+    }
+
+    /// The socket's close dispatch detached this parser: the transport is gone.
+    /// Plain `detach` would leave `None`, which means "write through JS" - on a
+    /// session whose socket just closed that hands the frames still in flight
+    /// to `socket.write()` on a `net.Socket` with no handle, and the failed
+    /// write reports ERR_SOCKET_CLOSED on a session Node leaves silent.
+    fn mark_closed(&self) {
+        self.detach();
+        self.0.set(BunSocket::Closed);
     }
 }
 
@@ -2690,6 +2726,8 @@ impl H2FrameParser {
             BunSocket::TcpWriteonly(socket) | BunSocket::Tcp(socket) => {
                 self.generic_flush(socket.get())
             }
+            // The transport closed: the buffered bytes can never reach the peer.
+            BunSocket::Closed => return written,
             BunSocket::None => {
                 // consider that backpressure is gone and flush data queue
                 self.has_nonnative_backpressure.set(false);
@@ -2765,6 +2803,16 @@ impl H2FrameParser {
             BunSocket::TcpWriteonly(socket) | BunSocket::Tcp(socket) => {
                 self.generic_write(socket.get(), bytes)
             }
+            BunSocket::Closed => {
+                bun_output::scoped_log!(
+                    H2FrameParser,
+                    "_write dropped {} (transport closed)",
+                    bytes.len()
+                );
+                // Report them as sent: queueing bytes for a transport that is
+                // gone only grows the buffer until the session is destroyed.
+                true
+            }
             BunSocket::None => {
                 let global = self.global();
                 if self.has_nonnative_backpressure.get() {
@@ -2825,6 +2873,8 @@ impl H2FrameParser {
     fn transport_write_runs_js(&self) -> bool {
         match self.native_socket.get() {
             BunSocket::None => true,
+            // `_write` drops the bytes without calling anything.
+            BunSocket::Closed => false,
             BunSocket::Tls(s) | BunSocket::TlsWriteonly(s) => matches!(
                 s.get().socket.get().socket,
                 bun_uws::InternalSocket::UpgradedDuplex(_)
@@ -2984,7 +3034,7 @@ impl H2FrameParser {
             BunSocket::Tcp(socket) | BunSocket::TcpWriteonly(socket) => {
                 Self::close_socket_for_dead_transport::<false>(socket.get());
             }
-            BunSocket::None => {}
+            BunSocket::None | BunSocket::Closed => {}
         }
     }
 
@@ -3187,6 +3237,10 @@ impl H2FrameParser {
 
     pub(crate) fn write(&self, mut bytes: &[u8]) -> bool {
         bun_output::scoped_log!(H2FrameParser, "write {}", bytes.len());
+        if matches!(self.native_socket.get(), BunSocket::Closed) {
+            // Nothing to cork for: `_write` has no transport to hand them to.
+            return self._write(bytes);
+        }
         if !ENABLE_AUTO_CORK {
             return self._write(bytes);
         }
@@ -7510,10 +7564,10 @@ impl H2FrameParser {
 
     pub(crate) fn on_native_close(&self) {
         bun_output::scoped_log!(H2FrameParser, "onNativeClose");
-        // detach_native_socket can drop the socket's last ref (Writeonly deref),
-        // so match on_native_read/on_native_writable and hold our own +1.
+        // mark_closed can drop the socket's last ref (Writeonly deref), so
+        // match on_native_read/on_native_writable and hold our own +1.
         let _keepalive = self.keepalive();
-        self.detach_native_socket();
+        self.native_socket.mark_closed();
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -135,10 +135,7 @@ impl NativeSocket {
         socket: *mut crate::socket::NewSocket<SSL>,
         h2: RefPtr<H2FrameParser>,
     ) {
-        debug_assert!(matches!(
-            self.0.get(),
-            BunSocket::None | BunSocket::Closed
-        ));
+        debug_assert!(matches!(self.0.get(), BunSocket::None | BunSocket::Closed));
         // BACKREF: `socket` is the live `m_ctx` borrowed from the JS wrapper
         // rooted by the caller's `socket_js`.
         let socket_nn = NonNull::new(socket).expect("NewSocket m_ctx");

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -98,14 +98,10 @@ const MAX_PAYLOAD_SIZE_WITHOUT_FRAME: usize = 16384 - FrameHeader::BYTE_SIZE - 1
 /// holds on them.
 #[derive(Default, Clone, Copy)]
 enum BunSocket {
-    /// No native socket: the bytes go out through the `onWrite` handler, which
-    /// writes them to the session's JS transport (a `Duplex`, a socket that is
-    /// still connecting).
+    /// No native socket: `_write` hands the bytes to the `onWrite` handler.
     #[default]
     None,
-    /// The native socket this parser was attached to has closed. Frames
-    /// serialized after that have no transport, so `_write` drops them instead
-    /// of taking the `None` route back into JS.
+    /// The native socket closed: `_write` drops the bytes, there is no transport.
     Closed,
     Tls(bun_ptr::BackRef<TLSSocket>),
     TlsWriteonly(bun_ptr::BackRef<TLSSocket>),
@@ -158,11 +154,10 @@ impl NativeSocket {
             });
     }
 
-    /// Releases whatever `attach` took. The state the cell is left in is set
-    /// before the release call, which can re-enter through
-    /// `NewSocket::detach_native_callback`. `Closed` is sticky: only a new
-    /// `attach` clears it.
+    /// Releases whatever `attach` took. `Closed` is sticky: only `attach` clears it.
     fn detach(&self) {
+        // Each arm sets the cell before its release call, which re-enters through
+        // `NewSocket::detach_native_callback`.
         match self.0.get() {
             BunSocket::Tcp(socket) => {
                 self.0.set(BunSocket::None);
@@ -185,11 +180,8 @@ impl NativeSocket {
         }
     }
 
-    /// The socket's close dispatch detached this parser: the transport is gone.
-    /// Plain `detach` would leave `None`, which means "write through JS" - on a
-    /// session whose socket just closed that hands the frames still in flight
-    /// to `socket.write()` on a `net.Socket` with no handle, and the failed
-    /// write reports ERR_SOCKET_CLOSED on a session Node leaves silent.
+    /// The socket's close dispatch detached this parser. `Closed`, not the `None`
+    /// `detach` leaves: a frame written after the close must not go out through JS.
     fn mark_closed(&self) {
         self.detach();
         self.0.set(BunSocket::Closed);
@@ -2806,8 +2798,7 @@ impl H2FrameParser {
                     "_write dropped {} (transport closed)",
                     bytes.len()
                 );
-                // Report them as sent: queueing bytes for a transport that is
-                // gone only grows the buffer until the session is destroyed.
+                // Sent, not queued: a transport that is gone never drains.
                 true
             }
             BunSocket::None => {
@@ -7561,8 +7552,7 @@ impl H2FrameParser {
 
     pub(crate) fn on_native_close(&self) {
         bun_output::scoped_log!(H2FrameParser, "onNativeClose");
-        // mark_closed can drop the socket's last ref (Writeonly deref), so
-        // match on_native_read/on_native_writable and hold our own +1.
+        // mark_closed can drop the socket's last ref (Writeonly deref): hold a +1.
         let _keepalive = self.keepalive();
         self.native_socket.mark_closed();
     }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1,5 +1,5 @@
 import { jscDescribe } from "bun:jsc";
-import { bunEnv, bunExe, isASAN, isCI, isDebug, isWindows, nodeExe } from "harness";
+import { bunEnv, bunExe, isASAN, isCI, isDebug, isLinux, nodeExe } from "harness";
 import { createTest } from "node-harness";
 import { AsyncLocalStorage } from "node:async_hooks";
 import dc from "node:diagnostics_channel";
@@ -6145,9 +6145,11 @@ server.listen(0, "127.0.0.1", async () => {
 });
 `;
 
-// Windows drops the data still in the receive queue when the reset arrives, so the request never
-// reaches the 'stream' handler there and the server has nothing queued when the socket closes.
-it.skipIf(isWindows)("a peer reset reports no ERR_SOCKET_CLOSED on a server session or its streams", async () => {
+// Linux only. The reproduction needs the kernel to hand over the buffered request and then report
+// a plain close, which is what epoll does. kqueue and IOCP report the reset as a socket error and
+// drop the bytes still in the receive queue, so the request never reaches the 'stream' handler and
+// the server has nothing queued when the socket closes.
+it.skipIf(!isLinux)("a peer reset reports no ERR_SOCKET_CLOSED on a server session or its streams", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", peerResetChild],
     env: bunEnv,

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6135,9 +6135,14 @@ describe.concurrent("frames written after the native transport closed count as s
         server.once("connection", socket => socket.once("end", resolve).once("close", resolve)),
       );
       const socket = net.connect(server.address().port, "127.0.0.1", () => {
-        socket.write(http2utils.kClientMagic);
-        socket.write(new http2utils.SettingsFrame().data);
-        socket.write(new http2utils.HeadersFrame(1, requestBlock, 0, true, !openBody).data);
+        // One write, so one segment is on the wire before the RST. Nagle cannot hold a part back.
+        socket.write(
+          Buffer.concat([
+            http2utils.kClientMagic,
+            new http2utils.SettingsFrame().data,
+            new http2utils.HeadersFrame(1, requestBlock, 0, true, !openBody).data,
+          ]),
+        );
         socket.resetAndDestroy();
       });
       socket.on("error", () => {});
@@ -6180,8 +6185,7 @@ describe.concurrent("frames written after the native transport closed count as s
           // The request's HEADERS frame: from here on the request is open on both sides.
           if (received[offset + 3] === 1) {
             socket.off("data", onData);
-            socket.write(new http2utils.SettingsFrame().data);
-            socket.write(new http2utils.PingFrame().data);
+            socket.write(Buffer.concat([new http2utils.SettingsFrame().data, new http2utils.PingFrame().data]));
             socket.resetAndDestroy();
             return;
           }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1,5 +1,5 @@
 import { jscDescribe } from "bun:jsc";
-import { bunEnv, bunExe, isASAN, isCI, isDebug, nodeExe } from "harness";
+import { bunEnv, bunExe, isASAN, isCI, isDebug, isWindows, nodeExe } from "harness";
 import { createTest } from "node-harness";
 import { AsyncLocalStorage } from "node:async_hooks";
 import dc from "node:diagnostics_channel";
@@ -6092,6 +6092,78 @@ it("remoteSettings/localSettings are never null before the peer's SETTINGS arriv
     client?.destroy();
     server.close();
   }
+});
+
+// A peer that resets the connection in the same breath as its request leaves the server session
+// with the response frames still queued. Node tears that session down silently: the socket is
+// gone, so the frames go nowhere. Bun handed them to socket.write() on a net.Socket whose handle
+// the close had already detached, and the failed write reported ERR_SOCKET_CLOSED on the session
+// and on a stream with no 'error' listener, which is an uncaught exception.
+// The child process keeps the scenario out of the test runner's own uncaught-exception handling.
+const peerResetChild = `
+const http2 = require("node:http2");
+const net = require("node:net");
+
+const observed = { streams: 0, sessionErrors: [], uncaught: [] };
+process.on("uncaughtException", err => observed.uncaught.push(err.code || err.message));
+
+const server = http2.createServer();
+server.on("session", session => session.on("error", err => observed.sessionErrors.push(err.code || err.message)));
+server.on("stream", stream => {
+  observed.streams++;
+  stream.respond({ ":status": 200 });
+  stream.end("hello");
+});
+
+const PREFACE = Buffer.from("505249202a20485454502f322e300d0a0d0a534d0d0a0d0a", "hex");
+// :method GET, :scheme http and :path / from the static table, then a literal :authority.
+const REQUEST_BLOCK = Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01, 0x09]), Buffer.from("localhost")]);
+function frame(type, flags, streamId, payload) {
+  const header = Buffer.alloc(9);
+  header.writeUIntBE(payload.length, 0, 3);
+  header[3] = type;
+  header[4] = flags;
+  header.writeUInt32BE(streamId, 5);
+  return Buffer.concat([header, payload]);
+}
+
+server.listen(0, "127.0.0.1", async () => {
+  for (let i = 0; i < 5; i++) {
+    const closed = Promise.withResolvers();
+    server.once("session", session => session.once("close", closed.resolve));
+    const socket = net.connect(server.address().port, "127.0.0.1", () => {
+      socket.write(PREFACE);
+      socket.write(frame(4, 0, 0, Buffer.alloc(0)));
+      socket.write(frame(1, 0x4 | 0x1, 1, REQUEST_BLOCK));
+      socket.resetAndDestroy();
+    });
+    socket.on("error", () => {});
+    await closed.promise;
+  }
+  console.log(JSON.stringify(observed));
+  server.close();
+});
+`;
+
+// Windows drops the data still in the receive queue when the reset arrives, so the request never
+// reaches the 'stream' handler there and the server has nothing queued when the socket closes.
+it.skipIf(isWindows)("a peer reset reports no ERR_SOCKET_CLOSED on a server session or its streams", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", peerResetChild],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const observed = JSON.parse(stdout);
+  // A reset can beat the request out of the receive queue, so an iteration can end before the
+  // request is read. At least one of the five has to reach the 'stream' handler.
+  expect(observed.streams).toBeGreaterThan(0);
+  // The read side can see the reset itself, which node reports as ECONNRESET. Any other code
+  // here is the session erroring on its own write.
+  expect([...observed.sessionErrors, ...observed.uncaught].filter(code => code !== "ECONNRESET")).toEqual([]);
+  expect(exitCode).toBe(0);
 });
 
 // node's ServerHttp2Session exposes the Http2Server/Http2SecureServer that accepted the connection

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6094,78 +6094,125 @@ it("remoteSettings/localSettings are never null before the peer's SETTINGS arriv
   }
 });
 
-// A peer that resets the connection in the same breath as its request leaves the server session
-// with the response frames still queued. Node tears that session down silently: the socket is
-// gone, so the frames go nowhere. Bun handed them to socket.write() on a net.Socket whose handle
-// the close had already detached, and the failed write reported ERR_SOCKET_CLOSED on the session
-// and on a stream with no 'error' listener, which is an uncaught exception.
-// The child process keeps the scenario out of the test runner's own uncaught-exception handling.
-const peerResetChild = `
-const http2 = require("node:http2");
-const net = require("node:net");
+// A session whose native transport closes still has frames to write: a queued response, a SETTINGS
+// or PING ACK. Node counts them as sent (Http2Session::ClearOutgoing completes every write with
+// status 0), so the stream finishes and nothing errors. Bun handed them to socket.write() on a
+// socket whose handle was gone. That reported ERR_SOCKET_CLOSED (server) or EBADF (client) on the
+// session and on its streams, which is an uncaught exception for a stream with no 'error' listener.
+// The expected values are what node v26.3.0 gives. Every emitter here records its 'error' instead.
+// Linux only. Each case needs the kernel to deliver the bytes queued ahead of the RST and then
+// report the close, which is what epoll does. kqueue and IOCP drop those bytes with the reset.
+describe.concurrent("frames written after the native transport closed count as sent", () => {
+  // :method GET, :scheme http and :path / from the static table, then a literal :authority.
+  const requestBlock = Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01, 0x09]), Buffer.from("localhost")]);
 
-const observed = { streams: 0, sessionErrors: [], uncaught: [] };
-process.on("uncaughtException", err => observed.uncaught.push(err.code || err.message));
-
-const server = http2.createServer();
-server.on("session", session => session.on("error", err => observed.sessionErrors.push(err.code || err.message)));
-server.on("stream", stream => {
-  observed.streams++;
-  stream.respond({ ":status": 200 });
-  stream.end("hello");
-});
-
-const PREFACE = Buffer.from("505249202a20485454502f322e300d0a0d0a534d0d0a0d0a", "hex");
-// :method GET, :scheme http and :path / from the static table, then a literal :authority.
-const REQUEST_BLOCK = Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01, 0x09]), Buffer.from("localhost")]);
-function frame(type, flags, streamId, payload) {
-  const header = Buffer.alloc(9);
-  header.writeUIntBE(payload.length, 0, 3);
-  header[3] = type;
-  header[4] = flags;
-  header.writeUInt32BE(streamId, 5);
-  return Buffer.concat([header, payload]);
-}
-
-server.listen(0, "127.0.0.1", async () => {
-  for (let i = 0; i < 5; i++) {
-    const closed = Promise.withResolvers();
-    server.once("session", session => session.once("close", closed.resolve));
-    const socket = net.connect(server.address().port, "127.0.0.1", () => {
-      socket.write(PREFACE);
-      socket.write(frame(4, 0, 0, Buffer.alloc(0)));
-      socket.write(frame(1, 0x4 | 0x1, 1, REQUEST_BLOCK));
-      socket.resetAndDestroy();
+  // The peer sends one request and resets the connection before the server reads it.
+  async function serverLosesPeer({ allowHalfOpen, openBody }) {
+    const seen = { streams: 0, shapes: [], streamErrors: [], sessionErrors: [] };
+    const streamsClosed = [];
+    const server = http2.createServer({ allowHalfOpen });
+    server.on("session", session => session.on("error", err => seen.sessionErrors.push(err.code)));
+    server.on("stream", stream => {
+      seen.streams++;
+      const events = [];
+      for (const name of ["finish", "aborted"]) stream.on(name, () => events.push(name));
+      stream.on("error", err => seen.streamErrors.push(err.code));
+      streamsClosed.push(
+        new Promise(resolve =>
+          stream.on("close", () => {
+            events.push(`close:${stream.rstCode}`);
+            if (!seen.shapes.includes(events.join())) seen.shapes.push(events.join());
+            resolve();
+          }),
+        ),
+      );
+      stream.respond({ ":status": 200 });
+      stream.end("hello", () => events.push("endcb"));
     });
-    socket.on("error", () => {});
-    await closed.promise;
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    for (let i = 0; i < 5; i++) {
+      const peerGone = new Promise(resolve =>
+        server.once("connection", socket => socket.once("end", resolve).once("close", resolve)),
+      );
+      const socket = net.connect(server.address().port, "127.0.0.1", () => {
+        socket.write(http2utils.kClientMagic);
+        socket.write(new http2utils.SettingsFrame().data);
+        socket.write(new http2utils.HeadersFrame(1, requestBlock, 0, true, !openBody).data);
+        socket.resetAndDestroy();
+      });
+      socket.on("error", () => {});
+      await peerGone;
+    }
+    // Calls back only once every session and socket of the server is released.
+    await new Promise(resolve => server.close(resolve));
+    await Promise.all(streamsClosed);
+    return seen;
   }
-  console.log(JSON.stringify(observed));
-  server.close();
-});
-`;
 
-// Linux only. The reproduction needs the kernel to hand over the buffered request and then report
-// a plain close, which is what epoll does. kqueue and IOCP report the reset as a socket error and
-// drop the bytes still in the receive queue, so the request never reaches the 'stream' handler and
-// the server has nothing queued when the socket closes.
-it.skipIf(!isLinux)("a peer reset reports no ERR_SOCKET_CLOSED on a server session or its streams", async () => {
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", peerResetChild],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+  const finished = ["endcb,finish,close:0"];
+  for (const [name, options, shapes] of [
+    ["server", { allowHalfOpen: false, openBody: false }, finished],
+    // allowHalfOpen keeps the socket open after 'end'. The session has to end it, or close() hangs.
+    ["server with allowHalfOpen", { allowHalfOpen: true, openBody: false }, finished],
+    // Only that it completes and stays silent. Node also closes this stream with NO_ERROR, because
+    // the response finished while the request was open. Bun does not do that yet, transport or not.
+    ["server with allowHalfOpen and the request body still open", { allowHalfOpen: true, openBody: true }, undefined],
+  ]) {
+    it.skipIf(!isLinux)(name, async () => {
+      const { streams, shapes: seen, ...errors } = await serverLosesPeer(options);
+      // A reset can beat the request out of the receive queue. At least one of five is read.
+      expect(streams).toBeGreaterThan(0);
+      expect({ shapes: shapes && seen, ...errors }).toEqual({ shapes, streamErrors: [], sessionErrors: [] });
+    });
+  }
+
+  // The peer answers a request with SETTINGS and a PING, then resets: the client owes two ACKs.
+  it.skipIf(!isLinux)("client", async () => {
+    const server = net.createServer(socket => {
+      socket.on("error", () => {});
+      let received = Buffer.alloc(0);
+      socket.on("data", function onData(chunk) {
+        received = Buffer.concat([received, chunk]);
+        let offset = http2utils.kClientMagic.length;
+        while (offset + 9 <= received.length) {
+          const end = offset + 9 + received.readUIntBE(offset, 3);
+          if (end > received.length) break;
+          // The request's HEADERS frame: from here on the request is open on both sides.
+          if (received[offset + 3] === 1) {
+            socket.off("data", onData);
+            socket.write(new http2utils.SettingsFrame().data);
+            socket.write(new http2utils.PingFrame().data);
+            socket.resetAndDestroy();
+            return;
+          }
+          offset = end;
+        }
+      });
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const requests = [];
+    for (let i = 0; i < 3; i++) {
+      const events = [];
+      const session = http2.connect(`http://127.0.0.1:${server.address().port}`);
+      session.on("error", err => events.push(`session error:${err.code}`));
+      const sessionClosed = new Promise(resolve => session.on("close", resolve));
+      const req = session.request({ ":method": "POST", ":path": "/" });
+      req.on("error", err => events.push(`error:${err.code}`));
+      req.on("aborted", () => events.push("aborted"));
+      const reqClosed = new Promise(resolve =>
+        req.on("close", () => {
+          events.push(`close:${req.rstCode}`);
+          resolve();
+        }),
+      );
+      // The body stays open, so the request is in flight when the transport closes.
+      req.write("x");
+      await Promise.all([sessionClosed, reqClosed]);
+      requests.push(events.join());
+    }
+    await new Promise(resolve => server.close(resolve));
+    expect(requests).toEqual(["aborted,close:8", "aborted,close:8", "aborted,close:8"]);
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  const observed = JSON.parse(stdout);
-  // A reset can beat the request out of the receive queue, so an iteration can end before the
-  // request is read. At least one of the five has to reach the 'stream' handler.
-  expect(observed.streams).toBeGreaterThan(0);
-  // The read side can see the reset itself, which node reports as ECONNRESET. Any other code
-  // here is the session erroring on its own write.
-  expect([...observed.sessionErrors, ...observed.uncaught].filter(code => code !== "ECONNRESET")).toEqual([]);
-  expect(exitCode).toBe(0);
 });
 
 // node's ServerHttp2Session exposes the Http2Server/Http2SecureServer that accepted the connection


### PR DESCRIPTION
### Problem
- A `node:http2` session whose native socket closes still has frames to write: a queued response, a SETTINGS or PING ACK. Bun hands them to `socket.write()` on a socket with no handle. The session and its streams emit `ERR_SOCKET_CLOSED` (`EBADF` on a client). For a stream with no `'error'` listener that is an uncaught exception. Node is silent.
- Regression: 1.3.14 is silent, 1.4.0 errors the session, 1.4.1 adds the uncaught exception. No user issue exists.
- Cause: after the close the parser has no native socket, and that state means "write through the session's `onWrite` handler" (`src/js/node/http2.ts:4295`).

### Fix
- The parser records that its socket closed (`NativeSocket.closed`, `src/runtime/api/bun/h2_frame_parser.rs:114`) and passes the flag to `onWrite`. No native write path changes.
- The handler reports the frame as sent. Node does the same: `Http2Session::ClearOutgoing` completes each write with status 0. The stream finishes with rstCode 0.
- With `allowHalfOpen` the handler also ends the socket. Nothing else does, and `server.close()` would never call back.
- Verified: four new cases in `test/js/node/http2/node-http2.test.js`, 1.4.3 fails all four. Also all of `test/js/node/http2/`, the 256 upstream `test-http2-*` files, and Windows x64.

### Background
- `H2FrameParser` is the native engine behind one `Http2Session`. It writes to a `net.Socket` natively. With a user `Duplex` it calls the session's `onWrite` handler, which calls `socket.write()`.
- A native close detaches the parser before the JS `'close'` event. Frames flushed in between take the `onWrite` route.
- `allowHalfOpen` keeps a socket writable after the peer's FIN. `net` reads a clean native close as a FIN, so the socket stays open with no handle.

<details><summary>Notes</summary>

**Reproduction** (one file, no network). A peer sends one request and resets the connection in the same tick.

```js
const http2 = require("node:http2"), net = require("node:net");
const server = http2.createServer();
server.on("stream", stream => { stream.respond({ ":status": 200 }); stream.end("hello"); });
server.listen(0, "127.0.0.1", () => {
  const frame = (type, flags, sid, p = Buffer.alloc(0)) => {
    const h = Buffer.alloc(9);
    h.writeUIntBE(p.length, 0, 3); h[3] = type; h[4] = flags; h.writeUInt32BE(sid, 5);
    return Buffer.concat([h, p]);
  };
  const block = Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01, 0x09]), Buffer.from("localhost")]);
  const socket = net.connect(server.address().port, "127.0.0.1", () => {
    socket.write(Buffer.concat([Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "latin1"), frame(4, 0, 0), frame(1, 0x5, 1, block)]));
    socket.resetAndDestroy();
  });
  socket.on("error", () => {});
});
```

- node v26.3.0: silent. The stream emits `'finish'` and `'close'` with rstCode 0, the session emits `'close'`.
- bun 1.4.1 to 1.4.3 and main: `Uncaught ERR_SOCKET_CLOSED: Socket is closed`, from `_write` in `node:net` under `setStreamReading` -> `flush`.
- This branch: the same events as node.

**Releases**, same script, five iterations each:

| | server session | uncaught | client (SETTINGS + PING, then RST) |
|---|---|---|---|
| 1.3.14 | silent | none | n/a |
| 1.4.0 | `ERR_SOCKET_CLOSED` x5 | none | `aborted,close:8` |
| 1.4.1, 1.4.2, main | `ERR_SOCKET_CLOSED` x5 | `ERR_SOCKET_CLOSED` x5 | `session error:EBADF,aborted,error:EBADF,close:2` |
| node v26.3.0, this branch | silent | none | `aborted,close:8` |

**Why not drop the frames in the parser.** The first version of this PR did that, with a sticky `Closed` state that `_write` and `flush()` short-circuited. Two things were wrong with it.

- A stream with a queued response never finished (`'aborted'`, rstCode 8, where node gives `'finish'`, rstCode 0), because `flush()` returned before it drained the stream queues.
- With `allowHalfOpen: true` nothing ended the JS socket, so no `'close'` reached the session and `server.close()` never called back. On main the failing `socket.write()` is what tears that session down, noisily. A drain in `flush()` alone fixes that only for a request that carried END_STREAM. A request with an open body still hung.

The shape here leaves every native write path as it is on main. The one place that changes is the place where main produces the error. So every teardown trigger that main has is still there.

**Event shapes against node v26.3.0**, server side, immediate reset, 20 iterations each:

| | node | this branch |
|---|---|---|
| default, request with END_STREAM | `endcb,finish,close:0` | same |
| `allowHalfOpen`, request with END_STREAM | `endcb,finish,close:0` | same |
| default, request body open | `endcb,finish,close:0` | `aborted,endcb,close:8` |
| `allowHalfOpen`, request body open | `endcb,finish,close:0` | `aborted,endcb,close:8` |

No case reports an error or hangs. The last two rows differ for a reason that does not involve the transport. After a complete response to a request that is still open, node sends `RST_STREAM(NO_ERROR)` and closes the stream. Bun does not: on a healthy connection the same stream stays open (`endcb,finish`, no `'close'`, no RST_STREAM on the wire). That gap is older than this PR and is not addressed here. The test asserts only that this case completes and stays silent.

A reset that the read side sees still reports `ECONNRESET` on the session, as before and as node does (checked with a reset that arrives after the response left).

**Platform.** The new cases run on Linux only. They need the kernel to deliver the bytes queued ahead of the RST and then report the close, which is what epoll does. kqueue and IOCP drop those bytes with the reset, so the request never reaches the `'stream'` handler.

**#42182** (head a3ff86e46e) reports the send errno on client sessions. It does not change the server path, so the three server cases fail there the same way as on main, and they pass with both PRs applied. The client case is where the two differ. On main plus #42182, and also with both PRs applied, it gives `session error:ECONNRESET,aborted,error:ECONNRESET,close:2`. Node v26.3.0 and this branch give `aborted,close:8`. So the PR that lands second has to settle that one case. This PR does not depend on #42182.

**Suites run with the debug build**: `test/js/node/http2/` (521 pass), the 256 `test-http2-*` files in `test/js/node/test/parallel/`, `test/js/bun/http/serve-http2*`, `test/js/web/fetch/fetch-http2-client.test.ts`, and the http2 regression tests under `test/regression/issue/`. Windows x64: `test/js/node/http2/` 509 pass, and the one failure there (a GC count in `h2-conformance.test.ts`) fails the same way with `src/` from main.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/http2/node-http2.test.js

<!-- robobun:evidence:end -->