### PR TITLE
docs: say when Bun.SQL reads query parameters, and that https.Server cannot adopt sockets

### DIFF
--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -49,7 +49,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:https`](https://nodejs.org/api/https.html)
 
-🟡 `request`, `get`, `Agent` and `globalAgent` are implemented, including connection pooling. Client sockets are `tls.TLSSocket`s. `https.Server` is `http.Server` with TLS options rather than a `tls.Server`. Its request sockets (`req.socket`) are not `tls.TLSSocket`s: `encrypted`, `authorized` and `servername` work, but `getPeerCertificate()` and `getCipher()` are missing. `setSecureContext()`, `addContext()`, `SNICallback` and `handshakeTimeout` are not supported.
+🟡 `request`, `get`, `Agent` and `globalAgent` are implemented, including connection pooling. Client sockets are `tls.TLSSocket`s. `https.Server` is `http.Server` with TLS options rather than a `tls.Server`, so you cannot hand it connections the way Node allows: `server.emit('connection', socket)` reads the socket as plaintext HTTP (a raw TLS connection fails with `'clientError'`) and nothing listens for `'secureConnection'`. To route connections yourself, terminate TLS with a `tls.Server` and pass each `TLSSocket` to a plain `http.Server` with `emit('connection', tlsSocket)`. `https.Server` request sockets (`req.socket`) are not `tls.TLSSocket`s: `encrypted`, `authorized` and `servername` work, but `getPeerCertificate()` and `getCipher()` are missing. `setSecureContext()`, `addContext()`, `SNICallback` and `handshakeTimeout` are not supported.
 
 ### [`node:os`](https://nodejs.org/api/os.html)
 

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -477,6 +477,15 @@ setTimeout(() => query.cancel(), 100);
 await query;
 ```
 
+Parameters are lazy too. Bun keeps a reference to each interpolated value and serializes it when it sends the query, not when the template literal is evaluated. This can be later than the `.execute()` call, for example while the statement is still being prepared. A `TypedArray`, `Buffer`, `ArrayBuffer`, `Date` or `sql(object)` value that you modify before the query settles is sent with its new contents, and a buffer that you transfer or detach before then is sent without its bytes. If you need to reuse a buffer right away, pass a copy (`new Uint8Array(bytes)`, not a view such as `subarray()` or `Buffer#slice()`).
+
+```ts
+const bytes = new Uint8Array([1, 2, 3, 4]);
+const query = sql`INSERT INTO files (data) VALUES (${bytes})`;
+bytes.fill(0); // the query has not read `bytes` yet
+await query; // stores 00000000, not 01020304
+```
+
 ---
 
 ## Database Environment Variables

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -477,7 +477,7 @@ setTimeout(() => query.cancel(), 100);
 await query;
 ```
 
-Parameters are lazy too. Bun keeps a reference to each interpolated value and serializes it when it sends the query, not when the template literal is evaluated. This can be later than the `.execute()` call, for example while the statement is still being prepared. A `TypedArray`, `Buffer`, `ArrayBuffer`, `Date` or `sql(object)` value that you modify before the query settles is sent with its new contents, and a buffer that you transfer or detach before then is sent without its bytes. If you need to reuse a buffer right away, pass a copy (`new Uint8Array(bytes)`, not a view such as `subarray()` or `Buffer#slice()`).
+Parameters are lazy too. Bun keeps a reference to each interpolated value and serializes it when it sends the query, not when the template literal is evaluated. This can be later than the `.execute()` call, for example while the statement is still being prepared. A `TypedArray`, `Buffer`, `ArrayBuffer`, `Date` or `sql(object)` value that you modify before the query settles is sent with its new contents, and a buffer that you transfer or detach before then is sent without its bytes. If you need to reuse a buffer right away, pass a copy: `new Uint8Array(view)` for a `TypedArray` or `Buffer`, `arrayBuffer.slice(0)` for an `ArrayBuffer`. `subarray()`, `Buffer#slice()` and `new Uint8Array(arrayBuffer)` return views of the same memory, not copies.
 
 ```ts
 const bytes = new Uint8Array([1, 2, 3, 4]);

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -477,7 +477,7 @@ setTimeout(() => query.cancel(), 100);
 await query;
 ```
 
