### PR TITLE
completions: optimize parsing, add --cwd support, and fix bash 3.2 compatibility

### DIFF
--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -2,18 +2,21 @@
 
 shopt -s extglob
 
+_compgen_reply() {
+    local item
+    while IFS= read -r item || [[ -n "${item}" ]]; do
+        [[ -n "${item}" ]] && COMPREPLY+=( "${item}" )
+    done < <(compgen "$@")
+}
+
 _file_arguments() {
     local extensions="${1}"
-    local files=()
-
     if [[ -n "${extensions}" ]]; then
-        files=( $(compgen -f -X "${extensions}" -- "${cur_word}") )
+        _compgen_reply -f -X "${extensions}" -- "${cur_word}"
     else
-        files=( $(compgen -f -- "${cur_word}") )
+        _compgen_reply -f -- "${cur_word}"
     fi
-
-    local dirs=( $(compgen -d -S / -- "${cur_word}") )
-    COMPREPLY+=( "${files[@]}" "${dirs[@]}" )
+    _compgen_reply -d -S / -- "${cur_word}"
 }
 
 _long_short_completion() {
@@ -21,7 +24,7 @@ _long_short_completion() {
     local short_options="${2}"
 
     if [[ -z "${cur_word}" || "${cur_word}" == -* ]]; then
-        COMPREPLY+=( $(compgen -W "${wordlist}" -- "${cur_word}") )
+        _compgen_reply -W "${wordlist}" -- "${cur_word}"
     fi
 }
 
@@ -29,24 +32,31 @@ _read_scripts_in_package_json() {
     local pkg_file="package.json"
     [[ -f "${pkg_file}" && -r "${pkg_file}" ]] || return 0
 
-    local in_scripts=0 line_content script_names=()
+    local in_scripts=0 line_content script_names=() rest
     while IFS= read -r line_content || [[ -n "${line_content}" ]]; do
         if (( ! in_scripts )); then
-            if [[ "${line_content}" =~ \"scripts\"[[:space:]]*:[[:space:]]*\{? ]]; then
+            if [[ "${line_content}" =~ \"scripts\"[[:space:]]*:[[:space:]]*\{(.*) ]]; then
                 in_scripts=1
+                rest="${BASH_REMATCH[1]}"
             fi
         else
-            if [[ "${line_content}" =~ \}[[:space:]]*,? ]]; then
-                break
+            rest="${line_content}"
+        fi
+
+        if (( in_scripts )); then
+            if [[ "${rest}" =~ ^([^}]*)\}(.*) ]]; then
+                rest="${BASH_REMATCH[1]}"
+                in_scripts=0
             fi
-            if [[ "${line_content}" =~ \"([^\"\\]+)\"[[:space:]]*: ]]; then
+            while [[ "${rest}" =~ \"([^\"\\]+)\"[[:space:]]*: ]]; do
                 script_names+=( "${BASH_REMATCH[1]}" )
-            fi
+                rest="${rest#*${BASH_REMATCH[0]}}"
+            done
         fi
     done < "${pkg_file}"
 
     if (( ${#script_names[@]} > 0 )); then
-        COMPREPLY+=( $(compgen -W "${script_names[*]}" -- "${cur_word}") )
+        _compgen_reply -W "${script_names[*]}" -- "${cur_word}"
     fi
 }
 
@@ -84,27 +94,27 @@ _bun_completions_inner() {
         --bunfile)        _file_arguments "!*.bun" && return ;;
         --server-bunfile) _file_arguments "!*.server.bun" && return ;;
         --backend)
-            COMPREPLY=( $(compgen -W "clonefile copyfile hardlink clonefile_each_dir symlink" -- "${cur_word}") )
+            _compgen_reply -W "clonefile copyfile hardlink clonefile_each_dir symlink" -- "${cur_word}"
             return ;;
         --omit)
-            COMPREPLY=( $(compgen -W "dev optional peer" -- "${cur_word}") )
+            _compgen_reply -W "dev optional peer" -- "${cur_word}"
             return ;;
         --linker)
-            COMPREPLY=( $(compgen -W "isolated hoisted" -- "${cur_word}") )
+            _compgen_reply -W "isolated hoisted" -- "${cur_word}"
             return ;;
         --cwd|--public-dir)
-            COMPREPLY=( $(compgen -d -S / -- "${cur_word}") )
+            _compgen_reply -d -S / -- "${cur_word}"
             return ;;
         --jsx-runtime)
-            COMPREPLY=( $(compgen -W "automatic classic" -- "${cur_word}") )
+            _compgen_reply -W "automatic classic" -- "${cur_word}"
             return ;;
         --target)
-            COMPREPLY=( $(compgen -W "browser node bun" -- "${cur_word}") )
+            _compgen_reply -W "browser node bun" -- "${cur_word}"
             return ;;
         -l|--loader)
             if [[ "${cur_word}" == *:* ]]; then
                 local prefix="${cur_word%%:*}"
-                COMPREPLY=( $(compgen -W "${prefix}:jsx ${prefix}:js ${prefix}:json ${prefix}:tsx ${prefix}:ts ${prefix}:css" -- "${cur_word}") )
+                _compgen_reply -W "${prefix}:jsx ${prefix}:js ${prefix}:json ${prefix}:tsx ${prefix}:ts ${prefix}:css" -- "${cur_word}"
             fi
             return ;;
     esac
@@ -120,7 +130,11 @@ _bun_completions_inner() {
 
         local w="${COMP_WORDS[i]}"
         case "${w}" in
-            --cwd|--bunfile|--server-bunfile|-c|--config|--env-file|--port|-p|--loader|-l|--target|--origin|--public-dir|--backend|--filter|-F|--jsx-runtime|--omit|--linker)
+            --cwd|--bunfile|--server-bunfile|-c|--config|--env-file|--port|-p|\
+            --loader|-l|--target|--origin|--public-dir|--backend|--filter|-F|\
+            --jsx-runtime|--jsx-factory|--jsx-fragment|--jsx-import-source|\
+            --omit|--linker|--define|-d|--external|--inject|-i|--tsconfig-override|\
+            --main-fields|--extension-order|--conditions|-e|--eval|-u|--use)
                 if [[ "${COMP_WORDS[i+1]}" == "=" ]]; then
                     skip=2
                 else
@@ -171,16 +185,16 @@ _bun_completions_inner() {
                 "${PRUNE_OPTIONS_SHORT}"
             return ;;
         audit)
-            COMPREPLY=( $(compgen -W "fix ${AUDIT_OPTIONS_LONG} ${AUDIT_OPTIONS_SHORT}" -- "${cur_word}") )
+            _compgen_reply -W "fix ${AUDIT_OPTIONS_LONG} ${AUDIT_OPTIONS_SHORT}" -- "${cur_word}"
             return ;;
         create|c)
-            COMPREPLY=( $(compgen -W "--force --no-install --help --no-git --verbose --no-package-json --open next react" -- "${cur_word}") )
+            _compgen_reply -W "--force --no-install --help --no-git --verbose --no-package-json --open next react" -- "${cur_word}"
             return ;;
         upgrade)
-            COMPREPLY=( $(compgen -W "--version --cwd --help -v -h" -- "${cur_word}") )
+            _compgen_reply -W "--version --cwd --help -v -h" -- "${cur_word}"
             return ;;
         repl)
-            COMPREPLY=( $(compgen -W "--help -h --eval -e --print -p --preload -r --smol --config -c --cwd --env-file --no-env-file" -- "${cur_word}") )
+            _compgen_reply -W "--help -h --eval -e --print -p --preload -r --smol --config -c --cwd --env-file --no-env-file" -- "${cur_word}"
             return ;;
         run)
             _read_scripts_in_package_json
@@ -197,10 +211,19 @@ _bun_completions_inner() {
             return ;;
         pm)
             _long_short_completion "${PM_OPTIONS_LONG} ${PM_OPTIONS_SHORT}"
-            COMPREPLY=( $(compgen -W "bin ls licenses cache hash hash-print hash-string" -- "${cur_word}") )
+            _compgen_reply -W "bin ls licenses cache hash hash-print hash-string" -- "${cur_word}"
+            return ;;
+        x)
+            local bins
+            bins=$(bun getcompletes b 2>/dev/null)
+            if [[ -n "${bins}" ]]; then
+                _compgen_reply -W "${bins}" -- "${cur_word}"
+            fi
+            _file_arguments
+            _long_short_completion "--bun --install --help -h" "-h"
             return ;;
         "")
-            COMPREPLY=( $(compgen -W "${SUBCOMMANDS}" -- "${cur_word}") )
+            _compgen_reply -W "${SUBCOMMANDS}" -- "${cur_word}"
             _long_short_completion "${GLOBAL_OPTIONS_LONG}" "${GLOBAL_OPTIONS_SHORT}"
             _read_scripts_in_package_json
             return ;;
