### PR TITLE
Throw instead of aborting when an underlying source type or a domainToASCII host passes the string length limit

### DIFF
--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -117,21 +117,20 @@ bool hasValidPunycodeHost(WTF::StringView host)
 
 // Mirrors Node's url.domainToASCII/domainToUnicode, which run the input
 // through a WHATWG URL host parse (ada's url.set_hostname on a "ws://x"
-// base). Returns a null String when host parsing fails.
-static String parseDomainAsHost(const String& domain)
+// base). Returns a null String when host parsing fails. Throws when the URL
+// string for that parse would be longer than String::MaxLength.
+static String parseDomainAsHost(JSC::JSGlobalObject* globalObject, const String& domain)
 {
+    auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));
+
     // The hostname setter's basic-URL parse stops at the first path, query,
     // fragment, or backslash (special scheme) terminator.
     StringView view { domain };
-    size_t end = view.length();
-    for (size_t i = 0; i < view.length(); i++) {
-        char16_t c = view[i];
-        if (c == '/' || c == '?' || c == '#' || c == '\\') {
-            end = i;
-            break;
-        }
+    for (char16_t terminator : { u'/', u'?', u'#', u'\\' }) {
+        if (size_t index = view.find(terminator); index != notFound)
+            view = view.left(index);
     }
-    String host = domain.left(end);
+    String host = domain.left(view.length());
     if (host.isEmpty())
         return {};
 
@@ -147,7 +146,13 @@ static String parseDomainAsHost(const String& domain)
             return {};
     }
 
-    WTF::URL url(makeString("ws://"_s, host, "/"_s));
+    // `host` comes from JS. `makeString` calls `CRASH()` past `String::MaxLength`.
+    auto urlString = tryMakeString("ws://"_s, host, "/"_s);
+    if (urlString.isNull()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return {};
+    }
+    WTF::URL url(WTF::move(urlString));
     if (!url.isValid())
         return {};
 
