### PR TITLE
Make Bun.$, Bun.sql, Bun.postgres and Bun.SQL custom value getters so reifying the Bun object passes exception check validation

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -103,10 +103,7 @@ static JSValue constructWebViewObject(VM& vm, JSObject* bunObject);
 
 static JSValue constructEnvObject(VM& vm, JSObject* object)
 {
-    // A PropertyCallback builder is checked with vm.exceptionForInspection(), not a scope, so the
-    // ThrowScope that builds the env map on first use is checked here at the top rather than
-    // leaving its simulated throw for the next builder in JSObject::reifyAllStaticProperties
-    // ({ ...Bun }, Object.entries(Bun)).
+    // JSC runs PropertyCallback builders with no caller scope that checks (reifyAllStaticProperties), so check here.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSValue env = uncheckedDowncast<Zig::GlobalObject>(object->globalObject())->processEnvObject();
     RETURN_IF_EXCEPTION(scope, {});
@@ -386,13 +383,7 @@ static JSValue createBunShell(VM& vm, Zig::GlobalObject* globalObject)
     return bunShell;
 }
 
-// Bun.$, Bun.sql, Bun.postgres and Bun.SQL evaluate builtin JS the first time they are read, so
-// they are self-replacing custom values rather than PropertyCallback entries. JSC runs a
-// PropertyCallback builder with no exception scope around it, also when it reifies the whole
-// table in one loop ({ ...Bun }, Object.entries(Bun)), so a builder that enters JS has no caller
-// that checks what it threw. A custom value getter runs under the reading code's scope like any
-// other getter. The first read stores the result as the plain data property that reifying the
-// PropertyCallback used to produce; reifying the table alone builds nothing.
+// $, sql, postgres and SQL run builtin JS, so they are CustomValue getters (checked by the caller's scope) that store a plain data property on first read.
 static EncodedJSValue lazyBunObjectValue(JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName propertyName, JSValue (*create)(VM&, Zig::GlobalObject*))
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -103,7 +103,14 @@ static JSValue constructWebViewObject(VM& vm, JSObject* bunObject);
 
 static JSValue constructEnvObject(VM& vm, JSObject* object)
 {
-    return uncheckedDowncast<Zig::GlobalObject>(object->globalObject())->processEnvObject();
+    // A PropertyCallback builder is checked with vm.exceptionForInspection(), not a scope, so the
+    // ThrowScope that builds the env map on first use is checked here at the top rather than
+    // leaving its simulated throw for the next builder in JSObject::reifyAllStaticProperties
+    // ({ ...Bun }, Object.entries(Bun)).
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    JSValue env = uncheckedDowncast<Zig::GlobalObject>(object->globalObject())->processEnvObject();
+    RETURN_IF_EXCEPTION(scope, {});
+    return env;
 }
 
 JSC::EncodedJSValue flattenArrayOfBuffersIntoArrayBufferOrUint8Array(JSGlobalObject* lexicalGlobalObject, JSValue arrayValue, size_t maxLength, bool asUint8Array)
@@ -310,19 +317,17 @@ static JSValue constructPluginObject(VM& vm, JSObject* bunObject)
     return pluginFunction;
 }
 
-static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
+static JSValue createBunSql(VM& vm, Zig::GlobalObject* globalObject)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
 
-static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
+static JSValue createBunSQLConstructor(VM& vm, Zig::GlobalObject* globalObject)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
@@ -347,11 +352,10 @@ JSValue constructBunFetchObject(VM& vm, JSObject* bunObject)
     return fetchFn;
 }
 
-static JSValue constructBunShell(VM& vm, JSObject* bunObject)
+static JSValue createBunShell(VM& vm, Zig::GlobalObject* globalObject)
 {
-    auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(bunObject->globalObject());
-    JSFunction* createParsedShellScript = JSFunction::create(vm, bunObject->globalObject(), 2, "createParsedShellScript"_s, BunObject_callback_createParsedShellScript, ImplementationVisibility::Private, NoIntrinsic);
-    JSFunction* createShellInterpreterFunction = JSFunction::create(vm, bunObject->globalObject(), 1, "createShellInterpreter"_s, BunObject_callback_createShellInterpreter, ImplementationVisibility::Private, NoIntrinsic);
+    JSFunction* createParsedShellScript = JSFunction::create(vm, globalObject, 2, "createParsedShellScript"_s, BunObject_callback_createParsedShellScript, ImplementationVisibility::Private, NoIntrinsic);
+    JSFunction* createShellInterpreterFunction = JSFunction::create(vm, globalObject, 1, "createShellInterpreter"_s, BunObject_callback_createShellInterpreter, ImplementationVisibility::Private, NoIntrinsic);
     JSC::JSFunction* createShellFn = JSC::JSFunction::create(vm, globalObject, shellCreateBunShellTemplateFunctionCodeGenerator(vm), globalObject);
 
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -381,6 +385,40 @@ static JSValue constructBunShell(VM& vm, JSObject* bunObject)
 
     return bunShell;
 }
