### PR TITLE
WebSocket: bound every script-supplied value that an error message quotes

### DIFF
--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -58,6 +58,7 @@
 #include "BunClientData.h"
 #include "ErrorEvent.h"
 #include "WebSocketDeflate.h"
+#include "helpers.h"
 
 namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebSocket);
@@ -136,10 +137,29 @@ static bool isValidProtocolString(StringView protocol)
     return true;
 }
 
+// Script supplies the values that the error messages here quote back. An
+// unbounded quote builds a message past String::MaxLength, and both
+// makeString() and StringBuilder abort the process on overflow. 1024 is the
+// bound URL::stringCenterEllipsizedToLength() already applies to the URLs.
+static constexpr unsigned maximumQuotedValueLength = 1024;
+
+static String quoteForErrorMessage(StringView value)
+{
+    if (value.length() <= maximumQuotedValueLength)
+        return value.toString();
+    return makeString(value.left(maximumQuotedValueLength), "..."_s);
+}
+
+// The escape expands one code unit to six characters, so bound the output and
+// not the input.
 static String encodeProtocolString(const String& protocol)
 {
     StringBuilder builder;
     for (size_t i = 0; i < protocol.length(); i++) {
+        if (builder.length() >= maximumQuotedValueLength) {
+            builder.append("..."_s);
+            break;
+        }
         if (protocol[i] < 0x20 || protocol[i] > 0x7E)
             builder.append("\\u"_s, hex(protocol[i], 4));
         else if (protocol[i] == 0x5c)
@@ -150,14 +170,29 @@ static String encodeProtocolString(const String& protocol)
     return builder.toString();
 }
 
+// The joined value becomes the Sec-WebSocket-Protocol header, so it cannot be
+// truncated. Returns a null String when the result does not fit in one string.
 static String joinStrings(const Vector<String>& strings, ASCIILiteral separator)
 {
-    StringBuilder builder;
+    size_t maximumLength = std::min(Bun__stringSyntheticAllocationLimit, static_cast<size_t>(String::MaxLength));
+    size_t totalLength = 0;
+    for (size_t i = 0; i < strings.size(); ++i) {
+        if (i)
+            totalLength += separator.length();
+        totalLength += strings[i].length();
+        if (totalLength > maximumLength)
+            return String();
+    }
+
+    StringBuilder builder(OverflowPolicy::RecordOverflow);
+    builder.reserveCapacity(static_cast<unsigned>(totalLength));
     for (size_t i = 0; i < strings.size(); ++i) {
         if (i)
             builder.append(separator);
         builder.append(strings[i]);
     }
+    if (builder.hasOverflowed())
+        return String();
     return builder.toString();
 }
 
@@ -216,13 +251,13 @@ static ExceptionOr<std::optional<ProxyConfig>> setupProxy(const String& proxyUrl
 
     URL url { proxyUrl };
     if (!url.isValid())
-        return Exception { SyntaxError, makeString("Invalid proxy URL: "_s, proxyUrl) };
+        return Exception { SyntaxError, makeString("Invalid proxy URL: "_s, url.stringCenterEllipsizedToLength()) };
 
     // Only HTTP CONNECT proxies are supported. Reject socks5://, ftp://, etc. up front
     // instead of silently sending an HTTP CONNECT request to a non-HTTP proxy, matching
     // fetch()'s UnsupportedProxyProtocol behaviour.
     if (!url.protocolIsInHTTPFamily())
-        return Exception { SyntaxError, makeString("Unsupported proxy protocol \""_s, url.protocol(), "\" (expected \"http\" or \"https\")"_s) };
+        return Exception { SyntaxError, makeString("Unsupported proxy protocol \""_s, quoteForErrorMessage(url.protocol()), "\" (expected \"http\" or \"https\")"_s) };
 
     ProxyConfig config;
     config.host = url.host().toString();
@@ -456,13 +491,18 @@ __attribute__((minsize)) ExceptionOr<void> WebSocket::connect(const String& url,
         if (!visited.add(protocol).isNewEntry) {
             // context.addConsoleMessage(MessageSource::JS, MessageLevel::Error, );
             m_state = CLOSED;
-            return Exception { SyntaxError, makeString("WebSocket protocols contain duplicates:"_s, encodeProtocolString(protocol), "'"_s) };
+            return Exception { SyntaxError, makeString("WebSocket protocols contain duplicates: '"_s, encodeProtocolString(protocol), "'"_s) };
         }
     }
 
     String protocolString;
-    if (!protocols.isEmpty())
+    if (!protocols.isEmpty()) {
         protocolString = joinStrings(protocols, subprotocolSeparator());
+        if (protocolString.isNull()) {
+            m_state = CLOSED;
+            return Exception { OutOfMemoryError };
+        }
+    }
 
     // `Bun::toString(WTF::String&)` borrows the impl, so materialize the
     // `m_url` views into `WTF::String`s that outlive the connect call.
@@ -1187,7 +1227,7 @@ ExceptionOr<void> WebSocket::setBinaryType(const String& binaryType)
         return {};
     }
     // scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "'" + binaryType + "' is not a valid value for binaryType; binaryType remains unchanged.");
-    return Exception { SyntaxError, makeString("'"_s, binaryType, "' is not a valid value for binaryType; binaryType remains unchanged."_s) };
+    return Exception { SyntaxError, makeString("'"_s, quoteForErrorMessage(binaryType), "' is not a valid value for binaryType; binaryType remains unchanged."_s) };
 }
 
 EventTargetInterface WebSocket::eventTargetInterface() const

