### PR TITLE
Make repeated Headers.append on one name linear instead of quadratic

### DIFF
--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -411,7 +411,7 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
     for (const auto& header : internalHeaders.commonHeaders()) {
 
         const auto& name = WebCore::httpHeaderNameString(header.key);
-        const auto& value = header.value;
+        const WTF::String& value = header.value.string();
 
         // We have to tell uWS not to automatically insert a TransferEncoding or Date header.
         // Otherwise, you get this when using Fastify;
@@ -460,7 +460,7 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
 
     for (auto& header : internalHeaders.uncommonHeaders()) {
         const auto& name = header.key;
-        const auto& value = header.value;
+        const WTF::String& value = header.value.string();
 
         writeResponseHeader<isSSL>(res, name, value);
     }
@@ -864,11 +864,11 @@ static void writeFetchHeadersToStreamResponse(WebCore::FetchHeaders& headers, Re
         }
         // No Transfer-Encoding on these transports; if a user header reaches
         // here it was already stripped by doWriteHeaders().
-        writeOne(WebCore::httpHeaderNameString(header.key), header.value);
+        writeOne(WebCore::httpHeaderNameString(header.key), header.value.string());
     }
 
     for (auto& header : internalHeaders.uncommonHeaders()) {
-        writeOne(header.key, header.value);
+        writeOne(header.key, header.value.string());
     }
 }
 

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -411,7 +411,7 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
     for (const auto& header : internalHeaders.commonHeaders()) {
 
         const auto& name = WebCore::httpHeaderNameString(header.key);
-        const WTF::String& value = header.value.string();
+        const WTF::String value = header.value.string();
 
         // We have to tell uWS not to automatically insert a TransferEncoding or Date header.
         // Otherwise, you get this when using Fastify;
@@ -460,7 +460,7 @@ static void writeFetchHeadersToUWSResponse(WebCore::FetchHeaders& headers, uWS::
 
     for (auto& header : internalHeaders.uncommonHeaders()) {
         const auto& name = header.key;
-        const WTF::String& value = header.value.string();
+        const WTF::String value = header.value.string();
 
         writeResponseHeader<isSSL>(res, name, value);
     }

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -67,7 +67,7 @@ static inline const String& trimHTTPSpaceIfNeeded(const String& value, String& s
     return storage;
 }
 
-static ExceptionOr<bool> canWriteHeader(const HTTPHeaderName name, const String& value, const String& combinedValue, FetchHeaders::Guard guard)
+static ExceptionOr<bool> canWriteHeader(const HTTPHeaderName name, const String& value, FetchHeaders::Guard guard)
 {
     ASSERT(value.isEmpty() || (!isHTTPSpace(value[0]) && !isHTTPSpace(value[value.length() - 1])));
     if (!isValidHTTPHeaderValue((value)))
@@ -77,7 +77,7 @@ static ExceptionOr<bool> canWriteHeader(const HTTPHeaderName name, const String&
     return true;
 }
 
-static ExceptionOr<bool> canWriteHeader(const String& name, const String& value, const String& combinedValue, FetchHeaders::Guard guard)
+static ExceptionOr<bool> canWriteHeader(const String& name, const String& value, FetchHeaders::Guard guard)
 {
     if (!isValidHTTPToken(name))
         return Exception { TypeError, makeString("Invalid header name: '"_s, name, "'"_s) };
@@ -93,57 +93,32 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
 {
     // The common path here is a brand-new header with no leading/trailing HTTP
     // whitespace. Avoid taking ownership (and the atomic ref-count round-trip
-    // that comes with it) of the value String unless we actually have to trim
-    // or merge with an existing header.
+    // that comes with it) of the value String unless we actually have to trim.
     String trimStorage;
     const String& normalizedValue = trimHTTPSpaceIfNeeded(value, trimStorage);
-    String combinedTemp;
-    const String* valueToSet = &normalizedValue;
     HTTPHeaderName headerName;
     if (findHTTPHeaderName(name, headerName)) {
-        auto index = headers.indexOf(headerName);
-
-        if (headerName != HTTPHeaderName::SetCookie) {
-            if (index.isValid()) {
-                auto existing = headers.getIndex(index);
-                if (headerName == HTTPHeaderName::Cookie) {
-                    combinedTemp = makeString(existing, "; "_s, normalizedValue);
-                } else {
-                    combinedTemp = makeString(existing, ", "_s, normalizedValue);
-                }
-                valueToSet = &combinedTemp;
-            }
-        }
-
-        auto canWriteResult = canWriteHeader(headerName, normalizedValue, *valueToSet, guard);
-
+        auto canWriteResult = canWriteHeader(headerName, normalizedValue, guard);
         if (canWriteResult.hasException())
             return canWriteResult.releaseException();
         if (!canWriteResult.releaseReturnValue())
             return {};
 
-        if (headerName != HTTPHeaderName::SetCookie) {
-            if (!headers.setIndex(index, *valueToSet))
-                headers.set(headerName, *valueToSet);
-        } else {
-            headers.add(headerName, normalizedValue);
-        }
-
+        // The combined value does not fit in a String. This is the error JSC
+        // throws for an over-long string: RangeError: Out of memory.
+        if (!headers.add(headerName, normalizedValue))
+            return Exception { OutOfMemoryError };
         return {};
     }
-    auto index = headers.indexOf(name);
-    if (index.isValid()) {
-        combinedTemp = makeString(headers.getIndex(index), ", "_s, normalizedValue);
-        valueToSet = &combinedTemp;
-    }
-    auto canWriteResult = canWriteHeader(name, normalizedValue, *valueToSet, guard);
+
+    auto canWriteResult = canWriteHeader(name, normalizedValue, guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();
     if (!canWriteResult.releaseReturnValue())
         return {};
 
-    if (!headers.setIndex(index, *valueToSet))
-        headers.set(name, *valueToSet);
+    if (!headers.addUncommonHeader(name, normalizedValue))
+        return Exception { OutOfMemoryError };
 
     // if (guard == FetchHeaders::Guard::RequestNoCors)
     //     removePrivilegedNoCORSRequestHeaders(headers);
@@ -155,15 +130,16 @@ static ExceptionOr<void> appendToHeaderMap(const HTTPHeaderMap::HTTPHeaderMapCon
 {
     String trimStorage;
     const String& normalizedValue = trimHTTPSpaceIfNeeded(header.value, trimStorage);
-    auto canWriteResult = canWriteHeader(header.key, normalizedValue, header.value, guard);
+    auto canWriteResult = canWriteHeader(header.key, normalizedValue, guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();
     if (!canWriteResult.releaseReturnValue())
         return {};
-    if (header.keyAsHTTPHeaderName)
-        headers.add(header.keyAsHTTPHeaderName.value(), header.value);
-    else
-        headers.add(header.key, header.value);
+    bool stored = header.keyAsHTTPHeaderName
+        ? headers.add(header.keyAsHTTPHeaderName.value(), header.value)
+        : headers.add(header.key, header.value);
+    if (!stored)
+        return Exception { OutOfMemoryError };
 
     return {};
 }
@@ -287,7 +263,7 @@ ExceptionOr<bool> FetchHeaders::has(const StringView name) const
 ExceptionOr<void> FetchHeaders::set(const HTTPHeaderName name, const String& value)
 {
     String normalizedValue = trimHTTPSpaceIfNeeded(value);
-    auto canWriteResult = canWriteHeader(name, normalizedValue, normalizedValue, m_guard);
+    auto canWriteResult = canWriteHeader(name, normalizedValue, m_guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();
     if (!canWriteResult.releaseReturnValue())
@@ -305,7 +281,7 @@ ExceptionOr<void> FetchHeaders::set(const HTTPHeaderName name, const String& val
 ExceptionOr<void> FetchHeaders::set(const String& name, const String& value)
 {
     String normalizedValue = trimHTTPSpaceIfNeeded(value);
-    auto canWriteResult = canWriteHeader(name, normalizedValue, normalizedValue, m_guard);
+    auto canWriteResult = canWriteHeader(name, normalizedValue, m_guard);
     if (canWriteResult.hasException())
         return canWriteResult.releaseException();
     if (!canWriteResult.releaseReturnValue())

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -104,8 +104,6 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
         if (!canWriteResult.releaseReturnValue())
             return {};
 
-        // The combined value does not fit in a String. This is the error JSC
-        // throws for an over-long string: RangeError: Out of memory.
         if (!headers.add(headerName, normalizedValue))
             return Exception { OutOfMemoryError };
         return {};

--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -104,7 +104,7 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
         if (!canWriteResult.releaseReturnValue())
             return {};
 
-        if (!headers.add(headerName, normalizedValue))
+        if (headers.add(headerName, normalizedValue) == HTTPHeaderMap::AddResult::ValueTooLong)
             return Exception { OutOfMemoryError };
         return {};
     }
@@ -115,7 +115,7 @@ static ExceptionOr<void> appendToHeaderMap(const String& name, const String& val
     if (!canWriteResult.releaseReturnValue())
         return {};
 
-    if (!headers.addUncommonHeader(name, normalizedValue))
+    if (headers.addUncommonHeader(name, normalizedValue) == HTTPHeaderMap::AddResult::ValueTooLong)
         return Exception { OutOfMemoryError };
 
     // if (guard == FetchHeaders::Guard::RequestNoCors)
@@ -133,10 +133,10 @@ static ExceptionOr<void> appendToHeaderMap(const HTTPHeaderMap::HTTPHeaderMapCon
         return canWriteResult.releaseException();
     if (!canWriteResult.releaseReturnValue())
         return {};
-    bool stored = header.keyAsHTTPHeaderName
+    auto result = header.keyAsHTTPHeaderName
         ? headers.add(header.keyAsHTTPHeaderName.value(), header.value)
         : headers.add(header.key, header.value);
-    if (!stored)
+    if (result == HTTPHeaderMap::AddResult::ValueTooLong)
         return Exception { OutOfMemoryError };
 
     return {};

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
@@ -94,11 +94,11 @@ size_t HTTPHeaderMap::memoryCost() const
     cost += m_uncommonHeaders.size() * sizeof(UncommonHeader);
     cost += m_setCookieHeaders.size() * sizeof(String);
     for (auto& header : m_commonHeaders)
-        cost += header.value.sizeInBytes();
+        cost += header.value.memoryCost();
 
     for (auto& header : m_uncommonHeaders) {
         cost += header.key.sizeInBytes();
-        cost += header.value.sizeInBytes();
+        cost += header.value.memoryCost();
     }
 
     for (auto& header : m_setCookieHeaders)
@@ -112,7 +112,7 @@ String HTTPHeaderMap::getUncommonHeader(const StringView name) const
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
     });
-    return index != notFound ? m_uncommonHeaders[index].value : String();
+    return index != notFound ? m_uncommonHeaders[index].value.string() : String();
 }
 
 void HTTPHeaderMap::set(const String& name, const String& value)
@@ -137,18 +137,19 @@ void HTTPHeaderMap::setUncommonHeader(const String& name, const String& value)
         m_uncommonHeaders[index].value = value;
 }
 
-void HTTPHeaderMap::addUncommonHeader(const String& name, const String& value)
+bool HTTPHeaderMap::addUncommonHeader(const String& name, const String& value)
 {
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
     });
-    if (index == notFound)
+    if (index == notFound) {
         m_uncommonHeaders.append(UncommonHeader { name, value });
-    else
-        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
+        return true;
+    }
+    return m_uncommonHeaders[index].value.append(", "_s, value);
 }
 
-void HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const String& value)
+bool HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const String& value)
 {
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
@@ -158,24 +159,18 @@ void HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const Stri
         auto nameCopy = WTF::String::createUninitialized(name.length(), ptr);
         memcpy(ptr.data(), name.span8().data(), name.length());
         m_uncommonHeaders.append(UncommonHeader { nameCopy, value });
-    } else
-        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
+        return true;
+    }
+    return m_uncommonHeaders[index].value.append(", "_s, value);
 }
 
-void HTTPHeaderMap::add(const String& name, const String& value)
+bool HTTPHeaderMap::add(const String& name, const String& value)
 {
     HTTPHeaderName headerName;
-    if (findHTTPHeaderName(name, headerName)) {
-        add(headerName, value);
-        return;
-    }
-    auto index = m_uncommonHeaders.findIf([&](auto& header) {
-        return equalIgnoringASCIICase(header.key, name);
-    });
-    if (index == notFound)
-        m_uncommonHeaders.append(UncommonHeader { name, value });
-    else
-        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
+    if (findHTTPHeaderName(name, headerName))
+        return add(headerName, value);
+
+    return addUncommonHeader(name, value);
 }
 
 bool HTTPHeaderMap::contains(const StringView name) const
@@ -236,7 +231,7 @@ String HTTPHeaderMap::get(HTTPHeaderName name) const
     auto index = m_commonHeaders.findIf([&](auto& header) {
         return header.key == name;
     });
-    return index != notFound ? m_commonHeaders[index].value : String();
+    return index != notFound ? m_commonHeaders[index].value.string() : String();
 }
 
 HTTPHeaderMap::HeaderIndex HTTPHeaderMap::indexOf(HTTPHeaderName name) const
@@ -260,8 +255,8 @@ String HTTPHeaderMap::getIndex(HTTPHeaderMap::HeaderIndex index) const
     if (index.index == notFound)
         return String();
     if (index.isCommon)
-        return m_commonHeaders[index.index].value;
-    return m_uncommonHeaders[index.index].value;
+        return m_commonHeaders[index.index].value.string();
+    return m_uncommonHeaders[index.index].value.string();
 }
 void HTTPHeaderMap::set(HTTPHeaderName name, const String& value)
 {
@@ -316,20 +311,21 @@ bool HTTPHeaderMap::remove(HTTPHeaderName name)
     });
 }
 
