### PR TITLE
Bun.build: keep an import's `with { type }` loader through onResolve and onLoad plugins

### DIFF
--- a/docs/bundler/plugins.mdx
+++ b/docs/bundler/plugins.mdx
@@ -228,7 +228,7 @@ The callback receives the path to the matching module, its namespace, its defaul
 
 The callback can return a new `contents` string for the module as well as a new `loader`.
 
-If the callback returns `contents` without a `loader`, `Bun.build` uses the default loader. The default loader is the loader that Bun picks for the module without the plugin: the import's `type` attribute (`with { type: "text" }`) when the import has one, and the loader for the file extension otherwise. One case differs. Where Bun picks the `file` loader for an extension that has no loader, the default loader is `js`.
+If the callback returns `contents` without a `loader`, `Bun.build` uses the default loader. The default loader is the loader that Bun picks for the module without the plugin: the import's `type` attribute (`with { type: "text" }`) when the import has one, and the loader for the file extension otherwise. One case differs. For an extension that has no loader, Bun picks the `file` loader, but the default loader is `js`. The default loader is also `js` when the import of such a file has `with { type: "file" }`.
 
 For example:
 

--- a/docs/bundler/plugins.mdx
+++ b/docs/bundler/plugins.mdx
@@ -228,6 +228,8 @@ The callback receives the path to the matching module, its namespace, its defaul
 
 The callback can return a new `contents` string for the module as well as a new `loader`.
 
