### PR TITLE
webview: Chrome backend delivers its own CDP events to listeners, starts history at the first page, answers dialogs

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -206,7 +206,7 @@ await view.goForward(); // like the browser's forward button
 await view.reload(); // reload the current page
 ```
 
-Calling `goBack()` at the beginning of history (or `goForward()` at the end) resolves `undefined` without navigating — it doesn't reject.
+A view's history starts with its first navigation. Calling `goBack()` at the beginning of history (or `goForward()` at the end) resolves `undefined` without navigating — it doesn't reject.
 
 ### Navigation callbacks
 
@@ -223,6 +223,21 @@ view.onNavigationFailed = error => {
 ```
 
 These fire **before** the corresponding `navigate()` promise settles, so by the time `await view.navigate(...)` returns, your callback has already run. Set to `null` to remove.
+
+### Dialogs
+
+`alert()`, `confirm()`, `prompt()`, and `beforeunload` prompts never block a view. Bun answers them the way a browser with nobody at the keyboard would: `alert()` returns, `confirm()` returns `false`, `prompt()` returns `null`, and a `beforeunload` prompt is accepted so the navigation that triggered it goes ahead.
+
+With the Chrome backend you can take over by listening for the [`Page.javascriptDialogOpening`](https://chromedevtools.github.io/devtools-protocol/tot/Page/#event-javascriptDialogOpening) CDP event (see [Raw Chrome DevTools Protocol](#cdp)). Once a listener is registered, Bun stops answering dialogs for that view. The listener must answer every dialog with `Page.handleJavaScriptDialog`, or the page, and any pending `evaluate()` or `navigate()`, stays blocked:
+
+```ts
+view.addEventListener("Page.javascriptDialogOpening", event => {
+  const { type, message } = event.data; // "alert" | "confirm" | "prompt" | "beforeunload"
+  view.cdp("Page.handleJavaScriptDialog", { accept: true, promptText: "typed into prompt()" });
+});
+
+await view.evaluate("confirm('Delete everything?')"); // true
+```
 
 ---
 
@@ -491,6 +506,8 @@ await view.navigate("https://example.com");
 ```
 
 Bun drops events that have no registered listener before it even parses their JSON `params`, so enabling a chatty domain (like `Network`) is cheap if you only listen for one or two event types.
+
+The `Page` and `Runtime` domains are already enabled: Bun uses `Page.frameNavigated`, `Page.loadEventFired`, and `Runtime.consoleAPICalled` itself to drive `view.url`, `navigate()`, and the `console` option. Listeners still receive those events, after Bun has processed them. A `Page.loadEventFired` listener therefore runs before the `navigate()` it belongs to resolves.
 
 On the WebKit backend, `cdp()` throws `ERR_METHOD_NOT_IMPLEMENTED` — there is no DevTools Protocol bridge. The `EventTarget` interface still works for your own `dispatchEvent()` calls.
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9648,7 +9648,15 @@ declare module "bun" {
      * Enable the domain first with `cdp("Domain.enable")`, or Chrome
      * won't send those events. Events without a registered listener
      * are dropped before JSON parsing (no overhead for domains you
-     * enabled but don't fully listen to).
+     * enabled but don't fully listen to). `Page` and `Runtime` are
+     * already enabled; the events Bun consumes itself
+     * (`Page.frameNavigated`, `Page.loadEventFired`,
+     * `Runtime.consoleAPICalled`) are delivered to listeners as well.
+     *
+     * A `"Page.javascriptDialogOpening"` listener takes over dialog
+     * handling for the view: Bun stops auto-dismissing `alert`/`confirm`/
+     * `prompt`/`beforeunload`, and the listener answers each one with
+     * `cdp("Page.handleJavaScriptDialog", { accept, promptText })`.
      *
      * @example
      * ```ts

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1097,6 +1097,89 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     }
 }
 
