### PR TITLE
markdown: skip thematic-break rescans on same-line nested list markers

### DIFF
--- a/src/md/blocks.rs
+++ b/src/md/blocks.rs
@@ -54,6 +54,7 @@ impl Parser<'_> {
         let mut n_brothers: u32 = 0;
         let mut n_children: u32 = 0;
         let mut container = Container::default();
+        let mut hr_killer: OFF = 0;
         let prev_line_has_list_loosening_effect = self.last_line_has_list_loosening_effect;
 
         *line = Line::default();
@@ -283,14 +284,15 @@ impl Parser<'_> {
             // Check for thematic break
             if line.indent < self.code_indent_offset
                 && off < self.size
-                && (self.text[off as usize] == b'-'
-                    || self.text[off as usize] == b'_'
-                    || self.text[off as usize] == b'*')
+                && off >= hr_killer
+                && matches!(self.text[off as usize], b'-' | b'_' | b'*')
             {
-                if self.is_hr_line(off) {
+                let hr_result = self.is_hr_line(off);
+                if hr_result.is_hr {
                     line.r#type = LineType::Hr;
                     break;
                 }
+                hr_killer = hr_result.end;
             }
 
             // Check for brother container (another list item in same list)

--- a/src/md/line_analysis.rs
+++ b/src/md/line_analysis.rs
@@ -19,6 +19,17 @@ pub struct SetextResult {
 }
 
 #[derive(Copy, Clone)]
+pub struct HrResult {
+    pub(crate) is_hr: bool,
+    /// Where the scan stopped. Every byte in `off..end` is the marker or a
+    /// blank, so when `!is_hr` no thematic break can start anywhere before
+    /// `end` either, and `analyze_line` skips re-checking until `off` reaches
+    /// it (md4c's `hr_killer`). Without that, N list markers nested on one
+    /// line (`- - - … a`) rescan the tail once per container level: O(N²).
+    pub(crate) end: OFF,
+}
+
+#[derive(Copy, Clone)]
 pub struct AtxResult {
     pub(crate) is_atx: bool,
     pub(crate) level: u32,
@@ -84,24 +95,24 @@ impl Parser<'_> {
         }
     }
 
