### PR TITLE
fix(node:fs): return undefined from promises.access

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4279,7 +4279,7 @@ pub struct Null;
 pub mod ret {
     use super::*;
 
-    pub(crate) type Access = Null;
+    pub(crate) type Access = ();
     pub(crate) type AppendFile = ();
     pub type Close = ();
     pub(crate) type CopyFile = ();
@@ -4443,7 +4443,7 @@ impl NodeFS {
                 if (mode & sys::posix::W_OK) != 0 || ((mode & sys::posix::X_OK) != 0 && !is_dir) {
                     return Err(sys::Error::from_code(E::EACCES, sys::Tag::access).with_path(p));
                 }
-                return Ok(Null);
+                return Ok(());
             }
         }
         // The `bun_sys::access` Windows
@@ -4457,7 +4457,7 @@ impl NodeFS {
         };
         match Syscall::access(path, args.mode.as_int()) {
             Err(err) => Err(err.with_path(args.path.slice())),
-            Ok(_) => Ok(Null),
+            Ok(_) => Ok(()),
         }
     }
 

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -88,7 +88,7 @@ it("should be enumerable", () => {
 
 describe("access", () => {
   it("should work", async () => {
-    await access(__filename, 0);
+    expect(await access(__filename, 0)).toBeUndefined();
   });
 
   it("should fail on non-existant files", async () => {


### PR DESCRIPTION
### What does this PR do?

Makes successful `fs.promises.access()` calls resolve to `undefined`, matching Node.js. Bun currently returns `null` because the native access result is represented by the binding's `Null` type on both the Windows-specific success path and the general syscall success path.

Change the result type to Rust's unit value and return it from both success paths. The existing failure behavior is unchanged, and the focused assertion now distinguishes the correct result from the previous `null` value.

This was found while validating OpenClaw under Bun: the incorrect result broke assertions around read-only Doctor checks even though the file access itself succeeded.

AI assistance: This change was developed and reviewed with Codex.

### How did you verify your code works?

- The original custom Bun build reproduced `null`; the rebuilt binary returns `undefined`.
- Incremental release build completed successfully with LLVM 21.1.8 and the repository's pinned Rust toolchain.
- Focused `fs.promises.access` tests: 2 passed, 2 platform skips, 0 failed.
- The affected OpenClaw Doctor suite passed under the rebuilt Bun: 308 passed, 2 platform skips, 0 failed.
- `cargo fmt --all -- --check`, configured Prettier, and `git diff --check` passed.
- Independent P0-P2 review found no actionable issues.