--- a/test/js/web/websocket/websocket-subprotocol-strict.test.ts
+++ b/test/js/web/websocket/websocket-subprotocol-strict.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, mock } from "bun:test";
+import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
+import { afterAll, beforeAll, describe, expect, it, mock } from "bun:test";
 import crypto from "node:crypto";
 import net from "node:net";
 
@@ -218,5 +219,109 @@ describe("WebSocket strict RFC 6455 subprotocol handling", () => {
     } finally {
       bare.terminate();
     }
+  });
+});
+
+// Each of these error messages quotes a value that script supplies. An
+// unbounded quote builds a string past String::MaxLength (2^31-1) and aborts
+// the process, because makeString() and StringBuilder both crash on overflow.
+// Every quote is bounded to 1024 characters plus an ellipsis now.
+describe("WebSocket error messages bound the value they quote", () => {
+  // 200000 characters: far below String::MaxLength, far above the 1024 bound.
+  const longAscii = Buffer.alloc(200_000, 0x61).toString("latin1");
+  const longLatin1 = Buffer.alloc(200_000, 0xff).toString("latin1");
+
+  function thrown(run: () => void): Error {
+    try {
+      run();
+    } catch (error) {
+      return error as Error;
+    }
+    throw new Error("the call did not throw");
+  }
+
+  it("an invalid subprotocol", () => {
+    const error = thrown(() => new WebSocket("ws://127.0.0.1:1/", [longLatin1]));
+    expect(error.name).toBe("SyntaxError");
+    expect(error.message).toStartWith("Wrong protocol for WebSocket '\\u00FF\\u00FF");
+    expect(error.message).toEndWith("\\u00FF...'");
+    expect(error.message.length).toBeLessThan(1200);
+  });
+
+  it("a duplicate subprotocol", () => {
+    const error = thrown(() => new WebSocket("ws://127.0.0.1:1/", [longAscii, longAscii]));
+    expect(error.name).toBe("SyntaxError");
+    expect(error.message).toStartWith("WebSocket protocols contain duplicates: 'aa");
+    expect(error.message).toEndWith("a...'");
+    expect(error.message.length).toBeLessThan(1200);
+  });
+
+  it("an invalid proxy URL", () => {
+    const error = thrown(() => new WebSocket("ws://127.0.0.1:1/", { proxy: longAscii }));
+    expect(error.name).toBe("SyntaxError");
+    expect(error.message).toStartWith("Invalid proxy URL: aa");
+    expect(error.message).toContain("...");
+    expect(error.message.length).toBeLessThan(1200);
+  });
+
+  it("an unsupported proxy protocol", () => {
+    const error = thrown(() => new WebSocket("ws://127.0.0.1:1/", { proxy: `${longAscii}://host` }));
+    expect(error.name).toBe("SyntaxError");
+    expect(error.message).toStartWith('Unsupported proxy protocol "aa');
+    expect(error.message).toEndWith('a..." (expected "http" or "https")');
+    expect(error.message.length).toBeLessThan(1200);
+  });
+
+  it("an invalid binaryType", () => {
+    const socket = new WebSocket("ws://127.0.0.1:1/");
+    socket.onerror = () => {};
+    try {
+      const error = thrown(() => {
+        socket.binaryType = longAscii as any;
+      });
+      expect(error.name).toBe("SyntaxError");
+      expect(error.message).toStartWith("'aa");
+      expect(error.message).toEndWith("a...' is not a valid value for binaryType; binaryType remains unchanged.");
+      expect(error.message.length).toBeLessThan(1200);
+    } finally {
+      socket.terminate();
+    }
+  });
+});
+
+// joinStrings() builds the Sec-WebSocket-Protocol header value, so it cannot
+// truncate. A list that does not fit in one string has to throw. The real
+// limit is String::MaxLength, which needs 2 GiB of live strings to reach, so
+// lower the process-wide string limit instead.
+describe("WebSocket subprotocol list that does not fit in one string", () => {
+  const ALLOCATION_LIMIT = 4 * 1024 * 1024;
+
+  // The limit is process-wide, so put it back for whatever runs after this.
+  let previousLimit: number;
+  beforeAll(() => {
+    previousLimit = setSyntheticAllocationLimitForTesting(ALLOCATION_LIMIT);
+  });
+  afterAll(() => {
+    setSyntheticAllocationLimitForTesting(previousLimit);
+  });
+
+  it("throws RangeError: Out of memory instead of aborting", () => {
+    const first = Buffer.alloc(3 * 1024 * 1024, 0x61).toString("latin1");
+    const second = Buffer.alloc(3 * 1024 * 1024, 0x62).toString("latin1");
+
+    let socket: WebSocket | undefined;
+    try {
+      expect(() => {
+        socket = new WebSocket("ws://127.0.0.1:1/", [first, second]);
+      }).toThrow(expect.objectContaining({ name: "RangeError", message: "Out of memory" }));
+    } finally {
+      socket?.terminate();
+    }
+  });
+
+  it("still accepts a list that fits", () => {
+    const socket = new WebSocket("ws://127.0.0.1:1/", ["chat", "echo"]);
+    socket.onerror = () => {};
+    socket.terminate();
   });
 });


