### PR TITLE
Bun.Cookie: throw instead of aborting when the Set-Cookie string passes the string length limit

### DIFF
--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -166,11 +166,13 @@ bool Cookie::isExpired() const
     return currentTime > m_expires;
 }
 
-String Cookie::toString(JSC::VM& vm) const
+ExceptionOr<String> Cookie::toString(JSC::VM& vm) const
 {
-    StringBuilder builder;
+    StringBuilder builder(OverflowPolicy::RecordOverflow);
     appendTo(vm, builder);
-    return builder.toString();
+    if (builder.hasOverflowed()) [[unlikely]]
+        return Exception { OutOfMemoryError };
+    return String { builder.toString() };
 }
 
 static inline bool isValidCharacterInCookieName(char16_t c)

--- a/src/jsc/bindings/Cookie.h
+++ b/src/jsc/bindings/Cookie.h
@@ -105,8 +105,8 @@ public:
 
     bool isExpired() const;
 
-    void appendTo(JSC::VM& vm, StringBuilder& builder) const;
-    String toString(JSC::VM& vm) const;
+    // OutOfMemoryError when the Set-Cookie string would be longer than String::MaxLength.
+    ExceptionOr<String> toString(JSC::VM& vm) const;
     JSC::JSValue toJSON(JSC::VM& vm, JSC::JSGlobalObject*) const;
     size_t memoryCost() const;
 
@@ -119,6 +119,9 @@ private:
         const String& domain, const String& path,
         int64_t expires, bool secure, CookieSameSite sameSite,
         bool httpOnly, double maxAge, bool partitioned);
+
+    // The builder must use OverflowPolicy::RecordOverflow; the caller checks hasOverflowed().
+    void appendTo(JSC::VM& vm, StringBuilder& builder) const;
 
     String m_name;
     String m_value;

--- a/src/jsc/bindings/CookieMap.cpp
+++ b/src/jsc/bindings/CookieMap.cpp
@@ -1,5 +1,6 @@
 #include "CookieMap.h"
 #include "JSCookieMap.h"
+#include "JSDOMExceptionHandling.h"
 #include <bun-uws/src/App.h>
 #include <bun-uws/src/Http3Response.h>
 #include <bun-uws/src/Http2Context.h>
@@ -15,9 +16,17 @@ namespace WebCore {
 template<typename Res>
 static void CookieMap__writeFetchHeadersToUWSResponse(CookieMap* cookie_map, JSC::JSGlobalObject* global_this, Res* res)
 {
+    auto& vm = global_this->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
     // Loop over modified cookies and write Set-Cookie headers to the response
     for (auto& cookie : cookie_map->getAllChanges()) {
-        auto utf8 = cookie->toString(global_this->vm()).utf8();
+        auto header = cookie->toString(vm);
+        if (header.hasException()) [[unlikely]] {
+            propagateException(*global_this, scope, header.releaseException());
+            return;
+        }
+        auto utf8 = header.returnValue().utf8();
         res->writeHeader("Set-Cookie", utf8.data());
     }
 }

--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -336,7 +336,9 @@ static inline JSC::EncodedJSValue jsCookieMapPrototypeFunction_toSetCookieHeader
     RETURN_IF_EXCEPTION(throwScope, {});
     size_t i = 0;
     for (auto& item : cookies) {
-        resultArray->putDirectIndex(lexicalGlobalObject, i, jsString(vm, item->toString(vm)));
+        auto header = toJS<IDLDOMString>(*lexicalGlobalObject, throwScope, item->toString(vm));
+        RETURN_IF_EXCEPTION(throwScope, {});
+        resultArray->putDirectIndex(lexicalGlobalObject, i, header);
         RETURN_IF_EXCEPTION(throwScope, {});
         i += 1;
     }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3805,13 +3805,19 @@ where
         }
 
         if let Some(mut cookies) = self.cookies.replace(None) {
-            let global_this = self.server().global_this();
+            let server = self.server();
+            let global_this = server.global_this();
             let resp = self.resp.get().expect("infallible: resp bound");
-            let r = cookies.write(global_this, uws::ResponseKind::of(resp), resp.as_ptr());
+            // The status line is already written, so a cookie that cannot be
+            // serialized (longer than the maximum string length) is reported
+            // and the response goes out without its Set-Cookie header.
+            if let Err(err) = cookies.write(global_this, uws::ResponseKind::of(resp), resp.as_ptr()) {
+                server
+                    .vm()
+                    .as_mut()
+                    .run_error_handler(global_this.take_exception(err), None);
+            }
             // `cookies` drops here, releasing the ref taken in `set_cookies`.
-            if r.is_err() {
-                return;
-            } // TODO: properly propagate exception upwards
         }
         let blob = self.blob.get();
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3811,7 +3811,8 @@ where
             // The status line is already written, so a cookie that cannot be
             // serialized (longer than the maximum string length) is reported
             // and the response goes out without its Set-Cookie header.