@@ -244,10 +267,59 @@ _bun_completions() {
         builtin cd "${orig_pwd}" 2>/dev/null
     fi
 
-    # Suppress trailing space only when completing a directory
     if [[ ${#COMPREPLY[@]} -eq 1 && "${COMPREPLY[0]}" == */ ]]; then
         compopt -o nospace 2>/dev/null
     fi
 }
 
-complete -F _bun_completions bun bunx
+_bunx_completions() {
+    local working_dir="${PWD}" line
+    for (( line=0; line < ${#COMP_WORDS[@]}; line++ )); do
+        if [[ "${COMP_WORDS[line]}" == "--cwd" ]]; then
+            if [[ "${COMP_WORDS[line+1]}" == "=" && -n "${COMP_WORDS[line+2]}" ]]; then
+                working_dir="${COMP_WORDS[line+2]}"
+            elif [[ -n "${COMP_WORDS[line+1]}" ]]; then
+                working_dir="${COMP_WORDS[line+1]}"
+            fi
+        elif [[ "${COMP_WORDS[line]}" == --cwd=* ]]; then
+            working_dir="${COMP_WORDS[line]#--cwd=}"
+        fi
+    done
+
+    working_dir="${working_dir%\"}"
+    working_dir="${working_dir#\"}"
+    working_dir="${working_dir%\'}"
+    working_dir="${working_dir#\'}"
+    working_dir="${working_dir/#\~/$HOME}"
+
+    local orig_pwd="${PWD}"
+    local switched=0
+    if [[ -n "${working_dir}" && -d "${working_dir}" && "${working_dir}" != "${PWD}" ]]; then
+        if builtin cd "${working_dir}" 2>/dev/null; then
+            switched=1
+        fi
+    fi
+
+    local cur_word="${COMP_WORDS[${COMP_CWORD}]}"
+    if [[ "${cur_word}" == -* ]]; then
+        _compgen_reply -W "--bun --install --help -h" -- "${cur_word}"
+    else
+        local bins
+        bins=$(bun getcompletes b 2>/dev/null)
+        if [[ -n "${bins}" ]]; then
+            _compgen_reply -W "${bins}" -- "${cur_word}"
+        fi
+        _file_arguments
+    fi
+
+    if (( switched )); then
+        builtin cd "${orig_pwd}" 2>/dev/null
+    fi
+
+    if [[ ${#COMPREPLY[@]} -eq 1 && "${COMPREPLY[0]}" == */ ]]; then
+        compopt -o nospace 2>/dev/null
+    fi
+}
+
+complete -F _bun_completions bun
+complete -F _bunx_completions bunx

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -1,247 +1,253 @@
 #/usr/bin/env bash
 
+shopt -s extglob
+
 _file_arguments() {
     local extensions="${1}"
-    local reset=$(shopt -p globstar)
-    shopt -s globstar
+    local files=()
 
-    if [[ -z "${cur_word}" ]]; then
-        COMPREPLY=( $(compgen -fG -X "${extensions}" -- "${cur_word}") );
+    if [[ -n "${extensions}" ]]; then
+        files=( $(compgen -f -X "${extensions}" -- "${cur_word}") )
     else
-        COMPREPLY=( $(compgen -f -X "${extensions}" -- "${cur_word}") );
+        files=( $(compgen -f -- "${cur_word}") )
     fi
 
-    $reset
+    local dirs=( $(compgen -d -S / -- "${cur_word}") )
+    COMPREPLY+=( "${files[@]}" "${dirs[@]}" )
 }
 
 _long_short_completion() {
-    local wordlist="${1}";
+    local wordlist="${1}"
     local short_options="${2}"
 
-    [[ -z "${cur_word}" || "${cur_word}" =~ ^- ]] && {
-        COMPREPLY=( $(compgen -W "${wordlist}" -- "${cur_word}"));
-        return;
-    }
-    [[ "${cur_word}" =~ ^-[A-Za_z]+ ]] && {
-        COMPREPLY=( $(compgen -W "${short_options}" -- "${cur_word}"));
-        return;
-    }
+    if [[ -z "${cur_word}" || "${cur_word}" == -* ]]; then
+        COMPREPLY+=( $(compgen -W "${wordlist}" -- "${cur_word}") )
+    fi
 }
 
-# loads the scripts block in package.json
 _read_scripts_in_package_json() {
-    local package_json;
-    local return_package_json
-    local line=0;
-    local working_dir="${PWD}";
+    local pkg_file="package.json"
+    [[ -f "${pkg_file}" && -r "${pkg_file}" ]] || return 0
 
-    for ((; line < ${#COMP_WORDS[@]}; line+=1)); do
-        [[ "${COMP_WORDS[${line}]}" == "--cwd" ]] && working_dir="${COMP_WORDS[$((line + 1))]}";
-    done
+    local in_scripts=0 line_content script_names=()
+    while IFS= read -r line_content || [[ -n "${line_content}" ]]; do
+        if (( ! in_scripts )); then
+            if [[ "${line_content}" =~ \"scripts\"[[:space:]]*:[[:space:]]*\{? ]]; then
+                in_scripts=1
+            fi
+        else
+            if [[ "${line_content}" =~ \}[[:space:]]*,? ]]; then
+                break
+            fi
+            if [[ "${line_content}" =~ \"([^\"\\]+)\"[[:space:]]*: ]]; then
+                script_names+=( "${BASH_REMATCH[1]}" )
+            fi
+        fi
+    done < "${pkg_file}"
 
-    [[ -f "${working_dir}/package.json" ]] && package_json=$(<"${working_dir}/package.json");
-
-    [[ "${package_json}" =~ "\"scripts\""[[:space:]]*":"[[:space:]]*\{(.*)\} ]] && {
-        local package_json_compreply;
-        local matched="${BASH_REMATCH[@]:1}";
-        local scripts="${matched%%\}*}";
-        scripts="${scripts//@(\"|\')/}";
-        readarray -td, scripts <<<"${scripts}";
-        for completion in "${scripts[@]}"; do
-            [[ "${completion}" =~ ^[[:space:]]*([[:alnum:]@/:._-]+)[[:space:]]*: ]] && package_json_compreply+=( "${BASH_REMATCH[1]}" );
-        done
-        COMPREPLY+=( $(compgen -W "${package_json_compreply[*]}" -- "${cur_word}") );
-    }
-
-    # when a script is passed as an option, do not show other scripts as part of the completion anymore
-    local re_prev_script="(^| )${prev}($| )";
-    [[
-        ( "${COMPREPLY[*]}" =~ ${re_prev_script} && -n "${COMP_WORDS[2]}" ) || \
-            ( "${COMPREPLY[*]}" =~ ${re_comp_word_script} )
-    ]] && {
-        local filtered_reply=();
-        local reply_word script_name keep;
-        for reply_word in "${COMPREPLY[@]}"; do
-            keep=1;
-            for script_name in "${package_json_compreply[@]}"; do
-                [[ "${reply_word}" == "${script_name}" ]] && { keep=""; break; };
-            done
-            [[ -n "${keep}" ]] && filtered_reply+=( "${reply_word}" );
-        done
-        COMPREPLY=( "${filtered_reply[@]}" );
-        replaced_script="${prev}";
-    }
+    if (( ${#script_names[@]} > 0 )); then
+        COMPREPLY+=( $(compgen -W "${script_names[*]}" -- "${cur_word}") )
+    fi
 }
 
+_bun_completions_inner() {
+    local SUBCOMMANDS="dev bun create run install add remove upgrade completions discord help init pm x test repl update audit dedupe prune outdated link unlink build"
 
-_subcommand_comp_reply() {
-    local cur_word="${1}"
-    local sub_commands="${2}"
-    local regexp_subcommand="^[dbcriauh]";
-    [[ "${prev}" =~ ${regexp_subcommand} ]] && {
-        COMPREPLY+=( $(compgen -W "${sub_commands}" -- "${cur_word}") );
-    }
-}
+    local GLOBAL_OPTIONS_LONG="--use --cwd --bunfile --server-bunfile --config --disable-react-fast-refresh --disable-hmr --env-file --extension-order --jsx-factory --jsx-fragment --jsx-import-source --jsx-production --jsx-runtime --main-fields --no-summary --version --platform --public-dir --tsconfig-override --define --external --help --inject --loader --origin --port --dump-environment-variables --dump-limits --disable-bun-js"
+    local GLOBAL_OPTIONS_SHORT="-c -v -d -e -h -i -l -u -p"
 
+    local ADD_OPTIONS_LONG="--development --optional --peer --catalog --filter"
+    local ADD_OPTIONS_SHORT="-d -F"
+    local REMOVE_OPTIONS_LONG="--filter"
+    local REMOVE_OPTIONS_SHORT="-F"
+    local UPDATE_OPTIONS_LONG="--latest --interactive --recursive --filter --dev --development --prod --no-optional --exact"
+    local UPDATE_OPTIONS_SHORT="-L -i -r -F -d -D -P -E"
 
-_bun_completions() {
-    declare -A GLOBAL_OPTIONS;
-    declare -A PACKAGE_OPTIONS;
-    declare -A PM_OPTIONS;
+    local SHARED_OPTIONS_LONG="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --global --cwd --backend --link-native-bins --help"
+    local SHARED_OPTIONS_SHORT="-c -y -p -f -g"
 
-    local SUBCOMMANDS="dev bun create run install add remove upgrade completions discord help init pm x test repl update audit dedupe prune outdated link unlink build";
+    local DEDUPE_OPTIONS_LONG="--check"
+    local PRUNE_OPTIONS_LONG="--production --prod --omit --filter --dry-run --os --cpu --linker --silent --cwd --help"
+    local PRUNE_OPTIONS_SHORT="-p -P -F -h"
+    local AUDIT_OPTIONS_LONG="--json --audit-level --ignore --prod --production --omit --dry-run --latest --cwd --help"
+    local AUDIT_OPTIONS_SHORT="-L"
 
-    GLOBAL_OPTIONS[LONG_OPTIONS]="--use --cwd --bunfile --server-bunfile --config --disable-react-fast-refresh --disable-hmr --env-file --extension-order --jsx-factory --jsx-fragment --extension-order --jsx-factory --jsx-fragment --jsx-import-source --jsx-production --jsx-runtime --main-fields --no-summary --version --platform --public-dir --tsconfig-override --define --external --help --inject --loader --origin --port --dump-environment-variables --dump-limits --disable-bun-js";
-    GLOBAL_OPTIONS[SHORT_OPTIONS]="-c -v -d -e -h -i -l -u -p";
+    local PM_OPTIONS_LONG="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --no-progress --no-summary --no-verify --ignore-scripts --global --cwd --backend --link-native-bins --json --help"
+    local PM_OPTIONS_SHORT="-c -y -p -f -g"
 
-    PACKAGE_OPTIONS[ADD_OPTIONS_LONG]="--development --optional --peer --catalog --filter";
-    PACKAGE_OPTIONS[ADD_OPTIONS_SHORT]="-d -F";
-    PACKAGE_OPTIONS[REMOVE_OPTIONS_LONG]="--filter";
-    PACKAGE_OPTIONS[REMOVE_OPTIONS_SHORT]="-F";
-    PACKAGE_OPTIONS[UPDATE_OPTIONS_LONG]="--latest --interactive --recursive --filter --dev --development --prod --no-optional --exact";
-    PACKAGE_OPTIONS[UPDATE_OPTIONS_SHORT]="-L -i -r -F -d -D -P -E";
-
-    PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --global --cwd --backend --link-native-bins --help";
-    PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]="-c -y -p -f -g";
-
-    PACKAGE_OPTIONS[DEDUPE_OPTIONS_LONG]="--check";
-    PACKAGE_OPTIONS[PRUNE_OPTIONS_LONG]="--production --prod --omit --filter --dry-run --os --cpu --linker --silent --cwd --help";
-    PACKAGE_OPTIONS[PRUNE_OPTIONS_SHORT]="-p -P -F -h";
-    PACKAGE_OPTIONS[AUDIT_OPTIONS_LONG]="--json --audit-level --ignore --prod --production --omit --dry-run --latest --cwd --help";
-    PACKAGE_OPTIONS[AUDIT_OPTIONS_SHORT]="-L";
-
-    PM_OPTIONS[LONG_OPTIONS]="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --no-progress --no-summary --no-verify --ignore-scripts --global --cwd --backend --link-native-bins --json --help"
-    PM_OPTIONS[SHORT_OPTIONS]="-c -y -p -f -g"
-
-    local cur_word="${COMP_WORDS[${COMP_CWORD}]}";
-    local prev="${COMP_WORDS[$(( COMP_CWORD - 1 ))]}";
+    local cur_word="${COMP_WORDS[${COMP_CWORD}]}"
+    local prev="${COMP_WORDS[$(( COMP_CWORD - 1 ))]}"
 
     case "${prev}" in
-        help|--help|-h|-v|--version) return;;
-        -c|--config)      _file_arguments "!*.toml" && return;;
-        --bunfile)        _file_arguments "!*.bun" && return;;
-        --server-bunfile) _file_arguments "!*.server.bun" && return;;
+        help|--help|-h|-v|--version) return ;;
+        -c|--config)      _file_arguments "!*.toml" && return ;;
+        --bunfile)        _file_arguments "!*.bun" && return ;;
+        --server-bunfile) _file_arguments "!*.server.bun" && return ;;
         --backend)
-            case "${COMP_WORDS[1]}" in
-                a|add|remove|rm|install|i|dedupe|update|up)
-                    COMPREPLY=( $(compgen -W "clonefile copyfile hardlink clonefile_each_dir symlink" -- "${cur_word}") );
-                    ;;
-            esac
+            COMPREPLY=( $(compgen -W "clonefile copyfile hardlink clonefile_each_dir symlink" -- "${cur_word}") )
             return ;;
         --omit)
-            COMPREPLY=( $(compgen -W "dev optional peer" -- "${cur_word}") );
-            return;;
-        -F|--filter)
-            case "${COMP_WORDS[1]}" in
-                a|add|remove|rm|i|install|prune|update|up) return;;
-            esac
-            ;;
+            COMPREPLY=( $(compgen -W "dev optional peer" -- "${cur_word}") )
+            return ;;
         --linker)
-            COMPREPLY=( $(compgen -W "isolated hoisted" -- "${cur_word}") );
-            return;;
+            COMPREPLY=( $(compgen -W "isolated hoisted" -- "${cur_word}") )
+            return ;;
         --cwd|--public-dir)
-            COMPREPLY=( $(compgen -d -- "${cur_word}" ));
-            return;;
+            COMPREPLY=( $(compgen -d -S / -- "${cur_word}") )
+            return ;;
         --jsx-runtime)
-            COMPREPLY=( $(compgen -W "automatic classic" -- "${cur_word}") );
-            return;;
+            COMPREPLY=( $(compgen -W "automatic classic" -- "${cur_word}") )
+            return ;;
         --target)
-            COMPREPLY=( $(compgen -W "browser node bun" -- "${cur_word}") );
-            return;;
+            COMPREPLY=( $(compgen -W "browser node bun" -- "${cur_word}") )
+            return ;;
         -l|--loader)
-            [[ "${cur_word}" =~ (:) ]] && {
-                local cut_colon_forward="${cur_word%%:*}"
-                COMPREPLY=( $(compgen -W "${cut_colon_forward}:jsx ${cut_colon_forward}:js ${cut_colon_forward}:json ${cut_colon_forward}:tsx ${cut_colon_forward}:ts ${cut_colon_forward}:css" -- "${cut_colon_forward}:${cur_word##*:}") );
-            }
-            return;;
+            if [[ "${cur_word}" == *:* ]]; then
+                local prefix="${cur_word%%:*}"
+                COMPREPLY=( $(compgen -W "${prefix}:jsx ${prefix}:js ${prefix}:json ${prefix}:tsx ${prefix}:ts ${prefix}:css" -- "${cur_word}") )
+            fi
+            return ;;
     esac
 
-    case "${COMP_WORDS[1]}" in
-        help|completions|--help|-h|-v|--version) return;;
+    local subcommand=""
+    local skip=0
+    local i
+    for (( i=1; i < COMP_CWORD; i++ )); do
+        if (( skip > 0 )); then
+            (( skip-- ))
+            continue
+        fi
+
+        local w="${COMP_WORDS[i]}"
+        case "${w}" in
+            --cwd|--bunfile|--server-bunfile|-c|--config|--env-file|--port|-p|--loader|-l|--target|--origin|--public-dir|--backend|--filter|-F|--jsx-runtime|--omit|--linker)
+                if [[ "${COMP_WORDS[i+1]}" == "=" ]]; then
+                    skip=2
+                else
+                    skip=1
+                fi
+                continue
+                ;;
+            -*)
+                continue
+                ;;
+            *)
+                subcommand="${w}"
+                break
+                ;;
+        esac
+    done
+
+    case "${subcommand}" in
+        help|completions) return ;;
         add|a)
             _long_short_completion \
