### PR TITLE
node:fs: keep async readv and writev off a WebAssembly.Memory block that grow() freed

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6972,6 +6972,9 @@ extern "C" JSC::EncodedJSValue Bun__REPL__formatValue(
 // every pinned element with `JSC__JSValue__unpinArrayBuffer`. SharedArrayBuffer
 // is never detachable and never moves, so it is left unpinned.
 //
+// `volatileStorage` marks an element the pin does not hold; the caller copies
+// those.
+//
 // Returns 0 on success, 1 if the value is not a JSArray or an element is not
 // an ArrayBufferView, 2 on allocation failure, -1 if an exception is pending.
 extern "C" int32_t Bun__JSArray__collectBufferSpans(
@@ -6979,7 +6982,7 @@ extern "C" int32_t Bun__JSArray__collectBufferSpans(
     JSC::EncodedJSValue encodedValue,
     bool pinBuffers,
     void* ctx,
-    void (*append)(void* ctx, JSC::EncodedJSValue element, void* data, size_t byteLength))
+    void (*append)(void* ctx, JSC::EncodedJSValue element, void* data, size_t byteLength, bool volatileStorage))
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -7006,6 +7009,7 @@ extern "C" int32_t Bun__JSArray__collectBufferSpans(
         auto* view = dynamicDowncast<JSC::JSArrayBufferView>(values.at(i));
         if (!view)
             return 1;
+        bool volatileStorage = false;
         if (pinBuffers) {
             // possiblySharedBuffer() converts a FastTypedArray (GC-movable
             // storage, no ArrayBuffer yet) into a malloc-backed one and can
@@ -7013,10 +7017,14 @@ extern "C" int32_t Bun__JSArray__collectBufferSpans(
             auto* buf = view->possiblySharedBuffer();
             if (!buf) [[unlikely]]
                 return 2;
-            if (!buf->isShared())
+            if (!buf->isShared()) {
                 buf->pin();
+                // `ArrayBuffer::detach` ignores the pin count for a wasm memory,
+                // and `grow()` on a bounds-checked one frees the block.
+                volatileStorage = buf->isWasmMemory();
+            }
         }
-        append(ctx, JSC::JSValue::encode(view), view->vector(), view->byteLength());
+        append(ctx, JSC::JSValue::encode(view), view->vector(), view->byteLength(), volatileStorage);
     }
     return 0;
 }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1038,7 +1038,6 @@ mod _async_tasks {
     impl_fs_argument!(
         args::Rename<'static>,
         args::Truncate<'static>,
-        args::FdVectorIo,
         args::FTruncate,
         args::Chown<'static>,
         args::Lutimes<'static>,
@@ -1081,6 +1080,22 @@ mod _async_tasks {
             let len = bytes_written.unwrap_or(0).min(self.length) as usize;
             if let args::ReadBuffer::PinnedBuffer(buffer) = &mut self.buffer {
                 buffer.write_back(global, len);
+            }
+        }
+    }
+    // `readv` and `writev` share this argument set. `write_back` reaches only
+    // `readv`: `ret::Writev` is `ret::Write`, which reports no bytes.
+    // SAFETY: as for `impl_fs_argument!`.
+    unsafe impl ThreadIsolatedArg for args::FdVectorIo {}
+    impl FsArgument for args::FdVectorIo {
+        #[inline]
+        fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Self> {
+            args::FdVectorIo::from_js(ctx, arguments)
+        }
+        #[inline]
+        fn write_back(&mut self, global: &JSGlobalObject, bytes_written: Option<u64>) {
+            if let Some(bytes_read) = bytes_written {
+                self.buffers.write_back(global, bytes_read);
             }
         }
     }

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1293,12 +1293,34 @@ impl Valid {
 
 // ──────────────────────────────────────────────────────────────────────────
 
+/// What one element's iovec points at.
+enum Span {
+    /// The element's own bytes, of this length.
+    Borrowed(usize),
+    /// A copy of them, for storage a pin does not hold.
+    Copied(Vec<u8>),
+}
+
+impl Span {
+    #[inline]
+    fn len(&self) -> usize {
+        match self {
+            Span::Borrowed(len) => *len,
+            Span::Copied(bytes) => bytes.len(),
+        }
+    }
+}
+
 pub struct VectorArrayBuffer {
     pub value: JSValue,
     pub(crate) buffers: Vec<PlatformIoVec>,
     /// The collected elements, in order. Rooted (and their backing stores
     /// pinned), along with `value`, from `from_js(.., pin: true)` until drop.
     pub(crate) views: Vec<JSValue>,
+    /// Parallel to `views`: what each iovec points at.
+    spans: Vec<Span>,
+    /// A copy could not be allocated. `from_js` turns this into a throw.
+    oom: bool,
     pinned: bool,
 }
 
@@ -1327,6 +1349,7 @@ unsafe extern "C" {
             element: JSValue,
             data: *mut u8,
             byte_len: usize,
+            volatile_storage: bool,
         ),
     ) -> i32;
 }
@@ -1336,6 +1359,7 @@ unsafe extern "C" fn append_buffer_span(
     element: JSValue,
     data: *mut u8,
     byte_len: usize,
+    volatile_storage: bool,
 ) {
     // SAFETY: `ctx` is the `&mut VectorArrayBuffer` passed to
     // `Bun__JSArray__collectBufferSpans` by `from_js` below, alive for the
@@ -1348,7 +1372,24 @@ unsafe extern "C" fn append_buffer_span(
         // backing store, valid and unaliased for the duration of the callback.
         unsafe { std::slice::from_raw_parts_mut(data, byte_len) }
     };
-    out.buffers.push(bun_sys::platform_iovec_create(slice));
+    let mut span = Span::Borrowed(slice.len());
+    if volatile_storage && !slice.is_empty() {
+        let mut copy = Vec::new();
+        if copy.try_reserve_exact(slice.len()).is_err() {
+            out.oom = true;
+        } else {
+            copy.extend_from_slice(slice);
+            span = Span::Copied(copy);
+        }
+    }
+    // The `out.spans` push below moves the `Vec`, not its bytes, so the
+    // pointer this takes stays good.
+    let iovec = match &mut span {
+        Span::Copied(copy) => bun_sys::platform_iovec_create(copy.as_mut_slice()),
+        Span::Borrowed(_) => bun_sys::platform_iovec_create(slice),
+    };
+    out.buffers.push(iovec);
+    out.spans.push(span);
     out.views.push(element);
 }
 
@@ -1370,6 +1411,8 @@ impl VectorArrayBuffer {
             value: val,
             buffers: Vec::new(),
             views: Vec::new(),
+            spans: Vec::new(),
+            oom: false,
             pinned: false,
         };
         bun_jsc::validation_scope!(scope, global_object);
@@ -1396,6 +1439,9 @@ impl VectorArrayBuffer {
             }
             val.protect();
         }