-            if let Err(err) = cookies.write(global_this, uws::ResponseKind::of(resp), resp.as_ptr()) {
+            if let Err(err) = cookies.write(global_this, uws::ResponseKind::of(resp), resp.as_ptr())
+            {
                 server
                     .vm()
                     .as_mut()

--- a/test/js/bun/cookie/cookie-string-limit.test.ts
+++ b/test/js/bun/cookie/cookie-string-limit.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { totalmem } from "node:os";
+
+// A Set-Cookie string is built in a WTF::StringBuilder, whose limit is 2^31-1
+// characters. Serializing a cookie past that limit must throw a catchable error
+// instead of aborting the process. The name below leaves 29 characters of room
+// and the ten quotes in the value percent-encode to 30, so the append that
+// passes the limit is the one inside the value encoder. The child needs ~4.3 GB
+// (a 2 GB name plus a 2 GB builder), and validating the name takes about a
+// minute in debug builds, so both entry points share one child and one cookie.
+describe.skipIf(totalmem() < 10 * 1024 ** 3)("serializing a cookie past the maximum string length", () => {
+  test("Bun.Cookie#toString() and Bun.CookieMap#toSetCookieHeaders() throw instead of aborting", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const cookie = new Bun.Cookie("a".repeat(2 ** 31 - 30), '"'.repeat(10));
+          try {
+            const header = cookie.toString();
+            console.log("toString resolved", header.length);
+          } catch (e) {
+            console.log("toString threw", e.name, e.message);
+          }
+
+          const map = new Bun.CookieMap();
+          map.set(cookie);
+          try {
+            const headers = map.toSetCookieHeaders();
+            console.log("toSetCookieHeaders resolved", headers.length);
+          } catch (e) {
+            console.log("toSetCookieHeaders threw", e.name, e.message);
+          }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "toString threw RangeError Out of memory\ntoSetCookieHeaders threw RangeError Out of memory\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  }, 180_000);
+});

--- a/test/js/bun/cookie/cookie-string-limit.test.ts
+++ b/test/js/bun/cookie/cookie-string-limit.test.ts
@@ -8,9 +8,9 @@ import { totalmem } from "node:os";
 // and the ten quotes in the value percent-encode to 30, so the append that
 // passes the limit is the one inside the value encoder. The child needs ~4.3 GB
 // (a 2 GB name plus a 2 GB builder), and validating the name takes about a
-// minute in debug builds, so both entry points share one child and one cookie.
+// minute in debug builds, so every entry point shares one child and one cookie.
 describe.skipIf(totalmem() < 10 * 1024 ** 3)("serializing a cookie past the maximum string length", () => {
-  test("Bun.Cookie#toString() and Bun.CookieMap#toSetCookieHeaders() throw instead of aborting", async () => {
+  test("throws from toString() and toSetCookieHeaders(), and Bun.serve reports it and still responds", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -32,6 +32,22 @@ describe.skipIf(totalmem() < 10 * 1024 ** 3)("serializing a cookie past the maxi
           } catch (e) {
             console.log("toSetCookieHeaders threw", e.name, e.message);
           }
+
+          // The status line is written before the cookies, so the server cannot
+          // turn this into an error response: it prints the error and sends the
+          // response without the Set-Cookie header.
+          using server = Bun.serve({
+            port: 0,
+            development: false,
+            routes: {
+              "/": req => {
+                req.cookies.set(cookie);
+                return new Response("hello");
+              },
+            },
+          });
+          const res = await fetch(server.url);
+          console.log("serve", res.status, res.headers.get("set-cookie"), res.headers.get("content-type"), await res.text());
         `,
       ],
       env: bunEnv,
@@ -39,10 +55,12 @@ describe.skipIf(totalmem() < 10 * 1024 ** 3)("serializing a cookie past the maxi
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: "toString threw RangeError Out of memory\ntoSetCookieHeaders threw RangeError Out of memory\n",
-      stderr: "",
-      exitCode: 0,
-    });
+    expect(stdout).toBe(
+      "toString threw RangeError Out of memory\n" +
+        "toSetCookieHeaders threw RangeError Out of memory\n" +
+        "serve 200 null text/plain;charset=utf-8 hello\n",
+    );
+    expect(stderr).toContain("RangeError: Out of memory");
+    expect(exitCode).toBe(0);
   }, 180_000);
 });


### PR DESCRIPTION
### Problem
- `Bun.Cookie#toString()`, `Bun.CookieMap#toSetCookieHeaders()` and the `Bun.serve` Set-Cookie writer abort the process (`panic(main thread): abort() called`, exit 134) when the serialized cookie is longer than `String::MaxLength` (2^31-1). Top frames: `StringBuilder::didOverflow` <- `JSC::encode` <- `Cookie::appendTo`. Found by inspection during #42218, no user report.
- `Cookie::toString` (`src/jsc/bindings/Cookie.cpp:169`) builds into a default `WTF::StringBuilder`, which uses `OverflowPolicy::CrashOnOverflow`. A value of 2^30 `"` characters gets there because each one percent-encodes to `%22`.

### Fix
- `Cookie::toString` builds with `OverflowPolicy::RecordOverflow` and returns `ExceptionOr<String>`: `OutOfMemoryError` on overflow. JS sees `RangeError: Out of memory`, the error JSC throws for `"x".repeat(2**31)`.
- The three callers report it: `JSCookie` `toString`, `JSCookieMap` `toSetCookieHeaders`, and `CookieMap__write`. `Bun.serve` writes the status line before the cookies, so `render_metadata` prints the error, like other errors after the status line, and finishes the headers instead of returning early with the exception pending.
- Out of scope: the `Set-Cookie` join in `HTTPHeaderMap::get` (`HTTPHeaderMap.cpp:224`) has the same builder. #42218 changes it. #42191 and #42202 fix the same mechanism elsewhere.
- Verified: `test/js/bun/cookie/cookie-string-limit.test.ts` aborts on stock bun and passes with the fix. `test/js/bun/cookie/` and `bun-serve-cookies.test.ts` pass. Self-reviewed: 3 concerns raised, 3 addressed.

### Background
- `WTF::StringBuilder` takes an `OverflowPolicy`. The default, `CrashOnOverflow`, calls `CRASH()` when the length would pass `String::MaxLength`. `RecordOverflow` marks the builder as overflowed instead. Later appends do nothing, and the owner must check `hasOverflowed()` before `toString()`.
- `ExceptionOr<T>` is the WebCore return type for an operation that can fail. `propagateException` turns it into a pending JS exception. `ExceptionCode::OutOfMemoryError` maps to `createOutOfMemoryError`.

<details><summary>Notes</summary>

- Repro on 1.4.2, 1.4.3 and main: `bun -e 'new Bun.Cookie("a", String.fromCharCode(34).repeat(2**30)).toString()'`. It needs about 4.3 GB of RSS. Reach is small: the application itself has to hand a string of about 2^31 characters to `Bun.Cookie`. Inbound request headers are capped far below that.
- The test uses a name of 2^31-30 characters and a value of ten quotes instead of a value of 2^30 quotes. The name is appended in one copy. The value encoder appends character by character, which takes more than ten minutes for 2^30 quotes in a debug build. The append that overflows is still the one inside `encodeURIComponent`.
- The test is guarded with `totalmem() < 10 GiB`, like `source-too-large.test.ts` and `fs-oom.test.ts` (#37215 and #39564 use the same shape). It lives in its own file so the other cookie suites stay fast in debug builds, where validating the 2 GB name alone takes about a minute. One child covers all three entry points so that cost is paid once. Release build: about 8 s.
- `Bun.serve` before this PR: abort. With only the C++ change, the old `if r.is_err() { return; } // TODO` branch in `render_metadata` became reachable. It skipped `Content-Type` and `Content-Length` and left the exception pending on the VM, which was later reported as uncaught with exit code 1. Now `RangeError: Out of memory` is printed through `VirtualMachine::run_error_handler` (the path `RequestContext` already uses when a body stream fails after the status line), the response is `200` with its other headers and no `Set-Cookie`, and the exit code is 0. `server.upgrade()` already propagated the error with `?`.
- `StringBuilder::toString()` on an overflowed `RecordOverflow` builder does not return a null string in this WebKit revision: `reifyString()` has `RELEASE_ASSERT(!hasOverflowed())`. The check has to be `hasOverflowed()` first.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/cookie/cookie-string-limit.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/cookie/cookie-string-limit.test.ts:
53 |       env: bunEnv,
54 |       stdout: "pipe",
55 |       stderr: "pipe",
56 |     });
57 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
58 |     expect(stdout).toBe(
                        ^
error: expect(received).toBe(expected)

- "toString threw RangeError Out of memory
- toSetCookieHeaders threw RangeError Out of memory
- serve 200 null text/plain;charset=utf-8 hello
- "
+ ""

- Expected  - 4
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/cookie/cookie-string-limit.test.ts:58:20)
(fail) serializing a cookie past the maximum string length > throws from toString() and toSetCookieHeaders(), and Bun.serve reports it and still responds [63488.30ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 test across 1 file. [65.52s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (5f554969b)

test/js/bun/cookie/cookie-string-limit.test.ts:
53 |       env: bunEnv,
54 |       stdout: "pipe",
55 |       stderr: "pipe",
56 |     });
57 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
58 |     expect(stdout).toBe(
                        ^
error: expect(received).toBe(expected)

- "toString threw RangeError Out of memory
- toSetCookieHeaders threw RangeError Out of memory
- serve 200 null text/plain;charset=utf-8 hello
- "
+ ""

- Expected  - 4
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/cookie/cookie-string-limit.test.ts:58:20)
(fail) serializing a cookie past the maximum string length > throws from toString() and toSetCookieHeaders(), and Bun.serve reports it and still responds [6061.94ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 test across 1 file. [6.13s]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/cookie/cookie-string-limit.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/cookie/cookie-string-limit.test.ts:
(pass) serializing a cookie past the maximum string length > throws from toString() and toSetCookieHeaders(), and Bun.serve reports it and still responds [66973.36ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [68.89s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     1fd298acc6
  features     baseline

23 deps, 131 codegen, 1172 objects in 631ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (5f554969b)

Checked 22 installs across 61 packages (no changes) [13.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (5f554969b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (5f554969b)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[5/1244] gen bindgenv2
[6/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 3ms

  react-refresh.js  4.81 KB  (entry point)

[7/1244] fetch zlib
[zlib] up to date
[8/1244] fetch tinycc
[tinycc] up to date
[9/1243] gen .bind.ts → GeneratedBindings.cpp
[10/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/Cookie.cpp                    |  8 ++--
 src/jsc/bindings/Cookie.h                      |  7 ++-
 src/jsc/bindings/CookieMap.cpp                 | 11 ++++-
 src/jsc/bindings/webcore/JSCookieMap.cpp       |  4 +-
 src/runtime/server/RequestContext.rs           | 17 +++++--
 test/js/bun/cookie/cookie-string-limit.test.ts | 66 ++++++++++++++++++++++++++
 6 files changed, 101 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/jsc/bindings/Cookie.cpp                         1      1      7
src/jsc/bindings/Cookie.h                           1      1      7
src/jsc/bindings/CookieMap.cpp                      1      2      7
src/jsc/bindings/webcore/JSCookieMap.cpp            1      1      8
src/runtime/server/RequestContext.rs                1      1      7
test/js/bun/cookie/cookie-string-limit.test.ts      1      2      7
```

</details>

<!-- robobun:evidence:end -->