-Parameters are lazy too. Bun keeps a reference to each interpolated value and serializes it when it sends the query, not when the template literal is evaluated. This can be later than the `.execute()` call, for example while the statement is still being prepared. A `TypedArray`, `Buffer`, `ArrayBuffer`, `Date` or `sql(object)` value that you modify before the query settles is sent with its new contents, and a buffer that you transfer or detach before then is sent without its bytes. If you need to reuse a buffer right away, pass a copy: `new Uint8Array(view)` for a `TypedArray` or `Buffer`, `arrayBuffer.slice(0)` for an `ArrayBuffer`. `subarray()`, `Buffer#slice()` and `new Uint8Array(arrayBuffer)` return views of the same memory, not copies.
+Parameters are lazy too. Bun keeps a reference to each interpolated value and serializes it when it sends the query, not when the template literal is evaluated. This can be later than the `.execute()` call, for example while the statement is still being prepared. Until the query settles, treat a `TypedArray`, `Buffer`, `ArrayBuffer`, `Date` or `sql(object)` value as lent to Bun: a change you make to it can still end up in what is sent, and a buffer that you transfer or detach can be sent without its bytes. If you need to reuse a buffer right away, pass a copy: `typedArray.slice()`, `Buffer.from(buffer)` for a `Buffer`, or `arrayBuffer.slice(0)` for an `ArrayBuffer`. `subarray()`, `Buffer#slice()` and `new Uint8Array(arrayBuffer)` return views of the same memory, not copies.
 
 ```ts
 const bytes = new Uint8Array([1, 2, 3, 4]);

--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -522,13 +522,6 @@ declare module "bun" {
   interface SQL extends AsyncDisposable {
     /**
      * Executes a SQL query using template literals
-     *
-     * Interpolated values are kept by reference and serialized when the
-     * query is sent, which is no earlier than `await` or `.execute()`, not
-     * when the template is evaluated. Don't modify, transfer or detach a
-     * `TypedArray`/`ArrayBuffer`/`Date`/`sql(object)` value until the query
-     * settles, or pass a copy (`new Uint8Array(bytes)`).
-     *
      * @example
      * ```ts
      * const [user] = await sql<Users[]>`select * from users where id = ${1}`;

