### PR TITLE
EventTarget: index listener entries by type past 16 event types

### DIFF
--- a/src/jsc/bindings/webcore/EventListenerMap.cpp
+++ b/src/jsc/bindings/webcore/EventListenerMap.cpp
@@ -67,6 +67,7 @@ void EventListenerMap::clear()
     }
 
     m_entries.clear();
+    m_entryPositions.clear();
 }
 
 Vector<AtomString> EventListenerMap::eventTypes() const
@@ -103,6 +104,15 @@ RegisteredEventListener* EventListenerMap::add(const AtomString& eventType, Ref<
     auto registeredListener = RegisteredEventListener::create(WTF::move(listener), options);
     auto* result = registeredListener.ptr();
     m_entries.append({ eventType, EventListenerVector { WTF::move(registeredListener) } });
+
+    if (!m_entryPositions.isEmpty())
+        m_entryPositions.add(positionKey(eventType), static_cast<unsigned>(m_entries.size() - 1));
+    else if (m_entries.size() > maxEntriesForLinearSearch) [[unlikely]] {
+        m_entryPositions.reserveInitialCapacity(m_entries.size());
+        for (unsigned i = 0; i < m_entries.size(); ++i)
+            m_entryPositions.add(positionKey(m_entries[i].first), i);
+    }
+
     return result;
 }
 
@@ -122,26 +132,55 @@ bool EventListenerMap::remove(const AtomString& eventType, EventListener& listen
     releaseAssertOrSetThreadUID();
     Locker locker { m_lock };
 
-    for (unsigned i = 0; i < m_entries.size(); ++i) {
-        if (m_entries[i].first == eventType) {
-            bool wasRemoved = removeListenerFromVector(m_entries[i].second, listener, useCapture);
-            if (m_entries[i].second.isEmpty())
-                m_entries.removeAt(i);
-            return wasRemoved;
-        }
+    size_t position = findEntryPosition(eventType);
+    if (position == notFound)
+        return false;
+
+    bool wasRemoved = removeListenerFromVector(m_entries[position].second, listener, useCapture);
+    if (m_entries[position].second.isEmpty())
+        removeEntryAt(position);
+    return wasRemoved;
+}
+
+// Fills the hole with the last entry instead of shifting, so removing a type is
+// O(1). Nothing relies on the order of m_entries.
+void EventListenerMap::removeEntryAt(size_t position)
+{
+    size_t last = m_entries.size() - 1;
+
+    if (!m_entryPositions.isEmpty()) {
+        m_entryPositions.remove(positionKey(m_entries[position].first));
+        if (position != last)
+            m_entryPositions.set(positionKey(m_entries[last].first), static_cast<unsigned>(position));
     }
 
-    return false;
+    if (position != last)
+        m_entries[position] = WTF::move(m_entries[last]);
+    m_entries.removeLast();
+
+    if (m_entries.size() < maxEntriesForLinearSearch / 2)
+        m_entryPositions.clear();
+}
+
+size_t EventListenerMap::findEntryPosition(const AtomString& eventType) const
+{
+    if (!m_entryPositions.isEmpty()) {
+        ASSERT(m_entryPositions.size() == m_entries.size());
+        auto it = m_entryPositions.find(positionKey(eventType));
+        return it == m_entryPositions.end() ? notFound : it->value;
+    }
+
+    for (size_t i = 0; i < m_entries.size(); ++i) {
+        if (m_entries[i].first == eventType)
+            return i;
+    }
+    return notFound;
 }
 
 EventListenerVector* EventListenerMap::find(const AtomString& eventType)
 {
-    for (auto& entry : m_entries) {
-        if (entry.first == eventType)
-            return &entry.second;
-    }
-
-    return nullptr;
+    size_t position = findEntryPosition(eventType);
+    return position == notFound ? nullptr : &m_entries[position].second;
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/EventListenerMap.h
+++ b/src/jsc/bindings/webcore/EventListenerMap.h
@@ -37,6 +37,7 @@
 #include <memory>
 #include <wtf/Assertions.h>
 #include <wtf/Forward.h>
+#include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/Threading.h>
 #include <wtf/text/AtomString.h>
@@ -77,7 +78,23 @@ private:
         RELEASE_ASSERT(Thread::mayBeGCThread());
     }
 
+    size_t findEntryPosition(const AtomString& eventType) const;
+    void removeEntryAt(size_t position);
+
+    // Nearly every target has a handful of event types, so a linear scan of
+    // m_entries is the fast path. Past this many types m_entryPositions maps
+    // type -> position in m_entries so find/add/remove stop being O(types).
+    static constexpr unsigned maxEntriesForLinearSearch = 16;
+
+    // Keyed by the type's AtomStringImpl*: atoms compare by pointer and m_entries
+    // keeps them alive. The zero-key traits make nullAtom an ordinary key, which
+    // the linear scan also accepts. Callers do look it up: AtomString::fromUTF8
+    // returns it for invalid UTF-8.
+    using EntryPositionMap = HashMap<uintptr_t, unsigned, DefaultHash<uintptr_t>, WTF::UnsignedWithZeroKeyHashTraits<uintptr_t>>;
+    static uintptr_t positionKey(const AtomString& eventType) { return reinterpret_cast<uintptr_t>(eventType.impl()); }
+
     Vector<std::pair<AtomString, EventListenerVector>, 0, CrashOnOverflow, 4> m_entries;
+    EntryPositionMap m_entryPositions;
     Lock m_lock;
     uint32_t m_threadUID { 0 };
 };

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -56,6 +56,11 @@ Object.assign(globalThis, {
     closeSync(COMMANDS);
     setInterval(() => {}, 2 ** 30);
   },
+  // Sends one frame as given, ahead of the reply to the evaluate() that asked
+  // for it, so a scenario can deliver frames a real browser would not.
+  __fake_send(message: unknown) {
+    send(message);
+  },
 });
 
 function send(message: unknown) {

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -74,6 +74,28 @@ test.concurrent("navigate, events and evaluate cross the pipes", async () => {
   });
 });
 
