### PR TITLE
markdown: remove two O(depth^2) costs from Bun.markdown.render()

### DIFF
--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -1047,6 +1047,8 @@ struct JsCallbackRenderer<'a> {
     // Note: #allocator field dropped — global mimalloc.
     src_text: &'a [u8],
     stack: Vec<CallbackStackEntry>,
+    /// Number of ul/ol entries currently on `stack`.
+    list_depth: u32,
     callbacks: Callbacks,
     heading_tracker: md::helpers::HeadingIdTracker,
     stack_check: StackCheck,
@@ -1146,6 +1148,7 @@ impl<'a> JsCallbackRenderer<'a> {
             global_object,
             src_text,
             stack: Vec::new(),
+            list_depth: 0,
             callbacks: Callbacks::default(),
             heading_tracker: md::helpers::HeadingIdTracker::init(heading_ids),
             stack_check: StackCheck::init(),
@@ -1274,6 +1277,9 @@ impl<'a> JsCallbackRenderer<'a> {
         if block_type == md::BlockType::H {
             self.heading_tracker.enter_heading();
         }
+        if matches!(block_type, md::BlockType::Ul | md::BlockType::Ol) {
+            self.list_depth += 1;
+        }
 
         // For li: record its 0-based index within the parent list, then
         // increment the parent's counter so the next sibling gets index+1.
@@ -1300,6 +1306,12 @@ impl<'a> JsCallbackRenderer<'a> {
         }
         if block_type == md::BlockType::Doc {
             return Ok(());
+        }
+
+        // Leaving a ul/ol: drop it from the count first so `list_depth` is the
+        // number of *enclosing* lists while its meta is built.
+        if matches!(block_type, md::BlockType::Ul | md::BlockType::Ol) {
+            self.list_depth = self.list_depth.saturating_sub(1);
         }
 
         let callback = self.get_block_callback(block_type);
@@ -1457,24 +1469,6 @@ impl<'a> JsCallbackRenderer<'a> {
     // Metadata object creation
     // ========================================
 
-    /// Walks the stack to count enclosing ul/ol blocks. Called during leave,
-    /// so the top entry is the block itself (skip it for li, count it for ul/ol's
-    /// own depth which excludes self).
-    fn count_list_depth(&self) -> u32 {
-        let mut depth: u32 = 0;
-        // Skip the top entry (self) — we want enclosing lists only.
-        let len = self.stack.len();
-        if len < 2 {
-            return 0;
-        }
-        for entry in &self.stack[0..len - 1] {
-            if entry.block_type == md::BlockType::Ul || entry.block_type == md::BlockType::Ol {
-                depth += 1;
-            }
-        }
-        depth
-    }
-
     /// Returns the parent ul/ol entry for the current li (top of stack).
     /// Returns None if the stack shape is unexpected.
     fn parent_list(&self) -> Option<&CallbackStackEntry> {
@@ -1513,7 +1507,7 @@ impl<'a> JsCallbackRenderer<'a> {
                     g,
                     true,
                     JSValue::js_number(data as f64),
-                    self.count_list_depth(),
+                    self.list_depth,
                 )))
             }
             md::BlockType::Ul => {
@@ -1522,7 +1516,7 @@ impl<'a> JsCallbackRenderer<'a> {
                     g,
                     false,
                     JSValue::UNDEFINED,
-                    self.count_list_depth(),
+                    self.list_depth,
                 )))
             }
             md::BlockType::Code => {
@@ -1557,10 +1551,9 @@ impl<'a> JsCallbackRenderer<'a> {
                 let parent = self.parent_list();
                 let is_ordered =
                     parent.is_some() && parent.unwrap().block_type == md::BlockType::Ol;
-                // count_list_depth() includes the immediate parent list; subtract it
+                // `list_depth` includes the immediate parent list; subtract it
                 // so that items in a top-level list report depth 0.
-                let enclosing = self.count_list_depth();
-                let depth: u32 = if enclosing > 0 { enclosing - 1 } else { 0 };
+                let depth = self.list_depth.saturating_sub(1);
                 let task_mark = md::types::task_mark_from_data(data);
 
                 let start_js = if is_ordered {

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -1038,9 +1038,7 @@ impl<'a> ParseRenderer<'a> {
 }
 
 /// Renderer that calls JavaScript callbacks for each markdown element.
-/// An element with a callback collects its children in its own buffer; on
-/// leave the callback gets them and its result goes to the enclosing buffer.
-/// An element without one writes straight into the enclosing buffer.
+/// Only an element with a callback buffers its children; the rest write to the enclosing buffer.
 struct JsCallbackRenderer<'a> {
     global_object: &'a JSGlobalObject,
     // Note: #allocator field dropped — global mimalloc.

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -1038,15 +1038,20 @@ impl<'a> ParseRenderer<'a> {
 }
 
 /// Renderer that calls JavaScript callbacks for each markdown element.
-/// Uses a content-stack pattern: each enter pushes a new buffer, text
-/// appends to the top buffer, and each leave pops the buffer, calls
-/// the JS callback with the accumulated children, and appends the
-/// callback's return value to the parent buffer.
+/// Every enter pushes a stack entry. An element with a registered callback
+/// *captures*: output produced inside it collects in its own buffer, and on
+/// leave the callback is called with that buffer and its return value is
+/// appended to the enclosing capture. An element without a callback renders
+/// straight into the enclosing capture (ultimately the root), so leaving it
+/// copies nothing and nesting depth alone costs O(1) per element.
 struct JsCallbackRenderer<'a> {
     global_object: &'a JSGlobalObject,
     // Note: #allocator field dropped — global mimalloc.
     src_text: &'a [u8],
     stack: Vec<CallbackStackEntry>,
+    /// Indices into `stack` of the capturing entries, innermost last. Output
+    /// is appended to the last one. Never empty: the root (index 0) captures.
+    capture_stack: Vec<usize>,
     /// Number of ul/ol entries currently on `stack`.
     list_depth: u32,
     callbacks: Callbacks,
@@ -1081,7 +1086,10 @@ struct Callbacks {
 // Note: `Default` for JSValue must be `JSValue::ZERO`.
 
 struct CallbackStackEntry {
+    /// Children output; only written while this entry is the innermost capture.
     buffer: Vec<u8>,
+    /// Set when a callback is registered for this element (and for the root).
+    captures: bool,
     block_type: md::BlockType,
     data: u32,
     flags: u32,
@@ -1098,6 +1106,7 @@ impl Default for CallbackStackEntry {
     fn default() -> Self {
         Self {
             buffer: Vec::new(),
+            captures: false,
             block_type: md::BlockType::Doc,
             data: 0,
             flags: 0,
@@ -1148,12 +1157,16 @@ impl<'a> JsCallbackRenderer<'a> {
             global_object,
             src_text,
             stack: Vec::new(),
+            capture_stack: Vec::new(),
             list_depth: 0,
             callbacks: Callbacks::default(),
             heading_tracker: md::helpers::HeadingIdTracker::init(heading_ids),
             stack_check: StackCheck::init(),
         };
-        self_.stack.push(CallbackStackEntry::default());
+        self_.push_entry(CallbackStackEntry {
+            captures: true,
+            ..Default::default()
+        });
         Ok(self_)
     }
 
@@ -1206,26 +1219,46 @@ impl<'a> JsCallbackRenderer<'a> {
     // Content stack operations
     // ========================================
 
-    fn append_to_top(&mut self, data: &[u8]) -> Result<(), bun_alloc::AllocError> {
-        if let Some(top) = self.stack.last_mut() {
-            top.buffer.extend_from_slice(data);
+    fn push_entry(&mut self, entry: CallbackStackEntry) {
+        if entry.captures {
+            self.capture_stack.push(self.stack.len());
+        }
+        self.stack.push(entry);
+    }
+
+    /// Pops the top entry. Never pops the root.
+    fn pop_entry(&mut self) -> Option<CallbackStackEntry> {
+        if self.stack.len() <= 1 {
+            return None;
+        }
+        let entry = self.stack.pop()?;
+        if entry.captures {
+            self.capture_stack.pop();
+        }
+        Some(entry)
+    }
+
+    fn top_captures(&self) -> bool {
+        self.stack.len() > 1 && self.stack.last().is_some_and(|e| e.captures)
+    }
+
+    /// Appends rendered output to the innermost capturing entry.
+    fn append_output(&mut self, data: &[u8]) -> Result<(), bun_alloc::AllocError> {
+        if let Some(&i) = self.capture_stack.last() {
+            self.stack[i].buffer.extend_from_slice(data);
         }
         Ok(())
     }
 
+    /// Pops the top (capturing) entry, calls `callback` with its collected
+    /// children, and appends the callback's result to the enclosing capture.
     fn pop_and_callback(&mut self, callback: JSValue, meta: Option<JSValue>) -> JsResult<()> {
-        if self.stack.len() <= 1 {
-            return Ok(()); // don't pop root
-        }
-        let Some(entry) = self.stack.pop() else {
+        let Some(entry) = self.pop_entry() else {
             return Ok(());
         };
-
-        let children = entry.buffer.as_slice();
-
         if callback.is_empty() {
-            // No callback registered - pass children through to parent
-            self.append_to_top(children)?;
+            // Only reachable if an enter/leave pair disagrees on the element type.
+            self.append_output(&entry.buffer)?;
             return Ok(());
         }
 
@@ -1234,7 +1267,8 @@ impl<'a> JsCallbackRenderer<'a> {
         }
 
         // Convert children to JS string
-        let children_js = bun_string_jsc::create_utf8_for_js(self.global_object, children)?;
+        let children_js =
+            bun_string_jsc::create_utf8_for_js(self.global_object, entry.buffer.as_slice())?;
 
         // Call the JS callback
         let result = if let Some(m) = meta {
@@ -1247,7 +1281,7 @@ impl<'a> JsCallbackRenderer<'a> {
             return Ok(()); // callback returned null/undefined → omit element
         }
         let slice = result.to_utf8(self.global_object)?;
-        self.append_to_top(slice.slice())?;
+        self.append_output(slice.slice())?;
         Ok(())
     }
 
@@ -1290,7 +1324,9 @@ impl<'a> JsCallbackRenderer<'a> {
             parent.child_index += 1;
         }
 
-        self.stack.push(CallbackStackEntry {
+        let captures = !self.get_block_callback(block_type).is_empty();
+        self.push_entry(CallbackStackEntry {
+            captures,
             block_type,
             data,
             flags,
@@ -1314,21 +1350,20 @@ impl<'a> JsCallbackRenderer<'a> {
             self.list_depth = self.list_depth.saturating_sub(1);
         }
 
-        let callback = self.get_block_callback(block_type);
-        // Note: reshaped for borrowck — clone the saved entry (cheap; buffer not used) instead of holding a borrow across method calls.
-        let saved = if self.stack.len() > 1 {
-            CallbackStackEntry {
-                block_type: self.stack.last().unwrap().block_type,
-                data: self.stack.last().unwrap().data,
-                flags: self.stack.last().unwrap().flags,
-                child_index: self.stack.last().unwrap().child_index,
-                ..Default::default()
-            }
+        if self.top_captures() {
+            let callback = self.get_block_callback(block_type);
+            let top = self.stack.last().unwrap();
+            let (data, flags) = (top.data, top.flags);
+            // Built while the entry is still on the stack: li meta reads it and its parent.
+            let meta = self.create_block_meta(block_type, data, flags)?;
+            self.pop_and_callback(callback, meta)?;
         } else {
-            CallbackStackEntry::default()
-        };
-        let meta = self.create_block_meta(block_type, saved.data, saved.flags)?;
-        self.pop_and_callback(callback, meta)?;
+            // No callback: the children already went to the enclosing capture.
+            self.pop_entry();
+            if block_type == md::BlockType::H {
+                let _ = self.heading_tracker.leave_heading();
+            }
+        }
 
         if block_type == md::BlockType::H {
             self.heading_tracker.clear_after_heading();
@@ -1336,15 +1371,25 @@ impl<'a> JsCallbackRenderer<'a> {
         Ok(())
     }
 
-    fn enter_span_impl(&mut self, _: md::SpanType, detail: md::SpanDetail<'_>) -> JsResult<()> {
+    fn enter_span_impl(
+        &mut self,
+        span_type: md::SpanType,
+        detail: md::SpanDetail<'_>,
+    ) -> JsResult<()> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(self.global_object.throw_stack_overflow());
         }
-        self.stack.push(CallbackStackEntry {
-            href: Box::from(detail.href),
-            title: Box::from(detail.title),
-            ..Default::default()
-        });
+        let entry = if self.get_span_callback(span_type).is_empty() {
+            CallbackStackEntry::default()
+        } else {
+            CallbackStackEntry {
+                captures: true,
+                href: Box::from(detail.href),
+                title: Box::from(detail.title),
+                ..Default::default()
+            }
+        };
+        self.push_entry(entry);
         Ok(())
     }
 
@@ -1353,14 +1398,15 @@ impl<'a> JsCallbackRenderer<'a> {
             return Err(self.global_object.throw_stack_overflow());
         }
 
+        if !self.top_captures() {
+            // No callback: the children already went to the enclosing capture.
+            self.pop_entry();
+            return Ok(());
+        }
+
         let callback = self.get_span_callback(span_type);
-        let (href, title): (&[u8], &[u8]) = if self.stack.len() > 1 {
-            let top = self.stack.last().unwrap();
-            (&top.href, &top.title)
-        } else {
-            (b"", b"")
-        };
-        let meta = self.create_span_meta(span_type, href, title)?;
+        let top = self.stack.last().unwrap();
+        let meta = self.create_span_meta(span_type, &top.href, &top.title)?;
         self.pop_and_callback(callback, meta)?;
         Ok(())
     }
@@ -1374,15 +1420,15 @@ impl<'a> JsCallbackRenderer<'a> {
         self.heading_tracker.track_text(text_type, content);
 
         match text_type {
-            md::TextType::NullChar => self.append_to_top(b"\xEF\xBF\xBD")?,
-            md::TextType::Br => self.append_to_top(b"\n")?,
-            md::TextType::Softbr => self.append_to_top(b"\n")?,
+            md::TextType::NullChar => self.append_output(b"\xEF\xBF\xBD")?,
+            md::TextType::Br => self.append_output(b"\n")?,
+            md::TextType::Softbr => self.append_output(b"\n")?,
             md::TextType::Entity => self.decode_and_append_entity(content)?,
             _ => {
                 if !self.callbacks.text.is_empty() {
                     self.call_text_callback(content)?;
                 } else {
-                    self.append_to_top(content)?;
+                    self.append_output(content)?;
                 }
             }
         }
@@ -1404,7 +1450,7 @@ impl<'a> JsCallbackRenderer<'a> {
                 .call(self.global_object, JSValue::UNDEFINED, &[text_js])?;
         if !result.is_undefined_or_null() {
             let slice = result.to_utf8(self.global_object)?;
-            self.append_to_top(slice.slice())?;
+            self.append_output(slice.slice())?;
         }
         Ok(())
     }
@@ -1424,7 +1470,7 @@ impl<'a> JsCallbackRenderer<'a> {
         if !self.callbacks.text.is_empty() {
             self.call_text_callback(content)
         } else {
-            self.append_to_top(content)?;
+            self.append_output(content)?;
             Ok(())
         }
     }

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -1038,21 +1038,17 @@ impl<'a> ParseRenderer<'a> {
 }
 
 /// Renderer that calls JavaScript callbacks for each markdown element.
-/// Every enter pushes a stack entry. An element with a registered callback
-/// *captures*: output produced inside it collects in its own buffer, and on
-/// leave the callback is called with that buffer and its return value is
-/// appended to the enclosing capture. An element without a callback renders
-/// straight into the enclosing capture (ultimately the root), so leaving it
-/// copies nothing and nesting depth alone costs O(1) per element.
+/// An element with a callback collects its children in its own buffer; on
+/// leave the callback gets them and its result goes to the enclosing buffer.
+/// An element without one writes straight into the enclosing buffer.
 struct JsCallbackRenderer<'a> {
     global_object: &'a JSGlobalObject,
     // Note: #allocator field dropped — global mimalloc.
     src_text: &'a [u8],
     stack: Vec<CallbackStackEntry>,
-    /// Indices into `stack` of the capturing entries, innermost last. Output
-    /// is appended to the last one. Never empty: the root (index 0) captures.
-    capture_stack: Vec<usize>,
-    /// Number of ul/ol entries currently on `stack`.
+    /// Indices into `stack` of the entries that collect output, innermost last.
+    collecting: Vec<usize>,
+    /// Number of ul/ol entries on `stack`.
     list_depth: u32,
     callbacks: Callbacks,
     heading_tracker: md::helpers::HeadingIdTracker,
@@ -1086,10 +1082,7 @@ struct Callbacks {
 // Note: `Default` for JSValue must be `JSValue::ZERO`.
 
 struct CallbackStackEntry {
-    /// Children output; only written while this entry is the innermost capture.
     buffer: Vec<u8>,
-    /// Set when a callback is registered for this element (and for the root).
-    captures: bool,
     block_type: md::BlockType,
     data: u32,
     flags: u32,
@@ -1106,7 +1099,6 @@ impl Default for CallbackStackEntry {
     fn default() -> Self {
         Self {
             buffer: Vec::new(),
-            captures: false,
             block_type: md::BlockType::Doc,
             data: 0,
             flags: 0,
@@ -1157,16 +1149,13 @@ impl<'a> JsCallbackRenderer<'a> {
             global_object,
             src_text,
             stack: Vec::new(),
-            capture_stack: Vec::new(),
+            collecting: Vec::new(),
             list_depth: 0,
             callbacks: Callbacks::default(),
             heading_tracker: md::helpers::HeadingIdTracker::init(heading_ids),
             stack_check: StackCheck::init(),
         };
-        self_.push_entry(CallbackStackEntry {
-            captures: true,
-            ..Default::default()
-        });
+        self_.push_entry(CallbackStackEntry::default(), true);
         Ok(self_)
     }
 
@@ -1219,47 +1208,44 @@ impl<'a> JsCallbackRenderer<'a> {
     // Content stack operations
     // ========================================
 
-    fn push_entry(&mut self, entry: CallbackStackEntry) {
-        if entry.captures {
-            self.capture_stack.push(self.stack.len());
+    fn push_entry(&mut self, entry: CallbackStackEntry, collects: bool) {
+        if collects {
+            self.collecting.push(self.stack.len());
+        }
+        if matches!(entry.block_type, md::BlockType::Ul | md::BlockType::Ol) {
+            self.list_depth += 1;
         }
         self.stack.push(entry);
     }
 
-    /// Pops the top entry. Never pops the root.
+    /// Never pops the root.
     fn pop_entry(&mut self) -> Option<CallbackStackEntry> {
         if self.stack.len() <= 1 {
             return None;
         }
         let entry = self.stack.pop()?;
-        if entry.captures {
-            self.capture_stack.pop();
+        if self.collecting.last() == Some(&self.stack.len()) {
+            self.collecting.pop();
+        }
+        if matches!(entry.block_type, md::BlockType::Ul | md::BlockType::Ol) {
+            self.list_depth -= 1;
         }
         Some(entry)
     }
 
-    fn top_captures(&self) -> bool {
-        self.stack.len() > 1 && self.stack.last().is_some_and(|e| e.captures)
-    }
-
-    /// Appends rendered output to the innermost capturing entry.
     fn append_output(&mut self, data: &[u8]) -> Result<(), bun_alloc::AllocError> {
-        if let Some(&i) = self.capture_stack.last() {
+        if let Some(&i) = self.collecting.last() {
             self.stack[i].buffer.extend_from_slice(data);
         }
         Ok(())
     }
 
-    /// Pops the top (capturing) entry, calls `callback` with its collected
-    /// children, and appends the callback's result to the enclosing capture.
     fn pop_and_callback(&mut self, callback: JSValue, meta: Option<JSValue>) -> JsResult<()> {
         let Some(entry) = self.pop_entry() else {
             return Ok(());
         };
         if callback.is_empty() {
-            // The parser left a span open (#39496: `*a *b *c *d *e *f *g*******`
-            // with an `emphasis` callback), so a later leave of another element
-            // type pops that span's entry. Keep what it collected.
+            // Empty unless the parser's enter/leave events were unbalanced (#39496).
             self.append_output(&entry.buffer)?;
             return Ok(());
         }
@@ -1313,9 +1299,6 @@ impl<'a> JsCallbackRenderer<'a> {
         if block_type == md::BlockType::H {
             self.heading_tracker.enter_heading();
         }
-        if matches!(block_type, md::BlockType::Ul | md::BlockType::Ol) {
-            self.list_depth += 1;
-        }
 
         // For li: record its 0-based index within the parent list, then
         // increment the parent's counter so the next sibling gets index+1.
@@ -1326,15 +1309,17 @@ impl<'a> JsCallbackRenderer<'a> {
             parent.child_index += 1;
         }
 
-        let captures = !self.get_block_callback(block_type).is_empty();
-        self.push_entry(CallbackStackEntry {
-            captures,
-            block_type,
-            data,
-            flags,
-            child_index,
-            ..Default::default()
-        });
+        let collects = !self.get_block_callback(block_type).is_empty();
+        self.push_entry(
+            CallbackStackEntry {
+                block_type,
+                data,
+                flags,
+                child_index,
+                ..Default::default()
+            },
+            collects,
+        );
         Ok(())
     }
 
@@ -1346,26 +1331,20 @@ impl<'a> JsCallbackRenderer<'a> {
             return Ok(());
         }
 
-        // Leaving a ul/ol: drop it from the count first so `list_depth` is the
-        // number of *enclosing* lists while its meta is built.
-        if matches!(block_type, md::BlockType::Ul | md::BlockType::Ol) {
-            self.list_depth = self.list_depth.saturating_sub(1);
-        }
-
-        if self.top_captures() {
-            let callback = self.get_block_callback(block_type);
-            let top = self.stack.last().unwrap();
-            let (data, flags) = (top.data, top.flags);
-            // Built while the entry is still on the stack: li meta reads it and its parent.
-            let meta = self.create_block_meta(block_type, data, flags)?;
-            self.pop_and_callback(callback, meta)?;
-        } else {
-            // No callback: the children already went to the enclosing capture.
-            self.pop_entry();
+        let callback = self.get_block_callback(block_type);
+        let meta = if callback.is_empty() {
             if block_type == md::BlockType::H {
                 let _ = self.heading_tracker.leave_heading();
             }
-        }
+            None
+        } else {
+            let (data, flags) = self
+                .stack
+                .last()
+                .map_or((0, 0), |top| (top.data, top.flags));
+            self.create_block_meta(block_type, data, flags)?
+        };
+        self.pop_and_callback(callback, meta)?;
 
         if block_type == md::BlockType::H {
             self.heading_tracker.clear_after_heading();
@@ -1381,17 +1360,17 @@ impl<'a> JsCallbackRenderer<'a> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(self.global_object.throw_stack_overflow());
         }
-        let entry = if self.get_span_callback(span_type).is_empty() {
-            CallbackStackEntry::default()
-        } else {
+        let collects = !self.get_span_callback(span_type).is_empty();
+        let entry = if collects {
             CallbackStackEntry {
-                captures: true,
                 href: Box::from(detail.href),
                 title: Box::from(detail.title),
                 ..Default::default()
             }
+        } else {
+            CallbackStackEntry::default()
         };
-        self.push_entry(entry);
+        self.push_entry(entry, collects);
         Ok(())
     }
 
@@ -1400,15 +1379,13 @@ impl<'a> JsCallbackRenderer<'a> {
             return Err(self.global_object.throw_stack_overflow());
         }
 
-        if !self.top_captures() {
-            // No callback: the children already went to the enclosing capture.
-            self.pop_entry();
-            return Ok(());
-        }
-
         let callback = self.get_span_callback(span_type);
-        let top = self.stack.last().unwrap();
-        let meta = self.create_span_meta(span_type, &top.href, &top.title)?;
+        let meta = match self.stack.last() {
+            Some(top) if !callback.is_empty() => {
+                self.create_span_meta(span_type, &top.href, &top.title)?
+            }
+            _ => None,
+        };
         self.pop_and_callback(callback, meta)?;
         Ok(())
     }
@@ -1555,7 +1532,7 @@ impl<'a> JsCallbackRenderer<'a> {
                     g,
                     true,
                     JSValue::js_number(data as f64),
-                    self.list_depth,
+                    self.list_depth.saturating_sub(1),
                 )))
             }
             md::BlockType::Ul => {
@@ -1564,7 +1541,7 @@ impl<'a> JsCallbackRenderer<'a> {
                     g,
                     false,
                     JSValue::UNDEFINED,
-                    self.list_depth,
+                    self.list_depth.saturating_sub(1),
                 )))
             }
             md::BlockType::Code => {

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -1257,7 +1257,9 @@ impl<'a> JsCallbackRenderer<'a> {
             return Ok(());
         };
         if callback.is_empty() {
-            // Only reachable if an enter/leave pair disagrees on the element type.
+            // The parser left a span open (#39496: `*a *b *c *d *e *f *g*******`
+            // with an `emphasis` callback), so a later leave of another element
+            // type pops that span's entry. Keep what it collected.
             self.append_output(&entry.buffer)?;
             return Ok(());
         }

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -4,6 +4,23 @@ import { renderToString } from "react-dom/server";
 
 const Markdown = Bun.markdown;
 
+// Runs `script` in a child that is killed after 30s, so a super-linear
+// regression fails fast instead of hanging the test runner.
+async function expectRendersQuickly(script: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 30_000,
+    killSignal: "SIGKILL",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toContain("DONE");
+  expect(exitCode).toBe(0);
+}
+
 // ============================================================================
 // Fuzzer-like tests: edge cases, pathological inputs, invariant checks
 // ============================================================================
@@ -566,21 +583,6 @@ code
 // ============================================================================
 
 describe("pathological bracket inputs", () => {
-  async function expectRendersQuickly(script: string) {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-      timeout: 30_000,
-      killSignal: "SIGKILL",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toContain("DONE");
-    expect(exitCode).toBe(0);
-  }
-
   test("bracket floods render in linear time (html)", async () => {
     await expectRendersQuickly(`
         const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
@@ -758,21 +760,6 @@ describe("pathological bracket inputs", () => {
 // ============================================================================
 
 describe("pathological inline HTML inputs", () => {
-  async function expectRendersQuickly(script: string) {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-      timeout: 30_000,
-      killSignal: "SIGKILL",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toContain("DONE");
-    expect(exitCode).toBe(0);
-  }
-
   test("unterminated inline HTML openers render in linear time", async () => {
     await expectRendersQuickly(`
         const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
@@ -853,6 +840,111 @@ describe("pathological inline HTML inputs", () => {
     expect(Markdown.html("[<!-- [<!-- [<!-- x](u)](u)](u)\n")).toBe(
       '<p>[&lt;!-- [&lt;!-- <a href="u">&lt;!-- x</a>](u)](u)</p>\n',
     );
+  });
+});
+
+// ============================================================================
+// Pathological inputs: deep nesting through `Bun.markdown.render()`. Two
+// separate O(depth²) costs, both found by fuzzing, while html() and react()
+// on the same inputs take milliseconds:
+// - The `depth` field of the list / listItem meta was computed by walking the
+//   whole open-block stack on every list and list-item leave (300 KB of `>- `
+//   markers took ~100s). It is now a counter.
+// - Every element collected its children in its own buffer and copied them
+//   into the parent's buffer on leave, even with no callback registered, so
+//   text nested D levels deep was copied D times (1.2 MB of nested `*a … b*`
+//   took 5s with an empty callback set). Elements without a callback now
+//   render straight into the nearest enclosing element that has one.
+// The child process is killed after 30s so a regression fails fast.
+// ============================================================================
+
+describe("pathological nesting through render()", () => {
+  test("deeply nested lists render in linear time with correct depth meta", async () => {
+    await expectRendersQuickly(`
+        const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
+        {
+          // listItem meta at every one of 100k levels.
+          const depth = 100000;
+          let items = 0, maxDepth = -1, ordered = 0;
+          const out = Bun.markdown.render(fill(depth, "1. ") + "hi", {
+            listItem: (children, meta) => { items++; if (meta.depth > maxDepth) maxDepth = meta.depth; if (meta.ordered) ordered++; return children; },
+          });
+          const got = JSON.stringify({ out, items, maxDepth, ordered });
+          const want = JSON.stringify({ out: "hi", items: depth, maxDepth: depth - 1, ordered: depth });
+          if (got !== want) throw new Error("unexpected listItem result: " + got.slice(0, 300));
+          console.log("OK listItem depth");
+        }
+        // No callbacks registered: every block passes its children through.
+        for (const [unit, depth] of [[">- ", 100000], ["+ ", 50000], ["1) ", 50000]]) {
+          const out = Bun.markdown.render(fill(depth, unit) + "hi", {});
+          if (out !== "hi") throw new Error("unexpected output for " + JSON.stringify(unit) + ": " + JSON.stringify(out.slice(0, 200)));
+          console.log("OK " + JSON.stringify(unit));
+        }
+        // The counter reports the same list / listItem depths the stack walk did.
+        for (const unit of ["1. ", ">- ", "- > "]) {
+          const depth = 4000;
+          let items = 0, lists = 0, maxItemDepth = -1, maxListDepth = -1;
+          const out = Bun.markdown.render(fill(depth, unit) + "hi", {
+            listItem: (children, meta) => { items++; if (meta.depth > maxItemDepth) maxItemDepth = meta.depth; return children; },
+            list: (children, meta) => { lists++; if (meta.depth > maxListDepth) maxListDepth = meta.depth; return children; },
+          });
+          const got = JSON.stringify({ out, items, lists, maxItemDepth, maxListDepth });
+          const want = JSON.stringify({ out: "hi", items: depth, lists: depth, maxItemDepth: depth - 1, maxListDepth: depth - 1 });
+          if (got !== want) throw new Error("unexpected depth meta for " + JSON.stringify(unit) + ": " + got.slice(0, 300));
+          console.log("OK depth meta " + JSON.stringify(unit));
+        }
+        console.log("DONE");
+      `);
+  }, 90_000);
+
+  test("deeply nested inline spans render in linear time", async () => {
+    await expectRendersQuickly(`
+        const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
+        const n = 600000;
+        const input = fill(n, "*a ") + fill(n, " b*");
+        const text = fill(n, "a ") + fill(n, " b");
+        {
+          const out = Bun.markdown.render(input, {});
+          if (out !== text) throw new Error("unexpected output (no callbacks): " + out.length + " " + JSON.stringify(out.slice(0, 100)));
+          console.log("OK no callbacks");
+        }
+        {
+          // Only the outermost element captures; the nested spans inside it do not.
+          const out = Bun.markdown.render(input, { paragraph: children => "<p>" + children + "</p>\\n" });
+          if (out !== "<p>" + text + "</p>\\n") throw new Error("unexpected output (paragraph callback): " + out.length + " " + JSON.stringify(out.slice(0, 100)));
+          console.log("OK paragraph callback");
+        }
+        console.log("DONE");
+      `);
+  }, 90_000);
+
+  test("capturing and pass-through elements interleave correctly", () => {
+    // An element with a callback collects exactly its own children, whether or
+    // not the elements between it and the text have callbacks of their own.
+    const nested = (n: number) => Buffer.alloc(n * 3, "*a ").toString() + Buffer.alloc(n * 3, " b*").toString() + "\n";
+    const callbacks = {
+      emphasis: (c: string) => "<em>" + c + "</em>",
+      paragraph: (c: string) => "<p>" + c + "</p>\n",
+    };
+    for (const n of [1, 2, 3, 50, 2000]) {
+      expect(Markdown.render(nested(n), callbacks)).toBe(Markdown.html(nested(n)));
+    }
+    const mixed = "**x *y **z *w* z** y* x**\n";
+    expect(Markdown.render(mixed, {})).toBe("x y z w z y x");
+    expect(Markdown.render(mixed, { strong: c => `[${c}]` })).toBe("[x y [z w z] y x]");
+    expect(Markdown.render(mixed, { emphasis: c => `(${c})` })).toBe("x (y z (w) z y) x");
+    expect(Markdown.render(mixed, { strong: c => `[${c}]`, emphasis: c => `(${c})` })).toBe("[x (y [z (w) z] y) x]");
+    // A callback that returns null drops the element together with everything
+    // that rendered into it, including pass-through descendants.
+    expect(Markdown.render(mixed, { emphasis: () => null })).toBe("x  x");
+    expect(Markdown.render(mixed, { strong: c => `[${c}]`, emphasis: () => null })).toBe("[x  x]");
+    expect(
+      Markdown.render("> - one\n>   - two [l](u)\n\npara `code`\n", {
+        blockquote: c => `<bq>${c}</bq>`,
+        link: (c, m) => `<${m.href}|${c}>`,
+        paragraph: c => `<p>${c}</p>`,
+      }),
+    ).toBe("<bq>onetwo <u|l></bq><p>para code</p>");
   });
 });
 

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { renderToString } from "react-dom/server";
 
 const Markdown = Bun.markdown;
@@ -945,7 +947,225 @@ describe("pathological nesting through render()", () => {
         paragraph: c => `<p>${c}</p>`,
       }),
     ).toBe("<bq>onetwo <u|l></bq><p>para code</p>");
+    // Text that does not come from a plain text event (entity, soft break, hard
+    // break, NUL) lands in the same place as the text around it.
+    const pieces = "**a *b &amp; c\nd  \ne\0f* g**\n";
+    expect(Markdown.render(pieces, {})).toBe("a b & c\nd\ne\uFFFDf g");
+    expect(Markdown.render(pieces, { strong: c => `[${c}]` })).toBe("[a b & c\nd\ne\uFFFDf g]");
+    expect(Markdown.render(pieces, { emphasis: c => `(${c})` })).toBe("a (b & c\nd\ne\uFFFDf) g");
+    expect(Markdown.render(pieces, { emphasis: c => `(${c})`, text: t => t.toUpperCase() })).toBe(
+      "A (B & C\nD\nE\uFFFDF) G",
+    );
   });
+
+  test("list and listItem meta do not depend on which of the two has a callback", () => {
+    const input = "3. a\n4. b\n   - [x] c\n   - [ ] d\n\n- e\n- f\n\n> 1) g\n> 2) h\n";
+    const itemMeta = [
+      { children: "a", index: 0, depth: 0, ordered: true, start: 3, checked: undefined },
+      { children: "c", index: 0, depth: 1, ordered: false, start: undefined, checked: true },
+      { children: "d", index: 1, depth: 1, ordered: false, start: undefined, checked: false },
+      { children: "bcd", index: 1, depth: 0, ordered: true, start: 3, checked: undefined },
+      { children: "e", index: 0, depth: 0, ordered: false, start: undefined, checked: undefined },
+      { children: "f", index: 1, depth: 0, ordered: false, start: undefined, checked: undefined },
+      { children: "g", index: 0, depth: 0, ordered: true, start: 1, checked: undefined },
+      { children: "h", index: 1, depth: 0, ordered: true, start: 1, checked: undefined },
+    ];
+    const listMeta = [
+      { children: "cd", ordered: false, start: undefined, depth: 1 },
+      { children: "abcd", ordered: true, start: 3, depth: 0 },
+      { children: "ef", ordered: false, start: undefined, depth: 0 },
+      { children: "gh", ordered: true, start: 1, depth: 0 },
+    ];
+    const record = (log: object[]) => (children: string, meta: object) => (log.push({ children, ...meta }), children);
+
+    // listItem only: every ul/ol passes through, but each li still finds its parent list.
+    let items: object[] = [];
+    expect(Markdown.render(input, { listItem: record(items) })).toBe("abcdefgh");
+    expect(items).toEqual(itemMeta);
+
+    // list only: every li passes through.
+    let lists: object[] = [];
+    expect(Markdown.render(input, { list: record(lists) })).toBe("abcdefgh");
+    expect(lists).toEqual(listMeta);
+
+    // Both.
+    items = [];
+    lists = [];
+    expect(Markdown.render(input, { listItem: record(items), list: record(lists) })).toBe("abcdefgh");
+    expect(items).toEqual(itemMeta);
+    expect(lists).toEqual(listMeta);
+  });
+});
+
+// ============================================================================
+// render() oracle. `Bun.markdown.react()` builds its element tree with a
+// separate renderer, so folding that tree with the same callbacks states
+// independently what render() must return: every callback gets exactly the
+// output of its children, an element without a callback splices its children
+// into the nearest ancestor that has one, and the list / listItem meta
+// (`depth`, `index`, `ordered`, `start`) follows from the tree shape alone.
+// Checked over the spec corpus with every callback, with none, and with two
+// complementary halves, so each element type is seen both collecting its
+// children and passing them through.
+// ============================================================================
+
+describe("render() agrees with a fold over the react() tree", () => {
+  const names = [
+    "heading",
+    "paragraph",
+    "blockquote",
+    "code",
+    "list",
+    "listItem",
+    "hr",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+    "html",
+    "strong",
+    "emphasis",
+    "link",
+    "image",
+    "codespan",
+    "strikethrough",
+    "text",
+  ];
+  const callbackForTag: Record<string, string> = {
+    p: "paragraph",
+    blockquote: "blockquote",
+    pre: "code",
+    ul: "list",
+    ol: "list",
+    li: "listItem",
+    hr: "hr",
+    table: "table",
+    thead: "thead",
+    tbody: "tbody",
+    tr: "tr",
+    th: "th",
+    td: "td",
+    html: "html",
+    strong: "strong",
+    em: "emphasis",
+    a: "link",
+    img: "image",
+    code: "codespan",
+    del: "strikethrough",
+  };
+  type Callbacks = Record<string, (children: string, meta?: unknown) => string>;
+  type ParentList = { ordered: boolean; start?: number; index: number };
+
+  // Every callback wraps its children in unambiguous markers together with its
+  // meta. `text` must commute with concatenation and keep "\n" (soft and hard
+  // breaks bypass it), which upper-casing does.
+  const callbacks = (subset: string[]): Callbacks =>
+    Object.fromEntries(
+      subset.map(name => [
+        name,
+        name === "text"
+          ? (children: string) => children.toUpperCase()
+          : (children: string, meta?: unknown) =>
+              "\x01" + name + (meta === undefined ? "" : JSON.stringify(meta)) + "\x02" + children + "\x03",
+      ]),
+    );
+
+  function fold(node: any, cbs: Callbacks, enclosingLists: number, parent?: ParentList): string {
+    if (node == null || typeof node === "boolean") return "";
+    if (typeof node === "string") return cbs.text ? cbs.text(node) : node;
+    if (Array.isArray(node)) {
+      let out = "";
+      let items = 0;
+      for (const child of node) {
+        out += fold(child, cbs, enclosingLists, parent && { ...parent, index: child?.type === "li" ? items++ : 0 });
+      }
+      return out;
+    }
+    const tag: string = typeof node.type === "symbol" ? "fragment" : node.type;
+    const props = node.props ?? {};
+    if (tag === "br") return "\n";
+    const isList = tag === "ul" || tag === "ol";
+    const children =
+      tag === "img"
+        ? fold(props.alt, cbs, enclosingLists)
+        : fold(
+            props.children,
+            cbs,
+            enclosingLists + (isList ? 1 : 0),
+            isList ? { ordered: tag === "ol", start: props.start, index: 0 } : undefined,
+          );
+    const level = /^h([1-6])$/.exec(tag);
+    const cb = cbs[level ? "heading" : callbackForTag[tag]];
+    if (!cb) return children;
+    let meta: unknown;
+    if (level) meta = { level: +level[1], id: props.id };
+    else if (isList) meta = { ordered: tag === "ol", start: props.start, depth: enclosingLists };
+    else if (tag === "li")
+      meta = {
+        index: parent?.index ?? 0,
+        depth: Math.max(enclosingLists - 1, 0),
+        ordered: parent?.ordered ?? false,
+        start: parent?.ordered ? parent.start : undefined,
+        checked: props.checked,
+      };
+    else if (tag === "pre") meta = props.language === undefined ? undefined : { language: props.language };
+    else if (tag === "th" || tag === "td") meta = { align: props.align };
+    else if (tag === "a") meta = { href: props.href, title: props.title };
+    else if (tag === "img") meta = { src: props.src, title: props.title };
+    return meta === undefined ? cb(children) : cb(children, meta);
+  }
+
+  function specExamples(file: string): string[] {
+    const content = readFileSync(join(import.meta.dir, file), "utf8").replace(/\r\n?/g, "\n");
+    const examples: string[] = [];
+    for (const match of content.matchAll(/^`{32} example\n([\s\S]*?)^\.$/gm)) {
+      examples.push(match[1].replaceAll("\u2192", "\t") + "\n");
+    }
+    return examples;
+  }
+
+  const callbackSets = [
+    names,
+    [],
+    names.filter((_, i) => i % 2 === 0), // list without listItem, heading, link, text, ...
+    names.filter((_, i) => i % 2 === 1), // listItem without list, paragraph, emphasis, image, ...
+  ].map(callbacks);
+
+  // One test per 100 examples keeps each test near a second on a debug build.
+  const chunkSize = 100;
+  for (const [file, options] of [
+    ["spec.txt", { headings: { ids: true } }],
+    ["spec-gfm.txt", {}],
+    ["spec-tables.txt", {}],
+    ["spec-strikethrough.txt", {}],
+    ["spec-tasklists.txt", {}],
+    ["spec-permissive-autolinks.txt", { autolinks: true }],
+    ["regressions.txt", {}],
+  ] as const) {
+    const examples = specExamples(file);
+    test(`${file} has examples`, () => {
+      expect(examples.length).toBeGreaterThan(0);
+    });
+    for (let start = 0; start < examples.length; start += chunkSize) {
+      const chunk = examples.slice(start, start + chunkSize);
+      test(`${file} examples ${start + 1}-${start + chunk.length}`, () => {
+        const mismatches: unknown[] = [];
+        for (const markdown of chunk) {
+          const tree = Markdown.react(markdown, undefined, { ...options, reactVersion: 18 });
+          for (const cbs of callbackSets) {
+            const rendered = Markdown.render(markdown, cbs, options);
+            const folded = fold(tree, cbs, 0);
+            if (rendered !== folded && mismatches.length < 5) {
+              mismatches.push({ markdown, callbacks: Object.keys(cbs), rendered, folded });
+            }
+          }
+        }
+        expect(mismatches).toEqual([]);
+      });
+    }
+  }
 });
 
 // ============================================================================


### PR DESCRIPTION
### Problem
- `Bun.markdown.render()` has two costs that grow with the square of the nesting depth. `html()` and `react()` do not. On 1.4.2 with `{}` callbacks, 300 KB of nested `>- ` lists takes 99.5 s.
- Cause 1: `count_list_depth()` (`MarkdownObject.rs:1463` on main) walked the whole open-block stack on every list and list-item leave to fill the `depth` meta field.
- Cause 2: every element collected its children in its own buffer, which `pop_and_callback` copied into the parent's buffer on leave, callback or not. Text at depth D was copied D times.

### Fix
- A `list_depth` counter (up on `ul`/`ol` enter, down on leave) replaces the stack walk. Reported depths do not change.
- An element gets its own buffer only when a callback is registered for it. Other elements render straight into the nearest enclosing element that has one, or the root.
- Output is unchanged wherever the parser pairs its enter and leave events. A new oracle test checks it over the spec corpus: `render()` must equal a fold over the `react()` tree.
- Verified: `test/js/bun/md/md-edge-cases.test.ts` (1.4.3 fails the two timing tests at the 30 s kill). All of `test/js/bun/md/` passes.

### Background
- `render(text, callbacks)` calls one JS callback per element with its rendered children as a string and a meta object. `list` and `listItem` meta carry `depth` (#27688).
- Not fixed here: with a callback on the nested element type itself, each level still turns its children from bytes into a JS string and back. That case stays super-linear.

<details><summary>Notes</summary>

- Sampling the debug build on the list input put every main-thread sample in `count_list_depth()`.
- Timings, release 1.4.3, `render(s, {})` for `"1. ".repeat(n) + "a"`: n = 5k / 10k / 20k / 40k = 25 / 120 / 1330 / 6055 ms before (8.4 s at 40k on 1.4.2). The growth steeper than 4x per doubling is the stack walk (72-byte entries) falling out of L2/L3, not a second algorithmic factor: with only the counter applied, the debug+ASAN build is a clean 2x per doubling (16k / 32k / 100k = 0.48 / 0.76 / 1.9 s, was 12.8 s at 16k).
- Nested emphasis `"*a ".repeat(n) + " b*".repeat(n)` with `{}` (1.2 MB takes 5 s on 1.4.2), release 1.4.3: n = 32k / 64k / 128k = 113 / 423 / 1724 ms (4x per doubling). After: debug+ASAN at n = 524k takes 2.2 s, the same as `html()` on that build.
- The residual, measured on this branch (debug+ASAN), n = 8k / 16k / 32k: nested emphasis with an `emphasis` callback 3.7 / 10.9 / 41 s, nested lists with a `listItem` callback 2.7 / 7.6 / 22.6 s, against 0.06 / 0.11 / 0.22 s and 0.12 / 0.12 / 0.45 s with `{}`. The cost is the per-level bytes to JS string to bytes round trip in `pop_and_callback`. Removing it means handing callbacks rope or lazy children strings, which is a separate change that can build on the capture stack added here.
- Unbalanced event streams. A few parser bugs make the parser open a span and never close it, or the reverse: #39496 (`*a *b *c *d *e *f *g*******`, fix in #39497), wiki links (#39494), and permissive autolinks that swallow an emphasis closer (`__a@b.cob__` with `autolinks: true`). For those inputs `render()` returned `""` for the whole document before. Now the text of elements without a callback survives (`"a b c d e f g"` for the first input with `{}`), because it no longer sits in a buffer that is never popped. With a `paragraph` callback the result is still `""`. The root cause is in the parser and is not touched here. In `pop_and_callback` the `callback.is_empty()` branch still appends the popped entry's buffer, as on main. That buffer is empty unless the stream is unbalanced.
- `list_depth` and the stack of collecting entries change only in `push_entry` / `pop_entry`, so both match the entry stack by construction. Elements without a callback still push a stack entry, so `li` index lookups, `parent_list()` and the heading-id tracker see the same stack shape as before. They no longer build a meta object, since nothing receives it. The heading-id tracker still runs its leave step for headings without a callback, as before.
- Tests. The two timing tests take 7.5 s and 4.5 s on a local debug+ASAN build, in line with the other pathological-input tests in the file. The oracle derives `depth`, `index`, `ordered` and `start` from the `react()` tree shape, so it checks the counter independently. It runs with all, none, and each half of the callbacks, in chunks of 100 examples (about 1 s each on debug+ASAN). Breaking either the depth or the pass-through in the fold makes it fail. Two more in-process tests pin the `list` / `listItem` meta when only one of the two has a callback, and where entity, break and NUL text lands between capturing and pass-through spans. All 1092 tests in `test/js/bun/md/` pass on the debug build.
- Differential check, not in the tree: 400 generated documents rendered with random, all, single, and no callbacks, including callbacks that return `null` or a number, and with several parser option sets. Output and callback call counts are identical between 1.4.3 and this branch.
- Self-review asked for the in-tree oracle, a title that does not claim linear time for every callback set, an exact statement of the residual cost, the unchanged-output claim scoped to balanced event streams, and a comment on the `callback.is_empty()` branch that says when its buffer is not empty. All are in this revision.
- `"- ".repeat(n)` and `"* ".repeat(n)` are also quadratic in `html()`: `is_hr_line` rescans to the end of the line at every `-`/`*` container mark (`src/md/blocks.rs:290`, md4c's `hr_killer` guard is missing). That is a separate root in the block parser and is not touched here. The tests use `1. `, `1) `, `+ `, `>- ` and `- > ` to stay clear of it.
- The docs recipe "Stripping all formatting" registers identity callbacks (`strong: c => c`, ...). Leaving those out gives the same output and takes the pass-through path. That is a docs follow-up.
- The two copies of the `expectRendersQuickly` helper in the test file are folded into one at module scope.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-edge-cases.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/42] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/42] gen cpp.rs (cppbind)
[3/42] gen JS modules (bundle-modules)
Preprocess modules (10922ms)
Bundle modules (92ms)
Postprocesss modules (144ms)
Bundle Functions (712ms)
Generate Code (40ms)

[11.92s] Bundled "src/js" for development
  2791 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/29] cargo bun_runtime → libbun_runtime.a
[22/29] cxx obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o
FAILED: obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -fno-asynchronous-u
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (b24d9bb14)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [1.27ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [0.26ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [0.05ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [0.10ms]
(pass) fuzzer-like edge cases > control characters in input [0.02ms]
(pass) fuzzer-like edge cases > Buffer input works [0.03ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [0.07ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [0.14ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [0.08ms]
(pass) fuzzer-like edge cases > deeply nested lists [0.10ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [6.66ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [4.57ms]
(pass) fuzzer-like edge cases > deeply nested emphasis [0.09ms]
(pass) fuzzer-like edge cases > deeply nested links [0.06ms]
(pass) fuzzer-like edge cases > very long s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-edge-cases.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [80.23ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [9.75ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [1.81ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [7.05ms]
(pass) fuzzer-like edge cases > control characters in input [1.54ms]
(pass) fuzzer-like edge cases > Buffer input works [2.39ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [4.57ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [8.60ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [2.62ms]
(pass) fuzzer-like edge cases > deeply nested lists [10.95ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [181.94ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [120.53ms]
(p
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 770ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/31] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/31] gen cpp.rs (cppbind)
[3/31] gen JS modules (bundle-modules)
Preprocess modules (8289ms)
Bundle modules (60ms)
Postprocesss modules (39ms)
Bundle Functions (591ms)
Generate Code (46ms)

[9.03s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/23] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/c
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/MarkdownObject.rs    | 170 ++++++++--------
 test/js/bun/md/md-edge-cases.test.ts | 372 ++++++++++++++++++++++++++++++++---
 2 files changed, 435 insertions(+), 107 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/runtime/api/MarkdownObject.rs         7     18     28
test/js/bun/md/md-edge-cases.test.ts      7     12     27
```

</details>

<!-- robobun:evidence:end -->