### PR TITLE
test(process-stdin): join stdin chunks before comparing, ignore ENOTCONN on macOS

### DIFF
--- a/test/js/node/process/process-stdin.test.ts
+++ b/test/js/node/process/process-stdin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isMacOS, isWindows, tempDir } from "harness";
 import { exec } from "node:child_process";
 
 test.concurrent("pipe does the right thing", async () => {
@@ -35,24 +35,22 @@ test.concurrent("file does the right thing", async () => {
 });
 
 test.concurrent("stdin with 'readable' event handler should receive data when paused", async () => {
+  // Nothing but stdin keeps the child alive: it has to stay up until EOF and
+  // get every byte through read() while paused.
   const proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
       `
-      const handleReadable = () => {
+      const chunks = [];
+      process.stdin.on("readable", () => {
         let chunk;
-        while ((chunk = process.stdin.read())) {
-          console.log("got chunk", JSON.stringify(chunk));
-        }
-      };
-      
-      process.stdin.on("readable", handleReadable);
+        while ((chunk = process.stdin.read()) !== null) chunks.push(chunk);
+      });
       process.stdin.pause();
-      
-      setTimeout(() => {
-        process.exit(1);
-      }, 1000);
+      process.stdin.on("end", () => {
+        console.log(JSON.stringify({ data: Buffer.concat(chunks).toString(), isPaused: process.stdin.isPaused() }));
+      });
       `,
     ],
     stdin: "pipe",
@@ -61,18 +59,17 @@ test.concurrent("stdin with 'readable' event handler should receive data when pa
     env: bunEnv,
   });
 
+  // Whether these reach the child as one chunk or as two depends on when it
+  // starts to read (on Windows the second write leaves one event loop turn
+  // after the first), so the child joins what read() returns.
   proc.stdin.write("abc\n");
   proc.stdin.write("def\n");
   proc.stdin.end();
 
-  await proc.exited;
-
-  expect(await proc.stdout.text()).toMatchInlineSnapshot(`
-    "got chunk {"type":"Buffer","data":[97,98,99,10,100,101,102,10]}
-    "
-  `);
-  expect(await proc.stderr.text()).toMatchInlineSnapshot(`""`);
-  expect(proc.exitCode).toBe(1);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe(JSON.stringify({ data: "abc\ndef\n", isPaused: true }) + "\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });
 
 test.concurrent("stdin with 'data' event handler should NOT receive data when paused", async () => {
@@ -494,9 +491,11 @@ describe.skipIf(isWindows)("pipe backpressure", () => {
     });
     // The child exits under backpressure having accepted only a few KB, so
     // the queued writes here fail with EPIPE; that is the expected outcome.
+    // macOS reports ENOTCONN instead when the child closes its end while a
+    // write is still inside the kernel.
     const chunk = Buffer.alloc(1024 * 1024, 0x78);
     const ignoreEpipe = (e: any) => {
-      if (e?.code !== "EPIPE") throw e;
+      if (e?.code !== "EPIPE" && !(isMacOS && e?.code === "ENOTCONN")) throw e;
     };
     for (let i = 0; i < feedMB; i++) {
       const r = proc.stdin.write(chunk);


### PR DESCRIPTION
### Problem
- `test/js/node/process/process-stdin.test.ts` is red on `main`. Windows: "stdin with 'readable' event handler should receive data when paused" gets `got chunk {"type":"Buffer","data":[97,98,99,10]}` and a second chunk. The snapshot has one. macOS: `22 pass, 0 fail, 42 errors`, each `ENOTCONN: socket is not connected, write`.
- Windows: `WindowsStreamingWriter::process_send` (`src/io/PipeWriter.rs:2260`) keeps one `uv_write` in flight, so the second `write()` leaves one event loop turn later. Since #33622 made the tests concurrent, 12 more `Bun.spawn` calls come before that turn, and the child reads first.
- macOS: the `run()` helper rethrows every write error except `EPIPE`. XNU returns `ENOTCONN` when the peer closes while `send()` is inside the kernel. #42038 added children that exit right after a read.

### Fix
- The child joins what `read()` returns and prints it on `'end'`. No exit timer: only stdin keeps the child alive.
- `run()` also ignores `ENOTCONN` on macOS.
- Correct: pipe chunk boundaries are not a contract. Node reports the same `ENOTCONN` (libuv remaps only `EPROTOTYPE`).
- Verified on Windows 11 arm64, canary e5f9986a4: the old file fails 10 of 10 runs, the new file 0 of 20. Linux release and debug+ASAN pass. Bun 1.2.18 (before #17690) fails the new test.

### Background
- `Bun.spawn({ stdin: "pipe" })` gives the child a named pipe on Windows and a `socketpair` on POSIX (512 KB buffers on macOS, `src/spawn_sys/spawn_process.rs:826`).
- `process.stdin.read()` returns the bytes buffered at that moment.
- `test.concurrent` runs the synchronous start of every test before the event loop turns again.

<details><summary>Notes</summary>

**Windows**

- The one-chunk snapshot is from #17690 (2025-08), when the tests ran one at a time. #33622 (2026-07-07) made them `test.concurrent`: 9 synchronous `Bun.spawn` calls then sat between the first and the second `WriteFile`. #34019 and #42038 added concurrent tests that also run on Windows, so it is 12 now. The lane went from a one-retry flake (on `main` since at least build 104713, 2026-08-24) to red on every attempt (113935).
- Measured on a Windows 11 arm64 VM (Cobalt 100, canary e5f9986a4): `Bun.spawn` takes about 6 ms, and the child's first `read()` comes about 16 ms after its script starts. A parent that writes `"abc\n"`, `"def\n"`, `end()` and then stays busy delivers one chunk when busy for 0, 10 or 20 ms and two chunks (`"abc\n"` at 15 ms, `"def\n"` right after the busy time) when busy for 40, 80 or 160 ms.
- The old test alone (`-t`) passes 10 of 10 runs on that VM. With the whole file it fails 10 of 10.
- On POSIX both writes go to the socket in the same tick, so the snapshot held there.

**macOS**

- XNU `sosend()` checks the socket state (`sosendcheck`: `SS_CANTSENDMORE` first, so `EPIPE`), then drops the socket lock while it copies the user data, then calls `uipc_send()`. `uipc_send()` tests `SS_ISCONNECTED` first (`ENOTCONN`) and `SS_CANTSENDMORE` second (`bsd/kern/uipc_usrreq.c`). `unp_disconnect()` changes both flags at once. A close that lands during the copy gives `ENOTCONN`. With 512 KB buffers the copy is long enough to hit.
- Reproduced outside Bun on macOS 15.7 arm64 with a Perl `socketpair`, 512 KB buffers, a child that reads twice and closes, and a non-blocking writer: `ENOTCONN` in 40 to 59 of 500 runs, `EPIPE` in the rest. The same script on Linux: `EPIPE` in 500 of 500.
- Reproduced with Bun 1.3.14 on the same Mac: six children at a time that exit after the first read, 40 MB queued on each stdin: 149 `EPIPE`, 1 `ENOTCONN`. Linux: `EPIPE` only.
- `ignoreEpipe` dates from #35977, whose children stop reading and wait 1.5 s before they exit. The parent's socket is full by then, so no write is in progress at the close. First `ENOTCONN` in CI: build 113381, two hours after #42038 merged. None in the `main` builds from 2026-08-21 up to then. Seen since in 113463, 113483, 113533, 113549, 113565, 113566, 113625, 113635, 113709, 113725, 113732, 113737, 113771, 113795, 113805, 113824, 113831, 113843, 113899, 113906, 113910, 113926, 113933, 113935. All 25 builds contain #42038.
- 42 errors is one `run()` call: 40 writes, `flush()` and `end()` reject with the same error. Forcing a mismatch in `ignoreEpipe` on Linux gives the same signature: `1 pass, 0 fail, 42 errors`.
- `ENOTCONN` stays an error on Linux: the check is gated on `isMacOS`.

**Coverage**

- The old child held itself alive with a 1 s timer and exited with code 1. The new child has nothing but stdin, so the test now also fails if `pause()` lets the process exit before EOF. It also asserts `isPaused()` is still `true` at `'end'`.
- No other test in the file depends on chunk boundaries: the rest use a single write or a handshake.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process-stdin.test.ts

<!-- robobun:evidence:end -->