+
+// Bun.$, Bun.sql, Bun.postgres and Bun.SQL evaluate builtin JS the first time they are read, so
+// they are self-replacing custom values rather than PropertyCallback entries. JSC runs a
+// PropertyCallback builder with no exception scope around it, also when it reifies the whole
+// table in one loop ({ ...Bun }, Object.entries(Bun)), so a builder that enters JS has no caller
+// that checks what it threw. A custom value getter runs under the reading code's scope like any
+// other getter. The first read stores the result as the plain data property that reifying the
+// PropertyCallback used to produce; reifying the table alone builds nothing.
+static EncodedJSValue lazyBunObjectValue(JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName propertyName, JSValue (*create)(VM&, Zig::GlobalObject*))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    // A CustomValue getter is passed the object that holds the property, not the receiver.
+    JSObject* bunObject = JSValue::decode(thisValue).getObject();
+    JSValue value = create(vm, defaultGlobalObject(bunObject->globalObject()));
+    RETURN_IF_EXCEPTION(scope, {});
+    bunObject->putDirect(vm, propertyName, value, PropertyAttribute::DontDelete | 0);
+    return JSValue::encode(value);
+}
+
+// Assignment stores a plain data property, as it did when these were PropertyCallback entries.
+static bool replaceLazyBunObjectValue(JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, EncodedJSValue value, PropertyName propertyName)
+{
+    if (JSObject* object = JSValue::decode(thisValue).getObject())
+        object->putDirect(JSC::getVM(lexicalGlobalObject), propertyName, JSValue::decode(value), PropertyAttribute::DontDelete | 0);
+    return true;
+}
+
+static JSC_DEFINE_CUSTOM_GETTER(bunObjectShell, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName propertyName)) { return lazyBunObjectValue(globalObject, thisValue, propertyName, createBunShell); }
+static JSC_DEFINE_CUSTOM_GETTER(bunObjectSql, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName propertyName)) { return lazyBunObjectValue(globalObject, thisValue, propertyName, createBunSql); }
+static JSC_DEFINE_CUSTOM_GETTER(bunObjectSQL, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName propertyName)) { return lazyBunObjectValue(globalObject, thisValue, propertyName, createBunSQLConstructor); }
+static JSC_DEFINE_CUSTOM_SETTER(setBunObjectShell, (JSGlobalObject * globalObject, EncodedJSValue thisValue, EncodedJSValue value, PropertyName propertyName)) { return replaceLazyBunObjectValue(globalObject, thisValue, value, propertyName); }
+static JSC_DEFINE_CUSTOM_SETTER(setBunObjectSql, (JSGlobalObject * globalObject, EncodedJSValue thisValue, EncodedJSValue value, PropertyName propertyName)) { return replaceLazyBunObjectValue(globalObject, thisValue, value, propertyName); }
+static JSC_DEFINE_CUSTOM_SETTER(setBunObjectSQL, (JSGlobalObject * globalObject, EncodedJSValue thisValue, EncodedJSValue value, PropertyName propertyName)) { return replaceLazyBunObjectValue(globalObject, thisValue, value, propertyName); }
 
 static JSValue constructDNSObject(VM& vm, JSObject* bunObject)
 {
@@ -914,7 +952,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
 
 /* Source for BunObject.lut.h
 @begin bunObjectTable
-    $                                              constructBunShell                                                   DontDelete|PropertyCallback
+    $                                              bunObjectShell                                                      DontDelete|CustomValue
     Archive                                        BunObject_lazyPropCb_wrap_Archive                                   DontDelete|PropertyCallback
     ArrayBufferSink                                BunObject_lazyPropCb_wrap_ArrayBufferSink                           DontDelete|PropertyCallback
     Cookie                                         constructCookieObject                                               DontDelete|ReadOnly|PropertyCallback
@@ -999,9 +1037,9 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
     resolveSync                                    BunObject_callback_resolveSync                                      DontDelete|Function 1
     revision                                       constructBunRevision                                                ReadOnly|DontDelete|PropertyCallback
     semver                                         BunObject_lazyPropCb_wrap_semver                                    ReadOnly|DontDelete|PropertyCallback
-    sql                                            defaultBunSQLObject                                                 DontDelete|PropertyCallback
-    postgres                                       defaultBunSQLObject                                                 DontDelete|PropertyCallback
-    SQL                                            constructBunSQLObject                                               DontDelete|PropertyCallback
+    sql                                            bunObjectSql                                                        DontDelete|CustomValue
+    postgres                                       bunObjectSql                                                        DontDelete|CustomValue
+    SQL                                            bunObjectSQL                                                        DontDelete|CustomValue
     serve                                          BunObject_callback_serve                                            DontDelete|Function 1
     sha                                            BunObject_callback_sha                                              DontDelete|Function 1
     shrink                                         BunObject_callback_shrink                                           DontDelete|Function 1

--- a/src/jsc/bindings/ProcessBindingFs.cpp
+++ b/src/jsc/bindings/ProcessBindingFs.cpp
@@ -111,10 +111,7 @@ PROCESS_BINDING_NOT_IMPLEMENTED(writeFileUtf8)
 
 PROCESS_BINDING_NOT_IMPLEMENTED(writeString)
 
-// A PropertyCallback builder is checked with vm.exceptionForInspection(), not a scope, so
-// the ThrowScope inside JSGenericTypedArrayView::create is checked here at the top rather than
-// leaving its simulated throw for the next builder in JSObject::reifyAllStaticProperties
-// ({ ...process.binding("fs") }).
+// JSC runs PropertyCallback builders with no caller scope that checks (reifyAllStaticProperties), so check create() here.
 template<typename ArrayType>
 static JSValue statValuesArray(VM& vm, JSObject* binding, size_t length)
 {

--- a/src/jsc/bindings/ProcessBindingFs.cpp
+++ b/src/jsc/bindings/ProcessBindingFs.cpp
@@ -111,28 +111,38 @@ PROCESS_BINDING_NOT_IMPLEMENTED(writeFileUtf8)
 
 PROCESS_BINDING_NOT_IMPLEMENTED(writeString)
 
+// A PropertyCallback builder is checked with vm.exceptionForInspection(), not a scope, so
+// the ThrowScope inside JSGenericTypedArrayView::create is checked here at the top rather than
+// leaving its simulated throw for the next builder in JSObject::reifyAllStaticProperties
+// ({ ...process.binding("fs") }).
+template<typename ArrayType>
+static JSValue statValuesArray(VM& vm, JSObject* binding, size_t length)
+{
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto* globalObject = binding->globalObject();
+    auto* array = ArrayType::create(globalObject, globalObject->typedArrayStructureWithTypedArrayType<ArrayType::TypedArrayStorageType>(), length);
+    RETURN_IF_EXCEPTION(scope, {});
+    return array;
+}
+
 static JSValue ProcessBindingFs_statValues(VM& vm, JSObject* object)
 {
-    auto* globalObject = object->globalObject();
-    return JSC::JSFloat64Array::create(globalObject, globalObject->m_typedArrayFloat64.get(globalObject), 36);
+    return statValuesArray<JSC::JSFloat64Array>(vm, object, 36);
 }
 
 static JSValue ProcessBindingFs_bigintStatValues(VM& vm, JSObject* object)
 {
-    auto* globalObject = object->globalObject();
-    return JSC::JSBigInt64Array::create(globalObject, globalObject->m_typedArrayBigInt64.get(globalObject), 36);
+    return statValuesArray<JSC::JSBigInt64Array>(vm, object, 36);
 }
 
 static JSValue ProcessBindingFs_statFsValues(VM& vm, JSObject* object)
 {
-    auto* globalObject = object->globalObject();
-    return JSC::JSFloat64Array::create(globalObject, globalObject->m_typedArrayFloat64.get(globalObject), 7);
+    return statValuesArray<JSC::JSFloat64Array>(vm, object, 7);
 }
 
 static JSValue ProcessBindingFs_bigintStatFsValues(VM& vm, JSObject* object)
 {
-    auto* globalObject = object->globalObject();
-    return JSC::JSBigInt64Array::create(globalObject, globalObject->m_typedArrayBigInt64.get(globalObject), 7);
+    return statValuesArray<JSC::JSBigInt64Array>(vm, object, 7);
 }
 
 /* Source for ProcessBindingFs.lut.h

--- a/src/jsc/bindings/ProcessBindingHTTPParser.cpp
+++ b/src/jsc/bindings/ProcessBindingHTTPParser.cpp
@@ -13,9 +13,7 @@ static constexpr ASCIILiteral httpAllMethodNames[] = { HTTP_ALL_METHOD_MAP(METHO
 
 static JSValue methodNamesArray(VM& vm, JSObject* binding, std::span<const ASCIILiteral> names)
 {
-    // A PropertyCallback builder is checked with vm.exceptionForInspection(), not a scope,
-    // so it checks at the top rather than leaving a ThrowScope's simulated throw for the
-    // next builder in JSObject::reifyAllStaticProperties ({ ...process.binding("http_parser") }).
+    // JSC runs PropertyCallback builders with no caller scope that checks (reifyAllStaticProperties), so check here.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSGlobalObject* globalObject = binding->globalObject();
     JSArray* methods = constructEmptyArray(globalObject, nullptr, names.size());

--- a/src/jsc/bindings/ProcessBindingHTTPParser.cpp
+++ b/src/jsc/bindings/ProcessBindingHTTPParser.cpp
@@ -13,7 +13,10 @@ static constexpr ASCIILiteral httpAllMethodNames[] = { HTTP_ALL_METHOD_MAP(METHO
 
 static JSValue methodNamesArray(VM& vm, JSObject* binding, std::span<const ASCIILiteral> names)
 {
-    auto scope = DECLARE_THROW_SCOPE(vm);
+    // A PropertyCallback builder is checked with vm.exceptionForInspection(), not a scope,
+    // so it checks at the top rather than leaving a ThrowScope's simulated throw for the
+    // next builder in JSObject::reifyAllStaticProperties ({ ...process.binding("http_parser") }).
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSGlobalObject* globalObject = binding->globalObject();
     JSArray* methods = constructEmptyArray(globalObject, nullptr, names.size());
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5551,7 +5551,13 @@ restart:
 
                 // Ignore exceptions from getters.
                 if (scope.exception()) [[unlikely]] {
-                    (void)scope.tryClearException();
+                    if (!scope.tryClearException())
+                        return;
+                    // A CustomValue getter produces a lazily built data property (Bun.$, Bun.sql). When it
+                    // throws there is no value yet, so leave the property out, like a lazy static property
+                    // whose builder throws inside getPropertySlot above.
+                    if (slot.attributes() & PropertyAttribute::CustomValue)
+                        continue;
                     propertyValue = jsUndefined();
                 }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5553,9 +5553,7 @@ restart:
                 if (scope.exception()) [[unlikely]] {
                     if (!scope.tryClearException())
                         return;
-                    // A CustomValue getter produces a lazily built data property (Bun.$, Bun.sql). When it
-                    // throws there is no value yet, so leave the property out, like a lazy static property
-                    // whose builder throws inside getPropertySlot above.
+                    // A CustomValue getter that throws has built no value (Bun.$): leave it out, like a throwing lazy builder above.
                     if (slot.attributes() & PropertyAttribute::CustomValue)
                         continue;
                     propertyValue = jsUndefined();

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -632,8 +632,13 @@ static JSValue getSourceMapFunction(VM& vm, JSObject* moduleObject)
     return zigGlobalObject->JSSourceMapConstructor();
 }
 
+// A PropertyCallback builder is checked with vm.exceptionForInspection(), not a scope, so the
+// ThrowScope inside constructArray / constructEmptyArray is checked here at the top rather than
+// leaving its simulated throw for the next builder in JSObject::reifyAllStaticProperties
+// (Object.entries(require("node:module")), as jest-runtime does).
 static JSValue getBuiltinModulesObject(VM& vm, JSObject* moduleObject)
 {
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     MarkedArgumentBuffer args;
     args.ensureCapacity(countof(builtinModuleNames));
 
@@ -642,7 +647,9 @@ static JSValue getBuiltinModulesObject(VM& vm, JSObject* moduleObject)
     }
 
     auto* globalObject = defaultGlobalObject(moduleObject->globalObject());
-    return JSC::constructArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), JSC::ArgList(args));
+    auto* builtinModules = JSC::constructArray(globalObject, static_cast<JSC::ArrayAllocationProfile*>(nullptr), JSC::ArgList(args));
+    RETURN_IF_EXCEPTION(scope, {});
+    return builtinModules;
 }
 
 static JSValue getConstantsObject(VM& vm, JSObject* moduleObject)
@@ -670,9 +677,13 @@ static JSValue getConstantsObject(VM& vm, JSObject* moduleObject)
 
 static JSValue getGlobalPathsObject(VM& vm, JSObject* moduleObject)
 {
-    return JSC::constructEmptyArray(
+    // See getBuiltinModulesObject for why this checks at the top.
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto* globalPaths = JSC::constructEmptyArray(
         moduleObject->globalObject(),
         static_cast<ArrayAllocationProfile*>(nullptr), 0);
+    RETURN_IF_EXCEPTION(scope, {});
+    return globalPaths;
 }
 
 // Like the _resolveFilename / runMain setters: writing back the default (e.g. copying Module's statics onto a

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -632,12 +632,9 @@ static JSValue getSourceMapFunction(VM& vm, JSObject* moduleObject)
     return zigGlobalObject->JSSourceMapConstructor();
 }
 
-// A PropertyCallback builder is checked with vm.exceptionForInspection(), not a scope, so the
-// ThrowScope inside constructArray / constructEmptyArray is checked here at the top rather than
-// leaving its simulated throw for the next builder in JSObject::reifyAllStaticProperties
-// (Object.entries(require("node:module")), as jest-runtime does).
 static JSValue getBuiltinModulesObject(VM& vm, JSObject* moduleObject)
 {
+    // JSC runs PropertyCallback builders with no caller scope that checks (reifyAllStaticProperties), so check here.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     MarkedArgumentBuffer args;
     args.ensureCapacity(countof(builtinModuleNames));

--- a/test/js/bun/util/BunObject.test.ts
+++ b/test/js/bun/util/BunObject.test.ts
@@ -35,6 +35,33 @@ test("await import('bun')", async () => {
   expect(BunESM.default).toBe(Bun);
 });
 
+test("reifying every lazy property at once passes exception check validation", async () => {
+  // { ...Bun } and Object.entries(Bun) run every PropertyCallback builder of the Bun object back
+  // to back (JSObject::reifyAllStaticProperties). Builds with exception scope verification
+  // (debug, ASAN) abort if one of them returns with an unchecked simulated throw; release
+  // builds ignore the option, so there this only checks the copy is complete.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const spread = { ...Bun };
+       const entries = Object.entries(Bun);
+       const keys = Object.keys(Bun);
+       const mismatched = keys.filter(key => !(key in spread) || spread[key] !== Bun[key]);
+       console.log(JSON.stringify({ keys: keys.length > 0, entries: entries.length === keys.length, mismatched }));`,
+    ],
+    env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({ keys: true, entries: true, mismatched: [] }),
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 test("a lazy property whose builtin fails to load throws from the read", async () => {
   // The shell builtin ($) and the sql module body (sql, SQL, postgres) call Symbol(), so
   // breaking it makes each builder throw. The read must throw that error (debug builds used to

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -30,6 +30,32 @@ describe.concurrent("node-module-module", () => {
     expect(Array.isArray(require("module").globalPaths)).toBe(true);
   });
 
+  test("Object.entries(Module) passes exception check validation", async () => {
+    // jest-runtime copies Module's statics this way. It runs every lazy PropertyCallback builder of
+    // the module object back to back (JSObject::reifyAllStaticProperties); builds with exception
+    // scope verification (debug, ASAN) abort if one of them returns with an unchecked simulated
+    // throw. Release builds ignore the option, so there this only checks the copy is complete.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const Module = require("node:module");
+         const copy = Object.fromEntries(Object.entries(Module));
+         const missing = Object.keys(Module).filter(key => !(key in copy));
+         console.log(JSON.stringify({ missing, builtinModules: copy.builtinModules.length, globalPaths: Array.isArray(copy.globalPaths) }));`,
+      ],
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ missing: [], builtinModules: 76, globalPaths: true }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   test("Module._findPath propagates an error thrown by an onResolve plugin", async () => {
     // Plugins are process-global; run in a child so the throwing resolver can't affect other tests.
     await using proc = Bun.spawn({

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -705,6 +705,39 @@ it("process.binding", () => {
   expect(() => process.binding(Object.freeze({ __proto__: null }))).toThrow();
 });
 
+it("spreading a process.binding() object passes exception check validation", async () => {
+  // { ...binding } runs every lazy PropertyCallback builder of the object back to back
+  // (JSObject::reifyAllStaticProperties). Builds with exception scope verification (debug,
+  // ASAN) abort if one of them returns with an unchecked simulated throw; release builds
+  // ignore the option, so there this only checks the copy is complete.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const missing = [];
+       for (const name of ["buffer", "config", "constants", "crypto/x509", "fs", "http_parser", "natives", "tty_wrap", "util", "uv"]) {
+         const binding = process.binding(name);
+         const spread = { ...binding };
+         for (const key of Object.keys(binding)) {
+           if (!(key in spread) || spread[key] !== binding[key]) missing.push(name + "." + key);
+         }
+       }
+       const { methods, allMethods } = process.binding("http_parser");
+       const { statValues, bigintStatValues } = process.binding("fs");
+       console.log(JSON.stringify({ missing, methods: methods.length, allMethods: allMethods.length, statValues: statValues.length, bigintStatValues: bigintStatValues.length }));`,
+    ],
+    env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({ missing: [], methods: 35, allMethods: 47, statValues: 36, bigintStatValues: 36 }),
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 it("process.argv in testing", () => {
   expect(process.argv).toBeInstanceOf(Array);
   expect(process.argv[0]).toBe(process.execPath);

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -4,9 +4,7 @@
 test/bake/dev/production.test.ts
 test/integration/vite-build/vite-build.test.ts
 test/js/bun/test/parallel/test-integration-rspack.ts
-test/js/bun/util/BunObject.test.ts
 test/js/bun/util/fuzzy-wuzzy.test.ts
-test/js/node/module/node-module-module.test.js
 test/js/node/test/parallel/test-vm-module-referrer-realm.mjs
 test/js/third_party/astro/astro-post.test.js
 


### PR DESCRIPTION
### Problem
- With exception check validation on (debug builds and the ASAN CI lane), `({ ...Bun })` and `Object.entries(Bun)` abort: `Unchecked JS exception: This scope can throw a JS exception: constructBunShell`, then `ASSERTION FAILED: exception check validation failed`. So do spreads of `process.binding("fs")`, `process.binding("http_parser")` and `require("node:module")`. No builder throws.
- `JSObject::reifyAllStaticProperties` runs every `PropertyCallback` builder back to back and checks `vm.exceptionForInspection()` between them, which the validator does not count. A builder that returns through a `ThrowScope` leaves a simulated throw behind for the next builder's scope.

### Fix
- `Bun.$`, `Bun.sql`, `Bun.postgres` and `Bun.SQL`, the builders that enter JS, become self-replacing `CustomValue` getters, as #39526 does for `process.nextTick`. The getter runs under the reading code's scope with a plain `ThrowScope` and stores the same data property the builder produced.
- The allocation-only builders (`Bun.env`, the `fs` stat arrays, the `http_parser` method lists, `node:module` `builtinModules` and `globalPaths`) check at the top with a `TopExceptionScope`, like the `process` builders.
- Correct because descriptors, assignment, `delete`, identity and `Bun.inspect(Bun)` match a release build, and a throwing getter still throws from each read (#29642). `Bun.inspect` leaves out a `CustomValue` property whose getter throws, as it does for a throwing builder.
- Verified: new tests in `BunObject.test.ts`, `process.test.js` and `node-module-module.test.js` exit 134 on an unfixed debug build and pass with it. Self-reviewed: reworked from per-builder top scopes to this shape.

### Background
- These objects declare a static property table. JSC runs a `PropertyCallback` entry's builder with no scope around it, on the first read or when it reifies the whole table. It calls a `CustomValue` entry's getter like any getter.
- Under validation a destroyed `ThrowScope` demands that its caller check before the next scope is constructed. A `TopExceptionScope` only asserts that its own body checked.

<details><summary>Notes</summary>

- `test/no-validate-exceptions.txt` drops `BunObject.test.ts` and `node-module-module.test.js`, which now pass in-process with validation on.
- `JSC__JSValue__forEachPropertyImpl` (`bindings.cpp`) printed `$: undefined` for a `CustomValue` getter that threw (the generic "getter threw" branch), while a throwing `PropertyCallback` builder makes `getPropertySlot` report a miss and the property is skipped. #29642's inspect test (`globalThis.Symbol = 0; Bun.inspect(Bun)`) expects `$` to be skipped, so a throwing `CustomValue` getter is now skipped too. That branch also stops the walk when the pending exception is a termination instead of calling the next callback.
- Full message: `ERROR: Unchecked JS exception: This scope can throw a JS exception: constructBunShell @ src/jsc/bindings/BunObject.cpp:357 ... But the exception was unchecked as of this scope: <rust> @ src/runtime/api/BunObject.rs:293`, exit code 134. `Object.values(Bun)` and `Object.assign({}, Bun)` take the same path.
- Why getters for the four JS-entering properties: oven-sh/WebKit#479 was closed with "the embedder-side fix is to stop entering JS from PropertyCallback builders (use checked custom getters for the few properties that need it)". #39526 does that for `process.stdin/stdout/stderr/nextTick`; this does it for the Bun object. The JSC-side alternatives (oven-sh/WebKit#514, oven-sh/WebKit#475, #39703) stay unneeded for these tables.
- #29581 fixes the two `node:module` builders with scope-free `JSArray::tryCreate`. This PR covers them with the top-scope check instead, which keeps the "empty result means an exception is pending" contract on OOM. If #29581's shape is preferred I can switch those two.
- `Bun.env` only showed up once `$` stopped being built during the loop: the shell builtin reads `process.env`, which used to initialize the env map (a `ThrowScope` in `createEnvironmentVariablesMap`) before `Bun.env`'s builder ran.
- Observable behavior, compared against the release build of the same revision with a probe script: `Object.getOwnPropertyDescriptor(Bun, "SQL")` before and after a read (data descriptor, writable, enumerable, not configurable), `Bun.sql === Bun.sql`, `Bun.postgres === Bun.sql`, `Object.create(Bun).$ === Bun.$`, `delete Bun.$` (still fails), `Bun.SQL = 123`, `Object.keys(Bun)`, `{ ...Bun }`, `console.log(Bun)`: identical output.
- A plain `Bun.$` read never hit the abort: `setUpStaticFunctionSlot` also checks with `exceptionForInspection()`, but `JSValue::get` higher up calls `scope.exception()` before anything else constructs a scope.
- With a getter that really throws (`globalThis.Symbol = NaN`), `{ ...Bun }`, `Object.entries/values/assign`, `Bun.$` and `Bun.sql` each throw the `TypeError` under validation, and everything works after `Symbol` is restored.
- `{ ...process }`, `Object.entries(globalThis)` and the other `process.binding()` objects (`buffer`, `config`, `constants`, `crypto/x509`, `natives`, `tty_wrap`, `util`, `uv`) already passed with validation on.
- Other entries under "tests that potentially throw inside of reifyStaticProperties" in `test/no-validate-exceptions.txt` were left alone; they are integration tests I did not run under validation here.
- Also ran with validation on: `test/js/bun/shell/bunshell.test.ts` and four smaller shell files, `test/js/sql/{adapter-env-var-precedence,adapter-override,sqlite-sql}.test.ts`, `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts`, `test/js/node/http/node-http-parser.test.ts`, `test/js/bun/globals.test.js`, `test/js/bun/namespace-prototype-pollution.test.ts`, the whole `BunObject.test.ts` and `node-module-module.test.js` in-process with `BUN_JSC_dumpSimulatedThrows=1`, named ESM imports of `$`/`sql`/`SQL`/`postgres` from `"bun"`, and `{ ...Bun }` plus `Bun.$` inside a `worker_threads` worker.
- Seen in CI build 113610 (Debian x64 ASAN) through a test that did `Object.keys({ ...Bun })` in a child process. That test has since changed, so nothing in the tree exercised this path under validation.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process.test.js, test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->