### PR TITLE
node:crypto: make Hash update()/copy() after end() throw instead of reusing the finalized context

### DIFF
--- a/src/jsc/bindings/node/crypto/JSHash.cpp
+++ b/src/jsc/bindings/node/crypto/JSHash.cpp
@@ -132,6 +132,13 @@ bool JSHash::initZig(JSGlobalObject* globalObject, ThrowScope& scope, ExternZigH
 
 bool JSHash::update(std::span<const uint8_t> input)
 {
+    // Zero-length input succeeds even after digest() released the state, as
+    // in Node, where OpenSSL returns before its finalized check:
+    // https://github.com/openssl/openssl/blob/openssl-3.5.0/crypto/evp/digest.c#L387-L393
+    if (input.empty()) {
+        return true;
+    }
+
     if (m_ctx) {
         ncrypto::Buffer<const void> buffer {
             .data = input.data(),
@@ -229,8 +236,17 @@ JSC_DEFINE_HOST_FUNCTION(jsHashProtoFuncDigest, (JSC::JSGlobalObject * lexicalGl
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "Hash"_s);
     }
 
-    // Check if already finalized
-    if (hash->m_finalized) {
+    // Hash.prototype._flush passes `false`. Like Node's _flush it skips the
+    // finalized check and does not finalize, so end() works after digest()
+    // and one digest() works after end() (https://github.com/nodejs/node/issues/28245):
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/crypto/hash.js#L129-L160
+    bool finalize = true;
+    JSValue finalizeValue = callFrame->argument(1);
+    if (finalizeValue.isBoolean()) {
+        finalize = finalizeValue.asBoolean();
+    }
+
+    if (finalize && hash->m_finalized) {
         return Bun::ERR::CRYPTO_HASH_FINALIZED(scope, globalObject);
     }
 
@@ -246,19 +262,11 @@ JSC_DEFINE_HOST_FUNCTION(jsHashProtoFuncDigest, (JSC::JSGlobalObject * lexicalGl
         encoding = parseEnumerationFromString<BufferEncodingType>(encodingString).value_or(BufferEncodingType::buffer);
     }
 
-    bool finalized = true;
-    JSValue setFinalizedValue = callFrame->argument(1);
-    if (setFinalizedValue.isBoolean()) {
-        finalized = setFinalizedValue.asBoolean();
-    }
-
     uint32_t len = hash->m_mdLen;
 
     // Finalizing leaves the native state unusable (EVP_DigestFinal_ex cleanses
     // the EVP_MD_CTX; EVP_DigestUpdate on a cleansed SHA-3 context never
-    // returns), so release it and serve later calls from m_digest. _flush
-    // passes finalized=false so that one explicit digest() after the stream
-    // ends still works, as in Node: https://github.com/nodejs/node/issues/28245
+    // returns), so release it now and serve every later call from m_digest.
     if (!hash->m_digest && len > 0) {
         if (hash->m_zigHasher) {
             size_t maxDigestLen = std::max((uint32_t)EVP_MAX_MD_SIZE, len);
@@ -288,9 +296,12 @@ JSC_DEFINE_HOST_FUNCTION(jsHashProtoFuncDigest, (JSC::JSGlobalObject * lexicalGl
             hash->m_digest = ByteSource::allocated(data.release());
             hash->m_ctx.reset();
         }
+        hash->m_sizeForGC = hash->m_digest.size();
     }
 
-    hash->m_finalized = finalized;
+    if (finalize) {
+        hash->m_finalized = true;
+    }
 
     RELEASE_AND_RETURN(scope, StringBytes::encode(lexicalGlobalObject, scope, std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(hash->m_digest.data()), len }, encoding));
 }

--- a/src/jsc/bindings/node/crypto/JSHash.cpp
+++ b/src/jsc/bindings/node/crypto/JSHash.cpp
@@ -254,48 +254,44 @@ JSC_DEFINE_HOST_FUNCTION(jsHashProtoFuncDigest, (JSC::JSGlobalObject * lexicalGl
 
     uint32_t len = hash->m_mdLen;
 
-    if (hash->m_zigHasher) {
-        if (hash->m_digest || len == 0) {
-            RELEASE_AND_RETURN(scope, StringBytes::encode(lexicalGlobalObject, scope, std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(hash->m_digest.data()), hash->m_mdLen }, encoding));
-        }
-
-        size_t maxDigestLen = std::max((uint32_t)EVP_MAX_MD_SIZE, len);
-        auto data = ncrypto::DataPointer::Alloc(maxDigestLen);
-        if (!data) {
-            throwOutOfMemoryError(lexicalGlobalObject, scope);
-            return {};
-        }
-
-        auto totalDigestLen = ExternZigHash::digest(hash->m_zigHasher, globalObject, std::span { data.get<uint8_t>(), data.size() });
-        if (!totalDigestLen) {
-            throwCryptoError(lexicalGlobalObject, scope, ERR_get_error(), "Failed to finalize digest"_s);
-            return {};
-        }
-
-        hash->m_finalized = finalized;
-        hash->m_mdLen = std::min(len, totalDigestLen);
-        hash->m_digest = ByteSource::allocated(data.release());
-
-        RELEASE_AND_RETURN(scope, StringBytes::encode(lexicalGlobalObject, scope, std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(hash->m_digest.data()), hash->m_mdLen }, encoding));
-    }
-
-    // Only compute the digest if it hasn't been cached yet
+    // Finalizing leaves the native state unusable (EVP_DigestFinal_ex cleanses
+    // the EVP_MD_CTX; EVP_DigestUpdate on a cleansed SHA-3 context never
+    // returns), so release it and serve later calls from m_digest. _flush
+    // passes finalized=false so that one explicit digest() after the stream
+    // ends still works, as in Node: https://github.com/nodejs/node/issues/28245
     if (!hash->m_digest && len > 0) {
-        auto data = hash->m_ctx.digestFinal(len);
-        if (!data) {
-            throwCryptoError(lexicalGlobalObject, scope, ERR_get_error(), "Failed to finalize digest"_s);
-            return {};
-        }
+        if (hash->m_zigHasher) {
+            size_t maxDigestLen = std::max((uint32_t)EVP_MAX_MD_SIZE, len);
+            auto data = ncrypto::DataPointer::Alloc(maxDigestLen);
+            if (!data) {
+                throwOutOfMemoryError(lexicalGlobalObject, scope);
+                return {};
+            }
 
-        // Some hash algorithms don't support calling EVP_DigestFinal_ex more than once
-        // We need to cache the result for future calls
-        hash->m_digest = ByteSource::allocated(data.release());
+            auto totalDigestLen = ExternZigHash::digest(hash->m_zigHasher, globalObject, std::span { data.get<uint8_t>(), data.size() });
+            if (!totalDigestLen) {
+                throwCryptoError(lexicalGlobalObject, scope, ERR_get_error(), "Failed to finalize digest"_s);
+                return {};
+            }
+
+            len = hash->m_mdLen = std::min(len, totalDigestLen);
+            hash->m_digest = ByteSource::allocated(data.release());
+            ExternZigHash::destroy(hash->m_zigHasher);
+            hash->m_zigHasher = nullptr;
+        } else {
+            auto data = hash->m_ctx.digestFinal(len);
+            if (!data) {
+                throwCryptoError(lexicalGlobalObject, scope, ERR_get_error(), "Failed to finalize digest"_s);
+                return {};
+            }
+
+            hash->m_digest = ByteSource::allocated(data.release());
+            hash->m_ctx.reset();
+        }
     }
 
-    // Mark as finalized
     hash->m_finalized = finalized;
 
-    // Return the digest with the requested encoding
     RELEASE_AND_RETURN(scope, StringBytes::encode(lexicalGlobalObject, scope, std::span<const uint8_t> { reinterpret_cast<const uint8_t*>(hash->m_digest.data()), len }, encoding));
 }
 
@@ -330,7 +326,10 @@ JSC_DEFINE_HOST_FUNCTION(constructHash, (JSC::JSGlobalObject * globalObject, JSC
     const EVP_MD* md = nullptr;
     std::unique_ptr<ExternZigHash::Hasher, decltype(&ExternZigHash::destroy)> zigHasher(nullptr, ExternZigHash::destroy);
     if ((original = dynamicDowncast<JSHash>(algorithmOrHashInstanceValue))) {
-        if (original->m_finalized) {
+        // m_digest without m_finalized means the stream's _flush took the
+        // digest. Node hands back a copy there whose update() and digest()
+        // both throw; there is no live state to copy, so throw here instead.
+        if (original->m_finalized || original->m_digest) {
             return Bun::ERR::CRYPTO_HASH_FINALIZED(scope, globalObject);
         }
 

--- a/src/jsc/bindings/node/crypto/JSHash.cpp
+++ b/src/jsc/bindings/node/crypto/JSHash.cpp
@@ -132,8 +132,7 @@ bool JSHash::initZig(JSGlobalObject* globalObject, ThrowScope& scope, ExternZigH
 
 bool JSHash::update(std::span<const uint8_t> input)
 {
-    // Succeeds even once digest() freed the state, as in OpenSSL (and so Node):
-    // https://github.com/openssl/openssl/blob/openssl-3.5.0/crypto/evp/digest.c#L387-L393
+    // Empty input succeeds even once digest() freed the state, as in OpenSSL and so Node: https://github.com/openssl/openssl/blob/openssl-3.5.0/crypto/evp/digest.c#L387-L393
     if (input.empty()) {
         return true;
     }
@@ -235,8 +234,7 @@ JSC_DEFINE_HOST_FUNCTION(jsHashProtoFuncDigest, (JSC::JSGlobalObject * lexicalGl
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "Hash"_s);
     }
 
-    // Hash.prototype._flush passes `false`: no finalized check and no finalizing, as in Node.
-    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/crypto/hash.js#L129-L160
+    // Hash.prototype._flush passes `false`: no finalized check and no finalizing, like Node's _flush: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/crypto/hash.js#L129-L160
     bool finalize = true;
     JSValue finalizeValue = callFrame->argument(1);
     if (finalizeValue.isBoolean()) {
@@ -261,8 +259,7 @@ JSC_DEFINE_HOST_FUNCTION(jsHashProtoFuncDigest, (JSC::JSGlobalObject * lexicalGl
 
     uint32_t len = hash->m_mdLen;
 
-    // EVP_DigestFinal_ex cleanses the context (SHA-3 then spins in EVP_DigestUpdate),
-    // so free the native state here and serve later calls from m_digest.
+    // EVP_DigestFinal_ex cleanses the context (SHA-3 then spins in EVP_DigestUpdate), so free it here and serve later calls from m_digest.
     if (!hash->m_digest && len > 0) {
         if (hash->m_zigHasher) {
             size_t maxDigestLen = std::max((uint32_t)EVP_MAX_MD_SIZE, len);

--- a/src/jsc/bindings/node/crypto/JSHash.cpp
+++ b/src/jsc/bindings/node/crypto/JSHash.cpp
@@ -132,8 +132,7 @@ bool JSHash::initZig(JSGlobalObject* globalObject, ThrowScope& scope, ExternZigH
 
 bool JSHash::update(std::span<const uint8_t> input)
 {
-    // Zero-length input succeeds even after digest() released the state, as
-    // in Node, where OpenSSL returns before its finalized check:
+    // Succeeds even once digest() freed the state, as in OpenSSL (and so Node):
     // https://github.com/openssl/openssl/blob/openssl-3.5.0/crypto/evp/digest.c#L387-L393
     if (input.empty()) {
         return true;
@@ -236,9 +235,7 @@ JSC_DEFINE_HOST_FUNCTION(jsHashProtoFuncDigest, (JSC::JSGlobalObject * lexicalGl
         return Bun::ERR::INVALID_THIS(scope, lexicalGlobalObject, "Hash"_s);
     }
 
-    // Hash.prototype._flush passes `false`. Like Node's _flush it skips the
-    // finalized check and does not finalize, so end() works after digest()
-    // and one digest() works after end() (https://github.com/nodejs/node/issues/28245):
+    // Hash.prototype._flush passes `false`: no finalized check and no finalizing, as in Node.
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/crypto/hash.js#L129-L160
     bool finalize = true;
     JSValue finalizeValue = callFrame->argument(1);
@@ -264,9 +261,8 @@ JSC_DEFINE_HOST_FUNCTION(jsHashProtoFuncDigest, (JSC::JSGlobalObject * lexicalGl
 
     uint32_t len = hash->m_mdLen;
 
-    // Finalizing leaves the native state unusable (EVP_DigestFinal_ex cleanses
-    // the EVP_MD_CTX; EVP_DigestUpdate on a cleansed SHA-3 context never
-    // returns), so release it now and serve every later call from m_digest.
+    // EVP_DigestFinal_ex cleanses the context (SHA-3 then spins in EVP_DigestUpdate),
+    // so free the native state here and serve later calls from m_digest.
     if (!hash->m_digest && len > 0) {
         if (hash->m_zigHasher) {
             size_t maxDigestLen = std::max((uint32_t)EVP_MAX_MD_SIZE, len);
@@ -337,9 +333,7 @@ JSC_DEFINE_HOST_FUNCTION(constructHash, (JSC::JSGlobalObject * globalObject, JSC
     const EVP_MD* md = nullptr;
     std::unique_ptr<ExternZigHash::Hasher, decltype(&ExternZigHash::destroy)> zigHasher(nullptr, ExternZigHash::destroy);
     if ((original = dynamicDowncast<JSHash>(algorithmOrHashInstanceValue))) {
-        // m_digest without m_finalized means the stream's _flush took the
-        // digest. Node hands back a copy there whose update() and digest()
-        // both throw; there is no live state to copy, so throw here instead.
+        // m_digest alone: _flush took the digest. No live state to copy (Node returns an unusable copy).
         if (original->m_finalized || original->m_digest) {
             return Bun::ERR::CRYPTO_HASH_FINALIZED(scope, globalObject);
         }

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -518,6 +518,53 @@ describe("createHash", () => {
     expect(copy.digest("hex")).toBe(hash.digest("hex"));
   });
 
+  // end() takes the digest in _flush. After that update() and copy() must
+  // throw (SHA-3 used to spin forever in BoringSSL's keccak absorb loop, other
+  // digests kept hashing from a zeroed state) while one explicit digest()
+  // still returns the cached value, as in Node. Runs in a child because the
+  // unfixed behaviour is a hang. sha3-*/sha256 are BoringSSL EVP digests,
+  // blake2b512/shake128 take the ExternZigHash path.
+  it("update() and copy() after the stream has ended throw instead of reusing finalized state", async () => {
+    const algorithms = ["sha3-256", "sha3-512", "sha256", "blake2b512", "shake128"];
+    const script = `
+      const crypto = require("node:crypto");
+      const code = fn => { try { fn(); return "returned"; } catch (e) { return e.code; } };
+      const out = {};
+      for (const algo of ${JSON.stringify(algorithms)}) {
+        const expected = crypto.createHash(algo).update("abc").digest("hex");
+        const h = crypto.createHash(algo);
+        h.update("abc");
+        h.end();
+        out[algo] = {
+          streamed: h.read().toString("hex") === expected,
+          update: code(() => h.update("late")),
+          copy: code(() => h.copy()),
+          digest: h.digest("hex") === expected,
+          digestAgain: code(() => h.digest("hex")),
+        };
+      }
+      console.log(JSON.stringify(out));
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout && JSON.parse(stdout), stderr, exitCode }).toEqual({
+      stdout: Object.fromEntries(
+        algorithms.map(algo => [
+          algo,
+          {
+            streamed: true,
+            update: "ERR_CRYPTO_HASH_UPDATE_FAILED",
+            copy: "ERR_CRYPTO_HASH_FINALIZED",
+            digest: true,
+            digestAgain: "ERR_CRYPTO_HASH_FINALIZED",
+          },
+        ]),
+      ),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   it("treats a view over a detached ArrayBuffer as empty input", () => {
     const detachedView = () => {
       const ab = new ArrayBuffer(8);

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -520,9 +520,9 @@ describe("createHash", () => {
 
   // end() takes the digest in _flush. After that update() and copy() must
   // throw (SHA-3 used to spin forever in BoringSSL's keccak absorb loop, other
-  // digests kept hashing from a zeroed state) while one explicit digest()
-  // still returns the cached value, as in Node. Runs in a child because the
-  // unfixed behaviour is a hang. sha3-*/sha256 are BoringSSL EVP digests,
+  // digests kept hashing from a zeroed state) while a zero-length update()
+  // and one explicit digest() still work, as in Node. Runs in a child because
+  // the unfixed behaviour is a hang. sha3-*/sha256 are BoringSSL EVP digests,
   // blake2b512/shake128 take the ExternZigHash path.
   it("update() and copy() after the stream has ended throw instead of reusing finalized state", async () => {
     const algorithms = ["sha3-256", "sha3-512", "sha256", "blake2b512", "shake128"];
@@ -538,9 +538,11 @@ describe("createHash", () => {
         out[algo] = {
           streamed: h.read().toString("hex") === expected,
           update: code(() => h.update("late")),
+          updateEmpty: code(() => h.update("").update(Buffer.alloc(0))),
           copy: code(() => h.copy()),
           digest: h.digest("hex") === expected,
           digestAgain: code(() => h.digest("hex")),
+          updateEmptyAfterDigest: code(() => h.update("")),
         };
       }
       console.log(JSON.stringify(out));
@@ -554,15 +556,44 @@ describe("createHash", () => {
           {
             streamed: true,
             update: "ERR_CRYPTO_HASH_UPDATE_FAILED",
+            updateEmpty: "returned",
             copy: "ERR_CRYPTO_HASH_FINALIZED",
             digest: true,
             digestAgain: "ERR_CRYPTO_HASH_FINALIZED",
+            updateEmptyAfterDigest: "ERR_CRYPTO_HASH_FINALIZED",
           },
         ]),
       ),
       stderr: "",
       exitCode: 0,
     });
+  });
+
+  // The reverse order: the readable's 'end' handler calls digest() and pipe()
+  // then ends the hash. Node's _flush pushes the cached digest without the
+  // finalized check; this used to emit ERR_CRYPTO_HASH_FINALIZED instead.
+  it("end() after digest() pushes the cached digest and keeps the hash finalized", async () => {
+    for (const algo of ["sha3-256", "sha256", "blake2b512"]) {
+      const expected = crypto.createHash(algo).update("abc").digest();
+      const hash = crypto.createHash(algo);
+      hash.update("abc");
+      expect(hash.digest()).toEqual(expected);
+
+      const chunks = [];
+      const { promise, resolve, reject } = Promise.withResolvers();
+      hash.on("data", chunk => chunks.push(chunk));
+      hash.on("end", resolve);
+      hash.on("error", reject);
+      hash.end();
+      await promise;
+
+      expect(Buffer.concat(chunks)).toEqual(expected);
+      const finalized = expect.objectContaining({ code: "ERR_CRYPTO_HASH_FINALIZED" });
+      expect(() => hash.update("d")).toThrow(finalized);
+      expect(() => hash.update("")).toThrow(finalized);
+      expect(() => hash.copy()).toThrow(finalized);
+      expect(() => hash.digest()).toThrow(finalized);
+    }
   });
 
   it("treats a view over a detached ArrayBuffer as empty input", () => {


### PR DESCRIPTION
### Problem
- `createHash("sha3-*")`: `hash.update()` after `hash.end()` never returns. The thread spins in `bssl::BORINGSSL_keccak_absorb` ← `EVP_DigestUpdate` ← `Bun::jsHashProtoFuncUpdate`. A `copy()` made after `end()` hangs on use.
- Cause: `Hash.prototype._flush` calls `digest(null, false)`, so `jsHashProtoFuncDigest` (`src/jsc/bindings/node/crypto/JSHash.cpp:225`) runs `EVP_DigestFinal_ex` but leaves `m_finalized` clear. `update()` and `copy()` check only that and reuse the cleansed `EVP_MD_CTX`. Zeroed keccak state has `rate_bytes == 0`, so the absorb loop never advances.
- The reverse order, `digest()` then `end()`, emitted `ERR_CRYPTO_HASH_FINALIZED` from `_flush`. Node pushes the cached digest.

### Fix
- `digest()` frees the native state once the result is cached in `m_digest`. Later calls read it. The `_flush` call (`finalized == false`) skips the finalized check and never clears `m_finalized`, as in Node.
- `update()` with no native state throws `ERR_CRYPTO_HASH_UPDATE_FAILED` like Node (zero-length input still succeeds, as in OpenSSL). `copy()` also checks `m_digest` and throws `ERR_CRYPTO_HASH_FINALIZED`.
- Deliberate difference: Node's `copy()` after `end()` returns a `Hash` whose methods all throw. Bun throws at `copy()`.
- Verified: `test/js/node/crypto/node-crypto.test.js` (two new cases, both fail on 1.4.3), all of `test/js/node/crypto/`, the `test-crypto-hash*` Node tests. Self-reviewed: 3 concerns, 3 addressed.

### Background
- `crypto.Hash` is a JS `LazyTransform` over a native `JSHash` cell holding a BoringSSL `EVP_MD_CTX` (md5, sha1/2/3) or an `ExternZigHash` handle (blake2, shake).
- `m_finalized` is the JS-visible "Digest already called" bit. Node's `_flush` bypasses it: `end()` works after `digest()`, one `digest()` works after `end()` (nodejs/node#28245).
- BoringSSL's `EVP_DigestFinal_ex` zeroes the context. OpenSSL 3 flags it `FINALISED` and fails the next non-empty update, hence Node's error code.

<details><summary>Notes</summary>

Repro:

```js
import crypto from "node:crypto";
const h = crypto.createHash("sha3-256"); // also sha3-224 / sha3-384 / sha3-512
h.update("abc");
h.end();
h.update("late"); // never returned before this change
```

Deterministic on 1.4.2, 1.4.3 and main, release and ASAN builds. `h.copy().update()`, `h.copy().digest()` and even `h.update("")` after `end()` spin too (the loop is `while (in_len >= ctx->rate_bytes)` with both zero). On sha256, `h.copy().digest("hex")` after `end()` returned 64 zeros.

Behaviour after `h.update("abc"); h.end()` (Node v26.3.0 / Bun 1.4.3 / this PR):

| call | node | bun 1.4.3 | this PR |
| --- | --- | --- | --- |
| `h.update("late")` | `ERR_CRYPTO_HASH_UPDATE_FAILED` | sha3: hang, others: returns | `ERR_CRYPTO_HASH_UPDATE_FAILED` |
| `h.update("")` | returns `h` ([OpenSSL returns before the finalized check](https://github.com/openssl/openssl/blob/openssl-3.5.0/crypto/evp/digest.c#L387-L393)) | sha3: hang, others: returns | returns `h` |
| `h.copy()` | returns an unusable Hash (OpenSSL 3 copies the `FINALISED` flag, so its `update()`/`digest()` throw) | sha3: returns, then hangs on use. others: zeroed-state copy | `ERR_CRYPTO_HASH_FINALIZED` |
| `h.digest("hex")` | cached digest | cached digest | cached digest |
| `h.digest("hex")` again | `ERR_CRYPTO_HASH_FINALIZED` | EVP: same. blake2b512/shake128: returns again | `ERR_CRYPTO_HASH_FINALIZED` |

And after `h.update("abc"); h.digest()`:

| call | node | bun 1.4.3 | this PR |
| --- | --- | --- | --- |
| `h.end()` | stream emits the cached digest | `'error'` with `ERR_CRYPTO_HASH_FINALIZED` (uncaught without a listener) | stream emits the cached digest |
| `h.update()` / `h.copy()` / `h.digest()` afterwards | `ERR_CRYPTO_HASH_FINALIZED` | same | same |

The realistic shape of the second table is:

```js
const hash = crypto.createHash("sha256");
const rs = fs.createReadStream(file);
rs.on("end", () => console.log(hash.digest("hex")));
rs.pipe(hash); // pipe ends the hash after the 'end' handler above ran
```

This exited with an uncaught `ERR_CRYPTO_HASH_FINALIZED` on 1.4.3 and works in Node.

The "digest again" row changes for blake2b512/shake128 because the `ExternZigHash` branch returned the cached digest before reaching the `m_finalized` assignment. Both branches now share one tail.

`Hmac` is not touched: `JSHmac::digest` already resets its context and sets `m_finalized` even from `_flush`.

#35991 (stream `write()` after a direct `digest()`, the `_transform` path) and #40075 (Hash/Hmac as single native classes) touch the same file. #40075 will conflict in `jsHashProtoFuncDigest` and needs to keep the context release on rebase; its `_flush() after digest()` test expects the behaviour this PR implements.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.3 (5f554969b)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.21ms]
(pass) crypto.randomInt should return a number [2.20ms]
(pass) crypto.randomInt with no arguments [3.82ms]
(pass) crypto.randomInt with one argument [2.23ms]
(pass) crypto.randomInt with a callback [38.17ms]
(pass) createHash > rsa-md5 - "Hello World" [7.56ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.37ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.81ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.80ms]
(pass) createHash > rsa-sha1 - "Hello World" [8.11ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.13ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.58ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.67ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.30ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.80ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.56ms]
(pass) createH
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (acb6f23e4)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [0.09ms]
(pass) crypto.randomInt should return a number [0.03ms]
(pass) crypto.randomInt with no arguments [0.06ms]
(pass) crypto.randomInt with one argument [0.02ms]
(pass) crypto.randomInt with a callback [0.54ms]
(pass) createHash > rsa-md5 - "Hello World" [0.14ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [0.05ms]
(pass) createHash > rsa-ripemd160 - "Hello World"
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary
(pass) createHash > rsa-sha1 - "Hello World" [0.07ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [0.02ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.01ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary
(pass) createHash > rsa-sha224 - "Hello World" [0.02ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary
(pass) createHash > rsa-sha256 - "Hello World" [0.01ms]
(pass) createHash > rsa-sha256 - "Hello World" -> binary
(pass) createHash > rsa-sha3-224 - "Hello World"
(pass) createHash > rsa-sha3-224 - "Hello World" -> binary
(pass) createHash > rsa-sha3-256 - "Hello World"

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/crypto/node-crypto.test.js
bun test v1.4.3 (5f554969b)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.01ms]
(pass) crypto.randomInt should return a number [2.11ms]
(pass) crypto.randomInt with no arguments [3.63ms]
(pass) crypto.randomInt with one argument [2.19ms]
(pass) crypto.randomInt with a callback [37.74ms]
(pass) createHash > rsa-md5 - "Hello World" [7.37ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.36ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.78ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.83ms]
(pass) createHash > rsa-sha1 - "Hello World" [7.67ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.10ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.63ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.64ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.26ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.77ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.53ms]
(pass) createH
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 583ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-0.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 22s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.3-canary.1+dc573eede
[build] done
bun test v1.4.3-canary.1 (dc573eede)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [0.10ms]
(pass) crypto.randomInt should return a number [0.03ms]
(pass) crypto.randomInt with no arguments [0.05ms]
(pass) crypto.randomInt with one argument [0.02ms]
(pass) crypto.randomInt with a callback [0.56ms]
(pass) createHash > rsa-md5 - "Hello World" [0.14ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [0.06ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.01ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary
(pass) createHash > rsa-sha1 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/node/crypto/JSHash.cpp | 93 +++++++++++++++++----------------
 test/js/node/crypto/node-crypto.test.js | 78 +++++++++++++++++++++++++++
 2 files changed, 125 insertions(+), 46 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/jsc/bindings/node/crypto/JSHash.cpp      7     11     18
test/js/node/crypto/node-crypto.test.js      2      3     18
```

</details>

<!-- robobun:evidence:end -->
