### PR TITLE
Report the memory footprint as rss on macOS

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5451,16 +5451,15 @@ declare module "bun" {
     function setJITPolicy(scale: number): void;
 
     /**
-     * Accurate per-process memory footprint in bytes.
+     * Per-process memory footprint in bytes: the memory that only this
+     * process keeps the machine from reusing.
      *
-     * Unlike `process.memoryUsage.rss()`, this excludes pages already
-     * returned to the OS that the kernel keeps mapped lazily (Darwin's
-     * `MADV_FREE_REUSABLE`), so leak tests are platform-comparable.
-     *
-     * Backed by `task_info(TASK_VM_INFO).phys_footprint` on Darwin, `Pss:`
-     * from `/proc/self/smaps_rollup` on Linux, and `PrivateUsage` on Windows.
-     * Returns `undefined` on platforms with no accurate accessor; callers
-     * should fall back: `Bun.unsafe.memoryFootprint() ?? process.memoryUsage.rss()`.
+     * Backed by `task_info(TASK_VM_INFO).phys_footprint` on macOS (the same
+     * number `process.memoryUsage.rss()` reports there), `Pss:` from
+     * `/proc/self/smaps_rollup` on Linux (shared pages are split between the
+     * processes that map them), and `PrivateUsage` on Windows (this process's
+     * commit charge). Returns `undefined` on platforms with no such accessor;
+     * callers should fall back: `Bun.unsafe.memoryFootprint() ?? process.memoryUsage.rss()`.
      */
     function memoryFootprint(): number | undefined;
   }

