### PR TITLE
Headers: throw instead of aborting when a value passes the string length limit

### DIFF
--- a/src/jsc/bindings/Exception.h
+++ b/src/jsc/bindings/Exception.h
@@ -70,4 +70,18 @@ inline Exception isolatedCopy(Exception&& value)
     return Exception { value.code(), value.releaseMessage().isolatedCopy(), value.releaseExtra().isolatedCopy() };
 }
 
+// makeString() aborts the process when the result is longer than a String can
+// be (String::MaxLength, 2**31 - 1 characters). A message that embeds a string
+// from JS can reach that length, so build it with tryMakeString() and report
+// the failure the way JSC reports an over-long string: RangeError: Out of
+// memory.
+template<typename... StringTypes>
+Exception exceptionWithMessage(ExceptionCode code, const StringTypes&... parts)
+{
+    String message = tryMakeString(parts...);
+    if (message.isNull()) [[unlikely]]
+        return Exception { OutOfMemoryError };
+    return Exception { code, WTF::move(message) };
+}
+
 }

--- a/src/jsc/bindings/Exception.h
+++ b/src/jsc/bindings/Exception.h
@@ -70,11 +70,7 @@ inline Exception isolatedCopy(Exception&& value)
     return Exception { value.code(), value.releaseMessage().isolatedCopy(), value.releaseExtra().isolatedCopy() };
 }
 
