### PR TITLE
node:fs: copy a Buffer path at call time for async operations

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -120,12 +120,12 @@ UTF-8 bytes _and_ the source `String` so the value can go back to JS without
 re-encoding; `Utf8WithString::js_only(string)` wraps an output-only string.
 `PathLike<'a>` / `StringOrBuffer<'a>` arms: `String`/`ThreadIsolatedString`
 (`Utf8WithString` from a JS string), `Utf8(Utf8Bytes<'a>)` (transcoded JS
-string, or Rust-side bytes: `PathLike::borrowed(bytes)` lends `&'a [u8]` to a
-synchronous call, `PathLike::owned(vec)` when the value must own them),
-`Buffer` (`PathLike`: a `PinnedArrayBuffer`, GC-rooted too when parsed for an
-async call; `StringOrBuffer`: borrowed for a sync call) and
-`StringOrBuffer::PinnedBuffer` (pinned and GC-rooted, parsed for an async
-call). Values parsed from JS for an async call, stored, or sent to another thread (the
+string, a JS buffer path copied for an async call, or Rust-side bytes:
+`PathLike::borrowed(bytes)` lends `&'a [u8]` to a synchronous call,
+`PathLike::owned(vec)` when the value must own them), `Buffer` (`PathLike`: a
+`PinnedArrayBuffer`, parsed for a sync call only; `StringOrBuffer`: borrowed
+for a sync call) and `StringOrBuffer::PinnedBuffer` (pinned and GC-rooted,
+parsed for an async call). Values parsed from JS for an async call, stored, or sent to another thread (the
 `from_js_async` parsers, which return `ThreadIsolated<T>`;
 `PathLike::thread_isolated_copy` for a `Blob` store) is `'static`.
 

--- a/src/jsc/node_path.rs
+++ b/src/jsc/node_path.rs
@@ -15,7 +15,8 @@ use crate::array_buffer::PinnedArrayBuffer;
 /// `node.PathLike`. Parsed from JS it is `PathLike<'static>`; `Utf8` may
 /// instead borrow Rust-side bytes for a synchronous call ([`PathLike::borrowed`]).
 pub enum PathLike<'a> {
-    /// Pinned for the call; also GC-rooted when parsed for an async call.
+    /// Pinned for a synchronous call. An async call copies a buffer path into
+    /// `Utf8(Owned)` instead, so a pool thread never reads JS-writable bytes.
     Buffer(PinnedArrayBuffer),
     /// Always shares its WTF string's bytes (built by `shared_or_utf8`);
     /// transcoded paths are `Utf8(Owned)`.

--- a/src/jsc/node_path.rs
+++ b/src/jsc/node_path.rs
@@ -15,8 +15,7 @@ use crate::array_buffer::PinnedArrayBuffer;
 /// `node.PathLike`. Parsed from JS it is `PathLike<'static>`; `Utf8` may
 /// instead borrow Rust-side bytes for a synchronous call ([`PathLike::borrowed`]).
 pub enum PathLike<'a> {
-    /// Pinned for a synchronous call. An async call copies a buffer path into
-    /// `Utf8(Owned)` instead, so a pool thread never reads JS-writable bytes.
+    /// Pinned for a synchronous call (an async call copies a buffer path into `Utf8(Owned)`).
     Buffer(PinnedArrayBuffer),
     /// Always shares its WTF string's bytes (built by `shared_or_utf8`);
     /// transcoded paths are `Utf8(Owned)`.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -999,9 +999,7 @@ mod _async_tasks {
         /// `from_js`; the trait forwards to it so the generic `Bindings` in
         /// `node_fs_binding.rs` can call it without per-type macro arms.
         fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Self>;
