### PR TITLE
Copy a shared input before libdeflate compresses it in Bun.gzipSync and Bun.deflateSync

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2530,6 +2530,23 @@ pub mod JSZlib {
                     bun_libdeflate::Encoding::Deflate
                 };
 
+                // libdeflate sizes a block from one pass over the input, checks
+                // the output space once, then emits the block from a second pass
+                // with no bounds check. Input that changes in between overruns
+                // the reservation, so a shared buffer is compressed from a copy.
+                let snapshot: Vec<u8>;
+                let compressed = if buffer.is_shared() {
+                    let mut copy: Vec<u8> = Vec::new();
+                    if copy.try_reserve_exact(compressed.len()).is_err() {
+                        return Err(global_this.throw_out_of_memory());
+                    }
+                    copy.extend_from_slice(compressed);
+                    snapshot = copy;
+                    snapshot.as_slice()
+                } else {
+                    compressed
+                };
+
                 let mut list: Vec<u8> = Vec::new();
                 let result = compressor
                     .compress_to_vec(compressed, &mut list, encoding)

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2530,26 +2530,14 @@ pub mod JSZlib {
                     bun_libdeflate::Encoding::Deflate
                 };
 
-                // libdeflate sizes a block from one pass over the input, checks
-                // the output space once, then emits the block from a second pass
-                // with no bounds check. Input that changes in between overruns
-                // the reservation, so a shared buffer is compressed from a copy.
-                let snapshot: Vec<u8>;
-                let compressed = if buffer.is_shared() {
-                    let mut copy: Vec<u8> = Vec::new();
-                    if copy.try_reserve_exact(compressed.len()).is_err() {
-                        return Err(global_this.throw_out_of_memory());
-                    }
-                    copy.extend_from_slice(compressed);
-                    snapshot = copy;
-                    snapshot.as_slice()
-                } else {
-                    compressed
-                };
+                // libdeflate checks the output space once per block, then reads the input again to emit it.
+                let input = buffer
+                    .slice_copied_if_shared()
+                    .map_err(|_| global_this.throw_out_of_memory())?;
 
                 let mut list: Vec<u8> = Vec::new();
                 let result = compressor
-                    .compress_to_vec(compressed, &mut list, encoding)
+                    .compress_to_vec(&input, &mut list, encoding)
                     .map_err(|_| global_this.throw_out_of_memory())?;
                 if result.status != bun_libdeflate::Status::Success {
                     drop(list);

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -312,6 +312,17 @@ impl<'a> StringOrBuffer<'a> {
             Self::PinnedBuffer(buffer) => buffer.slice(),
         }
     }
+
+    /// True when [`slice`](Self::slice) reads a `SharedArrayBuffer`: another
+    /// thread can write those bytes while this one reads them. A caller that
+    /// needs the bytes to hold still must copy them first.
+    pub(crate) fn is_shared(&self) -> bool {
+        match self {
+            Self::Buffer(buffer) => buffer.buffer.shared,
+            Self::PinnedBuffer(buffer) => buffer.shared,
+            Self::String(_) | Self::ThreadIsolatedString(_) | Self::Utf8(_) => false,
+        }
+    }
 }
 
 impl StringOrBuffer<'_> {

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1,5 +1,6 @@
 use bun_paths::strings;
 use core::ffi::c_int;
+use std::borrow::Cow;
 
 use crate::jsc::{self, CallFrame, JSGlobalObject, JSValue, JsResult};
 use bun_core::{self, Utf8Bytes, Utf8WithString, fmt as bun_fmt};
@@ -313,15 +314,22 @@ impl<'a> StringOrBuffer<'a> {
         }
     }
 
-    /// True when [`slice`](Self::slice) reads a `SharedArrayBuffer`: another
-    /// thread can write those bytes while this one reads them. A caller that
-    /// needs the bytes to hold still must copy them first.
-    pub(crate) fn is_shared(&self) -> bool {
-        match self {
+    /// [`slice`](Self::slice), copied when it reads a `SharedArrayBuffer`, whose bytes another thread can write during the call.
+    pub(crate) fn slice_copied_if_shared(&self) -> Result<Cow<'_, [u8]>, bun_alloc::AllocError> {
+        let shared = match self {
             Self::Buffer(buffer) => buffer.buffer.shared,
             Self::PinnedBuffer(buffer) => buffer.shared,
             Self::String(_) | Self::ThreadIsolatedString(_) | Self::Utf8(_) => false,
+        };
+        let bytes = self.slice();
+        if !shared {
+            return Ok(Cow::Borrowed(bytes));
         }
+        let mut copy = Vec::new();
+        copy.try_reserve_exact(bytes.len())
+            .map_err(|_| bun_alloc::AllocError)?;
+        copy.extend_from_slice(bytes);
+        Ok(Cow::Owned(copy))
     }
 }
 

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -1,6 +1,6 @@
 import { deflateSync, gunzipSync, gzipSync, inflateSync } from "bun";
 import { describe, expect, it } from "bun:test";