+        if out.oom {
+            return Err(global_object.throw_out_of_memory());
+        }
         match status {
             0 => Ok(out),
             -1 => Err(jsc::JsError::Thrown),
@@ -1404,6 +1450,30 @@ impl VectorArrayBuffer {
                 Err(global_object
                     .throw_invalid_arguments(format_args!("Expected ArrayBufferView[]")))
             }
+        }
+    }
+
+    /// Copies what a read produced back into the elements it could not write
+    /// into directly. `bytes_read` fills the spans in order. JS thread: each
+    /// range is read from the JS value again, because a `grow()` since the
+    /// call moved the block or detached the view.
+    pub(crate) fn write_back(&mut self, global_object: &JSGlobalObject, bytes_read: u64) {
+        let mut left = bytes_read;
+        for (view, span) in self.views.iter().zip(self.spans.iter()) {
+            if left == 0 {
+                return;
+            }
+            let filled = left.min(span.len() as u64);
+            left -= filled;
+            let Span::Copied(bytes) = span else {
+                continue;
+            };
+            let Some(mut live) = view.as_array_buffer(global_object) else {
+                continue;
+            };
+            let dst = live.byte_slice_mut();
+            let n = (filled as usize).min(dst.len());
+            dst[..n].copy_from_slice(&bytes[..n]);
         }
     }
 }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -7324,3 +7324,181 @@ describe("module init", () => {
     expect(mismatched).toStrictEqual([]);
   });
 });