### PR DESCRIPTION
### Problem
- `new WebSocket(url, protocols)` aborts the process instead of throwing when an argument is large: `panic(main thread): abort() called`, exit 134, peak RSS 4.68 GB. Reproduced on main at 4ff91937 with `new WebSocket("ws://localhost/", ["\u00ff".repeat(357913942)])`.
- The constructor quotes the value it rejects back in the error message. Nothing bounded the quote, so the message grew past `String::MaxLength` (2^31-1), and both `makeString()` and `StringBuilder` call `CRASH()` on overflow (`StringBuilder.cpp:46`). Five sites echoed a script-supplied value: the invalid subprotocol and the duplicate subprotocol through `encodeProtocolString()` (`WebSocket.cpp:144`), the invalid proxy URL and the unsupported proxy protocol (`WebSocket.cpp:253`, `:259`), and the invalid `binaryType` (`WebSocket.cpp:1230`).
- `joinStrings()` (`WebSocket.cpp:175`) builds the `Sec-WebSocket-Protocol` header value. Two 2^30-character protocols sum past `String::MaxLength` and abort the same way.

### Fix
- Add `quoteForErrorMessage()`. It keeps 1024 characters and appends an ellipsis. 1024 is the bound that `URL::stringCenterEllipsizedToLength()` already applies to the URLs in this file. `encodeProtocolString()` bounds its output, because the escape expands one code unit to six characters.
- `joinStrings()` measures the result first and returns a null `String` when it does not fit in one string. `connect()` then throws `RangeError: Out of memory`, the code `Base64Helpers.cpp:24` already uses for a value that cannot be represented. The header value is sent on the wire, so it cannot be truncated. The builder also records overflow now, so an allocation failure throws instead of aborting.
- The limit is the lower of `String::MaxLength` and `Bun__stringSyntheticAllocationLimit`, so the test reaches it through `setSyntheticAllocationLimitForTesting` instead of allocating 2 GB.
- Verified: `test/js/web/websocket/websocket-subprotocol-strict.test.ts` (6 new blocks, stock bun fails all 6). Also all of `test/js/web/websocket/` and `test/js/first_party/ws/` (384 pass, 3 pre-existing failures that need `wss://ws.postman-echo.com`).

