### PR TITLE
webview: evaluate() rejections keep the page error's class and message; allow a trailing line comment

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -251,7 +251,12 @@ await view.evaluate("() => 1"); // undefined (functions don't serialize)
 await view.evaluate("fetch('/api').then(r => r.json())"); // awaited
 ```
 
-If the script throws (or returns a rejected promise), `evaluate()` rejects with an `Error` whose message comes from the page-side exception.
+If the script throws (or returns a rejected promise), `evaluate()` rejects with an error rebuilt from the page-side exception. A standard error class keeps its class and message, so a page `TypeError` rejects as a `TypeError` in Bun. With the Chrome backend the error also carries the page-side `stack`, and any other `Error` subclass arrives as a plain `Error` that keeps the page's `name`. With the WebKit backend anything but a standard class arrives as a plain `Error` whose message is the page's string form of the thrown value.
+
+```ts
+await view.evaluate("null.x"); // rejects with a TypeError
+await view.evaluate("1 + 1 // comments are fine"); // 2
+```
 
 Only one `evaluate()` may be in flight per view at a time; a second concurrent call throws `ERR_INVALID_STATE`.
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9560,6 +9560,12 @@ declare module "bun" {
      * symbols, `undefined` itself) resolve to `undefined`. Circular
      * references reject.
      *
+     * If the script throws (or its promise rejects), the returned promise
+     * rejects with an error rebuilt from the page-side exception. A standard
+     * class (`TypeError`, `RangeError`, ...) stays that class with the
+     * page's message. Chrome backend: other `Error` subclasses keep the
+     * page's `name`, and `stack` is the page-side stack trace.
+     *
      * Only one `evaluate()` may be in flight at a time per view; a second
      * concurrent call throws `ERR_INVALID_STATE`.
      */

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -708,6 +708,7 @@ static void rejectViewSlotsAsHandled(JSGlobalObject* g, JSWebView* view, JSValue
 // a JSC-side trace (which would show ChromeBackend.cpp, not page frames).
 static JSValue errorFromExceptionDetails(JSGlobalObject* g, std::span<const char> excDetails)
 {
+    auto& vm = g->vm();
     auto root = JSON::Value::parseJSON(
         StringView::fromLatin1(std::span<const Latin1Character>(
             reinterpret_cast<const Latin1Character*>(excDetails.data()), excDetails.size())));
@@ -718,31 +719,44 @@ static JSValue errorFromExceptionDetails(JSGlobalObject* g, std::span<const char
     // exception.value (thrown string) → the string itself.
     // text ("Uncaught (in promise)") → fallback only.
     WTF::String stack;
+    bool isErrorObject = false;
     if (auto exc = d->getObject("exception"_s)) {
+        isErrorObject = exc->getString("subtype"_s) == "error"_s;
         stack = exc->getString("description"_s);
         if (stack.isEmpty()) stack = exc->getString("value"_s);
     }
     if (stack.isEmpty()) stack = d->getString("text"_s);
     if (stack.isEmpty()) stack = "JavaScript exception"_s;
 
-    // Message: first line past "ErrorName: " prefix. V8's first line is
-    // Error.prototype.toString() which is `${name}: ${message}` (or just
-    // `${name}` if message empty). Frame parsing is V8StackTraceIterator's
-    // job; we only need the message here.
-    auto nl = stack.find('\n');
-    auto firstLine = (nl == WTF::notFound) ? stack : stack.substring(0, nl);
-    auto colon = firstLine.find(": "_s);
-    auto message = (colon != WTF::notFound && colon < 32)
-        ? firstLine.substring(colon + 2)
-        : firstLine;
+    // An Error's description is `${name}: ${message}` (the message may span lines), then "\n    at" frames.
+    WTF::String name;
+    WTF::String message = stack;
+    if (isErrorObject) {
+        auto framesAt = stack.find("\n    at "_s);
+        auto header = framesAt == WTF::notFound ? stack : stack.left(framesAt);
+        auto colon = header.find(": "_s);
+        auto candidate = colon == WTF::notFound ? header : header.left(colon);
+        bool looksLikeName = !candidate.isEmpty() && candidate.find([](UChar c) -> bool { return isASCIIWhitespace(c); }) == WTF::notFound;
+        if (looksLikeName) {
+            name = candidate;
+            message = colon == WTF::notFound ? emptyString() : header.substring(colon + 2);
+        } else {
+            message = header;
+        }
+    }
 
     unsigned line = static_cast<unsigned>(d->getInteger("lineNumber"_s).value_or(0));
     unsigned col = static_cast<unsigned>(d->getInteger("columnNumber"_s).value_or(0));
     WTF::String url = d->getString("url"_s);
 
-    return ErrorInstance::create(g, WTF::move(message), ErrorType::Error,
+    ErrorType type = pageErrorType(name);
+    auto* error = ErrorInstance::create(g, WTF::move(message), type,
         LineColumn { line + 1, col + 1 }, // CDP 0-based → JS 1-based
         WTF::move(url), WTF::move(stack));
+    // A page-side subclass has no class here; keep its name so String(error) still matches.
+    if (type == ErrorType::Error && !name.isEmpty() && name != "Error"_s)
+        error->putDirect(vm, vm.propertyNames->name, jsString(vm, name), static_cast<unsigned>(PropertyAttribute::DontEnum));
+    return error;
 }
 
 // Per-method result handlers. Each knows the schema of its result object
@@ -1475,7 +1489,8 @@ JSPromise* evaluate(JSGlobalObject* g, JSWebView* view, const WTF::String& scrip
     // Same "await (expr)" wrap as WKWebView: forces expression context,
     // unwraps thenables. Chrome's awaitPromise does the await part; we
     // just need the paren-wrap for statement-sequence rejection consistency.
-    auto body = makeString("(async()=>{return await ("_s, script, ")})()"_s);
+    // The newline ends a trailing `// comment` in the script before our `)`.
+    auto body = makeString("(async()=>{return await ("_s, script, "\n)})()"_s);
     return sendChromeOp(g, view, view->m_pendingEval, PendingSlot::Evaluate,
         Method::RuntimeEvaluate, id,
         Command(id, "Runtime.evaluate"_s, sidSpan(view->m_sessionId))

--- a/src/runtime/webview/JSWebView.cpp
+++ b/src/runtime/webview/JSWebView.cpp
@@ -12,6 +12,7 @@
 #include "BunClientData.h"
 #include "ScriptExecutionContext.h"
 #include "ScriptWrappableInlines.h"
+#include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/LazyClassStructure.h>
 #include <JavaScriptCore/LazyClassStructureInlines.h>
@@ -74,6 +75,31 @@ void rejectSlotAsHandled(JSGlobalObject* g, JSWebView* v,
     slot.clear();
     v->m_pendingActivityCount.fetch_sub(1, std::memory_order_release);
     p->rejectAsHandled(g->vm(), err);
+}
+
+ErrorType pageErrorType(const WTF::String& name)
+{
+    if (name == "TypeError"_s) return ErrorType::TypeError;
+    if (name == "RangeError"_s) return ErrorType::RangeError;
+    if (name == "SyntaxError"_s) return ErrorType::SyntaxError;
+    if (name == "ReferenceError"_s) return ErrorType::ReferenceError;
+    if (name == "URIError"_s) return ErrorType::URIError;
+    if (name == "EvalError"_s) return ErrorType::EvalError;
+    if (name == "AggregateError"_s) return ErrorType::AggregateError;
+    return ErrorType::Error;
+}
+
+JSValue errorFromPageExceptionString(JSGlobalObject* g, const WTF::String& text)
+{
+    // Only a standard name is split off: the text alone cannot tell `throw "a: b"` from an Error.
+    auto colon = text.find(": "_s);
+    if (colon != WTF::notFound) {
+        auto name = text.left(colon);
+        auto type = pageErrorType(name);
+        if (type != ErrorType::Error || name == "Error"_s)
+            return createError(g, type, text.substring(colon + 2));
+    }
+    return createError(g, text);
 }
 
 // --- WebViewEventTarget ----------------------------------------------------

--- a/src/runtime/webview/JSWebView.cpp
+++ b/src/runtime/webview/JSWebView.cpp
@@ -85,20 +85,19 @@ ErrorType pageErrorType(const WTF::String& name)
     if (name == "ReferenceError"_s) return ErrorType::ReferenceError;
     if (name == "URIError"_s) return ErrorType::URIError;
     if (name == "EvalError"_s) return ErrorType::EvalError;
-    if (name == "AggregateError"_s) return ErrorType::AggregateError;
+    // An AggregateError cannot be rebuilt from text: it needs its `errors`.
     return ErrorType::Error;
 }
 
 JSValue errorFromPageExceptionString(JSGlobalObject* g, const WTF::String& text)
 {
     // Only a standard name is split off: the text alone cannot tell `throw "a: b"` from an Error.
+    // With an empty message Error.prototype.toString() is the bare name.
     auto colon = text.find(": "_s);
-    if (colon != WTF::notFound) {
-        auto name = text.left(colon);
-        auto type = pageErrorType(name);
-        if (type != ErrorType::Error || name == "Error"_s)
-            return createError(g, type, text.substring(colon + 2));
-    }
+    auto name = colon == WTF::notFound ? text : text.left(colon);
+    auto type = pageErrorType(name);
+    if (type != ErrorType::Error || name == "Error"_s)
+        return createError(g, type, colon == WTF::notFound ? emptyString() : text.substring(colon + 2));
     return createError(g, text);
 }
 

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -245,7 +245,7 @@ void settleSlot(JSC::JSGlobalObject*, JSWebView*,
 void rejectSlotAsHandled(JSC::JSGlobalObject*, JSWebView*,
     JSC::WriteBarrier<JSC::JSPromise>& slot, JSC::JSValue);
 
-// The JSC class for a page-side error name; ErrorType::Error for anything but the standard ones.
+// The JSC class for a page-side error name; ErrorType::Error for anything createError() cannot build from a message.
 JSC::ErrorType pageErrorType(const WTF::String& name);
 
 // An evaluate() rejection from the page exception's string form, `${name}: ${message}` for an

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -4,6 +4,7 @@
 #include "BunClientData.h"
 #include "JSEventTarget.h"
 #include "WebViewEventTarget.h"
+#include <JavaScriptCore/ErrorType.h>
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/LazyClassStructure.h>
@@ -243,6 +244,14 @@ void settleSlot(JSC::JSGlobalObject*, JSWebView*,
 // unhandled rejection. For user-initiated close() teardown (#40991).
 void rejectSlotAsHandled(JSC::JSGlobalObject*, JSWebView*,
     JSC::WriteBarrier<JSC::JSPromise>& slot, JSC::JSValue);
+
+// The JSC class for a page-side error name; ErrorType::Error for anything but the standard ones.
+JSC::ErrorType pageErrorType(const WTF::String& name);
+
+// An evaluate() rejection from the page exception's string form, `${name}: ${message}` for an
+// Error (all WebKit reports). A standard class keeps its class; anything else is an Error with
+// the whole text as its message.
+JSC::JSValue errorFromPageExceptionString(JSC::JSGlobalObject*, const WTF::String&);
 
 // Implemented in JSWebViewPrototype.cpp / JSWebViewConstructor.cpp.
 // setupJSWebViewClassStructure calls these.

--- a/src/runtime/webview/WebKitBackend.cpp
+++ b/src/runtime/webview/WebKitBackend.cpp
@@ -427,7 +427,7 @@ void HostClient::handleReply(const Frame& h, Reader r)
         return;
     }
     case Reply::EvalFailed:
-        settleSlot(g, view, view->m_pendingEval, false, createError(g, r.str()));
+        settleSlot(g, view, view->m_pendingEval, false, errorFromPageExceptionString(g, r.str()));
         return;
 
     case Reply::ScreenshotDone: {

--- a/src/runtime/webview/WebViewHost.cpp
+++ b/src/runtime/webview/WebViewHost.cpp
@@ -269,7 +269,8 @@ void WebViewHost::evaluateIPC(const WTF::String& script)
     // JSON.stringify(undefined) evaluates to undefined (the value, not
     // the string) → callAsync returns nil → parent resolves jsUndefined().
     // Functions/symbols become undefined. Circular refs throw → rejection.
-    auto body = makeString("return JSON.stringify(await ("_s, script, "))"_s);
+    // The newline ends a trailing `// comment` in the script before our `)`.
+    auto body = makeString("return JSON.stringify(await ("_s, script, "\n))"_s);
     m_webview.callAsync(objc::NSString::fromWTF(body), nullptr,
         makeHostBlock<&WebViewHost::onEvalComplete, id, id>(*this));
 }

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -101,10 +101,13 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       try {
         value = await (0, eval)(params.expression);
       } catch (e) {
-        return reply({
-          result: { type: "object", subtype: "error" },
-          exceptionDetails: { text: "Uncaught", exception: { description: String(e) } },
-        });
+        // Same shape Chrome sends: an Error is a RemoteObject with subtype
+        // "error" whose description is V8's `${name}: ${message}\n    at ...`.
+        const exception =
+          e instanceof Error
+            ? { type: "object", subtype: "error", className: e.name, description: e.stack }
+            : { type: typeof e, value: e };
+        return reply({ result: exception, exceptionDetails: { text: "Uncaught", exception } });
       }
       if (value === NO_REPLY) return;
       if (value === undefined) return reply({ result: { type: "undefined" } });

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -136,6 +136,37 @@ test.concurrent("an expression that throws rejects", async () => {
   expect(result).toEqual({ rejected: expect.stringContaining("inside the fake") });
 });
 
+test.concurrent("a rejection keeps the page error's class, its whole message, and a custom name", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/");
+    const describe = promise =>
+      promise.then(
+        () => "resolved",
+        e => ({ class: Object.getPrototypeOf(e).constructor.name, name: e.name, message: e.message, string: String(e) }),
+      );
+    print({
+      typeError: await describe(view.evaluate("(() => { throw new TypeError('first line\\\\nsecond line'); })()")),
+      custom: await describe(view.evaluate("(() => { const e = new Error('over quota'); e.name = 'QuotaError'; throw e; })()")),
+      string: await describe(view.evaluate("(() => { throw 'reason: plain string'; })()")),
+      // The wrapper closes its parenthesis on its own line.
+      comment: await view.evaluate("6 * 7 // trailing comment"),
+    });
+    view.close();
+  `);
+  expect(result).toEqual({
+    typeError: {
+      class: "TypeError",
+      name: "TypeError",
+      message: "first line\nsecond line",
+      string: "TypeError: first line\nsecond line",
+    },
+    custom: { class: "Error", name: "QuotaError", message: "over quota", string: "QuotaError: over quota" },
+    string: { class: "Error", name: "Error", message: "reason: plain string", string: "Error: reason: plain string" },
+    comment: 42,
+  });
+});
+
 test.concurrent("the browser exiting rejects what it owed, and the next WebView respawns it", async () => {
   const result = await runScenario(`
     const first = newView();

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -890,6 +890,11 @@ it("chrome: evaluate() rejections keep the page error's class, name and whole me
   expect(emptyMessage).toBeInstanceOf(TypeError);
   expect(emptyMessage.message).toBe("");
 
+  // AggregateError needs its errors array, so it arrives as a plain Error that keeps the name.
+  const aggregate = await caught("Promise.any([])");
+  expect(Object.getPrototypeOf(aggregate)).toBe(Error.prototype);
+  expect(aggregate.name).toBe("AggregateError");
+
   // A thrown string is not an Error: the message is the string, verbatim.
   const thrownString = await caught("(() => { throw 'reason: plain string'; })()");
   expect(Object.getPrototypeOf(thrownString)).toBe(Error.prototype);

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -853,6 +853,56 @@ it("chrome: evaluate() rejected Promise carries rejection reason", async () => {
   await expect(view.evaluate("Promise.reject(new TypeError('bad'))")).rejects.toThrow(/bad/);
 });
 
+it("chrome: evaluate() rejections keep the page error's class, name and whole message", async () => {
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(html("<body></body>"));
+  const caught = (script: string) =>
+    view.evaluate(script).then(
+      () => {
+        throw new Error("should have rejected");
+      },
+      e => e,
+    );
+
+  const typeError = await caught("null.x");
+  expect(typeError).toBeInstanceOf(TypeError);
+  expect(typeError.name).toBe("TypeError");
+
+  const rangeError = await caught("Promise.reject(new RangeError('first line\\nsecond line'))");
+  expect(rangeError).toBeInstanceOf(RangeError);
+  expect(rangeError.message).toBe("first line\nsecond line");
+
+  const syntaxError = await caught("JSON.parse('{')");
+  expect(syntaxError).toBeInstanceOf(SyntaxError);
+
+  // A page-side subclass has no counterpart here: plain Error, page's name.
+  const custom = await caught(
+    "(() => { class QuotaError extends Error { constructor(m) { super(m); this.name = 'QuotaError'; } } throw new QuotaError('over quota'); })()",
+  );
+  expect(Object.getPrototypeOf(custom)).toBe(Error.prototype);
+  expect({ name: custom.name, message: custom.message, string: String(custom) }).toEqual({
+    name: "QuotaError",
+    message: "over quota",
+    string: "QuotaError: over quota",
+  });
+
+  const emptyMessage = await caught("(() => { throw new TypeError(); })()");
+  expect(emptyMessage).toBeInstanceOf(TypeError);
+  expect(emptyMessage.message).toBe("");
+
+  // A thrown string is not an Error: the message is the string, verbatim.
+  const thrownString = await caught("(() => { throw 'reason: plain string'; })()");
+  expect(Object.getPrototypeOf(thrownString)).toBe(Error.prototype);
+  expect(thrownString.message).toBe("reason: plain string");
+});
+
+it("chrome: evaluate() accepts a script that ends in a line comment", async () => {
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(html("<body></body>"));
+  expect(await view.evaluate("1 + 1 // the answer")).toBe(2);
+  expect(await view.evaluate("// leading comment\n6 * 7")).toBe(42);
+});
+
 it("chrome: evaluate() with circular reference throws", async () => {
   await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   await view.navigate(html("<body></body>"));

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -267,6 +267,14 @@ it("evaluate() rejections keep a standard error class and its message", async ()
   const rangeError = await caught("Promise.reject(new RangeError('out of range'))");
   expect(rangeError).toBeInstanceOf(RangeError);
   expect(rangeError.message).toBe("out of range");
+  // An empty message stringifies to the bare name.
+  const emptyMessage = await caught("(() => { throw new TypeError(); })()");
+  expect(emptyMessage).toBeInstanceOf(TypeError);
+  expect(emptyMessage.message).toBe("");
+  // AggregateError needs its errors array, so it stays a plain Error with the text.
+  const aggregate = await caught("Promise.any([])");
+  expect(Object.getPrototypeOf(aggregate)).toBe(Error.prototype);
+  expect(aggregate.message).toStartWith("AggregateError");
   // A thrown string is not an Error: plain Error, the string as the message.
   const thrownString = await caught("(() => { throw 'reason: plain string'; })()");
   expect(Object.getPrototypeOf(thrownString)).toBe(Error.prototype);

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -240,6 +240,39 @@ it("evaluate() with statement sequence throws SyntaxError (use an IIFE)", async 
   expect(await view.evaluate("(() => { let x = 1; return x + 1 })()")).toBe(2);
 });
 
+it("evaluate() accepts a script that ends in a line comment", async () => {
+  await using view = new Bun.WebView({ width: 200, height: 200 });
+  await view.navigate(html("<body></body>"));
+  // The wrap closes its parenthesis on a new line, so a trailing `//`
+  // comment does not swallow it.
+  expect(await view.evaluate("1 + 1 // the answer")).toBe(2);
+  expect(await view.evaluate("// leading comment\n6 * 7")).toBe(42);
+});
+
+it("evaluate() rejections keep a standard error class and its message", async () => {
+  await using view = new Bun.WebView({ width: 200, height: 200 });
+  await view.navigate(html("<body></body>"));
+  const caught = (script: string) =>
+    view.evaluate(script).then(
+      () => {
+        throw new Error("should have rejected");
+      },
+      e => e,
+    );
+  // WebKit reports the exception's string form ("TypeError: ..."); the class
+  // is rebuilt from it and the message is what follows the name.
+  const typeError = await caught("null.x");
+  expect(typeError).toBeInstanceOf(TypeError);
+  expect(typeError.message).not.toStartWith("TypeError:");
+  const rangeError = await caught("Promise.reject(new RangeError('out of range'))");
+  expect(rangeError).toBeInstanceOf(RangeError);
+  expect(rangeError.message).toBe("out of range");
+  // A thrown string is not an Error: plain Error, the string as the message.
+  const thrownString = await caught("(() => { throw 'reason: plain string'; })()");
+  expect(Object.getPrototypeOf(thrownString)).toBe(Error.prototype);
+  expect(thrownString.message).toBe("reason: plain string");
+});
+
 it("scroll(NaN/Infinity) throws before sending", () => {
   // NaN would permanently poison m_pendingScrollDx/Dy (NaN + anything = NaN)
   // and hit UB at the static_cast<int32_t> in CGEventCreateScrollWheelEvent.


### PR DESCRIPTION
### Problem
- `evaluate()` rejections lose what the page threw. On Chrome `error.name` is always `"Error"` (a page `TypeError` is indistinguishable), the message is cut at its first newline, and a thrown string `"a: b"` becomes `"b"`. On WebKit the class is always `Error` too, with the name folded into the message.
- A script whose last line is a `// comment` rejects with `SyntaxError: Unexpected end of input`: both backends append the wrapper's `)` on the same line, so the comment swallows it.

### Fix
- Chrome (`errorFromExceptionDetails`): for a `subtype: "error"` exception, read `name` and the whole message from V8's description (everything before the first `\n    at` frame), map the standard names to the JSC class, and keep any other name as an own `name` on a plain `Error`. Other thrown values keep their full text.
- WebKit (`Reply::EvalFailed`): the host only has the exception's string form (`TypeError: ...`); split a standard name off it the same way. Shared helpers live in `JSWebView.cpp`.
- Both wrappers close `await (<script>` with `\n)`.
- Verified: `webview-chrome-pipe.test.ts` (fake browser, every platform), `webview-chrome.test.ts` (real Chrome 153), `webview.test.ts` (WebKit, macOS CI). The new tests fail on 1.4.3.

### Background
- Chrome reports a thrown value as a CDP `RemoteObject`. For an `Error` its `description` is V8's `stack` text: `Name: message`, then `    at` frames. The backend already stamps that text on `error.stack`.
- WebKit's `callAsyncJavaScript` reports only `WKJavaScriptExceptionMessage`, the exception's `toString()`. There is no class flag, so only the standard names are trusted there; `throw "TypeError: x"` is the one ambiguous case.

<details><summary>Notes</summary>

From a docs-vs-backend pass over `docs/runtime/webview.mdx` (item 3 of seven); the docs sentence "rejects with an `Error` whose message comes from the page-side exception" now spells out what each backend preserves. Sibling PRs: #42167 (spawn/connect errors, `press()`), #42222 (Chrome events, history start, dialogs). Independent of both.

- #39085 changes the same wrapper string in `Ops::evaluate` (JSON round trip); whichever lands second keeps the `\n` before the closing parenthesis.
- The fake Chrome (`fake-chrome-fixture.ts`) now reports a thrown `Error` the way Chrome does (`subtype: "error"`, `className`, V8-style `description`), so the class mapping is covered on Windows and macOS lanes without a browser.
- An `Error` with an empty message (`new TypeError()`) maps to an empty message, not `"TypeError"`, on both backends (WebKit reports the bare name in that case).
- `AggregateError` is not rebuilt: JSC cannot create one from a message alone (it needs its `errors`). It arrives as a plain `Error`; on Chrome it keeps `name === "AggregateError"`.

</details>
