### PR TITLE
Headers: throw a RangeError instead of aborting when the set-cookie list cannot grow

### DIFF
--- a/src/jsc/bindings/VectorSizeLimit.h
+++ b/src/jsc/bindings/VectorSizeLimit.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "root.h"
+#include <wtf/Vector.h>
+
+extern "C" size_t Bun__stringSyntheticAllocationLimit;
+
+namespace Bun {
+
+// The most elements a Vector<T> can hold, lowered by Bun__stringSyntheticAllocationLimit so tests reach it cheaply.
+template<typename T>
+size_t maxVectorSize()
+{
+    constexpr size_t maxBytes = std::numeric_limits<unsigned>::max() >> 1;
+    static_assert(WTF::isValidCapacityForVector<T>(maxBytes / sizeof(T)));
+    static_assert(!WTF::isValidCapacityForVector<T>(maxBytes / sizeof(T) + 1));
+    return std::min(maxBytes, Bun__stringSyntheticAllocationLimit) / sizeof(T);
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2527,18 +2527,17 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromPicoHeaders_(const void*
             // memory safety: the header names must be cloned if they're not statically known
             // the value must also be cloned
             // isolatedCopy() doesn't actually clone, it's only for threadlocal isolation
-            // The parser bounds one request's header count, so the map cannot reach
-            // the size where an append fails. Stop adding if it ever does.
+            bool added;
             if (WebCore::findHTTPHeaderName(nameView, name)) {
-                if (!map.add(name, value)) [[unlikely]]
-                    break;
+                added = map.add(name, value);
             } else {
                 // the case where we do not need to clone the name
                 // when the header name is already present in the list
                 // we don't have that information here, so map.addUncommonHeaderCloneName exists
-                if (!map.addUncommonHeaderCloneName(nameView, value)) [[unlikely]]
-                    break;
+                added = map.addUncommonHeaderCloneName(nameView, value);
             }
+            // picohttpparser caps the header count at 256, far below the map's limit.
+            ASSERT_UNUSED(added, added);
         }
 
         headers->setInternalHeaders(WTF::move(map));
@@ -2562,14 +2561,11 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromUWS(void* arg1)
 
         HTTPHeaderName name;
 
-        // The request bounds the header count, so the map cannot reach the size
-        // where an append fails. Stop adding if it ever does.
-        if (WebCore::findHTTPHeaderName(nameView, name)) {
-            if (!map.add(name, WTF::move(value))) [[unlikely]]
-                break;
-        } else if (!map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value))) [[unlikely]] {
-            break;
-        }
+        bool added = WebCore::findHTTPHeaderName(nameView, name)
+            ? map.add(name, WTF::move(value))
+            : map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
+        // The parser caps the header count at UWS_HTTP_MAX_HEADERS_COUNT, far below the map's limit.
+        ASSERT_UNUSED(added, added);
     }
     headers->setInternalHeaders(WTF::move(map));
     return headers;
@@ -2589,13 +2585,11 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH3(void* arg1)
             memcpy(data.data(), val.data(), val.length());
 
         HTTPHeaderName hn;
-        // The request bounds the header count, so the map cannot reach the size
-        // where an append fails. Skip the header if it ever does.
-        if (WebCore::findHTTPHeaderName(nameView, hn)) {
-            (void)map.add(hn, WTF::move(value));
-        } else {
-            (void)map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
-        }
+        bool added = WebCore::findHTTPHeaderName(nameView, hn)
+            ? map.add(hn, WTF::move(value))
+            : map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
+        // One request's header block is size-limited, so its count stays far below the map's limit.
+        ASSERT_UNUSED(added, added);
     });
     headers->setInternalHeaders(WTF::move(map));
     return headers;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2536,8 +2536,8 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromPicoHeaders_(const void*
                 // we don't have that information here, so map.addUncommonHeaderCloneName exists
                 added = map.addUncommonHeaderCloneName(nameView, value);
             }
-            // picohttpparser caps the header count at 256, far below the map's limit.
-            ASSERT_UNUSED(added, added);
+            // Every transport caps one response's header block, so only a failed allocation gets here.
+            RELEASE_ASSERT(added);
         }
 
         headers->setInternalHeaders(WTF::move(map));
@@ -2564,8 +2564,8 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromUWS(void* arg1)
         bool added = WebCore::findHTTPHeaderName(nameView, name)
             ? map.add(name, WTF::move(value))
             : map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
-        // The parser caps the header count at UWS_HTTP_MAX_HEADERS_COUNT, far below the map's limit.
-        ASSERT_UNUSED(added, added);
+        // The parser caps the header count at UWS_HTTP_MAX_HEADERS_COUNT, so only a failed allocation gets here.
+        RELEASE_ASSERT(added);
     }
     headers->setInternalHeaders(WTF::move(map));
     return headers;
@@ -2588,8 +2588,8 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH3(void* arg1)
         bool added = WebCore::findHTTPHeaderName(nameView, hn)
             ? map.add(hn, WTF::move(value))
             : map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
-        // One request's header block is size-limited, so its count stays far below the map's limit.
-        ASSERT_UNUSED(added, added);
+        // es_max_header_list_size caps one request's headers at 64 KiB, so only a failed allocation gets here.
+        RELEASE_ASSERT(added);
     });
     headers->setInternalHeaders(WTF::move(map));
     return headers;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2527,13 +2527,17 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromPicoHeaders_(const void*
             // memory safety: the header names must be cloned if they're not statically known
             // the value must also be cloned
             // isolatedCopy() doesn't actually clone, it's only for threadlocal isolation
+            // The parser bounds one request's header count, so the map cannot reach
+            // the size where an append fails. Stop adding if it ever does.
             if (WebCore::findHTTPHeaderName(nameView, name)) {
-                map.add(name, value);
+                if (!map.add(name, value)) [[unlikely]]
+                    break;
             } else {
                 // the case where we do not need to clone the name
                 // when the header name is already present in the list
                 // we don't have that information here, so map.addUncommonHeaderCloneName exists
-                map.addUncommonHeaderCloneName(nameView, value);
+                if (!map.addUncommonHeaderCloneName(nameView, value)) [[unlikely]]
+                    break;
             }
         }
 
@@ -2558,10 +2562,13 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromUWS(void* arg1)
 
         HTTPHeaderName name;
 
+        // The request bounds the header count, so the map cannot reach the size
+        // where an append fails. Stop adding if it ever does.
         if (WebCore::findHTTPHeaderName(nameView, name)) {
-            map.add(name, WTF::move(value));
-        } else {
-            map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
+            if (!map.add(name, WTF::move(value))) [[unlikely]]
+                break;
+        } else if (!map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value))) [[unlikely]] {
+            break;
         }
     }
     headers->setInternalHeaders(WTF::move(map));
@@ -2582,10 +2589,12 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH3(void* arg1)
             memcpy(data.data(), val.data(), val.length());
 
         HTTPHeaderName hn;
