### PR TITLE
Throw ERR_STRING_TOO_LONG from Bun.wrapAnsi instead of aborting when the output passes the string length limit

### DIFF
--- a/docs/runtime/utils.mdx
+++ b/docs/runtime/utils.mdx
@@ -896,6 +896,8 @@ Bun.wrapAnsi("\u001b[31mThe quick brown fox jumps over the lazy dog\u001b[0m", 2
 // => "\u001b[31mThe quick brown fox\u001b[39m\n\u001b[31mjumps over the lazy\u001b[39m\n\u001b[31mdog\u001b[0m"
 ```
 
+The output can be longer than the input, because every row re-opens an open style or OSC 8 hyperlink. If the output passes the maximum string length (2^31 - 1 characters), `Bun.wrapAnsi()` throws an `Error` with the code `ERR_STRING_TOO_LONG`.
+
 ### Options
 
 ```ts

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1029,6 +1029,11 @@ declare module "bun" {
    * @param options Wrapping options
    * @returns The wrapped string
    *
+   * @throws An `Error` with the code `ERR_STRING_TOO_LONG` when the wrapped
+   * output passes the maximum string length (2^31 - 1 characters). The output
+   * can be longer than the input, because every row re-opens an open style or
+   * OSC 8 hyperlink.
+   *
    * @example
    * ```ts
    * import { wrapAnsi } from "bun";

--- a/src/jsc/bindings/wrapAnsi.cpp
+++ b/src/jsc/bindings/wrapAnsi.cpp
@@ -636,9 +636,7 @@ static void processLine(const Char* lineStart, const Char* lineEnd, size_t colum
 // Main Implementation
 // ============================================================================
 
-// Every row re-emits the open hyperlink, so the output can pass
-// StringImpl::MaxLength. The builders record the overflow and the caller
-// throws ERR_STRING_TOO_LONG. nullopt means that throw.
+// Rows re-emit the open hyperlink, so the output can pass MaxLength. nullopt: throw ERR_STRING_TOO_LONG.
 static std::optional<WTF::String> finishWrapAnsi(StringBuilder& result)
 {
     if (result.hasOverflowed() || result.length() > Bun__stringSyntheticAllocationLimit) [[unlikely]]

--- a/src/jsc/bindings/wrapAnsi.cpp
+++ b/src/jsc/bindings/wrapAnsi.cpp
@@ -636,12 +636,9 @@ static void processLine(const Char* lineStart, const Char* lineEnd, size_t colum
 // Main Implementation
 // ============================================================================
 
-// The output is not bounded by the input: every wrapped row re-emits the open
-// hyperlink sequence, so a long URI and many rows multiply. A default
-// StringBuilder aborts the process once the built string passes
-// StringImpl::MaxLength, so every builder here records the overflow instead and
-// the caller turns it into ERR_STRING_TOO_LONG. `Bun__stringSyntheticAllocationLimit`
-// is the same limit lowered for tests (u32::MAX, above MaxLength, in production).
+// Every row re-emits the open hyperlink, so the output can pass
+// StringImpl::MaxLength. The builders record the overflow and the caller
+// throws ERR_STRING_TOO_LONG. nullopt means that throw.
 static std::optional<WTF::String> finishWrapAnsi(StringBuilder& result)
 {
     if (result.hasOverflowed() || result.length() > Bun__stringSyntheticAllocationLimit) [[unlikely]]
@@ -649,8 +646,7 @@ static std::optional<WTF::String> finishWrapAnsi(StringBuilder& result)
     return result.toString();
 }
 
-// Capacity past MaxLength fails the whole build, so cap the estimate. An input
-// near MaxLength still wraps when its output fits.
+// reserveCapacity() past MaxLength fails the builder before any append.
 static unsigned wrapAnsiCapacity(size_t estimate)
 {
     return static_cast<unsigned>(std::min<size_t>(estimate, WTF::String::MaxLength));

--- a/src/jsc/bindings/wrapAnsi.cpp
+++ b/src/jsc/bindings/wrapAnsi.cpp
@@ -1,12 +1,15 @@
 #include "root.h"
 #include "wrapAnsi.h"
 #include "ANSIHelpers.h"
+#include "ErrorCode.h"
+#include "helpers.h"
 
 #include <wtf/text/WTFString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/Vector.h>
 #include <wtf/MathExtras.h>
 #include <cmath>
+#include <optional>
 
 // Native exports (implemented in stringWidth.cpp) for visible width calculation
 extern "C" size_t Bun__visibleWidthExcludeANSI_utf16(const uint16_t* ptr, size_t len, bool ambiguous_as_wide);
@@ -633,24 +636,44 @@ static void processLine(const Char* lineStart, const Char* lineEnd, size_t colum
 // Main Implementation
 // ============================================================================
 
+// The output is not bounded by the input: every wrapped row re-emits the open
+// hyperlink sequence, so a long URI and many rows multiply. A default
+// StringBuilder aborts the process once the built string passes
+// StringImpl::MaxLength, so every builder here records the overflow instead and
+// the caller turns it into ERR_STRING_TOO_LONG. `Bun__stringSyntheticAllocationLimit`
+// is the same limit lowered for tests (u32::MAX, above MaxLength, in production).
+static std::optional<WTF::String> finishWrapAnsi(StringBuilder& result)
+{
+    if (result.hasOverflowed() || result.length() > Bun__stringSyntheticAllocationLimit) [[unlikely]]
+        return std::nullopt;
+    return result.toString();
+}
+
+// Capacity past MaxLength fails the whole build, so cap the estimate. An input
+// near MaxLength still wraps when its output fits.
+static unsigned wrapAnsiCapacity(size_t estimate)
+{
+    return static_cast<unsigned>(std::min<size_t>(estimate, WTF::String::MaxLength));
+}
+
 template<typename Char>
-static WTF::String wrapAnsiImpl(std::span<const Char> input, size_t columns, const WrapAnsiOptions& options)
+static std::optional<WTF::String> wrapAnsiImpl(std::span<const Char> input, size_t columns, const WrapAnsiOptions& options)
 {
     if (columns == 0 || input.empty()) {
         // Return copy of input
-        StringBuilder result;
-        result.reserveCapacity(input.size());
+        StringBuilder result { OverflowPolicy::RecordOverflow };
+        result.reserveCapacity(wrapAnsiCapacity(input.size()));
         for (auto c : input)
             result.append(static_cast<UChar>(c));
-        return result.toString();
+        return finishWrapAnsi(result);
     }
 
     // Process each line separately. \n, a bare \r and a \r\n pair each
     // break a line and are emitted as one \n — callers (Claude Code's
     // wrap-text) map wrapped output back to the original text by relying on
     // every \r becoming a break.
-    StringBuilder result;
-    result.reserveCapacity(input.size() + input.size() / 10);
+    StringBuilder result { OverflowPolicy::RecordOverflow };
+    result.reserveCapacity(wrapAnsiCapacity(input.size() + input.size() / 10));
 
     const Char* lineStart = input.data();
     const Char* const dataEnd = input.data() + input.size();
@@ -687,7 +710,7 @@ static WTF::String wrapAnsiImpl(std::span<const Char> input, size_t columns, con
         lineStart = (*lineEnd == '\r' && lineEnd + 1 != dataEnd && *(lineEnd + 1) == '\n') ? lineEnd + 2 : lineEnd + 1;
     }
 
-    return result.toString();
+    return finishWrapAnsi(result);
 }
 
 // ============================================================================
@@ -751,14 +774,17 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionBunWrapAnsi, (JSC::JSGlobalObject * globalObj
     }
 
     // Process based on encoding
-    WTF::String result;
+    std::optional<WTF::String> result;
     if (view->is8Bit()) {
         result = wrapAnsiImpl<Latin1Character>(view->span8(), columns, options);
     } else {
         result = wrapAnsiImpl<UChar>(view->span16(), columns, options);
     }
 
-    return JSC::JSValue::encode(JSC::jsString(vm, result));
+    if (!result) [[unlikely]]
+        return Bun::ERR::STRING_TOO_LONG(scope, globalObject);
+
+    return JSC::JSValue::encode(JSC::jsString(vm, WTF::move(*result)));
 }
 
 } // namespace Bun

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -1059,7 +1059,8 @@ describe("Bun.wrapAnsi", () => {
       }
     });
 
-    // The real limit needs the child to build 2 GiB of Latin-1 output: measured
+    // The real limit: a 1 MB URI re-emitted on 2300 rows is 2.3e9 characters.
+    // The child builds 2 GiB of Latin-1 output before the overflow: measured
     // 2.5 s and a 3.2 GiB peak under ASAN (the builder stops growing once it
     // records the overflow), 4.4 GiB for the abort it replaces. os.totalmem()
     // reports the host's RAM inside a container, process.constrainedMemory()
@@ -1074,7 +1075,7 @@ describe("Bun.wrapAnsi", () => {
             "-e",
             [
               `const uri = Buffer.alloc(1_000_000, "a").toString();`,
-              `const input = "\\x1b]8;;http://example.com/" + uri + "\\x07" + Buffer.alloc(4600, "a ").toString();`,
+              `const input = "\\x1b]8;;http://example.com/" + uri + "\\x07" + Buffer.alloc(2300 * 2, "a ").toString();`,
               `let result;`,
               `try {`,
               `  result = "UNEXPECTED_SUCCESS:" + Bun.wrapAnsi(input, 1).length;`,

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -1,5 +1,7 @@
+import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import os from "node:os";
 
 describe("Bun.wrapAnsi", () => {
   describe("basic wrapping", () => {
@@ -1012,5 +1014,90 @@ describe("Bun.wrapAnsi", () => {
       expect(stdout).toBe("match\n");
       expect(exitCode).toBe(0);
     });
+  });
+
+  // The output is not bounded by the input: every wrapped row re-emits the open
+  // hyperlink sequence, so a long URI and enough rows build a string past
+  // WTF::StringImpl::MaxLength (2^31 - 1). The StringBuilder aborted the process
+  // there (SIGABRT in StringBuilder::didOverflow) instead of throwing.
+  describe("output past the string length limit", () => {
+    const stringTooLong = {
+      name: "Error",
+      code: "ERR_STRING_TOO_LONG",
+      message: "Cannot create a string longer than 2147483647 characters",
+    };
+
+    // An open hyperlink with a URI of `uriLength` characters, then `words`
+    // one-character words. At columns: 1 every word is a row of its own, and
+    // every row boundary re-emits the URI.
+    function hyperlinkedWords(uriLength: number, words: number) {
+      const uri = Buffer.alloc(uriLength, "a").toString();
+      return `\x1b]8;;http://example.com/${uri}\x07` + Buffer.alloc(words * 2, "a ").toString();
+    }
+
+    function caught(input: string) {
+      try {
+        return `UNEXPECTED_SUCCESS:${Bun.wrapAnsi(input, 1).length}`;
+      } catch (e) {
+        return e;
+      }
+    }
+
+    test("throws ERR_STRING_TOO_LONG when the output passes the limit", () => {
+      // The limit is process-wide, so put it back. 1 MiB is the lowest value the
+      // hook accepts.
+      const previousLimit = setSyntheticAllocationLimitForTesting(1024 * 1024);
+      try {
+        expect(caught(hyperlinkedWords(100_000, 64))).toMatchObject(stringTooLong);
+        // The same input as a 16-bit string: the other template instantiation.
+        expect(caught(hyperlinkedWords(100_000, 64) + "\u2603")).toMatchObject(stringTooLong);
+
+        // An output under the limit still wraps.
+        expect(Bun.wrapAnsi(hyperlinkedWords(1_000, 2), 1)).toHaveLength(2059);
+      } finally {
+        setSyntheticAllocationLimitForTesting(previousLimit);
+      }
+    });
+
+    // The real limit needs the child to build 2 GiB. os.totalmem() reports the
+    // host's RAM inside a container, process.constrainedMemory() the cgroup
+    // limit. Measured peak for this child: 4.5 GiB.
+    const memory = Math.min(os.totalmem(), process.constrainedMemory() || Infinity);
+    test.skipIf(memory < 10 * 1024 ** 3)(
+      "throws at 2^31 output characters instead of aborting",
+      async () => {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            [
+              `const uri = Buffer.alloc(1_000_000, "a").toString();`,
+              `const input = "\\x1b]8;;http://example.com/" + uri + "\\x07" + Buffer.alloc(4600, "a ").toString();`,
+              `let result;`,
+              `try {`,
+              `  result = "UNEXPECTED_SUCCESS:" + Bun.wrapAnsi(input, 1).length;`,
+              `} catch (e) {`,
+              `  result = { name: e.name, code: e.code, message: e.message };`,
+              `}`,
+              `console.log(JSON.stringify(result));`,
+            ].join("\n"),
+          ],
+          env: bunEnv,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        // One assertion: an abort shows its signal and its stderr next to the
+        // missing stdout.
+        expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+          stdout: JSON.stringify(stringTooLong) + "\n",
+          stderr: "",
+          exitCode: 0,
+          signalCode: null,
+        });
+      },
+      120_000,
+    );
   });
 });

