### PR TITLE
node:tls: report a wrapped stream's error on the TLS socket

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2299,6 +2299,7 @@ function hasUnflushedWrites(connection) {
 
 // `events` are the stream-level TLS engine's data/end/drain/close thunks.
 // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L739-L741
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L976-L977
 function attachUpgradedDuplex(self, connection, events) {
   // Ahead of events[3], so the engine's close finds the socket already
   // destroyed and reports neither the aborted handshake nor a second 'close'.
@@ -2308,6 +2309,13 @@ function attachUpgradedDuplex(self, connection, events) {
     // stream's own end finishes the socket then; a destroy would drop the data.
     if (!self[kended] && !self[kOnreadPendingEnd]) self.destroy();
   });
+  // _emitTLSError keeps the error on '_tlsError' while a server still owns
+  // the socket and emits 'error' once control is released (every client).
+  // Not on a net.Socket: its close paths report a peer reset only when
+  // listenerCount("error") > 0, so this listener would turn a teardown reset
+  // that is silent today into an 'error' on the TLS socket (TLS over TLS,
+  // test-tls-inception.js).
+  if (!(connection instanceof Socket)) connection.on("error", err => self._emitTLSError(err));
   connection.on("data", events[0]);
   connection.on("end", events[1]);
   connection.on("drain", events[2]);

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1190,6 +1190,100 @@ describe("a TLS socket over a Duplex transport follows that transport's teardown
   });
 });
 
