### PR TITLE
node:fs: fs.read into a WebAssembly.Memory view writes into the block a grow freed

### DIFF
--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -31,6 +31,9 @@ pub struct ArrayBuffer {
     /// True for resizable ArrayBuffer or growable SharedArrayBuffer — borrowing
     /// a slice from one is unsafe (it can shrink/reallocate underneath you).
     pub resizable: bool,
+    /// True when the bytes belong to a `WebAssembly.Memory`. A pin does not
+    /// hold them: see [`PinnedArrayBuffer::copy_out_for_write`].
+    pub wasm_memory: bool,
     /// Set by [`JSValue::as_pinned_arraybuffer`] when an ArrayBuffer was actually pinned (as opposed to a bufferless view merely held); [`ArrayBuffer::unpin`] is a no-op otherwise.
     pub pinned: bool,
 }
@@ -45,6 +48,7 @@ impl Default for ArrayBuffer {
             typed_array_type: JSType::Cell,
             shared: false,
             resizable: false,
+            wasm_memory: false,
             pinned: false,
         }
     }
@@ -300,6 +304,7 @@ impl ArrayBuffer {
         typed_array_type: JSType::Uint8Array,
         shared: false,
         resizable: false,
+        wasm_memory: false,
         pinned: false,
     };
 
@@ -651,8 +656,11 @@ impl ArrayBuffer {
 pub struct PinnedArrayBuffer {
     buffer: ArrayBuffer,
     rooted: bool,
-    /// The bytes `buffer.ptr` points at when [`copy_if_resizable`](Self::copy_if_resizable) took a copy.
+    /// The bytes `buffer.ptr` points at when [`copy_if_resizable`](Self::copy_if_resizable)
+    /// or [`copy_out_for_write`](Self::copy_out_for_write) replaced the JS storage.
     copy: Option<Vec<u8>>,
+    /// `copy` is a write scratch that [`write_back`](Self::write_back) returns to the view.
+    writes_back: bool,
 }
 
 impl PinnedArrayBuffer {
@@ -672,6 +680,7 @@ impl PinnedArrayBuffer {
             buffer,
             rooted: false,
             copy: None,
+            writes_back: false,
         })
     }
 
@@ -710,9 +719,72 @@ impl PinnedArrayBuffer {
         true
     }
 
+    /// A pin stops a detach. It does not stop `WebAssembly.Memory.prototype.grow()`.
+    /// A bounds-checked memory allocates a new block on a grow, copies into it, frees
+    /// the old one, and detaches the ArrayBuffer, which `ArrayBuffer::detach` permits
+    /// for a pinned wasm buffer by design. A job that WRITES through the borrow then
+    /// writes into the freed block, and so does the kernel on the job's behalf: the
+    /// range is unmapped, so another allocation can already own it.
+    ///
+    /// Give such a job a private copy to write into, and return what it wrote with
+    /// [`write_back`](Self::write_back) on the JS thread. The copy starts as the
+    /// view's current bytes, so a partial write leaves the rest correct. A shared
+    /// memory grows in place and needs none of this. `false` if the copy cannot be
+    /// allocated.
+    pub fn copy_out_for_write(&mut self, global: &JSGlobalObject) -> bool {
+        if !self.buffer.wasm_memory
+            || self.buffer.shared
+            || self.buffer.byte_len == 0
+            || self.copy.is_some()
+        {
+            return true;
+        }
+        let bytes = self.buffer.byte_slice();
+        let mut copy = Vec::new();
+        if copy.try_reserve_exact(bytes.len()).is_err() {
+            return false;
+        }
+        copy.extend_from_slice(bytes);
+        global.vm().report_extra_memory(copy.len());
+        self.buffer.ptr = copy.as_mut_ptr();
+        self.copy = Some(copy);
+        self.writes_back = true;
+        true
+    }
+
+    /// JS thread, once the job is done and before JS reads the view again: copy what
+    /// the job wrote into the view's own storage. The view can be gone (a grow
+    /// detaches it) or shorter (a resize), so re-read its extent from the JS value
+    /// and copy only what still fits. A no-op without
+    /// [`copy_out_for_write`](Self::copy_out_for_write).
+    pub fn write_back(&mut self, global: &JSGlobalObject) {
+        if !self.writes_back {
+            return;
+        }
+        self.writes_back = false;
+        let Some(scratch) = self.copy.take() else {
+            return;
+        };
+        let Some(mut live) = self.buffer.value.as_array_buffer(global) else {
+            return;
+        };
+        // `as_array_buffer` reports no pin; keep the one this value still holds so
+        // `Drop` stays balanced.
+        live.pinned = self.buffer.pinned;
+        self.buffer = live;
+        if self.buffer.is_detached() {
+            return;
+        }
+        let n = self.buffer.byte_len.min(scratch.len());
+        self.buffer.byte_slice_mut()[..n].copy_from_slice(&scratch[..n]);
+    }
+
     #[inline]
     pub fn slice_mut(&mut self) -> &mut [u8] {
-        debug_assert!(self.copy.is_none(), "a read-only root is not writable");
+        debug_assert!(
+            self.copy.is_none() || self.writes_back,
+            "a read-only root is not writable"
+        );
         self.buffer.byte_slice_mut()
     }
 
