### PR TITLE
Bun.serve: graceful stop() also drains TLS connections parked in the handshake queue

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -435,6 +435,18 @@ public:
             }
             s = next;
         }
+        /* A TLS socket whose handshake waits in the loop's low-priority queue
+         * (loop.c, MAX_LOW_PRIO_SOCKETS_PER_LOOP_ITERATION) is unlinked from
+         * head_sockets until its turn comes. It is mid-handshake, so it is
+         * never idle; it only needs the mark. */
+        if (closeWhenIdle && group->low_prio_count) {
+            for (s = group->loop->data.low_prio_head; s; s = s->next) {
+                if (s->group == group) {
+                    auto *data = (HttpResponseData<SSL> *) ((AsyncSocket<SSL> *) s)->getAsyncSocketData();
+                    data->state |= HttpResponseData<SSL>::HTTP_CLOSE_WHEN_IDLE;
+                }
+            }
+        }
         if (Http2Context *h2 = httpContext->getSocketContextData()->http2Context) {
             closed += h2->closeIdle(closeWhenIdle);
         }

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1378,6 +1378,75 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
     });
   });
 
+  test("stop() drains TLS connections whose handshake is queued behind the per-iteration budget", async () => {
+    // The loop runs five TLS handshakes per iteration and parks the rest of a
+    // burst in a loop-wide low-priority queue, unlinked from the socket list
+    // the stop() sweep walks. The first request to arrive stops the server, so
+    // most of the burst is still parked at that moment. A parked connection
+    // that the sweep misses stays keep-alive: it answers every later request
+    // and holds the drain promise open until the client hangs up. The client
+    // only hangs up after a third answer, so one answer on a connection means
+    // the server closed it after the first response.
+    const connections = 30;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          let stopped;
+          let resolved = false;
+          const server = Bun.serve({
+            port: 0, hostname: "127.0.0.1", tls: ${JSON.stringify(tls)},
+            idleTimeout: 255,
+            fetch() {
+              stopped ??= server.stop().then(() => { resolved = true; });
+              return new Response("ok");
+            },
+          });
+          const GET = "GET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n";
+          const END = "\\r\\n\\r\\nok";
+          const conns = [];
+          for (let i = 0; i < ${connections}; i++) {
+            const closed = Promise.withResolvers();
+            const conn = { answers: 0, closed: closed.promise };
+            let buf = "";
+            Bun.connect({
+              hostname: "127.0.0.1", port: server.port, tls: { rejectUnauthorized: false },
+              socket: {
+                handshake: s => void s.write(GET),
+                data(s, d) {
+                  buf += d.toString("latin1");
+                  while (buf.includes(END)) {
+                    buf = buf.slice(buf.indexOf(END) + END.length);
+                    if (++conn.answers < 3) s.write(GET);
+                    else s.end();
+                  }
+                },
+                close: () => closed.resolve(),
+                error: () => {},
+                connectError: () => closed.resolve(),
+              },
+            }).catch(() => {});
+            conns.push(conn);
+          }
+          await Promise.all(conns.map(c => c.closed));
+          await stopped;
+          console.log(JSON.stringify({ resolved, answers: conns.map(c => c.answers).join("") }));
+          process.exit(0);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, out: JSON.parse(stdout.trim() || "null"), exitCode }).toEqual({
+      stderr: "",
+      out: { resolved: true, answers: "1".repeat(connections) },
+      exitCode: 0,
+    });
+  });
+
   test("server.reload() keeps the connection count coherent", async () => {
     // clearRoutes() used to wipe filterHandlers, so a connection open across
     // reload left active_connection_count stuck > 0 forever. With the stuck

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1442,7 +1442,7 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stderr, out: JSON.parse(stdout.trim() || "null"), exitCode }).toEqual({
       stderr: "",
-      out: { resolved: true, answers: "1".repeat(connections) },
+      out: { resolved: true, answers: Buffer.alloc(connections, "1").toString() },
       exitCode: 0,
     });
   });