--- a/test/js/bun/util/wrapAnsi.test.ts
+++ b/test/js/bun/util/wrapAnsi.test.ts
@@ -1059,11 +1059,13 @@ describe("Bun.wrapAnsi", () => {
       }
     });
 
-    // The real limit needs the child to build 2 GiB. os.totalmem() reports the
-    // host's RAM inside a container, process.constrainedMemory() the cgroup
-    // limit. Measured peak for this child: 4.5 GiB.
+    // The real limit needs the child to build 2 GiB of Latin-1 output: measured
+    // 2.5 s and a 3.2 GiB peak under ASAN (the builder stops growing once it
+    // records the overflow), 4.4 GiB for the abort it replaces. os.totalmem()
+    // reports the host's RAM inside a container, process.constrainedMemory()
+    // the cgroup limit.
     const memory = Math.min(os.totalmem(), process.constrainedMemory() || Infinity);
-    test.skipIf(memory < 10 * 1024 ** 3)(
+    test.skipIf(memory < 8 * 1024 ** 3)(
       "throws at 2^31 output characters instead of aborting",
       async () => {
         await using proc = Bun.spawn({
@@ -1097,7 +1099,7 @@ describe("Bun.wrapAnsi", () => {
           signalCode: null,
         });
       },
-      120_000,
+      60_000,
     );
   });
 });


