### PR TITLE
Throw instead of aborting when a MIME string does not fit in a string

### DIFF
--- a/src/jsc/bindings/webcore/JSMIMEParams.cpp
+++ b/src/jsc/bindings/webcore/JSMIMEParams.cpp
@@ -165,48 +165,67 @@ static String removeBackslashes(const StringView& view)
     return builder.toString();
 }
 
-static void escapeQuoteOrBackslash(const StringView& view, StringBuilder& builder)
+// Returns the number of characters the escaped view adds to the result. The
+// builder stops counting at WTF::String::MaxLength and this count does not, so
+// the caller can tell a result that is too long from a failed allocation.
+static uint64_t escapeQuoteOrBackslash(const StringView& view, StringBuilder& builder)
 {
     if (view.find([](char16_t c) { return c == '"' || c == '\\'; }) == notFound) {
         builder.append(view);
-        return;
+        return view.length();
     }
 
+    uint64_t length = 0;
     if (view.is8Bit()) {
         auto span = view.span8();
         for (Latin1Character c : span) {
             if (c == '"' || c == '\\') {
                 builder.append('\\');
+                length++;
             }
             builder.append(c);
+            length++;
         }
     } else {
         auto span = view.span16();
         for (char16_t c : span) {
             if (c == '"' || c == '\\') {
                 builder.append('\\');
+                length++;
             }
             builder.append(c);
+            length++;
         }
     }
+    return length;
 }
 
-// Encodes a parameter value for serialization.
-static void encodeParamValue(const StringView& value, StringBuilder& builder)
+// Encodes a parameter value for serialization. Returns the number of
+// characters it adds to the result.
+static uint64_t encodeParamValue(const StringView& value, StringBuilder& builder)
 {
     if (value.isEmpty()) {
         builder.append("\"\""_s);
-        return;
+        return 2;
     }
     if (findFirstInvalidHTTPTokenChar(value) == -1) {
         // It's a simple token, no quoting needed.
         builder.append(value);
-        return;
+        return value.length();
     }
     // Needs quoting and escaping.
     builder.append('"');
-    escapeQuoteOrBackslash(value, builder);
+    uint64_t length = escapeQuoteOrBackslash(value, builder);
     builder.append('"');
+    return length + 2;
+}
+
+JSC::EncodedJSValue throwMIMEStringBuildFailure(JSGlobalObject* globalObject, ThrowScope& scope, uint64_t intendedLength)
+{
+    if (intendedLength > WTF::String::MaxLength) {
+        return Bun::ERR::STRING_TOO_LONG(scope, globalObject);
+    }
+    return Bun::ERR::MEMORY_ALLOCATION_FAILED(scope, globalObject);
 }
 
 // Parses the parameter string and populates the map.
@@ -516,7 +535,11 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncToString, (JSGlobalObject * global
     }
 
     JSMap* map = thisObject->jsMap();
-    StringBuilder builder;
+    // The result length comes from the parameters, and escaping doubles a value.
+    // A crash-on-overflow builder aborts the process once the result passes
+    // String::MaxLength, so record the overflow and throw below instead.
+    StringBuilder builder(WTF::OverflowPolicy::RecordOverflow);
+    uint64_t intendedLength = 0;
     bool first = true;
 
     JSMapIterator* iterator = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), map, IterationKind::Entries);
@@ -540,12 +563,18 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncToString, (JSGlobalObject * global
 
         if (!first) {
             builder.append(';');
+            intendedLength++;
         }
         first = false;
 
         builder.append(key);
         builder.append('=');
-        encodeParamValue(value, builder);
+        intendedLength += static_cast<uint64_t>(key.length()) + 1;
+        intendedLength += encodeParamValue(value, builder);
+    }
+
+    if (builder.hasOverflowed()) [[unlikely]] {
+        return throwMIMEStringBuildFailure(globalObject, scope, intendedLength);
     }
 
     return JSValue::encode(jsString(vm, builder.toString()));

--- a/src/jsc/bindings/webcore/JSMIMEParams.cpp
+++ b/src/jsc/bindings/webcore/JSMIMEParams.cpp
@@ -165,9 +165,7 @@ static String removeBackslashes(const StringView& view)
     return builder.toString();
 }
 