+        // The request bounds the header count, so the map cannot reach the size
+        // where an append fails. Skip the header if it ever does.
         if (WebCore::findHTTPHeaderName(nameView, hn)) {
-            map.add(hn, WTF::move(value));
+            (void)map.add(hn, WTF::move(value));
         } else {
-            map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
+            (void)map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
         }
     });
     headers->setInternalHeaders(WTF::move(map));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2496,6 +2496,13 @@ typedef struct PicoHTTPHeaders {
     size_t len;
 } PicoHTTPHeaders;
 
+// One message cannot carry the 262 million set-cookie fields that fill the list, so only a failed allocation fails here.
+static void addParsedHeader(HTTPHeaderMap& map, HTTPHeaderName name, const String& value)
+{
+    bool added = map.add(name, value);
+    RELEASE_ASSERT(added);
+}
+
 WebCore::FetchHeaders* WebCore__FetchHeaders__createFromPicoHeaders_(const void* arg1)
 {
     PicoHTTPHeaders pico_headers = *reinterpret_cast<const PicoHTTPHeaders*>(arg1);
@@ -2527,17 +2534,14 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromPicoHeaders_(const void*
             // memory safety: the header names must be cloned if they're not statically known
             // the value must also be cloned
             // isolatedCopy() doesn't actually clone, it's only for threadlocal isolation
-            bool added;
             if (WebCore::findHTTPHeaderName(nameView, name)) {
-                added = map.add(name, value);
+                addParsedHeader(map, name, value);
             } else {
                 // the case where we do not need to clone the name
                 // when the header name is already present in the list
                 // we don't have that information here, so map.addUncommonHeaderCloneName exists
-                added = map.addUncommonHeaderCloneName(nameView, value);
+                map.addUncommonHeaderCloneName(nameView, value);
             }
-            // Every transport caps one response's header block, so only a failed allocation gets here.
-            RELEASE_ASSERT(added);
         }
 
         headers->setInternalHeaders(WTF::move(map));
@@ -2561,11 +2565,11 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromUWS(void* arg1)
 
         HTTPHeaderName name;
 
-        bool added = WebCore::findHTTPHeaderName(nameView, name)
-            ? map.add(name, WTF::move(value))
-            : map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
-        // The parser caps the header count at UWS_HTTP_MAX_HEADERS_COUNT, so only a failed allocation gets here.
-        RELEASE_ASSERT(added);
+        if (WebCore::findHTTPHeaderName(nameView, name)) {
+            addParsedHeader(map, name, value);
+        } else {
+            map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
+        }
     }
     headers->setInternalHeaders(WTF::move(map));
     return headers;
@@ -2585,11 +2589,11 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH3(void* arg1)
             memcpy(data.data(), val.data(), val.length());
 
         HTTPHeaderName hn;