--- a/packages/bun-types/jsc.d.ts
+++ b/packages/bun-types/jsc.d.ts
@@ -444,12 +444,15 @@ declare module "bun:jsc" {
    */
   interface MemoryUsage {
     /**
-     * Resident set size: the physical memory the process is using right now.
-     * The same measurement as `process.memoryUsage().rss`.
+     * The physical memory the process is using right now. The same
+     * measurement as `process.memoryUsage().rss`: the resident set size on
+     * Linux and Windows, and on macOS the memory footprint that Activity
+     * Monitor shows (`phys_footprint`, which also counts compressed pages and
+     * leaves out clean file-backed ones).
      */
     current: number;
     /**
-     * The largest resident set size the process has had.
+     * The largest value `current` has had over the life of the process.
      */
     peak: number;
     /**

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2262,8 +2262,7 @@ mod draft {
             )
             .map_err(fmt_err)?;
 
-            // What process.memoryUsage().rss reports: on macOS phys_footprint,
-            // where mi_process_info reads resident_size.
+            // Match process.memoryUsage().rss: mi_process_info reads resident_size on macOS.
             let current_rss = bun_sys::self_process_memory_usage().unwrap_or(current_rss);
             let peak_rss = bun_sys::self_process_peak_memory_usage().unwrap_or(peak_rss);
 

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2262,6 +2262,11 @@ mod draft {
             )
             .map_err(fmt_err)?;
 
+            // What process.memoryUsage().rss reports: on macOS phys_footprint,
+            // where mi_process_info reads resident_size.
+            let current_rss = bun_sys::self_process_memory_usage().unwrap_or(current_rss);
+            let peak_rss = bun_sys::self_process_peak_memory_usage().unwrap_or(peak_rss);
+
             // bun_fmt::bytes() — human-readable metadata, not the trace string.
             write!(
                 writer,

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3889,9 +3889,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionResourceUsage, (JSC::JSGlobalObject * g
     result->putDirectOffset(vm, 0, jsNumber(std::chrono::microseconds::period::den * rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec));
     result->putDirectOffset(vm, 1, jsNumber(std::chrono::microseconds::period::den * rusage.ru_stime.tv_sec + rusage.ru_stime.tv_usec));
 #if OS(DARWIN)
-    // The peak of the phys_footprint that memoryUsage().rss reports, so that
-    // maxRSS is never below rss. ru_maxrss (peak resident_size, in bytes on
-    // darwin) is only the fallback. Node reports kilobytes.
+    // Peak phys_footprint, where Node reports ru_maxrss (see getPeakRSS).
+    // ru_maxrss, in bytes on darwin, is only the fallback. Node's unit is
+    // kilobytes.
     size_t maxRSS = 0;
     if (getPeakRSS(&maxRSS) != 0)
         maxRSS = static_cast<size_t>(rusage.ru_maxrss);
@@ -4092,13 +4092,14 @@ static bool readTaskVMInfo(task_vm_info_data_t& info)
 extern "C" int getRSS(size_t* rss)
 {
 #if defined(__APPLE__)
-    // Deliberately not Node's number: libuv's uv_resident_set_memory reads
-    // TASK_BASIC_INFO.resident_size.
-    // https://github.com/libuv/libuv/blob/91ffa7ba6e4d0d7e92ee8074ed85579f56380b5a/src/unix/darwin.c#L146-L164
-    // phys_footprint is the "Memory" column in Activity Monitor and what
-    // footprint(1) and the jetsam limits use. It counts anonymous memory that
-    // was compressed or swapped out, and leaves out clean file-backed pages and
-    // pages freed with MADV_FREE_REUSABLE that the kernel has not reclaimed yet.
+    // Same as libuv's uv_resident_set_memory since libuv/libuv#5217:
+    // https://github.com/libuv/libuv/blob/071d26c819cc041bd1f8e2b363ef581e14b3f5b0/src/unix/darwin.c#L154-L175
+    // Node releases that bundle libuv 1.52.1 or older still report
+    // TASK_BASIC_INFO.resident_size. phys_footprint is the "Memory" column in
+    // Activity Monitor and what footprint(1) and the jetsam limits use. It
+    // counts anonymous memory that was compressed or swapped out, and leaves
+    // out clean file-backed pages and pages freed with MADV_FREE_REUSABLE that
+    // the kernel has not reclaimed yet.
     task_vm_info_data_t info = {};
     if (!readTaskVMInfo(info))
         return -1;
@@ -4184,6 +4185,9 @@ err:
 extern "C" int getPeakRSS(size_t* peak)
 {
 #if defined(__APPLE__)
+    // Deliberately not Node's number: libuv's uv_getrusage still reports
+    // ru_maxrss, the peak resident_size. The peak has to come from the same
+    // ledger as getRSS(), or rss can exceed maxRSS once memory is compressed.
     task_vm_info_data_t info = {};
     if (!readTaskVMInfo(info))
         return -1;

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -3889,9 +3889,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionResourceUsage, (JSC::JSGlobalObject * g
     result->putDirectOffset(vm, 0, jsNumber(std::chrono::microseconds::period::den * rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec));
     result->putDirectOffset(vm, 1, jsNumber(std::chrono::microseconds::period::den * rusage.ru_stime.tv_sec + rusage.ru_stime.tv_usec));
 #if OS(DARWIN)
-    // Peak phys_footprint, where Node reports ru_maxrss (see getPeakRSS).
-    // ru_maxrss, in bytes on darwin, is only the fallback. Node's unit is
-    // kilobytes.
+    // getPeakRSS and ru_maxrss (the fallback) are bytes on darwin; Node reports kilobytes.
     size_t maxRSS = 0;
     if (getPeakRSS(&maxRSS) != 0)
         maxRSS = static_cast<size_t>(rusage.ru_maxrss);
@@ -4092,14 +4090,7 @@ static bool readTaskVMInfo(task_vm_info_data_t& info)
 extern "C" int getRSS(size_t* rss)
 {
 #if defined(__APPLE__)
-    // Same as libuv's uv_resident_set_memory since libuv/libuv#5217:
-    // https://github.com/libuv/libuv/blob/071d26c819cc041bd1f8e2b363ef581e14b3f5b0/src/unix/darwin.c#L154-L175
-    // Node releases that bundle libuv 1.52.1 or older still report
-    // TASK_BASIC_INFO.resident_size. phys_footprint is the "Memory" column in
-    // Activity Monitor and what footprint(1) and the jetsam limits use. It
-    // counts anonymous memory that was compressed or swapped out, and leaves
-    // out clean file-backed pages and pages freed with MADV_FREE_REUSABLE that
-    // the kernel has not reclaimed yet.
+    // Same as libuv since https://github.com/libuv/libuv/pull/5217 (Node on libuv <= 1.52.1 reports resident_size).
     task_vm_info_data_t info = {};
     if (!readTaskVMInfo(info))
         return -1;
@@ -4185,9 +4176,7 @@ err:
 extern "C" int getPeakRSS(size_t* peak)
 {
 #if defined(__APPLE__)
-    // Deliberately not Node's number: libuv's uv_getrusage still reports
-    // ru_maxrss, the peak resident_size. The peak has to come from the same
-    // ledger as getRSS(), or rss can exceed maxRSS once memory is compressed.
+    // Not Node's ru_maxrss (peak resident_size): with compressed memory that can be lower than getRSS().
     task_vm_info_data_t info = {};
     if (!readTaskVMInfo(info))
         return -1;

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2411,16 +2411,22 @@ __attribute__((minsize)) static JSValue constructReportObjectComplete(VM& vm, Zi
 
         getrusage(RUSAGE_SELF, &usage);
 
+        // Bytes, like Node's report: rss is the current value, maxRss the peak.
+        size_t rss = 0;
+        size_t maxRss = 0;
+        getRSS(&rss);
+        getPeakRSS(&maxRss);
+
         putDirectNamed(vm, resourceUsage, "free_memory"_s, JSC::jsNumber(usage.ru_maxrss));
         putDirectNamed(vm, resourceUsage, "total_memory"_s, JSC::jsNumber(usage.ru_maxrss));
-        putDirectNamed(vm, resourceUsage, "rss"_s, JSC::jsNumber(usage.ru_maxrss));
+        putDirectNamed(vm, resourceUsage, "rss"_s, JSC::jsNumber(rss));
         putDirectNamed(vm, resourceUsage, "available_memory"_s, JSC::jsNumber(usage.ru_maxrss));
         putDirectNamed(vm, resourceUsage, "userCpuSeconds"_s, JSC::jsNumber(usage.ru_utime.tv_sec));
         putDirectNamed(vm, resourceUsage, "kernelCpuSeconds"_s, JSC::jsNumber(usage.ru_stime.tv_sec));
         putDirectNamed(vm, resourceUsage, "cpuConsumptionPercent"_s, JSC::jsNumber(usage.ru_utime.tv_sec));
         putDirectNamed(vm, resourceUsage, "userCpuConsumptionPercent"_s, JSC::jsNumber(usage.ru_utime.tv_sec));
         putDirectNamed(vm, resourceUsage, "kernelCpuConsumptionPercent"_s, JSC::jsNumber(usage.ru_utime.tv_sec));
-        putDirectNamed(vm, resourceUsage, "maxRss"_s, JSC::jsNumber(usage.ru_maxrss));
+        putDirectNamed(vm, resourceUsage, "maxRss"_s, JSC::jsNumber(maxRss));
 
         JSC::JSObject* pageFaults = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
         RETURN_IF_EXCEPTION(scope, {});
@@ -3883,8 +3889,13 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionResourceUsage, (JSC::JSGlobalObject * g
     result->putDirectOffset(vm, 0, jsNumber(std::chrono::microseconds::period::den * rusage.ru_utime.tv_sec + rusage.ru_utime.tv_usec));
     result->putDirectOffset(vm, 1, jsNumber(std::chrono::microseconds::period::den * rusage.ru_stime.tv_sec + rusage.ru_stime.tv_usec));
 #if OS(DARWIN)
-    // ru_maxrss is bytes on darwin; Node reports kilobytes everywhere.
-    result->putDirectOffset(vm, 2, jsNumber(rusage.ru_maxrss / 1024));
+    // The peak of the phys_footprint that memoryUsage().rss reports, so that
+    // maxRSS is never below rss. ru_maxrss (peak resident_size, in bytes on
+    // darwin) is only the fallback. Node reports kilobytes.
+    size_t maxRSS = 0;
+    if (getPeakRSS(&maxRSS) != 0)
+        maxRSS = static_cast<size_t>(rusage.ru_maxrss);
+    result->putDirectOffset(vm, 2, jsNumber(maxRSS / 1024));
 #else
     result->putDirectOffset(vm, 2, jsNumber(rusage.ru_maxrss));
 #endif
@@ -4070,25 +4081,29 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionThreadCpuUsage, (JSC::JSGlobalObject * 
     RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(result));
 }
 
+#if defined(__APPLE__)
+static bool readTaskVMInfo(task_vm_info_data_t& info)
+{
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    return task_info(mach_task_self(), TASK_VM_INFO, reinterpret_cast<task_info_t>(&info), &count) == KERN_SUCCESS;
+}
+#endif
+
 extern "C" int getRSS(size_t* rss)
 {
 #if defined(__APPLE__)
-    mach_msg_type_number_t count;
-    task_basic_info_data_t info;
-    kern_return_t err;
-
-    count = TASK_BASIC_INFO_COUNT;
-    err = task_info(mach_task_self(),
-        TASK_BASIC_INFO,
-        reinterpret_cast<task_info_t>(&info),
-        &count);
-
-    if (err == KERN_SUCCESS) {
-        *rss = (size_t)info.resident_size;
-        return 0;
-    }
-
-    return -1;
+    // Deliberately not Node's number: libuv's uv_resident_set_memory reads
+    // TASK_BASIC_INFO.resident_size.
+    // https://github.com/libuv/libuv/blob/91ffa7ba6e4d0d7e92ee8074ed85579f56380b5a/src/unix/darwin.c#L146-L164
+    // phys_footprint is the "Memory" column in Activity Monitor and what
+    // footprint(1) and the jetsam limits use. It counts anonymous memory that
+    // was compressed or swapped out, and leaves out clean file-backed pages and
+    // pages freed with MADV_FREE_REUSABLE that the kernel has not reclaimed yet.
+    task_vm_info_data_t info = {};
+    if (!readTaskVMInfo(info))
+        return -1;
+    *rss = static_cast<size_t>(info.phys_footprint);
+    return 0;
 #elif defined(__linux__)
     // Taken from libuv.
     char buf[1024];
@@ -4162,6 +4177,33 @@ err:
     return uv_resident_set_memory(rss);
 #else
 #error "Unknown platform"
+#endif
+}
+
+// High-water mark of the number getRSS() reports, in bytes.
+extern "C" int getPeakRSS(size_t* peak)
+{
+#if defined(__APPLE__)
+    task_vm_info_data_t info = {};
+    if (!readTaskVMInfo(info))
+        return -1;
+    *peak = static_cast<size_t>(info.ledger_phys_footprint_peak);
+    return 0;
+#elif OS(WINDOWS)
+    uv_rusage_t rusage;
+    int err = uv_getrusage(&rusage);
+    if (err)
+        return err;
+    // libuv converts PeakWorkingSetSize to kilobytes.
+    *peak = static_cast<size_t>(rusage.ru_maxrss) * 1024;
+    return 0;
+#else
+    struct rusage rusage;
+    if (getrusage(RUSAGE_SELF, &rusage) != 0)
+        return errno;
+    // ru_maxrss is kilobytes on Linux and FreeBSD.
+    *peak = static_cast<size_t>(rusage.ru_maxrss) * 1024;
+    return 0;
 #endif
 }
 

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -13,7 +13,10 @@ class GlobalObject;
 namespace Bun {
 using namespace JSC;
 
+// Bytes. On macOS both read the phys_footprint ledger (Activity Monitor's
+// number), not resident_size.
 extern "C" int getRSS(size_t* rss);
+extern "C" int getPeakRSS(size_t* peak);
 
 class Process : public WebCore::JSEventEmitter {
     using Base = WebCore::JSEventEmitter;

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -13,8 +13,7 @@ class GlobalObject;
 namespace Bun {
 using namespace JSC;
 
-// Bytes. On macOS both read the phys_footprint ledger (Activity Monitor's
-// number), not resident_size.
+// Bytes. phys_footprint (Activity Monitor's number) on macOS, the resident set size elsewhere.
 extern "C" int getRSS(size_t* rss);
 extern "C" int getPeakRSS(size_t* peak);
 

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -146,27 +146,23 @@ extern "C" void dump_zone_malloc_stats()
 
 #endif
 
-// Accurate per-process memory footprint, in bytes. Unlike RSS this excludes
-// pages already returned to the OS that the kernel keeps mapped lazily
-// (Darwin's MADV_FREE_REUSABLE), so leak tests get the same answer on every
-// platform. Returns 0 when no platform-specific accessor is available; the
-// JS caller falls back to process.memoryUsage.rss().
+// Per-process memory footprint, in bytes: the memory this process alone keeps
+// the machine from reusing. Returns 0 when no platform-specific accessor is
+// available; the JS caller falls back to process.memoryUsage.rss().
 //
 // Darwin:  task_info(TASK_VM_INFO).phys_footprint — Activity Monitor's number;
-//          counts dirty + compressed, NOT reusable.
+//          counts dirty + compressed, NOT reusable. process.memoryUsage().rss
+//          reads the same ledger on Darwin (getRSS in BunProcess.cpp).
 // Linux:   /proc/self/smaps_rollup Pss: — proportional set size, attributes
 //          shared pages by share count instead of fully to every mapper.
 // Windows: GetProcessMemoryInfo PrivateUsage — commit charge for this process.
 #if OS(DARWIN)
-#include <mach/mach.h>
+extern "C" int getRSS(size_t* rss);
 extern "C" size_t Bun__memoryFootprint()
 {
-    task_vm_info_data_t info;
-    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
-    kern_return_t kr = task_info(mach_task_self(), TASK_VM_INFO,
-        reinterpret_cast<task_info_t>(&info), &count);
-    if (kr != KERN_SUCCESS) return 0;
-    return static_cast<size_t>(info.phys_footprint);
+    size_t footprint = 0;
+    if (getRSS(&footprint) != 0) return 0;
+    return footprint;
 }
 #elif OS(LINUX)
 extern "C" size_t Bun__memoryFootprint()

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -146,13 +146,11 @@ extern "C" void dump_zone_malloc_stats()
 
 #endif
 
-// Per-process memory footprint, in bytes: the memory this process alone keeps
-// the machine from reusing. Returns 0 when no platform-specific accessor is
-// available; the JS caller falls back to process.memoryUsage.rss().
+// Accurate per-process memory footprint, in bytes. Returns 0 when the platform has no accessor; the
+// JS caller falls back to process.memoryUsage.rss().
 //
 // Darwin:  task_info(TASK_VM_INFO).phys_footprint — Activity Monitor's number;
-//          counts dirty + compressed, NOT reusable. process.memoryUsage().rss
-//          reads the same ledger on Darwin (getRSS in BunProcess.cpp).
+//          counts dirty + compressed, NOT reusable.
 // Linux:   /proc/self/smaps_rollup Pss: — proportional set size, attributes
 //          shared pages by share count instead of fully to every mapper.
 // Windows: GetProcessMemoryInfo PrivateUsage — commit charge for this process.

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -430,9 +430,7 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateMemoryFootprint,
     mi_process_info(&elapsed_msecs, &user_msecs, &system_msecs, &current_rss,
         &peak_rss, &current_commit, &peak_commit, &page_faults);
 
-    // The numbers process.memoryUsage().rss and process.resourceUsage().maxRSS
-    // report. On macOS that is phys_footprint, where mi_process_info reads
-    // resident_size.
+    // Match process.memoryUsage().rss and resourceUsage().maxRSS: mi_process_info reads resident_size on macOS.
     Bun::getRSS(&current_rss);
     Bun::getPeakRSS(&peak_rss);
 

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -430,8 +430,11 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateMemoryFootprint,
     mi_process_info(&elapsed_msecs, &user_msecs, &system_msecs, &current_rss,
         &peak_rss, &current_commit, &peak_commit, &page_faults);
 
-    // mi_process_info produces incorrect rss size on linux.
+    // The numbers process.memoryUsage().rss and process.resourceUsage().maxRSS
+    // report. On macOS that is phys_footprint, where mi_process_info reads
+    // resident_size.
     Bun::getRSS(&current_rss);
+    Bun::getPeakRSS(&peak_rss);
 
     VM& vm = globalObject->vm();
     JSC::JSObject* object = JSC::constructEmptyObject(

--- a/src/runtime/api/UnsafeObject.rs
+++ b/src/runtime/api/UnsafeObject.rs
@@ -61,9 +61,8 @@ unsafe extern "C" {
     safe fn Bun__memoryFootprint() -> usize;
 }
 
-/// Per-process memory footprint in bytes. Backed by
-/// `task_info(TASK_VM_INFO).phys_footprint` (Darwin, the same number
-/// `process.memoryUsage().rss` reports there), `Pss:` from
+/// Accurate per-process memory footprint in bytes.
+/// Backed by `task_info(TASK_VM_INFO).phys_footprint` (Darwin), `Pss:` from
 /// `/proc/self/smaps_rollup` (Linux), `PrivateUsage` (Windows). Returns
 /// `undefined` when no platform-specific accessor is available so the caller
 /// can `?? process.memoryUsage.rss()`.

--- a/src/runtime/api/UnsafeObject.rs
+++ b/src/runtime/api/UnsafeObject.rs
@@ -61,10 +61,9 @@ unsafe extern "C" {
     safe fn Bun__memoryFootprint() -> usize;
 }
 
-/// Accurate per-process memory footprint in bytes. Unlike RSS this excludes
-/// pages already returned to the OS that the kernel keeps mapped lazily
-/// (Darwin's `MADV_FREE_REUSABLE`), so leak tests are platform-comparable.
-/// Backed by `task_info(TASK_VM_INFO).phys_footprint` (Darwin), `Pss:` from
+/// Per-process memory footprint in bytes. Backed by
+/// `task_info(TASK_VM_INFO).phys_footprint` (Darwin, the same number
+/// `process.memoryUsage().rss` reports there), `Pss:` from
 /// `/proc/self/smaps_rollup` (Linux), `PrivateUsage` (Windows). Returns
 /// `undefined` when no platform-specific accessor is available so the caller
 /// can `?? process.memoryUsage.rss()`.

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -4805,20 +4805,33 @@ pub use bun_core::Timespec;
 /// `bun_sys::time::timestamp()` resolve without an extra dep.
 pub use bun_core::time;
 
-/// `bun.sys.selfProcessMemoryUsage()` — returns the resident set size of the
-/// current process in bytes, or `None` on failure. Thin wrapper around the
-/// C++ `getRSS` shim (lives in `src/jsc/bindings/memory.cpp`).
+unsafe extern "C" {
+    // safe: out-param is `&mut usize` (non-null, valid for write); C++ side
+    // only writes the slot and returns a status code — no other preconditions.
+    safe fn getRSS(rss: &mut usize) -> ::core::ffi::c_int;
+    safe fn getPeakRSS(peak: &mut usize) -> ::core::ffi::c_int;
+}
+
+/// `bun.sys.selfProcessMemoryUsage()` — the memory usage of the current
+/// process in bytes, as `process.memoryUsage().rss` reports it, or `None` on
+/// failure. On macOS this is the `phys_footprint` ledger (Activity Monitor's
+/// number) rather than `resident_size`. Thin wrapper around the C++ `getRSS`
+/// shim in `src/jsc/bindings/BunProcess.cpp`.
 pub fn self_process_memory_usage() -> Option<usize> {
-    unsafe extern "C" {
-        // safe: out-param is `&mut usize` (non-null, valid for write); C++ side
-        // only writes the slot and returns a status code — no other preconditions.
-        safe fn getRSS(rss: &mut usize) -> ::core::ffi::c_int;
-    }
     let mut rss: usize = 0;
     if getRSS(&mut rss) != 0 {
         return None;
     }
     Some(rss)
+}
+
+/// High-water mark of [`self_process_memory_usage`], in bytes.
+pub fn self_process_peak_memory_usage() -> Option<usize> {
+    let mut peak: usize = 0;
+    if getPeakRSS(&mut peak) != 0 {
+        return None;
+    }
+    Some(peak)
 }
 
 /// `bun.sys.PosixStat` — uv-shaped stat struct.

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -4806,17 +4806,12 @@ pub use bun_core::Timespec;
 pub use bun_core::time;
 
 unsafe extern "C" {
-    // safe: out-param is `&mut usize` (non-null, valid for write); C++ side
-    // only writes the slot and returns a status code — no other preconditions.
+    // safe: the out-param is a valid `&mut usize`; C++ only writes it and returns a status code.
     safe fn getRSS(rss: &mut usize) -> ::core::ffi::c_int;
     safe fn getPeakRSS(peak: &mut usize) -> ::core::ffi::c_int;
 }
 
-/// `bun.sys.selfProcessMemoryUsage()` — the memory usage of the current
-/// process in bytes, as `process.memoryUsage().rss` reports it, or `None` on
-/// failure. On macOS this is the `phys_footprint` ledger (Activity Monitor's
-/// number) rather than `resident_size`. Thin wrapper around the C++ `getRSS`
-/// shim in `src/jsc/bindings/BunProcess.cpp`.
+/// What `process.memoryUsage().rss` reports, in bytes (C++ `getRSS` in `BunProcess.cpp`), or `None` on failure.
 pub fn self_process_memory_usage() -> Option<usize> {
     let mut rss: usize = 0;
     if getRSS(&mut rss) != 0 {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1788,7 +1788,7 @@ test.skipIf(!isDebug && !isASAN)(
     const dir = tempDirWithFiles("bun-build-inline-sourcemap-leak", {
       "entry.ts": "export const a = 1;\n/* " + Buffer.alloc(30 * 1024 * 1024, "x").toString() + " */\n",
       "run.ts": `
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
         const entry = process.argv[2];
         async function build() {
           const res = await Bun.build({ entrypoints: [entry], sourcemap: "inline" });
@@ -1867,7 +1867,7 @@ test.skip("Bun.build NumberRenamer does not leak intermediate NumberScope.name_c
   const dir = tempDirWithFiles("bun-build-number-renamer-leak", {
     "entry.js": entry,
     "run.ts": `
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
         const entry = process.argv[2];
         async function build() {
           // No identifier minification → NumberRenamer path (not MinifyRenamer).

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -7,7 +7,6 @@ import {
   bunRun,
   isASAN,
   isDebug,
-  isMacOS,
   isWindows,
   tempDir,
   tempDirWithFiles,
@@ -241,11 +240,11 @@ describe("Bun.build", () => {
         console.log(JSON.stringify({ base, after }));
       `,
     });
-    // Linux/Windows release, 20k functions: ~+65 MB without freeing the VM, about level with the baseline with it.
+    // Release, 20k functions: ~+65 MB without freeing the VM, about level with the baseline with it.
     // Debug/ASAN parse far slower and hold freed pages in quarantine, so they get a smaller module and only guard against
-    // gross retention. macOS reports +230-280 MB here even with the VM freed (the pages leave RSS lazily), so same there.
+    // gross retention.
     const slow = isASAN || isDebug;
-    const [functions, limit] = slow ? [3000, 400] : [20000, isMacOS ? 400 : 40];
+    const [functions, limit] = slow ? [3000, 400] : [20000, 40];
     await using proc = Bun.spawn({
       cmd: [bunExe(), "retained-fixture.ts", String(functions), String(limit)],
       env: bunEnv,

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -701,7 +701,7 @@ it(
       bundleIn,
       `// ${long_comment}
 //
-console.error("RSS: %s", process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint() : process.memoryUsage.rss());
+console.error("RSS: %s", process.memoryUsage.rss());
 throw new Error('0');`,
     );
     await using bundler = spawn({
@@ -745,7 +745,7 @@ throw new Error('0');`,
           writeHotFileAtomicSync(
             bundleIn,
             `// ${long_comment}
-console.error("RSS: %s", process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint() : process.memoryUsage.rss());
+console.error("RSS: %s", process.memoryUsage.rss());
 //
 ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
           );

--- a/test/cli/run/cjs-fixture-leak-small.js
+++ b/test/cli/run/cjs-fixture-leak-small.js
@@ -2,10 +2,7 @@ const dest = require.resolve("./leak-fixture-small-ast.js");
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
 // run far higher under bun-asan; widen the threshold to avoid false positives.
 const isASAN = process.execPath.includes("bun-asan");
-const rss =
-  process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 let gc = globalThis.gc;
 if (typeof Bun !== "undefined") {

--- a/test/cli/run/esm-bug-leak-fixture.mjs
+++ b/test/cli/run/esm-bug-leak-fixture.mjs
@@ -4,10 +4,7 @@ const dest = await import.meta.resolve("./esm-leak-fixture-large-ast.mjs");
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
 // run far higher under bun-asan; widen the threshold to avoid false positives.
 const isASAN = process.execPath.includes("bun-asan");
-const rss =
-  process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 if (typeof Bun !== "undefined") Bun.gc(true);
 for (let i = 0; i < 5; i++) {

--- a/test/cli/run/esm-fixture-leak-small.mjs
+++ b/test/cli/run/esm-fixture-leak-small.mjs
@@ -4,10 +4,7 @@ const dest = require.resolve("./leak-fixture-small-ast.js");
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
 // run far higher under bun-asan; widen the threshold to avoid false positives.
 const isASAN = process.execPath.includes("bun-asan");
-const rss =
-  process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 if (typeof Bun !== "undefined") Bun.gc(true);
 for (let i = 0; i < 5; i++) {

--- a/test/cli/run/require-cache-bug-leak-fixture.js
+++ b/test/cli/run/require-cache-bug-leak-fixture.js
@@ -2,10 +2,7 @@ const dest = require.resolve("./require-cache-bug-leak-fixture-large-ast.js");
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
 // run far higher under bun-asan; widen the threshold to avoid false positives.
 const isASAN = process.execPath.includes("bun-asan");
-const rss =
-  process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 if (typeof Bun !== "undefined") Bun.gc(true);
 for (let i = 0; i < 5; i++) {

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -64,7 +64,7 @@ describe.concurrent("require.cache", () => {
         "require-cache-bug-leak-fixture.js": `
           const path = require.resolve("./index.js");
           const gc = global.gc || globalThis?.Bun?.gc || (() => {});
-          const rss = process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+          const rss = process.memoryUsage.rss;
           const noChildren = module.children = { indexOf() { return 0; } }; // disable children tracking
           function bust() {
             const mod = require.cache[path];
@@ -123,7 +123,7 @@ describe.concurrent("require.cache", () => {
         "require-cache-bug-leak-fixture.js": `
           const path = require.resolve("./index.js");
           const gc = global.gc || globalThis?.Bun?.gc || (() => {});
-          const rss = process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+          const rss = process.memoryUsage.rss;
           function bust() {
             delete require.cache[path];
           }
@@ -173,7 +173,7 @@ describe.concurrent("require.cache", () => {
         "require-cache-bug-leak-fixture.js": `
           const path = require.resolve("./index.js");
           const gc = global.gc || globalThis?.Bun?.gc || (() => {});
-          const rss = process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+          const rss = process.memoryUsage.rss;
           function bust() {
             delete require.cache[path];
           }
@@ -234,7 +234,7 @@ describe.concurrent("require.cache", () => {
           "require-cache-bug-leak-fixture.js": `
           const path = require.resolve("./index.js");
           const gc = global.gc || globalThis?.Bun?.gc || (() => {});
-          const rss = process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+          const rss = process.memoryUsage.rss;
           function bust() {
             const mod = require.cache[path];
             if (mod) {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -2304,10 +2304,7 @@ export function compileFixture(sourcePath: string, options: { flags?: string[] }
   return outPath;
 }
 
-export const rss: () => number =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? (Bun.unsafe.memoryFootprint as () => number)
-    : process.memoryUsage.rss;
+export const rss: () => number = process.memoryUsage.rss;
 
 /** Read exactly `len` bytes from `fd` at absolute `offset`. */
 export function preadExact(fd: number, offset: number, len: number): Buffer {

--- a/test/js/bun/archive-extract-leak-repro.ts
+++ b/test/js/bun/archive-extract-leak-repro.ts
@@ -5,10 +5,7 @@ import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 const dir = mkdtempSync(join(tmpdir(), "archive-leak-"));
 

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -653,7 +653,7 @@ describe("Bun.Archive", () => {
       // iterations would leak ~190MB. A 64MB threshold comfortably separates
       // "fixed" (stable RSS) from "leaking".
       const code = /* ts */ `
-          const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+          const rss = process.memoryUsage.rss;
           function ustarHeader(name, size) {
             const h = Buffer.alloc(512);
             h.write(name, 0, 100, "utf8");

--- a/test/js/bun/css/small-list-grow.test.ts
+++ b/test/js/bun/css/small-list-grow.test.ts
@@ -36,7 +36,7 @@ test("CSS bundler doesn't over-allocate SmallList when growing past the first he
   const lastSel = `.r${numRules - 1}-s${selectorsPerRule - 1}`;
 
   const fixture = /* js */ `
-    const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    const rss = process.memoryUsage.rss;
     const baseline = rss();
     const result = await Bun.build({
       entrypoints: [${JSON.stringify(path.join(String(dir), "wide.css"))}],

--- a/test/js/bun/css/token-list-backtracking.test.ts
+++ b/test/js/bun/css/token-list-backtracking.test.ts
@@ -28,7 +28,7 @@ function spawnMinify(css: string) {
       bunExe(),
       "-e",
       `const c = require("bun:internal-for-testing").cssInternals;
-       const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+       const rss = process.memoryUsage.rss;
        const css = ${JSON.stringify(css)};
        const rssBefore = rss();
        let threw = false;

--- a/test/js/bun/glob/leak.test.ts
+++ b/test/js/bun/glob/leak.test.ts
@@ -24,7 +24,7 @@ describe("leaks", () => {
       await run(
         String(dir),
         /* ts */ `
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
         const glob = new Bun.Glob("**/*");
         for (let i = 0; i < 1000; i++) Array.from(glob.scanSync());
         Bun.gc(true);
@@ -46,7 +46,7 @@ describe("leaks", () => {
       await run(
         String(dir),
         /* ts */ `
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
         const glob = new Bun.Glob("**/*");
         for (let i = 0; i < 1000; i++) await Array.fromAsync(glob.scan());
         Bun.gc(true);
@@ -68,7 +68,7 @@ describe("leaks", () => {
       await run(
         String(dir),
         /* ts */ `
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
         const glob = new Bun.Glob("*.txt");
         for (let i = 0; i < 1000; i++) Array.from(glob.scanSync());
         Bun.gc(true);
@@ -90,7 +90,7 @@ describe("leaks", () => {
       await run(
         String(dir),
         /* ts */ `
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
         const glob = new Bun.Glob("*.txt");
         for (let i = 0; i < 1000; i++) await Array.fromAsync(glob.scan());
         Bun.gc(true);

--- a/test/js/bun/http/body-leak-test-fixture.ts
+++ b/test/js/bun/http/body-leak-test-fixture.ts
@@ -1,9 +1,4 @@
-// RSS on darwin keeps freed-but-mapped (MADV_FREE_REUSABLE) pages, so it only reports
-// the high-water mark; memoryFootprint() is what the process actually retains.
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 async function memoryUsage() {
   Bun.gc(true);

--- a/test/js/bun/http/proxy-stress-memory-fixture.ts
+++ b/test/js/bun/http/proxy-stress-memory-fixture.ts
@@ -108,10 +108,7 @@ function recordError(i: number, e: unknown) {
   }
 }
 
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 async function one(i: number): Promise<void> {
   const path = mode === "redirect" ? "/start" : `/${i}`;

--- a/test/js/bun/http/req-url-leak-fixture.js
+++ b/test/js/bun/http/req-url-leak-fixture.js
@@ -1,7 +1,4 @@
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 let existingPromise = null;
 const server = Bun.serve({
   port: 0,

--- a/test/js/bun/http/request-constructor-leak-fixture.js
+++ b/test/js/bun/http/request-constructor-leak-fixture.js
@@ -4,10 +4,7 @@
 // - the headers leak
 // - the url leaks
 //
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 const buf = new Uint8Array(1024 * 1024 * 16);
 
 for (var i = 0; i < 1000; i++) {

--- a/test/js/bun/http/response-constructor-leak-fixture.js
+++ b/test/js/bun/http/response-constructor-leak-fixture.js
@@ -4,10 +4,7 @@
 // - the headers leak
 //
 
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 const buf = new Uint8Array(1024 * 1024 * 32);
 
 for (var i = 0; i < 1000; i++) {

--- a/test/js/bun/http/serve-request-extra-memory-fixture.ts
+++ b/test/js/bun/http/serve-request-extra-memory-fixture.ts
@@ -1,7 +1,4 @@
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 const server = Bun.serve({
   port: 0,

--- a/test/js/bun/http/serve-response-stream-sink-leak-fixture.ts
+++ b/test/js/bun/http/serve-response-stream-sink-leak-fixture.ts
@@ -4,10 +4,7 @@
 // heap HTTPServerWritable/JSSink plus the promise plumbing used to wait for
 // the close, and all of it must be released when end() completes the
 // response; otherwise each request leaks the struct plus its buffer.
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 let controller: any;
 let pulled: { promise: Promise<void>; resolve: () => void };

--- a/test/js/bun/http/server-fetch-string-leak-fixture.js
+++ b/test/js/bun/http/server-fetch-string-leak-fixture.js
@@ -3,10 +3,7 @@
 // bun.String. Both code paths are exercised:
 //   - absolute URL with a hostname (dupe branch)
 //   - relative path with no hostname (append-to-base-url branch)
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 const isASAN = process.execPath.includes("bun-asan");
 using server = Bun.serve({
   port: 0,

--- a/test/js/bun/http/tls-bunfile-leak-fixture.js
+++ b/test/js/bun/http/tls-bunfile-leak-fixture.js
@@ -11,10 +11,7 @@
 //
 // Env: TLS_CERT_PATH, TLS_KEY_PATH - paths to (large) PEM files
 
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 const certPath = process.env.TLS_CERT_PATH;
 const keyPath = process.env.TLS_KEY_PATH;
 const iterations = parseInt(process.env.ITERATIONS || "100", 10);

--- a/test/js/bun/http/tls-keepalive-leak-fixture.js
+++ b/test/js/bun/http/tls-keepalive-leak-fixture.js
@@ -7,10 +7,7 @@
 //      WARMUP_REQUESTS - warmup iterations to stabilize the RSS baseline (default 20000)
 //      MODE - "same" (same TLS config) or "distinct" (unique configs)
 
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 const cert = process.env.TLS_CERT;
 const key = process.env.TLS_KEY;
 const numRequests = parseInt(process.env.NUM_REQUESTS || "50000", 10);

--- a/test/js/bun/io/bun-write-leak-fixture.js
+++ b/test/js/bun/io/bun-write-leak-fixture.js
@@ -5,10 +5,7 @@
 const isASAN = process.execPath.includes("bun-asan");
 const MAX_ALLOWED_MEMORY_USAGE = isASAN ? 768 : 256;
 const dest = process.argv.at(-1);
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 async function run(inputType) {
   for (let i = 0; i < 100; i++) {

--- a/test/js/bun/json5/json5.test.ts
+++ b/test/js/bun/json5/json5.test.ts
@@ -1716,7 +1716,7 @@ describe("stringify memory", () => {
         "--smol",
         "-e",
         /* js */ `
-          const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+          const rss = process.memoryUsage.rss;
           const obj = { a: [1, 2, 3], b: { c: 4 }, d: 5 };
           const pad = Buffer.alloc(1024 * 1024, " ").toString();
           for (let i = 0; i < 20; i++) Bun.JSON5.stringify(obj, null, pad + i);

--- a/test/js/bun/s3/bun-write-leak-fixture.js
+++ b/test/js/bun/s3/bun-write-leak-fixture.js
@@ -3,10 +3,7 @@
 let MAX_ALLOWED_MEMORY_USAGE = 0;
 let MAX_ALLOWED_MEMORY_USAGE_INCREMENT = 15;
 const { randomUUID } = require("crypto");
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 const payload = new Buffer(1024 * 1024 * 1, "A".charCodeAt(0)).toString("utf-8");
 async function writeLargeFile() {

--- a/test/js/bun/s3/s3-stream-leak-fixture.js
+++ b/test/js/bun/s3/s3-stream-leak-fixture.js
@@ -3,10 +3,7 @@
 let MAX_ALLOWED_MEMORY_USAGE = 0;
 let MAX_ALLOWED_MEMORY_USAGE_INCREMENT = 15;
 const { randomUUID } = require("crypto");
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 const s3Dest = randomUUID() + "-s3-stream-leak-fixture";
 

--- a/test/js/bun/s3/s3-text-leak-fixture.js
+++ b/test/js/bun/s3/s3-text-leak-fixture.js
@@ -3,10 +3,7 @@
 let MAX_ALLOWED_MEMORY_USAGE = 0;
 let MAX_ALLOWED_MEMORY_USAGE_INCREMENT = 15;
 const { randomUUID } = require("crypto");
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 const s3Dest = randomUUID() + "-s3-stream-leak-fixture";
 

--- a/test/js/bun/s3/s3-write-leak-fixture.js
+++ b/test/js/bun/s3/s3-write-leak-fixture.js
@@ -4,10 +4,7 @@ let MAX_ALLOWED_MEMORY_USAGE = 0;
 let MAX_ALLOWED_MEMORY_USAGE_INCREMENT = 15;
 const dest = process.argv.at(-1);
 const { randomUUID } = require("crypto");
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 const payload = new Buffer(1024 * 1024 + 1, "A".charCodeAt(0)).toString("utf-8");
 async function writeLargeFile() {
   const s3file = Bun.s3.file(randomUUID());

--- a/test/js/bun/s3/s3-writer-leak-fixture.js
+++ b/test/js/bun/s3/s3-writer-leak-fixture.js
@@ -4,10 +4,7 @@ let MAX_ALLOWED_MEMORY_USAGE = 0;
 let MAX_ALLOWED_MEMORY_USAGE_INCREMENT = 15;
 const dest = process.argv.at(-1);
 const { randomUUID } = require("crypto");
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 const payload = new Buffer(1024 * 256, "A".charCodeAt(0)).toString("utf-8");
 async function writeLargeFile() {
   const s3file = Bun.s3.file(randomUUID());

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -150,7 +150,7 @@ test.skipIf(!isASAN)("seq piped to an fd does not clone its output buffer before
     cmd: [
       bunExe(),
       "-e",
-      `const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;` +
+      `const rss = process.memoryUsage.rss;` +
         `const sep = Buffer.alloc(100, "x").toString();` +
         `await Bun.$\`seq 1 10 > /dev/null\`;` +
         `const b = rss();` +

--- a/test/js/bun/shell/leak.test.ts
+++ b/test/js/bun/shell/leak.test.ts
@@ -119,7 +119,7 @@ describe.concurrent("fd leak", () => {
       const impl = /* ts */ `
               import { heapStats } from "bun:jsc";
               const TestBuilder = createTestBuilder(import.meta.path);
-              const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+              const rss = process.memoryUsage.rss;
 
               const threshold = ${threshold}
               let prev: number | undefined = undefined;

--- a/test/js/bun/sourcemap/external-sourcemap-stack-leak.test.ts
+++ b/test/js/bun/sourcemap/external-sourcemap-stack-leak.test.ts
@@ -60,10 +60,7 @@ const mainSource = /* js */ `
   const mode = process.argv[2];
   const marker = ${JSON.stringify(remappedMarker)};
   Error.stackTraceLimit = ${FRAMES};
-  const rss =
-    process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-      ? Bun.unsafe.memoryFootprint
-      : process.memoryUsage.rss;
+  const rss = process.memoryUsage.rss;
 
   let remappedFrames = 0;
   if (mode === "prepareStackTrace") {

--- a/test/js/bun/spawn/spawn-stdout-iterate-leak.fixture.ts
+++ b/test/js/bun/spawn/spawn-stdout-iterate-leak.fixture.ts
@@ -18,10 +18,7 @@ import { once } from "events";
 
 const MB = 1024 * 1024;
 const CHUNK = 32768;
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 async function run(iters: number) {
   const proc = spawn("cat", [], { stdio: ["pipe", "pipe", "ignore"] });

--- a/test/js/bun/transpiler/transpiler-comma-chain-oom.test.ts
+++ b/test/js/bun/transpiler/transpiler-comma-chain-oom.test.ts
@@ -8,7 +8,7 @@ import { bunEnv, bunExe } from "harness";
 
 test("long comma expression does not blow up memory with target: bun", async () => {
   const fixture = `
-    const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    const rss = process.memoryUsage.rss;
     const n = 4000;
     const input = Array(n).fill("a").join(",");
     const expected = Array(n).fill("a").join(", ") + ";\\n";

--- a/test/js/bun/transpiler/transpiler-enum-concat-chain-oom.test.ts
+++ b/test/js/bun/transpiler/transpiler-enum-concat-chain-oom.test.ts
@@ -11,7 +11,7 @@ import { bunEnv, bunExe } from "harness";
 
 test.concurrent("long `+` chain of inlined enum members folds in linear memory", async () => {
   const fixture = /* js */ `
-    const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    const rss = process.memoryUsage.rss;
     const n = 4096;
     // The same chain twice: at top level (folds because target is "bun") and
     // as an enum member initializer (always folds).

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -579,7 +579,7 @@ it("MatchedRoute.params does not leak", async () => {
   // garbage-collected. Use long segment values so any leak is large enough to
   // dominate RSS noise.
   const code = /* ts */ `
-    const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    const rss = process.memoryUsage.rss;
     const router = new Bun.FileSystemRouter({
       dir: ${JSON.stringify(path.join(String(dir), "pages"))},
       style: "nextjs",

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -24,7 +24,7 @@ describe.skipIf(isDebug)("does not leak", () => {
 
   test("hashSync", async () => {
     await run(/* js */ `
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
         const opts = { algorithm: "argon2id", memoryCost: 8, timeCost: 1 };
         // Large warm-up so the JSC heap and allocator arenas reach steady state
         // before we start measuring (debug/ASAN builds especially need this).
@@ -43,7 +43,7 @@ describe.skipIf(isDebug)("does not leak", () => {
 
   test("hash", async () => {
     await run(/* js */ `
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
         const opts = { algorithm: "argon2id", memoryCost: 8, timeCost: 1 };
         async function batch(n) {
           const promises = [];

--- a/test/js/node/fs/readdirSync-recursive-error-leak-fixture.js
+++ b/test/js/node/fs/readdirSync-recursive-error-leak-fixture.js
@@ -14,10 +14,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 const seg = (ch, n = 220) => Buffer.alloc(n, ch).toString();
 

--- a/test/js/node/http/fixtures/http.compress.leak.server.ts
+++ b/test/js/node/http/fixtures/http.compress.leak.server.ts
@@ -20,10 +20,7 @@ function listen(server: Server, protocol: string = "http"): Promise<URL> {
   });
 }
 
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 const baseline = rss();
 let count = 0;
 

--- a/test/js/node/http2/node-http2-memory-leak.js
+++ b/test/js/node/http2/node-http2-memory-leak.js
@@ -20,10 +20,7 @@ function getHeapStats() {
   }
 }
 const gc = globalThis.gc || globalThis.Bun?.gc || (() => {});
-const rss =
-  process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 const sleep = dur => new Promise(resolve => setTimeout(resolve, dur));
 const ASAN_MULTIPLIER = process.env.ASAN_OPTIONS ? 1 / 10 : 1;
 

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -526,7 +526,7 @@ console.log("survived", require("./late.js"));`,
     // dominates RSS noise within a few thousand iterations.
     const code = /* js */ `
         const m = require("module");
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
         const comp = Buffer.alloc(30, "a").toString();
         const base = "/" + Array(20).fill(comp).join("/");
         for (let i = 0; i < 200; i++) m._nodeModulePaths(base + i);

--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -513,7 +513,7 @@ describe.skipIf(isWindows)("pipe backpressure", () => {
 
   test.concurrent("Bun.stdin.stream(): a single read does not ingest the whole pipe", async () => {
     const { first, deltaMB } = await run(`
-      const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+      const rss = process.memoryUsage.rss;
       const rd = Bun.stdin.stream().getReader();
       const c = await rd.read();
       const base = rss();
@@ -530,7 +530,7 @@ describe.skipIf(isWindows)("pipe backpressure", () => {
 
   test.concurrent("process.stdin.pause() stops the fd from being read", async () => {
     const { bytesAfter, deltaMB } = await run(`
-      const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+      const rss = process.memoryUsage.rss;
       let bytes = 0, pausedAt = 0;
       process.stdin.on("data", chunk => {
         bytes += chunk.length;

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1,5 +1,6 @@
 import { spawnSync, which } from "bun";
 import { CString, dlopen, ptr } from "bun:ffi";
+import { memoryUsage as jscMemoryUsage } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
 import { familySync } from "detect-libc";
 import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
@@ -1062,6 +1063,61 @@ describe.concurrent(() => {
 
   it("process.memoryUsage.rss", () => {
     expect(process.memoryUsage.rss()).toEqual(expect.any(Number));
+  });
+
+  // Other threads (GC, JIT) allocate and free memory while these tests run, so
+  // they compare the closest of a few back-to-back reads.
+  function closestDelta(read, reference) {
+    let best = Infinity;
+    for (let i = 0; i < 8; i++) {
+      const value = read();
+      best = Math.min(best, Math.abs(value - reference()));
+    }
+    return best;
+  }
+
+  // On macOS, rss is the task's phys_footprint ledger: the "Memory" column in
+  // Activity Monitor, not resident_size. proc_pid_rusage() hands out the same
+  // ledger and its lifetime peak, so it is the independent reference here.
+  it.skipIf(!isMacOS)("process.memoryUsage().rss is the memory footprint on macOS", () => {
+    const { symbols } = dlopen("libSystem.B.dylib", {
+      proc_pid_rusage: { args: ["int", "int", "ptr"], returns: "int" },
+    });
+    const RUSAGE_INFO_V4 = 4;
+    // struct rusage_info_v4 (<sys/resource.h>): uint8_t ri_uuid[16], then uint64_t fields.
+    const info = new BigUint64Array(2 + 35);
+    const ri_phys_footprint = 2 + 7;
+    const ri_lifetime_max_phys_footprint = 2 + 28;
+    const kernel = field => () => {
+      expect(symbols.proc_pid_rusage(process.pid, RUSAGE_INFO_V4, ptr(info))).toBe(0);
+      return Number(info[field]);
+    };
+    const footprint = kernel(ri_phys_footprint);
+    const peakFootprint = kernel(ri_lifetime_max_phys_footprint);
+
+    const MB = 1024 * 1024;
+    expect(closestDelta(() => process.memoryUsage.rss(), footprint)).toBeLessThan(4 * MB);
+    expect(closestDelta(() => process.memoryUsage().rss, footprint)).toBeLessThan(4 * MB);
+    expect(closestDelta(() => jscMemoryUsage().current, footprint)).toBeLessThan(4 * MB);
+    expect(closestDelta(() => Bun.unsafe.memoryFootprint(), footprint)).toBeLessThan(4 * MB);
+    // maxRSS is kilobytes.
+    expect(closestDelta(() => process.resourceUsage().maxRSS * 1024, peakFootprint)).toBeLessThan(4 * MB);
+    expect(closestDelta(() => jscMemoryUsage().peak, peakFootprint)).toBeLessThan(4 * MB);
+    expect(closestDelta(() => process.report.getReport().resourceUsage.maxRss, peakFootprint)).toBeLessThan(4 * MB);
+  });
+
+  it("bun:jsc memoryUsage() and process.report agree with process.memoryUsage() and resourceUsage()", () => {
+    // Everything is bytes except maxRSS (kilobytes). getReport() allocates
+    // between the two reads, hence the slack. A unit or source mix-up is off
+    // by far more: rss in kilobytes, or a peak where the current value belongs.
+    const slack = 16 * 1024 * 1024;
+    const rss = () => process.memoryUsage.rss();
+    const maxRSS = () => process.resourceUsage().maxRSS * 1024;
+    expect(closestDelta(() => jscMemoryUsage().current, rss)).toBeLessThan(slack);
+    expect(closestDelta(() => process.report.getReport().resourceUsage.rss, rss)).toBeLessThan(slack);
+    expect(closestDelta(() => jscMemoryUsage().peak, maxRSS)).toBeLessThan(slack);
+    expect(closestDelta(() => process.report.getReport().resourceUsage.maxRss, maxRSS)).toBeLessThan(slack);
+    expect(maxRSS() + slack).toBeGreaterThan(rss());
   });
 
   // JSC measures the live size of the heap at the end of each collection and

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -5,6 +5,7 @@ import { describe, expect, it } from "bun:test";
 import { familySync } from "detect-libc";
 import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import { basename, join, resolve } from "path";
+import { getHeapStatistics } from "v8";
 
 const process_sleep = resolve(import.meta.dir, "process-sleep.js");
 
@@ -1104,6 +1105,8 @@ describe.concurrent(() => {
     expect(closestDelta(() => process.resourceUsage().maxRSS * 1024, peakFootprint)).toBeLessThan(4 * MB);
     expect(closestDelta(() => jscMemoryUsage().peak, peakFootprint)).toBeLessThan(4 * MB);
     expect(closestDelta(() => process.report.getReport().resourceUsage.maxRss, peakFootprint)).toBeLessThan(4 * MB);
+    // node:v8 derives its physical size from the same peak.
+    expect(closestDelta(() => getHeapStatistics().total_physical_size, peakFootprint)).toBeLessThan(4 * MB);
   });
 
   it("bun:jsc memoryUsage() and process.report agree with process.memoryUsage() and resourceUsage()", () => {

--- a/test/js/node/tls/node-tls-set-session-leak.fixture.ts
+++ b/test/js/node/tls/node-tls-set-session-leak.fixture.ts
@@ -15,10 +15,7 @@ import tls from "node:tls";
 
 const fixturesDir = path.join(import.meta.dirname, "fixtures");
 const iterations = parseInt(process.argv[2] || "20000", 10);
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 const server = tls.createServer(
   {

--- a/test/js/node/url/pathToFileURL-leak-fixture.js
+++ b/test/js/node/url/pathToFileURL-leak-fixture.js
@@ -3,10 +3,7 @@ const isDebugBuildOfBun = globalThis?.Bun?.version?.includes("debug");
 // ASAN's quarantine retains freed allocations (default 256 MB) and shadow
 // memory raises the absolute RSS floor; widen the cap to avoid false positives.
 const isASAN = process.execPath.includes("bun-asan");
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 import { pathToFileURL } from "url";
 for (let i = 0; i < 1024 * (isDebugBuildOfBun ? 2 : 256); i++) {
   pathToFileURL(longPath);

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -1498,7 +1498,7 @@ test.skipIf(!isMacOS)("fs.watch(dir) on macOS does not leak the resolved FSEvent
       /* ts */ `
         const fs = require("fs");
         const dir = process.argv[1];
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
 
         async function cycle(count) {
           for (let i = 0; i < count; i++) fs.watch(dir, () => {}).close();

--- a/test/js/node/worker_threads/eval-source-leak-fixture.js
+++ b/test/js/node/worker_threads/eval-source-leak-fixture.js
@@ -5,10 +5,7 @@ const { Worker } = require("node:worker_threads");
 
 const eachSizeMiB = 100;
 const iterations = 5;
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 function test() {
   const code = " ".repeat(eachSizeMiB * 1024 * 1024);

--- a/test/js/node/worker_threads/worker_thread_check.ts
+++ b/test/js/node/worker_threads/worker_thread_check.ts
@@ -4,10 +4,7 @@ const RUN_COUNT = 5;
 import { Worker, isMainThread, workerData } from "worker_threads";
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 const actions = {
   async ["Bun.connect"](port) {

--- a/test/js/sql/sql-mysql-query-string-leak.test.ts
+++ b/test/js/sql/sql-mysql-query-string-leak.test.ts
@@ -20,7 +20,7 @@ if (isDockerEnabled()) {
       using dir = tempDir("mysql-query-string-leak", {
         "fixture.js": /* js */ `
         const { SQL } = require("bun");
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
 
         const sql = new SQL({ url: process.env.MYSQL_URL, max: 1 });
 

--- a/test/js/third_party/body-parser/express-memory-leak-fixture.mjs
+++ b/test/js/third_party/body-parser/express-memory-leak-fixture.mjs
@@ -1,9 +1,6 @@
 import express from "express";
 
-const rss =
-  process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 const app = express();
 const port = 0;

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -391,7 +391,7 @@ test("Bun.file(path, {type}).text() does not leak the duped content_type", async
     "data.txt": "hello",
   });
   const script = `
-    const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    const rss = process.memoryUsage.rss;
     const p = ${JSON.stringify(path.join(String(dir), "data.txt"))};
     const type = "application/x-" + Buffer.alloc(64 * 1024, "a").toString();
     const file = Bun.file(p, { type });

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1328,7 +1328,7 @@ describe.concurrent("string body consumption does not leak", () => {
           : `b => new Response(b)`;
       const src = `
         const SZ = 2_000_000, WARM = 50, BLOCK = 40;
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
         const mb = () => (rss() / 1048576) | 0;
         const body = ${makeBody};
         const make = ${make};

--- a/test/js/web/fetch/fetch-abort-stream-leak-fixture.ts
+++ b/test/js/web/fetch/fetch-abort-stream-leak-fixture.ts
@@ -1,10 +1,7 @@
 // https://github.com/oven-sh/bun/issues/32659
 import { heapStats } from "bun:jsc";
 
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 const ITER = Number(process.env.ITERATIONS ?? "60");
 const MAX_GROWTH_MB = Number(process.env.MAX_GROWTH_MB ?? "55");

--- a/test/js/web/fetch/fetch-http2-adversarial.test.ts
+++ b/test/js/web/fetch/fetch-http2-adversarial.test.ts
@@ -141,7 +141,7 @@ describe.concurrent("fetch() HTTP/2 adversarial", () => {
       },
       async url => {
         await using proc = spawnFetch(`
-          const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+          const rss = process.memoryUsage.rss;
           const baseline = rss();
           let peak = baseline;
           const t = setInterval(() => {

--- a/test/js/web/fetch/fetch-leak-test-fixture-2.js
+++ b/test/js/web/fetch/fetch-leak-test-fixture-2.js
@@ -1,9 +1,6 @@
 import { heapStats } from "bun:jsc";
 
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 const { SERVER } = process.env;
 

--- a/test/js/web/fetch/fetch-leak-test-fixture-4.js
+++ b/test/js/web/fetch/fetch-leak-test-fixture-4.js
@@ -1,9 +1,6 @@
 import { heapStats } from "bun:jsc";
 import { expect } from "bun:test";
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 function getHeapStats() {
   return heapStats().objectTypeCounts;
 }

--- a/test/js/web/fetch/fetch-leak-test-fixture-5.js
+++ b/test/js/web/fetch/fetch-leak-test-fixture-5.js
@@ -1,9 +1,6 @@
 import { heapStats } from "bun:jsc";
 import { expect } from "bun:test";
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 function getHeapStats() {
   return heapStats().objectTypeCounts;
 }

--- a/test/js/web/fetch/fetch-leak-test-fixture-6.js
+++ b/test/js/web/fetch/fetch-leak-test-fixture-6.js
@@ -1,8 +1,5 @@
 import { expect } from "bun:test";
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 let rssSample = 0;
 const url = process.env.SERVER_URL;
 const maxMemoryIncrease = parseInt(process.env.MAX_MEMORY_INCREASE || "0", 10);

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -206,7 +206,7 @@ test("fetch(data:) with percent-encoding does not leak", async () => {
   // base64 output buffer on decode error). Each fetch of a percent-encoded
   // data: URL leaked ~len(url.data) bytes from bun.default_allocator.
   const script = `
-    const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    const rss = process.memoryUsage.rss;
     // ~240KB of percent-encoded payload; the intermediate percent-decoded
     // buffer is allocated at url.data.len bytes and was previously leaked.
     const plain = "data:text/plain," + Buffer.alloc(240000, "%41").toString();
@@ -277,7 +277,7 @@ test("fetch() compress option does not leak bodies or compressor state", async (
     // > 512 KiB shared buffer → slow path; large enough that the compressed
     // output also spans multiple socket writes.
     const big = Buffer.alloc(700 * 1024, "abcdefghij");
-    const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    const rss = process.memoryUsage.rss;
     const opts = [
       { compress: "gzip" },
       { compress: "deflate" },
@@ -337,7 +337,7 @@ test("fetch() does not leak streaming decompressor state across fragmented compr
   const script = /* js */ `
     import { createServer } from "node:net";
     import { gzipSync, brotliCompressSync, zstdCompressSync } from "node:zlib";
-    const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    const rss = process.memoryUsage.rss;
 
     const plain = Buffer.alloc(64 * 1024, "abcdefghij");
     const bodies = {
@@ -455,7 +455,7 @@ describe.each(["string", "object"])("fetch({proxy}) %s form does not leak the pr
         // JS string would make href_from_js return the same StringImpl every
         // call (only the refcount grows, RSS stays flat) and hide the leak.
         const pad = Buffer.alloc(256 * 1024, "a").toString();
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
 
         async function hit(i) {
           const proxyUrl = "http://127.0.0.1:1/" + i + "/" + pad;
@@ -534,7 +534,7 @@ test.concurrent(
     // Windows strips the leading "/" then asserts is_absolute_windows() in
     // PosixToWinNormalizer under debug_assertions, which needs a drive letter.
     const prefix = process.platform === "win32" ? "file:///C:/" : "file:///";
-    const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    const rss = process.memoryUsage.rss;
     async function hit(i) {
       // Fresh path per iteration so each leaked ref pins a distinct impl.
       // The file does not exist; the Response is created (with url_string set)
@@ -676,7 +676,7 @@ describe("Request body HiveRef pool returns slot via Body.Value.deinit (does not
         const payload = Buffer.alloc(128 * 1024, 0x61); // 128 KiB of 'a'
         const str = payload.toString("latin1");
         const sharedBlob = new Blob([payload]);
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
 
         function makeBody() {
           ${

--- a/test/js/web/fetch/fetch-redirect.test.ts
+++ b/test/js/web/fetch/fetch-redirect.test.ts
@@ -307,7 +307,7 @@ it("fetch() does not leak intermediate redirect URLs in multi-hop chains", async
   // pollute the RSS we measure. The child samples RSS after warmup and
   // again after two equal batches so we can assert on steady-state growth.
   const script = `
-    const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    const rss = process.memoryUsage.rss;
     const url = "${server.url.origin}/hop/0";
     async function once() {
       const res = await fetch(url, { redirect: "follow" });

--- a/test/js/web/html/FormData-file-error-leak-fixture.ts
+++ b/test/js/web/html/FormData-file-error-leak-fixture.ts
@@ -15,10 +15,7 @@
 // `using tempDir(...)` so cleanup is guaranteed even if this process is
 // killed by signal.
 
-const rss =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 const iterations = parseInt(process.env.ITERATIONS || "100", 10);
 const warmup = parseInt(process.env.WARMUP || "10", 10);
 const realPath = process.env.REAL_PATH;

--- a/test/js/web/timers/setInterval-leak-fixture.js
+++ b/test/js/web/timers/setInterval-leak-fixture.js
@@ -5,10 +5,7 @@ let runs = initialRuns;
 // run far higher under bun-asan; widen the threshold to avoid false positives.
 const isASAN = process.execPath.includes("bun-asan");
 
-const usage =
-  process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const usage = process.memoryUsage.rss;
 
 Promise.withResolvers ??= () => {
   let promise, resolve, reject;

--- a/test/js/web/timers/setTimeout-clear-in-callback-leak-fixture.js
+++ b/test/js/web/timers/setTimeout-clear-in-callback-leak-fixture.js
@@ -12,10 +12,7 @@ if (mode !== "clear" && mode !== "refresh" && mode !== "repeat") {
 // ASAN's quarantine retains freed allocations (default 256 MB) so RSS deltas
 // run far higher under bun-asan; widen the threshold to avoid false positives.
 const isASAN = process.execPath.includes("bun-asan");
-const rss =
-  process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 const BATCH = 2_000;
 

--- a/test/js/web/timers/setinterval-cancel-fixture.js
+++ b/test/js/web/timers/setinterval-cancel-fixture.js
@@ -2,10 +2,7 @@ const huge = Array.from({ length: 1000000 }, () => 0);
 huge.fill(0);
 let hasRun = false;
 const gc = typeof Bun !== "undefined" ? Bun.gc : typeof globalThis.gc !== "undefined" ? globalThis.gc : () => {};
-const rss =
-  process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 var timers = new Array(50_000);
 

--- a/test/js/web/websocket/websocket.test.js
+++ b/test/js/web/websocket/websocket.test.js
@@ -878,7 +878,7 @@ describe("WebSocket tls option does not leak SSLConfig on error paths", () => {
     // 256 KiB duped per SSLConfig -> ~128 MiB per path if every iteration leaks.
     const bigCA = Buffer.alloc(256 * 1024, "A").toString();
     const tls = { ca: bigCA, rejectUnauthorized: false };
-    const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+    const rss = process.memoryUsage.rss;
 
     function hit() {
       // Path 1: getter on a later option throws after the SSLConfig has

--- a/test/js/web/workers/message-port-closed-leak.test.ts
+++ b/test/js/web/workers/message-port-closed-leak.test.ts
@@ -10,7 +10,7 @@ describe("MessagePortChannel closed port", () => {
         bunExe(),
         "-e",
         `
-          const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+          const rss = process.memoryUsage.rss;
           const { port1, port2 } = new MessageChannel();
           port2.close();
 
@@ -65,7 +65,7 @@ describe("MessagePortChannel closed port", () => {
           bunExe(),
           "-e",
           `
-            const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+            const rss = process.memoryUsage.rss;
             const closeBeforePost = ${closeBeforePost};
             const ITERATIONS = 1000;
             const PAYLOAD_SIZE = 128 * 1024;

--- a/test/js/web/workers/message-port-context-destroy-leak.test.ts
+++ b/test/js/web/workers/message-port-context-destroy-leak.test.ts
@@ -20,7 +20,7 @@ test.skipIf(isWindows)(
         bunExe(),
         "-e",
         `
-        const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+        const rss = process.memoryUsage.rss;
         const workerBody = ${JSON.stringify(`
           const keep = [];
           for (let i = 0; i < 8000; i++) {

--- a/test/js/web/workers/performance-observer-leak.test.ts
+++ b/test/js/web/workers/performance-observer-leak.test.ts
@@ -24,7 +24,7 @@ test("PerformanceObserver without disconnect() does not leak Performance when Wo
       // Intentionally never call observer.disconnect().
     `,
     "main.js": `
-      const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+      const rss = process.memoryUsage.rss;
       const workerPath = new URL("./worker.js", import.meta.url).href;
 
       async function runOne() {

--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -179,7 +179,7 @@ test.skipIf(isDebug)(
   "HTMLRewriter does not leak element/document handler allocations",
   async () => {
     const code = /* js */ `
-      const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+      const rss = process.memoryUsage.rss;
       const noop = { element() {}, comments() {}, text() {} };
       const docNoop = { doctype() {}, comments() {}, text() {}, end() {} };
 

--- a/test/napi/napi-app/leak-fixture.js
+++ b/test/napi/napi-app/leak-fixture.js
@@ -1,10 +1,7 @@
 // UNUSED as of #14501
 const nativeTests = require("./build/Debug/napitests.node");
 
-const rss =
-  process.platform === "darwin" && typeof Bun !== "undefined" && typeof Bun.unsafe.memoryFootprint === "function"
-    ? Bun.unsafe.memoryFootprint
-    : process.memoryUsage.rss;
+const rss = process.memoryUsage.rss;
 
 function usage() {
   return rss();

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1655,7 +1655,7 @@ describe.skipIf(!canBuildNodeAddons())("napi_create_string_latin1", () => {
   it("does not leak the WTFStringImpl", async () => {
     const fixture = /* js */ `
       const nativeTests = require(${JSON.stringify(join(__dirname, "napi-app/build/Debug/napitests.node"))});
-      const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+      const rss = process.memoryUsage.rss;
       const size = 256 * 1024;
       for (let i = 0; i < 20; i++) {
         const s = nativeTests.create_latin1_string(size);

--- a/test/regression/issue/28756.test.ts
+++ b/test/regression/issue/28756.test.ts
@@ -12,7 +12,7 @@ test("AbortSignal.timeout + util.aborted does not leak memory", async () => {
       "-e",
       `
       const { aborted } = require("util");
-      const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;
+      const rss = process.memoryUsage.rss;
 
       // 10 batches * 8000 = 80k signals.
       // Without fix: leaks ~0.8 KB/signal => ~60 MB growth.


### PR DESCRIPTION
### Problem
- On macOS, `process.memoryUsage().rss` reads `TASK_BASIC_INFO.resident_size` (`getRSS`, `src/jsc/bindings/BunProcess.cpp`). Activity Monitor shows the `phys_footprint` ledger, so the two numbers disagree.
- `resident_size` counts clean file-backed pages and pages freed with `MADV_FREE_REUSABLE` that the kernel has not reclaimed. It misses compressed and swapped memory.

### Fix
- `getRSS()` reads `task_info(TASK_VM_INFO).phys_footprint` on macOS. libuv made the same change in `uv_resident_set_memory` (libuv/libuv#5217, not released yet), so Node reports this number once it bundles that libuv.
- A new `getPeakRSS()` reads `ledger_phys_footprint_peak` on macOS (`ru_maxrss` or `PeakWorkingSetSize` elsewhere). This part differs from Node for good: libuv's `uv_getrusage` still reports `ru_maxrss`. The peak must come from the same ledger, or `rss` can exceed `maxRSS` when memory is compressed.
- All readers use the two helpers: `process.memoryUsage()`, `.rss()`, `process.resourceUsage().maxRSS`, `bun:jsc` `memoryUsage()`, `process.report`, the crash report `RSS:` line, the dev server visualizer, `Bun.unsafe.memoryFootprint()`.
- Verified: `test/js/node/process/process.test.js`. The macOS test compares each reader with `proc_pid_rusage`. The cross-platform test fails on Linux without the `src/` change.

### Background
- `phys_footprint` is a per-task kernel ledger: anonymous memory (resident or compressed), IOKit mappings, page tables. `footprint(1)` and the jetsam limits use it.
- `MADV_FREE_REUSABLE` lets the kernel take pages back. They leave `phys_footprint` at once but stay in `resident_size` until reclaimed. mimalloc and JavaScriptCore both use it, so `resident_size` acted like a high-water mark.
- The second commit is mechanical: 72 test files picked `Bun.unsafe.memoryFootprint` on macOS for that reason. They now call `process.memoryUsage.rss`.

<details><summary>Notes</summary>

Values that change outside macOS:
- `process.report.getReport().resourceUsage.rss` was `ru_maxrss` (a peak, in KB on Linux). It is now the current value in bytes. `maxRss` was `ru_maxrss` in KB on Linux and is now bytes. Node reports both in bytes.
- FreeBSD crash report: the `RSS:` line came from mimalloc, which has no FreeBSD reader and printed its commit count. It now prints `ki_rssize` through `getRSS()`.
- Linux and Windows values of every other reader stay the same.

macOS numbers that differ from Node after Node picks up libuv/libuv#5217: `process.resourceUsage().maxRSS`, `process.report` `maxRss`, `bun:jsc` `memoryUsage().peak`, and the `v8.getHeapStatistics()` fields derived from that peak (`total_physical_size`, `peak_malloced_memory`, `heap_size_limit`).

Not in this PR: `Bun.spawn`'s `resourceUsage().maxRSS` for a child process. It comes from the `rusage` that `wait4` returns, which is the peak `resident_size`. The peak footprint of a child is available from `proc_pid_rusage` on the exited child before it is reaped (`/usr/bin/time -l` does that). That is a change to the reaping path.

Not in this PR: the other placeholder fields of `process.report`'s `resourceUsage` (`free_memory`, `total_memory`, `available_memory`, the CPU fields). #34403 covers them. #34403 and #30596 read the peak on their own (`ru_maxrss`, `mi_process_info`). They need `Bun::getPeakRSS()` after this lands, and the macOS test now checks `v8.getHeapStatistics().total_physical_size` for that reason.

`test/bundler/bun-build-api.test.ts` ("repeated builds don't retain the generated code") allowed 400 MB of growth on macOS because freed pages left `resident_size` lazily. It now uses the same 40 MB bound as Linux and Windows, and passes with it on the darwin aarch64 and darwin x64 CI lanes.

Standalone check of the same `task_info` calls on macOS 26.6.1 (arm64), C program, values in KB:

```
                              phys_footprint  footprint peak  resident_size
startup                                  896             896           1312
after 64MB dirty anon                  66480           66480          66848
after MADV_FREE_REUSABLE                 944           66480          66848
after touching 64MB file map            2016           66480         133424
```

`phys_footprint` and `ledger_phys_footprint_peak` matched `proc_pid_rusage`'s `ri_phys_footprint` and `ri_lifetime_max_phys_footprint` exactly at each step. `sizeof(struct rusage_info_v4)` is 296, `ri_phys_footprint` is at offset 72 and `ri_lifetime_max_phys_footprint` at offset 240. The macOS test relies on those offsets.

`ledger_phys_footprint_peak` is a rev3 field of `task_vm_info` (macOS 10.15). Bun's deployment target is 13.0.

Suites run locally on Linux with the debug build: `test/js/node/process/process.test.js` (one unrelated failure: the container has no `USER` env var), `test/js/bun/jsc/bun-jsc.test.ts`. 26 of the touched test files also pass on Linux with a release build. `fetch-leak.test.ts` "should not leak using readable stream" fails there with and without this change. I could not build for macOS locally. The macOS test first ran in CI, where `process.test.js` passes on the darwin aarch64 and darwin x64 lanes.
</details>