### Background
- `StringBuilder` crashes on overflow by default (`m_shouldCrashOnOverflow { true }`). `OverflowPolicy::RecordOverflow` makes it set a flag that `hasOverflowed()` reports instead. `makeString()` has no such mode. It calls `CRASH()` when `tryMakeString()` returns a null `String`.
- `String::MaxLength` is `INT32_MAX`. A string of that length is 2 GB as Latin-1. One character more is the abort.
- `Bun__stringSyntheticAllocationLimit` is the process-wide character cap that Bun's string constructors check (`src/jsc/bindings/helpers.h`). `bun:internal-for-testing` can lower it, which is how a test reaches a limit that needs gigabytes in production.
- The WebSocket spec does not define the text of these errors. It defines only the exception type. Node does not echo the subprotocol at all.

<details><summary>Notes</summary>

Boundary, measured on main at 4ff91937 with the released binary:

| input | result |
| --- | --- |
| `"\u00ff".repeat(357913936)` | `SyntaxError`, message length 2147483647 (exactly `String::MaxLength`) |
| `"\u00ff".repeat(357913942)` | abort, exit 134, peak RSS 4.68 GB |
| two protocols of 2^30 characters | abort, exit 134, peak RSS 3.25 GB |

With this change, both reproductions throw on the ASAN debug build: a `SyntaxError` with a 1060-character message, and `RangeError: Out of memory`. The truncation boundary is exact: 1024 escaped characters produce no ellipsis, 1025 produce one.

Sibling sites, checked and deliberately excluded:

- `makeString(url.user(), ':', url.password())` plus `base64EncodeToString()` at `WebSocket.cpp:269` and `:662`. Base64 grows the input by 4/3, so roughly 1.6 GB of URL userinfo overflows `makeString()` inside `base64EncodeToString()`. WebKit has `base64EncodeToStringReturnNullIfOverflow()` for this. The fix belongs in a separate change: these build the `Authorization` header rather than an error message, the error path has to move above `makePendingActivity()` to avoid a pending activity that never settles, and no test can reach it, since the synthetic allocation limit does not apply to `makeString()`.
- `HTTPHeaderMap::get()` at `src/jsc/bindings/webcore/HTTPHeaderMap.cpp:224` joins the `Set-Cookie` values with the same shape. It returns `String` and has no exception channel, so the guard has to go at the `FetchHeaders` boundary that can throw. That is a separate change.
- `WTF::URLParser::URLParser` aborts in `makeString(' ', inputString)` (`URLParser.cpp:1572`) for any input of exactly `String::MaxLength` characters. That code is inside `#if ASSERT_ENABLED`, so it affects debug and ASAN builds only, it is in `vendor/WebKit`, and it fires for every `WTF::URL` built from a maximum-length string, not only for WebSocket.

