### PR TITLE
node:net: honor readable/writable in the Socket constructor so a write-only adopted fd stays open

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2342,6 +2342,9 @@ Socket.prototype.resume = function resume() {
   // kOnreadDraining is still set and does not queue a second drain: Node's
   // override sets handle.reading synchronously for the same reason.
   const ret = Duplex.prototype.resume.$call(this);
+  // Nothing restarts the handle once the readable side has ended (EOF emitted,
+  // or built with `readable: false`): node only reaches readStart from _read.
+  if (this.readableEnded) return ret;
   if (!this.connecting && !drainOnreadTail(this)) {
     this._handle?.resume?.();
   }
@@ -2441,7 +2444,8 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
 };
 
 Socket.prototype.read = function read(size) {
-  if (!this.connecting && !drainOnreadTail(this, true)) {
+  // See resume(): an ended readable side never restarts the handle.
+  if (!this.readableEnded && !this.connecting && !drainOnreadTail(this, true)) {
     this._handle?.resume?.();
     restorePausedHold(this, this._handle);
   }
@@ -3383,7 +3387,8 @@ function afterConnect(status, handle, req, readable, writable) {
     }
 
     // Ours already reads, Node's starts at read(): stop a paused plain socket now, and after the listeners unless one asked for a read.
-    const pausedBeforeConnect = self.isPaused();
+    // A socket built with `readable: false` never reads: read() cannot reach _read once the readable side has ended.
+    const pausedBeforeConnect = self.isPaused() || self.readableEnded;
     if (pausedBeforeConnect && !self.encrypted) readStop(self, self._handle);
 
     self.emit("connect");

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1621,7 +1621,7 @@ function Socket(options?) {
   this.on("end", onSocketEnd);
 
   if (fd !== undefined) {
-    // Adopt pipe/character-device/file fds with synchronous writes. Matches
+    // Adopt pipe/character-device fds with synchronous writes. Matches
     // node's effective semantics for stdio-style sockets: writes to a pipe
     // complete inline, so data survives an immediate process.exit().
     // Gated on an explicit `writable: true` (how node's own stdio wraps fds,
@@ -1640,16 +1640,15 @@ function Socket(options?) {
         // for an fd it cannot fstat, then throws ERR_INVALID_FD_TYPE.
         throw $ERR_INVALID_FD_TYPE("UNKNOWN");
       }
+      // Node's createHandle() wraps PIPE and TCP fds only: https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L183-L199
+      if (stats.isFile()) {
+        throw $ERR_INVALID_FD_TYPE("FILE");
+      }
       // isSocket() covers stdio handed to a child as a socketpair (how spawn
       // implements pipes on unix); writable-only adoption with sync write(2)
       // is correct there too.
       const optionsReadable = opts.readable;
-      if (
-        stats.isFIFO() ||
-        stats.isCharacterDevice() ||
-        stats.isFile() ||
-        (stats.isSocket() && optionsReadable !== true)
-      ) {
+      if (stats.isFIFO() || stats.isCharacterDevice() || (stats.isSocket() && optionsReadable !== true)) {
         this[kSyncWriteFd] = fd;
         this._write = fdSyncWrite;
         this._writev = fdSyncWritev;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1565,14 +1565,17 @@ function Socket(options?) {
     if (keepAliveInitialDelay < 0) keepAliveInitialDelay = 0;
   }
 
-  if (options?.fd !== undefined) {
-    validateInt32(options.fd, "options.fd", 0);
+  // Like node's `options = { ...options }`: `fd`, `readable` and `writable` are
+  // read from own properties only, the same view the Duplex gets below.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L410-L419
+  const fd = opts.fd;
+  if (fd !== undefined) {
+    validateInt32(fd, "options.fd", 0);
   }
 
   // `readable` / `writable` pass through to the Duplex like node's do: a
   // `readable: false` socket starts with its readable side finished (no 'end',
   // so no allowHalfOpen teardown of the writable side).
-  // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L410-L419
   Duplex.$call(this, {
     ...opts,
     allowHalfOpen,
@@ -1621,9 +1624,7 @@ function Socket(options?) {
   // Shut down the socket when we're finished with it.
   this.on("end", onSocketEnd);
 
-  if (options?.fd !== undefined) {
-    const { fd } = options;
-    validateInt32(fd, "fd", 0);
+  if (fd !== undefined) {
     // Adopt pipe/character-device/file fds with synchronous writes. Matches
     // node's effective semantics for stdio-style sockets: writes to a pipe
     // complete inline, so data survives an immediate process.exit().
@@ -1634,7 +1635,7 @@ function Socket(options?) {
     // here would end its readable side and stomp its write path.
     // Network-socket fds are not supported (handle adoption needs native
     // support); those keep the previous validated-but-inert behavior.
-    if (options.writable === true) {
+    if (opts.writable === true) {
       let stats;
       try {
         stats = require("node:fs").fstatSync(fd);
@@ -1646,7 +1647,7 @@ function Socket(options?) {
       // isSocket() covers stdio handed to a child as a socketpair (how spawn
       // implements pipes on unix); writable-only adoption with sync write(2)
       // is correct there too.
-      const optionsReadable = options.readable;
+      const optionsReadable = opts.readable;
       if (
         stats.isFIFO() ||
         stats.isCharacterDevice() ||
@@ -2542,6 +2543,8 @@ Object.defineProperty(Socket.prototype, "remoteFamily", {
 
 function fdSyncWrite(chunk, encoding, callback) {
   const fs = require("node:fs");
+  // node's _writeGeneric restarts the idle timer on every write.
+  this._unrefTimer();
   try {
     const buf = typeof chunk === "string" ? Buffer.from(chunk, encoding) : chunk;
     let offset = 0;
@@ -2559,6 +2562,7 @@ function fdSyncWrite(chunk, encoding, callback) {
 
 function fdSyncWritev(data, callback) {
   const fs = require("node:fs");
+  this._unrefTimer();
   try {
     let total = 0;
     for (let i = 0; i < data.length; i++) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1569,11 +1569,13 @@ function Socket(options?) {
     validateInt32(options.fd, "options.fd", 0);
   }
 
+  // `readable` / `writable` pass through to the Duplex like node's do: a
+  // `readable: false` socket starts with its readable side finished (no 'end',
+  // so no allowHalfOpen teardown of the writable side).
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L410-L419
   Duplex.$call(this, {
     ...opts,
     allowHalfOpen,
-    readable: true,
-    writable: true,
     //For node.js compat do not emit close on destroy.
     emitClose: false,
     autoDestroy: true,
@@ -1654,7 +1656,10 @@ function Socket(options?) {
         this[kSyncWriteFd] = fd;
         this._write = fdSyncWrite;
         this._writev = fdSyncWritev;
-        if (optionsReadable !== true) {
+        // `readable: false` finished the readable side in the Duplex already.
+        // Reads on this path need a native pipe handle, so an unspecified
+        // `readable` still ends it here.
+        if (optionsReadable !== true && optionsReadable !== false) {
           this.push(null);
           this.read(0);
         }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1565,17 +1565,13 @@ function Socket(options?) {
     if (keepAliveInitialDelay < 0) keepAliveInitialDelay = 0;
   }
 
-  // Like node's `options = { ...options }`: `fd`, `readable` and `writable` are
-  // read from own properties only, the same view the Duplex gets below.
-  // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L410-L419
+  // Own properties only, as after node's `options = { ...options }`: https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L410-L419
   const fd = opts.fd;
   if (fd !== undefined) {
     validateInt32(fd, "options.fd", 0);
   }
 
-  // `readable` / `writable` pass through to the Duplex like node's do: a
-  // `readable: false` socket starts with its readable side finished (no 'end',
-  // so no allowHalfOpen teardown of the writable side).
+  // `opts` carries the caller's readable / writable like node: a `readable: false` side starts ended and never emits 'end'.
   Duplex.$call(this, {
     ...opts,
     allowHalfOpen,
@@ -1657,9 +1653,7 @@ function Socket(options?) {
         this[kSyncWriteFd] = fd;
         this._write = fdSyncWrite;
         this._writev = fdSyncWritev;
-        // `readable: false` finished the readable side in the Duplex already.
-        // Reads on this path need a native pipe handle, so an unspecified
-        // `readable` still ends it here.
+        // No native reads on this path: an unspecified `readable` gets EOF here (`false` already ended it in the Duplex).
         if (optionsReadable !== true && optionsReadable !== false) {
           this.push(null);
           this.read(0);
@@ -2343,8 +2337,7 @@ Socket.prototype.resume = function resume() {
   // kOnreadDraining is still set and does not queue a second drain: Node's
   // override sets handle.reading synchronously for the same reason.
   const ret = Duplex.prototype.resume.$call(this);
-  // Nothing restarts the handle once the readable side has ended (EOF emitted,
-  // or built with `readable: false`): node only reaches readStart from _read.
+  // An ended readable side (EOF emitted, or `readable: false`) never restarts the handle: node reaches readStart only from _read.
   if (this.readableEnded) return ret;
   if (!this.connecting && !drainOnreadTail(this)) {
     this._handle?.resume?.();

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -744,9 +744,7 @@ function TLSSocket(socket?, options?) {
 
   this._rejectUnauthorized = !!options.rejectUnauthorized;
 
-  // A TLS socket is always a full duplex: node builds the net.Socket options
-  // itself and never forwards the caller's `readable` / `writable`.
-  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L590-L600
+  // Never forward readable / writable: node's TLSSocket builds its own net.Socket options. https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L590-L600
   NetSocket.$call(
     this,
     options.readable === undefined && options.writable === undefined

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -744,7 +744,15 @@ function TLSSocket(socket?, options?) {
 
   this._rejectUnauthorized = !!options.rejectUnauthorized;
 
-  NetSocket.$call(this, options);
+  // A TLS socket is always a full duplex: node builds the net.Socket options
+  // itself and never forwards the caller's `readable` / `writable`.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L590-L600
+  NetSocket.$call(
+    this,
+    options.readable === undefined && options.writable === undefined
+      ? options
+      : { ...options, readable: undefined, writable: undefined },
+  );
 
   // Node's _init installs this as the first 'error' listener and removes it in
   // _releaseControl: until control is handed to the user it routes errors

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -769,7 +769,9 @@ test("https-proxy-agent reports a refused CONNECT as the proxy's response, like 
     const events: string[] = [];
     const closed = Promise.withResolvers<void>();
     const ended = Promise.withResolvers<void>();
+    let sawResponse = false;
     const req = http.request({ host: "example.test", port: 80, path: "/", agent }, res => {
+      sawResponse = true;
       events.push(`response ${res.statusCode} ${res.headers["proxy-authenticate"]}`);
       res.on("error", ended.reject);
       res.on("end", () => {
@@ -779,7 +781,11 @@ test("https-proxy-agent reports a refused CONNECT as the proxy's response, like 
       res.resume();
     });
     req.on("error", err => events.push(`req error ${(err as NodeJS.ErrnoException).code}`));
-    req.on("close", () => closed.resolve());
+    req.on("close", () => {
+      closed.resolve();
+      // A request that died without a response has nothing left to end.
+      if (!sawResponse) ended.resolve();
+    });
     req.end();
     await Promise.all([closed.promise, ended.promise]);
     expect(events).toEqual(['response 407 Basic realm="test"', "res end"]);

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tls as tlsCert } from "harness";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { once } from "node:events";
+import http from "node:http";
 import net from "node:net";
 import tls from "node:tls";
 async function createProxyServer(is_tls: boolean) {
@@ -745,6 +746,47 @@ test("axios with https-proxy-agent", async () => {
   expect(result.data).toBe("");
   // did we got proxied?
   expect(httpProxyServer.log).toEqual([`CONNECT localhost:${httpsServer.port}`]);
+});
+
+// For a refused CONNECT, https-proxy-agent hands node:http a detached
+// `new net.Socket({ writable: false })` and replays the proxy's reply into it.
+// node:http only parses from a socket that is not writable and never writes the
+// request to it, so the caller sees the proxy's status. With `writable` forced
+// to true the request was written to the handle-less socket and failed with
+// ERR_SOCKET_CLOSED instead.
+test("https-proxy-agent reports a refused CONNECT as the proxy's response, like node", async () => {
+  const proxy = net.createServer(socket => {
+    socket.on("error", () => {});
+    socket.once("data", () => {
+      socket.end(
+        'HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm="test"\r\nContent-Length: 0\r\n\r\n',
+      );
+    });
+  });
+  await once(proxy.listen(0, "127.0.0.1"), "listening");
+  const agent = new HttpsProxyAgent(`http://127.0.0.1:${(proxy.address() as net.AddressInfo).port}`);
+  try {
+    const events: string[] = [];
+    const closed = Promise.withResolvers<void>();
+    const ended = Promise.withResolvers<void>();
+    const req = http.request({ host: "example.test", port: 80, path: "/", agent }, res => {
+      events.push(`response ${res.statusCode} ${res.headers["proxy-authenticate"]}`);
+      res.on("error", ended.reject);
+      res.on("end", () => {
+        events.push("res end");
+        ended.resolve();
+      });
+      res.resume();
+    });
+    req.on("error", err => events.push(`req error ${(err as NodeJS.ErrnoException).code}`));
+    req.on("close", () => closed.resolve());
+    req.end();
+    await Promise.all([closed.promise, ended.promise]);
+    expect(events).toEqual(['response 407 Basic realm="test"', "res end"]);
+  } finally {
+    agent.destroy();
+    proxy.close();
+  }
 });
 
 test("HTTPS proxy tunnel keep-alive reuses CONNECT across sequential requests", async () => {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -18,6 +18,7 @@ import {
   Stream,
 } from "node:net";
 import { join } from "node:path";
+import { TLSSocket } from "node:tls";
 
 const socket_domain = tmpdirSync();
 
@@ -1252,6 +1253,22 @@ it.skipIf(isWindows)(
   60_000,
 );
 
+it("passes readable / writable through to the Duplex like node (a TLSSocket is always a full duplex)", () => {
+  // Values observed under node v26.3.0.
+  const a = new Socket({ readable: false });
+  const b = new Socket({ writable: false });
+  const c = new TLSSocket(undefined, { readable: false, writable: false });
+  expect({
+    a: [a.readable, a.writable, a.readableEnded],
+    b: [b.readable, b.writable, b.writableEnded, b.writableFinished],
+    c: [c.readable, c.writable],
+  }).toEqual({
+    a: [false, true, true],
+    b: [true, false, true, true],
+    c: [true, true],
+  });
+});
+
 describe("Socket fd adoption", () => {
   it("writes synchronously to an adopted fd and closes it (> 2) on destroy", async () => {
     const path = join(tmpdirSync(), "adopted-fd.txt");
@@ -1268,6 +1285,72 @@ describe("Socket fd adoption", () => {
     // The adopted fd must be released on destroy (node closes the wrapping
     // libuv handle in the equivalent path).
     expect(() => fs.fstatSync(fd)).toThrow();
+  });
+
+  // node wraps a piped stdout/stderr exactly this way (new Socket({ fd, readable:
+  // false, writable: true })). The readable side must start out finished without
+  // an 'end' event; emitting one let allowHalfOpen=false end the writable side,
+  // destroy the socket and close the fd one tick after construction.
+  it("readable: false leaves the writable side and the adopted fd open", async () => {
+    const path = join(tmpdirSync(), "adopted-write-only.txt");
+    const fd = fs.openSync(path, "w");
+    const socket = new Socket({ fd, readable: false, writable: true });
+    const events: string[] = [];
+    for (const name of ["end", "finish", "close"]) socket.on(name, () => events.push(name));
+    socket.on("error", err => events.push(`error:${(err as NodeJS.ErrnoException).code}`));
+
+    // The teardown being guarded against ran purely on process.nextTick
+    // (end -> finish -> destroy -> close), so two immediate turns are past it.
+    await new Promise<void>(resolve => setImmediate(() => setImmediate(resolve)));
+    expect(events).toEqual([]);
+    expect(socket.destroyed).toBe(false);
+    expect(fs.fstatSync(fd).isFile()).toBe(true);
+    expect([socket.readable, socket.readableEnded, socket.writable]).toEqual([false, true, true]);
+
+    await new Promise<void>((resolve, reject) => socket.write("late", err => (err ? reject(err) : resolve())));
+    const closed = once(socket, "close");
+    socket.end();
+    await closed;
+    expect(events).toEqual(["finish", "close"]);
+    expect(fs.readFileSync(path, "utf8")).toBe("late");
+    let closeError: NodeJS.ErrnoException | undefined;
+    try {
+      fs.fstatSync(fd);
+    } catch (e) {
+      closeError = e as NodeJS.ErrnoException;
+    }
+    expect(closeError?.code).toBe("EBADF");
+  });
+
+  it("a write-only socket over the process's piped stdout keeps delivering later writes", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const net = require("node:net");
+          const s = new net.Socket({ fd: 1, readable: false, writable: true });
+          const events = [];
+          for (const n of ["end", "finish", "close"]) s.on(n, () => events.push(n));
+          s.on("error", e => events.push("error:" + e.code));
+          s.write("now\\n");
+          setImmediate(() => setImmediate(() => {
+            s.write("late\\n", err => {
+              console.error(JSON.stringify({ events, destroyed: s.destroyed, cb: err ? err.code : null }));
+            });
+          }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, report: JSON.parse(stderr.trim().split("\n").pop()!), exitCode }).toEqual({
+      stdout: "now\nlate\n",
+      report: { events: [], destroyed: false, cb: null },
+      exitCode: 0,
+    });
   });
 
   it("throws ERR_INVALID_FD_TYPE for a writable fd that cannot be fstat'ed", () => {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1253,6 +1253,49 @@ it.skipIf(isWindows)(
   60_000,
 );
 
+// node only reaches readStart() from _read(), and read(0) never calls _read once
+// the readable side has ended, so a `readable: false` client leaves the peer's
+// bytes unread. Bun's handle reads unless stopped, and pushing those bytes into
+// the ended Readable raised ERR_STREAM_PUSH_AFTER_EOF.
+it("a client dialed with readable: false never reads and keeps writing", async () => {
+  const done = Promise.withResolvers<string>();
+  const server = createServer(socket => {
+    socket.on("error", done.reject);
+    socket.setEncoding("utf8");
+    let got = "";
+    socket.on("data", chunk => {
+      got += chunk;
+      if (got.endsWith("second\n")) done.resolve(got);
+    });
+    socket.write("banner\n");
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  try {
+    const client = connect({ port: (server.address() as import("node:net").AddressInfo).port, host: "127.0.0.1", readable: false });
+    client.on("error", done.reject);
+    const events: string[] = [];
+    for (const name of ["data", "end", "close"]) client.on(name, () => events.push(name));
+    await once(client, "connect");
+    client.write("first\n");
+    // The banner is in flight the whole time; give the loop several turns to
+    // (wrongly) read it before the second write proves the socket still works.
+    for (let i = 0; i < 5; i++) await new Promise<void>(resolve => setImmediate(resolve));
+    client.resume();
+    client.write("second\n");
+    expect(await done.promise).toBe("first\nsecond\n");
+    expect({ events, destroyed: client.destroyed, readable: client.readable, readableEnded: client.readableEnded }).toEqual({
+      events: [],
+      destroyed: false,
+      readable: false,
+      readableEnded: true,
+    });
+    client.destroy();
+    await once(client, "close");
+  } finally {
+    server.close();
+  }
+});
+
 it("passes readable / writable through to the Duplex like node (a TLSSocket is always a full duplex)", () => {
   // Values observed under node v26.3.0.
   const a = new Socket({ readable: false });

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1429,18 +1429,24 @@ describe("Socket fd adoption", () => {
     const fd = fs.openSync(path, "w");
     const socket = new Socket({ fd, readable: false, writable: true });
     try {
+      const idle = 500;
+      const writes: number[] = [];
       const timeouts: number[] = [];
-      const start = performance.now();
-      socket.on("timeout", () => timeouts.push(performance.now() - start));
-      socket.setTimeout(500);
-      // Two full timeout periods of steady writes: never 500ms idle.
+      socket.on("timeout", () => timeouts.push(performance.now()));
+      socket.setTimeout(idle);
+      // Two full timeout periods of steady writes, then let it go idle.
       for (let i = 0; i < 20; i++) {
+        writes.push(performance.now());
         socket.write("x");
         await Bun.sleep(50);
       }
-      expect(timeouts).toEqual([]);
-      // The timer is still armed from the last write and fires once it goes idle.
-      await once(socket, "timeout");
+      if (timeouts.length === 0) await once(socket, "timeout");
+      // Whenever 'timeout' fired, a full idle period had passed since the last
+      // write before it: each write restarted the timer. (A scheduler stall
+      // longer than `idle` between two writes is then a legitimate timeout, not
+      // a failure.) Without the restart the first one lands ~50ms after a write.
+      const gaps = timeouts.map(at => at - Math.max(...writes.filter(w => w <= at)));
+      expect(gaps.filter(gap => gap < idle * 0.9)).toEqual([]);
       expect(fs.readFileSync(path, "utf8")).toBe(Buffer.alloc(20, "x").toString());
     } finally {
       socket.destroy();

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1271,7 +1271,11 @@ it("a client dialed with readable: false never reads and keeps writing", async (
   });
   await once(server.listen(0, "127.0.0.1"), "listening");
   try {
-    const client = connect({ port: (server.address() as import("node:net").AddressInfo).port, host: "127.0.0.1", readable: false });
+    const client = connect({
+      port: (server.address() as import("node:net").AddressInfo).port,
+      host: "127.0.0.1",
+      readable: false,
+    });
     client.on("error", done.reject);
     const events: string[] = [];
     for (const name of ["data", "end", "close"]) client.on(name, () => events.push(name));
@@ -1283,7 +1287,12 @@ it("a client dialed with readable: false never reads and keeps writing", async (
     client.resume();
     client.write("second\n");
     expect(await done.promise).toBe("first\nsecond\n");
-    expect({ events, destroyed: client.destroyed, readable: client.readable, readableEnded: client.readableEnded }).toEqual({
+    expect({
+      events,
+      destroyed: client.destroyed,
+      readable: client.readable,
+      readableEnded: client.readableEnded,
+    }).toEqual({
       events: [],
       destroyed: false,
       readable: false,
@@ -1411,6 +1420,56 @@ describe("Socket fd adoption", () => {
     // No explicit writable: true -> no adoption, no fstat. child_process
     // extra stdio relies on this path (connect({ fd }) attaches natively).
     expect(() => new Socket({ fd: 0x7ffff })).not.toThrow();
+  });
+
+  // node's _writeGeneric restarts the idle timer before every write; the
+  // synchronous fd write path has no handle doing that for it.
+  it("writes to an adopted fd restart the setTimeout() idle timer", async () => {
+    const path = join(tmpdirSync(), "adopted-timeout.txt");
+    const fd = fs.openSync(path, "w");
+    const socket = new Socket({ fd, readable: false, writable: true });
+    try {
+      const timeouts: number[] = [];
+      const start = performance.now();
+      socket.on("timeout", () => timeouts.push(performance.now() - start));
+      socket.setTimeout(500);
+      // Two full timeout periods of steady writes: never 500ms idle.
+      for (let i = 0; i < 20; i++) {
+        socket.write("x");
+        await Bun.sleep(50);
+      }
+      expect(timeouts).toEqual([]);
+      // The timer is still armed from the last write and fires once it goes idle.
+      await once(socket, "timeout");
+      expect(fs.readFileSync(path, "utf8")).toBe("x".repeat(20));
+    } finally {
+      socket.destroy();
+    }
+  });
+
+  // node copies the options ({ ...options }) before reading fd / readable /
+  // writable, so inherited properties never adopt anything; the Duplex flags and
+  // the adoption decision must come from the same view.
+  it("ignores fd / readable / writable that are not own properties of the options", async () => {
+    const path = join(tmpdirSync(), "inherited-fd.txt");
+    const fd = fs.openSync(path, "w");
+    try {
+      const socket = new Socket(Object.create({ fd, readable: false, writable: true }));
+      const readableAfterConstruct = socket.readable;
+      socket.on("error", () => {});
+      const writeError = await new Promise<string | undefined>(resolve =>
+        socket.write("x", err => resolve((err as NodeJS.ErrnoException | null)?.code)),
+      );
+      // No handle and nothing adopted: the write fails the way node's does.
+      expect({ writeError, readableAfterConstruct, file: fs.readFileSync(path, "utf8") }).toEqual({
+        writeError: "ERR_SOCKET_CLOSED",
+        readableAfterConstruct: true,
+        file: "",
+      });
+      expect(fs.fstatSync(fd).isFile()).toBe(true);
+    } finally {
+      fs.closeSync(fd);
+    }
   });
 });
 

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1380,7 +1380,7 @@ describe("Socket fd adoption", () => {
         bunExe(),
         "-e",
         `
-          const net = require("node:net");
+          import net from "node:net";
           const s = new net.Socket({ fd: 1, readable: false, writable: true });
           const events = [];
           for (const n of ["end", "finish", "close"]) s.on(n, () => events.push(n));
@@ -1441,7 +1441,7 @@ describe("Socket fd adoption", () => {
       expect(timeouts).toEqual([]);
       // The timer is still armed from the last write and fires once it goes idle.
       await once(socket, "timeout");
-      expect(fs.readFileSync(path, "utf8")).toBe("x".repeat(20));
+      expect(fs.readFileSync(path, "utf8")).toBe(Buffer.alloc(20, "x").toString());
     } finally {
       socket.destroy();
     }

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -2,6 +2,7 @@ import { Socket as _BunSocket, TCPSocketListener } from "bun";
 import { heapStats } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, expectMaxObjectTypeCount, gc, isASAN, isDebug, isWindows, tmpdirSync } from "harness";
+import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { once } from "node:events";
 import fs from "node:fs";
@@ -1322,56 +1323,119 @@ it("passes readable / writable through to the Duplex like node (a TLSSocket is a
 });
 
 describe("Socket fd adoption", () => {
-  it("writes synchronously to an adopted fd and closes it (> 2) on destroy", async () => {
-    const path = join(tmpdirSync(), "adopted-fd.txt");
-    const fd = fs.openSync(path, "w");
-    const socket = new Socket({ fd, readable: false, writable: true });
-    await new Promise<void>((resolve, reject) => {
-      socket.on("close", () => resolve());
-      socket.on("error", reject);
-      socket.end("hello");
-    });
-    expect(fs.readFileSync(path, "utf8")).toBe("hello");
-    // Sync fd writes must feed the byte counters (no native handle to do it).
-    expect(socket._bytesDispatched).toBe(5);
-    // The adopted fd must be released on destroy (node closes the wrapping
-    // libuv handle in the equivalent path).
-    expect(() => fs.fstatSync(fd)).toThrow();
+  // A named pipe with both ends open in this process: the non-blocking read end
+  // is opened first so opening the write end does not block. The other fd kind
+  // node's `new Socket({ fd })` accepts besides TCP sockets is a pipe.
+  function openFifo(name: string) {
+    const path = join(tmpdirSync(), name);
+    execFileSync("mkfifo", [path]);
+    const rfd = fs.openSync(path, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+    const wfd = fs.openSync(path, "w");
+    return { rfd, wfd };
+  }
+  // Everything the (non-blocking) read end has right now; "" at EOF or when empty.
+  function drain(rfd: number) {
+    const chunk = Buffer.alloc(256);
+    let out = "";
+    for (;;) {
+      let n: number;
+      try {
+        n = fs.readSync(rfd, chunk);
+      } catch (e) {
+        if ((e as NodeJS.ErrnoException).code === "EAGAIN") break;
+        throw e;
+      }
+      if (n === 0) break;
+      out += chunk.toString("utf8", 0, n);
+    }
+    return out;
+  }
+  function fstatCode(fd: number) {
+    try {
+      fs.fstatSync(fd);
+      return "open";
+    } catch (e) {
+      return (e as NodeJS.ErrnoException).code;
+    }
+  }
+
+  it.skipIf(isWindows)("writes synchronously to an adopted pipe fd and closes it (> 2) on destroy", async () => {
+    const { rfd, wfd } = openFifo("adopted.fifo");
+    try {
+      const socket = new Socket({ fd: wfd, readable: false, writable: true });
+      await new Promise<void>((resolve, reject) => {
+        socket.on("close", () => resolve());
+        socket.on("error", reject);
+        socket.end("hello");
+      });
+      expect(drain(rfd)).toBe("hello");
+      // Sync fd writes must feed the byte counters (no native handle to do it).
+      expect(socket._bytesDispatched).toBe(5);
+      // The adopted fd must be released on destroy (node closes the wrapping
+      // libuv handle in the equivalent path).
+      expect(fstatCode(wfd)).toBe("EBADF");
+    } finally {
+      fs.closeSync(rfd);
+    }
+  });
+
+  // Node's createHandle() wraps PIPE and TCP fds only; a regular file is
+  // ERR_INVALID_FD_TYPE there (process.stdout over a file is a SyncWriteStream,
+  // not a net.Socket).
+  it("rejects a regular-file fd with ERR_INVALID_FD_TYPE, like node", () => {
+    const fd = fs.openSync(join(tmpdirSync(), "not-a-pipe.txt"), "w");
+    try {
+      let error: any;
+      try {
+        new Socket({ fd, readable: false, writable: true });
+      } catch (e) {
+        error = e;
+      }
+      expect({ code: error?.code, message: error?.message }).toEqual({
+        code: "ERR_INVALID_FD_TYPE",
+        message: "Unsupported fd type: FILE",
+      });
+      expect(fstatCode(fd)).toBe("open");
+    } finally {
+      fs.closeSync(fd);
+    }
   });
 
   // node wraps a piped stdout/stderr exactly this way (new Socket({ fd, readable:
   // false, writable: true })). The readable side must start out finished without
   // an 'end' event; emitting one let allowHalfOpen=false end the writable side,
   // destroy the socket and close the fd one tick after construction.
-  it("readable: false leaves the writable side and the adopted fd open", async () => {
-    const path = join(tmpdirSync(), "adopted-write-only.txt");
-    const fd = fs.openSync(path, "w");
-    const socket = new Socket({ fd, readable: false, writable: true });
-    const events: string[] = [];
-    for (const name of ["end", "finish", "close"]) socket.on(name, () => events.push(name));
-    socket.on("error", err => events.push(`error:${(err as NodeJS.ErrnoException).code}`));
-
-    // The teardown being guarded against ran purely on process.nextTick
-    // (end -> finish -> destroy -> close), so two immediate turns are past it.
-    await new Promise<void>(resolve => setImmediate(() => setImmediate(resolve)));
-    expect(events).toEqual([]);
-    expect(socket.destroyed).toBe(false);
-    expect(fs.fstatSync(fd).isFile()).toBe(true);
-    expect([socket.readable, socket.readableEnded, socket.writable]).toEqual([false, true, true]);
-
-    await new Promise<void>((resolve, reject) => socket.write("late", err => (err ? reject(err) : resolve())));
-    const closed = once(socket, "close");
-    socket.end();
-    await closed;
-    expect(events).toEqual(["finish", "close"]);
-    expect(fs.readFileSync(path, "utf8")).toBe("late");
-    let closeError: NodeJS.ErrnoException | undefined;
+  it.skipIf(isWindows)("readable: false leaves the writable side and the adopted fd open", async () => {
+    const { rfd, wfd } = openFifo("write-only.fifo");
     try {
-      fs.fstatSync(fd);
-    } catch (e) {
-      closeError = e as NodeJS.ErrnoException;
+      const socket = new Socket({ fd: wfd, readable: false, writable: true });
+      const events: string[] = [];
+      for (const name of ["end", "finish", "close"]) socket.on(name, () => events.push(name));
+      socket.on("error", err => events.push(`error:${(err as NodeJS.ErrnoException).code}`));
+
+      // The teardown being guarded against ran purely on process.nextTick
+      // (end -> finish -> destroy -> close), so two immediate turns are past it.
+      await new Promise<void>(resolve => setImmediate(() => setImmediate(resolve)));
+      expect({
+        events,
+        destroyed: socket.destroyed,
+        fd: fstatCode(wfd),
+        flags: [socket.readable, socket.readableEnded, socket.writable],
+      }).toEqual({ events: [], destroyed: false, fd: "open", flags: [false, true, true] });
+
+      await new Promise<void>((resolve, reject) => socket.write("late", err => (err ? reject(err) : resolve())));
+      expect(drain(rfd)).toBe("late");
+      const closed = once(socket, "close");
+      socket.end();
+      await closed;
+      expect({ events, fd: fstatCode(wfd), eof: drain(rfd) }).toEqual({
+        events: ["finish", "close"],
+        fd: "EBADF",
+        eof: "",
+      });
+    } finally {
+      fs.closeSync(rfd);
     }
-    expect(closeError?.code).toBe("EBADF");
   });
 
   it("a write-only socket over the process's piped stdout keeps delivering later writes", async () => {
@@ -1424,10 +1488,9 @@ describe("Socket fd adoption", () => {
 
   // node's _writeGeneric restarts the idle timer before every write; the
   // synchronous fd write path has no handle doing that for it.
-  it("writes to an adopted fd restart the setTimeout() idle timer", async () => {
-    const path = join(tmpdirSync(), "adopted-timeout.txt");
-    const fd = fs.openSync(path, "w");
-    const socket = new Socket({ fd, readable: false, writable: true });
+  it.skipIf(isWindows)("writes to an adopted fd restart the setTimeout() idle timer", async () => {
+    const { rfd, wfd } = openFifo("timeout.fifo");
+    const socket = new Socket({ fd: wfd, readable: false, writable: true });
     try {
       const idle = 500;
       const writes: number[] = [];
@@ -1447,15 +1510,17 @@ describe("Socket fd adoption", () => {
       // a failure.) Without the restart the first one lands ~50ms after a write.
       const gaps = timeouts.map(at => at - Math.max(...writes.filter(w => w <= at)));
       expect(gaps.filter(gap => gap < idle * 0.9)).toEqual([]);
-      expect(fs.readFileSync(path, "utf8")).toBe(Buffer.alloc(20, "x").toString());
+      expect(drain(rfd)).toBe(Buffer.alloc(20, "x").toString());
     } finally {
       socket.destroy();
+      fs.closeSync(rfd);
     }
   });
 
   // node copies the options ({ ...options }) before reading fd / readable /
-  // writable, so inherited properties never adopt anything; the Duplex flags and
-  // the adoption decision must come from the same view.
+  // writable, so inherited properties never adopt anything (an own file fd
+  // would throw ERR_INVALID_FD_TYPE); the Duplex flags and the adoption
+  // decision must come from the same view.
   it("ignores fd / readable / writable that are not own properties of the options", async () => {
     const path = join(tmpdirSync(), "inherited-fd.txt");
     const fd = fs.openSync(path, "w");


### PR DESCRIPTION
### Problem
- `new net.Socket({ fd, readable: false, writable: true })` destroys itself one tick after construction. `'end'`, `'finish'`, `'close'` fire on their own, `close(2)` runs on the caller's fd, and later writes fail with `EPIPE` ("This socket has been ended by the other party"). Node wraps a piped stdout this way.
- Cause: the `Socket` constructor forced `readable: true, writable: true` into the Duplex (`src/js/node/net.ts:1572`) and the fd branch faked EOF with `push(null)`. That `'end'` makes `allowHalfOpen: false` end the writable side, and autoDestroy closes the fd.
- The forced `writable` also broke `https-proxy-agent`, which hands node:http a `new net.Socket({ writable: false })`: a refused CONNECT surfaced as `ERR_SOCKET_CLOSED` instead of the proxy's 407.

### Fix
- Pass `readable` / `writable` to the Duplex as node does ([net.js#L410-L419](https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L410-L419)). A `readable: false` Duplex starts with `endEmitted` set, so no `'end'` fires. `tls.ts` drops both flags like node's `TLSSocket` ([wrap.js#L590-L600](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L590-L600)).
- A socket whose readable side has ended never starts native reads: `afterConnect` stops the handle, `read()` / `resume()` leave it stopped. Node reaches `readStart()` only from `_read()`, which an ended Readable never calls.
- Sync fd writes restart the idle timer like `_writeGeneric`. A regular-file fd now throws `ERR_INVALID_FD_TYPE` ("Unsupported fd type: FILE") like node's `createHandle()`. `fd` / `readable` / `writable` are read as own properties, the view the Duplex gets.
- Verified: 8 new tests in `node-net.test.ts` and `proxy.test.ts`, all red on 1.4.3; the fd tests adopt the write end of a FIFO. No new failures there or in 805 vendored net, tls and http files.

### Background
- With `allowHalfOpen: false` (the `net.Socket` default) the stream layer ends the writable side once the readable side emits `'end'`, and autoDestroy follows.
- Given `writable: true`, Bun adopts pipe, tty and socketpair fds with a synchronous `write(2)` `_write` and no native handle. Its native sockets read as soon as they open. `readStop()` pauses one to emulate node's lazy `readStart()`.

<details><summary>Notes</summary>

- Repro (needs `mkfifo`), bun 1.4.3 and main @4ff91937 vs node v26.3.0:

  ```js
  const net = require('node:net'), fs = require('node:fs'), cp = require('node:child_process');
  const p = require('node:os').tmpdir() + '/m2-' + process.pid + '.fifo'; cp.execFileSync('mkfifo', [p]);
  const fd = fs.openSync(p, 'r+');
  const s = new net.Socket({ fd, readable: false, writable: true });
  for (const n of ['end', 'finish', 'close', 'error']) s.on(n, a => console.log('event', n, a && a.code || ''));
  setTimeout(() => {
    console.log('before late write: destroyed =', s.destroyed, 'fd open =', fs.existsSync('/proc/self/fd/' + fd));
    s.write('late\n', e => console.log('write callback:', e ? e.code : 'ok'));
  }, 100);
  setTimeout(() => { let got = ''; try { const b = Buffer.alloc(16); const rfd = fs.openSync(p, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK); got = b.toString('latin1', 0, fs.readSync(rfd, b)); } catch (e) { got = 'read: ' + e.code; } console.log('bytes in the FIFO:', JSON.stringify(got)); fs.unlinkSync(p); process.exit(0); }, 300);
  ```

  node: `before late write: destroyed = false fd open = true` / `write callback: ok` / `bytes in the FIFO: "late\n"`.
  bun before: `event end` / `event finish` / `event close` / `destroyed = true fd open = false` / `write callback: EPIPE` / `bytes in the FIFO: ""`.
  bun after: identical to node. The same happened on Windows with a piped stdout (verified on 1.4.3).
- A write issued in the construction tick was still delivered (the teardown runs on `process.nextTick`), which is why the existing adoption test passed.
- Because the fd number freed by the self-close is recycled by the caller's next `open()`, a caller that still believed it owned the fd and later ran `fs.closeSync(fd)` closed an unrelated file. That goes away with the self-close.
- `https-proxy-agent` (7.0.6), proxy answers CONNECT with 407: node `response 407, res end`; bun 1.4.3 `response 407, req error ERR_SOCKET_CLOSED, res end` (with a 403 plus body the error wins and no response is delivered); bun after: same as node. node:http never writes a request to a socket that is not `writable` (`_http_outgoing` buffers it), which is what the fake `{ writable: false }` socket relies on.
- Probes that now match node v26.3.0 event for event: `net.connect({ port, readable: false })` against a server that sends a banner (no `'data'`, later writes succeed, destroying with the banner unread resets the peer like node); `net.connect({ port, writable: false })` (`ERR_STREAM_WRITE_AFTER_END` on write); `new net.Socket({ readable: false })` / `{ writable: false }` flag values; `new tls.TLSSocket(undefined, { readable: false, writable: false })` stays `readable: true, writable: true`; write-only FIFO whose reader went away (`EPIPE`, destroyed, fd closed); `setTimeout()` with steady writes on an adopted fd (no spurious timeout); options carrying `fd` on the prototype (ignored, like node's spread).
- `{ fd, writable: true }` with `readable` unspecified still goes through the `push(null)` EOF emulation and so still tears itself down on a pipe. Node reads from the fd in that case (or destroys with `read ENOTCONN` for an `O_WRONLY` pipe). Matching that needs read support for adopted pipe fds (#29141 / #29142), so it is left as is.
- Not addressed, separate root causes: a `write()` larger than a blocking pipe's free space blocks inside `write(2)` on the sync path (#41835 touches the same function for the non-blocking case); a bare `{ fd }` creates no handle, so `destroy()` never closes the fd and `connect()` ignores it (#35341 covers connected socket fds, #29141 pipes); a bare `{ fd }` (no `writable: true`) is still not fstat'ed, so a regular-file or TTY fd there does not throw the way node's does; a TTY or other character device given `writable: true` is still adopted with sync writes where node throws `Unsupported fd type: TTY` / `FILE`; `connect({ fd })` (Bun-internal, used by child_process extra stdio) does not apply the never-read rule for `readable: false`.
- #35341 (open) changes the same constructor lines, scoped to sockets built with an fd. Whichever lands second is a small rebase.
- Self-reviewed: the review agreed the change should exist in this shape. The execution concerns it raised (a `readable: false` client erroring on peer data, the idle timer on the sync write path, inherited option properties) are addressed above.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->