-        bool added = WebCore::findHTTPHeaderName(nameView, hn)
-            ? map.add(hn, WTF::move(value))
-            : map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
-        // es_max_header_list_size caps one request's headers at 64 KiB, so only a failed allocation gets here.
-        RELEASE_ASSERT(added);
+        if (WebCore::findHTTPHeaderName(nameView, hn)) {
+            addParsedHeader(map, hn, value);
+        } else {
+            map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
+        }
     });
     headers->setInternalHeaders(WTF::move(map));
     return headers;

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -220,9 +220,11 @@ ExceptionOr<void> FetchHeaders::fill(const FetchHeaders& otherHeaders)
 {
     if (this->size() == 0) {
         HTTPHeaderMap headers;
-        headers.commonHeaders().appendVector(otherHeaders.m_headers.commonHeaders());
-        headers.uncommonHeaders().appendVector(otherHeaders.m_headers.uncommonHeaders());
-        headers.getSetCookieHeaders().appendVector(otherHeaders.m_headers.getSetCookieHeaders());
+        auto& other = otherHeaders.m_headers;
+        if (!headers.commonHeaders().tryAppend(other.commonHeaders().span())
+            || !headers.uncommonHeaders().tryAppend(other.uncommonHeaders().span())
+            || !headers.getSetCookieHeaders().tryAppend(other.getSetCookieHeaders().span()))
+            return headersTooLargeException();
         setInternalHeaders(WTF::move(headers));
         m_updateCounter++;
         return {};

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -89,6 +89,11 @@ static ExceptionOr<bool> canWriteHeader(const String& name, const String& value,
     return true;
 }
 
+static Exception headersTooLargeException()
+{
+    return Exception { RangeError, "Headers maximum size exceeded"_s };
+}
+
 static ExceptionOr<void> appendToHeaderMap(const String& name, const String& value, HTTPHeaderMap& headers, FetchHeaders::Guard guard)
 {
     // The common path here is a brand-new header with no leading/trailing HTTP
@@ -123,10 +128,10 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
             return {};
 
         if (headerName != HTTPHeaderName::SetCookie) {
-            if (!headers.setIndex(index, *valueToSet))
-                headers.set(headerName, *valueToSet);
-        } else {
-            headers.add(headerName, normalizedValue);
+            if (!headers.setIndex(index, *valueToSet) && !headers.set(headerName, *valueToSet))
+                return headersTooLargeException();
+        } else if (!headers.add(headerName, normalizedValue)) {
+            return headersTooLargeException();
         }
 
         return {};
@@ -142,8 +147,8 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
     if (!canWriteResult.releaseReturnValue())
         return {};
 
-    if (!headers.setIndex(index, *valueToSet))
-        headers.set(name, *valueToSet);
+    if (!headers.setIndex(index, *valueToSet) && !headers.set(name, *valueToSet))
+        return headersTooLargeException();
 
     // if (guard == FetchHeaders::Guard::RequestNoCors)
     //     removePrivilegedNoCORSRequestHeaders(headers);
@@ -160,10 +165,11 @@ static ExceptionOr<void> appendToHeaderMap(const HTTPHeaderMap::HTTPHeaderMapCon
         return canWriteResult.releaseException();
     if (!canWriteResult.releaseReturnValue())
         return {};
-    if (header.keyAsHTTPHeaderName)
-        headers.add(header.keyAsHTTPHeaderName.value(), header.value);
-    else
-        headers.add(header.key, header.value);
+    bool stored = header.keyAsHTTPHeaderName
+        ? headers.add(header.keyAsHTTPHeaderName.value(), header.value)
+        : headers.add(header.key, header.value);
+    if (!stored)
+        return headersTooLargeException();
 
     return {};
 }
@@ -294,7 +300,8 @@ ExceptionOr<void> FetchHeaders::set(const HTTPHeaderName name, const String& val
         return {};
 
     ++m_updateCounter;
-    m_headers.set(name, normalizedValue);
+    if (!m_headers.set(name, normalizedValue))
+        return headersTooLargeException();
 
     if (m_guard == FetchHeaders::Guard::RequestNoCors)
         removePrivilegedNoCORSRequestHeaders(m_headers);
@@ -312,7 +319,8 @@ ExceptionOr<void> FetchHeaders::set(const String& name, const String& value)
         return {};
 
     ++m_updateCounter;
-    m_headers.set(name, normalizedValue);
+    if (!m_headers.set(name, normalizedValue))
+        return headersTooLargeException();
 
     if (m_guard == FetchHeaders::Guard::RequestNoCors)
         removePrivilegedNoCORSRequestHeaders(m_headers);

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -89,11 +89,6 @@ static ExceptionOr<bool> canWriteHeader(const String& name, const String& value,
     return true;
 }
 
-static Exception headersTooLargeException()
-{
-    return Exception { RangeError, "Headers maximum size exceeded"_s };
-}
-
 static ExceptionOr<void> appendToHeaderMap(const String& name, const String& value, HTTPHeaderMap& headers, FetchHeaders::Guard guard)
 {
     // The common path here is a brand-new header with no leading/trailing HTTP
@@ -128,10 +123,10 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
             return {};
 
         if (headerName != HTTPHeaderName::SetCookie) {
-            if (!headers.setIndex(index, *valueToSet) && !headers.set(headerName, *valueToSet))
-                return headersTooLargeException();
+            if (!headers.setIndex(index, *valueToSet))
+                headers.set(headerName, *valueToSet);
         } else if (!headers.add(headerName, normalizedValue)) {
-            return headersTooLargeException();
+            return Exception { OutOfMemoryError };
         }
 
         return {};
@@ -147,8 +142,8 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
     if (!canWriteResult.releaseReturnValue())
         return {};
 
-    if (!headers.setIndex(index, *valueToSet) && !headers.set(name, *valueToSet))
-        return headersTooLargeException();
+    if (!headers.setIndex(index, *valueToSet))
+        headers.set(name, *valueToSet);
 
     // if (guard == FetchHeaders::Guard::RequestNoCors)
     //     removePrivilegedNoCORSRequestHeaders(headers);
@@ -165,11 +160,11 @@ static ExceptionOr<void> appendToHeaderMap(const HTTPHeaderMap::HTTPHeaderMapCon
         return canWriteResult.releaseException();
     if (!canWriteResult.releaseReturnValue())
         return {};
-    bool stored = header.keyAsHTTPHeaderName
+    bool added = header.keyAsHTTPHeaderName
         ? headers.add(header.keyAsHTTPHeaderName.value(), header.value)
         : headers.add(header.key, header.value);
-    if (!stored)
-        return headersTooLargeException();
+    if (!added)
+        return Exception { OutOfMemoryError };
 
     return {};
 }
@@ -220,11 +215,9 @@ ExceptionOr<void> FetchHeaders::fill(const FetchHeaders& otherHeaders)
 {
     if (this->size() == 0) {
         HTTPHeaderMap headers;
-        auto& other = otherHeaders.m_headers;
-        if (!headers.commonHeaders().tryAppend(other.commonHeaders().span())
-            || !headers.uncommonHeaders().tryAppend(other.uncommonHeaders().span())
-            || !headers.getSetCookieHeaders().tryAppend(other.getSetCookieHeaders().span()))
-            return headersTooLargeException();
+        headers.commonHeaders().appendVector(otherHeaders.m_headers.commonHeaders());
+        headers.uncommonHeaders().appendVector(otherHeaders.m_headers.uncommonHeaders());
+        headers.getSetCookieHeaders().appendVector(otherHeaders.m_headers.getSetCookieHeaders());
         setInternalHeaders(WTF::move(headers));
         m_updateCounter++;
         return {};
@@ -302,8 +295,7 @@ ExceptionOr<void> FetchHeaders::set(const HTTPHeaderName name, const String& val
         return {};
 
     ++m_updateCounter;
-    if (!m_headers.set(name, normalizedValue))
-        return headersTooLargeException();
+    m_headers.set(name, normalizedValue);
 
     if (m_guard == FetchHeaders::Guard::RequestNoCors)
         removePrivilegedNoCORSRequestHeaders(m_headers);
@@ -321,8 +313,7 @@ ExceptionOr<void> FetchHeaders::set(const String& name, const String& value)
         return {};
 
     ++m_updateCounter;
-    if (!m_headers.set(name, normalizedValue))
-        return headersTooLargeException();
+    m_headers.set(name, normalizedValue);
 
     if (m_guard == FetchHeaders::Guard::RequestNoCors)
         removePrivilegedNoCORSRequestHeaders(m_headers);
@@ -335,7 +326,7 @@ std::optional<KeyValuePair<String, String>> FetchHeaders::Iterator::next()
     if (m_keys.isEmpty() || m_updateCounter != m_headers->m_updateCounter) {
         bool hasSetCookie = !m_headers->getSetCookieHeaders().isEmpty();
         m_keys.resize(0);
-        m_keys.reserveCapacity(m_headers->m_headers.size() + (hasSetCookie ? 1 : 0));
+        m_keys.reserveCapacity(m_headers->sizeAfterJoiningSetCookieHeader());
         if (m_lowerCaseKeys) {
             for (auto& header : m_headers->m_headers)
                 m_keys.unsafeAppendWithoutCapacityCheck(header.asciiLowerCaseName());

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
@@ -43,15 +43,6 @@ extern "C" void highway_lower_ascii16(const uint16_t* src, size_t len, uint16_t*
 
 namespace WebCore {
 
-// Script controls how long these vectors get, and Vector::append CRASH()es past the largest capacity.
-template<typename VectorType, typename U>
-static bool tryAppendHeader(VectorType& vector, U&& value)
-{
-    if (vector.size() >= Bun::maxVectorSize<typename VectorType::ValueType>()) [[unlikely]]
-        return false;
-    return vector.tryAppend(std::forward<U>(value));
-}
-
 String lowercaseHeaderName(const String& name)
 {
     if (name.isEmpty())
@@ -125,40 +116,40 @@ String HTTPHeaderMap::getUncommonHeader(const StringView name) const
     return index != notFound ? m_uncommonHeaders[index].value : String();
 }
 
-bool HTTPHeaderMap::set(const String& name, const String& value)
+void HTTPHeaderMap::set(const String& name, const String& value)
 {
     HTTPHeaderName headerName;
-    if (findHTTPHeaderName(name, headerName))
-        return set(headerName, value);
+    if (findHTTPHeaderName(name, headerName)) {
+        set(headerName, value);
+        return;
+    }
 
-    return setUncommonHeader(name, value);
+    setUncommonHeader(name, value);
 }
 
-bool HTTPHeaderMap::setUncommonHeader(const String& name, const String& value)
+void HTTPHeaderMap::setUncommonHeader(const String& name, const String& value)
 {
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
     });
     if (index == notFound)
-        return tryAppendHeader(m_uncommonHeaders, UncommonHeader { name, value });
-
-    m_uncommonHeaders[index].value = value;
-    return true;
+        m_uncommonHeaders.append(UncommonHeader { name, value });
+    else
+        m_uncommonHeaders[index].value = value;
 }
 
-bool HTTPHeaderMap::addUncommonHeader(const String& name, const String& value)
+void HTTPHeaderMap::addUncommonHeader(const String& name, const String& value)
 {
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
     });
     if (index == notFound)
-        return tryAppendHeader(m_uncommonHeaders, UncommonHeader { name, value });
-
-    m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
-    return true;
+        m_uncommonHeaders.append(UncommonHeader { name, value });
+    else
+        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
 }
 
-bool HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const String& value)
+void HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const String& value)
 {
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
@@ -167,11 +158,9 @@ bool HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const Stri
         std::span<Latin1Character> ptr;
         auto nameCopy = WTF::String::createUninitialized(name.length(), ptr);
         memcpy(ptr.data(), name.span8().data(), name.length());
-        return tryAppendHeader(m_uncommonHeaders, UncommonHeader { nameCopy, value });
-    }
-
-    m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
-    return true;
+        m_uncommonHeaders.append(UncommonHeader { nameCopy, value });
+    } else
+        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
 }
 
 bool HTTPHeaderMap::add(const String& name, const String& value)
@@ -184,9 +173,9 @@ bool HTTPHeaderMap::add(const String& name, const String& value)
         return equalIgnoringASCIICase(header.key, name);
     });
     if (index == notFound)
-        return tryAppendHeader(m_uncommonHeaders, UncommonHeader { name, value });
-
-    m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
+        m_uncommonHeaders.append(UncommonHeader { name, value });
+    else
+        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
     return true;
 }
 
@@ -275,14 +264,12 @@ String HTTPHeaderMap::getIndex(HTTPHeaderMap::HeaderIndex index) const
         return m_commonHeaders[index.index].value;
     return m_uncommonHeaders[index.index].value;
 }