-    pub(crate) fn is_hr_line(&self, off: OFF) -> bool {
+    pub(crate) fn is_hr_line(&self, off: OFF) -> HrResult {
         let c = ch(self.text, off);
-        if c != b'-' && c != b'_' && c != b'*' {
-            return false;
-        }
+        debug_assert!(matches!(c, b'-' | b'_' | b'*'));
 
-        let mut pos = off;
-        let mut count: u32 = 0;
-        while pos < self.size && !helpers::is_newline(ch(self.text, pos)) {
+        let mut pos = off + 1;
+        let mut count: u32 = 1;
+        while pos < self.size && (ch(self.text, pos) == c || helpers::is_blank(ch(self.text, pos)))
+        {
             if ch(self.text, pos) == c {
                 count += 1;
-            } else if !helpers::is_blank(ch(self.text, pos)) {
-                return false;
             }
             pos += 1;
         }
 
-        count >= 3
+        HrResult {
+            is_hr: count >= 3 && (pos >= self.size || helpers::is_newline(ch(self.text, pos))),
+            end: pos,
+        }
     }
 
     pub(crate) fn is_atx_header_line(&self, off: OFF) -> AtxResult {

--- a/src/md/line_analysis.rs
+++ b/src/md/line_analysis.rs
@@ -21,11 +21,7 @@ pub struct SetextResult {
 #[derive(Copy, Clone)]
 pub struct HrResult {
     pub(crate) is_hr: bool,
-    /// Where the scan stopped. Every byte in `off..end` is the marker or a
-    /// blank, so when `!is_hr` no thematic break can start anywhere before
-    /// `end` either, and `analyze_line` skips re-checking until `off` reaches
-    /// it (md4c's `hr_killer`). Without that, N list markers nested on one
-    /// line (`- - - … a`) rescan the tail once per container level: O(N²).
+    /// Where the scan stopped. If `!is_hr`, no thematic break starts before it (md4c `hr_killer`).
     pub(crate) end: OFF,
 }
 

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1219,6 +1219,62 @@ describe("pathological autolink opener inputs", () => {
   }, 90_000);
 });
 
+// ============================================================================
+// Pathological inputs: list markers nested on one line. `-` and `*` can also
+// open a thematic break, and the thematic-break check rescanned the rest of the
+// line at every container level before giving up at the first non-marker byte,
+// so N same-line markers (`- - - … a`) cost O(N^2): ~14s for a 200 KB line,
+// while the same shape with `+` was instant (md4c#66, the port had dropped
+// md4c's `hr_killer`). A failed check now records where its scan stopped and
+// later levels on that line skip straight past it. The child process is killed
+// after 30s so a regression fails fast instead of hanging the test runner.
+// ============================================================================
+
+describe("pathological thematic break inputs", () => {
+  test("same-line nested list markers render in linear time", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
+        const nested = n => fill(n - 1, "<ul>\\n<li>\\n") + "<ul>\\n<li>a</li>\\n</ul>\\n" + fill(n - 1, "</li>\\n</ul>\\n");
+        for (const mark of ["- ", "* "]) {
+          const n = 200000;
+          const html = Bun.markdown.html(fill(n, mark) + "a");
+          if (html !== nested(n)) throw new Error("unexpected html for " + JSON.stringify(mark) + ": " + JSON.stringify(html.slice(0, 120)));
+          console.log("OK html " + JSON.stringify(mark));
+        }
+        const ansi = Bun.markdown.ansi(fill(50000, "- ") + "a", { colors: false });
+        if (!ansi.startsWith("  * \\n") || !ansi.endsWith(" a\\n")) throw new Error("unexpected ansi: " + JSON.stringify(ansi.slice(0, 120)));
+        console.log("OK ansi");
+        console.log("DONE");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("DONE");
+    expect(exitCode).toBe(0);
+
+    // Thematic breaks are still recognized at every container level, including
+    // right where an earlier level's scan gave up.
+    expect(Markdown.html("- - -\n")).toBe("<hr />\n");
+    expect(Markdown.html("* * * a\n")).toBe(
+      "<ul>\n<li>\n<ul>\n<li>\n<ul>\n<li>a</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    );
+    expect(Markdown.html("- * * *\n")).toBe("<ul>\n<li>\n<hr />\n</li>\n</ul>\n");
+    expect(Markdown.html("- - _ _ _\n")).toBe("<ul>\n<li>\n<ul>\n<li>\n<hr />\n</li>\n</ul>\n</li>\n</ul>\n");
+    expect(Markdown.html("> - ***\n")).toBe("<blockquote>\n<ul>\n<li>\n<hr />\n</li>\n</ul>\n</blockquote>\n");
+    expect(Markdown.html("- foo\n- * * *\n")).toBe("<ul>\n<li>foo</li>\n<li>\n<hr />\n</li>\n</ul>\n");
+  }, 90_000);
+});
+
 describe("inputs the parser cannot address", () => {
   // The parser addresses its input with u32 offsets and probes up to 9 bytes
   // past an offset (the `<![CDATA[` check), so everything longer than

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1261,9 +1261,10 @@ describe("pathological thematic break inputs", () => {
     expect(stderr).toBe("");
     expect(stdout).toContain("DONE");
     expect(exitCode).toBe(0);
+  }, 90_000);
 
-    // Thematic breaks are still recognized at every container level, including
-    // right where an earlier level's scan gave up.
+  test("thematic breaks are still recognized at every container level", () => {
+    // Including right where an earlier level's failed scan stopped.
     expect(Markdown.html("- - -\n")).toBe("<hr />\n");
     expect(Markdown.html("* * * a\n")).toBe(
       "<ul>\n<li>\n<ul>\n<li>\n<ul>\n<li>a</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
@@ -1272,7 +1273,7 @@ describe("pathological thematic break inputs", () => {
     expect(Markdown.html("- - _ _ _\n")).toBe("<ul>\n<li>\n<ul>\n<li>\n<hr />\n</li>\n</ul>\n</li>\n</ul>\n");
     expect(Markdown.html("> - ***\n")).toBe("<blockquote>\n<ul>\n<li>\n<hr />\n</li>\n</ul>\n</blockquote>\n");
     expect(Markdown.html("- foo\n- * * *\n")).toBe("<ul>\n<li>foo</li>\n<li>\n<hr />\n</li>\n</ul>\n");
-  }, 90_000);
+  });
 });
 
 describe("inputs the parser cannot address", () => {


### PR DESCRIPTION
### Problem
- `Bun.markdown.html()`, `ansi()` and `react()` are quadratic in list markers nested on one line. `"- ".repeat(100000) + "a"` takes 13.9 s on 1.4.2, and 6 ms with `"+ "`. Only `-` and `*` are slow: they can also open a thematic break.
- Cause: `analyze_line` (`src/md/blocks.rs:285`) runs the thematic-break check once per container level. `is_hr_line` (`src/md/line_analysis.rs:98`) scans to the first non-marker byte each time. N markers cost about N²/2 byte reads.

### Fix
- Port md4c's `hr_killer` (mity/md4c#66, mity/md4c@b21086522e), which the port dropped. A failed `is_hr_line` reports where its scan stopped. `analyze_line` skips the check while `off` is before that offset.
- Correct because every byte before the stop offset is the marker or a blank. A later check there stops at the same offset and fails the same way. The first check on a line always runs, so `- * * *` still ends in a thematic break.
- Verified: the new timing test in `test/js/bun/md/md-edge-cases.test.ts` is killed at 30 s on stock bun and passes with the fix. All of `test/js/bun/md/` passes. 30,000 random documents render identical HTML before and after.
- Not covered: `render()` has a separate super-linear cost in its callback renderer. #42244 fixes that one.

### Background
- `src/md/` is a port of [md4c](https://github.com/mity/md4c). `analyze_line` classifies one line. It loops once per container (`>` or list item) on that line.
- A thematic break is three or more of `-`, `_`, or `*` with only blanks between. `- - -` is a thematic break, not three nested items, so that check runs first at every level.
- `off` only moves forward inside `analyze_line`. `hr_killer` is a local, so it resets on every line.

<details><summary>Notes</summary>

- Timings on this container, release 1.4.3-canary (unfixed): `"- "` n=12500/25000/50000: 184/729/2912 ms (x4 per doubling). `"+ "`: 1/3/6 ms. Debug ASAN build with the fix: `"- "` 76/147/294 ms, identical to `"+ "`. The new test's 400 KB cases take 1.2 s each on the debug build.
- Per entry point at n=16384/32768. Unfixed release: `html` 376/1249 ms, `ansi` 321/1266 ms, `react` 326/1269 ms, `render` 906/4686 ms. Debug ASAN build with the fix: `html` 99/193 ms, `ansi` 583/1173 ms, `react` 2264/4300 ms (all x2 per doubling), `render` 11463/45814 ms (still x4). The `render` remainder is in the callback renderer, not in the block parser (#42244).
- md4c's `md_is_hr_line` writes `*p_killer` on failure and `*p_end` on success. Both are the same scan-stop offset, so `HrResult` carries one `end` field.
- The differential corpus: 30,000 documents built from `- * _ + >`, `1.`, `=`, `#`, blanks, tabs, newlines and text, each also placed after a paragraph, a list item, and a blockquote. Stock bun and the fixed build produce identical output for all of them.
- The other per-level checks in the loop do not have this shape. Setext and table-underline checks only run while `n_parents == n_containers` with a text pivot (at most once per line). Fence, HTML, and ATX openers are not container markers. `+` and ordered markers never enter the thematic-break check, which is why they were already linear.
- Checked line by line against md4c's `md_is_hr_line` and `md_analyze_line`. `cargo clippy -p bun_md` is clean.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-edge-cases.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [77.05ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [9.45ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [2.07ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [7.33ms]
(pass) fuzzer-like edge cases > control characters in input [1.57ms]
(pass) fuzzer-like edge cases > Buffer input works [2.45ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [4.82ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [8.33ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [2.64ms]
(pass) fuzzer-like edge cases > deeply nested lists [8.60ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [145.16ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [127.32ms]
(pa
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (5f554969b)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [1.22ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [0.10ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [0.04ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [0.09ms]
(pass) fuzzer-like edge cases > control characters in input [0.02ms]
(pass) fuzzer-like edge cases > Buffer input works [0.02ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [0.06ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [0.15ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [0.04ms]
(pass) fuzzer-like edge cases > deeply nested lists [0.07ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [7.25ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [5.38ms]
(pass) fuzzer-like edge cases > deeply nested emphasis [0.07ms]
(pass) fuzzer-like edge cases > deeply nested links [0.07ms]
(pass) fuzzer-like edge cases > very long s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-edge-cases.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [74.69ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [9.22ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [1.91ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [6.84ms]
(pass) fuzzer-like edge cases > control characters in input [1.40ms]
(pass) fuzzer-like edge cases > Buffer input works [1.96ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [4.25ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [8.10ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [2.50ms]
(pass) fuzzer-like edge cases > deeply nested lists [8.20ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [93.37ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [66.17ms]
(pass
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4238962297
  features     baseline

23 deps, 131 codegen, 1172 objects in 686ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (5f554969b)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (5f554969b)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (5f554969b)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[5/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 7ms

  react-refresh.js  4.81 KB  (entry point)

[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1216] gen ErrorCode+*.h
[9/1216] fetch zlib
[zlib] up to date
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen .bind.ts → Gene
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/md/blocks.rs                     | 10 ++++---
 src/md/line_analysis.rs              | 27 ++++++++++-------
 test/js/bun/md/md-edge-cases.test.ts | 57 ++++++++++++++++++++++++++++++++++++
 3 files changed, 80 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/md/blocks.rs                          3      2     16
src/md/line_analysis.rs                   3      4     16
test/js/bun/md/md-edge-cases.test.ts      5      4     15
```

</details>

<!-- robobun:evidence:end -->