### PR TITLE
deepEquals: skip array indices that hold no element on either side

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -694,6 +694,44 @@ JSValue getIndexWithoutAccessors(JSGlobalObject* globalObject, JSObject* obj, ui
     return JSValue();
 }
 
+// The own index properties of an array live in its element vector and in its sparse map.
+// JSObject::getOwnPropertySlotByIndex reads those two places and nothing else, so every
+// other index is a hole. This reports where they are, so that a caller which walks indices
+// can jump over the holes instead of probing each one.
+//
+// `vectorEnd` receives the end of the element vector, and the sparse map's indices are
+// appended to `sparseIndices` unsorted. Returns false when the layout is not one of the
+// known ones, which means "probe every index".
+static bool indexedStorageOfArray(JSObject* object, uint64_t& vectorEnd, WTF::Vector<uint32_t, 16>& sparseIndices)
+{
+    switch (object->indexingType()) {
+    case ALL_BLANK_INDEXING_TYPES:
+    case ALL_UNDECIDED_INDEXING_TYPES:
+        // No element was ever stored, so every index is a hole. The butterfly can be null here.
+        vectorEnd = 0;
+        return true;
+    case ALL_INT32_INDEXING_TYPES:
+    case ALL_DOUBLE_INDEXING_TYPES:
+    case ALL_CONTIGUOUS_INDEXING_TYPES:
+        vectorEnd = object->butterfly()->vectorLength();
+        return true;
+    case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
+        JSC::ArrayStorage* storage = object->butterfly()->arrayStorage();
+        vectorEnd = std::min<uint64_t>(storage->length(), storage->vectorLength());
+        JSC::SparseArrayValueMap* map = storage->m_sparseMap.get();
+        if (!map)
+            return true;
+        if (!sparseIndices.tryReserveCapacity(sparseIndices.size() + map->size()))
+            return false;
+        for (const auto& entry : *map)
+            sparseIndices.append(entry.index());
+        return true;
+    }
+    default:
+        return false;
+    }
+}
+
 template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity = false>
 std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSCell* _Nonnull c1, JSCell* _Nonnull c2);
 
@@ -976,16 +1014,63 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         JSC::JSArray* array1 = uncheckedDowncast<JSC::JSArray>(v1);
         JSC::JSArray* array2 = uncheckedDowncast<JSC::JSArray>(v2);
 
-        size_t array1Length = array1->length();
-        size_t array2Length = array2->length();
+        uint64_t array1Length = array1->length();
+        uint64_t array2Length = array2->length();
         if constexpr (isStrict) {
             if (array1Length != array2Length) {
                 return false;
             }
         }
 