+
+// `fs.readv` and `fs.writev` pin each element's ArrayBuffer and hand the pool
+// thread the iovec it built. A pin does not keep the bytes of a
+// `WebAssembly.Memory` mapped: `grow()` on a bounds-checked memory allocates a
+// new block, copies into it, and frees the old one, and JSC detaches the old
+// buffer whatever its pin count. Each fixture below takes the fast memory
+// slots first, so the memory it grows is bounds-checked, and gates the syscall
+// on the parent, so the grow always lands while the call is in flight.
+describe("fs.readv/fs.writev over a WebAssembly.Memory", () => {
+  const FAST_SLOTS = `const hold = Array.from({ length: 10 }, () => new WebAssembly.Memory({ initial: 1, maximum: 2 }));`;
+
+  it("readv puts the bytes in the memory, not in the block the grow freed", async () => {
+    // The view comes from `toResizableBuffer()`, so it tracks the memory
+    // instead of detaching. That makes the result observable from JS: the
+    // payload has to appear in the grown memory.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const fs = require("node:fs");
+        ${FAST_SLOTS}
+        const mem = new WebAssembly.Memory({ initial: 32, maximum: 40 });
+        const view = new Uint8Array(mem.toResizableBuffer());
+        const { promise, resolve } = Promise.withResolvers();
+        fs.readv(0, [view], null, (err, n) => resolve({ err: err ? err.code : null, n }));
+        mem.grow(2);
+        const victim = new WebAssembly.Memory({ initial: 32, maximum: 40 });
+        process.stderr.write("ready\\n");
+        const { err, n } = await promise;
+        console.log(JSON.stringify({
+          err,
+          n,
+          payloadInMemory: Buffer.from(mem.buffer, 0, 8192).equals(Buffer.alloc(8192, 0x41)),
+          victimUntouched: Buffer.from(victim.buffer).indexOf(0x41) === -1,
+        }));
+        `,
+      ],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // The child prints this after the grow, so the read below cannot complete
+    // before the block it aims at is freed.
+    const stderr = await readUntil(proc.stderr as ReadableStream<Uint8Array>, "ready\n");
+    expect(stderr).toContain("ready\n");
+    proc.stdin.write(Buffer.alloc(8192, 0x41));
+    await proc.stdin.flush();
+
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({ err: null, n: 8192, payloadInMemory: true, victimUntouched: true });
+    expect(exitCode).toBe(0);
+  });
+
+  it.skipIf(isWindows)("writev sends the memory's bytes, not what took the block the grow freed", async () => {
+    // The child writes the whole memory to a FIFO and drains it itself. The
+    // first bytes to arrive prove the pool thread is inside writev(2), so the
+    // grow that follows frees the block while the call still reads from it.
+    //
+    // Malloc=1 is what makes a build without the fix fail every time. The
+    // freed block goes back to the system and is unmapped, so the kernel
+    // faults and the write ends short. The default allocator often keeps the
+    // block mapped with its old bytes, and a stale read of those is the same
+    // bytes a correct read sends.
+    using dir = tempDir("fs-writev-wasm", {});
+    const fifo = join(String(dir), "sink");
+    mkfifo(fifo);
+    const TOTAL = 32 * 65536;
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const fs = require("node:fs");
+        ${FAST_SLOTS}
+        const PAGES = 32;
+        const mem = new WebAssembly.Memory({ initial: PAGES, maximum: PAGES + 8 });
+        const view = new Uint8Array(mem.toResizableBuffer());
+        view.fill(0x41);
+        // O_RDWR so the open does not wait for a reader.
+        const wfd = fs.openSync(${JSON.stringify(fifo)}, fs.constants.O_RDWR);
+        // The reads must not block: a write that ends short leaves the pipe
+        // empty for good, and a blocking read of it would never return.
+        const rfd = fs.openSync(${JSON.stringify(fifo)}, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+        let written;
+        fs.writev(wfd, [view], null, (err, n) => { written = err ? err.code : n; });
+
+        const chunk = Buffer.alloc(1 << 16);
+        const payload = Buffer.alloc(chunk.length, 0x41);
+        const read = () => new Promise(res =>
+          fs.read(rfd, chunk, 0, chunk.length, null, (err, n) => res(err ? err.code : n)));
+        let drained = 0, foreign = 0, grown = false;
+        for (;;) {
+          const n = await read();
+          if (typeof n === "number" && n > 0) {
+            if (!chunk.subarray(0, n).equals(payload.subarray(0, n))) foreign++;
+            drained += n;
+            if (!grown) {
+              grown = true;
+              mem.grow(2);
+              new Uint8Array(new WebAssembly.Memory({ initial: PAGES, maximum: PAGES + 8 }).buffer).fill(0x5a);
+            }
+            continue;
+          }
+          if (n !== "EAGAIN") throw new Error("read: " + n);
+          // Done once the write has reported and every byte it reported is
+          // drained. An EAGAIN alone does not say so: that read may have run
+          // before the writer's last bytes reached the pipe, and its result
+          // can be delivered after the write's completion.
+          if (written !== undefined && (typeof written !== "number" || drained >= written)) break;
+          await new Promise(res => setImmediate(res));
+        }
+        console.log(JSON.stringify({ drained, foreignChunks: foreign, written }));
+        `,
+      ],
+      env: {
+        ...bunEnv,
+        Malloc: "1",
+        // detect_leaks=0: Malloc=1 exposes JSC's never-freed startup allocations to LSAN.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Every byte the child read back is the byte it filled the memory with,
+    // and the write reported all of them. stderr only stands in when the child
+    // printed nothing, so that the failure shows why.
+    expect(stdout || stderr).toBe(JSON.stringify({ drained: TOTAL, foreignChunks: 0, written: TOTAL }) + "\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("readv and writev still round-trip an ordinary buffer", async () => {
+    using dir = tempDir("fs-vector-io", {});
+    const file = join(String(dir), "round-trip.bin");
+    const first = Buffer.alloc(64, 0x61);
+    const second = Buffer.alloc(32, 0x62);
+
+    const out = openSync(file, "w");
+    const written = await new Promise<number>((resolve, reject) =>
+      fs.writev(out, [first, second], null, (err, n) => (err ? reject(err) : resolve(n))),
+    );
+    closeSync(out);
+    expect(written).toBe(96);
+
+    const into = [Buffer.alloc(64), Buffer.alloc(32)];
+    const input = openSync(file, "r");
+    const read = await new Promise<number>((resolve, reject) =>
+      fs.readv(input, into, null, (err, n) => (err ? reject(err) : resolve(n))),
+    );
+    closeSync(input);
+    expect({ read, first: into[0].equals(first), second: into[1].equals(second) }).toEqual({
+      read: 96,
+      first: true,
+      second: true,
+    });
+  });
+});
+
+/// Reads `stream` until `marker` has arrived, and returns what was read.
+async function readUntil(stream: ReadableStream<Uint8Array>, marker: string): Promise<string> {
+  const reader = stream.getReader();
+  let seen = "";
+  try {
+    while (!seen.includes(marker)) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      seen += Buffer.from(value).toString();
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return seen;
+}


### PR DESCRIPTION
### Problem

- An async `fs.readv` into a `WebAssembly.Memory` view makes the kernel write the file's bytes into memory the process already freed. The callback reports success: `err: null, n: 8192`, with the payload inside an unrelated live memory. `fs.writev` sends whatever took the freed range to the sink. Released 1.4.3, 3 of 3 runs each.
- The cause is the pin in `Bun__JSArray__collectBufferSpans`, which builds the iovecs for both. A pin does not hold a wasm memory: `grow()` on a bounds-checked one frees the old block, and `ArrayBuffer::detach` ignores the pin count.

### Fix

- Stacked on #42203. That PR adds `FsArgument::write_back` at the two fs completion sites, and this one is its second consumer. On its own this declared a second hook at the same sites, which conflicted.
- `collectBufferSpans` flags an element over a non-shared wasm memory, and `VectorArrayBuffer` points that iovec at a copy. The syscall never touches storage JS can free.
- `write_back` copies what a read produced into each view's live range. `writev` never reaches it, because `ret::Writev` is `ret::Write`, which reports no bytes.
- Cost: a fixed-length `mem.buffer` view that a grow detaches mid-call receives nothing, the same trade #42203 makes. The notes have the table.
- Verified: `test/js/node/fs/fs.test.ts`, three new tests, two fail on the base. Whole file 571 pass, 0 fail, with #42203's three. `bun run rust:check-all`: 12 ok.

### Background

- An iovec is a `(pointer, length)` pair. The kernel fills or drains an array of them on a pool thread, after the JS call returned.
- `ArrayBuffer::pin()` makes `transfer()` copy instead of detach. It is not ownership.
- A fast `WebAssembly.Memory` grows in place. A bounds-checked one moves its block. A process gets those past 8 memories, or 3.
- A grow detaches the fixed-length `mem.buffer`. `mem.toResizableBuffer()` tracks the memory, so the tests can observe the fix.

<details><summary>Notes</summary>

**Reproduction, released 1.4.3.** Take the fast memory slots, start the read on a pipe, grow, then allocate one fresh memory so the freed range is handed out again:

```js
import fs from "node:fs";
const hold = Array.from({ length: 10 }, () => new WebAssembly.Memory({ initial: 1, maximum: 2 }));
const mem = new WebAssembly.Memory({ initial: 128, maximum: 136 });
const view = new Uint8Array(mem.buffer);
let victim;
fs.readv(0, [view], -1, (e, n) => {
  console.log(JSON.stringify({
    err: e ? e.code : null, n, viewByteLength: view.byteLength,
    victimFirst8: Buffer.from(new Uint8Array(victim.buffer).subarray(0, 8)).toString("latin1"),
  }));
});
mem.grow(2);
victim = new WebAssembly.Memory({ initial: 128, maximum: 136 });
```

```
{"err":null,"n":8192,"viewByteLength":0,"victimFirst8":"AAAAAAAA"}
```

With nothing allocated after the grow the old range stays unmapped and the same script reports `EFAULT` instead. Both outcomes are the same bug. Which one appears depends on whether anything takes the range before the syscall returns, so a probe that allocates nothing sees only the benign one.

**What this gives up.** A grow detaches a fixed-length `mem.buffer` view, and a detached view has no range to copy into, so the bytes a `readv` produced are dropped. `n` still reports what the syscall read, because the file position did move. Measured, `readv` into `new Uint8Array(mem.buffer)` with a grow mid-call, then a fresh `mem.buffer` read:

| memory | released 1.4.3 | this PR |
| --- | --- | --- |
| bounds-checked | payload in an unrelated memory, or `EFAULT` | nothing written anywhere, bytes dropped |
| fast | payload in the memory | bytes dropped |
| either, `toResizableBuffer()` view | fast: in the memory. bounds-checked: as row 1 | payload in the memory |

The middle row is a real loss: on a fast memory the block does not move, so today the bytes arrive. I could not keep it. After the grow nothing the request holds keeps that block mapped in either mode. The detach drops the buffer's reference to the memory handle, so the block then lives exactly as long as the `WebAssembly.Memory` object, which the request does not root. And a fixed-length buffer carries no link back to its memory, so `write_back` cannot find the live block once the view is detached. Node has the same outcome when V8 relocates a memory on grow: the bytes land in the old backing store. #42203 makes the same trade for `fs.read`.

**Why a plain resizable ArrayBuffer is left alone.** The first version of this PR copied those too. That was scope it did not need. A resizable buffer keeps its `maxByteLength` reservation for as long as it lives, so nothing else can take the pages a `resize()` trims. A syscall against them reports `EFAULT`, which is memory-safe, and main already states the policy on `PinnedArrayBuffer::copy_if_resizable`: "a syscall reader gets `EFAULT` and needs no copy". `readv` into a resizable buffer now behaves exactly as on 1.4.3 for `resize(0)`, a shrink, a grow, and no resize, checked one by one. #34758 proposes a snapshot for that case and is a separate decision.

**Why the direction matters.** The copy alone fixes `writev`: the iovec holds a snapshot and the syscall never reads JS memory. `readv` needs the bytes back, and a write-back on `writev` would clobber any change JS made to the view while the write was in flight. Tying it to `FsReturn::bytes_read` keeps that static.

**Short reads.** `write_back` walks the spans in order and gives each one `min(left, span length)` bytes, so a read that stopped part way through the list copies into exactly the elements the kernel filled. It clamps again to the view's live length.

**Cost.** The copy is the size of the view, not of the memory. A WASI-style caller passes small `new Uint8Array(mem.buffer, ptr, len)` views, and the sync calls copy nothing. For `readv` the copy-in is wasted work, since only the bytes the syscall wrote are copied back. Avoiding it needs the direction at parse time, which `FdVectorIo` does not have.

**Sites this does not change.** `Bun.concatArrayBuffers` and `Buffer.concat` also use `collectBufferSpans`, with `pinBuffers = false`. They read the spans inside the call, with no JS in between.

**Other doors for the same hazard**, each with its own PR: #42179 (the shell's `> ${buf}` redirect), #42185 (a bufferless `OversizeTypedArray`), #42192 (`StringOrBuffer::from_js_async`, which covers `fs.write`), #42194 (`HTTPParser.execute`), #38289 (`Bun.Image` and MySQL blob binds).

**Test runs.** `test/js/node/fs/fs.test.ts`: 568 pass, 0 fail. `test/js/node/fs/`, `test/js/node/buffer.test.js`, `test/js/bun/util/concat.test.js` together: 1505 pass, 1 fail. The failure is `should not leak memory with already aborted signals`, which times out at its own 300 s limit on the debug and ASAN build. It does the same on `origin/main` in this container, checked with `src/` reverted.

**Fail-before, derived the way the gate does it.** `git checkout --no-overlay origin/main -- src/ packages/`, rebuild, run the file: the `readv` test reports `payloadInMemory: false, victimUntouched: false`, and the `writev` test reports `{"drained":16384,"foreignChunks":0,"written":16384}`, a write that ended short of 2097152. Restore, rebuild: both pass. The third test, an ordinary two-buffer round trip, passes either way on purpose. It is the control for the copy path.

**The writev test on a release build.** Its first version passed on an unfixed release binary whenever the allocator kept the freed block mapped with its old bytes: a stale read of those is the same bytes a correct read sends. Pinned to one CPU, unfixed 1.4.3 passed it 6 of 8 runs. The child now runs with `Malloc=1`, so the freed block goes back to the system and is unmapped, and the kernel faults. Unfixed 1.4.3 fails it 7 of 7, on 1 CPU and on 16, in about 20 ms. A short write also left the old drain loop in a blocking read of an empty pipe, so it failed through its timeout. The child now drains through a non-blocking fd and stops once the write has reported and the pipe is empty.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->