-void HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
+bool HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
 {
     if (name == HTTPHeaderName::SetCookie) {
         m_setCookieHeaders.append(value);
-        return;
+        return true;
     }
 
     auto index = m_commonHeaders.findIf([&](auto& header) {
         return header.key == name;
     });
-    if (index != notFound)
-        m_commonHeaders[index].value = makeString(m_commonHeaders[index].value, name == HTTPHeaderName::Cookie ? "; "_s : ", "_s, value);
-    else
+    if (index == notFound) {
         m_commonHeaders.append(CommonHeader { name, value });
+        return true;
+    }
+    return m_commonHeaders[index].value.append(name == HTTPHeaderName::Cookie ? "; "_s : ", "_s, value);
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
@@ -234,30 +234,6 @@ String HTTPHeaderMap::get(HTTPHeaderName name) const
     return index != notFound ? m_commonHeaders[index].value.string() : String();
 }
 
-HTTPHeaderMap::HeaderIndex HTTPHeaderMap::indexOf(HTTPHeaderName name) const
-{
-    auto index = m_commonHeaders.findIf([&](auto& header) {
-        return header.key == name;
-    });
-    return (HeaderIndex) { .index = index, .isCommon = true };
-}
-
-HTTPHeaderMap::HeaderIndex HTTPHeaderMap::indexOf(const String& name) const
-{
-    auto index = m_uncommonHeaders.findIf([&](auto& header) {
-        return equalIgnoringASCIICase(header.key, name);
-    });
-    return (HeaderIndex) { .index = index, .isCommon = false };
-}
-
-String HTTPHeaderMap::getIndex(HTTPHeaderMap::HeaderIndex index) const
-{
-    if (index.index == notFound)
-        return String();
-    if (index.isCommon)
-        return m_commonHeaders[index.index].value.string();
-    return m_uncommonHeaders[index.index].value.string();
-}
 void HTTPHeaderMap::set(HTTPHeaderName name, const String& value)
 {
     if (name == HTTPHeaderName::SetCookie) {
@@ -273,19 +249,6 @@ void HTTPHeaderMap::set(HTTPHeaderName name, const String& value)
         m_commonHeaders.append(CommonHeader { name, value });
     else
         m_commonHeaders[index].value = value;
-}
-
-bool HTTPHeaderMap::setIndex(HTTPHeaderMap::HeaderIndex index, const String& value)
-{
-    if (!index.isValid())
-        return false;
-
-    if (index.isCommon) {
-        m_commonHeaders[index.index].value = value;
-    } else {
-        m_uncommonHeaders[index.index].value = value;
-    }
-    return true;
 }
 
 bool HTTPHeaderMap::contains(HTTPHeaderName name) const

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
@@ -75,6 +75,49 @@ String lowercaseHeaderName(const String& name)
     return result;
 }
 
+// Values are Latin-1 (isValidHTTPHeaderValue). A 16-bit builder can grow to a capacity StringImpl refuses, which aborts.
+static String as8Bit(const String& value)
+{
+    if (value.is8Bit())
+        return value;
+    return StringImpl::create8BitIfPossible(value.span16());
+}
+
+void HeaderValue::deleteBuilder()
+{
+    delete builder();
+}
+
+String HeaderValue::builderString() const
+{
+    return builder()->toStringPreserveCapacity();
+}
+
+bool HeaderValue::appendToBuilder(ASCIILiteral delimiter, const String& value)
+{
+    auto* builder = this->builder();
+    String current = builder ? String() : string();
+    if (static_cast<uint64_t>(builder ? builder->length() : current.length()) + delimiter.length() + value.length() > String::MaxLength)
+        return false;
+
+    if (!builder) {
+        auto promoted = makeUnique<StringBuilder>();
+        promoted->append(as8Bit(current));
+        builder = promoted.get();
+        *this = HeaderValue(WTF::move(promoted));
+    }
+    builder->append(delimiter, as8Bit(value));
+    return true;
+}
+
+size_t HeaderValue::memoryCost() const
+{
+    if (auto* builder = this->builder())
+        return sizeof(StringBuilder) + builder->capacity() * (builder->is8Bit() ? sizeof(Latin1Character) : sizeof(char16_t));
+    auto* impl = reinterpret_cast<StringImpl*>(m_bits);
+    return impl ? impl->length() * (impl->is8Bit() ? sizeof(Latin1Character) : sizeof(char16_t)) : 0;
+}
+
 HTTPHeaderMap::HTTPHeaderMap()
 {
 }
@@ -137,19 +180,19 @@ void HTTPHeaderMap::setUncommonHeader(const String& name, const String& value)
         m_uncommonHeaders[index].value = value;
 }
 
-bool HTTPHeaderMap::addUncommonHeader(const String& name, const String& value)
+HTTPHeaderMap::AddResult HTTPHeaderMap::addUncommonHeader(const String& name, const String& value)
 {
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
     });
     if (index == notFound) {
         m_uncommonHeaders.append(UncommonHeader { name, value });
-        return true;
+        return AddResult::Stored;
     }
-    return m_uncommonHeaders[index].value.append(", "_s, value);
+    return m_uncommonHeaders[index].value.append(", "_s, value) ? AddResult::Stored : AddResult::ValueTooLong;
 }
 
-bool HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const String& value)
+HTTPHeaderMap::AddResult HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const String& value)
 {
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
@@ -159,12 +202,12 @@ bool HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const Stri
         auto nameCopy = WTF::String::createUninitialized(name.length(), ptr);
         memcpy(ptr.data(), name.span8().data(), name.length());
         m_uncommonHeaders.append(UncommonHeader { nameCopy, value });
-        return true;
+        return AddResult::Stored;
     }