-bool HTTPHeaderMap::set(HTTPHeaderName name, const String& value)
+void HTTPHeaderMap::set(HTTPHeaderName name, const String& value)
 {
     if (name == HTTPHeaderName::SetCookie) {
-        Vector<String, 0> replacement;
-        if (!tryAppendHeader(replacement, value)) [[unlikely]]
-            return false;
-        m_setCookieHeaders = WTF::move(replacement);
-        return true;
+        m_setCookieHeaders.clear();
+        m_setCookieHeaders.append(value);
+        return;
     }
 
     auto index = m_commonHeaders.findIf([&](auto& header) {
@@ -292,7 +279,6 @@ bool HTTPHeaderMap::set(HTTPHeaderName name, const String& value)
         m_commonHeaders.append(CommonHeader { name, value });
     else
         m_commonHeaders[index].value = value;
-    return true;
 }
 
 bool HTTPHeaderMap::setIndex(HTTPHeaderMap::HeaderIndex index, const String& value)
@@ -333,8 +319,12 @@ bool HTTPHeaderMap::remove(HTTPHeaderName name)
 
 bool HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
 {
-    if (name == HTTPHeaderName::SetCookie)
-        return tryAppendHeader(m_setCookieHeaders, value);
+    if (name == HTTPHeaderName::SetCookie) {
+        // Script grows this list one cheap call at a time, and Vector::append CRASH()es past the largest capacity.
+        if (m_setCookieHeaders.size() >= Bun::maxVectorSize<String>()) [[unlikely]]
+            return false;
+        return m_setCookieHeaders.tryAppend(value);
+    }
 
     auto index = m_commonHeaders.findIf([&](auto& header) {
         return header.key == name;

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
@@ -32,6 +32,7 @@
 #include "config.h"
 #include "HTTPHeaderMap.h"
 
+#include "VectorSizeLimit.h"
 #include <utility>
 #include <wtf/text/StringView.h>
 
@@ -41,6 +42,17 @@ extern "C" size_t highway_index_of_first_ascii_upper16(const uint16_t* input, si
 extern "C" void highway_lower_ascii16(const uint16_t* src, size_t len, uint16_t* dst);
 
 namespace WebCore {
+
+// Vector::append CRASH()es when the buffer has to grow past the largest capacity a
+// WTF::Vector can have. Script sets the length of the set-cookie and uncommon-header
+// vectors, so they grow through this instead.
+template<typename VectorType, typename U>
+static bool tryAppendHeader(VectorType& vector, U&& value)
+{
+    if (vector.size() >= Bun::maxVectorSize<typename VectorType::ValueType>()) [[unlikely]]
+        return false;
+    return vector.tryAppend(std::forward<U>(value));
+}
 
 String lowercaseHeaderName(const String& name)
 {
@@ -115,40 +127,40 @@ String HTTPHeaderMap::getUncommonHeader(const StringView name) const
     return index != notFound ? m_uncommonHeaders[index].value : String();
 }
 
-void HTTPHeaderMap::set(const String& name, const String& value)
+bool HTTPHeaderMap::set(const String& name, const String& value)
 {
     HTTPHeaderName headerName;
-    if (findHTTPHeaderName(name, headerName)) {
-        set(headerName, value);
-        return;
-    }
+    if (findHTTPHeaderName(name, headerName))
+        return set(headerName, value);
 
-    setUncommonHeader(name, value);
+    return setUncommonHeader(name, value);
 }
 
-void HTTPHeaderMap::setUncommonHeader(const String& name, const String& value)
+bool HTTPHeaderMap::setUncommonHeader(const String& name, const String& value)
 {
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
     });
     if (index == notFound)
-        m_uncommonHeaders.append(UncommonHeader { name, value });
-    else
-        m_uncommonHeaders[index].value = value;
+        return tryAppendHeader(m_uncommonHeaders, UncommonHeader { name, value });
+
+    m_uncommonHeaders[index].value = value;
+    return true;
 }
 
-void HTTPHeaderMap::addUncommonHeader(const String& name, const String& value)
+bool HTTPHeaderMap::addUncommonHeader(const String& name, const String& value)
 {
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
     });
     if (index == notFound)
-        m_uncommonHeaders.append(UncommonHeader { name, value });
-    else
-        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
+        return tryAppendHeader(m_uncommonHeaders, UncommonHeader { name, value });
+
+    m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
+    return true;
 }
 
-void HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const String& value)
+bool HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const String& value)
 {
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
@@ -157,25 +169,27 @@ void HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const Stri
         std::span<Latin1Character> ptr;
         auto nameCopy = WTF::String::createUninitialized(name.length(), ptr);
         memcpy(ptr.data(), name.span8().data(), name.length());
-        m_uncommonHeaders.append(UncommonHeader { nameCopy, value });
-    } else
-        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
+        return tryAppendHeader(m_uncommonHeaders, UncommonHeader { nameCopy, value });
+    }
+
+    m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
+    return true;
 }
 
-void HTTPHeaderMap::add(const String& name, const String& value)
+bool HTTPHeaderMap::add(const String& name, const String& value)
 {
     HTTPHeaderName headerName;
-    if (findHTTPHeaderName(name, headerName)) {
-        add(headerName, value);
-        return;
-    }
+    if (findHTTPHeaderName(name, headerName))
+        return add(headerName, value);
+
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
     });
     if (index == notFound)
