### PR TITLE
fix(node:fs): preserve symlink traversal in realpath

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -218,9 +218,6 @@ pub use super::node_fs_binding::Binding;
 use bun_jsc::JSPromiseStrong;
 
 use super::dir_iterator as DirIterator;
-#[cfg(not(windows))]
-use bun_resolver::fs::FileSystem;
-
 // On POSIX the libuv-backed code paths (`UVFSRequest`, `uv_fs_*`) are absent:
 // `UVFSRequest` aliases `AsyncFSTask` and every `uv::*` reference is gated
 // behind `#[cfg(windows)]`. There is intentionally **no** POSIX stub module
@@ -7385,27 +7382,18 @@ impl NodeFS {
         {
             let mut outbuf = bun_paths::path_buffer_pool::get();
             let inbuf = &mut self.sync_error_buf;
-            // SAFETY: single-threaded init flag (resolver/fs.rs).
-            debug_assert!(
-                bun_resolver::fs::INSTANCE_LOADED.load(core::sync::atomic::Ordering::Relaxed)
-            );
-
             let path_slice = args.path.slice();
-            // SAFETY: instance() returns the leaked singleton; INSTANCE_LOADED checked above.
-            let fs = FileSystem::get();
-            let parts = [fs.top_level_dir, path_slice];
-            let inbuf_len = inbuf.len();
-            let Some(joined) = fs.abs_buf_checked(&parts, &mut inbuf[..inbuf_len - 1]) else {
+            if path_slice.len() >= inbuf.len() {
                 return Err(sys::Error {
                     errno: E::ENAMETOOLONG as _,
                     syscall: sys::Tag::realpath,
                     path: args.path.slice().into(),
                     ..Default::default()
                 });
-            };
-            let path_len = joined.len();
-            inbuf[path_len] = 0;
-            let path = ZStr::from_buf(&inbuf[..], path_len);
+            }
+            // Let the OS walk the original components. Resolving to an absolute
+            // path first would collapse `..` before a preceding symlink is followed.
+            let path = args.path.slice_z(inbuf);
 
             #[cfg(any(target_os = "linux", target_os = "android"))]
             let flags = sys::O::PATH; // O_PATH is faster

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3235,6 +3235,27 @@ it.if(isPosix)("realpathSync resolves root, regular files, and symlinks", () => 
   expect(realpathSync(linkPath)).toBe(self);
 });
 
+it.if(isPosix)("realpath resolves a symlink before a following parent traversal", async () => {
+  using dir = tempDir("fs-realpath-symlink-parent", {});
+  const root = String(dir);
+  const actualDir = join(root, "actual");
+  const nestedDir = join(actualDir, "nested");
+  const expected = join(actualDir, "target.txt");
+  const collision = join(root, "target.txt");
+  const linkPath = join(root, "link");
+  mkdirSync(nestedDir, { recursive: true });
+  writeFileSync(expected, "expected");
+  writeFileSync(collision, "collision");
+  symlinkSync(nestedDir, linkPath);
+  const input = `${linkPath}${path.sep}..${path.sep}target.txt`;
+
+  expect(realpathSync(input)).toBe(expected);
+  expect(realpathSync.native(input)).toBe(expected);
+  expect(await promises.realpath(input)).toBe(expected);
+  expect(await promisify(fs.realpath)(input)).toBe(expected);
+  expect(await promisify(fs.realpath.native)(input)).toBe(expected);
+});
+
 // src/sys/sys.zig getFdPath has an exhaustive per-OS switch: .windows
 // (GetFinalPathNameByHandle), .mac (F_GETPATH), .linux (/proc/self/fd, also
 // covers Android), .freebsd (fcntl F_KINFO + struct_kinfo_file). On every


### PR DESCRIPTION
### What does this PR do?

Fixes POSIX `node:fs` realpath handling when `..` follows a symlink. The native implementation first normalized the input to an absolute path, so `link/../target` could resolve to a lexical collision beside `link` instead of following `link` and then traversing to its parent.

Pass the original NUL-terminated path to the OS so component traversal keeps POSIX semantics. The explicit input-length check preserves `ENAMETOOLONG` behavior, and Windows remains on its existing implementation.

This was found while validating OpenClaw under Bun; the matching application workaround is tracked in openclaw/openclaw#144700.

AI assistance: This change was developed and reviewed with Codex.

### How did you verify your code works?

- The new collision regression failed on the original release binary and passed after the source change.
- Incremental release build completed successfully with LLVM 21.1.8 and the repository's pinned Rust toolchain.
- Focused realpath tests: 11 passed, 1 platform skip, 0 failed.
- `cargo fmt --all -- --check`, configured Prettier check, and `git diff --check` passed.
- Independent P0-P2 review found no actionable issues.
