### PR TITLE
inspect: don't probe every index of an arguments object with a huge length

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4305,24 +4305,27 @@ pub mod formatter {
                 let mut nonempty_count: u32 = 1;
 
                 while (i as u64) < len {
+                    if i > jsc::MAX_ARRAY_INDEX {
+                        // An array cannot be this long, but an arguments
+                        // object's `length` is a plain writable property.
+                        // Nothing past this index is an indexed property.
+                        if empty_start.is_none() {
+                            empty_start = Some(i);
+                        }
+                        break;
+                    }
                     let element = value.get_direct_index(self.global_this, i)?;
                     if element.is_empty() {
                         if empty_start.is_none() {
                             empty_start = Some(i);
                         }
-                        if js_type.is_array() {
-                            // Skip the whole run of holes at once: probing each
-                            // index is O(length), and a sparse array's length
-                            // can be 2^32 - 1 with no elements at all.
-                            match value.next_present_index(i + 1) {
-                                Some(next) if (next as u64) < len => i = next,
-                                _ => break,
-                            }
-                        } else {
-                            // Arguments objects store their elements outside
-                            // the butterfly; their length is small, so probe
-                            // each index like before.
-                            i += 1;
+                        // Skip the whole run of holes at once: probing each
+                        // index is O(length), and `length` can be 2^32 - 1 for
+                        // a sparse array (anything for an arguments object)
+                        // with no elements at all.
+                        match value.next_present_index(i + 1) {
+                            Some(next) if (next as u64) < len => i = next,
+                            _ => break,
                         }
                         continue;
                     }

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4306,9 +4306,7 @@ pub mod formatter {
 
                 while (i as u64) < len {
                     if i > jsc::MAX_ARRAY_INDEX {
-                        // An array cannot be this long, but an arguments
-                        // object's `length` is a plain writable property.
-                        // Nothing past this index is an indexed property.
+                        // An arguments object's `length` can exceed the index space.
                         if empty_start.is_none() {
                             empty_start = Some(i);
                         }
@@ -4319,10 +4317,7 @@ pub mod formatter {
                         if empty_start.is_none() {
                             empty_start = Some(i);
                         }
-                        // Skip the whole run of holes at once: probing each
-                        // index is O(length), and `length` can be 2^32 - 1 for
-                        // a sparse array (anything for an arguments object)
-                        // with no elements at all.
+                        // Skip the run of holes at once: probing each index is O(length).
                         match value.next_present_index(i + 1) {
                             Some(next) if (next as u64) < len => i = next,
                             _ => break,

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2555,11 +2555,7 @@ impl JSValue {
         }
         crate::call_check_slow(global, || JSC__JSValue__getDirectIndex(self, global, i))
     }
-    /// Smallest own present index of an array, arguments object or ordinary
-    /// object that is `>= start`, or `None` when every index from `start`
-    /// on is a hole. Walks the backing storage (butterfly, sparse map,
-    /// argument slots) so a run of holes is skipped in one call instead of
-    /// probing each index. Asserts `self` is an object.
+    /// Smallest own index `>= start` that holds an element, read off the object's indexed storage.
     pub(crate) fn next_present_index(self, start: u32) -> Option<u32> {
         debug_assert!(self.is_object());
         unsafe extern "C" {

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2555,17 +2555,17 @@ impl JSValue {
         }
         crate::call_check_slow(global, || JSC__JSValue__getDirectIndex(self, global, i))
     }
-    /// Smallest own present index of a `JSArray` that is `>= start`, or
-    /// `None` when every index from `start` to the end of the array is a
-    /// hole. Walks the array's backing storage (and sparse map) so a run of
-    /// holes is skipped in one call instead of probing each index.
-    /// Asserts `self` is a `JSArray` (`Array` or `DerivedArray`).
+    /// Smallest own present index of an array, arguments object or ordinary
+    /// object that is `>= start`, or `None` when every index from `start`
+    /// on is a hole. Walks the backing storage (butterfly, sparse map,
+    /// argument slots) so a run of holes is skipped in one call instead of
+    /// probing each index. Asserts `self` is an object.
     pub(crate) fn next_present_index(self, start: u32) -> Option<u32> {
-        debug_assert!(self.is_cell() && self.js_type().is_array());
+        debug_assert!(self.is_object());
         unsafe extern "C" {
-            safe fn Bun__JSArray__nextPresentIndex(this: JSValue, start: u32) -> u64;
+            safe fn Bun__JSObject__nextPresentIndex(this: JSValue, start: u32) -> u64;
         }
-        match Bun__JSArray__nextPresentIndex(self, start) {
+        match Bun__JSObject__nextPresentIndex(self, start) {
             u64::MAX => None,
             index => Some(index as u32),
         }

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2555,7 +2555,7 @@ impl JSValue {
         }
         crate::call_check_slow(global, || JSC__JSValue__getDirectIndex(self, global, i))
     }
-    /// Smallest own index `>= start` that holds an element, read off the object's indexed storage.
+    /// Smallest own present index `>= start`. Can scan the whole sparse map: bound the calls.
     pub(crate) fn next_present_index(self, start: u32) -> Option<u32> {
         debug_assert!(self.is_object());
         unsafe extern "C" {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -7116,8 +7116,7 @@ static uint64_t nextPresentButterflyIndex(JSC::JSObject* object, uint32_t start)
     }
 }
 
-// DirectArguments and ScopedArguments keep the arguments themselves outside the
-// butterfly; a deleted one is unmapped. Mirrors GenericArgumentsImpl::getOwnPropertyNames.
+// The arguments live outside the butterfly. Mirrors GenericArgumentsImpl::getOwnPropertyNames.
 template<typename Arguments>
 static uint64_t nextMappedArgumentIndex(Arguments* arguments, uint32_t start)
 {
@@ -7128,10 +7127,7 @@ static uint64_t nextMappedArgumentIndex(Arguments* arguments, uint32_t start)
     return noPresentIndex;
 }
 
-// Smallest own present index of an array, arguments object or ordinary object
-// that is >= `start`, or UINT64_MAX when every index from `start` on is a hole.
-// Walks the backing storage so the caller can skip a run of holes without
-// probing each index up to a huge `length`.
+// Smallest own present index >= `start`, or UINT64_MAX when every index from `start` on is a hole.
 extern "C" uint64_t Bun__JSObject__nextPresentIndex(
     JSC::EncodedJSValue encodedValue,
     uint32_t start)

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -38,6 +38,8 @@
 #include "JavaScriptCore/BytecodeIndex.h"
 #include "JavaScriptCore/CodeBlock.h"
 #include "JavaScriptCore/Completion.h"
+#include "JavaScriptCore/DirectArguments.h"
+#include "JavaScriptCore/ScopedArguments.h"
 #include "JavaScriptCore/ErrorInstance.h"
 #include "JavaScriptCore/ExceptionHelpers.h"
 #include "JavaScriptCore/ExceptionScope.h"
@@ -7055,57 +7057,50 @@ extern "C" bool Bun__JSArray__contiguousVectorIsStillValid(
     return reinterpret_cast<const JSC::EncodedJSValue*>(butterfly->contiguous().data()) == expected;
 }
 
-// Smallest own present index of a JSArray that is >= `start`, or UINT64_MAX
-// when every index from `start` to the end of the array is a hole. Mirrors the
-// butterfly walk in JSObject::getOwnIndexedPropertyNames so the caller can skip
-// a run of holes without probing each index of a huge sparse array.
-extern "C" uint64_t Bun__JSArray__nextPresentIndex(
-    JSC::EncodedJSValue encodedValue,
-    uint32_t start)
+static constexpr uint64_t noPresentIndex = std::numeric_limits<uint64_t>::max();
+
+// Mirrors the butterfly walk in JSObject::getOwnIndexedPropertyNames.
+static uint64_t nextPresentButterflyIndex(JSC::JSObject* object, uint32_t start)
 {
-    static constexpr uint64_t notFound = std::numeric_limits<uint64_t>::max();
-
-    JSC::JSArray* array = uncheckedDowncast<JSC::JSArray>(JSC::JSValue::decode(encodedValue).asCell());
-
-    switch (array->indexingType()) {
+    switch (object->indexingType()) {
     case ALL_BLANK_INDEXING_TYPES:
     case ALL_UNDECIDED_INDEXING_TYPES:
-        return notFound;
+        return noPresentIndex;
 
     case ALL_INT32_INDEXING_TYPES:
     case ALL_CONTIGUOUS_INDEXING_TYPES: {
-        JSC::Butterfly* butterfly = array->butterfly();
+        JSC::Butterfly* butterfly = object->butterfly();
         unsigned usedLength = butterfly->publicLength();
         for (unsigned i = start; i < usedLength; ++i) {
-            if (butterfly->contiguous().at(array, i))
+            if (butterfly->contiguous().at(object, i))
                 return i;
         }
-        return notFound;
+        return noPresentIndex;
     }
 
     case ALL_DOUBLE_INDEXING_TYPES: {
-        JSC::Butterfly* butterfly = array->butterfly();
+        JSC::Butterfly* butterfly = object->butterfly();
         unsigned usedLength = butterfly->publicLength();
         for (unsigned i = start; i < usedLength; ++i) {
-            double value = butterfly->contiguousDouble().at(array, i);
+            double value = butterfly->contiguousDouble().at(object, i);
             // In DoubleShape storage the hole is NaN. A real NaN element can
             // never be stored there: JSObject::putByIndex / putDirectIndex
-            // convert the array to ContiguousShape first.
+            // convert the object to ContiguousShape first.
             if (value == value)
                 return i;
         }
-        return notFound;
+        return noPresentIndex;
     }
 
     case ALL_ARRAY_STORAGE_INDEXING_TYPES: {
-        JSC::ArrayStorage* storage = array->butterfly()->arrayStorage();
+        JSC::ArrayStorage* storage = object->butterfly()->arrayStorage();
         unsigned usedVectorLength = std::min(storage->length(), storage->vectorLength());
         for (unsigned i = start; i < usedVectorLength; ++i) {
             if (storage->m_vector[i])
                 return i;
         }
 
-        uint64_t result = notFound;
+        uint64_t result = noPresentIndex;
         if (JSC::SparseArrayValueMap* map = storage->m_sparseMap.get()) {
             for (const auto& entry : *map) {
                 if (entry.index() >= start && entry.index() < result)
@@ -7118,6 +7113,39 @@ extern "C" uint64_t Bun__JSArray__nextPresentIndex(
     default:
         ASSERT_NOT_REACHED();
         return start;
+    }
+}
+
+// DirectArguments and ScopedArguments keep the arguments themselves outside the
+// butterfly; a deleted one is unmapped. Mirrors GenericArgumentsImpl::getOwnPropertyNames.
+template<typename Arguments>
+static uint64_t nextMappedArgumentIndex(Arguments* arguments, uint32_t start)
+{
+    for (unsigned i = start; i < arguments->internalLength(); ++i) {
+        if (arguments->isMappedArgument(i))
+            return i;
+    }
+    return noPresentIndex;
+}
+
+// Smallest own present index of an array, arguments object or ordinary object
+// that is >= `start`, or UINT64_MAX when every index from `start` on is a hole.
+// Walks the backing storage so the caller can skip a run of holes without
+// probing each index up to a huge `length`.
+extern "C" uint64_t Bun__JSObject__nextPresentIndex(
+    JSC::EncodedJSValue encodedValue,
+    uint32_t start)
+{
+    JSC::JSObject* object = JSC::JSValue::decode(encodedValue).getObject();
+    uint64_t result = nextPresentButterflyIndex(object, start);
+
+    switch (object->type()) {
+    case JSC::DirectArgumentsType:
+        return std::min(result, nextMappedArgumentIndex(uncheckedDowncast<JSC::DirectArguments>(object), start));
+    case JSC::ScopedArgumentsType:
+        return std::min(result, nextMappedArgumentIndex(uncheckedDowncast<JSC::ScopedArguments>(object), start));
+    default:
+        return result;
     }
 }
 

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1554,7 +1554,6 @@ pub fn to_js_time(sec: isize, nsec: isize) -> JSTimeType {
 pub const MAX_SAFE_INTEGER: i64 = 9007199254740991;
 pub const MIN_SAFE_INTEGER: i64 = -9007199254740991;
 /// JSC's `MAX_ARRAY_INDEX`: the largest index that indexed storage can hold.
-/// A larger "index" is an ordinary string-keyed property.
 pub const MAX_ARRAY_INDEX: u32 = 0xFFFF_FFFE;
 
 unsafe extern "C" {

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -1553,6 +1553,9 @@ pub fn to_js_time(sec: isize, nsec: isize) -> JSTimeType {
 
 pub const MAX_SAFE_INTEGER: i64 = 9007199254740991;
 pub const MIN_SAFE_INTEGER: i64 = -9007199254740991;
+/// JSC's `MAX_ARRAY_INDEX`: the largest index that indexed storage can hold.
+/// A larger "index" is an ordinary string-keyed property.
+pub const MAX_ARRAY_INDEX: u32 = 0xFFFF_FFFE;
 
 unsafe extern "C" {
     fn JSCInitialize(

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -590,8 +590,8 @@ it("Bun.inspect huge sparse array summarizes holes without iterating them", asyn
 
 // JSC has three kinds of arguments objects: DirectArguments (sloppy function), ScopedArguments
 // (sloppy function with a parameter captured by a closure) and ClonedArguments (strict function).
-// The first two keep the arguments outside the regular indexed property storage. `new Function`
-// bodies are sloppy even though this module is strict.
+// The first two keep the arguments outside the regular indexed property storage. This file is a
+// module, so its own functions are strict; the body of a `new Function` is sloppy regardless.
 const argumentsObjectKinds = [
   ["direct", new Function("return arguments")],
   ["scoped", new Function("a", "const f = () => a; return arguments")],
@@ -602,8 +602,12 @@ const argumentsObjectKinds = [
     },
   ],
 ];
+// Only a sloppy function's arguments object has `callee` as a data property (a strict one has a
+// throwing accessor), so this tells the first two kinds from the third.
+const isSloppyArguments = a => "value" in Object.getOwnPropertyDescriptor(a, "callee");
 
 it.each(argumentsObjectKinds)("Bun.inspect %s arguments object with holes and extra indexes", (kind, args) => {
+  expect(isSloppyArguments(args())).toBe(kind !== "cloned");
   let a = args(1, 2, 3);
   delete a[1];
   expect(Bun.inspect(a)).toBe("[ 1, empty item, 3 ]");
@@ -636,12 +640,15 @@ it.each(argumentsObjectKinds)("Bun.inspect %s arguments object with holes and ex
 // anything at all (past 2^32 - 1, a getter) with only a handful of elements behind it, so it must
 // not drive an index-by-index probe either. In a child for the same reason as above.
 it("Bun.inspect arguments object with a huge length summarizes holes without iterating them", async () => {
+  // Code given to -e without a require() is a module as well, so the same three definitions.
   const code = `
-    function direct() { return arguments; }
-    function scoped(a) { scoped.f = () => a; return arguments; }
+    const direct = new Function("return arguments");
+    const scoped = new Function("a", "const f = () => a; return arguments");
     class K { static cloned() { return arguments; } }
+    const isSloppyArguments = ${isSloppyArguments};
     for (const args of [direct, scoped, K.cloned]) {
       const a = args(1, 2, 3);
+      console.log(isSloppyArguments(a));
       a.length = 2 ** 32;
       console.log(a);
       const b = args(1, 2, 3);
@@ -659,11 +666,11 @@ it("Bun.inspect arguments object with a huge length summarizes holes without ite
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const formatted =
+    "[\n  1, 2, 3, 4294967293 x empty items\n]\n" +
+    '{\n  b: [\n    1, empty item, 3, 67 x empty items, 70, 4294967223 x empty items, "max", 1125895611875329 x empty items\n  ],\n}\n';
   expect({ stdout, stderr, exitCode }).toEqual({
-    stdout: (
-      "[\n  1, 2, 3, 4294967293 x empty items\n]\n" +
-      '{\n  b: [\n    1, empty item, 3, 67 x empty items, 70, 4294967223 x empty items, "max", 1125895611875329 x empty items\n  ],\n}\n'
-    ).repeat(3),
+    stdout: "true\n" + formatted + "true\n" + formatted + "false\n" + formatted,
     stderr: "",
     exitCode: 0,
   });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -614,6 +614,18 @@ it.each(argumentsObjectKinds)("Bun.inspect %s arguments object with holes and ex
   a = args(1, 2, 3);
   delete a[2];
   expect(Bun.inspect(a)).toBe("[ 1, 2, empty item ]");
+  // Runs of more than one deleted argument, each followed by an argument that is still there.
+  a = args(1, 2, 3, 4, 5, 6, 7);
+  for (const i of [1, 2, 4, 5]) delete a[i];
+  a.length = 9;
+  expect(Bun.inspect(a)).toBe("[ 1, 2 x empty items, 4, 2 x empty items, 7, 2 x empty items ]");
+  // A deleted argument that is assigned again lives in the regular indexed storage. Here it
+  // comes after a hole and before an argument that was never deleted.
+  a = args(1, 2, 3, 4);
+  delete a[1];
+  delete a[2];
+  a[2] = "x";
+  expect(Bun.inspect(a)).toBe('[ 1, empty item, "x", 4 ]');
   a = args(1, 2, 3);
   Object.defineProperty(a, 1, { value: "x", enumerable: false });
   expect(Bun.inspect(a)).toBe('[ 1, "x", 3 ]');

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -588,6 +588,87 @@ it("Bun.inspect huge sparse array summarizes holes without iterating them", asyn
   });
 });
 
+// JSC has three kinds of arguments objects: DirectArguments (sloppy function), ScopedArguments
+// (sloppy function with a parameter captured by a closure) and ClonedArguments (strict function).
+// The first two keep the arguments outside the regular indexed property storage. `new Function`
+// bodies are sloppy even though this module is strict.
+const argumentsObjectKinds = [
+  ["direct", new Function("return arguments")],
+  ["scoped", new Function("a", "const f = () => a; return arguments")],
+  [
+    "cloned",
+    function () {
+      return arguments;
+    },
+  ],
+];
+
+it.each(argumentsObjectKinds)("Bun.inspect %s arguments object with holes and extra indexes", (kind, args) => {
+  let a = args(1, 2, 3);
+  delete a[1];
+  expect(Bun.inspect(a)).toBe("[ 1, empty item, 3 ]");
+  a = args(1, 2, 3);
+  delete a[2];
+  expect(Bun.inspect(a)).toBe("[ 1, 2, empty item ]");
+  a = args(1, 2, 3);
+  Object.defineProperty(a, 1, { value: "x", enumerable: false });
+  expect(Bun.inspect(a)).toBe('[ 1, "x", 3 ]');
+  a = args(1, 2, 3);
+  a.length = 2;
+  expect(Bun.inspect(a)).toBe("[ 1, 2 ]");
+  a = args();
+  a.length = 3;
+  expect(Bun.inspect(a)).toBe("[ 3 x empty items ]");
+  // An index past the arguments themselves lands in the regular indexed storage
+  // and only shows once `length` covers it, like any other array-like.
+  a = args(1, 2, 3);
+  a[5] = 6;
+  expect(Bun.inspect(a)).toBe("[ 1, 2, 3 ]");
+  a.length = 8;
+  expect(Bun.inspect(a)).toBe("[ 1, 2, 3, 2 x empty items, 6, 2 x empty items ]");
+  delete a[2];
+  a[1_000_000] = "far";
+  a.length = 1_000_002;
+  expect(Bun.inspect(a)).toBe('[\n  1, 2, 3 x empty items, 6, 999994 x empty items, "far", empty item\n]');
+});
+
+// Unlike an array's, an arguments object's `length` is an ordinary writable property: it can be
+// anything at all (past 2^32 - 1, a getter) with only a handful of elements behind it, so it must
+// not drive an index-by-index probe either. In a child for the same reason as above.
+it("Bun.inspect arguments object with a huge length summarizes holes without iterating them", async () => {
+  const code = `
+    function direct() { return arguments; }
+    function scoped(a) { scoped.f = () => a; return arguments; }
+    class K { static cloned() { return arguments; } }
+    for (const args of [direct, scoped, K.cloned]) {
+      const a = args(1, 2, 3);
+      a.length = 2 ** 32;
+      console.log(a);
+      const b = args(1, 2, 3);
+      delete b[1];
+      b[70] = 70;
+      b[4294967294] = "max";
+      Object.defineProperty(b, "length", { get: () => 2 ** 50 });
+      console.log(Bun.inspect({ b }));
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: (
+      "[\n  1, 2, 3, 4294967293 x empty items\n]\n" +
+      '{\n  b: [\n    1, empty item, 3, 67 x empty items, 70, 4294967223 x empty items, "max", 1125895611875329 x empty items\n  ],\n}\n'
+    ).repeat(3),
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 // A property lookup that throws while an object is being formatted (a Proxy trap in the
 // prototype chain, a lazily initialized property whose initializer throws, a module namespace
 // export that is still in its temporal dead zone) used to leave the exception pending: the


### PR DESCRIPTION
### Problem
- `console.log` / `Bun.inspect` of an `arguments` object with a huge `length` never returns: `const a = (function () { return arguments; })(1, 2, 3); a.length = 2 ** 32; console.log(a)`.
- Cause: `print_array` (`src/jsc/ConsoleObject.rs:4307`) probes every index up to `get_length()`, which for an arguments object is its writable `length` property. The hole-skipping walk from #33158 was `is_array()` only. Past 2^32 - 1 the `u32` index also overflowed.

### Fix
- `Bun__JSArray__nextPresentIndex` becomes `Bun__JSObject__nextPresentIndex`: the same butterfly walk, plus the argument slots that `DirectArguments` / `ScopedArguments` keep outside the butterfly. `print_array` uses it for arguments objects too.
- The probe loop stops at `MAX_ARRAY_INDEX`. Nothing above it is an indexed property, so the rest of `length` counts as holes and the index cannot overflow.
- Output is unchanged for every input that used to complete (7500 random mutation sequences print identically on 1.4.3). The cost is now bounded by the storage that exists.
- Verified: `test/js/bun/util/inspect.test.js` (the child-process test times out on 1.4.3). Also `test/js/bun/console/`, `test/js/web/console/`. Self-reviewed: all surviving concerns addressed, see Notes.

### Background
- JSC has three arguments objects. `DirectArguments` (sloppy function) stores the arguments inline. `ScopedArguments` (a closure captures a parameter) aliases them into the scope. `ClonedArguments` (strict function) keeps them in the butterfly.
- The butterfly is JSC's out-of-line storage for indexed properties: a vector, plus a sparse map in `ArrayStorage` mode.
- `MAX_ARRAY_INDEX` is 2^32 - 2. A larger integer key is a string-named property. Only an arguments object's `length` can exceed it.

<details><summary>Notes</summary>

**Scope and what is left**
- Found by fuzzing, not from a user report. `a.length = 1e9` takes ~13 s on 1.4.3. A `length` getter returning `1e12`, `console.log({ a })`, and an `Error` with such a property all hang the same way. They all reach `print_array`. Node prints `[Arguments] { '0': 1, '1': 2, '2': 3 }` immediately for the same object (it never reads `length` for an arguments object).
- `console.table` / `Bun.inspect.table` of the same object is not fixed here. That path does not go through `print_array`: it builds one row per claimed index (1e6 rows in 630 ms on 1.4.3), so it still does not return for `length = 2 ** 32`. #41119 (open) owns that path.
- The JSX-children path (`ConsoleObject.rs:5233`) also iterates up to `get_length`. It prints every child, so its cost is proportional to its output. With `length > 2 ** 32` it ends in `panic: int cast: TryFromIntError(PosOverflow)`, but only after 2^32 iterations (about 9 minutes). Pre-existing, left alone to keep this PR to one loop.
- A string-keyed "index" above `MAX_ARRAY_INDEX` (for example `a["4294967295"]` with `length = 2 ** 33`) is counted as a hole, not printed. Arrays can never have one below their `length`. For arguments objects the old loop read it once and then wrapped the counter.

**How the walk works**
- For the first two kinds a deleted argument is "unmapped", and an index written past the argument count goes to the butterfly like on any object. `getDirectIndex` on a `GenericArgumentsImpl` consults the mapped argument slots (`isMappedArgument(i)` for `i < internalLength()`) and then the ordinary butterfly path. So "next present index" is the minimum over both, the same two sources `GenericArgumentsImpl::getOwnPropertyNames` enumerates. `ClonedArguments` needs nothing special: its elements are butterfly elements.
- `next_present_index` can scan the whole sparse map on each call. `print_array` bounds the number of calls (it stops after 100 present elements). A caller that wants a full walk should snapshot and sort the keys instead, as `JSObject::getOwnIndexedPropertyNames` does. The doc comment says so.

**Evidence**
- Timings on the debug build, all three kinds (real `DirectArguments` / `ScopedArguments` / `ClonedArguments`, three distinct JSC structures): `length` of 2^32, 1e9, 2^32 ± k, 2^53, `Infinity`, a 2^50 getter, and an element at index 2^32 - 2 under a 2^33 `length` all format in 2 ms or less. `-1` and `NaN` give `[]` as before.
- Differential check: 7500 seeded random mutation sequences over the three kinds (delete, set, `defineProperty` with accessor and data descriptors, `length` up to 5000, `freeze` / `seal` / `preventExtensions`) print byte-identical output on 1.4.3 and on this branch.
- Mutation check of the new C++: a mutant that stops the slot walk at the first unmapped slot fails only the "runs of deleted arguments" row. A mutant that ignores the butterfly result when a mapped slot is found fails only the "re-assigned index" row. Both rows are in the per-kind test.

**Related open PRs**
- #40420 (Jarred-Sumner) renames `self` to `this` on the `get_direct_index` line inside this loop, adjacent to this diff. Whichever lands second needs a one-line manual merge.
- #37303 adds an `array_layout` pre-pass that carries a copy of the old `is_array()` gate and a `u32` index. It merges cleanly over this PR and would probe every index of an arguments object again. It needs the same two changes. I left a note there.
- #38910 changes `get_length` for an object with no `length` property (`delete arguments.length`) and for `length = Infinity`. It has had no review activity since 2026-08-15 and this PR does not depend on it. With this PR alone those two cases no longer hang in `print_array` (they print the clamped hole count).
- The "100 items" cap double counts a hole run that ends at the 101st element (`... 1 more items, 6 x empty items` for a plain 106-element array on 1.4.3). Pre-existing, not touched here, reported separately.

**Self-review**
- Concerns that survived: no test made the slot walk step over two deleted arguments in a row or take the butterfly side of the minimum (two rows added, each kills a mutant), the cost of `next_present_index` was undocumented (doc comment), and the Related list above was incomplete (fixed). The child test at first only produced `ClonedArguments` because `-e` code is a strict module (fixed with `new Function`, and both tests now assert which kinds are sloppy).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->