### PR TITLE
Request: take the Content-Type from the body init at construction, not from a stream's source

### DIFF
--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2346,7 +2346,8 @@ where
                 // Moves `body` into the per-VM hive pool (ref_count = 1).
                 crate::webcore::body::hive_alloc(body),
                 method,
-            ))
+                ctx,
+            )?)
         } else if let Some(request_) = first_arg
             .is_object()
             .then(|| <Request as bun_jsc::JsClass>::from_js(first_arg))

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2308,19 +2308,14 @@ where
 
                 if let Some(headers_) = opts.fast_get(ctx, jsc::BuiltinName::Headers)? {
                     if let Some(headers__) = FetchHeaders::cast_(headers_, ctx.vm()) {
-                        // NOTE: `cast_` returns the `FetchHeaders*` held by the
-                        // JS `Headers` wrapper (`JSFetchHeaders`'s internal
-                        // `Ref<FetchHeaders>`) without bumping the refcount —
-                        // the FFI surface has `WebCore__FetchHeaders__deref` but
-                        // no `ref()`, so a +1 cannot be taken here. Adopting
-                        // hands that wrapper-held ref to the constructed
-                        // `Request` (via `Request::init2` below): the eventual
-                        // single deref happens when the Request's finalizer
-                        // drops its `headers` field (`HeadersRef::Drop`,
-                        // Response.rs), pairing with the wrapper's +1.
-                        // SAFETY: `headers__` is live (rooted by `headers_`),
-                        // and ownership of one ref transfers as described above.
-                        headers = Some(unsafe { HeadersRef::adopt(headers__) });
+                        // Copy the caller's `Headers`, as `new Request()` does: the Request owns
+                        // its list (and may append the body's Content-Type to it).
+                        // `FetchHeaders` is an opaque ZST FFI handle (S008) — safe deref.
+                        let original = bun_opaque::opaque_deref_mut(headers__.as_ptr());
+                        // SAFETY: `clone_this` returns a fresh +1 ref.
+                        headers = original
+                            .clone_this(ctx)?
+                            .map(|p| unsafe { HeadersRef::adopt(p) });
                     } else if let Some(headers__) = FetchHeaders::create_from_js(ctx, headers_)? {
                         // SAFETY: create_from_js returns a +1 ref.
                         headers = Some(unsafe { HeadersRef::adopt(headers__) });

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2308,9 +2308,7 @@ where
 
                 if let Some(headers_) = opts.fast_get(ctx, jsc::BuiltinName::Headers)? {
                     if let Some(headers__) = FetchHeaders::cast_(headers_, ctx.vm()) {
-                        // Copy the caller's `Headers`, as `new Request()` does: the Request owns
-                        // its list (and may append the body's Content-Type to it).
-                        // `FetchHeaders` is an opaque ZST FFI handle (S008) — safe deref.
+                        // Copy the caller's `Headers`, as `new Request()` does; the Request owns its list.
                         let original = bun_opaque::opaque_deref_mut(headers__.as_ptr());
                         // SAFETY: `clone_this` returns a fresh +1 ref.
                         headers = original

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -405,8 +405,7 @@ impl Request {
         Ok(request)
     }
 
-    /// Fetch "extract a body", last step: a Blob, FormData or URLSearchParams
-    /// body has a MIME type, appended at construction unless a `Content-Type` is set.
+    /// Fetch "extract a body": append a Blob body's MIME type unless a `Content-Type` is set.
     fn append_content_type_from_body(&self, global_this: &JSGlobalObject) -> JsResult<()> {
         let BodyValue::Blob(blob) = self.body_value() else {
             return Ok(());

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -239,14 +239,13 @@ impl Request {
     /// Returns the headers of the request. If the headers are not already cached, it will create a new FetchHeaders object.
     /// If the headers are empty, it will look at request_context to get the headers.
     /// If the headers are empty and request_context is null, it will create an empty FetchHeaders object.
+    /// Nothing is derived from the body here: a body's MIME type went into the
+    /// list when the Request was made (`append_content_type_from_body`).
     #[allow(clippy::mut_from_ref)]
-    pub(crate) fn ensure_fetch_headers(
-        &self,
-        global_this: &JSGlobalObject,
-    ) -> JsResult<&mut HeadersRef> {
+    pub(crate) fn ensure_fetch_headers(&self) -> &mut HeadersRef {
         if self.headers.get().is_some() {
             // headers is already set
-            return Ok(self.headers_mut().as_mut().unwrap());
+            return self.headers_mut().as_mut().unwrap();
         }
 
         if let Some(req) = self.request_context.get_request() {
@@ -257,21 +256,9 @@ impl Request {
         } else {
             // we don't have a request context, so we need to create an empty headers object
             self.headers.set(Some(HeadersRef::create_empty()));
-            // `construct_into` already appended a JS-constructed body's type. A
-            // stream body has no MIME type, whatever backs the stream.
-            if let BodyValue::Blob(blob) = self.body_value() {
-                let content_type = blob.content_type_slice();
-                if !content_type.is_empty() {
-                    self.headers_mut().as_mut().unwrap().put(
-                        HTTPHeaderName::ContentType,
-                        &BunString::ascii(content_type),
-                        global_this,
-                    )?;
-                }
-            }
         }
 
-        Ok(self.headers_mut().as_mut().unwrap())
+        self.headers_mut().as_mut().unwrap()
     }
 
     #[allow(clippy::mut_from_ref)]
@@ -294,7 +281,7 @@ impl Request {
 
     /// This should only be called by the JS code. use getFetchHeaders to get the current headers or ensureFetchHeaders to get the headers and create them if they don't exist.
     pub(crate) fn get_headers(&self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(self.ensure_fetch_headers(global_this)?.to_js(global_this))
+        Ok(self.ensure_fetch_headers().to_js(global_this))
     }
 
     pub(crate) fn clone_headers(
@@ -392,14 +379,16 @@ impl Request {
 }
 
 impl Request {
-    /// TODO: do we need this?
+    /// A Request made outside the JS constructor and outside the server's
+    /// request path (`server.fetch(url, init)`).
     pub(crate) fn init2(
         url: BunString,
         headers: Option<HeadersRef>,
         body: BodyHiveHandle,
         method: Method,
-    ) -> Request {
-        Request {
+        global_this: &JSGlobalObject,
+    ) -> JsResult<Request> {
+        let request = Request {
             url: JsCell::new(url),
             headers: JsCell::new(headers),
             signal: JsCell::new(None),
@@ -410,7 +399,41 @@ impl Request {
             request_context: AnyRequestContext::NULL,
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),
+        };
+        if let Err(err) = request.append_content_type_from_body(global_this) {
+            // SAFETY: `request` is dropped right after; this is the only release of its body.
+            let mut request = request;
+            unsafe { ManuallyDrop::drop(&mut request.body) };
+            return Err(err);
         }
+        Ok(request)
+    }
+
+    /// Fetch "extract a body": a Blob, FormData or URLSearchParams body has a
+    /// MIME type, and a new Request appends it to its header list unless a
+    /// `Content-Type` is already there. This runs when the Request is made:
+    /// later the body may be a stream or used up, and a stream's source says
+    /// nothing about this Request (`body: new Response(formData).body` has no
+    /// type).
+    fn append_content_type_from_body(&self, global_this: &JSGlobalObject) -> JsResult<()> {
+        let BodyValue::Blob(blob) = self.body_value() else {
+            return Ok(());
+        };
+        let content_type = blob.content_type_slice();
+        if content_type.is_empty() {
+            return Ok(());
+        }
+        let headers = self
+            .headers_mut()
+            .get_or_insert_with(HeadersRef::create_empty);
+        if headers.fast_has(HTTPHeaderName::ContentType) {
+            return Ok(());
+        }
+        headers.put(
+            HTTPHeaderName::ContentType,
+            &BunString::ascii(content_type),
+            global_this,
+        )
     }
 
     pub(crate) fn get_form_data_encoding(
@@ -1056,6 +1079,11 @@ impl Request {
         let values_to_try = &values_to_try_[0..((!is_first_argument_a_url) as usize
             + (arguments.len() > 1 && arguments[1].is_object()) as usize)];
 
+        // The body came from `init.body` (fetch "extract a body", which also yields
+        // its MIME type), as opposed to being copied from an input Request along
+        // with that Request's header list.
+        let mut body_extracted = false;
+
         for &value in values_to_try {
             let value_type = value.js_type();
             let explicit_check = values_to_try.len() == 2
@@ -1166,6 +1194,9 @@ impl Request {
                                 match response.clone_body_value_via_cached_stream(global_this) {
                                     Ok(v) => {
                                         *req.body_value_mut() = v;
+                                        // A Response as init is a Bun extension: its body stands
+                                        // in for `init.body`, type included.
+                                        body_extracted = true;
                                     }
                                     Err(e) => bail!(Err(e)),
                                 }
@@ -1196,6 +1227,7 @@ impl Request {
                         match BodyValue::from_js(global_this, body_) {
                             Ok(v) => {
                                 *req.body_value_mut() = v;
+                                body_extracted = true;
                             }
                             Err(e) => bail!(Err(e)),
                         }
@@ -1377,26 +1409,10 @@ impl Request {
 
         req.url.set(href);
 
-        // Fetch "extract a body": a Blob, FormData or URLSearchParams init has a
-        // MIME type and the constructor appends it to the header list now. Later
-        // the body may be a stream or used up, and a stream's source says nothing
-        // about this Request: `body: new Response(formData).body` has no type.
-        if let BodyValue::Blob(blob) = req.body_value() {
-            let content_type = blob.content_type_slice();
-            if !content_type.is_empty() {
-                let headers = req
-                    .headers_mut()
-                    .get_or_insert_with(HeadersRef::create_empty);
-                if !headers.fast_has(HTTPHeaderName::ContentType) {
-                    match headers.put(
-                        HTTPHeaderName::ContentType,
-                        &BunString::ascii(content_type),
-                        global_this,
-                    ) {
-                        Ok(()) => {}
-                        Err(e) => bail!(Err(e)),
-                    }
-                }
+        if body_extracted {
+            match req.append_content_type_from_body(global_this) {
+                Ok(()) => {}
+                Err(e) => bail!(Err(e)),
             }
         }
 

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -257,35 +257,14 @@ impl Request {
         } else {
             // we don't have a request context, so we need to create an empty headers object
             self.headers.set(Some(HeadersRef::create_empty()));
-            // Snapshot the pointer first; it stays valid across the field borrow.
-            let content_type: Option<*const [u8]> = match self.body_value() {
-                BodyValue::Blob(blob) => {
-                    Some(std::ptr::from_ref::<[u8]>(blob.content_type_slice()))
-                }
-                BodyValue::Locked(locked) => match locked.readable.get() {
-                    Some(readable) => match readable.ptr {
-                        crate::webcore::readable_stream::Source::Blob(blob) => {
-                            // SAFETY: `Source::Blob` holds a live `*mut ByteBlobLoader`
-                            // for as long as the readable stream exists; we only read
-                            // its `content_type` slice and immediately copy below.
-                            let ct: &[u8] = unsafe { (*blob).content_type.as_slice() };
-                            Some(std::ptr::from_ref::<[u8]>(ct))
-                        }
-                        _ => None,
-                    },
-                    None => None,
-                },
-                _ => None,
-            };
-
-            if let Some(content_type_) = content_type {
-                // SAFETY: the sources above are live for the duration of this
-                // call; the bytes are copied into the header map below.
-                let content_type_ = unsafe { &*content_type_ };
-                if !content_type_.is_empty() {
+            // `construct_into` already appended a JS-constructed body's type. A
+            // stream body has no MIME type, whatever backs the stream.
+            if let BodyValue::Blob(blob) = self.body_value() {
+                let content_type = blob.content_type_slice();
+                if !content_type.is_empty() {
                     self.headers_mut().as_mut().unwrap().put(
                         HTTPHeaderName::ContentType,
-                        &BunString::ascii(content_type_),
+                        &BunString::ascii(content_type),
                         global_this,
                     )?;
                 }
@@ -1398,22 +1377,20 @@ impl Request {
 
         req.url.set(href);
 
-        if matches!(req.body_value(), BodyValue::Blob(_)) && req.headers.get().is_some() {
-            if let BodyValue::Blob(blob) = req.body_value() {
-                let ct: &[u8] = blob.content_type_slice();
-                if !ct.is_empty()
-                    && !req
-                        .headers_mut()
-                        .as_mut()
-                        .unwrap()
-                        .fast_has(HTTPHeaderName::ContentType)
-                {
-                    // Reshaped for borrowck — split borrow of req.body and req.headers
-                    let ct_ptr: *const [u8] = ct;
-                    match req.headers_mut().as_mut().unwrap().put(
+        // Fetch "extract a body": a Blob, FormData or URLSearchParams init has a
+        // MIME type and the constructor appends it to the header list now. Later
+        // the body may be a stream or used up, and a stream's source says nothing
+        // about this Request: `body: new Response(formData).body` has no type.
+        if let BodyValue::Blob(blob) = req.body_value() {
+            let content_type = blob.content_type_slice();
+            if !content_type.is_empty() {
+                let headers = req
+                    .headers_mut()
+                    .get_or_insert_with(HeadersRef::create_empty);
+                if !headers.fast_has(HTTPHeaderName::ContentType) {
+                    match headers.put(
                         HTTPHeaderName::ContentType,
-                        // SAFETY: ct_ptr borrows req.body which is not mutated here.
-                        &BunString::ascii(unsafe { &*ct_ptr }),
+                        &BunString::ascii(content_type),
                         global_this,
                     ) {
                         Ok(()) => {}

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -239,8 +239,6 @@ impl Request {
     /// Returns the headers of the request. If the headers are not already cached, it will create a new FetchHeaders object.
     /// If the headers are empty, it will look at request_context to get the headers.
     /// If the headers are empty and request_context is null, it will create an empty FetchHeaders object.
-    /// Nothing is derived from the body here: a body's MIME type went into the
-    /// list when the Request was made (`append_content_type_from_body`).
     #[allow(clippy::mut_from_ref)]
     pub(crate) fn ensure_fetch_headers(&self) -> &mut HeadersRef {
         if self.headers.get().is_some() {
@@ -379,8 +377,7 @@ impl Request {
 }
 
 impl Request {
-    /// A Request made outside the JS constructor and outside the server's
-    /// request path (`server.fetch(url, init)`).
+    /// The Request that `server.fetch(url, init)` hands to the handler.
     pub(crate) fn init2(
         url: BunString,
         headers: Option<HeadersRef>,
@@ -388,7 +385,7 @@ impl Request {
         method: Method,
         global_this: &JSGlobalObject,
     ) -> JsResult<Request> {
-        let request = Request {
+        let mut request = Request {
             url: JsCell::new(url),
             headers: JsCell::new(headers),
             signal: JsCell::new(None),
@@ -402,19 +399,14 @@ impl Request {
         };
         if let Err(err) = request.append_content_type_from_body(global_this) {
             // SAFETY: `request` is dropped right after; this is the only release of its body.
-            let mut request = request;
             unsafe { ManuallyDrop::drop(&mut request.body) };
             return Err(err);
         }
         Ok(request)
     }
 
-    /// Fetch "extract a body": a Blob, FormData or URLSearchParams body has a
-    /// MIME type, and a new Request appends it to its header list unless a
-    /// `Content-Type` is already there. This runs when the Request is made:
-    /// later the body may be a stream or used up, and a stream's source says
-    /// nothing about this Request (`body: new Response(formData).body` has no
-    /// type).
+    /// Fetch "extract a body", last step: a Blob, FormData or URLSearchParams
+    /// body has a MIME type, appended at construction unless a `Content-Type` is set.
     fn append_content_type_from_body(&self, global_this: &JSGlobalObject) -> JsResult<()> {
         let BodyValue::Blob(blob) = self.body_value() else {
             return Ok(());
@@ -1079,9 +1071,7 @@ impl Request {
         let values_to_try = &values_to_try_[0..((!is_first_argument_a_url) as usize
             + (arguments.len() > 1 && arguments[1].is_object()) as usize)];
 
-        // The body came from `init.body` (fetch "extract a body", which also yields
-        // its MIME type), as opposed to being copied from an input Request along
-        // with that Request's header list.
+        // The body came from `init.body`, not from an input Request (whose header list comes along).
         let mut body_extracted = false;
 
         for &value in values_to_try {
@@ -1194,8 +1184,7 @@ impl Request {
                                 match response.clone_body_value_via_cached_stream(global_this) {
                                     Ok(v) => {
                                         *req.body_value_mut() = v;
-                                        // A Response as init is a Bun extension: its body stands
-                                        // in for `init.body`, type included.
+                                        // Bun extension: the Response's body stands in for `init.body`.
                                         body_extracted = true;
                                     }
                                     Err(e) => bail!(Err(e)),

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1775,9 +1775,11 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
 
   // The same spec step gives a Blob, FormData or URLSearchParams init a MIME
   // type, and the Request constructor appends it to the header list right
-  // there. So the header does not depend on what is read first.
+  // there. So the header does not depend on what is read first, and
+  // `new Request(input, init)` copies input's header list instead of looking
+  // at the body again.
   describe("new Request() takes the Content-Type from the body init at construction", () => {
-    const make = (body: BodyInit) => new Request("http://a/", { method: "POST", body });
+    const make = (body: BodyInit) => new Request("http://a/", { method: "POST", body, duplex: "half" } as RequestInit);
     for (const [name, init, type] of typedSources) {
       test(name, async () => {
         const contentType = (request: Request) => request.headers.get("content-type")?.slice(0, type.length) ?? null;
@@ -1790,6 +1792,9 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
         touched.body;
         const clone = touched.clone();
         await clone.text();
+        const adopted = () => make(new Response(init()).body!);
+        const adoptedThenCloned = adopted();
+        adoptedThenCloned.clone();
         expect({
           headersFirst: await after(() => {}),
           bodyFirst: await after(request => request.body),
@@ -1800,12 +1805,18 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
           bodyThenClone: contentType(touched),
           readCloneOfTouched: contentType(clone),
           sameBoundary: clone.headers.get("content-type") === touched.headers.get("content-type"),
-          copiedByNewRequest: contentType(new Request(make(init()))),
+          copied: contentType(new Request(make(init()))),
+          copiedWithInit: contentType(new Request(make(init()), { method: "PUT" })),
+          copiedWithNewHeaders: contentType(new Request(make(init()), { headers: { "x-a": "1" } })),
           explicitWins: new Request("http://a/", {
             method: "POST",
             body: init(),
             headers: { "content-type": "text/x-other" },
           }).headers.get("content-type"),
+          cloneOfAdoptedStream: contentType(adopted().clone()),
+          adoptedStreamAfterClone: contentType(adoptedThenCloned),
+          copyOfAdoptedStream: contentType(new Request(adopted())),
+          copyOfAdoptedStreamWithInit: contentType(new Request(adopted(), { method: "PUT" })),
         }).toEqual({
           headersFirst: type,
           bodyFirst: type,
@@ -1816,11 +1827,38 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
           bodyThenClone: type,
           readCloneOfTouched: type,
           sameBoundary: true,
-          copiedByNewRequest: type,
+          copied: type,
+          copiedWithInit: type,
+          copiedWithNewHeaders: null,
           explicitWins: "text/x-other",
+          cloneOfAdoptedStream: null,
+          adoptedStreamAfterClone: null,
+          copyOfAdoptedStream: null,
+          copyOfAdoptedStreamWithInit: null,
         });
       });
     }
+
+    test("also when Bun.serve's server.fetch() builds the Request", async () => {
+      const seen: (string | null)[] = [];
+      using server = Bun.serve({
+        port: 0,
+        fetch(request) {
+          request.body;
+          seen.push(request.headers.get("content-type"));
+          return new Response("ok");
+        },
+      });
+      const body = new Blob(["a=1"], { type: "text/x-custom" });
+      await server.fetch(new URL("/", server.url).href, { method: "POST", body });
+      await server.fetch(new URL("/", server.url).href, { method: "POST", body, headers: { "x-a": "1" } });
+      await server.fetch(new URL("/", server.url).href, {
+        method: "POST",
+        body,
+        headers: { "content-type": "text/x-other" },
+      });
+      expect(seen).toEqual(["text/x-custom", "text/x-custom", "text/x-other"]);
+    });
   });
 
   // A null body is not a zero-length body: nothing can use it up.

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1757,18 +1757,17 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
       // https://fetch.spec.whatwg.org/#concept-bodyinit-extract gives a
       // ReadableStream init no MIME type, whatever the stream was made from.
       describe("a stream body contributes no Content-Type, whatever is behind the stream", () => {
-        for (const [name, init, , content] of typedSources) {
-          for (const [fromName, makeFrom] of owners) {
-            test(`a stream taken from a ${fromName} made from ${name}`, async () => {
-              expect({
-                bare: make(makeFrom(init()).body!).headers.get("content-type"),
-                otherHeaders: make(makeFrom(init()).body!, { "x-a": "1" }).headers.get("content-type"),
-                explicit: make(makeFrom(init()).body!, { "content-type": "text/x-other" }).headers.get("content-type"),
-                text: await make(makeFrom(init()).body!).text(),
-              }).toEqual({ bare: null, otherHeaders: null, explicit: "text/x-other", text: content });
-            });
-          }
-        }
+        const cases = typedSources.flatMap(([name, init, , content]) =>
+          owners.map(([fromName, makeFrom]) => [fromName, name, makeFrom, init, content] as const),
+        );
+        test.each(cases)("a stream taken from a %s made from %s", async (fromName, name, makeFrom, init, content) => {
+          expect({
+            bare: make(makeFrom(init()).body!).headers.get("content-type"),
+            otherHeaders: make(makeFrom(init()).body!, { "x-a": "1" }).headers.get("content-type"),
+            explicit: make(makeFrom(init()).body!, { "content-type": "text/x-other" }).headers.get("content-type"),
+            text: await make(makeFrom(init()).body!).text(),
+          }).toEqual({ bare: null, otherHeaders: null, explicit: "text/x-other", text: content });
+        });
       });
     });
   }
@@ -1780,64 +1779,62 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
   // at the body again.
   describe("new Request() takes the Content-Type from the body init at construction", () => {
     const make = (body: BodyInit) => new Request("http://a/", { method: "POST", body, duplex: "half" } as RequestInit);
-    for (const [name, init, type] of typedSources) {
-      test(name, async () => {
-        const contentType = (request: Request) => request.headers.get("content-type")?.slice(0, type.length) ?? null;
-        const after = async (use: (request: Request) => unknown) => {
-          const request = make(init());
-          await use(request);
-          return contentType(request);
-        };
-        const touched = make(init());
-        touched.body;
-        const clone = touched.clone();
-        await clone.text();
-        const adopted = () => make(new Response(init()).body!);
-        const adoptedThenCloned = adopted();
-        adoptedThenCloned.clone();
-        expect({
-          headersFirst: await after(() => {}),
-          bodyFirst: await after(request => request.body),
-          textFirst: await after(request => request.text()),
-          arrayBufferFirst: await after(request => request.arrayBuffer()),
-          blobFirst: await after(request => request.blob()),
-          cloneFirst: await after(request => request.clone().text()),
-          bodyThenClone: contentType(touched),
-          readCloneOfTouched: contentType(clone),
-          sameBoundary: clone.headers.get("content-type") === touched.headers.get("content-type"),
-          copied: contentType(new Request(make(init()))),
-          copiedWithInit: contentType(new Request(make(init()), { method: "PUT" })),
-          copiedWithNewHeaders: contentType(new Request(make(init()), { headers: { "x-a": "1" } })),
-          explicitWins: new Request("http://a/", {
-            method: "POST",
-            body: init(),
-            headers: { "content-type": "text/x-other" },
-          }).headers.get("content-type"),
-          cloneOfAdoptedStream: contentType(adopted().clone()),
-          adoptedStreamAfterClone: contentType(adoptedThenCloned),
-          copyOfAdoptedStream: contentType(new Request(adopted())),
-          copyOfAdoptedStreamWithInit: contentType(new Request(adopted(), { method: "PUT" })),
-        }).toEqual({
-          headersFirst: type,
-          bodyFirst: type,
-          textFirst: type,
-          arrayBufferFirst: type,
-          blobFirst: type,
-          cloneFirst: type,
-          bodyThenClone: type,
-          readCloneOfTouched: type,
-          sameBoundary: true,
-          copied: type,
-          copiedWithInit: type,
-          copiedWithNewHeaders: null,
-          explicitWins: "text/x-other",
-          cloneOfAdoptedStream: null,
-          adoptedStreamAfterClone: null,
-          copyOfAdoptedStream: null,
-          copyOfAdoptedStreamWithInit: null,
-        });
+    test.each(typedSources)("%s", async (name, init, type) => {
+      const contentType = (request: Request) => request.headers.get("content-type")?.slice(0, type.length) ?? null;
+      const after = async (use: (request: Request) => unknown) => {
+        const request = make(init());
+        await use(request);
+        return contentType(request);
+      };
+      const touched = make(init());
+      touched.body;
+      const clone = touched.clone();
+      await clone.text();
+      const adopted = () => make(new Response(init()).body!);
+      const adoptedThenCloned = adopted();
+      adoptedThenCloned.clone();
+      expect({
+        headersFirst: await after(() => {}),
+        bodyFirst: await after(request => request.body),
+        textFirst: await after(request => request.text()),
+        arrayBufferFirst: await after(request => request.arrayBuffer()),
+        blobFirst: await after(request => request.blob()),
+        cloneFirst: await after(request => request.clone().text()),
+        bodyThenClone: contentType(touched),
+        readCloneOfTouched: contentType(clone),
+        sameBoundary: clone.headers.get("content-type") === touched.headers.get("content-type"),
+        copied: contentType(new Request(make(init()))),
+        copiedWithInit: contentType(new Request(make(init()), { method: "PUT" })),
+        copiedWithNewHeaders: contentType(new Request(make(init()), { headers: { "x-a": "1" } })),
+        explicitWins: new Request("http://a/", {
+          method: "POST",
+          body: init(),
+          headers: { "content-type": "text/x-other" },
+        }).headers.get("content-type"),
+        cloneOfAdoptedStream: contentType(adopted().clone()),
+        adoptedStreamAfterClone: contentType(adoptedThenCloned),
+        copyOfAdoptedStream: contentType(new Request(adopted())),
+        copyOfAdoptedStreamWithInit: contentType(new Request(adopted(), { method: "PUT" })),
+      }).toEqual({
+        headersFirst: type,
+        bodyFirst: type,
+        textFirst: type,
+        arrayBufferFirst: type,
+        blobFirst: type,
+        cloneFirst: type,
+        bodyThenClone: type,
+        readCloneOfTouched: type,
+        sameBoundary: true,
+        copied: type,
+        copiedWithInit: type,
+        copiedWithNewHeaders: null,
+        explicitWins: "text/x-other",
+        cloneOfAdoptedStream: null,
+        adoptedStreamAfterClone: null,
+        copyOfAdoptedStream: null,
+        copyOfAdoptedStreamWithInit: null,
       });
-    }
+    });
 
     test("also when Bun.serve's server.fetch() builds the Request", async () => {
       const seen: (string | null)[] = [];
@@ -1849,15 +1846,17 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
           return new Response("ok");
         },
       });
+      const url = new URL("/", server.url).href;
       const body = new Blob(["a=1"], { type: "text/x-custom" });
-      await server.fetch(new URL("/", server.url).href, { method: "POST", body });
-      await server.fetch(new URL("/", server.url).href, { method: "POST", body, headers: { "x-a": "1" } });
-      await server.fetch(new URL("/", server.url).href, {
-        method: "POST",
-        body,
-        headers: { "content-type": "text/x-other" },
+      const callerHeaders = new Headers({ "x-a": "1" });
+      await server.fetch(url, { method: "POST", body });
+      await server.fetch(url, { method: "POST", body, headers: { "x-a": "1" } });
+      await server.fetch(url, { method: "POST", body, headers: callerHeaders });
+      await server.fetch(url, { method: "POST", body, headers: { "content-type": "text/x-other" } });
+      expect({ seen, callerHeaders: [...callerHeaders] }).toEqual({
+        seen: ["text/x-custom", "text/x-custom", "text/x-custom", "text/x-other"],
+        callerHeaders: [["x-a", "1"]],
       });
-      expect(seen).toEqual(["text/x-custom", "text/x-custom", "text/x-other"]);
     });
   });
 

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1558,6 +1558,22 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
     ["Uint8Array(0)", () => new Uint8Array(0), ""],
     ["Blob([])", () => new Blob([]), ""],
   ];
+  // [name, init, the Content-Type it gives a body, its payload read as text]
+  const typedSources: [string, () => BodyInit, string, unknown][] = [
+    ["Blob", () => new Blob(["a=1"], { type: "text/x-custom" }), "text/x-custom", "a=1"],
+    ["File", () => new File(["a=1"], "a.txt", { type: "text/x-custom" }), "text/x-custom", "a=1"],
+    ["URLSearchParams", () => new URLSearchParams("a=1"), "application/x-www-form-urlencoded;charset=UTF-8", "a=1"],
+    [
+      "FormData",
+      () => {
+        const form = new FormData();
+        form.append("a", "1");
+        return form;
+      },
+      "multipart/form-data; boundary=",
+      expect.stringContaining('name="a"'),
+    ],
+  ];
   const owners: [string, (body: BodyInit, headers?: HeadersInit) => Request | Response][] = [
     // `duplex` is what undici wants for a stream body; Bun accepts and ignores it.
     [
@@ -1737,8 +1753,75 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
           });
         }
       });
+
+      // https://fetch.spec.whatwg.org/#concept-bodyinit-extract gives a
+      // ReadableStream init no MIME type, whatever the stream was made from.
+      describe("a stream body contributes no Content-Type, whatever is behind the stream", () => {
+        for (const [name, init, , content] of typedSources) {
+          for (const [fromName, makeFrom] of owners) {
+            test(`a stream taken from a ${fromName} made from ${name}`, async () => {
+              expect({
+                bare: make(makeFrom(init()).body!).headers.get("content-type"),
+                otherHeaders: make(makeFrom(init()).body!, { "x-a": "1" }).headers.get("content-type"),
+                explicit: make(makeFrom(init()).body!, { "content-type": "text/x-other" }).headers.get("content-type"),
+                text: await make(makeFrom(init()).body!).text(),
+              }).toEqual({ bare: null, otherHeaders: null, explicit: "text/x-other", text: content });
+            });
+          }
+        }
+      });
     });
   }
+
+  // The same spec step gives a Blob, FormData or URLSearchParams init a MIME
+  // type, and the Request constructor appends it to the header list right
+  // there. So the header does not depend on what is read first.
+  describe("new Request() takes the Content-Type from the body init at construction", () => {
+    const make = (body: BodyInit) => new Request("http://a/", { method: "POST", body });
+    for (const [name, init, type] of typedSources) {
+      test(name, async () => {
+        const contentType = (request: Request) => request.headers.get("content-type")?.slice(0, type.length) ?? null;
+        const after = async (use: (request: Request) => unknown) => {
+          const request = make(init());
+          await use(request);
+          return contentType(request);
+        };
+        const touched = make(init());
+        touched.body;
+        const clone = touched.clone();
+        await clone.text();
+        expect({
+          headersFirst: await after(() => {}),
+          bodyFirst: await after(request => request.body),
+          textFirst: await after(request => request.text()),
+          arrayBufferFirst: await after(request => request.arrayBuffer()),
+          blobFirst: await after(request => request.blob()),
+          cloneFirst: await after(request => request.clone().text()),
+          bodyThenClone: contentType(touched),
+          readCloneOfTouched: contentType(clone),
+          sameBoundary: clone.headers.get("content-type") === touched.headers.get("content-type"),
+          copiedByNewRequest: contentType(new Request(make(init()))),
+          explicitWins: new Request("http://a/", {
+            method: "POST",
+            body: init(),
+            headers: { "content-type": "text/x-other" },
+          }).headers.get("content-type"),
+        }).toEqual({
+          headersFirst: type,
+          bodyFirst: type,
+          textFirst: type,
+          arrayBufferFirst: type,
+          blobFirst: type,
+          cloneFirst: type,
+          bodyThenClone: type,
+          readCloneOfTouched: type,
+          sameBoundary: true,
+          copiedByNewRequest: type,
+          explicitWins: "text/x-other",
+        });
+      });
+    }
+  });
 
   // A null body is not a zero-length body: nothing can use it up.
   test("Response.redirect() and Response.error() have a null body", async () => {


### PR DESCRIPTION
### Problem
- `new Request(url, { body: stream })` reports a `Content-Type` taken from the Blob or FormData behind a blob-backed stream such as `new Response(formData).body`. `new Response(stream)` reports none since #42116, like undici.
- Cause: `Request::ensure_fetch_headers` (`webcore/Request.rs`) built the header list on first use from the body as it was then, and for a stream read the type off its `ByteBlobLoader` source. That covered a `.body` read before `headers` (#21011) but cannot tell the Request's own Blob from a stream the user passed in.

### Fix
- A Request appends its Blob body's type to the header list when it is made, as fetch's "extract a body" does: in `construct_into` for `init.body`, in `init2` for `server.fetch()`. `ensure_fetch_headers` derives nothing.
- `server.fetch(url, { headers })` copies a caller's `Headers` object instead of sharing it, so the append cannot write into it.
- Verified: `test/js/web/fetch/body.test.ts`, 21 new cases (13 fail on main), each checked against node v26.3.0.
- Self-reviewed: 4 concerns on a first version, 3 resolved by this shape. The fourth, the type `fetch()` sends for a stream body, is existing behavior (notes).

### Background
- `Request` and `Response` allocate their `FetchHeaders`, a C++ object, on first use. A `Request` with a typed Blob body now allocates it in the constructor.
- Later the body can be a stream, used up, or a Blob that `clone()` lifted back out of a stream. Its type then says nothing about the Request.
- #42015 (open) has the same `construct_into` hunk, next to its `Response` fix. This PR leaves `Response` alone.

<details><summary>Notes</summary>

- The reduced program from the report:
  ```
  main   {"response":null,"request":"text/css;charset=utf-8","requestFormData":"multipart/form-data; boundary=<hidden source's>","requestBlobType":"text/css;charset=utf-8"}
  this   {"response":null,"request":null,"requestFormData":null,"requestBlobType":"text/css;charset=utf-8"}
  node   {"response":null,"request":null,"requestFormData":null,"requestBlobType":""}
  ```
- What changes, all matching node: `new Request(url, { body: stream }).headers` has no `Content-Type` unless the init headers set one, whatever backs the stream, also after `clone()`, on the clone, and on `new Request(request[, init])`. `new Request(url, { body: formData })` keeps its `multipart/form-data; boundary=...` header after `text()`, `arrayBuffer()`, `blob()`, `.body` and `clone()`, and on a clone that was read; on main only the `.body` order kept it. `new Request(typedRequest, { headers })` takes the given headers as they are (main re-added the body's type). `server.fetch(url, { body: typedBlob })` gives the handler the type whatever it reads first and whether or not `headers` were passed (main: only without `headers`, and only through the lazy path).
- What does not change, for both constructors: `blob().type` on a blob-backed stream body still reports the type of the Blob behind the stream (`body.test.ts` "blob-backed stream bodies" and `body-clone.test.ts` pin that; ledger #44056 and #42016 are about its precedence against the header). `formData()` on an adopted multipart stream still parses with the source's boundary. `fetch()` uploads and `Bun.serve` responses still type and frame a payload they lift out of an unread blob-backed stream. `Response` read before `headers`, and `Response.clone()` over an adopted stream, still derive the type from the body (#42015's area).
- `new Request(url, response)` (a `Response` as init, which undici rejects) keeps treating the Response's body as `init.body`, type included.
- `fetch()` on the wire, `content-type` and framing as the server sees them (a FormData body, a `text/css` Blob, `r.body`/`r.headers` read before `fetch(r)`):
  ```
                                             main                this PR             node v26.3.0
  fetch(url, {body: res.body})               text/css, cl=3      text/css, cl=3      none, chunked
  fetch(new Request(url, {body: res.body}))  text/css, cl=3      text/css, cl=3      none, chunked
  FormData Request, .body read               multipart, cl=165   multipart, cl=165   multipart, cl=121
  FormData Request                           multipart, cl=165   multipart, cl=165   multipart, cl=121
  FormData Request, .headers read            multipart, cl=165   multipart, cl=165   multipart, cl=121
  FormData Request subclass (#14988)         multipart, cl=165   multipart, cl=165   multipart, cl=121
  Blob Request, .body read                   text/css, cl=3      text/css, cl=3      text/css, cl=3
  Blob Request, explicit header              text/x-other, cl=3  text/x-other, cl=3  text/x-other, cl=3
  ```
- The first version of this change kept the lazy header list and created it from the `.body` getter before the Blob became a stream. Review found that `Bun.serve` keys the automatic 206 for a sliced `Bun.file()` body on the header list not existing, so `r.body; return r` turned a 206 into a 200, and that #42015 already captures the type at construction. Appending at construction for `Request` has neither problem: a `Request` is never served.
- The old `server.fetch()` path adopted the `FetchHeaders` pointer held by the caller's JS `Headers` wrapper without taking a ref of its own. Copying it (`clone_this`, as `Response`'s init parsing does) also ends that sharing.
- Suites run on the debug build: `body`, `FormData` (the #14988 and #21011 cases), `body-clone`, `body-stream`, `request` (web and deno), `request-subclass`, `request-cyclic-reference`, `response`, `headers`, `inspect`, `client-fetch`, `fetch-file-upload`, `bun-server`, `bun-serve-routes`, `bun-serve-fetch-invalid-args`, `bun-serve-headers`, `ws`, `serve.test.ts`, `fetch.test.ts`, `fetch.stream.test.ts`. The failures left are environment-only and reproduce with `origin/main`'s `src/` (IPv6, running as root, no internet egress, ASAN timeouts, and RSS bounds in `request-clone-leak` and `leaks-test` whose fixtures do not detect a `bun-debug` ASAN build).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/body.test.ts

<!-- robobun:evidence:end -->