--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -522,6 +522,13 @@ declare module "bun" {
   interface SQL extends AsyncDisposable {
     /**
      * Executes a SQL query using template literals
+     *
+     * Interpolated values are kept by reference and serialized when the
+     * query is sent, which is no earlier than `await` or `.execute()`, not
+     * when the template is evaluated. Don't modify, transfer or detach a
+     * `TypedArray`/`ArrayBuffer`/`Date`/`sql(object)` value until the query
+     * settles, or pass a copy (`new Uint8Array(bytes)`).
+     *
      * @example
      * ```ts
      * const [user] = await sql<Users[]>`select * from users where id = ${1}`;


### PR DESCRIPTION
### Problem
- `docs/runtime/sql.mdx` says queries are lazy but says nothing about parameters. `Bun.SQL` keeps each interpolated value by reference and serializes it when it sends the query. ``const q = sql`insert … ${u8}`; u8.fill(9); await q`` stores `09…` on PostgreSQL, MySQL and SQLite. A `transfer()` in between stores an empty value with no error. `Date` and `sql(object)` values are read late too.
- `docs/runtime/nodejs-compat.mdx` says `https.Server` is `http.Server` with TLS options rather than a `tls.Server`, but not the consequence. `server.emit('connection', rawSocket)` parses the TLS ClientHello as HTTP and fails with `'clientError'` (`HPE_INVALID_METHOD`). `emit('secureConnection', tlsSocket)` has no listener. Node serves a request in both cases.

### Fix
- `sql.mdx`, under "Execute and Cancelling Queries": one paragraph and a short example. Parameters are read when the query is sent, which can be after `.execute()` returns. To reuse a buffer at once, pass a copy: `typedArray.slice()`, `Buffer.from(buffer)` for a `Buffer`, or `arrayBuffer.slice(0)` for an `ArrayBuffer` (`subarray()`, `Buffer#slice()` and `new Uint8Array(arrayBuffer)` are views).
- `nodejs-compat.mdx`, `node:https`: say that `https.Server` cannot be handed connections with `emit()`, and give the portable form: terminate TLS with a `tls.Server` and pass each `TLSSocket` to a plain `http.Server` with `emit('connection', tlsSocket)`.
- No runtime change. Reading parameters at send time matches postgres.js.
- Verified: each sentence was checked against Bun 1.4.3 (same as `main` at 4ff9193770) with the probes in the notes.

### Background
- A `sql`…`` call returns a `Query` that stores the `values` array as is (`src/js/internal/sql/query.ts`). Each adapter reads the parameter bytes when it writes the bind message, on or after `await`/`.execute()`.
- In Node, `https.Server` extends `tls.Server`: `'connection'` starts a TLS handshake on any socket it is given, and `'secureConnection'` feeds the HTTP parser. Bun's `https.Server` has only the `http.Server` `'connection'` path, which reads plaintext.

<details><summary>Notes</summary>

Probe results on Bun 1.4.3 / main 4ff9193770 (local PostgreSQL 16, MariaDB, SQLite):

```
mutate u8 between sql`` and await      -> postgres 09090909, mysql 09090909, sqlite 09090909
u8.buffer.transfer() in between        -> postgres empty bytea, mysql empty blob, sqlite NULL (no error)
sql({ id, data: u8 }) then u8.fill(7)  -> 07070707 on all three
await first, mutate after              -> 01020304 (control)
.execute() on an already-prepared statement, then mutate synchronously (postgres) -> 01020304
.execute() on a new statement shape, then mutate synchronously (postgres)         -> bbbbbbbb (read after the prepare round trip)
sql(obj, "id", "name") then obj.name = "after" -> stores "after"
${date} then date.setTime(...)                 -> stores the new time
sql.array([1,2], "int4") then push(3)          -> stores {1,2} (sql.array serializes at call time)
```

Where the bytes are read: PostgreSQL in `write_bind` (`src/sql_jsc/postgres/PostgresRequest.rs`), after the Parse/Describe round trip when the statement is new. MySQL in `Value::from_js` at bind time (`src/sql_jsc/mysql/MySQLValue.rs`). The SQLite adapter binds in `run()` through `bun:sqlite`.

The SQLite `NULL` for a detached view (instead of a zero-length blob like the other adapters and like `node:sqlite`) comes from `sqlite3_bind_blob(stmt, i, nullptr, 0, …)` in `JSSQLStatement.cpp` and is tracked separately. The doc sentence does not depend on which way that goes.

https probes (server cert from `test/js/node/tls/fixtures/agent1-*`):

```
net.Server front, httpsServer.emit('connection', rawSocket):
  bun  -> 'clientError' HPE_INVALID_METHOD, client gets nothing
  node -> 200 "hello over tls"
tls.Server front, httpsServer.emit('secureConnection', tlsSocket):
  bun  -> emit() returns false, listenerCount('secureConnection') === 0, client gets nothing
  node -> 200
tls.Server front, httpServer.emit('connection', tlsSocket)   (the documented alternative):
  bun  -> 200, req.socket.encrypted === true
  node -> 200
tls.Server front, httpsServer.emit('connection', tlsSocket):
  bun  -> 200 (treated as plaintext over the decrypted stream)
  node -> ERR_SSL_HTTP_REQUEST (double TLS), so not documented as portable
```

Scope notes: the `Bun.zstdCompress`/`zstdDecompress` borrow note is #41692, the `Bun.file(Uint8Array)` path copy is #42199/#40682, and the `net.Socket({ fd })` adopted-fd wording belongs with #41835. None of those are touched here. `prettier --check` passes on both files. The change is documentation only: two `.mdx` files, no `src/`, `packages/` or test changes.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->