### PR DESCRIPTION
### Problem
- A graceful `server.stop()` on a TLS `Bun.serve` misses connections whose TLS handshake is queued. They stay keep-alive, the server keeps answering them, and the `stop()` promise does not resolve until the client hangs up. 20 handshakes started in one tick leave 15 survivors. 5 leave none.
- The cause is `App::closeIdle(true)` (`packages/bun-uws/src/App.h:421`), the sweep that `stop_listening` runs. It walks `group->head_sockets` only. A socket parked in `loop->data.low_prio_head` is unlinked from that list (`packages/bun-usockets/src/loop.c:637`), so it never gets the `HTTP_CLOSE_WHEN_IDLE` mark.

### Fix
- `closeIdle(true)` also walks `loop->data.low_prio_head` and sets `HTTP_CLOSE_WHEN_IDLE` on each parked socket of its group. A parked socket is mid-handshake, so it is never idle and only needs the mark.
- Correct because an in-budget handshake already gets this mark from the same sweep: it completes, serves one request, then the server closes the connection. `us_socket_group_close_all_ex` and `us_internal_listen_socket_ssl_free` filter the same queue by group the same way. `closeIdle(false)` does not change.
- Verified: new test in `test/js/bun/http/bun-server.test.ts` (30 TLS connections, the first request calls `stop()`. Without the fix, 20 of them answer three requests). Also ran `serve.test.ts`, `serve-http2*`, `tls-keepalive.test.ts`, `node-http.test.ts`, `node-tls-server.test.ts`.

### Background
- usockets runs at most 5 TLS handshake reads per loop iteration (`MAX_LOW_PRIO_SOCKETS_PER_LOOP_ITERATION`). It parks the rest in a loop-wide queue that reuses the socket's `prev`/`next` links. A parked socket is therefore not in `head_sockets`.
- `HTTP_CLOSE_WHEN_IDLE` (#37074) is a per-connection bit. `shouldCloseConnection()` acts on it once the response in flight completes.
- A graceful `stop()` is one-shot. A second `stop()` finds no listener and returns, so nothing visits a missed connection again.

<details><summary>Notes</summary>

Repro from the report (20 raw TCP connections, all ClientHellos in one tick, `server.stop()` one tick later, one GET per second per connection):

```
1.4.3-canary (4ff919377)  N=20 | still open after 8 s: 15 | responses per connection: 1,1,1,1,1,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8 | stop() resolved: never
this branch (debug+ASAN)  N=20 | still open after 8 s: 0  | responses per connection: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1 | stop() resolved: 1765 ms
1.4.3-canary              N=5  | still open after 6 s: 0  | responses per connection: 1,1,1,1,1 | stop() resolved: 115 ms
```

The new test, per-connection answer counts (the client hangs up after a third answer):

```
without the fix (release and debug+ASAN, 12 of 12 runs): 111113333333333333333333311111
with the fix:                                            111111111111111111111111111111
```

The first five and the last five connections are the ones the loop had already taken out of the queue when the first request arrived (the queue is LIFO).

Why the test stops from the first request handler: the server needs three loop iterations to finish the first handshake, and it takes five sockets out of the queue per iteration. With 30 connections, 20 are still parked when the first request dispatches. No timer is involved.

Not covered here: with `http2: true`, a connection that negotiates h2 after `stop()` loses the mark when `Http2Context::attach`'s `onHttp2` hook destructs the `HttpResponseData` and adopts the socket. It never receives GOAWAY. That happens for in-budget handshakes too, so it is a separate cause. HTTP/1.1 clients of an `http2: true` server are covered by this change.

Related open PRs on the same population: #36403 (the timeout sweep does not visit the queue either) and #37889 (changes how idle is classified, leaves the iteration as is). Neither touches this walk. A parked socket is also "not idle" under #37889's `isIdle()`, because `betweenRequests` starts false.

Suites with failures that also fail on an unmodified build in this container: `bun-server.test.ts` "allows listen on IPV6", `serve.test.ts` "root range port (#7187)" and "/bun:info loopback", `node-tls-server.test.ts` "SNICallback ... bind hostname" (ECONNREFUSED on the system bun too).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/http/bun-server.test.ts

<!-- robobun:evidence:end -->