### PR TITLE
node:tls: report a peer reset on a wrap of an accepted socket

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -276,6 +276,16 @@ function onUpgradedClose(self, connection) {
 function destroyWhenUpgradedCloses(self, connection) {
   connection.once("close", (self[kOnUpgradedClose] = onUpgradedClose.bind(null, self, connection)));
 }
+// An fd upgrade leaves two native handles on one fd. When the fd closes under them (a peer reset),
+// the native dispatch runs the connection's close callback, drains the tick queue (this 'close'),
+// and only then runs this socket's own close callback, the one that reports the read error.
+function onAdoptedClose(self, connection) {
+  if (connection[kclosed] && !self[kclosed]) setImmediate(onUpgradedClose, self, connection);
+  else onUpgradedClose(self, connection);
+}
+function destroyWhenAdoptedCloses(self, connection) {
+  connection.once("close", (self[kOnUpgradedClose] = onAdoptedClose.bind(null, self, connection)));
+}
 let addAbortListener;
 function destroyWhenAborted(err) {
   if (!this.destroyed) {
@@ -2060,7 +2070,7 @@ Socket.prototype.connect = function connect(...args) {
               // replace socket
               connection._handle = raw;
               raw[kAdoptedTLSRaw] = true;
-              destroyWhenUpgradedCloses(this, connection);
+              destroyWhenAdoptedCloses(this, connection);
               this.once("end", this[kCloseRawConnection]);
               raw.connecting = false;
               this._handle = tls;
@@ -2109,7 +2119,7 @@ Socket.prototype.connect = function connect(...args) {
                   // replace socket
                   connection._handle = raw;
                   raw[kAdoptedTLSRaw] = true;
-                  destroyWhenUpgradedCloses(this, connection);
+                  destroyWhenAdoptedCloses(this, connection);
                   this.once("end", this[kCloseRawConnection]);
                   raw.connecting = false;
                   this._handle = tls;
@@ -2454,7 +2464,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
     const [raw, tlsHandle] = result;
     connection._handle = raw;
     raw[kAdoptedTLSRaw] = true;
-    destroyWhenUpgradedCloses(this, connection);
+    destroyWhenAdoptedCloses(this, connection);
     this.once("end", this[kCloseRawConnection]);
     raw.connecting = false;
     this._handle = tlsHandle;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -276,16 +276,6 @@ function onUpgradedClose(self, connection) {
 function destroyWhenUpgradedCloses(self, connection) {
   connection.once("close", (self[kOnUpgradedClose] = onUpgradedClose.bind(null, self, connection)));
 }
-// An fd upgrade leaves two native handles on one fd. When the fd closes under them (a peer reset),
-// the native dispatch runs the connection's close callback, drains the tick queue (this 'close'),
-// and only then runs this socket's own close callback, the one that reports the read error.
-function onAdoptedClose(self, connection) {
-  if (connection[kclosed] && !self[kclosed]) setImmediate(onUpgradedClose, self, connection);
-  else onUpgradedClose(self, connection);
-}
-function destroyWhenAdoptedCloses(self, connection) {
-  connection.once("close", (self[kOnUpgradedClose] = onAdoptedClose.bind(null, self, connection)));
-}
 let addAbortListener;
 function destroyWhenAborted(err) {
   if (!this.destroyed) {
@@ -2070,7 +2060,7 @@ Socket.prototype.connect = function connect(...args) {
               // replace socket
               connection._handle = raw;
               raw[kAdoptedTLSRaw] = true;
-              destroyWhenAdoptedCloses(this, connection);
+              destroyWhenUpgradedCloses(this, connection);
               this.once("end", this[kCloseRawConnection]);
               raw.connecting = false;
               this._handle = tls;
@@ -2119,7 +2109,7 @@ Socket.prototype.connect = function connect(...args) {
                   // replace socket
                   connection._handle = raw;
                   raw[kAdoptedTLSRaw] = true;
-                  destroyWhenAdoptedCloses(this, connection);
+                  destroyWhenUpgradedCloses(this, connection);
                   this.once("end", this[kCloseRawConnection]);
                   raw.connecting = false;
                   this._handle = tls;
@@ -2464,7 +2454,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
     const [raw, tlsHandle] = result;
     connection._handle = raw;
     raw[kAdoptedTLSRaw] = true;
-    destroyWhenAdoptedCloses(this, connection);
+    destroyWhenUpgradedCloses(this, connection);
     this.once("end", this[kCloseRawConnection]);
     raw.connecting = false;
     this._handle = tlsHandle;

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2115,7 +2115,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         );
         this.detach_native_callback();
         this.socket.set(SocketHandler::<SSL>::DETACHED);
-        // Dropped after `_pair_scope`, so the tick queue still drains ahead of the teardown.
+        // Declared first so it drops last: ticks drain ahead of the teardown.
         let _cleanup = CloseTeardown {
             socket: this,
             entered: Rc::clone(&handlers),
@@ -2124,9 +2124,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         // gets its own dispatch — fire its (pre-upgrade) close handler
         // here, then retire it. `raw.twin == None` so this doesn't
         // recurse, and `onClose` derefs the +1 we took at creation.
-        // The pair closes as one event: the scope holds the tick queue until
-        // this socket's own close handler, the one with the read error, has run.
         let _pair_scope = this.twin.with_mut(|t| t.take()).map(|raw| {
+            // No tick checkpoint between the twin's close handler and this socket's own.
             // SAFETY: the VM owns its event loop for the life of the process.
             let scope =
                 unsafe { jsc::event_loop::EventLoop::enter_scope(handlers.vm.event_loop()) };

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2115,25 +2115,31 @@ impl<const SSL: bool> NewSocket<SSL> {
         );
         this.detach_native_callback();
         this.socket.set(SocketHandler::<SSL>::DETACHED);
+        // Dropped after `_pair_scope`, so the tick queue still drains ahead of the teardown.
+        let _cleanup = CloseTeardown {
+            socket: this,
+            entered: Rc::clone(&handlers),
+        };
         // The upgradeTLS raw twin shares the same us_socket_t so it never
         // gets its own dispatch — fire its (pre-upgrade) close handler
         // here, then retire it. `raw.twin == None` so this doesn't
         // recurse, and `onClose` derefs the +1 we took at creation.
-        if let Some(raw) = this.twin.with_mut(|t| t.take()) {
+        // The pair closes as one event: the scope holds the tick queue until
+        // this socket's own close handler, the one with the read error, has run.
+        let _pair_scope = this.twin.with_mut(|t| t.take()).map(|raw| {
+            // SAFETY: the VM owns its event loop for the life of the process.
+            let scope =
+                unsafe { jsc::event_loop::EventLoop::enter_scope(handlers.vm.event_loop()) };
             // `on_close` consumes the twin's +1 via its `CloseTeardown`, so
             // hand over the raw pointer rather than letting `RefPtr::drop`
             // release it a second time. This frame is the twin's trampoline for
             // the event, so what its handlers left pending is folded here and
             // this socket's own close proceeds regardless.
             crate::dispatch::fold(Self::on_close(raw.into_this_ptr(), socket, err, reason));
-        }
-        let cleanup = CloseTeardown {
-            socket: this,
-            entered: Rc::clone(&handlers),
-        };
+            scope
+        });
 
         if this.flags.get().contains(Flags::FINALIZING) {
-            drop(cleanup);
             return Ok(());
         }
 
@@ -2142,7 +2148,6 @@ impl<const SSL: bool> NewSocket<SSL> {
         let callback = handlers.on_close();
 
         if callback.is_empty() {
-            drop(cleanup);
             return Ok(());
         }
 
@@ -2151,7 +2156,6 @@ impl<const SSL: bool> NewSocket<SSL> {
         // above is unwinding with a termination pending: it belongs to that
         // frame, so this dispatch neither enters JS over it nor claims it.
         if handlers.global_object.has_exception() {
-            drop(cleanup);
             return Ok(());
         }
 

--- a/test/js/node/tls/node-tls-socket-allow-half-open-option.test.ts
+++ b/test/js/node/tls/node-tls-socket-allow-half-open-option.test.ts
@@ -409,4 +409,71 @@ describe("TLSSocket allowHalfOpen", () => {
       }
     });
   });
+
+  describe.concurrent("a peer reset under a server-side wrap", () => {
+    // The reset closes the wrapped socket too, and the wrapped socket's 'close'
+    // destroys the TLS socket. That must not run ahead of the TLS socket's own
+    // close, which is what reports the reset. In both tests the server also
+    // listens for errors on the raw socket it wrapped (the usual STARTTLS shape).
+
+    test("new TLSSocket(socket, { isServer }): the reset is an 'error' on the TLS socket", async () => {
+      const events: string[] = [];
+      const teardown = Promise.withResolvers<string[]>();
+      const gotData = Promise.withResolvers<void>();
+      let wrapped: TLSSocket | undefined;
+      const rawServer = net.createServer(socket => {
+        socket.on("error", () => {});
+        wrapped = new TLSSocket(socket, { isServer: true, ...COMMON_CERT });
+        wrapped.on("error", (err: NodeJS.ErrnoException) => events.push(`error:${err.code}`));
+        wrapped.on("close", hadError => {
+          events.push(`close:${hadError}`);
+          teardown.resolve(events);
+        });
+        wrapped.once("data", () => gotData.resolve());
+      });
+      let raw: net.Socket | undefined;
+      let client: TLSSocket | undefined;
+      try {
+        const port = await listen(rawServer);
+        raw = net.connect({ port, host: "127.0.0.1" });
+        raw.on("error", () => {});
+        client = tls.connect({ socket: raw, rejectUnauthorized: false }, () => client!.write("hi"));
+        client.on("error", () => {});
+        await gotData.promise;
+        raw.resetAndDestroy();
+        expect(await teardown.promise).toEqual(["error:ECONNRESET", "close:true"]);
+      } finally {
+        client?.destroy();
+        raw?.destroy();
+        wrapped?.destroy();
+        rawServer.close();
+      }
+    });
+
+    test("a socket injected into a tls.Server: a reset during the handshake is a 'tlsClientError'", async () => {
+      const tlsServer = tls.createServer(COMMON_CERT);
+      const clientError = Promise.withResolvers<NodeJS.ErrnoException>();
+      tlsServer.on("tlsClientError", clientError.resolve);
+      tlsServer.on("secureConnection", () => clientError.reject(new Error("the handshake completed")));
+      const injected = Promise.withResolvers<void>();
+      const rawServer = net.createServer(socket => {
+        socket.on("error", () => {});
+        tlsServer.emit("connection", socket);
+        injected.resolve();
+      });
+      let raw: net.Socket | undefined;
+      try {
+        const port = await listen(rawServer);
+        raw = net.connect({ port, host: "127.0.0.1" });
+        raw.on("error", () => {});
+        await injected.promise;
+        raw.resetAndDestroy();
+        expect((await clientError.promise).code).toBe("ECONNRESET");
+      } finally {
+        raw?.destroy();
+        rawServer.close();
+        tlsServer.close();
+      }
+    });
+  });
 });

--- a/test/js/node/tls/node-tls-socket-allow-half-open-option.test.ts
+++ b/test/js/node/tls/node-tls-socket-allow-half-open-option.test.ts
@@ -428,6 +428,7 @@ describe("TLSSocket allowHalfOpen", () => {
         wrapped.on("close", hadError => {
           events.push(`close:${hadError}`);
           teardown.resolve(events);
+          gotData.reject(new Error(`the TLS socket closed before it got data (${events.join(", ")})`));
         });
         wrapped.once("data", () => gotData.resolve());
       });
@@ -436,9 +437,10 @@ describe("TLSSocket allowHalfOpen", () => {
       try {
         const port = await listen(rawServer);
         raw = net.connect({ port, host: "127.0.0.1" });
-        raw.on("error", () => {});
+        // Both are no-ops once the data has arrived, which is before the reset.
+        raw.on("error", gotData.reject);
         client = tls.connect({ socket: raw, rejectUnauthorized: false }, () => client!.write("hi"));
-        client.on("error", () => {});
+        client.on("error", gotData.reject);
         await gotData.promise;
         raw.resetAndDestroy();
         expect(await teardown.promise).toEqual(["error:ECONNRESET", "close:true"]);
@@ -458,6 +460,13 @@ describe("TLSSocket allowHalfOpen", () => {
       const injected = Promise.withResolvers<void>();
       const rawServer = net.createServer(socket => {
         socket.on("error", () => {});
+        // The TLS socket the server builds over an injected socket is not reachable from
+        // here, so a lost 'tlsClientError' shows only as silence. The error comes from the
+        // same native close that closes the raw socket: a few event-loop turns bound it.
+        socket.on("close", async () => {
+          for (let turn = 0; turn < 10; turn++) await new Promise<void>(resolve => setImmediate(resolve));
+          clientError.reject(new Error("the raw socket closed and no 'tlsClientError' followed"));
+        });
         tlsServer.emit("connection", socket);
         injected.resolve();
       });
@@ -465,7 +474,8 @@ describe("TLSSocket allowHalfOpen", () => {
       try {
         const port = await listen(rawServer);
         raw = net.connect({ port, host: "127.0.0.1" });
-        raw.on("error", () => {});
+        // A no-op once the server has the connection, which is before the reset.
+        raw.on("error", injected.reject);
         await injected.promise;
         raw.resetAndDestroy();
         expect((await clientError.promise).code).toBe("ECONNRESET");


### PR DESCRIPTION
### Problem

- A server-side wrap of an accepted socket (`new tls.TLSSocket(raw, { isServer: true })`, `tlsServer.emit('connection', raw)`) no longer reports a peer RST. The TLS socket emits `'close'` with `hadError === false` and no `'error'`. During the handshake the `tls.Server` gets no `'tlsClientError'`. Bun 1.4.2 and Node report ECONNRESET.
- Regression from #39066: the wrapped socket's `'close'` now destroys the TLS socket (`onUpgradedClose`, `src/js/node/net.ts:273`). The native `on_close` (`src/runtime/socket/socket_body.rs:2122`) runs the raw socket's close callback, drains the tick queue (raw `'close'`, so the destroy), and only then runs the TLS socket's own close callback with ECONNRESET.

### Fix

- `on_close` holds the event loop entered (`EventLoop::enter_scope`) across both close callbacks of an `upgradeTLS` pair. The tick queue drains after both ran, not between them.
- The TLS socket's own close callback now destroys it with ECONNRESET before the raw socket's `'close'` event runs. That listener then finds the socket destroyed. `net.ts` does not change.
- The JS events keep the 1.4.2 order: `raw error, raw close, tls error, tls close`.
- Verified: `test/js/node/tls/node-tls-socket-allow-half-open-option.test.ts`, 2 new tests, both fail on main's `src/`. Also `test/js/node/tls/`, `net/`, `http2/`, `test/js/bun/net/`, vendored `test-tls-*` and `test-https-*`.

### Background

- A wrap is TLS over an existing socket. For a connected `net.Socket` Bun adopts the fd: `upgradeTLS` returns a raw handle, which stays on the wrapped socket, and a TLS handle for the TLS socket.
- Only the TLS handle gets native events. Its `on_close` first calls the raw handle's close callback (the "twin") as a full dispatch of its own.
- Each dispatch brackets its JS callback with `enter()` and `exit()` on the event loop. The outermost `exit()` drains `process.nextTick` and microtasks. The twin's dispatch was an outermost pair, so it drained before the TLS callback ran.

<details><summary>Notes</summary>

#### Scope

The raw socket needs an `'error'` listener of its own for this to show, the usual STARTTLS server shape. Without one it is not destroyed on the reset, so it emits no `'close'`.

`CloseTeardown` is now created ahead of the scope, so it drops after it. The drain still comes ahead of the teardown (`mark_inactive`, the final `deref`), as it does for a socket with no twin. The three early returns lose their explicit `drop(cleanup)` for the same reason: the natural drop order is the scope first, then the teardown.

The change applies to every `upgradeTLS` pair, also the ones from `Bun.connect` and `socket.upgradeTLS()`. What moves is when the ticks queued by the raw socket's `close` handler run: after the TLS socket's `close` handler, not before it.

An earlier revision of this PR deferred the destroy in `net.ts` with a `setImmediate` when it saw the state between the two callbacks. Review asked to fix the ordering at its source, which is this version.

Since #39066 a wrap takes `allowHalfOpen` from the wrapped socket. A half-open wrap does not end itself after EOF, so the wrapped socket's `'close'` must destroy it. This change keeps that.

#### Measurements

Linux x64. "main" is a debug+ASAN build of 81f97bb0. "before" is bun 1.4.3-canary.1+4ff919377, which predates #39066 and prints what 1.4.2 prints. Node is v26.3.0. The server wraps the accepted socket and also listens for `'error'` on it. The client does `resetAndDestroy()`.

| case | node | before | main | this PR |
| --- | --- | --- | --- | --- |
| `new TLSSocket(raw)`, after the handshake | tls error ECONNRESET, raw close, tls close:true | raw error, raw close, tls error ECONNRESET, tls close:true | raw error, raw close, tls close:false | same as before |
| `tlsServer.emit('connection', raw)`, after the handshake | same | same | same | same as before |
| `new TLSSocket(raw)`, during the handshake | tls error ECONNRESET, raw close, tls close:true | raw error, raw close, tls error ECONNRESET, tls close:true | raw error, raw close, tls close:false | same as before |
| `tlsServer.emit('connection', raw)`, during the handshake | tlsClientError ECONNRESET | tlsClientError ECONNRESET | nothing | tlsClientError ECONNRESET |

`tls.connect({ socket })` over a `net.Socket` it dialed itself was not affected. Its raw socket keeps its handle through the close callback, so `_destroy` takes the `kAdoptedTLSRaw` branch and `'close'` comes two check phases later (`closeAdoptedTLSRawNT`). An accepted socket's callback (`ServerHandlers.close`) detaches the handle first, so `'close'` comes from `process.nextTick`.

#### The trace

`BUN_DEBUG_Socket=1 BUN_DEBUG_JS=1` on main, after the client's RST:

```
[socket] onClose C            <- TLS handle
[socket] onClose S            <- raw handle, dispatched from inside the first
[net] Bun.Server close        <- raw socket's callback: destroy(ECONNRESET)
[events] Socket.emit error
[events] Socket.emit close    <- onUpgradedClose: tlsSocket.destroy()
[net] Socket.prototype._destroy
[net] Bun.Server close        <- TLS socket's callback, socket already destroyed
```

#### Relation to #42176

#42176 now carries the other face of the #39066 regression: a TLS socket over a `stream.Duplex` that loses unread data when the duplex closes. That is the stream-engine path and it changes `onUpgradedClose`. This PR touches neither that function nor `net.ts`, so the two do not conflict.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-socket-allow-half-open-option.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/tls/node-tls-socket-allow-half-open-option.test.ts:
(pass) TLSSocket allowHalfOpen > new TLSSocket(socket) takes the wrapped socket's allowHalfOpen, ignoring the option [228.65ms]
(pass) TLSSocket allowHalfOpen > without a socket to wrap, the option is honored [10.30ms]
(pass) TLSSocket allowHalfOpen > tls.connect({ socket }) takes the given socket's allowHalfOpen, ignoring the option [207.34ms]
(pass) TLSSocket allowHalfOpen > over a connection > a server-side wrap of a half-open socket stays writable after the peer ends [946.31ms]
(pass) TLSSocket allowHalfOpen > over a connection > a server-side wrap of a regular socket ends itself after the peer ends, even with allowHalfOpen: true [836.51ms]
(pass) TLSSocket allowHalfOpen > over a connection > a socket injected into a tls.Server keeps its own allowHalfOpen [845.82ms]
(pass) TLSSocket allowHalfOpen > over a connection > tls.connect({ socket }) over a half-open socket stays writab
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (00fab6991)

test/js/node/tls/node-tls-socket-allow-half-open-option.test.ts:
(pass) TLSSocket allowHalfOpen > new TLSSocket(socket) takes the wrapped socket's allowHalfOpen, ignoring the option [8.83ms]
(pass) TLSSocket allowHalfOpen > without a socket to wrap, the option is honored [0.16ms]
(pass) TLSSocket allowHalfOpen > tls.connect({ socket }) takes the given socket's allowHalfOpen, ignoring the option [4.39ms]
(pass) TLSSocket allowHalfOpen > a peer reset under a server-side wrap > a socket injected into a tls.Server: a reset during the handshake is a 'tlsClientError' [20.27ms]
(pass) TLSSocket allowHalfOpen > the wrapped socket closing > new TLSSocket(duplex, { isServer }): the duplex closing [36.67ms]
(pass) TLSSocket allowHalfOpen > over a connection > a server-side wrap of a half-open socket stays writable after the peer ends [48.42ms]
(pass) TLSSocket allowHalfOpen > over a connection > a server-side wrap of a regular socket ends itself after the peer ends, even with allowHalfOpen: true [44.45ms]
(pass) TLSSocket allowHalfOpen > over a connection > a socket injected into a tls.Server keeps its own allowHalfOpen [44.65ms]
(pass) TL
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-socket-allow-half-open-option.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/tls/node-tls-socket-allow-half-open-option.test.ts:
(pass) TLSSocket allowHalfOpen > new TLSSocket(socket) takes the wrapped socket's allowHalfOpen, ignoring the option [215.09ms]
(pass) TLSSocket allowHalfOpen > without a socket to wrap, the option is honored [9.47ms]
(pass) TLSSocket allowHalfOpen > tls.connect({ socket }) takes the given socket's allowHalfOpen, ignoring the option [206.47ms]
(pass) TLSSocket allowHalfOpen > over a connection > a server-side wrap of a half-open socket stays writable after the peer ends [953.62ms]
(pass) TLSSocket allowHalfOpen > over a connection > a server-side wrap of a regular socket ends itself after the peer ends, even with allowHalfOpen: true [840.71ms]
(pass) TLSSocket allowHalfOpen > over a connection > a socket injected into a tls.Server keeps its own allowHalfOpen [839.34ms]
(pass) TLSSocket allowHalfOpen > over a connection > tls.connect({ socket }) over a half-open socket stays writabl
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 692ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/socket/socket_body.rs                  | 21 +++---
 .../node-tls-socket-allow-half-open-option.test.ts | 77 ++++++++++++++++++++++
 2 files changed, 89 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/socket/socket_body.rs                             4      1     23
…node/tls/node-tls-socket-allow-half-open-option.test.ts      4      4     23
```

</details>

<!-- robobun:evidence:end -->