### PR TITLE
test(http2): cover session.socket after the session is destroyed

### DIFF
--- a/test/js/node/http2/node-http2-session-socket.test.ts
+++ b/test/js/node/http2/node-http2-session-socket.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Http2Session#socket once the session has detached from its socket.
+ *
+ * Each session caches the Proxy that `session.socket` returns. After destroy() every trap of that
+ * Proxy throws ERR_HTTP2_SOCKET_UNBOUND, including the getPrototypeOf trap that `instanceof` calls.
+ * Node returns undefined from the getter from then on, so the getter must not return the cached Proxy.
+ *
+ * Works with both:
+ *   bun bd test test/js/node/http2/node-http2-session-socket.test.ts
+ *   node --test test/js/node/http2/node-http2-session-socket.test.ts
+ */
+import assert from "node:assert";
+import { once } from "node:events";
+import http2 from "node:http2";
+import net from "node:net";
+import { test } from "node:test";
+
+type Side = { session: http2.Http2Session; socketBefore: unknown };
+
+function isSocket(value: unknown): boolean | string {
+  try {
+    return value instanceof net.Socket;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code ?? String(e);
+  }
+}
+
+function probe({ session, socketBefore }: Side) {
+  return {
+    before: typeof socketBefore,
+    after: typeof session.socket,
+    afterIsSocket: isSocket(session.socket),
+    // A reference taken before destroy() still throws, as in node.
+    beforeIsSocket: isSocket(socketBefore),
+  };
+}
+
+test("session.socket is undefined after the session is destroyed", async () => {
+  const server = http2.createServer();
+  let client: http2.ClientHttp2Session | undefined;
+  try {
+    const serverSide = Promise.withResolvers<Side>();
+    const serverSideClosed = Promise.withResolvers<void>();
+    server.on("session", session => {
+      session.on("error", () => {});
+      session.on("close", () => serverSideClosed.resolve());
+      // Read the getter while the socket is attached, so the session caches its Proxy.
+      serverSide.resolve({ session, socketBefore: session.socket });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
+    await once(client, "connect");
+    const sides = { client: { session: client, socketBefore: client.socket }, server: await serverSide.promise };
+
+    const clientSideClosed = once(client, "close");
+    client.destroy();
+    await Promise.all([clientSideClosed, serverSideClosed.promise]);
+
+    const detached = {
+      before: "object",
+      after: "undefined",
+      afterIsSocket: false,
+      beforeIsSocket: "ERR_HTTP2_SOCKET_UNBOUND",
+    };
+    assert.deepStrictEqual(
+      { client: probe(sides.client), server: probe(sides.server) },
+      { client: detached, server: detached },
+    );
+  } finally {
+    client?.destroy();
+    server.close();
+  }
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1832,50 +1832,6 @@ it("Symbol keys of the headers object are not sent as headers", async () => {
   }
 });
 
-// Each session caches the Proxy that session.socket returns. After destroy()
-// the traps of that Proxy throw ERR_HTTP2_SOCKET_UNBOUND, including the
-// getPrototypeOf trap that instanceof calls. The getter must not return it.
-it("session.socket is undefined after the session is destroyed", async () => {
-  const server = http2.createServer();
-  try {
-    const serverSide = Promise.withResolvers();
-    const serverSideClosed = Promise.withResolvers();
-    server.on("session", session => {
-      session.on("error", () => {});
-      session.on("close", serverSideClosed.resolve);
-      serverSide.resolve({ session, socketBefore: session.socket });
-    });
-    const listening = Promise.withResolvers();
-    server.on("error", listening.reject);
-    server.listen(0, "127.0.0.1", listening.resolve);
-    await listening.promise;
-
-    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
-    const connected = Promise.withResolvers();
-    client.on("error", connected.reject);
-    client.on("connect", connected.resolve);
-    await connected.promise;
-    const sides = [{ session: client, socketBefore: client.socket }, await serverSide.promise];
-
-    const clientSideClosed = Promise.withResolvers();
-    client.on("close", clientSideClosed.resolve);
-    client.destroy();
-    await Promise.all([clientSideClosed.promise, serverSideClosed.promise]);
-
-    for (const { session, socketBefore } of sides) {
-      expect(socketBefore).toBeDefined();
-      expect(session.socket).toBeUndefined();
-      expect(session.socket instanceof net.Socket).toBe(false);
-      // A reference taken before destroy() still throws, as in node.
-      expect(() => socketBefore instanceof net.Socket).toThrow(
-        expect.objectContaining({ code: "ERR_HTTP2_SOCKET_UNBOUND" }),
-      );
-    }
-  } finally {
-    server.close();
-  }
-});
-
 it("http2 session.goaway() validates input types", async done => {
   const { mustCall } = createCallCheckCtx(done);
   const server = http2.createServer((req, res) => {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1832,6 +1832,50 @@ it("Symbol keys of the headers object are not sent as headers", async () => {
   }
 });
 
+// Each session caches the Proxy that session.socket returns. After destroy()
+// the traps of that Proxy throw ERR_HTTP2_SOCKET_UNBOUND, including the
+// getPrototypeOf trap that instanceof calls. The getter must not return it.
+it("session.socket is undefined after the session is destroyed", async () => {
+  const server = http2.createServer();
+  try {
+    const serverSide = Promise.withResolvers();
+    const serverSideClosed = Promise.withResolvers();
+    server.on("session", session => {
+      session.on("error", () => {});
+      session.on("close", serverSideClosed.resolve);
+      serverSide.resolve({ session, socketBefore: session.socket });
+    });
+    const listening = Promise.withResolvers();
+    server.on("error", listening.reject);
+    server.listen(0, "127.0.0.1", listening.resolve);
+    await listening.promise;
+
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    const connected = Promise.withResolvers();
+    client.on("error", connected.reject);
+    client.on("connect", connected.resolve);
+    await connected.promise;
+    const sides = [{ session: client, socketBefore: client.socket }, await serverSide.promise];
+
+    const clientSideClosed = Promise.withResolvers();
+    client.on("close", clientSideClosed.resolve);
+    client.destroy();
+    await Promise.all([clientSideClosed.promise, serverSideClosed.promise]);
+
+    for (const { session, socketBefore } of sides) {
+      expect(socketBefore).toBeDefined();
+      expect(session.socket).toBeUndefined();
+      expect(session.socket instanceof net.Socket).toBe(false);
+      // A reference taken before destroy() still throws, as in node.
+      expect(() => socketBefore instanceof net.Socket).toThrow(
+        expect.objectContaining({ code: "ERR_HTTP2_SOCKET_UNBOUND" }),
+      );
+    }
+  } finally {
+    server.close();
+  }
+});
+
 it("http2 session.goaway() validates input types", async done => {
   const { mustCall } = createCallCheckCtx(done);
   const server = http2.createServer((req, res) => {


### PR DESCRIPTION
### Problem
- `session.socket` must be `undefined` after an `Http2Session` is destroyed ([Node docs](https://nodejs.org/api/http2.html#http2sessionsocket)). #34432 (a07354aca7) fixed both getters, at `src/js/node/http2.ts:4554` and `:5553`. No test covers that behavior.
- Before #34432, a session that had handed out its socket proxy returned that proxy forever. After `destroy()`, `session.socket instanceof net.Socket` threw `ERR_HTTP2_SOCKET_UNBOUND`.

### Fix
- Add `test/js/node/http2/node-http2-session-socket.test.ts` with one test. There is no change under `src/`.
- The test reads `session.socket` on the client session and on the server session while the socket is attached. It destroys the client and waits for `'close'` on both sessions. Then `session.socket` is `undefined` on both sides. A reference taken before `destroy()` still throws `ERR_HTTP2_SOCKET_UNBOUND`.
- The file uses `node:test` and `node:assert`, like `node-http2-client-close.test.ts`. The same file passes under `node --test` (v26.3.0) and `bun bd test`.
- Verified: `bun bd test test/js/node/http2/node-http2-session-socket.test.ts` passes in 25 of 25 runs. With both getters put back to their form before #34432, the test fails for both sessions (`after: 'object'`, `afterIsSocket: 'ERR_HTTP2_SOCKET_UNBOUND'`).

### Background
- An `Http2Session` owns a `net.Socket` or a `tls.TLSSocket`. `session.socket` returns a `Proxy` around the session, not the socket. The `Proxy` blocks methods such as `write` and `destroy`, because a raw write corrupts the HTTP/2 framing.
- Each session caches that `Proxy` in `#socket_proxy`. `destroy()` clears the real socket (`this[bunHTTP2Socket]`). From then on every trap of the cached `Proxy` throws `ERR_HTTP2_SOCKET_UNBOUND`. That includes `getPrototypeOf`, which `instanceof` calls.
- Teardown code often guards with `if (session.socket && !session.socket.destroyed)`. That guard needs `undefined`, not the stale `Proxy`.

<details><summary>Notes</summary>

- The test comes from #33791. That PR proposed the same getter change and is now closed, because #34432 landed it first. The test there covered the client session only. This version also covers the server session, because #34432 changed both getters.
- The first version of this PR added the test to `node-http2.test.js`. It now has its own file. A run of that whole file with a debug build has timing sensitive tests: on a machine under load, the `http2 DATA payload survives its ArrayBuffer being detached/resized by transport JS mid-send` block reaches its 5000 ms timeouts (9 of 9 with 3 CPUs), and `http2 server with minimal maxSessionMemory handles multiple requests` timed out once on macOS aarch64 in build 114070 before it passed on the retry. The new test passed in each of those runs.
- The test waits for the server `'session'` event before it destroys the client. So the server always has a session to close, and the test does not depend on the accept order.
- Output with the getters of main:

  ```
  $ node --test test/js/node/http2/node-http2-session-socket.test.ts
  ✔ session.socket is undefined after the session is destroyed (13.511606ms)
  ℹ tests 1
  ℹ pass 1
  ℹ fail 0

  $ bun bd test test/js/node/http2/node-http2-session-socket.test.ts
  (pass) session.socket is undefined after the session is destroyed [695.49ms]
   1 pass
   0 fail
  ```

- Output with the getters put back to their form before #34432:

  ```
    client: {
  +     after: 'object',
  +     afterIsSocket: 'ERR_HTTP2_SOCKET_UNBOUND',
  -     after: 'undefined',
  -     afterIsSocket: false,
        before: 'object',
        beforeIsSocket: 'ERR_HTTP2_SOCKET_UNBOUND'
    },
    server: { (the same four lines) }
  ```

- `test/js/node/test/parallel/test-http2-unbound-socket-proxy.js` already covers the captured reference on the client. It does not read `session.socket` again after the close.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/http2/node-http2-session-socket.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/node/http2/node-http2-session-socket.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/http2/node-http2-session-socket.test.ts:
(pass) session.socket is undefined after the session is destroyed [726.66ms]

 1 pass
 0 fail
Ran 1 test across 1 file. [3.51s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../node/http2/node-http2-session-socket.test.ts   | 75 ++++++++++++++++++++++
 1 file changed, 75 insertions(+)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
test/js/node/http2/node-http2-session-socket.test.ts      0      1      7
```

</details>

<!-- robobun:evidence:end -->