### PR TITLE
HTMLRewriter: make element.onEndTag() on nested elements linear

### DIFF
--- a/scripts/build/deps/lolhtml.ts
+++ b/scripts/build/deps/lolhtml.ts
@@ -26,7 +26,7 @@ import type { Dependency } from "../source.ts";
 // base commit is recorded here so a rebase onto a new upstream tag is
 // `git rebase --onto <new-tag> <LOLHTML_UPSTREAM_BASE> bun` in the fork.
 const LOLHTML_UPSTREAM_BASE = "77127cd2b8545998756e8d64e36ee2313c4bb312"; // v2.7.2
-const LOLHTML_COMMIT = "725ce499aa9b71e38b7a2d0a9fbb6d7294a4079e";
+const LOLHTML_COMMIT = "77a97289c845d4d71824c10a865dedc02b9f50eb";
 void LOLHTML_UPSTREAM_BASE;
 
 export const lolhtml: Dependency = {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -3345,7 +3345,7 @@ describe("end tag handler dispatch", () => {
   // scan and takes well under a second without it. A debug build spends
   // ~0.2 ms of JS per element, so it gets a size that only keeps it short.
   it("stays linear when every nested element registers onEndTag", async () => {
-    const n = isDebug ? 40_000 : 400_000;
+    const n = isDebug ? 10_000 : 400_000;
     const fixture = /* js */ `
       const n = ${n};
       const doc = Buffer.alloc(n * 3, "<a>").toString() + "x" + Buffer.alloc(n * 4, "</a>").toString();
@@ -3363,11 +3363,16 @@ describe("end tag handler dispatch", () => {
       killSignal: "SIGKILL",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), stderr, exitCode, signal: proc.signalCode }).toEqual({
+    expect({
+      stdout: stdout.trim(),
+      stderr: /error|panic|assert|abort/i.test(stderr) ? stderr : "",
+      exitCode,
+      signal: proc.signalCode,
+    }).toEqual({
       stdout: JSON.stringify({ ends: n, same: true }),
       stderr: "",
       exitCode: 0,
       signal: null,
     });
-  }, 60_000);
+  });
 });

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -3314,3 +3314,60 @@ describe("GC pressure mid-rewrite", () => {
     });
   });
 });
+
+describe("end tag handler dispatch", () => {
+  const annotate = () =>
+    new HTMLRewriter().on("*", {
+      element(el) {
+        const id = el.getAttribute("id");
+        el.onEndTag(end => {
+          end.before(`<!--${id}:${end.name}-->`, { html: true });
+        });
+      },
+    });
+
+  it("runs nested handlers innermost first, including when one end tag closes several elements", () => {
+    expect([
+      annotate().transform('<a id="0"><a id="1"><a id="2">x</a></a></a>'),
+      // </div> pops <b>, <span> and <div> at once: all three handlers run on it.
+      annotate().transform('<div id="0"><span id="1"><b id="2">x</div><p id="3">y</p>'),
+    ]).toEqual([
+      '<a id="0"><a id="1"><a id="2">x<!--2:a--></a><!--1:a--></a><!--0:a--></a>',
+      '<div id="0"><span id="1"><b id="2">x<!--2:div--><!--1:div--><!--0:div--></div><p id="3">y<!--3:p--></p>',
+    ]);
+  });
+
+  // Every open element that called onEndTag() keeps a pending handler, and
+  // each end tag used to scan all of them: n nested elements cost n^2/2
+  // visits (n = 100k, a 700 KB document, took 5.3 s in a release build).
+  // The scan now stops once the handlers that end tag activated have run.
+  // The release size cannot finish inside the spawn timeout with the old
+  // scan and takes well under a second without it. A debug build spends
+  // ~0.2 ms of JS per element, so it gets a size that only keeps it short.
+  it("stays linear when every nested element registers onEndTag", async () => {
+    const n = isDebug ? 40_000 : 400_000;
+    const fixture = /* js */ `
+      const n = ${n};
+      const doc = Buffer.alloc(n * 3, "<a>").toString() + "x" + Buffer.alloc(n * 4, "</a>").toString();
+      let ends = 0;
+      const onEnd = () => { ends++; };
+      const out = new HTMLRewriter().on("a", { element(el) { el.onEndTag(onEnd); } }).transform(doc);
+      console.log(JSON.stringify({ ends, same: out === doc }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, signal: proc.signalCode }).toEqual({
+      stdout: JSON.stringify({ ends: n, same: true }),
+      stderr: "",
+      exitCode: 0,
+      signal: null,
+    });
+  }, 60_000);
+});


### PR DESCRIPTION
### Problem
- `element.onEndTag()` on n nested elements is quadratic. n nested `<a>` that each call `e.onEndTag(() => {})` take 2.4 s at n = 65536 and 5.3 s at 100000 (700 KB) on 1.4.3. Without `onEndTag`: 91 ms.
- The cause is `HandlerVec::do_for_each_active_and_remove` (`vendor/lolhtml/src/rewriter/handlers_dispatcher.rs:155`). Each captured end tag walks every registered end-tag handler, and every still-open element that called `onEndTag` has one: n^2/2 visits.

### Fix
- oven-sh/lol-html#5 stops the walk once no active handler is left. It is @sosukesuzuki's commit from oven-sh/lol-html#3, cherry-picked alone so that it does not wait for #41527.
- Correct because handlers are pushed in open-element-stack order and an end tag pops a suffix of that stack. So the handlers it activates are the last ones pushed. Skipped items were never called: output does not change.
- This PR pins `LOLHTML_COMMIT` to 77a9728, on top of the fork `bun` head ea6125b. So it also carries the selector-VM change that #41479 pins.
- Verified: `test/js/workerd/html-rewriter.test.js`, two new cases. 1.4.3 is killed at the 30 s spawn timeout on the 400k one. The fix takes 0.42 s. All HTMLRewriter test files pass.

### Background
- `HTMLRewriter` is the vendored oven-sh/lol-html fork, fetched by commit. A fix there lands in bun by moving the pin.
- lol-html keeps one `HandlerVec` per handler kind. An item is active while `user_count > 0`. `onEndTag` pushes an inactive item.
- An end tag pops elements off the open-element stack and activates their items. The dispatcher then runs and removes them.

<details><summary>Notes</summary>

- Repro: `"<a>".repeat(n) + "</a>".repeat(n)` through `new HTMLRewriter().on("a", { element(e) { e.onEndTag(() => {}); } }).transform(doc)`.
- Release timings, before / after: 8192: 53 / 9 ms, 16384: 190 / 15 ms, 32768: 690 / 30 ms, 65536: 2416 / 72 ms, 100000: 5304 / 91 ms, 131072: n/a / 115 ms, 400000: killed at 30 s / 424 ms. Flat siblings (`"<a></a>".repeat(n)`) were already linear: 131 ms at 100000.
- Debug ASAN build, same document: 8192: 2245 / 1231 ms, 16384: 6102 / 2419 ms, 32768: 19037 / 4883 ms. About 0.2 ms per element is JS call overhead in a debug build, so the test uses n = 10000 there (2.0 s, inside the default 5 s per-test timeout) and 400000 elsewhere. Peak RSS of the 400k run is 271 MB in release.
- A handler that suspends (returns a Promise) is removed before it runs, so `resume` still finds the remaining active items at the tail. The fork's `cargo test` passes (172 lib + 34 other). All 9 HTMLRewriter test files in bun pass on debug and release builds (217 tests).
- Upstream cloudflare/lol-html master replaced this function with `do_for_each_active_and_remove_tail` (05ff4b0, "Drain end handlers"). It finds the first active item with a front `position()` scan, so it is still O(open handlers) per end tag for this shape, and its `drain` drops the remaining handlers when one returns early, which does not fit the fork's suspend and resume. The fork keeps the reverse walk and adds the early stop.
- The gate strips `src/` and `packages/` for its fail-before run. This fix lives in the pin and the vendored crate, so that run already has the fix. The released binary is the fail-before proof: `USE_SYSTEM_BUN=1 bun test test/js/workerd/html-rewriter.test.js -t "stays linear"` is killed at 30 s with exit code 137.
- Other open lol-html pins (#41479 at ea6125b, #41475 at 4340f76, #41968 at 5816ca4) each sit on ea6125b. Whichever merges later moves the pin to a commit that contains both, after its fork PR merges into `bun`.
- Found by a fuzz harness by construction. There is no user report.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/workerd/html-rewriter.test.js

<!-- robobun:evidence:end -->