### PR DESCRIPTION
### Problem
- `Bun.wrapAnsi()` aborts the process when its output passes 2^31 - 1 characters: `panic(main thread): abort() called` from `WTF::StringBuilder::didOverflow` under `joinRowsWithAnsiPreservation`. A 1 MB input is enough: every wrapped row re-emits the open OSC 8 hyperlink, so a 1 MB URI plus 2300 one-letter words at `columns: 1` gets there (2.3e9 characters).
- The cause is the two default-constructed builders in `wrapAnsiImpl` (`src/jsc/bindings/wrapAnsi.cpp:641`, `:652`). The default policy is `CrashOnOverflow`, and the output length (rows x URI length) comes from the caller.

### Fix
- Construct both builders with `OverflowPolicy::RecordOverflow`. When the builder `hasOverflowed()`, the binding throws through the existing `Bun::ERR::STRING_TOO_LONG`. Outputs that fit are unchanged.
- Clamp the `reserveCapacity()` estimate to `String::MaxLength`. Before, an input over about 1.95e9 characters aborted on the reserve itself.
- The final check also honours `Bun__stringSyntheticAllocationLimit`, as `helpers.h` does, so a test reaches the throw with a 1 MiB limit.
- Verified: `test/js/bun/util/wrapAnsi.test.ts` (two new tests, both fail on bun 1.4.2, one with the real SIGABRT), plus the sliceAnsi and stringWidth suites. Self-reviewed: 2 concerns raised (cost of the real-limit test), 2 addressed.