+If the callback returns `contents` without a `loader`, `Bun.build` uses the default loader. The default loader is the loader that Bun picks for the module without the plugin: the import's `type` attribute (`with { type: "text" }`) when the import has one, and the loader for the file extension otherwise. One case differs. Where Bun picks the `file` loader for an extension that has no loader, the default loader is `js`.
+
 For example:
 
 ```ts title="index.ts" icon="/icons/typescript.svg"

--- a/docs/runtime/plugins.mdx
+++ b/docs/runtime/plugins.mdx
@@ -221,7 +221,7 @@ The callback receives the matching module's _path_, its _namespace_, the default
 
 The callback can return a new `contents` string for the module as well as a new `loader`.
 
-If the callback returns `contents` without a `loader`, `Bun.build` uses the default loader. The default loader is the loader that Bun picks for the module without the plugin: the import's `type` attribute (`with { type: "text" }`) when the import has one, and the loader for the file extension otherwise. One case differs. Where Bun picks the `file` loader for an extension that has no loader, the default loader is `js`.
+If the callback returns `contents` without a `loader`, `Bun.build` uses the default loader. The default loader is the loader that Bun picks for the module without the plugin: the import's `type` attribute (`with { type: "text" }`) when the import has one, and the loader for the file extension otherwise. One case differs. For an extension that has no loader, Bun picks the `file` loader, but the default loader is `js`. The default loader is also `js` when the import of such a file has `with { type: "file" }`.
 
 For example:
 

--- a/docs/runtime/plugins.mdx
+++ b/docs/runtime/plugins.mdx
@@ -221,6 +221,8 @@ The callback receives the matching module's _path_, its _namespace_, the default
 
 The callback can return a new `contents` string for the module as well as a new `loader`.
 
+If the callback returns `contents` without a `loader`, `Bun.build` uses the default loader. The default loader is the loader that Bun picks for the module without the plugin: the import's `type` attribute (`with { type: "text" }`) when the import has one, and the loader for the file extension otherwise. One case differs. Where Bun picks the `file` loader for an extension that has no loader, the default loader is `js`.
+
 For example:
 
 ```ts index.ts icon="/icons/typescript.svg"

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6177,9 +6177,11 @@ declare module "bun" {
      *
      * It is the loader that Bun picks for the module without the plugin: the
      * `type` attribute of the import (`with { type: "text" }`) when the import
-     * has one, and the loader for the file extension otherwise. One case
-     * differs. Where Bun picks the `"file"` loader for an extension that has no
-     * loader, the default loader is `"js"`.
+     * has one, and the loader for the file extension otherwise.
+     *
+     * One case differs. For an extension that has no loader, Bun picks the
+     * `"file"` loader, but the default loader is `"js"`. The default loader is
+     * also `"js"` when the import of such a file has `with { type: "file" }`.
      */
     loader: Loader;
     /**

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -6172,7 +6172,14 @@ declare module "bun" {
      */
     namespace: string;
     /**
-     * The default loader for this file extension
+     * The default loader for this module. `Bun.build` uses it when the callback
+     * returns `contents` without a `loader`.
+     *
+     * It is the loader that Bun picks for the module without the plugin: the
+     * `type` attribute of the import (`with { type: "text" }`) when the import
+     * has one, and the loader for the file extension otherwise. One case
+     * differs. Where Bun picks the `"file"` loader for an extension that has no
+     * loader, the default loader is `"js"`.
      */
     loader: Loader;
     /**

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1251,10 +1251,15 @@ pub mod bv2_impl {
             }
             impl Load {
                 pub(crate) fn init(bv2: &mut BundleV2<'_>, parse: &mut ParseTask) -> Self {
-                    let default_loader = parse
-                        .path
-                        .loader(&bv2.transpiler.options.loaders)
-                        .unwrap_or(Loader::Js);
+                    let path_loader = parse.path.loader(&bv2.transpiler.options.loaders);
+                    // `parse.loader` is the loader the bundle picked (a `with { type }` attribute wins over
+                    // the extension). A file it would only copy because nothing claims its extension still
+                    // defaults to js for plugin contents, as in esbuild.
+                    let default_loader = match parse.loader.or(path_loader) {
+                        Some(Loader::File) if path_loader.is_none() => Loader::Js,
+                        Some(loader) => loader,
+                        None => Loader::Js,
+                    };
                     Self {
                     bv2: std::ptr::from_mut::<BundleV2<'_>>(bv2).cast::<BundleV2<'static>>(),
                     parse_task: bun_ptr::BackRef::new_mut(parse),
@@ -4997,14 +5002,22 @@ pub mod bv2_impl {
                             unsafe { *value_ptr = source_index.get() };
                             out_source_index = Some(source_index);
                             let _ = this.graph.ast.append(JSAst::empty_in(this.graph.heap)); // OOM/capacity: fire-and-forget
-                            // A file that a plugin resolved the record to instead keeps its own loader.
-                            let loader = this.requested_file_loader(
-                                &path,
-                                resolve
-                                    .import_record
-                                    .loader
-                                    .filter(|_| path.text == &*resolve.import_record.specifier),
-                            );
+                            let requested_loader =
+                                if resolve.import_record.kind == ImportKind::EntryPointBuild {
+                                    // A file that a plugin resolved the entry point to instead keeps its own loader.
+                                    resolve
+                                        .import_record
+                                        .loader
+                                        .filter(|_| path.text == &*resolve.import_record.specifier)
+                                } else {
+                                    // A `with { type }` loader belongs to the import, whichever path the plugin returned.
+                                    this.graph.ast.items_import_records()
+                                        [resolve.import_record.importer_source_index as usize]
+                                        .as_slice()
+                                        [resolve.import_record.import_record_index as usize]
+                                        .loader
+                                };
+                            let loader = this.requested_file_loader(&path, requested_loader);
 
                             this.graph
                                 .input_files

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1252,13 +1252,12 @@ pub mod bv2_impl {
             impl Load {
                 pub(crate) fn init(bv2: &mut BundleV2<'_>, parse: &mut ParseTask) -> Self {
                     let path_loader = parse.path.loader(&bv2.transpiler.options.loaders);
-                    // `parse.loader` is the loader the bundle picked (a `with { type }` attribute wins over
-                    // the extension). A file it would only copy because nothing claims its extension still
-                    // defaults to js for plugin contents, as in esbuild.
-                    let default_loader = match parse.loader.or(path_loader) {
-                        Some(Loader::File) if path_loader.is_none() => Loader::Js,
-                        Some(loader) => loader,
-                        None => Loader::Js,
+                    let default_loader = match parse.loader {
+                        // They differ when something requested the loader, such as an import's `with { type }`.
+                        Some(requested) if requested != path_loader.unwrap_or(Loader::File) => {
+                            requested
+                        }
+                        _ => path_loader.unwrap_or(Loader::Js),
                     };
                     Self {
                     bv2: std::ptr::from_mut::<BundleV2<'_>>(bv2).cast::<BundleV2<'static>>(),

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4642,6 +4642,13 @@ pub mod bv2_impl {
                     // If it's a file namespace, we should run it through the parser like normal.
                     // The file could be on disk.
                     if source.path.is_file() {
+                        // The enqueue site left the asset bookkeeping to the plugin's answer.
+                        let index = load.source_index.get() as usize;
+                        if this.graph.input_files.items_loader()[index].should_copy_for_bundling() {
+                            this.graph.input_files.items_side_effects_mut()[index] =
+                                bun_ast::SideEffects::NoSideEffectsPureData;
+                            this.graph.estimated_file_loader_count += 1;
+                        }
                         this.graph.pool().schedule(load.parse_task_mut());
                         return;
                     }

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -96,6 +96,89 @@ describe("bundler", () => {
       stdout: '[{"config":{"@env":"test","name":"app"}},{"feed":{"entry":["1","2"]}}]',
     },
   });
+  // A `with { type }` import attribute picks the loader. onLoad reports it as
+  // args.loader, and contents returned without a loader are loaded with it,
+  // both for an unknown extension and for one that has its own loader.
+  itBundled("plugin/LoadImportAttributeLoader", {
+    files: {
+      "/index.ts": /* ts */ `
+        import page from "./page.htmlx" with { type: "text" };
+        import raw from "./data.json" with { type: "text" };
+        import config from "./config.cfgx" with { type: "json" };
+        const late = await import("./late.htmlx", { with: { type: "text" } });
+        console.log(JSON.stringify([page, raw, config, late.default]));
+      `,
+      "/page.htmlx": `<b>not js</b> <`,
+      "/data.json": `{"a":1}`,
+      "/config.cfgx": `{"k":[1,2]}`,
+      "/late.htmlx": `<i>late</i> <`,
+    },
+    plugins(builder) {
+      builder.onLoad({ filter: /\.(htmlx|json|cfgx)$/ }, async args => {
+        const expected = args.path.endsWith(".cfgx") ? "json" : "text";
+        if (args.loader !== expected) throw new Error(`expected args.loader to be ${expected}, got ${args.loader}`);
+        return { contents: (await Bun.file(args.path).text()).toUpperCase() };
+      });
+    },
+    run: {
+      stdout: String.raw`["<B>NOT JS</B> <","{\"A\":1}",{"K":[1,2]},"<I>LATE</I> <"]`,
+    },
+  });
+  // The attribute belongs to the import. Its loader also applies when onResolve
+  // returned the path, for the same file or for another one, with or without an
+  // onLoad hook for that file.
+  for (const withLoad of [false, true]) {
+    itBundled(`plugin/ResolveImportAttributeLoader${withLoad ? "AndLoad" : ""}`, ({ root }) => ({
+      files: {
+        "/index.ts": /* ts */ `
+          import page from "./page.htmlx" with { type: "text" };
+          import raw from "alias:data" with { type: "text" };
+          console.log(JSON.stringify([page, raw]));
+        `,
+        "/page.htmlx": `<b>not js</b> <`,
+        "/data.json": `{"a":1}`,
+      },
+      plugins(builder) {
+        builder.onResolve({ filter: /\.htmlx$/ }, args => ({ path: resolve(dirname(args.importer), args.path) }));
+        builder.onResolve({ filter: /^alias:data$/ }, () => ({ path: join(root, "data.json") }));
+        if (withLoad) {
+          builder.onLoad({ filter: /\.(htmlx|json)$/ }, async args => {
+            if (args.loader !== "text") throw new Error("expected args.loader to be text, got " + args.loader);
+            return { contents: await Bun.file(args.path).text() };
+          });
+        }
+      },
+      run: {
+        stdout: String.raw`["<b>not js</b> <","{\"a\":1}"]`,
+      },
+    }));
+  }
+  // The same rule in a plugin's own namespace: the attribute's loader is the
+  // default for contents returned without a loader, and js is the default for
+  // an import that has no attribute.
+  itBundled("plugin/LoadImportAttributeLoaderInNamespace", {
+    files: {
+      "/index.ts": /* ts */ `
+        import page from "virtual:page" with { type: "text" };
+        import code from "virtual:code";
+        console.log(JSON.stringify([page, code]));
+      `,
+    },
+    plugins(builder) {
+      builder.onResolve({ filter: /^virtual:/ }, args => ({
+        path: args.path.slice("virtual:".length),
+        namespace: "virtual",
+      }));
+      builder.onLoad({ filter: /.*/, namespace: "virtual" }, args => {
+        const expected = args.path === "page" ? "text" : "js";
+        if (args.loader !== expected) throw new Error(`expected args.loader to be ${expected}, got ${args.loader}`);
+        return { contents: args.path === "page" ? "<b>virtual</b> <" : "export default 'code';" };
+      });
+    },
+    run: {
+      stdout: String.raw`["<b>virtual</b> <","code"]`,
+    },
+  });
 
   // Load Plugin Errors
   itBundled("plugin/LoadThrow", {

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1040,6 +1040,67 @@ describe("bundler", () => {
     },
   });
 
+  // An onLoad hook that matches an asset and returns nothing leaves the file to
+  // its own loader. The linker used to abort, because nothing recorded that the
+  // build has an asset to copy.
+  test.concurrent("plugin/onLoad that declines an asset leaves it to the file loader", async () => {
+    using dir = tempDir("plugin-onload-declines-asset", {
+      "index.ts": `
+        import asset from "./asset.bin";
+        import mod from "./mod.js" with { type: "file" };
+        console.log(JSON.stringify([asset, mod]));
+      `,
+      "asset.bin": "asset bytes",
+      "mod.js": "export default 1;",
+      "build.mjs": `
+        import { basename } from "node:path";
+        const declined = [];
+        const result = await Bun.build({
+          entrypoints: ["./index.ts"],
+          outdir: "./out",
+          naming: { asset: "[name].[ext]" },
+          throw: false,
+          plugins: [
+            {
+              name: "decline",
+              setup(build) {
+                build.onLoad({ filter: /\\.(bin|js)$/ }, args => {
+                  declined.push(basename(args.path));
+                });
+              },
+            },
+          ],
+        });
+        console.log(
+          JSON.stringify({
+            success: result.success,
+            logs: result.logs.map(log => log.message),
+            outputs: result.outputs.map(output => output.kind + " " + basename(output.path)).sort(),
+            declined: declined.sort(),
+          }),
+        );
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      success: true,
+      logs: [],
+      outputs: ["asset asset.bin", "asset mod.js", "entry-point index.js"],
+      declined: ["asset.bin", "mod.js"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
   itBundled("plugin/OnEndBasic", ({ root }) => {
     let onEndCalled = false;
 


### PR DESCRIPTION
### Problem
- `Bun.build` drops an import's `with { type }` loader when an `onLoad` or `onResolve` plugin handles the import. For `import t from "./page.htmlx" with { type: "text" }`, a hook that returns `{ contents }` sees `args.loader === "js"`, and the build fails with `error: Unexpected <`. Without plugins the import is text.
- `Load::init` and the `Success` arm of `on_resolve` (`src/bundler/bundle_v2.rs`) pick the loader from the extension only.
- Also, an `onLoad` hook that matches an asset and returns nothing aborts: `panic: index out of bounds: the len is 0 but the index is 0`. The `NoMatch` arm of `on_load` skips the asset bookkeeping.

### Fix
- `Load::init` takes `parse.loader`, which carries the attribute, before the extension. An extension with no loader still gets `"js"`.
- The `Success` arm reads the importer's import record, as `run_resolver` does when a hook declines.
- The `NoMatch` arm now counts the asset in `estimated_file_loader_count`, as the `Success` arm of `on_load` does.
- Verified: `test/bundler/bundler_plugin.test.ts`, 5 new cases, all fail on main. Self-reviewed: 14 concerns raised, 12 addressed (Notes).

### Background
- The parser stores `with { type: "text" }` in `ImportRecord.loader`. Without plugins, `resolve_import_records` copies it to `ParseTask.loader`.
- A matching `onLoad` filter wraps the `ParseTask` in a `Load`. Its `default_loader` is `args.loader` and the fallback for a result with no `loader`.
- `on_resolve` gets a hook's answer: `Success` for a path, `NoMatch` for nothing.
- `process_files_to_copy` emits assets only when `estimated_file_loader_count > 0`.

<details><summary>Notes</summary>

**Origin.** Found by inspection during other work. No user issue reports it. #7293 and #16147 ask for the import attributes in the hook arguments (`args.with`). This PR does not add that.

**The rule after this PR.** The loader for plugin contents is: the `loader` the hook returns, else the import's `type` attribute, else the loader for the file extension, else `js`. The rule is the same in a plugin's own namespace (`plugin/LoadImportAttributeLoaderInNamespace` pins it). An import with no attribute behaves as before everywhere.

**Known limit.** `with { type: "file" }` on an extension that has no loader still gives `"js"`. `ParseTask.loader` holds `file` both for that attribute and for the bundle's fallback, and `Load::init` cannot tell them apart. This is the old behaviour for that case. The docs and the `OnLoadArgs.loader` JSDoc describe it.

**Behaviour changes besides the attribute.**
- An HTML `<link href="./manifest.json">` forces the `file` loader so the asset is copied. A plugin that matches that file now sees `"file"`, not `"json"`. That is what the bundle does without the plugin.
- A server-components client copy of a file is enqueued with the loader of the first parse. A plugin that loads it again now sees that loader in `args.loader`.

**Supporting facts.**
- The native `onBeforeParse` path already passes the task's loader as `default_loader` (`src/bundler/ParseTask.rs:2078`). The JS `onLoad` path was the only one that recomputed it from the extension.
- A dynamic `import("./x.htmlx", { with: { type: "text" } })` sets the same `ImportRecord.loader`. The first test covers it.
- The `Success` arm indexes the importer's records on the graph directly. `run_resolver` and the external-import arm do the same. A plugin answer runs as a posted task, after `on_parse_task_complete` put the importer's records on the graph. The error path keeps them there for this reason (`bundle_v2.rs:6148`).
- The `NoMatch` arm does not push an `AdditionalFile::SourceIndex` entry. Nothing reads those entries. The linker reads the `OutputFile` entry that `process_files_to_copy` appends.
- The loader that the dev server requests for an entry point keeps its rule: it applies to the entry point's own path only.

**Not changed.** The runtime `Bun.plugin` path picks the loader from the extension (`Bun__getDefaultLoader`, `src/jsc/ModuleLoader.rs`). It is a separate code path.

**Related open PRs.** #37476 and #41834 key modules by (path, loader), so one file under two attributes becomes two modules. That is a different problem. Here the first import of a path still decides its loader. #37476 carries an equivalent change to the `on_resolve` arm, and it has conflicts.

**Self-review.** The first version of this change had only the `Load::init` hunk. The review found the `onResolve` gap and the declined-asset abort, and asked for the namespace rule to be explicit, a `type: "json"` case, and the doc updates. Two concerns are left out: a differential test harness mode that runs every loader test through an identity plugin (test infrastructure, a separate change), and one shared loader chooser for all enqueue sites (a larger refactor that overlaps #31998, and the only way to remove the known limit above).

**Local runs.** `bundler_plugin`, `bundler_loader`, `bundler_html`, `bundler_defer`, `bundler_barrel`, `bundler_plugin_chain`, `bundler_files`, `plugin-error-nested-throw`, `plugin-sync-exception-fallback`, `native-plugin`, `test/bake/dev/plugins.test.ts`, `test/js/bun/plugin/plugins.test.ts`. With `src/` from main and the debug build, the 5 new cases fail, the declined-asset case with `panic: assertion failed: !additional_files.is_empty()`. `test/integration/bun-types/bun-types.test.ts` fails in my container the same way with and without the JSDoc change. Two `bytecode:` cases in `bun-build-api.test.ts` time out under the debug build with and without this change.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_plugin.test.ts

<!-- robobun:evidence:end -->