### PR TITLE
secrets: serialize Windows Credential Manager calls

### DIFF
--- a/docs/runtime/secrets.mdx
+++ b/docs/runtime/secrets.mdx
@@ -277,6 +277,7 @@ await Bun.secrets.set({
   - Linux: Secret service daemon must be running
   - macOS: Keychain Access must be available
   - Windows: Credential Manager service must be enabled
+- On Windows, Credential Manager can report a `set()` or `delete()` as done and not apply it when another process reads or writes credentials at the same moment. Bun runs the calls of one process one at a time, so calls made with `Promise.all` are safe. Bun cannot order calls across processes. A read after the change does not prove that it stays applied. If several processes use `Bun.secrets` at the same time, make them take turns, for example with a lock file.
 
 ---
 

--- a/src/jsc/bindings/SecretsWindows.cpp
+++ b/src/jsc/bindings/SecretsWindows.cpp
@@ -3,6 +3,7 @@
 #if OS(WINDOWS)
 
 #include "Secrets.h"
+#include <wtf/Lock.h>
 #include <wtf/text/WTFString.h>
 #include <wtf/NeverDestroyed.h>
 #include <windows.h>
@@ -61,6 +62,24 @@ static CredentialFramework* credentialFramework()
         }
     });
     return framework->loaded ? &framework.get() : nullptr;
+}
+
+// Credential Manager loses changes when calls overlap: CredWriteW and CredDeleteW
+// return TRUE, but the entry is absent (or still present) afterwards. An
+// overlapping CredReadW is enough to cause it, so reads take the lock too. Every
+// job runs on its own pool thread. The lock orders the calls of this process
+// only: a call from another process can still overlap.
+static Lock credentialManagerLock;
+
+template<typename Call>
+static bool callCredentialManager(DWORD& errorCode, const Call& call)
+{
+    Locker locker { credentialManagerLock };
+    if (call()) {
+        return true;
+    }
+    errorCode = GetLastError();
+    return false;
 }
 
 // Convert CString to Windows wide string
