### PR TITLE
Remove 7 stale module-level dead_code escapes from the node:http2 engine and react_compiler::hir

### DIFF
--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -2,7 +2,6 @@
     clippy::disallowed_types,
     clippy::disallowed_methods,
     unreachable_pub,
-    dead_code,
     reason = "ported from facebook/react react_compiler_hir; uses std collections by design"
 )]
 #![allow(

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -4,8 +4,6 @@
 //! §4.2/§6 validation. Connection-level framing lives here; stream-level (HEADERS/DATA/RST) and the
 //! outbound request/respond paths build on top of this.
 
-#![allow(dead_code)]
-
 use super::flow_control::{RecvWindow, SendWindow};
 use super::hpack;
 use super::settings::{self, Settings};

--- a/src/runtime/api/bun/h2/flow_control.rs
+++ b/src/runtime/api/bun/h2/flow_control.rs
@@ -6,8 +6,6 @@
 //!   * Recv window  — how much DATA the peer may still send us; replenished by emitting
 //!     WINDOW_UPDATE once enough has been consumed.
 
-#![allow(dead_code)]
-
 use super::wire::{DEFAULT_WINDOW_SIZE, ErrorCode, MAX_WINDOW_SIZE};
 
 /// Outbound (send) window. Signed because a SETTINGS-driven INITIAL_WINDOW_SIZE decrease can push

--- a/src/runtime/api/bun/h2/hpack.rs
+++ b/src/runtime/api/bun/h2/hpack.rs
@@ -6,8 +6,6 @@
 //! lockstep. Decode results alias a shared buffer and MUST be copied before the next call
 //! (see lshpack.rs).
 
-#![allow(dead_code)]
-
 use bun_http::lshpack::{DecodeResult, HpackError, HpackHandle};
 
 /// RFC 7541 §6.3: a Dynamic Table Size Update integer never needs more than 6 bytes for a u32.

--- a/src/runtime/api/bun/h2/settings.rs
+++ b/src/runtime/api/bun/h2/settings.rs
@@ -1,8 +1,6 @@
 //! HTTP/2 SETTINGS (RFC 9113 §6.5). Pure: value semantics, range validation, on-wire packing,
 //! and the INITIAL_WINDOW_SIZE retroactive-window delta. Part of the from-scratch rewrite.
 
-#![allow(dead_code)]
-
 use super::wire::{self, ErrorCode, SettingId};
 
 /// Logical SETTINGS values. Defaults match Node v27 `getDefaultSettings()` exactly

--- a/src/runtime/api/bun/h2/stream.rs
+++ b/src/runtime/api/bun/h2/stream.rs
@@ -4,8 +4,6 @@
 //! as the stream `state`): IDLE=1, OPEN=2, RESERVED_LOCAL=3, RESERVED_REMOTE=4,
 //! HALF_CLOSED_LOCAL=5, HALF_CLOSED_REMOTE=6, CLOSED=7.
 