-        /// [`from_js`](Self::from_js) for a work-pool job: under `will_be_async`
-        /// a path parses thread-isolated (string) or copied (buffer), and a data
-        /// buffer parses pinned and rooted.
+        /// [`from_js`](Self::from_js) under `will_be_async`: paths parse thread-isolated or copied, data pinned and rooted.
         fn from_js_async(
             ctx: &JSGlobalObject,
             arguments: &mut ArgumentsSlice,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -999,8 +999,9 @@ mod _async_tasks {
         /// `from_js`; the trait forwards to it so the generic `Bindings` in
         /// `node_fs_binding.rs` can call it without per-type macro arms.
         fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Self>;
-        /// [`from_js`](Self::from_js) for a work-pool job: paths and data parse
-        /// thread-isolated / pinned and rooted under `will_be_async`.
+        /// [`from_js`](Self::from_js) for a work-pool job: under `will_be_async`
+        /// a path parses thread-isolated (string) or copied (buffer), and a data
+        /// buffer parses pinned and rooted.
         fn from_js_async(
             ctx: &JSGlobalObject,
             arguments: &mut ArgumentsSlice,
@@ -1020,8 +1021,8 @@ mod _async_tasks {
     macro_rules! impl_fs_argument {
     ( $( $ty:ty ),+ $(,)? ) => {
         $(
-        // SAFETY: `from_js_async` parses paths and data thread-isolated / pinned
-        // and rooted; the remaining fields are plain data.
+        // SAFETY: `from_js_async` parses paths thread-isolated or copied and data
+        // pinned and rooted; the remaining fields are plain data.
         unsafe impl ThreadIsolatedArg for $ty {}
         impl FsArgument for $ty {
             #[inline] fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Self> { <$ty>::from_js(ctx, arguments) }

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1105,20 +1105,9 @@ impl PathLikeExt for PathLike<'_> {
         use jsc::JSType;
         let path = match arg.js_type() {
             JSType::Uint8Array | JSType::DataView | JSType::ArrayBuffer => {
-                let mut buffer = if arguments.will_be_async {
-                    PinnedArrayBuffer::root(ctx, arg)
-                } else {
-                    PinnedArrayBuffer::pin(ctx, arg)
-                }
-                .ok_or_else(|| ctx.throw_out_of_memory())?;
-                // Read after this call (pool thread, a later argument's getter, a `Blob` store): a shrink in between unmaps the pages.
-                if !buffer.copy_if_resizable(ctx) {
-                    return Err(ctx.throw_out_of_memory());
-                }
-                Valid::path_buffer(buffer.slice(), ctx)?;
-                Valid::path_null_bytes(buffer.slice(), ctx)?;
+                let path = path_like_from_buffer(ctx, arg, arguments.will_be_async)?;
                 arguments.eat();
-                PathLike::Buffer(buffer)
+                path
             }
 
             JSType::String | JSType::StringObject | JSType::DerivedStringObject => {
@@ -1186,6 +1175,43 @@ impl PathLikeExt for PathLike<'_> {
             None => Ok(path),
         }
     }
+}
+
+/// `value`'s bytes as a `PathLike`, NUL-checked; the caller checks the length
+/// ([`Valid::path_length`]).
+///
+/// An async op copies the bytes, like node's `BufferValue`: the name is the one
+/// the call was made with, not whatever the buffer holds when a pool thread
+/// reads it. The copy is also what the NUL check validates, so a NUL written
+/// after the check cannot truncate the name.
+fn path_like_from_buffer(
+    global: &JSGlobalObject,
+    value: jsc::JSValue,
+    will_be_async: bool,
+) -> JsResult<PathLike<'static>> {
+    let mut buffer =
+        PinnedArrayBuffer::pin(global, value).ok_or_else(|| global.throw_out_of_memory())?;
+
+    if will_be_async {
+        let mut copy = Vec::new();
+        if copy.try_reserve_exact(buffer.slice().len()).is_err() {
+            return Err(global.throw_out_of_memory());
+        }
+        copy.extend_from_slice(buffer.slice());
+        drop(buffer);
+        Valid::path_buffer(&copy, global)?;
+        Valid::path_null_bytes(&copy, global)?;
+        global.vm().report_extra_memory(copy.len());
+        return Ok(PathLike::owned(copy));
+    }
+
+    // Read after this call (a later argument's getter, a `Blob` store): a shrink in between unmaps the pages.
+    if !buffer.copy_if_resizable(global) {
+        return Err(global.throw_out_of_memory());
+    }
+    Valid::path_buffer(buffer.slice(), global)?;
+    Valid::path_null_bytes(buffer.slice(), global)?;
+    Ok(PathLike::Buffer(buffer))
 }
 
 /// `str` as a `PathLike`, NUL-checked; the caller checks the length ([`Valid::path_length`]).

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1177,13 +1177,7 @@ impl PathLikeExt for PathLike<'_> {
     }
 }
 
-/// `value`'s bytes as a `PathLike`, NUL-checked; the caller checks the length
-/// ([`Valid::path_length`]).
-///
-/// An async op copies the bytes, like node's `BufferValue`: the name is the one
-/// the call was made with, not whatever the buffer holds when a pool thread
-/// reads it. The copy is also what the NUL check validates, so a NUL written
-/// after the check cannot truncate the name.
+/// `value`'s bytes as a `PathLike`, NUL-checked (the caller checks the length): an async call validates and keeps a copy, so a pool thread reads the call-time name.
 fn path_like_from_buffer(
     global: &JSGlobalObject,
     value: jsc::JSValue,

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -113,6 +113,82 @@ it("fs.statSync keeps a Uint8Array path's ArrayBuffer attached while reading opt
   expect(arrayBuffer.detached).toBe(true);
 });
 
+describe("a Buffer path an async call copies at call time", () => {
+  // Both names exist and differ in one byte, so the result says which one the
+  // job opened instead of only failing.
+  const twoFiles = { "a.txt": "AAAA", "b.txt": "BBBB" };
+
+  it("fs.promises.readFile", async () => {
+    using dir = tempDir("fs-async-buffer-path-promises", twoFiles);
+    const a = join(String(dir), "a.txt");
+    for (let i = 0; i < 20; i++) {
+      const p = Buffer.from(a);
+      const read = fs.promises.readFile(p, "utf8");
+      p[p.length - 5] = 0x62; // "a.txt" -> "b.txt", after the call returned
+      expect(await read).toBe("AAAA");
+    }
+  });
+
+  it("fs.readFile", async () => {
+    using dir = tempDir("fs-async-buffer-path-callback", twoFiles);
+    const a = join(String(dir), "a.txt");
+    for (let i = 0; i < 20; i++) {
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
+      const p = Buffer.from(a);
+      readFile(p, "utf8", (err, data) => (err ? reject(err) : resolve(data as string)));
+      p[p.length - 5] = 0x62;
+      expect(await promise).toBe("AAAA");
+    }
+  });
+
+  it("one scratch buffer, three queued unlinks", async () => {
+    using dir = tempDir("fs-async-buffer-path-scratch", {
+      "tmp-0": "0",
+      "tmp-1": "1",
+      "tmp-2": "2",
+      "keep!": "keep",
+    });
+    // Every name is 5 bytes, so each write overwrites the whole buffer.
+    const scratch = Buffer.alloc(String(dir).length + 6);
+    const jobs = [];
+    for (const name of ["tmp-0", "tmp-1", "tmp-2"]) {
+      scratch.write(join(String(dir), name));
+      jobs.push(
+        fs.promises.unlink(scratch).then(
+          () => "ok",
+          err => err.code,
+        ),
+      );
+    }
+    scratch.write(join(String(dir), "keep!")); // the buffer's next use
+    expect(await Promise.all(jobs)).toEqual(["ok", "ok", "ok"]);
+    expect(readdirSync(String(dir)).sort()).toEqual(["keep!"]);
+  });
+
+  // A NUL written after the call used to truncate the name the job opened. On a
+  // build with debug assertions it aborted the process, so run it in a child.
+  it("a NUL written after the call", async () => {
+    using dir = tempDir("fs-async-buffer-path-nul", { "a.txt": "AAAA", "a.txt.png": "PNG" });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const fs = require("fs");
+        const p = Buffer.from(require("path").join(process.argv[1], "a.txt.png"));
+        fs.readFile(p, "utf8", (err, data) => console.log(err ? err.code : data));
+        p[p.length - 4] = 0;`,
+        String(dir),
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("PNG");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});
+
 it.skipIf(isWindows)("fs.chmodSync applies mode bits above 0o777", () => {
   using dir = tempDir("fs-chmod-special-bits", {});
   const dirPath = join(String(dir), "subdir");
@@ -6947,7 +7023,7 @@ it("fs.writeFile (callback) keeps the source buffer attached while the write is 
   expect(readFileSync(file, "latin1")).toBe("FFFFFFFF");
 });
 
-it("fs.promises.writeFile keeps a buffer path argument attached while options are read", async () => {
+it("fs.promises.writeFile copies a buffer path argument before options are read", async () => {
   using dir = tempDir("fs-writefile-path-pin", {});
   const file = join(String(dir), "out.txt");
   const pathBytes = new TextEncoder().encode(file);
@@ -6958,9 +7034,9 @@ it("fs.promises.writeFile keeps a buffer path argument attached while options ar
 
   let detachedDuringOptions: boolean | undefined;
   await fs.promises.writeFile(pathBuf as any, "hello world", {
-    // Reading the options object re-enters JavaScript after the native call
-    // captured a pointer into the path buffer; the backing store must not be
-    // detachable out from under it.
+    // Reading the options object re-enters JavaScript after the path was
+    // parsed. The call owns a copy of the name, so detaching the backing store
+    // here neither faults nor moves the write.
     get flag() {
       pathBuf.buffer.transfer();
       detachedDuringOptions = pathBuf.buffer.detached;
@@ -6968,7 +7044,7 @@ it("fs.promises.writeFile keeps a buffer path argument attached while options ar
     },
   });
 
-  expect(detachedDuringOptions).toBe(false);
+  expect(detachedDuringOptions).toBe(true);
   expect(readFileSync(file, "utf8")).toBe("hello world");
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -173,8 +173,9 @@ describe("a Buffer path an async call copies at call time", () => {
       cmd: [
         bunExe(),
         "-e",
-        `const fs = require("fs");
-        const p = Buffer.from(require("path").join(process.argv[1], "a.txt.png"));
+        `import fs from "node:fs";
+        import path from "node:path";
+        const p = Buffer.from(path.join(process.argv[1], "a.txt.png"));
         fs.readFile(p, "utf8", (err, data) => console.log(err ? err.code : data));
         p[p.length - 4] = 0;`,
         String(dir),


### PR DESCRIPTION
### Problem

- An async `node:fs` call with a `Buffer`, `Uint8Array`, or `DataView` path keeps a pointer into the caller's bytes. The pool job reads the name when it runs. Code that reuses one scratch buffer reads, writes, or deletes the wrong file. Node copies the name at call time.
- The NUL check runs on the call-time bytes and the job reads them again, so a NUL written after the call truncates the name. A debug build panics: `ZStr::as_cstr: interior NUL would truncate the C view`, under `NodeFS::read_file_with_options`.
- Cause: the typed-array arm of `PathLike::from_js_with_allocator` (`src/runtime/node/types.rs:1107`) pins and roots the buffer and stores pointer plus length. The job reads them at `slice_z` (`types.rs:980`).

### Fix

- `path_like_from_buffer` copies the bytes when the operation is async, then validates the copy. Node's `BufferValue` does the same.
- A sync operation keeps the borrow: it is done with the bytes before it returns. An options getter can still write to the buffer first, in Node too (see Notes).
- One expectation changes: a `transfer()` of the path buffer from an options getter of an async call now detaches it. The write still lands on the call-time name.
- Verified: `test/js/node/fs/fs.test.ts`, 4 new tests, all fail on bun 1.4.3. Also `fs-leak`, `promises`, `fs-path-length`, `dir`, `bun-file`, and 8 node `test-fs-*buffer*` files.
- Self-reviewed: 5 concerns raised, 5 addressed (stale `PathLike` docs fixed in code; the copy-versus-pin rationale, the sync arm, and two sibling PRs covered in Notes).

### Background

- `PathLike` is the parsed form of an `fs` path argument. Its `Buffer` arm holds a `PinnedArrayBuffer`: a pin that stops a detach, plus a GC root when the value outlives the call.
- `FsArgument::from_js_async` sets `arguments.will_be_async`: a pool job reads the value after the call returns to JS. A pin keeps the bytes mapped, not read-only, so only a copy fixes this.
- String paths already copy for an async call (`into_utf8_with_string_thread_isolated`). Buffer paths now follow the same rule.

<details><summary>Notes</summary>

The wrong file, on bun 1.4.3 and on main:

```js
import fs from "node:fs";
fs.writeFileSync("a.txt", "AAAA");
fs.writeFileSync("b.txt", "BBBB");
const p = Buffer.from(process.cwd() + "/a.txt");
fs.readFile(p, (e, d) => console.log(String(d))); // node: AAAA, bun: BBBB
p[p.length - 5] = 0x62; // "a.txt" -> "b.txt", after the call returned
```

The truncated name, same builds:

```js
import fs from "node:fs";
fs.writeFileSync("a.txt", "AAAA");
fs.writeFileSync("a.txt.png", "PNG");
const p = Buffer.from(process.cwd() + "/a.txt.png"); // passes the NUL check
fs.readFile(p, (e, d) => console.log(e ? e.code : String(d)));
p[p.length - 4] = 0; // ".../a.txt\0png"
// node: PNG, bun 1.4.3: AAAA, main with debug assertions: panic
```

Extent: the callback and the promise flavour are one native site, so both are affected. 1.3.14, 1.4.0, 1.4.1, 1.4.2, 1.4.3 and main behave the same. The conversion code is unchanged between the 1.4.2 tag and main, so this is not a regression.

A same-tick flip is a race that the JS thread usually but not always wins, so the two loop tests run 20 iterations each. With the fix they pass every time, because the copy removes the race.

The third test is the user-visible damage: three `fs.promises.unlink` calls that share one scratch buffer delete the file whose name the buffer holds last.

Memory safety: the storage was pinned, so the reported behaviour is a wrong name, not a use after free. The copy also covers two cases the pin did not: a `SharedArrayBuffer` path that another thread writes, and a resizable buffer, which the async arm used to keep alive through `copy_if_resizable`.

The sync path and option getters. A getter on the options object runs after bun parses the path and before the syscall, so it can write into the path buffer of a sync call. Node has a similar window, and the call decides where it sits. `statSync` and the utf8 fast path of `readFileSync` run `getValidatedPath(path)` first, then the getter, then the binding's `BufferValue` copies the changed bytes. `readFileSync` without a utf8 encoding reads `options.flag` as an argument of `openSync(path, options.flag)`, before `openSync` validates the path, so Node's NUL check sees the NUL and throws. Probes on `a.txt` (4 bytes), `a.txt.png` (3 bytes), `b.txt.png` (6 bytes):

| probe | node v26.3.0 | bun release, main `367d939d9` |
|---|---|---|
| `readFileSync(p, { encoding: "utf8", get flag() { p[i] = 0 } })` | `"AAAA"` (truncated) | `"AAAA"` |
| `readFileSync(p, { get flag() { p[i] = 0 } })` | throws `ERR_INVALID_ARG_VALUE` | `"AAAA"` (truncated) |
| `statSync(p, { get throwIfNoEntry() { p[i] = 0 } })` | size 4 (truncated) | size 4 |
| `statSync(p, { get throwIfNoEntry() { p[j] = 0x62 } })` | size 6 (flipped) | size 6 |
| `readFileSync(p, { get flag() { p[j] = 0x62 } })` | `"BBBBBB"` (flipped) | `"BBBBBB"` |

Correction: an earlier version of this table had one `readFileSync` row. It showed the call of row 2 with the Node result of row 1, because the run behind it had `encoding: "utf8"` and the label dropped it. So bun matches Node on four of these five rows, not on all of them. On row 2 Node rejects and bun opens the truncated name.

Bun parses the path before it reads the options object, so a copy at parse time would close that window for a sync call in bun (stricter than Node, which copies after its getters run). This PR does not do that. It is deferred, see "Follow-up" below. A debug build hits the `ZStr::as_cstr` assert for the two NUL rows. That is reachable only through a getter that mutates the path argument mid-call.

Assert build. The panic needs a build with debug assertions, so I ran the NUL script above in 20 fresh processes per build. A debug build of main `367d939d9` (unfixed, same conversion code as the base of this PR): `panic: ZStr::as_cstr: interior NUL would truncate the C view`, exit 134, in 19 of 20. The pool thread won the race once and printed `PNG`. A debug build of this head merged onto main `ca415039cd`: `PNG`, exit 0, in 20 of 20. The first two scripts in one process print `AAAA ["ok","ok","ok"] ["keep!"]` in 20 of 20 on that build, with no AddressSanitizer report. Both sync `readFileSync` getter rows of the table below (with and without `encoding: "utf8"`) still hit the same assert on that build, 20 of 20 each. That is the sync arm, which this diff does not change, and it is part of the follow-up below.

Why a copy and not a pin. #40511 ("Still zero-copy") and #40641 ("Why not copy every input: the pinned borrow is the zero-copy path") kept a Buffer path borrowed for performance. #40641 itself notes that Node copies a Buffer path at call time. A pin keeps the bytes mapped. It does not freeze them, so it cannot make the validated bytes be the bytes the syscall opens. For a path the zero-copy argument is also weak: a name is at most `MAX_PATH_BYTES`, `slice_z` copies it into a `PathBuffer` on the pool thread anyway, string paths already take a thread-isolated copy for an async call, and `PathLike::clone` already turns a `Buffer` arm into `Utf8(Owned)`. On #40682 the review asked for `PinnedArrayBuffer` instead of a copy. That PR is about a `Blob` store that kept its path buffer protected forever, where a pin with RAII release is a real alternative for the lifetime problem. It does not address a name that changes under the job, which is the problem here.

Follow-up, for one maintainer decision: copy at parse time for the sync arm too and delete `PathLike::Buffer`. That removes `PinnedArrayBuffer` from `PathLike`, makes the `Bun.file(buffer)` store own its name (the aliasing #40682 is about), and removes the getter rows above. It is not in this PR because it changes the arm #40682 is changing under review.

Sibling PRs that touch the same hunk:

- #42185 adds a test, "a by-length path argument keeps its bytes while an async call is pending", that expects the path buffer to stay pinned (`byteLength` N after `transfer(0)`) during an async call. Under this PR the call owns a copy, so the transfer detaches the buffer and the job still opens the call-time name. Whichever lands second adjusts that assertion. The data-buffer part of #42185 is unaffected.
- #42192 renames `PinnedArrayBuffer::copy_if_resizable` to `copy_if_pin_cannot_hold` and edits the block this PR moves into `path_like_from_buffer`. A trial merge of the two heads gives one conflict region, in `src/runtime/node/types.rs`. Resolution: keep the `path_like_from_buffer` call, then rename the one `copy_if_resizable` call in that helper's sync branch. Git does not flag the second step. Without it the build fails with an unknown method. The async branch needs nothing from #42192: it owns a copy, so a wasm-memory grow cannot move the name.
- #40682 copies the path for the `Bun.file(buffer)` store. It changes `node_path.rs` and `array_buffer.rs` only, so the async `node:fs` conversion is untouched.
- #38509 holds the buffer's backing store instead of rooting the JS object. That keeps async fs paths aliased by design.

The `transfer()` from an options getter of an async `writeFile`: Node rejects with `TypeError: Cannot perform %TypedArray%.prototype.includes on a detached or out-of-bounds ArrayBuffer` (its NUL check runs on the detached view). Bun used to turn the transfer into a copy through the pin and write the file. It now detaches the buffer and still writes the file under the call-time name.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->

