### PR TITLE
react-compiler: fix regex literals that end in `\/` or exceed 65535 bytes

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2356,46 +2356,30 @@ impl Template {
 }
 
 pub struct RegExp {
+    /// The literal as written, `/pattern/flags`.
     // Arena-owned slice (`StoreStr`: lifetime-erased arena ownership, bulk-freed
     // at `Store::reset()` — see `nodes.rs` StoreStr docs).
     pub value: Str,
-
-    /// This exists for JavaScript bindings
-    /// The RegExp constructor expects flags as a second argument.
-    /// We want to avoid re-lexing the flags, so we store them here.
-    /// This is the index of the first character in a flag, not the "/"
-    /// /foo/gim
-    ///      ^
-    pub flags_offset: Option<u16>,
 }
 impl RegExp {
+    /// `/foo/gim` → `foo`
     pub fn pattern(&self) -> &[u8] {
-        // rewind until we reach the /foo/gim
-        //                               ^
-        // should only ever be a single character
-        // but we're being cautious
-        if let Some(i_) = self.flags_offset {
-            let mut i = i_;
-            while i > 0 && self.value[i as usize] != b'/' {
-                i -= 1;
-            }
-
-            return bun_core::trim(&self.value[..i as usize], b"/");
-        }
-
-        bun_core::trim(&self.value, b"/")
+        self.pattern_and_flags().0
     }
 
+    /// `/foo/gim` → `gim`
     pub fn flags(&self) -> &[u8] {
-        // rewind until we reach the /foo/gim
-        //                               ^
-        // should only ever be a single character
-        // but we're being cautious
-        if let Some(i) = self.flags_offset {
-            return &self.value[i as usize..];
-        }
+        self.pattern_and_flags().1
+    }
 
-        b""
+    /// Flags are identifier characters, so the last `/` closes the pattern
+    /// even when the pattern itself contains `\/` or `[/]`.
+    fn pattern_and_flags(&self) -> (&[u8], &[u8]) {
+        let value: &[u8] = &self.value;
+        match strings::last_index_of_char(value, b'/') {
+            Some(end) if end > 0 => (&value[1..end], &value[end + 1..]),
+            _ => (value.strip_prefix(b"/").unwrap_or(value), b""),
+        }
     }
 }
 

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2372,8 +2372,7 @@ impl RegExp {
         self.pattern_and_flags().1
     }
 