Overlap with an open PR: #41698 also edits `WebSocket.cpp:253` (`Invalid proxy URL`). It wraps the value in `urlForErrorMessage(proxyUrl)` to mask a password. This change calls `url.stringCenterEllipsizedToLength()` on the same line. Whichever lands second should use the `URL` overload, `urlForErrorMessage(url)`, which masks and then ellipsizes.

The duplicate subprotocol message read `WebSocket protocols contain duplicates:` with no space and no opening quote, while the closing quote was there. Upstream WebCore has `duplicates: '`. Restored, rather than pinned in a new test.

Self-reviewed: 4 concerns raised, 3 addressed (the sibling quote sites in the same path, the synthetic allocation limit test hook for the join, and the duplicate message text). The fourth asked to fold in `HTTPHeaderMap.cpp:224`. Excluded above, with the reason.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/websocket/websocket-subprotocol-strict.test.ts
bun test v1.4.3 (5f554969b)

test/js/web/websocket/websocket-subprotocol-strict.test.ts:
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols [328.85ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols with spaces [87.84ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols (3 protocols) [39.06ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject duplicate Sec-WebSocket-Protocol headers (same value) [35.93ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject duplicate Sec-WebSocket-Protocol headers (different values) [35.86ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject three Sec-WebSocket-Protocol headers [36.29ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject empty Sec-WebSocket-Protocol header [31.94ms]
(pass) WebSocket strict R
... (truncated)

release without fix: 6 FAILED
bun test v1.4.3-canary.1 (5f554969b)

test/js/web/websocket/websocket-subprotocol-strict.test.ts:
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols [5.42ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols with spaces [1.79ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols (3 protocols) [0.77ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject duplicate Sec-WebSocket-Protocol headers (same value) [0.76ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject duplicate Sec-WebSocket-Protocol headers (different values) [0.74ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject three Sec-WebSocket-Protocol headers [0.68ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject empty Sec-WebSocket-Protocol header [0.62ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject Sec-WebSocket-Protocol with only comma [0.58ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject Sec-WebSocket-Protocol with
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/websocket/websocket-subprotocol-strict.test.ts
bun test v1.4.3 (5f554969b)

test/js/web/websocket/websocket-subprotocol-strict.test.ts:
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols [315.79ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols with spaces [84.68ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject multiple comma-separated protocols (3 protocols) [36.58ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject duplicate Sec-WebSocket-Protocol headers (same value) [35.83ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject duplicate Sec-WebSocket-Protocol headers (different values) [33.97ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject three Sec-WebSocket-Protocol headers [34.16ms]
(pass) WebSocket strict RFC 6455 subprotocol handling > should reject empty Sec-WebSocket-Protocol header [30.22ms]
(pass) WebSocket strict R
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     95a21fe9d9
  features     baseline

23 deps, 131 codegen, 1172 objects in 606ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.3-canary.1 (5f554969b)

Checked 22 installs across 61 packages (no changes) [14.00ms]
[3/1244] fetch tinycc
[tinycc] up to date
[4/1243] gen bindgenv2
[5/1243] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (5f554969b)

Checked 1 install across 2 packages (no changes) [13.00ms]
[6/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[8/1216] gen .bind.ts → GeneratedBindings.cpp
[9/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (5f554969b)

Checked 111 installs across 104 packages (no changes) [12.00ms]
[10/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /works
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/WebSocket.cpp             |  52 ++++++++--
 .../websocket/websocket-subprotocol-strict.test.ts | 107 ++++++++++++++++++++-
 2 files changed, 152 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/webcore/WebSocket.cpp                        3      9     12
…t/js/web/websocket/websocket-subprotocol-strict.test.ts      2      5     12
```

</details>

<!-- robobun:evidence:end -->