+describe("a TLS socket over a Duplex transport hears that transport's error", () => {
+  // Node's JSStreamSocket re-emits the wrapped stream's 'error', and the TLS
+  // socket routes it through _emitTLSError:
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L65
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L976-L977
+  // A client socket reports it as 'error'. A server wrap still owns its socket,
+  // so the error stays on the internal '_tlsError' (a tls.Server turns that
+  // into 'tlsClientError'). Without the listener the transport's error had no
+  // handler at all and became an uncaughtException, so every case runs in its
+  // own process and prints each event it saw when that process exits. The
+  // expected lists are what node v26.3.0 prints for the same script.
+  const prelude = `
+    const { Duplex } = require("node:stream");
+    const tls = require("node:tls");
+    const events = [];
+    process.on("uncaughtException", e => events.push("uncaught:" + (e.code || e.message)));
+    process.on("exit", () => console.log(JSON.stringify(events)));
+    const boom = () => Object.assign(new Error("boom"), { code: "EBOOM" });
+    // "same-tick": fails before the TLS engine exists. "mid-handshake": fails
+    // right after the first handshake record it is asked to write. "started":
+    // fails one turn later, when the engine is up and waits for its peer.
+    function failingTransport(when) {
+      let armed = when === "mid-handshake";
+      const transport = new Duplex({
+        read() {},
+        write(chunk, encoding, callback) {
+          callback();
+          if (!armed) return;
+          armed = false;
+          queueMicrotask(() => transport.destroy(boom()));
+        },
+      });
+      if (when === "same-tick") queueMicrotask(() => transport.destroy(boom()));
+      if (when === "started") setImmediate(() => transport.destroy(boom()));
+      return transport;
+    }
+    const serverOptions = { isServer: true, key: ${JSON.stringify(COMMON_CERT_.key)}, cert: ${JSON.stringify(COMMON_CERT_.cert)} };
+  `;
+  async function run(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", prelude + script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { events: stdout.trim(), stderr, exitCode };
+  }
+  const expected = (events: string[]) => ({ events: JSON.stringify(events), stderr: "", exitCode: 0 });
+
+  it.concurrent.each(["same-tick", "mid-handshake"])(
+    "tls.connect({ socket }) reports it as 'error' (%s)",
+    async when => {
+      const result = await run(`
+        const transport = failingTransport(${JSON.stringify(when)});
+        const socket = tls.connect({ socket: transport, rejectUnauthorized: false });
+        events.push("listeners:" + transport.listenerCount("error"));
+        socket.on("error", e => events.push("error:" + e.code));
+        socket.on("close", hadError => events.push("close:" + hadError));
+      `);
+      expect(result).toEqual(expected(["listeners:1", "error:EBOOM", "close:false"]));
+    },
+  );
+
+  it.concurrent.each(["same-tick", "started"])("a server wrap keeps it on '_tlsError' (%s)", async when => {
+    const result = await run(`
+      const transport = failingTransport(${JSON.stringify(when)});
+      const socket = new tls.TLSSocket(transport, serverOptions);
+      events.push("listeners:" + transport.listenerCount("error"));
+      socket.on("_tlsError", e => events.push("_tlsError:" + e.code));
+      socket.on("error", e => events.push("error:" + e.code));
+      socket.on("close", hadError => events.push("close:" + hadError));
+    `);
+    expect(result).toEqual(expected(["listeners:1", "_tlsError:EBOOM", "close:false"]));
+  });
+
+  it.concurrent("https.request() over it settles with the transport's error", async () => {
+    // The http layer only listens on the TLS socket, so the request used to
+    // stay pending for good: no 'error', no 'close', destroyed === false.
+    const result = await run(`
+      const https = require("node:https");
+      const req = https.request({
+        host: "localhost",
+        path: "/",
+        createConnection: () => tls.connect({ socket: failingTransport("mid-handshake"), rejectUnauthorized: false }),
+      });
+      req.on("error", e => events.push("req.error:" + e.code));
+      req.on("close", () => events.push("req.close:" + req.destroyed));
+      req.end();
+    `);
+    expect(result).toEqual(expected(["req.error:EBOOM", "req.close:true"]));
+  });
+});
+
 it("delivers 'session' even when the data handler destroys the socket immediately", async () => {
   // The TLS1.3 NewSessionTickets ride in the same read pass as the response
   // bytes. If the parked session were only flushed after the data dispatch,


### PR DESCRIPTION
Stacked on #42176, which names this gap as its hand-off.

### Problem
- A TLS socket over a user stream (`tls.connect({ socket: duplex })`, `new tls.TLSSocket(duplex, { isServer: true })`) never hears that stream's `'error'`. `transport.listenerCount("error")` is 0 after the wrap (node: 1). `transport.destroy(err)` becomes an `uncaughtException`, and `https.request()` over such a socket never settles.
- Cause: `attachUpgradedDuplex` (`src/js/node/net.ts:2303`) wires only the engine's thunks. Node routes the stream's error: `wrap.on('error', err => this._emitTLSError(err))`.

### Fix
- `attachUpgradedDuplex` adds `connection.on("error", err => self._emitTLSError(err))` when the transport is not a `net.Socket`. `_emitTLSError` already exists in `tls.ts` with node's routing: a client reports `'error'`, a server wrap keeps it on `'_tlsError'`.
- Correct because it is node's listener at node's attach point. #42176's `'close'` listener destroys the socket afterwards, so every case prints node v26.3.0's event list.
- A `net.Socket` transport is unchanged. Its close paths report a peer reset only when `listenerCount("error") > 0`, so the listener made silent teardown resets uncaught (`test-tls-inception.js`). See Notes.
- Verified: `test/js/node/tls/node-tls-connect.test.ts` ("hears that transport's error", 5 cases, all fail on the base branch and on main). Also `test/js/node/tls/`, 245 vendored `test-tls-*`/`test-https-*` files, and the tls suites on Windows.

### Background
- A stream with no fd cannot take the kernel TLS path. bun runs a BoringSSL engine over it (`upgradeDuplexToTLS`), fed by four native thunks on the stream's events.
- `_controlReleased` is node's ownership flag. `tls.connect()` releases control at once, a server socket on `'secure'`. Until then errors stay on `'_tlsError'`, which a `tls.Server` turns into `'tlsClientError'`.

<details><summary>Notes</summary>

#### node v26.3.0 vs this branch, same scripts

| case | bun 1.4.3 | this branch | node |
| --- | --- | --- | --- |
| `tls.connect({ socket })`, `transport.destroy(err)` same tick | `uncaught:EBOOM`, socket never closes | `error:EBOOM`, `close:false` | same |
| same, mid-handshake | `uncaught:EBOOM` | `error:EBOOM`, `close:false` | same |
| server wrap, same tick | `uncaught:EBOOM` | `_tlsError:EBOOM`, `close:false` | same |
| server wrap, engine started | `uncaught:EBOOM` | `_tlsError:EBOOM`, `close:false` | same |
| `https.request` over the wrap | `uncaught:EBOOM`, `req.destroyed === false` for good | `req.error:EBOOM`, `req.close` | same |
| `tlsSocket.destroy()` over `Duplex.from({ readable, writable })` | uncaught `ABORT_ERR` | `error:ABORT_ERR`, `close:false` | same |
| transport whose `write` calls back with an error, `s.write(data, cb)` queued | uncaught, `cb` never called | `error`, `cb(ERR_SOCKET_CLOSED)`, `close:false` | `error`, `cb(ECANCELED)`, `close:false` |

The last row's callback code differs (node cancels the queued write through `JSStreamSocket.doClose`). #35386 covers ECANCELED for cancelled TLS writes.

#### Left out on purpose: every `net.Socket` transport

Two arms wrap a `net.Socket`, and neither gets the listener here:

- The fd-adoption arm. `tls.connect({ socket: connectedNetSocket })` with no queued writes hands the fd to a native TLS pair (`upgradeTLS`, `net.ts` around lines 2028 and 2426) and attaches nothing to the `net.Socket`.
- The stream-level engine over a `net.Socket`: TLS over TLS, a named pipe, or a socket with queued plain writes. These go through `attachUpgradedDuplex` and are skipped by the `instanceof Socket` check.

Node attaches the same listener in both, so `sock.destroy(err)` on such a transport is still uncaught in bun. The reason is one mechanism. `SocketEmitEndNT`, `SocketHandlers2.close`, `failWrite` and `ServerHandlers.error` turn a peer reset into `destroy(ECONNRESET)` only when the socket has an `'error'` listener, and stay silent otherwise. A forwarder counts as a listener. The first push of this PR attached it to every transport, and `test-tls-inception.js` (TLS over TLS, no `'error'` listener anywhere) then failed on Windows x64, Windows arm64 and macOS arm64 with an uncaught `read ECONNRESET`: the proxy's teardown reset on the inner socket, silent before, reached the outer socket. On Windows the base branch passes 5 of 5 runs, the first push failed 5 of 5, and this head passes 6 of 6.

Covering these transports needs those four gates to look through the forwarder to the TLS socket's own listeners, and that changes what an HTTPS-proxy flow with an `'error'` listener sees at teardown. That wants its own cross-platform validation. It overlaps #38122 (connect failure of a wrapped socket) and #36534 (`tieToWrappedStream`, which forwards with `destroy(err)` rather than `_emitTLSError`). Tracked as a follow-up.

#### Self-review

Concerns raised: conflicting helper with #42176 (stacked on it instead), server test loosened with `slice(0, 2)` (now exact lists), no same-tick `destroy(err)` case (added), wrong wrap.js citation (now L976-L977 and js_stream_socket.js L65), reach claim too broad (narrowed to user streams), fd-adoption arm uncovered (left out, above).

#### Related open PRs

- #42176: the base. Transport `'close'` destroys the TLS socket, plus the staged native close.
- #37664: client-side `new TLSSocket(socket)` upgrade. It carries a `destroy(err)` forwarder for the duplex arm as a side change. The `_emitTLSError` routing here is what node does, and it keeps a server wrap's transport error off the public `'error'`.
- #36534: larger rewrite of the wrap paths, stalled.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (5f554969b)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [4.16ms]
(pass) should thow ECONNRESET if FIN is received before handshake [497.69ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [12.13ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [177.38ms]
(pass) should be able to grab the JSStreamSocket constructor [21.61ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [117.21ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [141.93ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port
... (truncated)

release without fix: 8 failed, 18 skipped
bun test v1.4.3-canary.1 (5f554969b)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.03ms]
(pass) should thow ECONNRESET if FIN is received before handshake [6.75ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [0.17ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [3.33ms]
(pass) should be able to grab the JSStreamSocket constructor [0.20ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [6.48ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [5.07ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls.c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (5f554969b)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.83ms]
(pass) should thow ECONNRESET if FIN is received before handshake [315.79ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [7.57ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [110.82ms]
(pass) should be able to grab the JSStreamSocket constructor [12.40ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [76.24ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [80.68ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port an
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 664ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (8158ms)
Bundle modules (47ms)
Postprocesss modules (187ms)
Bundle Functions (513ms)
Generate Code (36ms)

[8.95s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compil
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                        |  8 +++
 test/js/node/tls/node-tls-connect.test.ts | 94 +++++++++++++++++++++++++++++++
 2 files changed, 102 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/net.ts                            16      8     14
test/js/node/tls/node-tls-connect.test.ts      1      1     10
```

</details>

<!-- robobun:evidence:end -->