### PR TITLE
node:http2: tear the session down when a user-supplied transport reports EOF

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4491,6 +4491,7 @@ class ServerHttp2Session extends Http2Session {
     socket.on("close", this.#onClose.bind(this));
     socket.on("error", this.#onError.bind(this));
     socket.on("timeout", this.#onTimeout.bind(this));
+    watchGenericTransportEnd(socket);
     initHttp2SessionPerf(this, "server");
     socket.on("data", this.#onRead.bind(this));
     socket.on("drain", this.#onDrain.bind(this));
@@ -4855,6 +4856,30 @@ function destroySessionSocketDelayedNT(socket, error) {
 }
 function endThenDestroySessionSocket(socket, error) {
   socket.end(() => setImmediate(destroySessionSocketDelayedNT, socket, error));
+}
+// Node wraps a transport that is not a net.Socket (an options.createConnection Duplex, a stream
+// handed to server.emit('connection')) in a JSStreamSocket: a net.Socket with allowHalfOpen off.
+// The transport's EOF then ends its writable side and destroys it (net's destroySoon), and that
+// 'close' is what tears the session down. A net.Socket applies its own allowHalfOpen. The
+// wrapper acts a tick after the transport's own 'end' listeners have run.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js
+// https://github.com/nodejs/node/blob/v26.3.0/lib/net.js (onReadableStreamEnd, destroySoon)
+function destroyGenericTransportSoonNT(socket) {
+  if (socket.destroyed) return;
+  if (socket.writable) socket.end();
+  if (socket.writableFinished) {
+    socket.destroy();
+  } else {
+    socket.once("finish", socket.destroy);
+  }
+}
+function onGenericTransportEnd() {
+  process.nextTick(destroyGenericTransportSoonNT, this);
+}
+function watchGenericTransportEnd(socket) {
+  if (!(socket instanceof net.Socket)) {
+    socket.on("end", onGenericTransportEnd);
+  }
 }
 // node callTimeout (lib/internal/http2/core.js): when the timer expires while writes are still in
 // flight and bytes have reached the wire since the previous expiry, the session is not idle —
@@ -5723,6 +5748,7 @@ class ClientHttp2Session extends Http2Session {
     socket.on("close", this.#onClose.bind(this));
     socket.on("error", this.#onError.bind(this));
     socket.on("timeout", this.#onTimeout.bind(this));
+    watchGenericTransportEnd(socket);
     initHttp2SessionPerf(this, "client");
     if (connectOnNextTick) {
       // Queued only now that the session is fully built: the parser's construction

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -5705,6 +5705,105 @@ it("client connects over a user Duplex that already has a 'data' listener", asyn
   server.close();
 });
 
+describe.concurrent("a session over a user-supplied Duplex tears down when the transport reports EOF", () => {
+  // The transport's readable side ending is the peer going away. Node wraps a transport that is
+  // not a net.Socket in a JSStreamSocket (allowHalfOpen off), so the EOF ends the transport's
+  // writable side, destroys it, and that close tears the session down. Bun subscribed to
+  // data/drain/close/error/timeout only, so a pending request over an in-memory pair, an SSH
+  // channel or a proxy tunnel never settled.
+  async function settle(done) {
+    for (let turn = 0; turn < 200 && !done(); turn++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+  }
+  // Per object the order is fixed ('aborted' precedes 'close'), so each object's events are
+  // asserted on their own. How the stream's 'close' interleaves with the session's is not part
+  // of this behaviour, and it already differs from node for every transport, sockets included.
+  const eventsFor = (events, prefix) => events.filter(event => event.startsWith(prefix));
+
+  it("client side: a pending request closes when the peer ends its side", async () => {
+    const [clientSide, serverSide] = duplexPair();
+    const server = http2.createServer();
+    const requested = Promise.withResolvers();
+    // Never respond: the request is still pending when the peer goes away.
+    server.on("stream", () => requested.resolve());
+    server.emit("connection", serverSide);
+
+    const client = http2.connect("http://localhost", { createConnection: () => clientSide });
+    const events = [];
+    client.on("error", e => events.push("session.error:" + e.code));
+    client.on("close", () => events.push("session.close"));
+    const req = client.request({ ":path": "/" });
+    req.on("error", e => events.push("stream.error:" + e.code));
+    req.on("close", () => events.push("stream.close"));
+    req.end();
+    await requested.promise;
+
+    serverSide.end();
+    await settle(() => events.includes("session.close") && events.includes("stream.close"));
+
+    expect(eventsFor(events, "stream.")).toEqual(["stream.close"]);
+    expect(eventsFor(events, "session.")).toEqual(["session.close"]);
+    expect({
+      sessionDestroyed: client.destroyed,
+      streamDestroyed: req.destroyed,
+      rstCode: req.rstCode,
+      transportDestroyed: clientSide.destroyed,
+    }).toEqual({
+      sessionDestroyed: true,
+      streamDestroyed: true,
+      rstCode: http2.constants.NGHTTP2_CANCEL,
+      transportDestroyed: true,
+    });
+    server.close();
+  });
+
+  it("server side: an injected connection's stream aborts when the client ends its side", async () => {
+    const [clientSide, serverSide] = duplexPair();
+    const server = http2.createServer();
+    const events = [];
+    const serverStream = Promise.withResolvers();
+    const serverSession = Promise.withResolvers();
+    server.on("session", session => {
+      session.on("error", e => events.push("session.error:" + e.code));
+      session.on("close", () => events.push("session.close"));
+      serverSession.resolve(session);
+    });
+    server.on("stream", stream => {
+      stream.on("aborted", () => events.push("stream.aborted"));
+      stream.on("error", e => events.push("stream.error:" + e.code));
+      stream.on("close", () => events.push("stream.close"));
+      serverStream.resolve(stream);
+    });
+    server.emit("connection", serverSide);
+
+    const client = http2.connect("http://localhost", { createConnection: () => clientSide });
+    client.on("error", () => {});
+    const req = client.request({ ":path": "/" });
+    req.on("error", () => {});
+    req.end();
+    const [stream, session] = await Promise.all([serverStream.promise, serverSession.promise]);
+
+    clientSide.end();
+    await settle(() => events.includes("session.close") && events.includes("stream.close"));
+
+    expect(eventsFor(events, "stream.")).toEqual(["stream.aborted", "stream.close"]);
+    expect(eventsFor(events, "session.")).toEqual(["session.close"]);
+    expect({
+      sessionDestroyed: session.destroyed,
+      streamDestroyed: stream.destroyed,
+      rstCode: stream.rstCode,
+      transportDestroyed: serverSide.destroyed,
+    }).toEqual({
+      sessionDestroyed: true,
+      streamDestroyed: true,
+      rstCode: http2.constants.NGHTTP2_CANCEL,
+      transportDestroyed: true,
+    });
+    server.close();
+  });
+});
+
 // node's Http2Session.remoteSettings/localSettings getters return `{}` while the session is
 // connecting or destroyed and a cached Settings object once the handle is live, so
 // `session.remoteSettings.maxConcurrentStreams` is always a safe read. Bun previously returned


### PR DESCRIPTION
### Problem

- `http2.connect(url, { createConnection: () => duplex })`: the peer ends its side while a request is pending. Bun emits nothing, ever. The stream and the session never close, `session.destroyed` stays `false`, and the transport is not destroyed. Node closes the stream, closes the session, and destroys the transport.
- A server session over an injected stream (`server.emit('connection', duplex)`) behaves the same way. The client's EOF leaves the server stream and session alive.
- Cause: both session constructors subscribe to the transport's `data`, `drain`, `close`, `error` and `timeout` (`src/js/node/http2.ts:4491` and `:5721`). There is no `'end'` listener, so the EOF reaches nothing.

### Fix

- Watch `'end'` on a transport that is not a `net.Socket`, then apply net's `destroySoon` to it: end the writable side, and destroy it once that side finishes. The existing `'close'` path then tears the session down.
- This is what node does. It wraps that class of transport in a `JSStreamSocket`, which is a `net.Socket` with `allowHalfOpen` off. A real `net.Socket` (a `TLSSocket` too) already applies its own `allowHalfOpen`, so the guard leaves those transports on their current path.
- Found by a node-parity audit. Nobody reported it.
- Verified: `test/js/node/http2/node-http2.test.js`, two new tests, both fail on stock bun. Also all 256 upstream `test-http2-*` tests, the 10 files in `test/js/node/http2`, `serve-http2*`, the http2 regression tests, and grpc-js.

### Background

- Node's `Http2Session` constructor wraps a transport that has no StreamBase handle in a `JSStreamSocket`. Bun binds the user's Duplex directly, so the session has to apply the socket-layer behaviour itself.
- `allowHalfOpen` off means the peer's EOF also ends our writable side and then destroys the stream. Bun's `net.Socket` already does this, which is why only non-socket transports are affected.
- Who reaches this path: in-memory pairs (`stream.duplexPair`), an SSH channel, a WebSocket stream, a proxy-tunnel Duplex, `server.emit('connection', duplex)`, and grpc-js `createConnectionInjector().injectConnection(duplex)`. A client behind an HTTP proxy does not: those agents hand bun a `net.Socket` or a `TLSSocket`.
- The tls layer has the same missing coupling, for the same reason: #41851, #42176, #39066.

<details><summary>Notes</summary>

#### The repro

```js
const http2 = require("node:http2");
const { duplexPair } = require("node:stream");

const [clientSide, serverSide] = duplexPair();
const server = http2.createServer();
server.on("stream", () => {}); // never respond
server.emit("connection", serverSide);

const client = http2.connect("http://x.test", { createConnection: () => clientSide });
const req = client.request({ ":path": "/" });
req.on("close", () => console.log("stream close"));
client.on("close", () => console.log("session close"));
req.end();
setTimeout(() => serverSide.end(), 50);
```

node v26.3.0 prints both lines. Stock bun prints nothing and exits 0 with the request unanswered.

#### Parity measured against node v26.3.0

Each shape was run on node v26.3.0, on stock bun 1.4.3, and on this build.

| shape | stock bun | this build |
| --- | --- | --- |
| client, request pending, peer ends | nothing | matches node |
| client, idle session, peer ends | nothing | matches node |
| client, mid response body, peer ends | nothing | matches node |
| client, peer ends in the same tick as the request | nothing | matches node |
| server over an injected Duplex, client ends | nothing | matches node |
| `Duplex.from({ readable, writable })` transport | nothing | matches node |
| peer ends while a transport write is stalled | nothing | matches node, the destroy waits for the write |
| client half-closes, server responds late | response delivered | matches node, `ERR_HTTP2_INVALID_STREAM` on the late respond |
| `stream.finished(req)` after the peer's EOF | never settles | `ERR_STREAM_PREMATURE_CLOSE`, like node |

Guard checks, which must not change:

- A `net.Socket` transport with `allowHalfOpen: true`, peer FIN: the session stays alive and a ping still reaches the peer. Client and server. Same on node, stock bun, and this build.
- `net.Socket` and `TLSSocket` transports with the default `allowHalfOpen: false`, client and server, plain TCP and TLS: unchanged.
- A transport already at EOF before the session is built: unchanged. Node hangs there too.

#### Divergences that remain, all of them older than this change

- The session's `'close'` can precede the stream's `'close'`. Reproducible over plain TCP on stock bun, so it is not from this change. #33802 covers it.
- An aborted `Http2Stream` does not emit `'finish'` and reports `writableFinished === false`. Same on stock bun through the workaround path (`duplex.on('end', () => duplex.destroy())`).
- `session.closed` stays `false` after any transport closes, including a plain TCP socket. Handed off separately.
- `session.destroy(err)` over a Duplex propagates the error to the peer differently from node. Same on stock bun, different tail. #38124 covers it.

#### Why the guard is `instanceof net.Socket`

Node's condition is `!socket._handle || !socket._handle.isStreamBase`. Bun's `_handle` is a native socket object with no `isStreamBase`, so a literal port of that test would wrap every socket. `instanceof net.Socket` selects the same population: in node a `JSStreamSocket` is itself a `net.Socket`, and `tls.connect({ socket: duplex })` returns a `TLSSocket`, which is a `net.Socket` in both runtimes.

#### Reviews

Self-reviewed. Four concerns survived: three about how this body states the reach of the change, which are addressed above, and one about the execution, which the guard checks and the parity table answer.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (5f554969b)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [921.37ms]
(pass) node none > Client Basics > should be able to send a POST request [626.06ms]
(pass) node none > Client Basics > constants [18.85ms]
(pass) node none > Client Basics > getDefaultSettings [7.85ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [17.78ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.67ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.21ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.11ms]
(pass) node none > Client Basics > should be able to send data using end [645.87ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [625.41ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release without fix: 2 failed, 6 skipped
bun test v1.4.3-canary.1 (5f554969b)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.85ms]
(pass) node none > Client Basics > getDefaultSettings [0.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.30ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.13ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.09ms]
(pass) node none > Client Basics > is possible to abort request [1.69ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.74ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.67ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [0.81ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [29.86ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (5f554969b)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [859.62ms]
(pass) node none > Client Basics > should be able to send a POST request [571.43ms]
(pass) node none > Client Basics > constants [18.52ms]
(pass) node none > Client Basics > getDefaultSettings [6.97ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [17.18ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.42ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.15ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [4.95ms]
(pass) node none > Client Basics > should be able to send data using end [595.39ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [583.86ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving d
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 614ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7888ms)
Bundle modules (46ms)
Postprocesss modules (20ms)
Bundle Functions (540ms)
Generate Code (33ms)

[8.53s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 32s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.3-canary.1+b3b42f48a
[build] done
bun test v1.4.3-canary.1 (b3b42f48a)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.82ms]
(pass) node none > Client Basics > getDefaultSettings [0.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.28ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.12ms]
(pass) node none > Client Basics > 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                  | 26 +++++++++
 test/js/node/http2/node-http2.test.js | 99 +++++++++++++++++++++++++++++++++++
 2 files changed, 125 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js/node/http2.ts                       9      5     13
test/js/node/http2/node-http2.test.js      4      4     13
```

</details>

<!-- robobun:evidence:end -->