### PR TITLE
node:util: create aborted()'s listener without Function.prototype.bind

### DIFF
--- a/src/js/node/util.ts
+++ b/src/js/node/util.ts
@@ -628,6 +628,12 @@ function onAbortedCallback(promise: Promise<void>) {
   $resolvePromiseWithFirstResolvingFunctionCallCheck(promise, undefined);
 }
 
+// Its own function so the listener's scope holds `promise` and not aborted()'s `resource`. Not
+// onAbortedCallback.bind(): that looks up `bind` on Function.prototype, which user code can replace.
+function createAbortedListener(promise: Promise<void>) {
+  return () => onAbortedCallback(promise);
+}
+
 function aborted(signal: AbortSignal, resource: object) {
   if (!$isObject(signal) || !(signal instanceof AbortSignal)) {
     throw $ERR_INVALID_ARG_TYPE("signal", "AbortSignal", signal);
@@ -642,14 +648,8 @@ function aborted(signal: AbortSignal, resource: object) {
   }
 
   const promise = $newPromise();
-  const listener = onAbortedCallback.bind(undefined, promise);
-  signal.addEventListener(
-    "abort",
-    // Do not leak the current scope into the listener.
-    // Instead, create a new function.
-    listener,
-    resistStopPropagation({ __proto__: null, once: true }),
-  );
+  const listener = createAbortedListener(promise);
+  signal.addEventListener("abort", listener, resistStopPropagation({ __proto__: null, once: true }));
 
   if (!lazyAbortedRegistry) {
     lazyAbortedRegistry = new FinalizationRegistry(({ ref, listener }) => {

--- a/test/js/node/util/test-aborted.test.ts
+++ b/test/js/node/util/test-aborted.test.ts
@@ -106,3 +106,18 @@ test("aborted resolves every waiter on the same signal with undefined", async ()
   expect(await Promise.all([first, second])).toEqual([undefined, undefined]);
   expect(getEventListeners(ac.signal, "abort")).toHaveLength(0);
 });
+
+test("aborted does not hand its internal settle function to a patched Function.prototype.bind", () => {
+  const originalBind = Function.prototype.bind;
+  const receivers: Function[] = [];
+  Function.prototype.bind = function (this: Function, ...args: any[]) {
+    receivers.push(this);
+    return originalBind.apply(this, args as [any, ...any[]]);
+  };
+  try {
+    aborted(new AbortController().signal, {});
+  } finally {
+    Function.prototype.bind = originalBind;
+  }
+  expect(receivers).toEqual([]);
+});


### PR DESCRIPTION
### What does this PR do?

`util.aborted()` built its abort listener with `onAbortedCallback.bind(undefined, promise)`. `bind` is looked up on `Function.prototype`, so if user code has replaced `Function.prototype.bind`, that replacement is called with the internal `onAbortedCallback` as its receiver. `onAbortedCallback` is a private helper that assumes its argument is the promise `aborted()` created, and it is not meant to be reachable from user code.

The listener is now created by a small `createAbortedListener(promise)` helper that returns a closure. It does no user-visible property lookups, and being its own function it still keeps `resource` out of the listener's scope, which is what the `bind` was there for (the listener must not keep `resource` alive).

Behavior of `aborted()` is otherwise unchanged.

### How did you verify your code works?

Added a test to `test/js/node/util/test-aborted.test.ts` that replaces `Function.prototype.bind` around a call to `aborted()` and asserts it is never invoked.

- `USE_SYSTEM_BUN=1 bun test test/js/node/util/test-aborted.test.ts` (Bun 1.4.2): the new test fails with `[Function: onAbortedCallback]` captured, the other 7 pass.
- I have not run the file against a debug build of this branch; relying on CI for that.