-// makeString() aborts the process when the result is longer than a String can
-// be (String::MaxLength, 2**31 - 1 characters). A message that embeds a string
-// from JS can reach that length, so build it with tryMakeString() and report
-// the failure the way JSC reports an over-long string: RangeError: Out of
-// memory.
+// A message past String::MaxLength becomes OutOfMemoryError. makeString() would crash.
 template<typename... StringTypes>
 Exception exceptionWithMessage(ExceptionCode code, const StringTypes&... parts)
 {

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -71,7 +71,7 @@ static ExceptionOr<bool> canWriteHeader(const HTTPHeaderName name, const String&
 {
     ASSERT(value.isEmpty() || (!isHTTPSpace(value[0]) && !isHTTPSpace(value[value.length() - 1])));
     if (!isValidHTTPHeaderValue((value)))
-        return Exception { TypeError, makeString("Header '"_s, httpHeaderNameString(name), "' has invalid value: '"_s, value, "'"_s) };
+        return exceptionWithMessage(TypeError, "Header '"_s, httpHeaderNameString(name), "' has invalid value: '"_s, value, "'"_s);
     if (guard == FetchHeaders::Guard::Immutable)
         return Exception { TypeError, "Headers object's guard is 'immutable'"_s };
     return true;
@@ -80,10 +80,10 @@ static ExceptionOr<bool> canWriteHeader(const HTTPHeaderName name, const String&
 static ExceptionOr<bool> canWriteHeader(const String& name, const String& value, const String& combinedValue, FetchHeaders::Guard guard)
 {
     if (!isValidHTTPToken(name))
-        return Exception { TypeError, makeString("Invalid header name: '"_s, name, "'"_s) };
+        return exceptionWithMessage(TypeError, "Invalid header name: '"_s, name, "'"_s);
     ASSERT(value.isEmpty() || (!isHTTPSpace(value[0]) && !isHTTPSpace(value[value.length() - 1])));
     if (!isValidHTTPHeaderValue((value)))
-        return Exception { TypeError, makeString("Header '"_s, name, "' has invalid value: '"_s, value, "'"_s) };
+        return exceptionWithMessage(TypeError, "Header '"_s, name, "' has invalid value: '"_s, value, "'"_s);
     if (guard == FetchHeaders::Guard::Immutable)
         return Exception { TypeError, "Headers object's guard is 'immutable'"_s };
     return true;
@@ -107,10 +107,12 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
             if (index.isValid()) {
                 auto existing = headers.getIndex(index);
                 if (headerName == HTTPHeaderName::Cookie) {
-                    combinedTemp = makeString(existing, "; "_s, normalizedValue);
+                    combinedTemp = tryMakeString(existing, "; "_s, normalizedValue);
                 } else {
-                    combinedTemp = makeString(existing, ", "_s, normalizedValue);
+                    combinedTemp = tryMakeString(existing, ", "_s, normalizedValue);
                 }
+                if (combinedTemp.isNull()) [[unlikely]]
+                    return Exception { OutOfMemoryError };
                 valueToSet = &combinedTemp;
             }
         }
@@ -133,7 +135,9 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
     }
     auto index = headers.indexOf(name);
     if (index.isValid()) {
-        combinedTemp = makeString(headers.getIndex(index), ", "_s, normalizedValue);
+        combinedTemp = tryMakeString(headers.getIndex(index), ", "_s, normalizedValue);
+        if (combinedTemp.isNull()) [[unlikely]]
+            return Exception { OutOfMemoryError };
         valueToSet = &combinedTemp;
     }
     auto canWriteResult = canWriteHeader(name, normalizedValue, *valueToSet, guard);
@@ -250,7 +254,7 @@ ExceptionOr<void> FetchHeaders::remove(const StringView name)
     }
 
     if (!isValidHTTPToken(name))
-        return Exception { TypeError, makeString("Invalid header name: '"_s, name, "'"_s) };
+        return exceptionWithMessage(TypeError, "Invalid header name: '"_s, name, "'"_s);
 
     ++m_updateCounter;
     m_headers.removeUncommonHeader(name);
@@ -265,11 +269,24 @@ size_t FetchHeaders::memoryCost() const
 
 ExceptionOr<String> FetchHeaders::get(const StringView name) const
 {
-    auto result = m_headers.get(name);
-    if (result.isEmpty()) {
-        if (!isValidHTTPToken(name))
-            return Exception { TypeError, makeString("Invalid header name: '"_s, name, "'"_s) };
+    HTTPHeaderName headerName;
+    if (findHTTPHeaderName(name, headerName)) {
+        // A Headers object can hold more Set-Cookie bytes than one String can
+        // hold, and the ", "-joined value is the only value to return here.
+        // Report that instead of aborting the process.
+        if (headerName == HTTPHeaderName::SetCookie) {
+            auto joined = m_headers.tryJoinSetCookieHeaders();
+            if (!joined) [[unlikely]]
+                return Exception { OutOfMemoryError };
+            return WTF::move(*joined);
+        }
+        return m_headers.get(headerName);
     }
+
+    // A known header name is always a valid token, so only this path can fail.
+    auto result = m_headers.getUncommonHeader(name);
+    if (result.isEmpty() && !isValidHTTPToken(name))
+        return exceptionWithMessage(TypeError, "Invalid header name: '"_s, name, "'"_s);
 
     return result;
 }
@@ -279,7 +296,7 @@ ExceptionOr<bool> FetchHeaders::has(const StringView name) const
     bool has = m_headers.contains(name);
     if (!has) {
         if (!isValidHTTPToken(name))
-            return Exception { TypeError, makeString("Invalid header name: '"_s, name, '"') };
+            return exceptionWithMessage(TypeError, "Invalid header name: '"_s, name, '"');
     }
     return has;
 }

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -296,7 +296,7 @@ ExceptionOr<bool> FetchHeaders::has(const StringView name) const
     bool has = m_headers.contains(name);
     if (!has) {
         if (!isValidHTTPToken(name))
-            return exceptionWithMessage(TypeError, "Invalid header name: '"_s, name, '"');
+            return exceptionWithMessage(TypeError, "Invalid header name: '"_s, name, "'"_s);
     }
     return has;
 }

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -271,9 +271,7 @@ ExceptionOr<String> FetchHeaders::get(const StringView name) const
 {
     HTTPHeaderName headerName;
     if (findHTTPHeaderName(name, headerName)) {
-        // A Headers object can hold more Set-Cookie bytes than one String can
-        // hold, and the ", "-joined value is the only value to return here.
-        // Report that instead of aborting the process.
+        // The stored Set-Cookie values can add up to more than one String holds.
         if (headerName == HTTPHeaderName::SetCookie) {
             auto joined = m_headers.tryJoinSetCookieHeaders();
             if (!joined) [[unlikely]]
@@ -283,7 +281,7 @@ ExceptionOr<String> FetchHeaders::get(const StringView name) const
         return m_headers.get(headerName);
     }
 
-    // A known header name is always a valid token, so only this path can fail.
+    // A known header name is always a valid token, so only this path checks.
     auto result = m_headers.getUncommonHeader(name);
     if (result.isEmpty() && !isValidHTTPToken(name))
         return exceptionWithMessage(TypeError, "Invalid header name: '"_s, name, "'"_s);

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
@@ -223,10 +223,7 @@ std::optional<String> HTTPHeaderMap::tryJoinSetCookieHeaders() const
         break;
     }
 
-    // Sum the real lengths, in 64 bits. Every pair is joined by ", ", and the
-    // headers have independent lengths, so the first length times the count is
-    // both the wrong total and a product that wraps. A capacity past
-    // String::MaxLength aborts the process, and so does an append past it.
+    // ", " between each pair. StringBuilder crashes past String::MaxLength.
     uint64_t length = 2 * static_cast<uint64_t>(count - 1);
     for (const auto& header : m_setCookieHeaders)
         length += header.length();
@@ -245,11 +242,9 @@ std::optional<String> HTTPHeaderMap::tryJoinSetCookieHeaders() const
 
 String HTTPHeaderMap::get(HTTPHeaderName name) const
 {
-    if (name == HTTPHeaderName::SetCookie) {
-        // A joined value that does not fit in a String reads as absent here.
-        // FetchHeaders::get() reports it to JS as an out-of-memory error.
+    // A join past String::MaxLength reads as absent. FetchHeaders::get() throws.
+    if (name == HTTPHeaderName::SetCookie)
         return tryJoinSetCookieHeaders().value_or(String());
-    }
 
     auto index = m_commonHeaders.findIf([&](auto& header) {
         return header.key == name;

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
@@ -211,26 +211,44 @@ bool HTTPHeaderMap::removeUncommonHeader(const StringView name)
     });
 }
 
+std::optional<String> HTTPHeaderMap::tryJoinSetCookieHeaders() const
+{
+    unsigned count = m_setCookieHeaders.size();
+    switch (count) {
+    case 0:
+        return String();
+    case 1:
+        return m_setCookieHeaders[0];
+    default:
+        break;
+    }
+
+    // Sum the real lengths, in 64 bits. Every pair is joined by ", ", and the
+    // headers have independent lengths, so the first length times the count is
+    // both the wrong total and a product that wraps. A capacity past
+    // String::MaxLength aborts the process, and so does an append past it.
+    uint64_t length = 2 * static_cast<uint64_t>(count - 1);
+    for (const auto& header : m_setCookieHeaders)
+        length += header.length();
+    if (length > String::MaxLength) [[unlikely]]
+        return std::nullopt;
+
+    StringBuilder builder;
+    builder.reserveCapacity(static_cast<unsigned>(length));
+    builder.append(m_setCookieHeaders[0]);
+    for (unsigned i = 1; i < count; ++i) {
+        builder.append(", "_s);
+        builder.append(m_setCookieHeaders[i]);
+    }
+    return builder.toString();
+}
+
 String HTTPHeaderMap::get(HTTPHeaderName name) const
 {
     if (name == HTTPHeaderName::SetCookie) {
-        unsigned count = m_setCookieHeaders.size();
-        switch (count) {
-        case 0:
-            return String();
-        case 1:
-            return m_setCookieHeaders[0];
-        default: {
-            StringBuilder builder;
-            builder.reserveCapacity(m_setCookieHeaders[0].length() * count + (count - 1));
-            builder.append(m_setCookieHeaders[0]);
-            for (unsigned i = 1; i < count; ++i) {
-                builder.append(", "_s);
-                builder.append(m_setCookieHeaders[i]);
-            }
-            return builder.toString();
-        }
-        }
+        // A joined value that does not fit in a String reads as absent here.
+        // FetchHeaders::get() reports it to JS as an out-of-memory error.
+        return tryJoinSetCookieHeaders().value_or(String());
     }
 
     auto index = m_commonHeaders.findIf([&](auto& header) {

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -177,11 +177,8 @@ public:
     HeaderIndex indexOf(HTTPHeaderName name) const;
 
     WEBCORE_EXPORT String get(HTTPHeaderName) const;
-
-    // The ", "-joined Set-Cookie value, or nullopt when the join is longer than
-    // String::MaxLength.
+    // The ", "-joined Set-Cookie value. nullopt when it passes String::MaxLength.
     WEBCORE_EXPORT std::optional<String> tryJoinSetCookieHeaders() const;
-
     void set(HTTPHeaderName, const String& value);
     void add(HTTPHeaderName, const String& value);
     WEBCORE_EXPORT bool contains(HTTPHeaderName) const;

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -177,6 +177,11 @@ public:
     HeaderIndex indexOf(HTTPHeaderName name) const;
 
     WEBCORE_EXPORT String get(HTTPHeaderName) const;
+
+    // The ", "-joined Set-Cookie value, or nullopt when the join is longer than
+    // String::MaxLength.
+    WEBCORE_EXPORT std::optional<String> tryJoinSetCookieHeaders() const;
+
     void set(HTTPHeaderName, const String& value);
     void add(HTTPHeaderName, const String& value);
     WEBCORE_EXPORT bool contains(HTTPHeaderName) const;
@@ -232,10 +237,9 @@ public:
     void setUncommonHeader(const String& name, const String& value);
     void addUncommonHeader(const String& name, const String& value);
     void addUncommonHeaderCloneName(const StringView name, const String& value);
-
-private:
     WEBCORE_EXPORT String getUncommonHeader(const StringView name) const;
 
+private:
     CommonHeadersVector m_commonHeaders;
     UncommonHeadersVector m_uncommonHeaders;
     Vector<String, 0> m_setCookieHeaders;

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -393,7 +393,8 @@ describe("Headers", () => {
     test("names the invalid header the same way get() and delete() do", () => {
       const headers = new Headers();
       for (const method of ["has", "get", "delete"] as const) {
-        expect(() => headers[method]("a b")).toThrow("Invalid header name: 'a b'");
+        // An Error argument compares the whole message, not a substring.
+        expect(() => headers[method]("a b")).toThrow(new TypeError("Invalid header name: 'a b'"));
       }
     });
   });

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -390,6 +390,12 @@ describe("Headers", () => {
       // @ts-expect-error
       expect(() => headers.has()).toThrow(TypeError);
     });
+    test("names the invalid header the same way get() and delete() do", () => {
+      const headers = new Headers();
+      for (const method of ["has", "get", "delete"] as const) {
+        expect(() => headers[method]("a b")).toThrow("Invalid header name: 'a b'");
+      }
+    });
   });
   describe("entries()", () => {
     test("can get header entries when empty", () => {

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -2,6 +2,8 @@ import { beforeAll, describe, expect, test } from "bun:test";
 // Namespace import so a missing binding fails only the kernel tests below
 // (accessing an absent export is `undefined`), not the whole file.
 import * as internalForTesting from "bun:internal-for-testing";
+import { bunEnv, bunExe } from "harness";
+import { totalmem } from "node:os";
 
 beforeAll(() => {
   // expect(Headers).toBeDefined();
@@ -735,4 +737,101 @@ describe("Headers", () => {
       expect(lowercaseHeaderNameSIMD(s)).toBe("x-ab\u0100cd\u0101ef\uffffgz");
     });
   });
+});
+
+// A header value is one String, so it holds at most String::MaxLength
+// (2**31 - 1) characters. Each case runs in a child process because what it
+// covers aborted the process.
+describe("the string length limit", () => {
+  // The capacity for the Set-Cookie join used to be the first value's length
+  // times the count, as a 32-bit product. 2048 values whose first one is 1 MiB
+  // reach String::MaxLength that way, while the join itself is about 1 MiB.
+  test("joins Set-Cookie values that only the old capacity could not hold", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const headers = new Headers();
+          headers.append("set-cookie", "x".repeat(2 ** 20));
+          for (let i = 0; i < 2047; i++) headers.append("set-cookie", "a");
+          const joined = headers.get("set-cookie");
+          console.log(JSON.stringify({ length: joined.length, head: joined.slice(0, 3), tail: joined.slice(-4) }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout || "{}")).toEqual({
+      // 2048 values and 2047 ", " separators.
+      length: 2 ** 20 + 2047 + 2 * 2047,
+      head: "xxx",
+      tail: "a, a",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // This case is the only one that needs a value of its own past the limit.
+  // Each length is computed before any character is copied, so the child never
+  // allocates the over-long value: it needs room for the one 2**30-character
+  // string it reuses. The timeout covers the part that is not free, `append()`
+  // checking 1 GiB of value for invalid characters, which takes a few seconds
+  // per call in a debug build.
+  test.skipIf(totalmem() < 8 * 1024 ** 3)(
+    "a value past it is an error instead of an abort",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const big = "x".repeat(2 ** 30);
+            const results = {};
+            const record = (name, fn) => {
+              try {
+                results[name] = fn();
+              } catch (e) {
+                results[name] = e.name + ": " + e.message;
+              }
+            };
+
+            // Appending to a header that already has a value combines the two.
+            const combined = new Headers();
+            combined.append("accept", big);
+            record("append", () => {
+              combined.append("accept", big);
+              return combined.get("accept").length;
+            });
+            // The append that failed leaves the value that was there alone.
+            record("the value already there", () => combined.get("accept").length);
+
+            // Set-Cookie keeps each value of its own, and get() joins them.
+            const cookies = new Headers();
+            cookies.append("set-cookie", big);
+            cookies.append("set-cookie", big);
+            record("get set-cookie", () => cookies.get("set-cookie").length);
+            record("getSetCookie", () => cookies.getSetCookie().length);
+
+            console.log(JSON.stringify(results));
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout || "{}")).toEqual({
+        "append": "RangeError: Out of memory",
+        "the value already there": 2 ** 30,
+        "get set-cookie": "RangeError: Out of memory",
+        "getSetCookie": 2,
+      });
+      expect(exitCode).toBe(0);
+    },
+    60_000,
+  );
 });


### PR DESCRIPTION
### Problem

- `Headers.append()` and `Headers.get("set-cookie")` abort the process when the value they build passes `String::MaxLength` (2\*\*31 - 1 characters): `panic(main thread): abort() called`, exit code 134. A `Headers` method that rejects a name or value that long aborts too, because the message quotes it.
- `get("set-cookie")` also aborts on about 1 MB of data. It reserved the first value's length times the count, as a 32-bit product.
- The cause: `makeString()` calls `CRASH()` on overflow (MakeString.h:105), and so does a default `StringBuilder` (StringBuilder.cpp:46).

### Fix

- `appendToHeaderMap` (FetchHeaders.cpp:110) combines with `tryMakeString()`, which returns a null String on overflow, and reports `Exception { OutOfMemoryError }`. JS sees `RangeError: Out of memory`, the error JSC throws for an over-long string. The stored value stays.
- `HTTPHeaderMap::tryJoinSetCookieHeaders()` sums the real length of every value in 64 bits. It returns nullopt past the limit, and `FetchHeaders::get()` throws the same error.
- The six messages that quote a name or value go through `exceptionWithMessage()`, new in Exception.h. #42202 merged the same `tryMakeString` pattern for `performance.measure`.
- Verified: `test/js/web/fetch/headers.test.ts`, four new cases, all fail on main. Also 12 related suites (notes). Self-reviewed: 3 concerns raised, 3 addressed.

### Background

- A `WTF::String` holds at most 2\*\*31 - 1 characters. JS has the same limit.
- `makeString` and `StringBuilder` default to `CrashOnOverflow`. `tryMakeString` and `OverflowPolicy::RecordOverflow` report the overflow instead.
- `Headers` stores each Set-Cookie value of its own. `get("set-cookie")` is the one reader that joins them with `", "`. `getSetCookie()` returns the array and is unaffected.
- `ExceptionCode::OutOfMemoryError` becomes `createOutOfMemoryError` in JSDOMExceptionHandling.cpp.

<details><summary>Notes</summary>

Reproductions on main (each exits 134):

```js
// append: combine past the limit
const h = new Headers();
const s = "x".repeat(2 ** 30);
h.append("accept", s);
h.append("accept", s);

// get("set-cookie"): join past the limit
const c = new Headers();
c.append("set-cookie", s);
c.append("set-cookie", s);
c.get("set-cookie");

// get("set-cookie"): only the 32-bit capacity product passes the limit, the join is ~1 MiB
const k = new Headers();
k.append("set-cookie", "x".repeat(2 ** 20));
for (let i = 0; i < 2047; i++) k.append("set-cookie", "a");
k.get("set-cookie");

// a message that quotes a name or value past the limit
const bad = "\0".repeat(2 ** 31 - 20);
new Headers().set("x-bun", bad);   // also append(), and set/get/has/delete with `bad` as the name
```

The new test cases:
1. `has()` names the invalid header the way `get()` and `delete()` do. It closed the name with `"` instead of `'` (pre-existing typo on a line this change rewrites).
2. The Set-Cookie capacity case: about 1 MB, 0.3 s, no memory gate.
3. A value past the limit: `append` combine and `get("set-cookie")` join, with one 2\*\*30-character string. About 9 to 16 s on a debug ASAN build, mostly `append()` checking 1 GiB of value for invalid characters. Skipped below 8 GiB of RAM, 60 s ceiling.
4. A message past the limit: all six messages in FetchHeaders.cpp, with one 2\*\*31 - 20 character string. Validation stops at the first character, so each call takes 2 to 5 ms. The whole child takes about 2 s and 2.4 GB on a debug ASAN build. Own child, so that the two big strings never coexist. Skipped below 8 GiB of RAM, 30 s ceiling (the one `test/js/bun/util/error-message-string-length-limit.test.ts` uses for the same work).

Neither heavy case allocates the over-long result: each length is computed before any character is copied.

Coverage of the subsystem: `FetchHeaders.cpp` has four value joins reachable from JS (`", "` for a common header, `"; "` for Cookie, `", "` for an uncommon name, and the Set-Cookie join). All four are in this change. The `makeString` joins left in `HTTPHeaderMap::add` / `addUncommonHeader` are fed by the wire parsers, whose header bytes are bounded, and by a fill into an empty map.

`FetchHeaders::get()` is rewritten to look the name up once and branch, instead of calling `HTTPHeaderMap::get(StringView)` and then inspecting the result. For every input that does not overflow it returns what it returned before: the common header value, the uncommon header value, a null String for an absent header, and the TypeError for a name that is not a valid token. The token check now lives only on the uncommon path, because a name that `findHTTPHeaderName` resolves is always a valid token.

`HTTPHeaderMap::get(HTTPHeaderName::SetCookie)` returns a null String when the join does not fit, which reads as an absent header. No C++ or Rust caller reads the joined Set-Cookie value today. The JS path goes through `FetchHeaders::get()`, which throws.

The message for an invalid header value still embeds the whole value, as it did before. This change only removes the abort.

Suites run with the debug build, all green: `headers.test.ts`, `headers.undici.test.ts`, `headers-case.test.ts`, `fetch_headers.test.js`, `fetch-header-str-bounds.test.ts`, `cookies.test.ts`, `deno/fetch/headers.test.ts`, `bun-serve-headers.test.ts`, `bun-serve-cookies.test.ts`, `cookie-map.test.ts`, `cookie.test.ts`, `fetch-header-count-limit.test.ts`, `error-message-string-length-limit.test.ts`.

Same mechanism, other files, other PRs: #42202 (ERR\_\* messages, merged), #42314 (stack frames, merged), #42216 (WebSocket messages), #42259 (`domainToASCII`, ReadableStream `type`), #42237 (Cookie), #42312 (YAML, JSON5, XML stringify), #42534 (URL, URLSearchParams), #42308 (`process.execve`). #42250 (linear `Headers.append`) builds on the append hunk here.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/headers.test.ts
bun test v1.4.3 (09bb54630)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [5.59ms]
(pass) Headers > constructor > cannot create headers from null [4.22ms]
(pass) Headers > constructor > can create headers from empty object [3.32ms]
(pass) Headers > constructor > can create headers from object [2.77ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [2.71ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [4.76ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [7.01ms]
(pass) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [9.31ms]
(pass) Headers > constructor > constructing headers from an object propagates an exception from a getter installed by an earlier value's toString [6.72ms]
(pass) Headers > constructor > construc
... (truncated)

release without fix: 4 FAILED
bun test v1.4.3-canary.1 (09bb54630)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [0.04ms]
(pass) Headers > constructor > cannot create headers from null [0.06ms]
(pass) Headers > constructor > can create headers from empty object [0.02ms]
(pass) Headers > constructor > can create headers from object [0.02ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [0.04ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [0.06ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [0.06ms]
(pass) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [0.11ms]
(pass) Headers > constructor > constructing headers from an object propagates an exception from a getter installed by an earlier value's toString [0.06ms]
(pass) Headers > constructor > constructing headers from an object keeps own-property semantics after setPrototypeOf mid-conversion [0.05ms]
(pass) Headers > constructor > can create headers from 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/headers.test.ts
bun test v1.4.3 (09bb54630)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [6.55ms]
(pass) Headers > constructor > cannot create headers from null [5.94ms]
(pass) Headers > constructor > can create headers from empty object [3.98ms]
(pass) Headers > constructor > can create headers from object [3.54ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [4.57ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [8.18ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [11.40ms]
(pass) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [13.92ms]
(pass) Headers > constructor > constructing headers from an object propagates an exception from a getter installed by an earlier value's toString [9.88ms]
(pass) Headers > constructor > constr
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     48d8e92721
  features     lto, baseline

23 deps, 131 codegen, 1176 objects in 806ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1254] mkdir codegen
[2/1254] mkdir stamps
[3/1254] mkdir pch
[4/1254] mkdir obj
[5/1254] install /workspace/bun
bun install v1.4.3-canary.1 (09bb54630)

Checked 22 installs across 61 packages (no changes) [26.00ms]
[6/1254] gen ErrorCode+*.h
[7/1254] fetch zlib
[zlib] up to date
[8/1254] gen bindgenv2
[9/1254] fetch tinycc
[tinycc] up to date
[10/1254] fetch picohttpparser
[picohttpparser] up to date
[11/1254] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[12/1254] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[13/1254] gen .bind.ts → GeneratedBindings.cpp
[14/1254] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[15/1254] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingCons
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/Exception.h               |  10 ++
 src/jsc/bindings/webcore/FetchHeaders.cpp  |  39 ++++---
 src/jsc/bindings/webcore/HTTPHeaderMap.cpp |  51 +++++----
 src/jsc/bindings/webcore/HTTPHeaderMap.h   |   5 +-
 test/js/web/fetch/headers.test.ts          | 160 +++++++++++++++++++++++++++++
 5 files changed, 232 insertions(+), 33 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/jsc/bindings/Exception.h                    3      3     28
src/jsc/bindings/webcore/FetchHeaders.cpp       4      8     28
src/jsc/bindings/webcore/HTTPHeaderMap.cpp      2      3     28
src/jsc/bindings/webcore/HTTPHeaderMap.h        4      3     28
test/js/web/fetch/headers.test.ts               7      8     28
```

</details>

<!-- robobun:evidence:end -->