-        m_uncommonHeaders.append(UncommonHeader { name, value });
-    else
-        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
+        return tryAppendHeader(m_uncommonHeaders, UncommonHeader { name, value });
+
+    m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
+    return true;
 }
 
 bool HTTPHeaderMap::contains(const StringView name) const
@@ -263,21 +277,21 @@ String HTTPHeaderMap::getIndex(HTTPHeaderMap::HeaderIndex index) const
         return m_commonHeaders[index.index].value;
     return m_uncommonHeaders[index.index].value;
 }
-void HTTPHeaderMap::set(HTTPHeaderName name, const String& value)
+bool HTTPHeaderMap::set(HTTPHeaderName name, const String& value)
 {
     if (name == HTTPHeaderName::SetCookie) {
         m_setCookieHeaders.clear();
-        m_setCookieHeaders.append(value);
-        return;
+        return tryAppendHeader(m_setCookieHeaders, value);
     }
 
     auto index = m_commonHeaders.findIf([&](auto& header) {
         return header.key == name;
     });
     if (index == notFound)
-        m_commonHeaders.append(CommonHeader { name, value });
-    else
-        m_commonHeaders[index].value = value;
+        return tryAppendHeader(m_commonHeaders, CommonHeader { name, value });
+
+    m_commonHeaders[index].value = value;
+    return true;
 }
 
 bool HTTPHeaderMap::setIndex(HTTPHeaderMap::HeaderIndex index, const String& value)
@@ -316,20 +330,19 @@ bool HTTPHeaderMap::remove(HTTPHeaderName name)
     });
 }
 
-void HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
+bool HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
 {
-    if (name == HTTPHeaderName::SetCookie) {
-        m_setCookieHeaders.append(value);
-        return;
-    }
+    if (name == HTTPHeaderName::SetCookie)
+        return tryAppendHeader(m_setCookieHeaders, value);
 
     auto index = m_commonHeaders.findIf([&](auto& header) {
         return header.key == name;
     });
-    if (index != notFound)
-        m_commonHeaders[index].value = makeString(m_commonHeaders[index].value, name == HTTPHeaderName::Cookie ? "; "_s : ", "_s, value);
-    else
-        m_commonHeaders.append(CommonHeader { name, value });
+    if (index == notFound)
+        return tryAppendHeader(m_commonHeaders, CommonHeader { name, value });
+
+    m_commonHeaders[index].value = makeString(m_commonHeaders[index].value, name == HTTPHeaderName::Cookie ? "; "_s : ", "_s, value);
+    return true;
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
@@ -289,9 +289,9 @@ bool HTTPHeaderMap::set(HTTPHeaderName name, const String& value)
         return header.key == name;
     });
     if (index == notFound)
-        return tryAppendHeader(m_commonHeaders, CommonHeader { name, value });
-
-    m_commonHeaders[index].value = value;
+        m_commonHeaders.append(CommonHeader { name, value });
+    else
+        m_commonHeaders[index].value = value;
     return true;
 }
 
@@ -339,10 +339,10 @@ bool HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
     auto index = m_commonHeaders.findIf([&](auto& header) {
         return header.key == name;
     });