-import { tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import * as buffer from "node:buffer";
 import { randomFillSync } from "node:crypto";
 import * as fs from "node:fs";
@@ -135,7 +135,96 @@ describe("zlib", () => {
       });
     }
   });
+
+  // libdeflate reads the input twice: it costs a block from the symbol
+  // frequencies of the first pass, checks the output reservation once, then
+  // emits the block in the second pass with no further bounds check. A worker
+  // that rewrites a SharedArrayBuffer input between the two passes used to make
+  // the emitted block longer than the costed one, which wrote past the output
+  // reservation.
+  describe("libdeflate of a SharedArrayBuffer", () => {
+    it.concurrent.each(["gzip", "deflate"])(
+      "%s stays inside the output reservation while another thread writes the input",
+      async kind => {
+        using dir = tempDir("libdeflate-shared", { "fixture.mjs": sharedArrayBufferRaceFixture });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "fixture.mjs", kind],
+          env: bunEnv,
+          cwd: String(dir),
+          stderr: "pipe",
+        });
+
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        expect(stderr).toBe("");
+        expect(stdout).toBe("ok\n");
+        expect(exitCode).toBe(0);
+      },
+    );
+  });
 });
+
+// Compresses a SharedArrayBuffer `CALLS` times while a worker rewrites it
+// between two symbol sets: one that codes in few bits, one that costs more.
+// libdeflate reserves `SIZE + 23` bytes for a gzip stream of `SIZE` bytes, so
+// `LIMIT` leaves room for any output a correct compressor can produce.
+const sharedArrayBufferRaceFixture = `
+import { isMainThread, parentPort, Worker, workerData } from "node:worker_threads";
+
+const SIZE = 4096;
+const LIMIT = SIZE + 256;
+const CALLS = 500;
+
+if (isMainThread) {
+  const input = new SharedArrayBuffer(SIZE);
+  const worker = new Worker(new URL(import.meta.url), { workerData: input });
+  const ready = Promise.withResolvers();
+  worker.on("message", ready.resolve);
+  await ready.promise;
+  worker.unref();
+
+  const raw = process.argv[2] === "deflate";
+  const compress = raw ? Bun.deflateSync : Bun.gzipSync;
+  const decompress = raw ? Bun.inflateSync : Bun.gunzipSync;
+  const view = new Uint8Array(input);
+
+  for (let i = 0; i < CALLS; i++) {
+    const out = compress(view, { library: "libdeflate", level: 1 + (i % 12) });
+    if (out.length > LIMIT) {
+      console.error(\`call \${i}: wrote \${out.length} bytes into a \${LIMIT} byte reservation\`);
+      process.exit(1);
+    }
+    const back = decompress(out, { library: "libdeflate" });
+    if (back.length !== SIZE) {
+      console.error(\`call \${i}: round trip returned \${back.length} bytes, want \${SIZE}\`);
+      process.exit(1);
+    }
+  }
+
+  console.log("ok");
+  process.exit(0);
+} else {
+  const view = new Uint8Array(workerData);
+  let seed = 88172645;
+  const next = () => ((seed ^= seed << 13), (seed ^= seed >>> 17), (seed ^= seed << 5), seed >>> 0);
+  const cheap = new Uint8Array(view.length);
+  const costly = new Uint8Array(view.length);
+  for (let i = 0; i < view.length; i++) {
+    cheap[i] = next() & 127;
+    costly[i] = 0xf0 + (next() & 15);
+  }
+  for (let i = 0; i < 16; i++) cheap[next() % view.length] = 0xf0 + i;
+
+  parentPort.postMessage("ready");
+  for (;;) {
+    view.set(cheap);
+    for (let i = next() % 50000; i > 0; i--);
+    view.set(costly);
+    for (let i = next() % 5000; i > 0; i--);
+  }
+}
+`;
 
 function* window(buffer, size, advance = size) {
   let i = 0;

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -167,13 +167,14 @@ describe("zlib", () => {
 
 // Compresses a SharedArrayBuffer `CALLS` times while a worker rewrites it
 // between two symbol sets: one that codes in few bits, one that costs more.
-// libdeflate reserves `SIZE + 23` bytes for a gzip stream of `SIZE` bytes, so
-// `LIMIT` leaves room for any output a correct compressor can produce.
+// `RESERVED` is what Bun allocates for the output, libdeflate's bound for
+// `SIZE` bytes: one stored block costs 5 bytes more than its input, and gzip
+// adds a 10 byte header and an 8 byte trailer. libdeflate never picks a block
+// that costs more than a stored one, so a longer output ran past the allocation.
 const sharedArrayBufferRaceFixture = `
 import { isMainThread, parentPort, Worker, workerData } from "node:worker_threads";
 
 const SIZE = 4096;
-const LIMIT = SIZE + 256;
 const CALLS = 500;
 
 if (isMainThread) {
@@ -185,14 +186,15 @@ if (isMainThread) {
   worker.unref();
 
   const raw = process.argv[2] === "deflate";
+  const RESERVED = SIZE + (raw ? 5 : 23);
   const compress = raw ? Bun.deflateSync : Bun.gzipSync;
   const decompress = raw ? Bun.inflateSync : Bun.gunzipSync;
   const view = new Uint8Array(input);
 
   for (let i = 0; i < CALLS; i++) {
     const out = compress(view, { library: "libdeflate", level: 1 + (i % 12) });
-    if (out.length > LIMIT) {
-      console.error(\`call \${i}: wrote \${out.length} bytes into a \${LIMIT} byte reservation\`);
+    if (out.length > RESERVED) {
+      console.error(\`call \${i}: wrote \${out.length} bytes into a \${RESERVED} byte reservation\`);
       process.exit(1);
     }
     const back = decompress(out, { library: "libdeflate" });


### PR DESCRIPTION
### Problem

- `Bun.gzipSync(view, { library: "libdeflate" })` and `Bun.deflateSync` write past the output allocation when `view` reads a `SharedArrayBuffer` that another thread writes. ASAN: heap-buffer-overflow WRITE in `deflate_flush_block` (`vendor/libdeflate/lib/deflate_compress.c:1982`). A release build segfaults.
- `gzip_or_deflate_sync` (`src/runtime/api/BunObject.rs`) hands the shared backing store to libdeflate. Without a crash, a 4096 byte input returns up to 6259 bytes from a 4119 byte reservation, or a corrupt stream.

### Fix

- `StringOrBuffer::slice_copied_if_shared` returns the input, copied when it belongs to a `SharedArrayBuffer`. The libdeflate arm compresses that, so both passes read the same bytes.
- The zlib arm keeps the borrow. zlib copies input into its window once and bounds every write by `avail_out`.
- A resizable buffer that is not shared needs no copy. No user JS runs between argument coercion and the compress call.
- Verified: `test/js/node/zlib/zlib.test.js`. A worker rewrites a 4096 byte `SharedArrayBuffer` during 500 compress calls. Each output is checked against the exact reservation. Without the fix the ASAN build fails 12 of 12 runs. Also ran `test/js/node/zlib/`, `zstd.test.ts`, `compression.test.ts`.

### Background

- libdeflate makes two passes per block. `deflate_flush_block` costs the block from the first pass and checks the space left once. Then it reads the input again to emit the block, with no bounds check.
- Bytes that change to symbols with longer codes make the emitted block longer than its cost.
- `libdeflate_gzip_compress_bound` sizes the reservation (`src/libdeflate_sys/libdeflate.rs`): here the input plus 5 bytes for raw deflate, plus 23 for gzip.
- `TextDecoder.decode` copies a shared buffer for the same reason (`src/runtime/webcore/TextDecoder.rs:304`).

<details><summary>Notes</summary>

**libdeflate's own words.** The comment in `deflate_flush_block` after the single check: "now we know that the block fits, so no further bounds checks on the output buffer are required until the next block". For 4096 bytes the bound is one stored block (5 bytes over the input), and gzip adds a 10 byte header and an 8 byte trailer.

**Not covered by this PR: `Bun.mmap`.** `Bun.mmap(path)` returns a plain `Uint8Array` over a `MAP_SHARED` mapping. JSC does not report that buffer as shared, so the check in this PR does not see it. A Worker (or another process) that rewrites the file with `write(2)` during `Bun.gzipSync(Bun.mmap(path), { library: "libdeflate" })` reproduces the same overrun on 1.4.3-canary: 4700 bytes from a 4119 byte reservation, after 671 to 4631 calls in three runs. The only general fix at this call site is to always copy the input in the libdeflate arm. I measured that on a release build (`buf.slice()` before the call): +0.2% to +2.4% up to 1 MiB, +3.4% to +12.9% at 64 MiB, plus one input-sized allocation. That cost falls on every caller of an option people choose for speed, so I left the decision to a maintainer. Another direction is for `Bun.mmap` to hand out a view that JSC reports as shared, so that every existing shared check covers it. That changes what users see.

**Other libdeflate compress call sites.**
- `Bun.serve` websockets: `ws.send(sharedView, true)` with `perMessageDeflate: true` reaches `libdeflate_deflate_compress` in `packages/bun-uws/src/PerMessageDeflate.h:120` with a 4096 byte output buffer. It overruns the same way (ASAN, first run). That needs its own fix across `send`, `sendBinary`, `publish`, `ping` and `pong`, and is tracked separately.
- `fetch()` request body compression (`src/http/compress_body.rs`): safe. `Body::Value::from_js` copies every typed array body into an owned `Vec<u8>` (`src/runtime/webcore/Body.rs:982`).
- `Bun.Archive` gzip (`src/runtime/api/Archive.rs:1212`): safe. The constructor copies typed array input (`Archive.rs:188`, `:464`).
- `bun audit` (`src/runtime/cli/audit_command.rs:701`): Rust-owned JSON.
- The client `WebSocket` uses zlib for its deflate stream, and its `send` does not accept a shared view.

**Failure modes seen without the fix** (same race, three symptoms): the ASAN abort, an output longer than the reservation (`call 51: wrote 4154 bytes into a 4101 byte reservation`), and a corrupt stream (`libdeflate returned an error: bad data` on the round trip, when a byte changes to a symbol that had zero frequency in the first pass). The test checks the length and the round trip, so it catches all three. An earlier revision of the test allowed 256 bytes over the input. A review pointed out that this lets a small overrun pass on a build without ASAN. The 53 byte overrun quoted above is such a case.

**Decompression.** `Bun.gunzipSync` and `Bun.inflateSync` with either library were not changed. The libdeflate decompressor reads the input once and bounds its writes. The gzip ISIZE pre-read only sizes a hint, and `decompress_to_vec_grow` grows on `InsufficientSpace`.

**Unrelated.** `test/js/node/zlib/leak.test.ts` times out in its `beforeAll` (10,000 `zlib.deflateSync` calls) on the local debug ASAN build, with and without this change. It does not touch this code path.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/zlib/zlib.test.js
bun test v1.4.3 (5f554969b)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [2.03ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [1.57ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [1.08ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [2.03ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.47ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.28ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip [0.24ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib [0.28ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto
... (truncated)

release without fix: 2 failed, 2 skipped
bun test v1.4.3-canary.1 (5f554969b)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [0.02ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [0.01ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [0.01ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [0.01ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto__
(pass) prototype and name and constructor > Deflate > Deflate.prototype.constructor should be Deflate
(pass) prototype and name and constructor > Deflate > Deflate.name should be Deflate

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/zlib/zlib.test.js
bun test v1.4.3 (5f554969b)

test/js/node/zlib/zlib.test.js:
(pass) prototype and name and constructor > Gzip > Gzip.prototype should be instanceof Gzip.__proto__ [2.35ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.constructor should be Gzip [1.58ms]
(pass) prototype and name and constructor > Gzip > Gzip.name should be Gzip [1.19ms]
(pass) prototype and name and constructor > Gzip > Gzip.prototype.__proto__.constructor.name should be Zlib [2.72ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype should be instanceof Gunzip.__proto__ [0.47ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.constructor should be Gunzip [0.27ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.name should be Gunzip [0.26ms]
(pass) prototype and name and constructor > Gunzip > Gunzip.prototype.__proto__.constructor.name should be Zlib [0.32ms]
(pass) prototype and name and constructor > Deflate > Deflate.prototype should be instanceof Deflate.__proto
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 822ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/31] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/31] gen cpp.rs (cppbind)
[3/31] gen JS modules (bundle-modules)
Preprocess modules (8901ms)
Bundle modules (53ms)
Postprocesss modules (195ms)
Bundle Functions (581ms)
Generate Code (37ms)

[9.77s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/21] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/BunObject.rs   |  7 +++-
 src/runtime/node/types.rs      | 19 +++++++++
 test/js/node/zlib/zlib.test.js | 93 +++++++++++++++++++++++++++++++++++++++++-
 3 files changed, 117 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/runtime/api/BunObject.rs        4      3     21
src/runtime/node/types.rs           2      2     21
test/js/node/zlib/zlib.test.js      4      6     21
```

</details>

**root cause** · written by the author bot

The libdeflate compressor sizes its output reservation from symbol frequencies gathered in a first pass over the input, then emits the block in a second pass without further bounds checks, so when the input lives in a `SharedArrayBuffer` that another thread rewrites between the two passes, the re-read bytes can encode to longer codes and the emitted block runs past the reservation. The fix snapshots shared input into owned memory before handing it to libdeflate, via a new `StringOrBuffer::slice_copied_if_shared` helper used by `gzip_or_deflate_sync`, so both passes read identical bytes and …

<!-- robobun:evidence:end -->