@@ -722,6 +794,7 @@ impl PinnedArrayBuffer {
         self.buffer = ArrayBuffer::default();
         self.rooted = false;
         self.copy = None;
+        self.writes_back = false;
     }
 }
 

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -659,8 +659,20 @@ pub struct PinnedArrayBuffer {
     /// The bytes `buffer.ptr` points at when [`copy_if_resizable`](Self::copy_if_resizable)
     /// or [`copy_out_for_write`](Self::copy_out_for_write) replaced the JS storage.
     copy: Option<Vec<u8>>,
-    /// `copy` is a write scratch, not a read-only snapshot.
-    writes_back: bool,
+    /// Where in the view [`write_back`](Self::write_back) puts `copy`. `None` when
+    /// `copy` is a read-only snapshot.
+    write_back_at: Option<usize>,
+}
+
+/// What [`PinnedArrayBuffer::copy_out_for_write`] arranged for the job.
+#[derive(PartialEq, Eq)]
+pub enum WriteTarget {
+    /// The view's own storage, at the caller's own offset.
+    InPlace,
+    /// Scratch space that starts at index 0 and is exactly the requested length.
+    Scratch,
+    /// The scratch space could not be allocated.
+    OutOfMemory,
 }
 
 impl PinnedArrayBuffer {
@@ -680,7 +692,7 @@ impl PinnedArrayBuffer {
             buffer,
             rooted: false,
             copy: None,
-            writes_back: false,
+            write_back_at: None,
         })
     }
 
@@ -719,42 +731,46 @@ impl PinnedArrayBuffer {
         true
     }
 
