### PR TITLE
webview: capture a Chrome screenshot again when a navigation strands it

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -307,6 +307,18 @@ process.stdout.write(`\x1b_Gf=100,t=s,a=T,S=${size};${btoa(name)}\x1b\\`);
 
 On WebKit, the shm name looks like `/bun-webview-<pid>-<seq>`; on Chrome, `/bun-chrome-<pid>-<seq>`. If you request `"shmem"` and don't hand the name to something that will `shm_unlink` it, the segment leaks until your process exits.
 
+### A screenshot during a navigation
+
+A page can commit a new document while a capture is still running. Chrome throws that capture away. On the Chrome backend, Bun takes the screenshot again when the new document fires its load event, so the promise resolves with an image of the page that loaded:
+
+```ts
+const shot = view.screenshot(); // starts against the current document
+await view.navigate(url); // the new document replaces it
+await shot; // an image of the new document
+```
+
+Bun repeats the capture once. If the page navigates a second time before the repeat completes, the promise rejects with `screenshot: the page navigated before the capture completed`.
+
 ---
 
 ## Input simulation

--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -309,7 +309,7 @@ On WebKit, the shm name looks like `/bun-webview-<pid>-<seq>`; on Chrome, `/bun-
 
 ### A screenshot during a navigation
 
-A page can commit a new document while a capture is still running. Chrome throws that capture away. On the Chrome backend, Bun takes the screenshot again when the new document fires its load event, so the promise resolves with an image of the page that loaded:
+A page can commit a new document while a capture is still running. Chrome can throw that capture away. On the Chrome backend, Bun takes the screenshot again once the new document has loaded, so the promise resolves with an image of the page that replaced the old one:
 
 ```ts
 const shot = view.screenshot(); // starts against the current document

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -616,6 +616,21 @@ static constexpr ASCIILiteral cdpButton(uint8_t b)
     }
 }
 
+// Page.captureScreenshot for one view's options. Built in two places: the
+// screenshot() op, and the repeat that recovers a capture a navigation
+// stranded. CDP takes format as a JSON string; quality is 0-100 for
+// JPEG/WebP and Chrome ignores it for PNG.
+static Command captureScreenshotCommand(uint32_t id, std::span<const char> sessionId,
+    ScreenshotFormat format, uint8_t quality)
+{
+    ASCIILiteral fmtLit = format == ScreenshotFormat::Jpeg ? "\"jpeg\""_s
+        : format == ScreenshotFormat::Webp                 ? "\"webp\""_s
+                                                           : "\"png\""_s;
+    return Command(id, "Page.captureScreenshot"_s, sessionId)
+        .raw("format"_s, fmtLit)
+        .num("quality"_s, static_cast<int32_t>(quality));
+}
+
 // Bun modifier bits → CDP modifier integer. CDP uses bit 0=Alt, 1=Ctrl,
 // 2=Meta, 3=Shift. ipc_protocol.h's ModShift=1 ModCtrl=2 ModAlt=4 ModMeta=8.
 static constexpr int32_t cdpModifiers(uint8_t m)
@@ -1148,6 +1163,14 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it.
 
+        // A main-frame commit replaces the document. Chrome answers a
+        // capture that was in flight across one about half the time and
+        // drops the rest with no reply, so the load event below repeats
+        // it. A subframe commit (frame.parentId present) keeps the main
+        // document, and its captures complete.
+        if (view->m_pendingScreenshot && jsonField(frame, { "parentId", 8 }).empty())
+            view->m_screenshotStranded = true;
+
         if (JSObject* cb = view->m_onNavigated.get()) {
             Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
                 JSValue::encode(jsString(vm, urlStr)), JSValue::encode(jsUndefined()));
@@ -1168,6 +1191,25 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         uint32_t tid = nextId();
         m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
         send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
+
+        // A capture the commit stranded: its id owes a reply that Chrome
+        // never sends, so drop the id and capture the document that just
+        // loaded instead. The repeat runs once per screenshot() call. A
+        // second commit over it rejects, so the promise always settles.
+        if (view->m_screenshotStranded && view->m_pendingScreenshot) {
+            view->m_screenshotStranded = false;
+            m_pending.remove(view->m_screenshotCdpId);
+            if (view->m_screenshotResent) {
+                settle(g, view, PendingSlot::Screenshot, false,
+                    createError(g, "screenshot: the page navigated before the capture completed"_s));
+                return;
+            }
+            view->m_screenshotResent = true;
+            uint32_t cid = nextId();
+            view->m_screenshotCdpId = cid;
+            m_pending.add(cid, Pending { Method::PageCaptureScreenshot, PendingSlot::Screenshot, view->m_viewId });
+            send(cid, captureScreenshotCommand(cid, sidSpan(view->m_sessionId), view->m_screenshotFormat, view->m_screenshotQuality));
+        }
         return;
     }
 
