### PR TITLE
console: do not hang on an iterator that never ends

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -559,48 +559,30 @@ fn message_with_type_and_level_(
     Ok(())
 }
 
-/// What [`for_each_limited`] did.
-pub(crate) struct LimitedForEach {
-    /// The number of elements passed to the callback.
-    pub(crate) visited: u32,
-    /// True when the iterable holds an element past the limit.
-    pub(crate) truncated: bool,
-}
+/// Steps the formatters give an iterable that has no element count of its own, such as a generator.
+const UNSIZED_ITERABLE_BUDGET: u32 = 1000;
 
-impl LimitedForEach {
-    /// Elements left out, going by the `size` property. `None` when `size` does not say.
-    fn hidden_of(&self, size: i32) -> Option<u32> {
-        u32::try_from(size)
-            .ok()?
-            .checked_sub(self.visited)
-            .filter(|hidden| *hidden > 0)
-    }
-}
-
-/// A bounded [`JSValue::for_each`] for formatters. `Bun__ConsoleObject__forEachLimited` has the rules.
+/// A bounded [`JSValue::for_each`] for formatters. True when elements were left. `Bun__ConsoleObject__forEachLimited` has the rules.
 pub(crate) fn for_each_limited(
     iterable: JSValue,
     global: &JSGlobalObject,
-    limit: u32,
+    budget: u32,
     ctx: *mut c_void,
     callback: jsc::ForEachCallback,
-) -> JsResult<LimitedForEach> {
+) -> JsResult<bool> {
     unsafe extern "C" {
-        // safe: C++ only writes `truncated`, and only forwards `ctx` to `callback`.
+        // safe: `ctx` is an opaque round-trip pointer that C++ only forwards to `callback`.
         safe fn Bun__ConsoleObject__forEachLimited(
             iterable: JSValue,
             global: &JSGlobalObject,
-            limit: u32,
-            truncated: &mut bool,
+            budget: u32,
             ctx: *mut c_void,
             callback: jsc::ForEachCallback,
-        ) -> u32;
+        ) -> bool;
     }
-    let mut truncated = false;
-    let visited = jsc::host_fn::from_js_host_call_generic(global, || {
-        Bun__ConsoleObject__forEachLimited(iterable, global, limit, &mut truncated, ctx, callback)
-    })?;
-    Ok(LimitedForEach { visited, truncated })
+    jsc::host_fn::from_js_host_call_generic(global, || {
+        Bun__ConsoleObject__forEachLimited(iterable, global, budget, ctx, callback)
+    })
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -689,9 +671,6 @@ struct CollectedRow {
 }
 
 const PADDING: u32 = 1;
