### PR TITLE
node:url: don't crash in url.parse() when validating the argument throws a primitive

### DIFF
--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -127,12 +127,7 @@ function urlParse(
   if ($isObject(url) && url instanceof Url) return url;
 
   var u = new Url();
-  try {
-    u.parse(url, parseQueryString, slashesDenoteHost);
-  } catch (e) {
-    $putByIdDirect(e, "input", url);
-    throw e;
-  }
+  u.parse(url, parseQueryString, slashesDenoteHost);
   return u;
 }
 

--- a/test/js/node/url/url-parse-invalid-input.test.js
+++ b/test/js/node/url/url-parse-invalid-input.test.js
@@ -126,7 +126,7 @@ describe("url.parse", () => {
         bunExe(),
         "-e",
         `
-        const url = require("node:url");
+        import url from "node:url";
         for (const thrown of ["nope", 1, null, undefined, Symbol.for("nope")]) {
           const arg = { get constructor() { throw thrown; } };
           for (const fn of [() => url.parse(arg), () => url.resolve(arg, "/a"), () => url.resolve("/a", arg)]) {

--- a/test/js/node/url/url-parse-invalid-input.test.js
+++ b/test/js/node/url/url-parse-invalid-input.test.js
@@ -1,4 +1,5 @@
-import { describe, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import assert from "node:assert";
 import url from "node:url";
 
@@ -119,28 +120,36 @@ describe("url.parse", () => {
     }
   });
 
-  test.each(["nope", 1, null, undefined, Symbol.for("nope")])(
-    "rethrows %p thrown while describing the argument",
-    thrown => {
-      const arg = {
-        get constructor() {
-          throw thrown;
-        },
-      };
-      for (const fn of [() => url.parse(arg), () => url.resolve(arg, "/a"), () => url.resolve("/a", arg)]) {
-        let caught;
-        let didThrow = false;
-        try {
-          fn();
-        } catch (e) {
-          didThrow = true;
-          caught = e;
+  test("rethrows a primitive thrown while describing the argument", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const url = require("node:url");
+        for (const thrown of ["nope", 1, null, undefined, Symbol.for("nope")]) {
+          const arg = { get constructor() { throw thrown; } };
+          for (const fn of [() => url.parse(arg), () => url.resolve(arg, "/a"), () => url.resolve("/a", arg)]) {
+            try {
+              fn();
+              console.log("did not throw");
+            } catch (e) {
+              console.log(e === thrown ? "rethrown" : "wrong value", String(thrown));
+            }
+          }
         }
-        assert.strictEqual(didThrow, true);
-        assert.strictEqual(caught, thrown);
-      }
-    },
-  );
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe(
+      ["nope", "1", "null", "undefined", "Symbol(nope)"].flatMap(v => Array(3).fill(`rethrown ${v}\n`)).join(""),
+    );
+    expect(exitCode).toBe(0);
+  });
 
   test("only ERR_INVALID_URL carries the input", () => {
     assert.throws(

--- a/test/js/node/url/url-parse-invalid-input.test.js
+++ b/test/js/node/url/url-parse-invalid-input.test.js
@@ -118,4 +118,42 @@ describe("url.parse", () => {
       });
     }
   });
+
+  test.each(["nope", 1, null, undefined, Symbol.for("nope")])(
+    "rethrows %p thrown while describing the argument",
+    thrown => {
+      const arg = {
+        get constructor() {
+          throw thrown;
+        },
+      };
+      for (const fn of [() => url.parse(arg), () => url.resolve(arg, "/a"), () => url.resolve("/a", arg)]) {
+        let caught;
+        let didThrow = false;
+        try {
+          fn();
+        } catch (e) {
+          didThrow = true;
+          caught = e;
+        }
+        assert.strictEqual(didThrow, true);
+        assert.strictEqual(caught, thrown);
+      }
+    },
+  );
+
+  test("only ERR_INVALID_URL carries the input", () => {
+    assert.throws(
+      () => url.parse(1),
+      e => e.code === "ERR_INVALID_ARG_TYPE" && !("input" in e),
+    );
+    assert.throws(
+      () => url.parse("http://%E0%A4%A@fail"),
+      e => e instanceof URIError && !("input" in e),
+    );
+    assert.throws(() => url.parse("http://[127.0.0.1\x00c8763]:8000/"), {
+      code: "ERR_INVALID_URL",
+      input: "http://[127.0.0.1\x00c8763]:8000/",
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

`url.parse()` and `url.resolve()` crash the process when describing an invalid argument throws a non-object:

```js
require("url").parse({ get constructor() { throw "nope" } });
// release: Segmentation fault at address 0x0 / abort()
// debug:   ASSERTION FAILED: cell->isObjectSlow()
// node:    throws "nope"
```

`urlParse` wrapped `Url.prototype.parse` in

```js
try { u.parse(...) } catch (e) { $putByIdDirect(e, "input", url); throw e; }
```

`$putByIdDirect` requires its base to be an object. `ERR_INVALID_ARG_TYPE` reads `value.constructor.name` to build its "Received an instance of …" message, so a getter or Proxy trap on the argument can throw any value, and a primitive `e` reaches `$putByIdDirect` and is used as a cell.

The fix is removing the `try`/`catch` in `urlParse` (`src/js/node/url.ts`). It was only there to attach `input`, and `$ERR_INVALID_URL(url)` already sets `input` itself. This also matches Node's `urlParse`, which has no `try`/`catch`: in Node only `ERR_INVALID_URL` carries `input`, while the `ERR_INVALID_ARG_TYPE` and `URIError` thrown from `url.parse()` do not. Previously Bun added `input` to those too.

### How did you verify your code works?

New tests in `test/js/node/url/url-parse-invalid-input.test.js`:

- `rethrows a primitive thrown while describing the argument` — a spawned `bun -e` fixture checks that `url.parse(arg)`, `url.resolve(arg, "/a")` and `url.resolve("/a", arg)` rethrow the exact thrown value for a string, number, `null`, `undefined` and a symbol. The child aborts on the unfixed build (`USE_SYSTEM_BUN=1`), so the test fails there; it passes with this change.
- `only ERR_INVALID_URL carries the input` — pins the Node-matching `input` behavior described above. Also fails on the unfixed build.

Expectations were checked against Node v26.