-    if (index == notFound)
-        return tryAppendHeader(m_commonHeaders, CommonHeader { name, value });
-
-    m_commonHeaders[index].value = makeString(m_commonHeaders[index].value, name == HTTPHeaderName::Cookie ? "; "_s : ", "_s, value);
+    if (index != notFound)
+        m_commonHeaders[index].value = makeString(m_commonHeaders[index].value, name == HTTPHeaderName::Cookie ? "; "_s : ", "_s, value);
+    else
+        m_commonHeaders.append(CommonHeader { name, value });
     return true;
 }
 

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
@@ -43,9 +43,7 @@ extern "C" void highway_lower_ascii16(const uint16_t* src, size_t len, uint16_t*
 
 namespace WebCore {
 
-// Vector::append CRASH()es when the buffer has to grow past the largest capacity a
-// WTF::Vector can have. Script sets the length of the set-cookie and uncommon-header
-// vectors, so they grow through this instead.
+// Script controls how long these vectors get, and Vector::append CRASH()es past the largest capacity.
 template<typename VectorType, typename U>
 static bool tryAppendHeader(VectorType& vector, U&& value)
 {

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
@@ -280,8 +280,11 @@ String HTTPHeaderMap::getIndex(HTTPHeaderMap::HeaderIndex index) const
 bool HTTPHeaderMap::set(HTTPHeaderName name, const String& value)
 {
     if (name == HTTPHeaderName::SetCookie) {
-        m_setCookieHeaders.clear();
-        return tryAppendHeader(m_setCookieHeaders, value);
+        Vector<String, 0> replacement;
+        if (!tryAppendHeader(replacement, value)) [[unlikely]]
+            return false;
+        m_setCookieHeaders = WTF::move(replacement);
+        return true;
     }
 
     auto index = m_commonHeaders.findIf([&](auto& header) {

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -164,8 +164,7 @@ public:
     int size() const { return m_commonHeaders.size() + m_uncommonHeaders.size() + m_setCookieHeaders.size(); }
 
     WEBCORE_EXPORT String get(const StringView name) const;
-    // The mutators return false, and leave the map unchanged, when a vector is at
-    // Bun::maxVectorSize<T>() or its allocation fails.
+    // Mutators return false, map unchanged, when a vector is at Bun::maxVectorSize<T>() or allocation fails.
     [[nodiscard]] WEBCORE_EXPORT bool set(const String& name, const String& value);
     [[nodiscard]] WEBCORE_EXPORT bool add(const String& name, const String& value);
     WEBCORE_EXPORT bool contains(const StringView) const;

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -164,8 +164,12 @@ public:
     int size() const { return m_commonHeaders.size() + m_uncommonHeaders.size() + m_setCookieHeaders.size(); }
 
     WEBCORE_EXPORT String get(const StringView name) const;
-    WEBCORE_EXPORT void set(const String& name, const String& value);
-    WEBCORE_EXPORT void add(const String& name, const String& value);
+    // These return false when the header does not fit, because the set-cookie or
+    // uncommon-header vector is at the largest capacity a WTF::Vector can have, or
+    // because the allocation failed. The map stays as it was. FetchHeaders turns a
+    // false into a RangeError.
+    [[nodiscard]] WEBCORE_EXPORT bool set(const String& name, const String& value);
+    [[nodiscard]] WEBCORE_EXPORT bool add(const String& name, const String& value);
     WEBCORE_EXPORT bool contains(const StringView) const;
     WEBCORE_EXPORT int64_t indexOf(StringView name) const;
     WEBCORE_EXPORT bool remove(const StringView);
@@ -177,8 +181,8 @@ public:
     HeaderIndex indexOf(HTTPHeaderName name) const;
 
     WEBCORE_EXPORT String get(HTTPHeaderName) const;
-    void set(HTTPHeaderName, const String& value);
-    void add(HTTPHeaderName, const String& value);
+    [[nodiscard]] bool set(HTTPHeaderName, const String& value);
+    [[nodiscard]] bool add(HTTPHeaderName, const String& value);
     WEBCORE_EXPORT bool contains(HTTPHeaderName) const;
     WEBCORE_EXPORT bool remove(HTTPHeaderName);
 
@@ -229,9 +233,9 @@ public:
         return !(a == b);
     }
 
-    void setUncommonHeader(const String& name, const String& value);
-    void addUncommonHeader(const String& name, const String& value);
-    void addUncommonHeaderCloneName(const StringView name, const String& value);
+    [[nodiscard]] bool setUncommonHeader(const String& name, const String& value);
+    [[nodiscard]] bool addUncommonHeader(const String& name, const String& value);
+    [[nodiscard]] bool addUncommonHeaderCloneName(const StringView name, const String& value);
 
 private:
     WEBCORE_EXPORT String getUncommonHeader(const StringView name) const;

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -164,8 +164,8 @@ public:
     int size() const { return m_commonHeaders.size() + m_uncommonHeaders.size() + m_setCookieHeaders.size(); }
 
     WEBCORE_EXPORT String get(const StringView name) const;
-    // Mutators return false, map unchanged, when a vector is at Bun::maxVectorSize<T>() or allocation fails.
-    [[nodiscard]] WEBCORE_EXPORT bool set(const String& name, const String& value);
+    WEBCORE_EXPORT void set(const String& name, const String& value);
+    // add() returns false, map unchanged, when the set-cookie list is full or its allocation fails.
     [[nodiscard]] WEBCORE_EXPORT bool add(const String& name, const String& value);
     WEBCORE_EXPORT bool contains(const StringView) const;
     WEBCORE_EXPORT int64_t indexOf(StringView name) const;
@@ -178,7 +178,7 @@ public:
     HeaderIndex indexOf(HTTPHeaderName name) const;
 
     WEBCORE_EXPORT String get(HTTPHeaderName) const;
-    [[nodiscard]] bool set(HTTPHeaderName, const String& value);
+    void set(HTTPHeaderName, const String& value);
     [[nodiscard]] bool add(HTTPHeaderName, const String& value);
     WEBCORE_EXPORT bool contains(HTTPHeaderName) const;
     WEBCORE_EXPORT bool remove(HTTPHeaderName);
@@ -230,9 +230,9 @@ public:
         return !(a == b);
     }
 
-    [[nodiscard]] bool setUncommonHeader(const String& name, const String& value);
-    [[nodiscard]] bool addUncommonHeader(const String& name, const String& value);
-    [[nodiscard]] bool addUncommonHeaderCloneName(const StringView name, const String& value);
+    void setUncommonHeader(const String& name, const String& value);
+    void addUncommonHeader(const String& name, const String& value);
+    void addUncommonHeaderCloneName(const StringView name, const String& value);
 
 private:
     WEBCORE_EXPORT String getUncommonHeader(const StringView name) const;

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -164,10 +164,8 @@ public:
     int size() const { return m_commonHeaders.size() + m_uncommonHeaders.size() + m_setCookieHeaders.size(); }
 
     WEBCORE_EXPORT String get(const StringView name) const;
-    // These return false when the header does not fit, because the set-cookie or
-    // uncommon-header vector is at the largest capacity a WTF::Vector can have, or
-    // because the allocation failed. The map stays as it was. FetchHeaders turns a
-    // false into a RangeError.
+    // The mutators return false, and leave the map unchanged, when a vector is at
+    // Bun::maxVectorSize<T>() or its allocation fails.
     [[nodiscard]] WEBCORE_EXPORT bool set(const String& name, const String& value);
     [[nodiscard]] WEBCORE_EXPORT bool add(const String& name, const String& value);
     WEBCORE_EXPORT bool contains(const StringView) const;

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -216,7 +216,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFetchHeadersPrototypeFunction_getAll, (JSGlobalObject
         return {};
     }
 
-    auto values = impl.getSetCookieHeaders();
+    auto& values = impl.getSetCookieHeaders();
     unsigned count = values.size();
     if (!count) {
         RELEASE_AND_RETURN(scope, JSValue::encode(JSC::constructEmptyArray(lexicalGlobalObject, nullptr, 0)));
@@ -261,7 +261,7 @@ JSC::EncodedJSValue fetchHeadersGetSetCookie(JSC::JSGlobalObject* lexicalGlobalO
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto values = impl->getSetCookieHeaders();
+    auto& values = impl->getSetCookieHeaders();
     unsigned count = values.size();
 
     if (!count) {

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -759,6 +759,14 @@ describe("Headers", () => {
         expect(headers.getSetCookie().length).toBe(MAX_SET_COOKIE);
         headers.set("content-type", "text/plain");
         expect(headers.get("content-type")).toBe("text/plain");
+
+        // A Headers at the bound can still be copied: the copy holds exactly the bound.
+        const response = new Response(null, { headers });
+        expect(response.clone().headers.getSetCookie().length).toBe(MAX_SET_COOKIE);
+
+        // set() replaces every set-cookie value with one, so it succeeds at the bound.
+        headers.set("set-cookie", "b=2");
+        expect(headers.getSetCookie()).toEqual(["b=2"]);
       } finally {
         setLimit(previousLimit);
       }

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -741,8 +741,11 @@ describe("Headers", () => {
     // most min(INT32_MAX, the synthetic allocation limit) / 8 entries.
     // setSyntheticAllocationLimitForTesting floors at 1 MiB, which puts the bound at
     // 131072 values. Without it the bound is 262343954 values and about 2 GB.
+    // 131072 append() calls take about 4 s on a debug ASAN build (milliseconds on a
+    // release build), which is too close to the 5 s default, so the test names a timeout.
     const LIMIT_BYTES = 1024 * 1024;
     const MAX_SET_COOKIE = LIMIT_BYTES / 8;
+    const TIMEOUT_MS = 30_000;
 
     test("append('set-cookie') throws a RangeError past the vector's largest size", () => {
       const setLimit = internalForTesting.setSyntheticAllocationLimitForTesting;
@@ -770,6 +773,6 @@ describe("Headers", () => {
       } finally {
         setLimit(previousLimit);
       }
-    });
+    }, TIMEOUT_MS);
   });
 });

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -735,4 +735,33 @@ describe("Headers", () => {
       expect(lowercaseHeaderNameSIMD(s)).toBe("x-ab\u0100cd\u0101ef\uffffgz");
     });
   });
+
+  describe("growth limit", () => {
+    // Every set-cookie value is one entry in a Vector<String>. That vector holds at
+    // most min(INT32_MAX, the synthetic allocation limit) / 8 entries.
+    // setSyntheticAllocationLimitForTesting floors at 1 MiB, which puts the bound at
+    // 131072 values. Without it the bound is 262343954 values and about 2 GB.
+    const LIMIT_BYTES = 1024 * 1024;
+    const MAX_SET_COOKIE = LIMIT_BYTES / 8;
+
+    test("append('set-cookie') throws a RangeError past the vector's largest size", () => {
+      const setLimit = internalForTesting.setSyntheticAllocationLimitForTesting;
+      const previousLimit = setLimit(LIMIT_BYTES);
+      try {
+        const headers = new Headers();
+        for (let i = 0; i < MAX_SET_COOKIE; i++) headers.append("set-cookie", "a=1");
+        expect(headers.getSetCookie().length).toBe(MAX_SET_COOKIE);
+
+        expect(() => headers.append("set-cookie", "a=1")).toThrow(RangeError);
+        expect(() => headers.append("set-cookie", "a=1")).toThrow("Headers maximum size exceeded");
+
+        // The refused value is not stored, and the object still works.
+        expect(headers.getSetCookie().length).toBe(MAX_SET_COOKIE);
+        headers.set("content-type", "text/plain");
+        expect(headers.get("content-type")).toBe("text/plain");
+      } finally {
+        setLimit(previousLimit);
+      }
+    });
+  });
 });

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, test } from "bun:test";
 // Namespace import so a missing binding fails only the kernel tests below
 // (accessing an absent export is `undefined`), not the whole file.
 import * as internalForTesting from "bun:internal-for-testing";