+static bool spanIs(std::span<const char> span, ASCIILiteral literal)
+{
+    return span.size() == literal.length() && memcmp(span.data(), literal.characters(), literal.length()) == 0;
+}
+
+// Runtime.consoleAPICalled → the view's console sink. May leave the user callback's exception pending.
+static void forwardConsoleCall(JSGlobalObject* g, JSWebView* view, std::span<const char> params)
+{
+    auto& vm = g->vm();
+
+    // WTF::JSON parse — small payload per call, console-path-only.
+    auto root = JSON::Value::parseJSON(WTF::String::fromUTF8(params));
+    auto o = root ? root->asObject() : nullptr;
+    if (!o) return;
+    auto type = o->getString("type"_s);
+    auto argsArr = o->getArray("args"_s);
+
+    // Both sinks re-enter JS under their own ThrowScope: check after building args, release before dispatch.
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Primitives unwrap to plain values; objects keep the whole RemoteObject (className, description, preview).
+    auto remoteToJS = [&](RefPtr<JSON::Object> ao) -> JSValue {
+        auto t = ao->getString("type"_s);
+        if (t == "string"_s) return jsString(vm, ao->getString("value"_s));
+        if (t == "number"_s) return jsNumber(ao->getDouble("value"_s).value_or(0));
+        if (t == "boolean"_s) return jsBoolean(ao->getBoolean("value"_s).value_or(false));
+        if (t == "undefined"_s) return jsUndefined();
+        if (t == "bigint"_s || t == "symbol"_s)
+            // No .value — .description is "42n" / "Symbol(foo)".
+            return jsString(vm, ao->getString("description"_s));
+        auto s = ao->toJSONString();
+        auto v = JSONParse(g, s);
+        return v ? v : jsNull();
+    };
+
+    MarkedArgumentBuffer args;
+    if (argsArr) {
+        for (auto& a : *argsArr) {
+            auto ao = a->asObject();
+            JSValue v = ao ? remoteToJS(ao) : jsUndefined();
+            RETURN_IF_EXCEPTION(scope, void());
+            args.append(v);
+        }
+    }
+
+    if (view->m_consoleIsGlobal) {
+        // The path console.log() itself takes after argument collection; the level picks coloring and stderr routing.
+        using JSC::MessageLevel;
+        MessageLevel ml = MessageLevel::Log;
+        if (type == "error"_s || type == "assert"_s)
+            ml = MessageLevel::Error;
+        else if (type == "warning"_s)
+            ml = MessageLevel::Warning;
+        else if (type == "debug"_s)
+            ml = MessageLevel::Debug;
+        else if (type == "info"_s)
+            ml = MessageLevel::Info;
+
+        WTF::Vector<Strong<Unknown>> strongArgs;
+        strongArgs.reserveInitialCapacity(args.size());
+        for (unsigned i = 0; i < args.size(); ++i)
+            strongArgs.append(Strong<Unknown>(vm, args.at(i)));
+        auto scriptArgs = Inspector::ScriptArguments::create(g, WTF::move(strongArgs));
+        scope.release();
+        if (auto clientRef = g->consoleClient())
+            clientRef->logWithLevel(g, WTF::move(scriptArgs), ml);
+        return;
+    }
+
+    // Custom callback: (type, ...args).
+    JSObject* cb = view->m_onConsole.get();
+    auto callData = getCallData(cb);
+    if (callData.type == CallData::Type::None) return;
+    JSValue typeStr = jsString(vm, type.isEmpty() ? "log"_s : type);
+    RETURN_IF_EXCEPTION(scope, void());
+    MarkedArgumentBuffer cbArgs;
+    cbArgs.append(typeStr);
+    for (unsigned i = 0; i < args.size(); ++i)
+        cbArgs.append(args.at(i));
+    scope.release();
+    call(g, cb, callData, jsUndefined(), cbArgs);
+}
+
 void Transport::handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId)
 {
     auto* g = m_global;
@@ -1108,8 +1191,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     // initiated closes eagerly; this is the only notification for external
     // death. Without it, pending evaluates on the dead view hang forever.
     if (sessionId.empty()) {
-        if (method.size() != 25 || memcmp(method.data(), "Target.detachedFromTarget", 25) != 0)
-            return;
+        if (!spanIs(method, "Target.detachedFromTarget"_s)) return;
         auto sid = jsonString(jsonField(params, { "sessionId", 9 }));
         auto sidStr = WTF::String::fromUTF8(sid);
         auto it = m_sessions.find(sidStr);
@@ -1138,21 +1220,30 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto methodAtom = AtomString::fromUTF8(method);
+
     // Page.frameNavigated — commit. Update m_url and fire onNavigated.
     // Same timing as WKWebView's NavDone (didFinishNavigation): the URL is
     // now the new document, resources may still be loading.
-    if (method.size() == 19 && memcmp(method.data(), "Page.frameNavigated", 19) == 0) {
+    if (spanIs(method, "Page.frameNavigated"_s)) {
         auto frame = jsonField(params, { "frame", 5 });
         auto url = jsonString(jsonField(frame, { "url", 3 }));
         auto urlStr = WTF::String::fromUTF8(url);
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it.
 
+        // Drop the about:blank entry the tab was created on, so history starts at the first real page.
+        if (!view->m_chromeHistoryPruned) {
+            view->m_chromeHistoryPruned = true;
+            send(0, Command(nextId(), "Page.resetNavigationHistory"_s, sidSpan(view->m_sessionId)));
+        }
+
+        // runCallback reports a throwing callback itself.
         if (JSObject* cb = view->m_onNavigated.get()) {
             Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
                 JSValue::encode(jsString(vm, urlStr)), JSValue::encode(jsUndefined()));
         }
-        return;
     }
 
     // Page.loadEventFired — load complete. Chain a document.title fetch
@@ -1163,126 +1254,37 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     //
     // If no navigate is pending (uninitiated navigation, redirect), the
     // PageTitle handler settles a no-op and m_title still updates.
-    if (method.size() == 19 && memcmp(method.data(), "Page.loadEventFired", 19) == 0) {
+    if (spanIs(method, "Page.loadEventFired"_s)) {
         view->m_loading = false;
         uint32_t tid = nextId();
         m_pending.add(tid, Pending { Method::PageTitle, PendingSlot::Navigate, view->m_viewId });
         send(tid, Command(tid, "Runtime.evaluate"_s, sidSpan(view->m_sessionId)).str("expression"_s, "document.title"_s).boolean("returnByValue"_s, true));
+    }
+
+    if (spanIs(method, "Runtime.consoleAPICalled"_s) && (view->m_consoleIsGlobal || view->m_onConsole)) {
+        forwardConsoleCall(g, view, params);
+        // Report a throwing sink now so the listeners below still run.
+        if (auto* exception = scope.exception()) [[unlikely]] {
+            if (!scope.tryClearException()) return;
+            g->reportUncaughtExceptionAtEventLoop(g, exception);
+        }
+    }
+
+    // The page blocks until the dialog is answered. Nobody listens, so answer as WKWebView does: dismiss; accept beforeunload.
+    if (spanIs(method, "Page.javascriptDialogOpening"_s) && !view->wrapped().hasEventListeners(methodAtom)) {
+        auto type = jsonString(jsonField(params, { "type", 4 }));
+        send(0, Command(nextId(), "Page.handleJavaScriptDialog"_s, sidSpan(view->m_sessionId)).boolean("accept"_s, spanIs(type, "beforeunload"_s)));
         return;
     }
 
-    // Runtime.consoleAPICalled — fires for every console.* call in the page.
-    // params: {"type":"log","args":[<RemoteObject>,...],"stackTrace":{...}}.
-    if (method.size() == 24 && memcmp(method.data(), "Runtime.consoleAPICalled", 24) == 0) {
-        if (!view->m_consoleIsGlobal && !view->m_onConsole) return;
-
-        // WTF::JSON parse — small payload per call, console-path-only.
-        auto root = JSON::Value::parseJSON(WTF::String::fromUTF8(params));
-        auto o = root ? root->asObject() : nullptr;
-        if (!o) return;
-        auto type = o->getString("type"_s);
-        auto argsArr = o->getArray("args"_s);
-
-        // remoteToJS allocates (jsString/JSONParse). Both dispatch paths
-        // re-enter JS — logWithLevel via ConsoleClient, the custom callback
-        // via call() — and each opens its own ThrowScope which asserts
-        // under validateExceptionChecks if a prior simulated throw wasn't
-        // checked. Check after building args; release before dispatch so
-        // the nested scope takes over. Real exceptions propagate to
-        // onData's TopExceptionScope.
-        auto scope = DECLARE_THROW_SCOPE(vm);
-
-        // RemoteObject → JSValue. Primitives unwrap to raw values (so
-        // console.log("hi") forwards as "hi", not {type:"string",value:"hi"}).
-        // Object/function RemoteObjects JSONParse whole — the user (or
-        // util.inspect) sees {className, description, preview:{properties}}
-        // which is the best we get without a Runtime.getProperties roundtrip.
-        auto remoteToJS = [&](RefPtr<JSON::Object> ao) -> JSValue {
-            auto t = ao->getString("type"_s);
-            if (t == "string"_s) return jsString(vm, ao->getString("value"_s));
-            if (t == "number"_s) return jsNumber(ao->getDouble("value"_s).value_or(0));
-            if (t == "boolean"_s) return jsBoolean(ao->getBoolean("value"_s).value_or(false));
-            if (t == "undefined"_s) return jsUndefined();
-            if (t == "bigint"_s || t == "symbol"_s)
-                // No .value — .description is "42n" / "Symbol(foo)".
-                return jsString(vm, ao->getString("description"_s));
-            // object / function. JSONParse the whole RemoteObject so the
-            // caller can inspect preview.properties. toJSONString round-
-            // trips the WTF::JSON tree back to a string; JSC::JSONParse
-            // builds the JSValue tree.
-            auto s = ao->toJSONString();
-            auto v = JSONParse(g, s);
-            return v ? v : jsNull();
-        };
-
-        MarkedArgumentBuffer args;
-        if (argsArr) {
-            for (auto& a : *argsArr) {
-                auto ao = a->asObject();
-                JSValue v = ao ? remoteToJS(ao) : jsUndefined();
-                RETURN_IF_EXCEPTION(scope, void());
-                args.append(v);
-            }
-        }
-
-        if (view->m_consoleIsGlobal) {
-            // ConsoleClient::logWithLevel — the same path console.log()
-            // takes after argument collection. ScriptArguments holds
-            // Vector<Strong<Unknown>> which GC-roots across the call
-            // (util.format allocates). Inspector forwarding + Bun's
-            // console formatter apply.
-            //
-            // CDP type → MessageLevel. trace/dir/table/assert all render
-            // through Log level with their formatting intact (the args
-            // carry the structure); level distinction matters for
-            // error/warn coloring and stderr routing.
-            using JSC::MessageLevel;
-            MessageLevel ml = MessageLevel::Log;
-            if (type == "error"_s || type == "assert"_s)
-                ml = MessageLevel::Error;
-            else if (type == "warning"_s)
-                ml = MessageLevel::Warning;
-            else if (type == "debug"_s)
-                ml = MessageLevel::Debug;
-            else if (type == "info"_s)
-                ml = MessageLevel::Info;
-
-            WTF::Vector<Strong<Unknown>> strongArgs;
-            strongArgs.reserveInitialCapacity(args.size());
-            for (unsigned i = 0; i < args.size(); ++i)
-                strongArgs.append(Strong<Unknown>(vm, args.at(i)));
-            auto scriptArgs = Inspector::ScriptArguments::create(g, WTF::move(strongArgs));
-            scope.release();
-            if (auto clientRef = g->consoleClient())
-                clientRef->logWithLevel(g, WTF::move(scriptArgs), ml);
-            return;
-        }
-
-        // Custom callback: (type, ...args).
-        JSObject* cb = view->m_onConsole.get();
-        auto callData = getCallData(cb);
-        if (callData.type == CallData::Type::None) return;
-        JSValue typeStr = jsString(vm, type.isEmpty() ? "log"_s : type);
-        RETURN_IF_EXCEPTION(scope, void());
-        MarkedArgumentBuffer cbArgs;
-        cbArgs.append(typeStr);
-        for (unsigned i = 0; i < args.size(); ++i)
-            cbArgs.append(args.at(i));
-        scope.release();
-        call(g, cb, callData, jsUndefined(), cbArgs);
-        return;
-    }
-
-    // Unhandled CDP event — dispatch to the view's EventTarget if it has
-    // a listener for this method name. Check hasEventListeners first:
-    // Chrome is chatty (frameScheduledNavigation, lifecycleEvent, etc.)
-    // and most events won't have listeners; skipping the JSONParse saves
-    // an alloc per unwanted event. The listener was added via
-    // view.addEventListener("Network.responseReceived", e => e.data.response).
-    auto methodAtom = AtomString::fromUTF8(method);
+    // Every event, the ones handled above included, reaches the view's
+    // EventTarget if it has a listener for this method name. Check
+    // hasEventListeners first: Chrome is chatty (frameScheduledNavigation,
+    // lifecycleEvent, etc.) and most events won't have listeners; skipping
+    // the JSONParse saves an alloc per unwanted event. The listener was added
+    // via view.addEventListener("Network.responseReceived", e => e.data.response).
     if (!view->wrapped().hasEventListeners(methodAtom)) return;
 
-    auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue data = JSONParse(g, WTF::String::fromUTF8(params));
     RETURN_IF_EXCEPTION(scope, void());
     if (!data) data = jsUndefined();

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -761,6 +761,9 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     if (!view) return; // user dropped both view and the awaited promise
 
     if (!error.empty()) {
+        // The bootstrap history fetch is bookkeeping: a failure costs goBack()
+        // its stop, not the navigation the user asked for.
+        if (entry.method == Method::PageBootstrapHistory) return;
         // {"code":-32000,"message":"..."}
         auto msgSlice = jsonString(jsonField(error, { "message", 7 }));
         auto errStr = WTF::String::fromUTF8(std::span<const char>(msgSlice));
@@ -815,6 +818,14 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         uint32_t rid = nextId();
         send(0, Command(rid, "Runtime.enable"_s, sidSpan));
 
+        // The tab was created on about:blank so that Page.enable could run
+        // before the first real navigation. Chrome keeps that as a history
+        // entry; ask for its id now, while it is the only one, so goBack()
+        // can stop above it.
+        uint32_t hid = nextId();
+        m_pending.add(hid, Pending { Method::PageBootstrapHistory, entry.slot, entry.viewId });
+        send(hid, Command(hid, "Page.getNavigationHistory"_s, sidSpan));
+
         // Page.navigate with the url stashed by the first navigate() call.
         // The response confirms the navigation STARTED; Page.loadEventFired
         // confirms completion. We keep the pending entry alive for the
@@ -861,6 +872,22 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         return;
     }
 
+    case Method::PageBootstrapHistory: {
+        // {"currentIndex":N,"entries":[{"id":N,"url":"..."},...]} for a tab
+        // that has only ever loaded about:blank, so the current entry is it.
+        auto root = JSON::Value::parseJSON(
+            StringView::fromLatin1(std::span<const Latin1Character>(
+                reinterpret_cast<const Latin1Character*>(result.data()), result.size())));
+        auto o = root ? root->asObject() : nullptr;
+        auto entries = o ? o->getArray("entries"_s) : nullptr;
+        if (!entries) return;
+        int32_t cur = o->getInteger("currentIndex"_s).value_or(0);
+        if (cur < 0 || static_cast<unsigned>(cur) >= entries->length()) return;
+        auto elem = entries->get(static_cast<unsigned>(cur))->asObject();
+        view->m_chromeBootstrapEntryId = elem ? elem->getInteger("id"_s).value_or(0) : 0;
+        return;
+    }
+
     case Method::PageGetNavigationHistory: {
         // {"currentIndex":N,"entries":[{"id":N,"url":"..."},...]}
         // Pick entries[currentIndex + delta].id and chain into
@@ -885,6 +912,11 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         }
         auto elem = entries->get(static_cast<unsigned>(target))->asObject();
         int32_t entryId = elem ? elem->getInteger("id"_s).value_or(0) : 0;
+        if (entryId && entryId == view->m_chromeBootstrapEntryId) {
+            // The blank page the view started on is not part of its history.
+            settle(g, view, entry.slot, true, jsUndefined());
+            return;
+        }
         // Chain into navigateToHistoryEntry. Page.loadEventFired settles.
         uint32_t cid = nextId();
         m_pending.add(cid, Pending { Method::PageNavigateToHistoryEntry, entry.slot, entry.viewId });
@@ -1232,12 +1264,6 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         auto urlStr = WTF::String::fromUTF8(url);
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it.
-
-        // Drop the about:blank entry the tab was created on, so history starts at the first real page.
-        if (!view->m_chromeHistoryPruned) {
-            view->m_chromeHistoryPruned = true;
-            send(0, Command(nextId(), "Page.resetNavigationHistory"_s, sidSpan(view->m_sessionId)));
-        }
 
         // runCallback reports a throwing callback itself.
         if (JSObject* cb = view->m_onNavigated.get()) {

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -761,8 +761,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     if (!view) return; // user dropped both view and the awaited promise
 
     if (!error.empty()) {
-        // The bootstrap history fetch is bookkeeping: a failure costs goBack()
-        // its stop, not the navigation the user asked for.
+        // Bookkeeping only: a failure costs goBack() its stop, not the user's navigation.
         if (entry.method == Method::PageBootstrapHistory) return;
         // {"code":-32000,"message":"..."}
         auto msgSlice = jsonString(jsonField(error, { "message", 7 }));
@@ -818,10 +817,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         uint32_t rid = nextId();
         send(0, Command(rid, "Runtime.enable"_s, sidSpan));
 
-        // The tab was created on about:blank so that Page.enable could run
-        // before the first real navigation. Chrome keeps that as a history
-        // entry; ask for its id now, while it is the only one, so goBack()
-        // can stop above it.
+        // The tab's about:blank is still its only history entry; learn its id so goBack() stops above it.
         uint32_t hid = nextId();
         m_pending.add(hid, Pending { Method::PageBootstrapHistory, entry.slot, entry.viewId });
         send(hid, Command(hid, "Page.getNavigationHistory"_s, sidSpan));
@@ -873,8 +869,7 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     }
 
     case Method::PageBootstrapHistory: {
-        // {"currentIndex":N,"entries":[{"id":N,"url":"..."},...]} for a tab
-        // that has only ever loaded about:blank, so the current entry is it.
+        // {"currentIndex":N,"entries":[{"id":N,...}]}; the current entry is the tab's initial about:blank.
         auto root = JSON::Value::parseJSON(
             StringView::fromLatin1(std::span<const Latin1Character>(
                 reinterpret_cast<const Latin1Character*>(result.data()), result.size())));
@@ -1303,12 +1298,8 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Every event, the ones handled above included, reaches the view's
-    // EventTarget if it has a listener for this method name. Check
-    // hasEventListeners first: Chrome is chatty (frameScheduledNavigation,
-    // lifecycleEvent, etc.) and most events won't have listeners; skipping
-    // the JSONParse saves an alloc per unwanted event. The listener was added
-    // via view.addEventListener("Network.responseReceived", e => e.data.response).
+    // Every event, the ones above included, reaches a listener for its method name. Checking first skips the
+    // JSONParse for Chrome's unlistened chatter (frameScheduledNavigation, lifecycleEvent, ...).
     if (!view->wrapped().hasEventListeners(methodAtom)) return;
 
     JSValue data = JSONParse(g, WTF::String::fromUTF8(params));

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -1298,8 +1298,7 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         return;
     }
 
-    // Every event, the ones above included, reaches a listener for its method name. Checking first skips the
-    // JSONParse for Chrome's unlistened chatter (frameScheduledNavigation, lifecycleEvent, ...).
+    // Every event, the ones above included, goes to listeners; checking first skips the JSONParse for unlistened chatter.
     if (!view->wrapped().hasEventListeners(methodAtom)) return;
 
     JSValue data = JSONParse(g, WTF::String::fromUTF8(params));

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -246,6 +246,9 @@ enum class Method : uint8_t {
     // → set m_title, settle Navigate. Makes `await navigate(); view.title`
     // work like WKWebView (which packs title in NavDone).
     PageTitle,
+    // Sent once during the attach chain, before the first Page.navigate, so
+    // the reply names the entry the tab was created on. goBack() stops there.
+    PageBootstrapHistory,
     // goBack/goForward chain: getNavigationHistory → navigateToHistoryEntry.
     // The first picks entries[currentIndex + delta].id; the second navigates.
     // Page.loadEventFired settles, same as navigate/reload.

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -246,8 +246,7 @@ enum class Method : uint8_t {
     // → set m_title, settle Navigate. Makes `await navigate(); view.title`
     // work like WKWebView (which packs title in NavDone).
     PageTitle,
-    // Sent once during the attach chain, before the first Page.navigate, so
-    // the reply names the entry the tab was created on. goBack() stops there.
+    // Attach chain: Page.getNavigationHistory while about:blank is the only entry; goBack() stops there.
     PageBootstrapHistory,
     // goBack/goForward chain: getNavigationHistory → navigateToHistoryEntry.
     // The first picks entries[currentIndex + delta].id; the second navigates.

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -107,8 +107,9 @@ public:
     // goBack/goForward stash — PageGetNavigationHistory chains into
     // navigateToHistoryEntry with entries[currentIndex + delta].id.
     int8_t m_chromeHistoryDelta = 0;
-    // Chrome: the about:blank entry the tab was created on has been dropped.
-    bool m_chromeHistoryPruned = false;
+    // Chrome: session-history id of the about:blank entry the tab was created
+    // on, or 0 before the attach chain reports it. goBack() stops above it.
+    int32_t m_chromeBootstrapEntryId = 0;
     // Screenshot format/encoding stash — set by screenshot() before
     // dispatch, read by both backends' response handlers. CDP/IPC payloads
     // don't echo these; stashing here is simpler than threading them

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -107,6 +107,8 @@ public:
     // goBack/goForward stash — PageGetNavigationHistory chains into
     // navigateToHistoryEntry with entries[currentIndex + delta].id.
     int8_t m_chromeHistoryDelta = 0;
+    // Chrome: the about:blank entry the tab was created on has been dropped.
+    bool m_chromeHistoryPruned = false;
     // Screenshot format/encoding stash — set by screenshot() before
     // dispatch, read by both backends' response handlers. CDP/IPC payloads
     // don't echo these; stashing here is simpler than threading them

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -107,8 +107,7 @@ public:
     // goBack/goForward stash — PageGetNavigationHistory chains into
     // navigateToHistoryEntry with entries[currentIndex + delta].id.
     int8_t m_chromeHistoryDelta = 0;
-    // Chrome: session-history id of the about:blank entry the tab was created
-    // on, or 0 before the attach chain reports it. goBack() stops above it.
+    // Chrome: history id of the about:blank the tab was created on (0 until known); goBack() stops above it.
     int32_t m_chromeBootstrapEntryId = 0;
     // Screenshot format/encoding stash — set by screenshot() before
     // dispatch, read by both backends' response handlers. CDP/IPC payloads

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -74,6 +74,21 @@ test.concurrent("navigate, events and evaluate cross the pipes", async () => {
   });
 });
 
+test.concurrent("the events the backend consumes itself still reach addEventListener", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/first");
+    const seen = [];
+    view.addEventListener("Page.frameNavigated", e => seen.push("frameNavigated " + e.data.frame.url + " loading=" + view.loading));
+    view.addEventListener("Page.loadEventFired", e => seen.push("loadEventFired " + typeof e.data.timestamp + " loading=" + view.loading));
+    await view.navigate("http://fake/second");
+    print(seen);
+    view.close();
+  `);
+  // The backend has already applied each event (url, loading) when the listener runs.
+  expect(result).toEqual(["frameNavigated http://fake/second loading=true", "loadEventFired number loading=false"]);
+});
+
 test.concurrent("a reply larger than the read buffer is reassembled", async () => {
   const result = await runScenario(`
     const view = newView();

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -1110,25 +1110,21 @@ it("chrome: goBack/goForward navigates history", async () => {
 
 it("chrome: goBack at history start resolves undefined (no-op)", async () => {
   await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
-  await view.navigate(html("<body>only</body>"));
-  // The tab is created on about:blank before it can be driven; that bootstrap
-  // entry is dropped once the first page commits, so history starts at the
-  // first page the caller asked for, as on WKWebView. Session history is the
-  // browser's, so ask it, not the page (the page's copy of history.length
-  // arrives on its own channel and can lag this evaluate).
-  const history = (await view.cdp("Page.getNavigationHistory")) as { currentIndex: number; entries: unknown[] };
-  expect({ currentIndex: history.currentIndex, entries: history.entries.length }).toEqual({
-    currentIndex: 0,
-    entries: 1,
-  });
-  const r = await view.goBack();
-  expect(r).toBeUndefined();
-  expect(view.url).toBe(html("<body>only</body>"));
+  const first = html("<body>only</body>");
+  await view.navigate(first);
+  // The tab is created on a blank page before it can be driven. That page is
+  // not part of the view's history, so the first goBack() has nowhere to go,
+  // as on WKWebView.
+  expect(await view.goBack()).toBeUndefined();
+  expect(view.url).toBe(first);
   expect(await view.evaluate("document.body.textContent")).toBe("only");
   // A later navigation still gets a real back entry.
   await view.navigate(html("<body>second</body>"));
   await view.goBack();
-  expect(await view.evaluate("document.body.textContent")).toBe("only");
+  expect({ url: view.url, body: await view.evaluate("document.body.textContent") }).toEqual({
+    url: first,
+    body: "only",
+  });
   expect(await view.goBack()).toBeUndefined();
   expect(await view.evaluate("document.body.textContent")).toBe("only");
 });

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -379,6 +379,28 @@ it("chrome: cdp() enable + addEventListener receives CDP events", async () => {
   // no accumulation.
 });
 
+it("chrome: events the backend consumes itself still reach addEventListener", async () => {
+  // Page.frameNavigated / Page.loadEventFired drive view.url, onNavigated and
+  // the navigate() promise; Runtime.consoleAPICalled drives the console
+  // option. Listeners see them too, in protocol order, before navigate()
+  // resolves (that waits for one more round trip after the load event).
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(html("<body>init</body>"));
+  const seen: string[] = [];
+  view.addEventListener("Page.frameNavigated", (e: MessageEvent<any>) =>
+    seen.push("frameNavigated " + e.data.frame.url),
+  );
+  view.addEventListener("Page.loadEventFired", (e: MessageEvent<any>) =>
+    seen.push("loadEventFired " + typeof e.data.timestamp),
+  );
+  view.addEventListener("Runtime.consoleAPICalled", (e: MessageEvent<any>) =>
+    seen.push("consoleAPICalled " + e.data.type + " " + e.data.args[0].value),
+  );
+  const page = html("<script>console.warn('from page')</script><body>second</body>");
+  await view.navigate(page);
+  expect(seen).toEqual(["frameNavigated " + page, "consoleAPICalled warning from page", "loadEventFired number"]);
+});
+
 it("chrome: screenshot quality option affects JPEG size", async () => {
   await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   // Gradient + text → lossy compression has work to do.
@@ -1089,15 +1111,68 @@ it("chrome: goBack/goForward navigates history", async () => {
 it("chrome: goBack at history start resolves undefined (no-op)", async () => {
   await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   await view.navigate(html("<body>only</body>"));
-  // Target.createTarget({url:"about:blank"}) means history[0]=about:blank,
-  // history[1]=our page after navigate. goBack once → about:blank.
-  await view.goBack();
-  expect(await view.evaluate("document.body.textContent")).toBe("");
-  // Now at index 0. Second goBack hits the boundary — target=-1 → out of
-  // range → resolve undefined. Same semantics as WKWebView's goBack no-op.
+  // The tab is created on about:blank before it can be driven; that bootstrap
+  // entry is dropped once the first page commits, so history starts at the
+  // first page the caller asked for, as on WKWebView. Session history is the
+  // browser's, so ask it, not the page (the page's copy of history.length
+  // arrives on its own channel and can lag this evaluate).
+  const history = (await view.cdp("Page.getNavigationHistory")) as { currentIndex: number; entries: unknown[] };
+  expect({ currentIndex: history.currentIndex, entries: history.entries.length }).toEqual({
+    currentIndex: 0,
+    entries: 1,
+  });
   const r = await view.goBack();
   expect(r).toBeUndefined();
-  expect(await view.evaluate("document.body.textContent")).toBe("");
+  expect(view.url).toBe(html("<body>only</body>"));
+  expect(await view.evaluate("document.body.textContent")).toBe("only");
+  // A later navigation still gets a real back entry.
+  await view.navigate(html("<body>second</body>"));
+  await view.goBack();
+  expect(await view.evaluate("document.body.textContent")).toBe("only");
+  expect(await view.goBack()).toBeUndefined();
+  expect(await view.evaluate("document.body.textContent")).toBe("only");
+});
+
+// --- Dialogs ----------------------------------------------------------------
+
+it("chrome: dialogs are answered when nothing listens for Page.javascriptDialogOpening", async () => {
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  // alert() during load would otherwise block the load event forever.
+  await view.navigate(html("<script>alert('on load')</script><body>loaded</body>"));
+  expect(await view.evaluate("document.body.textContent")).toBe("loaded");
+  // Dismissed, like WKWebView with no UI delegate: confirm() is false,
+  // prompt() is null, alert() just returns.
+  expect(await view.evaluate("[confirm('sure?'), prompt('name?', 'default'), (alert('hi'), 'after')]")).toEqual([
+    false,
+    null,
+    "after",
+  ]);
+  // A beforeunload prompt is accepted so the navigation that raised it
+  // proceeds. Chrome only shows it after a user gesture, hence the typing.
+  await view.navigate(
+    html(
+      "<input id=i><script>addEventListener('beforeunload', e => { e.preventDefault(); e.returnValue = 'stay'; })</script>",
+    ),
+  );
+  await view.click("#i");
+  await view.type("unsaved");
+  await view.navigate(html("<body>left anyway</body>"));
+  expect(await view.evaluate("document.body.textContent")).toBe("left anyway");
+});
+
+it("chrome: a Page.javascriptDialogOpening listener takes over dialog handling", async () => {
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(html("<body></body>"));
+  const seen: { type: string; message: string }[] = [];
+  view.addEventListener("Page.javascriptDialogOpening", (e: MessageEvent<any>) => {
+    seen.push({ type: e.data.type, message: e.data.message });
+    view.cdp("Page.handleJavaScriptDialog", { accept: true, promptText: "typed" });
+  });
+  expect(await view.evaluate("[confirm('sure?'), prompt('name?')]")).toEqual([true, "typed"]);
+  expect(seen).toEqual([
+    { type: "confirm", message: "sure?" },
+    { type: "prompt", message: "name?" },
+  ]);
 });
 
 // --- Console capture -------------------------------------------------------

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -274,6 +274,15 @@ it("Symbol.dispose / Symbol.asyncDispose call close()", async () => {
   view.close();
 });
 
+it("page dialogs are answered without blocking", async () => {
+  await using view = new Bun.WebView({ width: 200, height: 200 });
+  // No UI delegate method for JS dialogs: WebKit answers them itself.
+  await view.navigate(html("<script>alert('on load')</script><body>loaded</body>"));
+  expect(
+    await view.evaluate("[document.body.textContent, confirm('sure?'), prompt('name?', 'x'), (alert('hi'), 'after')]"),
+  ).toEqual(["loaded", false, null, "after"]);
+});
+
 it("concurrent evaluate() across two views works", async () => {
   // Completion blocks carry Ref<WebViewHost> per-call (heap-allocated
   // _NSConcreteMallocBlock, same layout as WTF::BlockPtr). No process-global


### PR DESCRIPTION
### Problem
- Three documented behaviours that the Chrome backend did not have, while the WebKit backend does. Listeners for `Page.loadEventFired`, `Page.frameNavigated` and `Runtime.consoleAPICalled` never fire: `handleEvent` consumed them with an early `return`. `goBack()` right after the first `navigate()` is documented as a no-op but went to the `about:blank` the tab was created on. A page `alert()`/`confirm()`/`prompt()`, or a `beforeunload` prompt, blocked `navigate()`/`evaluate()` forever.

### Fix
- `Transport::handleEvent` does the view's bookkeeping for those events and then falls through to the listener dispatch. The console forwarding moves into `forwardConsoleCall` so it can fall through too; a throwing `console` callback is reported before the listeners run.
- During the attach chain, before the first `Page.navigate`, the backend reads the id of the entry the tab was created on. `goBack()` stops above it, so a view's history starts at the first page the caller asked for, as on WKWebView.
- `Page.javascriptDialogOpening` with no listener on the view is answered with `Page.handleJavaScriptDialog`: dismiss, except `beforeunload` which is accepted so its navigation proceeds. That is what WKWebView does with no UI delegate, and Playwright's default. A listener takes over and answers through `cdp()`. New docs section "Dialogs".
- Verified: `webview-chrome.test.ts` (4 new or rewritten blocks, real Chrome 153), `webview-chrome-pipe.test.ts` (event pass-through, every platform), `webview.test.ts` (WebKit dialog defaults, macOS CI). The Chrome tests fail on 1.4.3.

### Background
- The Chrome backend creates each tab with `Target.createTarget({url: "about:blank"})` so `Page.enable` can run before the first real navigation. That leaves one session-history entry nobody asked for.
- Chrome pauses a page, and every command that needs it, while a JavaScript dialog is open, until `Page.handleJavaScriptDialog` answers it.

<details><summary>Notes</summary>

From a docs-vs-backend pass over `docs/runtime/webview.mdx` (items 1, 4 and 5 of seven). Sibling PRs: #42167 (spawn/connect errors, `press()`), #42221 (evaluate() errors). Independent of both.

- #42162 (same-document navigations) rewrites the `Page.frameNavigated`/`Page.loadEventFired` handling into helpers and also lets those two events reach listeners. The two PRs agree on behaviour; whichever lands second rebases `handleEvent`. This PR keeps the existing block structure to keep that small, and adds the `Runtime.consoleAPICalled` pass-through and the dialog/history pieces #42162 does not have.
- A `Page.loadEventFired` listener runs before the `navigate()` it belongs to resolves (that waits for the `document.title` round trip). Documented.
- The first approach here deleted the bootstrap entry with `Page.resetNavigationHistory` on the first commit. That races: `Page.frameNavigated` comes from the renderer, while the prune runs in the browser, which may not have recorded the commit yet. `NavigationControllerImpl::DeleteNavigationEntries` then keeps `about:blank` as the last committed entry and drops nothing. It failed on three CI lanes. The id is read instead during the attach chain, where the tab has exactly one entry and command order alone decides the result. Chrome's history is left as it is, so the page's own `history.length` still counts the blank page.
- An explicit `navigate("about:blank")` is a different entry with a different id, so `goBack()` still returns to it.
- The dialog default is keyed on listener presence, like Playwright's `page.on('dialog')`. The alternative, an option on the constructor, is new API surface; this takes none and keeps the escape hatch the docs already had (`cdp()` plus the raw event).
- `cdp()` has one slot per view, so a listener that answers a dialog while another `cdp()` call is in flight gets `ERR_INVALID_STATE`. Pre-existing; the docs example awaits nothing else.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview.test.ts, test/js/bun/webview/webview-chrome.test.ts, test/js/bun/webview/webview-chrome-pipe.test.ts

<!-- robobun:evidence:end -->