### PR TITLE
fetch: deliver the chunks ahead of a malformed chunk-size before the error

### DIFF
--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -78,6 +78,8 @@ pub struct InternalStateFlags {
     /// `reset()`/`init()` so each redirect/retry hop re-compresses from the
     /// original uncompressed `original_request_body`.
     pub(crate) body_compressed: bool,
+    /// `decoded_body` holds chunks decoded ahead of an invalid one; the failure reports them first.
+    pub(crate) has_body_ahead_of_failure: bool,
 }
 
 impl InternalStateFlags {
@@ -93,6 +95,7 @@ impl InternalStateFlags {
             is_waiting_for_cert_check: false,
             receive_paused: false,
             body_compressed: false,
+            has_body_ahead_of_failure: false,
         }
     }
 }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4655,10 +4655,16 @@ impl<'a> HTTPClient<'a> {
         );
 
         match pret {
+            // -1: invalid HTTP response body. A compressed body gets nothing
+            // from this read, as in Node.js, whose decompressor is torn down
+            // by the error before it emits.
+            -1 if self.state.encoding.is_compressed() => {
+                return Err(crate::Error::InvalidHTTPResponse);
+            }
             // -2: needs more data.
-            // -1: invalid HTTP response body. The chunks decoded ahead of the
-            // invalid one are body all the same; `fail` reports them to a
-            // streaming consumer before the error.
+            // -1: the chunks decoded ahead of the invalid one are body all the
+            // same; `fail` reports them to a streaming consumer before the
+            // error.
             -1 | -2 => {
                 self.report_progress(buffer_len);
                 let mut processed = false;
@@ -4734,10 +4740,14 @@ impl<'a> HTTPClient<'a> {
             self.state.total_body_received
         );
         match pret {
+            // -1: invalid HTTP response body. A compressed body gets nothing
+            // from this read, as in Node.js, whose decompressor is torn down
+            // by the error before it emits.
+            -1 if self.state.encoding.is_compressed() => Err(crate::Error::InvalidHTTPResponse),
             // -2: needs more data.
-            // -1: invalid HTTP response body. The chunks decoded ahead of the
-            // invalid one are body all the same; `fail` reports them to a
-            // streaming consumer before the error.
+            // -1: the chunks decoded ahead of the invalid one are body all the
+            // same; `fail` reports them to a streaming consumer before the
+            // error.
             -1 | -2 => {
                 self.report_progress(buffer.len());
                 self.state.get_body_buffer().append_slice_exact(buffer)?;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1618,10 +1618,7 @@ impl<'a> HTTPClient<'a> {
         }
         callback.run(self.parent_async_http(), result);
     }
-    /// A read can hold valid body bytes followed by the bytes that fail the
-    /// response (a malformed chunk-size line). A streaming consumer gets the
-    /// body bytes in a progress callback of their own ahead of the failure,
-    /// as it would have had the two arrived in separate reads.
+    /// Body bytes decoded ahead of the failure reach a streaming consumer first, in a progress callback.
     fn report_body_decoded_before_failure(&mut self) {
         let is_streaming = self.signals.get(signals::Field::ResponseBodyStreaming)
             || self.signals.body_receive_mode.is_some();
@@ -4655,16 +4652,11 @@ impl<'a> HTTPClient<'a> {
         );
 
         match pret {
-            // -1: invalid HTTP response body. A compressed body gets nothing
-            // from this read, as in Node.js, whose decompressor is torn down
-            // by the error before it emits.
+            // Invalid HTTP response body. Node.js gives a compressed body nothing from this read.
             -1 if self.state.encoding.is_compressed() => {
                 return Err(crate::Error::InvalidHTTPResponse);
             }
-            // -2: needs more data.
-            // -1: the chunks decoded ahead of the invalid one are body all the
-            // same; `fail` reports them to a streaming consumer before the
-            // error.
+            // -1: invalid, -2: needs more data. The chunks decoded so far are body either way.
             -1 | -2 => {
                 self.report_progress(buffer_len);
                 let mut processed = false;
@@ -4740,14 +4732,9 @@ impl<'a> HTTPClient<'a> {
             self.state.total_body_received
         );
         match pret {
-            // -1: invalid HTTP response body. A compressed body gets nothing
-            // from this read, as in Node.js, whose decompressor is torn down
-            // by the error before it emits.
+            // Invalid HTTP response body. Node.js gives a compressed body nothing from this read.
             -1 if self.state.encoding.is_compressed() => Err(crate::Error::InvalidHTTPResponse),
-            // -2: needs more data.
-            // -1: the chunks decoded ahead of the invalid one are body all the
-            // same; `fail` reports them to a streaming consumer before the
-            // error.
+            // -1: invalid, -2: needs more data. The chunks decoded so far are body either way.
             -1 | -2 => {
                 self.report_progress(buffer.len());
                 self.state.get_body_buffer().append_slice_exact(buffer)?;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1618,31 +1618,16 @@ impl<'a> HTTPClient<'a> {
         }
         callback.run(self.parent_async_http(), result);
     }
-    /// Body bytes decoded ahead of the failure reach a streaming consumer first, in a progress callback.
+    /// The chunks a `-1` arm decoded ahead of the invalid one go out in a progress callback of their own.
     fn report_body_decoded_before_failure(&mut self) {
-        let is_streaming = self.signals.get(signals::Field::ResponseBodyStreaming)
-            || self.signals.body_receive_mode.is_some();
-        if !is_streaming
+        if !core::mem::take(&mut self.state.flags.has_body_ahead_of_failure)
             || self.state.decoded_body.list.is_empty()
-            || self.state.flags.is_redirect_pending
         {
             return;
         }
-        // An abort or a timeout ends the body where the consumer stands.
-        let fail = match self.state.fail.take() {
-            None => return,
-            Some(
-                fail @ (crate::Error::Aborted
-                | crate::Error::AbortedBeforeConnecting
-                | crate::Error::Timeout),
-            ) => {
-                self.state.fail = Some(fail);
-                return;
-            }
-            Some(fail) => fail,
-        };
+        let fail = self.state.fail.take();
         let mut result = self.to_result();
-        self.state.fail = Some(fail);
+        self.state.fail = fail;
         result.has_more = true;
         let decoded_body = core::mem::take(&mut self.state.decoded_body);
         result.body = decoded_body.list.as_slice();
@@ -4595,6 +4580,11 @@ impl<'a> HTTPClient<'a> {
         Ok(false)
     }
 
+    /// `fetch()` reads the chunks decoded ahead of an invalid one, as in Node.js, which gives a compressed body nothing.
+    fn keeps_chunks_ahead_of_invalid_one(&self) -> bool {
+        self.signals.body_receive_mode.is_some() && !self.state.encoding.is_compressed()
+    }
+
     pub(crate) fn handle_response_body_chunked_encoding(
         &mut self,
         incoming_data: &[u8],
@@ -4652,8 +4642,8 @@ impl<'a> HTTPClient<'a> {
         );
 
         match pret {
-            // Invalid HTTP response body. Node.js gives a compressed body nothing from this read.
-            -1 if self.state.encoding.is_compressed() => {
+            // Invalid HTTP response body.
+            -1 if !self.keeps_chunks_ahead_of_invalid_one() => {
                 return Err(crate::Error::InvalidHTTPResponse);
             }
             // -1: invalid, -2: needs more data. The chunks decoded so far are body either way.
@@ -4672,6 +4662,7 @@ impl<'a> HTTPClient<'a> {
                     processed = self.state.process_body_buffer(buffer_snap, false)?;
                 }
                 if pret == -1 {
+                    self.state.flags.has_body_ahead_of_failure = processed;
                     return Err(crate::Error::InvalidHTTPResponse);
                 }
 
@@ -4732,8 +4723,10 @@ impl<'a> HTTPClient<'a> {
             self.state.total_body_received
         );
         match pret {
-            // Invalid HTTP response body. Node.js gives a compressed body nothing from this read.
-            -1 if self.state.encoding.is_compressed() => Err(crate::Error::InvalidHTTPResponse),
+            // Invalid HTTP response body.
+            -1 if !self.keeps_chunks_ahead_of_invalid_one() => {
+                Err(crate::Error::InvalidHTTPResponse)
+            }
             // -1: invalid, -2: needs more data. The chunks decoded so far are body either way.
             -1 | -2 => {
                 self.report_progress(buffer.len());
@@ -4754,6 +4747,7 @@ impl<'a> HTTPClient<'a> {
                     processed = self.state.process_body_buffer(buffer_snap, false)?;
                 }
                 if pret == -1 {
+                    self.state.flags.has_body_ahead_of_failure = processed;
                     return Err(crate::Error::InvalidHTTPResponse);
                 }
 

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -4582,7 +4582,10 @@ impl<'a> HTTPClient<'a> {
 
     /// `fetch()` reads the chunks decoded ahead of an invalid one, as in Node.js, which gives a compressed body nothing.
     fn keeps_chunks_ahead_of_invalid_one(&self) -> bool {
-        self.signals.body_receive_mode.is_some() && !self.state.encoding.is_compressed()
+        self.signals.body_receive_mode.is_some()
+            && !self.state.encoding.is_compressed()
+            // A failure that still carries the response head builds the Response: no body can be read from it.
+            && self.state.cloned_metadata.is_none()
     }
 
     pub(crate) fn handle_response_body_chunked_encoding(

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1596,6 +1596,7 @@ impl<'a> HTTPClient<'a> {
     /// Common tail of `fail` / `fail_from_h2` / `complete_connecting_process`:
     /// build the result, reset request state, and dispatch the callback.
     fn dispatch_result_and_reset(&mut self, clear_proxy_tunneling: bool) {
+        self.report_body_decoded_before_failure();
         let callback = self.result_callback;
         let result = self.to_result();
         self.state.reset();
@@ -1616,6 +1617,39 @@ impl<'a> HTTPClient<'a> {
             self.flags.proxy_tunneling = false;
         }
         callback.run(self.parent_async_http(), result);
+    }
+    /// A read can hold valid body bytes followed by the bytes that fail the
+    /// response (a malformed chunk-size line). A streaming consumer gets the
+    /// body bytes in a progress callback of their own ahead of the failure,
+    /// as it would have had the two arrived in separate reads.
+    fn report_body_decoded_before_failure(&mut self) {
+        let is_streaming = self.signals.get(signals::Field::ResponseBodyStreaming)
+            || self.signals.body_receive_mode.is_some();
+        if !is_streaming
+            || self.state.decoded_body.list.is_empty()
+            || self.state.flags.is_redirect_pending
+        {
+            return;
+        }
+        // An abort or a timeout ends the body where the consumer stands.
+        let fail = match self.state.fail.take() {
+            None => return,
+            Some(
+                fail @ (crate::Error::Aborted
+                | crate::Error::AbortedBeforeConnecting
+                | crate::Error::Timeout),
+            ) => {
+                self.state.fail = Some(fail);
+                return;
+            }
+            Some(fail) => fail,
+        };
+        let mut result = self.to_result();
+        self.state.fail = Some(fail);
+        result.has_more = true;
+        let decoded_body = core::mem::take(&mut self.state.decoded_body);
+        result.body = decoded_body.list.as_slice();
+        self.result_callback.run(self.parent_async_http(), result);
     }
     #[inline]
     fn progress_node_mut(&mut self) -> Option<&mut bun_core::Progress::Node> {
@@ -4621,11 +4655,13 @@ impl<'a> HTTPClient<'a> {
         );
 
         match pret {
-            // Invalid HTTP response body
-            -1 => return Err(crate::Error::InvalidHTTPResponse),
-            // Needs more data
-            -2 => {
+            // -2: needs more data.
+            // -1: invalid HTTP response body. The chunks decoded ahead of the
+            // invalid one are body all the same; `fail` reports them to a
+            // streaming consumer before the error.
+            -1 | -2 => {
                 self.report_progress(buffer_len);
+                let mut processed = false;
                 // streaming chunks
                 if self.signals.get(signals::Field::ResponseBodyStreaming)
                     || self.signals.body_receive_mode.is_some()
@@ -4635,10 +4671,13 @@ impl<'a> HTTPClient<'a> {
                     // Move the
                     // bytes out so no `&` into self.state aliases the `&mut self.state` call.
                     let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
-                    return self.state.process_body_buffer(buffer_snap, false);
+                    processed = self.state.process_body_buffer(buffer_snap, false)?;
+                }
+                if pret == -1 {
+                    return Err(crate::Error::InvalidHTTPResponse);
                 }
 
-                return Ok(false);
+                return Ok(processed);
             }
             // Done
             _ => {
@@ -4695,13 +4734,15 @@ impl<'a> HTTPClient<'a> {
             self.state.total_body_received
         );
         match pret {
-            // Invalid HTTP response body
-            -1 => Err(crate::Error::InvalidHTTPResponse),
-            // Needs more data
-            -2 => {
+            // -2: needs more data.
+            // -1: invalid HTTP response body. The chunks decoded ahead of the
+            // invalid one are body all the same; `fail` reports them to a
+            // streaming consumer before the error.
+            -1 | -2 => {
                 self.report_progress(buffer.len());
                 self.state.get_body_buffer().append_slice_exact(buffer)?;
 
+                let mut processed = false;
                 // streaming chunks
                 if self.signals.get(signals::Field::ResponseBodyStreaming)
                     || self.signals.body_receive_mode.is_some()
@@ -4713,10 +4754,13 @@ impl<'a> HTTPClient<'a> {
                     // the bytes out so no `&` into self.state aliases the `&mut self.state`
                     // taken by process_body_buffer (which mutates compressed_body/decoded_body).
                     let buffer_snap = core::mem::take(&mut self.state.get_body_buffer().list);
-                    return self.state.process_body_buffer(buffer_snap, false);
+                    processed = self.state.process_body_buffer(buffer_snap, false)?;
+                }
+                if pret == -1 {
+                    return Err(crate::Error::InvalidHTTPResponse);
                 }
 
-                Ok(false)
+                Ok(processed)
             }
             // Done
             _ => {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -881,10 +881,7 @@ impl FetchTasklet {
         Ok(())
     }
 
-    /// The HTTP thread can report body bytes and then fail before the JS thread runs, so one
-    /// `on_progress_update` sees both. The error must not overtake bytes that arrived before
-    /// it: this run handles the bytes as the progress update they arrived as, and a second run
-    /// on the next task handles the failure (returned here, restored by `cleanup`).
+    /// Takes a failure that arrived behind body bytes this thread has not seen out of `result`.
     fn hold_failure_behind_unseen_body(&mut self) -> Option<http::Error> {
         let fail = self.result.fail?;
         if self.scheduled_response_buffer.list.is_empty() {
@@ -944,8 +941,7 @@ impl FetchTasklet {
         // explicit cleanup at each return (a closure keeps borrowck happy)
         let cleanup = |this: &mut FetchTasklet| {
             if let Some(fail) = failure_behind_body {
-                // This run consumed the body bytes. The failure is the terminal update again,
-                // and it carries this thread's ref like the task the HTTP thread posted.
+                // The next task handles the failure as the terminal update, and owns this thread's ref.
                 this.result.fail = Some(fail);
                 this.result.has_more = false;
                 // SAFETY: `vm.event_loop()` is the live JS-thread loop.

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -881,14 +881,47 @@ impl FetchTasklet {
         Ok(())
     }
 
+    /// The HTTP thread can report body bytes and then fail before the JS thread runs, so one
+    /// `on_progress_update` sees both. The error must not overtake bytes that arrived before
+    /// it: this run handles the bytes as the progress update they arrived as, and a second run
+    /// on the next task handles the failure (returned here, restored by `cleanup`).
+    fn hold_failure_behind_unseen_body(&mut self) -> Option<http::Error> {
+        let fail = self.result.fail?;
+        if self.scheduled_response_buffer.list.is_empty() {
+            return None;
+        }
+        // Without a head the promise rejects and nothing can read the bytes.
+        if !self.is_waiting_body && self.metadata.is_none() {
+            return None;
+        }
+        // An abort ends the body where the consumer stands.
+        if self.is_waiting_abort
+            || self.abort_reason.has()
+            || self.result.abort_reason().is_some()
+            || self.signal_store.aborted.load(Ordering::Relaxed)
+        {
+            return None;
+        }
+        self.result.fail = None;
+        self.result.has_more = true;
+        Some(fail)
+    }
+
     pub(crate) fn on_progress_update(&mut self) -> JsResult<()> {
         jsc::mark_binding!();
         bun_output::scoped_log!(FetchTasklet, "onProgressUpdate");
         self.mutex.lock();
-        self.has_schedule_callback.store(false, Ordering::Relaxed);
-        let is_done = !self.result.has_more;
+        // Set by `callback` only: this run was posted by the HTTP thread.
+        let posted_by_http_thread = self.has_schedule_callback.swap(false, Ordering::Relaxed);
 
         let vm = self.global_this.bun_vm();
+        let failure_behind_body = if posted_by_http_thread && vm.script_allowed() {
+            self.hold_failure_behind_unseen_body()
+        } else {
+            None
+        };
+        let is_done = !self.result.has_more;
+
         // teardown forbade script: we cannot touch JS
         if !vm.script_allowed() {
             // The certificate will never be checked; release the parked
@@ -910,6 +943,16 @@ impl FetchTasklet {
         let global_this = self.global_this;
         // explicit cleanup at each return (a closure keeps borrowck happy)
         let cleanup = |this: &mut FetchTasklet| {
+            if let Some(fail) = failure_behind_body {
+                // This run consumed the body bytes. The failure is the terminal update again,
+                // and it carries this thread's ref like the task the HTTP thread posted.
+                this.result.fail = Some(fail);
+                this.result.has_more = false;
+                // SAFETY: `vm.event_loop()` is the live JS-thread loop.
+                unsafe {
+                    (*vm.event_loop()).enqueue_task(Task::init(std::ptr::from_mut(this)));
+                }
+            }
             this.mutex.unlock();
             // if we are not done we wait until the next call
             if is_done {
@@ -929,8 +972,9 @@ impl FetchTasklet {
             // start streaming
             if let Err(err) = self.start_request_stream() {
                 // The VM is being stopped: leave like the `!script_allowed()` gate above does.
+                // A failure held back for a second run is the terminal update; no run follows.
                 self.mutex.unlock();
-                if is_done {
+                if is_done || failure_behind_body.is_some() {
                     // SAFETY: `self` is the live heap tasklet; we hold a ref.
                     FetchTasklet::deref(std::ptr::from_mut(self));
                 }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -887,8 +887,8 @@ impl FetchTasklet {
         if self.scheduled_response_buffer.list.is_empty() {
             return None;
         }
-        // Without a head the promise rejects and nothing can read the bytes.
-        if !self.is_waiting_body && self.metadata.is_none() {
+        // A Response built from the failure keeps it; a stream made between the two runs would drop it.
+        if !self.is_waiting_body {
             return None;
         }
         // An abort ends the body where the consumer stands.

--- a/test/js/web/fetch/fetch-chunked-size.test.ts
+++ b/test/js/web/fetch/fetch-chunked-size.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, tls as tlsCert } from "harness";
 import net from "node:net";
 
 async function serveChunked(body: string) {
@@ -100,6 +101,79 @@ describe("fetch: chunked chunk-size token validation", () => {
       expect(code).toBe("InvalidHTTPResponse");
       expect(body.length).toBe(payload.length);
       expect(body).toBe(payload);
+    });
+
+    // The same body through a CONNECT tunnel to a TLS origin, which fails from `ProxyTunnel`'s data callback.
+    it("through a CONNECT tunnel", async () => {
+      // A subprocess, so that a NO_PROXY that covers loopback cannot bypass the `proxy` option.
+      const env = { ...bunEnv };
+      for (const name of ["NO_PROXY", "no_proxy", "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy"]) {
+        delete env[name];
+      }
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            import net from "node:net";
+            import tls from "node:tls";
+            const cert = ${JSON.stringify(tlsCert)};
+            const accepted = Promise.withResolvers();
+            const origin = tls.createServer({ key: cert.key, cert: cert.cert }, socket => {
+              socket.on("error", () => {});
+              socket.once("data", () => {
+                socket.write(${JSON.stringify(`${head}\r\n`)});
+                accepted.resolve(socket);
+              });
+            });
+            await new Promise(r => origin.listen(0, "127.0.0.1", r));
+            const proxy = net.createServer(client => {
+              client.on("error", () => {});
+              client.once("data", () => {
+                const upstream = net.connect(origin.address().port, "127.0.0.1", () => {
+                  client.write("HTTP/1.1 200 Connection established\\r\\n\\r\\n");
+                  client.pipe(upstream);
+                  upstream.pipe(client);
+                });
+                upstream.on("error", () => client.destroy());
+              });
+            });
+            await new Promise(r => proxy.listen(0, "127.0.0.1", r));
+
+            const res = await fetch("https://127.0.0.1:" + origin.address().port + "/", {
+              proxy: "http://127.0.0.1:" + proxy.address().port,
+              tls: { rejectUnauthorized: false },
+              keepalive: false,
+            });
+            const reader = res.body.getReader();
+            const chunks = [];
+            let code = "(stream ended)";
+            // A read is pending before the origin writes the rest, in one TLS record.
+            const reading = (async () => {
+              try {
+                for (;;) {
+                  const { done, value } = await reader.read();
+                  if (done) break;
+                  chunks.push(Buffer.from(value));
+                }
+              } catch (e) {
+                code = e?.code;
+              }
+            })();
+            (await accepted.promise).write(${JSON.stringify(`1\r\nx\r\n${malformed}`)});
+            await reading;
+            console.log(JSON.stringify({ status: res.status, body: Buffer.concat(chunks).toString(), code }));
+            process.exit(0);
+          `,
+        ],
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout.trim())).toEqual({ status: 200, body: "x", code: "InvalidHTTPResponse" });
+      expect(exitCode).toBe(0);
     });
 
     // node v26.3.0 delivers nothing here: the error tears its gunzip down before it emits.

--- a/test/js/web/fetch/fetch-chunked-size.test.ts
+++ b/test/js/web/fetch/fetch-chunked-size.test.ts
@@ -37,6 +37,106 @@ describe("fetch: chunked chunk-size token validation", () => {
     });
   });
 
+  // The chunks ahead of the malformed one are body. A reader that reads at once gets them,
+  // then the read rejects, whether or not they share a socket read with the malformed line.
+  // node v26.3.0: chunks ["x"], then `TypeError: terminated` (HPE_INVALID_CHUNK_SIZE).
+  describe("delivers the chunks ahead of a malformed chunk-size to a streaming reader", () => {
+    const head = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n";
+    // "C" is a hex digit, so this line is chunk-size 0xC followed by junk.
+    const malformed = "Connection: close\r\n\r\n";
+
+    // Writes `first` when the request arrives and keeps the socket open, so the failure can
+    // only come from the parser. `send()` writes one more piece.
+    async function serveParts(first: string | Buffer) {
+      const { promise, resolve } = Promise.withResolvers<net.AddressInfo>();
+      const accepted = Promise.withResolvers<net.Socket>();
+      const server = net
+        .createServer(socket => {
+          socket.on("error", () => {});
+          socket.once("data", () => {
+            socket.write(first);
+            accepted.resolve(socket);
+          });
+        })
+        .listen(0, "127.0.0.1", () => resolve(server.address() as net.AddressInfo));
+      const address = await promise;
+      return {
+        server,
+        url: `http://127.0.0.1:${address.port}/`,
+        send: async (part: string | Buffer) => void (await accepted.promise).write(part),
+      };
+    }
+
+    async function readUntilError(reader: ReadableStreamDefaultReader<Uint8Array>) {
+      const chunks: Buffer[] = [];
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) return { body: Buffer.concat(chunks).toString(), code: "(stream ended)" };
+          chunks.push(Buffer.from(value));
+        }
+      } catch (e: any) {
+        return { body: Buffer.concat(chunks).toString(), code: e?.code };
+      }
+    }
+
+    it("in the same read as the response head", async () => {
+      const { server, url } = await serveParts(`${head}\r\n1\r\nx\r\n${malformed}`);
+      await using _s = server;
+      const res = await fetch(url);
+      expect(await readUntilError(res.body!.getReader())).toEqual({ body: "x", code: "InvalidHTTPResponse" });
+    });
+
+    it("in a read after the response head", async () => {
+      const { server, url, send } = await serveParts(`${head}\r\n`);
+      await using _s = server;
+      const res = await fetch(url);
+      // A read is pending before the server writes the rest.
+      const result = readUntilError(res.body!.getReader());
+      await send(`1\r\nx\r\n${malformed}`);
+      expect(await result).toEqual({ body: "x", code: "InvalidHTTPResponse" });
+    });
+
+    it("with Content-Encoding: gzip", async () => {
+      const gz = Bun.gzipSync("hello hello hello hello");
+      const wire = Buffer.concat([
+        Buffer.from(`${head}Content-Encoding: gzip\r\n\r\n${gz.length.toString(16)}\r\n`),
+        gz,
+        Buffer.from(`\r\n${malformed}`),
+      ]);
+      const { server, url } = await serveParts(wire);
+      await using _s = server;
+      const res = await fetch(url);
+      expect(await readUntilError(res.body!.getReader())).toEqual({
+        body: "hello hello hello hello",
+        code: "InvalidHTTPResponse",
+      });
+    });
+
+    it("with a chunk larger than one socket read", async () => {
+      const payload = Buffer.alloc(256 * 1024, "abcdefghijklmnopqrstuvwxyz").toString();
+      const { server, url } = await serveParts(
+        `${head}\r\n${payload.length.toString(16)}\r\n${payload}\r\n${malformed}`,
+      );
+      await using _s = server;
+      const res = await fetch(url);
+      const { body, code } = await readUntilError(res.body!.getReader());
+      expect(code).toBe("InvalidHTTPResponse");
+      expect(body.length).toBe(payload.length);
+      expect(body).toBe(payload);
+    });
+
+    it("text() still rejects", async () => {
+      const { server, url } = await serveParts(`${head}\r\n1\r\nx\r\n${malformed}`);
+      await using _s = server;
+      const result = await fetch(url)
+        .then(res => res.text())
+        .then(body => ({ resolved: body }))
+        .catch(e => e);
+      expect(result?.code).toBe("InvalidHTTPResponse");
+    });
+  });
+
   describe("accepts well-formed chunk-size", () => {
     it.each([
       ["5", "hello"],

--- a/test/js/web/fetch/fetch-chunked-size.test.ts
+++ b/test/js/web/fetch/fetch-chunked-size.test.ts
@@ -97,7 +97,8 @@ describe("fetch: chunked chunk-size token validation", () => {
       expect(await result).toEqual({ body: "x", code: "InvalidHTTPResponse" });
     });
 
-    it("with Content-Encoding: gzip", async () => {
+    // node v26.3.0 delivers nothing here: the error tears its gunzip down before it emits.
+    it("but not of a compressed body", async () => {
       const gz = Bun.gzipSync("hello hello hello hello");
       const wire = Buffer.concat([
         Buffer.from(`${head}Content-Encoding: gzip\r\n\r\n${gz.length.toString(16)}\r\n`),
@@ -107,10 +108,7 @@ describe("fetch: chunked chunk-size token validation", () => {
       const { server, url } = await serveParts(wire);
       await using _s = server;
       const res = await fetch(url);
-      expect(await readUntilError(res.body!.getReader())).toEqual({
-        body: "hello hello hello hello",
-        code: "InvalidHTTPResponse",
-      });
+      expect(await readUntilError(res.body!.getReader())).toEqual({ body: "", code: "InvalidHTTPResponse" });
     });
 
     it("with a chunk larger than one socket read", async () => {

--- a/test/js/web/fetch/fetch-chunked-size.test.ts
+++ b/test/js/web/fetch/fetch-chunked-size.test.ts
@@ -37,9 +37,8 @@ describe("fetch: chunked chunk-size token validation", () => {
     });
   });
 
-  // The chunks ahead of the malformed one are body. A reader that reads at once gets them,
-  // then the read rejects, whether or not they share a socket read with the malformed line.
-  // node v26.3.0: chunks ["x"], then `TypeError: terminated` (HPE_INVALID_CHUNK_SIZE).
+  // The chunks ahead of the malformed one are body: a reader that is waiting gets them, then the
+  // read rejects. node v26.3.0: chunks ["x"], then `TypeError: terminated` (HPE_INVALID_CHUNK_SIZE).
   describe("delivers the chunks ahead of a malformed chunk-size to a streaming reader", () => {
     const head = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n";
     // "C" is a hex digit, so this line is chunk-size 0xC followed by junk.
@@ -80,14 +79,7 @@ describe("fetch: chunked chunk-size token validation", () => {
       }
     }
 
-    it("in the same read as the response head", async () => {
-      const { server, url } = await serveParts(`${head}\r\n1\r\nx\r\n${malformed}`);
-      await using _s = server;
-      const res = await fetch(url);
-      expect(await readUntilError(res.body!.getReader())).toEqual({ body: "x", code: "InvalidHTTPResponse" });
-    });
-
-    it("in a read after the response head", async () => {
+    it("in one read", async () => {
       const { server, url, send } = await serveParts(`${head}\r\n`);
       await using _s = server;
       const res = await fetch(url);
@@ -97,41 +89,81 @@ describe("fetch: chunked chunk-size token validation", () => {
       expect(await result).toEqual({ body: "x", code: "InvalidHTTPResponse" });
     });
 
-    // node v26.3.0 delivers nothing here: the error tears its gunzip down before it emits.
-    it("but not of a compressed body", async () => {
-      const gz = Bun.gzipSync("hello hello hello hello");
-      const wire = Buffer.concat([
-        Buffer.from(`${head}Content-Encoding: gzip\r\n\r\n${gz.length.toString(16)}\r\n`),
-        gz,
-        Buffer.from(`\r\n${malformed}`),
-      ]);
-      const { server, url } = await serveParts(wire);
-      await using _s = server;
-      const res = await fetch(url);
-      expect(await readUntilError(res.body!.getReader())).toEqual({ body: "", code: "InvalidHTTPResponse" });
-    });
-
-    it("with a chunk larger than one socket read", async () => {
+    it("in a chunk larger than one read", async () => {
       const payload = Buffer.alloc(256 * 1024, "abcdefghijklmnopqrstuvwxyz").toString();
-      const { server, url } = await serveParts(
-        `${head}\r\n${payload.length.toString(16)}\r\n${payload}\r\n${malformed}`,
-      );
+      const { server, url, send } = await serveParts(`${head}\r\n`);
       await using _s = server;
       const res = await fetch(url);
-      const { body, code } = await readUntilError(res.body!.getReader());
+      const result = readUntilError(res.body!.getReader());
+      await send(`${payload.length.toString(16)}\r\n${payload}\r\n${malformed}`);
+      const { body, code } = await result;
       expect(code).toBe("InvalidHTTPResponse");
       expect(body.length).toBe(payload.length);
       expect(body).toBe(payload);
     });
 
-    it("text() still rejects", async () => {
-      const { server, url } = await serveParts(`${head}\r\n1\r\nx\r\n${malformed}`);
+    // node v26.3.0 delivers nothing here: the error tears its gunzip down before it emits.
+    it("but not of a compressed body", async () => {
+      const gz = Bun.gzipSync("hello hello hello hello");
+      const { server, url, send } = await serveParts(`${head}Content-Encoding: gzip\r\n\r\n`);
       await using _s = server;
-      const result = await fetch(url)
-        .then(res => res.text())
-        .then(body => ({ resolved: body }))
-        .catch(e => e);
-      expect(result?.code).toBe("InvalidHTTPResponse");
+      const res = await fetch(url);
+      const result = readUntilError(res.body!.getReader());
+      await send(Buffer.concat([Buffer.from(`${gz.length.toString(16)}\r\n`), gz, Buffer.from(`\r\n${malformed}`)]));
+      expect(await result).toEqual({ body: "", code: "InvalidHTTPResponse" });
+    });
+
+    it("and no inflater output ahead of a corrupted gzip body's error", async () => {
+      const text = Buffer.alloc(8192, "the quick brown fox jumps over the lazy dog ").toString();
+      const gz = Buffer.from(Bun.gzipSync(text, { level: 1 }));
+      gz[gz.length >> 1] ^= 0xff;
+      gz[(gz.length >> 1) + 1] ^= 0xff;
+      const { server, url, send } = await serveParts(`${head}Content-Encoding: gzip\r\n\r\n`);
+      await using _s = server;
+      const res = await fetch(url);
+      const result = readUntilError(res.body!.getReader());
+      await send(Buffer.concat([Buffer.from(`${gz.length.toString(16)}\r\n`), gz, Buffer.from("\r\n0\r\n\r\n")]));
+      expect(await result).toEqual({ body: "", code: "ZlibError" });
+    });
+
+    // With the response head in the same read the Response is built from the failure, so every
+    // way of reading the body rejects. (node v26.3.0 gives a reader that reads at once "x" first.)
+    describe("when the response head shares the read, the body rejects", () => {
+      const yieldToEventLoop = () => new Promise<void>(resolve => setImmediate(resolve));
+      it.each([
+        ["a reader that reads at once", async (res: Response) => readUntilError(res.body!.getReader())],
+        [
+          "a body stream made before a later first read",
+          async (res: Response) => {
+            const body = res.body!;
+            await yieldToEventLoop();
+            return readUntilError(body.getReader());
+          },
+        ],
+        [
+          "a body stream made before a later arrayBuffer()",
+          async (res: Response) => {
+            const body = res.body!;
+            await yieldToEventLoop();
+            return new Response(body).arrayBuffer().then(
+              bytes => ({ body: Buffer.from(bytes).toString(), code: "(resolved)" }),
+              e => ({ body: "", code: e?.code }),
+            );
+          },
+        ],
+        [
+          "text()",
+          async (res: Response) =>
+            res.text().then(
+              body => ({ body, code: "(resolved)" }),
+              e => ({ body: "", code: e?.code }),
+            ),
+        ],
+      ])("%s", async (_, consume) => {
+        const { server, url } = await serveParts(`${head}\r\n1\r\nx\r\n${malformed}`);
+        await using _s = server;
+        expect(await consume(await fetch(url))).toEqual({ body: "", code: "InvalidHTTPResponse" });
+      });
     });
   });
 


### PR DESCRIPTION
Follow-up to #34918 ([request](https://github.com/oven-sh/bun/pull/34918#issuecomment-5625853836)).

### Problem
- One socket read can hold valid chunks followed by a malformed chunk-size line (`1\r\nx\r\nConnection: close\r\n`). A reader that waits on `res.body` then gets no body, only `InvalidHTTPResponse`. Node v26.3.0 gives the reader `"x"`, then rejects the next read. With a 256 KiB chunk ahead of the bad line the reader lost up to 134198 of 262144 bytes.
- `phr_decode_chunked` returns `-1` after it decoded the valid chunks. Both `-1` arms in `src/http/lib.rs` (`handle_response_body_chunked_encoding_from_single_packet`, `_from_multiple_packets`) dropped those bytes.

### Fix
- For `fetch()`, an uncompressed body and a response head that was already reported, the `-1` arms keep the decoded bytes and set `has_body_ahead_of_failure`. `dispatch_result_and_reset` then reports them in their own progress callback (`report_body_decoded_before_failure`) before it sends the failure. A compressed body gets nothing, as in Node.
- On the JS thread both callbacks usually land in one `on_progress_update`. Once the Response exists, `FetchTasklet` handles the bytes in that run and the failure in a second run, on the next task (`hold_failure_behind_unseen_body`). Not for an abort.
- Correct because a reader already gets this result when the bytes and the bad line arrive in separate reads.
- Verified: `test/js/web/fetch/fetch-chunked-size.test.ts` (9 new tests, 3 fail on canary `e5f9986a4`, 6 pin what must not change). Other suites: see Notes.

### Limit
- If the failure reaches the JS thread before it built the Response (head, chunks and bad line in one read, or a slow JS thread), the Response is built from the failure, as on main, and the bytes are dropped. Node gives a reader that reads at once `"x"` there.
- Holding the failure in that case needs #38003 first, see Notes.

### Background
- `fetch()` parses responses on the HTTP thread. It reports body bytes to `FetchTasklet::callback`, which stores them and posts one task to the JS thread. Two callbacks before that task runs reach the JS thread as one update.
- A failure result is terminal. `on_progress_update` errors the body and drops undelivered bytes.

### Node v26.3.0 vs main vs this PR
What a `res.body.getReader()` loop collects before the read rejects. Bad line: `Connection: close\r\n\r\n`. Script: https://github.com/oven-sh/bun/pull/42261#issuecomment-5628807802

| # | wire (raw TCP server, `Transfer-Encoding: chunked`) | Node v26.3.0 | main (canary `e5f9986a4`) | this PR (`5ff541592a`) |
| --- | --- | --- | --- | --- |
| 1 | head + `1\r\nx\r\n` + bad line, one write, read at once | `"x"`, then rejects | `""`, then rejects | `""`, then rejects (Limit) |
| 2 | same as 1, reader attaches after 300 ms | `""`, then rejects | `""`, then rejects | `""`, then rejects |
| 3 | head first, then `1\r\nx\r\n` + bad line in one write | `"x"`, then rejects | `""`, then rejects | `"x"`, then rejects |
| 4 | head + `1\r\nx\r\n`, bad line only after `"x"` was read | `"x"`, then rejects | `"x"`, then rejects | `"x"`, then rejects |
| 5 | head first, then one 256 KiB chunk + bad line in one write | 262144 bytes, then rejects | part of it, then rejects | 262144 bytes, then rejects |
| 6 | gzip: head + gzip member in one chunk + bad line | `""`, then rejects | `""`, then rejects | `""`, then rejects |
| 7 | case 1 with `await res.text()` | rejects | rejects | rejects |

<details><summary>Notes</summary>

Regressions that review found on earlier heads of this PR (`c799f5915c`, `5a92cbd53f`), fixed in `5a92cbd53f` and `3db5d26cf8` and pinned by tests:

1. The flush reported any non-empty `decoded_body`. A corrupted gzip body gave a reader inflater output, wrong bytes included, ahead of `ZlibError`. main and Node give nothing. The flush is now opt-in: only the two `-1` arms set `has_body_ahead_of_failure`, and only for `fetch()` (`signals.body_receive_mode`) with an uncompressed body. `bun install` tarball streaming sets only `ResponseBodyStreaming`, so it gets no new callback. An S3 download stream wires the same backpressure signals as `fetch()` (`to_with_backpressure`), so it is included. It already handles a progress callback that is followed by a failure.
2. The failure was held back even before the Response existed. The Response was then built with a live body. A body stream made from it before its first read (`const body = res.body`, read one task later) drops an error that arrives next: `ByteStream::append` stores the error and `on_start` reports `Start::Empty`, so the stream ended cleanly with no error. main builds that Response from the failure (`BodyValue::Error`), which every consumer sees. The failure is now held only once the Response exists, where the outcome for such a stream is the same as on main. #38003 fixes the stored-error path itself. With it in, the failure can be held in the first case too and row 1 can match Node.

3. (Found in review of `5a92cbd53f`.) With the head in the same read, the chunks went out in a callback of their own ahead of the failure. If the JS thread ran between the two callbacks it built a live body, with the same lost error as in 2. The `-1` arms now keep the chunks only when the head was already reported (`state.cloned_metadata.is_none()`), so that case sends one failure callback, as on main.

Why the JS-thread part is needed. For row 3 the HTTP thread sends `"x"` and then the failure before the JS thread runs. `on_body_received` sent the error to the stream and its `defer` cleared the buffer. Now the first run delivers `"x"` to the pending read and the second run errors the stream. Node does the same: its parser error reaches the body one tick after the data.

`hold_failure_behind_unseen_body` only triggers when `has_schedule_callback` was set, which only `FetchTasklet::callback` does. The second run is enqueued by the JS thread itself, so it cannot hold the failure again. The second run carries the JS thread's ref, the same as the task the HTTP thread posted. If `start_request_stream` fails in the first run because the VM stops, the ref is dropped there. The hold applies to every failure kind except aborts, not only to `InvalidHTTPResponse`: a connection that closes early no longer overtakes the bytes that arrived before it once the Response exists (`test/js/web/fetch/body.test.ts` works around that today with its `consumedFirstChunk` handshake, and the test is in `test/flaky-tests.txt`). I did not change that test here.

The flush lives in `dispatch_result_and_reset`, so the CONNECT-tunnel path (`ProxyTunnel::on_data` -> `close_from_callback` -> `fail`) gets it with no change at the call sites. h2 and h3 do not use chunked encoding and never set the flag.

Compressed bodies (row 6). Node delivers nothing from the read that holds the bad line, because the error tears its gunzip down before it emits. The `-1` arms match that. Bytes that earlier reads already decompressed and reported are not affected.

A late reader (row 2) sees no chunks in Node and in Bun. Erroring a stream discards what is queued, and by then the error has arrived.

Suites run with the debug build on `5a92cbd53f`: `fetch-chunked-size`, `body.test.ts`, `body-clone`, `body-mixin-errors`, `body-stream`, `body-async-iterator`, `fetch-gzip`, `fetch.brotli`, `fetch-retry-chunked`, `fetch-abort-stream-body`, `fetch-abort-socket-close-race`, `fetch-stream-cancel-leak`, `fetch-response-finalizer-sweep`, `fetch.stream`, `fetch-keepalive`, `fetch-redirect`, `fetch-http2-client`, `node-http.test.ts`, `node-fetch`, `client-timeout-error`, `node-http-transfer-encoding`. The only failures were 5 s timeouts in `fetch.stream` "Content-Length response works (multiple parts)" on a machine with load average 74. They pass when run alone and do not touch a failure path. An earlier head also ran `fetch.test.ts`, the other `test/js/node/http/` client files and 27 `test-http-client-*` / `test-http-chunk*` / `test-http-abort*` files from `test/js/node/test/parallel/`.

The CONNECT-tunnel path has its own test (`through a CONNECT tunnel`): an HTTP CONNECT proxy in front of a TLS origin that writes `1\r\nx\r\n` and the malformed line in one TLS record. It fails on the main canary and passes here.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 3 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/fetch-chunked-size.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/42] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/42] gen cpp.rs (cppbind)
[3/42] gen JS modules (bundle-modules)
Preprocess modules (12320ms)
Bundle modules (289ms)
Postprocesss modules (231ms)
Bundle Functions (657ms)
Generate Code (49ms)

[13.56s] Bundled "src/js" for development
  2791 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/29] cargo bun_runtime → libbun_runtime.a
[22/29] cxx obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o
FAILED: obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -fno-async
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (5a92cbd53)

test/js/web/fetch/fetch-chunked-size.test.ts:
(pass) fetch: chunked chunk-size token validation > rejects malformed chunk-size > token "0x5" [7.80ms]
(pass) fetch: chunked chunk-size token validation > rejects malformed chunk-size > token "5g" [1.25ms]
(pass) fetch: chunked chunk-size token validation > rejects malformed chunk-size > token "5 " [0.83ms]
(pass) fetch: chunked chunk-size token validation > rejects malformed chunk-size > token "5\t" [1.10ms]
(pass) fetch: chunked chunk-size token validation > rejects malformed chunk-size > token "5.0" [0.82ms]
(pass) fetch: chunked chunk-size token validation > rejects malformed chunk-size > token "5-" [2.30ms]
(pass) fetch: chunked chunk-size token validation > delivers the chunks ahead of a malformed chunk-size to a streaming reader > in one read [1.82ms]
(pass) fetch: chunked chunk-size token validation > delivers the chunks ahead of a malformed chunk-size to a streaming reader > in a chunk larger than one read [6.22ms]
(pass) fetch: chunked chunk-size token validation > delivers the chunks ahead of a malformed chunk-size to a streaming reader > through a CONNECT tunnel [65.85ms
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/fetch-chunked-size.test.ts
bun test v1.4.3 (5f554969b)

test/js/web/fetch/fetch-chunked-size.test.ts:
(pass) fetch: chunked chunk-size token validation > rejects malformed chunk-size > token "0x5" [527.23ms]
(pass) fetch: chunked chunk-size token validation > rejects malformed chunk-size > token "5g" [42.41ms]
(pass) fetch: chunked chunk-size token validation > rejects malformed chunk-size > token "5 " [24.26ms]
(pass) fetch: chunked chunk-size token validation > rejects malformed chunk-size > token "5\t" [28.41ms]
(pass) fetch: chunked chunk-size token validation > rejects malformed chunk-size > token "5.0" [34.29ms]
(pass) fetch: chunked chunk-size token validation > rejects malformed chunk-size > token "5-" [35.12ms]
(pass) fetch: chunked chunk-size token validation > delivers the chunks ahead of a malformed chunk-size to a streaming reader > in one read [94.49ms]
(pass) fetch: chunked chunk-size token validation > delivers the chunks ahead of a malformed chunk-size to a streaming reader > in a chunk larger than one
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 940ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/31] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/31] gen cpp.rs (cppbind)
[3/31] gen JS modules (bundle-modules)
Preprocess modules (13554ms)
Bundle modules (66ms)
Postprocesss modules (162ms)
Bundle Functions (626ms)
Generate Code (47ms)

[14.46s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/23] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/InternalState.rs                    |   3 +
 src/http/lib.rs                              |  62 ++++++--
 src/runtime/webcore/fetch/FetchTasklet.rs    |  46 +++++-
 test/js/web/fetch/fetch-chunked-size.test.ts | 204 +++++++++++++++++++++++++++
 4 files changed, 300 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/http/InternalState.rs                         4      0     24
src/http/lib.rs                                   9      5     28
src/runtime/webcore/fetch/FetchTasklet.rs         6      4     24
test/js/web/fetch/fetch-chunked-size.test.ts      2      3     24
```

</details>

<!-- robobun:evidence:end -->