+import { bunEnv, bunExe } from "harness";
 
 beforeAll(() => {
   // expect(Headers).toBeDefined();
@@ -737,42 +738,73 @@ describe("Headers", () => {
   });
 
   describe("growth limit", () => {
-    // Every set-cookie value is one entry in a Vector<String>. That vector holds at
-    // most min(INT32_MAX, the synthetic allocation limit) / 8 entries.
-    // setSyntheticAllocationLimitForTesting floors at 1 MiB, which puts the bound at
-    // 131072 values. Without it the bound is 262343954 values and about 2 GB.
-    // 131072 append() calls take about 4 s on a debug ASAN build (milliseconds on a
-    // release build), which is too close to the 5 s default, so the test names a timeout.
-    const LIMIT_BYTES = 1024 * 1024;
+    // Every set-cookie value is one entry in a Vector<String>, which holds at most
+    // min(INT32_MAX, the synthetic allocation limit) / 8 entries. The real limit
+    // needs 262343954 values and 2 GB. The child runs with a 64 KiB limit, which
+    // puts it at 8192 values.
+    const LIMIT_BYTES = 64 * 1024;
     const MAX_SET_COOKIE = LIMIT_BYTES / 8;
-    const TIMEOUT_MS = 30_000;
 
-    test("append('set-cookie') throws a RangeError past the vector's largest size", () => {
-      const setLimit = internalForTesting.setSyntheticAllocationLimitForTesting;
-      const previousLimit = setLimit(LIMIT_BYTES);
-      try {
-        const headers = new Headers();
-        for (let i = 0; i < MAX_SET_COOKIE; i++) headers.append("set-cookie", "a=1");
-        expect(headers.getSetCookie().length).toBe(MAX_SET_COOKIE);
+    test("append('set-cookie') throws a RangeError when the list cannot grow", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const headers = new Headers();
+            let stored = 0;
+            let appendError = null;
+            try {
+              for (; stored < ${MAX_SET_COOKIE} + 100; stored++) headers.append("set-cookie", "a=" + stored);
+            } catch (e) {
+              appendError = e.name + ": " + e.message;
+            }
+            const values = headers.getSetCookie();
 
-        expect(() => headers.append("set-cookie", "a=1")).toThrow(RangeError);
-        expect(() => headers.append("set-cookie", "a=1")).toThrow("Headers maximum size exceeded");
+            let constructorError = null;
+            try {
+              new Headers([...values, "one=more"].map(value => ["set-cookie", value]));
+            } catch (e) {
+              constructorError = e.name + ": " + e.message;
+            }
 
-        // The refused value is not stored, and the object still works.
-        expect(headers.getSetCookie().length).toBe(MAX_SET_COOKIE);
-        headers.set("content-type", "text/plain");
-        expect(headers.get("content-type")).toBe("text/plain");
+            // The object still works at the limit.
+            headers.set("content-type", "text/plain");
+            const iterated = [...headers].length;
+            const copied = new Response(null, { headers }).clone().headers.getSetCookie().length;
+            headers.set("set-cookie", "b=2");
 
-        // A Headers at the bound can still be copied: the copy holds exactly the bound.
-        const response = new Response(null, { headers });
-        expect(response.clone().headers.getSetCookie().length).toBe(MAX_SET_COOKIE);
+            console.log(JSON.stringify({
+              stored,
+              appendError,
+              kept: values.length,
+              last: values.at(-1),
+              constructorError,
+              iterated,
+              copied,
+              afterSet: headers.getSetCookie(),
+            }));
+          `,
+        ],
+        env: { ...bunEnv, BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT: String(LIMIT_BYTES) },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-        // set() replaces every set-cookie value with one, so it succeeds at the bound.
-        headers.set("set-cookie", "b=2");
-        expect(headers.getSetCookie()).toEqual(["b=2"]);
-      } finally {
-        setLimit(previousLimit);
-      }
-    }, TIMEOUT_MS);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout || "{}")).toEqual({
+        stored: MAX_SET_COOKIE,
+        appendError: "RangeError: Out of memory",
+        // The refused value is not stored.
+        kept: MAX_SET_COOKIE,
+        last: "a=" + (MAX_SET_COOKIE - 1),
+        constructorError: "RangeError: Out of memory",
+        iterated: MAX_SET_COOKIE + 1,
+        copied: MAX_SET_COOKIE,
+        afterSet: ["b=2"],
+      });
+      expect(exitCode).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
### Problem
- `h.append("set-cookie", v)` on one `Headers`, 262,343,954 times, aborts the process: `panic(main thread): abort() called`, SIGABRT, exit 134, at 2.0 GB RSS. A fuzzing run found it. No user has reported it.
- `HTTPHeaderMap::add` keeps set-cookie values in a `Vector<String>` (`src/jsc/bindings/webcore/HTTPHeaderMap.cpp:322`). `Vector::append` calls `CRASH()` once the next capacity passes `isValidCapacityForVector<T>`.

### Fix
- `add` grows the set-cookie list with `tryAppend` and returns false when the value is not stored. `Headers.append` and the constructor then throw `RangeError: Out of memory`, the error #37237, #42218 and #42250 use.
- Only this site is fallible: script grows it at a small, constant cost per call. Network input cannot, because each transport caps one message's headers. Every other header vector stays as on `main` (Notes says why).
- Iteration reserved one key slot per set-cookie value and used one. It now reserves the exact count. `getSetCookie()` reads the list by reference.
- Verified: `test/js/web/fetch/headers.test.ts` (one new test, fails on the branch-point sources). Also the `headers*`, `response`, `request`, cookie, `serve` and `node-http` suites.

### Background
- `WTF::Vector<T>` holds at most `(UINT_MAX >> 1) / sizeof(T)` elements. `append` calls `CRASH()` past that. `tryAppend` returns false.
- `Bun::maxVectorSize<T>()` is that bound, lowered by `Bun__stringSyntheticAllocationLimit`. In production `tryAppend` refuses first. The check binds only when a test lowers the limit: `BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT=65536` gives 8192 values.
- `Bun::maxVectorSize<T>()` lives in `VectorSizeLimit.h`, which #42649 put on `main`. #42218 and #42250 also edit `appendToHeaderMap` and `add`. The changes are independent. Whichever lands second re-applies its half.

<details><summary>Notes</summary>

**Sites left as on `main`, and why each cannot reach the capacity limit**
- `m_uncommonHeaders` (unknown header names): every insert scans the vector for the name, so growing it to its 134 million entries is quadratic, about a year of CPU.
- `m_commonHeaders`: one entry per `HTTPHeaderName`, so the enum bounds it.
- `set("set-cookie", v)`: the list holds one value after `clear()`.
- `FetchHeaders::fill(const FetchHeaders&)`, the `clone()` fast path: it copies a list that already fits, with an exact-size reserve, which is a valid capacity.
- On all four, only a failed allocation can fail, and that is fatal everywhere else in Bun too.
- The parser-side builders (`createFromPicoHeaders_`, `createFromUWS`, `createFromH3`): HTTP/1 caps the header count at 256 (client) and 200 (server), the HTTP/2 client enforces a 256 KiB header block, and an HTTP/3 message would need over 10 GB of parser state before it delivered 262 million fields. `RELEASE_ASSERT` there is the same outcome `append` had.

**What was verified at the real limit**
- On a release build of an earlier revision of this PR (c65a828293), whose set-cookie path is the same `tryAppend` call: the 262,343,954th `append` throws after 19 s at 1.99 GiB RSS, the process keeps running, and `set`, `get`, `has`, iteration and `delete` all work. Exit code 0. The error message differed at that revision.
- The real limit is not in the test. It needs 2 GB, and hours on a debug build.

**The test**
- It runs in a child process with `BUN_FEATURE_FLAG_SYNTHETIC_MEMORY_LIMIT=65536`, the same knob `scrypt.test.ts` and `argon2.test.ts` use. It takes 1.5 s on a debug ASAN build, most of it child start-up.
- On the branch-point sources nothing refuses: all 8292 appends succeed, both errors are `null`, and the child exits 0. So the fail-before is an assertion failure, not an abort.
- It also covers the constructor, iteration, `Response.clone()` and `set("set-cookie")` at the limit.

**History of this PR**
- Earlier revisions made every `HTTPHeaderMap` mutator fallible and threw `RangeError: Headers maximum size exceeded`. A self-review narrowed it to the one site script can drive, and moved to the error the sibling changes throw.
- Self-reviewed: 17 concerns raised, 13 addressed. Four were not taken. Folding #42218 into this PR: it is an independent change (`String::MaxLength`, not `Vector` capacity) with its own owner, and #42250's body records the landing rule. Parking until a user report: a fuzzing run found it, and `REVIEW.md` treats an abort that user input reaches as a defect. A prerequisite PR for `VectorSizeLimit.h`: moot now, #42649 landed the file on `main` and this branch merged it. A growth-site lint and a script-sized vector type: those are policy calls for a maintainer.

**Found along the way, reported separately**
- `WebCore__FetchHeaders__count` stores a `size_t` total through a `uint32_t*`. A `Headers` that totals 4 GiB or more, passed to `fetch()`, makes `copyTo` write past a buffer sized from the truncated value. This PR does not touch that code.

**Environment**
- `serve.test.ts` fails 2 tests in this container with and without this diff (a root-range port test, and a loopback check). CI on the previous head was green except `serve-pending-promise-abort-leak.test.ts` on x64-asan, which fails the same way on unrelated PRs and is reported for triage.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/headers.test.ts
bun test v1.4.3 (09bb54630)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [4.34ms]
(pass) Headers > constructor > cannot create headers from null [3.17ms]
(pass) Headers > constructor > can create headers from empty object [2.36ms]
(pass) Headers > constructor > can create headers from object [1.99ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [2.68ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [5.01ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [6.53ms]
(pass) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [8.51ms]
(pass) Headers > constructor > constructing headers from an object propagates an exception from a getter installed by an earlier value's toString [5.60ms]
(pass) Headers > constructor > construc
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (09bb54630)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [0.06ms]
(pass) Headers > constructor > cannot create headers from null [0.08ms]
(pass) Headers > constructor > can create headers from empty object [0.03ms]
(pass) Headers > constructor > can create headers from object [0.04ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [0.07ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [0.10ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [0.10ms]
(pass) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [0.18ms]
(pass) Headers > constructor > constructing headers from an object propagates an exception from a getter installed by an earlier value's toString [0.09ms]
(pass) Headers > constructor > constructing headers from an object keeps own-property semantics after setPrototypeOf mid-conversion [0.09ms]
(pass) Headers > constructor > can create headers from 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/headers.test.ts
bun test v1.4.3 (09bb54630)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [4.27ms]
(pass) Headers > constructor > cannot create headers from null [3.17ms]
(pass) Headers > constructor > can create headers from empty object [2.38ms]
(pass) Headers > constructor > can create headers from object [2.01ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [2.57ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [4.88ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [6.44ms]
(pass) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [8.30ms]
(pass) Headers > constructor > constructing headers from an object propagates an exception from a getter installed by an earlier value's toString [5.45ms]
(pass) Headers > constructor > construc
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 658ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/16] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[2/16] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[3/16] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-1.cpp.o
[4/16] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[5/16] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[6/16] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[7/16] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[8/16] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[9/16] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[10/16] cxx obj/src/jsc/bindings/bindings.cpp.o
[11/16] gen cpp.rs (cppbind)
[11/16] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 28s
[12/16] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-0.cpp.o
[13/16] link bun-profile
[15/16] strip bun
[15/16] bun-profile --revision
1.4.3-canary.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp               | 13 ++++--
 src/jsc/bindings/webcore/FetchHeaders.cpp   | 15 +++---
 src/jsc/bindings/webcore/HTTPHeaderMap.cpp  | 20 ++++----
 src/jsc/bindings/webcore/HTTPHeaderMap.h    |  5 +-
 src/jsc/bindings/webcore/JSFetchHeaders.cpp |  4 +-
 test/js/web/fetch/headers.test.ts           | 72 +++++++++++++++++++++++++++++
 6 files changed, 107 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/bindings.cpp                    5     10     20
src/jsc/bindings/webcore/FetchHeaders.cpp        6     10     20
src/jsc/bindings/webcore/HTTPHeaderMap.cpp       5     12     20
src/jsc/bindings/webcore/HTTPHeaderMap.h         3      8     20
src/jsc/bindings/webcore/JSFetchHeaders.cpp      1      1     20
test/js/web/fetch/headers.test.ts                5      6     20
```

</details>

<!-- robobun:evidence:end -->