### Background
- `WTF::StringBuilder` takes an `OverflowPolicy`. The default calls `CRASH()` when an append would pass `StringImpl::MaxLength` (2^31 - 1). `RecordOverflow` sets a flag instead, later appends are no-ops, and the owner checks `hasOverflowed()` before `toString()`.
- `Bun.wrapAnsi()` closes an open SGR style and OSC 8 hyperlink at the end of every row and re-opens them on the next row. That is what makes the output grow faster than the input.
- `Bun__stringSyntheticAllocationLimit` is `u32::MAX` in production, above `MaxLength`, so it never fires there. `setSyntheticAllocationLimitForTesting` (`bun:internal-for-testing`) lowers it, as in `blob-oom.test.ts`.

<details><summary>Notes</summary>

- Repro (stock bun 1.4.2 and canary 5f554969b, Linux x64): `Bun.wrapAnsi("\x1b]8;;http://example.com/" + "a".repeat(1e6) + "\x07" + "a ".repeat(2300), 1)`. Input length 1,004,625, output would be 2.3e9 characters (2300 rows, each re-emitting the 1,000,019-character URI). Exit code 134, `RSS: 2.29 GB | Peak: 4.44 GB`. The full frame chain: `StringBuilder::didOverflow` (StringBuilder.cpp:46, `if (m_shouldCrashOnOverflow) CRASH()`) <- `reallocateBuffer` <- `StringBuilder::append(span)` <- `joinRowsWithAnsiPreservation` <- `wrapAnsiImpl` <- `jsFunctionBunWrapAnsi`.
- The same input with 2000 words instead of 2300 builds 2,000,065,993 characters and returns normally, at about the same RSS. The abort follows the built length, not memory.
- With the fix, the real-limit child takes 2.4 s and peaks at 3.2 GB under debug ASAN: once the overflow is recorded the builder stops growing, so `toString()` of a 2 GiB buffer never happens.
- The real-limit test runs in a child process so the 2 GiB buffer stays out of the test runner. It asserts stdout, stderr, exit code and signal in one `toEqual`, so an abort shows its signal next to the missing stdout. It is skipped below 8 GiB of RAM (cgroup-aware through `process.constrainedMemory()`) and carries a 60 s timeout.
- The synthetic-limit test is the primary coverage. It covers both template instantiations (Latin-1 and UTF-16 input) and restores the process-wide limit in `finally`. 1 MiB is the lowest value the hook accepts.
- `sliceAnsi.cpp` also uses default-policy builders. Its output is bounded by about the input length plus the active style state, so it needs an input that is itself near the limit. Not changed here.
- Docs: one sentence in `docs/runtime/utils.mdx` and a `@throws` in `bun.d.ts`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/wrapAnsi.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [1.71ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [1.49ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [1.46ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [1.18ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [1.42ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [1.14ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [1.87ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [1.76ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [1.57ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap: undefined keeps word wrapping on [1.64ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap: null keeps word wrapping on [0.39ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap: 0 keeps word wrapping on [0.29ms]
(pass) Bun.wrapAnsi > wordWrap opti
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (4f8670b54)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [0.05ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [0.02ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [0.02ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [0.01ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [0.01ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [0.88ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [0.03ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [0.02ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap: undefined keeps word wrapping on [0.02ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap: null keeps word wrapping on
(pass) Bun.wrapAnsi > wordWrap option > wordWrap: 0 keeps word wrapping on
(pass) Bun.wrapAnsi > wordWrap option > wordWrap: "" keeps word wrapping on
(pass) Bun.wrapAnsi > wordWrap option > wordWrap: false breaks words character-by-character [0.04ms]
(pass) Bun.wrapAnsi > trim option
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/wrapAnsi.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/util/wrapAnsi.test.ts:
(pass) Bun.wrapAnsi > basic wrapping > wraps text at word boundaries [1.66ms]
(pass) Bun.wrapAnsi > basic wrapping > handles empty string [1.44ms]
(pass) Bun.wrapAnsi > basic wrapping > no wrapping needed [1.49ms]
(pass) Bun.wrapAnsi > basic wrapping > wraps multiple words [1.18ms]
(pass) Bun.wrapAnsi > basic wrapping > handles single long word [1.47ms]
(pass) Bun.wrapAnsi > basic wrapping > handles columns = 0 [1.10ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks long words in middle [1.80ms]
(pass) Bun.wrapAnsi > hard wrap option > breaks very long word [1.81ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap false disables wrapping [1.50ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap: undefined keeps word wrapping on [1.66ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap: null keeps word wrapping on [0.42ms]
(pass) Bun.wrapAnsi > wordWrap option > wordWrap: 0 keeps word wrapping on [0.29ms]
(pass) Bun.wrapAnsi > wordWrap opti
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 673ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/utils.mdx            |  2 +
 packages/bun-types/bun.d.ts       |  5 +++
 src/jsc/bindings/wrapAnsi.cpp     | 38 +++++++++++++----
 test/js/bun/util/wrapAnsi.test.ts | 90 +++++++++++++++++++++++++++++++++++++++
 4 files changed, 126 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
docs/runtime/utils.mdx                 1      1     19
packages/bun-types/bun.d.ts            1      2     21
src/jsc/bindings/wrapAnsi.cpp          4      7     19
test/js/bun/util/wrapAnsi.test.ts      5      8     19
```

</details>

**root cause** · written by the author bot

`Bun.wrapAnsi` built its output with a default-constructed `StringBuilder`, which crashes on overflow, so any input whose wrapped result exceeded `StringImpl::MaxLength` aborted the process with SIGABRT instead of surfacing an error; this was reachable with inputs around 1 MB because every wrapped row re-emits the open ANSI styles and OSC 8 hyperlink, multiplying the output length. The fix switches the string builders to `OverflowPolicy::RecordOverflow` and checks `hasOverflowed()` after construction, propagating the failure up through the wrapping helpers so the binding throws `ERR_STRING_…

<!-- robobun:evidence:end -->