### PR TITLE
spawn: enforce maxBuffer when lazy is set

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7797,6 +7797,9 @@ declare module "bun" {
        * This can improve performance when you don't need to read output
        * immediately.
        *
+       * Has no effect when `maxBuffer` is set. Output is counted against
+       * `maxBuffer` as it is read, so reading starts right away.
+       *
        * @default false
        *
        * @example

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1696,6 +1696,11 @@ fn spawn_maybe_sync(
         }
     }
 
+    // `maxBuffer` is charged only as bytes are read. A reader that waits for the
+    // first JS pull never counts the child's output, so it never kills the
+    // child. The budget itself bounds what an eager reader can buffer.
+    let lazy = !is_sync && lazy && max_buffer.is_none();
+
     // Start the readers before the Writable::Buffer stdin writer so that if
     // the writer's start() throws below, both PipeReaders have taken their
     // start() ref and on_process_exit's later drain is refcount-balanced.
@@ -1703,8 +1708,8 @@ fn spawn_maybe_sync(
         // Note: pass `subprocess_nn` (the `NonNull<Subprocess<'static>>`
         // captured above) instead of the live `&mut subprocess`, which would
         // alias with the `&mut subprocess.stdout` borrow held by `pipe`.
-        Readable::pipe_reader_mut(pipe).start(subprocess_nn, event_loop_nn, !is_sync && lazy);
-        if (is_sync || !lazy) && matches!(subprocess.stdout.get(), Readable::Pipe(_)) {
+        Readable::pipe_reader_mut(pipe).start(subprocess_nn, event_loop_nn, lazy);
+        if !lazy && matches!(subprocess.stdout.get(), Readable::Pipe(_)) {
             if let Readable::Pipe(pipe) = subprocess.stdout.get() {
                 Readable::pipe_reader_mut(pipe).read_all();
             }
@@ -1713,9 +1718,9 @@ fn spawn_maybe_sync(
 
     if let Readable::Pipe(pipe) = subprocess.stderr.get() {
         // Note: see stdout arm above — avoid aliased &mut.
-        Readable::pipe_reader_mut(pipe).start(subprocess_nn, event_loop_nn, !is_sync && lazy);
+        Readable::pipe_reader_mut(pipe).start(subprocess_nn, event_loop_nn, lazy);
 
-        if (is_sync || !lazy) && matches!(subprocess.stderr.get(), Readable::Pipe(_)) {
+        if !lazy && matches!(subprocess.stderr.get(), Readable::Pipe(_)) {
             if let Readable::Pipe(pipe) = subprocess.stderr.get() {
                 Readable::pipe_reader_mut(pipe).read_all();
             }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1696,9 +1696,7 @@ fn spawn_maybe_sync(
         }
     }
 
-    // `maxBuffer` is charged only as bytes are read. A reader that waits for the
-    // first JS pull never counts the child's output, so it never kills the
-    // child. The budget itself bounds what an eager reader can buffer.
+    // `maxBuffer` is charged as bytes are read, so a paused reader would never enforce it.
     let lazy = !is_sync && lazy && max_buffer.is_none();
 
     // Start the readers before the Writable::Buffer stdin writer so that if

--- a/test/js/bun/spawn/spawn-maxbuf.test.ts
+++ b/test/js/bun/spawn/spawn-maxbuf.test.ts
@@ -168,14 +168,14 @@ describe.each(["stdout", "stderr"] as const)("maxBuffer kills the process with l
       killSignal,
     });
     await proc.exited;
-    expect({ exitCode: proc.exitCode, signalCode: proc.signalCode }).toEqual({
-      exitCode: null,
-      signalCode: killSignal,
-    });
     // A late reader still gets what was read up to the limit.
     const bytes = await proc[fd].bytes();
     expect(bytes.length).toBeGreaterThan(1000);
     expect(bytes.length).toBeLessThanOrEqual(1000 + 64 * 1024);
+    expect({ exitCode: proc.exitCode, signalCode: proc.signalCode }).toEqual({
+      exitCode: null,
+      signalCode: killSignal,
+    });
   });
 });
 

--- a/test/js/bun/spawn/spawn-maxbuf.test.ts
+++ b/test/js/bun/spawn/spawn-maxbuf.test.ts
@@ -148,6 +148,37 @@ describe.each(["stdout", "stderr"] as const)("maxBuffer kills the process after 
   });
 });
 
