### PR TITLE
node:stream: take the native handle in Readable.fromWeb only from a stream no consumer has started

### DIFF
--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -3,9 +3,17 @@
 // child_process' stderr/out streams go through less hoops.
 //
 // Normally, Readable.fromWeb will wrap the ReadableStream in JavaScript. In
-// Bun, `fromWeb` is able to check if the stream is backed by a native handle,
-// to which it will take this path.
+// Bun, `fromWeb` takes this path instead when the stream is backed by a native
+// handle that no consumer has started yet.
 const Readable = require("internal/streams/readable");
+// https://github.com/oven-sh/bun/pull/12801
+// https://github.com/oven-sh/bun/issues/9555
+// There may be a ReadableStream.Strong handle to the ReadableStream.
+// We can't update those handles to point to the NativeReadable from JS,
+// so this marks the web stream as no longer usable and hands back its native
+// handle. Returns undefined, and marks nothing, when the stream has no handle
+// or a consumer already started it (getReader(), cancel()): the web stream's
+// controller owns the handle then and its queue may already hold chunks.
 const transferToNativeReadable = $newCppFunction(
   "streams/BunStreamConsumers.cpp",
   "jsFunctionTransferToNativeReadableStream",
@@ -53,11 +61,25 @@ interface NativePtr {
 
 let debugId = 0;
 
+// node:child_process stdio: the stream comes straight from Bun.spawn, nothing has started it.
 function constructNativeReadable(readableStream: ReadableStream, options): NativeReadable {
   $assert(typeof readableStream === "object" && readableStream instanceof ReadableStream, "Invalid readable stream");
-  const bunNativePtr = (readableStream as any).$bunNativePtr;
+  const bunNativePtr = transferToNativeReadable(readableStream);
   $assert(typeof bunNativePtr === "object", "Invalid native ptr");
+  return fromNativeHandle(bunNativePtr, options);
+}
 
+// Readable.fromWeb: undefined unless the stream still had an unstarted handle to give.
+function tryConstructNativeReadable(readableStream: ReadableStream, options): NativeReadable | undefined {
+  const bunNativePtr = transferToNativeReadable(readableStream);
+  if (bunNativePtr === undefined) return undefined;
+  return fromNativeHandle(bunNativePtr, options);
+}
+
+// The handle is claimed before this runs: `new Readable(options)` reads user
+// getters (highWaterMark, signal.aborted) that could otherwise start the stream
+// between the check and the transfer.
+function fromNativeHandle(bunNativePtr: NativePtr | undefined, options): NativeReadable {
   const stream = new Readable(options);
   stream._read = read;
   stream._destroy = destroy;
@@ -84,13 +106,6 @@ function constructNativeReadable(readableStream: ReadableStream, options): Nativ
     // Only used by node:tty on Windows
     stream.$start = ensureConstructed;
   }
-
-  // https://github.com/oven-sh/bun/pull/12801
-  // https://github.com/oven-sh/bun/issues/9555
-  // There may be a ReadableStream.Strong handle to the ReadableStream.
-  // We can't update those handles to point to the NativeReadable from JS
-  // So we instead mark it as no longer usable, and create a new NativeReadable
-  transferToNativeReadable(readableStream);
 
   $debug(`[${stream.debugId}] constructed!`);
 
@@ -277,4 +292,4 @@ function unref(this: NativeReadable) {
   }
 }
 
-export default { constructNativeReadable };
+export default { constructNativeReadable, tryConstructNativeReadable };

--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -80,7 +80,14 @@ function tryConstructNativeReadable(readableStream: ReadableStream, options): Na
 // getters (highWaterMark, signal.aborted) that could otherwise start the stream
 // between the check and the transfer.
 function fromNativeHandle(bunNativePtr: NativePtr | undefined, options): NativeReadable {
-  const stream = new Readable(options);
+  let stream;
+  try {
+    stream = new Readable(options);
+  } catch (error) {
+    // The web stream is spent, so nothing else can release the handle.
+    bunNativePtr?.cancel(error);
+    throw error;
+  }
   stream._read = read;
   stream._destroy = destroy;
 

--- a/src/js/internal/webstreams_adapters.ts
+++ b/src/js/internal/webstreams_adapters.ts
@@ -33,14 +33,6 @@ const SafePromisePrototypeFinally = $Promise.prototype.finally;
 
 const constants_zlib = $processBindingConstants.zlib;
 
-function tryTransferToNativeReadable(stream, options) {
-  const ptr = stream.$bunNativePtr;
-  if (!ptr || ptr === -1) {
-    return undefined;
-  }
-  return require("internal/streams/native-readable").constructNativeReadable(stream, options);
-}
-
 class ReadableFromWeb extends Readable {
   #reader;
   #closed;
@@ -559,7 +551,13 @@ function newStreamReadableFromReadableStream(readableStream, options: Record<str
   // Node acquires the reader at this point, so a locked stream throws here too.
   if (readableStream.locked) throw $ERR_INVALID_STATE_TypeError("ReadableStream is locked");
 
-  const nativeStream = tryTransferToNativeReadable(readableStream, options);
+  // A native stream that no consumer has started hands over its handle instead.
+  const nativeStream = require("internal/streams/native-readable").tryConstructNativeReadable(readableStream, {
+    highWaterMark,
+    encoding,
+    objectMode,
+    signal,
+  });
 
   return (
     nativeStream ||

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -1396,13 +1396,17 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionReadableStreamToFormData, (JSGlobalObject * g
     RELEASE_AND_RETURN(scope, JSValue::encode(Bun::WebStreams::readableStreamToFormData(globalObject, stream, callFrame->argument(1))));
 }
 
+// Claims the native handle for node:stream's NativeReadable and returns it. undefined, with the
+// stream untouched, when there is no unstarted handle to claim (JSReadableStream::hasPendingNativeSource()).
 JSC_DEFINE_HOST_FUNCTION(jsFunctionTransferToNativeReadableStream, (JSGlobalObject*, CallFrame* callFrame))
 {
-    if (auto* stream = dynamicDowncast<JSReadableStream>(callFrame->argument(0))) {
-        stream->m_transferred = true;
-        stream->m_disturbed = true;
-    }
-    return JSValue::encode(jsUndefined());
+    auto* stream = dynamicDowncast<JSReadableStream>(callFrame->argument(0));
+    if (!stream || !stream->hasPendingNativeSource())
+        return JSValue::encode(jsUndefined());
+    JSValue handle = stream->nativePtrForJS();
+    stream->m_transferred = true;
+    stream->m_disturbed = true;
+    return JSValue::encode(handle);
 }
 
 // [reaction-convention] handlers (FOR_EACH_WEB_STREAMS_REACTION_HANDLER_BUN_CONSUMERS).

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.h
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.h
@@ -17,8 +17,8 @@ JSC_DECLARE_HOST_FUNCTION(jsFunctionReadableStreamToBytes);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionReadableStreamToJSON);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionReadableStreamToBlob);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionReadableStreamToFormData);
-// body: dynamicDowncast<JSReadableStream>(arg0)->{m_transferred = true, m_disturbed = true}.
-// Referenced by src/js/internal/streams/native-readable.ts via $newCppFunction.
+// If arg0 hasPendingNativeSource(): {m_transferred = true, m_disturbed = true}, returns the handle;
+// else undefined. userJS: no. Referenced by src/js/internal/streams/native-readable.ts via $newCppFunction.
 JSC_DECLARE_HOST_FUNCTION(jsFunctionTransferToNativeReadableStream);
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -414,6 +414,10 @@ void materializeNativeSource(JSGlobalObject* globalObject, JSReadableStream* str
     auto scope = DECLARE_THROW_SCOPE(vm);
     if (stream->nativeHandleDetached())
         return;
+    // Errored before anything read it (addAbortSignal, ReadableStream__error): no chunk can ever
+    // come out, so a started handle would hold its fd, or stall a child on a full pipe, for nothing.
+    if (stream->m_state != ReadableStreamState::Readable)
+        return;
     JSObject* handle = stream->m_nativePtr.get().getObject();
     if (!handle)
         return;

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.h
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.h
@@ -120,6 +120,19 @@ public:
     {
         return m_transferred || m_consumedAsBody || (m_nativePtr.get().isInt32() && m_nativePtr.get().asInt32() == -1);
     }
+    // A native handle that no consumer has started or claimed: a taker (node:stream's
+    // NativeReadable) may drive it directly. Once materialized or cancelled, the stream's
+    // controller owns the handle and its queue may hold chunks, so the only way to the data is
+    // a reader. A native sink that attached without a reader (m_lockedWithoutReader) owns it too.
+    bool hasPendingNativeSource() const
+    {
+        if (m_bunMode != BunStreamMode::NativePending || m_state != ReadableStreamState::Readable)
+            return false;
+        if (m_reader || m_lockedWithoutReader)
+            return false;
+        JSC::JSValue handle = nativePtrForJS();
+        return handle && handle.isObject();
+    }
 
 private:
     JSReadableStream(JSC::VM&, JSC::Structure*);

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -3,7 +3,17 @@ import { describe, expect, it, jest } from "bun:test";
 import { bunEnv, bunExe, bunRun, isGlibcVersionAtLeast, isMacOS, tempDir, tmpdirSync } from "harness";
 import { createReadStream, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { Duplex, duplexPair, finished, PassThrough, Readable, Stream, Transform, Writable } from "node:stream";
+import {
+  addAbortSignal,
+  Duplex,
+  duplexPair,
+  finished,
+  PassThrough,
+  Readable,
+  Stream,
+  Transform,
+  Writable,
+} from "node:stream";
 import { finished as finishedP } from "node:stream/promises";
 import { join } from "path";
 
@@ -651,6 +661,206 @@ it("Readable.toWeb(Readable.fromWeb(rs)).cancel(reason) propagates to the web so
   expect({ name: cancelReason?.name, message: cancelReason?.message }).toEqual({
     name: "RangeError",
     message: "consumer-gone",
+  });
+});
+
+// Readable.fromWeb drives a native stream's handle directly only while no consumer has
+// started it. getReader() or cancel() start the handle: from then on the web stream's
+// controller owns it and may already hold chunks in its queue, so fromWeb has to read
+// through the stream like it does for any other ReadableStream.
+describe.concurrent("Readable.fromWeb over a native stream that a consumer already started", () => {
+  // 16 blocks with a distinct fill byte each, so a dropped or reordered chunk shows.
+  const payload = Buffer.concat(Array.from({ length: 16 }, (_, i) => Buffer.alloc(64 * 1024, i)));
+  const collect = async readable => {
+    const chunks = [];
+    for await (const chunk of readable) chunks.push(chunk);
+    return Buffer.concat(chunks);
+  };
+
+  const sources = {
+    "Bun.file().stream()": file => Bun.file(file).stream(),
+    "new Response(Bun.file()).body": file => new Response(Bun.file(file)).body,
+    "new Blob().stream()": () => new Blob([payload]).stream(),
+    "new Response(bytes).body": () => new Response(payload).body,
+  };
+
+  // The reader-based adapter class. The native path returns a plain Readable instead.
+  const { _ReadableFromWeb: ReadableFromWeb } = exposedInternals["internal/webstreams/adapters"];
+
+  it.each(Object.keys(sources))("%s: native path while fresh, reader path once started", async name => {
+    using dir = tempDir("fromweb-started-native", { "payload.bin": payload });
+    const file = join(String(dir), "payload.bin");
+
+    const fresh = Readable.fromWeb(sources[name](file));
+    expect(fresh).toBeInstanceOf(Readable);
+    expect(fresh).not.toBeInstanceOf(ReadableFromWeb);
+    fresh.destroy();
+
+    const started = sources[name](file);
+    started.getReader().releaseLock();
+    const fallback = Readable.fromWeb(started);
+    expect(fallback).toBeInstanceOf(ReadableFromWeb);
+    fallback.destroy();
+
+    const cancelled = sources[name](file);
+    await cancelled.cancel();
+    expect(Readable.fromWeb(cancelled)).toBeInstanceOf(ReadableFromWeb);
+  });
+
+  // The Readable constructor reads user getters. fromWeb reads each option once, like Node,
+  // and a getter that starts the stream must not leave a window where the handle is still taken.
+  it("an options getter that starts the stream sends fromWeb down the reader path", async () => {
+    using dir = tempDir("fromweb-started-native", { "payload.bin": payload });
+    const web = Bun.file(join(String(dir), "payload.bin")).stream();
+    let reads = 0;
+    const readable = Readable.fromWeb(web, {
+      get highWaterMark() {
+        reads++;
+        web.getReader().releaseLock();
+        return 64 * 1024;
+      },
+    });
+    expect(reads).toBe(1);
+    expect(readable).toBeInstanceOf(ReadableFromWeb);
+    const out = await collect(readable);
+    expect(out.length).toBe(payload.length);
+    expect(out.equals(payload)).toBe(true);
+  });
+
+  // Node holds the reader before it constructs the Readable. The native path claims the handle
+  // at the same point, so user code the constructor runs (a signal's getters) sees a locked stream.
+  it("the native handle is claimed before the Readable constructor runs user code", () => {
+    using dir = tempDir("fromweb-started-native", { "payload.bin": payload });
+    const web = Bun.file(join(String(dir), "payload.bin")).stream();
+    let lockedInGetter;
+    const signal = {
+      get aborted() {
+        lockedInGetter = web.locked;
+        return false;
+      },
+      addEventListener() {},
+      removeEventListener() {},
+    };
+    const readable = Readable.fromWeb(web, { signal });
+    expect(lockedInGetter).toBe(true);
+    expect(readable).not.toBeInstanceOf(ReadableFromWeb);
+    readable.destroy();
+  });
+
+  it.each(Object.keys(sources))("%s after getReader() + releaseLock()", async name => {
+    using dir = tempDir("fromweb-started-native", { "payload.bin": payload });
+    const web = sources[name](join(String(dir), "payload.bin"));
+    web.getReader().releaseLock();
+    const out = await collect(Readable.fromWeb(web));
+    expect(out.length).toBe(payload.length);
+    expect(out.equals(payload)).toBe(true);
+  });
+
+  it.each(Object.keys(sources))("%s after a partial read", async name => {
+    using dir = tempDir("fromweb-started-native", { "payload.bin": payload });
+    const web = sources[name](join(String(dir), "payload.bin"));
+    const reader = web.getReader();
+    const first = await reader.read();
+    expect(first.done).toBe(false);
+    reader.releaseLock();
+    const out = Buffer.concat([Buffer.from(first.value), await collect(Readable.fromWeb(web))]);
+    expect(out.length).toBe(payload.length);
+    expect(out.equals(payload)).toBe(true);
+  });
+
+  // A drained stream is closed. fromWeb must end without data, not start the handle over.
+  it.each(Object.keys(sources))("%s after reading to the end", async name => {
+    using dir = tempDir("fromweb-started-native", { "payload.bin": payload });
+    const web = sources[name](join(String(dir), "payload.bin"));
+    const reader = web.getReader();
+    let drained = 0;
+    for (let result = await reader.read(); !result.done; result = await reader.read()) drained += result.value.length;
+    reader.releaseLock();
+    expect(drained).toBe(payload.length);
+    expect((await collect(Readable.fromWeb(web))).length).toBe(0);
+  });
+
+  it("Bun.spawn().stdout after getReader() + releaseLock()", async () => {
+    const expected = Buffer.alloc(100 * 1024, "x");
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "process.stdout.write(Buffer.alloc(100 * 1024, 'x'))"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const web = proc.stdout;
+    web.getReader().releaseLock();
+    const [out, exitCode] = await Promise.all([collect(Readable.fromWeb(web)), proc.exited]);
+    expect(out.length).toBe(expected.length);
+    expect(out.equals(expected)).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  // cancel() on a never-read native stream closes it. fromWeb must see a closed stream
+  // and end without data, not restart the handle and read the file again.
+  it("Bun.file().stream() after cancel() ends without data", async () => {
+    using dir = tempDir("fromweb-started-native", { "payload.bin": payload });
+    const web = Bun.file(join(String(dir), "payload.bin")).stream();
+    await web.cancel();
+    const readable = Readable.fromWeb(web);
+    const { promise: ended, resolve, reject } = Promise.withResolvers();
+    readable.on("end", resolve);
+    readable.on("error", reject);
+    const chunks = [];
+    readable.on("data", chunk => chunks.push(chunk));
+    await ended;
+    expect(Buffer.concat(chunks).length).toBe(0);
+  });
+
+  // addAbortSignal() errors a web stream in place. A never-read native stream has no
+  // controller yet, so only its state changes. fromWeb must report that error, not
+  // start the handle and read the data.
+  it.each(
+    Object.keys(sources).flatMap(name => [
+      [name, "never read"],
+      [name, "started"],
+    ]),
+  )("%s (%s) errored through addAbortSignal() errors the Readable", async (name, state) => {
+    using dir = tempDir("fromweb-started-native", { "payload.bin": payload });
+    const web = sources[name](join(String(dir), "payload.bin"));
+    if (state === "started") web.getReader().releaseLock();
+    const controller = new AbortController();
+    const reason = new Error("stop");
+    addAbortSignal(controller.signal, web);
+    controller.abort(reason);
+    const readable = Readable.fromWeb(web);
+    expect(readable).toBeInstanceOf(ReadableFromWeb);
+    const { promise: closed, resolve } = Promise.withResolvers();
+    const events = [];
+    readable.on("data", chunk => events.push(["data", chunk.length]));
+    readable.on("end", () => events.push(["end"]));
+    readable.on("error", error => events.push(["error", error.name, error.code, error.cause === reason]));
+    readable.on("close", resolve);
+    await closed;
+    expect(events).toEqual([["error", "AbortError", "ABORT_ERR", true]]);
+  });
+
+  // Bun.spawn drains a piped stdout in the background until a consumer starts the stream's
+  // handle. From then on it only reads when the stream pulls. An errored stream never pulls,
+  // so starting its handle would stall the child on a full pipe.
+  it("a never-read Bun.spawn().stdout that is errored does not stall the child", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "process.stdout.write(Buffer.alloc(4 * 1024 * 1024, 'x'))"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const web = proc.stdout;
+    const controller = new AbortController();
+    addAbortSignal(controller.signal, web);
+    controller.abort();
+    const readable = Readable.fromWeb(web);
+    const { promise: errored, resolve, reject } = Promise.withResolvers();
+    readable.on("error", resolve);
+    readable.on("end", () => reject(new Error("ended without an error")));
+    readable.resume();
+    expect((await errored).name).toBe("AbortError");
+    expect({ exitCode: await proc.exited, signalCode: proc.signalCode }).toEqual({ exitCode: 0, signalCode: null });
   });
 });
 

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -747,6 +747,51 @@ describe.concurrent("Readable.fromWeb over a native stream that a consumer alrea
     readable.destroy();
   });
 
+  // A throw from the Readable constructor comes after the claim, so the web stream stays
+  // locked, as in Node. Nothing else can release the handle then, so fromWeb cancels it:
+  // the pipe closes and the child's write fails. The child writes more than a pipe holds,
+  // so the result does not depend on when the pipe closes.
+  it("a throw from the Readable constructor cancels the claimed handle", async () => {
+    const child = `
+      const fs = require("fs");
+      process.stdin.once("data", () => {
+        let result = "written";
+        try {
+          for (let rest = Buffer.alloc(1024 * 1024, "x"); rest.length; ) rest = rest.subarray(fs.writeSync(1, rest));
+        } catch (error) {
+          result = "failed:" + error.code;
+        }
+        fs.writeSync(2, result);
+        process.exit(0);
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", child],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const web = proc.stdout;
+    const signal = {
+      get aborted() {
+        throw new Error("boom");
+      },
+      addEventListener() {},
+      removeEventListener() {},
+    };
+    expect(() => Readable.fromWeb(web, { signal })).toThrow("boom");
+    expect(web.locked).toBe(true);
+    proc.stdin.write("go");
+    await proc.stdin.end();
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stderr: "failed:EPIPE",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
   it.each(Object.keys(sources))("%s after getReader() + releaseLock()", async name => {
     using dir = tempDir("fromweb-started-native", { "payload.bin": payload });
     const web = sources[name](join(String(dir), "payload.bin"));


### PR DESCRIPTION
### Problem
- `Readable.fromWeb(stream)` drops data when `stream` is a native stream that a consumer already started (`getReader()` + `releaseLock()`, a partial read, or `cancel()`). A 4 MiB `Bun.file().stream()` reads as 3932160 bytes, a `Blob` stream as 0 bytes. A cancelled file stream is read again.
- `tryTransferToNativeReadable` (`src/js/internal/webstreams_adapters.ts:36`) took the native fast path whenever `stream.$bunNativePtr` was an object. That accessor still returns the handle after `materializeNativeSource` (`BunStreamSource.cpp:411`) started it, so the `NativeReadable` drove a handle the stream's controller already owned.

### Fix
- Add `JSReadableStream::hasPendingNativeSource()`: the stream is `NativePending`, readable, not locked, with a live handle.
- `jsFunctionTransferToNativeReadableStream` checks it and claims the handle in one call. `native-readable.ts` claims before it builds the `Readable`, so no user getter runs in between. If the claim fails, `Readable.fromWeb` uses the reader-based `ReadableFromWeb`.
- `materializeNativeSource` skips a stream that is already errored. The reader path reaches it, and a started handle that nothing pulls stalls a child on a full pipe.
- Verified: `test/js/node/stream/node-stream.test.js` (29 new cases, 25 fail on stock bun, 4 are controls). Also `streams.test.js`, `body.test.ts`, `child_process.test.ts`, upstream adapter tests.

### Background
- A native `ReadableStream` (file, blob, bytes, pipe) starts in `BunStreamMode::NativePending` with a handle in `m_nativePtr`. The first consumer runs `materializeIfNeeded()`, which calls `handle.start()` and installs a controller that owns the handle and fills the queue.
- The `Readable.fromWeb` fast path builds a `NativeReadable` (`native-readable.ts`) that calls `start()`/`pull()` on the handle itself. That is sound only on an untouched handle. #42116 set the same rule for locked streams.
- `$bunNativePtr` must keep returning a started handle: `process.stdin` reads it from `Bun.stdin.stream()`.

<details><summary>Notes</summary>

- Self-reviewed: 8 concerns raised, 8 addressed. The first version gated on a separate predicate host function and kept the transfer blind. The review found a window between the check and the transfer: `new Readable(options)` reads user getters (`highWaterMark`, a duck-typed `signal.aborted`) that could start the stream in between. That re-opened the bug in release and tripped a debug assertion. The claim is now one native call that runs before any user code, and `fromWeb` passes the option values it already read. The review also asked for the predicate to refuse a locked stream on its own (`ReadableStream__lockNative` leaves `m_bunMode` at `NativePending`), for tests that pin the `m_state` clause, and for the errored-stream guard in `materializeNativeSource`.
- Node parity of the claim order: Node calls `readableStream.getReader()` before `new Readable(...)`. So in Node the stream is locked while the constructor runs, each option is read once, and an invalid `highWaterMark` or `signal` throws with the stream left locked. The native path now behaves the same (stock bun: `highWaterMark` read 4 times, `stream.locked === false` inside `signal.aborted`). Checked against node v26.3.0.
- Errored never-read streams. `addAbortSignal(signal, webStream)` errors a stream in place. A `NativePending` stream has no controller yet, so only `m_state` changes (`webStreamControllerError`, `ControllerKind::None` arm). Stock bun then reads the whole file through `fromWeb`. Now `fromWeb` reports the `AbortError`, as Node does. Without the guard in `materializeNativeSource`, the reader path's `getReader()` started the handle: `Bun.spawn` stops draining a piped stdout in the background once the handle starts, nothing ever pulls an errored stream, and a child that writes 4 MiB blocks until it is killed. `getReader()`, `for await`, `tee()` and `pipeTo()` on such a stream stalled the child the same way on stock bun. Rust callers of `ReadableStream::error` already cancel the native source right after (`done()`), so they never relied on a later start.
- Not changed: the other takers of a native handle (`tryUseReadableStreamBufferedFastPath` in C++, `to_any_blob` and the body extractors in Rust). They refuse a started stream through `m_disturbed` / `is_disturbed || is_locked`. They still serve the data of an errored never-read stream. That is a separate, older behavior of `text()`/`blob()` and body extraction, with no link to `fromWeb`.
- #33461 (open) adds a stored `m_nativeSourceMaterialized` bit for the same fact on the body side. `m_bunMode != NativePending` already derives it, so that PR can use `hasPendingNativeSource()` or its parts instead of a new bit.
- `child_process.ts` is the other caller of `constructNativeReadable`, on the subprocess stdio stream it creates itself. That stream is always fresh (or has no handle at all, see #41608), so `constructNativeReadable` keeps its debug assertion that the claim returned a handle. In release a failed claim there gives an ended `Readable`, as a missing handle already did.
- Stock bun results for the new cases: file after `releaseLock()` 786432/1048576 bytes, blob 1032192/1048576 (first 16 KiB chunk lost), blob after a partial read 16384/1048576, spawn stdout never ends, cancelled file stream yields 65536 bytes instead of 0, errored stream ends with all its data, a started or cancelled stream still produces a `NativeReadable`. The 4 "after reading to the end" rows pass on stock too (a drained handle yields nothing when restarted). They pin the closed state for the new path.
- Other suites run: the rest of `node-stream.test.js`, `test/js/web/streams/streams.test.js`, `test/js/web/fetch/{body,body-stream,body-clone,body-mixin-errors,fetch-backpressure}.test.ts`, `node-stream-uint8array.test.ts`, `process-stdin.test.ts`, `child_process-node.test.js`, `test/js/node/readline/`, `test/js/bun/spawn/{readablestream-helpers,spawn-maxbuf,spawn-streaming-stdout,spawn-stdin-readable-stream,spawn-pipe-start-error,spawn-noread-leak}.test.ts`, and upstream `test-stream-add-abort-signal`, `test-webstreams-abort-controller`, `test-whatwg-readablestream`, `test-filehandle-readablestream`, `test-readable-from-web-enqueue-then-close`, `test-stream-readable-from-web-termination`, `test-webstream-readable-from`, `test-whatwg-webstreams-adapters-to-{readablestream,streamduplex,readablewritablepair}`, `test-whatwg-webstreams-coverage`, `test-stream-readable-to-web`, `test-stream-duplex-from`, `test-child-process-{stdio,spawn-event,stdout-flush,stdout-flush-exit,stdio-big-write-end,exec-maxbuf,flush-stdio,stdio-inherit}`.
- Pre-existing failures in this container, with or without the change: `child_process.test.ts` "spawn in the default shell" (`$SHELL` unset under `sh -c`, fails on release bun too) and "extra stdio pipes are not double-closed on GC" (20 sequential debug spawns exceed 5 s); `spawn-pipe-leak.test.ts` (750 debug spawns exceed its 30 s budget); `stdin-pause-pty.test.ts` (its python harness has a 3 s alarm a debug build exceeds); the S3 cases in `fetch-backpressure.test.ts` (no egress); `test-stdin-from-file-spawn.js` (the debug-only assertion #41608 fixes).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/stream/node-stream.test.js

<!-- robobun:evidence:end -->