@@ -1511,21 +1553,17 @@ JSPromise* screenshot(JSGlobalObject* g, JSWebView* view, ScreenshotFormat forma
 {
     auto& t = transport();
     uint32_t id = t.nextId();
-    // CDP takes format as a JSON string. quality is ignored for PNG by
-    // Chrome; for JPEG/WebP it's 0-100. Pass it unconditionally — Chrome
-    // silently ignores quality for PNG, and the builder's && ref-qualifier
-    // means conditionals break the chain (lvalue after materialization).
     // The response handler reads view->m_screenshotFormat (stashed by
     // JSWebView::screenshot before dispatch) to stamp the right MIME type
-    // on the Blob.
-    ASCIILiteral fmtLit = format == ScreenshotFormat::Jpeg ? "\"jpeg\""_s
-        : format == ScreenshotFormat::Webp                 ? "\"webp\""_s
-                                                           : "\"png\""_s;
+    // on the Blob. The id, the quality and the two flags are what the
+    // load-event handler needs to repeat a capture a navigation stranded.
+    view->m_screenshotCdpId = id;
+    view->m_screenshotQuality = quality;
+    view->m_screenshotStranded = false;
+    view->m_screenshotResent = false;
     return sendChromeOp(g, view, view->m_pendingScreenshot, PendingSlot::Screenshot,
         Method::PageCaptureScreenshot, id,
-        Command(id, "Page.captureScreenshot"_s, sidSpan(view->m_sessionId))
-            .raw("format"_s, fmtLit)
-            .num("quality"_s, static_cast<int32_t>(quality)));
+        captureScreenshotCommand(id, sidSpan(view->m_sessionId), format, quality));
 }
 
 // One mousePressed + one mouseReleased. CDP's Input.dispatchMouseEvent is

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -616,10 +616,7 @@ static constexpr ASCIILiteral cdpButton(uint8_t b)
     }
 }
 
-// Page.captureScreenshot for one view's options. Built in two places: the
-// screenshot() op, and the repeat that recovers a capture a navigation
-// stranded. CDP takes format as a JSON string; quality is 0-100 for
-// JPEG/WebP and Chrome ignores it for PNG.
+// format is a JSON string; quality is 0-100 and Chrome ignores it for PNG.
 static Command captureScreenshotCommand(uint32_t id, std::span<const char> sessionId,
     ScreenshotFormat format, uint8_t quality)
 {
@@ -1158,19 +1155,15 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     // now the new document, resources may still be loading.
     if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0) {
         auto frame = jsonField(params, { "frame", 5 });
-        // An <iframe>'s own commit (frame.parentId present) arrives on the
-        // page's session too. The view's document, its url and the captures
-        // in flight across it are all untouched by it.
+        // An <iframe>'s commit: the page's document, url and in-flight captures are unaffected.
         if (!jsonField(frame, { "parentId", 8 }).empty()) return;
         auto url = jsonString(jsonField(frame, { "url", 3 }));
         auto urlStr = WTF::String::fromUTF8(url);
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it.
 
-        mainFrameCommitted(view);
-        // A page restored from the back/forward cache is complete at its
-        // commit and fires no load event, so nothing later would repeat a
-        // capture this commit stranded.
+        mainFrameCommitted(g, view);
+        // A back/forward cache restore fires no load event: the restored page is complete now.
         auto type = jsonString(jsonField(params, { "type", 4 }));
         if (type.size() == 23 && memcmp(type.data(), "BackForwardCacheRestore", 23) == 0)
             repeatStrandedCapture(g, view);
@@ -1327,27 +1320,33 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     view->wrapped().dispatchEvent(event);
 }
 