-    /// [`copy_if_resizable`](Self::copy_if_resizable) for a job that WRITES through the
-    /// borrow. A pin does not hold wasm memory: a non-shared `grow()` can move the block
-    /// and free the old one, and `ArrayBuffer::detach` ignores the pin count there by
-    /// design, so the job (or the kernel on its behalf) writes into freed pages. The copy
-    /// starts as the view's bytes, so a short write leaves the rest correct, and
-    /// [`write_back`](Self::write_back) returns it. `false` if it cannot be allocated.
-    pub fn copy_out_for_write(&mut self, global: &JSGlobalObject) -> bool {
-        if !self.buffer.wasm_memory
-            || self.buffer.shared
-            || self.buffer.byte_len == 0
-            || self.copy.is_some()
-        {
-            return true;
+    /// [`copy_if_resizable`](Self::copy_if_resizable) for a job that WRITES `len` bytes
+    /// at `offset`. A pin does not hold wasm memory: a non-shared `grow()` can move the
+    /// block and free the old one, and `ArrayBuffer::detach` ignores the pin count there
+    /// by design, so the job (or the kernel on its behalf) writes into freed pages.
+    ///
+    /// On [`WriteTarget::Scratch`] the borrow now describes `len` bytes of scratch space,
+    /// so the job drops its own offset and writes from index 0.
+    /// [`write_back`](Self::write_back) puts the result at `offset` in the view.
+    pub fn copy_out_for_write(
+        &mut self,
+        global: &JSGlobalObject,
+        offset: usize,
+        len: usize,
+    ) -> WriteTarget {
+        if !self.buffer.wasm_memory || self.buffer.shared || len == 0 || self.copy.is_some() {
+            return WriteTarget::InPlace;
         }
-        let bytes = self.buffer.byte_slice();
         let mut copy = Vec::new();
-        if copy.try_reserve_exact(bytes.len()).is_err() {
-            return false;
+        if copy.try_reserve_exact(len).is_err() {
+            return WriteTarget::OutOfMemory;
         }
-        copy.extend_from_slice(bytes);
-        global.vm().report_extra_memory(copy.len());
+        copy.resize(len, 0);
+        global.vm().report_extra_memory(len);
         self.buffer.ptr = copy.as_mut_ptr();
+        self.buffer.len = len;
+        self.buffer.byte_len = len;
         self.copy = Some(copy);
-        self.writes_back = true;
-        true
+        self.write_back_at = Some(offset);
+        WriteTarget::Scratch
     }
 
-    /// JS thread, once the job is done: copy what it wrote into the view's own storage.
-    /// The view can be gone (a grow detaches it) or shorter (a resize), so take its
-    /// extent from the JS value again and copy what still fits. A no-op without
+    /// JS thread, once the job is done: copy the `len` bytes it wrote into the view, and
+    /// nothing else, so a JS write elsewhere in the view survives. The view can be gone
+    /// (a grow detaches it) or shorter (a resize), so take its extent from the JS value
+    /// again and clamp. A no-op without
     /// [`copy_out_for_write`](Self::copy_out_for_write).
-    pub fn write_back(&mut self, global: &JSGlobalObject) {
-        if !self.writes_back {
+    pub fn write_back(&mut self, global: &JSGlobalObject, len: usize) {
+        let Some(offset) = self.write_back_at.take() else {
             return;
-        }
-        self.writes_back = false;
+        };
         let Some(scratch) = self.copy.take() else {
             return;
         };
@@ -764,17 +780,19 @@ impl PinnedArrayBuffer {
         self.buffer.ptr = live.ptr;
         self.buffer.len = live.len;
         self.buffer.byte_len = live.byte_len;
-        if self.buffer.is_detached() {
+        let n = len
+            .min(scratch.len())
+            .min(self.buffer.byte_len.saturating_sub(offset));
+        if n == 0 {
             return;
         }
-        let n = self.buffer.byte_len.min(scratch.len());
-        self.buffer.byte_slice_mut()[..n].copy_from_slice(&scratch[..n]);
+        self.buffer.byte_slice_mut()[offset..offset + n].copy_from_slice(&scratch[..n]);
     }
 
     #[inline]
     pub fn slice_mut(&mut self) -> &mut [u8] {
         debug_assert!(
-            self.copy.is_none() || self.writes_back,
+            self.copy.is_none() || self.write_back_at.is_some(),
             "a read-only root is not writable"
         );
         self.buffer.byte_slice_mut()
@@ -786,7 +804,7 @@ impl PinnedArrayBuffer {
         self.buffer = ArrayBuffer::default();
         self.rooted = false;
         self.copy = None;
-        self.writes_back = false;
+        self.write_back_at = None;
     }
 }
 

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -31,8 +31,8 @@ pub struct ArrayBuffer {
     /// True for resizable ArrayBuffer or growable SharedArrayBuffer — borrowing
     /// a slice from one is unsafe (it can shrink/reallocate underneath you).
     pub resizable: bool,
-    /// True when the bytes belong to a `WebAssembly.Memory`. A pin does not
-    /// hold them: see [`PinnedArrayBuffer::copy_out_for_write`].
+    /// True when the bytes belong to a `WebAssembly.Memory` — a `grow()` can free
+    /// them under a pin ([`PinnedArrayBuffer::copy_out_for_write`]).
     pub wasm_memory: bool,
     /// Set by [`JSValue::as_pinned_arraybuffer`] when an ArrayBuffer was actually pinned (as opposed to a bufferless view merely held); [`ArrayBuffer::unpin`] is a no-op otherwise.
     pub pinned: bool,
@@ -659,7 +659,7 @@ pub struct PinnedArrayBuffer {
     /// The bytes `buffer.ptr` points at when [`copy_if_resizable`](Self::copy_if_resizable)
     /// or [`copy_out_for_write`](Self::copy_out_for_write) replaced the JS storage.
     copy: Option<Vec<u8>>,
-    /// `copy` is a write scratch that [`write_back`](Self::write_back) returns to the view.
+    /// `copy` is a write scratch, not a read-only snapshot.
     writes_back: bool,
 }
 
@@ -719,18 +719,12 @@ impl PinnedArrayBuffer {
         true
     }
 
-    /// A pin stops a detach. It does not stop `WebAssembly.Memory.prototype.grow()`.
-    /// A bounds-checked memory allocates a new block on a grow, copies into it, frees
-    /// the old one, and detaches the ArrayBuffer, which `ArrayBuffer::detach` permits
-    /// for a pinned wasm buffer by design. A job that WRITES through the borrow then
-    /// writes into the freed block, and so does the kernel on the job's behalf: the
-    /// range is unmapped, so another allocation can already own it.
-    ///
-    /// Give such a job a private copy to write into, and return what it wrote with
-    /// [`write_back`](Self::write_back) on the JS thread. The copy starts as the
-    /// view's current bytes, so a partial write leaves the rest correct. A shared
-    /// memory grows in place and needs none of this. `false` if the copy cannot be
-    /// allocated.
+    /// [`copy_if_resizable`](Self::copy_if_resizable) for a job that WRITES through the
+    /// borrow. A pin does not hold wasm memory: a non-shared `grow()` can move the block
+    /// and free the old one, and `ArrayBuffer::detach` ignores the pin count there by
+    /// design, so the job (or the kernel on its behalf) writes into freed pages. The copy
+    /// starts as the view's bytes, so a short write leaves the rest correct, and
+    /// [`write_back`](Self::write_back) returns it. `false` if it cannot be allocated.
     pub fn copy_out_for_write(&mut self, global: &JSGlobalObject) -> bool {
         if !self.buffer.wasm_memory
             || self.buffer.shared
@@ -752,10 +746,9 @@ impl PinnedArrayBuffer {
         true
     }
 
-    /// JS thread, once the job is done and before JS reads the view again: copy what
-    /// the job wrote into the view's own storage. The view can be gone (a grow
-    /// detaches it) or shorter (a resize), so re-read its extent from the JS value
-    /// and copy only what still fits. A no-op without
+    /// JS thread, once the job is done: copy what it wrote into the view's own storage.
+    /// The view can be gone (a grow detaches it) or shorter (a resize), so take its
+    /// extent from the JS value again and copy what still fits. A no-op without
     /// [`copy_out_for_write`](Self::copy_out_for_write).
     pub fn write_back(&mut self, global: &JSGlobalObject) {
         if !self.writes_back {
@@ -765,13 +758,12 @@ impl PinnedArrayBuffer {
         let Some(scratch) = self.copy.take() else {
             return;
         };
-        let Some(mut live) = self.buffer.value.as_array_buffer(global) else {
+        let Some(live) = self.buffer.value.as_array_buffer(global) else {
             return;
         };
-        // `as_array_buffer` reports no pin; keep the one this value still holds so
-        // `Drop` stays balanced.
-        live.pinned = self.buffer.pinned;
-        self.buffer = live;
+        self.buffer.ptr = live.ptr;
+        self.buffer.len = live.len;
+        self.buffer.byte_len = live.byte_len;
         if self.buffer.is_detached() {
             return;
         }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3476,6 +3476,25 @@ JSC::EncodedJSValue JSC__JSValue__values(JSC::JSGlobalObject* globalObject, JSC:
     return JSValue::encode(JSC::objectValues(vm, globalObject, value));
 }
 
+// True when a view's bytes belong to a WebAssembly.Memory. A pin cannot hold
+// such storage: `WebAssembly.Memory.prototype.grow()` on a bounds-checked
+// memory allocates a new block, copies into it, frees the old one, and then
+// detaches the ArrayBuffer. `ArrayBuffer::detach` ignores the pin count for a
+// wasm buffer by design ("We allow detaching wasm memory ArrayBuffers even
+// though they are locked", WebKit `ArrayBuffer.cpp`).
+//
+// The `hasArrayBuffer()` guard keeps this free of side effects:
+// `possiblySharedBuffer()` returns the buffer the view already has for every
+// such mode, and only materializes one for a Fast or Oversize view. Neither of
+// those holds wasm memory, because `memory.buffer` is where the view comes from.
+static bool isWasmMemoryStorage(JSC::JSArrayBufferView* view)
+{
+    if (!view->hasArrayBuffer())
+        return false;
+    auto* buffer = view->possiblySharedBuffer();
+    return buffer && buffer->isWasmMemory();
+}
+
 bool JSC__JSValue__asArrayBuffer(
     JSC::EncodedJSValue encodedValue,
     JSC::JSGlobalObject* globalObject,
@@ -3511,6 +3530,7 @@ bool JSC__JSValue__asArrayBuffer(
         out->cell_type = type;
         out->shared = view->isShared();
         out->resizable = view->isResizableOrGrowableShared();
+        out->wasm_memory = isWasmMemoryStorage(view);
         break;
     }
     case JSC::JSType::ArrayBufferType: {
@@ -3521,6 +3541,7 @@ bool JSC__JSValue__asArrayBuffer(
         out->cell_type = JSC::JSType::ArrayBufferType;
         out->shared = buffer->isShared();
         out->resizable = buffer->isResizableOrGrowableShared();
+        out->wasm_memory = buffer->isWasmMemory();
         break;
     }
     case JSC::JSType::ObjectType:
@@ -3532,6 +3553,7 @@ bool JSC__JSValue__asArrayBuffer(
             out->cell_type = view->type();
             out->shared = view->isShared();
             out->resizable = view->isResizableOrGrowableShared();
+            out->wasm_memory = isWasmMemoryStorage(view);
         } else if (JSC::JSArrayBuffer* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(value)) {
             JSC::ArrayBuffer* buffer = jsBuffer->impl();
             if (!buffer)
@@ -3542,6 +3564,7 @@ bool JSC__JSValue__asArrayBuffer(
             out->cell_type = JSC::JSType::ArrayBufferType;
             out->shared = buffer->isShared();
             out->resizable = buffer->isResizableOrGrowableShared();
+            out->wasm_memory = buffer->isWasmMemory();
         } else {
             return false;
         }
@@ -7133,5 +7156,6 @@ extern "C" void JSC__ArrayBuffer__asBunArrayBuffer(JSC::ArrayBuffer* self, Bun__
     out->cell_type = JSC::JSType::ArrayBufferType;
     out->shared = self->isShared();
     out->resizable = self->isResizableOrGrowableShared();
+    out->wasm_memory = self->isWasmMemory();
     out->pinned = false;
 }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3476,17 +3476,12 @@ JSC::EncodedJSValue JSC__JSValue__values(JSC::JSGlobalObject* globalObject, JSC:
     return JSValue::encode(JSC::objectValues(vm, globalObject, value));
 }
 
-// True when a view's bytes belong to a WebAssembly.Memory. A pin cannot hold
-// such storage: `WebAssembly.Memory.prototype.grow()` on a bounds-checked
-// memory allocates a new block, copies into it, frees the old one, and then
-// detaches the ArrayBuffer. `ArrayBuffer::detach` ignores the pin count for a
-// wasm buffer by design ("We allow detaching wasm memory ArrayBuffers even
-// though they are locked", WebKit `ArrayBuffer.cpp`).
-//
-// The `hasArrayBuffer()` guard keeps this free of side effects:
-// `possiblySharedBuffer()` returns the buffer the view already has for every
-// such mode, and only materializes one for a Fast or Oversize view. Neither of
-// those holds wasm memory, because `memory.buffer` is where the view comes from.
+// A pin cannot hold wasm memory: `ArrayBuffer::detach` ignores the pin count
+// for it ("We allow detaching wasm memory ArrayBuffers even though they are
+// locked", WebKit `ArrayBuffer.cpp`), and a non-shared `grow()` frees the block.
+// The `hasArrayBuffer()` guard keeps this side-effect free: only a Fast or
+// Oversize view makes `possiblySharedBuffer()` materialize one, and a view over
+// wasm memory comes from `memory.buffer`, so it always has one already.
 static bool isWasmMemoryStorage(JSC::JSArrayBufferView* view)
 {
     if (!view->hasArrayBuffer())

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -367,6 +367,7 @@ typedef struct {
     uint8_t cell_type;
     bool shared;
     bool resizable;
+    bool wasm_memory;
     bool pinned;
 } Bun__ArrayBuffer;
 

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -189,6 +189,7 @@ pub use self::js_value::{
 // hook is re-exported from the crate root.
 pub use self::array_buffer::{
     ArrayBuffer, BinaryType, JSCArrayBuffer, MarkedArrayBuffer, PinnedArrayBuffer, TypedArrayType,
+    WriteTarget,
 };
 pub use self::console_object as ConsoleObject;
 pub use self::console_object::Formatter;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -947,7 +947,9 @@ mod _async_tasks {
             // Move `result` out so the `global_object()` `&self` borrow can coexist
             // with consuming it below; the sentinel left behind is dropped in `destroy()`.
             let result = core::mem::replace(&mut self.result, Err(sys::Error::default()));
-            let global_object = self.global_object();
+            // Read the back-reference field, not the `&self` method: `write_back` takes
+            // `&mut self.args`, and only a field borrow is disjoint from it.
+            let global_object = self.global_object.get();
             self.args.write_back(global_object);
             let success = matches!(result, Ok(_));
             let promise_value = self.promise.value();

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -18,7 +18,7 @@ use bun_jsc::debugger::AsyncTaskTracker;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
     ArrayBuffer, EventLoopHandle, JSGlobalObject, JSValue, JsResult, PinnedArrayBuffer,
-    StringJsc as _,
+    StringJsc as _, WriteTarget,
 };
 use bun_paths::{self as paths, OSPathBuffer, OSPathChar, OSPathSliceZ, PathBuffer};
 use bun_sys::FdExt as _;
@@ -947,10 +947,11 @@ mod _async_tasks {
             // Move `result` out so the `global_object()` `&self` borrow can coexist
             // with consuming it below; the sentinel left behind is dropped in `destroy()`.
             let result = core::mem::replace(&mut self.result, Err(sys::Error::default()));
+            let bytes_written = result.as_ref().ok().and_then(FsReturn::bytes_written);
             // The field, not the `&self` method: only a field borrow is disjoint
             // from the `&mut self.args` that `write_back` takes.
             let global_object = self.global_object.get();
-            self.args.write_back(global_object);
+            self.args.write_back(global_object, bytes_written);
             let success = matches!(result, Ok(_));
             let promise_value = self.promise.value();
             let promise = self.promise.get();
@@ -1018,7 +1019,7 @@ mod _async_tasks {
         }
         /// JS thread, before the result reaches JS: hand back a write destination's
         /// scratch copy ([`jsc::PinnedArrayBuffer::write_back`]). Only `fs.read` has one.
-        fn write_back(&mut self, _global: &JSGlobalObject) {}
+        fn write_back(&mut self, _global: &JSGlobalObject, _bytes_written: Option<u64>) {}
     }
 
     /// Forward [`FsArgument`] to the inherent `from_js` each `args::*` struct
@@ -1076,9 +1077,10 @@ mod _async_tasks {
         fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Self> {
             args::Read::from_js(ctx, arguments)
         }
-        fn write_back(&mut self, global: &JSGlobalObject) {
+        fn write_back(&mut self, global: &JSGlobalObject, bytes_written: Option<u64>) {
+            let len = bytes_written.unwrap_or(0).min(self.length) as usize;
             if let args::ReadBuffer::PinnedBuffer(buffer) = &mut self.buffer {
-                buffer.write_back(global);
+                buffer.write_back(global, len);
             }
         }
     }
@@ -1130,6 +1132,10 @@ mod _async_tasks {
     /// Each `ret::*` type implements this by forwarding to its inherent method.
     pub trait FsReturn {
         fn fs_to_js(self, global: &JSGlobalObject) -> JsResult<JSValue>;
+        /// Bytes the job wrote into a destination buffer. `None` unless it has one.
+        fn bytes_written(&self) -> Option<u64> {
+            None
+        }
     }
     impl FsReturn for JSValue {
         #[inline]
@@ -1183,6 +1189,10 @@ mod _async_tasks {
         #[inline]
         fn fs_to_js(self, global: &JSGlobalObject) -> JsResult<JSValue> {
             Ok(self.to_js(global))
+        }
+        #[inline]
+        fn bytes_written(&self) -> Option<u64> {
+            Some(self.bytes_read)
         }
     }
     impl FsReturn for ret::Write {
@@ -1271,7 +1281,8 @@ mod _async_tasks {
         ) -> bun_jsc::JsResult<()> {
             let global_object = cx.global();
             let _dispatch = js.tracker.dispatch(global_object);
-            this.args.write_back(global_object);
+            let bytes_written = this.result.as_ref().ok().and_then(FsReturn::bytes_written);
+            this.args.write_back(global_object, bytes_written);
 
             let success = this.result.is_ok();
             let promise_value = js.promise.value();
@@ -3770,13 +3781,10 @@ pub mod args {
                 ctx.throw_invalid_argument_type_value(b"buffer", b"TypedArray", buffer_value)
             })?;
             let buffer = if arguments.will_be_async {
-                let mut pinned = PinnedArrayBuffer::root(ctx, buffer_value)
-                    .ok_or_else(|| ctx.throw_out_of_memory())?;
-                // The pool thread writes into this buffer after JS has run again.
-                if !pinned.copy_out_for_write(ctx) {
-                    return Err(ctx.throw_out_of_memory());
-                }
-                ReadBuffer::PinnedBuffer(pinned)
+                ReadBuffer::PinnedBuffer(
+                    PinnedArrayBuffer::root(ctx, buffer_value)
+                        .ok_or_else(|| ctx.throw_out_of_memory())?,
+                )
             } else {
                 ReadBuffer::Buffer(buffer)
             };
@@ -3901,6 +3909,19 @@ pub mod args {
             } else {
                 None
             };
+
+            // A non-shared `WebAssembly.Memory` can free the bytes under the pin, so the
+            // job writes into scratch space. It holds the requested range and nothing
+            // else, so the job starts at 0.
+            let mut buffer = buffer;
+            let mut offset = offset;
+            if let ReadBuffer::PinnedBuffer(pinned) = &mut buffer {
+                match pinned.copy_out_for_write(ctx, offset as usize, length as usize) {
+                    WriteTarget::InPlace => {}
+                    WriteTarget::Scratch => offset = 0,
+                    WriteTarget::OutOfMemory => return Err(ctx.throw_out_of_memory()),
+                }
+            }
 
             Ok(Read {
                 fd,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -947,8 +947,8 @@ mod _async_tasks {
             // Move `result` out so the `global_object()` `&self` borrow can coexist
             // with consuming it below; the sentinel left behind is dropped in `destroy()`.
             let result = core::mem::replace(&mut self.result, Err(sys::Error::default()));
-            // Read the back-reference field, not the `&self` method: `write_back` takes
-            // `&mut self.args`, and only a field borrow is disjoint from it.
+            // The field, not the `&self` method: only a field borrow is disjoint
+            // from the `&mut self.args` that `write_back` takes.
             let global_object = self.global_object.get();
             self.args.write_back(global_object);
             let success = matches!(result, Ok(_));
@@ -1016,10 +1016,8 @@ mod _async_tasks {
         fn signal(&self) -> Option<&AbortSignal> {
             None
         }
-        /// JS thread, before the result reaches JS: return to its view whatever the
-        /// job wrote into a scratch copy
-        /// ([`PinnedArrayBuffer::copy_out_for_write`](jsc::PinnedArrayBuffer::copy_out_for_write)).
-        /// Only an argument set with a write destination overrides this.
+        /// JS thread, before the result reaches JS: hand back a write destination's
+        /// scratch copy ([`jsc::PinnedArrayBuffer::write_back`]). Only `fs.read` has one.
         fn write_back(&mut self, _global: &JSGlobalObject) {}
     }
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -948,6 +948,7 @@ mod _async_tasks {
             // with consuming it below; the sentinel left behind is dropped in `destroy()`.
             let result = core::mem::replace(&mut self.result, Err(sys::Error::default()));
             let global_object = self.global_object();
+            self.args.write_back(global_object);
             let success = matches!(result, Ok(_));
             let promise_value = self.promise.value();
             let promise = self.promise.get();
@@ -1013,6 +1014,11 @@ mod _async_tasks {
         fn signal(&self) -> Option<&AbortSignal> {
             None
         }
+        /// JS thread, before the result reaches JS: return to its view whatever the
+        /// job wrote into a scratch copy
+        /// ([`PinnedArrayBuffer::copy_out_for_write`](jsc::PinnedArrayBuffer::copy_out_for_write)).
+        /// Only an argument set with a write destination overrides this.
+        fn write_back(&mut self, _global: &JSGlobalObject) {}
     }
 
     /// Forward [`FsArgument`] to the inherent `from_js` each `args::*` struct
@@ -1050,7 +1056,6 @@ mod _async_tasks {
         args::Readdir<'static>,
         args::Open<'static>,
         args::Write<'static>,
-        args::Read,
         args::Exists<'static>,
         args::Access<'static>,
         args::CopyFile<'static>,
@@ -1063,6 +1068,20 @@ mod _async_tasks {
         args::FdataSync,
         args::Fsync,
     );
+    // `fs.read` is the one argument set whose buffer is a write destination.
+    // SAFETY: as for `impl_fs_argument!`; the buffer is pinned and GC-rooted.
+    unsafe impl ThreadIsolatedArg for args::Read {}
+    impl FsArgument for args::Read {
+        #[inline]
+        fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Self> {
+            args::Read::from_js(ctx, arguments)
+        }
+        fn write_back(&mut self, global: &JSGlobalObject) {
+            if let args::ReadBuffer::PinnedBuffer(buffer) = &mut self.buffer {
+                buffer.write_back(global);
+            }
+        }
+    }
     // `ReadFile`/`WriteFile` carry an `AbortSignal` field — opt them in so the
     // `const _ = assert!(…::HAVE_ABORT_SIGNAL)` invariants in `async_` hold and
     // `signal()` exposes it to `AsyncFSTask::run_from_js_thread`.
@@ -1252,6 +1271,7 @@ mod _async_tasks {
         ) -> bun_jsc::JsResult<()> {
             let global_object = cx.global();
             let _dispatch = js.tracker.dispatch(global_object);
+            this.args.write_back(global_object);
 
             let success = this.result.is_ok();
             let promise_value = js.promise.value();
@@ -3750,10 +3770,13 @@ pub mod args {
                 ctx.throw_invalid_argument_type_value(b"buffer", b"TypedArray", buffer_value)
             })?;
             let buffer = if arguments.will_be_async {
-                ReadBuffer::PinnedBuffer(
-                    PinnedArrayBuffer::root(ctx, buffer_value)
-                        .ok_or_else(|| ctx.throw_out_of_memory())?,
-                )
+                let mut pinned = PinnedArrayBuffer::root(ctx, buffer_value)
+                    .ok_or_else(|| ctx.throw_out_of_memory())?;
+                // The pool thread writes into this buffer after JS has run again.
+                if !pinned.copy_out_for_write(ctx) {
+                    return Err(ctx.throw_out_of_memory());
+                }
+                ReadBuffer::PinnedBuffer(pinned)
             } else {
                 ReadBuffer::Buffer(buffer)
             };

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -7228,8 +7228,8 @@ describe.if(isPosix)("fs.read into a view over a WebAssembly.Memory", () => {
     `;
   }
 
-  async function run(fixtureBody: string, env: Record<string, string>) {
-    using dir = tempDir("fs-read-wasm-grow", { "run.mjs": fixture(fixtureBody) });
+  async function run(source: string, env: Record<string, string>) {
+    using dir = tempDir("fs-read-wasm-grow", { "run.mjs": source });
     const fifo = join(String(dir), "fifo");
     mkfifo(fifo, 0o666);
     await using proc = Bun.spawn({
@@ -7246,7 +7246,10 @@ describe.if(isPosix)("fs.read into a view over a WebAssembly.Memory", () => {
     // `toResizableBuffer()` tracks the memory, so the view survives the grow and
     // must hold what the read produced. Without the fix those bytes went into
     // the block the grow freed.
-    const { stdout, exitCode } = await run(`const view = new Uint8Array(mem.toResizableBuffer());`, boundsCheckedEnv);
+    const { stdout, exitCode } = await run(
+      fixture(`const view = new Uint8Array(mem.toResizableBuffer());`),
+      boundsCheckedEnv,
+    );
     expect(stdout).toBe("read 4096, 4096 of 4096 in the view");
     expect(exitCode).toBe(0);
   });
@@ -7256,11 +7259,51 @@ describe.if(isPosix)("fs.read into a view over a WebAssembly.Memory", () => {
     // of parked on a cage free list. Without the fix the kernel reports EFAULT
     // for the write, and with the Gigacage on it writes into whatever took the
     // block. `mem.buffer` is detached by the grow, so nothing is copied back.
-    const { stdout, exitCode } = await run(`const view = new Uint8Array(mem.buffer);`, {
+    const { stdout, exitCode } = await run(fixture(`const view = new Uint8Array(mem.buffer);`), {
       ...boundsCheckedEnv,
       Malloc: "1",
     });
     expect(stdout).toBe("read 4096, 0 of 4096 in the view");
+    expect(exitCode).toBe(0);
+  });
+
+  it("touches only the bytes the read returned", async () => {
+    // A short read must leave the rest of the requested range alone, and a JS
+    // write anywhere else in the memory must survive the write-back.
+    const source = `
+      import fs from "node:fs";
+      const fd = fs.openSync(process.argv[2], fs.constants.O_RDWR);
+      const mem = new WebAssembly.Memory({ initial: 1, maximum: 4 });
+      const view = new Uint8Array(mem.toResizableBuffer());
+      view.fill(0x2e);
+      const { promise, resolve } = Promise.withResolvers();
+      fs.read(fd, view, 64, 4096, null, (err, bytesRead) => resolve({ err, bytesRead }));
+      mem.grow(1);
+      view[50000] = 0x5a;
+      fs.writeSync(fd, Buffer.alloc(100, 0x41));
+      const { err, bytesRead } = await promise;
+      const payload = view.subarray(64, 164).every(b => b === 0x41);
+      const beforeOffset = view.subarray(0, 64).every(b => b === 0x2e);
+      const shortReadTail = view.subarray(164, 4160).every(b => b === 0x2e);
+      console.log(JSON.stringify({
+        err: err?.code ?? null,
+        bytesRead,
+        payload,
+        beforeOffset,
+        shortReadTail,
+        outsideTheRange: view[50000] === 0x5a,
+      }));
+      fs.closeSync(fd);
+    `;
+    const { stdout, exitCode } = await run(source, boundsCheckedEnv);
+    expect(JSON.parse(stdout)).toEqual({
+      err: null,
+      bytesRead: 100,
+      payload: true,
+      beforeOffset: true,
+      shortReadTail: true,
+      outsideTheRange: true,
+    });
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -7191,6 +7191,80 @@ describe("fs.Utf8Stream", () => {
   });
 });
 
+describe.if(isPosix)("fs.read into a view over a WebAssembly.Memory", () => {
+  // `WebAssembly.Memory.prototype.grow()` on a bounds-checked memory allocates a
+  // new block, copies into it, and frees the old one. `fs.read` gave the pool
+  // thread a pointer into that old block, so the kernel writes the file bytes
+  // into freed memory.
+  //
+  // `BUN_JSC_useWasmFastMemory=0` makes every memory bounds-checked. The default
+  // configuration reaches the same mode once the process holds more fast
+  // memories than the platform reserves slots for (8, or 3 without a large
+  // Gigacage).
+  const boundsCheckedEnv = { ...bunEnv, BUN_JSC_useWasmFastMemory: "0" };
+
+  // The read target is a fifo with no data in it, so the pool thread waits in
+  // read(2) until the grow has already happened.
+  function fixture(body: string) {
+    return `
+      import fs from "node:fs";
+      const fifo = process.argv[2];
+      const fd = fs.openSync(fifo, fs.constants.O_RDWR);
+      const mem = new WebAssembly.Memory({ initial: 1, maximum: 4 });
+      ${body}
+      const { promise, resolve } = Promise.withResolvers();
+      fs.read(fd, view, 0, 4096, null, (err, bytesRead) => resolve({ err, bytesRead }));
+      mem.grow(1);
+      fs.writeSync(fd, Buffer.alloc(4096, 0x41));
+      const { err, bytesRead } = await promise;
+      if (err) {
+        console.log("error " + err.code);
+      } else {
+        let seen = 0;
+        for (let i = 0; i < Math.min(4096, view.byteLength); i++) if (view[i] === 0x41) seen++;
+        console.log("read " + bytesRead + ", " + seen + " of 4096 in the view");
+      }
+      fs.closeSync(fd);
+    `;
+  }
+
+  async function run(fixtureBody: string, env: Record<string, string>) {
+    using dir = tempDir("fs-read-wasm-grow", { "run.mjs": fixture(fixtureBody) });
+    const fifo = join(String(dir), "fifo");
+    mkfifo(fifo, 0o666);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run.mjs", fifo],
+      env,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode };
+  }
+
+  it("keeps the bytes the read produced when the grow moves the memory", async () => {
+    // `toResizableBuffer()` tracks the memory, so the view survives the grow and
+    // must hold what the read produced. Without the fix those bytes went into
+    // the block the grow freed.
+    const { stdout, exitCode } = await run(`const view = new Uint8Array(mem.toResizableBuffer());`, boundsCheckedEnv);
+    expect(stdout).toBe("read 4096, 4096 of 4096 in the view");
+    expect(exitCode).toBe(0);
+  });
+
+  it("does not hand the kernel an address the grow unmapped", async () => {
+    // `Malloc=1` turns off the Gigacage, so the freed block is unmapped instead
+    // of parked on a cage free list. Without the fix the kernel reports EFAULT
+    // for the write, and with the Gigacage on it writes into whatever took the
+    // block. `mem.buffer` is detached by the grow, so nothing is copied back.
+    const { stdout, exitCode } = await run(`const view = new Uint8Array(mem.buffer);`, {
+      ...boundsCheckedEnv,
+      Malloc: "1",
+    });
+    expect(stdout).toBe("read 4096, 0 of 4096 in the view");
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("module init", () => {
   it("fs.promises is a lazy getter that resolves to node:fs/promises", () => {
     const desc = Object.getOwnPropertyDescriptor(fs, "promises")!;


### PR DESCRIPTION
### Problem

- An async `fs.read` into a view over a `WebAssembly.Memory` makes the kernel write the file bytes into freed memory. On release 1.4.3 the payload lands inside another `WebAssembly.Memory` (a byte oracle finds it 1 of 1), and with `Malloc=1` the read reports `EFAULT`.
- The cause is the pin. `Read::from_js` takes `PinnedArrayBuffer::root` and hands the pool thread that pointer. A pin does not hold wasm memory: `grow()` on a bounds-checked memory allocates a new block, copies into it, drops the last ref on the old `BufferMemoryHandle`, and calls `ArrayBuffer::detach(VM&)`, which ignores the pin count ("We allow detaching wasm memory ArrayBuffers even though they are locked", WebKit `ArrayBuffer.cpp`). `Gigacage::freeVirtualPages` then unmaps the block.
- No flag is needed. A memory is bounds-checked once the process holds more fast memories than the platform reserves slots for (8, or 3 without a large Gigacage).

### Fix

- `Bun__ArrayBuffer` now reports `wasm_memory`, read from the buffer the view already has, so the check adds two loads and never materializes one.
- `PinnedArrayBuffer::copy_out_for_write` gives the job scratch space instead. It runs after the range is validated and holds the requested length and nothing more, so the cost follows the read and not the size of the view. The job writes from index 0, which is why `Read::from_js` drops its own offset for that case.
- `PinnedArrayBuffer::write_back` copies the bytes the read returned into the view at the caller's offset, and nothing else, so a short read and a JS write elsewhere in the view both survive. It runs on the JS thread before the result reaches JS, through a new no-op `FsArgument::write_back` that only `args::Read` overrides.
- It takes the view's extent from the JS value again, so a grow that moved the block copies into the new one, and a detach or a shrink copies less or nothing.
- Verified: `test/js/node/fs/fs.test.ts`, three new tests, all three fail on the released binary. Also all of `test/js/node/fs/`, `test/js/node/zlib/zlib.test.js`, `test/js/node/buffer.test.js`, `test/js/bun/util/zstd.test.ts`, `test/js/bun/wasm/`, and `bun run rust:check-all` (12 targets).

### Background

- `PinnedArrayBuffer` is the borrow helper for a JS buffer whose bytes an async job touches after the call returns. It pins the `JSC::ArrayBuffer` and GC-roots the cell.
- `ArrayBuffer::pin()` clears `isDetachable()`. That makes `transfer()` copy instead of detach, so the bytes stay put. It does not own the storage, and wasm memory is the documented exception to the detach rule.
- `WebAssembly.Memory` hands out an ArrayBuffer over the block the memory owns. A fast (signal-handling) memory reserves a large address range and maps more of it on `grow()`, so the base pointer never moves. A bounds-checked memory has no reservation, so `grow()` moves the block and frees the old one.
- `mem.toResizableBuffer()` gives a view that tracks the memory instead of detaching on a grow. That is what makes the fix observable from JS: the bytes the read produced have to appear in the grown memory.

<details><summary>Notes</summary>

Reproduction (released 1.4.3). The read target is a fifo with no data in it, so the pool thread waits in `read(2)` until the grow has already happened:

```js
const fd = fs.openSync(fifo, fs.constants.O_RDWR);
const pool = [];
for (let i = 0; i < 8; i++) pool.push(new WebAssembly.Memory({ initial: 1, maximum: 4 }));
const mem = new WebAssembly.Memory({ initial: 1, maximum: 4 });
const view = new Uint8Array(mem.buffer);
const { promise, resolve } = Promise.withResolvers();
fs.read(fd, view, 0, 4096, null, (err, n) => resolve({ err, n }));
mem.grow(1);
const victims = [];
for (let i = 0; i < 8; i++) {
  const v = new WebAssembly.Memory({ initial: 1, maximum: 4 });
  new Uint8Array(v.buffer).fill(0x2e);
  victims.push(v);
}
fs.writeSync(fd, Buffer.alloc(4096, 0x41));
await promise;
// victims[0] holds the 0x41 payload: the kernel wrote into the freed block.
```

The eight memories before it exhaust the fast-memory pool, which is what makes the ninth bounds-checked. The tests use `BUN_JSC_useWasmFastMemory=0` instead, so they do not depend on `maxNumWasmFastMemories`.

Why `Malloc=1` in the second test: with the Gigacage on, `Gigacage::freeVirtualPages` parks the block on a cage free list and it stays mapped, so the stale write silently corrupts whatever takes it. With the Gigacage off the block is unmapped and the kernel answers `EFAULT`, which is the assertion that reads as a memory-safety check.

Why a copy and not a clamp. The shell's `> ${buf}` redirect can re-read the live extent before each write because it writes on the JS thread. `fs.read` writes from the pool thread, which cannot touch a JS value, so the only place to resolve the destination again is after the job is done.

Cost. The scratch is the read's own length, so a 64 KiB read costs a 64 KiB allocation and one copy back, whatever the size of the memory behind the view. An ArrayBuffer does not say whether its memory is fast or bounds-checked, so every non-shared wasm destination pays this, including a fast memory that would not have moved.

Not covered, and still live:

- `fs.readv` / `FileHandle.readv`. Those pin through `Bun__JSArray__collectBufferSpans`, which is a separate mechanism with one span per element.
- The read direction of the same hole (`crypto` KDFs, `node:zlib`, `Bun.file`, `node:http` pending writes). #42192 covers it. That PR also adds a `wasm_memory` field to `Bun__ArrayBuffer`, so whichever of the two lands first leaves the other a small rebase in `bindings.cpp` and `array_buffer.rs`. This change deliberately does not touch `copy_if_resizable` or any read-side caller.

Behaviour outside wasm is unchanged. A resizable non-shared `ArrayBuffer` keeps its reservation when it shrinks, so the kernel write there gets `EFAULT` against an address that is still reserved, and this change leaves that path alone.

Self-reviewed: a review of the first revision raised two concerns about the scratch contract, both fixed in `81f2948`. The scratch held the whole view, which cost an allocation and two copies of a whole wasm heap for a destination such as an Emscripten `HEAPU8`, and the write-back restored all of it, which reverted a JS write made elsewhere in the view while the read was pending. The third test covers both, plus a short read.

Test runs with the debug build. Green: `test/js/node/fs/fs.test.ts` (568), `test/js/node/zlib/zlib.test.js` with `test/js/node/buffer.test.js` and `test/js/bun/util/zstd.test.ts` (1162), `test/js/bun/wasm/` with `test/js/web/fetch/body-stream.test.ts` (9091). Red before and after this change, for the container and not for the diff: `should not leak memory with already aborted signals` in `test/js/node/fs/abort-signal-leak-read-write-file.test.ts`. Its fixture runs 100 000 rounds of `fs.promises.readFile` and `writeFile` against a 300 s budget. Here it takes 3.3 s on a release binary and 351 s on this debug and ASAN build, a factor of 107. It uses neither `fs.read` nor the write scratch.

</details>