-#![allow(dead_code)]
-
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[repr(u8)]
 pub enum State {

--- a/src/runtime/api/bun/h2/wire.rs
+++ b/src/runtime/api/bun/h2/wire.rs
@@ -3,8 +3,6 @@
 //! This is part of the from-scratch rewrite of `node:http2` (replacing the ported
 //! `h2_frame_parser.rs`). Spec section numbers reference RFC 9113 unless noted.
 
-#![allow(dead_code)]
-
 /// RFC 9113 §3.4: the 24-octet client connection preface.
 pub const CONNECTION_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 

--- a/test/internal/source-lints/dead-code-escapes.test.ts
+++ b/test/internal/source-lints/dead-code-escapes.test.ts
@@ -44,6 +44,7 @@ const MODULE_ESCAPE_ALLOWED = new Set([
   "src/runtime/generated_classes.rs",
   // Shares files with bun_install; each of the two builds uses a different half.
   "src/install/windows-shim/main.rs",
+  // Stale. #40690 removes it together with the items it hides.
   "src/react_compiler/diagnostics/mod.rs",
 ]);
 
@@ -116,7 +117,7 @@ describe("#[allow(dead_code)] escapes", () => {
 });
 
 describe("module-level #![allow(dead_code)] escapes", () => {
-  test("only generated surfaces and the standalone shim opt a whole file out", () => {
-    expect(moduleLevel.filter(source => !MODULE_ESCAPE_ALLOWED.has(source))).toEqual([]);
+  test("the files that opt out wholesale are exactly MODULE_ESCAPE_ALLOWED", () => {
+    expect(moduleLevel.toSorted()).toEqual([...MODULE_ESCAPE_ALLOWED].toSorted());
   });
 });

--- a/test/internal/source-lints/dead-code-escapes.test.ts
+++ b/test/internal/source-lints/dead-code-escapes.test.ts
@@ -31,9 +31,21 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // after the allow, e.g. `#[cfg_attr(test, allow(dead_code), derive(Debug))]`
 // (`[^\]]*\]` tail). Neither `[^\]]` class can cross a `]`, so a match is always
 // fenced inside a single attribute and cannot span from one `#[...]` to the next.
-// Module-level `#![allow(...)]` blocks (codegen surfaces such as
-// `runtime/generated_classes.rs` and `jsc/cpp.rs`) are intentionally not counted.
+// Module-level `#![allow(...)]` blocks are not part of this inventory; see
+// `MODULE_ESCAPE` below.
 const ESCAPE = /#\[\s*(?:cfg_attr\([^\]]+?,\s*)?allow\([^)]*\bdead_code\b[^)]*\)[^\]]*\]/g;
+
+// A module-level `#![allow(dead_code)]` hides a whole file from rustc, and the
+// cross-crate hawk analysis treats every item under it as a reachability root.
+const MODULE_ESCAPE = /#!\[\s*(?:cfg_attr\([^\]]+?,\s*)?allow\([^\]]*?(?<![\w:])dead_code\b[^\]]*\]/;
+const MODULE_ESCAPE_ALLOWED = new Set([
+  // Generated extern surfaces: most declarations are unused by design.
+  "src/jsc/cpp.rs",
+  "src/runtime/generated_classes.rs",
+  // Shares files with bun_install; each of the two builds uses a different half.
+  "src/install/windows-shim/main.rs",
+  "src/react_compiler/diagnostics/mod.rs",
+]);
 
 const limits: Record<string, number> = await Bun.file(import.meta.dir + "/dead-code-escape-limits.json").json();
 
@@ -55,6 +67,7 @@ const tracked: Set<string> | null = (() => {
 })();
 
 const counts: Record<string, number> = {};
+const moduleLevel: string[] = [];
 for (const abs of rustSources) {
   const source = path.relative(root, abs).replaceAll(path.sep, "/");
   // `src/cli` is a symlink into `src/runtime/cli`; count each file once
@@ -67,6 +80,7 @@ for (const abs of rustSources) {
   const stripped = content.replace(/^\s*\/\/.*$/gm, "");
   const n = [...stripped.matchAll(ESCAPE)].length;
   if (n > 0) counts[source] = n;
+  if (MODULE_ESCAPE.test(stripped)) moduleLevel.push(source);
 }
 
 if (typeof describe === "undefined") {
@@ -99,4 +113,10 @@ describe("#[allow(dead_code)] escapes", () => {
       }
     });
   }
+});
+
+describe("module-level #![allow(dead_code)] escapes", () => {
+  test("only generated surfaces and the standalone shim opt a whole file out", () => {
+    expect(moduleLevel.filter(source => !MODULE_ESCAPE_ALLOWED.has(source))).toEqual([]);
+  });
 });


### PR DESCRIPTION
### Problem
- Seven module-level `dead_code` lint escapes are stale. Six are the `#![allow(dead_code)]` lines at the top of `src/runtime/api/bun/h2/{wire,settings,flow_control,hpack,stream,connection}.rs`. One is the `dead_code` entry in the `#![allow(...)]` block of `src/react_compiler/hir/mod.rs`.
- Nothing in those modules is dead today. The escapes only hide 3,244 and 9,035 lines from rustc.
- `hawk` treats every item under `allow(dead_code)` as a reachability root. It never reports these modules, and it keeps alive anything they reference.

### Fix
- Delete the seven escapes. `test/internal/source-lints/dead-code-escapes.test.ts` now requires the set of files with a module-level `allow(dead_code)` to equal a short allowlist (two generated surfaces, the standalone shim). It fails on `main` with the seven files listed and passes here.
- Correct because `dead_code` is `deny` for the workspace and the build still passes: `cargo check` in dev and release on the host, `bun run rust:check-all` on all 12 targets, and `bun bd` (which adds `--cfg bun_debug` and `--cfg bun_asan`).
- `hawk` on linux-x64 with the escapes removed reports no `dead_public` item in either directory.
- Verified: that lint, `test/js/node/http2/h2-conformance.test.ts`, `node-http2-settings-ack-ordering.test.ts`, `node-http2-continuation.test.ts`, `test/bundler/transpiler/react-compiler.test.ts`.

### Background
- The workspace sets `dead_code = "deny"`. An `#[allow(dead_code)]` is a deliberate escape. `test/internal/source-lints/dead-code-escapes.test.ts` pins the item-level escapes per file. It does not count module-level `#![allow]` blocks, so these seven were never audited.
- `hawk` (`hawk.toml`, `tools/hawk/`) is the cross-crate analysis that finds `pub` items no other crate uses. rustc cannot see those.
- `src/runtime/api/bun/h2/` is the `node:http2` engine that `h2_frame_parser.rs` drives. `src/react_compiler/hir/` is the HIR of the React Compiler port.

<details><summary>Notes</summary>

This run of the dead-code sweep found no other deletion that an open PR does not already hold. What it covered, on `81f97bb020`:

- `hawk` on `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin` and `x86_64-pc-windows-msvc`. 367 items are dead on all three. They are FFI struct fields, enum variants that mirror external code tables (already listed in `hawk.toml`), items an open PR deletes, or false positives (constants used only as array lengths, modules used only through a re-export, helpers named from `generate-classes.ts` templates).
- `hawk --fix` to narrow visibility in a scratch tree, then `cargo check` with lints capped at warn. 36 `dead_code` hits: `MultiArrayList` column structs, holder fields, items used only from `#[cfg(test)]`, or items an open PR deletes.
- A relink of the debug objects with `--gc-sections --print-gc-sections`. 92 discarded C++ functions have an out-of-line definition in `src/` or `packages/`. 76 are in open PRs. The rest have a caller on Windows or macOS, are exported API (`napi_*`, `v8::`), or are template instantiations. 1,158 discarded C-ABI symbols: the same result.
- `clang -fsyntax-only -Wunused-function -Wunused-template -Wunused-member-function -Wunused-const-variable` over all 664 translation units (the build passes `-Wno-unused-function`). 13 hits. Four are in open PRs. The others are used on another platform or in another translation unit.
- `c-index-test -index-file` over the same 664 translation units: 23,572 declarations in `src/` and `packages/`, 7,320 with no reference. After a textual cross-check 62 names remain. All are macro-pasted names, JSC template hooks, or mirrors of the v8, libuv and llhttp headers.
- No header that nothing includes. No `.rs` file outside a module tree. No unused Cargo dependency. No internal JS module that nothing requires. 179 lines of commented-out code in total.

Not in the diff:

- `src/react_compiler/diagnostics/mod.rs` has the same stale entry. #40690 already removes it, so the new lint allows that file for now. #40690 also adds a separate inventory of module-level escapes (`module-lint-escapes.test.ts`) that pins the six `h2` files at one each. Whichever of the two PRs merges second has to regenerate that inventory.
- `src/install/windows-shim/main.rs` allows `dead_code` for the whole standalone shim crate. That one is justified: `bun_shim_impl.rs` is compiled twice and each build uses a different half.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 3 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/internal/source-lints/dead-code-escapes.test.ts
bun test v1.4.3 (4ff919377)

test/internal/source-lints/dead-code-escapes.test.ts:
(pass) #[allow(dead_code)] escapes > src/ast/runtime.rs (1) [1.95ms]
(pass) #[allow(dead_code)] escapes > src/bun_core/lib.rs (1) [0.06ms]
(pass) #[allow(dead_code)] escapes > src/bun_core/output.rs (1) [0.04ms]
(pass) #[allow(dead_code)] escapes > src/bun_core_macros/comptime_string_map.rs (2) [0.04ms]
(pass) #[allow(dead_code)] escapes > src/bundler/Chunk.rs (2) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/collections/multi_array_list.rs (8) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/crash_handler/lib.rs (1) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/css_derive/lib.rs (3) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/install/isolated_install/FileCloner.rs (3) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/install/lockfile/Package.rs (1) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/io/lib.rs (2) [0.04ms]
(pass) #[allow(dead_code)] escapes > src/io/posix_event_loop.rs (8) 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (84a1fe8fe)

test/internal/source-lints/dead-code-escapes.test.ts:
(pass) #[allow(dead_code)] escapes > src/ast/runtime.rs (1) [0.04ms]
(pass) #[allow(dead_code)] escapes > src/bun_core/lib.rs (1)
(pass) #[allow(dead_code)] escapes > src/bun_core/output.rs (1)
(pass) #[allow(dead_code)] escapes > src/bun_core_macros/comptime_string_map.rs (2)
(pass) #[allow(dead_code)] escapes > src/bundler/Chunk.rs (2)
(pass) #[allow(dead_code)] escapes > src/collections/multi_array_list.rs (8)
(pass) #[allow(dead_code)] escapes > src/crash_handler/lib.rs (1)
(pass) #[allow(dead_code)] escapes > src/css_derive/lib.rs (3)
(pass) #[allow(dead_code)] escapes > src/install/isolated_install/FileCloner.rs (3)
(pass) #[allow(dead_code)] escapes > src/install/lockfile/Package.rs (1)
(pass) #[allow(dead_code)] escapes > src/io/lib.rs (2)
(pass) #[allow(dead_code)] escapes > src/io/posix_event_loop.rs (8)
(pass) #[allow(dead_code)] escapes > src/jsc/PosixSignalHandle.rs (4)
(pass) #[allow(dead_code)] escapes > src/jsc_macros/lib.rs (2)
(pass) #[allow(dead_code)] escapes > src/opaque/lib.rs (4)
(pass) #[allow(dead_code)] escapes > src/patch/lib.rs (2)
(pass) #[allow(d
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/internal/source-lints/dead-code-escapes.test.ts
bun test v1.4.3 (4ff919377)

test/internal/source-lints/dead-code-escapes.test.ts:
(pass) #[allow(dead_code)] escapes > src/ast/runtime.rs (1) [2.34ms]
(pass) #[allow(dead_code)] escapes > src/bun_core/lib.rs (1) [0.07ms]
(pass) #[allow(dead_code)] escapes > src/bun_core/output.rs (1) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/bun_core_macros/comptime_string_map.rs (2) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/bundler/Chunk.rs (2) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/collections/multi_array_list.rs (8) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/crash_handler/lib.rs (1) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/css_derive/lib.rs (3) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/install/isolated_install/FileCloner.rs (3) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/install/lockfile/Package.rs (1) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/io/lib.rs (2) [0.03ms]
(pass) #[allow(dead_code)] escapes > src/io/posix_event_loop.rs (8) 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 712ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/react_compiler/hir/mod.rs                      |  1 -
 src/runtime/api/bun/h2/connection.rs               |  2 --
 src/runtime/api/bun/h2/flow_control.rs             |  2 --
 src/runtime/api/bun/h2/hpack.rs                    |  2 --
 src/runtime/api/bun/h2/settings.rs                 |  2 --
 src/runtime/api/bun/h2/stream.rs                   |  2 --
 src/runtime/api/bun/h2/wire.rs                     |  2 --
 .../source-lints/dead-code-escapes.test.ts         | 25 ++++++++++++++++++++--
 8 files changed, 23 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/react_compiler/hir/mod.rs                             0      0     12
src/runtime/api/bun/h2/connection.rs                      0      0     12
src/runtime/api/bun/h2/flow_control.rs                    0      0     12
src/runtime/api/bun/h2/hpack.rs                           0      0     12
src/runtime/api/bun/h2/settings.rs                        0      0     12
src/runtime/api/bun/h2/stream.rs                          0      0     12
src/runtime/api/bun/h2/wire.rs                            0      0     12
test/internal/source-lints/dead-code-escapes.test.ts      1      3     12
```

</details>

<!-- robobun:evidence:end -->