@@ -179,8 +198,9 @@ Error setPassword(const CString& service, const CString& name, CString&& passwor
     cred.CredentialBlob = (LPBYTE)password.data();
     cred.Persist = CRED_PERSIST_ENTERPRISE;
 
-    if (!framework->CredWriteW(&cred, 0)) {
-        updateError(err, GetLastError());
+    DWORD errorCode = ERROR_SUCCESS;
+    if (!callCredentialManager(errorCode, [&] { return framework->CredWriteW(&cred, 0); })) {
+        updateError(err, errorCode);
     }
 
     // Best-effort scrub of plaintext from memory.
@@ -206,8 +226,8 @@ std::optional<WTF::Vector<uint8_t>> getPassword(const CString& service, const CS
     auto targetNameWide = cstringToWideChar(targetNameUtf8);
 
     PCREDENTIALW cred = nullptr;
-    if (!framework->CredReadW(targetNameWide.data(), CRED_TYPE_GENERIC, 0, &cred)) {
-        DWORD errorCode = GetLastError();
+    DWORD errorCode = ERROR_SUCCESS;
+    if (!callCredentialManager(errorCode, [&] { return framework->CredReadW(targetNameWide.data(), CRED_TYPE_GENERIC, 0, &cred); })) {
         updateError(err, errorCode);
         return std::nullopt;
     }
@@ -242,14 +262,9 @@ bool deletePassword(const CString& service, const CString& name, Error& err)
     auto targetNameUtf8 = targetName.utf8();
     auto targetNameWide = cstringToWideChar(targetNameUtf8);
 
-    if (!framework->CredDeleteW(targetNameWide.data(), CRED_TYPE_GENERIC, 0)) {
-        DWORD errorCode = GetLastError();
+    DWORD errorCode = ERROR_SUCCESS;
+    if (!callCredentialManager(errorCode, [&] { return framework->CredDeleteW(targetNameWide.data(), CRED_TYPE_GENERIC, 0); })) {
         updateError(err, errorCode);
-
-        if (errorCode == ERROR_NOT_FOUND) {
-            return false;
-        }
-
         return false;
     }
 

--- a/test/js/bun/secrets.test.ts
+++ b/test/js/bun/secrets.test.ts
@@ -299,3 +299,34 @@ test.todoIf(isCI && !isWindows)("Bun.secrets handles concurrent operations", asy
 
   await Promise.all(promises);
 });
+
+test.todoIf(isCI && !isWindows)("Bun.secrets applies every concurrent set and delete", async () => {
+  const service = `bun-concurrent-applied-${Date.now()}-${Math.random()}`;
+  const names = Array.from({ length: 8 }, (_, i) => `name-${i}`);
+  const options = shouldUseUnrestrictedAccess() ? { allowUnrestrictedAccess: true } : {};
+
+  // Reads one entry at a time, so that the check is not part of the race.
+  const readAll = async () => {
+    const values: (string | null)[] = [];
+    for (const name of names) values.push(await Bun.secrets.get({ service, name }));
+    return values;
+  };
+
+  try {
+    for (let round = 0; round < 5; round++) {
+      await Promise.all(names.map(name => Bun.secrets.set({ service, name, value: `${name}-${round}`, ...options })));
+      expect(await readAll()).toEqual(names.map(name => `${name}-${round}`));
+
+      // The reads run next to the deletes: on Windows, one concurrent read is enough to make
+      // Credential Manager report a delete as done and keep the entry.
+      const [deleted] = await Promise.all([
+        Promise.all(names.map(name => Bun.secrets.delete({ service, name }))),
+        Promise.all(names.map(name => Bun.secrets.get({ service, name }))),
+      ]);
+      expect(deleted).toEqual(names.map(() => true));
+      expect(await readAll()).toEqual(names.map(() => null));
+    }
+  } finally {
+    for (const name of names) await Bun.secrets.delete({ service, name });
+  }
+});


### PR DESCRIPTION
### Problem

- On Windows, concurrent `Bun.secrets` calls lose changes. `await Promise.all(names.map(name => Bun.secrets.delete({ service, name })))` resolves `true` for every call, and some entries stay. Concurrent `set()` calls resolve, and some entries are missing.
- The cause is in Credential Manager. When `CredWriteW`, `CredDeleteW` or `CredReadW` calls overlap, a write or delete returns `TRUE` and does not stay applied. A C++ program with no Bun code loses deletes in 26 of 30 trials. Each `Bun.secrets` call runs on its own pool thread with no lock (`src/jsc/bindings/SecretsWindows.cpp`).

### Fix

- One process-wide `WTF::Lock` around every `CredWriteW`, `CredReadW` and `CredDeleteW` call.
- Reads take the lock too. With only writes and deletes locked, unlocked readers lost deletes in 30 of 30 trials.
- Verified on Windows Server 2019: the new test in `test/js/bun/secrets.test.ts` fails on Bun 1.4.3-canary and on an unfixed debug build. The fixed debug build passes it 5 of 5 times and loses nothing in 30 trials of 32 parallel calls.
- macOS and Linux (gnome-keyring) lose nothing in the same stress run. They get no lock.

### Background

- On Windows, `Bun.secrets` stores entries in Credential Manager. Each `Cred*` call is an RPC to LSASS, which owns the credential set of the user.
- Each call is a `SecretsJob` (`src/jsc/JSSecrets.rs`) on the work pool, one thread per call in flight.
- The lock orders the calls of one process only. Two processes still race, and a read-back does not detect it (Notes). `docs/runtime/secrets.mdx` now says so under Limitations.

<details><summary>Notes</summary>

**How to reproduce.** Credential Manager needs a real logon session. Over SSH or WinRM (a network logon) every call fails with `ERROR_NO_SUCH_LOGON_SESSION` (1312). As `SYSTEM` the calls work and nothing is lost (0 of 30 trials, 32 entries). As a normal local user with a profile (a scheduled task with a stored password) the loss shows at once.

```ts
const service = "bun-secrets-concurrency-repro";
const names = Array.from({ length: 6 }, (_, i) => `entry-${i}`);
for (const name of names) await Bun.secrets.set({ service, name, value: Buffer.alloc(100, "x").toString() });
await Promise.all(names.map(name => Bun.secrets.delete({ service, name })));
for (const name of names) console.log(name, await Bun.secrets.get({ service, name }));
```

**Numbers, Windows Server 2019 (10.0.17763), 6 entries per trial unless noted.**

| build | parallel delete lost | parallel set lost |
| --- | --- | --- |
| bun 1.4.3-canary (e5f9986a4) | 12 of 15 trials | 0 of 15 |
| debug build of this branch without the `src/` change | 27 of 30 | 0 of 30 |
| debug build of this branch | 0 of 30 | 0 of 30 |
| debug build of this branch, 32 entries | 0 of 30 | 0 of 30 |

The new test (8 entries, reads next to the deletes) fails on every unfixed run. Three runs on 1.4.3-canary: 3 of 8 deletes lost, 6 of 8 sets lost, 2 of 8 deletes lost. One run on the unfixed debug build: 2 of 8 sets lost.

**Standalone C++ probe (threads call `CredWriteW` / `CredDeleteW` / `CredReadW` directly, no Bun), 30 trials each.**

| variant | trials with a lost delete | trials with a lost write |
| --- | --- | --- |
| no lock, `CRED_PERSIST_ENTERPRISE` | 24 | 1 |
| no lock, `CRED_PERSIST_LOCAL_MACHINE` | 22 | 3 |
| one mutex around all three calls, 4 reader threads running | 0 | 0 |
| mutex around write and delete only, 4 unlocked reader threads | 30 | 0 |
| 6 processes, one delete each, released by a shared event (20 trials, two runs) | 17 and 9 | n/a |

<details><summary>Minimal probe source (first table row, this build of it: 23 of 30)</summary>

```cpp
// clang-cl /EHsc /O2 credprobe.cpp advapi32.lib
// Run as a normal user in an interactive or batch logon session.
#include <windows.h>
#include <wincred.h>
#include <stdio.h>
#include <string>
#include <thread>
#include <vector>

static std::wstring target(int i) { return L"credprobe/entry-" + std::to_wstring(i); }

static bool exists(int i)
{
    PCREDENTIALW cred = nullptr;
    if (!CredReadW(target(i).c_str(), CRED_TYPE_GENERIC, 0, &cred)) return false;
    CredFree(cred);
    return true;
}

int main()
{
    const int n = 6, trials = 30;
    int lost = 0;
    for (int t = 0; t < trials; t++) {
        for (int i = 0; i < n; i++) {
            std::wstring name = target(i);
            wchar_t user[] = L"user";
            char blob[100];
            memset(blob, 'x', sizeof(blob));
            CREDENTIALW cred = {};
            cred.Type = CRED_TYPE_GENERIC;
            cred.TargetName = &name[0];
            cred.UserName = user;
            cred.CredentialBlobSize = sizeof(blob);
            cred.CredentialBlob = (LPBYTE)blob;
            cred.Persist = CRED_PERSIST_ENTERPRISE;
            if (!CredWriteW(&cred, 0)) printf("write %d failed: %lu\n", i, GetLastError());
        }
        std::vector<std::thread> threads;
        for (int i = 0; i < n; i++)
            threads.emplace_back([i] {
                if (!CredDeleteW(target(i).c_str(), CRED_TYPE_GENERIC, 0)) printf("delete %d failed: %lu\n", i, GetLastError());
            });
        for (auto& th : threads) th.join();
        int survivors = 0;
        for (int i = 0; i < n; i++) survivors += exists(i);
        if (survivors) lost++;
        for (int i = 0; i < n; i++) CredDeleteW(target(i).c_str(), CRED_TYPE_GENERIC, 0);
    }
    printf("every CredDeleteW returned TRUE unless printed above. trials with a surviving entry: %d of %d\n", lost, trials);
}
```

</details>

So the persist type does not matter (#42161 changes it, the lock is needed either way), and the race is not per process.

**A read-back does not surface the cross-process loss.** In the 6-process probe, each child deleted its entry, read it back, and repeated the delete until the entry read as gone. Every child saw its own entry gone. The parent still found entries present in 16 of 20 trials (9 of 20 in the paired run without the read-back). An entry can come back after a passing check, and the extra reads are themselves a trigger. This is why the fix does not verify after the call.

**Cross-process options not taken here.** A named mutex would order Bun processes against each other, not against other programs that use Credential Manager. Bun's own code has no named mutex or other cross-process lock today (the only `CreateMutexW` is inside vendored SQLite), so this PR does not add that pattern. The docs note tells callers to make processes take turns.

**Other platforms.** Same script, parallel set, update and delete with a check after each phase.
- macOS 26.6.1, bun 1.3.13, throwaway file keychain: 0 lost, 0 rejected in 30 trials of 32 entries.
- Debian 13, gnome-keyring + libsecret, bun 1.4.3-canary: 0 lost, 0 rejected in 20 trials of 32 entries. The new test passes there on the stock binary.

**Why the existing "handles concurrent operations" test did not catch this.** It checks that `delete()` resolves `true`. It never reads the entry again. The lost delete resolves `true`.

**Related open PRs.** #40642 moves `SecretsJob` to its own 4-thread pool. Four threads still overlap, so the lock is still needed. #40645 adds a timeout. Neither removes the overlap.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/secrets.test.ts

<!-- robobun:evidence:end -->