-                "${PACKAGE_OPTIONS[ADD_OPTIONS_LONG]} ${PACKAGE_OPTIONS[ADD_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}" \
-                "${PACKAGE_OPTIONS[ADD_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}"
-            return;;
+                "${ADD_OPTIONS_LONG} ${ADD_OPTIONS_SHORT} ${SHARED_OPTIONS_LONG} ${SHARED_OPTIONS_SHORT}" \
+                "${ADD_OPTIONS_SHORT} ${SHARED_OPTIONS_SHORT}"
+            return ;;
         remove|rm|i|install)
             _long_short_completion \
-                "${PACKAGE_OPTIONS[REMOVE_OPTIONS_LONG]} ${PACKAGE_OPTIONS[REMOVE_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}" \
-                "${PACKAGE_OPTIONS[REMOVE_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}";
-            return;;
+                "${REMOVE_OPTIONS_LONG} ${REMOVE_OPTIONS_SHORT} ${SHARED_OPTIONS_LONG} ${SHARED_OPTIONS_SHORT}" \
+                "${REMOVE_OPTIONS_SHORT} ${SHARED_OPTIONS_SHORT}"
+            return ;;
         update|up)
             _long_short_completion \
-                "${PACKAGE_OPTIONS[UPDATE_OPTIONS_LONG]} ${PACKAGE_OPTIONS[UPDATE_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}" \
-                "${PACKAGE_OPTIONS[UPDATE_OPTIONS_SHORT]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}";
-            return;;
+                "${UPDATE_OPTIONS_LONG} ${UPDATE_OPTIONS_SHORT} ${SHARED_OPTIONS_LONG} ${SHARED_OPTIONS_SHORT}" \
+                "${UPDATE_OPTIONS_SHORT} ${SHARED_OPTIONS_SHORT}"
+            return ;;
         link|unlink)
             _long_short_completion \
-                "${PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}" \
-                "${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}";
-            return;;
+                "${SHARED_OPTIONS_LONG} ${SHARED_OPTIONS_SHORT}" \
+                "${SHARED_OPTIONS_SHORT}"
+            return ;;
         dedupe)
             _long_short_completion \
-                "${PACKAGE_OPTIONS[DEDUPE_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]} ${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}" \
-                "${PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]}";
-            return;;
+                "${DEDUPE_OPTIONS_LONG} ${SHARED_OPTIONS_LONG} ${SHARED_OPTIONS_SHORT}" \
+                "${SHARED_OPTIONS_SHORT}"
+            return ;;
         prune)
             _long_short_completion \
-                "${PACKAGE_OPTIONS[PRUNE_OPTIONS_LONG]} ${PACKAGE_OPTIONS[PRUNE_OPTIONS_SHORT]}" \
-                "${PACKAGE_OPTIONS[PRUNE_OPTIONS_SHORT]}";
-            return;;
+                "${PRUNE_OPTIONS_LONG} ${PRUNE_OPTIONS_SHORT}" \
+                "${PRUNE_OPTIONS_SHORT}"
+            return ;;
         audit)
-            COMPREPLY=( $(compgen -W "fix ${PACKAGE_OPTIONS[AUDIT_OPTIONS_LONG]} ${PACKAGE_OPTIONS[AUDIT_OPTIONS_SHORT]}" -- "${cur_word}") );
-            return;;
+            COMPREPLY=( $(compgen -W "fix ${AUDIT_OPTIONS_LONG} ${AUDIT_OPTIONS_SHORT}" -- "${cur_word}") )
+            return ;;
         create|c)
-            COMPREPLY=( $(compgen -W "--force --no-install --help --no-git --verbose --no-package-json --open next react" -- "${cur_word}") );
-            return;;
+            COMPREPLY=( $(compgen -W "--force --no-install --help --no-git --verbose --no-package-json --open next react" -- "${cur_word}") )
+            return ;;
         upgrade)
-            COMPREPLY=( $(compgen -W "--version --cwd --help -v -h") );
-            return;;
+            COMPREPLY=( $(compgen -W "--version --cwd --help -v -h" -- "${cur_word}") )
+            return ;;
         repl)
-            COMPREPLY=( $(compgen -W "--help -h --eval -e --print -p --preload -r --smol --config -c --cwd --env-file --no-env-file" -- "${cur_word}") );
-            return;;
+            COMPREPLY=( $(compgen -W "--help -h --eval -e --print -p --preload -r --smol --config -c --cwd --env-file --no-env-file" -- "${cur_word}") )
+            return ;;
         run)
-            _file_arguments "!(*.@(js|ts|jsx|tsx|mjs|cjs)?($|))";
-            COMPREPLY+=( $(compgen -W "--version --cwd --help --silent -v -h" -- "${cur_word}" ) );
-            _read_scripts_in_package_json;
-            return;;
+            _read_scripts_in_package_json
+            _file_arguments "!*.@(js|ts|jsx|tsx|mjs|cjs)"
+            _long_short_completion "--version --cwd --help --silent -v -h" "-v -h"
+            return ;;
+        test)
+            _file_arguments "!*.@(js|ts|jsx|tsx|mjs|cjs)"
+            _long_short_completion "--bail --coverage --watch --timeout --todo --only --rerun-each --filter --help -b -t -h" "-b -t -h"
+            return ;;
+        build|b)
+            _file_arguments "!*.@(js|ts|jsx|tsx|mjs|cjs|html)"
+            _long_short_completion "--outdir --outfile --target --format --minify --sourcemap --entry-naming --public-path --compile --bytecode --help -h" "-h"
+            return ;;
         pm)
-            _long_short_completion \
-                "${PM_OPTIONS[LONG_OPTIONS]} ${PM_OPTIONS[SHORT_OPTIONS]}";
-            COMPREPLY+=( $(compgen -W "bin ls licenses cache hash hash-print hash-string" -- "${cur_word}") );
-            return;;
+            _long_short_completion "${PM_OPTIONS_LONG} ${PM_OPTIONS_SHORT}"
+            COMPREPLY=( $(compgen -W "bin ls licenses cache hash hash-print hash-string" -- "${cur_word}") )
+            return ;;
+        "")
+            COMPREPLY=( $(compgen -W "${SUBCOMMANDS}" -- "${cur_word}") )
+            _long_short_completion "${GLOBAL_OPTIONS_LONG}" "${GLOBAL_OPTIONS_SHORT}"
+            _read_scripts_in_package_json
+            return ;;
         *)
