### PR TITLE
Format download progress byte counts in human-readable units

### DIFF
--- a/src/bun_core/Progress.rs
+++ b/src/bun_core/Progress.rs
@@ -110,6 +110,12 @@ impl File {
 
 use crate::time::NS_PER_MS;
 
+/// `Unit::Bytes` renders as `[1.5MB/22.9MB]`, the same shape as the other
+/// size outputs of the CLI.
+const BYTES_FMT: crate::fmt::SizeFormatterOptions = crate::fmt::SizeFormatterOptions {
+    space_between_number_and_unit: false,
+};
+
 pub struct Progress {
     /// `None` if the current node (and its children) should
     /// not print on update()
@@ -572,10 +578,14 @@ impl Progress {
                                 &mut end,
                                 format_args!("[{}/{} files] ", current_item, eti),
                             ),
-                            // Raw byte counts are printed until an IEC-units
-                            // (KiB/MiB) formatting helper lands.
-                            Unit::Bytes => self
-                                .buf_write(&mut end, format_args!("[{}/{}] ", current_item, eti)),
+                            Unit::Bytes => self.buf_write(
+                                &mut end,
+                                format_args!(
+                                    "[{}/{}] ",
+                                    crate::fmt::size(current_item, BYTES_FMT),
+                                    crate::fmt::size(eti, BYTES_FMT)
+                                ),
+                            ),
                         }
                         need_ellipse = false;
                     } else if completed_items != 0 {
@@ -589,10 +599,10 @@ impl Progress {
                             Unit::Files => {
                                 self.buf_write(&mut end, format_args!("[{} files] ", current_item))
                             }
-                            // Raw byte counts; see the note above.
-                            Unit::Bytes => {
-                                self.buf_write(&mut end, format_args!("[{}] ", current_item))
-                            }
+                            Unit::Bytes => self.buf_write(
+                                &mut end,
+                                format_args!("[{}] ", crate::fmt::size(current_item, BYTES_FMT)),
+                            ),
                         }
                         need_ellipse = false;
                     }

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -123,6 +123,8 @@ function startReleaseServer(opts: {
   assetNames?: string[];
   zipPath?: string;
   zipBody?: string;
+  zipStream?: () => ReadableStream<Uint8Array>;
+  size?: number;
   digest?: string;
 }): ReleaseServer {
   const assetNames = opts.assetNames ?? allAssetNames();
@@ -133,6 +135,7 @@ function startReleaseServer(opts: {
       const { pathname } = new URL(req.url);
       if (pathname.startsWith("/download/")) {
         if (opts.zipPath) return new Response(Bun.file(opts.zipPath));
+        if (opts.zipStream) return new Response(opts.zipStream());
         return new Response(opts.zipBody ?? "this is not a real zip archive");
       }
       return new Response(
@@ -142,6 +145,7 @@ function startReleaseServer(opts: {
             url: "foo",
             content_type: "application/zip",
             name,
+            ...(opts.size !== undefined ? { size: opts.size } : {}),
             ...(opts.digest ? { digest: opts.digest } : {}),
             browser_download_url: `https://${server.hostname}:${server.port}/download/${name}`,
           })),
@@ -255,6 +259,46 @@ describe.concurrent(() => {
     );
     expect(err.split(/\r?\n/)).not.toContain("note: Use `bun update --stable --profile` instead.");
     await proc.exited;
+  });
+
+  // The progress bar prints only after its 500ms initial delay, so the
+  // server paces the body over about one second. With stderr piped, each
+  // refresh is one "Downloading [current/total]" line.
+  it.skipIf(isWindows)("download progress prints sizes in human-readable units", async () => {
+    const chunk = new Uint8Array(64 * 1024);
+    const chunkCount = 40;
+    using server = startReleaseServer({
+      tagName: "bun-v9.9.9",
+      size: chunk.length * chunkCount,
+      zipStream: () => {
+        let sent = 0;
+        return new ReadableStream({
+          async pull(controller) {
+            await Bun.sleep(30);
+            controller.enqueue(chunk);
+            if (++sent === chunkCount) controller.close();
+          },
+        });
+      },
+    });
+    const cwd = tmpdirSync();
+    const execPath = join(cwd, basename(bunExe()));
+    await copyFile(bunExe(), execPath);
+    await using proc = spawn({
+      cmd: [execPath, "upgrade", "--stable"],
+      cwd,
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env: server.env,
+    });
+
+    const [err] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const progress = err.split(/\r?\n/).filter(line => line.startsWith("Downloading ["));
+    expect(progress).not.toBeEmpty();
+    expect(progress).toEqual(
+      progress.map(() => expect.stringMatching(/^Downloading \[\d+(\.\d+)?[KM]?B\/2\.62MB\] $/)),
+    );
   });
 });
 


### PR DESCRIPTION
### Problem
- `bun upgrade` prints the download progress as raw byte counts: `Downloading [23982378/23982840]`. Bun 1.3.10 to 1.3.12 printed `[22.87MiB/22.87MiB]` (#24266). The Rust port of the progress bar (#30412) dropped the formatting.
- The cause is the `Unit::Bytes` arms in `src/bun_core/Progress.rs:577` and `:594`. They format `current_item` and `eti` with plain `{}`.

### Fix
- Format both values with the existing `bun_core::fmt::size` (`SizeFormatter`) and no space before the unit. The output is now `Downloading [1.31MB/2.62MB]`. This is the same size format as the rest of the CLI (`bun build` output sizes).
- `SizeFormatter` is a `Display` impl. It writes into the fixed `output_buffer` through `buf_write`, so the refresh path still does not allocate.
- Verified: `test/cli/install/bun-upgrade.test.ts` has a new test. It serves a paced 2.62 MB release from a local server and checks every `Downloading [...]` line. It fails on bun 1.4.3 and passes with this change. The whole file passes.

### Background
- `Progress` (`src/bun_core/Progress.rs`) is the terminal progress bar. A `Node` has a `Unit` (`None`, `Files`, `Bytes`). `refresh` walks the nodes and writes `[current/total]` into a 100 byte buffer.
- `bun upgrade` is the only user of `Unit::Bytes`. The HTTP client calls `set_completed_items` with the byte count after each body chunk.
- When stderr is not a terminal, `Progress` prints one line per refresh instead of redrawing in place. The test uses that mode.

Fixes #42289

<details><summary>Notes</summary>

- The 1.3.x output used IEC units (`MiB`, two decimals) from Zig's `{Bi:.2}`. No IEC formatter exists in the Rust code. `SizeFormatter` uses SI units (`KB`, `MB`) with one or two decimals. Reusing it keeps one size format across the CLI.
- The first refresh happens before any byte arrives and prints `[1B/2.62MB]` because `current_item` is `completed_items + 1`. The `Unit::None` and `Unit::Files` arms use the same `+ 1`. This change does not touch it.
- The progress bar refreshes only after a 500 ms initial delay, so the test server paces the body at 64 KiB every 30 ms. The test asserts on the process output after exit, not on time.
- The test is skipped on Windows: with a piped stderr, `Progress` prints nothing there.
</details>