-    return m_uncommonHeaders[index].value.append(", "_s, value);
+    return m_uncommonHeaders[index].value.append(", "_s, value) ? AddResult::Stored : AddResult::ValueTooLong;
 }
 
-bool HTTPHeaderMap::add(const String& name, const String& value)
+HTTPHeaderMap::AddResult HTTPHeaderMap::add(const String& name, const String& value)
 {
     HTTPHeaderName headerName;
     if (findHTTPHeaderName(name, headerName))
@@ -274,11 +317,11 @@ bool HTTPHeaderMap::remove(HTTPHeaderName name)
     });
 }
 
-bool HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
+HTTPHeaderMap::AddResult HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
 {
     if (name == HTTPHeaderName::SetCookie) {
         m_setCookieHeaders.append(value);
-        return true;
+        return AddResult::Stored;
     }
 
     auto index = m_commonHeaders.findIf([&](auto& header) {
@@ -286,9 +329,9 @@ bool HTTPHeaderMap::add(HTTPHeaderName name, const String& value)
     });
     if (index == notFound) {
         m_commonHeaders.append(CommonHeader { name, value });
-        return true;
+        return AddResult::Stored;
     }
-    return m_commonHeaders[index].value.append(name == HTTPHeaderName::Cookie ? "; "_s : ", "_s, value);
+    return m_commonHeaders[index].value.append(name == HTTPHeaderName::Cookie ? "; "_s : ", "_s, value) ? AddResult::Stored : AddResult::ValueTooLong;
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -28,6 +28,7 @@
 
 #include "HTTPHeaderNames.h"
 #include <utility>
+#include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -41,11 +42,100 @@ namespace WebCore {
 // behavior.
 String lowercaseHeaderName(const String&);
 
+// The value of one header, and the buffer that `append` grows.
+//
+// A name with a single value holds it in `m_string` and costs what a String
+// costs. The second value for the same name moves into a StringBuilder, so N
+// appends copy O(N) bytes in total instead of O(N^2): the builder over-allocates
+// and writes each new value into the spare capacity. `string()` hands readers
+// the combined value without a copy, as a substring of that buffer.
+class HeaderValue {
+public:
+    HeaderValue() = default;
+    HeaderValue(const String& value)
+        : m_string(value)
+    {
+    }
+    HeaderValue(String&& value)
+        : m_string(WTF::move(value))
+    {
+    }
+
+    // A copy takes the combined value but never the builder: two header maps
+    // must not append into one buffer.
+    HeaderValue(const HeaderValue& other)
+        : m_string(other.string())
+    {
+    }
+    HeaderValue& operator=(const HeaderValue& other)
+    {
+        *this = other.string();
+        return *this;
+    }
+    HeaderValue(HeaderValue&&) = default;
+    HeaderValue& operator=(HeaderValue&&) = default;
+
+    HeaderValue& operator=(const String& value)
+    {
+        // Assign before dropping the builder. `value` can be the String the
+        // builder owns, which is what `*this = other.string()` passes when a
+        // HeaderValue is assigned to itself.
+        m_string = value;
+        m_builder = nullptr;
+        return *this;
+    }
+
+    const String& string() const LIFETIME_BOUND { return m_builder ? m_builder->toStringPreserveCapacity() : m_string; }
+    unsigned length() const { return m_builder ? m_builder->length() : m_string.length(); }
+
+    // Returns false, and stores nothing, when the combined value does not fit in
+    // a String. StringBuilder aborts the process on overflow, so the limit is
+    // checked here instead and reported to the caller.
+    bool append(ASCIILiteral delimiter, const String& value)
+    {
+        if (static_cast<uint64_t>(length()) + delimiter.length() + value.length() > String::MaxLength)
+            return false;
+
+        if (!m_builder) {
+            m_builder = makeUnique<StringBuilder>();
+            m_builder->append(as8Bit(m_string));
+            m_string = {};
+        }
+        m_builder->append(delimiter, as8Bit(value));
+        return true;
+    }
+
+    size_t memoryCost() const
+    {
+        if (!m_builder)
+            return m_string.sizeInBytes();
+        return sizeof(StringBuilder) + m_builder->capacity() * (m_builder->is8Bit() ? sizeof(Latin1Character) : sizeof(char16_t));
+    }
+
+    bool operator==(const HeaderValue& other) const { return string() == other.string(); }
+
+private:
+    // A stored header value holds only Latin-1 characters (isValidHTTPHeaderValue)
+    // but the String can still be 16-bit. An 8-bit builder needs half the
+    // buffer. It also never asks for a capacity that a StringImpl cannot hold:
+    // the builder grows by doubling up to String::MaxLength, and a 16-bit
+    // StringImpl holds a few characters less than that, which aborts.
+    static String as8Bit(const String& value)
+    {
+        if (value.is8Bit())
+            return value;
+        return StringImpl::create8BitIfPossible(value.span16());
+    }
+
+    String m_string;
+    std::unique_ptr<StringBuilder> m_builder;
+};
+
 class HTTPHeaderMap {
 public:
     struct CommonHeader {
         HTTPHeaderName key;
-        String value;
+        HeaderValue value;
 
         bool operator==(const CommonHeader& other) const { return key == other.key && value == other.value; }
     };
@@ -59,7 +149,7 @@ public:
 
     struct UncommonHeader {
         String key;
-        String value;
+        HeaderValue value;
 
         bool operator==(const UncommonHeader& other) const { return key == other.key && value == other.value; }
     };
@@ -138,7 +228,7 @@ public:
                 return false;
             m_keyValue.key = httpHeaderNameString(it->key).toStringWithoutCopying();
             m_keyValue.keyAsHTTPHeaderName = it->key;
-            m_keyValue.value = it->value;
+            m_keyValue.value = it->value.string();
             return true;
         }
         bool updateKeyValue(UncommonHeadersVector::const_iterator it)
@@ -147,7 +237,7 @@ public:
                 return false;
             m_keyValue.key = it->key;
             m_keyValue.keyAsHTTPHeaderName = std::nullopt;
-            m_keyValue.value = it->value;
+            m_keyValue.value = it->value.string();
             return true;
         }
 
@@ -165,7 +255,9 @@ public:
 
     WEBCORE_EXPORT String get(const StringView name) const;
     WEBCORE_EXPORT void set(const String& name, const String& value);
-    WEBCORE_EXPORT void add(const String& name, const String& value);
+    // The `add` overloads combine a repeated name into one value. They return
+    // false, and store nothing, when that value does not fit in a String.
+    WEBCORE_EXPORT bool add(const String& name, const String& value);
     WEBCORE_EXPORT bool contains(const StringView) const;
     WEBCORE_EXPORT int64_t indexOf(StringView name) const;
     WEBCORE_EXPORT bool remove(const StringView);
@@ -178,7 +270,7 @@ public:
 
     WEBCORE_EXPORT String get(HTTPHeaderName) const;
     void set(HTTPHeaderName, const String& value);
-    void add(HTTPHeaderName, const String& value);
+    bool add(HTTPHeaderName, const String& value);
     WEBCORE_EXPORT bool contains(HTTPHeaderName) const;
     WEBCORE_EXPORT bool remove(HTTPHeaderName);
 
@@ -207,7 +299,7 @@ public:
             return false;
 
         for (auto& commonHeader : a.m_commonHeaders) {
-            if (b.get(commonHeader.key) != commonHeader.value)
+            if (b.get(commonHeader.key) != commonHeader.value.string())
                 return false;
         }
 
@@ -217,7 +309,7 @@ public:
         }
 
         for (auto& uncommonHeader : a.m_uncommonHeaders) {
-            if (b.getUncommonHeader(uncommonHeader.key) != uncommonHeader.value)
+            if (b.getUncommonHeader(uncommonHeader.key) != uncommonHeader.value.string())
                 return false;
         }
 
@@ -230,8 +322,8 @@ public:
     }
 
     void setUncommonHeader(const String& name, const String& value);
-    void addUncommonHeader(const String& name, const String& value);
-    void addUncommonHeaderCloneName(const StringView name, const String& value);
+    bool addUncommonHeader(const String& name, const String& value);
+    bool addUncommonHeaderCloneName(const StringView name, const String& value);
 
 private:
     WEBCORE_EXPORT String getUncommonHeader(const StringView name) const;

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -28,6 +28,7 @@
 
 #include "HTTPHeaderNames.h"
 #include <utility>
