### PR TITLE
libuv(windows): keep a pipe's completed read counted until its read callback returns

### DIFF
--- a/patches/libuv/win-pipe-read-req-count-across-callback.patch
+++ b/patches/libuv/win-pipe-read-req-count-across-callback.patch
@@ -8,7 +8,7 @@
    eof_timer_stop(handle);
  
    if (handle->read_req.wait_handle != INVALID_HANDLE_VALUE) {
-@@ -2191,11 +2190,23 @@ void uv__process_pipe_read_req(uv_loop_t* loop,
+@@ -2191,11 +2190,26 @@ void uv__process_pipe_read_req(uv_loop_t* loop,
      handle->read_req.wait_handle = INVALID_HANDLE_VALUE;
    }
  
@@ -16,16 +16,19 @@
 -   * reading the pipe in the meantime, there is nothing left to do, since there
 -   * is no callback that we can call. */
 -  if (!(handle->flags & UV_HANDLE_READING))
-+  /* The completed zero-read stays counted in reqs_pending until this function
-+   * is done with the handle. Every other request processor in this file, and
-+   * the tcp and tty read paths, decrement last for the same reason; the read
-+   * one moved its decrement up here in libuv/libuv#1843. While the request is
-+   * counted, a uv_close() from alloc_cb or read_cb cannot reach
-+   * uv__want_endgame(), so the close callback - where the owner frees the
-+   * handle - cannot run before this function returns, even when the read
-+   * callback runs the loop again (Bun re-enters uv_run() from JS that runs
-+   * inside read_cb). With the decrement at the top such a nested uv_run() ran
-+   * the endgame and the handle was freed while it is still used below. */
++  /* Keep the completed zero-read counted in reqs_pending until this function
++   * is done with the handle, like every other user of
++   * DECREASE_PENDING_REQ_COUNT (the other pipe processors, tcp, udp, tty).
++   * libuv/libuv#1843 moved this one to the top as part of a rewrite. While the
++   * request is counted, a uv_close() from alloc_cb or read_cb cannot queue the
++   * endgame, so the close callback, where the owner frees the handle, cannot
++   * run while the handle is still used below.
++   *
++   * Stock libuv runs endgames only at the end of a loop iteration, so the
++   * order does not matter there. It matters in Bun today because JS that runs
++   * inside read_cb can still run the loop again (oven-sh/bun#33261). That
++   * re-entry is a bug, and oven-sh/bun#40023 removes it. Delete this patch
++   * when it lands. */
 +
 +  /* If the user has stopped reading the pipe in the meantime, there is nothing
 +   * left to do, since there is no callback that we can call. */
@@ -36,7 +39,7 @@
  
    if (!REQ_SUCCESS(req)) {
      /* An error occurred doing the zero-read. */
-@@ -2226,11 +2237,17 @@ void uv__process_pipe_read_req(uv_loop_t* loop,
+@@ -2226,11 +2240,17 @@ void uv__process_pipe_read_req(uv_loop_t* loop,
      }
    }
  

--- a/patches/libuv/win-pipe-read-req-count-across-callback.patch
+++ b/patches/libuv/win-pipe-read-req-count-across-callback.patch
@@ -1,0 +1,56 @@
+--- a/src/win/pipe.c
++++ b/src/win/pipe.c
+@@ -2183,7 +2183,6 @@ void uv__process_pipe_read_req(uv_loop_t* loop,
+   assert(handle->type == UV_NAMED_PIPE);
+ 
+   handle->flags &= ~(UV_HANDLE_READ_PENDING | UV_HANDLE_CANCELLATION_PENDING);
+-  DECREASE_PENDING_REQ_COUNT(handle);
+   eof_timer_stop(handle);
+ 
+   if (handle->read_req.wait_handle != INVALID_HANDLE_VALUE) {
+@@ -2191,11 +2190,23 @@ void uv__process_pipe_read_req(uv_loop_t* loop,
+     handle->read_req.wait_handle = INVALID_HANDLE_VALUE;
+   }
+ 
+-  /* At this point, we're done with bookkeeping. If the user has stopped
+-   * reading the pipe in the meantime, there is nothing left to do, since there
+-   * is no callback that we can call. */
+-  if (!(handle->flags & UV_HANDLE_READING))
++  /* The completed zero-read stays counted in reqs_pending until this function
++   * is done with the handle. Every other request processor in this file, and
++   * the tcp and tty read paths, decrement last for the same reason; the read
++   * one moved its decrement up here in libuv/libuv#1843. While the request is
++   * counted, a uv_close() from alloc_cb or read_cb cannot reach
++   * uv__want_endgame(), so the close callback - where the owner frees the
++   * handle - cannot run before this function returns, even when the read
++   * callback runs the loop again (Bun re-enters uv_run() from JS that runs
++   * inside read_cb). With the decrement at the top such a nested uv_run() ran
++   * the endgame and the handle was freed while it is still used below. */
++
++  /* If the user has stopped reading the pipe in the meantime, there is nothing
++   * left to do, since there is no callback that we can call. */
++  if (!(handle->flags & UV_HANDLE_READING)) {
++    DECREASE_PENDING_REQ_COUNT(handle);
+     return;
++  }
+ 
+   if (!REQ_SUCCESS(req)) {
+     /* An error occurred doing the zero-read. */
+@@ -2226,11 +2237,17 @@ void uv__process_pipe_read_req(uv_loop_t* loop,
+     }
+   }
+ 
++  /* The read callback may have closed the handle, but its close callback -
++   * where the owner frees the handle - must not have run yet. */
++  assert(!(handle->flags & UV_HANDLE_CLOSED));
++
+   /* Start another zero-read request if necessary. */
+   if ((handle->flags & UV_HANDLE_READING) &&
+       !(handle->flags & UV_HANDLE_READ_PENDING)) {
+     uv__pipe_queue_read(loop, handle);
+   }
++
++  DECREASE_PENDING_REQ_COUNT(handle);
+ }
+ 
+ 

--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -60,7 +60,19 @@ export const libuv: Dependency = {
   // an in-process loopback fetch().abort() can fall into. To upstream:
   // send to libuv/libuv with the wepoll/ReactOS references in the patch
   // comment as the rationale.
-  patches: ["patches/libuv/win-poll-rearm-before-callback.patch", "patches/libuv/win-poll-abort-with-disconnect.patch"],
+  //
+  // win-pipe-read-req-count-across-callback: uv__process_pipe_read_req keeps
+  // the completed read counted in reqs_pending until it is done with the
+  // handle, like the tcp and tty read paths. Bun re-enters uv_run() from JS
+  // that runs inside read_cb; with upstream's early decrement a uv_close()
+  // from that JS let the nested uv_run() run the close callback and free the
+  // uv_pipe_t under uv__process_pipe_read_req. For oven-sh/libuv's `bun`
+  // branch, not upstream (upstream forbids re-entering uv_run).
+  patches: [
+    "patches/libuv/win-poll-rearm-before-callback.patch",
+    "patches/libuv/win-poll-abort-with-disconnect.patch",
+    "patches/libuv/win-pipe-read-req-count-across-callback.patch",
+  ],
 
   build: () => ({
     kind: "direct",

--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -62,7 +62,8 @@ export const libuv: Dependency = {
   // comment as the rationale.
   //
   // win-pipe-read-req-count-across-callback: interim, delete when #40023
-  // lands. uv__process_pipe_read_req decrements reqs_pending last, like every
+  // lands (workarounds.ts "libuv-win-pipe-read-req-count" fails configure
+  // then). uv__process_pipe_read_req decrements reqs_pending last, like every
   // other DECREASE_PENDING_REQ_COUNT user (libuv/libuv#1843 moved this one
   // up). JS that runs inside read_cb can still re-enter the loop (#33261, a
   // bug that #40023 removes). Until then a uv_close() from that JS plus the

--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -61,13 +61,13 @@ export const libuv: Dependency = {
   // send to libuv/libuv with the wepoll/ReactOS references in the patch
   // comment as the rationale.
   //
-  // win-pipe-read-req-count-across-callback: uv__process_pipe_read_req keeps
-  // the completed read counted in reqs_pending until it is done with the
-  // handle, like the tcp and tty read paths. Bun re-enters uv_run() from JS
-  // that runs inside read_cb; with upstream's early decrement a uv_close()
-  // from that JS let the nested uv_run() run the close callback and free the
-  // uv_pipe_t under uv__process_pipe_read_req. For oven-sh/libuv's `bun`
-  // branch, not upstream (upstream forbids re-entering uv_run).
+  // win-pipe-read-req-count-across-callback: interim, delete when #40023
+  // lands. uv__process_pipe_read_req decrements reqs_pending last, like every
+  // other DECREASE_PENDING_REQ_COUNT user (libuv/libuv#1843 moved this one
+  // up). JS that runs inside read_cb can still re-enter the loop (#33261, a
+  // bug that #40023 removes). Until then a uv_close() from that JS plus the
+  // nested uv_run() ran the close callback early and freed the uv_pipe_t
+  // under uv__process_pipe_read_req.
   patches: [
     "patches/libuv/win-poll-rearm-before-callback.patch",
     "patches/libuv/win-poll-abort-with-disconnect.patch",

--- a/scripts/build/workarounds.ts
+++ b/scripts/build/workarounds.ts
@@ -29,7 +29,7 @@
  *     ambiguous case.
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Config } from "./config.ts";
 import { BuildError } from "./error.ts";
@@ -176,6 +176,26 @@ export const workarounds: Workaround[] = [
       `In src/spawn_sys/posix_spawn.rs (Attr::set) and src/spawn_sys/spawn_process.rs ` +
       `(options.detached block), replace the local 0x80 with libc::POSIX_SPAWN_SETSID, ` +
       `drop the explanatory comments, and delete this entry.`,
+  },
+  {
+    id: "libuv-win-pipe-read-req-count",
+    issue: "https://github.com/oven-sh/bun/pull/40023",
+    description:
+      "libuv's uv__process_pipe_read_req drops reqs_pending before read_cb, so a uv_close() from JS " +
+      "inside read_cb plus a nested uv_run() (#33261) frees the uv_pipe_t under it. " +
+      "patches/libuv/win-pipe-read-req-count-across-callback.patch decrements last until JS stops " +
+      "running inside libuv callbacks.",
+    applies: cfg => cfg.windows,
+    expectedToBeFixed: cfg => {
+      // #40023 dispatches every libuv completion after uv_run returns, through
+      // src/libuv_sys/deferred.rs; with that, nothing closes a pipe from inside
+      // its own read_cb. If it lands in another shape, point this at whatever
+      // marks it.
+      return existsSync(join(cfg.cwd, "src", "libuv_sys", "deferred.rs"));
+    },
+    cleanup:
+      `Delete patches/libuv/win-pipe-read-req-count-across-callback.patch, its line and comment in the ` +
+      `patches list in scripts/build/deps/libuv.ts, and this entry.`,
   },
 ];
 

--- a/test/js/bun/spawn/spawn-pipe-cancel-nested-tick.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-cancel-nested-tick.test.ts
@@ -13,6 +13,11 @@
 // memory, queues another read on the freed handle. That crashed `bun test`
 // itself in test/cli/inspect/inspect.test.ts, in uv_timer_stop through
 // eof_timer_start and in the zero-read worker thread, both on a freed pipe.
+//
+// The nesting here comes from the un-awaited `expect().resolves`, which waits
+// for its promise in place (#33261). Once matchers stop doing that (#33289),
+// or pipe reads are dispatched outside libuv callbacks (#40023), this sequence
+// no longer re-enters the loop and the test only checks the plain cancel path.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 

--- a/test/js/bun/spawn/spawn-pipe-cancel-nested-tick.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-cancel-nested-tick.test.ts
@@ -1,0 +1,67 @@
+// A chunk that completes a pending read on a subprocess pipe is handed to JS
+// from inside that pipe's read callback, and the `for await` body resumes
+// there, in the microtask drain that follows. Breaking out of the loop cancels
+// the stream, which closes the pipe. A synchronous `expect().resolves` then
+// runs the event loop again, still inside the same read callback.
+//
+// On Windows the pipe is a libuv uv_pipe_t that its reader frees in the
+// uv_close() callback. libuv's uv__process_pipe_read_req() dropped the pipe's
+// pending-request count before it called the read callback, so the uv_close()
+// from the cancel queued the close callback right away, the nested loop run ran
+// it, and the uv_pipe_t was freed while uv__process_pipe_read_req() was still
+// using it: it reads handle->flags after the callback returns and, on reused
+// memory, queues another read on the freed handle. That crashed `bun test`
+// itself in test/cli/inspect/inspect.test.ts, in uv_timer_stop through
+// eof_timer_start and in the zero-read worker thread, both on a freed pipe.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("cancelling a subprocess pipe and running the event loop from inside its read callback", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    fetch: () => new Response("ok"),
+  });
+  const url = `http://127.0.0.1:${server.port}/`;
+
+  // Writes one line now and one line per millisecond after that, so the second
+  // chunk lands while the stream's read is pending.
+  const child = `
+    process.stderr.write("ready\\n");
+    setInterval(() => process.stderr.write("tick\\n"), 1);
+  `;
+
+  // Spawned together so the children start up in parallel: the cancel below
+  // only needs a pipe with a write end that stays open.
+  const procs = Array.from({ length: 3 }, () =>
+    Bun.spawn({
+      cmd: [bunExe(), "-e", child],
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "pipe",
+    }),
+  );
+
+  const decoder = new TextDecoder();
+  for (const proc of procs) {
+    let stderr = "";
+    let chunks = 0;
+    for await (const chunk of proc.stderr) {
+      stderr += decoder.decode(chunk, { stream: true });
+      if (++chunks >= 2 && stderr.includes("tick")) break;
+    }
+    expect(stderr).toStartWith("ready\n");
+
+    // Both of these run the event loop synchronously (`expect().resolves`
+    // waits for the promise in place), from inside the read callback the
+    // `break` above returned into. The timer is the loop turn that used to run
+    // the freed pipe's close callback; the request reuses native memory in the
+    // same window, which is what turned the freed handle into a crash.
+    expect(Bun.sleep(1)).resolves.toBeUndefined();
+    expect(fetch(url).then(r => r.text())).resolves.toBe("ok");
+
+    proc.kill();
+    await proc.exited;
+    expect(proc.killed).toBe(true);
+  }
+});

--- a/test/js/bun/spawn/spawn-pipe-cancel-nested-tick.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-cancel-nested-tick.test.ts
@@ -42,26 +42,33 @@ test("cancelling a subprocess pipe and running the event loop from inside its re
     }),
   );
 
-  const decoder = new TextDecoder();
-  for (const proc of procs) {
-    let stderr = "";
-    let chunks = 0;
-    for await (const chunk of proc.stderr) {
-      stderr += decoder.decode(chunk, { stream: true });
-      if (++chunks >= 2 && stderr.includes("tick")) break;
+  try {
+    const decoder = new TextDecoder();
+    for (const proc of procs) {
+      let stderr = "";
+      let chunks = 0;
+      for await (const chunk of proc.stderr) {
+        stderr += decoder.decode(chunk, { stream: true });
+        if (++chunks >= 2 && stderr.includes("tick")) break;
+      }
+      expect(stderr).toStartWith("ready\n");
+
+      // Both of these run the event loop synchronously (`expect().resolves`
+      // waits for the promise in place), from inside the read callback the
+      // `break` above returned into. The timer is the loop turn that used to
+      // run the freed pipe's close callback; the request reuses native memory in
+      // the same window, which is what turned the freed handle into a crash.
+      expect(Bun.sleep(1)).resolves.toBeUndefined();
+      expect(fetch(url).then(r => r.text())).resolves.toBe("ok");
+
+      proc.kill();
+      await proc.exited;
+      expect(proc.killed).toBe(true);
     }
-    expect(stderr).toStartWith("ready\n");
-
-    // Both of these run the event loop synchronously (`expect().resolves`
-    // waits for the promise in place), from inside the read callback the
-    // `break` above returned into. The timer is the loop turn that used to run
-    // the freed pipe's close callback; the request reuses native memory in the
-    // same window, which is what turned the freed handle into a crash.
-    expect(Bun.sleep(1)).resolves.toBeUndefined();
-    expect(fetch(url).then(r => r.text())).resolves.toBe("ok");
-
-    proc.kill();
-    await proc.exited;
-    expect(proc.killed).toBe(true);
+  } finally {
+    // The children never exit on their own; reap them even when an assertion
+    // above failed.
+    for (const proc of procs) proc.kill();
+    await Promise.all(procs.map(proc => proc.exited));
   }
 });


### PR DESCRIPTION
### Problem
- On Windows, `bun test test/cli/inspect/inspect.test.ts` segfaults: `panic(main thread): Segmentation fault at address 0xFFFFFFFFFFFFFFFF` in `uv__queue_remove` under `eof_timer_start` and `uv__pipe_queue_read`, plus a crash in `uv_pipe_zero_readfile_thread_proc`. Seen in CI builds 113734 and 113776.
- `uv__process_pipe_read_req` (`vendor/libuv/src/win/pipe.c:2186`) drops the handle's pending-request count before it calls the read callback. A `uv_close()` inside the callback then queues the close callback at once, and a nested `uv_run()` from the same callback runs it.
- The test does both: `break` in `for await (const chunk of proc.stderr)` closes the pipe, then the un-awaited `expect(p).resolves` runs the loop in place (#33261). Bun frees the `uv_pipe_t` in the close callback (`src/io/PipeReader.rs:1842`). libuv then uses the freed handle.

### Fix
- Interim. #40023 is the fix of record: it stops JS from running inside libuv callbacks. Its head passes this PR's test without this patch. Delete this patch when it lands.
- Count the completed read in `reqs_pending` until `uv__process_pipe_read_req` is done with the handle, as every other `DECREASE_PENDING_REQ_COUNT` user does. libuv/libuv#1843 moved this one up.
- Assert after the callbacks that the handle is not closed (debug builds only).
- Verified: `test/js/bun/spawn/spawn-pipe-cancel-nested-tick.test.ts` (new, fails before on Windows, passes after). The spawn, shell, child_process, net and inspect suites on Windows match `main`.

### Background
- `reqs_pending` counts a handle's requests in flight. `uv_close()` waits for zero before it runs the close callback.
- The direction is to remove nested loop runs, not to make lower layers survive them (#32233, #33261). This patch only closes one memory-safety hole until they are gone.

<details><summary>Notes</summary>

**Relation to #40023, #33261 and #32233.** A self-review of this PR found that context after it was opened. The earlier revision of the patch comment said that Bun re-enters `uv_run()` from `read_cb` as if that were a contract. It is not: #33261 tracks its removal, #32233 was closed to avoid teaching lower layers to tolerate it, and #40023 makes Windows dispatch every handler after `uv_run` returns. The comments in the patch and in `scripts/build/deps/libuv.ts` now say that, and mark the patch for deletion when #40023 lands.

- I built #40023's head (32fe1bf6fd) on Windows with the upstream decrement position and the assert from this patch added by hand. This PR's test passes 3 of 3 runs and `inspect.test.ts` passes 3 of 3. So #40023 alone covers this crash. Its `nested-event-loop-fixture.ts` has no cancel-inside-read case. The test here could move there.
- Whether to carry this 3-line reorder in the meantime, or to close this PR and take only the test, is a maintainer call. #40023 does not touch `scripts/build/deps/libuv.ts` or `patches/libuv/`, so the two do not conflict.
- `scripts/build/workarounds.ts` registers the patch as `libuv-win-pipe-read-req-count`. Configure for a Windows target fails with the cleanup steps once `src/libuv_sys/deferred.rs` exists, the file #40023 adds. I ran both paths on Windows: configure passes today, and fails with the hint when that file is present.
- Once `expect().resolves` stops waiting in place (#33289), the test no longer nests the loop and only checks the plain cancel path. The test header says so.
- Not covered by this patch: `uv__fast_poll_process_poll_req` and `uv__slow_poll_process_poll_req` have the same shape with their own bookkeeping (`submitted_events_*`). #40023 covers those on the usockets side.
- How often CI hits it: rarely. I know of two sightings, both on PR branches (113734, 113776). The same `main` commit passed the test in build 113617. The host in the table below is a 16-core VM that pulls from the pipe earlier than the 4-core CI agents do, which is why it crashes in most runs there.

**Symbolized CI traces (build 113776, commit 799b9f473).**

```
uv__queue_remove            vendor/libuv/src/win/queue.h:86
uv_timer_stop               vendor/libuv/src/win/timer.c:104
uv_timer_start              vendor/libuv/src/win/timer.c:78
eof_timer_start             vendor/libuv/src/win/pipe.c:2419
uv__pipe_queue_read         vendor/libuv/src/win/pipe.c:1465
uv__process_pipe_read_req   vendor/libuv/src/win/pipe.c:2232
uv__process_reqs            vendor/libuv/src/win/core.c:636
uv_run                      vendor/libuv/src/win/core.c:801
```

Thread 4348 of the same crash is `uv_pipe_zero_readfile_thread_proc` (`pipe.c:1278`), the worker thread that the bogus `uv__pipe_queue_read` started on the freed handle.

**The path, from a local crash on the same commit.** The frames between the read callback and the free are:

```
uv__process_pipe_read_req -> uv__pipe_read_data -> on_stream_read        (bun's read_cb)
  -> FileReader::resolve_pending_read -> StreamResult::fulfill_promise
  -> EventLoop::exit -> drainMicrotasks                                  (the `for await` body resumes)
  -> Expect::to_be_undefined -> VM::wait_for_promise -> auto_tick
  -> us_loop_run -> uv_run -> uv__process_endgames -> uv__pipe_endgame
  -> WindowsBufferedReader::on_pipe_close                                (frees the uv_pipe_t)
```

An instrumented debug build prints, for one pipe, `ENDGAME` between the read callback's entry and its exit, and `flags=0xdfdfdfdf` (mimalloc's free fill) when `uv__process_pipe_read_req` resumes.

**Measurements**, all on one Windows Server 2019 x64 host, `bun test test/cli/inspect/inspect.test.ts`:

| build | crashes |
| --- | --- |
| CI artifact, `main` @ 4ff9193770 (the base of this branch) | 6 of 8 |
| CI artifact, build 113776 | 5 of 5 |
| 1.4.2 release | 5 of 8 |
| release build of this branch | 0 of 10 |

The new test is the reduced case. On a debug build it fails deterministically without the patch (3 of 3 runs: `Assertion failed: !(handle->flags & UV_HANDLE_CLOSED)`) and passes with it (3 of 3). On a release build it reaches the same use-after-free but the crash needs the freed block to be reused with a value that still has `UV_HANDLE_READING` set, which is why `inspect.test.ts`, with its WebSocket and inspector round trip in that window, is the case that crashes often.

**No culprit PR.** The defect is not new: the 1.4.2 release crashes too, and the test file is unchanged since #36194. The decrement moved to the top of the function in libuv upstream in 2018 (libuv/libuv#1843, commit 4e53af9120). It only shows as a crash when the chunk that completes a pending read is also the chunk the reader cancels on, and when the freed block is reused in that window, so it surfaces intermittently.

**The automated proof gate cannot run this.** libuv is built on Windows only, and the gate builds and runs tests on linux, where `test/js/bun/spawn/spawn-pipe-cancel-nested-tick.test.ts` exercises the POSIX reader and passes either way. The fail-before numbers above are from the Windows host.

**Same class elsewhere.** `WindowsNamedPipe` (`src/runtime/socket/WindowsNamedPipe.rs`) and `PipeWriter` also free their `uv_pipe_t` in the `uv_close` callback, so they had the same exposure through any read callback that runs JS. The fix is in the shared layer, so it covers them.

**Other libuv request processors, audited for the same shape** (a user callback, then more use of the handle, with the request already uncounted):

- Every other user of `DECREASE_PENDING_REQ_COUNT` decrements as its last statement: pipe write, accept, connect and shutdown, all four tcp processors, both udp processors, and the tty read, write and shutdown processors. The pipe read processor was the only exception in that family.
- `uv__process_proc_exit` calls `exit_cb` as its last statement.
- `uv__process_fs_event_req` and `uv__process_signal_req` do read `handle->flags` after the callback with their own bookkeeping already cleared. Bun does not reach them: `PathWatcher` defers its `uv_close` until its callback is done (`emit_in_progress` / `maybe_deinit` in `src/runtime/node/win_watcher.rs`), and the signal callback only posts a task (`signalHandler` in `src/jsc/bindings/BunProcess.cpp`).

The assert is compiled out of release builds (libuv is built with `-DNDEBUG` there), so it costs nothing in production.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:dep]** gate passed · iteration 0 · 4 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/spawn/spawn-pipe-cancel-nested-tick.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/spawn/spawn-pipe-cancel-nested-tick.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/spawn/spawn-pipe-cancel-nested-tick.test.ts:
(pass) cancelling a subprocess pipe and running the event loop from inside its read callback [1799.83ms]

 1 pass
 0 fail
 12 expect() calls
Ran 1 test across 1 file. [4.14s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../win-pipe-read-req-count-across-callback.patch  | 59 ++++++++++++++++
 scripts/build/deps/libuv.ts                        | 15 +++-
 scripts/build/workarounds.ts                       | 22 +++++-
 .../spawn/spawn-pipe-cancel-nested-tick.test.ts    | 79 ++++++++++++++++++++++
 4 files changed, 173 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…hes/libuv/win-pipe-read-req-count-across-callback.patch      0      0     37
scripts/build/deps/libuv.ts                                   2      3     38
scripts/build/workarounds.ts                                  2      2     37
test/js/bun/spawn/spawn-pipe-cancel-nested-tick.test.ts       3      6     36
```

</details>

<!-- robobun:evidence:end -->
