### PR TITLE
spawn: add a windowsKeepAlive option (hidden console of its own, outlives the parent)

### DIFF
--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -189,6 +189,30 @@ const proc = Bun.spawn({
 
 You can pass the same directory to any number of spawns; the limit applies to their combined usage. Bun supports both cgroup v1 and v2 hierarchies. Creating cgroups typically requires root or a delegated subtree. Bun ignores the option on other platforms; on Linux, the spawn fails if the child cannot join the cgroup.
 
+## Outliving the parent on Windows
+
+On Windows, Bun puts each subprocess in a [job object](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects) that terminates it when the parent `bun` process exits. `detached: true` prevents that, but a detached subprocess has no console, so each console program it starts opens a new console window.
+
+Pass `windowsKeepAlive: true` to start a subprocess that keeps running after the parent exits and has a hidden console of its own:
+
+```ts index.ts icon="/icons/typescript.svg"
+import { openSync } from "node:fs";
+
+const log = openSync("worker.log", "a");
+
+const proc = Bun.spawn({
+  cmd: ["powershell.exe", "-NoProfile", "-File", "worker.ps1"],
+  stdio: ["ignore", log, log],
+  windowsKeepAlive: true,
+});
+
+proc.unref(); // let the parent exit while the subprocess runs
+```
+
+The subprocess is not added to the job object. It gets a new console that has no window (`CREATE_NO_WINDOW`), also when `stdio` contains file descriptors, and the programs it starts share that console. Unlike `detached`, it stays in the parent's process group. `proc.exited` and `onExit` work as usual while the parent is alive.
+
+Send stdio to files or `"ignore"`. A `"pipe"` breaks when the parent exits, and output to an inherited console goes to the new hidden console, not to the parent's terminal. The option has no effect with `detached: true`, and Bun ignores it on other platforms. `node:child_process` accepts the same option.
+
 ## Using AbortSignal
 
 You can abort a subprocess using an `AbortSignal`:
@@ -537,6 +561,7 @@ namespace SpawnOptions {
     serialization?: "json" | "advanced";
     windowsHide?: boolean;
     windowsVerbatimArguments?: boolean;
+    windowsKeepAlive?: boolean; // Windows only; outlive the parent with a hidden console of its own
     argv0?: string;
     signal?: AbortSignal;
     timeout?: number;

--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -191,7 +191,7 @@ You can pass the same directory to any number of spawns; the limit applies to th
 
 ## Outliving the parent on Windows
 
-On Windows, Bun puts each subprocess in a [job object](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects) that terminates it when the parent `bun` process exits. `detached: true` prevents that, but a detached subprocess has no console, so each console program it starts opens a new console window.
+On Windows, Bun puts each subprocess in a [job object](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects) that terminates it when the parent `bun` process exits. `detached: true` prevents that, but a detached subprocess has no console. Each console program it starts opens a new console window, and some programs exit at once when they have no console (`powershell.exe`, for example).
 
 Pass `windowsKeepAlive: true` to start a subprocess that keeps running after the parent exits and has a hidden console of its own:
 
@@ -212,6 +212,8 @@ proc.unref(); // let the parent exit while the subprocess runs
 The subprocess is not added to the job object. It gets a new console that has no window (`CREATE_NO_WINDOW`), also when `stdio` contains file descriptors, and the programs it starts share that console. Unlike `detached`, it stays in the parent's process group. `proc.exited` and `onExit` work as usual while the parent is alive.
 
 Send stdio to files or `"ignore"`. A `"pipe"` breaks when the parent exits, and output to an inherited console goes to the new hidden console, not to the parent's terminal. The option has no effect with `detached: true`, and Bun ignores it on other platforms. `node:child_process` accepts the same option.
+
+The option only keeps the subprocess out of the job object that Bun creates. If the parent `bun` process itself runs inside a job object that terminates its members (some CI runners and process supervisors do this), the subprocess is a member of that job too.
 
 ## Using AbortSignal
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7700,6 +7700,49 @@ declare module "bun" {
       windowsVerbatimArguments?: boolean;
 
       /**
+       * Let the subprocess keep running after this process exits, with a
+       * hidden console of its own.
+       *
+       * Windows only; ignored on other platforms. By default, Bun puts each
+       * subprocess in a job object that terminates it when this process
+       * exits. `detached: true` prevents that, but the subprocess then has no
+       * console, and each console program it starts opens a new console
+       * window.
+       *
+       * With `windowsKeepAlive: true` the subprocess:
+       * - is not terminated when this process exits,
+       * - gets a new console that has no window, also when `stdio` contains
+       *   file descriptors. The programs it starts share that console, so
+       *   they open no windows either,
+       * - stays in this process's process group.
+       *
+       * {@link Subprocess.exited} and `onExit` work as usual while this
+       * process is alive. Call {@link Subprocess.unref} to let this process
+       * exit before the subprocess does.
+       *
+       * Send stdio to files or `"ignore"`. A `"pipe"` breaks when this
+       * process exits, and output to an inherited console goes to the new
+       * hidden console.
+       *
+       * Has no effect with `detached: true`.
+       *
+       * @default false
+       *
+       * @example
+       * ```ts
+       * import { openSync } from "node:fs";
+       * const log = openSync("worker.log", "a");
+       * const proc = Bun.spawn({
+       *   cmd: ["powershell.exe", "-NoProfile", "-File", "worker.ps1"],
+       *   stdio: ["ignore", log, log],
+       *   windowsKeepAlive: true,
+       * });
+       * proc.unref();
+       * ```
+       */
+      windowsKeepAlive?: boolean;
+
+      /**
        * Path to the executable to run in the subprocess.
        *
        * Use this to wrap another application or to simulate a symlink.

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7724,7 +7724,9 @@ declare module "bun" {
        * process exits, and output to an inherited console goes to the new
        * hidden console.
        *
-       * Has no effect with `detached: true`.
+       * Has no effect with `detached: true`. A job object that this process
+       * itself runs in (some CI runners and process supervisors use one) still
+       * applies to the subprocess.
        *
        * @default false
        *

--- a/packages/bun-types/overrides.d.ts
+++ b/packages/bun-types/overrides.d.ts
@@ -348,6 +348,19 @@ declare module "node:fs/promises" {
   function exists(path: Bun.PathLike): Promise<boolean>;
 }
 
+declare module "node:child_process" {
+  interface CommonOptions {
+    /**
+     * Bun only. Let the child process keep running after this process exits,
+     * with a hidden console of its own. Windows only; ignored on other
+     * platforms. Same as `windowsKeepAlive` in {@link Bun.spawn}.
+     *
+     * @default false
+     */
+    windowsKeepAlive?: boolean | undefined;
+  }
+}
+
 declare module "node:tls" {
   interface BunConnectionOptions extends Omit<ConnectionOptions, "key" | "ca" | "tls" | "cert"> {
     /**

--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -22,10 +22,11 @@ import { LIBC_ALLOCATION_SYMBOLS } from "../source.ts";
 // can be uv__free'd under uv_replace_allocator (oven-sh/libuv#14), Winsock /
 // console-resize watcher / suspend-resume detection initialized on first use
 // instead of in uv__init, with uv__winsock_ensure() for callers that reach
-// ws2_32 directly (oven-sh/libuv#15), and LoadLibraryExW for those lazy
-// loads (oven-sh/libuv#16).
+// ws2_32 directly (oven-sh/libuv#15), LoadLibraryExW for those lazy
+// loads (oven-sh/libuv#16), and the UV_PROCESS_WINDOWS_CREATE_NO_WINDOW and
+// UV_PROCESS_WINDOWS_NO_JOB_OBJECT spawn flags (oven-sh/libuv#17).
 // To bump, update `bun`.
-const LIBUV_COMMIT = "8023581113b276e7c1aee3f82da57ca0893faab1";
+const LIBUV_COMMIT = "2f8626d9fb0dbfafe99aff1a7446086a1b206900";
 
 // prettier-ignore
 const SHARED = [

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -245,6 +245,7 @@ function execFile(file, args, options, callback) {
     cgroup: options.cgroup,
     windowsHide: options.windowsHide,
     windowsVerbatimArguments: options.windowsVerbatimArguments,
+    windowsKeepAlive: options.windowsKeepAlive,
     shell: options.shell,
     signal: options.signal,
   });
@@ -577,6 +578,7 @@ function spawnSync(file, args, options) {
       cgroup: options.cgroup,
       windowsVerbatimArguments: options.windowsVerbatimArguments,
       windowsHide: options.windowsHide,
+      windowsKeepAlive: options.windowsKeepAlive,
       argv0: options.args[0],
       timeout: options.timeout,
       killSignal: options.killSignal,
@@ -981,6 +983,11 @@ function normalizeSpawnArguments(file, args, options) {
     validateBoolean(windowsVerbatimArguments, "options.windowsVerbatimArguments");
   }
 
+  const windowsKeepAlive = options.windowsKeepAlive;
+  if (windowsKeepAlive != null) {
+    validateBoolean(windowsKeepAlive, "options.windowsKeepAlive");
+  }
+
   let windowsBatchFileError: Error | undefined;
   // Handle shell
   if (shell) {
@@ -1065,6 +1072,7 @@ function normalizeSpawnArguments(file, args, options) {
     file,
     windowsHide: !!options.windowsHide,
     windowsVerbatimArguments: !!windowsVerbatimArguments,
+    windowsKeepAlive: !!windowsKeepAlive,
     argv0: options.argv0,
     windowsBatchFileError,
   };
@@ -1444,6 +1452,7 @@ class ChildProcess extends EventEmitter {
         argv0: spawnargs[0],
         windowsHide: !!options.windowsHide,
         windowsVerbatimArguments: !!options.windowsVerbatimArguments,
+        windowsKeepAlive: !!options.windowsKeepAlive,
       });
       this.pid = this.#handle.pid;
 

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -2617,6 +2617,9 @@ pub const UV_PROCESS_DETACHED: c_uint = 8;
 pub const UV_PROCESS_WINDOWS_HIDE: c_uint = 16;
 pub const UV_PROCESS_WINDOWS_HIDE_CONSOLE: c_uint = 32;
 pub const UV_PROCESS_WINDOWS_HIDE_GUI: c_uint = 64;
+// oven-sh/libuv only. High bits, so a flag that upstream adds cannot collide.
+pub const UV_PROCESS_WINDOWS_CREATE_NO_WINDOW: c_uint = 1 << 16;
+pub const UV_PROCESS_WINDOWS_NO_JOB_OBJECT: c_uint = 1 << 17;
 
 pub const SIGHUP: c_int = 1;
 pub const SIGQUIT: c_int = 3;

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -374,6 +374,8 @@ fn spawn_maybe_sync(
     let mut windows_hide: bool = false;
     #[cfg(windows)]
     let mut windows_verbatim_arguments: bool = false;
+    #[cfg(windows)]
+    let mut windows_keep_alive: bool = false;
     let mut abort_signal: Option<bun_jsc::AbortSignalRef> = None;
     let mut terminal_info: Option<terminal_body::CreateResult> = None;
     let mut existing_terminal: Option<bun_ptr::BackRef<Terminal, bun_ptr::Mut>> = None; // Existing terminal passed by user
@@ -707,6 +709,12 @@ fn spawn_maybe_sync(
                 if let Some(val) = args.get(global_this, "windowsVerbatimArguments")? {
                     if val.is_boolean() {
                         windows_verbatim_arguments = val.as_boolean();
+                    }
+                }
+
+                if let Some(val) = args.get(global_this, "windowsKeepAlive")? {
+                    if val.is_boolean() {
+                        windows_keep_alive = val.as_boolean();
                     }
                 }
             }
@@ -1145,6 +1153,7 @@ fn spawn_maybe_sync(
         windows: spawn::WindowsOptions {
             hide_window: windows_hide,
             verbatim_arguments: windows_verbatim_arguments,
+            keep_alive: windows_keep_alive,
             loop_: loop_handle,
         },
         #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -1656,9 +1656,7 @@ impl Default for WindowsSpawnOptions {
 pub struct WindowsOptions {
     pub verbatim_arguments: bool,
     pub hide_window: bool,
-    /// The child gets a new console without a window and is not put in the
-    /// job object that kills it when this process exits. No effect with
-    /// `detached`.
+    /// New console without a window, and no kill-on-parent-exit job object.
     pub keep_alive: bool,
     pub loop_: EventLoopHandle,
 }

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -1656,6 +1656,10 @@ impl Default for WindowsSpawnOptions {
 pub struct WindowsOptions {
     pub verbatim_arguments: bool,
     pub hide_window: bool,
+    /// The child gets a new console without a window and is not put in the
+    /// job object that kills it when this process exits. No effect with
+    /// `detached`.
+    pub keep_alive: bool,
     pub loop_: EventLoopHandle,
 }
 
@@ -1665,6 +1669,7 @@ impl Default for WindowsOptions {
         Self {
             verbatim_arguments: false,
             hide_window: true,
+            keep_alive: false,
             // Every `bun.spawnSync` call site sets `loop_` explicitly. A
             // zeroed handle here keeps `..Default::default()` usable
             // for the other fields. `spawn_process_windows` (the sole consumer)
@@ -1949,6 +1954,11 @@ mod spawn_process_body {
 
         if options.windows.verbatim_arguments {
             uv_process_options.flags |= uv::UV_PROCESS_WINDOWS_VERBATIM_ARGUMENTS;
+        }
+
+        if options.windows.keep_alive {
+            uv_process_options.flags |=
+                uv::UV_PROCESS_WINDOWS_CREATE_NO_WINDOW | uv::UV_PROCESS_WINDOWS_NO_JOB_OBJECT;
         }
 
         if options.detached {

--- a/test/integration/bun-types/fixture/child_process.ts
+++ b/test/integration/bun-types/fixture/child_process.ts
@@ -1,0 +1,17 @@
+import { execFile, spawn, spawnSync } from "node:child_process";
+
+// windowsKeepAlive is a Bun-only option that node:child_process forwards to Bun.spawn.
+{
+  const child = spawn("cmd.exe", ["/c", "exit"], {
+    stdio: ["ignore", 1, 2],
+    windowsHide: true,
+    windowsKeepAlive: true,
+  });
+  child.unref();
+
+  execFile("cmd.exe", ["/c", "exit"], { windowsKeepAlive: true }, () => {});
+  spawnSync("cmd.exe", ["/c", "exit"], { windowsKeepAlive: false });
+
+  // @ts-expect-error windowsKeepAlive is a boolean
+  spawn("cmd.exe", [], { windowsKeepAlive: "yes" });
+}

--- a/test/integration/bun-types/fixture/spawn.ts
+++ b/test/integration/bun-types/fixture/spawn.ts
@@ -226,3 +226,18 @@ tsd.expectAssignable<SyncSubprocess<Bun.SpawnOptions.Readable, Bun.SpawnOptions.
   Bun.spawnSync({ cmd: ["echo", "hello"], stdout: "pipe", stderr: "pipe", lazy: true,
   });
 }
+
+// windowsKeepAlive (Windows only at runtime, typed everywhere)
+{
+  const p3 = Bun.spawn(["powershell.exe", "-NoProfile", "-Command", "exit 0"], {
+    stdio: ["ignore", 1, 2],
+    windowsHide: true,
+    windowsKeepAlive: true,
+  });
+  p3.unref();
+
+  Bun.spawnSync({ cmd: ["cmd.exe", "/c", "exit"], windowsKeepAlive: false });
+
+  // @ts-expect-error windowsKeepAlive is a boolean
+  Bun.spawn({ cmd: ["cmd.exe"], windowsKeepAlive: "yes" });
+}

--- a/test/js/bun/spawn/spawn-windows-keep-alive.test.ts
+++ b/test/js/bun/spawn/spawn-windows-keep-alive.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { spawn as cpSpawn } from "node:child_process";
+import { closeSync, openSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// The grandchild. It reports what console it has, then appends a line to stdout
+// every 100ms until the stop file exists, and exits with 42. It gives up after
+// 300 lines so that a failed test cannot leave it running.
+const grandchildScript = /* ps1 */ `
+param([string]$StopFile)
+Add-Type -Namespace Win32 -Name Console -MemberDefinition @'
+[DllImport("kernel32.dll")] public static extern IntPtr GetConsoleWindow();
+[DllImport("kernel32.dll")] public static extern uint GetConsoleCP();
+[DllImport("kernel32.dll")] public static extern uint GetConsoleProcessList(uint[] list, uint count);
+'@
+$list = New-Object 'uint32[]' 64
+$count = [Win32.Console]::GetConsoleProcessList($list, 64)
+$attached = @()
+for ($i = 0; $i -lt $count; $i++) { $attached += [int64]$list[$i] }
+$info = @{
+  pid = $PID
+  hasConsole = ([Win32.Console]::GetConsoleCP() -ne 0)
+  window = [Win32.Console]::GetConsoleWindow().ToInt64()
+  attached = $attached
+}
+Write-Output ("info " + (ConvertTo-Json -Compress -InputObject $info))
+for ($i = 0; $i -lt 300 -and -not (Test-Path -LiteralPath $StopFile); $i++) {
+  Write-Output "tick $i"
+  Start-Sleep -Milliseconds 100
+}
+exit 42
+`;
+
+// The intermediate process. It spawns the grandchild with ["ignore", fd, fd],
+// unrefs it, prints both pids and exits. With "wait" it stays alive until the
+// grandchild has reported its console, so that report is made while this
+// process is still attached to its own console.
+const intermediateScript = /* ts */ `
+import { spawn as cpSpawn } from "node:child_process";
+import { openSync, readFileSync } from "node:fs";
+
+const [api, keepAlive, wait, log, script, stopFile] = process.argv.slice(2);
+const fd = openSync(log, "a");
+const cmd = ["powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", script, stopFile];
+const options = { stdio: ["ignore", fd, fd], windowsHide: true, windowsKeepAlive: keepAlive === "true" };
+
+let pid;
+if (api === "Bun.spawn") {
+  const proc = Bun.spawn({ cmd, ...options });
+  proc.unref();
+  pid = proc.pid;
+} else {
+  const child = cpSpawn(cmd[0], cmd.slice(1), options);
+  child.unref();
+  pid = child.pid;
+}
+
+if (wait === "wait") {
+  const deadline = Date.now() + 20_000;
+  while (!/info .*\\r?\\n/.test(readFileSync(log, "utf8"))) {
+    if (Date.now() > deadline) throw new Error("the grandchild did not report its console");
+    await Bun.sleep(50);
+  }
+}
+console.log(JSON.stringify({ intermediate: process.pid, grandchild: pid }));
+`;
+
+const files = { "intermediate-fixture.ts": intermediateScript, "grandchild.ps1": grandchildScript };
+
+type GrandchildInfo = { pid: number; hasConsole: boolean; window: number; attached: number[] };
+
+function isAlive(pid: number) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function until(what: string, condition: () => boolean) {
+  const deadline = Date.now() + 30_000;
+  while (!condition()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting until ${what}`);
+    await Bun.sleep(50);
+  }
+}
+
+// Only complete lines. Windows PowerShell can start its output with a BOM.
+function readLines(log: string) {
+  const lines = readFileSync(log, "utf8")
+    .replace(/^\uFEFF/, "")
+    .split(/\r?\n/);
+  lines.pop();
+  return lines;
+}
+
+function readInfo(log: string): GrandchildInfo {
+  return JSON.parse(
+    readLines(log)
+      .find(l => l.startsWith("info "))!
+      .slice("info ".length),
+  );
+}
+
+function tickCount(log: string) {
+  return readLines(log).filter(l => l.startsWith("tick ")).length;
+}
+
+async function expectStillAppending(grandchild: number, log: string) {
+  expect(isAlive(grandchild)).toBe(true);
+  const before = tickCount(log);
+  await until("the grandchild appends more lines", () => tickCount(log) >= before + 3);
+  expect(isAlive(grandchild)).toBe(true);
+}
+
+// Runs the intermediate to completion, then `fn`, then stops the grandchild.
+// The intermediate has a console of its own (windowsHide with no inherited
+// stdio gives it one), so what the grandchild shares does not depend on the
+// console of the test runner.
+async function withGrandchild(
+  options: { api: string; keepAlive: boolean; wait: boolean },
+  fn: (ctx: { intermediate: number; grandchild: number; log: string }) => Promise<void>,
+) {
+  using dir = tempDir("windows-keep-alive", files);
+  const log = join(String(dir), "grandchild.log");
+  const stopFile = join(String(dir), "stop");
+  let grandchild: number | undefined;
+  try {
+    await using intermediate = Bun.spawn({
+      cmd: [
+        bunExe(),
+        join(String(dir), "intermediate-fixture.ts"),
+        options.api,
+        String(options.keepAlive),
+        options.wait ? "wait" : "nowait",
+        log,
+        join(String(dir), "grandchild.ps1"),
+        stopFile,
+      ],
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      intermediate.stdout.text(),
+      intermediate.stderr.text(),
+      intermediate.exited,
+    ]);
+    expect({ stdout: stdout.trim().startsWith("{"), stderr, exitCode }).toEqual({
+      stdout: true,
+      stderr: "",
+      exitCode: 0,
+    });
+    const pids = JSON.parse(stdout) as { intermediate: number; grandchild: number };
+    grandchild = pids.grandchild;
+    // The intermediate has exited. Its job object is closed.
+    expect(isAlive(pids.intermediate)).toBe(false);
+    await fn({ ...pids, log });
+  } finally {
+    writeFileSync(stopFile, "");
+    if (grandchild !== undefined) {
+      const pid = grandchild;
+      await until("the grandchild exits", () => !isAlive(pid)).catch(() => {
+        if (isAlive(pid)) process.kill(pid);
+      });
+    }
+  }
+}
+
+describe.skipIf(!isWindows)("windowsKeepAlive", () => {
+  describe.each(["Bun.spawn", "child_process.spawn"])("%s", api => {
+    test.concurrent("the child has a hidden console of its own and outlives the parent", async () => {
+      await withGrandchild({ api, keepAlive: true, wait: true }, async ({ grandchild, log }) => {
+        // Reported while the intermediate was alive: it is not on this console.
+        expect(readInfo(log)).toEqual({ pid: grandchild, hasConsole: true, window: 0, attached: [grandchild] });
+        await expectStillAppending(grandchild, log);
+      });
+    });
+
+    test.concurrent(
+      "without it, a windowsHide child shares the parent's console and dies with the parent",
+      async () => {
+        await withGrandchild({ api, keepAlive: false, wait: true }, async ({ intermediate, grandchild, log }) => {
+          const info = readInfo(log);
+          expect({ ...info, attached: info.attached.includes(intermediate) }).toEqual({
+            pid: grandchild,
+            hasConsole: true,
+            window: 0,
+            attached: true,
+          });
+          await until("the grandchild is terminated", () => !isAlive(grandchild));
+        });
+      },
+    );
+  });
+
+  test.concurrent("the parent can exit right after the spawn", async () => {
+    await withGrandchild({ api: "Bun.spawn", keepAlive: true, wait: false }, async ({ grandchild, log }) => {
+      await until("the grandchild starts to append lines", () => tickCount(log) > 0);
+      await expectStillAppending(grandchild, log);
+    });
+  });
+
+  test.concurrent("Bun.spawn: exited and onExit report the exit code while the parent is alive", async () => {
+    using dir = tempDir("windows-keep-alive-exit", {});
+    const fd = openSync(join(String(dir), "out.log"), "a");
+    try {
+      const onExit = Promise.withResolvers<number | null>();
+      const proc = Bun.spawn({
+        cmd: ["cmd.exe", "/d", "/s", "/c", "echo hello& exit 42"],
+        stdio: ["ignore", fd, fd],
+        windowsHide: true,
+        windowsKeepAlive: true,
+        onExit(_proc, exitCode) {
+          onExit.resolve(exitCode);
+        },
+      });
+      expect(await proc.exited).toBe(42);
+      expect(await onExit.promise).toBe(42);
+      expect(proc.exitCode).toBe(42);
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(join(String(dir), "out.log"), "utf8").trim()).toBe("hello");
+  });
+
+  test.concurrent("child_process.spawn: 'exit' reports the exit code while the parent is alive", async () => {
+    using dir = tempDir("windows-keep-alive-exit-cp", {});
+    const fd = openSync(join(String(dir), "out.log"), "a");
+    try {
+      const child = cpSpawn("cmd.exe", ["/d", "/s", "/c", "echo hello& exit 42"], {
+        stdio: ["ignore", fd, fd],
+        windowsHide: true,
+        windowsKeepAlive: true,
+      });
+      const { promise, resolve, reject } = Promise.withResolvers<[number | null, string | null]>();
+      child.on("error", reject);
+      child.on("exit", (code, signal) => resolve([code, signal]));
+      expect(await promise).toEqual([42, null]);
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(join(String(dir), "out.log"), "utf8").trim()).toBe("hello");
+  });
+
+  test("child_process.spawn rejects a windowsKeepAlive that is not a boolean", () => {
+    expect(() => cpSpawn("cmd.exe", [], { windowsKeepAlive: "yes" as any })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+  });
+});


### PR DESCRIPTION
### Problem
- On Windows, a subprocess cannot have all three: a hidden console of its own, file handles for stdio, and a lifetime longer than the parent. Example: `powershell.exe` with `stdio: ["ignore", fd, fd]`.
- libuv's `uv_spawn` (`src/win/process.c`) skips `CREATE_NO_WINDOW` when a stdio slot is `UV_INHERIT_FD`, so the child stays on the parent's console. It also puts each child in a job object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, so the child dies with the parent.
- `detached: true` is the only opt-out. It passes `DETACHED_PROCESS`: the child has no console. Each console program it starts opens a visible window, and `powershell.exe` itself exits at once (#31603).

### Fix
- New boolean option `windowsKeepAlive` on `Bun.spawn`, `Bun.spawnSync` and `node:child_process`. It sets two new `uv_spawn` flags from oven-sh/libuv#17: always pass `CREATE_NO_WINDOW`, and skip `AssignProcessToJobObject`.
- `exited`, `onExit` and `'exit'` work as before: the exit wait is on the process handle. No effect with `detached: true` or off Windows.
- Verified on Windows x64: `test/js/bun/spawn/spawn-windows-keep-alive.test.ts` (8 pass, the released build fails 4), `spawn.test.ts`, `child_process.test.ts`. The #31603 repro passes with `windowsKeepAlive` in place of `detached`.
- Self-reviewed: 2 concerns raised, 1 addressed (docs: a job object around the parent still applies). Not adopted: remap `detached` + `windowsHide` to `CREATE_NO_WINDOW` with no new option. It changes an existing Node-compatible pair. A maintainer decides (see Notes).

### Background
- A job object is a kernel group of processes. With `KILL_ON_JOB_CLOSE`, Windows terminates the members when the last handle to the job closes. libuv holds the only handle.
- `CREATE_NO_WINDOW` gives a console program a new console that has no window. The programs it starts attach to that console.
- `DETACHED_PROCESS` gives the child no console.

<details><summary>Notes</summary>

**Shape: a new option or `detached` + `windowsHide`.** The self-review proposed no new option: when a caller passes both `detached: true` and `windowsHide: true`, create the child with `CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP` in place of `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP`. That fixes callers that already use that pair (#31603, the Nx daemon, nodejs/node#21825, nodejs/node#51018) with no change on their side, and adds no name. It also changes what an existing Node-compatible pair does (Node passes `DETACHED_PROCESS`), and the child is a new process group, which the request for this PR excludes. This PR keeps the requested shape: an opt-in that changes nothing for a caller that does not set it. The two shapes do not exclude each other. Both libuv flags are needed only for the opt-in shape.

**#31603.** Measured on Windows Server 2019 (PowerShell 5.1): `powershell.exe -NoProfile -Command "Set-Content marker.txt ran; exit 5"` with `stdio: ["ignore", fd, fd]` exits with code 5 and writes the marker. With `detached: true` added it exits with code 0 after 43 ms, writes no marker and no output. The child is not killed by the job: it has no console and gives up. The repro of that issue (a helper that waits for the parent to exit, then writes a marker) writes the marker with `windowsKeepAlive: true` in place of `detached: true`. It writes none with `detached: true` and none with neither.

**Why not refine the existing rule.** The rule (libuv/libuv#1659) protects one case: an inherited handle to the parent's console. I measured it with a C probe: with `CREATE_NO_WINDOW` the inherited console handles in the child point at its new console (`GetConsoleMode` and `WriteFile` succeed) and nothing reaches the parent's screen buffer. Files and pipes are not affected, so the rule could check `GetConsoleMode` on each inherited handle. That changes existing callers. Bun sets `UV_PROCESS_WINDOWS_HIDE` for `bun run`, lifecycle scripts and the shell, with inherited fds 0 to 2. When those are pipes or files (every CI run, any redirect), each child would get its own `conhost.exe` and would no longer receive Ctrl+C or Ctrl+Break from the shared console. The new flag changes nothing for a caller that does not set it.

**Tests.** An intermediate `bun` process spawns `powershell.exe` with `["ignore", fd, fd]`, `unref()`s it and exits. The PowerShell script calls `GetConsoleWindow`, `GetConsoleCP` and `GetConsoleProcessList` through `Add-Type`, then appends a line every 100 ms. The intermediate runs with a console of its own, so the result does not depend on the console of the CI agent.
- With the option: the grandchild reports `window: 0`, a console, and only itself attached, while the intermediate is still alive. After the intermediate exits, the grandchild is alive and keeps appending. Covered for `Bun.spawn` and `child_process.spawn`, plus a case where the intermediate exits right after the spawn.
- Without the option (`windowsHide` only): the intermediate is attached to the grandchild's console, and the grandchild is terminated when the intermediate exits. This passes before and after the change.
- `exited`, `onExit` and `'exit'` report exit code 42 with the option set while the parent stays alive.
- The grandchild stops by itself after 300 lines, so a failed run cannot leave it behind.

**Manual checks.** `detached: true` plus `windowsKeepAlive: true` gives a child with no console (`GetConsoleCP() == 0`), the same as `detached` alone. libuv's own `spawn_*` tests pass with the change, and oven-sh/libuv#17 adds two tests there.

**Types and docs.** `windowsKeepAlive` in `Bun.Spawn.BaseOptions`, an augmentation of `CommonOptions` in `node:child_process`, a section in `docs/runtime/child-process.mdx`. The bun-types fixture has positive and `@ts-expect-error` cases for both APIs.

**libuv pin.** `LIBUV_COMMIT` points at the head of oven-sh/libuv#17. It needs a re-pin to the merge commit on the `bun` branch once that PR lands.

</details>
