### PR TITLE
css: split target-incompatible selectors out of a rule in linear time

### DIFF
--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -664,7 +664,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
 
     // If some of the selectors in this rule are not compatible with the targets,
     // we need to either wrap in :is() or split them into multiple rules.
-    let mut incompatible: SmallList<Selector, 1> = if sty.selectors.v.len() > 1
+    let incompatible: SmallList<Selector, 1> = if sty.selectors.v.len() > 1
         && context.targets.should_compile_selectors()
         && !sty.is_compatible(context.targets)
     {
@@ -687,15 +687,11 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
             // Otherwise, partition the selectors and keep the compatible ones in this rule.
             // We will generate additional rules for incompatible selectors later.
             let mut incompatible = SmallList::<Selector, 1>::default();
-            let mut i: u32 = 0;
-            while i < sty.selectors.v.len() {
-                if selector::is_compatible(
-                    &sty.selectors.v.slice()[i as usize..i as usize + 1],
-                    context.targets,
-                ) {
-                    i += 1;
+            for sel in core::mem::take(&mut sty.selectors.v) {
+                if selector::is_compatible(core::slice::from_ref(&sel), context.targets) {
+                    sty.selectors.v.append(sel);
                 } else {
-                    incompatible.append(sty.selectors.v.ordered_remove(i));
+                    incompatible.append(sel);
                 }
             }
             incompatible
@@ -781,8 +777,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
     }
     let mut incompatible_rules: SmallList<IncompatibleRuleEntry<R>, 1> =
         SmallList::init_capacity(incompatible.len());
-    while incompatible.len() > 0 {
-        let sel = incompatible.ordered_remove(0);
+    for sel in incompatible {
         let list = SelectorList {
             v: SmallList::with_one(sel),
         };
@@ -878,8 +873,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         rules.append(&mut log.v);
     }
     rules.extend(supps);
-    while incompatible_rules.len() > 0 {
-        let entry = incompatible_rules.ordered_remove(0);
+    for entry in incompatible_rules {
         if !entry.rule.is_empty() {
             rules.push(CssRule::Style(entry.rule));
         }

--- a/test/js/bun/css/nested-selector-list-split-hang.test.ts
+++ b/test/js/bun/css/nested-selector-list-split-hang.test.ts
@@ -6,43 +6,58 @@
 // Every selector of a nested rule is target-incompatible when nesting has to
 // be compiled away, which the default `bun build` targets require, so a 120 KB
 // nested rule with 16k selectors took 6 s to build.
-//
-// The nested rule is timed against the same selector list as a top-level rule
-// (nothing to split), so the check does not depend on machine speed.
 import { cssInternals } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
+
+const { minifyTest } = cssInternals;
 
 // Supports neither CSS nesting nor :is(), like the default bundler targets.
 const OLD_TARGETS = { chrome: 80 << 16 };
 
-/** Best-of timing; repeats while cheap so release builds get several samples. */
-function bench(run: () => unknown, maxRuns = 5, budgetMs = 2000): number {
-  let best = Infinity;
+/**
+ * Best-of timing. Repeats only while a run is cheap, so a release build takes
+ * several samples and a debug build takes one.
+ */
+function bench(run: () => string): { ms: number; out: string } {
+  let ms = Infinity;
   let spent = 0;
-  for (let i = 0; i < maxRuns && spent < budgetMs; i++) {
+  let out = "";
+  for (let i = 0; i < 5 && spent < 400; i++) {
     const start = performance.now();
-    run();
+    out = run();
     const elapsed = performance.now() - start;
-    best = Math.min(best, elapsed);
+    ms = Math.min(ms, elapsed);
     spent += elapsed;
   }
-  return best;
+  return { ms, out };
 }
 
+test("splitting target-incompatible selectors out of a rule keeps both halves in source order", () => {
+  // Chrome 60 supports neither :is() nor :focus-visible.
+  expect(minifyTest(".a,.b:focus-visible,.c,.d:focus-visible,.e{color:red}", "", { chrome: 60 << 16 })).toBe(
+    ".a,.c,.e{color:red}.b:focus-visible{color:red}.d:focus-visible{color:red}",
+  );
+  expect(minifyTest(".p{.a,.b:focus-visible,.c{color:red}}", "", { chrome: 60 << 16 })).toBe(
+    ".p .a{color:red}.p .b:focus-visible{color:red}.p .c{color:red}",
+  );
+});
+
 test("splitting a long nested selector list into separate rules is linear", () => {
-  const n = 60_000;
-  const list = Array.from({ length: n }, (_, i) => ".c" + i.toString(36)).join(",");
-  const nested = ".a{" + list + "{top:0}}";
-  const flat = ".a{.b{top:0}}" + list + "{top:0}";
+  // The nested rule is timed against the same selector list as a top-level
+  // rule, which has nothing to split, so the check does not depend on how fast
+  // the machine is.
+  const n = 50_000;
+  // ".c0,.c1,…": join() formats the numbers natively. Building 50k strings in
+  // a JS loop takes over a second in a debug build.
+  const list = ".c" + [...Array(n).keys()].join(",.c");
+  const flat = bench(() => minifyTest(".a{.b{top:0}}" + list + "{top:0}", "", OLD_TARGETS));
+  const nested = bench(() => minifyTest(".a{" + list + "{top:0}}", "", OLD_TARGETS));
 
-  const out = cssInternals.minifyTest(nested, "", OLD_TARGETS);
-  expect(out).toStartWith(".a .c0{top:0}.a .c1{top:0}.a .c2{top:0}");
-  expect(out).toEndWith(`.a .c${(n - 1).toString(36)}{top:0}`);
-  expect(cssInternals.minifyTest(flat, "", OLD_TARGETS)).toStartWith(".a .b{top:0}.c0,.c1,.c2,");
+  expect(flat.out).toStartWith(".a .b{top:0}.c0,.c1,.c2,");
+  expect(nested.out).toStartWith(".a .c0{top:0}.a .c1{top:0}.a .c2{top:0}");
+  expect(nested.out).toEndWith(`.a .c${n - 1}{top:0}`);
 
-  const flatMs = bench(() => cssInternals.minifyTest(flat, "", OLD_TARGETS));
-  const nestedMs = bench(() => cssInternals.minifyTest(nested, "", OLD_TARGETS));
   // 2x to 4x with the fix (the nested rule emits n rules instead of one);
-  // 20x (debug) to 1000x+ (release) before it.
-  expect(nestedMs / flatMs).toBeLessThan(8);
-}, 90_000);
+  // 19x (debug) to 1000x+ (release) before it.
+  expect(nested.ms / flat.ms).toBeLessThan(8);
+});

--- a/test/js/bun/css/nested-selector-list-split-hang.test.ts
+++ b/test/js/bun/css/nested-selector-list-split-hang.test.ts
@@ -1,0 +1,48 @@
+// bun-fuzz: when a style rule's selector list has to be split into one rule
+// per selector because the targets support neither the selectors as written
+// nor `:is()`, the minifier moved the selectors out of the list one at a time
+// from the front and drained the two follow-up lists the same way. Each removal
+// shifted the rest of the list, so a rule with n such selectors was O(n^2).
+// Every selector of a nested rule is target-incompatible when nesting has to
+// be compiled away, which the default `bun build` targets require, so a 120 KB
+// nested rule with 16k selectors took 6 s to build.
+//
+// The nested rule is timed against the same selector list as a top-level rule
+// (nothing to split), so the check does not depend on machine speed.
+import { cssInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+
+// Supports neither CSS nesting nor :is(), like the default bundler targets.
+const OLD_TARGETS = { chrome: 80 << 16 };
+
+/** Best-of timing; repeats while cheap so release builds get several samples. */
+function bench(run: () => unknown, maxRuns = 5, budgetMs = 2000): number {
+  let best = Infinity;
+  let spent = 0;
+  for (let i = 0; i < maxRuns && spent < budgetMs; i++) {
+    const start = performance.now();
+    run();
+    const elapsed = performance.now() - start;
+    best = Math.min(best, elapsed);
+    spent += elapsed;
+  }
+  return best;
+}
+
+test("splitting a long nested selector list into separate rules is linear", () => {
+  const n = 60_000;
+  const list = Array.from({ length: n }, (_, i) => ".c" + i.toString(36)).join(",");
+  const nested = ".a{" + list + "{top:0}}";
+  const flat = ".a{.b{top:0}}" + list + "{top:0}";
+
+  const out = cssInternals.minifyTest(nested, "", OLD_TARGETS);
+  expect(out).toStartWith(".a .c0{top:0}.a .c1{top:0}.a .c2{top:0}");
+  expect(out).toEndWith(`.a .c${(n - 1).toString(36)}{top:0}`);
+  expect(cssInternals.minifyTest(flat, "", OLD_TARGETS)).toStartWith(".a .b{top:0}.c0,.c1,.c2,");
+
+  const flatMs = bench(() => cssInternals.minifyTest(flat, "", OLD_TARGETS));
+  const nestedMs = bench(() => cssInternals.minifyTest(nested, "", OLD_TARGETS));
+  // 2x to 4x with the fix (the nested rule emits n rules instead of one);
+  // 20x (debug) to 1000x+ (release) before it.
+  expect(nestedMs / flatMs).toBeLessThan(8);
+}, 90_000);


### PR DESCRIPTION
### Problem
- A nested rule whose selector list has n selectors is O(n^2) to minify for the default browser targets. A 120 KB file (`.a,.b{ .c0,…,.c16383 {color:red} }`) takes 6 s in `Bun.build`. The same list at the top level takes 38 ms for 65k selectors (60% of samples in `memmove` called from `minify_style_arm`).
- When the selectors are not all target-compatible and cannot be wrapped in `:is()`, `minify_style_arm` (`src/css/rules/mod.rs`) moved the incompatible ones out with `ordered_remove(i)` (line 698) and drained two follow-up lists with `ordered_remove(0)` (lines 785, 882). Each call shifts the rest of the list.

### Fix
- Partition the selector list in one pass, and consume `incompatible` and `incompatible_rules` by value.
- Order is preserved in all three places, so the output is byte-identical.
- Verified: `test/js/bun/css/nested-selector-list-split-hang.test.ts` (time ratio of a 50k-selector nested rule against the same list at the top level: 2x to 3x with the fix, 21x on debug main, 2600x on 1.4.2, plus an order check for a mixed list). Also `test/js/bun/css/css.test.ts`, the other `nested-*` tests, `test/bundler/esbuild/css.test.ts`.

### Background
- If one selector in a list is invalid for a browser, that browser drops the whole rule. So the minifier wraps a list with unsupported selectors in `:is()`, or, when `:is()` is not available, splits the unsupported selectors into one rule each.
- A nested rule's selectors carry an implicit `&`. For targets without native nesting every one of them counts as unsupported, so the split runs over the whole list.
- The default `bun build` targets predate both nesting and `:is()`.

<details><summary>Notes</summary>

- Release timings for the ledger script (`Bun.build`, nested / flat): n = 2048 / 4096 / 8192 / 16384 was 62 / 331 / 965 / 4104 ms nested before, 5 / 9 / 10 / 20 ms after; flat is 2 to 10 ms either way.
- #40464 changes which incompatible selectors share a rule and touches the same loop. This change keeps the current output and only removes the quadratic list handling, so the two are independent apart from the textual conflict.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/nested-selector-list-split-hang.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/184] fetch picohttpparser
[picohttpparser] fetching h2o/picohttpparser@066d2b1e
[picohttpparser] applying strict-chunk-size.patch
[picohttpparser] done → /workspace/bun/vendor/picohttpparser
[2/184] gen cpp.rs (cppbind)
[3/184] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[4/184] gen JS modules (bundle-modules)
Preprocess modules (14336ms)
Bundle modules (83ms)
Postprocesss modules (159ms)
Bundle Functions (561ms)
Generate Code (43ms)

[15.19s] Bundled "src/js" for development
  2791 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[4/184] cargo bun_runtime → libbun_runtime.a
[177/184] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
FAILED: obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalo
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (4ff919377)

test/js/bun/css/nested-selector-list-split-hang.test.ts:
(pass) splitting target-incompatible selectors out of a rule keeps both halves in source order [14.09ms]
(pass) splitting a long nested selector list into separate rules is linear [566.78ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [1013.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/nested-selector-list-split-hang.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/css/nested-selector-list-split-hang.test.ts:
(pass) splitting target-incompatible selectors out of a rule keeps both halves in source order [13.31ms]
(pass) splitting a long nested selector list into separate rules is linear [2894.65ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [5.77s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2fa92b585d
  features     baseline

23 deps, 131 codegen, 1172 objects in 800ms

ninja: Entering directory `/workspace/bun/build/release'
[1/143] fetch picohttpparser
[picohttpparser] up to date
[2/143] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/143] gen cpp.rs (cppbind)
[4/143] gen JS modules (bundle-modules)
Preprocess modules (12292ms)
Bundle modules (60ms)
Postprocesss modules (174ms)
Bundle Functions (588ms)
Generate Code (49ms)

[13.18s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[4/142] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/borin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/rules/mod.rs                               | 20 +++----
 .../css/nested-selector-list-split-hang.test.ts    | 63 ++++++++++++++++++++++
 2 files changed, 70 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/css/rules/mod.rs                                         1      4     11
test/js/bun/css/nested-selector-list-split-hang.test.ts      2      3     11
```

</details>

<!-- robobun:evidence:end -->