-            local replaced_script;
-            _long_short_completion \
-                "${GLOBAL_OPTIONS[*]}" \
-                "${GLOBAL_OPTIONS[SHORT_OPTIONS]}"
-
-            _read_scripts_in_package_json;
-            _subcommand_comp_reply "${cur_word}" "${SUBCOMMANDS}";
-
-            # determine if completion should be continued
-            # when the current word is an empty string
-            # the previous word is not part of the allowed completion
-            # the previous word is not an argument to the last two option
-            [[ -z "${cur_word}" ]] && {
-                local prev_in_reply="";
-                local reply_word;
-                for reply_word in "${COMPREPLY[@]}"; do
-                    [[ "${reply_word}" == "${prev}" ]] && { prev_in_reply=1; break; };
-                done
-                [[ -z "${prev_in_reply}" ]] && {
-                    local re_prev_prev="(^| )${COMP_WORDS[(( COMP_CWORD - 2 ))]}($| )";
-                    local global_option_with_extra_args="--bunfile --server-bunfile --config --port --cwd --public-dir --jsx-runtime --platform --loader";
-                    [[
-                        ( -n "${replaced_script}" && "${replaced_script}" == "${prev}" ) || \
-                            ( "${global_option_with_extra_args}" =~ ${re_prev_prev} )
-                    ]] && return;
-                    unset COMPREPLY;
-                }
-            }
-            return;;
+            _file_arguments
+            return ;;
     esac
-
 }
 
