### PR TITLE
node:https: adopt connections fed through emit('connection') / emit('secureConnection')

### DIFF
--- a/src/js/internal/net/symbols.ts
+++ b/src/js/internal/net/symbols.ts
@@ -3,5 +3,8 @@ export default {
   // Internal handshake-settled signal: server-side sockets emit no user
   // 'secureConnect' (node parity), so internal deferrals park on this instead.
   kSecureConnectDone: Symbol("kSecureConnectDone"),
+  // tls.Server.prototype slot for Node's tlsConnectionListener. node:http's TLS-mode Server (an
+  // https.Server, a tls.Server in Node but not here) registers the same listener through it.
+  kTlsConnectionListener: Symbol("kTlsConnectionListener"),
   kVerifyError: Symbol("kVerifyError"),
 };

--- a/src/js/internal/net/symbols.ts
+++ b/src/js/internal/net/symbols.ts
@@ -3,8 +3,7 @@ export default {
   // Internal handshake-settled signal: server-side sockets emit no user
   // 'secureConnect' (node parity), so internal deferrals park on this instead.
   kSecureConnectDone: Symbol("kSecureConnectDone"),
-  // tls.Server.prototype slot for Node's tlsConnectionListener. node:http's TLS-mode Server (an
-  // https.Server, a tls.Server in Node but not here) registers the same listener through it.
+  // tls.Server.prototype slot: node:http's TLS-mode Server registers the same listener.
   kTlsConnectionListener: Symbol("kTlsConnectionListener"),
   kVerifyError: Symbol("kVerifyError"),
 };

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -256,12 +256,10 @@ function normalizeServerTls(tls) {
 // Node registers connectionListener on every http.Server so `server.emit("connection", socket)`
 // works for foreign Duplex sockets. The native listener handles its own sockets end to end;
 // this picks up the rest. https://github.com/nodejs/node/blob/main/lib/_http_server.js
-// An https.Server is a tls.Server there: 'connection' runs tls.Server's tlsConnectionListener,
-// which puts the server-side TLS layer over the fed duplex, and the parser attaches on the
-// 'secureConnection' its handshake emits. https://github.com/nodejs/node/blob/v26.3.0/lib/https.js#L93-L99
 function connectionListener(this: Server, socket) {
   if (NodeHTTPServerSocket && socket instanceof NodeHTTPServerSocket) return;
   if (this[tlsSymbol]) {
+    // Node's https.Server is a tls.Server: https://github.com/nodejs/node/blob/v26.3.0/lib/https.js#L93-L99
     tlsConnectionListener ??= lazyTls().Server.prototype[kTlsConnectionListener];
     if (socket) tlsConnectionListener.$call(this, socket);
     return;
@@ -394,8 +392,7 @@ function Server(options, callback): void {
         requestCert: options.requestCert,
         rejectUnauthorized: options.rejectUnauthorized,
       }));
-      // The tls.Server fields its tlsConnectionListener reads for a fed connection (with
-      // [kSharedCreds] below). https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1367-L1391
+      // tls.Server state that tlsConnectionListener reads. https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1367-L1391
       this._requestCert = tls.requestCert;
       this._rejectUnauthorized = tls.rejectUnauthorized;
       const { SNICallback, ALPNCallback, ALPNProtocols } = options;
@@ -431,13 +428,14 @@ Server.prototype[kServerResponse] = undefined;
 
 Server.prototype[kConnectionsCheckingInterval] = undefined;
 
-// Node's https.Server inherits _sharedCreds from tls.Server. The native listener builds its own
-// context from this[tlsSymbol]; this one serves fed connections (tlsConnectionListener) and is
-// built on first use, with tls.Server's server-cipher-preference default.
+// tls.Server's _sharedCreds, for fed connections only: the native listener takes this[tlsSymbol].
 Server.prototype[kSharedCreds] = function () {
   const options = this[optionsSymbol];
+  const { requestCert, rejectUnauthorized } = this[tlsSymbol];
   return (this._sharedCreds ??= lazyTls().createSecureContext({
     ...options,
+    requestCert,
+    rejectUnauthorized,
     honorCipherOrder: options.honorCipherOrder !== false,
   }));
 };

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -398,12 +398,13 @@ function Server(options, callback): void {
       // [kSharedCreds] below). https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1367-L1391
       this._requestCert = tls.requestCert;
       this._rejectUnauthorized = tls.rejectUnauthorized;
-      const { SNICallback, ALPNCallback } = options;
+      const { SNICallback, ALPNCallback, ALPNProtocols } = options;
       if (SNICallback != null) validateFunction(SNICallback, "options.SNICallback");
       if (ALPNCallback != null) {
         validateFunction(ALPNCallback, "options.ALPNCallback");
-        if (options.ALPNProtocols) throw $ERR_TLS_ALPN_CALLBACK_WITH_PROTOCOLS();
+        if (ALPNProtocols) throw $ERR_TLS_ALPN_CALLBACK_WITH_PROTOCOLS();
       }
+      if (ALPNProtocols) lazyTls().convertALPNProtocols(ALPNProtocols, this);
       this._SNICallback = SNICallback;
       this._ALPNCallback = ALPNCallback;
       const handshakeTimeout = options.handshakeTimeout || 120 * 1000;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -15,6 +15,7 @@ const {
   validateBoolean,
   validateInteger,
   validateFunction,
+  validateNumber,
   validateOneOf,
 } = require("internal/validators");
 const { ConnResetException, hasObserver, startPerf, stopPerf, kInternalSendOptions } = require("internal/shared");
@@ -67,7 +68,10 @@ const {
 } = require("node:_http_outgoing");
 const OutgoingMessagePrototype = OutgoingMessage.prototype;
 const { kIncomingMessage } = require("node:_http_common");
+const { kArmHandshakeTimeout } = require("internal/net/symbols");
 let http1Fallback;
+let nodeTls;
+let armHandshakeTimeout;
 const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
 const kTrackedConnections = Symbol("http.server.trackedConnections");
 const kHttpAllowHalfOpen = Symbol("http.server.httpAllowHalfOpen");
@@ -250,14 +254,62 @@ function normalizeServerTls(tls) {
 // Node registers connectionListener on every http.Server so `server.emit("connection", socket)`
 // works for foreign Duplex sockets. The native listener handles its own sockets end to end;
 // this picks up the rest. https://github.com/nodejs/node/blob/main/lib/_http_server.js
+// An https.Server is a tls.Server there: 'connection' puts the server-side TLS layer over the
+// fed duplex (tlsConnectionListener) and the parser attaches on the 'secureConnection' that
+// its handshake emits. https://github.com/nodejs/node/blob/v26.3.0/lib/https.js#L93-L99
 function connectionListener(this: Server, socket) {
   if (NodeHTTPServerSocket && socket instanceof NodeHTTPServerSocket) return;
-  (http1Fallback ??= require("internal/http1_server_fallback")).connectionListenerHTTP1(this, socket, {
+  if (this[tlsSymbol]) {
+    tlsConnectionListener(this, socket);
+    return;
+  }
+  httpConnectionListener(this, socket);
+}
+
+function secureConnectionListener(this: Server, socket) {
+  if (NodeHTTPServerSocket && socket instanceof NodeHTTPServerSocket) return;
+  httpConnectionListener(this, socket);
+}
+
+function httpConnectionListener(server: Server, socket) {
+  (http1Fallback ??= require("internal/http1_server_fallback")).connectionListenerHTTP1(server, socket, {
     http1Options: {
-      IncomingMessage: this[kIncomingMessage],
-      ServerResponse: this[kServerResponse],
+      IncomingMessage: server[kIncomingMessage],
+      ServerResponse: server[kServerResponse],
     },
   });
+}
+
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1259-L1286, over the same
+// server-side TLSSocket wrap that tls.Server's 'connection' listener uses (tls.ts).
+function tlsConnectionListener(server: Server, socket) {
+  if (!socket) return;
+  const { TLSSocket, createSecureContext } = (nodeTls ??= require("node:tls"));
+  let secureContext = server._sharedCreds;
+  if (!secureContext) {
+    try {
+      secureContext = server._sharedCreds = createSecureContext(server[optionsSymbol]);
+    } catch (err) {
+      socket.destroy();
+      server.emit("error", err);
+      return;
+    }
+  }
+  const { requestCert, rejectUnauthorized } = server[tlsSymbol];
+  const wrapped = new TLSSocket(socket, {
+    secureContext,
+    isServer: true,
+    requestCert,
+    rejectUnauthorized,
+    ALPNProtocols: server.ALPNProtocols,
+  });
+  wrapped.server = server;
+  (armHandshakeTimeout ??= require("node:net").Server.prototype[kArmHandshakeTimeout]).$call(server, wrapped);
+}
+
+// https://github.com/nodejs/node/blob/v26.3.0/lib/https.js#L107-L110
+function onTlsClientError(this: Server, err, conn) {
+  if (!this.emit("clientError", err, conn)) conn.destroy(err);
 }
 
 function Server(options, callback): void {
@@ -366,6 +418,12 @@ function Server(options, callback): void {
         requestCert: options.requestCert,
         rejectUnauthorized: options.rejectUnauthorized,
       });
+      // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1386-L1391
+      const handshakeTimeout = options.handshakeTimeout || 120 * 1000;
+      validateNumber(handshakeTimeout, "options.handshakeTimeout");
+      this._handshakeTimeout = handshakeTimeout;
+      this.on("secureConnection", secureConnectionListener);
+      this.on("tlsClientError", onTlsClientError);
     } else {
       this[tlsSymbol] = null;
     }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -68,10 +68,12 @@ const {
 } = require("node:_http_outgoing");
 const OutgoingMessagePrototype = OutgoingMessage.prototype;
 const { kIncomingMessage } = require("node:_http_common");
-const { kArmHandshakeTimeout } = require("internal/net/symbols");
+const { kTlsConnectionListener } = require("internal/net/symbols");
+const kSharedCreds = Symbol.for("::buntlssharedcreds::");
 let http1Fallback;
 let nodeTls;
-let armHandshakeTimeout;
+const lazyTls = () => (nodeTls ??= require("node:tls"));
+let tlsConnectionListener;
 const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
 const kTrackedConnections = Symbol("http.server.trackedConnections");
 const kHttpAllowHalfOpen = Symbol("http.server.httpAllowHalfOpen");
@@ -254,13 +256,14 @@ function normalizeServerTls(tls) {
 // Node registers connectionListener on every http.Server so `server.emit("connection", socket)`
 // works for foreign Duplex sockets. The native listener handles its own sockets end to end;
 // this picks up the rest. https://github.com/nodejs/node/blob/main/lib/_http_server.js
-// An https.Server is a tls.Server there: 'connection' puts the server-side TLS layer over the
-// fed duplex (tlsConnectionListener) and the parser attaches on the 'secureConnection' that
-// its handshake emits. https://github.com/nodejs/node/blob/v26.3.0/lib/https.js#L93-L99
+// An https.Server is a tls.Server there: 'connection' runs tls.Server's tlsConnectionListener,
+// which puts the server-side TLS layer over the fed duplex, and the parser attaches on the
+// 'secureConnection' its handshake emits. https://github.com/nodejs/node/blob/v26.3.0/lib/https.js#L93-L99
 function connectionListener(this: Server, socket) {
   if (NodeHTTPServerSocket && socket instanceof NodeHTTPServerSocket) return;
   if (this[tlsSymbol]) {
-    tlsConnectionListener(this, socket);
+    tlsConnectionListener ??= lazyTls().Server.prototype[kTlsConnectionListener];
+    if (socket) tlsConnectionListener.$call(this, socket);
     return;
   }
   httpConnectionListener(this, socket);
@@ -278,33 +281,6 @@ function httpConnectionListener(server: Server, socket) {
       ServerResponse: server[kServerResponse],
     },
   });
-}
-
-// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1259-L1286, over the same
-// server-side TLSSocket wrap that tls.Server's 'connection' listener uses (tls.ts).
-function tlsConnectionListener(server: Server, socket) {
-  if (!socket) return;
-  const { TLSSocket, createSecureContext } = (nodeTls ??= require("node:tls"));
-  let secureContext = server._sharedCreds;
-  if (!secureContext) {
-    try {
-      secureContext = server._sharedCreds = createSecureContext(server[optionsSymbol]);
-    } catch (err) {
-      socket.destroy();
-      server.emit("error", err);
-      return;
-    }
-  }
-  const { requestCert, rejectUnauthorized } = server[tlsSymbol];
-  const wrapped = new TLSSocket(socket, {
-    secureContext,
-    isServer: true,
-    requestCert,
-    rejectUnauthorized,
-    ALPNProtocols: server.ALPNProtocols,
-  });
-  wrapped.server = server;
-  (armHandshakeTimeout ??= require("node:net").Server.prototype[kArmHandshakeTimeout]).$call(server, wrapped);
 }
 
 // https://github.com/nodejs/node/blob/v26.3.0/lib/https.js#L107-L110
@@ -405,7 +381,7 @@ function Server(options, callback): void {
         minVersion = tlsStringToProtocolVersion(options.minVersion);
         maxVersion = tlsStringToProtocolVersion(options.maxVersion);
       }
-      this[tlsSymbol] = normalizeServerTls({
+      const tls = (this[tlsSymbol] = normalizeServerTls({
         serverName,
         key,
         cert,
@@ -417,8 +393,19 @@ function Server(options, callback): void {
         ciphers: typeof options.ciphers === "string" && options.ciphers ? options.ciphers : undefined,
         requestCert: options.requestCert,
         rejectUnauthorized: options.rejectUnauthorized,
-      });
-      // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1386-L1391
+      }));
+      // The tls.Server fields its tlsConnectionListener reads for a fed connection (with
+      // [kSharedCreds] below). https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1367-L1391
+      this._requestCert = tls.requestCert;
+      this._rejectUnauthorized = tls.rejectUnauthorized;
+      const { SNICallback, ALPNCallback } = options;
+      if (SNICallback != null) validateFunction(SNICallback, "options.SNICallback");
+      if (ALPNCallback != null) {
+        validateFunction(ALPNCallback, "options.ALPNCallback");
+        if (options.ALPNProtocols) throw $ERR_TLS_ALPN_CALLBACK_WITH_PROTOCOLS();
+      }
+      this._SNICallback = SNICallback;
+      this._ALPNCallback = ALPNCallback;
       const handshakeTimeout = options.handshakeTimeout || 120 * 1000;
       validateNumber(handshakeTimeout, "options.handshakeTimeout");
       this._handshakeTimeout = handshakeTimeout;
@@ -442,6 +429,17 @@ Server.prototype[kIncomingMessage] = undefined;
 Server.prototype[kServerResponse] = undefined;
 
 Server.prototype[kConnectionsCheckingInterval] = undefined;
+
+// Node's https.Server inherits _sharedCreds from tls.Server. The native listener builds its own
+// context from this[tlsSymbol]; this one serves fed connections (tlsConnectionListener) and is
+// built on first use, with tls.Server's server-cipher-preference default.
+Server.prototype[kSharedCreds] = function () {
+  const options = this[optionsSymbol];
+  return (this._sharedCreds ??= lazyTls().createSecureContext({
+    ...options,
+    honorCipherOrder: options.honorCipherOrder !== false,
+  }));
+};
 
 function rethrowUncaught(err) {
   throw err;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1517,10 +1517,7 @@ Server.prototype[kSharedCreds] = function () {
   return this._sharedCreds || buildSharedCreds(this);
 };
 
-// Node's tlsConnectionListener: puts the server-side TLS layer over a duplex the server was fed
-// through 'connection'. The handshake then emits 'secureConnection' on `this` (net.ts
-// ServerHandlers). `this` is a tls.Server or node:http's TLS-mode Server, which is not a
-// tls.Server here but carries the fields read below.
+// `this` is a tls.Server or node:http's TLS-mode Server (same fields, not a tls.Server here).
 // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1259-L1286
 function tlsConnectionListener(this: Server, socket) {
   let secureContext;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1517,7 +1517,6 @@ Server.prototype[kSharedCreds] = function () {
   return this._sharedCreds || buildSharedCreds(this);
 };
 
-// `this` is a tls.Server or node:http's TLS-mode Server (same fields, not a tls.Server here).
 // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1259-L1286
 function tlsConnectionListener(this: Server, socket) {
   let secureContext;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -22,7 +22,12 @@ const {
 } = require("internal/validators");
 
 const { Server: NetServer, Socket: NetSocket } = net;
-const { kArmHandshakeTimeout, kSecureConnectDone, kVerifyError } = require("internal/net/symbols");
+const {
+  kArmHandshakeTimeout,
+  kSecureConnectDone,
+  kTlsConnectionListener,
+  kVerifyError,
+} = require("internal/net/symbols");
 
 const getBundledRootCertificates = $newCppFunction("NodeTLS.cpp", "getBundledRootCertificates", 1);
 const getExtraCACertificates = $newCppFunction("NodeTLS.cpp", "getExtraCACertificates", 1);
@@ -1497,27 +1502,7 @@ function Server(options, secureConnectionListener): void {
     // TLS layer, like Node's tls.Server wraps any injected duplex
     // (node v26.3.0 lib/_tls_wrap.js, Server's connection listener).
     if (!socket || (socket.encrypted && socket.server === this)) return;
-    let secureContext;
-    try {
-      secureContext = this[kSharedCreds]();
-    } catch (err) {
-      socket.destroy();
-      this.emit("error", err);
-      return;
-    }
-    const wrapped = new TLSSocket(socket, {
-      secureContext,
-      isServer: true,
-      requestCert: this._requestCert,
-      rejectUnauthorized: this._rejectUnauthorized,
-      SNICallback: this._SNICallback,
-      ALPNProtocols: this.ALPNProtocols,
-      ALPNCallback: this._ALPNCallback,
-    });
-    wrapped.server = this;
-    wrapped._requestCert = this._requestCert;
-    wrapped._rejectUnauthorized = this._rejectUnauthorized;
-    this[kArmHandshakeTimeout](wrapped);
+    tlsConnectionListener.$call(this, socket);
   });
 
   // Node registers the createServer callback as a plain "secureConnection"
@@ -1531,6 +1516,36 @@ $toClass(Server, "Server", NetServer);
 Server.prototype[kSharedCreds] = function () {
   return this._sharedCreds || buildSharedCreds(this);
 };
+
+// Node's tlsConnectionListener: puts the server-side TLS layer over a duplex the server was fed
+// through 'connection'. The handshake then emits 'secureConnection' on `this` (net.ts
+// ServerHandlers). `this` is a tls.Server or node:http's TLS-mode Server, which is not a
+// tls.Server here but carries the fields read below.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1259-L1286
+function tlsConnectionListener(this: Server, socket) {
+  let secureContext;
+  try {
+    secureContext = this[kSharedCreds]();
+  } catch (err) {
+    socket.destroy();
+    this.emit("error", err);
+    return;
+  }
+  const wrapped = new TLSSocket(socket, {
+    secureContext,
+    isServer: true,
+    requestCert: this._requestCert,
+    rejectUnauthorized: this._rejectUnauthorized,
+    SNICallback: this._SNICallback,
+    ALPNProtocols: this.ALPNProtocols,
+    ALPNCallback: this._ALPNCallback,
+  });
+  wrapped.server = this;
+  wrapped._requestCert = this._requestCert;
+  wrapped._rejectUnauthorized = this._rejectUnauthorized;
+  NetServer.prototype[kArmHandshakeTimeout].$call(this, wrapped);
+}
+Server.prototype[kTlsConnectionListener] = tlsConnectionListener;
 
 function createServer(options, connectionListener) {
   return new Server(options, connectionListener);

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -28,7 +28,7 @@ import { connect, createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { Duplex, duplexPair, PassThrough, Writable } from "node:stream";
-import { connect as tlsConnect } from "node:tls";
+import { createServer as createTlsServer, connect as tlsConnect, TLSSocket } from "node:tls";
 import tunnel from "tunnel";
 import { run as runHTTPProxyTest } from "./node-http-proxy.js";
 const { describe, expect, it, beforeAll, afterAll, createDoneDotAll, mock, test } = createTest(import.meta.path);
@@ -4240,6 +4240,104 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     expect(requestHandlerRan).toBe(false);
     expect(serverSide.destroyed).toBe(true);
   }
+});
+
+// One front port hands its accepted sockets to an https.Server that never listens itself (the
+// httpolyglot / SNI-router shape). Node's https.Server is a tls.Server: 'connection' runs the
+// server-side TLS handshake over the fed duplex and 'secureConnection' attaches the HTTP parser.
+describe("https.Server adopts connections fed through emit()", () => {
+  async function serveThroughFront(feed: "connection" | "secureConnection") {
+    const events = { connection: 0, secureConnection: 0, request: 0 };
+    const sockets: any[] = [];
+    const server = createHttpsServer(tlsCert, (req, res) => {
+      events.request++;
+      sockets.push(req.socket);
+      let body = 0;
+      req.on("data", d => (body += d.length));
+      req.on("end", () => res.end(`${req.method} ${req.url} ${body}`));
+    });
+    server.on("connection", () => events.connection++);
+    server.on("secureConnection", () => events.secureConnection++);
+    const front =
+      feed === "connection"
+        ? createNetServer(socket => server.emit("connection", socket))
+        : createTlsServer(tlsCert, socket => server.emit("secureConnection", socket));
+    await once(front.listen(0, "127.0.0.1"), "listening");
+    const agent = new https.Agent({ keepAlive: true, maxSockets: 1 });
+    try {
+      const send = (method: string, path: string, body?: Buffer) =>
+        new Promise<string>((resolve, reject) => {
+          const req = https.request(
+            {
+              host: "127.0.0.1",
+              port: (front.address() as AddressInfo).port,
+              method,
+              path,
+              agent,
+              rejectUnauthorized: false,
+            },
+            res => {
+              let text = "";
+              res.setEncoding("utf8");
+              res.on("data", d => (text += d));
+              res.on("end", () => resolve(`${res.statusCode} ${text}`));
+            },
+          );
+          req.on("error", reject);
+          req.end(body);
+        });
+      expect(await send("GET", "/a")).toBe("200 GET /a 0");
+      expect(await send("POST", "/b", Buffer.alloc(70_000, "x"))).toBe("200 POST /b 70000");
+    } finally {
+      agent.destroy();
+      front.close();
+    }
+    return { server, events, sockets };
+  }
+
+  it("emit('connection', socket) runs the TLS handshake, then parses HTTP", async () => {
+    const { server, events, sockets } = await serveThroughFront("connection");
+    expect(events).toEqual({ connection: 1, secureConnection: 1, request: 2 });
+    expect(sockets[1]).toBe(sockets[0]);
+    expect(sockets[0]).toBeInstanceOf(TLSSocket);
+    expect(sockets[0].encrypted).toBe(true);
+    expect(sockets[0].server).toBe(server);
+  });
+
+  it("emit('secureConnection', tlsSocket) parses HTTP over that socket", async () => {
+    const { events } = await serveThroughFront("secureConnection");
+    expect(events).toEqual({ connection: 0, secureConnection: 1, request: 2 });
+  });
+
+  it("a fed socket that does not speak TLS reaches 'clientError' and gets no plaintext reply", async () => {
+    const events: string[] = [];
+    const server = createHttpsServer(tlsCert, (req, res) => {
+      events.push("request");
+      res.end();
+    });
+    server.on("tlsClientError", (err: any) => events.push("tlsClientError " + err.code));
+    server.on("clientError", (err: any, socket) => {
+      events.push("clientError " + err.code);
+      socket.destroy();
+    });
+    const front = createNetServer(socket => server.emit("connection", socket));
+    await once(front.listen(0, "127.0.0.1"), "listening");
+    const client = connect((front.address() as AddressInfo).port, "127.0.0.1");
+    try {
+      let received = "";
+      client.on("data", d => (received += d.toString("latin1")));
+      client.on("error", () => {});
+      await once(client, "connect");
+      client.write("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n");
+      await once(client, "close");
+      expect(received).toBe("");
+      // https.Server turns 'tlsClientError' into 'clientError' from a listener it registers first.
+      expect(events).toEqual(["clientError ERR_SSL_HTTP_REQUEST", "tlsClientError ERR_SSL_HTTP_REQUEST"]);
+    } finally {
+      client.destroy();
+      front.close();
+    }
+  });
 });
 
 // A TLS client that is mid-handshake when an https server with a 'clientError' listener is closed still

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4274,6 +4274,7 @@ describe("https.Server adopts connections fed through emit()", () => {
               method,
               path,
               agent,
+              ALPNProtocols: ["h2", "http/1.1"],
               rejectUnauthorized: false,
             },
             res => {
@@ -4302,6 +4303,8 @@ describe("https.Server adopts connections fed through emit()", () => {
     expect(sockets[0]).toBeInstanceOf(TLSSocket);
     expect(sockets[0].encrypted).toBe(true);
     expect(sockets[0].server).toBe(server);
+    // https.createServer() answers ALPN from its ['http/1.1'] default, as in Node.
+    expect(sockets[0].alpnProtocol).toBe("http/1.1");
   });
 
   it("emit('secureConnection', tlsSocket) parses HTTP over that socket", async () => {
@@ -4384,6 +4387,10 @@ describe("https.Server adopts connections fed through emit()", () => {
     } finally {
       front.close();
     }
+    // The constructor stores a static list the same way (tls.Server does it in Node).
+    expect(new https.Server({ ...tlsCert, ALPNProtocols: ["h2", "http/1.1"] }).ALPNProtocols).toEqual(
+      Buffer.from("\u0002h2\u0008http/1.1", "latin1"),
+    );
   });
 });
 

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4338,6 +4338,53 @@ describe("https.Server adopts connections fed through emit()", () => {
       front.close();
     }
   });
+
+  it("a fed connection runs the server's SNICallback and ALPNCallback", async () => {
+    const calls: string[] = [];
+    const server = createHttpsServer(
+      {
+        ...tlsCert,
+        SNICallback: (servername, cb) => {
+          calls.push(`SNI ${servername}`);
+          cb(null, undefined);
+        },
+        ALPNCallback: ({ servername, protocols }) => {
+          calls.push(`ALPN ${servername} ${protocols.join(",")}`);
+          return "http/1.1";
+        },
+      },
+      (req, res) => res.end(`${(req.socket as TLSSocket).alpnProtocol} ${(req.socket as TLSSocket).servername}`),
+    );
+    const front = createNetServer(socket => server.emit("connection", socket));
+    await once(front.listen(0, "127.0.0.1"), "listening");
+    try {
+      const result = await new Promise<string>((resolve, reject) => {
+        https
+          .get(
+            {
+              host: "127.0.0.1",
+              port: (front.address() as AddressInfo).port,
+              servername: "localhost",
+              ALPNProtocols: ["h2", "http/1.1"],
+              rejectUnauthorized: false,
+              agent: false,
+            },
+            res => {
+              let text = "";
+              res.setEncoding("utf8");
+              res.on("data", d => (text += d));
+              res.on("end", () => resolve(`${res.statusCode} ${(res.socket as TLSSocket).alpnProtocol} ${text}`));
+            },
+          )
+          .on("error", reject);
+      });
+      expect(result).toBe("200 http/1.1 http/1.1 localhost");
+      // The TLS library decides which ClientHello extension it processes first.
+      expect(calls.sort()).toEqual(["ALPN localhost h2,http/1.1", "SNI localhost"]);
+    } finally {
+      front.close();
+    }
+  });
 });
 
 // A TLS client that is mid-handshake when an https server with a 'clientError' listener is closed still


### PR DESCRIPTION
### Problem
- An `https.Server` cannot be fed a connection by a front server that hands sockets over (`sticky-session` workers, SNI routers). `server.emit('connection', plainSocket)` parses the TLS ClientHello as HTTP: `clientError` fires with `HPE_INVALID_METHOD` and a plaintext `HTTP/1.1 400 Bad Request` goes into the TLS client. `server.emit('secureConnection', tlsSocket)` is ignored. Node serves both.
- Cause: `https.Server` is `http.Server` with TLS options (#41781), which registers only the plain-HTTP `connectionListener` (`src/js/node/_http_server.ts:267`). Node's `https.Server` is a `tls.Server`: `'connection'` runs `tlsConnectionListener`, `'secureConnection'` attaches the parser.

### Fix
- `tls.Server`'s `'connection'` wrap (a server-side `TLSSocket` over the fed duplex) becomes one `tlsConnectionListener` in `tls.ts`. The TLS-mode `http.Server` registers the same function and carries the `tls.Server` fields it reads (`_requestCert`, `_SNICallback`, `_ALPNCallback`, `_handshakeTimeout`, `[kSharedCreds]`, ...).
- On that server, `'secureConnection'` attaches the HTTP/1 parser that plain `http.Server.emit('connection')` already uses. `'tlsClientError'` forwards to `'clientError'` like [lib/https.js](https://github.com/nodejs/node/blob/v26.3.0/lib/https.js#L107-L110).
- Sockets the native listener accepted (`NodeHTTPServerSocket`) skip both listeners, so the `Bun.serve` path is unchanged.
- Verified: `test/js/node/http/node-http.test.ts` (four new tests, all fail on stock bun), the whole file, and the vendored `test-https-*` / `test-tls-*` subsets.

### Background
- In Node, `https.Server` extends `tls.Server` extends `net.Server`, and each layer is an event listener. So user code can inject a socket with `emit()`.
- Bun's `https.Server` serves its own connections natively through `Bun.serve`. Injected sockets take JS fallbacks: `new tls.TLSSocket(duplex, { isServer: true })` for TLS, `internal/http1_server_fallback` for HTTP/1.
- The fallback `TLSSocket` has `.server` set to the https server, so the accept handlers in `net.ts` emit `'secureConnection'` and `'tlsClientError'` there and run its SNI and ALPN callbacks.

<details><summary>Notes</summary>

- Probed against node v26.3.0 on both feeds: three keep-alive requests including a 100 KB POST, `Upgrade` handoff, `close()` / `closeIdleConnections()` / `closeAllConnections()` reaching an idle fed connection, handshake timeout (`ERR_TLS_HANDSHAKE_TIMEOUT` through `clientError`), plaintext into the fed socket (`ERR_SSL_HTTP_REQUEST` through `tlsClientError` then `clientError`, nothing written back), mutual TLS with `requestCert` (authorized peer, and `ERR_SSL_PEER_DID_NOT_RETURN_A_CERTIFICATE` without a client cert), `pfx`, `minVersion` / `maxVersion` / `ciphers`, `SNICallback` and `ALPNCallback`. Event counts and socket properties (`encrypted`, `instanceof TLSSocket`, `server`, `servername`, `alpnProtocol`, `getProtocol()`) match. The only difference seen is the order in which the TLS library calls the SNI and ALPN callbacks (BoringSSL: SNI first).
- The context for fed connections is built on the first fed connection and cached as `server._sharedCreds` (Node's field name), from the constructor options plus the normalized `requestCert` / `rejectUnauthorized`, with `honorCipherOrder` defaulting to true as on `tls.Server`. A context that fails to build destroys the socket and emits `'error'` on the server, as `tls.Server`'s fed path does. The native listener keeps building its own config from the same options.
- `options.handshakeTimeout`, `options.SNICallback` and `options.ALPNCallback` are now validated on an `https.Server` the way `tls.Server` validates them (`ERR_INVALID_ARG_TYPE`, `ERR_TLS_ALPN_CALLBACK_WITH_PROTOCOLS`), and `new https.Server({ ALPNProtocols })` stores the converted list on the server as `https.createServer()` already did. They only take effect on the fed path here. The native https listener still does not run them (#36707 threads `SNICallback` there, #33541 / #35538 enforce `handshakeTimeout` there, #33531 emits `tlsClientError` there). This PR does not conflict with what those do, but it touches the same constructor block, so whichever lands second rebases.
- #41672 and #41391 split `https.Server` into its own class. When one lands, the TLS-mode registrations added here move with the TLS option handling into that class unchanged.
- `test-https-timeout.js` hangs on debug builds with and without this change. That is a separate client-side bug (`req.setTimeout()` shorter than the TLS handshake never fires) and is tracked separately. So is a `tls.Server` gap found while probing: an `SNICallback` that returns a `SecureContext` drops ALPN negotiation.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http.test.ts
bun test v1.4.3 (5f554969b)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [561.10ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [75.88ms]
(pass) node:http > createServer > request & response body streaming (large) [178.08ms]
(pass) node:http > createServer > request & response body streaming (small) [119.36ms]
(pass) node:http > createServer > listen should return server [35.15ms]
(pass) node:http > createServer > listen callback should be bound to server [36.79ms]
(pass) node:http > createServer > emits 'listening' on the next tick, before the event loop polls [60.44ms]
(pass) node:http > createServer > emits a listen() error on the next tick, before the event loop polls [64.95ms]
(pass) node:http > createServer > calls the listen() callback after a retry from the EADDRINUSE 'error' handler [53.74ms]
(pass) node:http > createServer > http: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [1444.69ms]
(pass) node:http > cre
... (truncated)

release without fix: 1 failed, 1 skipped
bun test v1.4.3-canary.1 (02876d53a)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [10.06ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [2.14ms]
(pass) node:http > createServer > request & response body streaming (large) [3.42ms]
(pass) node:http > createServer > request & response body streaming (small) [1.78ms]
(pass) node:http > createServer > listen should return server [0.80ms]
(pass) node:http > createServer > listen callback should be bound to server [0.70ms]
(pass) node:http > createServer > emits 'listening' on the next tick, before the event loop polls [1.06ms]
(pass) node:http > createServer > emits a listen() error on the next tick, before the event loop polls [1.09ms]
(pass) node:http > createServer > calls the listen() callback after a retry from the EADDRINUSE 'error' handler [1.52ms]
(pass) node:http > createServer > http: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [23.44ms]
(pass) node:http > createServer > https: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [31.08ms]
(pass) node:http > createServer > should use the provided port [1.15ms]
(pa
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http.test.ts
bun test v1.4.3 (5f554969b)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [448.12ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [66.86ms]
(pass) node:http > createServer > request & response body streaming (large) [112.00ms]
(pass) node:http > createServer > request & response body streaming (small) [68.30ms]
(pass) node:http > createServer > listen should return server [23.51ms]
(pass) node:http > createServer > listen callback should be bound to server [21.58ms]
(pass) node:http > createServer > emits 'listening' on the next tick, before the event loop polls [38.54ms]
(pass) node:http > createServer > emits a listen() error on the next tick, before the event loop polls [41.81ms]
(pass) node:http > createServer > calls the listen() callback after a retry from the EADDRINUSE 'error' handler [51.20ms]
(pass) node:http > createServer > http: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [1334.10ms]
(pass) node:http > crea
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 717ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/31] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/31] gen cpp.rs (cppbind)
[3/31] gen JS modules (bundle-modules)
Preprocess modules (8147ms)
Bundle modules (41ms)
Postprocesss modules (258ms)
Bundle Functions (502ms)
Generate Code (34ms)

[8.99s] Bundled "src/js" for production
  2597 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/21] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/net/symbols.ts      |   2 +
 src/js/node/_http_server.ts         |  65 +++++++++++++--
 src/js/node/tls.ts                  |  55 +++++++------
 test/js/node/http/node-http.test.ts | 154 +++++++++++++++++++++++++++++++++++-
 4 files changed, 248 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/js/internal/net/symbols.ts           2      3     22
src/js/node/_http_server.ts             15     23     24
src/js/node/tls.ts                      12      5     22
test/js/node/http/node-http.test.ts      6      7     22
```

</details>

<!-- robobun:evidence:end -->