### PR TITLE
react-compiler: lower every identifier JSX tag as a component reference

### DIFF
--- a/src/react_compiler/lowering/build_hir/jsx.rs
+++ b/src/react_compiler/lowering/build_hir/jsx.rs
@@ -27,8 +27,7 @@ fn estring_to_store_str(s: &E::EString) -> StoreStr {
 fn lower_jsx_element_name(builder: &mut HirBuilder, tag: &Expr) -> Result<JsxTag, CompilerError> {
     let loc = convert_loc(tag.loc);
     match tag.data {
-        // Bun's parser already lowers host tags (`a..=z` first byte) to `EString`, so any
-        // identifier that reaches here is a component reference (`<Foo />`, `<_Foo />`, `<$Foo />`).
+        // The parser already lowered host tags (`a..=z` first byte) to `EString`.
         ExprData::EIdentifier(id) => {
             let temp = lower_tag_identifier(builder, id.ref_, loc, loc)?;
             Ok(JsxTag::Place(temp))

--- a/src/react_compiler/lowering/build_hir/jsx.rs
+++ b/src/react_compiler/lowering/build_hir/jsx.rs
@@ -27,32 +27,15 @@ fn estring_to_store_str(s: &E::EString) -> StoreStr {
 fn lower_jsx_element_name(builder: &mut HirBuilder, tag: &Expr) -> Result<JsxTag, CompilerError> {
     let loc = convert_loc(tag.loc);
     match tag.data {
+        // Bun's parser already lowers host tags (`a..=z` first byte) to `EString`, so any
+        // identifier that reaches here is a component reference (`<Foo />`, `<_Foo />`, `<$Foo />`).
         ExprData::EIdentifier(id) => {
-            // Upstream (build_hir.rs:6252) gates on `is_ascii_uppercase` of the first char,
-            // but Bun's parser only emits EString for `a..=z` — so `_foo` / `$Bar` arrive here
-            // as identifiers. Replicate upstream's Builtin classification for non-uppercase.
-            let name = builder.host().ref_name(id.ref_);
-            if name.first().is_some_and(u8::is_ascii_uppercase) {
-                let temp = lower_tag_identifier(builder, id.ref_, loc, loc)?;
-                Ok(JsxTag::Place(temp))
-            } else {
-                Ok(JsxTag::Builtin(BuiltinTag {
-                    name: StoreStr::new(name),
-                    loc,
-                }))
-            }
+            let temp = lower_tag_identifier(builder, id.ref_, loc, loc)?;
+            Ok(JsxTag::Place(temp))
         }
         ExprData::EImportIdentifier(id) => {
-            let name = builder.host().ref_name(id.ref_);
-            if name.first().is_some_and(u8::is_ascii_uppercase) {
-                let temp = lower_tag_identifier(builder, id.ref_, loc, loc)?;
-                Ok(JsxTag::Place(temp))
-            } else {
-                Ok(JsxTag::Builtin(BuiltinTag {
-                    name: StoreStr::new(name),
-                    loc,
-                }))
-            }
+            let temp = lower_tag_identifier(builder, id.ref_, loc, loc)?;
+            Ok(JsxTag::Place(temp))
         }
         ExprData::EString(s) => {
             let name = estring_to_store_str(&s);

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -89,6 +89,46 @@ describe("bundler", () => {
     },
   });
 
+  // https://github.com/oven-sh/bun/issues/42224
+  itBundled("react-compiler/UnderscoreAndDollarComponentTags", {
+    files: {
+      "/entry.tsx": /* tsx */ `
+        import { _Imported } from "./components";
+        const Plain = () => <span>a</span>;
+        const _Underscore = () => <span>b</span>;
+        const $Dollar = () => <span>c</span>;
+
+        export const App = () => (
+          <p>
+            <Plain />
+            <_Underscore />
+            <$Dollar />
+            <_Imported />
+          </p>
+        );
+      `,
+      "/components.tsx": /* tsx */ `
+        export const _Imported = () => <span>d</span>;
+      `,
+    },
+    reactCompiler: true,
+    backend: "cli",
+    external: ["react", "react/compiler-runtime", "react/jsx-runtime", "react/jsx-dev-runtime"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain("react/compiler-runtime");
+      // Only a tag that starts with a lowercase letter is a host element. An
+      // identifier that starts with `_` or `$` is a component reference.
+      expect(out).toMatch(/jsx\w*\(Plain,/);
+      expect(out).toMatch(/jsx\w*\(_Underscore,/);
+      expect(out).toMatch(/jsx\w*\(\$Dollar,/);
+      expect(out).toMatch(/jsx\w*\(_Imported,/);
+      expect(out).not.toContain('"_Underscore"');
+      expect(out).not.toContain('"$Dollar"');
+      expect(out).not.toContain('"_Imported"');
+    },
+  });
+
   itBundled("react-compiler/OutputModeDefaultsByTarget-Browser", {
     files: {
       "/entry.jsx": /* jsx */ `


### PR DESCRIPTION
### Problem
- With `--react-compiler` (or `Bun.build({ reactCompiler: true })`), `<_Underscore />` and `<$Dollar />` compile to `jsx("_Underscore", {})` and `jsx("$Dollar", {})`. React renders an unknown custom element and the component never mounts. Lingui's `<Trans>` macro emits a `_Trans` binding, so every translated string disappears in production builds.
- The cause is `lower_jsx_element_name` in `src/react_compiler/lowering/build_hir/jsx.rs:30`. It only kept an identifier tag as a component when its first byte was ASCII uppercase. Any other identifier became `JsxTag::Builtin`, which codegen prints as a string.

### Fix
- Lower every `EIdentifier` and `EImportIdentifier` tag through `lower_tag_identifier` and return `JsxTag::Place`. The `EString` arm still handles host tags.
- This is correct because Bun's parser already applies the JSX rule before the compiler runs: a tag whose first byte is `a..z` becomes `E::String` (`src/js_parser/parser.rs:777`). Any identifier that reaches the compiler is a component reference. Upstream `lowerJsxElementName` uses the same rule (`!tag.match(/^[a-z]/)`).
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (new `UnderscoreAndDollarComponentTags` case, fails on stock bun). All 41 cases in the file pass with the debug build.

### Background
- The React Compiler in Bun runs after the parser's visit pass. By then each JSX element is an `E::Call` with `was_jsx_element: true`, and the tag is either an `E::String` (host element) or an identifier or member expression (component).
- `JsxTag::Builtin` is the HIR form for a host element like `div`. Codegen prints it as a string literal. `JsxTag::Place` is a reference to a temporary that holds the component value.

Fixes #42224

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (5f554969b)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [600.47ms]
(pass) bundler > react-compiler/ComponentWithHooks [324.53ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [224.53ms]
118 |       const out = api.readFile("/out.js");
119 |       expect(out).toContain("react/compiler-runtime");
120 |       // Only a tag that starts with a lowercase letter is a host element. An
121 |       // identifier that starts with `_` or `$` is a component reference.
122 |       expect(out).toMatch(/jsx\w*\(Plain,/);
123 |       expect(out).toMatch(/jsx\w*\(_Underscore,/);
                        ^
error: expect(received).toMatch(expected)

Expected substring or pattern: /jsx\w*\(_Underscore,/
Received: "var __MEMO_CACHE_SENTINEL = /* @__PURE__ */ Symbol.for(\"react.memo_cache_sentinel\");\n\n// components.tsx\nimport { jsxDEV } from \"react/jsx-dev-runtime\";\nvar _Imported = () => /* @__PURE__ */ jsxDEV(\"span\", {\n  chi
... (truncated)

release without fix: 1 skipped
bun test v1.4.3-canary.1 (a32b1a9ee)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [15.08ms]
(pass) bundler > react-compiler/ComponentWithHooks [5.44ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [4.93ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [5.00ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [4.45ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [3.29ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [7.15ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [3.00ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [2.74ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [2.73ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [6.52ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [9.03ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [6.25ms]
(pass) bundler > react-compiler/BranchBooleanFeatureFlagPreservesDCE [5.94ms]
(pass) bundler > react-compiler/ForwardR
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (5f554969b)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [599.07ms]
(pass) bundler > react-compiler/ComponentWithHooks [373.26ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [251.36ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [235.78ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [134.97ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [94.99ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [339.31ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [109.83ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [131.59ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [103.10ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [254.17ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [389.76ms]
(p
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 618ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/react_compiler/lowering/build_hir/jsx.rs   | 28 ++++--------------
 test/bundler/transpiler/react-compiler.test.ts | 40 ++++++++++++++++++++++++++
 2 files changed, 45 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/react_compiler/lowering/build_hir/jsx.rs        2      3      6
test/bundler/transpiler/react-compiler.test.ts      2      3      6
```

</details>

**root cause** · written by the author bot

The React Compiler's JSX lowering applied an uppercase-first-letter check to `EIdentifier` and `EImportIdentifier` tags, so any component name beginning with `_` or `$` failed the check and was emitted as a string literal, which React then treated as an unknown host element. Bun's parser already lowers true host tags (those starting with a lowercase letter) to `EString` before this stage, so any identifier reaching the lowering is by construction a component reference. The fix removes the redundant uppercase check and lowers both identifier kinds through `lower_tag_identifier`, with a regre…

<!-- robobun:evidence:end -->