+test.concurrent("an event frame without a string method is ignored", async () => {
+  // The transport looks the method up on the view as AtomString::fromUTF8(method),
+  // which is the null atom when the frame has no string method. 20 listener types
+  // puts the view's EventListenerMap past the size where it finds a type through
+  // a hash index and not a scan; the index has to accept that key like the scan does.
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/page");
+    const seen = [];
+    for (let i = 0; i < 20; i++) view.addEventListener("Fake.event" + i, e => seen.push(["Fake.event" + i, e.data]));
+    const frames = [
+      { sessionId: "S1", params: {} },
+      { sessionId: "S1", method: 7, params: {} },
+      { sessionId: "S1", method: "Fake.event19", params: { ok: true } },
+    ];
+    await view.evaluate("[" + frames.map(frame => "__fake_send(" + JSON.stringify(frame) + ")").join(",") + "].length");
+    print(seen);
+    view.close();
+  `);
+  expect(result).toEqual([["Fake.event19", { ok: true }]]);
+});
+
 test.concurrent("a reply larger than the read buffer is reassembled", async () => {
   const result = await runScenario(`
     const view = newView();

--- a/test/js/web/events/event-target.test.ts
+++ b/test/js/web/events/event-target.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe("EventTarget with many event types", () => {
+  test("lookup cost does not depend on how many other types are registered", async () => {
+    // EventListenerMap keeps one entry per event type. Registering n types and
+    // then timing the same operations against the first-registered and the
+    // last-registered type isolates the per-type lookup: with a linear scan the
+    // last type costs O(n) per call while the first costs O(1), with an indexed
+    // lookup both cost the same. Comparing the two inside one process cancels
+    // out machine speed and build flavour.
+    const n = 16000;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const n = ${n};
+          const reps = 200;
+          const target = new EventTarget();
+          const f = () => {};
+          const g = () => {};
+          for (let i = 0; i < n; i++) target.addEventListener("e" + i, f);
+
+          function time(type) {
+            const ev = new Event(type);
+            const t0 = Bun.nanoseconds();
+            for (let i = 0; i < reps; i++) {
+              target.dispatchEvent(ev);
+              target.addEventListener(type, f); // duplicate, no-op
+              target.removeEventListener(type, g); // not registered, no-op
+            }
+            return Bun.nanoseconds() - t0;
+          }
+
+          let first = Infinity, last = Infinity;
+          for (let round = 0; round < 5; round++) {
+            first = Math.min(first, time("e0"));
+            last = Math.min(last, time("e" + (n - 1)));
+          }
+          console.log(JSON.stringify({ ratio: last / first, first, last }));
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout);
+    // Linear scan: ~60x in release, ~20x in debug+ASAN. Indexed: ~1x.
+    expect(result.ratio, stdout).toBeLessThan(4);
+    expect(exitCode).toBe(0);
+  });
+
+  // The cases below cross the size at which EventListenerMap switches from a
+  // linear scan to a type -> position index and back.
+
+  test("each type dispatches to its own listeners", () => {
+    const target = new EventTarget();
+    const calls: string[] = [];
+    const types = Array.from({ length: 40 }, (_, i) => "type" + i);
+    const listeners = new Map(types.map(type => [type, () => calls.push(type)]));
+    for (const type of types) target.addEventListener(type, listeners.get(type)!);
+
+    for (const type of types) target.dispatchEvent(new Event(type));
+    expect(calls).toEqual(types);
+
+    // Duplicates are still detected once the index is in use.
+    calls.length = 0;
+    for (const type of types) target.addEventListener(type, listeners.get(type)!);
+    for (const type of types) target.dispatchEvent(new Event(type));
+    expect(calls).toEqual(types);
+
+    expect(target.dispatchEvent(new Event("unregistered"))).toBe(true);
+    target.removeEventListener("unregistered", () => {});
+    expect(calls).toEqual(types);
+  });
+
+  test("removing a type leaves every other type intact", () => {
+    const target = new EventTarget();
+    const calls: string[] = [];
+    const types = Array.from({ length: 40 }, (_, i) => "type" + i);
+    const listeners = new Map(types.map(type => [type, () => calls.push(type)]));
+    for (const type of types) target.addEventListener(type, listeners.get(type)!);
+
+    const removed = ["type0", "type20", "type39"];
+    for (const type of removed) target.removeEventListener(type, listeners.get(type)!);
+    // Removing again, or removing a callback that was never added, is a no-op.
+    for (const type of removed) target.removeEventListener(type, listeners.get(type)!);
+    target.removeEventListener("type5", () => {});
+
+    for (const type of types) target.dispatchEvent(new Event(type));
+    expect(calls).toEqual(types.filter(type => !removed.includes(type)));
+
+    // A removed type can be registered again.
+    calls.length = 0;
+    for (const type of removed) target.addEventListener(type, listeners.get(type)!);
+    for (const type of types) target.dispatchEvent(new Event(type));
+    expect(calls).toEqual(types);
+  });
+
+  test("a type with several listeners survives removing one of them", () => {
+    const target = new EventTarget();
+    const calls: string[] = [];
+    for (let i = 0; i < 40; i++) target.addEventListener("type" + i, () => calls.push("type" + i));
+    const extra = () => calls.push("extra");
+    target.addEventListener("type25", extra);
+    target.addEventListener("type25", extra, { capture: true });
+
+    // The capture listener runs first.
+    target.dispatchEvent(new Event("type25"));
+    expect(calls).toEqual(["extra", "type25", "extra"]);
+
+    calls.length = 0;
+    target.removeEventListener("type25", extra);
+    target.dispatchEvent(new Event("type25"));
+    expect(calls).toEqual(["extra", "type25"]);
+
+    calls.length = 0;
+    target.removeEventListener("type25", extra, { capture: true });
+    target.dispatchEvent(new Event("type25"));
+    expect(calls).toEqual(["type25"]);
+  });
+
+  test("shrinking below the index threshold and growing past it again", () => {
+    const target = new EventTarget();
+    const calls: string[] = [];
+    const types = Array.from({ length: 40 }, (_, i) => "type" + i);
+    const listeners = new Map(types.map(type => [type, () => calls.push(type)]));
+
+    for (let round = 0; round < 3; round++) {
+      for (const type of types) target.addEventListener(type, listeners.get(type)!);
+      for (const type of types) target.dispatchEvent(new Event(type));
+      expect(calls).toEqual(types);
+      calls.length = 0;
+
+      // Remove from the front, the middle and the back so that both the removed
+      // entry and the entry that takes its place vary.
+      const order = [...types.slice(0, 20).reverse(), ...types.slice(30), ...types.slice(20, 30)];
+      const remaining = new Set(types);
+      for (const type of order) {
+        target.removeEventListener(type, listeners.get(type)!);
+        remaining.delete(type);
+        for (const other of types) target.dispatchEvent(new Event(other));
+        expect(calls).toEqual(types.filter(other => remaining.has(other)));
+        calls.length = 0;
+      }
+    }
+  });
+
+  test("once listeners and signal-removed listeners with many types", () => {
+    const target = new EventTarget();
+    const calls: string[] = [];
+    const controller = new AbortController();
+    for (let i = 0; i < 40; i++) {
+      const type = "type" + i;
+      if (i % 3 === 0) target.addEventListener(type, () => calls.push(type), { once: true });
+      else if (i % 3 === 1) target.addEventListener(type, () => calls.push(type), { signal: controller.signal });
+      else target.addEventListener(type, () => calls.push(type));
+    }
+
+    for (let i = 0; i < 40; i++) target.dispatchEvent(new Event("type" + i));
+    expect(calls).toHaveLength(40);
+
+    calls.length = 0;
+    controller.abort();
+    for (let i = 0; i < 40; i++) target.dispatchEvent(new Event("type" + i));
+    expect(calls).toEqual(Array.from({ length: 40 }, (_, i) => "type" + i).filter((_, i) => i % 3 === 2));
+  });
+});


### PR DESCRIPTION
### Problem
- An `EventTarget` gets slower with every distinct event type on it. `EventListenerMap::find` (`src/jsc/bindings/webcore/EventListenerMap.cpp`) scans a flat vector of `(type, listeners)` pairs on every `add`, `remove` and dispatch. On 1.4.3, 65,536 types take 1536 ms to add and 1488 ms to remove (node v26: 32 and 14 ms).
- WebCore sized it for DOM nodes with a handful of types.

### Fix
- Keep the vector. Past 16 types, build `m_entryPositions`, a hash map from type to position. Drop it below 8. Smaller targets scan as before.
- Removing a type moves the last entry into the hole, so it is O(1). Only `eventTypes()` exposes entry order. Its callers ignore it.
- The key is the type's `AtomStringImpl*` with zero-key traits, so the null atom is an ordinary key, as in the scan. The WebView transport looks it up for a CDP frame with no string `method`, where a `HashMap<AtomString, unsigned>` segfaults.
- Verified: `test/js/web/events/event-target.test.ts` times the last of 16,000 types against the first (72x on main, 1.0x fixed, limit 4), plus five correctness cases. `webview-chrome-pipe.test.ts` covers the null key. Self-reviewed: 6 concerns checked, 1 needed a change (the null key).

### Background
- `EventListenerMap` is the per-`EventTarget` table behind `addEventListener`: one entry per type, with its listener vector.
- `AtomString` is WebKit's interned string. Equal atoms share one impl, so the impl pointer identifies the type. `m_entries` keeps it alive.
- An empty `WTF::HashMap` is one null pointer, so the unused index costs 8 bytes.

<details><summary>Notes</summary>

**Numbers.** Release builds, Linux x64, same machine, all three binaries run back to back, minimum of 3 runs per cell. `add / 2000 dispatches to the last type / remove`, in ms. The script is the one from the report. The host was shared and busy during this set (load average about 70 on 16 cores), so every column is inflated by roughly 1.5x against a calmer run. The ratio is the result.

| types | main (5f554969b) | this PR (30c3842d4) | node v26.3.0 |
|---|---|---|---|
| 8,192 | 25 / 11 / 21 | 5 / 1 / 3 | 8 / 3 / 3 |
| 32,768 | 424 / 69 / 414 | 30 / 1 / 20 | 21 / 1 / 9 |
| 65,536 | 1915 / 347 / 2201 | 66 / 1 / 60 | 39 / 1 / 16 |

In a calmer run the same builds measured 1536 / 227 / 1488 (main) and 42 / 1 / 35 (this PR) for 65,536 types. The report's headline size, 110,000 types: add 88 ms and remove 101 ms with this PR (node: 135 and 56 ms), against 6.1 s to add on 1.4.2.

Small-target check (3 types, release, ns per op, minimum of 5 rounds, 3 runs): dispatch 149-151 before and 152-157 after. Add then remove a 4th type: 264-268 before, 271-278 after. Add then remove a 2nd listener on an existing type: 284-289 before, 287-298 after. That is inside the run-to-run spread on this host.

**The perf test.** It registers 16,000 types, then times the same three calls (dispatch, a duplicate add, a remove that misses) against the first-registered and the last-registered type, 200 repetitions, minimum of 5 rounds each, and asserts on the ratio inside one process. With the scan the last type costs O(n) and the first O(1). Ratio on main: 72x release, 21x debug+ASAN (the fixed per-call cost is larger there). With the fix: 0.98 to 1.01 on both. The limit is 4.

**The null atom.** My first version keyed the index as `HashMap<AtomString, unsigned>`. `AtomStringHash::hash` dereferences `key.impl()`, so looking up the null atom is a null dereference, where the scan just compares pointers and answers "not found". The lookup is reachable: `Transport::handleEvent` (`src/runtime/webview/ChromeBackend.cpp`) does `AtomString::fromUTF8(method)` and then `hasEventListeners(methodAtom)`. `fromUTF8` returns the null atom for a span with null data, which is what `jsonString` returns for a frame with no `"method"` or a non-string one, and for invalid UTF-8. With that first version, a WebView holding 20 listener types and one such frame gives `panic(main thread): Segmentation fault at address 0x10`. It is fine with 5 types (index not built) and on main. The new scenario in `test/js/bun/webview/webview-chrome-pipe.test.ts` sends those frames through the fake browser: it fails on the first version with that segfault, and passes on main and on this PR. The fixture gained a `__fake_send` hook for it.

Keying by `AtomStringImpl*` with `UnsignedWithZeroKeyHashTraits` (the pattern `BunHeapProfiler.cpp` and `NodeV8.h` use for keys that can be 0) makes null behave like every other key in every state, with no guard on the lookup path and no change to what `add` accepts. It also keeps refcount traffic and the impl dereference out of the index. The sentinels are `UINTPTR_MAX` and `UINTPTR_MAX - 1`, which are not heap addresses. JS cannot produce a null type: the bindings convert with `toAtomString`, and an `Event` with a null type is uninitialized, which `dispatchEvent` rejects.

**Why not a `HashMap<AtomString, EventListenerVector>` outright.** The minimum WTF table is 8 buckets of 32 bytes plus a header, against a 4-slot vector today, so every target with one listener would grow by about 136 bytes, and `eventTypes()` would come back in hash order. Upstream WebCore and Blink both keep a vector here for the same reason. The hybrid keeps the common case as it is and only pays for the index on the targets that need it.

**Thresholds.** 16 pointer compares over contiguous 32-byte entries cost about one hash probe, and no built-in target (AbortSignal, WebSocket, Worker, MessagePort, BroadcastChannel, EventSource) comes close to 16 types. The index is dropped below 8 and not at 16, so a target that hovers at the boundary does not rebuild it on every call. The index only ever becomes empty through `clear()`, which frees the table. That is what `reserveInitialCapacity` requires when the index is built again.

**References into `m_entries`.** Removing an entry used to shift everything after it. Now it moves one entry. Both invalidate references, so I checked every caller of `find()` and `eventListeners()`: dispatch copies the inner vector before it runs any listener, and the others (`attributeEventListener`, `containsActive`, the two `getEventListeners` helpers, the inspector listing) finish with the reference before any listener can be added or removed.

**Locking.** `find()` runs without the lock on the owning thread, as before. The index is mutated only inside `add`, `remove` and `clear`, which hold `m_lock` against the concurrent GC visitor, and the visitor does not read the index.

**Suites run with the debug+ASAN build.** `test/js/web/events/event-target.test.ts`, `test/js/bun/webview/webview-chrome-pipe.test.ts`, `test/js/deno/event/`, `test/js/web/abort/`, `test/js/web/broadcastchannel/`, `test/js/node/events/event-emitter.test.ts`, `test/js/web/workers/worker.test.ts`, and node's `test-eventtarget.js`, `test-eventtarget-once-twice.js`, `test-whatwg-events-eventtarget-this-of-listener.js`, `test-eventtarget-custom-inspect-does-not-throw.js`. `test/js/bun/webview/webview-chrome.test.ts` could not run locally on any build: Chrome refuses to start as root without `--no-sandbox` in my environment.

**Related open PRs.** #35830 indexes callbacks within one type (N listeners of one type) and #35804 compacts `once` listeners after dispatch. Both touch this file. Neither indexes types. This change overlaps with them only as text. #35811 is different: it adds `EventListenerMap::removeAll`, which drops an entry with a bare `m_entries.removeAt(i)`. Whichever of the two lands second has to route that removal through `removeEntryAt()`, or the index goes stale. The `size() == size()` assert in `findEntryPosition` catches that in debug builds.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome-pipe.test.ts

<!-- robobun:evidence:end -->