### PR TITLE
URLPattern: throw instead of aborting when the token list cannot grow

### DIFF
--- a/src/jsc/bindings/VectorSizeLimit.h
+++ b/src/jsc/bindings/VectorSizeLimit.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "root.h"
+#include <wtf/Vector.h>
+
+extern "C" size_t Bun__stringSyntheticAllocationLimit;
+
+namespace Bun {
+
+// The most elements a Vector<T> can hold, lowered by Bun__stringSyntheticAllocationLimit so tests reach it cheaply.
+template<typename T>
+size_t maxVectorSize()
+{
+    constexpr size_t maxBytes = std::numeric_limits<unsigned>::max() >> 1;
+    static_assert(WTF::isValidCapacityForVector<T>(maxBytes / sizeof(T)));
+    static_assert(!WTF::isValidCapacityForVector<T>(maxBytes / sizeof(T) + 1));
+    return std::min(maxBytes, Bun__stringSyntheticAllocationLimit) / sizeof(T);
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/webcore/URLPatternTokenizer.cpp
+++ b/src/jsc/bindings/webcore/URLPatternTokenizer.cpp
@@ -28,6 +28,7 @@
 
 #include "ExceptionOr.h"
 #include "URLPatternParser.h"
+#include "VectorSizeLimit.h"
 #include <unicode/utf16.h>
 #include <wtf/text/MakeString.h>
 
@@ -69,8 +70,10 @@ void Tokenizer::seekNextCodePoint(size_t index)
 // https://urlpattern.spec.whatwg.org/#add-a-token
 void Tokenizer::addToken(TokenType currentType, size_t nextPosition, size_t valuePosition, size_t valueLength)
 {
-    m_tokenList.append(Token { currentType, m_index, m_input.substring(valuePosition, valueLength) });
-    m_index = nextPosition;
+    if (m_tokenList.size() >= Bun::maxVectorSize<Token>() || !m_tokenList.tryAppend(Token { currentType, m_index, m_input.substring(valuePosition, valueLength) }))
+        m_tokenAppendFailure = true;
+    else
+        m_index = nextPosition;
 }
 
 // https://urlpattern.spec.whatwg.org/#add-a-token-with-default-length
@@ -109,7 +112,7 @@ ExceptionOr<Vector<Token>> Tokenizer::tokenize()
 {
     ExceptionOr<void> maybeException;
 
-    while (m_index < m_input.length()) {
+    while (m_index < m_input.length() && !m_tokenAppendFailure) {
         if (m_policy == TokenizePolicy::Strict && maybeException.hasException())
             return maybeException.releaseException();
 
@@ -266,6 +269,10 @@ ExceptionOr<Vector<Token>> Tokenizer::tokenize()
     }
 
     addToken(TokenType::End, m_index, m_index);
+
+    if (m_tokenAppendFailure)
+        return Exception { ExceptionCode::TypeError, "URLPattern constructor: Failed to create URLPattern (from input string)"_s };
+
     return WTF::move(m_tokenList);
 }
 

--- a/src/jsc/bindings/webcore/URLPatternTokenizer.h
+++ b/src/jsc/bindings/webcore/URLPatternTokenizer.h
@@ -67,6 +67,7 @@ private:
     size_t m_index { 0 };
     size_t m_nextIndex { 0 };
     char32_t m_codepoint;
+    bool m_tokenAppendFailure { false };
 
     void getNextCodePoint();
     void seekNextCodePoint(size_t index);

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -208,25 +208,40 @@ describe("URLPattern", () => {
     });
   });
 
-  // The tokenizer keeps one 40-byte token per code point in a WTF::Vector,
-  // which holds at most 2^31 - 1 bytes. A pattern near 52 million characters
-  // used to abort the process when that Vector could not grow. The bound
-  // follows the synthetic allocation limit, so 1 MiB puts it at 26214 tokens.
+  // The tokenizer keeps one token (40 bytes or more) per code point in a
+  // WTF::Vector, which holds at most 2^31 - 1 bytes. A pattern near 52 million
+  // characters used to abort the process when that Vector could not grow. The
+  // bound follows the synthetic allocation limit, so 1 MiB puts it below 64 Ki.
   test("a pattern with more tokens than the token list can hold throws", () => {
-    const tooLong = Buffer.alloc(64 * 1024, ".").toString();
-    const fits = Buffer.alloc(8 * 1024, ".").toString();
+    const dots = (length: number) => Buffer.alloc(length, ".").toString();
     const message = "URLPattern constructor: Failed to create URLPattern (from input string)";
 
     const originalLimit = setSyntheticAllocationLimitForTesting(1024 * 1024);
     try {
+      let tooLong = 64 * 1024;
       for (const component of ["username", "password", "hostname", "pathname", "search", "hash"] as const) {
-        expect(() => new URLPattern({ [component]: tooLong })).toThrow(message);
+        expect(() => new URLPattern({ [component]: dots(tooLong) })).toThrow(message);
       }
-      expect(() => new URLPattern("https://example.com/" + tooLong)).toThrow(message);
-      expect(() => new URLPattern({ search: "a", baseURL: "https://example.com/" + tooLong })).toThrow(message);
+      expect(() => new URLPattern("https://example.com/" + dots(tooLong))).toThrow(message);
+      expect(() => new URLPattern({ search: "a", baseURL: "https://example.com/" + dots(tooLong) })).toThrow(message);
 
-      expect(new URLPattern({ pathname: fits }).pathname).toBe(fits);
-      expect(new URLPattern("https://example.com/" + fits).test("https://example.com/" + fits)).toBe(true);
+      let fits = 8 * 1024;
+      expect(new URLPattern("https://example.com/" + dots(fits)).test("https://example.com/" + dots(fits))).toBe(true);
+
+      // Find the longest pathname that parses. It must come back whole: the
+      // End token counts against the bound too, and without it the parser
+      // would drop the pending text instead of throwing.
+      while (fits + 1 < tooLong) {
+        const length = (fits + tooLong) >>> 1;
+        try {
+          new URLPattern({ pathname: dots(length) });
+          fits = length;
+        } catch {
+          tooLong = length;
+        }
+      }
+      expect(new URLPattern({ pathname: dots(fits) }).pathname).toBe(dots(fits));
+      expect(() => new URLPattern({ pathname: dots(tooLong) })).toThrow(message);
     } finally {
       setSyntheticAllocationLimitForTesting(originalLimit);
     }

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -1,5 +1,6 @@
 // Test data from Web Platform Tests
 // https://github.com/web-platform-tests/wpt/blob/master/LICENSE.md
+import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import testData from "./urlpatterntestdata.json";
 
@@ -205,5 +206,29 @@ describe("URLPattern", () => {
     test("complex pathname with regexp", () => {
       expect(new URLPattern({ pathname: "/a/:foo/:baz([a-z]+)?/b/*" }).hasRegExpGroups).toBe(true);
     });
+  });
+
+  // The tokenizer keeps one 40-byte token per code point in a WTF::Vector,
+  // which holds at most 2^31 - 1 bytes. A pattern near 52 million characters
+  // used to abort the process when that Vector could not grow. The bound
+  // follows the synthetic allocation limit, so 1 MiB puts it at 26214 tokens.
+  test("a pattern with more tokens than the token list can hold throws", () => {
+    const tooLong = Buffer.alloc(64 * 1024, ".").toString();
+    const fits = Buffer.alloc(8 * 1024, ".").toString();
+    const message = "URLPattern constructor: Failed to create URLPattern (from input string)";
+
+    const originalLimit = setSyntheticAllocationLimitForTesting(1024 * 1024);
+    try {
+      for (const component of ["username", "password", "hostname", "pathname", "search", "hash"] as const) {
+        expect(() => new URLPattern({ [component]: tooLong })).toThrow(message);
+      }
+      expect(() => new URLPattern("https://example.com/" + tooLong)).toThrow(message);
+      expect(() => new URLPattern({ search: "a", baseURL: "https://example.com/" + tooLong })).toThrow(message);
+
+      expect(new URLPattern({ pathname: fits }).pathname).toBe(fits);
+      expect(new URLPattern("https://example.com/" + fits).test("https://example.com/" + fits)).toBe(true);
+    } finally {
+      setSyntheticAllocationLimitForTesting(originalLimit);
+    }
   });
 });

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -1,7 +1,7 @@
 // Test data from Web Platform Tests
 // https://github.com/web-platform-tests/wpt/blob/master/LICENSE.md
 import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import testData from "./urlpatterntestdata.json";
 
 const kComponents = ["protocol", "username", "password", "hostname", "port", "pathname", "search", "hash"] as const;
@@ -212,38 +212,50 @@ describe("URLPattern", () => {
   // WTF::Vector, which holds at most 2^31 - 1 bytes. A pattern near 52 million
   // characters used to abort the process when that Vector could not grow. The
   // bound follows the synthetic allocation limit, so 1 MiB puts it below 64 Ki.
-  test("a pattern with more tokens than the token list can hold throws", () => {
+  describe("a pattern with more tokens than the token list can hold throws", () => {
     const dots = (length: number) => Buffer.alloc(length, ".").toString();
     const message = "URLPattern constructor: Failed to create URLPattern (from input string)";
+    const tooLong = 64 * 1024;
+    const fits = 8 * 1024;
 
-    const originalLimit = setSyntheticAllocationLimitForTesting(1024 * 1024);
-    try {
-      let tooLong = 64 * 1024;
-      for (const component of ["username", "password", "hostname", "pathname", "search", "hash"] as const) {
-        expect(() => new URLPattern({ [component]: dots(tooLong) })).toThrow(message);
-      }
+    let originalLimit: number;
+    beforeAll(() => {
+      originalLimit = setSyntheticAllocationLimitForTesting(1024 * 1024);
+    });
+    afterAll(() => {
+      setSyntheticAllocationLimitForTesting(originalLimit);
+    });
+
+    test.each(["username", "password", "hostname", "pathname", "search", "hash"] as const)("in %s", component => {
+      expect(() => new URLPattern({ [component]: dots(tooLong) })).toThrow(message);
+    });
+
+    test("in a constructor string", () => {
       expect(() => new URLPattern("https://example.com/" + dots(tooLong))).toThrow(message);
-      expect(() => new URLPattern({ search: "a", baseURL: "https://example.com/" + dots(tooLong) })).toThrow(message);
-
-      let fits = 8 * 1024;
       expect(new URLPattern("https://example.com/" + dots(fits)).test("https://example.com/" + dots(fits))).toBe(true);
+    });
 
-      // Find the longest pathname that parses. It must come back whole: the
-      // End token counts against the bound too, and without it the parser
-      // would drop the pending text instead of throwing.
-      while (fits + 1 < tooLong) {
-        const length = (fits + tooLong) >>> 1;
+    test("in a pathname inherited from baseURL", () => {
+      expect(() => new URLPattern({ search: "a", baseURL: "https://example.com/" + dots(tooLong) })).toThrow(message);
+    });
+
+    // Find the longest pathname that parses. It must come back whole: the
+    // End token counts against the bound too, and without it the parser
+    // would drop the pending text instead of throwing.
+    test("at the exact bound, and one code point below it parses whole", () => {
+      let low = fits;
+      let high = tooLong;
+      while (low + 1 < high) {
+        const length = (low + high) >>> 1;
         try {
           new URLPattern({ pathname: dots(length) });
-          fits = length;
+          low = length;
         } catch {
-          tooLong = length;
+          high = length;
         }
       }
-      expect(new URLPattern({ pathname: dots(fits) }).pathname).toBe(dots(fits));
-      expect(() => new URLPattern({ pathname: dots(tooLong) })).toThrow(message);
-    } finally {
-      setSyntheticAllocationLimitForTesting(originalLimit);
-    }
+      expect(new URLPattern({ pathname: dots(low) }).pathname).toBe(dots(low));
+      expect(() => new URLPattern({ pathname: dots(high) })).toThrow(message);
+    });
   });
 });


### PR DESCRIPTION
### Problem
- `new URLPattern({ pathname: ".".repeat(53_000_000) })` aborts the process: `panic(main thread): abort() called`, exit 134. Any component and the string form reach it.
- `Tokenizer::addToken` (`src/jsc/bindings/webcore/URLPatternTokenizer.cpp:71`) appends one 40-byte `Token` per code point to a `WTF::Vector<Token>`. A `Vector` holds at most `INT32_MAX` bytes, and `Vector::expandCapacity` calls `CRASH()` when a growth step passes that.

### Fix
- Port WebKit [302131@main](https://commits.webkit.org/302131@main): append with `tryAppend`, stop the loop on failure, and return `TypeError: URLPattern constructor: Failed to create URLPattern (from input string)`. The check runs after the `End` token is appended (upstream checks before it), so a list that fills exactly at the bound throws too instead of losing `End`.
- Also bound the count by `Bun::maxVectorSize<Token>()` (`VectorSizeLimit.h`, byte-identical to the header #40577 adds). With the default limit it equals the `Vector` cap. The test reaches it with 64 KiB instead of 5.8 GB.
- Verified: `test/js/web/urlpattern/urlpattern.test.ts` (nine new tests, stock bun fails each: "Received function did not throw"). The real 53M input throws on debug ASAN and release builds. Also node's `test-urlpattern.js`.
- Self-reviewed: 3 concerns raised, 2 addressed. Rejected: upstream's check order, see above.

### Background
- `src/jsc/bindings/webcore/URLPattern*.cpp` is a copy of WebKit's `Modules/url-pattern/`, compiled into Bun. The tokenizer makes one token per code point of plain text, plus an `End` token that both parsers rely on.
- `WTF::Vector<T>::append` grows by 1.5x and crashes when the new capacity fails `isValidCapacityForVector<T>`. `tryAppend` returns false.
- `setSyntheticAllocationLimitForTesting` (`bun:internal-for-testing`) lowers `Bun__stringSyntheticAllocationLimit`, down to 1 MiB. `maxVectorSize<T>()` is `min(INT32_MAX, limit) / sizeof(T)`.

<details><summary>Notes</summary>

- Stock release: the 53M repro exits 134 after 3.6 s at 5.82 GB peak RSS. Debug ASAN build of main: exit 134 after 33 s. With this change both builds print `TypeError URLPattern constructor: Failed to create URLPattern (from input string)` for `{ pathname: ".".repeat(53_000_000) }`, for `new URLPattern("https://example.com/" + "\0".repeat(60_000_000))`, and for `{ hash: "x".repeat(51_821_100) }` (release, 5.5 s for all three).
- Growth from the minimum capacity 16 by 1.5x reaches 51821028, and the next step (77731542) is past the 53687091 cap, so the smallest aborting component was 51821029 code points.
- Why the check runs after the `End` token: with the check before it, an input whose tokens fill the list exactly passes the check, the `End` append fails unseen, and the list is returned without `End`. `URLPatternParser::performParse` flushes pending fixed text only when it consumes `End`, so such a pattern would compile to an empty part list (a pathname pattern of `""`) instead of throwing. `URLPatternConstructorStringParser::getSafeToken` asserts `last().type == End`. The last test finds the longest pathname that parses under the 1 MiB limit and checks that it comes back whole.
- `sizeof(Token)` is 40 in release and 48 in debug (`StringView` carries a lifetime-check pointer there), so the tests do not hardcode the bound. It bisects between 8 Ki (parses) and 64 Ki (throws): the longest pathname that parses is 26213 code points in release and 21844 in debug, plus the `End` token.
- `BUN_JSC_validateExceptionChecks=1` is clean on the new tests. The real limit is not in the test suite: it needs more than 5 GB and about 35 s per run under ASAN. The tests cover six init components, the constructor string, a pathname inherited from `baseURL`, a pattern below the bound that still matches, and both sides of the exact bound. `protocol` and `port` are left out because a 64 KiB value already fails their canonicalize step.
- `Vector<Part>` in `URLPatternParser` has the same cap in theory (48-byte parts). Reaching it needs more than 112 million tokens, or tens of millions of unique group names through the linear `isDuplicateName` scan, so the token bound covers it.
- #42191 fixes a different limit in the same constructor (`String::MaxLength` when escaping or joining the base URL) and does not touch the tokenizer. It throws `RangeError: Out of memory`, which is what Bun throws elsewhere for a string above the length limit. This PR keeps upstream's `TypeError`, which is also what every other failure in `URLPattern*.cpp` throws. #40577 adds the identical `VectorSizeLimit.h`; whichever lands second merges cleanly.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/urlpattern/urlpattern.test.ts
bun test v1.4.3 (5f554969b)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [33.12ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [6.66ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [6.25ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [6.98ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [11.61ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [8.34ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [11.34ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/b
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (afa0a6a1d)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [0.51ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [0.05ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [0.03ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [0.04ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [0.20ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [0.08ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [0.13ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] [0.07ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] [0.05ms]
(pass) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/urlpattern/urlpattern.test.ts
bun test v1.4.3 (5f554969b)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [34.46ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [6.89ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [6.45ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [7.00ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [11.56ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [8.32ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [11.65ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/b
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 618ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/VectorSizeLimit.h               | 20 +++++++++
 src/jsc/bindings/webcore/URLPatternTokenizer.cpp | 13 ++++--
 src/jsc/bindings/webcore/URLPatternTokenizer.h   |  1 +
 test/js/web/urlpattern/urlpattern.test.ts        | 54 +++++++++++++++++++++++-
 4 files changed, 84 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/jsc/bindings/VectorSizeLimit.h                    0      0     15
src/jsc/bindings/webcore/URLPatternTokenizer.cpp      1      1     15
src/jsc/bindings/webcore/URLPatternTokenizer.h        1      1     15
test/js/web/urlpattern/urlpattern.test.ts             4      5     15
```

</details>

<!-- robobun:evidence:end -->