@@ -170,7 +175,8 @@ JSC_DEFINE_HOST_FUNCTION(jsDomainToASCII, (JSC::JSGlobalObject * globalObject, J
     auto domain = callFrame->argument(0).toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    auto host = parseDomainAsHost(domain);
+    auto host = parseDomainAsHost(globalObject, domain);
+    RETURN_IF_EXCEPTION(scope, {});
     if (host.isNull())
         return JSC::JSValue::encode(jsEmptyString(vm));
     return JSC::JSValue::encode(JSC::jsString(vm, host));
@@ -189,7 +195,8 @@ JSC_DEFINE_HOST_FUNCTION(jsDomainToUnicode, (JSC::JSGlobalObject * globalObject,
 
     // Node: validate through the host parse first, then run ToUnicode on the
     // resulting ASCII host.
-    auto host = parseDomainAsHost(domain);
+    auto host = parseDomainAsHost(globalObject, domain);
+    RETURN_IF_EXCEPTION(scope, {});
     if (host.isNull())
         return JSC::JSValue::encode(jsEmptyString(vm));
 

--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -117,8 +117,7 @@ bool hasValidPunycodeHost(WTF::StringView host)
 
 // Mirrors Node's url.domainToASCII/domainToUnicode, which run the input
 // through a WHATWG URL host parse (ada's url.set_hostname on a "ws://x"
-// base). Returns a null String when host parsing fails. Throws when the URL
-// string for that parse would be longer than String::MaxLength.
+// base). Returns a null String when host parsing fails.
 static String parseDomainAsHost(JSC::JSGlobalObject* globalObject, const String& domain)
 {
     auto scope = DECLARE_THROW_SCOPE(JSC::getVM(globalObject));

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -199,8 +199,14 @@ static ConvertedUnderlyingSource convertUnderlyingSource(JSC::VM& vm, JSGlobalOb
             result.dict.type = ReadableStreamType::Bytes;
         } else if (typeString == "direct"_s)
             result.type = BunUnderlyingSourceType::Direct;
-        else
-            throwTypeError(globalObject, scope, makeString("'"_s, typeString, "' is not a valid underlying source 'type'; expected \"bytes\", \"direct\", or undefined"_s));
+        else {
+            // `typeString` comes from JS. `makeString` calls `CRASH()` past `String::MaxLength`.
+            auto message = tryMakeString("'"_s, typeString, "' is not a valid underlying source 'type'; expected \"bytes\", \"direct\", or undefined"_s);
+            if (message.isNull()) [[unlikely]]
+                throwOutOfMemoryError(globalObject, scope);
+            else
+                throwTypeError(globalObject, scope, message);
+        }
     }
     return result;
 }

--- a/test/js/node/url/url-domain-ascii-unicode.test.js
+++ b/test/js/node/url/url-domain-ascii-unicode.test.js
@@ -139,7 +139,9 @@ test("the host stops at the first path, query, fragment or backslash terminator"
 
 // Both functions parse the host as "ws://<host>/". With a host near 2^31-1 characters that
 // URL does not fit in a string, and building it used to abort the process in
-// WTF::makeString. The child commits ~2.2GB.
+// WTF::makeString. The child commits ~2.2GB. It builds the host with "a".repeat(n): JSC fills
+// a one-character repeat directly (1.4s in a debug build), and Buffer.alloc(n, "a").toString()
+// holds the buffer and the string at once, which doubles the peak to ~4.4GB.
 describe.skipIf(totalmem() < 8 * 1024 * 1024 * 1024)("a host too long for the URL parse throws", () => {
   for (const fn of ["domainToASCII", "domainToUnicode"]) {
     test(`url.${fn}`, async () => {

--- a/test/js/node/url/url-domain-ascii-unicode.test.js
+++ b/test/js/node/url/url-domain-ascii-unicode.test.js
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { totalmem } from "node:os";
 import url from "node:url";
 
 const pairs = [
@@ -97,6 +99,74 @@ describe("url.domainToUnicode", () => {
   for (const [input, expected] of invalids) {
     test(`-> '${input}' is '${expected}'`, () => {
       expect(url.domainToASCII(input)).toEqual(expected);
+    });
+  }
+});
+
+// The host ends at the first '/', '?', '#' or '\\', whichever comes first.
+test("the host stops at the first path, query, fragment or backslash terminator", () => {
+  const inputs = [
+    "example.com/path",
+    "example.com?q#h",
+    "example.com#h?q/p",
+    "example.com\\x",
+    "a?b/c#d\\e",
+    "a\\b?c",
+    "EXAMPLE.com/",
+    "ü.com/ü",
+    "xn--tda.com?ü",
+    "/x",
+    "?x",
+    "#",
+    "\\",
+  ];
+  expect(inputs.map(input => [url.domainToASCII(input), url.domainToUnicode(input)])).toEqual([
+    ["example.com", "example.com"],
+    ["example.com", "example.com"],
+    ["example.com", "example.com"],
+    ["example.com", "example.com"],
+    ["a", "a"],
+    ["a", "a"],
+    ["example.com", "example.com"],
+    ["xn--tda.com", "ü.com"],
+    ["xn--tda.com", "ü.com"],
+    ["", ""],
+    ["", ""],
+    ["", ""],
+    ["", ""],
+  ]);
+});
+
+// Both functions parse the host as "ws://<host>/". With a host near 2^31-1 characters that
+// URL does not fit in a string, and building it used to abort the process in
+// WTF::makeString. The child commits ~2.2GB.
+describe.skipIf(totalmem() < 8 * 1024 * 1024 * 1024)("a host too long for the URL parse throws", () => {
+  for (const fn of ["domainToASCII", "domainToUnicode"]) {
+    test(`url.${fn}`, async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const host = "a".repeat(2 ** 31 - 5);
+            try {
+              const result = require("node:url").${fn}(host);
+              console.log("returned", result.length);
+            } catch (e) {
+              console.log("threw", e.name, e.message);
+            }
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "threw RangeError Out of memory\n",
+        stderr: "",
+        exitCode: 0,
+      });
     });
   }
 });

--- a/test/js/node/url/url-domain-ascii-unicode.test.js
+++ b/test/js/node/url/url-domain-ascii-unicode.test.js
@@ -104,71 +104,55 @@ describe("url.domainToUnicode", () => {
 });
 
 // The host ends at the first '/', '?', '#' or '\\', whichever comes first.
-test("the host stops at the first path, query, fragment or backslash terminator", () => {
-  const inputs = [
-    "example.com/path",
-    "example.com?q#h",
-    "example.com#h?q/p",
-    "example.com\\x",
-    "a?b/c#d\\e",
-    "a\\b?c",
-    "EXAMPLE.com/",
-    "ü.com/ü",
-    "xn--tda.com?ü",
-    "/x",
-    "?x",
-    "#",
-    "\\",
-  ];
-  expect(inputs.map(input => [url.domainToASCII(input), url.domainToUnicode(input)])).toEqual([
-    ["example.com", "example.com"],
-    ["example.com", "example.com"],
-    ["example.com", "example.com"],
-    ["example.com", "example.com"],
-    ["a", "a"],
-    ["a", "a"],
-    ["example.com", "example.com"],
-    ["xn--tda.com", "ü.com"],
-    ["xn--tda.com", "ü.com"],
-    ["", ""],
-    ["", ""],
-    ["", ""],
-    ["", ""],
-  ]);
+describe("the host stops at the first path, query, fragment or backslash terminator", () => {
+  test.each([
+    ["example.com/path", "example.com", "example.com"],
+    ["example.com?q#h", "example.com", "example.com"],
+    ["example.com#h?q/p", "example.com", "example.com"],
+    ["example.com\\x", "example.com", "example.com"],
+    ["a?b/c#d\\e", "a", "a"],
+    ["a\\b?c", "a", "a"],
+    ["EXAMPLE.com/", "example.com", "example.com"],
+    ["ü.com/ü", "xn--tda.com", "ü.com"],
+    ["xn--tda.com?ü", "xn--tda.com", "ü.com"],
+    ["/x", "", ""],
+    ["?x", "", ""],
+    ["#", "", ""],
+    ["\\", "", ""],
+  ])("'%s'", (input, ascii, unicode) => {
+    expect([url.domainToASCII(input), url.domainToUnicode(input)]).toEqual([ascii, unicode]);
+  });
 });
 
-// Both functions parse the host as "ws://<host>/". With a host near 2^31-1 characters that
-// URL does not fit in a string, and building it used to abort the process in
-// WTF::makeString. The child commits ~2.2GB. It builds the host with "a".repeat(n): JSC fills
-// a one-character repeat directly (1.4s in a debug build), and Buffer.alloc(n, "a").toString()
-// holds the buffer and the string at once, which doubles the peak to ~4.4GB.
+// Both functions parse the host as "ws://<host>/". A host near 2^31-1 characters makes that
+// URL too long for a string, which used to abort in WTF::makeString. "a".repeat(n) is a direct
+// fill in JSC (1.4s in a debug build). Buffer.alloc(n, "a").toString() doubles the ~2.2GB peak.
 describe.skipIf(totalmem() < 8 * 1024 * 1024 * 1024)("a host too long for the URL parse throws", () => {
-  for (const fn of ["domainToASCII", "domainToUnicode"]) {
-    test(`url.${fn}`, async () => {
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `
-            const host = "a".repeat(2 ** 31 - 5);
-            try {
-              const result = require("node:url").${fn}(host);
-              console.log("returned", result.length);
-            } catch (e) {
-              console.log("threw", e.name, e.message);
-            }
-          `,
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout, stderr, exitCode }).toEqual({
-        stdout: "threw RangeError Out of memory\n",
-        stderr: "",
-        exitCode: 0,
-      });
+  test.each(["domainToASCII", "domainToUnicode"])("url.%s", async fn => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          import url from "node:url";
+          const host = "a".repeat(2 ** 31 - 5);
+          try {
+            const result = url.${fn}(host);
+            console.log("returned", result.length);
+          } catch (e) {
+            console.log("threw", e.name, e.message);
+          }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
     });
-  }
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "threw RangeError Out of memory\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
 });

--- a/test/js/web/streams/streams-string-limit.test.ts
+++ b/test/js/web/streams/streams-string-limit.test.ts
@@ -156,7 +156,9 @@ describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past
 
 // The TypeError for an unknown underlying source `type` quotes the value. With a value
 // near 2^31-1 characters the message does not fit in a string, and building it used to
-// abort the process in WTF::makeString.
+// abort the process in WTF::makeString. The child builds the value with "t".repeat(n): JSC
+// fills a one-character repeat directly (1.4s in a debug build), and
+// Buffer.alloc(n, "t").toString() holds the buffer and the string at once (~4.4GB peak).
 test.skipIf(!enoughMemory)("an underlying source type too long to quote in the error message throws", async () => {
   const result = await run(`
     const type = "t".repeat(2 ** 31 - 40);

--- a/test/js/web/streams/streams-string-limit.test.ts
+++ b/test/js/web/streams/streams-string-limit.test.ts
@@ -154,11 +154,9 @@ describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past
   });
 });
 
-// The TypeError for an unknown underlying source `type` quotes the value. With a value
-// near 2^31-1 characters the message does not fit in a string, and building it used to
-// abort the process in WTF::makeString. The child builds the value with "t".repeat(n): JSC
-// fills a one-character repeat directly (1.4s in a debug build), and
-// Buffer.alloc(n, "t").toString() holds the buffer and the string at once (~4.4GB peak).
+// The TypeError for an unknown underlying source `type` quotes the value. A value near 2^31-1
+// characters makes the message too long for a string, which used to abort in WTF::makeString.
+// "t".repeat(n) is a direct fill in JSC. Buffer.alloc(n, "t").toString() doubles the peak memory.
 test.skipIf(!enoughMemory)("an underlying source type too long to quote in the error message throws", async () => {
   const result = await run(`
     const type = "t".repeat(2 ** 31 - 40);

--- a/test/js/web/streams/streams-string-limit.test.ts
+++ b/test/js/web/streams/streams-string-limit.test.ts
@@ -153,3 +153,19 @@ describe.skipIf(!enoughMemory)("text consumers reject binary chunks summing past
     });
   });
 });
+
+// The TypeError for an unknown underlying source `type` quotes the value. With a value
+// near 2^31-1 characters the message does not fit in a string, and building it used to
+// abort the process in WTF::makeString.
+test.skipIf(!enoughMemory)("an underlying source type too long to quote in the error message throws", async () => {
+  const result = await run(`
+    const type = "t".repeat(2 ** 31 - 40);
+    try {
+      new ReadableStream({ type });
+      console.log("constructed");
+    } catch (e) {
+      console.log("threw", e.name, e.message);
+    }
+  `);
+  expect(result).toEqual(threw);
+});


### PR DESCRIPTION
### Problem
- Two calls abort with `panic(main thread): abort() called` (exit 134) on 1.4.3 and main: `new ReadableStream({ type: "t".repeat(2**31-40) })` and `url.domainToASCII("a".repeat(2**31-5))` (also `url.domainToUnicode`). The stack is `WTF::makeString<ASCIILiteral, String, ASCIILiteral>` <- `WebCore::convertUnderlyingSource`, or <- `Bun::jsDomainToASCII`.
- Cause: `WTF::makeString` calls `CRASH()` when the result would pass `String::MaxLength` (2^31-1). `JSReadableStream.cpp:203` quotes the unknown `type` in a TypeError message. `NodeURL.cpp:150` (`parseDomainAsHost`) builds `"ws://" + host + "/"` to parse the host.
- #42202 fixes the same class in the error builders, but it touches neither file. Both still abort on its head e488987926.

### Fix
- Both sites use `tryMakeString`, which returns a null string in that case, and throw `RangeError: Out of memory`. #42202 and #42191 use the same idiom.
- `parseDomainAsHost` now takes the global object and throws. Its two callers check for the exception.
- `parseDomainAsHost` finds the end of the host with four `StringView::find` calls in place of a per-character loop. The result is the same. The loop took 95 s on a 2^31 character host in a debug build. It now takes under 3 s.
- Verified: `test/js/web/streams/streams-string-limit.test.ts` (1 new test) and `test/js/node/url/url-domain-ascii-unicode.test.js` (2 new, 13 table rows). The three overflow tests exit 134 on 1.4.3 and pass here. Also `test/js/node/url/`, `streams.test.js -t type`.

### Background
- `tryMakeString` is the fallible form of `makeString`: same arguments, null result on overflow or allocation failure.
- `url.domainToASCII` mirrors Node: it runs the input through a URL host parse, so Bun wraps it in a `ws://` URL for `WTF::URL`.

<details><summary>Notes</summary>

- Why `Out of memory` and not a truncated TypeError for the `type` case: a message that embeds 2^31 characters cannot exist, and Node reports the equivalent (`RangeError: Invalid string length`) when V8 cannot build a string. A valid host of that length cannot be parsed through `WTF::URL` either, because the wrapped URL string itself does not fit.
- The terminator scan keeps the earliest of `/`, `?`, `#`, `\`: each search runs on the view already cut by the previous hit. A new in-process `test.each` table pins 13 inputs (mixed terminator order, empty host, IDN before and after the cut). Bun before, Bun after and Node 24 give identical output for all of them.
- On an unfixed debug build the two `url` overflow tests fail by the 5 s test timeout (the old loop needs 95 s before it reaches the abort). On the release binary they fail with exit 134 after 3 s.
- All new and nearby paths (`type: "nope"`, `"bytes"`, valid, invalid, empty and missing domains, and the three overflow cases) run clean under `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1`.
- The children commit about 2.2 GB (one 2^31 character string, `tryMakeString` fails before it allocates), so the tests skip below 8 GB of RAM like the rest of `streams-string-limit.test.ts`.
- Node parallel tests `test-url-domain-ascii-unicode.js` and `test-whatwg-url-custom-domainto.js` pass.
- Other `makeString` calls in `webcore/streams/` take internal property names or short inspected state, not lengths a user controls.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/url/url-domain-ascii-unicode.test.js test/js/web/streams/streams-string-limit.test.ts
bun test v1.4.3 (4ff919377)

test/js/web/streams/streams-string-limit.test.ts:
(pass) text consumers reject binary chunks summing past 2^31-1 > queue-backed ReadableStream [301.53ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > direct ReadableStream [281.48ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > Response(stream).text() [279.83ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > mixed chunks with a big ASCII string chunk resolve when the UTF-8 total fits [8522.28ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > mixed chunks whose UTF-8 expansion passes the limit reject [2482.20ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > direct stream with a buffer grown past the limit after write() rejects [391.95ms]
165 |       console.log("constructed");
166 |     } catch (e) {
167 |       console.log("threw", e.name, e.message);
168 |     }
169 | 
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (a9645a4a8)

test/js/web/streams/streams-string-limit.test.ts:
(pass) text consumers reject binary chunks summing past 2^31-1 > queue-backed ReadableStream [5.99ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > direct ReadableStream [5.83ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > Response(stream).text() [4.91ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > mixed chunks with a big ASCII string chunk resolve when the UTF-8 total fits [3174.73ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > mixed chunks whose UTF-8 expansion passes the limit reject [1613.54ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > direct stream with a buffer grown past the limit after write() rejects [7.29ms]
(pass) an underlying source type too long to quote in the error message throws [1345.64ms]

test/js/node/url/url-domain-ascii-unicode.test.js:
(pass) url.domainToASCII > convert from 'ıíd' to 'xn--d-iga7r' [0.06ms]
(pass) url.domainToASCII > convert from 'يٴ' to 'xn--mhb8f' [0.01ms]
(pass) url.domainToASCII > convert from 'www.ϧƽəʐ.com' to 'www.xn--cja62a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/url/url-domain-ascii-unicode.test.js test/js/web/streams/streams-string-limit.test.ts
bun test v1.4.3 (4ff919377)

test/js/web/streams/streams-string-limit.test.ts:
(pass) text consumers reject binary chunks summing past 2^31-1 > queue-backed ReadableStream [312.58ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > direct ReadableStream [277.90ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > Response(stream).text() [285.50ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > mixed chunks with a big ASCII string chunk resolve when the UTF-8 total fits [8384.16ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > mixed chunks whose UTF-8 expansion passes the limit reject [2525.83ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > direct stream with a buffer grown past the limit after write() rejects [329.45ms]
(pass) an underlying source type too long to quote in the error message throws [1669.10ms]

test/js/node/url/url-domain-ascii-unicode.t
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 694ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen cpp.rs (cppbind)
[2/23] gen JS modules (bundle-modules)
Preprocess modules (8599ms)
Bundle modules (48ms)
Postprocesss modules (19ms)
Bundle Functions (458ms)
Generate Code (25ms)

[9.16s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 49s
[4/8] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[5/8] link bun-profile
[7/8] strip bun
[7/8] bun-profile --revision
1.4.3-canary.1+4554c1e32
[build] done
bun test v1.4.3-canary.1 (4554c1e32)

test/js/web/streams/streams-string-limit.test.ts:
(pass) text consumers reject binary chunks summing past 2^31-1 > queue-backed ReadableStream [6.92ms]
(pass) text consumers reject binary chunks summing past 2^31-1 > direct ReadableStream [6.50ms]
(pass) text consumers reject binary 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeURL.cpp                       | 30 +++++++-----
 .../bindings/webcore/streams/JSReadableStream.cpp  | 10 +++-
 test/js/node/url/url-domain-ascii-unicode.test.js  | 56 ++++++++++++++++++++++
 test/js/web/streams/streams-string-limit.test.ts   | 16 +++++++
 4 files changed, 98 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/jsc/bindings/NodeURL.cpp                               3      6     18
src/jsc/bindings/webcore/streams/JSReadableStream.cpp      1      1     18
test/js/node/url/url-domain-ascii-unicode.test.js          3      5     14
test/js/web/streams/streams-string-limit.test.ts           2      3     14
```

</details>

<!-- robobun:evidence:end -->