-// Returns the number of characters the escaped view adds to the result. The
-// builder stops counting at WTF::String::MaxLength and this count does not, so
-// the caller can tell a result that is too long from a failed allocation.
+// Returns the characters it adds. The builder's own length stops at String::MaxLength.
 static uint64_t escapeQuoteOrBackslash(const StringView& view, StringBuilder& builder)
 {
     if (view.find([](char16_t c) { return c == '"' || c == '\\'; }) == notFound) {
@@ -200,8 +198,7 @@ static uint64_t escapeQuoteOrBackslash(const StringView& view, StringBuilder& bu
     return length;
 }
 
-// Encodes a parameter value for serialization. Returns the number of
-// characters it adds to the result.
+// Encodes a parameter value for serialization. Returns the characters it adds.
 static uint64_t encodeParamValue(const StringView& value, StringBuilder& builder)
 {
     if (value.isEmpty()) {
@@ -535,9 +532,7 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMEParamsProtoFuncToString, (JSGlobalObject * global
     }
 
     JSMap* map = thisObject->jsMap();
-    // The result length comes from the parameters, and escaping doubles a value.
-    // A crash-on-overflow builder aborts the process once the result passes
-    // String::MaxLength, so record the overflow and throw below instead.
+    // RecordOverflow: the default policy aborts the process past String::MaxLength.
     StringBuilder builder(WTF::OverflowPolicy::RecordOverflow);
     uint64_t intendedLength = 0;
     bool first = true;

--- a/src/jsc/bindings/webcore/JSMIMEParams.h
+++ b/src/jsc/bindings/webcore/JSMIMEParams.h
@@ -86,4 +86,9 @@ void setupJSMIMEParamsClassStructure(JSC::LazyClassStructure::Initializer&);
 JSC::JSValue createJSMIMEBinding(Zig::GlobalObject* globalObject);
 bool parseMIMEParamsString(JSGlobalObject* globalObject, JSMap* map, StringView input);
 
+// Throws for a MIME string that could not be built. `intendedLength` is the
+// length the result would have had, which is what separates a result past
+// WTF::String::MaxLength from a failed allocation.
+JSC::EncodedJSValue throwMIMEStringBuildFailure(JSC::JSGlobalObject*, JSC::ThrowScope&, uint64_t intendedLength);
+
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/JSMIMEParams.h
+++ b/src/jsc/bindings/webcore/JSMIMEParams.h
@@ -86,9 +86,7 @@ void setupJSMIMEParamsClassStructure(JSC::LazyClassStructure::Initializer&);
 JSC::JSValue createJSMIMEBinding(Zig::GlobalObject* globalObject);
 bool parseMIMEParamsString(JSGlobalObject* globalObject, JSMap* map, StringView input);
 
-// Throws for a MIME string that could not be built. `intendedLength` is the
-// length the result would have had, which is what separates a result past
-// WTF::String::MaxLength from a failed allocation.
+// Throws for a MIME string that could not be built. `intendedLength` is the length it would have had.
 JSC::EncodedJSValue throwMIMEStringBuildFailure(JSC::JSGlobalObject*, JSC::ThrowScope&, uint64_t intendedLength);
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/JSMIMEType.cpp
+++ b/src/jsc/bindings/webcore/JSMIMEType.cpp
@@ -426,7 +426,15 @@ JSC_DEFINE_CUSTOM_GETTER(jsMIMETypeProtoGetterEssence, (JSGlobalObject * globalO
         return {};
     }
 
-    String essence = makeString(thisObject->type(), '/', thisObject->subtype());
+    // makeString aborts the process when the result does not fit in a string,
+    // and the type and the subtype come from the caller.
+    const String& type = thisObject->type();
+    const String& subtype = thisObject->subtype();
+    String essence = tryMakeString(type, '/', subtype);
+    if (essence.isNull()) [[unlikely]] {
+        return throwMIMEStringBuildFailure(globalObject, scope, static_cast<uint64_t>(type.length()) + 1 + subtype.length());
+    }
+
     return JSValue::encode(jsString(vm, essence));
 }
 
@@ -465,13 +473,22 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMETypeProtoFuncToString, (JSGlobalObject * globalOb
     String paramsStr = paramsStrValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    StringBuilder builder;
+    // The type, the subtype and the serialized parameters all come from the
+    // caller. A crash-on-overflow builder aborts the process once the result
+    // passes String::MaxLength, so record the overflow and throw below instead.
+    StringBuilder builder(WTF::OverflowPolicy::RecordOverflow);
     builder.append(thisObject->type());
     builder.append('/');
     builder.append(thisObject->subtype());
+    uint64_t intendedLength = static_cast<uint64_t>(thisObject->type().length()) + 1 + thisObject->subtype().length();
     if (!paramsStr.isEmpty()) {
         builder.append(';');
         builder.append(paramsStr);
+        intendedLength += static_cast<uint64_t>(paramsStr.length()) + 1;
+    }
+
+    if (builder.hasOverflowed()) [[unlikely]] {
+        return throwMIMEStringBuildFailure(globalObject, scope, intendedLength);
     }
 
     return JSValue::encode(jsString(vm, builder.toString()));

--- a/src/jsc/bindings/webcore/JSMIMEType.cpp
+++ b/src/jsc/bindings/webcore/JSMIMEType.cpp
@@ -426,8 +426,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsMIMETypeProtoGetterEssence, (JSGlobalObject * globalO
         return {};
     }
 
-    // makeString aborts the process when the result does not fit in a string,
-    // and the type and the subtype come from the caller.
+    // makeString aborts the process when the result does not fit in a string.
     const String& type = thisObject->type();
     const String& subtype = thisObject->subtype();
     String essence = tryMakeString(type, '/', subtype);
@@ -473,9 +472,7 @@ JSC_DEFINE_HOST_FUNCTION(jsMIMETypeProtoFuncToString, (JSGlobalObject * globalOb
     String paramsStr = paramsStrValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    // The type, the subtype and the serialized parameters all come from the
-    // caller. A crash-on-overflow builder aborts the process once the result
-    // passes String::MaxLength, so record the overflow and throw below instead.
+    // RecordOverflow: the default policy aborts the process past String::MaxLength.
     StringBuilder builder(WTF::OverflowPolicy::RecordOverflow);
     builder.append(thisObject->type());
     builder.append('/');

--- a/test/js/node/util/mime-api.test.ts
+++ b/test/js/node/util/mime-api.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { bunExe, expectRssDeltaBelow } from "harness";
+import { bunEnv, bunExe, expectRssDeltaBelow, isDebug } from "harness";
+import { totalmem } from "node:os";
 import { MIMEParams, MIMEType } from "util";
 
 describe("MIME API", () => {
@@ -456,4 +457,119 @@ test("MIMEType releases its type and subtype strings when garbage-collected", as
 
   // Unfixed: ~42 MiB (160 x 256 KiB). Fixed: 1 to 4 MiB of allocator slack.
   await expectRssDeltaBelow(["--smol", "-e", code], { release: 20, debug: 25 });
+});
+
+// The two toString implementations build their result with a WTF
+// StringBuilder, and the essence getter with makeString. Both primitives call
+// CRASH() when the result passes String::MaxLength (2 ** 31 - 1 characters)
+// and when the allocation fails, so a large type or parameter made each of
+// them abort the process with no output. Each case below runs in a child,
+// because a child that aborts prints nothing and still lets the parent assert.
+describe("a MIME string that does not fit in a string", () => {
+  const tooLong = "Error ERR_STRING_TOO_LONG: Cannot create a string longer than 2147483647 characters\n";
+  const allocationFailed = "RangeError ERR_MEMORY_ALLOCATION_FAILED: Failed to allocate memory\n";
+
+  async function buildInChild(body: string, env: Record<string, string | undefined> = bunEnv) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { MIMEType, MIMEParams } = require("node:util");
+         try {
+           console.log("string of length " + ((() => { ${body} })()).length);
+         } catch (e) {
+           console.log(e.name + " " + e.code + ": " + e.message);
+         }`,
+      ],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // The child holds 2 GiB of strings. `repeat` builds each one in a single
+  // allocation, which `Buffer.alloc(...).toString()` does not.
+  describe.skipIf(totalmem() < 10 * 1024 ** 3)("a result past String::MaxLength", () => {
+    test(
+      "MIMEType.prototype.toString",
+      async () => {
+        expect(
+          await buildInChild(`
+            const mime = new MIMEType("text/plain");
+            MIMEParams.prototype.toString = () => "a".repeat(2 ** 31 - 1);
+            return String(mime);
+          `),
+        ).toEqual({ stdout: tooLong, stderr: "", exitCode: 0 });
+      },
+      120_000,
+    );
+
+    // A debug build validates a parameter name and a type at about 25 ns per
+    // character, so this case and the next take a minute each there. The case
+    // above covers both builds, and the capped block below covers these two.
+    test.skipIf(isDebug)(
+      "MIMEParams.prototype.toString",
+      async () => {
+        expect(
+          await buildInChild(`
+            const params = new MIMEParams();
+            params.set("a".repeat(2 ** 31 - 1), "x");
+            return String(params);
+          `),
+        ).toEqual({ stdout: tooLong, stderr: "", exitCode: 0 });
+      },
+      120_000,
+    );
+
+    test.skipIf(isDebug)(
+      "MIMEType#essence",
+      async () => {
+        expect(
+          await buildInChild(`
+            const mime = new MIMEType("text/plain");
+            const half = "a".repeat(2 ** 30);
+            mime.type = half;
+            mime.subtype = half;
+            return mime.essence;
+          `),
+        ).toEqual({ stdout: tooLong, stderr: "", exitCode: 0 });
+      },
+      120_000,
+    );
+  });
+
+  // BUN_JSC_maxSingleAllocationSize (debug WTF only) fails every allocation
+  // above the cap. That is the other way each primitive aborts, and it needs
+  // 9 MiB instead of 2 GiB. Node reports a failed string allocation as
+  // ERR_MEMORY_ALLOCATION_FAILED, which is what #41066 settled on.
+  describe.skipIf(!isDebug)("a failed allocation", () => {
+    const capped = { ...bunEnv, BUN_JSC_maxSingleAllocationSize: String(4 * 1024 * 1024) };
+
+    test("MIMEParams.prototype.toString", async () => {
+      expect(
+        await buildInChild(
+          `const params = new MIMEParams();
+           const value = Buffer.alloc(3 * 1024 * 1024, 97).toString("latin1");
+           for (const name of ["a", "b", "c"]) params.set(name, value);
+           return String(params);`,
+          capped,
+        ),
+      ).toEqual({ stdout: allocationFailed, stderr: "", exitCode: 0 });
+    });
+
+    test("MIMEType#essence", async () => {
+      expect(
+        await buildInChild(
+          `const mime = new MIMEType("text/plain");
+           const half = Buffer.alloc(3 * 1024 * 1024, 97).toString("latin1");
+           mime.type = half;
+           mime.subtype = half;
+           return mime.essence;`,
+          capped,
+        ),
+      ).toEqual({ stdout: allocationFailed, stderr: "", exitCode: 0 });
+    });
+  });
 });

--- a/test/js/node/util/mime-api.test.ts
+++ b/test/js/node/util/mime-api.test.ts
@@ -492,19 +492,15 @@ describe("a MIME string that does not fit in a string", () => {
   // The child holds 2 GiB of strings. `repeat` builds each one in a single
   // allocation, which `Buffer.alloc(...).toString()` does not.
   describe.skipIf(totalmem() < 10 * 1024 ** 3)("a result past String::MaxLength", () => {
-    test(
-      "MIMEType.prototype.toString",
-      async () => {
-        expect(
-          await buildInChild(`
+    test("MIMEType.prototype.toString", async () => {
+      expect(
+        await buildInChild(`
             const mime = new MIMEType("text/plain");
             MIMEParams.prototype.toString = () => "a".repeat(2 ** 31 - 1);
             return String(mime);
           `),
-        ).toEqual({ stdout: tooLong, stderr: "", exitCode: 0 });
-      },
-      120_000,
-    );
+      ).toEqual({ stdout: tooLong, stderr: "", exitCode: 0 });
+    }, 120_000);
 
     // A debug build validates a parameter name and a type at about 25 ns per
     // character, so this case and the next take a minute each there. The case

--- a/test/js/node/util/mime-api.test.ts
+++ b/test/js/node/util/mime-api.test.ts
@@ -503,16 +503,32 @@ describe("a MIME string that does not fit in a string", () => {
     }, 120_000);
 
     // A debug build validates a parameter name and a type at about 25 ns per
-    // character, so this case and the next take a minute each there. The case
-    // above covers both builds, and the capped block below covers these two.
+    // character and escapes a value at about 200 ns per character, so the three
+    // cases below take one to four minutes each there. The case above covers
+    // both builds, and the capped block below covers these three.
     test.skipIf(isDebug)(
-      "MIMEParams.prototype.toString",
+      "MIMEParams.prototype.toString with a long parameter name",
       async () => {
         expect(
           await buildInChild(`
             const params = new MIMEParams();
             params.set("a".repeat(2 ** 31 - 1), "x");
             return String(params);
+          `),
+        ).toEqual({ stdout: tooLong, stderr: "", exitCode: 0 });
+      },
+      120_000,
+    );
+
+    // Each quote gets a backslash, so 2 ** 30 of them serialize to 2 ** 31 characters.
+    test.skipIf(isDebug)(
+      "MIMEParams.prototype.toString with a value that escaping doubles",
+      async () => {
+        expect(
+          await buildInChild(`
+            const mime = new MIMEType("text/plain");
+            mime.params.set("a", '"'.repeat(2 ** 30));
+            return String(mime);
           `),
         ).toEqual({ stdout: tooLong, stderr: "", exitCode: 0 });
       },
@@ -549,6 +565,18 @@ describe("a MIME string that does not fit in a string", () => {
           `const params = new MIMEParams();
            const value = Buffer.alloc(3 * 1024 * 1024, 97).toString("latin1");
            for (const name of ["a", "b", "c"]) params.set(name, value);
+           return String(params);`,
+          capped,
+        ),
+      ).toEqual({ stdout: allocationFailed, stderr: "", exitCode: 0 });
+    });
+
+    // 3 MiB of quotes escape to 6 MiB, so the builder fails to grow inside the escape loop.
+    test("MIMEParams.prototype.toString with a value that escaping doubles", async () => {
+      expect(
+        await buildInChild(
+          `const params = new MIMEParams();
+           params.set("a", Buffer.alloc(3 * 1024 * 1024, '"').toString("latin1"));
            return String(params);`,
           capped,
         ),


### PR DESCRIPTION
### Problem

- `String(mime)`, `String(mime.params)` and `mime.essence` abort the process with a silent SIGABRT (exit 134) when the result does not fit in a string. Repro: `const m = new MIMEType("text/plain"); m.params.set("a", '"'.repeat(2 ** 30)); String(m)`.
- Each one uses a primitive that calls `CRASH()` on failure: a default-policy `StringBuilder` (`JSMIMEParams.cpp:518`, `JSMIMEType.cpp:468`) and `makeString` (`JSMIMEType.cpp:429`). The caller controls the length, and escaping a parameter value doubles it.

### Fix

- The builders now use `WTF::OverflowPolicy::RecordOverflow`, and `essence` uses `tryMakeString`, so each failure reaches its caller.
- Each site throws. It tracks the length the result would have had: past `String::MaxLength` that is `ERR_STRING_TOO_LONG`, otherwise the allocation failed and it is `ERR_MEMORY_ALLOCATION_FAILED`, the split #41066 settled.
- Verified: `test/js/node/util/mime-api.test.ts`, 7 new cases. A debug build runs 4 and a release build runs 4, and each fails without the fix. Also `test/js/node/util/`, `test-mime-api.js` and `test-mime-whatwg.js`.

### Background

- `MIMEParams.prototype.toString` writes each parameter as `name=value`. It quotes a value that is not an HTTP token and puts a backslash before each `"` or `\`, so the result can be twice the value's length. `MIMEType.prototype.toString` appends the type, the subtype and that string. `essence` is the type and the subtype.
- `WTF::StringBuilder` calls `didOverflow()` when the length passes `String::MaxLength` (2147483647) and when its allocation fails. The default policy makes that a `CRASH()`. `RecordOverflow` makes it a flag that `hasOverflowed()` reports.
- `makeString` aborts on the same two failures, and `tryMakeString` returns a null string. Neither report says which failure it was, so each site counts the length it meant to write.

<details><summary>Notes</summary>

Boundary, measured on this branch and on main: `m.params.set("a", '"'.repeat(2 ** 30 - 16)); String(m)` returns a 2147483631-character string on both. One more quote aborts main and throws `ERR_STRING_TOO_LONG` here. The abort tracks the built length crossing 2147483647, not the memory available: peak RSS is the same on both sides of the boundary.

The seven test cases. Four reach `String::MaxLength` with 2 GiB of strings, gated on the machine having 10 GiB of RAM. Times are from a release build of this branch:

- `MIMEType.prototype.toString` (1.3 s). It replaces `MIMEParams.prototype.toString` (a writable prototype method) with one that returns a 2147483647-character string. That reaches the `JSMIMEType.cpp` builder without the escape loop, so it is the one case of the four that also runs in a debug build (2 s).
- `MIMEParams.prototype.toString`, with a 2147483647-character parameter name (4.7 s). The name is appended first, so the `=` after it overflows the builder.
- `MIMEParams.prototype.toString`, with the repro above: a value of 2 ** 30 quotes that escaping doubles (6.2 s). This is the case that checks the count the escape loop returns. A count that left the backslashes out would stay under the limit and report a failed allocation.
- `mime.essence`, with a type and a subtype of 2 ** 30 characters each (4.6 s).

A debug build validates a parameter name and a type at about 25 ns per character and escapes a value at about 200 ns per character, so the last three take one to four minutes each there and are skipped in a debug build. I ran them against the debug build by hand: each reports `ERR_STRING_TOO_LONG` (the repro above after 270 s). All four abort on release 1.4.2, with exit code 134.

The other three run only in a debug build. They use `BUN_JSC_maxSingleAllocationSize` (debug WTF only) to fail the allocation instead: 9 MiB of token parameters, one value of 3 MiB of quotes, and a 6 MiB essence. The value of quotes makes the builder fail inside the escape loop, which is the stack of the report (`didOverflow`, `reallocateBuffer`, `escapeQuoteOrBackslash`, `encodeParamValue`, `jsMIMEParamsProtoFuncToString`) in about a second. Each reports `ERR_MEMORY_ALLOCATION_FAILED` and aborts without the fix.

`test/js/node/util/` on a release build of this branch: 598 pass, 0 fail. On the debug build the one failure is `parseArgs extra tests > stress test`, which needs 12 s there and has a 5 s timeout.

Not changed: `removeBackslashes` in both files builds a string whose output is never longer than its input, so it cannot pass `String::MaxLength`. Only its allocation can fail, as it can for most default `StringBuilder`s in the codebase. `escapeQuoteOrBackslash`, `encodeParamValue` and `removeBackslashes` in `JSMIMEType.cpp` have no callers (#40492 removes dead code in that file).

`StringBuilder` after an overflow: `extendBufferForAppendingSlowCase` returns early when `hasOverflowed()`, and so does `append(std::span<...>)`, so every append that follows the overflow is a no-op and one check after the loop is enough. The check has to come before `builder.toString()`, because `reifyString()` asserts that the builder has not overflowed.

Same abort class, elsewhere: #37215 landed this shape for `Buffer.prototype.toString`, and #42191 (URLPattern) and #42202 (error messages) are open for it.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/util/mime-api.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class instance integrity [19.22ms]
(pass) MIME API > basic properties and string conversion [10.71ms]
(pass) MIME API > type property manipulation [19.28ms]
(pass) MIME API > subtype property manipulation [19.51ms]
(pass) MIME API > parameters manipulation [21.24ms]
(pass) MIME API > invalid parameter names [13.54ms]
(pass) MIME API > invalid parameter values [7.03ms]
(pass) Exact match with node [513.22ms]
(pass) ERR_INVALID_MIME_SYNTAX message matches Node.js [6.88ms]
(pass) MIMEType releases its type and subtype strings when garbage-collected [2672.26ms]
497 |         await buildInChild(`
498 |             const mime = new MIMEType("text/plain");
499 |             MIMEParams.prototype.toString = () => "a".repeat(2 ** 31 - 1);
500 |             return String(mime);
501 |           `),
502 |       ).toEqual({ stdout: tooLong, stderr: "", exitCode: 0 });
              ^
error: expect(received).toEqual(expected)

  {
-   
... (truncated)

release without fix: 3 skipped
bun test v1.4.3-canary.1 (0eae3c999)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class instance integrity [0.08ms]
(pass) MIME API > basic properties and string conversion [0.13ms]
(pass) MIME API > type property manipulation [0.25ms]
(pass) MIME API > subtype property manipulation [0.18ms]
(pass) MIME API > parameters manipulation [0.22ms]
(pass) MIME API > invalid parameter names [0.11ms]
(pass) MIME API > invalid parameter values [0.06ms]
(pass) Exact match with node [10.38ms]
(pass) ERR_INVALID_MIME_SYNTAX message matches Node.js [0.12ms]
(pass) MIMEType releases its type and subtype strings when garbage-collected [110.44ms]
(pass) a MIME string that does not fit in a string > a result past String::MaxLength > MIMEType.prototype.toString [1276.11ms]
(pass) a MIME string that does not fit in a string > a result past String::MaxLength > MIMEParams.prototype.toString with a long parameter name [4686.61ms]
(pass) a MIME string that does not fit in a string > a result past String::MaxLength > MIMEParams.prototype.toString with a value that escaping doubles [6155.05ms]
(pass) a MIME string that does not fit in a string > a result past String::MaxLength > MI
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/util/mime-api.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/util/mime-api.test.ts:
(pass) MIME API > class instance integrity [22.87ms]
(pass) MIME API > basic properties and string conversion [10.21ms]
(pass) MIME API > type property manipulation [20.54ms]
(pass) MIME API > subtype property manipulation [24.84ms]
(pass) MIME API > parameters manipulation [21.32ms]
(pass) MIME API > invalid parameter names [14.00ms]
(pass) MIME API > invalid parameter values [7.52ms]
(pass) Exact match with node [684.75ms]
(pass) ERR_INVALID_MIME_SYNTAX message matches Node.js [11.28ms]
(pass) MIMEType releases its type and subtype strings when garbage-collected [2709.22ms]
(pass) a MIME string that does not fit in a string > a result past String::MaxLength > MIMEType.prototype.toString [1738.17ms]
(skip) a MIME string that does not fit in a string > a result past String::MaxLength > MIMEParams.prototype.toString with a long parameter name
(skip) a MIME string that does not fit in a string > a result past String::MaxLength > MIMEParams.
... (truncated)

release with fix: 3 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 644ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/33] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/33] gen cpp.rs (cppbind)
[3/33] gen JS modules (bundle-modules)
Preprocess modules (8954ms)
Bundle modules (42ms)
Postprocesss modules (173ms)
Bundle Functions (496ms)
Generate Code (30ms)

[9.70s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/24] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSMIMEParams.cpp |  42 +++++++--
 src/jsc/bindings/webcore/JSMIMEParams.h   |   3 +
 src/jsc/bindings/webcore/JSMIMEType.cpp   |  18 +++-
 test/js/node/util/mime-api.test.ts        | 142 +++++++++++++++++++++++++++++-
 4 files changed, 193 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/bindings/webcore/JSMIMEParams.cpp      4     12     21
src/jsc/bindings/webcore/JSMIMEParams.h        2      4     21
src/jsc/bindings/webcore/JSMIMEType.cpp        4      7     21
test/js/node/util/mime-api.test.ts             3      5     21
```

</details>

<!-- robobun:evidence:end -->
