### PR TITLE
webview: settle a Chrome scroll() or type() that a navigation strands

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -313,6 +313,8 @@ On WebKit, the shm name looks like `/bun-webview-<pid>-<seq>`; on Chrome, `/bun-
 
 All input methods dispatch **native** browser events. The page receives `pointerdown`/`mousedown`/`keydown`/`wheel` events with `isTrusted: true`. CSS `:active` and `:hover` states apply. Default actions (form submission, link navigation, text selection) fire exactly as if a user performed them.
 
+Input goes to whichever document the page shows when the event arrives. If the page navigates while an input call is in flight, the event can reach the old document, the new one, or neither, and the promise still settles. To act on the page you navigated to, `await` the navigation first.
+
 ### Clicking
 
 Click at viewport coordinates:
@@ -474,6 +476,8 @@ await view.cdp("DOM.focus", { nodeId });
 Commands are scoped to this view's session (they target this tab). You must `await navigate(...)` at least once before calling `cdp()` — the first navigation establishes the session. Calling `cdp()` before that throws `ERR_INVALID_STATE`.
 
 `params` must be a JSON-serializable object; omit it for commands that take no parameters. One `cdp()` call may be in flight at a time per view.
+
+Chrome never answers some commands that are in flight when the page navigates, for example `Page.captureScreenshot`, `Input.insertText`, or an `Input.dispatchMouseEvent` of type `mouseWheel`. Such a `cdp()` call stays pending, and keeps its slot, until `close()`. `await` the navigation before you send them.
 
 ### Subscribing to events
 

--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -673,6 +673,52 @@ static void settleFailure(JSGlobalObject* g, JSWebView* view, PendingSlot slot, 
     }
 }
 
+// Whether Transport::mainFrameCommitted resolves a command that is in flight
+// when the view's main frame commits another document, or leaves it to
+// Chrome's reply. Chrome answers most commands across a commit. It can drop,
+// with no reply ever, the ones whose answer is owed by the renderer that the
+// commit retires. No default: a new Method has to pick a side.
+static bool resolvesAtCommit(Method m)
+{
+    switch (m) {
+    // Dropped. Chrome parks a wheel behind a frame request to the old renderer
+    // before it injects it, and acks insertText through a reply pipe to that
+    // renderer. Neither is answered once that renderer is gone, or frozen in
+    // the back/forward cache.
+    case Method::InputDispatchMouseWheel:
+    case Method::InputInsertText:
+        return true;
+    // Dropped the same way, but a capture owes a result, so it cannot resolve.
+    case Method::PageCaptureScreenshot:
+    // view.cdp() can send any command, the droppable ones included, and
+    // nothing here tells them apart. Such a call stays pending until close().
+    case Method::UserRaw:
+    // Answered. Chrome acks the key and button events it has pending when it
+    // swaps the renderer, answers setDeviceMetricsOverride itself, and answers
+    // Runtime.evaluate with a result or with "Inspected target navigated".
+    case Method::InputDispatchMouseEvent:
+    case Method::InputDispatchKeyEvent:
+    case Method::EmulationSetDeviceMetricsOverride:
+    case Method::RuntimeEvaluate:
+    case Method::ClickSelectorEval:
+    case Method::ScrollToSelectorEval:
+    case Method::PageTitle:
+    // The navigation's own commands, and the ones that never have an entry.
+    case Method::TargetCreateTarget:
+    case Method::TargetAttachToTarget:
+    case Method::PageEnable:
+    case Method::RuntimeEnable:
+    case Method::TargetCloseTarget:
+    case Method::PageNavigate:
+    case Method::PageReload:
+    case Method::PageGetNavigationHistory:
+    case Method::PageNavigateToHistoryEntry:
+        return false;
+    }
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
 // Slots, not m_pending: a navigation that Chrome has already answered is
 // waiting for Page.loadEventFired and exists only in its slot.
 static void rejectViewSlots(JSGlobalObject* g, JSWebView* view, JSValue err)
@@ -1021,8 +1067,8 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
     }
 
     case Method::InputDispatchMouseEvent:
+    case Method::InputDispatchMouseWheel:
     case Method::InputDispatchKeyEvent:
-    case Method::InputDispatchScrollEvent:
     case Method::InputInsertText:
     case Method::EmulationSetDeviceMetricsOverride:
         // Input.* / Emulation.* reply with empty result on success. Sync-
@@ -1147,6 +1193,12 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
         auto urlStr = WTF::String::fromUTF8(url);
         view->m_url = urlStr;
         // m_loading stays true — loadEventFired flips it.
+
+        // A subframe commit (frame.parentId present) keeps the main document
+        // and its renderer, and Chrome answers what is in flight across it.
+        // Runs before onNavigated so the callback finds the slots it frees.
+        if (jsonField(frame, { "parentId", 8 }).empty())
+            mainFrameCommitted(g, view);
 
         if (JSObject* cb = view->m_onNavigated.get()) {
             Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
@@ -1297,6 +1349,27 @@ void Transport::handleEvent(std::span<const char> method, std::span<const char> 
     auto event = WebCore::MessageEvent::create(methodAtom, WTF::move(init), WebCore::Event::IsTrusted::Yes);
     scope.release();
     view->wrapped().dispatchEvent(event);
+}
+
+// Resolves the command Chrome can drop at this commit (resolvesAtCommit). If it
+// is still pending here, Chrome answers it later, once the new document took
+// the input (at times after the load event), or never, when no document did.
+// Nothing tells the two apart, and resolve is right for both: a reject or a
+// repeat is wrong for the input Chrome still applies. The id is forgotten so
+// that a late reply cannot settle whatever holds the slot by then. The
+// droppable commands share the Misc slot, so a view has one at most.
+void Transport::mainFrameCommitted(JSGlobalObject* g, JSWebView* view)
+{
+    uint32_t resolvedId = 0;
+    PendingSlot resolvedSlot = PendingSlot::Misc;
+    for (auto& [id, entry] : m_pending) {
+        if (entry.viewId != view->m_viewId || !resolvesAtCommit(entry.method)) continue;
+        resolvedId = id;
+        resolvedSlot = entry.slot;
+    }
+    if (!resolvedId) return;
+    m_pending.remove(resolvedId);
+    settle(g, view, resolvedSlot, true, jsUndefined());
 }
 
 void Transport::onClose()
@@ -1614,6 +1687,8 @@ JSPromise* type(JSGlobalObject* g, JSWebView* view, const WTF::String& text)
     uint32_t id = t.nextId();
     // Input.insertText does exactly what WKWebView's _executeEditCommand:
     // InsertText does — inserts text at the caret without keydown events.
+    // A main-frame commit while it is in flight settles it instead of
+    // Chrome's reply (resolvesAtCommit).
     return sendChromeOp(g, view, view->m_pendingMisc, PendingSlot::Misc,
         Method::InputInsertText, id,
         Command(id, "Input.insertText"_s, sidSpan(view->m_sessionId))
@@ -1694,9 +1769,10 @@ JSPromise* scroll(JSGlobalObject* g, JSWebView* view, double dx, double dy)
     auto& t = transport();
     uint32_t id = t.nextId();
     // mouseWheel at the center. No presentation-barrier dance — Chrome's
-    // reply means the scroll was processed.
+    // reply means the scroll was processed. A main-frame commit while it is
+    // in flight settles it instead of that reply (resolvesAtCommit).
     return sendChromeOp(g, view, view->m_pendingMisc, PendingSlot::Misc,
-        Method::InputDispatchMouseEvent, id,
+        Method::InputDispatchMouseWheel, id,
         Command(id, "Input.dispatchMouseEvent"_s, sidSpan(view->m_sessionId))
             .raw("type"_s, "\"mouseWheel\""_s)
             .num("x"_s, view->m_width / 2.0)

--- a/src/runtime/webview/ChromeBackend.h
+++ b/src/runtime/webview/ChromeBackend.h
@@ -254,9 +254,12 @@ enum class Method : uint8_t {
     PageCaptureScreenshot,
     RuntimeEvaluate,
     InputDispatchMouseEvent,
+    // Input.dispatchMouseEvent too, with type mouseWheel (scroll()). Tagged
+    // apart from clicks because Chrome can drop a wheel at a main-frame
+    // commit and answers a click; see resolvesAtCommit in ChromeBackend.cpp.
+    InputDispatchMouseWheel,
     InputDispatchKeyEvent,
     InputInsertText,
-    InputDispatchScrollEvent,
     EmulationSetDeviceMetricsOverride,
     // Selector ops — two-phase. Runtime.evaluate runs the rAF-polled
     // actionability check page-side; response chains into the actual
@@ -477,6 +480,10 @@ public:
     void handleMessage(std::span<const char> msg);
     void handleResponse(uint32_t id, std::span<const char> result, std::span<const char> error);
     void handleEvent(std::span<const char> method, std::span<const char> params, std::span<const char> sessionId);
+    // The view's main frame committed another document. Chrome drops some of
+    // the commands that are in flight at that point: their ids get no reply,
+    // ever. Settles the ones that resolvesAtCommit (ChromeBackend.cpp) picks.
+    void mainFrameCommitted(JSC::JSGlobalObject*, JSWebView*);
     void rejectAllAndMarkDead(const WTF::String& reason);
     void updateKeepAlive();
     void writeRaw(const char* data, size_t len);

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -3,7 +3,8 @@
 // and this file speaks the --remote-debugging-pipe protocol back to it:
 // NUL-delimited CDP JSON, commands arriving on fd 3, replies and events
 // leaving on fd 4. It implements just enough of CDP for navigate(),
-// evaluate() and screenshot(). evaluate() runs the expression in this
+// evaluate() and screenshot(), and acks Input.* the way Chrome does, with an
+// empty result. evaluate() runs the expression in this
 // process, which is how the tests move chosen payloads across the pipes and
 // how they make the fake browser misbehave on cue (the __fake_* globals).
 import { closeSync, readSync, writeSync } from "node:fs";
@@ -36,6 +37,14 @@ const cdpErrorOn = process.argv.find(a => a.startsWith("--cdp-error-on="))?.slic
 
 const NO_REPLY = Symbol("no reply");
 let commandsClosed = false;
+// Methods whose next command gets no reply, the way Chrome drops some
+// commands that are in flight when a navigation commits.
+const dropNext = new Set<string>();
+// Methods whose next command's reply waits until __fake_release().
+const holdNext = new Set<string>();
+const held: (() => void)[] = [];
+// Emits an event on the session of the command being handled.
+let emit: (name: string, params: unknown) => void = () => {};
 Object.assign(globalThis, {
   __fake_exit(code: number): never {
     process.exit(code);
@@ -56,6 +65,23 @@ Object.assign(globalThis, {
     closeSync(COMMANDS);
     setInterval(() => {}, 2 ** 30);
   },
+  // The next `method` command (for Input.dispatchMouseEvent, `method:type`
+  // picks one event type) gets no reply, ever.
+  __fake_drop_next(method: string) {
+    dropNext.add(method);
+  },
+  // The next `method` command's reply waits for __fake_release().
+  __fake_hold_next(method: string) {
+    holdNext.add(method);
+  },
+  // Sends the `count` oldest held replies, oldest first. Default: all of them.
+  __fake_release(count = held.length) {
+    for (const sendHeld of held.splice(0, count)) sendHeld();
+  },
+  // Sends a CDP event on this view's session before the evaluate() reply.
+  __fake_emit(name: string, params: unknown) {
+    emit(name, params);
+  },
 });
 
 function send(message: unknown) {
@@ -69,8 +95,16 @@ let loads = 0;
 
 async function handle(command: { id: number; method: string; params?: any; sessionId?: string }) {
   const { id, method, params = {}, sessionId } = command;
-  const reply = (result: unknown) => send(sessionId ? { id, result, sessionId } : { id, result });
+  let reply = (result: unknown) => send(sessionId ? { id, result, sessionId } : { id, result });
   const event = (name: string, eventParams: unknown) => send({ method: name, params: eventParams, sessionId });
+
+  const knob = (set: Set<string>) =>
+    set.delete(method) || (typeof params.type === "string" && set.delete(method + ":" + params.type));
+  if (knob(dropNext)) return;
+  if (knob(holdNext)) {
+    const sendReply = reply;
+    reply = result => void held.push(() => sendReply(result));
+  }
 
   if (method === cdpErrorOn) {
     const error = { code: -32000, message: "Cannot navigate to invalid URL" };
@@ -99,6 +133,7 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       }
       let value: unknown;
       try {
+        emit = event;
         value = await (0, eval)(params.expression);
       } catch (e) {
         return reply({

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -336,6 +336,89 @@ test.concurrent("onNavigationFailed can retry navigate() immediately", async () 
   expect(result).toBe("retry was accepted and failed too");
 });
 
+// Chrome answers most commands that are in flight when the main frame commits
+// another document. It can drop these two, with no reply ever, and both hold
+// the Misc slot that click, type, press, scroll, scrollTo and resize share.
+// The runtime resolves them at the commit instead, or the slot stays taken
+// for the life of the view.
+const droppedAtCommit = [
+  ["scroll(0, 100)", "Input.dispatchMouseEvent:mouseWheel"],
+  ['type("x")', "Input.insertText"],
+] as const;
+
+test.concurrent.each(droppedAtCommit)(
+  "a %s that Chrome drops at a navigation resolves at the commit and frees its slot",
+  async (call, command) => {
+    const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/a");
+    await view.evaluate("__fake_drop_next('${command}')");
+    let dropped = "pending";
+    view.${call}.then(() => { dropped = "resolved"; }, e => { dropped = "rejected: " + e.message; });
+    await view.navigate("http://fake/b");
+    let next;
+    try {
+      next = await outcome(view.${call});
+    } catch (e) {
+      next = "threw " + e.code;
+    }
+    print({ dropped, next });
+    view.close();
+  `);
+    expect(result).toEqual({ dropped: "resolved", next: {} });
+  },
+);
+
+// A subframe commit keeps the main document and its renderer, and Chrome
+// answers what is in flight across one, usually after the commit. That reply
+// must be the one that settles the call.
+test.concurrent.each(droppedAtCommit)(
+  "a subframe commit leaves an in-flight %s to Chrome's reply",
+  async (call, command) => {
+    const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/a");
+    await view.evaluate("__fake_hold_next('${command}')");
+    let state = "pending";
+    const settled = view.${call}.then(() => { state = "resolved"; }, e => { state = "rejected: " + e.message; });
+    await view.evaluate(\`__fake_emit("Page.frameNavigated", {
+      frame: { id: "child", parentId: "F", loaderId: "LC", url: "http://fake/child", mimeType: "text/html" },
+      type: "Navigation",
+    })\`);
+    const afterSubframeCommit = state;
+    await view.evaluate("__fake_release()");
+    await settled;
+    print({ afterSubframeCommit, final: state });
+    view.close();
+  `);
+    expect(result).toEqual({ afterSubframeCommit: "pending", final: "resolved" });
+  },
+);
+
+// Chrome does answer some of these commands after the commit, once the new
+// document has taken the input. By then the call has resolved and another
+// operation can hold the Misc slot; the late reply must not settle that one.
+test.concurrent("a reply that comes after the commit does not settle the next operation", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/a");
+    await view.evaluate("__fake_hold_next('Input.insertText')");
+    let first = "pending";
+    view.type("x").then(() => { first = "resolved"; }, e => { first = "rejected: " + e.message; });
+    await view.navigate("http://fake/b");
+    await view.evaluate("__fake_hold_next('Input.dispatchKeyEvent:keyUp')");
+    let second = "pending";
+    const pressed = view.press("Enter").then(() => { second = "resolved"; }, e => { second = "rejected: " + e.message; });
+    await view.evaluate("__fake_release(1)"); // the late Input.insertText reply
+    const afterLateReply = second;
+    await view.evaluate("__fake_release()"); // the keyUp reply
+    await pressed;
+    print({ first, afterLateReply, second });
+    view.close();
+  `);
+  expect(result).toEqual({ first: "resolved", afterLateReply: "pending", second: "resolved" });
+});
+
 // `bun test --isolate` replaces the global object between files. The transport
 // is bound to the global that spawned the browser, so it has to go with that
 // file: its open views are closed, their pending promises rejected, and the

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -520,6 +520,33 @@ it("chrome: scroll dispatches wheel event", async () => {
   expect(y).toBeGreaterThan(0);
 });
 
+// Chrome drops an Input.dispatchMouseEvent{mouseWheel} that is in flight when
+// the main frame commits another document, and never replies to it: about
+// every other round here. scroll() resolves at the commit instead, and the
+// commit comes before the load that resolves navigate(), so every round has
+// settled by then and the Misc slot is free for the click at the end.
+it("chrome: scroll() in flight across a navigation settles and frees its slot", async () => {
+  using server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch: () => new Response("<body style='height:3000px'></body>", { headers: { "content-type": "text/html" } }),
+  });
+  const base = `http://127.0.0.1:${server.port}/`;
+  await using view = new Bun.WebView({ backend: chrome, width: 300, height: 300 });
+  await view.navigate(base);
+  for (let i = 0; i < 6; i++) {
+    let state = "pending";
+    const scrolled = view.scroll(0, 100).then(
+      () => (state = "resolved"),
+      e => (state = "rejected: " + e.message),
+    );
+    await view.navigate(base + "?" + i);
+    expect(state).toBe("resolved");
+    await scrolled;
+  }
+  await view.click(5, 5);
+});
+
 it("chrome: url getter reflects committed URL", async () => {
   await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
   const url = html("<body>test</body>");


### PR DESCRIPTION
### Problem

- Chrome backend: `view.scroll()` and `view.type()` never settle when the main frame commits a new document while they are in flight. `await view.click(link); await view.scroll(0, 100)` hangs 7/10 times. It keeps the Misc slot, so `click()`, `type()`, `press()`, `scroll()`, `scrollTo()` and `resize()` throw `ERR_INVALID_STATE` until `close()`.
- Chrome drops a `mouseWheel` `Input.dispatchMouseEvent` and an `Input.insertText` that land in the commit window: no reply, ever. `CDP::Ops::scroll` and `CDP::Ops::type` (`src/runtime/webview/ChromeBackend.cpp`) settle only on that reply.

### Fix

- At a main-frame `Page.frameNavigated`, `Transport::mainFrameCommitted` resolves the view's in-flight wheel or `insertText` and forgets its id, so a late reply settles nothing. Subframe commits change nothing.
- `resolvesAtCommit(Method)` holds the policy in an exhaustive switch. The wheel gets its own tag, apart from clicks, which Chrome answers. `cdp()` stays with Chrome's reply, and the docs say so.
- Resolve, not reject or repeat: a command pending at the commit is answered later (by the new document) or never, and the pipe cannot tell which. Resolve is right for both.
- Verified: `webview-chrome-pipe.test.ts` (five new blocks, three fail on stock bun), `webview-chrome.test.ts` (one new block, fails 3/3 there), rest of `test/js/bun/webview/`. Self-reviewed: 5 concerns, 4 addressed, 1 declined (Notes).

### Background

- `Transport::m_pending` maps a CDP id to its view and the promise slot its reply settles. The "simple" operations share one Misc slot per view, so one unanswered id blocks them all.
- CDP reports a cross-document commit as `Page.frameNavigated` (main frame: no `parentId`) before `Page.loadEventFired`.
- #42207 handles `Page.captureScreenshot`, dropped the same way, and can fill that arm after this lands.

<details><summary>Notes</summary>

Reproduction on bun 1.4.3 and main, Chrome 153.0.8010.36: `scroll(0, 100)` then `navigate()` to a fast local page, 12 rounds, 3 runs. 5, 6 and 5 rounds hung. The first hang came in round 0 or 1, and after it every `scroll()` and `click()` threw `ERR_INVALID_STATE`.

Shapes against real Chrome, a fresh view per round (stock 1.4.3, then this build):

| shape | stock | with this change |
| --- | --- | --- |
| `await click(link)` then `scroll()` | 7/10 hang, then `click()` throws | 10/10 resolve |
| `scroll()` then `navigate()` | 7/10 hang | 5/5 |
| `navigate()` then `scroll()` | 5/10 hang | 5/5 |
| `scroll()` then `goBack()` (back/forward cache restore) | 7/10 hang | 5/5 |
| `navigate()`, 4 ms, `type()` | 2/10 hang | 10/10 |
| `navigate()`, 0/2/6/8 ms, `type()`, and `await click(link)` then `type()` | 0/50 hang | 50/50 |
| `scroll()` then `reload()` | 0/10 hang | 5/5 |
| two navigations in a row, a `scroll()` before each | 5/10 hang or throw | 5/5 |
| `onNavigated` callback calls `click()` | 6/10 throw `ERR_INVALID_STATE` (once with a `scroll()` that did resolve later) | 5/5 accepted |
| no navigation, and subframe commit only | 0/15 hang | 10/10 |
| `scroll()` after `navigate()` resolved | scrolls 10/10 | scrolls 5/5 |

What Chrome does, from a raw CDP client over the DevTools WebSocket (no bun). The command is sent N ms after `Page.navigate`, 30 rounds per cell unless noted, same-site navigation:

| command | same tick | ~4 ms | ~6 ms | ~8 ms |
| --- | --- | --- | --- | --- |
| `Input.dispatchMouseEvent` `mouseWheel` | 11 dropped | 8 dropped | 1 dropped | 0 dropped |
| `Input.insertText` | 0 | 0 (3 ms) | 6 dropped | n/a |
| `Input.dispatchKeyEvent` keyDown + keyUp | n/a | 0 | 0 | 0 |
| `Input.dispatchMouseEvent` pressed + released | 0 (10 rounds) | 0 | 0 | 0 |
| `Emulation.setDeviceMetricsOverride` | n/a | 0 | 0 | 0 |
| `Runtime.evaluate` with `awaitPromise` | 0, all answered with "Inspected target navigated or closed" | 0 | 0 | 0 |

A cross-site navigation (127.0.0.1 to localhost) gives the same split: wheel 7/20 dropped at 5 ms, `insertText` 1/20 at 9 ms, keys, buttons and metrics 0/40 each. A dropped id stays dropped: nothing in the 2.5 s after the load event. A wheel answered after the commit is often answered after the load event too (7 of 7 in a run at 6 ms), and that one scrolls the new document. A wheel across a same-process iframe commit is answered 12/12, about 25 ms after the subframe commit.

Why Chrome does it, from `content/browser/devtools/protocol/input_handler.cc` (chromium 8b96632e):

- `InputHandler::HandleMouseEvent` does not inject a wheel at once. It parks it behind `RenderWidgetHostImpl::InsertVisualStateCallback`, a request for the renderer's next frame ("make sure the compositor is up to date before sending a wheel event"). Presses and keys skip that step.
- The parked closure starts with `if (!self || !widget_host) return;`, and a renderer that is frozen in the back/forward cache never runs it at all. In both cases the CDP callback is destroyed without a response. If the widget survives the commit, the closure runs on the new document's first frame. That is the late reply that scrolls the new document.
- `InputHandler::InsertText` binds `sendSuccess` into the mojo reply of `WidgetInputHandler::ImeCommitText`. The reply dies with the pipe to the old renderer.
- For a key or button event that is already injected and waits for its ack at a renderer swap, `InputHandler::SetRenderer` calls `ClearInputState()`, and `InputInjector::Cleanup()` answers every pending callback with `sendSuccess()`. So "resolve" is what Chrome itself does for the other input at the same point.

Why resolve at the commit: a command that is still pending when bun reads the commit event either gets a late reply (the new document took the input) or none (no document did). Rejecting would report failure for input Chrome then applies. Repeating it would apply it twice in that case. Waiting for the load event still races the replies that come after load, and depends on a load event that some pages never fire and that a back/forward cache restore does not send. Resolving is right for every branch, at the cost of resolving a few milliseconds before Chrome's own ack in the late-reply case. `scroll()` already does not promise that `scrollY` has changed when it resolves (see the existing "scroll dispatches wheel event" test), and input that Chrome answers just before the commit went to a document that is gone, with a resolved promise.

The settle runs before `onNavigated`, so a callback that scrolls or clicks finds the slot free.

Self-review (an adversarial pass over the first version of this diff, which covered only the wheel):

- Addressed: `type()` strands the same slot the same way. Confirmed with the raw client (table above) and added to the sweep and the tests.
- Addressed: the first version's hook had the name and signature of #42207's `mainFrameCommitted` with another body. It is now the one per-`Method` sweep for this event. #42207's mark and re-send become the `PageCaptureScreenshot` arm when it rebases, and the fake browser's `__fake_drop_next(method[:type])`, `__fake_hold_next`, `__fake_release(count)` and `__fake_emit` cover its screenshot-specific knobs.
- Addressed: `cdp()` can send the droppable commands too. The decision is explicit in `resolvesAtCommit`: left to Chrome's reply, because nothing tells a raw droppable command from one that owes a result. `docs/runtime/webview.mdx` now says so.
- Addressed: comments, docs and the commit message no longer say that only the wheel is dropped.
- Declined here, as separate work: holding `click()`'s settle until the commit it triggers, a transport-level reply deadline, and a strand when an out-of-process iframe detaches.

This change does not depend on #42207 or #42162, which touch the same `Page.frameNavigated` arm. It needs no mark on the pending entry and no load-event hook.

Suites run with the debug build, after a rebase on main (6b394bfe): `webview-chrome-pipe.test.ts` (20 pass, 2 Windows-only skips), `webview-chrome.test.ts` (59 pass, through a `--no-sandbox` wrapper in `BUN_CHROME_PATH` because this machine runs as root), `webview-chrome-disconnect.test.ts` (7 pass), `webview.test.ts` (2 pass, 60 skipped off macOS). On stock bun the two "drops at a navigation" blocks and the "reply that comes after the commit" block fail. The two subframe blocks pass on both, as guards. The new real-Chrome block passed 6/6 repeat runs with the fix and failed 3/3 on stock bun.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome.test.ts, test/js/bun/webview/webview-chrome-pipe.test.ts

<!-- robobun:evidence:end -->