### PR TITLE
bun-types: correct the JSDoc for spawn `lazy` and JSON5.stringify quotes

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2087,7 +2087,7 @@ declare module "bun" {
 
     /**
      * Convert a JavaScript value into a JSON5 string. Object keys that are
-     * valid identifiers are unquoted, strings use double quotes, `Infinity`
+     * valid identifiers are unquoted, strings use single quotes, `Infinity`
      * and `NaN` are represented as literals, and indented output includes
      * trailing commas.
      *
@@ -2104,7 +2104,7 @@ declare module "bun" {
      * import { JSON5 } from "bun";
      *
      * console.log(JSON5.stringify({ a: 1, b: "two" }));
-     * // {a:1,b:"two"}
+     * // {a:1,b:'two'}
      *
      * console.log(JSON5.stringify({ a: 1, b: 2 }, null, 2));
      * // {
@@ -7791,8 +7791,12 @@ declare module "bun" {
       extends BaseOptions<In, Out, Err> {
       /**
        * If true, the stdout and stderr pipes don't automatically start reading
-       * data. Reading begins only when you access the `stdout` or `stderr`
-       * properties.
+       * data. Reading begins when you first read from the `stdout` or `stderr`
+       * stream, for example with `.text()` or `.getReader()`. Accessing the
+       * property alone does not start it.
+       *
+       * Until reading begins, a child process that fills the operating system's
+       * pipe buffer blocks on its next write.
        *
        * This can improve performance when you don't need to read output
        * immediately.
@@ -7803,7 +7807,7 @@ declare module "bun" {
        * ```ts
        * const subprocess = Bun.spawn({
        *   cmd: ["echo", "hello"],
-       *   lazy: true, // Don't start reading stdout until accessed
+       *   lazy: true, // Don't start reading stdout until it is read from
        * });
        * // stdout reading hasn't started yet
        * await subprocess.stdout.text(); // Now reading starts

--- a/test/integration/bun-types/jsdoc-examples.test.ts
+++ b/test/integration/bun-types/jsdoc-examples.test.ts
@@ -1,0 +1,99 @@
+// Runs what the JSDoc in packages/bun-types/bun.d.ts says about runtime behavior.
+// bun-types.test.ts type-checks the declarations. Nothing there executes an @example.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const dtsPath = join(import.meta.dir, "..", "..", "..", "packages", "bun-types", "bun.d.ts");
+const dts = readFileSync(dtsPath, "utf8");
+
+/** The code in the `@example` fence of `export function <fn>` in `namespace <ns>`. */
+function exampleOf(ns: string, fn: string): string {
+  const namespace = dts.indexOf(`\n  namespace ${ns} {\n`);
+  const declaration = namespace === -1 ? -1 : dts.indexOf(`\n    export function ${fn}(`, namespace);
+  if (declaration === -1) throw new Error(`${dtsPath} does not declare ${ns}.${fn}`);
+
+  const end = dts.lastIndexOf("*/", declaration);
+  const jsdoc = dts.slice(dts.lastIndexOf("/**", end), end).replace(/^[ \t]*\* ?/gm, "");
+  const fence = /^@example\n```\w*\n([\s\S]*?)\n```/m.exec(jsdoc);
+  if (fence === null) throw new Error(`${dtsPath}: the JSDoc of ${ns}.${fn} has no @example fence`);
+  return fence[1];
+}
+
+/** The `//` comment lines right after each `console.log(...);` are the output the example documents. */
+function documentedOutput(example: string): string {
+  const lines = example.split("\n");
+  const output: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^console\.log\(.*\);$/.test(lines[i])) continue;
+    while (lines[i + 1]?.startsWith("//")) output.push(lines[++i].replace(/^\/\/ ?/, ""));
+  }
+  return output.map(line => line + "\n").join("");
+}
+
+test.concurrent("the JSON5.stringify @example prints what its comments say", async () => {
+  const example = exampleOf("JSON5", "stringify");
+  const documented = documentedOutput(example);
+  expect(documented).not.toBe("");
+
+  using dir = tempDir("bun-types-jsdoc-example", { "example.ts": example });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "example.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout).toBe(documented);
+  expect(exitCode).toBe(0);
+});
+
+// SpawnOptions.lazy: "Reading begins when you first read from the `stdout` or `stderr` stream [...]
+// Accessing the property alone does not start it. Until reading begins, a child process that fills
+// the operating system's pipe buffer blocks on its next write."
+test.concurrent("SpawnOptions.lazy: reading begins at the first read, not at property access", async () => {
+  // More than the pipe holds on any platform (macOS has the most, about 1 MiB).
+  const SIZE = 4 * 1024 * 1024;
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const fs = require("fs");
+      fs.writeSync(2, "started\\n");
+      const chunk = Buffer.alloc(65536, 97);
+      let written = 0;
+      while (written < ${SIZE}) written += fs.writeSync(1, chunk, 0, Math.min(chunk.length, ${SIZE} - written));`,
+    ],
+    env: bunEnv,
+    lazy: true,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdout = proc.stdout;
+
+  // Wait until the child runs, so that the window below measures the pipe and not the startup of the child.
+  const stderr = proc.stderr.getReader();
+  const decoder = new TextDecoder();
+  let seen = "";
+  while (!seen.includes("started\n")) {
+    const { done, value } = await stderr.read();
+    if (done) throw new Error(`the child closed stderr before it wrote "started": ${JSON.stringify(seen)}`);
+    seen += decoder.decode(value, { stream: true });
+  }
+  stderr.releaseLock();
+
+  // A reader that runs drains the pipe and the child exits in a few milliseconds.
+  // Deadline-polled: the loop stops early if the child does exit.
+  const deadline = Date.now() + 500;
+  while (proc.exitCode === null && Date.now() < deadline) {
+    await new Promise(resolve => setImmediate(resolve));
+  }
+  expect(proc.exitCode).toBeNull();
+
+  expect((await stdout.text()).length).toBe(SIZE);
+  expect(await proc.exited).toBe(0);
+});


### PR DESCRIPTION
### Problem
- `SpawnOptions.lazy` (`packages/bun-types/bun.d.ts:7793`) says "Reading begins only when you access the `stdout` or `stderr` properties." Since #34971 a lazy pipe reader starts paused, and the first read from JS starts it. `p.stdout` alone starts nothing.
- `JSON5.stringify` (`bun.d.ts:2089`, example at `:2107`) says "strings use double quotes" and shows `{a:1,b:"two"}`. Bun prints `{a:1,b:'two'}`. `append_quoted_string` (`src/runtime/api/JSON5Object.rs:365`) always writes single quotes.

### Fix
- `lazy`: reading begins when you first read from the stream, for example `.text()` or `.getReader()`. Access to the property alone does not start it. A new sentence says that, until then, a child that fills the pipe buffer blocks.
- `JSON5.stringify`: the prose says "single quotes" and the example output is `{a:1,b:'two'}`.
- Comments only. No declaration changes.
- Verified: new `test/integration/bun-types/jsdoc-examples.test.ts`. It runs the `JSON5.stringify` example and compares stdout with the example's comments (fails with the old JSDoc). A second test covers the `lazy` text. Both pass on Linux x64 (debug build) and Windows x64.

### Background
- `node:child_process` passes `lazy: true` to `Bun.spawn`. #34971 made `lazy` defer poll registration (`SubprocessPipeReader.rs:192`, `:158` on Windows). The kernel pipe buffer then applies backpressure and the child blocks, as in Node.
- The `ReadableStream` over the pipe starts its native source when a consumer attaches. `getReader()`, `.text()`, `for await`, `tee()` and `pipeTo()` start the read. `p.stdout` and `new Response(p.stdout)` do not.
- The reference `json5` package also prints `{a:1,b:'two'}`. It uses double quotes only for a string with more `'` than `"`. Bun always writes single quotes and escapes `'`.

<details><summary>Notes</summary>

The new test file sits next to `bun-types.test.ts` and not inside it, because that file packs and installs `bun-types` in `beforeAll` and only type-checks. The `lazy` test passes with and without this diff, because the runtime does not change. It fails when the spawn uses `lazy: false`: the child exits within 16 ms.

`lazy` probe. The child writes 4 MB to stdout with `fs.writeSync`. `maxBuffer: 1000` shows when the reader runs, because the kill fires only after the reader counts bytes. The output is the same on Bun 1.4.3 on Linux x64 (4ff919377) and Windows x64 (canary e5f9986a4):

```
eager, nothing                  -> killed, SIGTERM, exited 143 (within 500 ms)
lazy, nothing                   -> not killed, not exited
lazy, nothing, no maxBuffer     -> not exited (child blocks on a full pipe)
lazy, p.stdout (property only)  -> not killed, not exited
lazy, p.stdout.getReader()      -> killed, SIGTERM, exited 143
lazy, p.stdout.text()           -> killed, SIGTERM, exited 143
lazy, new Response(p.stdout)    -> not killed, not exited
```

On Linux the same probe also covered `.bytes()`, `for await`, `tee()`, `pipeTo()` and `new Response(p.stdout).text()` (each starts the read), `p.stdout.locked` (does not), and `stderr` (same as `stdout`).

`JSON5.stringify` on 1.4.3:

```
JSON5.stringify({ a: 1, b: "two" })   // {a:1,b:'two'}
JSON5.stringify({ a: "it's" })        // {a:'it\'s'}     (json5 2.2.3: {a:"it's"})
JSON5.stringify({ a: 'say "hi"' })    // {a:'say "hi"'}
JSON5.stringify({ "not-ident": 1 })   // {'not-ident':1}
```

Before #34971 the poll was registered at spawn with or without `lazy`, and `lazy` only skipped the first synchronous read. #34971 gave `lazy` its current meaning and did not touch `bun.d.ts`. `docs/runtime/child-process.mdx` does not mention `lazy`, so it needs no edit. `docs/runtime/json5.mdx` already shows single quotes.

Two open PRs touch the same JSDoc blocks. #39925 (the `replacer` feature) carries the same two JSON5 lines with the same text. #42256 (enforce `maxBuffer` with `lazy`) adds a paragraph further down in the `lazy` block. Neither conflicts with this diff.

`test/integration/bun-types/bun-types.test.ts` gives identical output with and without this diff. The `TypeScript types` check fails on every PR that touches `packages/bun-types/**` since 2026-09-09, because the npm `latest` tag of `@types/node` moved to 22.20.2. #42230 has the cause and the fix. `prettier --check` passes.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/integration/bun-types/jsdoc-examples.test.ts
bun test v1.4.3 (4ff919377)

test/integration/bun-types/jsdoc-examples.test.ts:
45 |     stdout: "pipe",
46 |     stderr: "inherit",
47 |   });
48 |   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
49 | 
50 |   expect(stdout).toBe(documented);
                      ^
error: expect(received).toBe(expected)

- "{a:1,b:"two"}
+ "{a:1,b:'two'}
  {
    a: 1,
    b: 2,
  }
  "

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/integration/bun-types/jsdoc-examples.test.ts:50:18)
(fail) the JSON5.stringify @example prints what its comments say [430.27ms]
(pass) SpawnOptions.lazy: reading begins at the first read, not at property access [1246.00ms]

 1 pass
 1 fail
 5 expect() calls
Ran 2 tests across 1 file. [3.48s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/integration/bun-types/jsdoc-examples.test.ts:
45 |     stdout: "pipe",
46 |     stderr: "inherit",
47 |   });
48 |   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
49 | 
50 |   expect(stdout).toBe(documented);
                      ^
error: expect(received).toBe(expected)

- "{a:1,b:"two"}
+ "{a:1,b:'two'}
  {
    a: 1,
    b: 2,
  }
  "

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/integration/bun-types/jsdoc-examples.test.ts:50:18)
(fail) the JSON5.stringify @example prints what its comments say [10.35ms]
(pass) SpawnOptions.lazy: reading begins at the first read, not at property access [523.24ms]

 1 pass
 1 fail
 5 expect() calls
Ran 2 tests across 1 file. [626.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/integration/bun-types/jsdoc-examples.test.ts
bun test v1.4.3 (4ff919377)

test/integration/bun-types/jsdoc-examples.test.ts:
(pass) the JSON5.stringify @example prints what its comments say [327.00ms]
(pass) SpawnOptions.lazy: reading begins at the first read, not at property access [986.39ms]

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [3.05s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 705ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/26] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/26] gen cpp.rs (cppbind)
[3/26] gen JS modules (bundle-modules)
Preprocess modules (8061ms)
Bundle modules (52ms)
Postprocesss modules (196ms)
Bundle Functions (448ms)
Generate Code (48ms)

[8.81s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/15] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/bun.d.ts                       | 14 ++--
 test/integration/bun-types/jsdoc-examples.test.ts | 99 +++++++++++++++++++++++
 2 files changed, 108 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
packages/bun-types/bun.d.ts                            1      2     11
test/integration/bun-types/jsdoc-examples.test.ts      1      1     10
```

</details>

<!-- robobun:evidence:end -->