-
-/// Row budget for an iterable with no element count. Chrome's `console.table` limit (V8 `InjectedScript::wrapTable`).
-const MAX_ROWS_FROM_ITERATOR: u32 = 1000;
 
 impl<'a> TablePrinter<'a> {
     pub fn init(
@@ -991,26 +970,16 @@ impl<'a> TablePrinter<'a> {
                     }
                     ctx.idx += 1;
                 }
-                // Only user code can make a WeakMap or an ArrayBuffer iterable, so they get the budget too.
-                let jstype = ctx.this.jstype;
-                let has_element_count = matches!(jstype, jsc::JSType::Map | jsc::JSType::Set)
-                    || (jstype.is_array_like() && jstype != jsc::JSType::ArrayBuffer);
-                let limit = if has_element_count {
-                    u32::try_from(tabular_data.get_length(global_object)?).unwrap_or(u32::MAX)
-                } else {
-                    MAX_ROWS_FROM_ITERATOR
-                };
-                let collected = for_each_limited(
+                rows_truncated = for_each_limited(
                     tabular_data,
                     global_object,
-                    limit,
+                    UNSIZED_ITERABLE_BUDGET,
                     (&raw mut ctx).cast::<c_void>(),
                     callback::<ENABLE_ANSI_COLORS>,
                 )?;
                 if let Some(err) = ctx.err {
                     return Err(err);
                 }
-                rows_truncated = collected.truncated;
             } else {
                 let tabular_obj = self.tabular_data.to_object(global_object)?;
                 let rows_iter = jsc::JSPropertyIterator::init(
@@ -2811,11 +2780,10 @@ pub mod formatter {
             Ok(())
         }
 
-        /// Ends a truncated preview with `... N more items`, or `... more items` when `hidden` is `None`.
+        /// Ends a preview whose iterator had more to give than the walk allowed.
         fn print_more_entries<const C: bool>(
             &mut self,
             writer: &mut dyn bun_io::Write,
-            hidden: Option<u32>,
             wrote_entry: bool,
         ) {
             if !self.single_line {
@@ -2824,20 +2792,12 @@ pub mod formatter {
                 let _ = self.print_comma::<C>(writer);
                 let _ = writer.write_all(b" ");
             }
-            let (dim, reset) = (pfmt!("<r><d>", C), pfmt!("<r>", C));
-            let _ = match hidden {
-                Some(1) => write!(writer, "{dim}... 1 more item{reset}"),
-                Some(n) => write!(writer, "{dim}... {n} more items{reset}"),
-                None => write!(writer, "{dim}... more items{reset}"),
-            };
+            let _ = writer.write_all(pfmt!("<r><d>... more items<r>", C).as_bytes());
             if !self.single_line {
                 let _ = writer.write_all(b"\n");
             }
         }
     }
-
-    /// Entries printed before `... N more items`. The default of node's `maxArrayLength`.
-    const MAX_ENTRIES_SHOWN: u32 = 100;
 
     // ───────────────────────────────────────────────────────────────────────
     // MapIterator / SetIterator / PropertyIterator (forEach callback contexts)
@@ -4418,7 +4378,7 @@ pub mod formatter {
                         }
                         continue;
                     }
-                    if nonempty_count >= MAX_ENTRIES_SHOWN {
+                    if nonempty_count >= 100 {
                         writer.print_comma::<C>();
                         writer.write_all(b"\n"); // we want the line break to be unconditional here
                         *writer.estimated_line_length = 0;
@@ -4693,10 +4653,10 @@ pub mod formatter {
                         writer: writer_,
                         count: 0,
                     };
-                    let shown = for_each_limited(
+                    let truncated = for_each_limited(
                         value,
                         global_this,
-                        MAX_ENTRIES_SHOWN,
+                        UNSIZED_ITERABLE_BUDGET,
                         (&raw mut iter).cast::<c_void>(),
                         MapIteratorCtx::<C, false, true>::for_each,
                     )?;
@@ -4704,10 +4664,10 @@ pub mod formatter {
                     if iter.formatter.failed {
                         return Ok(());
                     }
-                    if shown.truncated {
-                        self.print_more_entries::<C>(writer_, shown.hidden_of(length), count > 0);
+                    if truncated {
+                        self.print_more_entries::<C>(writer_, count > 0);
                     }
-                    if count > 0 || shown.truncated {
+                    if count > 0 || truncated {
                         let _ = writer_.write_all(b" ");
                     }
                 } else {
@@ -4716,18 +4676,18 @@ pub mod formatter {
                         writer: writer_,
                         count: 0,
                     };
-                    let shown = for_each_limited(
+                    let truncated = for_each_limited(
                         value,
                         global_this,
-                        MAX_ENTRIES_SHOWN,
+                        UNSIZED_ITERABLE_BUDGET,
                         (&raw mut iter).cast::<c_void>(),
                         MapIteratorCtx::<C, false, false>::for_each,
                     )?;
                     if iter.formatter.failed {
                         return Ok(());
                     }
-                    if shown.truncated {
-                        self.print_more_entries::<C>(writer_, shown.hidden_of(length), true);
+                    if truncated {
+                        self.print_more_entries::<C>(writer_, true);
                     }
                 }
             }
@@ -4762,10 +4722,10 @@ pub mod formatter {
                         writer: writer_,
                         count: 0,
                     };
-                    let shown = for_each_limited(
+                    let truncated = for_each_limited(
                         value,
                         global_this,
-                        MAX_ENTRIES_SHOWN,
+                        UNSIZED_ITERABLE_BUDGET,
                         (&raw mut iter).cast::<c_void>(),
                         MapIteratorCtx::<C, true, true>::for_each,
                     )?;
@@ -4773,8 +4733,8 @@ pub mod formatter {
                     if iter.formatter.failed {
                         return Ok(());
                     }
-                    if shown.truncated {
-                        self.print_more_entries::<C>(writer_, None, count > 0);
+                    if truncated {
+                        self.print_more_entries::<C>(writer_, count > 0);
                     }
                     // Only the MapIterator case writes a trailing space.
                     if count > 0 && label == "MapIterator" {
@@ -4786,10 +4746,10 @@ pub mod formatter {
                         writer: writer_,
                         count: 0,
                     };
-                    let shown = for_each_limited(
+                    let truncated = for_each_limited(
                         value,
                         global_this,
-                        MAX_ENTRIES_SHOWN,
+                        UNSIZED_ITERABLE_BUDGET,
                         (&raw mut iter).cast::<c_void>(),
                         MapIteratorCtx::<C, true, false>::for_each,
                     )?;
@@ -4800,8 +4760,8 @@ pub mod formatter {
                     if count > 0 {
                         let _ = writer_.write_all(b"\n");
                     }
-                    if shown.truncated {
-                        self.print_more_entries::<C>(writer_, None, count > 0);
+                    if truncated {
+                        self.print_more_entries::<C>(writer_, count > 0);
                     }
                 }
             }
@@ -4855,10 +4815,10 @@ pub mod formatter {
                         writer: writer_,
                         is_first: true,
                     };
-                    let shown = for_each_limited(
+                    let truncated = for_each_limited(
                         value,
                         global_this,
-                        MAX_ENTRIES_SHOWN,
+                        UNSIZED_ITERABLE_BUDGET,
                         (&raw mut iter).cast::<c_void>(),
                         SetIteratorCtx::<C, true>::for_each,
                     )?;
@@ -4866,10 +4826,10 @@ pub mod formatter {
                     if iter.formatter.failed {
                         return Ok(());
                     }
-                    if shown.truncated {
-                        self.print_more_entries::<C>(writer_, shown.hidden_of(length), !is_first);
+                    if truncated {
+                        self.print_more_entries::<C>(writer_, !is_first);
                     }
-                    if !is_first || shown.truncated {
+                    if !is_first || truncated {
                         let _ = writer_.write_all(b" ");
                     }
                 } else {
@@ -4878,18 +4838,18 @@ pub mod formatter {
                         writer: writer_,
                         is_first: true,
                     };
-                    let shown = for_each_limited(
+                    let truncated = for_each_limited(
                         value,
                         global_this,
-                        MAX_ENTRIES_SHOWN,
+                        UNSIZED_ITERABLE_BUDGET,
                         (&raw mut iter).cast::<c_void>(),
                         SetIteratorCtx::<C, false>::for_each,
                     )?;
                     if iter.formatter.failed {
                         return Ok(());
                     }
-                    if shown.truncated {
-                        self.print_more_entries::<C>(writer_, shown.hidden_of(length), true);
+                    if truncated {
+                        self.print_more_entries::<C>(writer_, true);
                     }
                 }
             }

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -560,6 +560,60 @@ fn message_with_type_and_level_(
 }
 
 // ───────────────────────────────────────────────────────────────────────────
+// Bounded iteration
+// ───────────────────────────────────────────────────────────────────────────
+
+/// What [`for_each_limited`] did.
+pub(crate) struct LimitedForEach {
+    /// The number of elements passed to the callback.
+    pub(crate) visited: u32,
+    /// True when the iterable holds an element past the limit.
+    pub(crate) truncated: bool,
+}
+
+impl LimitedForEach {
+    /// The number of elements that were not visited, given the `size` the
+    /// collection reports. `size` is a property read, so it can disagree with
+    /// what the walk found. `None` means the count is not known.
+    fn hidden_of(&self, size: i32) -> Option<u32> {
+        u32::try_from(size)
+            .ok()?
+            .checked_sub(self.visited)
+            .filter(|hidden| *hidden > 0)
+    }
+}
+
+/// [`JSValue::for_each`] for a formatter, which prints values it does not
+/// control and so cannot wait for a user iterator to report `done`. The walk
+/// stops after `limit` elements. See `Bun__ConsoleObject__forEachLimited`.
+pub(crate) fn for_each_limited(
+    iterable: JSValue,
+    global: &JSGlobalObject,
+    limit: u32,
+    ctx: *mut c_void,
+    callback: jsc::ForEachCallback,
+) -> JsResult<LimitedForEach> {
+    unsafe extern "C" {
+        // safe: `JSGlobalObject` is an opaque handle, `truncated` is a live
+        // `&mut bool` that C++ only writes, and `ctx` is an opaque round-trip
+        // pointer that C++ only forwards to `callback`.
+        safe fn Bun__ConsoleObject__forEachLimited(
+            iterable: JSValue,
+            global: &JSGlobalObject,
+            limit: u32,
+            truncated: &mut bool,
+            ctx: *mut c_void,
+            callback: jsc::ForEachCallback,
+        ) -> u32;
+    }
+    let mut truncated = false;
+    let visited = jsc::host_fn::from_js_host_call_generic(global, || {
+        Bun__ConsoleObject__forEachLimited(iterable, global, limit, &mut truncated, ctx, callback)
+    })?;
+    Ok(LimitedForEach { visited, truncated })
+}
+
+// ───────────────────────────────────────────────────────────────────────────
 // TablePrinter
 // ───────────────────────────────────────────────────────────────────────────
 
@@ -645,6 +699,11 @@ struct CollectedRow {
 }
 
 const PADDING: u32 = 1;
+
+/// The number of rows `console.table` reads from an iterable that has no
+/// length of its own, such as a generator. Chrome applies the same limit to
+/// every `console.table` call (`InjectedScript::wrapTable` in V8).
+const MAX_ROWS_FROM_ITERATOR: u32 = 1000;
 
 impl<'a> TablePrinter<'a> {
     pub fn init(
@@ -898,6 +957,7 @@ impl<'a> TablePrinter<'a> {
         // ranges, so no property is re-read and no value is re-formatted.
         let mut cell_text: Vec<u8> = Vec::new();
         let mut rows: Vec<CollectedRow> = Vec::new();
+        let mut rows_truncated = false;
         {
             if self.is_iterable {
                 struct Ctx<'c, 'a> {
@@ -943,14 +1003,28 @@ impl<'a> TablePrinter<'a> {
                     }
                     ctx.idx += 1;
                 }
-                tabular_data.for_each_with_context(
+                // User code decides when an iterator ends. A Map or a Set is
+                // read from its own storage, and an array has no more rows
+                // than its length. Any other iterable gets a row budget.
+                let jstype = ctx.this.jstype;
+                let limit = if jstype.is_array_like() {
+                    u32::try_from(tabular_data.get_length(global_object)?).unwrap_or(u32::MAX)
+                } else if jstype.is_map() || jstype.is_set() {
+                    u32::MAX
+                } else {
+                    MAX_ROWS_FROM_ITERATOR
+                };
+                let collected = for_each_limited(
+                    tabular_data,
                     global_object,
+                    limit,
                     (&raw mut ctx).cast::<c_void>(),
                     callback::<ENABLE_ANSI_COLORS>,
                 )?;
                 if let Some(err) = ctx.err {
                     return Err(err);
                 }
+                rows_truncated = collected.truncated;
             } else {
                 let tabular_obj = self.tabular_data.to_object(global_object)?;
                 let rows_iter = jsc::JSPropertyIterator::init(
@@ -1061,6 +1135,11 @@ impl<'a> TablePrinter<'a> {
                 );
             }
             let _ = writer.write_all("┘\n".as_bytes());
+        }
+
+        if rows_truncated {
+            let _ =
+                writer.write_all(pfmt!("<r><d>... more rows<r>\n", ENABLE_ANSI_COLORS).as_bytes());
         }
 
         Ok(())
@@ -2745,7 +2824,40 @@ pub mod formatter {
             self.estimated_line_length += 1;
             Ok(())
         }
+
+        /// Writes the marker that ends a truncated Map, Set or iterator
+        /// preview: `... N more items`, or `... more items` when `hidden` is
+        /// `None` because the count is not known. `wrote_entry` tells the
+        /// single-line form whether it needs a separator first.
+        fn print_more_entries<const C: bool>(
+            &mut self,
+            writer: &mut dyn bun_io::Write,
+            hidden: Option<u32>,
+            wrote_entry: bool,
+        ) {
+            if !self.single_line {
+                let _ = self.write_indent(writer);
+            } else if wrote_entry {
+                let _ = self.print_comma::<C>(writer);
+                let _ = writer.write_all(b" ");
+            }
+            let (dim, reset) = (pfmt!("<r><d>", C), pfmt!("<r>", C));
+            let _ = match hidden {
+                Some(1) => write!(writer, "{dim}... 1 more item{reset}"),
+                Some(n) => write!(writer, "{dim}... {n} more items{reset}"),
+                None => write!(writer, "{dim}... more items{reset}"),
+            };
+            if !self.single_line {
+                let _ = writer.write_all(b"\n");
+            }
+        }
     }
+
+    /// The number of elements a collection prints before the
+    /// `... N more items` marker. This is the default of node's
+    /// `maxArrayLength`, which node applies to arrays, Maps, Sets and iterator
+    /// previews alike.
+    const MAX_ENTRIES_SHOWN: u32 = 100;
 
     // ───────────────────────────────────────────────────────────────────────
     // MapIterator / SetIterator / PropertyIterator (forEach callback contexts)
@@ -4326,7 +4438,7 @@ pub mod formatter {
                         }
                         continue;
                     }
-                    if nonempty_count >= 100 {
+                    if nonempty_count >= MAX_ENTRIES_SHOWN {
                         writer.print_comma::<C>();
                         writer.write_all(b"\n"); // we want the line break to be unconditional here
                         *writer.estimated_line_length = 0;
@@ -4601,8 +4713,10 @@ pub mod formatter {
                         writer: writer_,
                         count: 0,
                     };
-                    value.for_each(
+                    let shown = for_each_limited(
+                        value,
                         global_this,
+                        MAX_ENTRIES_SHOWN,
                         (&raw mut iter).cast::<c_void>(),
                         MapIteratorCtx::<C, false, true>::for_each,
                     )?;
@@ -4610,7 +4724,10 @@ pub mod formatter {
                     if iter.formatter.failed {
                         return Ok(());
                     }
-                    if count > 0 {
+                    if shown.truncated {
+                        self.print_more_entries::<C>(writer_, shown.hidden_of(length), count > 0);
+                    }
+                    if count > 0 || shown.truncated {
                         let _ = writer_.write_all(b" ");
                     }
                 } else {
@@ -4619,13 +4736,18 @@ pub mod formatter {
                         writer: writer_,
                         count: 0,
                     };
-                    value.for_each(
+                    let shown = for_each_limited(
+                        value,
                         global_this,
+                        MAX_ENTRIES_SHOWN,
                         (&raw mut iter).cast::<c_void>(),
                         MapIteratorCtx::<C, false, false>::for_each,
                     )?;
                     if iter.formatter.failed {
                         return Ok(());
+                    }
+                    if shown.truncated {
+                        self.print_more_entries::<C>(writer_, shown.hidden_of(length), true);
                     }
                 }
             }
@@ -4660,14 +4782,19 @@ pub mod formatter {
                         writer: writer_,
                         count: 0,
                     };
-                    value.for_each(
+                    let shown = for_each_limited(
+                        value,
                         global_this,
+                        MAX_ENTRIES_SHOWN,
                         (&raw mut iter).cast::<c_void>(),
                         MapIteratorCtx::<C, true, true>::for_each,
                     )?;
                     let count = iter.count;
                     if iter.formatter.failed {
                         return Ok(());
+                    }
+                    if shown.truncated {
+                        self.print_more_entries::<C>(writer_, None, count > 0);
                     }
                     // Only the MapIterator case writes a trailing space.
                     if count > 0 && label == "MapIterator" {
@@ -4679,8 +4806,10 @@ pub mod formatter {
                         writer: writer_,
                         count: 0,
                     };
-                    value.for_each(
+                    let shown = for_each_limited(
+                        value,
                         global_this,
+                        MAX_ENTRIES_SHOWN,
                         (&raw mut iter).cast::<c_void>(),
                         MapIteratorCtx::<C, true, false>::for_each,
                     )?;
@@ -4690,6 +4819,9 @@ pub mod formatter {
                     }
                     if count > 0 {
                         let _ = writer_.write_all(b"\n");
+                    }
+                    if shown.truncated {
+                        self.print_more_entries::<C>(writer_, None, count > 0);
                     }
                 }
             }
@@ -4743,8 +4875,10 @@ pub mod formatter {
                         writer: writer_,
                         is_first: true,
                     };
-                    value.for_each(
+                    let shown = for_each_limited(
+                        value,
                         global_this,
+                        MAX_ENTRIES_SHOWN,
                         (&raw mut iter).cast::<c_void>(),
                         SetIteratorCtx::<C, true>::for_each,
                     )?;
@@ -4752,7 +4886,10 @@ pub mod formatter {
                     if iter.formatter.failed {
                         return Ok(());
                     }
-                    if !is_first {
+                    if shown.truncated {
+                        self.print_more_entries::<C>(writer_, shown.hidden_of(length), !is_first);
+                    }
+                    if !is_first || shown.truncated {
                         let _ = writer_.write_all(b" ");
                     }
                 } else {
@@ -4761,13 +4898,18 @@ pub mod formatter {
                         writer: writer_,
                         is_first: true,
                     };
-                    value.for_each(
+                    let shown = for_each_limited(
+                        value,
                         global_this,
+                        MAX_ENTRIES_SHOWN,
                         (&raw mut iter).cast::<c_void>(),
                         SetIteratorCtx::<C, false>::for_each,
                     )?;
                     if iter.formatter.failed {
                         return Ok(());
+                    }
+                    if shown.truncated {
+                        self.print_more_entries::<C>(writer_, shown.hidden_of(length), true);
                     }
                 }
             }

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -559,10 +559,6 @@ fn message_with_type_and_level_(
     Ok(())
 }
 
-// ───────────────────────────────────────────────────────────────────────────
-// Bounded iteration
-// ───────────────────────────────────────────────────────────────────────────
-
 /// What [`for_each_limited`] did.
 pub(crate) struct LimitedForEach {
     /// The number of elements passed to the callback.
@@ -572,9 +568,7 @@ pub(crate) struct LimitedForEach {
 }
 
 impl LimitedForEach {
-    /// The number of elements that were not visited, given the `size` the
-    /// collection reports. `size` is a property read, so it can disagree with
-    /// what the walk found. `None` means the count is not known.
+    /// Elements left out, going by the `size` property. `None` when `size` does not say.
     fn hidden_of(&self, size: i32) -> Option<u32> {
         u32::try_from(size)
             .ok()?
@@ -583,9 +577,7 @@ impl LimitedForEach {
     }
 }
 
-/// [`JSValue::for_each`] for a formatter, which prints values it does not
-/// control and so cannot wait for a user iterator to report `done`. The walk
-/// stops after `limit` elements. See `Bun__ConsoleObject__forEachLimited`.
+/// A bounded [`JSValue::for_each`] for formatters. `Bun__ConsoleObject__forEachLimited` has the rules.
 pub(crate) fn for_each_limited(
     iterable: JSValue,
     global: &JSGlobalObject,
@@ -594,9 +586,7 @@ pub(crate) fn for_each_limited(
     callback: jsc::ForEachCallback,
 ) -> JsResult<LimitedForEach> {
     unsafe extern "C" {
-        // safe: `JSGlobalObject` is an opaque handle, `truncated` is a live
-        // `&mut bool` that C++ only writes, and `ctx` is an opaque round-trip
-        // pointer that C++ only forwards to `callback`.
+        // safe: C++ only writes `truncated`, and only forwards `ctx` to `callback`.
         safe fn Bun__ConsoleObject__forEachLimited(
             iterable: JSValue,
             global: &JSGlobalObject,
@@ -700,9 +690,7 @@ struct CollectedRow {
 
 const PADDING: u32 = 1;
 
-/// The number of rows `console.table` reads from an iterable that has no
-/// length of its own, such as a generator. Chrome applies the same limit to
-/// every `console.table` call (`InjectedScript::wrapTable` in V8).
+/// Row budget for an iterable with no element count. Chrome's `console.table` limit (V8 `InjectedScript::wrapTable`).
 const MAX_ROWS_FROM_ITERATOR: u32 = 1000;
 
 impl<'a> TablePrinter<'a> {
@@ -1003,10 +991,7 @@ impl<'a> TablePrinter<'a> {
                     }
                     ctx.idx += 1;
                 }
-                // User code decides when an iterator ends. An array, a typed
-                // array, a Map or a Set has no more rows than it has elements.
-                // Any other iterable gets a row budget. That includes a WeakMap
-                // or an ArrayBuffer, which only user code can make iterable.
+                // Only user code can make a WeakMap or an ArrayBuffer iterable, so they get the budget too.
                 let jstype = ctx.this.jstype;
                 let has_element_count = matches!(jstype, jsc::JSType::Map | jsc::JSType::Set)
                     || (jstype.is_array_like() && jstype != jsc::JSType::ArrayBuffer);
@@ -2826,10 +2811,7 @@ pub mod formatter {
             Ok(())
         }
 
-        /// Writes the marker that ends a truncated Map, Set or iterator
-        /// preview: `... N more items`, or `... more items` when `hidden` is
-        /// `None` because the count is not known. `wrote_entry` tells the
-        /// single-line form whether it needs a separator first.
+        /// Ends a truncated preview with `... N more items`, or `... more items` when `hidden` is `None`.
         fn print_more_entries<const C: bool>(
             &mut self,
             writer: &mut dyn bun_io::Write,
@@ -2854,10 +2836,7 @@ pub mod formatter {
         }
     }
 
-    /// The number of elements a collection prints before the
-    /// `... N more items` marker. This is the default of node's
-    /// `maxArrayLength`, which node applies to arrays, Maps, Sets and iterator
-    /// previews alike.
+    /// Entries printed before `... N more items`. The default of node's `maxArrayLength`.
     const MAX_ENTRIES_SHOWN: u32 = 100;
 
     // ───────────────────────────────────────────────────────────────────────

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -567,6 +567,7 @@ pub(crate) fn for_each_limited(
     iterable: JSValue,
     global: &JSGlobalObject,
     budget: u32,
+    size_already_read: Option<i32>,
     ctx: *mut c_void,
     callback: jsc::ForEachCallback,
 ) -> JsResult<bool> {
@@ -576,12 +577,21 @@ pub(crate) fn for_each_limited(
             iterable: JSValue,
             global: &JSGlobalObject,
             budget: u32,
+            size_already_read: i32,
             ctx: *mut c_void,
             callback: jsc::ForEachCallback,
         ) -> bool;
     }
+    let size_already_read = size_already_read.filter(|size| *size >= 0).unwrap_or(-1);
     jsc::host_fn::from_js_host_call_generic(global, || {
-        Bun__ConsoleObject__forEachLimited(iterable, global, budget, ctx, callback)
+        Bun__ConsoleObject__forEachLimited(
+            iterable,
+            global,
+            budget,
+            size_already_read,
+            ctx,
+            callback,
+        )
     })
 }
 
@@ -974,6 +984,7 @@ impl<'a> TablePrinter<'a> {
                     tabular_data,
                     global_object,
                     UNSIZED_ITERABLE_BUDGET,
+                    None,
                     (&raw mut ctx).cast::<c_void>(),
                     callback::<ENABLE_ANSI_COLORS>,
                 )?;
@@ -4657,6 +4668,7 @@ pub mod formatter {
                         value,
                         global_this,
                         UNSIZED_ITERABLE_BUDGET,
+                        Some(length),
                         (&raw mut iter).cast::<c_void>(),
                         MapIteratorCtx::<C, false, true>::for_each,
                     )?;
@@ -4680,6 +4692,7 @@ pub mod formatter {
                         value,
                         global_this,
                         UNSIZED_ITERABLE_BUDGET,
+                        Some(length),
                         (&raw mut iter).cast::<c_void>(),
                         MapIteratorCtx::<C, false, false>::for_each,
                     )?;
@@ -4726,6 +4739,7 @@ pub mod formatter {
                         value,
                         global_this,
                         UNSIZED_ITERABLE_BUDGET,
+                        None,
                         (&raw mut iter).cast::<c_void>(),
                         MapIteratorCtx::<C, true, true>::for_each,
                     )?;
@@ -4750,6 +4764,7 @@ pub mod formatter {
                         value,
                         global_this,
                         UNSIZED_ITERABLE_BUDGET,
+                        None,
                         (&raw mut iter).cast::<c_void>(),
                         MapIteratorCtx::<C, true, false>::for_each,
                     )?;
@@ -4819,6 +4834,7 @@ pub mod formatter {
                         value,
                         global_this,
                         UNSIZED_ITERABLE_BUDGET,
+                        Some(length),
                         (&raw mut iter).cast::<c_void>(),
                         SetIteratorCtx::<C, true>::for_each,
                     )?;
@@ -4842,6 +4858,7 @@ pub mod formatter {
                         value,
                         global_this,
                         UNSIZED_ITERABLE_BUDGET,
+                        Some(length),
                         (&raw mut iter).cast::<c_void>(),
                         SetIteratorCtx::<C, false>::for_each,
                     )?;

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1003,14 +1003,15 @@ impl<'a> TablePrinter<'a> {
                     }
                     ctx.idx += 1;
                 }
-                // User code decides when an iterator ends. A Map or a Set is
-                // read from its own storage, and an array has no more rows
-                // than its length. Any other iterable gets a row budget.
+                // User code decides when an iterator ends. An array, a typed
+                // array, a Map or a Set has no more rows than it has elements.
+                // Any other iterable gets a row budget. That includes a WeakMap
+                // or an ArrayBuffer, which only user code can make iterable.
                 let jstype = ctx.this.jstype;
-                let limit = if jstype.is_array_like() {
+                let has_element_count = matches!(jstype, jsc::JSType::Map | jsc::JSType::Set)
+                    || (jstype.is_array_like() && jstype != jsc::JSType::ArrayBuffer);
+                let limit = if has_element_count {
                     u32::try_from(tabular_data.get_length(global_object)?).unwrap_or(u32::MAX)
-                } else if jstype.is_map() || jstype.is_set() {
-                    u32::MAX
                 } else {
                     MAX_ROWS_FROM_ITERATOR
                 };

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2210,7 +2210,7 @@ struct SerializedScriptValueExternal {
     handle: *mut c_void,
 }
 
-/// Callback signature for [`JSValue::for_each`] / [`JSValue::for_each_with_context`].
+/// Callback signature for [`JSValue::for_each`].
 pub type ForEachCallback =
     extern "C" fn(vm: *mut crate::VM, global: &JSGlobalObject, ctx: *mut c_void, next: JSValue);
 
@@ -2442,17 +2442,6 @@ impl JSValue {
         host_fn::from_js_host_call_generic(global, || {
             JSC__JSValue__forEach(self, global, ctx, callback)
         })
-    }
-    /// `JSValue.forEachWithContext` — typed-ctx wrapper (callers pass
-    /// `*mut c_void` directly).
-    #[inline]
-    pub(crate) fn for_each_with_context(
-        self,
-        global: &JSGlobalObject,
-        ctx: *mut c_void,
-        callback: ForEachCallback,
-    ) -> JsResult<()> {
-        self.for_each(global, ctx, callback)
     }
     /// `JSValue.forEachProperty` — enumerate own props,
     /// invoking `callback` per (key, value, is_symbol, is_private_symbol).

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5440,15 +5440,15 @@ impl VirtualMachine {
                 printed_member: false,
             };
             // `errors` is user-assigned, so its iterator can be endless.
-            const MAX_MEMBERS_PRINTED: u32 = 100;
+            const UNSIZED_ERRORS_BUDGET: u32 = 100;
             match crate::console_object::for_each_limited(
                 errors,
                 global_ref,
-                MAX_MEMBERS_PRINTED,
+                UNSIZED_ERRORS_BUDGET,
                 (&raw mut ctx).cast(),
                 agg_iter,
             ) {
-                Ok(printed) if printed.truncated => {
+                Ok(true) => {
                     let marker = if allow_ansi_color {
                         bun_core::pretty_fmt!("<r><d>... more errors<r>\n", true)
                     } else {
@@ -5456,7 +5456,7 @@ impl VirtualMachine {
                     };
                     let _ = writer.write_all(marker.as_bytes());
                 }
-                Ok(_) => {}
+                Ok(false) => {}
                 Err(_) => global_ref.clear_exception(),
             }
             if ctx.printed_member {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5445,6 +5445,7 @@ impl VirtualMachine {
                 errors,
                 global_ref,
                 UNSIZED_ERRORS_BUDGET,
+                None,
                 (&raw mut ctx).cast(),
                 agg_iter,
             ) {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5439,11 +5439,26 @@ impl VirtualMachine {
                 allow_side_effects,
                 printed_member: false,
             };
-            if errors
-                .for_each(global_ref, (&raw mut ctx).cast(), agg_iter)
-                .is_err()
-            {
-                global_ref.clear_exception();
+            // `errors` is whatever the user put on the property, so it can be
+            // an iterable that never ends.
+            const MAX_MEMBERS_PRINTED: u32 = 100;
+            match crate::console_object::for_each_limited(
+                errors,
+                global_ref,
+                MAX_MEMBERS_PRINTED,
+                (&raw mut ctx).cast(),
+                agg_iter,
+            ) {
+                Ok(printed) if printed.truncated => {
+                    let marker = if allow_ansi_color {
+                        bun_core::pretty_fmt!("<r><d>... more errors<r>\n", true)
+                    } else {
+                        bun_core::pretty_fmt!("<r><d>... more errors<r>\n", false)
+                    };
+                    let _ = writer.write_all(marker.as_bytes());
+                }
+                Ok(_) => {}
+                Err(_) => global_ref.clear_exception(),
             }
             if ctx.printed_member {
                 return;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5439,8 +5439,7 @@ impl VirtualMachine {
                 allow_side_effects,
                 printed_member: false,
             };
-            // `errors` is whatever the user put on the property, so it can be
-            // an iterable that never ends.
+            // `errors` is user-assigned, so its iterator can be endless.
             const MAX_MEMBERS_PRINTED: u32 = 100;
             match crate::console_object::for_each_limited(
                 errors,

--- a/src/jsc/bindings/ConsoleObject.cpp
+++ b/src/jsc/bindings/ConsoleObject.cpp
@@ -131,13 +131,7 @@ void ConsoleObject::profileEnd(JSC::JSGlobalObject* globalObject, const String& 
 
 }
 
-// A bounded `JSC::forEachInIterable` for the console formatter. That function
-// ends only when the iterator reports `done`, and a replaced `Symbol.iterator`
-// or `next` can withhold it forever. Here a Map or a Set is read from its own
-// storage, which user code cannot redirect. Any other iterable gets at most
-// `limit` protocol steps and is then closed, like `break` closes a for-of loop.
-// `truncated` says whether an element past `limit` exists. Returns the number
-// of elements passed to `callback`.
+// Bounded `JSC::forEachInIterable`: a Map or a Set is read from its own storage, anything else gets `limit` iterator steps and is then closed.
 extern "C" uint32_t Bun__ConsoleObject__forEachLimited(JSC::EncodedJSValue encodedIterable, JSC::JSGlobalObject* globalObject, uint32_t limit, bool* truncated, void* ctx, void (*callback)(JSC::VM*, JSC::JSGlobalObject*, void* ctx, JSC::EncodedJSValue))
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/ConsoleObject.cpp
+++ b/src/jsc/bindings/ConsoleObject.cpp
@@ -6,6 +6,7 @@
 
 #include <JavaScriptCore/ConsoleClient.h>
 #include <JavaScriptCore/ConsoleMessage.h>
+#include <JavaScriptCore/IteratorOperations.h>
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/ScriptArguments.h>
 #include <wtf/text/WTFString.h>
@@ -128,4 +129,75 @@ void ConsoleObject::profileEnd(JSC::JSGlobalObject* globalObject, const String& 
     }
 }
 
+}
+
+// A bounded `JSC::forEachInIterable` for the console formatter. That function
+// ends only when the iterator reports `done`, and a replaced `Symbol.iterator`
+// or `next` can withhold it forever. Here a Map or a Set is read from its own
+// storage, which user code cannot redirect. Any other iterable gets at most
+// `limit` protocol steps and is then closed, like `break` closes a for-of loop.
+// `truncated` says whether an element past `limit` exists. Returns the number
+// of elements passed to `callback`.
+extern "C" uint32_t Bun__ConsoleObject__forEachLimited(JSC::EncodedJSValue encodedIterable, JSC::JSGlobalObject* globalObject, uint32_t limit, bool* truncated, void* ctx, void (*callback)(JSC::VM*, JSC::JSGlobalObject*, void* ctx, JSC::EncodedJSValue))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSC::JSValue iterable = JSC::JSValue::decode(encodedIterable);
+    uint32_t visited = 0;
+    *truncated = false;
+
+    auto visitStorageEntry = [&](JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue value) -> WTF::IterationStatus {
+        if (visited >= limit) {
+            *truncated = true;
+            return WTF::IterationStatus::Done;
+        }
+        visited++;
+        callback(&vm, globalObject, ctx, JSC::JSValue::encode(value));
+        return WTF::IterationStatus::Continue;
+    };
+
+    if (auto* map = dynamicDowncast<JSC::JSMap>(iterable)) {
+        JSC::JSCell* storage = map->storageOrSentinel(vm);
+        if (storage != vm.orderedHashTableSentinel()) {
+            JSC::forEachInMapStorage(vm, globalObject, storage, 0, JSC::IterationKind::Entries, visitStorageEntry);
+            RETURN_IF_EXCEPTION(scope, visited);
+        }
+        return visited;
+    }
+
+    if (auto* set = dynamicDowncast<JSC::JSSet>(iterable)) {
+        JSC::JSCell* storage = set->storageOrSentinel(vm);
+        if (storage != vm.orderedHashTableSentinel()) {
+            JSC::forEachInSetStorage(vm, globalObject, storage, 0, visitStorageEntry);
+            RETURN_IF_EXCEPTION(scope, visited);
+        }
+        return visited;
+    }
+
+    JSC::IterationRecord iterationRecord = JSC::iteratorForIterable(globalObject, iterable);
+    RETURN_IF_EXCEPTION(scope, visited);
+
+    while (true) {
+        JSC::JSValue next = JSC::iteratorStep(globalObject, iterationRecord);
+        RETURN_IF_EXCEPTION(scope, visited);
+        if (next.isFalse())
+            return visited;
+
+        if (visited >= limit) {
+            *truncated = true;
+            break;
+        }
+
+        JSC::JSValue nextValue = JSC::iteratorValue(globalObject, next);
+        RETURN_IF_EXCEPTION(scope, visited);
+
+        visited++;
+        callback(&vm, globalObject, ctx, JSC::JSValue::encode(nextValue));
+        if (scope.exception()) [[unlikely]]
+            break;
+    }
+
+    scope.release();
+    JSC::iteratorClose(globalObject, iterationRecord.iterator);
+    return visited;
 }

--- a/src/jsc/bindings/ConsoleObject.cpp
+++ b/src/jsc/bindings/ConsoleObject.cpp
@@ -176,8 +176,10 @@ extern "C" bool Bun__ConsoleObject__forEachLimited(JSC::EncodedJSValue encodedIt
         RETURN_IF_EXCEPTION(scope, false);
         double size = sizeValue.toNumber(globalObject);
         RETURN_IF_EXCEPTION(scope, false);
+        // `size` is a user-controlled claim once it exceeds what the storage holds, so past that only the budget applies.
+        uint64_t trusted = std::max<uint64_t>(map ? map->size() : set->size(), budget);
         if (size >= 0)
-            bound = size < static_cast<double>(UINT32_MAX) ? static_cast<uint64_t>(size) : UINT32_MAX;
+            bound = size < static_cast<double>(trusted) ? static_cast<uint64_t>(size) : trusted;
     } else if (auto* array = dynamicDowncast<JSC::JSArray>(iterable))
         bound = array->length();
     else if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(iterable))

--- a/src/jsc/bindings/ConsoleObject.cpp
+++ b/src/jsc/bindings/ConsoleObject.cpp
@@ -131,8 +131,8 @@ void ConsoleObject::profileEnd(JSC::JSGlobalObject* globalObject, const String& 
 
 }
 
-// `JSC::forEachInIterable` with the iterator protocol bounded: by the collection's element count when it has one, else by `budget`. True when elements were left.
-extern "C" bool Bun__ConsoleObject__forEachLimited(JSC::EncodedJSValue encodedIterable, JSC::JSGlobalObject* globalObject, uint32_t budget, void* ctx, void (*callback)(JSC::VM*, JSC::JSGlobalObject*, void* ctx, JSC::EncodedJSValue))
+// `JSC::forEachInIterable` with the iterator protocol bounded: by the collection's element count when it has one, else by `budget`. `sizeAlreadyRead` is a Map or Set `size` the caller read, or -1. True when elements were left.
+extern "C" bool Bun__ConsoleObject__forEachLimited(JSC::EncodedJSValue encodedIterable, JSC::JSGlobalObject* globalObject, uint32_t budget, int32_t sizeAlreadyRead, void* ctx, void (*callback)(JSC::VM*, JSC::JSGlobalObject*, void* ctx, JSC::EncodedJSValue))
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -171,15 +171,17 @@ extern "C" bool Bun__ConsoleObject__forEachLimited(JSC::EncodedJSValue encodedIt
     uint64_t bound = budget;
     if (map || set) {
         // Node's rule for a replaced iterator: it gets as many steps as the collection reports entries.
-        JSC::JSObject* collection = map ? static_cast<JSC::JSObject*>(map) : set;
-        JSC::JSValue sizeValue = collection->get(globalObject, vm.propertyNames->size);
-        RETURN_IF_EXCEPTION(scope, false);
-        double size = sizeValue.toNumber(globalObject);
-        RETURN_IF_EXCEPTION(scope, false);
-        // `size` is a user-controlled claim once it exceeds what the storage holds, so past that only the budget applies.
-        uint64_t trusted = std::max<uint64_t>(map ? map->size() : set->size(), budget);
-        if (size >= 0)
-            bound = size < static_cast<double>(trusted) ? static_cast<uint64_t>(size) : trusted;
+        double size = sizeAlreadyRead;
+        if (sizeAlreadyRead < 0) {
+            JSC::JSObject* collection = map ? static_cast<JSC::JSObject*>(map) : set;
+            JSC::JSValue sizeValue = collection->get(globalObject, vm.propertyNames->size);
+            RETURN_IF_EXCEPTION(scope, false);
+            size = sizeValue.toNumber(globalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+        }
+        // A size that is not a finite count says nothing about where the walk ends, so the budget stays.
+        if (std::isfinite(size) && size >= 0)
+            bound = size < static_cast<double>(UINT32_MAX) ? static_cast<uint64_t>(size) : UINT32_MAX;
     } else if (auto* array = dynamicDowncast<JSC::JSArray>(iterable))
         bound = array->length();
     else if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(iterable))

--- a/src/jsc/bindings/ConsoleObject.cpp
+++ b/src/jsc/bindings/ConsoleObject.cpp
@@ -131,61 +131,83 @@ void ConsoleObject::profileEnd(JSC::JSGlobalObject* globalObject, const String& 
 
 }
 
-// Bounded `JSC::forEachInIterable`: a Map or a Set is read from its own storage, anything else gets `limit` iterator steps and is then closed.
-extern "C" uint32_t Bun__ConsoleObject__forEachLimited(JSC::EncodedJSValue encodedIterable, JSC::JSGlobalObject* globalObject, uint32_t limit, bool* truncated, void* ctx, void (*callback)(JSC::VM*, JSC::JSGlobalObject*, void* ctx, JSC::EncodedJSValue))
+// `JSC::forEachInIterable` with the iterator protocol bounded: by the collection's element count when it has one, else by `budget`. True when elements were left.
+extern "C" bool Bun__ConsoleObject__forEachLimited(JSC::EncodedJSValue encodedIterable, JSC::JSGlobalObject* globalObject, uint32_t budget, void* ctx, void (*callback)(JSC::VM*, JSC::JSGlobalObject*, void* ctx, JSC::EncodedJSValue))
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::JSValue iterable = JSC::JSValue::decode(encodedIterable);
-    uint32_t visited = 0;
-    *truncated = false;
+    JSC::JSCell* sentinel = vm.orderedHashTableSentinel();
 
-    auto visitStorageEntry = [&](JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue value) -> WTF::IterationStatus {
-        if (visited >= limit) {
-            *truncated = true;
-            return WTF::IterationStatus::Done;
-        }
-        visited++;
+    auto visit = [&](JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue value) {
         callback(&vm, globalObject, ctx, JSC::JSValue::encode(value));
-        return WTF::IterationStatus::Continue;
     };
 
-    if (auto* map = dynamicDowncast<JSC::JSMap>(iterable)) {
+    // The walks `forEachInIterable` takes when user code cannot observe the iteration. The collection itself bounds them.
+    if (JSC::getIterationMode(iterable) == JSC::IterationMode::FastArray) {
+        JSC::forEachInFastArray(globalObject, iterable, uncheckedDowncast<JSC::JSArray>(iterable), visit);
+        RETURN_IF_EXCEPTION(scope, false);
+        return false;
+    }
+    auto* map = dynamicDowncast<JSC::JSMap>(iterable);
+    if (map && map->isIteratorProtocolFastAndNonObservable()) {
         JSC::JSCell* storage = map->storageOrSentinel(vm);
-        if (storage != vm.orderedHashTableSentinel()) {
-            JSC::forEachInMapStorage(vm, globalObject, storage, 0, JSC::IterationKind::Entries, visitStorageEntry);
-            RETURN_IF_EXCEPTION(scope, visited);
+        if (storage != sentinel) {
+            JSC::forEachInMapStorage(vm, globalObject, storage, 0, JSC::IterationKind::Entries, visit);
+            RETURN_IF_EXCEPTION(scope, false);
         }
-        return visited;
+        return false;
+    }
+    auto* set = dynamicDowncast<JSC::JSSet>(iterable);
+    if (set && set->isIteratorProtocolFastAndNonObservable()) {
+        JSC::JSCell* storage = set->storageOrSentinel(vm);
+        if (storage != sentinel) {
+            JSC::forEachInSetStorage(vm, globalObject, storage, 0, visit);
+            RETURN_IF_EXCEPTION(scope, false);
+        }
+        return false;
     }
 
-    if (auto* set = dynamicDowncast<JSC::JSSet>(iterable)) {
-        JSC::JSCell* storage = set->storageOrSentinel(vm);
-        if (storage != vm.orderedHashTableSentinel()) {
-            JSC::forEachInSetStorage(vm, globalObject, storage, 0, visitStorageEntry);
-            RETURN_IF_EXCEPTION(scope, visited);
-        }
-        return visited;
+    uint64_t bound = budget;
+    if (map || set) {
+        // Node's rule for a replaced iterator: it gets as many steps as the collection reports entries.
+        JSC::JSObject* collection = map ? static_cast<JSC::JSObject*>(map) : set;
+        JSC::JSValue sizeValue = collection->get(globalObject, vm.propertyNames->size);
+        RETURN_IF_EXCEPTION(scope, false);
+        double size = sizeValue.toNumber(globalObject);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (size >= 0)
+            bound = size < static_cast<double>(UINT32_MAX) ? static_cast<uint64_t>(size) : UINT32_MAX;
+    } else if (auto* array = dynamicDowncast<JSC::JSArray>(iterable))
+        bound = array->length();
+    else if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(iterable))
+        bound = view->length();
+    else if (auto* mapIterator = dynamicDowncast<JSC::JSMapIterator>(iterable)) {
+        if (auto* iterated = dynamicDowncast<JSC::JSMap>(mapIterator->internalField(JSC::JSMapIterator::Field::IteratedObject).get()))
+            bound = iterated->size();
+    } else if (auto* setIterator = dynamicDowncast<JSC::JSSetIterator>(iterable)) {
+        if (auto* iterated = dynamicDowncast<JSC::JSSet>(setIterator->internalField(JSC::JSSetIterator::Field::IteratedObject).get()))
+            bound = iterated->size();
     }
 
     JSC::IterationRecord iterationRecord = JSC::iteratorForIterable(globalObject, iterable);
-    RETURN_IF_EXCEPTION(scope, visited);
+    RETURN_IF_EXCEPTION(scope, false);
 
-    while (true) {
+    bool truncated = false;
+    for (uint64_t visited = 0;; visited++) {
         JSC::JSValue next = JSC::iteratorStep(globalObject, iterationRecord);
-        RETURN_IF_EXCEPTION(scope, visited);
+        RETURN_IF_EXCEPTION(scope, false);
         if (next.isFalse())
-            return visited;
+            return false;
 
-        if (visited >= limit) {
-            *truncated = true;
+        if (visited >= bound) {
+            truncated = true;
             break;
         }
 
         JSC::JSValue nextValue = JSC::iteratorValue(globalObject, next);
-        RETURN_IF_EXCEPTION(scope, visited);
+        RETURN_IF_EXCEPTION(scope, false);
 
-        visited++;
         callback(&vm, globalObject, ctx, JSC::JSValue::encode(nextValue));
         if (scope.exception()) [[unlikely]]
             break;
@@ -193,5 +215,5 @@ extern "C" uint32_t Bun__ConsoleObject__forEachLimited(JSC::EncodedJSValue encod
 
     scope.release();
     JSC::iteratorClose(globalObject, iterationRecord.iterator);
-    return visited;
+    return truncated;
 }

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -364,9 +364,9 @@ console.log("calls=" + calls);`,
   });
 });
 
-// Rows that come from an iterator end when user code says so. A Map or a Set
-// is read from its own storage, an array has no more rows than its length, and
-// any other iterable gets a budget of 1000 rows.
+// Rows that come from an iterator end when user code says so. A collection
+// gives a replaced iterator as many steps as it reports elements. Any other
+// iterable gets a budget of 1000 rows.
 describe("console.table reads a bounded number of rows from an iterator", () => {
   function* rows(count: number) {
     for (let i = 0; i < count; i++) yield { n: i };
@@ -462,16 +462,20 @@ function* endless() {
 
   test.concurrent("a Map whose iterator was replaced", async () => {
     const { lines, stderr, exitCode } = await run(
-      `Map.prototype[Symbol.iterator] = endless;\nconsole.table(new Map([["a", 1]]));`,
+      `Map.prototype[Symbol.iterator] = function* () { for (const row of endless()) yield ["k", row.t]; };
+console.table(new Map([["a", 1], ["b", 2]]));`,
     );
     expect(stderr).toBe("");
+    // Two entries, so two steps, then one more to learn that the iterator had more.
     expect(lines).toEqual([
       "┌───┬─────┬────────┐",
       "│   │ Key │ Values │",
       "├───┼─────┼────────┤",
-      "│ 0 │ a   │ 1      │",
+      "│ 0 │ k   │ 1      │",
+      "│ 1 │ k   │ 1      │",
       "└───┴─────┴────────┘",
-      "yielded=0",
+      "... more rows",
+      "yielded=3",
       "",
     ]);
     expect(exitCode).toBe(0);

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -425,6 +425,22 @@ function* endless() {
     expect(exitCode).toBe(0);
   });
 
+  // Only user code can make these iterable, so only the budget bounds the walk.
+  test.concurrent.each([
+    ["a WeakMap", `WeakMap.prototype[Symbol.iterator] = endless;\nconsole.table(new WeakMap());`],
+    ["a WeakSet", `WeakSet.prototype[Symbol.iterator] = endless;\nconsole.table(new WeakSet());`],
+    ["an ArrayBuffer", `ArrayBuffer.prototype[Symbol.iterator] = endless;\nconsole.table(new ArrayBuffer(1 << 20));`],
+  ])("%s that user code made iterable", async (_, source) => {
+    const { lines, stderr, exitCode } = await run(source);
+    expect(stderr).toBe("");
+    // Three header lines, the rows, the bottom border, then the three lines below.
+    expect({ rows: lines.length - 7, tail: lines.slice(-3) }).toEqual({
+      rows: 1000,
+      tail: ["... more rows", "yielded=1001", ""],
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("an array whose iterator was replaced", async () => {
     const { lines, stderr, exitCode } = await run(
       `Array.prototype[Symbol.iterator] = endless;\nconsole.table([{ a: 1 }, { a: 2 }]);`,

--- a/test/js/bun/console/console-table.test.ts
+++ b/test/js/bun/console/console-table.test.ts
@@ -363,3 +363,101 @@ console.log("calls=" + calls);`,
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: box("1") + "calls=1\n", stderr: "", exitCode: 0 });
   });
 });
+
+// Rows that come from an iterator end when user code says so. A Map or a Set
+// is read from its own storage, an array has no more rows than its length, and
+// any other iterable gets a budget of 1000 rows.
+describe("console.table reads a bounded number of rows from an iterator", () => {
+  function* rows(count: number) {
+    for (let i = 0; i < count; i++) yield { n: i };
+  }
+  const lastLines = (text: string, count: number) => text.split("\n").slice(-count);
+
+  test("a generator past the budget is cut and marked", () => {
+    expect(lastLines(Bun.inspect.table(rows(1001)), 4)).toEqual([
+      "│ 999 │ 999 │",
+      "└─────┴─────┘",
+      "... more rows",
+      "",
+    ]);
+  });
+
+  test("a generator that ends at the budget is not marked", () => {
+    expect(lastLines(Bun.inspect.table(rows(1000)), 3)).toEqual(["│ 999 │ 999 │", "└─────┴─────┘", ""]);
+  });
+
+  test("an array, a typed array, a Map and a Set print every row", () => {
+    const dataRows = (table: string) => table.split("\n").length - 5;
+    expect({
+      array: dataRows(Bun.inspect.table(Array.from(rows(1500)))),
+      typedArray: dataRows(Bun.inspect.table(new Uint8Array(1500))),
+      map: dataRows(Bun.inspect.table(new Map(Array.from({ length: 1500 }, (_, i) => [i, i])))),
+      set: dataRows(Bun.inspect.table(new Set(Array.from({ length: 1500 }, (_, i) => i)))),
+    }).toEqual({ array: 1500, typedArray: 1500, map: 1500, set: 1500 });
+  });
+
+  // Each child counts what its iterator hands out and exits with 2 well past
+  // the budget, so the unfixed printer fails here at once and does not run
+  // until memory is gone.
+  const endless = `let yielded = 0;
+function* endless() {
+  for (;;) {
+    if (++yielded > 5000) process.exit(2);
+    yield { t: 1 };
+  }
+}`;
+
+  async function run(source: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `${endless}\n${source}\nconsole.log("yielded=" + yielded);`],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { lines: stdout.split("\n"), stderr, exitCode };
+  }
+
+  test.concurrent("an iterator that never ends", async () => {
+    const { lines, stderr, exitCode } = await run(`console.table({ host: "db1", [Symbol.iterator]: endless });`);
+    expect(stderr).toBe("");
+    // One read past the budget tells a cut table from one that ends there.
+    expect(lines.slice(-5)).toEqual(["│ 999 │ 1 │", "└─────┴───┘", "... more rows", "yielded=1001", ""]);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("an array whose iterator was replaced", async () => {
+    const { lines, stderr, exitCode } = await run(
+      `Array.prototype[Symbol.iterator] = endless;\nconsole.table([{ a: 1 }, { a: 2 }]);`,
+    );
+    expect(stderr).toBe("");
+    expect(lines).toEqual([
+      "┌───┬───┐",
+      "│   │ t │",
+      "├───┼───┤",
+      "│ 0 │ 1 │",
+      "│ 1 │ 1 │",
+      "└───┴───┘",
+      "... more rows",
+      "yielded=3",
+      "",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("a Map whose iterator was replaced", async () => {
+    const { lines, stderr, exitCode } = await run(
+      `Map.prototype[Symbol.iterator] = endless;\nconsole.table(new Map([["a", 1]]));`,
+    );
+    expect(stderr).toBe("");
+    expect(lines).toEqual([
+      "┌───┬─────┬────────┐",
+      "│   │ Key │ Values │",
+      "├───┼─────┼────────┤",
+      "│ 0 │ a   │ 1      │",
+      "└───┴─────┴────────┘",
+      "yielded=0",
+      "",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1098,6 +1098,13 @@ describe("inspect bounds a replaced Map or Set iterator", () => {
     expect(Bun.inspect(new Set(values(150)).values())).toEndWith("  148,\n  149,\n}");
   });
 
+  it("a subclass with more stored entries than the budget prints every entry", () => {
+    class Collection extends Map {}
+    class Bag extends Set {}
+    expect(Bun.inspect(new Collection(entries(1500)))).toEndWith("  1498: 1498,\n  1499: 1499,\n}");
+    expect(Bun.inspect(new Bag(values(1500)))).toEndWith("  1498,\n  1499,\n}");
+  });
+
   // quick-lru is a Map subclass of this shape: it never calls `super.set`, so
   // the inherited storage stays empty.
   class Elsewhere extends Map {
@@ -1245,6 +1252,23 @@ describe.concurrent("inspect survives an iterator that never ends", () => {
     );
     expect({ values: count(output, '"k"'), runaway }).toEqual({ values: 2, runaway: false });
     expect(output).toEndWith("  ... more items\n}\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("a Map subclass that reports more entries than it can hold", async () => {
+    const { output, runaway, exitCode } = await run(
+      `let yielded = 0;
+       class Lazy extends Map {
+         get size() { return 1e18; }
+         *[Symbol.iterator]() { for (;;) { if (++yielded > 5000) process.exit(2); yield [yielded, yielded]; } }
+       }
+       console.log(new Lazy());
+       console.log("yielded=" + yielded);`,
+      "stdout",
+    );
+    expect(runaway).toBe(false);
+    // The storage is empty, so the claim is trusted up to the budget of 1000 steps.
+    expect(output).toEndWith("  1000: 1000,\n  ... more items\n}\nyielded=1001\n");
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1082,3 +1082,148 @@ it("object property enumeration scales linearly with property count", () => {
     expect(l.ms / 30000 / (s.ms / 3000)).toBeLessThan(3);
   });
 });
+
+describe("collection previews stop at the display limit", () => {
+  const entries = length => Array.from({ length }, (_, i) => [i, i]);
+  const values = length => Array.from({ length }, (_, i) => i);
+  const lastLines = (text, count) => text.split("\n").slice(-count);
+
+  it("a Map prints 100 entries and the remainder count", () => {
+    expect(lastLines(Bun.inspect(new Map(entries(150))), 3)).toEqual(["  99: 99,", "  ... 50 more items", "}"]);
+  });
+
+  it("a Set prints 100 values and the remainder count", () => {
+    expect(lastLines(Bun.inspect(new Set(values(150))), 3)).toEqual(["  99,", "  ... 50 more items", "}"]);
+  });
+
+  it("one hidden entry reads as a single item", () => {
+    expect(lastLines(Bun.inspect(new Map(entries(101))), 2)).toEqual(["  ... 1 more item", "}"]);
+    expect(lastLines(Bun.inspect(new Set(values(101))), 2)).toEqual(["  ... 1 more item", "}"]);
+  });
+
+  it("an iterator preview says it is cut short", () => {
+    expect(lastLines(Bun.inspect(new Map(entries(150)).entries()), 3)).toEqual([
+      "  [ 99, 99 ],",
+      "  ... more items",
+      "}",
+    ]);
+    expect(lastLines(Bun.inspect(new Set(values(150)).values()), 3)).toEqual(["  99,", "  ... more items", "}"]);
+  });
+
+  it("compact mode keeps the marker on one line", () => {
+    expect(Bun.inspect(new Map(entries(150)), { compact: true })).toEndWith(" 99: 99, ... 50 more items }");
+    expect(Bun.inspect(new Set(values(150)), { compact: true })).toEndWith(" 99, ... 50 more items }");
+    expect(Bun.inspect(new Map(entries(150)).entries(), { compact: true })).toEndWith(" [ 99, 99 ], ... more items }");
+    expect(Bun.inspect(new Set(values(150)).values(), { compact: true })).toEndWith(" 99, ... more items}");
+  });
+
+  it("a collection that fits prints in full", () => {
+    expect(Bun.inspect(new Map(entries(100)))).toEndWith("  99: 99,\n}");
+    expect(Bun.inspect(new Set(values(100)))).toEndWith("  99,\n}");
+    expect(Bun.inspect(new Map(entries(100)).entries())).toEndWith("  [ 99, 99 ],\n}");
+  });
+});
+
+// The formatter used to drive `Symbol.iterator`, so user code decided when the
+// walk ended. An iterator that never reports `done` printed forever at 100%
+// CPU. A Map or a Set is now read from its own storage, and every other
+// iterable is cut at the display limit.
+describe.concurrent("inspect survives an iterator that never ends", () => {
+  // The unfixed formatter prints without end. Stop the read at `limit` bytes
+  // and kill the child, so that failure reports `runaway` at once.
+  async function run(source, stream) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", source],
+      env: bunEnv,
+      stdout: stream === "stdout" ? "pipe" : "ignore",
+      stderr: stream === "stderr" ? "pipe" : "ignore",
+    });
+
+    const limit = 1024 * 1024;
+    const decoder = new TextDecoder();
+    let output = "";
+    let runaway = false;
+    for await (const chunk of proc[stream]) {
+      output += decoder.decode(chunk, { stream: true });
+      if (output.length > limit) {
+        runaway = true;
+        // Keep the assertion diff readable.
+        output = output.slice(0, 256);
+        proc.kill();
+        break;
+      }
+    }
+    return { output, runaway, exitCode: await proc.exited };
+  }
+
+  const count = (text, needle) => text.split(needle).length - 1;
+
+  it("Map.prototype[Symbol.iterator]", async () => {
+    const { output, runaway, exitCode } = await run(
+      `Map.prototype[Symbol.iterator] = function* () { for (;;) yield ["k", "v"]; };
+       console.log(new Map([["a", 1]]));`,
+      "stdout",
+    );
+    expect({ output, runaway }).toEqual({ output: 'Map(1) {\n  "a": 1,\n}\n', runaway: false });
+    expect(exitCode).toBe(0);
+  });
+
+  it("Set.prototype[Symbol.iterator]", async () => {
+    const { output, runaway, exitCode } = await run(
+      `Set.prototype[Symbol.iterator] = function* () { for (;;) yield "x"; };
+       console.log(new Set(["a"]));`,
+      "stdout",
+    );
+    expect({ output, runaway }).toEqual({ output: 'Set(1) {\n  "a",\n}\n', runaway: false });
+    expect(exitCode).toBe(0);
+  });
+
+  it("a replaced next() on the Map iterator prototype", async () => {
+    const { output, runaway, exitCode } = await run(
+      `const map = new Map([["a", 1]]);
+       Object.getPrototypeOf(map.entries()).next = () => ({ value: ["k", "v"], done: false });
+       console.log(map.entries());`,
+      "stdout",
+    );
+    expect({ entries: count(output, '"k"'), runaway }).toEqual({ entries: 100, runaway: false });
+    expect(output).toEndWith("  ... more items\n}\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("a replaced next() on the Set iterator prototype", async () => {
+    const { output, runaway, exitCode } = await run(
+      `const set = new Set(["a"]);
+       Object.getPrototypeOf(set.values()).next = () => ({ value: "k", done: false });
+       console.log(set.values());`,
+      "stdout",
+    );
+    expect({ values: count(output, '"k"'), runaway }).toEqual({ values: 100, runaway: false });
+    expect(output).toEndWith("  ... more items\n}\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it("an uncaught error that carries such a Map", async () => {
+    const { output, runaway, exitCode } = await run(
+      `Map.prototype[Symbol.iterator] = function* () { for (;;) yield ["k", "v"]; };
+       const err = new Error("boom");
+       err.ctx = new Map([["a", 1]]);
+       throw err;`,
+      "stderr",
+    );
+    expect(runaway).toBe(false);
+    expect(output).toContain('ctx: Map(1) {\n  "a": 1,\n}');
+    expect(exitCode).toBe(1);
+  });
+
+  it("an uncaught AggregateError whose errors list never ends", async () => {
+    const { output, runaway, exitCode } = await run(
+      `const err = new AggregateError([], "boom");
+       err.errors = { [Symbol.iterator]: function* () { for (;;) yield new Error("inner"); } };
+       throw err;`,
+      "stderr",
+    );
+    expect({ members: count(output, "error: inner"), runaway }).toEqual({ members: 100, runaway: false });
+    expect(output).toContain("... more errors\n");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1136,6 +1136,35 @@ describe("inspect bounds a replaced Map or Set iterator", () => {
     );
   });
 
+  it("such a subclass prints every entry past the budget for unsized iterables", () => {
+    class Cache extends Map {
+      #items = entries(1500);
+      get size() {
+        return this.#items.length;
+      }
+      *[Symbol.iterator]() {
+        yield* this.#items;
+      }
+    }
+    expect(Bun.inspect(new Cache())).toEndWith("  1498: 1498,\n  1499: 1499,\n}");
+    expect(Bun.inspect.table(new Cache())).toEndWith("│ 1499 │ 1499 │ 1499   │\n└──────┴──────┴────────┘\n");
+  });
+
+  it("reads `size` once", () => {
+    let reads = 0;
+    class Counted extends Map {
+      get size() {
+        reads++;
+        return 1;
+      }
+      *[Symbol.iterator]() {
+        yield ["a", 1];
+      }
+    }
+    expect(Bun.inspect(new Counted())).toBe('Map(1) {\n  "a": 1,\n}');
+    expect(reads).toBe(1);
+  });
+
   it("an iterator that yields more than `size` is cut there and marked", () => {
     class Overflow extends Map {
       get size() {
@@ -1255,20 +1284,26 @@ describe.concurrent("inspect survives an iterator that never ends", () => {
     expect(exitCode).toBe(0);
   });
 
-  it("a Map subclass that reports more entries than it can hold", async () => {
+  it("a Map subclass whose size is not a finite count", async () => {
     const { output, runaway, exitCode } = await run(
       `let yielded = 0;
        class Lazy extends Map {
-         get size() { return 1e18; }
+         get size() { return Infinity; }
          *[Symbol.iterator]() { for (;;) { if (++yielded > 5000) process.exit(2); yield [yielded, yielded]; } }
        }
-       console.log(new Lazy());
+       console.table(new Lazy());
        console.log("yielded=" + yielded);`,
       "stdout",
     );
     expect(runaway).toBe(false);
-    // The storage is empty, so the claim is trusted up to the budget of 1000 steps.
-    expect(output).toEndWith("  1000: 1000,\n  ... more items\n}\nyielded=1001\n");
+    // `Infinity` says nothing about where the walk ends, so the budget of 1000 rows applies.
+    expect(output.split("\n").slice(-5)).toEqual([
+      "│ 999 │ 1000 │ 1000   │",
+      "└─────┴──────┴────────┘",
+      "... more rows",
+      "yielded=1001",
+      "",
+    ]);
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1083,70 +1083,94 @@ it("object property enumeration scales linearly with property count", () => {
   });
 });
 
-describe("collection previews stop at the display limit", () => {
+// The formatter drives `Symbol.iterator` for a Map, a Set and their iterators.
+// Once user code replaces it, user code decides when the walk ends, and an
+// iterator that never reports `done` printed forever at 100% CPU. The walk now
+// stops at the number of entries the collection reports, as in node.
+describe("inspect bounds a replaced Map or Set iterator", () => {
   const entries = length => Array.from({ length }, (_, i) => [i, i]);
   const values = length => Array.from({ length }, (_, i) => i);
-  const lastLines = (text, count) => text.split("\n").slice(-count);
 
-  it("a Map prints 100 entries and the remainder count", () => {
-    expect(lastLines(Bun.inspect(new Map(entries(150))), 3)).toEqual(["  99: 99,", "  ... 50 more items", "}"]);
+  it("a collection that user code did not touch prints every entry", () => {
+    expect(Bun.inspect(new Map(entries(150)))).toEndWith("  148: 148,\n  149: 149,\n}");
+    expect(Bun.inspect(new Set(values(150)))).toEndWith("  148,\n  149,\n}");
+    expect(Bun.inspect(new Map(entries(150)).keys())).toEndWith("  148,\n  149,\n}");
+    expect(Bun.inspect(new Set(values(150)).values())).toEndWith("  148,\n  149,\n}");
   });
 
-  it("a Set prints 100 values and the remainder count", () => {
-    expect(lastLines(Bun.inspect(new Set(values(150))), 3)).toEqual(["  99,", "  ... 50 more items", "}"]);
+  // quick-lru is a Map subclass of this shape: it never calls `super.set`, so
+  // the inherited storage stays empty.
+  class Elsewhere extends Map {
+    #items = [
+      ["a", 1],
+      ["b", 2],
+    ];
+    get size() {
+      return this.#items.length;
+    }
+    *[Symbol.iterator]() {
+      yield* this.#items;
+    }
+  }
+
+  it("a Map subclass that keeps its entries elsewhere prints them", () => {
+    expect(Bun.inspect(new Elsewhere())).toBe('Map(2) {\n  "a": 1,\n  "b": 2,\n}');
+    expect(Bun.inspect(new Elsewhere(), { compact: true })).toBe('Map(2) { "a": 1, "b": 2 }');
+    expect(Bun.inspect.table(new Elsewhere())).toBe(
+      [
+        "┌───┬─────┬────────┐",
+        "│   │ Key │ Values │",
+        "├───┼─────┼────────┤",
+        "│ 0 │ a   │ 1      │",
+        "│ 1 │ b   │ 2      │",
+        "└───┴─────┴────────┘",
+        "",
+      ].join("\n"),
+    );
   });
 
-  it("one hidden entry reads as a single item", () => {
-    expect(lastLines(Bun.inspect(new Map(entries(101))), 2)).toEqual(["  ... 1 more item", "}"]);
-    expect(lastLines(Bun.inspect(new Set(values(101))), 2)).toEqual(["  ... 1 more item", "}"]);
+  it("an iterator that yields more than `size` is cut there and marked", () => {
+    class Overflow extends Map {
+      get size() {
+        return 2;
+      }
+      *[Symbol.iterator]() {
+        for (let i = 0; i < 5; i++) yield [i, i];
+      }
+    }
+    class OverflowSet extends Set {
+      get size() {
+        return 2;
+      }
+      *[Symbol.iterator]() {
+        for (let i = 0; i < 5; i++) yield i;
+      }
+    }
+    expect(Bun.inspect(new Overflow())).toBe("Map(2) {\n  0: 0,\n  1: 1,\n  ... more items\n}");
+    expect(Bun.inspect(new Overflow(), { compact: true })).toBe("Map(2) { 0: 0, 1: 1, ... more items }");
+    expect(Bun.inspect(new OverflowSet())).toBe("Set(2) {\n  0,\n  1,\n  ... more items\n}");
+    expect(Bun.inspect(new OverflowSet(), { compact: true })).toBe("Set(2) { 0, 1, ... more items }");
   });
 
-  it("an iterator preview says it is cut short", () => {
-    expect(lastLines(Bun.inspect(new Map(entries(150)).entries()), 3)).toEqual([
-      "  [ 99, 99 ],",
-      "  ... more items",
-      "}",
-    ]);
-    expect(lastLines(Bun.inspect(new Set(values(150)).values()), 3)).toEqual(["  99,", "  ... more items", "}"]);
-  });
-
-  it("compact mode keeps the marker on one line", () => {
-    expect(Bun.inspect(new Map(entries(150)), { compact: true })).toEndWith(" 99: 99, ... 50 more items }");
-    expect(Bun.inspect(new Set(values(150)), { compact: true })).toEndWith(" 99, ... 50 more items }");
-    expect(Bun.inspect(new Map(entries(150)).entries(), { compact: true })).toEndWith(" [ 99, 99 ], ... more items }");
-    expect(Bun.inspect(new Set(values(150)).values(), { compact: true })).toEndWith(" 99, ... more items}");
-  });
-
-  it("a collection that fits prints in full", () => {
-    expect(Bun.inspect(new Map(entries(100)))).toEndWith("  99: 99,\n}");
-    expect(Bun.inspect(new Set(values(100)))).toEndWith("  99,\n}");
-    expect(Bun.inspect(new Map(entries(100)).entries())).toEndWith("  [ 99, 99 ],\n}");
-  });
-
-  it("the preview of a large Map stays small", () => {
-    const lines = Bun.inspect(new Map(entries(10_000))).split("\n");
-    // The header, 100 entries, the marker and the closing brace.
-    expect(lines.length).toBe(103);
-    expect(lines.slice(-3)).toEqual(["  99: 99,", "  ... 9900 more items", "}"]);
-  });
-
-  it("the limit counts stored entries, not what a size getter reports", () => {
-    class Undercount extends Map {
+  it("closes the iterator it cuts short", () => {
+    let returned = 0;
+    class Overflow extends Map {
       get size() {
         return 1;
       }
+      [Symbol.iterator]() {
+        let i = 0;
+        return {
+          next: () => (i < 5 ? { value: [i, i++], done: false } : { value: undefined, done: true }),
+          return: () => (returned++, {}),
+        };
+      }
     }
-    const lines = Bun.inspect(new Undercount(entries(500))).split("\n");
-    expect(lines.length).toBe(103);
-    // `size` is below the number of entries printed, so the marker has no count.
-    expect(lines.slice(-3)).toEqual(["  99: 99,", "  ... more items", "}"]);
+    expect(Bun.inspect(new Overflow())).toBe("Map(1) {\n  0: 0,\n  ... more items\n}");
+    expect(returned).toBe(1);
   });
 });
 
-// The formatter used to drive `Symbol.iterator`, so user code decided when the
-// walk ended. An iterator that never reports `done` printed forever at 100%
-// CPU. A Map or a Set is now read from its own storage, and every other
-// iterable is cut at the display limit.
 describe.concurrent("inspect survives an iterator that never ends", () => {
   // The unfixed formatter prints without end. Stop the read at `limit` bytes
   // and kill the child, so that failure reports `runaway` at once.
@@ -1180,43 +1204,46 @@ describe.concurrent("inspect survives an iterator that never ends", () => {
   it("Map.prototype[Symbol.iterator]", async () => {
     const { output, runaway, exitCode } = await run(
       `Map.prototype[Symbol.iterator] = function* () { for (;;) yield ["k", "v"]; };
-       console.log(new Map([["a", 1]]));`,
+       console.log(new Map([["a", 1], ["b", 2]]));`,
       "stdout",
     );
-    expect({ output, runaway }).toEqual({ output: 'Map(1) {\n  "a": 1,\n}\n', runaway: false });
+    expect({ output, runaway }).toEqual({
+      output: 'Map(2) {\n  "k": "v",\n  "k": "v",\n  ... more items\n}\n',
+      runaway: false,
+    });
     expect(exitCode).toBe(0);
   });
 
   it("Set.prototype[Symbol.iterator]", async () => {
     const { output, runaway, exitCode } = await run(
       `Set.prototype[Symbol.iterator] = function* () { for (;;) yield "x"; };
-       console.log(new Set(["a"]));`,
+       console.log(new Set(["a", "b"]));`,
       "stdout",
     );
-    expect({ output, runaway }).toEqual({ output: 'Set(1) {\n  "a",\n}\n', runaway: false });
+    expect({ output, runaway }).toEqual({ output: 'Set(2) {\n  "x",\n  "x",\n  ... more items\n}\n', runaway: false });
     expect(exitCode).toBe(0);
   });
 
   it("a replaced next() on the Map iterator prototype", async () => {
     const { output, runaway, exitCode } = await run(
-      `const map = new Map([["a", 1]]);
+      `const map = new Map([["a", 1], ["b", 2]]);
        Object.getPrototypeOf(map.entries()).next = () => ({ value: ["k", "v"], done: false });
        console.log(map.entries());`,
       "stdout",
     );
-    expect({ entries: count(output, '"k"'), runaway }).toEqual({ entries: 100, runaway: false });
+    expect({ entries: count(output, '"k"'), runaway }).toEqual({ entries: 2, runaway: false });
     expect(output).toEndWith("  ... more items\n}\n");
     expect(exitCode).toBe(0);
   });
 
   it("a replaced next() on the Set iterator prototype", async () => {
     const { output, runaway, exitCode } = await run(
-      `const set = new Set(["a"]);
+      `const set = new Set(["a", "b"]);
        Object.getPrototypeOf(set.values()).next = () => ({ value: "k", done: false });
        console.log(set.values());`,
       "stdout",
     );
-    expect({ values: count(output, '"k"'), runaway }).toEqual({ values: 100, runaway: false });
+    expect({ values: count(output, '"k"'), runaway }).toEqual({ values: 2, runaway: false });
     expect(output).toEndWith("  ... more items\n}\n");
     expect(exitCode).toBe(0);
   });
@@ -1230,7 +1257,7 @@ describe.concurrent("inspect survives an iterator that never ends", () => {
       "stderr",
     );
     expect(runaway).toBe(false);
-    expect(output).toContain('ctx: Map(1) {\n  "a": 1,\n}');
+    expect(output).toContain('ctx: Map(1) {\n  "k": "v",\n  ... more items\n}');
     expect(exitCode).toBe(1);
   });
 
@@ -1244,5 +1271,19 @@ describe.concurrent("inspect survives an iterator that never ends", () => {
     expect({ members: count(output, "error: inner"), runaway }).toEqual({ members: 100, runaway: false });
     expect(output).toContain("... more errors\n");
     expect(exitCode).toBe(1);
+  });
+
+  it("an AggregateError whose errors is a long array prints every member", async () => {
+    const { output, runaway, exitCode } = await run(
+      `console.error(new AggregateError(Array.from({ length: 150 }, (_, i) => "member" + i + ";"), "boom"));`,
+      "stderr",
+    );
+    expect({
+      first: output.includes("member0;"),
+      last: output.includes("member149;"),
+      marker: output.includes("... more errors"),
+      runaway,
+    }).toEqual({ first: true, last: true, marker: false, runaway: false });
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1122,6 +1122,25 @@ describe("collection previews stop at the display limit", () => {
     expect(Bun.inspect(new Set(values(100)))).toEndWith("  99,\n}");
     expect(Bun.inspect(new Map(entries(100)).entries())).toEndWith("  [ 99, 99 ],\n}");
   });
+
+  it("the preview of a large Map stays small", () => {
+    const lines = Bun.inspect(new Map(entries(10_000))).split("\n");
+    // The header, 100 entries, the marker and the closing brace.
+    expect(lines.length).toBe(103);
+    expect(lines.slice(-3)).toEqual(["  99: 99,", "  ... 9900 more items", "}"]);
+  });
+
+  it("the limit counts stored entries, not what a size getter reports", () => {
+    class Undercount extends Map {
+      get size() {
+        return 1;
+      }
+    }
+    const lines = Bun.inspect(new Undercount(entries(500))).split("\n");
+    expect(lines.length).toBe(103);
+    // `size` is below the number of entries printed, so the marker has no count.
+    expect(lines.slice(-3)).toEqual(["  99: 99,", "  ... more items", "}"]);
+  });
 });
 
 // The formatter used to drive `Symbol.iterator`, so user code decided when the


### PR DESCRIPTION
### Problem
- `console.log`, `Bun.inspect`, an uncaught error and `console.table` never return when a value's iterator never reports `done`. An uncaught Error that carries a Map prints forever at 100% CPU once `Map.prototype[Symbol.iterator]` is an endless generator. `console.table` runs until the OOM kill.
- The native formatter walks these values with `JSC::forEachInIterable` (`bindings.cpp:4256`), which ends only on `done`. Callers include `print_map_like` and `TablePrinter::print_table`.

### Fix
- `Bun__ConsoleObject__forEachLimited` (`src/jsc/bindings/ConsoleObject.cpp`) is `forEachInIterable` with the iterator protocol bounded. A collection gives a replaced iterator as many steps as it reports elements: `size` for a Map or a Set, the length for an array or typed array. An iterable with no element count gets a budget: 1000 rows in `console.table`, 100 members of `AggregateError.errors`.
- A walk that stops with elements left closes the iterator, like `break` in a for-of loop, and the output ends with `... more items`, `... more rows` or `... more errors`.
- Output that ends today does not change, with one exception: an iterator that yields more than `size` is cut there and marked. Node cuts there too.
- Verified: `test/js/bun/util/inspect.test.js` and `test/js/bun/console/console-table.test.ts`. bun 1.4.3 fails 16 of 24 new tests (8 are controls). Also ran the console and inspect suites.

### Background
- These four entry points share one native formatter.
- `forEachInIterable` reads an unmodified Array, Map or Set from its own storage, and this PR keeps that. Once user code can observe the iteration, user code decides when the walk ends.
- Node bounds the Map walk with `min(maxArrayLength, map.size)`. 1000 rows is Chrome's `console.table` limit (`InjectedScript::wrapTable` in V8).

<details><summary>Notes</summary>

**Reworked after a self-review**

The first version of this PR also stopped every Map and Set preview at 100 entries, and read a Map or a Set from its storage even when user code had replaced the iterator. Both are gone.

- The 100-entry limit is a change of default output with no opt-out. `console.dir(map, { maxArrayLength: null })` prints every entry today. That limit belongs with `maxArrayLength` support: #31809, #15193, and #35826 which proposed the same limit.
- The unconditional storage read printed `Map(2) {}` for a Map subclass that keeps its entries outside the inherited storage. quick-lru has that shape: it never calls `super.set`. The test `a Map subclass that keeps its entries elsewhere prints them` pins the output for `Bun.inspect` and `Bun.inspect.table`.

**Output, before and after**

```js
Map.prototype[Symbol.iterator] = function* () { for (;;) yield ["k", "v"]; };
console.log(new Map([["a", 1], ["b", 2]]));
// bun 1.4.3:  Map(2) { "k": "v", "k": "v", ... }          never ends
// node 26:    Map(2) { 'k' => 'v', 'k' => 'v' }
// this PR:    Map(2) { "k": "v", "k": "v", ... more items }
```

A Map, Set, Map iterator or Set iterator that user code did not touch prints exactly as before, at any size. A script that prints 16 shapes (Proxy of a Map, a Map from `node:vm`, nested Maps and Sets, all four iterator kinds, `Headers`, `URLSearchParams`, `FormData`, errors, `AggregateError`) in both modes, plus 8 tables, gives byte-identical output on bun 1.4.3 and this branch. The one difference is a Map subclass whose iterator yields 2 entries while `size` says 1: it now prints 1 entry and `... more items`.

**Bounds, by kind of value**

- Array in fast mode, Map or Set whose iteration user code cannot observe: read from storage, as `forEachInIterable` does. No bound is needed.
- Map or Set otherwise (a subclass, an own `Symbol.iterator`, a replaced prototype method): the `size` property, read once. A finite `size` is taken at its word, so a subclass that keeps 1500 entries outside the inherited storage prints all of them. A `size` that is not a finite count (`Infinity`, `NaN`, negative) falls back to the budget. A subclass that reports a huge finite `size` and never stops yielding is not bounded here. Node bounds it with `maxArrayLength`, and the display limit in #35826 will do the same.
- Array or typed array otherwise: its length.
- Map iterator or Set iterator: the size of the collection it walks. A replaced `next` cannot yield more than that.
- Anything else (a generator, `Headers`, a WeakMap that user code made iterable): the caller's budget.

**`console.table`**

- Node's `console.table` uses `Object.keys` for anything that is not a Map or a Set, so it never calls `Symbol.iterator` on a plain object. bun reads generators and `Headers` through the iterator, and `console-table.test.ts` covers that (`a generator is not consumed twice`, `headers object`), so this PR keeps it and adds the budget.
- The test `an array, a typed array, a Map and a Set print every row` pins 1500 rows for each.
- One step past the bound tells a cut table from one that ends exactly there. A generator of 1000 rows prints no marker.

**Exceptions and iterator close**

- A throw from `next`, from the callback, or from `return()` propagates as before.
- The new tests pass under `BUN_JSC_validateExceptionChecks=1`. A script of 16 error paths prints identical results on bun 1.4.3 and this branch.

**Same class, not fixed here**

These sites also run a user iterator without a bound. They are in other subsystems and are handed off as separate work.

- `util.inspect(map.entries())`: `previewEntries` in `src/js/internal/util/inspect.js` uses `Array.from`. An earlier revision of this description said `util.inspect` is already bounded. That holds for a Map or a Set, not for their iterators.
- `new Console().table(map)`: `src/js/builtins/ConsoleObject.ts`.
- `expect(iterable).toBeEmpty()`: `src/runtime/test_runner/expect/toBeEmpty.rs` walks the whole iterable.
- The `expect()` diff and snapshot printer: `src/runtime/test_runner/pretty_format.rs`. A snapshot must list every entry, and a storage read would rewrite stored snapshots of Map subclasses, so it needs the `size`-bounded protocol walk, not a display limit.

**Other changes**

- `JSValue::for_each_with_context` is removed. `console.table` was its last caller.
- bun still advances a Map or Set iterator when it prints it. Node does not. That is unchanged here.

**Related PRs**

- #35826: the 100-entry limit for Map and Set. It was closed in favour of an earlier revision of this PR that carried the limit. The limit is no longer here.
- #31809 and #15193: `maxArrayLength` support in the native formatter.
- #41119 moves arrays off the iterator path in `console.table`. It keeps the iterator path for generators, Maps and Sets.

**Origin**

Two rows of a fuzzing ledger of hang-class bugs on main: an uncaught Error that carries a Map with a replaced iterator, and `console.table` of an object with an endless `Symbol.iterator`.

**Suites run on the debug build**

`test/js/bun/util/inspect.test.js`, `inspect-error.test.js`, `test/js/bun/console/`, `test/js/web/console/` (230 pass), `test/js/node/util/node-inspect-tests/` and `util.test.js` (228 pass). `util-inspect-long-running.test.mjs` took 5.5 s against the 5 s default in my CPU-capped debug container (245 ms on a release build). It formats a plain object with the JS `util.inspect` and calls none of the changed code.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->