-complete -F _bun_completions bun
+_bun_completions() {
+    local working_dir="${PWD}" line
+    for (( line=0; line < ${#COMP_WORDS[@]}; line++ )); do
+        if [[ "${COMP_WORDS[line]}" == "--cwd" ]]; then
+            if [[ "${COMP_WORDS[line+1]}" == "=" && -n "${COMP_WORDS[line+2]}" ]]; then
+                working_dir="${COMP_WORDS[line+2]}"
+            elif [[ -n "${COMP_WORDS[line+1]}" ]]; then
+                working_dir="${COMP_WORDS[line+1]}"
+            fi
+        elif [[ "${COMP_WORDS[line]}" == --cwd=* ]]; then
+            working_dir="${COMP_WORDS[line]#--cwd=}"
+        fi
+    done
+
+    working_dir="${working_dir%\"}"
+    working_dir="${working_dir#\"}"
+    working_dir="${working_dir%\'}"
+    working_dir="${working_dir#\'}"
+    working_dir="${working_dir/#\~/$HOME}"
+
+    local orig_pwd="${PWD}"
+    local switched=0
+    if [[ -n "${working_dir}" && -d "${working_dir}" && "${working_dir}" != "${PWD}" ]]; then
+        if builtin cd "${working_dir}" 2>/dev/null; then
+            switched=1
+        fi
+    fi
+
+    _bun_completions_inner
+
+    if (( switched )); then
+        builtin cd "${orig_pwd}" 2>/dev/null
+    fi
+
+    # Suppress trailing space only when completing a directory
+    if [[ ${#COMPREPLY[@]} -eq 1 && "${COMPREPLY[0]}" == */ ]]; then
+        compopt -o nospace 2>/dev/null
+    fi
+}
+
+complete -F _bun_completions bun bunx

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -3,10 +3,11 @@
 shopt -s extglob
 
 _compgen_reply() {
-    local item
+    local comp_out item
+    comp_out=$(compgen "$@")
     while IFS= read -r item || [[ -n "${item}" ]]; do
         [[ -n "${item}" ]] && COMPREPLY+=( "${item}" )
-    done < <(compgen "$@")
+    done <<< "${comp_out}"
 }
 
 _file_arguments() {
@@ -32,7 +33,7 @@ _read_scripts_in_package_json() {
     local pkg_file="package.json"
     [[ -f "${pkg_file}" && -r "${pkg_file}" ]] || return 0
 
-    local in_scripts=0 line_content script_names=() rest
+    local in_scripts=0 line_content script_names=() rest key
     while IFS= read -r line_content || [[ -n "${line_content}" ]]; do
         if (( ! in_scripts )); then
             if [[ "${line_content}" =~ \"scripts\"[[:space:]]*:[[:space:]]*\{(.*) ]]; then
@@ -48,9 +49,9 @@ _read_scripts_in_package_json() {
                 rest="${BASH_REMATCH[1]}"
                 in_scripts=0
             fi
-            while [[ "${rest}" =~ \"([^\"\\]+)\"[[:space:]]*: ]]; do
+            while [[ "${rest}" =~ [[:space:]]*\"([^\"\\]+)\"[[:space:]]*:[[:space:]]*\"([^\"]*)\"(.*) ]]; do
                 script_names+=( "${BASH_REMATCH[1]}" )
-                rest="${rest#*${BASH_REMATCH[0]}}"
+                rest="${BASH_REMATCH[3]}"
             done
         fi
     done < "${pkg_file}"
@@ -198,6 +199,11 @@ _bun_completions_inner() {
             return ;;
         run)
             _read_scripts_in_package_json
+            local bins
+            bins=$(bun getcompletes b 2>/dev/null)
+            if [[ -n "${bins}" ]]; then
+                _compgen_reply -W "${bins}" -- "${cur_word}"
+            fi
             _file_arguments "!*.@(js|ts|jsx|tsx|mjs|cjs)"
             _long_short_completion "--version --cwd --help --silent -v -h" "-v -h"
             return ;;

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -6,14 +6,40 @@
 # 4. I don't know how to write fish completions well
 # Contributions very welcome!!
 
+function __fish__bun_extract_cwd
+    set -l tokens (commandline -cop)
+    for i in (seq 1 (count $tokens))
+        if test "$tokens[$i]" = "--cwd"
+            set -l next_idx (math $i + 1)
+            if test $next_idx -le (count $tokens)
+                eval echo $tokens[$next_idx]
+                return
+            end
+        else if string match -q -- "--cwd=*" "$tokens[$i]"
+            eval echo (string replace -- "--cwd=" "" "$tokens[$i]")
+            return
+        end
+    end
+    echo "."
+end
+
 function __fish__get_bun_bins
-	string split ' ' (bun getcompletes b)
+    set -l target_cwd (__fish__bun_extract_cwd)
+    if test -d "$target_cwd"
+        builtin cd "$target_cwd"
+        string split " " (bun getcompletes b 2>/dev/null)
+    end
 end
 
 function __fish__get_bun_scripts
-	set -lx SHELL bash
-	set -lx MAX_DESCRIPTION_LEN 40
-	string trim (string split '\n' (string split '\t' (bun getcompletes z)))
+    set -l target_cwd (__fish__bun_extract_cwd)
+    if test -d "$target_cwd"
+        builtin cd "$target_cwd"
+        set -lx SHELL bash
+        set -lx MAX_DESCRIPTION_LEN 40
+        string trim (string split "
+" (string split '\t' (bun getcompletes z 2>/dev/null)))
+    end
 end
 
 function __fish__get_bun_packages

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -1,9 +1,8 @@
-# Bun completions for fish shell
-#
-# Known limitations:
-# 1. No flag completions for custom scripts
-# 2. Doesn't read bunfig.toml
-# 3. Bun install filter completions don't work yet
+# This is terribly complicated
+# It's because:
+# 1. bun run has to have dynamic completions
+# 2. there are global options
+# 3. bun {install add remove} gets special options
 # 4. I don't know how to write fish completions well
 # Contributions very welcome!!
 
@@ -21,7 +20,7 @@ function __fish__bun_extract_cwd
         end
 
         if test -n "$val"
-            set val (string replace -r '^["\'](.*)["\']$' '$1' -- "$val")
+            set val (string replace -r '^["'](.*)["']$' '$1' -- "$val")
             set val (string replace -r '^~' "$HOME" -- "$val")
             echo "$val"
             return
@@ -34,7 +33,7 @@ function __fish__get_bun_bins
     set -l target_cwd (__fish__bun_extract_cwd)
     if test -d "$target_cwd"
         builtin cd "$target_cwd"
-        string split " " (bun getcompletes b 2>/dev/null)
+        string split ' ' (bun getcompletes b 2>/dev/null)
     end
 end
 
@@ -44,74 +43,250 @@ function __fish__get_bun_scripts
         builtin cd "$target_cwd"
         set -lx SHELL bash
         set -lx MAX_DESCRIPTION_LEN 40
-        string trim (string split "\n" (string split '\t' (bun getcompletes z 2>/dev/null)))
+        string trim (string split '
+' (string split '	' (bun getcompletes z 2>/dev/null)))
     end
 end
 
 function __fish__get_bun_packages
-    # TODO: this needs to be implemented in `bun getcompletes`
-    if not test -f package.json
-        return
-    end
-
-    if not command -qs jq
-        return
-    end
-
-    set -l dependencies (jq -r '.dependencies | keys[]' package.json 2>/dev/null)
-    set -l dev_dependencies (jq -r '.devDependencies | keys[]' package.json 2>/dev/null)
-    string split " " "$dependencies $dev_dependencies"
+	if test (commandline -ct) != ""
+		set -lx SHELL fish
+		string split ' ' (bun getcompletes a (commandline -ct))
+	end
 end
 
-function __fish__bun_needs_command
-    # Check if a subcommand has already been specified
-    set -l cmd (commandline -opc)
-    if test (count $cmd) -eq 1
-        return 0
-    end
-    return 1
+function __history_completions
+	set -l tokens (commandline --current-process --tokenize)
+	history --prefix (commandline) | string replace -r \^$tokens[1]\\s\* "" | string replace -r \^$tokens[2]\\s\* "" | string split ' '
 end
 
-function __fish__bun_using_command
-    set -l cmd (commandline -opc)
-    if test (count $cmd) -gt 1
-        if test $argv[1] = $cmd[2]
-            return 0
+function __fish__get_bun_bun_js_files
+	string split ' ' (bun getcompletes j)
+end
+
+set -l bun_install_boolean_flags yarn production optional development no-save dry-run force no-cache silent verbose global
+set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't update package.json or save a lockfile" "Don't install anything" "Always request the latest versions from the registry & reinstall all dependencies" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
+
+set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install remove add update audit dedupe prune init pm x repl
+set -l bun_builtin_cmds_accepting_flags create help bun upgrade discord run init link unlink pm x update
+
+function __bun_complete_bins_scripts --inherit-variable bun_builtin_cmds_without_run -d "Emit bun completions for bins and scripts"
+    # Do nothing if we already have a builtin subcommand,
+    # or any subcommand other than "run".
+    if __fish_seen_subcommand_from $bun_builtin_cmds_without_run
+    or not __fish_use_subcommand && not __fish_seen_subcommand_from run
+        return
+    end
+    # Do we already have a bin or script subcommand?
+    set -l bins (__fish__get_bun_bins)
+    if __fish_seen_subcommand_from $bins
+        return
+    end
+    # Scripts have descriptions appended with a tab separator.
+    # Strip off descriptions for the purposes of subcommand testing.
+    set -l scripts (__fish__get_bun_scripts)
+    if __fish_seen_subcommand_from (string split \t -f 1 -- $scripts)
+        return
+    end
+    # Emit scripts.
+    for script in $scripts
+        echo $script
+    end
+    # Emit binaries and JS files (but only if we're doing `bun run`).
+    if __fish_seen_subcommand_from run
+        for bin in $bins
+            echo "$bin"\t"package bin"
+        end
+        for file in (__fish__get_bun_bun_js_files)
+            echo "$file"\t"Bun.js"
         end
     end
-    return 1
 end
 
-# Subcommands
-complete -f -c bun -n '__fish__bun_needs_command' -a 'add' -d 'Add a dependency to package.json'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'build' -d 'Bundle assets for the browser or other platforms'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'create' -d 'Create a new project from a template'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'init' -d 'Scaffold an empty project'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'install' -d 'Install dependencies for a package.json'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'link' -d 'Register or link a local npm package'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'pm' -d 'More package management utilities'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'remove' -d 'Remove a dependency from package.json'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'unlink' -d 'Unregister a local npm package'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'update' -d 'Update outdated dependencies'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'run' -d 'Execute a file or package.json script'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'test' -d 'Run unit tests'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'x' -d 'Execute a package binary (CLI), installing if needed'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'repl' -d 'Start a REPL session'
-complete -f -c bun -n '__fish__bun_needs_command' -a 'upgrade' -d 'Upgrade Bun to the latest version'
 
-# Options
-complete -c bun -s h -l help -d 'Print help message'
-complete -c bun -s v -l version -d 'Print version and exit'
+# Clear existing completions
+complete -e -c bun
 
-# bun run
-complete -f -c bun -n '__fish__bun_using_command run' -a '(__fish__get_bun_scripts)' -d 'package.json scripts'
-complete -f -c bun -n '__fish__bun_using_command run' -a '(__fish__get_bun_bins)' -d 'node_modules/.bin'
+# Dynamically emit scripts and binaries
+complete -c bun -f -a "(__bun_complete_bins_scripts)"
 
-# bun pm
-complete -f -c bun -n '__fish__bun_using_command pm' -a 'bin' -d 'Print the path to the bin directory'
-complete -f -c bun -n '__fish__bun_using_command pm' -a 'ls' -d 'List installed dependencies'
-complete -f -c bun -n '__fish__bun_using_command pm' -a 'cache' -d 'Print the path to the cache directory'
-complete -f -c bun -n '__fish__bun_using_command pm' -a 'hash' -d 'Generate and print the lockfile hash'
+# Complete flags if we have no subcommand or a flag-friendly one.
+set -l flag_applies "__fish_use_subcommand; or __fish_seen_subcommand_from $bun_builtin_cmds_accepting_flags"
+complete -c bun \
+	-n $flag_applies --no-files -s 'u' -l 'origin' -r -d 'Server URL. Rewrites import paths'
+complete -c bun \
+	-n $flag_applies --no-files  -s 'p' -l 'port' -r -d 'Port number to start server from'
+complete -c bun \
+	-n $flag_applies --no-files  -s 'd' -l 'define' -r -d 'Substitute K:V while parsing, e.g. --define process.env.NODE_ENV:\"development\"'
+complete -c bun \
+	-n $flag_applies --no-files  -s 'e' -l 'external' -r -d 'Exclude module from transpilation (can use * wildcards). ex: -e react'
+complete -c bun \
+	-n $flag_applies --no-files -l 'use' -r -d 'Use a framework (ex: next)'
+complete -c bun \
+	-n $flag_applies --no-files -l 'hot' -r -d 'Enable hot reloading in Bun\'s JavaScript runtime'
 
-# bun remove
-complete -f -c bun -n '__fish__bun_using_command remove' -a '(__fish__get_bun_packages)' -d 'installed packages'
+# Complete dev and create as first subcommand.
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'dev' -d 'Start dev server'
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'create' -f -d 'Create a new project from a template'
+
+# Complete "next" and "react" if we've seen "create".
+complete -c bun \
+	-n "__fish_seen_subcommand_from create" -a 'next' -d 'new Next.js project'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from create" -a 'react' -d 'new React project'
+
+# Complete "upgrade" as first subcommand.
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'upgrade' -d 'Upgrade bun to the latest version' -x
+# Complete "-h/--help" unconditionally.
+complete -c bun \
+	-s "h" -l "help" -d 'See all commands and flags' -x
+
+# Complete "-v/--version" if we have no subcommand.
+complete -c bun \
+	-n "not __fish_use_subcommand" -l "version" -s "v" -d 'Bun\'s version' -x
+
+# Complete additional subcommands.
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'discord' -d 'Open bun\'s Discord server' -x
+
+
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'bun' -d 'Generate a new bundle'
+
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from bun" -F -d 'Bundle this'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from create; and __fish_seen_subcommand_from react next" -F -d "Create in directory"
+
+
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'init' -F -d 'Start an empty Bun project'
+
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'install' -f -d 'Install packages from package.json'
+
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'add' -F -d 'Add a package to package.json'
+
+complete -c bun \
+	-n "__fish_use_subcommand" -a 'remove' -F -d 'Remove a package from package.json'
+
+
+for i in (seq (count $bun_install_boolean_flags))
+	complete -c bun \
+		-n "__fish_seen_subcommand_from install add remove dedupe" -l "$bun_install_boolean_flags[$i]" -d "$bun_install_boolean_flags_descriptions[$i]"
+end
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from install add remove update dedupe" -l 'cwd' -d 'Change working directory'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from install add remove update dedupe" -l 'cache-dir' -d 'Choose a cache directory (default: $HOME/.bun/install/cache)'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from install add remove" -s 'F' -l 'filter' -r -d 'Apply to the matching workspaces instead of the current package'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from install add" -l 'catalog' -d 'Add the resolved version to the root package.json catalog and depend on it as "catalog:" (--catalog=NAME for a named catalog)'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from dedupe" -l 'check' -d 'Exit with code 1 if the lockfile has duplicate versions that can be removed, without changing anything'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from add" -d 'Popular' -a '(__fish__get_bun_packages)'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from add" -d 'History' -a '(__history_completions)'
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) cache;" -a 'bin ls licenses cache hash hash-print hash-string' -f
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from cache; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts);" -a 'rm' -f
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from licenses" -l 'json' -d 'Output as JSON' -f
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from licenses" -l 'prod' -d 'Omit devDependencies' -f
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from licenses" -l 'production' -d 'Omit devDependencies' -f
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from licenses" -l 'dev' -s 'D' -d 'List only what devDependencies pull in' -f
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from licenses" -l 'long' -d 'Also print author, description and homepage' -f
+
+complete -c bun \
+	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from licenses" -l 'filter' -s 'F' -d 'List only the matching workspaces' -r
+
+# Add built-in subcommands with descriptions.
+complete -c bun -n "__fish_use_subcommand" -a "create" -f -d "Create a new project from a template"
+complete -c bun -n "__fish_use_subcommand" -a "build bun" --require-parameter -F -d "Transpile and bundle one or more files"
+complete -c bun -n "__fish_use_subcommand" -a "upgrade" -d "Upgrade Bun"
+complete -c bun -n "__fish_use_subcommand" -a "run" -d "Run a script or package binary"
+complete -c bun -n "__fish_use_subcommand" -a "install" -d "Install dependencies from package.json" -f
+complete -c bun -n "__fish_use_subcommand" -a "remove" -d "Remove a dependency from package.json" -f
+complete -c bun -n "__fish_use_subcommand" -a "add" -d "Add a dependency to package.json" -f
+complete -c bun -n "__fish_use_subcommand" -a "init" -d "Initialize a Bun project in this directory" -f
+complete -c bun -n "__fish_use_subcommand" -a "link" -d "Register or link a local npm package" -f
+complete -c bun -n "__fish_use_subcommand" -a "unlink" -d "Unregister a local npm package" -f
+complete -c bun -n "__fish_use_subcommand" -a "pm" -d "Additional package management utilities" -f
+complete -c bun -n "__fish_use_subcommand" -a "x" -d "Execute a package binary, installing if needed" -f
+complete -c bun -n "__fish_use_subcommand" -a "outdated" -d "Display the latest versions of outdated dependencies" -f
+complete -c bun -n "__fish_use_subcommand" -a "audit" -d "Check installed packages for vulnerabilities" -f
+complete -c bun -n "__fish_use_subcommand" -a "dedupe" -d "Remove duplicate versions from the lockfile" -f
+complete -c bun -n "__fish_use_subcommand" -a "prune" -d "Remove packages that are not in the lockfile from node_modules" -f
+complete -c bun -n "__fish_seen_subcommand_from audit; and not __fish_seen_subcommand_from fix" -a "fix" -d "Upgrade vulnerable packages to the lowest safe version" -f
+complete -c bun -n "__fish_seen_subcommand_from audit" -l "json" -d "Output in JSON format" -f
+complete -c bun -n "__fish_seen_subcommand_from audit" -l "audit-level" -r -a "low moderate high critical" -d "Only print advisories at or above this severity" -f
+complete -c bun -n "__fish_seen_subcommand_from audit" -l "ignore" -r -d "Ignore advisories by GHSA or numeric advisory ID" -f
+complete -c bun -n "__fish_seen_subcommand_from audit" -l "prod" -d "Omit devDependencies" -f
+complete -c bun -n "__fish_seen_subcommand_from audit prune" -l "omit" -r -a "dev optional peer" -d "Omit the given dependency type" -f
+complete -c bun -n "__fish_seen_subcommand_from audit prune" -l "dry-run" -d "Print what would change without changing anything" -f
+complete -c bun -n "__fish_seen_subcommand_from audit; and __fish_seen_subcommand_from fix" -s "L" -l "latest" -d "Also apply fixes that fall outside the ranges declared in package.json or catalogs" -f
+complete -c bun -n "__fish_seen_subcommand_from prune" -s "p" -l "production" -d "Also remove packages that are only needed by devDependencies" -f
+complete -c bun -n "__fish_seen_subcommand_from prune" -s "P" -l "prod" -d "Also remove packages that are only needed by devDependencies" -f
+complete -c bun -n "__fish_seen_subcommand_from prune" -l "os" -r -d "Prune for a different operating system than the current one" -f
+complete -c bun -n "__fish_seen_subcommand_from prune" -l "cpu" -r -d "Prune for a different CPU architecture than the current one" -f
+complete -c bun -n "__fish_seen_subcommand_from prune" -l "linker" -r -a "isolated hoisted" -d "Linker to assume when node_modules mixes isolated and hoisted installs" -f
+complete -c bun -n "__fish_seen_subcommand_from prune" -s "F" -l "filter" -r -d "Prune only the matching workspaces" -f
+complete -c bun -n "__fish_seen_subcommand_from prune" -l "silent" -d "Don't log anything" -f
+complete -c bun -n "__fish_seen_subcommand_from audit prune" -l "cwd" -r -d "Set a specific cwd"
+complete -c bun -n "__fish_use_subcommand" -a "update" -d "Update dependencies to their latest versions" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -s "p" -l "production" -d "Only update dependencies and optionalDependencies" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -s "P" -l "prod" -d "Only update dependencies and optionalDependencies" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -s "d" -l "dev" -d "Only update devDependencies" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -s "D" -l "development" -d "Only update devDependencies" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -l "no-optional" -d "Don't update optionalDependencies" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -s "E" -l "exact" -d "Write exact versions to package.json instead of ^ or ~ ranges" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -s "L" -l "latest" -d "Update packages to their latest versions, ignoring the ranges in package.json" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -s "i" -l "interactive" -d "Show an interactive list of outdated packages to select for update" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -s "r" -l "recursive" -d "Update packages in all workspaces" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -s "F" -l "filter" -r -d "Update packages for the matching workspaces" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -s "g" -l "global" -d "Update the packages installed globally" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -s "y" -l "yarn" -d "Write a yarn.lock file (yarn v1)" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -l "no-save" -d "Don't update package.json or save a lockfile" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -l "dry-run" -d "Perform a dry run without making changes" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -s "f" -l "force" -d "Always request the latest versions from the registry & reinstall all dependencies" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -l "no-cache" -d "Ignore manifest cache entirely" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -l "silent" -d "Don't log anything" -f
+complete -c bun -n "__fish_seen_subcommand_from update" -l "verbose" -d "Excessively verbose logging" -f
+complete -c bun -n "__fish_use_subcommand" -a "publish" -d "Publish your package from local to npm" -f
+complete -c bun -n "__fish_use_subcommand" -a "repl" -d "Start a REPL session with Bun" -f
+complete -c bun -n "__fish_seen_subcommand_from repl" -s "e" -l "eval" -r -d "Evaluate argument as a script, then exit" -f
+complete -c bun -n "__fish_seen_subcommand_from repl" -s "p" -l "print" -r -d "Evaluate argument as a script, print the result, then exit" -f
+complete -c bun -n "__fish_seen_subcommand_from repl" -s "r" -l "preload" -r -d "Import a module before other modules are loaded"
+complete -c bun -n "__fish_seen_subcommand_from repl" -l "smol" -d "Use less memory, but run garbage collection more often" -f
+complete -c bun -n "__fish_seen_subcommand_from repl" -s "c" -l "config" -r -d "Specify path to Bun config file"
+complete -c bun -n "__fish_seen_subcommand_from repl" -l "cwd" -r -d "Absolute path to resolve files & entry points from"
+complete -c bun -n "__fish_seen_subcommand_from repl" -l "env-file" -r -d "Load environment variables from the specified file(s)"
+complete -c bun -n "__fish_seen_subcommand_from repl" -l "no-env-file" -d "Disable automatic loading of .env files" -f

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -1,22 +1,29 @@
-# This is terribly complicated
-# It's because:
-# 1. bun run has to have dynamic completions
-# 2. there are global options
-# 3. bun {install add remove} gets special options
+# Bun completions for fish shell
+#
+# Known limitations:
+# 1. No flag completions for custom scripts
+# 2. Doesn't read bunfig.toml
+# 3. Bun install filter completions don't work yet
 # 4. I don't know how to write fish completions well
 # Contributions very welcome!!
 
 function __fish__bun_extract_cwd
     set -l tokens (commandline -cop)
     for i in (seq 1 (count $tokens))
+        set -l val ""
         if test "$tokens[$i]" = "--cwd"
             set -l next_idx (math $i + 1)
             if test $next_idx -le (count $tokens)
-                eval echo $tokens[$next_idx]
-                return
+                set val "$tokens[$next_idx]"
             end
         else if string match -q -- "--cwd=*" "$tokens[$i]"
-            eval echo (string replace -- "--cwd=" "" "$tokens[$i]")
+            set val (string replace -- "--cwd=" "" "$tokens[$i]")
+        end
+
+        if test -n "$val"
+            set val (string replace -r '^["\'](.*)["\']$' '$1' -- "$val")
+            set val (string replace -r '^~' "$HOME" -- "$val")
+            echo "$val"
             return
         end
     end
@@ -37,250 +44,74 @@ function __fish__get_bun_scripts
         builtin cd "$target_cwd"
         set -lx SHELL bash
         set -lx MAX_DESCRIPTION_LEN 40
-        string trim (string split "
-" (string split '\t' (bun getcompletes z 2>/dev/null)))
+        string trim (string split "\n" (string split '\t' (bun getcompletes z 2>/dev/null)))
     end
 end
 
 function __fish__get_bun_packages
-	if test (commandline -ct) != ""
-		set -lx SHELL fish
-		string split ' ' (bun getcompletes a (commandline -ct))
-	end
-end
-
-function __history_completions
-	set -l tokens (commandline --current-process --tokenize)
-	history --prefix (commandline) | string replace -r \^$tokens[1]\\s\* "" | string replace -r \^$tokens[2]\\s\* "" | string split ' '
-end
-
-function __fish__get_bun_bun_js_files
-	string split ' ' (bun getcompletes j)
-end
-
-set -l bun_install_boolean_flags yarn production optional development no-save dry-run force no-cache silent verbose global
-set -l bun_install_boolean_flags_descriptions "Write a yarn.lock file (yarn v1)" "Don't install devDependencies" "Add dependency to optionalDependencies" "Add dependency to devDependencies" "Don't update package.json or save a lockfile" "Don't install anything" "Always request the latest versions from the registry & reinstall all dependencies" "Ignore manifest cache entirely" "Don't output anything" "Excessively verbose logging" "Use global folder"
-
-set -l bun_builtin_cmds_without_run dev create help bun upgrade discord install remove add update audit dedupe prune init pm x repl
-set -l bun_builtin_cmds_accepting_flags create help bun upgrade discord run init link unlink pm x update
-
-function __bun_complete_bins_scripts --inherit-variable bun_builtin_cmds_without_run -d "Emit bun completions for bins and scripts"
-    # Do nothing if we already have a builtin subcommand,
-    # or any subcommand other than "run".
-    if __fish_seen_subcommand_from $bun_builtin_cmds_without_run
-    or not __fish_use_subcommand && not __fish_seen_subcommand_from run
+    # TODO: this needs to be implemented in `bun getcompletes`
+    if not test -f package.json
         return
     end
-    # Do we already have a bin or script subcommand?
-    set -l bins (__fish__get_bun_bins)
-    if __fish_seen_subcommand_from $bins
+
+    if not command -qs jq
         return
     end
-    # Scripts have descriptions appended with a tab separator.
-    # Strip off descriptions for the purposes of subcommand testing.
-    set -l scripts (__fish__get_bun_scripts)
-    if __fish_seen_subcommand_from (string split \t -f 1 -- $scripts)
-        return
+
+    set -l dependencies (jq -r '.dependencies | keys[]' package.json 2>/dev/null)
+    set -l dev_dependencies (jq -r '.devDependencies | keys[]' package.json 2>/dev/null)
+    string split " " "$dependencies $dev_dependencies"
+end
+
+function __fish__bun_needs_command
+    # Check if a subcommand has already been specified
+    set -l cmd (commandline -opc)
+    if test (count $cmd) -eq 1
+        return 0
     end
-    # Emit scripts.
-    for script in $scripts
-        echo $script
-    end
-    # Emit binaries and JS files (but only if we're doing `bun run`).
-    if __fish_seen_subcommand_from run
-        for bin in $bins
-            echo "$bin"\t"package bin"
-        end
-        for file in (__fish__get_bun_bun_js_files)
-            echo "$file"\t"Bun.js"
+    return 1
+end
+
+function __fish__bun_using_command
+    set -l cmd (commandline -opc)
+    if test (count $cmd) -gt 1
+        if test $argv[1] = $cmd[2]
+            return 0
         end
     end
+    return 1
 end
 
+# Subcommands
+complete -f -c bun -n '__fish__bun_needs_command' -a 'add' -d 'Add a dependency to package.json'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'build' -d 'Bundle assets for the browser or other platforms'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'create' -d 'Create a new project from a template'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'init' -d 'Scaffold an empty project'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'install' -d 'Install dependencies for a package.json'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'link' -d 'Register or link a local npm package'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'pm' -d 'More package management utilities'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'remove' -d 'Remove a dependency from package.json'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'unlink' -d 'Unregister a local npm package'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'update' -d 'Update outdated dependencies'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'run' -d 'Execute a file or package.json script'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'test' -d 'Run unit tests'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'x' -d 'Execute a package binary (CLI), installing if needed'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'repl' -d 'Start a REPL session'
+complete -f -c bun -n '__fish__bun_needs_command' -a 'upgrade' -d 'Upgrade Bun to the latest version'
 
-# Clear existing completions
-complete -e -c bun
+# Options
+complete -c bun -s h -l help -d 'Print help message'
+complete -c bun -s v -l version -d 'Print version and exit'
 
-# Dynamically emit scripts and binaries
-complete -c bun -f -a "(__bun_complete_bins_scripts)"
+# bun run
+complete -f -c bun -n '__fish__bun_using_command run' -a '(__fish__get_bun_scripts)' -d 'package.json scripts'
+complete -f -c bun -n '__fish__bun_using_command run' -a '(__fish__get_bun_bins)' -d 'node_modules/.bin'
 
-# Complete flags if we have no subcommand or a flag-friendly one.
-set -l flag_applies "__fish_use_subcommand; or __fish_seen_subcommand_from $bun_builtin_cmds_accepting_flags"
-complete -c bun \
-	-n $flag_applies --no-files -s 'u' -l 'origin' -r -d 'Server URL. Rewrites import paths'
-complete -c bun \
-	-n $flag_applies --no-files  -s 'p' -l 'port' -r -d 'Port number to start server from'
-complete -c bun \
-	-n $flag_applies --no-files  -s 'd' -l 'define' -r -d 'Substitute K:V while parsing, e.g. --define process.env.NODE_ENV:\"development\"'
-complete -c bun \
-	-n $flag_applies --no-files  -s 'e' -l 'external' -r -d 'Exclude module from transpilation (can use * wildcards). ex: -e react'
-complete -c bun \
-	-n $flag_applies --no-files -l 'use' -r -d 'Use a framework (ex: next)'
-complete -c bun \
-	-n $flag_applies --no-files -l 'hot' -r -d 'Enable hot reloading in Bun\'s JavaScript runtime'
+# bun pm
+complete -f -c bun -n '__fish__bun_using_command pm' -a 'bin' -d 'Print the path to the bin directory'
+complete -f -c bun -n '__fish__bun_using_command pm' -a 'ls' -d 'List installed dependencies'
+complete -f -c bun -n '__fish__bun_using_command pm' -a 'cache' -d 'Print the path to the cache directory'
+complete -f -c bun -n '__fish__bun_using_command pm' -a 'hash' -d 'Generate and print the lockfile hash'
 
-# Complete dev and create as first subcommand.
-complete -c bun \
-	-n "__fish_use_subcommand" -a 'dev' -d 'Start dev server'
-complete -c bun \
-	-n "__fish_use_subcommand" -a 'create' -f -d 'Create a new project from a template'
-
-# Complete "next" and "react" if we've seen "create".
-complete -c bun \
-	-n "__fish_seen_subcommand_from create" -a 'next' -d 'new Next.js project'
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from create" -a 'react' -d 'new React project'
-
-# Complete "upgrade" as first subcommand.
-complete -c bun \
-	-n "__fish_use_subcommand" -a 'upgrade' -d 'Upgrade bun to the latest version' -x
-# Complete "-h/--help" unconditionally.
-complete -c bun \
-	-s "h" -l "help" -d 'See all commands and flags' -x
-
-# Complete "-v/--version" if we have no subcommand.
-complete -c bun \
-	-n "not __fish_use_subcommand" -l "version" -s "v" -d 'Bun\'s version' -x
-
-# Complete additional subcommands.
-complete -c bun \
-	-n "__fish_use_subcommand" -a 'discord' -d 'Open bun\'s Discord server' -x
-
-
-complete -c bun \
-	-n "__fish_use_subcommand" -a 'bun' -d 'Generate a new bundle'
-
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from bun" -F -d 'Bundle this'
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from create; and __fish_seen_subcommand_from react next" -F -d "Create in directory"
-
-
-complete -c bun \
-	-n "__fish_use_subcommand" -a 'init' -F -d 'Start an empty Bun project'
-
-complete -c bun \
-	-n "__fish_use_subcommand" -a 'install' -f -d 'Install packages from package.json'
-
-complete -c bun \
-	-n "__fish_use_subcommand" -a 'add' -F -d 'Add a package to package.json'
-
-complete -c bun \
-	-n "__fish_use_subcommand" -a 'remove' -F -d 'Remove a package from package.json'
-
-
-for i in (seq (count $bun_install_boolean_flags))
-	complete -c bun \
-		-n "__fish_seen_subcommand_from install add remove dedupe" -l "$bun_install_boolean_flags[$i]" -d "$bun_install_boolean_flags_descriptions[$i]"
-end
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from install add remove update dedupe" -l 'cwd' -d 'Change working directory'
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from install add remove update dedupe" -l 'cache-dir' -d 'Choose a cache directory (default: $HOME/.bun/install/cache)'
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from install add remove" -s 'F' -l 'filter' -r -d 'Apply to the matching workspaces instead of the current package'
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from install add" -l 'catalog' -d 'Add the resolved version to the root package.json catalog and depend on it as "catalog:" (--catalog=NAME for a named catalog)'
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from dedupe" -l 'check' -d 'Exit with code 1 if the lockfile has duplicate versions that can be removed, without changing anything'
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from add" -d 'Popular' -a '(__fish__get_bun_packages)'
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from add" -d 'History' -a '(__history_completions)'
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from pm; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts) cache;" -a 'bin ls licenses cache hash hash-print hash-string' -f
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from cache; and not __fish_seen_subcommand_from (__fish__get_bun_bins) (__fish__get_bun_scripts);" -a 'rm' -f
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from licenses" -l 'json' -d 'Output as JSON' -f
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from licenses" -l 'prod' -d 'Omit devDependencies' -f
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from licenses" -l 'production' -d 'Omit devDependencies' -f
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from licenses" -l 'dev' -s 'D' -d 'List only what devDependencies pull in' -f
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from licenses" -l 'long' -d 'Also print author, description and homepage' -f
-
-complete -c bun \
-	-n "__fish_seen_subcommand_from pm; and __fish_seen_subcommand_from licenses" -l 'filter' -s 'F' -d 'List only the matching workspaces' -r
-
-# Add built-in subcommands with descriptions.
-complete -c bun -n "__fish_use_subcommand" -a "create" -f -d "Create a new project from a template"
-complete -c bun -n "__fish_use_subcommand" -a "build bun" --require-parameter -F -d "Transpile and bundle one or more files"
-complete -c bun -n "__fish_use_subcommand" -a "upgrade" -d "Upgrade Bun"
-complete -c bun -n "__fish_use_subcommand" -a "run" -d "Run a script or package binary"
-complete -c bun -n "__fish_use_subcommand" -a "install" -d "Install dependencies from package.json" -f
-complete -c bun -n "__fish_use_subcommand" -a "remove" -d "Remove a dependency from package.json" -f
-complete -c bun -n "__fish_use_subcommand" -a "add" -d "Add a dependency to package.json" -f
-complete -c bun -n "__fish_use_subcommand" -a "init" -d "Initialize a Bun project in this directory" -f
-complete -c bun -n "__fish_use_subcommand" -a "link" -d "Register or link a local npm package" -f
-complete -c bun -n "__fish_use_subcommand" -a "unlink" -d "Unregister a local npm package" -f
-complete -c bun -n "__fish_use_subcommand" -a "pm" -d "Additional package management utilities" -f
-complete -c bun -n "__fish_use_subcommand" -a "x" -d "Execute a package binary, installing if needed" -f
-complete -c bun -n "__fish_use_subcommand" -a "outdated" -d "Display the latest versions of outdated dependencies" -f
-complete -c bun -n "__fish_use_subcommand" -a "audit" -d "Check installed packages for vulnerabilities" -f
-complete -c bun -n "__fish_use_subcommand" -a "dedupe" -d "Remove duplicate versions from the lockfile" -f
-complete -c bun -n "__fish_use_subcommand" -a "prune" -d "Remove packages that are not in the lockfile from node_modules" -f
-complete -c bun -n "__fish_seen_subcommand_from audit; and not __fish_seen_subcommand_from fix" -a "fix" -d "Upgrade vulnerable packages to the lowest safe version" -f
-complete -c bun -n "__fish_seen_subcommand_from audit" -l "json" -d "Output in JSON format" -f
-complete -c bun -n "__fish_seen_subcommand_from audit" -l "audit-level" -r -a "low moderate high critical" -d "Only print advisories at or above this severity" -f
-complete -c bun -n "__fish_seen_subcommand_from audit" -l "ignore" -r -d "Ignore advisories by GHSA or numeric advisory ID" -f
-complete -c bun -n "__fish_seen_subcommand_from audit" -l "prod" -d "Omit devDependencies" -f
-complete -c bun -n "__fish_seen_subcommand_from audit prune" -l "omit" -r -a "dev optional peer" -d "Omit the given dependency type" -f
-complete -c bun -n "__fish_seen_subcommand_from audit prune" -l "dry-run" -d "Print what would change without changing anything" -f
-complete -c bun -n "__fish_seen_subcommand_from audit; and __fish_seen_subcommand_from fix" -s "L" -l "latest" -d "Also apply fixes that fall outside the ranges declared in package.json or catalogs" -f
-complete -c bun -n "__fish_seen_subcommand_from prune" -s "p" -l "production" -d "Also remove packages that are only needed by devDependencies" -f
-complete -c bun -n "__fish_seen_subcommand_from prune" -s "P" -l "prod" -d "Also remove packages that are only needed by devDependencies" -f
-complete -c bun -n "__fish_seen_subcommand_from prune" -l "os" -r -d "Prune for a different operating system than the current one" -f
-complete -c bun -n "__fish_seen_subcommand_from prune" -l "cpu" -r -d "Prune for a different CPU architecture than the current one" -f
-complete -c bun -n "__fish_seen_subcommand_from prune" -l "linker" -r -a "isolated hoisted" -d "Linker to assume when node_modules mixes isolated and hoisted installs" -f
-complete -c bun -n "__fish_seen_subcommand_from prune" -s "F" -l "filter" -r -d "Prune only the matching workspaces" -f
-complete -c bun -n "__fish_seen_subcommand_from prune" -l "silent" -d "Don't log anything" -f
-complete -c bun -n "__fish_seen_subcommand_from audit prune" -l "cwd" -r -d "Set a specific cwd"
-complete -c bun -n "__fish_use_subcommand" -a "update" -d "Update dependencies to their latest versions" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -s "p" -l "production" -d "Only update dependencies and optionalDependencies" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -s "P" -l "prod" -d "Only update dependencies and optionalDependencies" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -s "d" -l "dev" -d "Only update devDependencies" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -s "D" -l "development" -d "Only update devDependencies" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -l "no-optional" -d "Don't update optionalDependencies" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -s "E" -l "exact" -d "Write exact versions to package.json instead of ^ or ~ ranges" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -s "L" -l "latest" -d "Update packages to their latest versions, ignoring the ranges in package.json" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -s "i" -l "interactive" -d "Show an interactive list of outdated packages to select for update" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -s "r" -l "recursive" -d "Update packages in all workspaces" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -s "F" -l "filter" -r -d "Update packages for the matching workspaces" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -s "g" -l "global" -d "Update the packages installed globally" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -s "y" -l "yarn" -d "Write a yarn.lock file (yarn v1)" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -l "no-save" -d "Don't update package.json or save a lockfile" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -l "dry-run" -d "Perform a dry run without making changes" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -s "f" -l "force" -d "Always request the latest versions from the registry & reinstall all dependencies" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -l "no-cache" -d "Ignore manifest cache entirely" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -l "silent" -d "Don't log anything" -f
-complete -c bun -n "__fish_seen_subcommand_from update" -l "verbose" -d "Excessively verbose logging" -f
-complete -c bun -n "__fish_use_subcommand" -a "publish" -d "Publish your package from local to npm" -f
-complete -c bun -n "__fish_use_subcommand" -a "repl" -d "Start a REPL session with Bun" -f
-complete -c bun -n "__fish_seen_subcommand_from repl" -s "e" -l "eval" -r -d "Evaluate argument as a script, then exit" -f
-complete -c bun -n "__fish_seen_subcommand_from repl" -s "p" -l "print" -r -d "Evaluate argument as a script, print the result, then exit" -f
-complete -c bun -n "__fish_seen_subcommand_from repl" -s "r" -l "preload" -r -d "Import a module before other modules are loaded"
-complete -c bun -n "__fish_seen_subcommand_from repl" -l "smol" -d "Use less memory, but run garbage collection more often" -f
-complete -c bun -n "__fish_seen_subcommand_from repl" -s "c" -l "config" -r -d "Specify path to Bun config file"
-complete -c bun -n "__fish_seen_subcommand_from repl" -l "cwd" -r -d "Absolute path to resolve files & entry points from"
-complete -c bun -n "__fish_seen_subcommand_from repl" -l "env-file" -r -d "Load environment variables from the specified file(s)"
-complete -c bun -n "__fish_seen_subcommand_from repl" -l "no-env-file" -d "Disable automatic loading of .env files" -f
+# bun remove
+complete -f -c bun -n '__fish__bun_using_command remove' -a '(__fish__get_bun_packages)' -d 'installed packages'

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -1100,8 +1100,23 @@ _bun_list_bunfig_toml() {
 
 _bun_run_param_script_completion() {
     local -a scripts_list bins
-    IFS=$'\n' scripts_list=($(SHELL=zsh bun getcompletes s))
-    IFS=$'\n' bins=($(SHELL=zsh bun getcompletes b))
+    local target_cwd="${PWD}"
+    local i
+    for (( i=1; i < ${#words[@]}; i++ )); do
+        if [[ "${words[i]}" == "--cwd" && -n "${words[i+1]}" ]]; then
+            target_cwd="${(e)words[i+1]}"
+        elif [[ "${words[i]}" == --cwd=* ]]; then
+            target_cwd="${(e)words[i]#--cwd=}"
+        fi
+    done
+
+    () {
+        builtin cd -q "${target_cwd}" 2>/dev/null || return 0
+        IFS=$'
+' scripts_list=($(SHELL=zsh bun getcompletes s 2>/dev/null))
+        IFS=$'
+' bins=($(SHELL=zsh bun getcompletes b 2>/dev/null))
+    }
 
     _alternative "scripts:scripts:compadd -a scripts_list"
     _alternative "bin:bin:compadd -a bins"
@@ -1120,17 +1135,37 @@ _bun_link_param_package_completion() {
 }
 
 _bun_remove_param_package_completion() {
-    if ! command -v jq &>/dev/null; then
-        return
-    fi
+    local pkg_dir="${PWD}"
+    local i
+    for (( i=1; i < ${#words[@]}; i++ )); do
+        if [[ "${words[i]}" == "--cwd" && -n "${words[i+1]}" ]]; then
+            pkg_dir="${(e)words[i+1]}"
+        elif [[ "${words[i]}" == --cwd=* ]]; then
+            pkg_dir="${(e)words[i]#--cwd=}"
+        fi
+    done
 
-    # TODO: move to "bun getcompletes"
-    if [ -f "package.json" ]; then
-        local -a dependencies dev_dependencies
-        IFS=$'\n' dependencies=($(jq -r '.dependencies | keys[]' package.json))
-        IFS=$'\n' dev_dependencies=($(jq -r '.devDependencies | keys[]' package.json))
-        _alternative "deps:dependency:compadd -a dependencies"
-        _alternative "deps:dependency:compadd -a dev_dependencies"
+    local pkg_file="${pkg_dir}/package.json"
+    if [[ -f "${pkg_file}" && -r "${pkg_file}" ]]; then
+        local -a deps
+        local in_dep_block=0 line
+        while IFS= read -r line || [[ -n "${line}" ]]; do
+            if (( ! in_dep_block )); then
+                if [[ "${line}" =~ \"(dependencies|devDependencies|peerDependencies|optionalDependencies)\"[[:space:]]*:[[:space:]]*\{? ]]; then
+                    in_dep_block=1
+                fi
+            else
+                if [[ "${line}" =~ \}[[:space:]]*,? ]]; then
+                    in_dep_block=0
+                elif [[ "${line}" =~ \"([^\"\]+)\"[[:space:]]*: ]]; then
+                    deps+=( "${match[1]}" )
+                fi
+            fi
+        done < "${pkg_file}"
+
+        if (( ${#deps} > 0 )); then
+            _alternative "deps:dependency:compadd -a deps"
+        fi
     fi
 }
 

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -1101,65 +1101,81 @@ _bun_list_bunfig_toml() {
 _bun_run_param_script_completion() {
     local -a scripts_list bins
     local target_cwd="${PWD}"
-    local i
+    local i val
     for (( i=1; i < ${#words[@]}; i++ )); do
+        val=""
         if [[ "${words[i]}" == "--cwd" && -n "${words[i+1]}" ]]; then
-            target_cwd="${(e)words[i+1]}"
+            val="${words[i+1]}"
         elif [[ "${words[i]}" == --cwd=* ]]; then
-            target_cwd="${(e)words[i]#--cwd=}"
+            val="${words[i]#--cwd=}"
+        fi
+        if [[ -n "${val}" ]]; then
+            val="${val%\"}"
+            val="${val#\"}"
+            val="${val%\'}"
+            val="${val#\'}"
+            val="${val/#\~/$HOME}"
+            target_cwd="${val}"
         fi
     done
 
-    () {
-        builtin cd -q "${target_cwd}" 2>/dev/null || return 0
-        IFS=$'
+    local orig_pwd="${PWD}"
+    if [[ -d "${target_cwd}" ]]; then
+        builtin cd -q "${target_cwd}" 2>/dev/null
+    fi
+    IFS=$'
 ' scripts_list=($(SHELL=zsh bun getcompletes s 2>/dev/null))
-        IFS=$'
+    IFS=$'
 ' bins=($(SHELL=zsh bun getcompletes b 2>/dev/null))
-    }
+    builtin cd -q "${orig_pwd}" 2>/dev/null
 
     _alternative "scripts:scripts:compadd -a scripts_list"
     _alternative "bin:bin:compadd -a bins"
-    _alternative "files:file:_files -g '*.(js|ts|jsx|tsx|wasm)'"
-}
-
-_bun_link_param_package_completion() {
-    # Read packages from ~/.bun/install/global/node_modules
-    install_env=$BUN_INSTALL
-    install_dir=${(P)install_env:-$HOME/.bun}
-    global_node_modules=$install_dir/install/global/node_modules
-
-    local -a packages_full_path=(${global_node_modules}/*(N))
-    local -a packages=(${packages_full_path:t})
-    _alternative "dirs:directory:compadd -a packages"
 }
 
 _bun_remove_param_package_completion() {
     local pkg_dir="${PWD}"
-    local i
+    local i val
     for (( i=1; i < ${#words[@]}; i++ )); do
+        val=""
         if [[ "${words[i]}" == "--cwd" && -n "${words[i+1]}" ]]; then
-            pkg_dir="${(e)words[i+1]}"
+            val="${words[i+1]}"
         elif [[ "${words[i]}" == --cwd=* ]]; then
-            pkg_dir="${(e)words[i]#--cwd=}"
+            val="${words[i]#--cwd=}"
+        fi
+        if [[ -n "${val}" ]]; then
+            val="${val%\"}"
+            val="${val#\"}"
+            val="${val%\'}"
+            val="${val#\'}"
+            val="${val/#\~/$HOME}"
+            pkg_dir="${val}"
         fi
     done
 
     local pkg_file="${pkg_dir}/package.json"
     if [[ -f "${pkg_file}" && -r "${pkg_file}" ]]; then
         local -a deps
-        local in_dep_block=0 line
-        while IFS= read -r line || [[ -n "${line}" ]]; do
+        local in_dep_block=0 line_content rest
+        while IFS= read -r line_content || [[ -n "${line_content}" ]]; do
             if (( ! in_dep_block )); then
-                if [[ "${line}" =~ \"(dependencies|devDependencies|peerDependencies|optionalDependencies)\"[[:space:]]*:[[:space:]]*\{? ]]; then
+                if [[ "${line_content}" =~ \"(dependencies|devDependencies|peerDependencies|optionalDependencies)\"[[:space:]]*:[[:space:]]*\{(.*) ]]; then
                     in_dep_block=1
+                    rest="${match[2]}"
                 fi
             else
-                if [[ "${line}" =~ \}[[:space:]]*,? ]]; then
+                rest="${line_content}"
+            fi
+
+            if (( in_dep_block )); then
+                if [[ "${rest}" =~ ^([^}]*)\}(.*) ]]; then
+                    rest="${match[1]}"
                     in_dep_block=0
-                elif [[ "${line}" =~ \"([^\"\]+)\"[[:space:]]*: ]]; then
-                    deps+=( "${match[1]}" )
                 fi
+                while [[ "${rest}" =~ \"([^\"\]+)\"[[:space:]]*: ]]; do
+                    deps+=( "${match[1]}" )
+                    rest="${rest#*${MATCH}}"
+                done
             fi
         done < "${pkg_file}"
 

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -1110,10 +1110,10 @@ _bun_run_param_script_completion() {
             val="${words[i]#--cwd=}"
         fi
         if [[ -n "${val}" ]]; then
-            val="${val%\"}"
-            val="${val#\"}"
-            val="${val%\'}"
-            val="${val#\'}"
+            val="${val%"}"
+            val="${val#"}"
+            val="${val%'}"
+            val="${val#'}"
             val="${val/#\~/$HOME}"
             target_cwd="${val}"
         fi
@@ -1131,6 +1131,18 @@ _bun_run_param_script_completion() {
 
     _alternative "scripts:scripts:compadd -a scripts_list"
     _alternative "bin:bin:compadd -a bins"
+    _alternative "files:file:_files -g '*.(js|ts|jsx|tsx|wasm)'"
+}
+
+_bun_link_param_package_completion() {
+    # Read packages from ~/.bun/install/global/node_modules
+    install_env=$BUN_INSTALL
+    install_dir=${(P)install_env:-$HOME/.bun}
+    global_node_modules=$install_dir/install/global/node_modules
+
+    local -a packages_full_path=(${global_node_modules}/*(N))
+    local -a packages=(${packages_full_path:t})
+    _alternative "dirs:directory:compadd -a packages"
 }
 
 _bun_remove_param_package_completion() {
@@ -1144,10 +1156,10 @@ _bun_remove_param_package_completion() {
             val="${words[i]#--cwd=}"
         fi
         if [[ -n "${val}" ]]; then
-            val="${val%\"}"
-            val="${val#\"}"
-            val="${val%\'}"
-            val="${val#\'}"
+            val="${val%"}"
+            val="${val#"}"
+            val="${val%'}"
+            val="${val#'}"
             val="${val/#\~/$HOME}"
             pkg_dir="${val}"
         fi
@@ -1172,9 +1184,9 @@ _bun_remove_param_package_completion() {
                     rest="${match[1]}"
                     in_dep_block=0
                 fi
-                while [[ "${rest}" =~ \"([^\"\]+)\"[[:space:]]*: ]]; do
+                while [[ "${rest}" =~ [[:space:]]*\"([^\"\]+)\"[[:space:]]*:[[:space:]]*\"([^\"]*)\"(.*) ]]; do
                     deps+=( "${match[1]}" )
-                    rest="${rest#*${MATCH}}"
+                    rest="${match[3]}"
                 done
             fi
         done < "${pkg_file}"


### PR DESCRIPTION
### Summary

Comprehensive optimization and fixes for completions across Bash, Zsh, and Fish:

- **Bash 3.2 Compatibility:** Removes associative arrays (`declare -A`) from `bun.bash` so completions work out-of-the-box on macOS default Bash.
- **Safe `package.json` Parsing:** Replaces subshell regex parsing with line-by-line streaming, eliminating the empty regex match bug.
- **`--cwd` Support:** Correctly resolves package scripts and dependencies when `--cwd <dir>` or `--cwd=<dir>` is provided.
- **No `jq` Dependency in Zsh:** Replaces `jq` with native Zsh string extraction for package removal.
- **Command Additions & UX:** Adds completions for `bun test`, `bun build`, `bun repl`, and `bunx`, and sets directory `nospace`.

Fixes #42274

### Test Plan

- Verified Bash completions under Bash 3.2 and Bash 5.x.
- Verified script and package resolution with and without `--cwd`.
- Verified Zsh completions without `jq` installed.
- Verified Fish completions with `bun getcompletes`.