-    /// Flags are identifier characters, so the last `/` closes the pattern
-    /// even when the pattern itself contains `\/` or `[/]`.
+    /// Flags never contain `/`, so the last `/` is the closing one.
     fn pattern_and_flags(&self) -> (&[u8], &[u8]) {
         let value: &[u8] = &self.value;
         match strings::last_index_of_char(value, b'/') {

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2092,10 +2092,7 @@ impl Data {
                 Ok(Data::ETemplate(StoreRef::from_bump(item)))
             }
             Data::ERegExp(el) => {
-                let item = bump.alloc(E::RegExp {
-                    value: el.value,
-                    flags_offset: el.flags_offset,
-                });
+                let item = bump.alloc(E::RegExp { value: el.value });
                 Ok(Data::ERegExp(StoreRef::from_bump(item)))
             }
             Data::EAwait(el) => {

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -162,7 +162,6 @@ pub struct LexerSnapshot<'a> {
     pub(crate) prev_error_loc: Loc,
     pub(crate) prev_token_was_await_keyword: bool,
     pub(crate) fn_or_arrow_start_loc: Loc,
-    pub(crate) regex_flags_start: Option<u16>,
     pub(crate) string_literal_raw_content: &'a [u8],
     pub(crate) string_literal_start: usize,
     pub(crate) string_literal_raw_format: StringLiteralRawFormat,
@@ -232,7 +231,6 @@ pub struct Lexer<'a> {
     pub(crate) prev_error_loc: Loc,
     pub(crate) prev_token_was_await_keyword: bool,
     pub(crate) fn_or_arrow_start_loc: Loc,
-    pub(crate) regex_flags_start: Option<u16>,
     pub(crate) arena: &'a Arena,
     pub(crate) string_literal_raw_content: &'a [u8],
     pub(crate) string_literal_start: usize,
@@ -347,7 +345,6 @@ impl<'a> Lexer<'a> {
             prev_error_loc: self.prev_error_loc,
             prev_token_was_await_keyword: self.prev_token_was_await_keyword,
             fn_or_arrow_start_loc: self.fn_or_arrow_start_loc,
-            regex_flags_start: self.regex_flags_start,
             string_literal_raw_content: self.string_literal_raw_content,
             string_literal_start: self.string_literal_start,
             string_literal_raw_format: self.string_literal_raw_format,
@@ -385,7 +382,6 @@ impl<'a> Lexer<'a> {
         self.prev_error_loc = original.prev_error_loc;
         self.prev_token_was_await_keyword = original.prev_token_was_await_keyword;
         self.fn_or_arrow_start_loc = original.fn_or_arrow_start_loc;
-        self.regex_flags_start = original.regex_flags_start;
         self.string_literal_raw_content = original.string_literal_raw_content;
         self.string_literal_start = original.string_literal_start;
         self.string_literal_raw_format = original.string_literal_raw_format;
@@ -2263,7 +2259,6 @@ impl<'a> Lexer<'a> {
             prev_error_loc: Loc::EMPTY,
             prev_token_was_await_keyword: false,
             fn_or_arrow_start_loc: Loc::EMPTY,
-            regex_flags_start: None,
             arena,
             string_literal_raw_content: b"",
             string_literal_start: 0,
@@ -2334,13 +2329,11 @@ impl<'a> Lexer<'a> {
     }
 
     pub(crate) fn scan_reg_exp(&mut self) -> Result<(), Error> {
-        self.regex_flags_start = None;
         loop {
             match self.code_point {
                 0x2F => {
                     self.step();
 
-                    let mut has_set_flags_start = false;
                     const FLAG_CHARACTERS: &[u8] = b"dgimsuvy";
                     const MIN_FLAG: u8 = b'd'; // min of FLAG_CHARACTERS
                     const MAX_FLAG: u8 = b'y'; // max of FLAG_CHARACTERS
@@ -2351,10 +2344,6 @@ impl<'a> Lexer<'a> {
                     while is_identifier_continue(self.code_point) {
                         match self.code_point {
                             0x64 | 0x67 | 0x69 | 0x6D | 0x73 | 0x75 | 0x79 | 0x76 => {
-                                if !has_set_flags_start {
-                                    self.regex_flags_start = Some((self.end - self.start) as u16);
-                                    has_set_flags_start = true;
-                                }
                                 let flag = usize::from(
                                     MAX_FLAG - u8::try_from(self.code_point).expect("int cast"),
                                 );

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -325,23 +325,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn pfx_t_slash(p: &mut Self) -> PResult<Expr> {
         let loc = p.lexer.loc();
         p.lexer.scan_reg_exp()?;
-        // always set regex_flags_start to null to make sure we don't accidentally use the wrong value later
-        // Reset after both success and
-        // the `next()?` error path: capture, advance, then unconditionally reset before
-        // propagating any error from `next()`.
         let value = E::Str::new(p.lexer.raw());
-        let next_result = p.lexer.next();
-        let flags_offset = p.lexer.regex_flags_start;
-        p.lexer.regex_flags_start = None;
-        next_result?;
+        p.lexer.next()?;
 
-        Ok(p.new_expr(
-            E::RegExp {
-                value,
-                flags_offset,
-            },
-            loc,
-        ))
+        Ok(p.new_expr(E::RegExp { value }, loc))
     }
 
     fn pfx_t_void(p: &mut Self) -> PResult<Expr> {

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -2066,7 +2066,12 @@ fn codegen_base_instruction_value(
             raw.extend_from_slice(pattern.slice());
             raw.push(b'/');
             raw.extend_from_slice(flags.slice());
-            Ok(Expr::init(E::RegExp { value: store_str(&raw) }, loc))
+            Ok(Expr::init(
+                E::RegExp {
+                    value: store_str(&raw),
+                },
+                loc,
+            ))
         }
         InstructionValue::MetaProperty { meta, property, .. } => match (*meta, *property) {
             ("import", "meta") => Ok(Expr::init(E::ImportMeta {}, loc)),

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -2065,22 +2065,8 @@ fn codegen_base_instruction_value(
             raw.push(b'/');
             raw.extend_from_slice(pattern.slice());
             raw.push(b'/');
-            let flags_offset =
-                if flags.is_empty() {
-                    None
-                } else {
-                    Some(u16::try_from(raw.len()).map_err(|_| {
-                        invariant_err("RegExp pattern exceeds u16 flags_offset", None)
-                    })?)
-                };
             raw.extend_from_slice(flags.slice());
-            Ok(Expr::init(
-                E::RegExp {
-                    value: store_str(&raw),
-                    flags_offset,
-                },
-                loc,
-            ))
+            Ok(Expr::init(E::RegExp { value: store_str(&raw) }, loc))
         }
         InstructionValue::MetaProperty { meta, property, .. } => match (*meta, *property) {
             ("import", "meta") => Ok(Expr::init(E::ImportMeta {}, loc)),

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1189,6 +1189,60 @@ describe("bundler", () => {
       expect([...used].sort()).toEqual(["T0", "t0", "t1", "t2", "t3"]);
     },
   });
+
+  // The compiler lowers a regex literal to (pattern, flags) and codegen joins
+  // them back. `E::RegExp::pattern()`/`flags()` must split at the closing `/`
+  // exactly: a pattern that ends in `\/` keeps that slash, and a literal longer
+  // than 65535 bytes still finds its flags.
+  const longRegExpBody = Buffer.alloc(70_000, "a").toString();
+  itBundled("react-compiler/RegExpLiteralPatternAndFlagsRoundTrip", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        export function Comp({ x }) {
+          const long = /${longRegExpBody}/gi;
+          const trailing = /a\\//g;
+          const only = /\\//;
+          const inClass = /[/]\\//i;
+          return (
+            <div>
+              {[
+                long.source.length, long.flags, long.test(x),
+                trailing.source, trailing.flags, trailing.test("a/"),
+                only.source, only.flags, only.test("/"),
+                inClass.source, inClass.flags, inClass.test("//"),
+              ].join()}
+            </div>
+          );
+        }
+        const el = Comp({ x: Buffer.alloc(${longRegExpBody.length}, "A").toString() });
+        console.log(el.props.children);
+      `,
+      "/node_modules/react/index.js": `module.exports = {};`,
+      "/node_modules/react/jsx-runtime.js": `exports.jsx = exports.jsxs = (t, p) => ({ t, props: p });`,
+      "/node_modules/react/jsx-dev-runtime.js": `exports.jsxDEV = (t, p) => ({ t, props: p });`,
+      "/node_modules/react/compiler-runtime.js": `exports.c = n => new Array(n).fill(Symbol.for("react.memo_cache_sentinel"));`,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    run: { stdout: `${longRegExpBody.length},gi,true,a\\/,g,true,\\/,,true,[/]\\/,i,true` },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // The component must be compiled, not bailed out, for codegen to be on trial.
+      expect(out).toMatch(/\$\[\d+\]/);
+      // Every regex literal assigned in the output, with the long run of `a` abbreviated.
+      const literals = [...out.matchAll(/ = (\/[^\s*][^\s,;]*)/g)].map(m =>
+        m[1].replace(/a{100,}/, run => `a{${run.length}}`),
+      );
+      expect(literals).toEqual([
+        `/a{${longRegExpBody.length}}/gi`,
+        String.raw`/a\//g`,
+        String.raw`/\//`,
+        String.raw`/[/]\//i`,
+      ]);
+    },
+  });
 });
 
 // validate_locals_not_reassigned_after_render (src/react_compiler/validation)


### PR DESCRIPTION
### Problem
- `bun build --react-compiler` emits a broken regex literal in two cases. `/a\//g` becomes `/a\/g` (unterminated). A literal longer than 65535 bytes with flags becomes `//…/gi`, which the parser reads as a line comment, so the rest of the line is lost.
- The cause is `E::RegExp::pattern()` and `flags()` (`src/ast/e.rs:2372`). They split `value` at `flags_offset: Option<u16>`, which the lexer stored with `as u16` (`src/js_parser/lexer.rs:2355`). `pattern()` also used `trim(…, "/")`, which strips every trailing `/`, not one. The React compiler lowering (`src/react_compiler/lowering/build_hir/expr.rs:308`) is the only caller of both.

### Fix
- `pattern()` and `flags()` now split the literal at its last `/`. Flags are identifier characters, so the last `/` is always the closing one, even when the pattern contains `\/` or `[/]`.
- Remove `flags_offset` from `E::RegExp` and the lexer state (`regex_flags_start`) that fed it. Nothing else read them. The React compiler codegen loses its `u16` invariant error on the way back.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (new `RegExpLiteralPatternAndFlagsRoundTrip`, fails on 1.4.3 with `//a{65535}/gi`, `/a\/g`, `/\/`, `/[/]\/i`). Also ran `react-compiler-fixtures.test.ts`, `transpiler.test.js`, and `runtime-transpiler.test.ts`.
- Self-reviewed: 2 optional concerns raised, 1 addressed (the fallback arm for a literal with no closing `/` now strips the leading `/`). Kept the 70 KB literal: the test runs in 2.7 s under debug ASAN, most of it process startup.

### Background
- `E::RegExp` is the AST node for a regex literal. `value` holds the literal as written, `/pattern/flags`. The printer prints `value` verbatim, so a normal build never looked at `flags_offset`.
- The React compiler lowers a regex literal to a `(pattern, flags)` pair in its HIR. Codegen joins them back as `/` + pattern + `/` + flags. A wrong split shows up only on that path.
- The lexer accepts only `[dgimsuvy]` after the closing `/`. Any other identifier character there is a syntax error, so a parsed literal never has a `/` in its flags.

<details><summary>Notes</summary>

- Repro on bun 1.4.3: a component with `const re = /${"a".repeat(70000)}/gi;` built with `bun build --react-compiler` prints `re = //aaaa…`. With 65520 bytes it prints `re = /aaaa…` correctly. Without `--react-compiler` both are correct.
- The truncated offset made `pattern()` rewind to the opening `/` and return an empty pattern, while `flags()` returned the last 65536 bytes of the literal.
- `E::RegExp` shrinks from 16 to 12 bytes. It is arena-allocated behind a `StoreRef`, so `Expr`/`Data` sizes do not change.
- Other shapes checked through `--react-compiler` with the debug build: `/=/`, `/ü€😀/u`, `/a/dgimsy`, `/[\]\/]\//v`, `x.replace(/\//g, "-")`, named groups with `\/` and `\k<>`. Output matches a build without the compiler.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (5f554969b)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [574.64ms]
(pass) bundler > react-compiler/ComponentWithHooks [317.11ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [223.00ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [135.67ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [100.62ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [311.21ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [124.70ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [97.74ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [104.14ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [245.35ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [440.05ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [248.15ms]

... (truncated)

release without fix: 1 skipped
bun test v1.4.3-canary.1 (497f17f37)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [14.91ms]
(pass) bundler > react-compiler/ComponentWithHooks [7.20ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [5.89ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [5.56ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [3.35ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [7.61ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [3.58ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [3.46ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [3.15ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [6.01ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [8.73ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [5.02ms]
(pass) bundler > react-compiler/BranchBooleanFeatureFlagPreservesDCE [5.26ms]
(pass) bundler > react-compiler/ForwardRefSiblingFn [6.09ms]
(pass) bundler > react-compiler/SelfRefConstArrow [7.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (5f554969b)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [588.59ms]
(pass) bundler > react-compiler/ComponentWithHooks [231.99ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [228.50ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [127.48ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [103.73ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [340.04ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [140.40ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [118.69ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [124.06ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [301.42ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [451.43ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [267.71ms]
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 605ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/e.rs                                   | 43 +++++++-------------
 src/ast/expr.rs                                |  5 +--
 src/js_parser/lexer.rs                         | 11 ------
 src/js_parser/parse/parse_prefix.rs            | 17 +-------
 src/react_compiler/codegen.rs                  |  9 -----
 test/bundler/transpiler/react-compiler.test.ts | 54 ++++++++++++++++++++++++++
 6 files changed, 70 insertions(+), 69 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/ast/e.rs                                        3      5     11
src/ast/expr.rs                                     1      1     11
src/js_parser/lexer.rs                              3      2     11
src/js_parser/parse/parse_prefix.rs                 1      1     11
src/react_compiler/codegen.rs                       1      2     11
test/bundler/transpiler/react-compiler.test.ts      3      6     11
```

</details>

<!-- robobun:evidence:end -->