-void Transport::mainFrameCommitted(JSWebView* view)
+void Transport::mainFrameCommitted(JSGlobalObject* g, JSWebView* view)
 {
-    for (auto& entry : m_pending.values()) {
-        if (entry.viewId == view->m_viewId) entry.acrossCommit = true;
+    uint32_t strandedRepeat = 0;
+    for (auto& [id, entry] : m_pending) {
+        if (entry.viewId != view->m_viewId) continue;
+        entry.acrossCommit = true;
+        if (entry.repeat) strandedRepeat = id;
+    }
+    // One repeat per screenshot() call. A commit over the repeat rejects now,
+    // not at a load event that the new document might never fire.
+    if (strandedRepeat) {
+        m_pending.remove(strandedRepeat);
+        settle(g, view, PendingSlot::Screenshot, false,
+            createError(g, "screenshot: the page navigated before the capture completed"_s));
     }
 }
 
-// Runs once the document that a main-frame commit brought in is in place: at
-// Page.loadEventFired, or at the commit itself for a back/forward cache
-// restore. The slot model allows one capture in flight per view, so there is
-// at most one stranded entry. Its id is dropped either way: Chrome owes it a
-// reply that never comes, and a late one must not reach a slot that a newer
-// screenshot() call has taken since.
+// Chrome never answers about half of the Page.captureScreenshot commands that
+// are in flight when the main frame commits another document (all of them for
+// a reload or a back/forward cache restore). Once the new document is in
+// place, drop the stranded id and capture that document instead.
 void Transport::repeatStrandedCapture(JSGlobalObject* g, JSWebView* view)
 {
     uint32_t strandedId = 0;
-    bool wasRepeat = false;
     for (auto& [id, entry] : m_pending) {
         if (entry.viewId == view->m_viewId && entry.method == Method::PageCaptureScreenshot && entry.acrossCommit) {
             strandedId = id;
-            wasRepeat = entry.repeat;
             break;
         }
     }
@@ -1355,13 +1354,6 @@ void Transport::repeatStrandedCapture(JSGlobalObject* g, JSWebView* view)
     m_pending.remove(strandedId);
     if (!view->m_pendingScreenshot) return;
 
-    // One repeat per screenshot() call. A second commit over the repeat
-    // rejects, so the promise settles and the slot frees either way.
-    if (wasRepeat) {
-        settle(g, view, PendingSlot::Screenshot, false,
-            createError(g, "screenshot: the page navigated before the capture completed"_s));
-        return;
-    }
     uint32_t cid = nextId();
     Pending entry { Method::PageCaptureScreenshot, PendingSlot::Screenshot, view->m_viewId };
     entry.repeat = true;

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1163,13 +1163,17 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it.
 
-        // A main-frame commit replaces the document. Chrome answers a
-        // capture that was in flight across one about half the time and
-        // drops the rest with no reply, so the load event below repeats
-        // it. A subframe commit (frame.parentId present) keeps the main
-        // document, and its captures complete.
-        if (view->m_pendingScreenshot && jsonField(frame, { "parentId", 8 }).empty())
-            view->m_screenshotStranded = true;
+        // A subframe commit (frame.parentId present) keeps the main
+        // document, and Chrome completes the captures in flight across it.
+        if (jsonField(frame, { "parentId", 8 }).empty()) {
+            mainFrameCommitted(view);
+            // A page restored from the back/forward cache is complete at its
+            // commit and fires no load event, so nothing later would repeat
+            // a capture this commit stranded.
+            auto type = jsonString(jsonField(params, { "type", 4 }));
+            if (type.size() == 23 && memcmp(type.data(), "BackForwardCacheRestore", 23) == 0)
+                repeatStrandedCapture(g, view);
+        }
 
         if (JSObject* cb = view->m_onNavigated.get()) {
             Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
@@ -1191,25 +1195,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         uint32_t tid = nextId();
         m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
         send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
-
-        // A capture the commit stranded: its id owes a reply that Chrome
-        // never sends, so drop the id and capture the document that just
-        // loaded instead. The repeat runs once per screenshot() call. A
-        // second commit over it rejects, so the promise always settles.
-        if (view->m_screenshotStranded && view->m_pendingScreenshot) {
-            view->m_screenshotStranded = false;
-            m_pending.remove(view->m_screenshotCdpId);
-            if (view->m_screenshotResent) {
-                settle(g, view, PendingSlot::Screenshot, false,
-                    createError(g, "screenshot: the page navigated before the capture completed"_s));
-                return;
-            }
-            view->m_screenshotResent = true;
-            uint32_t cid = nextId();
-            view->m_screenshotCdpId = cid;
-            m_pending.add(cid, Pending { Method::PageCaptureScreenshot, PendingSlot::Screenshot, view->m_viewId });
-            send(cid, captureScreenshotCommand(cid, sidSpan(view->m_sessionId), view->m_screenshotFormat, view->m_screenshotQuality));
-        }
+        repeatStrandedCapture(g, view);
         return;
     }
 
@@ -1339,6 +1325,48 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     auto event = WebCore::MessageEvent::create(methodAtom, WTF::move(init), WebCore::Event::IsTrusted::Yes);
     scope.release();
     view->wrapped().dispatchEvent(event);
+}
+
+void Transport::mainFrameCommitted(JSWebView* view)
+{
+    for (auto& entry : m_pending.values()) {
+        if (entry.viewId == view->m_viewId) entry.acrossCommit = true;
+    }
+}
+
+// Runs once the document that a main-frame commit brought in is in place: at
+// Page.loadEventFired, or at the commit itself for a back/forward cache
+// restore. The slot model allows one capture in flight per view, so there is
+// at most one stranded entry. Its id is dropped either way: Chrome owes it a
+// reply that never comes, and a late one must not reach a slot that a newer
+// screenshot() call has taken since.
+void Transport::repeatStrandedCapture(JSGlobalObject* g, JSWebView* view)
+{
+    uint32_t strandedId = 0;
+    bool wasRepeat = false;
+    for (auto& [id, entry] : m_pending) {
+        if (entry.viewId == view->m_viewId && entry.method == Method::PageCaptureScreenshot && entry.acrossCommit) {
+            strandedId = id;
+            wasRepeat = entry.repeat;
+            break;
+        }
+    }
+    if (!strandedId) return;
+    m_pending.remove(strandedId);
+    if (!view->m_pendingScreenshot) return;
+
+    // One repeat per screenshot() call. A second commit over the repeat
+    // rejects, so the promise settles and the slot frees either way.
+    if (wasRepeat) {
+        settle(g, view, PendingSlot::Screenshot, false,
+            createError(g, "screenshot: the page navigated before the capture completed"_s));
+        return;
+    }
+    uint32_t cid = nextId();
+    Pending entry { Method::PageCaptureScreenshot, PendingSlot::Screenshot, view->m_viewId };
+    entry.repeat = true;
+    m_pending.add(cid, entry);
+    send(cid, captureScreenshotCommand(cid, sidSpan(view->m_sessionId), view->m_screenshotFormat, view->m_screenshotQuality));
 }
 
 void Transport::onClose()
@@ -1555,12 +1583,8 @@ JSPromise* screenshot(JSGlobalObject* g, JSWebView* view, ScreenshotFormat forma
     uint32_t id = t.nextId();
     // The response handler reads view->m_screenshotFormat (stashed by
     // JSWebView::screenshot before dispatch) to stamp the right MIME type
-    // on the Blob. The id, the quality and the two flags are what the
-    // load-event handler needs to repeat a capture a navigation stranded.
-    view->m_screenshotCdpId = id;
+    // on the Blob; repeatStrandedCapture reads both to send the capture again.
     view->m_screenshotQuality = quality;
-    view->m_screenshotStranded = false;
-    view->m_screenshotResent = false;
     return sendChromeOp(g, view, view->m_pendingScreenshot, PendingSlot::Screenshot,
         Method::PageCaptureScreenshot, id,
         captureScreenshotCommand(id, sidSpan(view->m_sessionId), format, quality));

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1158,22 +1158,22 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     // now the new document, resources may still be loading.
     if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0) {
         auto frame = jsonField(params, { "frame", 5 });
+        // An <iframe>'s own commit (frame.parentId present) arrives on the
+        // page's session too. The view's document, its url and the captures
+        // in flight across it are all untouched by it.
+        if (!jsonField(frame, { "parentId", 8 }).empty()) return;
         auto url = jsonString(jsonField(frame, { "url", 3 }));
         auto urlStr = WTF::String::fromUTF8(url);
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it.
 
-        // A subframe commit (frame.parentId present) keeps the main
-        // document, and Chrome completes the captures in flight across it.
-        if (jsonField(frame, { "parentId", 8 }).empty()) {
-            mainFrameCommitted(view);
-            // A page restored from the back/forward cache is complete at its
-            // commit and fires no load event, so nothing later would repeat
-            // a capture this commit stranded.
-            auto type = jsonString(jsonField(params, { "type", 4 }));
-            if (type.size() == 23 && memcmp(type.data(), "BackForwardCacheRestore", 23) == 0)
-                repeatStrandedCapture(g, view);
-        }
+        mainFrameCommitted(view);
+        // A page restored from the back/forward cache is complete at its
+        // commit and fires no load event, so nothing later would repeat a
+        // capture this commit stranded.
+        auto type = jsonString(jsonField(params, { "type", 4 }));
+        if (type.size() == 23 && memcmp(type.data(), "BackForwardCacheRestore", 23) == 0)
+            repeatStrandedCapture(g, view);
 
         if (JSObject* cb = view->m_onNavigated.get()) {
             Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -351,12 +351,8 @@ struct Pending {
     Method method;
     PendingSlot slot;
     uint32_t viewId;
-    // The view's main frame committed another document while this command
-    // was in flight. Chrome drops some commands at that point and never
-    // replies to them; Transport::repeatStrandedCapture acts on the mark.
-    bool acrossCommit = false;
-    // This command is itself the one repeat a stranded command gets.
-    bool repeat = false;
+    bool acrossCommit = false; // the view's main frame committed another document while this was in flight
+    bool repeat = false; // this is the one re-send a stranded command gets (Transport::repeatStrandedCapture)
 };
 
 // Transport mode. Pipe = we spawned Chrome with --remote-debugging-pipe,
@@ -483,12 +479,9 @@ public:
     void handleMessage(std::span<const char> msg);
     void handleResponse(uint32_t id, std::span<const char> result, std::span<const char> error);
     void handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId);
-    // A Page.captureScreenshot that is in flight when the main frame commits
-    // another document gets no reply from Chrome about half the time, ever.
-    // mainFrameCommitted marks the view's in-flight commands; once the new
-    // document is in place, repeatStrandedCapture drops the stranded id and
-    // captures that document instead, once per screenshot() call.
-    void mainFrameCommitted(JSWebView*);
+    // Recovery for a Page.captureScreenshot that a main-frame commit strands
+    // (Chrome never replies to it). See the definitions.
+    void mainFrameCommitted(JSC::JSGlobalObject*, JSWebView*);
     void repeatStrandedCapture(JSC::JSGlobalObject*, JSWebView*);
     void rejectAllAndMarkDead(const WTF::String& reason);
     void updateKeepAlive();

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -351,6 +351,12 @@ struct Pending {
     Method method;
     PendingSlot slot;
     uint32_t viewId;
+    // The view's main frame committed another document while this command
+    // was in flight. Chrome drops some commands at that point and never
+    // replies to them; Transport::repeatStrandedCapture acts on the mark.
+    bool acrossCommit = false;
+    // This command is itself the one repeat a stranded command gets.
+    bool repeat = false;
 };
 
 // Transport mode. Pipe = we spawned Chrome with --remote-debugging-pipe,
@@ -477,6 +483,13 @@ public:
     void handleMessage(std::span<const char> msg);
     void handleResponse(uint32_t id, std::span<const char> result, std::span<const char> error);
     void handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId);
+    // A Page.captureScreenshot that is in flight when the main frame commits
+    // another document gets no reply from Chrome about half the time, ever.
+    // mainFrameCommitted marks the view's in-flight commands; once the new
+    // document is in place, repeatStrandedCapture drops the stranded id and
+    // captures that document instead, once per screenshot() call.
+    void mainFrameCommitted(JSWebView*);
+    void repeatStrandedCapture(JSC::JSGlobalObject*, JSWebView*);
     void rejectAllAndMarkDead(const WTF::String& reason);
     void updateKeepAlive();
     void writeRaw(const char* data, size_t len);

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -114,9 +114,7 @@ public:
     // encoding → how the bytes are wrapped (Blob/Buffer/base64/shmem).
     ScreenshotFormat m_screenshotFormat = ScreenshotFormat::Png;
     ScreenshotEncoding m_screenshotEncoding = ScreenshotEncoding::Blob;
-    // Chrome: kept so a capture that a navigation stranded can be sent again
-    // with the options the call asked for (Transport::repeatStrandedCapture).
-    uint8_t m_screenshotQuality = 80;
+    uint8_t m_screenshotQuality = 80; // Chrome: re-sent by Transport::repeatStrandedCapture
 
     JSC::WriteBarrier<JSC::JSObject> m_onNavigated;
     JSC::WriteBarrier<JSC::JSObject> m_onNavigationFailed;

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -114,6 +114,16 @@ public:
     // encoding → how the bytes are wrapped (Blob/Buffer/base64/shmem).
     ScreenshotFormat m_screenshotFormat = ScreenshotFormat::Png;
     ScreenshotEncoding m_screenshotEncoding = ScreenshotEncoding::Blob;
+    // Chrome-only. A Page.captureScreenshot whose document is replaced
+    // before the capture completes gets no reply, ever. m_screenshotCdpId
+    // is the in-flight capture's CDP id, m_screenshotQuality repeats the
+    // capture with the options the user asked for, m_screenshotStranded
+    // records that a main-frame commit happened while the capture was in
+    // flight, and m_screenshotResent bounds the recovery to one repeat.
+    uint32_t m_screenshotCdpId = 0;
+    uint8_t m_screenshotQuality = 80;
+    bool m_screenshotStranded = false;
+    bool m_screenshotResent = false;
 
     JSC::WriteBarrier<JSC::JSObject> m_onNavigated;
     JSC::WriteBarrier<JSC::JSObject> m_onNavigationFailed;

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -114,16 +114,9 @@ public:
     // encoding → how the bytes are wrapped (Blob/Buffer/base64/shmem).
     ScreenshotFormat m_screenshotFormat = ScreenshotFormat::Png;
     ScreenshotEncoding m_screenshotEncoding = ScreenshotEncoding::Blob;
-    // Chrome-only. A Page.captureScreenshot whose document is replaced
-    // before the capture completes gets no reply, ever. m_screenshotCdpId
-    // is the in-flight capture's CDP id, m_screenshotQuality repeats the
-    // capture with the options the user asked for, m_screenshotStranded
-    // records that a main-frame commit happened while the capture was in
-    // flight, and m_screenshotResent bounds the recovery to one repeat.
-    uint32_t m_screenshotCdpId = 0;
+    // Chrome: kept so a capture that a navigation stranded can be sent again
+    // with the options the call asked for (Transport::repeatStrandedCapture).
     uint8_t m_screenshotQuality = 80;
-    bool m_screenshotStranded = false;
-    bool m_screenshotResent = false;
 
     JSC::WriteBarrier<JSC::JSObject> m_onNavigated;
     JSC::WriteBarrier<JSC::JSObject> m_onNavigationFailed;

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -36,6 +36,11 @@ const cdpErrorOn = process.argv.find(a => a.startsWith("--cdp-error-on="))?.slic
 
 const NO_REPLY = Symbol("no reply");
 let commandsClosed = false;
+// The next `dropScreenshots` captures get no reply, the way Chrome drops a
+// Page.captureScreenshot whose document is replaced before it completes.
+// `screenshots` keeps the options of every capture the fake received.
+let dropScreenshots = 0;
+const screenshots: { format: string; quality: number }[] = [];
 Object.assign(globalThis, {
   __fake_exit(code: number): never {
     process.exit(code);
@@ -55,6 +60,14 @@ Object.assign(globalThis, {
     commandsClosed = true;
     closeSync(COMMANDS);
     setInterval(() => {}, 2 ** 30);
+  },
+  // The next `count` Page.captureScreenshot commands get no reply.
+  __fake_drop_screenshots(count: number) {
+    dropScreenshots = count;
+  },
+  // The options of every capture the fake received, in order.
+  __fake_screenshots() {
+    return screenshots;
   },
 });
 
@@ -91,6 +104,11 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       return;
     }
     case "Page.captureScreenshot":
+      screenshots.push({ format: params.format, quality: params.quality });
+      if (dropScreenshots > 0) {
+        dropScreenshots--;
+        return;
+      }
       return reply({ data: screenshotBase64 });
     case "Runtime.evaluate": {
       if (params.expression === "document.title") {

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -38,9 +38,15 @@ const NO_REPLY = Symbol("no reply");
 let commandsClosed = false;
 // The next `dropScreenshots` captures get no reply, the way Chrome drops a
 // Page.captureScreenshot whose document is replaced before it completes.
-// `screenshots` keeps the options of every capture the fake received.
+// While `holdScreenshots` is set, capture replies wait in `heldScreenshots`
+// instead, the way a real capture takes a while. `screenshots` keeps the
+// options of every capture the fake received.
 let dropScreenshots = 0;
+let holdScreenshots = false;
+const heldScreenshots: (() => void)[] = [];
 const screenshots: { format: string; quality: number }[] = [];
+// Emits an event on the session of the command being handled.
+let emit: (name: string, params: unknown) => void = () => {};
 Object.assign(globalThis, {
   __fake_exit(code: number): never {
     process.exit(code);
@@ -65,9 +71,18 @@ Object.assign(globalThis, {
   __fake_drop_screenshots(count: number) {
     dropScreenshots = count;
   },
+  // true: capture replies wait. false: the waiting ones go out, in order.
+  __fake_hold_screenshots(hold: boolean) {
+    holdScreenshots = hold;
+    if (!hold) for (const release of heldScreenshots.splice(0)) release();
+  },
   // The options of every capture the fake received, in order.
   __fake_screenshots() {
     return screenshots;
+  },
+  // Sends a CDP event on this view's session before the evaluate() reply.
+  __fake_emit(name: string, params: unknown) {
+    emit(name, params);
   },
 });
 
@@ -109,6 +124,10 @@ async function handle(command: { id: number; method: string; params?: any; sessi
         dropScreenshots--;
         return;
       }
+      if (holdScreenshots) {
+        heldScreenshots.push(() => reply({ data: screenshotBase64 }));
+        return;
+      }
       return reply({ data: screenshotBase64 });
     case "Runtime.evaluate": {
       if (params.expression === "document.title") {
@@ -117,6 +136,7 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       }
       let value: unknown;
       try {
+        emit = event;
         value = await (0, eval)(params.expression);
       } catch (e) {
         return reply({

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -151,8 +151,9 @@ test.concurrent("a screenshot the browser drops at a navigation is captured agai
   });
 });
 
-// One repeat per screenshot() call. A second navigation over the repeat
-// rejects it, so the promise settles and the slot frees either way.
+// One repeat per screenshot() call. A second commit over the repeat rejects it
+// at that commit, whether or not the new document ever fires a load event, so
+// the promise settles and the slot frees either way.
 test.concurrent("a screenshot two navigations drop rejects instead of hanging", async () => {
   const result = await runScenario(`
     const view = newView();
@@ -160,7 +161,11 @@ test.concurrent("a screenshot two navigations drop rejects instead of hanging", 
     await view.evaluate("__fake_drop_screenshots(2)");
     const shot = outcome(view.screenshot().then(blob => blob.size));
     await view.navigate("http://fake/2");
-    await view.navigate("http://fake/3");
+    const afterOneNavigation = Bun.peek.status(shot);
+    await view.evaluate(\`__fake_emit("Page.frameNavigated", {
+      frame: { id: "F", loaderId: "L9", url: "http://fake/3-never-loads", mimeType: "text/html" },
+      type: "Navigation",
+    })\`);
     const settled = await within(shot, 2000);
     let again;
     try {
@@ -168,10 +173,11 @@ test.concurrent("a screenshot two navigations drop rejects instead of hanging", 
     } catch (e) {
       again = { threw: e.message };
     }
-    print({ settled, again });
+    print({ afterOneNavigation, settled, again });
     view.close();
   `);
   expect(result).toEqual({
+    afterOneNavigation: "pending",
     settled: { rejected: "screenshot: the page navigated before the capture completed" },
     again: { resolved: SCREENSHOT_BYTES.length },
   });

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -177,6 +177,53 @@ test.concurrent("a screenshot two navigations drop rejects instead of hanging", 
   });
 });
 
+// A page restored from the back/forward cache commits with
+// type:"BackForwardCacheRestore" and fires no load event, so the repeat goes
+// out at the commit itself.
+test.concurrent("a screenshot dropped at a back/forward cache restore is captured again", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/1");
+    await view.evaluate("__fake_drop_screenshots(1)");
+    const shot = outcome(view.screenshot().then(blob => blob.size));
+    await view.evaluate(\`__fake_emit("Page.frameNavigated", {
+      frame: { id: "F", loaderId: "LR", url: "http://fake/restored", mimeType: "text/html" },
+      type: "BackForwardCacheRestore",
+    })\`);
+    const settled = await within(shot, 2000);
+    print({ settled, url: view.url, sent: (await view.evaluate("__fake_screenshots()")).length });
+    view.close();
+  `);
+  expect(result).toEqual({ settled: { resolved: SCREENSHOT_BYTES.length }, url: "http://fake/restored", sent: 2 });
+});
+
+// A subframe commit keeps the main document and Chrome completes the capture,
+// so it must not be dropped or sent twice: an <iframe> that commits while the
+// page is still loading, then the page's own load event.
+test.concurrent("a subframe commit leaves a pending screenshot alone", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/1");
+    await view.evaluate("__fake_hold_screenshots(true)");
+    const shot = outcome(view.screenshot().then(blob => blob.size));
+    await view.evaluate(\`__fake_emit("Page.frameNavigated", {
+      frame: { id: "C", parentId: "F", loaderId: "LC", url: "http://fake/child", mimeType: "text/html" },
+      type: "Navigation",
+    })\`);
+    await view.evaluate(\`__fake_emit("Page.loadEventFired", { timestamp: 9 })\`);
+    const beforeRelease = Bun.peek.status(shot);
+    await view.evaluate("__fake_hold_screenshots(false)");
+    const settled = await within(shot, 2000);
+    print({ beforeRelease, settled, sent: (await view.evaluate("__fake_screenshots()")).length });
+    view.close();
+  `);
+  expect(result).toEqual({
+    beforeRelease: "pending",
+    settled: { resolved: SCREENSHOT_BYTES.length },
+    sent: 1,
+  });
+});
+
 test.concurrent("many views interleave their commands on the one transport", async () => {
   const result = await runScenario(`
     const views = Array.from({ length: 8 }, newView);

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -199,11 +199,14 @@ test.concurrent("a screenshot dropped at a back/forward cache restore is capture
 
 // A subframe commit keeps the main document and Chrome completes the capture,
 // so it must not be dropped or sent twice: an <iframe> that commits while the
-// page is still loading, then the page's own load event.
-test.concurrent("a subframe commit leaves a pending screenshot alone", async () => {
+// page is still loading, then the page's own load event. The commit is the
+// iframe's, so view.url and onNavigated stay with the page.
+test.concurrent("a subframe commit leaves a pending screenshot, url and onNavigated alone", async () => {
   const result = await runScenario(`
     const view = newView();
     await view.navigate("http://fake/1");
+    const navigated = [];
+    view.onNavigated = url => navigated.push(url);
     await view.evaluate("__fake_hold_screenshots(true)");
     const shot = outcome(view.screenshot().then(blob => blob.size));
     await view.evaluate(\`__fake_emit("Page.frameNavigated", {
@@ -214,13 +217,21 @@ test.concurrent("a subframe commit leaves a pending screenshot alone", async () 
     const beforeRelease = Bun.peek.status(shot);
     await view.evaluate("__fake_hold_screenshots(false)");
     const settled = await within(shot, 2000);
-    print({ beforeRelease, settled, sent: (await view.evaluate("__fake_screenshots()")).length });
+    print({
+      beforeRelease,
+      settled,
+      sent: (await view.evaluate("__fake_screenshots()")).length,
+      url: view.url,
+      navigated,
+    });
     view.close();
   `);
   expect(result).toEqual({
     beforeRelease: "pending",
     settled: { resolved: SCREENSHOT_BYTES.length },
     sent: 1,
+    url: "http://fake/1",
+    navigated: [],
   });
 });
 

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -34,6 +34,13 @@ const prelude = /* js */ `
   };
   const newView = () => new Bun.WebView({ backend, width: 100, height: 100 });
   const outcome = promise => promise.then(resolved => ({ resolved }), e => ({ rejected: e.message }));
+  // Resolves with { hang: ms } if the promise has not settled by then. Pass
+  // an outcome(), so a rejection is handled the moment it happens.
+  const within = (promise, ms) => {
+    let timer;
+    const hang = new Promise(resolve => { timer = setTimeout(() => resolve({ hang: ms }), ms); });
+    return Promise.race([promise, hang]).finally(() => clearTimeout(timer));
+  };
   const print = value => console.log(JSON.stringify(value));
   const big = ${BIG};
 `;
@@ -109,6 +116,64 @@ test.concurrent("screenshot bytes survive the trip back", async () => {
     type: "image/png",
     size: SCREENSHOT_BYTES.length,
     hash: String(Bun.hash(SCREENSHOT_BYTES)),
+  });
+});
+
+// Chrome answers a Page.captureScreenshot whose document is replaced while
+// the capture runs about half the time, and drops the rest: that id is never
+// answered, not after later navigations either. The backend repeats the
+// capture once the new document loads, with the options the call asked for.
+test.concurrent("a screenshot the browser drops at a navigation is captured again", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/1");
+    await view.evaluate("__fake_drop_screenshots(1)");
+    const shot = outcome(view.screenshot({ format: "jpeg", quality: 37 }).then(blob => blob.type));
+    await view.navigate("http://fake/2");
+    const captured = await within(shot, 2000);
+    let again;
+    try {
+      again = await outcome(view.screenshot().then(blob => blob.size));
+    } catch (e) {
+      again = { threw: e.message };
+    }
+    print({ captured, again, sent: await view.evaluate("__fake_screenshots()") });
+    view.close();
+  `);
+  expect(result).toEqual({
+    captured: { resolved: "image/jpeg" },
+    again: { resolved: SCREENSHOT_BYTES.length },
+    sent: [
+      { format: "jpeg", quality: 37 },
+      { format: "jpeg", quality: 37 },
+      { format: "png", quality: 80 },
+    ],
+  });
+});
+
+// One repeat per screenshot() call. A second navigation over the repeat
+// rejects it, so the promise settles and the slot frees either way.
+test.concurrent("a screenshot two navigations drop rejects instead of hanging", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/1");
+    await view.evaluate("__fake_drop_screenshots(2)");
+    const shot = outcome(view.screenshot().then(blob => blob.size));
+    await view.navigate("http://fake/2");
+    await view.navigate("http://fake/3");
+    const settled = await within(shot, 2000);
+    let again;
+    try {
+      again = await outcome(view.screenshot().then(blob => blob.size));
+    } catch (e) {
+      again = { threw: e.message };
+    }
+    print({ settled, again });
+    view.close();
+  `);
+  expect(result).toEqual({
+    settled: { rejected: "screenshot: the page navigated before the capture completed" },
+    again: { resolved: SCREENSHOT_BYTES.length },
   });
 });
 


### PR DESCRIPTION
### Problem

- On the Chrome backend, `view.screenshot()` never settles when the page commits a new document while the capture runs. The slot stays taken, so every later `screenshot()` on that view throws `Invalid state: a screenshot() is already pending`.
- Chrome drops a `Page.captureScreenshot` whose document is replaced. A raw CDP client shows it without bun: the id is answered about half the time and otherwise never. `reload()` and back/forward cache restores lose it every time.
- `Transport::handleEvent` (`src/runtime/webview/ChromeBackend.cpp:1159`) settled the Screenshot slot only on that reply.

### Fix

- A main-frame `Page.frameNavigated` marks the view's in-flight entries in `Transport::m_pending` (`acrossCommit`). A subframe commit returns early: it keeps the document, and it no longer overwrites `view.url` or fires `onNavigated` either.
- Once the new document is in place (`Page.loadEventFired`, or the commit itself for a back/forward cache restore, which fires no load event), `repeatStrandedCapture` drops the stranded id and sends the capture again with the caller's format and quality. The promise resolves with an image of the new page.
- One repeat per `screenshot()` call. A commit over the repeat rejects at that commit with `screenshot: the page navigated before the capture completed`. The slot frees either way.
- Verified: `test/js/bun/webview/webview-chrome-pipe.test.ts`, four new blocks, all fail on stock bun. Also all of `test/js/bun/webview/` and a nine-shape matrix against Chrome 153. Self-reviewed: 4 concerns, 3 addressed, 1 declined (Notes).

### Background

- The Chrome backend drives each view as one CDP target over `--remote-debugging-pipe`. A view holds one promise slot per operation kind, so one capture is in flight per view.
- A cross-document navigation replaces the document and the renderer that owed the capture. CDP reports the commit as a main-frame `Page.frameNavigated` (`type` `Navigation` or `BackForwardCacheRestore`), then `Page.loadEventFired` for a fresh load. A restored page sends no load event.
- `Transport::m_pending` maps a CDP id to a `Pending` entry: the view and the slot its reply settles. An unanswered id keeps its entry, so the repeat removes the stranded one.

<details><summary>Notes</summary>

Reproduction, from the report, on bun 1.4.2 and on main (4ff91937), Chrome 153:

```
navigate: settled
screenshot: HANG (still pending after 5000 ms)
second screenshot: Invalid state: a screenshot() is already pending
evaluate still works: 2
after close(): rejected: WebView closed
```

Nine shapes against real Chrome, 5 rounds each, stock bun 1.4.3 then this build:

| shape | stock | with this change |
| --- | --- | --- |
| `screenshot()` then `navigate()` | 2/5 image, 3/5 `ERR_INVALID_STATE` on the next call | 5/5 image |
| `navigate()` then `screenshot()` | 3/5 image, 2/5 hang | 5/5 image |
| `screenshot()` then `reload()` | 0/5, all hang | 5/5 image |
| `{format:"jpeg",quality:20}` | 3/5 image, 2/5 hang | 5/5 `image/jpeg` |
| `{encoding:"base64"}` | 1/5, 4/5 hang | 5/5 base64 |
| two navigations in a row | 2/5 image, 3/5 `ERR_INVALID_STATE` | 5/5 reject, slot free |
| no navigation | 5/5 image | 5/5 image |
| navigation slower than the capture | 5/5 image | 5/5 image |
| subframe commit only | 5/5 image | 5/5 image |

What Chrome does, from a raw CDP client (no bun):

- The capture is answered 20 to 60 ms after the commit, or never. `--disable-features=BackForwardCache` loses it 8/8, and the default alternates, which points at whether the old renderer is kept or torn down.
- A lost id stays lost. A 15 s wait, a further `Page.navigate` and a `Page.reload` all produce nothing for it.
- A capture sent after the commit is answered: 8/8 right at a `Navigation` commit, 8/8 right at a `BackForwardCacheRestore` commit, 10/10 at the load event. So repeating it is enough.
- A history traversal that restores from the back/forward cache sends `Page.frameNavigated` with `type: "BackForwardCacheRestore"` and no `Page.loadEventFired`, and loses the in-flight capture 6/8.
- A navigation to an unreachable URL commits `chrome-error://chromewebdata/` with a load event and loses the capture 4/4, so the repeat captures the error page. That is what the view shows.
- `fromSurface:false` and `captureBeyondViewport:true` lose it the same way, so the option set is not the cause.
- Of the other commands bun sends, only `Input.dispatchMouseEvent` `mouseWheel` (`view.scroll()`) is dropped the same way (3/6). Clicks, keys, `insertText`, `setDeviceMetricsOverride` and `Runtime.evaluate` are all answered. The `scroll()` case is filed separately; the `Pending` mark added here is the hook for it.

Implementation notes:

- The mark lives on `Transport::Pending`, not on the view: it is a fact about the in-flight command, and the same sweep can cover other droppable commands later.
- The repeat runs after the existing `document.title` fetch, so the navigate promise keeps its settle order.
- Dropping the stranded id matters for `encoding:"shmem"`: a late reply into an empty slot would create a shared-memory segment that nobody can unlink. It also keeps a late reply from settling a newer `screenshot()` call's slot.
- A page that commits with `type: "Navigation"` and then never fires a load event still leaves the capture pending. That is the same state its `navigate()` is in, and it needs the timeout work, not this change.
- `captureScreenshotCommand()` is the old inline command builder from `Ops::screenshot`, lifted so the repeat sends the same frame.

Self-review:

- Addressed: the mark moved from `JSWebView` fields to `Transport::Pending`; back/forward cache restores (no load event) are handled at the commit; the fake browser can now emit a commit without a load event (`__fake_emit`) and hold a capture reply (`__fake_hold_screenshots`), and two tests use that.
- Declined: stacking this on #42162, which reworks the same two event arms for same-document navigations. That PR is open and unreviewed, and this fix does not depend on it. Whichever lands second has a mechanical rebase: move `mainFrameCommitted` / `repeatStrandedCapture` into its `onFrameNavigated` / `onLoadEventFired`. The four fake-browser tests here pin the behaviour across that move.

Out of scope, found while testing this: with two or more views, Chrome answers a capture only for the first window, with no navigation anywhere. It reproduces with a raw CDP client, and neither `Target.activateTarget` nor `fromSurface:false` helps, so the repeat this change sends is dropped there too. That is the cause of the "20 views each start evaluate + screenshot + navigate" symptom in the report, and it is filed separately.

Suites run: `webview-chrome-pipe.test.ts` (19 pass, 2 skip), `webview-chrome-disconnect.test.ts` (7 pass), `webview-chrome-ws.test.ts` (5 todo, no Chrome endpoint here), `webview-chrome.test.ts` (58 pass, with a `--no-sandbox` wrapper because this container runs as root), `webview.test.ts` (2 pass, 60 skip off Darwin).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome-pipe.test.ts

<!-- robobun:evidence:end -->