### PR TITLE
node:net: do not push native reads into a socket whose readable side has ended

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -435,6 +435,8 @@ function tlsHandshakeError(verifyError) {
 
 // Node reports a throwing 'data' listener as uncaughtException and keeps reading.
 function pushDataToSocket(self, socket, buffer) {
+  // The raw half of a TLS pair still sees the connection's bytes; a readable side that has ended (`readable: false`) takes none.
+  if (self.readableEnded) return;
   let full;
   try {
     full = self.push(buffer) === false;

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -709,6 +709,35 @@ it("'session' and 'keylog' are emitted for a TLSSocket over a duplex stream (tls
   await once(server, "close");
 });
 
+// The raw half of the TLS pair still sees the connection's (encrypted) bytes.
+// Pushing them into a raw socket built with `readable: false` destroyed it with
+// ERR_STREAM_PUSH_AFTER_EOF and took the TLS socket down before its data arrived.
+// Node's TLSWrap reads from the handle, so the raw stream's flags do not matter.
+it.each(["connected", "connecting"])(
+  "tls.connect({ socket }) works over a %s socket built with readable: false",
+  async state => {
+    const server = tls.createServer({ ...COMMON_CERT_ }, socket => {
+      socket.on("error", () => {});
+      socket.end("hello");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const raw = net.connect({ port: (server.address() as AddressInfo).port, host: "127.0.0.1", readable: false });
+      const events: string[] = [];
+      raw.on("error", err => events.push(`raw error ${(err as NodeJS.ErrnoException).code}`));
+      if (state === "connected") await once(raw, "connect");
+      const client = tls.connect({ socket: raw, rejectUnauthorized: false }, () => events.push("secureConnect"));
+      client.setEncoding("utf8");
+      client.on("data", chunk => events.push(`data ${chunk}`));
+      client.on("error", err => events.push(`tls error ${(err as NodeJS.ErrnoException).code}`));
+      await once(client, "close");
+      expect(events).toEqual(["secureConnect", "data hello"]);
+    } finally {
+      server.close();
+    }
+  },
+);
+
 it("a write from inside 'data' does not re-enter 'data' on a TLSSocket over a duplex (tls.connect({ socket }))", async () => {
   // The TLS engine behind a duplex decrypts into a 64 KiB buffer and emits one
   // buffer at a time. A write() from inside the 'data' handler used to pump the


### PR DESCRIPTION
### Problem
- Regression from #42213. `tls.connect({ socket: raw })` over a `net.Socket` built with `readable: false` emits `ERR_STREAM_PUSH_AFTER_EOF` ("stream.push() after EOF") on `raw`. That destroys `raw`, which takes the TLS socket down before its data arrives. 1.4.3 and node v26.3.0 deliver the data.
- Cause: the raw half of a TLS pair still receives the connection's bytes, and `pushDataToSocket` (`src/js/node/net.ts:437`) pushes them into the raw `net.Socket`. Since #42213 a `readable: false` socket starts with its readable side ended, so that push is a push after EOF.

### Fix
- `pushDataToSocket` returns early when `self.readableEnded`. An ended readable side takes no data.
- Correct because node never delivers anything to such a stream: for a plain socket it never starts reading, and under TLS the `TLSWrap` reads from the handle, so the raw stream's flags do not matter. `bytesRead` and the idle-timer refresh stay in the callers, which matches node (`bytesRead` is the handle's count, and TLS reads refresh the parent's timer).
- Verified: `test/js/node/tls/node-tls-connect.test.ts` (new case for a connected and a connecting raw socket, both fail on main with `raw error ERR_STREAM_PUSH_AFTER_EOF`). Also all of that file, `node-tls-server.test.ts`, `node-net-server.test.ts` and the `readable` / fd adoption tests in `node-net.test.ts`.

### Background
- `tls.connect({ socket })` upgrades the connected handle in place (`upgradeTLSDeferred`). It returns a pair: a TLS handle for the new `TLSSocket` and a raw handle that stays on the original `net.Socket` and keeps feeding that socket's `data` handler.
- A Duplex built with `readable: false` starts with `endEmitted` set. `push()` on it reports `ERR_STREAM_PUSH_AFTER_EOF` through `errorOrDestroy`, which destroys the stream.

<details><summary>Notes</summary>

- Repro (any TLS server that writes after the handshake):

  ```js
  const raw = net.connect({ port, readable: false });
  const client = tls.connect({ socket: raw, rejectUnauthorized: false }, () => console.log("secureConnect"));
  raw.on("error", e => console.log("raw error", e.code));
  client.on("data", d => console.log("data", String(d)));
  ```

  node v26.3.0 and bun 1.4.3: `secureConnect` / `data hello`. main before this change: `raw error ERR_STREAM_PUSH_AFTER_EOF` / `secureConnect`, no data.
- The released 1.4.3 does not have #42213, so the new test passes there. It fails on a build of main.
- #36534 (open) stops surfacing TLS traffic on the raw socket at all. With it the raw handler would see nothing and this guard would be a no-op for the TLS case. The guard is still right on its own: the native layer can deliver data whatever the JS stream state is, for example `net.connect({ fd, readable: false })`.
- The `onread` variant of the handler does not push into the Readable, so it is not affected.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (5f554969b)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [3.02ms]
(pass) should thow ECONNRESET if FIN is received before handshake [345.43ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [8.80ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [112.13ms]
(pass) should be able to grab the JSStreamSocket constructor [13.78ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [82.06ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [83.22ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port an
... (truncated)

release without fix: 3 failed, 18 skipped
bun test v1.4.3-canary.1 (5f554969b)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.05ms]
(pass) should thow ECONNRESET if FIN is received before handshake [8.27ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [0.22ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [5.27ms]
(pass) should be able to grab the JSStreamSocket constructor [0.30ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [6.60ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [5.67ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls.c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (5f554969b)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.73ms]
(pass) should thow ECONNRESET if FIN is received before handshake [323.82ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [7.79ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [109.56ms]
(pass) should be able to grab the JSStreamSocket constructor [13.63ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [84.50ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [82.51ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port an
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 811ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (9131ms)
Bundle modules (57ms)
Postprocesss modules (173ms)
Bundle Functions (450ms)
Generate Code (35ms)

[9.85s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 48s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.3-canary.1+c53e913c7
[build] done
bun test v1.4.3-canary.1 (c53e913c7)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.04ms]
(pass) should thow ECONNRESET if FIN is received before handshake [5.99ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [0.15ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [3.46ms]
(pass) should be able to gra
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                        |  2 ++
 test/js/node/tls/node-tls-connect.test.ts | 29 +++++++++++++++++++++++++++++
 2 files changed, 31 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/net.ts                             9      7     19
test/js/node/tls/node-tls-connect.test.ts      1      2      9
```

</details>

<!-- robobun:evidence:end -->