-        uint64_t i = 0;
-        for (; i < array1Length; i++) {
+        const uint64_t walkEnd = std::max(array1Length, array2Length);
+
+        // An index that is a hole in both arrays compares equal in every mode: the strict arm
+        // skips it, and the loose arm reaches Bun__deepEquals, which answers true for two empty
+        // values. An array only holds index properties inside its element storage, so every
+        // index outside the storage of both arrays is such a pair. Visit the rest only.
+        // Without this, `a = []; a.length = 2 ** 32 - 1` costs one index probe per claimed
+        // element, about 60 s, where node answers in 1 ms.
+        uint64_t vectorEnd = walkEnd;
+        WTF::Vector<uint32_t, 16> sparseIndices;
+        uint64_t vectorEnd1 = 0;
+        uint64_t vectorEnd2 = 0;
+        if (indexedStorageOfArray(o1, vectorEnd1, sparseIndices) && indexedStorageOfArray(o2, vectorEnd2, sparseIndices)) {
+            vectorEnd = std::min(walkEnd, std::max(vectorEnd1, vectorEnd2));
+            std::sort(sparseIndices.begin(), sparseIndices.end());
+            // Keep the indices the vector walk does not already cover, once each.
+            size_t kept = 0;
+            for (uint32_t index : sparseIndices) {
+                if (index < vectorEnd || index >= walkEnd)
+                    continue;
+                if (kept && sparseIndices[kept - 1] == index)
+                    continue;
+                sparseIndices[kept++] = index;
+            }
+            sparseIndices.shrink(kept);
+        } else {
+            sparseIndices.clear();
+        }
+
+        for (uint64_t i = 0, sparseCursor = 0;; i++) {
+            if (i >= vectorEnd) {
+                if (sparseCursor >= sparseIndices.size())
+                    break;
+                i = sparseIndices[sparseCursor++];
+            }
+            if (i >= walkEnd)
+                break;
+
+            if (i >= array1Length) {
+                JSValue right = getIndexWithoutAccessors(globalObject, o2, i);
+                RETURN_IF_EXCEPTION(scope, false);
+
+                if (((right.isEmpty() || right.isUndefined()))) {
+                    continue;
+                }
+
+                return false;
+            }
+
             JSValue left = getIndexWithoutAccessors(globalObject, o1, i);
             RETURN_IF_EXCEPTION(scope, false);
             JSValue right = getIndexWithoutAccessors(globalObject, o2, i);
@@ -1009,17 +1094,6 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, left, right, gcBuffer, stack, scope, true);
             RETURN_IF_EXCEPTION(scope, false);
             if (!eql) return false;
-        }
-
-        for (; i < array2Length; i++) {
-            JSValue right = getIndexWithoutAccessors(globalObject, o2, i);
-            RETURN_IF_EXCEPTION(scope, false);
-
-            if (((right.isEmpty() || right.isUndefined()))) {
-                continue;
-            }
-
-            return false;
         }
 
         if constexpr (checkPrototypes) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -717,7 +717,7 @@ static bool indexedStorageOfArray(JSObject* object, uint64_t& vectorEnd, WTF::Ve
         return true;
     case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
         JSC::ArrayStorage* storage = object->butterfly()->arrayStorage();
-        vectorEnd = std::min<uint64_t>(storage->length(), storage->vectorLength());
+        vectorEnd = storage->vectorLength();
         JSC::SparseArrayValueMap* map = storage->m_sparseMap.get();
         if (!map)
             return true;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -694,8 +694,7 @@ JSValue getIndexWithoutAccessors(JSGlobalObject* globalObject, JSObject* obj, ui
     return JSValue();
 }
 
-// Mirrors the storage reads of JSObject::getOwnPropertySlotByIndex: every own index property of `object` is
-// below `vectorEnd` or in `sparseIndices` (appended unsorted). False means an unknown layout: probe every index.
+// Own index properties live below `vectorEnd` or in `sparseIndices` (unsorted), per JSObject::getOwnPropertySlotByIndex. False: unknown layout.
 static bool indexedStorageOfArray(JSObject* object, uint64_t& vectorEnd, WTF::Vector<uint32_t, 16>& sparseIndices)
 {
     switch (object->indexingType()) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -694,20 +694,14 @@ JSValue getIndexWithoutAccessors(JSGlobalObject* globalObject, JSObject* obj, ui
     return JSValue();
 }
 
-// The own index properties of an array live in its element vector and in its sparse map.
-// JSObject::getOwnPropertySlotByIndex reads those two places and nothing else, so every
-// other index is a hole. This reports where they are, so that a caller which walks indices
-// can jump over the holes instead of probing each one.
-//
-// `vectorEnd` receives the end of the element vector, and the sparse map's indices are
-// appended to `sparseIndices` unsorted. Returns false when the layout is not one of the
-// known ones, which means "probe every index".
+// Mirrors the storage reads of JSObject::getOwnPropertySlotByIndex: every own index property of `object` is
+// below `vectorEnd` or in `sparseIndices` (appended unsorted). False means an unknown layout: probe every index.
 static bool indexedStorageOfArray(JSObject* object, uint64_t& vectorEnd, WTF::Vector<uint32_t, 16>& sparseIndices)
 {
     switch (object->indexingType()) {
     case ALL_BLANK_INDEXING_TYPES:
     case ALL_UNDECIDED_INDEXING_TYPES:
-        // No element was ever stored, so every index is a hole. The butterfly can be null here.
+        // The butterfly can be null here.
         vectorEnd = 0;
         return true;
     case ALL_INT32_INDEXING_TYPES:
@@ -1024,12 +1018,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
 
         const uint64_t walkEnd = std::max(array1Length, array2Length);
 
-        // An index that is a hole in both arrays compares equal in every mode: the strict arm
-        // skips it, and the loose arm reaches Bun__deepEquals, which answers true for two empty
-        // values. An array only holds index properties inside its element storage, so every
-        // index outside the storage of both arrays is such a pair. Visit the rest only.
-        // Without this, `a = []; a.length = 2 ** 32 - 1` costs one index probe per claimed
-        // element, about 60 s, where node answers in 1 ms.
+        // A hole on both sides is equal in every mode, so visit only the indices that either array's storage can hold.
         uint64_t vectorEnd = walkEnd;
         WTF::Vector<uint32_t, 16> sparseIndices;
         uint64_t vectorEnd1 = 0;

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -148,6 +148,83 @@ describe("Bun.deepEquals strict mode", () => {
   });
 });
 
+// The array comparison probed every index from 0 to the array's length, so an
+// array that only claims a length cost one probe per claimed element: about a
+// minute for `a = []; a.length = 2 ** 32 - 1`, where node answers in 1 ms. An
+// index outside the element storage of both arrays is a hole on both sides,
+// and two holes are equal in every mode, so the walk skips those indices now.
+// The child is killed if it is still running after 20 s, which empties stdout.
+describe("sparse arrays that only claim a length", () => {
+  const cases = [
+    ["all holes strict", "equal(holes(), holes())", "true"],
+    ["all holes loose", "loose(holes(), holes())", "true"],
+    ["last index equal", "equal(at(last, 1), at(last, 1))", "true"],
+    ["last index differs", "equal(at(last, 1), at(last, 2))", "false"],
+    ["last index against a hole", "equal(at(last, 1), holes())", "false"],
+    ["first index against a hole", "equal(at(0, 1), holes())", "false"],
+    ["undefined against a hole loose", "loose(at(last, undefined), holes())", "true"],
+    ["undefined against a hole strict", "strict(at(last, undefined), holes())", "false"],
+    ["nested strict", "equal([holes()], [holes()])", "true"],
+  ] as const;
+
+  it("compare without walking every index", async () => {
+    const fixture = `
+      const util = require('node:util');
+      const assert = require('node:assert');
+
+      const last = 2 ** 32 - 2;
+      const holes = () => { const a = []; a.length = 2 ** 32 - 1; return a; };
+      const at = (index, value) => { const a = holes(); a[index] = value; return a; };
+      const equal = util.isDeepStrictEqual;
+      const loose = (a, b) => Bun.deepEquals(a, b);
+      const strict = (a, b) => Bun.deepEquals(a, b, true);
+
+      ${cases.map(([name, expression]) => `console.log(${JSON.stringify(name)}, ${expression});`).join("\n      ")}
+
+      assert.deepStrictEqual(holes(), holes());
+      console.log('assert.deepStrictEqual', true);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 20_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe(
+      [...cases.map(([name, , answer]) => `${name} ${answer}`), "assert.deepStrictEqual true", ""].join("\n"),
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  }, 60_000);
+
+  // An index that a sparse array does hold lives in its sparse map, which the
+  // walk reads instead of probing the gaps around it.
+  it.each([true, false])("still see the indices a sparse map holds (strict: %p)", strict => {
+    const sparse = (...indices: number[]) => {
+      const a: unknown[] = [];
+      a.length = 200_000;
+      for (const index of indices) a[index] = index;
+      return a;
+    };
+    const deepEquals = (a: unknown, b: unknown) => Bun.deepEquals(a, b, strict);
+
+    expect(deepEquals(sparse(199_999), sparse(199_999))).toBe(true);
+    expect(deepEquals(sparse(199_999), sparse(199_998))).toBe(false);
+    expect(deepEquals(sparse(199_999), sparse())).toBe(false);
+    expect(deepEquals(sparse(), sparse(199_999))).toBe(false);
+    expect(deepEquals(sparse(0, 100, 199_999), sparse(0, 100, 199_999))).toBe(true);
+    expect(deepEquals(sparse(0, 100, 199_999), sparse(0, 100, 199_998))).toBe(false);
+    expect(deepEquals(sparse(0, 199_999), sparse(0))).toBe(false);
+    expect(deepEquals(Object.freeze(sparse(199_999)), Object.freeze(sparse(199_999)))).toBe(true);
+    expect(deepEquals(Object.freeze(sparse(199_999)), Object.freeze(sparse(199_998)))).toBe(false);
+  });
+});
+
 // The object fast path used to recurse into nested values while walking the
 // structure's PropertyTable; a getter on a nested object that added or removed
 // properties on the parent rehashed that table and freed the vector being

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -205,24 +205,26 @@ describe("sparse arrays that only claim a length", () => {
 
   // An index that a sparse array does hold lives in its sparse map, which the
   // walk reads instead of probing the gaps around it.
-  it.each([true, false])("still see the indices a sparse map holds (strict: %p)", strict => {
-    const sparse = (...indices: number[]) => {
-      const a: unknown[] = [];
-      a.length = 200_000;
-      for (const index of indices) a[index] = index;
-      return a;
-    };
-    const deepEquals = (a: unknown, b: unknown) => Bun.deepEquals(a, b, strict);
+  describe.each([true, false])("strict: %p", strict => {
+    it("still see the indices a sparse map holds", () => {
+      const sparse = (...indices: number[]) => {
+        const a: unknown[] = [];
+        a.length = 200_000;
+        for (const index of indices) a[index] = index;
+        return a;
+      };
+      const deepEquals = (a: unknown, b: unknown) => Bun.deepEquals(a, b, strict);
 
-    expect(deepEquals(sparse(199_999), sparse(199_999))).toBe(true);
-    expect(deepEquals(sparse(199_999), sparse(199_998))).toBe(false);
-    expect(deepEquals(sparse(199_999), sparse())).toBe(false);
-    expect(deepEquals(sparse(), sparse(199_999))).toBe(false);
-    expect(deepEquals(sparse(0, 100, 199_999), sparse(0, 100, 199_999))).toBe(true);
-    expect(deepEquals(sparse(0, 100, 199_999), sparse(0, 100, 199_998))).toBe(false);
-    expect(deepEquals(sparse(0, 199_999), sparse(0))).toBe(false);
-    expect(deepEquals(Object.freeze(sparse(199_999)), Object.freeze(sparse(199_999)))).toBe(true);
-    expect(deepEquals(Object.freeze(sparse(199_999)), Object.freeze(sparse(199_998)))).toBe(false);
+      expect(deepEquals(sparse(199_999), sparse(199_999))).toBe(true);
+      expect(deepEquals(sparse(199_999), sparse(199_998))).toBe(false);
+      expect(deepEquals(sparse(199_999), sparse())).toBe(false);
+      expect(deepEquals(sparse(), sparse(199_999))).toBe(false);
+      expect(deepEquals(sparse(0, 100, 199_999), sparse(0, 100, 199_999))).toBe(true);
+      expect(deepEquals(sparse(0, 100, 199_999), sparse(0, 100, 199_998))).toBe(false);
+      expect(deepEquals(sparse(0, 199_999), sparse(0))).toBe(false);
+      expect(deepEquals(Object.freeze(sparse(199_999)), Object.freeze(sparse(199_999)))).toBe(true);
+      expect(deepEquals(Object.freeze(sparse(199_999)), Object.freeze(sparse(199_998)))).toBe(false);
+    });
   });
 });
 

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -190,6 +190,7 @@ describe("sparse arrays that only claim a length", () => {
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
+      // Kill switch: before the fix, the first comparison alone ran for about a minute.
       timeout: 20_000,
       killSignal: "SIGKILL",
     });
@@ -200,7 +201,7 @@ describe("sparse arrays that only claim a length", () => {
     );
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-  }, 60_000);
+  });
 
   // An index that a sparse array does hold lives in its sparse map, which the
   // walk reads instead of probing the gaps around it.


### PR DESCRIPTION
### Problem
- `Bun.deepEquals`, `expect().toEqual()`, `util.isDeepStrictEqual` and `assert.deepStrictEqual` take time proportional to the `length` an array claims. `a = []; a.length = 2 ** 32 - 1` against a copy runs about 60 s (1.4 s at `1e8`). Node answers in 1 ms.
- The array arm of `Bun__deepEquals` (`src/jsc/bindings/bindings.cpp:1025` before this change) loops `0..length` and calls `getIndexWithoutAccessors` for each index, holes included.

### Fix
- The loop visits only the indices that either array's storage can hold: the two element vectors, then the sorted keys of the sparse maps.
- Correct because any other index is a hole on both sides, and two holes are equal in every mode. `JSObject::getOwnPropertySlotByIndex` reads exactly that storage, so no index property is missed. An unknown layout probes every index, as before.
- 1089 array shape pairs give identical answers on `main` and on this branch, in every mode.
- Verified: `test/js/bun/bun-object/deep-equals.test.ts` (new `sparse arrays that only claim a length` block, bun 1.4.2 never finishes it). Also the `node:assert` deep-equal, `expect` and node parallel `assert` suites.

### Background
- `Bun__deepEquals` is the one C++ template behind every structural-equality API in bun. Template flags select the mode (strict, loose, `bun:test`, node).
- JSC keeps indexed properties in the object's butterfly. The `IndexingType` names the layout: nothing, a flat vector where an empty slot is a hole, or `ArrayStorage`, a vector plus a `SparseArrayValueMap` keyed by index. `a.length = n` only records the length. `a[bigIndex] = v` goes in the sparse map.
- `getIndexWithoutAccessors` reads one index without running getters. A hole reads as an empty value.

<details><summary>Notes</summary>

- JSC source check, at the pinned WebKit commit `dfd696443b9b` (`runtime/JSObject.cpp`, `runtime/JSObjectInlines.h`). `getOwnPropertySlotByIndex`: `blank`/`undecided` hold nothing. `Int32`/`Contiguous`/`Double` hold an index only when `i < butterfly->vectorLength()`. `ArrayStorage` holds it in `m_vector[i]` when `i < vectorLength()`, else in `m_sparseMap`. `canGetIndexQuickly` (the fast path) uses the same `vectorLength()` bounds. The helper uses `vectorLength()` for every layout, so it needs no extra invariant (for example, that slots past the public length are empty).
- `JSArray` overrides `getOwnPropertySlot` (for `length`) but not `getOwnPropertySlotByIndex`. `ArrayPrototype` is the only `JSArray` subclass in JSC and does not override it either. bun has no C++ `JSArray` subclass. Proxies never reach this arm (`!(o1->isProxy() || o2->isProxy())` above), so `indexingType()` is always the real object's.
- Node's `objEquiv` (lib/internal/util/comparisons.js) walks indices until the first hole, then compares `Object.keys` of both arrays. The fix here keeps bun's index walk and its existing hole semantics in all modes, and only removes the visits that cannot change the answer, so it needs no per-mode reasoning about key enumeration order or non-enumerable indices.
- Cost after the fix is O(vectorLength₁ + vectorLength₂ + k log k) for k sparse-map entries, versus O(max(length₁, length₂)) before. Dense arrays are unaffected: their vector covers `0..length` and the sparse list is empty, so the loop body is the same as before with one extra comparison per index. If the sparse-index copy cannot be allocated, the walk probes every index as before.
- `vectorEnd` uses the max of both arrays' vector lengths (clamped to the walk end), so an index inside either vector is still probed on both sides. Sparse-map keys from both arrays are merged, sorted, de-duplicated, and filtered to `[vectorEnd, walkEnd)`.
- Only `uint32_t` copies of the sparse keys outlive the setup. Each probe re-reads the butterfly through `getIndexWithoutAccessors`, so user code that mutates an array mid-comparison (a getter on a nested value) cannot leave a stale pointer. The lengths were already read once up front before this change.
- The `ALL_BLANK_INDEXING_TYPES` arm matters: `a = []; a.length = n` with no store can leave the array without `ArrayStorage`, and its butterfly may be null, so that arm returns before touching it.
- Timings, debug+ASAN build, both arrays `length = 2**32 - 1`: all holes, 163 ms on the first call and 1 ms after (one element at the last index). Release 1.4.3 at `1e8`: 1385 ms and 1816 ms for the same two cases.
- The new spawned test has a 20 s kill switch on the child and no per-test timeout, like the other hang-guard tests (`test/js/bun/css/angle-serialization-hang.test.ts`). It passes in 0.5 s on a debug+ASAN build.
- Part of a length-claim audit. The `Array.prototype.join`, `Promise.any/all/allSettled`, `includes`/`indexOf`/`concat` and `new URL` IDNA rows from the same audit live in JavaScriptCore / WTF (oven-sh/WebKit), not in this repository.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/bun-object/deep-equals.test.ts

<!-- robobun:evidence:end -->