+#include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 
@@ -42,65 +43,83 @@ namespace WebCore {
 // behavior.
 String lowercaseHeaderName(const String&);
 
-// One header's value. From the second value on it lives in a StringBuilder, so N appends copy O(N) bytes.
+// One header's value, in one word: a StringImpl*, or past builderThreshold a StringBuilder* tagged in bit 0, so N appends copy O(N) bytes.
 class HeaderValue {
 public:
     HeaderValue() = default;
     HeaderValue(const String& value)
-        : m_string(value)
+        : HeaderValue(String { value })
     {
     }
     HeaderValue(String&& value)
-        : m_string(WTF::move(value))
+        : m_bits(reinterpret_cast<uintptr_t>(value.releaseImpl().leakRef()))
     {
     }
     HeaderValue(const HeaderValue& other)
-        : m_string(other.string())
+        : HeaderValue(other.string())
     {
     }
-    HeaderValue(HeaderValue&&) = default;
+    HeaderValue(HeaderValue&& other)
+        : m_bits(std::exchange(other.m_bits, 0))
+    {
+    }
     HeaderValue& operator=(const HeaderValue& other) { return *this = HeaderValue(other); }
-    HeaderValue& operator=(HeaderValue&&) = default;
+    HeaderValue& operator=(HeaderValue&& other)
+    {
+        HeaderValue moved { WTF::move(other) };
+        std::swap(m_bits, moved.m_bits);
+        return *this;
+    }
+    ALWAYS_INLINE ~HeaderValue()
+    {
+        if (m_bits & builderTag) [[unlikely]]
+            deleteBuilder();
+        else if (auto* impl = reinterpret_cast<StringImpl*>(m_bits))
+            impl->deref();
+    }
 
-    const String& string() const LIFETIME_BOUND { return m_builder ? m_builder->toStringPreserveCapacity() : m_string; }
-    unsigned length() const { return m_builder ? m_builder->length() : m_string.length(); }
+    ALWAYS_INLINE String string() const
+    {
+        if (m_bits & builderTag) [[unlikely]]
+            return builderString();
+        return reinterpret_cast<StringImpl*>(m_bits);
+    }
 
     // False, with nothing stored, when the combined value would pass String::MaxLength.
-    bool append(ASCIILiteral delimiter, const String& value)
+    ALWAYS_INLINE bool append(ASCIILiteral delimiter, const String& value)
     {
-        if (static_cast<uint64_t>(length()) + delimiter.length() + value.length() > String::MaxLength)
-            return false;
-
-        if (!m_builder) {
-            m_builder = makeUnique<StringBuilder>();
-            m_builder->append(as8Bit(m_string));
-            m_string = {};
+        if (!(m_bits & builderTag)) [[likely]] {
+            String current { reinterpret_cast<StringImpl*>(m_bits) };
+            if (static_cast<uint64_t>(current.length()) + delimiter.length() + value.length() < builderThreshold) {
+                *this = HeaderValue(makeString(WTF::move(current), delimiter, value));
+                return true;
+            }
         }
-        m_builder->append(delimiter, as8Bit(value));
-        return true;
+        return appendToBuilder(delimiter, value);
     }
-
-    size_t memoryCost() const
-    {
-        if (!m_builder)
-            return m_string.sizeInBytes();
-        return sizeof(StringBuilder) + m_builder->capacity() * (m_builder->is8Bit() ? sizeof(Latin1Character) : sizeof(char16_t));
-    }
+    size_t memoryCost() const;
 
     bool operator==(const HeaderValue& other) const { return string() == other.string(); }
 
 private:
-    // Values are Latin-1 (isValidHTTPHeaderValue). A 16-bit builder can grow to a capacity StringImpl refuses, which aborts.
-    static String as8Bit(const String& value)
+    // Below this length a join is one exact-fit makeString, as before, so a short value never pays for a builder.
+    static constexpr unsigned builderThreshold = 4096;
+    static constexpr uintptr_t builderTag = 1;
+    static_assert(alignof(StringImpl) > builderTag && alignof(StringBuilder) > builderTag);
+
+    explicit HeaderValue(std::unique_ptr<StringBuilder>&& builder)
+        : m_bits(reinterpret_cast<uintptr_t>(builder.release()) | builderTag)
     {
-        if (value.is8Bit())
-            return value;
-        return StringImpl::create8BitIfPossible(value.span16());
     }
 
-    String m_string;
-    std::unique_ptr<StringBuilder> m_builder;
+    StringBuilder* builder() const { return (m_bits & builderTag) ? reinterpret_cast<StringBuilder*>(m_bits & ~builderTag) : nullptr; }
+    NEVER_INLINE void deleteBuilder();
+    NEVER_INLINE String builderString() const;
+    NEVER_INLINE bool appendToBuilder(ASCIILiteral delimiter, const String& value);
+
+    uintptr_t m_bits { 0 };
 };
+static_assert(sizeof(HeaderValue) == sizeof(String), "an entry of HTTPHeaderMap must not grow");
 
 class HTTPHeaderMap {
 public:
@@ -219,8 +238,12 @@ public:
 
     WEBCORE_EXPORT String get(const StringView name) const;
     WEBCORE_EXPORT void set(const String& name, const String& value);
-    // Every add function returns false, with nothing stored, when the combined value would pass String::MaxLength.
-    WEBCORE_EXPORT bool add(const String& name, const String& value);
+    // ValueTooLong: the combined value would pass String::MaxLength, and nothing is stored.
+    enum class AddResult : uint8_t {
+        Stored,
+        ValueTooLong,
+    };
+    WEBCORE_EXPORT AddResult add(const String& name, const String& value);
     WEBCORE_EXPORT bool contains(const StringView) const;
     WEBCORE_EXPORT int64_t indexOf(StringView name) const;
     WEBCORE_EXPORT bool remove(const StringView);
@@ -228,7 +251,7 @@ public:
 
     WEBCORE_EXPORT String get(HTTPHeaderName) const;
     void set(HTTPHeaderName, const String& value);
-    bool add(HTTPHeaderName, const String& value);
+    AddResult add(HTTPHeaderName, const String& value);
     WEBCORE_EXPORT bool contains(HTTPHeaderName) const;
     WEBCORE_EXPORT bool remove(HTTPHeaderName);
 
@@ -280,8 +303,8 @@ public:
     }
 
     void setUncommonHeader(const String& name, const String& value);
-    bool addUncommonHeader(const String& name, const String& value);
-    bool addUncommonHeaderCloneName(const StringView name, const String& value);
+    AddResult addUncommonHeader(const String& name, const String& value);
+    AddResult addUncommonHeaderCloneName(const StringView name, const String& value);
 
 private:
     WEBCORE_EXPORT String getUncommonHeader(const StringView name) const;

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -140,13 +140,6 @@ public:
         bool operator==(const CommonHeader& other) const { return key == other.key && value == other.value; }
     };
 
-    struct HeaderIndex {
-        size_t index;
-        bool isCommon;
-
-        bool isValid() const { return index != notFound; }
-    };
-
     struct UncommonHeader {
         String key;
         HeaderValue value;
@@ -262,11 +255,6 @@ public:
     WEBCORE_EXPORT int64_t indexOf(StringView name) const;
     WEBCORE_EXPORT bool remove(const StringView);
     WEBCORE_EXPORT bool removeUncommonHeader(const StringView);
-
-    WEBCORE_EXPORT String getIndex(HeaderIndex index) const;
-    WEBCORE_EXPORT bool setIndex(HeaderIndex index, const String& value);
-    HeaderIndex indexOf(const String& name) const;
-    HeaderIndex indexOf(HTTPHeaderName name) const;
 
     WEBCORE_EXPORT String get(HTTPHeaderName) const;
     void set(HTTPHeaderName, const String& value);

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -42,13 +42,7 @@ namespace WebCore {
 // behavior.
 String lowercaseHeaderName(const String&);
 
-// The value of one header, and the buffer that `append` grows.
-//
-// A name with a single value holds it in `m_string` and costs what a String
-// costs. The second value for the same name moves into a StringBuilder, so N
-// appends copy O(N) bytes in total instead of O(N^2): the builder over-allocates
-// and writes each new value into the spare capacity. `string()` hands readers
-// the combined value without a copy, as a substring of that buffer.
+// One header's value. From the second value on it lives in a StringBuilder, so N appends copy O(N) bytes.
 class HeaderValue {
 public:
     HeaderValue() = default;
@@ -60,37 +54,18 @@ public:
         : m_string(WTF::move(value))
     {
     }
-
-    // A copy takes the combined value but never the builder: two header maps
-    // must not append into one buffer.
     HeaderValue(const HeaderValue& other)
         : m_string(other.string())
     {
     }
-    HeaderValue& operator=(const HeaderValue& other)
-    {
-        *this = other.string();
-        return *this;
-    }
     HeaderValue(HeaderValue&&) = default;
+    HeaderValue& operator=(const HeaderValue& other) { return *this = HeaderValue(other); }
     HeaderValue& operator=(HeaderValue&&) = default;
-
-    HeaderValue& operator=(const String& value)
-    {
-        // Assign before dropping the builder. `value` can be the String the
-        // builder owns, which is what `*this = other.string()` passes when a
-        // HeaderValue is assigned to itself.
-        m_string = value;
-        m_builder = nullptr;
-        return *this;
-    }
 
     const String& string() const LIFETIME_BOUND { return m_builder ? m_builder->toStringPreserveCapacity() : m_string; }
     unsigned length() const { return m_builder ? m_builder->length() : m_string.length(); }
 
-    // Returns false, and stores nothing, when the combined value does not fit in
-    // a String. StringBuilder aborts the process on overflow, so the limit is
-    // checked here instead and reported to the caller.
+    // False, with nothing stored, when the combined value would pass String::MaxLength.
     bool append(ASCIILiteral delimiter, const String& value)
     {
         if (static_cast<uint64_t>(length()) + delimiter.length() + value.length() > String::MaxLength)
@@ -115,11 +90,7 @@ public:
     bool operator==(const HeaderValue& other) const { return string() == other.string(); }
 
 private:
-    // A stored header value holds only Latin-1 characters (isValidHTTPHeaderValue)
-    // but the String can still be 16-bit. An 8-bit builder needs half the
-    // buffer. It also never asks for a capacity that a StringImpl cannot hold:
-    // the builder grows by doubling up to String::MaxLength, and a 16-bit
-    // StringImpl holds a few characters less than that, which aborts.
+    // Values are Latin-1 (isValidHTTPHeaderValue). A 16-bit builder can grow to a capacity StringImpl refuses, which aborts.
     static String as8Bit(const String& value)
     {
         if (value.is8Bit())
@@ -248,8 +219,7 @@ public:
 
     WEBCORE_EXPORT String get(const StringView name) const;
     WEBCORE_EXPORT void set(const String& name, const String& value);
-    // The `add` overloads combine a repeated name into one value. They return
-    // false, and store nothing, when that value does not fit in a String.
+    // Every add function returns false, with nothing stored, when the combined value would pass String::MaxLength.
     WEBCORE_EXPORT bool add(const String& name, const String& value);
     WEBCORE_EXPORT bool contains(const StringView) const;
     WEBCORE_EXPORT int64_t indexOf(StringView name) const;

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -633,8 +633,7 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
         auto& vec = internal.commonHeaders();
         for (const auto& it : vec) {
             const auto& name = it.key;
-            const WTF::String& value = it.value.string();
-            obj->putDirect(vm, Identifier::fromString(vm, WTF::httpHeaderNameStringImpl(name)), jsString(vm, value), 0);
+            obj->putDirect(vm, Identifier::fromString(vm, WTF::httpHeaderNameStringImpl(name)), jsString(vm, it.value.string()), 0);
         }
     }
 
@@ -661,8 +660,7 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
         auto& vec = internal.uncommonHeaders();
         for (const auto& it : vec) {
             const auto& name = it.key;
-            const WTF::String& value = it.value.string();
-            obj->putDirectMayBeIndex(lexicalGlobalObject, Identifier::fromString(vm, lowercaseHeaderName(name)), jsString(vm, value));
+            obj->putDirectMayBeIndex(lexicalGlobalObject, Identifier::fromString(vm, lowercaseHeaderName(name)), jsString(vm, it.value.string()));
             RETURN_IF_EXCEPTION(throwScope, {});
         }
     }

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -633,7 +633,7 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
         auto& vec = internal.commonHeaders();
         for (const auto& it : vec) {
             const auto& name = it.key;
-            const auto& value = it.value;
+            const WTF::String& value = it.value.string();
             obj->putDirect(vm, Identifier::fromString(vm, WTF::httpHeaderNameStringImpl(name)), jsString(vm, value), 0);
         }
     }
@@ -661,7 +661,7 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
         auto& vec = internal.uncommonHeaders();
         for (const auto& it : vec) {
             const auto& name = it.key;
-            const auto& value = it.value;
+            const WTF::String& value = it.value.string();
             obj->putDirectMayBeIndex(lexicalGlobalObject, Identifier::fromString(vm, lowercaseHeaderName(name)), jsString(vm, value));
             RETURN_IF_EXCEPTION(throwScope, {});
         }

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, test } from "bun:test";
 // Namespace import so a missing binding fails only the kernel tests below
 // (accessing an absent export is `undefined`), not the whole file.
 import * as internalForTesting from "bun:internal-for-testing";
+import { jscDescribe } from "bun:jsc";
 import { isDebug, withoutAggressiveGC } from "harness";
 
 beforeAll(() => {
@@ -261,90 +262,92 @@ describe("Headers", () => {
     // Appending to a name that already has a value used to rebuild the whole
     // combined value with makeString(), so N appends copied O(N^2) bytes:
     // 200,000 appends took 1.8s and 400,000 took 9.4s on a release build, where
-    // Node takes 0.5s for 400,000. The blocks below cover both halves of the
-    // fix: the combined value is still exactly the same string, and the cost of
-    // producing it is now linear.
+    // Node takes 0.5s for 400,000. A combined value under 4 KB is still one
+    // exact-fit string. Past that it moves into a builder that grows in place.
+    // Every case below runs in both states, and the last one measures the cost.
     describe("with a name that repeats", () => {
-      describe.each(["x-repeated", "accept", "cookie"])("%s", name => {
-        const delimiter = name === "cookie" ? "; " : ", ";
-
-        test("2000 appends join in order", () => {
+      const COUNT = 100;
+      describe.each([
+        ["under 4 KB", "v"],
+        ["past 4 KB", Buffer.alloc(100, "v").toString()],
+      ])("combined value %s", (_, unit) => {
+        const valueAt = (i: number) => `${unit}${i}`;
+        const joined = (count: number, delimiter = ", ") =>
+          Array.from({ length: count }, (_, i) => valueAt(i)).join(delimiter);
+        const filled = (name = "x-repeated") => {
           const headers = new Headers();
-          const values: string[] = [];
-          for (let i = 0; i < 2000; i++) {
-            values.push(`v${i}`);
-            headers.append(name, `v${i}`);
-          }
-          expect(headers.get(name)).toBe(values.join(delimiter));
+          for (let i = 0; i < COUNT; i++) headers.append(name, valueAt(i));
+          return headers;
+        };
+
+        describe.each(["x-repeated", "accept", "cookie"])("%s", name => {
+          const delimiter = name === "cookie" ? "; " : ", ";
+
+          test("appends join in order", () => {
+            expect(filled(name).get(name)).toBe(joined(COUNT, delimiter));
+          });
+
+          test("reading between appends does not change the result", () => {
+            const headers = new Headers();
+            const snapshots: string[] = [];
+            for (let i = 0; i < COUNT; i++) {
+              headers.append(name, valueAt(i));
+              // Each read hands out the combined value so far. A later append
+              // must not edit a string that was already handed out.
+              snapshots.push(headers.get(name)!);
+            }
+            expect(snapshots).toEqual(Array.from({ length: COUNT }, (_, i) => joined(i + 1, delimiter)));
+          });
         });
 
-        test("reading between appends does not change the result", () => {
-          const headers = new Headers();
-          const values: string[] = [];
-          const snapshots: string[] = [];
-          for (let i = 0; i < 200; i++) {
-            values.push(`v${i}`);
-            headers.append(name, `v${i}`);
-            // Each read hands out the combined value so far. A later append
-            // must not edit a string that was already handed out.
-            snapshots.push(headers.get(name)!);
-          }
-          expect(snapshots.at(-1)).toBe(values.join(delimiter));
-          expect(snapshots[0]).toBe("v0");
-          expect(snapshots[99]).toBe(values.slice(0, 100).join(delimiter));
+        test("set() after appends replaces the combined value", () => {
+          const headers = filled();
+          headers.set("x-repeated", "only");
+          expect(headers.get("x-repeated")).toBe("only");
+          headers.append("x-repeated", "next");
+          expect(headers.get("x-repeated")).toBe("only, next");
         });
-      });
 
-      test("set() after appends replaces the combined value", () => {
-        const headers = new Headers();
-        for (let i = 0; i < 100; i++) headers.append("x-repeated", `v${i}`);
-        headers.set("x-repeated", "only");
-        expect(headers.get("x-repeated")).toBe("only");
-        headers.append("x-repeated", "next");
-        expect(headers.get("x-repeated")).toBe("only, next");
-      });
+        test("delete() after appends drops the header", () => {
+          const headers = filled();
+          headers.delete("x-repeated");
+          expect(headers.has("x-repeated")).toBe(false);
+          expect(headers.get("x-repeated")).toBeNull();
+        });
 
-      test("delete() after appends drops the header", () => {
-        const headers = new Headers();
-        for (let i = 0; i < 100; i++) headers.append("x-repeated", `v${i}`);
-        headers.delete("x-repeated");
-        expect(headers.has("x-repeated")).toBe(false);
-        expect(headers.get("x-repeated")).toBeNull();
-      });
+        test("a copy does not change when the original keeps appending", () => {
+          const original = filled();
+          const copy = new Headers(original);
+          original.append("x-repeated", "c");
+          expect(copy.get("x-repeated")).toBe(joined(COUNT));
+          expect(original.get("x-repeated")).toBe(`${joined(COUNT)}, c`);
+          copy.append("x-repeated", "d");
+          expect(copy.get("x-repeated")).toBe(`${joined(COUNT)}, d`);
+          expect(original.get("x-repeated")).toBe(`${joined(COUNT)}, c`);
+        });
 
-      test("a copy does not change when the original keeps appending", () => {
-        const original = new Headers();
-        original.append("x-repeated", "a");
-        original.append("x-repeated", "b");
-        const copy = new Headers(original);
-        original.append("x-repeated", "c");
-        expect(copy.get("x-repeated")).toBe("a, b");
-        expect(original.get("x-repeated")).toBe("a, b, c");
-        copy.append("x-repeated", "d");
-        expect(copy.get("x-repeated")).toBe("a, b, d");
-        expect(original.get("x-repeated")).toBe("a, b, c");
-      });
+        test("iteration and toJSON report the combined value", () => {
+          const headers = filled();
+          expect([...headers]).toEqual([["x-repeated", joined(COUNT)]]);
+          expect(headers.toJSON()).toEqual({ "x-repeated": joined(COUNT) });
+        });
 
-      test("iteration and toJSON report the combined value", () => {
-        const headers = new Headers();
-        for (let i = 0; i < 50; i++) headers.append("x-repeated", `v${i}`);
-        const expected = Array.from({ length: 50 }, (_, i) => `v${i}`).join(", ");
-        expect([...headers]).toEqual([["x-repeated", expected]]);
-        expect(headers.toJSON()).toEqual({ "x-repeated": expected });
-      });
-
-      // A Latin-1 value can arrive in a 16-bit string. Appending a code unit
-      // above 0xFF and slicing it off again forces that representation.
-      test("values in 16-bit strings combine with values in 8-bit strings", () => {
-        const to16 = (s: string) => (s + "\u0100").slice(0, -1);
-        for (const first of ["caf\u00e9", to16("caf\u00e9")]) {
-          const headers = new Headers();
-          headers.append("x-repeated", first);
-          headers.append("x-repeated", to16("th\u00e9"));
-          headers.append("x-repeated", "latte");
-          headers.append("x-repeated", to16("\u00ff"));
-          expect(headers.get("x-repeated")).toBe("caf\u00e9, th\u00e9, latte, \u00ff");
-        }
+        // A Latin-1 value can arrive in a 16-bit string. A UTF-16 round trip
+        // forces that storage, and the first assertion proves that it did.
+        test("values in 16-bit strings combine with values in 8-bit strings", () => {
+          const wide = (s: string) => Buffer.from(s, "utf16le").toString("utf16le");
+          expect(jscDescribe(wide(`${unit}caf\u00e9`))).toContain("8Bit:(0)");
+          for (const wideFirst of [false, true]) {
+            const headers = new Headers();
+            const values: string[] = [];
+            for (let i = 0; i < COUNT; i++) {
+              const value = `${unit}caf\u00e9${i}`;
+              values.push(value);
+              headers.append("x-repeated", (i % 2 === 0) === wideFirst ? wide(value) : value);
+            }
+            expect(headers.get("x-repeated")).toBe(values.join(", "));
+          }
+        });
       });
 
       // set() is the baseline. It makes the same number of calls with the same

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -265,21 +265,20 @@ describe("Headers", () => {
     // fix: the combined value is still exactly the same string, and the cost of
     // producing it is now linear.
     describe("with a name that repeats", () => {
-      const names = ["x-repeated", "accept", "cookie"];
-      const delimiterFor = (name: string) => (name === "cookie" ? "; " : ", ");
+      describe.each(["x-repeated", "accept", "cookie"])("%s", name => {
+        const delimiter = name === "cookie" ? "; " : ", ";
 
-      for (const name of names) {
-        test(`${name}: 2000 appends join in order`, () => {
+        test("2000 appends join in order", () => {
           const headers = new Headers();
           const values: string[] = [];
           for (let i = 0; i < 2000; i++) {
             values.push(`v${i}`);
             headers.append(name, `v${i}`);
           }
-          expect(headers.get(name)).toBe(values.join(delimiterFor(name)));
+          expect(headers.get(name)).toBe(values.join(delimiter));
         });
 
-        test(`${name}: reading between appends does not change the result`, () => {
+        test("reading between appends does not change the result", () => {
           const headers = new Headers();
           const values: string[] = [];
           const snapshots: string[] = [];
@@ -290,11 +289,11 @@ describe("Headers", () => {
             // must not edit a string that was already handed out.
             snapshots.push(headers.get(name)!);
           }
-          expect(snapshots.at(-1)).toBe(values.join(delimiterFor(name)));
+          expect(snapshots.at(-1)).toBe(values.join(delimiter));
           expect(snapshots[0]).toBe("v0");
-          expect(snapshots[99]).toBe(values.slice(0, 100).join(delimiterFor(name)));
+          expect(snapshots[99]).toBe(values.slice(0, 100).join(delimiter));
         });
-      }
+      });
 
       test("set() after appends replaces the combined value", () => {
         const headers = new Headers();

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, test } from "bun:test";
 // Namespace import so a missing binding fails only the kernel tests below
 // (accessing an absent export is `undefined`), not the whole file.
 import * as internalForTesting from "bun:internal-for-testing";
+import { isDebug, withoutAggressiveGC } from "harness";
 
 beforeAll(() => {
   // expect(Headers).toBeDefined();
@@ -255,6 +256,145 @@ describe("Headers", () => {
       const headers = new Headers();
       // @ts-expect-error
       expect(() => headers.append("expires")).toThrow(TypeError);
+    });
+
+    // Appending to a name that already has a value used to rebuild the whole
+    // combined value with makeString(), so N appends copied O(N^2) bytes:
+    // 200,000 appends took 1.8s and 400,000 took 9.4s on a release build, where
+    // Node takes 0.5s for 400,000. The blocks below cover both halves of the
+    // fix: the combined value is still exactly the same string, and the cost of
+    // producing it is now linear.
+    describe("with a name that repeats", () => {
+      const names = ["x-repeated", "accept", "cookie"];
+      const delimiterFor = (name: string) => (name === "cookie" ? "; " : ", ");
+
+      for (const name of names) {
+        test(`${name}: 2000 appends join in order`, () => {
+          const headers = new Headers();
+          const values: string[] = [];
+          for (let i = 0; i < 2000; i++) {
+            values.push(`v${i}`);
+            headers.append(name, `v${i}`);
+          }
+          expect(headers.get(name)).toBe(values.join(delimiterFor(name)));
+        });
+
+        test(`${name}: reading between appends does not change the result`, () => {
+          const headers = new Headers();
+          const values: string[] = [];
+          const snapshots: string[] = [];
+          for (let i = 0; i < 200; i++) {
+            values.push(`v${i}`);
+            headers.append(name, `v${i}`);
+            // Each read hands out the combined value so far. A later append
+            // must not edit a string that was already handed out.
+            snapshots.push(headers.get(name)!);
+          }
+          expect(snapshots.at(-1)).toBe(values.join(delimiterFor(name)));
+          expect(snapshots[0]).toBe("v0");
+          expect(snapshots[99]).toBe(values.slice(0, 100).join(delimiterFor(name)));
+        });
+      }
+
+      test("set() after appends replaces the combined value", () => {
+        const headers = new Headers();
+        for (let i = 0; i < 100; i++) headers.append("x-repeated", `v${i}`);
+        headers.set("x-repeated", "only");
+        expect(headers.get("x-repeated")).toBe("only");
+        headers.append("x-repeated", "next");
+        expect(headers.get("x-repeated")).toBe("only, next");
+      });
+
+      test("delete() after appends drops the header", () => {
+        const headers = new Headers();
+        for (let i = 0; i < 100; i++) headers.append("x-repeated", `v${i}`);
+        headers.delete("x-repeated");
+        expect(headers.has("x-repeated")).toBe(false);
+        expect(headers.get("x-repeated")).toBeNull();
+      });
+
+      test("a copy does not change when the original keeps appending", () => {
+        const original = new Headers();
+        original.append("x-repeated", "a");
+        original.append("x-repeated", "b");
+        const copy = new Headers(original);
+        original.append("x-repeated", "c");
+        expect(copy.get("x-repeated")).toBe("a, b");
+        expect(original.get("x-repeated")).toBe("a, b, c");
+        copy.append("x-repeated", "d");
+        expect(copy.get("x-repeated")).toBe("a, b, d");
+        expect(original.get("x-repeated")).toBe("a, b, c");
+      });
+
+      test("iteration and toJSON report the combined value", () => {
+        const headers = new Headers();
+        for (let i = 0; i < 50; i++) headers.append("x-repeated", `v${i}`);
+        const expected = Array.from({ length: 50 }, (_, i) => `v${i}`).join(", ");
+        expect([...headers]).toEqual([["x-repeated", expected]]);
+        expect(headers.toJSON()).toEqual({ "x-repeated": expected });
+      });
+
+      // A Latin-1 value can arrive in a 16-bit string. Appending a code unit
+      // above 0xFF and slicing it off again forces that representation.
+      test("values in 16-bit strings combine with values in 8-bit strings", () => {
+        const to16 = (s: string) => (s + "\u0100").slice(0, -1);
+        for (const first of ["caf\u00e9", to16("caf\u00e9")]) {
+          const headers = new Headers();
+          headers.append("x-repeated", first);
+          headers.append("x-repeated", to16("th\u00e9"));
+          headers.append("x-repeated", "latte");
+          headers.append("x-repeated", to16("\u00ff"));
+          expect(headers.get("x-repeated")).toBe("caf\u00e9, th\u00e9, latte, \u00ff");
+        }
+      });
+
+      // set() is the baseline. It makes the same number of calls with the same
+      // name and the same value, so it pays the same conversion, validation and
+      // lookup cost per call, and it never combines. The ratio of the two is
+      // what combining costs. With the quadratic join that ratio grows with the
+      // call count: measured 10 on debug+ASAN and 107 on release at 1000 calls.
+      // With the builder it is a small constant: 1.3 on debug+ASAN and 2.6 on
+      // release. The release bound is the looser one because a release set()
+      // call is 20x cheaper, so the bytes each append copies are a bigger share
+      // of it.
+      //
+      // Back-to-back runs in one process cancel machine speed out of each
+      // ratio, and the median over the repetitions discards a repetition that
+      // another process disturbed.
+      test("append costs about as much per call as set", () => {
+        const VALUE = Buffer.alloc(8192, "x").toString();
+        const CALLS = 1000;
+        const repetitions = isDebug ? 3 : 5;
+
+        function timeAppend() {
+          const headers = new Headers();
+          const started = performance.now();
+          for (let i = 0; i < CALLS; i++) headers.append("x-repeated", VALUE);
+          const elapsed = performance.now() - started;
+          expect(headers.get("x-repeated")!.length).toBe(CALLS * VALUE.length + (CALLS - 1) * 2);
+          return elapsed;
+        }
+
+        function timeSet() {
+          const headers = new Headers();
+          const started = performance.now();
+          for (let i = 0; i < CALLS; i++) headers.set("x-repeated", VALUE);
+          const elapsed = performance.now() - started;
+          expect(headers.get("x-repeated")!.length).toBe(VALUE.length);
+          return elapsed;
+        }
+
+        const ratios = withoutAggressiveGC(() => {
+          timeSet();
+          timeAppend();
+          const measured: number[] = [];
+          for (let i = 0; i < repetitions; i++) measured.push(timeAppend() / timeSet());
+          return measured;
+        }) as number[];
+
+        ratios.sort((a, b) => a - b);
+        expect(ratios[ratios.length >> 1]).toBeLessThan(isDebug ? 4 : 8);
+      });
     });
   });
   describe("set()", () => {


### PR DESCRIPTION
### Problem

- `Headers.prototype.append` on a name that already has a value is quadratic: 200,000 appends of `"1"` take 1.4 s, 400,000 take 11 s (Node 26: 34 ms, 106 ms).
- Cause: `appendToHeaderMap` (`FetchHeaders.cpp:112`) and the `HTTPHeaderMap::add*` overloads rebuild the combined value with `makeString(existing, ", ", value)` on every call.

### Fix

- An entry holds a one-word `HeaderValue`: a `StringImpl*`, or a `StringBuilder*` tagged in bit 0. Under 4 KB a join is the same exact-fit `makeString`. Past 4 KB the builder grows in place, so N appends copy O(N) bytes. 200,000 appends now take 14 ms.
- `FetchHeaders::append` validates, then calls `HTTPHeaderMap::add`, the one place that joins. `add` returns `AddResult`. `ValueTooLong` (past `String::MaxLength`, nothing stored) throws `RangeError: Out of memory`, like the #42218 hunk it replaces.
- No struct grows (`static_assert`). A/B against main, 80 cases: repeated names 2 to 17% faster, construction even or faster, worst case 2.8 ns slower (notes).
- Verified: `test/js/web/fetch/headers.test.ts` (23 new cases, under and past 4 KB; the cost test fails on main) plus 15 suites. Self-reviewed: 4 merge conditions raised, 4 addressed.

### Background

- `HTTPHeaderMap` backs `Headers`: one vector each for common names, uncommon names, and Set-Cookie values.
- `StringBuilder::toStringPreserveCapacity()` returns a `String` over the builder's buffer. Later appends write past that range, or copy when the buffer has other owners.
- JSC takes a slow path when an object reports over 256 bytes to the GC. Eight more bytes per entry made a 6-header object 20% slower.

<details><summary>Notes</summary>

**Large counts.** Release builds, same host, one process, minimum of 7 runs. The branch time doubles when the count doubles.

| appends of `"1"` to one name | main | this branch | Node 26.3 |
| --- | --- | --- | --- |
| `x-a` × 50,000 | 86 ms | 3.5 ms | 9.8 ms |
| `x-a` × 100,000 | 336 ms | 6.9 ms | 26.8 ms |
| `x-a` × 200,000 | 1414 ms | 13.7 ms | 33.7 ms |
| `x-a` × 400,000 | 11024 ms | 27.3 ms | 105.6 ms |
| `accept` × 200,000 | 1467 ms | 18.5 ms | 30.8 ms |
| `set-cookie` × 200,000 | 12.2 ms | 11.7 ms | 34.1 ms |
| `x-a`, 1 KB value × 4,000 | 495 ms | 2.6 ms | 7.7 ms |

Node is linear because V8 builds a rope on concatenation and flattens it on read. `WTF::String` has no rope, so the builder is the equivalent.

**Small counts, the range real callers reach.** Main and the branch were built with the same toolchain and flags (only the 11 translation units that include `HTTPHeaderMap.h` differ). The binaries ran at the same time on disjoint CPU sets that rotate each round, 12 processes per binary. The number is the best ns/op over all processes. `x-a/31 n=4` means 4 appends of a 31-character value to `x-a` on a fresh `Headers`.

| case | main ns | branch ns | change % |
| --- | --- | --- | --- |
| `new Headers()` | 53.5 | 53.9 | 0.7 |
| `new+1 append x-a` | 142.5 | 132.0 | -7.4 |
| `new+1 append+get x-a` | 171.6 | 165.1 | -3.8 |
| `new+1 append accept` | 116.7 | 116.3 | -0.3 |
| `new+1 set x-a` | 150.7 | 151.0 | 0.2 |
| `new Headers(3 common record)` | 409.6 | 401.7 | -1.9 |
| `new Headers(6 mixed record)` | 710.2 | 682.7 | -3.9 |
| `new Headers(9 mostly-uncommon record)` | 1586.9 | 1412.0 | -11.0 |
| `new Headers(6 pairs array)` | 904.2 | 874.0 | -3.3 |
| `new Headers(headers6)` | 107.6 | 108.2 | 0.6 |
| `new Headers(headers9)` | 160.0 | 162.7 | 1.7 |
| `get common` | 32.2 | 31.7 | -1.6 |
| `get uncommon` | 31.6 | 32.4 | 2.5 |
| `has uncommon` | 27.5 | 27.3 | -0.7 |
| `set common (existing)` | 92.4 | 92.5 | 0.1 |
| `set uncommon (existing)` | 93.6 | 93.8 | 0.2 |
| `toJSON 9` | 759.6 | 744.9 | -1.9 |
| `[...headers] 9` | 1953.2 | 1985.4 | 1.6 |
| `new Response(null,{headers:init6})` | 974.1 | 934.4 | -4.1 |
| `new Request(url,{headers:init6})` | 1206.1 | 1149.6 | -4.7 |
| `x-a/31 n=2 append` | 273.0 | 263.1 | -3.6 |
| `x-a/31 n=2 append+get` | 312.5 | 305.6 | -2.2 |
| `x-a/31 n=3 append` | 384.4 | 366.0 | -4.8 |
| `x-a/31 n=3 append+get` | 429.3 | 413.7 | -3.6 |
| `x-a/31 n=4 append` | 501.6 | 472.4 | -5.8 |
| `x-a/31 n=4 append+get` | 545.3 | 519.4 | -4.7 |
| `x-a/31 n=5 append` | 618.0 | 578.4 | -6.4 |
| `x-a/31 n=5 append+get` | 666.6 | 620.0 | -7.0 |
| `x-a/31 n=8 append` | 976.9 | 898.1 | -8.1 |
| `x-a/31 n=8 append+get` | 1140.0 | 1059.6 | -7.1 |
| `x-a/31 n=10 append` | 1236.7 | 1133.6 | -8.3 |
| `x-a/31 n=10 append+get` | 1377.9 | 1288.8 | -6.5 |
| `x-a/31 n=16 append` | 1974.2 | 1808.4 | -8.4 |
| `x-a/31 n=16 append+get` | 2153.1 | 1990.7 | -7.5 |
| `x-a/31 n=32 append` | 3941.0 | 3603.1 | -8.6 |
| `x-a/31 n=32 append+get` | 4193.3 | 3829.0 | -8.7 |
| `accept/31 n=2 append` | 260.8 | 240.1 | -7.9 |
| `accept/31 n=2 append+get` | 300.4 | 283.3 | -5.7 |
| `accept/31 n=3 append` | 385.8 | 342.0 | -11.4 |
| `accept/31 n=3 append+get` | 436.4 | 392.9 | -10.0 |
| `accept/31 n=5 append` | 644.6 | 558.0 | -13.4 |
| `accept/31 n=5 append+get` | 690.1 | 602.4 | -12.7 |
| `accept/31 n=10 append` | 1326.0 | 1105.6 | -16.6 |
| `accept/31 n=10 append+get` | 1456.5 | 1251.3 | -14.1 |
| `cookie/200 n=2 append` | 522.5 | 499.7 | -4.4 |
| `cookie/200 n=2 append+get` | 612.0 | 576.1 | -5.9 |
| `cookie/200 n=3 append` | 728.3 | 672.0 | -7.7 |
| `cookie/200 n=3 append+get` | 880.1 | 779.0 | -11.5 |
| `cookie/200 n=5 append` | 1193.7 | 1117.9 | -6.4 |
| `cookie/200 n=5 append+get` | 1363.5 | 1259.4 | -7.6 |
| `cookie/200 n=10 append` | 2390.7 | 2196.2 | -8.1 |
| `cookie/200 n=10 append+get` | 2605.8 | 2347.3 | -9.9 |
| `x-a/1 n=2 append` | 247.8 | 235.7 | -4.9 |
| `x-a/1 n=2 append+get` | 281.5 | 271.8 | -3.4 |
| `x-a/1 n=3 append` | 345.6 | 324.4 | -6.1 |
| `x-a/1 n=3 append+get` | 380.3 | 364.5 | -4.2 |
| `x-a/1 n=5 append` | 536.2 | 495.0 | -7.7 |
| `x-a/1 n=5 append+get` | 579.7 | 535.4 | -7.6 |
| `x-a/1 n=10 append` | 1015.9 | 918.9 | -9.5 |
| `x-a/1 n=10 append+get` | 1066.5 | 978.7 | -8.2 |
| `x-a/31 n=2 append,get each` | 346.8 | 340.8 | -1.7 |
| `x-a/31 n=3 append,get each` | 513.6 | 505.9 | -1.5 |
| `x-a/31 n=5 append,get each` | 868.3 | 829.4 | -4.5 |
| `x-a/31 n=10 append,get each` | 2205.5 | 2111.1 | -4.3 |
| `new Headers([[x-a],[ct],[x-a]])` | 597.8 | 587.1 | -1.8 |
| `new Headers(3x accept + host)` | 668.9 | 635.9 | -4.9 |
| `new Headers(headers w/ combined x3)` | 66.9 | 69.7 | 4.2 |
| `get combined x3` | 28.8 | 29.2 | 1.4 |
| `rec: 1 common` | 221.2 | 223.6 | 1.1 |
| `rec: 2 common` | 281.0 | 279.5 | -0.5 |
| `rec: 4 common` | 471.0 | 468.2 | -0.6 |
| `rec: 1 uncommon` | 226.8 | 227.0 | 0.1 |
| `rec: 2 uncommon` | 341.5 | 323.9 | -5.2 |
| `rec: 6 mixed` | 695.5 | 686.0 | -1.4 |
| `retained: new Headers(6 mixed record)` | 665.8 | 651.7 | -2.1 |
| `retained: new Headers(headers6)` | 79.3 | 81.4 | 2.6 |
| `retained: new Headers(4 common)` | 450.6 | 443.1 | -1.7 |
| `retained: new Headers(2 uncommon)` | 323.9 | 311.2 | -3.9 |
| `retained: x-a/31 n=2 append+get` | 292.1 | 281.1 | -3.8 |
| `retained: x-a/31 n=3 append+get` | 406.7 | 384.8 | -5.4 |

Seven cases are slower by more than 1%: `new Headers(headers w/ combined x3)` +2.8 ns, `retained: new Headers(headers6)` +2.1 ns, `new Headers(headers9)` +2.7 ns, `get uncommon` +0.8 ns, `[...headers] 9` +32 ns of 1953, `get combined x3` +0.4 ns, `rec: 1 common` +2.4 ns. The copy and read paths test the tag bit once per entry. Everything else is even or faster.

`bench/snippets/headers.mjs`, five alternating runs per binary, best average ns per iteration:

| case | main | branch |
| --- | --- | --- |
| `new Headers` | 56.9 | 56.8 |
| `new Headers([])` | 159.3 | 155.2 |
| `new Headers({})` | 123.0 | 119.5 |
| `new Headers(object)` | 428.9 | 426.5 |
| `new Headers(hugeObject)` | 13990 | 11550 |
| `Header.get` | 33.0 | 31.6 |
| `Header.set (standard)` | 95.5 | 94.8 |
| `Header.set (non-standard)` | 103.2 | 105.2 |
| `Headers.toJSON` | 825.7 | 827.3 |
| `Object.fromEntries(headers.entries())` | 3230 | 3340 |
| `Object.fromEntries(headers)` | 3250 | 3300 |

**How the shape was chosen.** Each step was measured with the A/B above.

- A two-word `HeaderValue` (`String` plus `std::unique_ptr<StringBuilder>`) made `new Headers({6 headers})` 20% slower. Main with 8 bytes of padding per entry and no other change was 23% slower, so the size alone did it. `JSFetchHeaders::computeMemoryCost` reports the cost to `Heap::reportExtraMemoryAllocated`, which takes a slow path past `minExtraMemory` (256 bytes), and a typical object crossed that line.
- A builder from the second value on cost 13 to 24% at 2 to 4 values per name: three allocations (builder, buffer, substring on read) against one. With a 4 KB limit those cases take the `makeString` path that main takes. Below the limit an append copies at most 4 KB, so the cost per call is bounded. Past it the cost is amortized constant.
- `WTF::CompactVariant<RefPtr<StringImpl>, std::unique_ptr<StringBuilder>>` fits in one word but was 10 to 15% slower on construction and `toJSON`. So was a tagged word with an out-of-line destructor: every temporary and every moved vector element paid a call. The common paths (copy, move, destroy, read) are now inline and equal to the `String` paths plus one bit test. The builder paths are `NEVER_INLINE`.
- The short join passes `String` operands to `makeString`, the same instance main calls. A `StringView` first operand was faster under about 60 characters and slower past it (45% at 800), so it is not used.

**Overlap with other open changes.** #42218 replaces `makeString` with `tryMakeString` at the join in `appendToHeaderMap`. That join no longer exists, so that hunk is superseded. The input that it guards throws the same `Exception { OutOfMemoryError }` here. Its Set-Cookie join and its message helper are independent of this change. #42214 makes the header vectors fallible at the same `add` calls, with a different error. `AddResult` gives that second cause its own value.

**Reach.** `Bun.serve` accepts 200 headers per request (`UWS_HTTP_MAX_HEADERS_COUNT`) and an HTTP/1 `fetch` response has 256 header slots, so those paths cannot build a long value. The HTTP/2 `fetch` client limits the compressed header block (256 KB, `LOCAL_MAX_HEADER_LIST_SIZE`) and not the field count. Script that builds `Headers` in a loop has no limit.

**Overflow.** The check is a pre-check and not `OverflowPolicy::RecordOverflow`: an overflowed `StringBuilder` sets its length to `UINT_MAX`, `length()` and `toString()` then `RELEASE_ASSERT`, and a failed reallocation frees the buffer. So a recorded overflow cannot keep the value that was already stored. The pre-check stores nothing. Checked by hand with two appends of a 2\*\*30-character value: they throw and the first value stays. That needs 2 GB, so it is not in the test file. #42218 carries that test.

**8-bit builder.** `StringBuilder::expandedCapacity` doubles up to `String::MaxLength`, but `StringImpl::isValidLength<char16_t>` is 12 characters below that, and `allocateBuffer` aborts when the allocation is refused. A 16-bit builder past 2\*\*30 characters can reach that. Every value that reaches `add` has passed `isValidHTTPHeaderValue` (nothing above 0xFF) or comes from a wire parser (8-bit), so narrowing loses nothing and halves the buffer. `create8BitIfPossible` keeps a 16-bit copy if a caller ever passes a wider character. The test feeds strings from a UTF-16 round trip and asserts `8Bit:(0)` on them with `jscDescribe`.

**Reads between appends.** `get()` reifies the builder into a `String` over `[0, length)`. The next append writes at `length` and beyond, in place when the buffer has room. `StringBuilder::reallocateBuffer` reallocates in place only when the builder is the one owner, else it copies. `StringImpl::tryReallocate` runs the old header's destructor first, so an impl that JSC atomized in place leaves the atom table before its storage moves.

**Copies.** The copy constructor takes the combined `String` and never the builder, so `new Headers(other)` cannot make two maps append into one buffer. **Memory accounting.** `memoryCost()` reports the builder's capacity, since the spare capacity is live memory. **Removed.** The `HeaderIndex` lookup API (`indexOf`, `getIndex`, `setIndex`): `appendToHeaderMap` was its only caller.

Two finds that are not part of this change are reported apart from it: the `StringBuilder` capacity limit above (in WebKit), and the `to16` helper in the `lowercaseHeaderNameSIMD` block of `headers.test.ts`, which returns 8-bit strings for every length it is used with.

Suites run on the debug build: `headers.test.ts`, `headers.undici.test.ts`, `headers-case.test.ts`, `fetch_headers.test.js`, `fetch-header-str-bounds.test.ts`, `fetch-connection-header.test.ts`, `cookies.test.ts`, `test/js/deno/fetch/headers.test.ts`, `bun-serve-headers.test.ts`, `bun-serve-cookies.test.ts`, `fetch-header-count-limit.test.ts`, `proxy-stress-headers.test.ts`, `test/js/bun/cookie/*`, `websocket-custom-headers.test.ts`, `websocket-utf16-headers.test.ts`, `serve.test.ts` and `node-http.test.ts` (two failures there need root or a non-loopback client and fail on main too).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/headers.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/48] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/48] gen cpp.rs (cppbind)
[3/48] gen JS modules (bundle-modules)
Preprocess modules (12654ms)
Bundle modules (372ms)
Postprocesss modules (694ms)
Bundle Functions (983ms)
Generate Code (72ms)

[14.79s] Bundled "src/js" for development
  2791 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/37] cargo bun_runtime → libbun_runtime.a
[30/37] cxx obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o
FAILED: obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -fno-asynchronous-unw
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (7acff6958)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [0.05ms]
(pass) Headers > constructor > cannot create headers from null [0.09ms]
(pass) Headers > constructor > can create headers from empty object [0.03ms]
(pass) Headers > constructor > can create headers from object [0.04ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [0.04ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [0.07ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [0.08ms]
(pass) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [1.61ms]
(pass) Headers > constructor > constructing headers from an object propagates an exception from a getter installed by an earlier value's toString [0.11ms]
(pass) Headers > constructor > constructing headers from an object keeps own-property semantics after setPrototypeOf mid-conversion [0.07ms]
(pass) Headers > constructor > can create headers from 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/headers.test.ts
bun test v1.4.3 (5f554969b)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [6.81ms]
(pass) Headers > constructor > cannot create headers from null [6.98ms]
(pass) Headers > constructor > can create headers from empty object [4.15ms]
(pass) Headers > constructor > can create headers from object [3.68ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [3.72ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [7.11ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [6.70ms]
(pass) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [10.41ms]
(pass) Headers > constructor > constructing headers from an object propagates an exception from a getter installed by an earlier value's toString [6.23ms]
(pass) Headers > constructor > constru
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1233ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/36] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/36] gen cpp.rs (cppbind)
[3/36] gen JS modules (bundle-modules)
Preprocess modules (11343ms)
Bundle modules (342ms)
Postprocesss modules (230ms)
Bundle Functions (831ms)
Generate Code (68ms)

[12.83s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/28] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeHTTP.cpp               |   8 +-
 src/jsc/bindings/webcore/FetchHeaders.cpp   |  62 ++++--------
 src/jsc/bindings/webcore/HTTPHeaderMap.cpp  | 132 +++++++++++++-------------
 src/jsc/bindings/webcore/HTTPHeaderMap.h    | 117 ++++++++++++++++++-----
 src/jsc/bindings/webcore/JSFetchHeaders.cpp |   6 +-
 test/js/web/fetch/headers.test.ts           | 142 ++++++++++++++++++++++++++++
 6 files changed, 328 insertions(+), 139 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/NodeHTTP.cpp                    0      0     31
src/jsc/bindings/webcore/FetchHeaders.cpp        4      9     31
src/jsc/bindings/webcore/HTTPHeaderMap.cpp       1      8     31
src/jsc/bindings/webcore/HTTPHeaderMap.h         6     18     32
src/jsc/bindings/webcore/JSFetchHeaders.cpp      1      0     31
test/js/web/fetch/headers.test.ts                7     10     31
```

</details>

<!-- robobun:evidence:end -->