### PR TITLE
node:fs: support O_NOFOLLOW in fs.open on Windows

### DIFF
--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -22,10 +22,11 @@ import { LIBC_ALLOCATION_SYMBOLS } from "../source.ts";
 // can be uv__free'd under uv_replace_allocator (oven-sh/libuv#14), Winsock /
 // console-resize watcher / suspend-resume detection initialized on first use
 // instead of in uv__init, with uv__winsock_ensure() for callers that reach
-// ws2_32 directly (oven-sh/libuv#15), and LoadLibraryExW for those lazy
-// loads (oven-sh/libuv#16).
+// ws2_32 directly (oven-sh/libuv#15), LoadLibraryExW for those lazy
+// loads (oven-sh/libuv#16), and UV_FS_O_NOFOLLOW mapped to
+// FILE_FLAG_OPEN_REPARSE_POINT in uv_fs_open (oven-sh/libuv#18).
 // To bump, update `bun`.
-const LIBUV_COMMIT = "8023581113b276e7c1aee3f82da57ca0893faab1";
+const LIBUV_COMMIT = "e337c914f78012babb43eb2a44c3e32b42abe7eb";
 
 // prettier-ignore
 const SHARED = [

--- a/src/jsc/bindings/ProcessBindingConstants.cpp
+++ b/src/jsc/bindings/ProcessBindingConstants.cpp
@@ -741,6 +741,8 @@ static JSValue processBindingConstantsGetFs(VM& vm, JSObject* bindingObject)
 #endif
 #ifdef O_NOFOLLOW
         { "O_NOFOLLOW", static_cast<double>(O_NOFOLLOW) },
+#elif OS(WINDOWS)
+        { "O_NOFOLLOW", static_cast<double>(UV_FS_O_NOFOLLOW) },
 #endif
 #ifdef O_SYNC
         { "O_SYNC", static_cast<double>(O_SYNC) },

--- a/src/jsc/modules/NodeConstantsModule.h
+++ b/src/jsc/modules/NodeConstantsModule.h
@@ -670,6 +670,8 @@ DEFINE_NATIVE_MODULE(NodeConstants)
 #endif
 #ifdef O_NOFOLLOW
         { "O_NOFOLLOW", static_cast<double>(O_NOFOLLOW) },
+#elif OS(WINDOWS)
+        { "O_NOFOLLOW", static_cast<double>(UV_FS_O_NOFOLLOW) },
 #endif
 #ifdef O_SYNC
         { "O_SYNC", static_cast<double>(O_SYNC) },

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -2365,12 +2365,13 @@ pub mod O {
     pub(crate) const DIRECT: i32 = 0x0200_0000;
     pub(crate) const DSYNC: i32 = 0x0400_0000;
     pub(crate) const SYNC: i32 = 0x0800_0000;
+    /// `FILE_FLAG_OPEN_REPARSE_POINT`. oven-sh/libuv only: upstream has 0 here.
+    pub(crate) const NOFOLLOW: i32 = 0x0100_0000;
     // No-ops on Windows.
     pub const DIRECTORY: i32 = 0;
     pub const EXLOCK: i32 = 0x1000_0000;
     pub const NOATIME: i32 = 0;
     pub const NOCTTY: i32 = 0;
-    pub(crate) const NOFOLLOW: i32 = 0;
     pub const NONBLOCK: i32 = 0;
     pub const SYMLINK: i32 = 0;
 
@@ -2469,6 +2470,9 @@ pub mod O {
             flags |= bun_o::SYNC;
         } else if uv_flags & DSYNC != 0 {
             flags |= bun_o::DSYNC;
+        }
+        if uv_flags & NOFOLLOW != 0 {
+            flags |= bun_o::NOFOLLOW;
         }
         if uv_flags & DIRECT != 0 {
             flags |= bun_o::DIRECT;

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5016,6 +5016,7 @@ it("fs.constants", () => {
       UV_FS_O_FILEMAP: 536870912,
       O_TRUNC: 512,
       O_APPEND: 8,
+      O_NOFOLLOW: 16777216,
       S_IRUSR: 256,
       S_IWUSR: 128,
       F_OK: 0,
@@ -5820,6 +5821,120 @@ it.if(isWindows)("writing to windows hidden file is possible", () => {
   writeFileSync(join(temp, "file.txt"), "Hello World");
   const content = readFileSync(join(temp, "file.txt"), "utf8");
   expect(content).toBe("Hello World");
+});
+
+describe.if(isWindows)("O_NOFOLLOW on Windows", () => {
+  const { O_RDONLY, O_WRONLY, O_CREAT, O_TRUNC, O_NOFOLLOW } = constants;
+
+  // A junction (`mklink /J`) and a file symlink, each next to its target.
+  function setup() {
+    const dir = tempDir("fs-open-nofollow", { "target-dir": { "inner.txt": "inner" }, "target.txt": "target data" });
+    const root = String(dir);
+    const mklink = spawnSync(
+      ["cmd.exe", "/d", "/c", "mklink", "/J", join(root, "junction"), join(root, "target-dir")],
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    expect({ stderr: mklink.stderr.toString(), exitCode: mklink.exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    symlinkSync(join(root, "target.txt"), join(root, "file-link"), "file");
+    return dir;
+  }
+
+  function inoOfOpen(file: string, flags: number) {
+    const fd = openSync(file, flags);
+    try {
+      return fstatSync(fd, { bigint: true }).ino;
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  function readOpen(file: string, flags: number) {
+    const fd = openSync(file, flags);
+    try {
+      return readFileSync(fd, "utf8");
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  it.each(["junction", "file-link"])("openSync opens a %s itself", name => {
+    using dir = setup();
+    const link = join(String(dir), name);
+    const target = statSync(link, { bigint: true }).ino;
+    const self = lstatSync(link, { bigint: true }).ino;
+    expect(self).not.toBe(target);
+    expect({
+      follow: inoOfOpen(link, O_RDONLY),
+      nofollow: inoOfOpen(link, O_RDONLY | O_NOFOLLOW),
+    }).toEqual({ follow: target, nofollow: self });
+  });
+
+  it("a file symlink has no data of its own", () => {
+    using dir = setup();
+    const link = join(String(dir), "file-link");
+    expect({
+      follow: readOpen(link, O_RDONLY),
+      nofollow: readOpen(link, O_RDONLY | O_NOFOLLOW),
+    }).toEqual({ follow: "target data", nofollow: "" });
+  });
+
+  it("a write does not reach the target of a file symlink", () => {
+    using dir = setup();
+    const root = String(dir);
+    const link = join(root, "file-link");
+
+    const fd = openSync(link, O_WRONLY | O_NOFOLLOW);
+    try {
+      writeSync(fd, "written");
+    } finally {
+      closeSync(fd);
+    }
+    // writeFileSync opens through NtCreateFile, openSync through libuv.
+    writeFileSync(link, "written", { flag: O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW });
+    expect(readFileSync(join(root, "target.txt"), "utf8")).toBe("target data");
+
+    writeFileSync(link, "written");
+    expect(readFileSync(join(root, "target.txt"), "utf8")).toBe("written");
+  });
+
+  it("promises.open and fs.open open a junction itself", async () => {
+    using dir = setup();
+    const link = join(String(dir), "junction");
+    const self = lstatSync(link, { bigint: true }).ino;
+
+    const handle = await promises.open(link, O_RDONLY | O_NOFOLLOW);
+    try {
+      expect((await handle.stat({ bigint: true })).ino).toBe(self);
+    } finally {
+      await handle.close();
+    }
+
+    const fd = await promisify(fs.open)(link, O_RDONLY | O_NOFOLLOW);
+    try {
+      expect(fstatSync(fd, { bigint: true }).ino).toBe(self);
+    } finally {
+      closeSync(fd);
+    }
+  });
+
+  it("has no effect on a path that is not a link", () => {
+    using dir = setup();
+    const root = String(dir);
+    expect(readOpen(join(root, "target.txt"), O_RDONLY | O_NOFOLLOW)).toBe("target data");
+    expect(inoOfOpen(join(root, "target-dir"), O_RDONLY | O_NOFOLLOW)).toBe(
+      statSync(join(root, "target-dir"), { bigint: true }).ino,
+    );
+
+    const fd = openSync(join(root, "new.txt"), O_WRONLY | O_CREAT | O_NOFOLLOW);
+    try {
+      writeSync(fd, "new");
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(join(root, "new.txt"), "utf8")).toBe("new");
+  });
 });
 
 it("fs.ReadStream allows functions", () => {


### PR DESCRIPTION
### Problem
- On Windows, `fs.constants.O_NOFOLLOW` is `undefined`, and `fs.open` cannot ask for "do not follow a link". An open of a path whose last component is a symlink or a junction always follows it.
- MSVC's `<fcntl.h>` has no `O_NOFOLLOW`, so the `#ifdef O_NOFOLLOW` rows in `ProcessBindingConstants.cpp:742` and `NodeConstantsModule.h:671` are empty. `UV_FS_O_NOFOLLOW` is `0` in libuv's `include/uv/win.h`, so `uv_fs_open` drops the flag. `to_bun_o` (`src/libuv_sys/libuv.rs`) has no arm for it.

### Fix
- oven-sh/libuv#18 gives `UV_FS_O_NOFOLLOW` the value `0x01000000` on Windows and maps it to `FILE_FLAG_OPEN_REPARSE_POINT` in `fs__open`. The open returns a handle to the link itself. Windows ignores the flag for a file that is not a reparse point.
- `fs.constants.O_NOFOLLOW` is that value on Windows. `to_bun_o` maps it to Bun's internal `O::NOFOLLOW`. `from_bun_o` already maps it back for `uv_fs_open`. The `NtCreateFile` path (`writeFile` with a numeric `flag`) already honors that bit.
- Verified on Windows x64: `test/js/node/fs/fs.test.ts` (7 new or changed tests pass, the released build fails 6). Also `test-constants.js`, `test-fs-open-flags.js`, `test-fs-open-numeric-flags.js`.
- Self-reviewed: 1 design concern raised, not adopted yet because it contradicts the request: under this name Node documents "the open fails" (`ELOOP`), and "open the link itself" is `O_SYMLINK`. A maintainer decides the contract (see Notes). Draft until then.

### Background
- A reparse point is a file or directory with a tag that tells NTFS to redirect an open. Symlinks and junctions (`mklink /J`) are reparse points. `FILE_FLAG_OPEN_REPARSE_POINT` turns the redirect off for the last path component.
- On Windows, `fs.constants` has the MSVC `_O_*` values. Bun converts a numeric flag to its internal Linux-style `O` values with `to_bun_o`, and back with `from_bun_o` before `uv_fs_open`. A bit without an arm in `to_bun_o` is lost.

<details><summary>Notes</summary>

**Contract: return the link, or fail with `ELOOP`.** The request for this PR says: map the flag to `FILE_FLAG_OPEN_REPARSE_POINT`, so the open returns the reparse point itself. The self-review argues for the other contract under this name:
- Node's docs say `O_NOFOLLOW` makes the open fail if the path is a symbolic link, and `O_SYMLINK` opens the link itself. libuv's docs say the same. Code that finds `fs.constants.O_NOFOLLOW` defined can rely on the failure. With this PR that code gets a descriptor for the link: a read returns no data, a write goes to the link's own stream. No case follows the link, but the caller does not learn that the path was a link.
- `FILE_FLAG_OPEN_REPARSE_POINT` also applies to reparse points that are not links (OneDrive placeholders, deduplicated files, `APPEXECLINK`). An open with the flag gets those raw. A POSIX `O_NOFOLLOW` does not change how a non-link opens.
- The two open paths differ for `O_CREAT | O_TRUNC` on a file symlink (see the table below): `openSync` replaces the link, `writeFileSync` keeps it.
- The fail-closed shape: open with the flag and a non-destructive disposition, read the reparse tag, return `ELOOP` for a name-surrogate tag (symlink, junction), reopen without the flag for any other tag, and truncate only after the check. That fits either in `fs__open` or in one `bun_sys` helper that `NodeFS::open` and `writeFile` share. The second needs no libuv change.
- Upstream libuv's open draft for `uv_fs_openat` (libuv/libuv#4434) uses `0x40000000` for `UV_FS_O_NOFOLLOW` on Windows. The same value here keeps `fs.constants` stable if that lands.

**What an open with the flag does**, measured on NTFS (Windows Server 2019):

| Path | `O_RDONLY`, `O_WRONLY` | `O_CREAT \| O_TRUNC` | `O_CREAT \| O_EXCL` |
| --- | --- | --- | --- |
| regular file, missing file | no change | no change | no change |
| file symlink | opens the link (size 0, a read returns no data, a write goes to the link's own stream) | `openSync` replaces the link with a regular file. `writeFileSync` keeps the link and writes to its own stream | `EEXIST` |
| junction, directory symlink | opens the link | `EISDIR`, as without the flag | `EEXIST` |

The target is never read or written in any of these.

**Choice of bit.** `0x01000000` sits below `UV_FS_O_DIRECT` (`0x02000000`) in the block of values that libuv defines itself. It is not a CRT `_O_*` bit (`fs__open` passes all flags to `_open_osfhandle`). It is not one of Bun's internal `O` bits, two of which (`0x800`, `0x80000`) reach `uv_fs_open` raw from `Blob.rs`.

**Internal callers.** Every Rust caller that passes `O::NOFOLLOW` on Windows goes through the `openat` family (`NtCreateFile`), which already honored it. None goes through `bun_sys::open` (libuv), so no internal open changes behavior.

**Tests.** `mklink /J` for the junction and `fs.symlinkSync(..., "file")` for the file symlink, in a temp dir. The tests compare `fstat(fd).ino` with `stat(path).ino` (target) and `lstat(path).ino` (link) for `openSync`, `promises.open` and `fs.open`. They check that a read from a file symlink returns no data, that a write with the flag does not reach the target (and does without it), and that the flag changes nothing for a plain file, a plain directory and a new file. `fstat(fd).isSymbolicLink()` stays `false` for such a descriptor: libuv's `uv_fs_fstat` does not look for link tags. That is why the tests compare inode numbers.

**Other runs.** The whole of `fs.test.ts` on the Windows debug build: 2 failures that do not touch this code. `readSync > works on large files` hits the local 5 s limit on a debug build. `keeps a non-throwing callback in the same place in the event loop` races `fs.stat` against `setImmediate` and passes on the release build.

**libuv pin.** `LIBUV_COMMIT` points at the head of oven-sh/libuv#18. It needs a re-pin to the commit on the `bun` branch after that PR merges. #42272 changes the same line for oven-sh/libuv#17. The second of the two to merge has to pin a commit that has both.

</details>