+// `lazy: true` defers the pipe reads until JS first pulls, and `maxBuffer` is
+// only charged as bytes are read. `maxBuffer` must still count the output of a
+// child whose pipes nothing has read yet.
+describe.each(["stdout", "stderr"] as const)("maxBuffer kills the process with lazy: true and .%s unread", fd => {
+  // The child writes well past `maxBuffer` and then blocks forever. Without the
+  // kill, `proc.exited` never resolves and the test times out.
+  const firehose = `process.${fd}.write(Buffer.alloc(300000, 65).toString()); setInterval(() => {}, 1e9);`;
+  const killSignal = isWindows ? "SIGKILL" : "SIGHUP";
+
+  test.concurrent("Bun.spawn", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", firehose],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      lazy: true,
+      maxBuffer: 1000,
+      killSignal,
+    });
+    await proc.exited;
+    expect({ exitCode: proc.exitCode, signalCode: proc.signalCode }).toEqual({
+      exitCode: null,
+      signalCode: killSignal,
+    });
+    // A late reader still gets what was read up to the limit.
+    const bytes = await proc[fd].bytes();
+    expect(bytes.length).toBeGreaterThan(1000);
+    expect(bytes.length).toBeLessThanOrEqual(1000 + 64 * 1024);
+  });
+});
+
 describe("maxBuffer infinity does not limit the number of bytes", () => {
   const sample = "this is a long example string\n";
   const sample_repeat_count = 10000;


### PR DESCRIPTION
### Problem
- `Bun.spawn({ lazy: true, maxBuffer })` never kills a child that writes past `maxBuffer` while nothing reads its pipes. The child blocks in `write()` on the full stdout socketpair, and `proc.exited` never settles.
- `lazy` starts the `PipeReader` paused (`PosixFlags::IS_PAUSED`, `SubprocessPipeReader.rs:192`; on Windows it defers `uv_read_start`). `MaxBuf::on_read_bytes` (`src/io/MaxBuf.rs:147`) runs only from the read path, so `on_max_buffer_overflow` (`subprocess.rs:678`) never runs. `timeout` has its own timer and still works.

### Fix
- `spawn_maybe_sync` starts the stdout and stderr readers eagerly when `maxBuffer` is set (`js_bun_spawn_bindings.rs:1699`). Without `maxBuffer`, `lazy` behaves as before.
- Correct because `lazy` exists to stop an unread pipe from buffering without bound, and `maxBuffer` already bounds it: reading stops at `maxBuffer` plus one 64 KiB read for each pipe (#33309).
- `node:child_process` does not change. It passes `lazy: true`, but it never passes `maxBuffer` to the async `Bun.spawn`.
- Verified: `test/js/bun/spawn/spawn-maxbuf.test.ts` (two new tests, both time out on stock bun). Also `spawn.test.ts`, `child_process.test.ts`, and the five `test-child-process-*-maxbuf.js` tests.

### Background
- `maxBuffer` is a documented kill limit: a process that outputs more bytes is killed with `killSignal`. A `MaxBuf` holds the remaining byte budget of one pipe, and each read charges it.
- `lazy: true` defers the pipe reads until JS first pulls from `proc.stdout` or `proc.stderr`. Until then the kernel pipe buffer blocks the child (#34971).
- A reader can count only the bytes that it reads. A byte limit and a deferred reader cannot both hold, so one option must yield.

<details><summary>Notes</summary>

Repro (run as `bun x.mjs hang | touch | eager`):

```js
const mode = process.argv[2], t0 = Date.now();
const p = Bun.spawn({ cmd: ["sh", "-c", "head -c 300000 /dev/zero; sleep 1; exit 3"], maxBuffer: 1000, ...(mode === "eager" ? {} : { lazy: true }) });
p.exited.then(c => console.log(`[+${Date.now() - t0} ms] exited ->`, c, p.signalCode));
if (mode === "touch") setTimeout(() => p.stdout.getReader().read().then(r => console.log(`[+${Date.now() - t0} ms] read ->`, r.value.length, "B")), 1500);
setTimeout(() => { console.log("guard: exitCode", p.exitCode); p.kill(9); }, 5000).unref();
```

| mode | 1.4.3-canary.1+4ff919377 | this branch (debug build) |
| --- | --- | --- |
| `eager` | `[+2 ms] exited -> 143 SIGTERM` | `[+24 ms] exited -> 143 SIGTERM` |
| `touch` | `[+1502 ms] read -> 66536 B`, then `[+1502 ms] exited -> 143 SIGTERM` | `[+25 ms] exited -> 143 SIGTERM`, then `[+1525 ms] read -> 16384 B` |
| `hang` | `guard: exitCode null` at +5003 ms, child never killed | `[+19 ms] exited -> 143 SIGTERM` |

On stock bun, `strace` shows that the only `EPOLL_CTL_ADD` after the spawn is the pidfd. The stdout socketpair fd is never registered or read until the first pull. At the first pull, `recvfrom(8, ..., 66536, MSG_DONTWAIT) = 66536` is followed at once by `kill(<child>, SIGTERM)`.

The other shape for this fix is to reject `lazy: true` together with `maxBuffer` as an argument error. I did not choose it. It breaks a caller that forwards both options, and the eager reader is already bounded by the limit. Node has the same model: `maxBuffer` exists only on `exec` and `execFile`, and those always read.

`maxBuffer: Infinity`, `0`, a negative number, or `NaN` does not set a limit, so `lazy` still applies with those values.

Suites run against the debug build:
- `test/js/bun/spawn/spawn-maxbuf.test.ts`: 18 pass.
- `test/js/bun/spawn/spawn.test.ts`: 0 fail.
- `test/js/node/child_process/child_process.test.ts`: 65 pass, 2 fail. `should allow us to spawn in the default shell` fails the same way on stock bun in this container (`$SHELL` is empty in the child). `extra stdio pipes are not double-closed on GC` runs 20 debug children in sequence and exceeds the 5 s budget under ASAN. Neither test sets `maxBuffer`, and with no `maxBuffer` the new expression is equal to the old one.
- `test-child-process-{exec,execfile,execfilesync,execsync,spawnsync}-maxbuf.js`: all exit 0.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-maxbuf.test.ts

<!-- robobun:evidence:end -->