### PR TITLE
Fix the segfault in TOML.stringify on a deeply nested table

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2204,8 +2204,11 @@ impl StackCheck {
     /// every frame in it, so the same path measures ~160 KB there against a
     /// few KB in a release build. The sanitizer reserve is 3x that measured
     /// depth, and it only costs recursion depth in builds nobody ships.
-    const THRESHOLD: usize = if cfg!(windows) { 256 * 1024 } else { 128 * 1024 }
-        + if cfg!(bun_asan) { 384 * 1024 } else { 0 };
+    const THRESHOLD: usize = if cfg!(windows) {
+        256 * 1024
+    } else {
+        128 * 1024
+    } + if cfg!(bun_asan) { 384 * 1024 } else { 0 };
 
     /// Is there enough stack space to safely recurse?
     #[inline]

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2197,20 +2197,24 @@ impl StackCheck {
     pub fn update(&mut self) {
         self.cached_stack_end = Bun__StackCheck__getMaxStack() as usize;
     }
+    /// Stack a check leaves unused, for the work the caller does before it
+    /// reaches the next check. One heap allocation needs most of it: a
+    /// `WTF::StringBuilder` growth reallocates through `libpas`, and that
+    /// thread-local-cache slow path is ~35 frames. A sanitizer build pads
+    /// every frame in it, so the same path measures ~160 KB there against a
+    /// few KB in a release build. The sanitizer reserve is 3x that measured
+    /// depth, and it only costs recursion depth in builds nobody ships.
+    const THRESHOLD: usize = if cfg!(windows) { 256 * 1024 } else { 128 * 1024 }
+        + if cfg!(bun_asan) { 384 * 1024 } else { 0 };
+
     /// Is there enough stack space to safely recurse?
-    /// Threshold: `> 256K` on Windows, `> 128K` elsewhere.
     #[inline]
     pub fn is_safe_to_recurse(self) -> bool {
         // Saturating sub: if probe < end (already past limit),
         // result saturates to 0 → "not safe". wrapping_sub would yield a huge
         // positive and incorrectly return true.
         let remaining = Self::frame_address().saturating_sub(self.cached_stack_end);
-        let threshold: usize = if cfg!(windows) {
-            256 * 1024
-        } else {
-            128 * 1024
-        };
-        remaining > threshold
+        remaining > Self::THRESHOLD
     }
 
     /// Like [`is_safe_to_recurse`] but reserves `extra` bytes of additional
@@ -2221,12 +2225,7 @@ impl StackCheck {
     #[inline]
     pub fn is_safe_to_recurse_with_extra(self, extra: usize) -> bool {
         let remaining = Self::frame_address().saturating_sub(self.cached_stack_end);
-        let threshold: usize = if cfg!(windows) {
-            256 * 1024
-        } else {
-            128 * 1024
-        };
-        remaining > threshold.saturating_add(extra)
+        remaining > Self::THRESHOLD.saturating_add(extra)
     }
 
     /// Approximate the current stack position. Reads the stack-pointer

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -2197,13 +2197,9 @@ impl StackCheck {
     pub fn update(&mut self) {
         self.cached_stack_end = Bun__StackCheck__getMaxStack() as usize;
     }
-    /// Stack a check leaves unused, for the work the caller does before it
-    /// reaches the next check. One heap allocation needs most of it: a
-    /// `WTF::StringBuilder` growth reallocates through `libpas`, and that
-    /// thread-local-cache slow path is ~35 frames. A sanitizer build pads
-    /// every frame in it, so the same path measures ~160 KB there against a
-    /// few KB in a release build. The sanitizer reserve is 3x that measured
-    /// depth, and it only costs recursion depth in builds nobody ships.
+    /// Stack reserved for the work a frame does before the next check. One
+    /// `WTF::StringBuilder` growth reallocates through libpas, a ~35 frame
+    /// path that measures ~160 KB under a sanitizer and a few KB without one.
     const THRESHOLD: usize = if cfg!(windows) {
         256 * 1024
     } else {

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -1,4 +1,5 @@
 use bun_collections::HashMap;
+use bun_collections::smallvec::SmallVec;
 use bun_core::StackCheck;
 use bun_core::String as BunString;
 use bun_jsc::{
@@ -423,12 +424,25 @@ impl Stringifier {
         self.wrote = true;
     }
 
+    /// The chain is one link per table nesting level, and the caller already
+    /// holds one checked `stringify_table_body` frame per level, so this walks
+    /// the chain instead of recursing over it: recursing here doubles the
+    /// depth the stack check accounted for.
     fn append_path(&mut self, path: &Path<'_>) {
-        if let Some(parent) = path.parent {
-            self.append_path(parent);
-            self.builder.append_lchar(b'.');
+        // A header path is a handful of segments in any real document; a
+        // deeper one spills to the heap.
+        let mut chain: SmallVec<[&BunString; 16]> = SmallVec::new();
+        let mut next = Some(path);
+        while let Some(link) = next {
+            chain.push(link.key);
+            next = link.parent;
         }
-        self.append_key_segment(path.key);
+        for (i, key) in chain.iter().rev().copied().enumerate() {
+            if i > 0 {
+                self.builder.append_lchar(b'.');
+            }
+            self.append_key_segment(key);
+        }
     }
 
     fn append_key_segment(&mut self, name: &BunString) {

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -424,13 +424,9 @@ impl Stringifier {
         self.wrote = true;
     }
 
-    /// The chain is one link per table nesting level, and the caller already
-    /// holds one checked `stringify_table_body` frame per level, so this walks
-    /// the chain instead of recursing over it: recursing here doubles the
-    /// depth the stack check accounted for.
+    /// Walks the chain. The caller holds one checked `stringify_table_body`
+    /// frame per link, so recursing here would double that depth.
     fn append_path(&mut self, path: &Path<'_>) {
-        // A header path is a handful of segments in any real document; a
-        // deeper one spills to the heap.
         let mut chain: SmallVec<[&BunString; 16]> = SmallVec::new();
         let mut next = Some(path);
         while let Some(link) = next {

--- a/test/js/bun/toml/toml.test.ts
+++ b/test/js/bun/toml/toml.test.ts
@@ -926,6 +926,61 @@ describe("TOML.stringify", () => {
     Bun.gc(true);
     expect(TOML.parse(TOML.stringify({ ok: true }))).toEqual({ ok: true });
   });
+
+  test("a long header path stays in root-first order", () => {
+    const segments = Array.from({ length: 200 }, (_, i) => "k" + i);
+    let table: object = {};
+    for (let i = segments.length; i-- > 0; ) table = { [segments[i]]: table };
+    expect(TOML.stringify(table)).toBe(`[${segments.join(".")}]\n`);
+  });
+
+  test("a table nested to the recursion limit reports the limit instead of crashing", async () => {
+    // The deepest table writes one header that holds its whole path. The walk
+    // over that path recursed once per segment, on top of the one frame per
+    // level the stack check had already accounted for, so it ran off the stack
+    // and the process died with SIGSEGV. That happens at a depth just under
+    // the limit the stack check allows, and the limit follows the frame sizes
+    // of the build (a debug+ASAN frame is several times a release frame), so
+    // the child searches for it: every probe near the limit probes the crash.
+    const fixture = `
+      const stringifies = depth => {
+        let table = {};
+        for (let i = 0; i < depth; i++) table = { a: table };
+        try {
+          Bun.TOML.stringify(table);
+          return true;
+        } catch (e) {
+          if (!(e instanceof RangeError)) throw e;
+          return false;
+        }
+      };
+      // The ceiling bounds the run on a host with a very large stack, where
+      // the limit is past any depth worth probing.
+      let accepted = 0;
+      let rejected = 1024;
+      while (rejected < 1 << 18 && stringifies(rejected)) {
+        accepted = rejected;
+        rejected *= 2;
+      }
+      while (rejected - accepted > 1) {
+        const probe = (accepted + rejected) >> 1;
+        if (stringifies(probe)) accepted = probe;
+        else rejected = probe;
+      }
+      console.log("limit " + accepted);
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.replace(/\d+/, "N"), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "limit N\n",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+    // The search costs ~20 stringify calls near the limit. That is ~0.2s on a
+    // release build and ~4s under debug+ASAN, so it needs more than the 5s
+    // default on a slow machine.
+  }, 60_000);
 });
 
 // The TOML.stringify suite above covers parse(stringify(jsValue)). These cover


### PR DESCRIPTION
### Problem
- `Bun.TOML.stringify` of a table nested about 20000 deep dies with SIGSEGV (exit 139, nothing printed) instead of throwing `RangeError: Maximum call stack size exceeded`.
- The cause is `Stringifier::append_path` (`src/runtime/api/TOMLObject.rs:426`). It wrote a `[a.a.a…]` header by recursing once per path segment, unchecked. Its caller `stringify_table_body` already holds one checked frame per level, so the deepest header doubled the depth the check had allowed.

### Fix
- `append_path` collects the parent-linked chain into a `SmallVec` and writes the segments root-first. The header costs no stack.
- `StackCheck` reserves 384 KB more in sanitizer builds only. With `append_path` fixed, the ASAN build still died in a narrow band below the limit: a `StringBuilder` growth after the check goes through libpas, ~160 KB of ASAN frames against a 128 KB reserve.
- Verified: `test/js/bun/toml/toml.test.ts` (the new limit test SIGSEGVs 5/5 on the unfixed ASAN build). Also the `yaml`, `json5`, `xml`, `jsonc`, `md`, `bun-inspect` and transpiler depth suites, debug+ASAN and release.

### Background
- `TOML.stringify` emits a nested object as a `[parent.child]` section. `stringify_table_body` recurses once per level and threads a `Path { parent, key }` link through each frame: the header path is a linked list on the recursion stack.
- `StackCheck::is_safe_to_recurse` (`src/bun_core/util.rs`) compares the stack pointer with the thread's stack end. It keeps a fixed reserve (128 KB POSIX, 256 KB Windows) for the work a frame does before the next check. ASAN pads every frame: the libpas reallocation path is a few KB in release and ~160 KB under ASAN.

<details><summary>Notes</summary>

- gdb on main showed 1439 copies of the `append_path` return address in the lowest 48 KB of the stack.
- The two hunks were separated by experiment. With `append_path` fixed and the sanitizer reserve at 0, the debug+ASAN build still dies with SIGSEGV: 3 of 3 runs for a fresh process at depth 3190 or 3199, and about half of the runs of the new test (4 of 8 fixture runs, 3 of 4 test runs). The rate is below 100% in the test because the crash needs the allocator slow path to land on the deepest level, and earlier probes in the same process warm the allocator. With both hunks the test passed every run. On the unfixed build it failed 5 of 5.
- Release build of this branch: the `{a:{a:…}}` limit is ~20594 levels, a sweep of depths 20500 to 21050 (step 50, 2 runs each) has no crash, and the bisection fixture runs in ~170 ms. Debug+ASAN: limit ~3046, sweep 2980 to 3100 clean, fixture ~3.5 s. Unfixed debug+ASAN: 3150 fine, 3190 SIGSEGV, 3201 `RangeError`.
- The residual ASAN crash, from gdb: `stringify_table_body -> append_header -> append_key_segment -> BunString::appendToBuilder -> WTF::StringBuilder::extendBufferForAppending -> StringImpl::tryReallocate -> bmalloc -> pas_thread_local_cache_get_local_allocator_slow -> flush_deallocation_log -> __asan memcpy interceptor`, with `rsp` on the guard page. Frames 0 to 24 of that chain span 122832 bytes.
- The limit test bisects for the recursion limit in a child process instead of using a fixed depth. The crash sits just under the limit, and the limit depends on the build's frame sizes and the platform's stack size, so a fixed depth that crashes one build is a clean `RangeError` or a success on another. Every probe near the limit exercises the crash.
- `append_header` is the only caller of `append_path`. `stringify_inline_value` has its own check. No other helper in the file recurses on input depth.
- Pre-existing failures seen with and without this diff: `XML.stringify > deep values are a catchable error` (5 s timeout while building 1M nested objects under ASAN) and the JSONL 4 GB tests.
- Self-review of the diff raised three points, all addressed. The sanitizer reserve applies to all 64 `is_safe_to_recurse` call sites under ASAN. It is 384 KB, about 5% of an 8 MB main-thread stack and about 9% of a 4 MB worker stack, so the depth-sensitive suites above were run to confirm nothing that must succeed now fails. The limit test got a 60 s timeout and a search ceiling. It takes ~0.2 s on a release build, ~3.5 s on debug+ASAN, and ~6.6 s under the environment CI gives the ASAN lane (`BUN_JSC_validateExceptionChecks=1`, `BUN_DESTRUCT_VM_ON_EXIT=1`, `detect_leaks=1`), where the whole file passes with no leak report. The `SmallVec` holds 16 segments inline, and `append_path` runs once per emitted header.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/toml/toml.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/toml/toml.test.ts:
(pass) input types > string [3.35ms]
(pass) input types > Buffer [2.32ms]
(pass) input types > Uint8Array subarray respects byteOffset and length [2.14ms]
(pass) input types > DataView [3.63ms]
(pass) input types > ArrayBuffer [1.79ms]
(pass) input types > SharedArrayBuffer [2.59ms]
(pass) input types > Blob parses synchronously [2.02ms]
(pass) input types > DataView over a SharedArrayBuffer [2.81ms]
(pass) input types > non-string values are coerced via toString [5.94ms]
(pass) input types > null and undefined throw [6.42ms]
(pass) input types > invalid UTF-8 bytes throw SyntaxError [3.71ms]
(pass) input types > lone surrogates: replaced in string input (USVString), rejected in byte input [3.39ms]
(pass) input types > UTF-8 BOM is skipped in both string and byte input [2.65ms]
(pass) JS value mapping > returns a plain object with Object.prototype [1.62ms]
(pass) JS value mapping > __proto__ key becomes an own property, not the prototype [4.30ms]
(
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (d9ea68b10)

test/js/bun/toml/toml.test.ts:
(pass) input types > string [0.05ms]
(pass) input types > Buffer [0.06ms]
(pass) input types > Uint8Array subarray respects byteOffset and length [0.03ms]
(pass) input types > DataView [0.05ms]
(pass) input types > ArrayBuffer [0.02ms]
(pass) input types > SharedArrayBuffer [1.42ms]
(pass) input types > Blob parses synchronously [0.05ms]
(pass) input types > DataView over a SharedArrayBuffer [0.04ms]
(pass) input types > non-string values are coerced via toString [1.37ms]
(pass) input types > null and undefined throw [0.07ms]
(pass) input types > invalid UTF-8 bytes throw SyntaxError [0.06ms]
(pass) input types > lone surrogates: replaced in string input (USVString), rejected in byte input [0.07ms]
(pass) input types > UTF-8 BOM is skipped in both string and byte input [0.02ms]
(pass) JS value mapping > returns a plain object with Object.prototype [0.02ms]
(pass) JS value mapping > __proto__ key becomes an own property, not the prototype [0.05ms]
(pass) JS value mapping > __proto__ table becomes an own property [0.02ms]
(pass) JS value mapping > constructor and prototype keys are plain data propert
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/toml/toml.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/toml/toml.test.ts:
(pass) input types > string [3.50ms]
(pass) input types > Buffer [2.87ms]
(pass) input types > Uint8Array subarray respects byteOffset and length [2.12ms]
(pass) input types > DataView [5.38ms]
(pass) input types > ArrayBuffer [3.40ms]
(pass) input types > SharedArrayBuffer [4.21ms]
(pass) input types > Blob parses synchronously [3.00ms]
(pass) input types > DataView over a SharedArrayBuffer [4.21ms]
(pass) input types > non-string values are coerced via toString [10.01ms]
(pass) input types > null and undefined throw [8.22ms]
(pass) input types > invalid UTF-8 bytes throw SyntaxError [4.06ms]
(pass) input types > lone surrogates: replaced in string input (USVString), rejected in byte input [3.52ms]
(pass) input types > UTF-8 BOM is skipped in both string and byte input [2.94ms]
(pass) JS value mapping > returns a plain object with Object.prototype [1.73ms]
(pass) JS value mapping > __proto__ key becomes an own property, not the prototype [5.21ms]

... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 689ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/31] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/31] gen cpp.rs (cppbind)
[3/31] gen JS modules (bundle-modules)
Preprocess modules (8633ms)
Bundle modules (52ms)
Postprocesss modules (165ms)
Bundle Functions (502ms)
Generate Code (41ms)

[9.40s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/21] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/util.rs          | 24 +++++++++----------
 src/runtime/api/TOMLObject.rs | 18 ++++++++++----
 test/js/bun/toml/toml.test.ts | 55 +++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 80 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/bun_core/util.rs               3      5      9
src/runtime/api/TOMLObject.rs      2      5      9
test/js/bun/toml/toml.test.ts      4      2      9
```

</details>

<!-- robobun:evidence:end -->