### PR TITLE
cron: stop the next() walk at the end of the Date range

### DIFF
--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -1872,16 +1872,13 @@ pub(crate) fn cron_parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
         bun_core::time::milli_timestamp() as f64
     };
 
-    // An out-of-range `from` is an invalid argument, not "no future match":
-    // throw before next() maps it to None.
+    // An out-of-range `from` is an invalid argument. next() would report it as "no match".
     if from_ms.is_nan() || from_ms.abs() > jsc::wtf::MAX_ECMASCRIPT_TIME {
         return Err(global.throw_invalid_arguments(format_args!("Invalid date value")));
     }
 
     let tz = resolve_cron_tz(global, args[2])?;
 
-    // next() stays inside the Date range, so this is null and never an
-    // Invalid Date: callers can rely on `=== null` for "no future match".
     let Some(next_ms) = parsed.next(global, from_ms, tz)? else {
         return Ok(JSValue::NULL);
     };

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -1872,21 +1872,19 @@ pub(crate) fn cron_parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
         bun_core::time::milli_timestamp() as f64
     };
 
-    // Out-of-range ms hits UB in WTF::msToGregorianDateTime's int casts and
-    // the resulting garbage components panic next()'s u32 conversions.
+    // An out-of-range `from` is an invalid argument, not "no future match":
+    // throw before next() maps it to None.
     if from_ms.is_nan() || from_ms.abs() > jsc::wtf::MAX_ECMASCRIPT_TIME {
         return Err(global.throw_invalid_arguments(format_args!("Invalid date value")));
     }
 
     let tz = resolve_cron_tz(global, args[2])?;
 
+    // next() stays inside the Date range, so this is null and never an
+    // Invalid Date: callers can rely on `=== null` for "no future match".
     let Some(next_ms) = parsed.next(global, from_ms, tz)? else {
         return Ok(JSValue::NULL);
     };
-    // Return null (not Invalid Date) so callers can rely on `=== null` for "no future match".
-    if next_ms > jsc::wtf::MAX_ECMASCRIPT_TIME {
-        return Ok(JSValue::NULL);
-    }
     Ok(JSValue::from_date_number(global, next_ms))
 }
 

--- a/src/runtime/api/cron_parser.rs
+++ b/src/runtime/api/cron_parser.rs
@@ -293,7 +293,10 @@ impl CronExpression {
             }
 
             if let Some(r) = self.resolve_local_match(global_object, tz, dt, from_ms, from_dt)? {
-                return Ok(Some(r));
+                // A candidate on the last day can still resolve past the range.
+                if r <= MAX_ECMASCRIPT_TIME {
+                    return Ok(Some(r));
+                }
             }
             dt.minute += 1;
         }

--- a/src/runtime/api/cron_parser.rs
+++ b/src/runtime/api/cron_parser.rs
@@ -222,18 +222,15 @@ impl CronExpression {
     }
 
     /// Compute the next time (in ms since epoch) that matches this expression
-    /// in `tz`, strictly after `from_ms`. Returns None if `from_ms` is outside
-    /// the Date range, or if no match is found within 8 years or before the
-    /// end of that range.
+    /// in `tz`, strictly after `from_ms`. Returns None if no match found
+    /// within 8 years and inside the Date range.
     pub(crate) fn next(
         &self,
         global_object: &JSGlobalObject,
         from_ms: f64,
         tz: CronTz,
     ) -> JsResult<Option<f64>> {
-        // JSC converts no time value more than a day outside the Date range
-        // to a calendar date: `ms_to_gregorian_date_time*` asserts or returns
-        // year 0. The scheduler's clock can be mocked that far out.
+        // The scheduler's clock can be mocked past the Date range, which JSC does not convert.
         if from_ms.is_nan() || from_ms.abs() > MAX_ECMASCRIPT_TIME {
             return Ok(None);
         }
@@ -257,9 +254,7 @@ impl CronExpression {
             }
             let noon_ms = global_object
                 .gregorian_date_time_to_ms_utc(dt.year, dt.month, dt.day, 12, 0, 0, 0)?;
-            // Every zone is within a day of UTC, so no instant on a later
-            // wall-clock day fits in a Date. A year 0 in `n` (see above) would
-            // also restart the walk.
+            // Check before the conversion: JSC asserts or returns year 0 for a later day.
             if noon_ms > LAST_DAY_NOON_MS {
                 return Ok(None);
             }
@@ -310,7 +305,7 @@ impl CronExpression {
 
 const MINUTE_MS: f64 = 60_000.0;
 const MAX_DST_SHIFT_MIN: f64 = 120.0;
-/// UTC noon of +275760-09-13, the day that `MAX_ECMASCRIPT_TIME` starts.
+/// UTC noon of +275760-09-13. No instant on a later wall-clock day fits in a Date, in any zone.
 const LAST_DAY_NOON_MS: f64 = MAX_ECMASCRIPT_TIME + 12.0 * 60.0 * MINUTE_MS;
 
 const ALL_MINUTES: u64 = (1 << 60) - 1;

--- a/src/runtime/api/cron_parser.rs
+++ b/src/runtime/api/cron_parser.rs
@@ -14,6 +14,7 @@
 //!   - Nicknames: @yearly, @annually, @monthly, @weekly, @daily, @midnight, @hourly
 
 use bun_core::strings;
+use bun_jsc::wtf::MAX_ECMASCRIPT_TIME;
 use bun_jsc::{GregorianDateTime, JSGlobalObject, JsResult};
 
 /// Time zone for `CronExpression::next`.
@@ -221,14 +222,21 @@ impl CronExpression {
     }
 
     /// Compute the next time (in ms since epoch) that matches this expression
-    /// in `tz`, strictly after `from_ms`. Returns None if no match found
-    /// within 8 years.
+    /// in `tz`, strictly after `from_ms`. Returns None if `from_ms` is outside
+    /// the Date range, or if no match is found within 8 years or before the
+    /// end of that range.
     pub(crate) fn next(
         &self,
         global_object: &JSGlobalObject,
         from_ms: f64,
         tz: CronTz,
     ) -> JsResult<Option<f64>> {
+        // JSC converts no time value more than a day outside the Date range
+        // to a calendar date: `ms_to_gregorian_date_time*` asserts or returns
+        // year 0. The scheduler's clock can be mocked that far out.
+        if from_ms.is_nan() || from_ms.abs() > MAX_ECMASCRIPT_TIME {
+            return Ok(None);
+        }
         let from_dt = tz.ms_to_gregorian(global_object, from_ms);
         let start_year = from_dt.year;
         let mut dt = from_dt;
@@ -247,10 +255,15 @@ impl CronExpression {
                 dt.hour -= 24;
                 dt.day += 1;
             }
-            let n = global_object.ms_to_gregorian_date_time_utc(
-                global_object
-                    .gregorian_date_time_to_ms_utc(dt.year, dt.month, dt.day, 12, 0, 0, 0)?,
-            );
+            let noon_ms = global_object
+                .gregorian_date_time_to_ms_utc(dt.year, dt.month, dt.day, 12, 0, 0, 0)?;
+            // Every zone is within a day of UTC, so no instant on a later
+            // wall-clock day fits in a Date. A year 0 in `n` (see above) would
+            // also restart the walk.
+            if noon_ms > LAST_DAY_NOON_MS {
+                return Ok(None);
+            }
+            let n = global_object.ms_to_gregorian_date_time_utc(noon_ms);
             dt.year = n.year;
             dt.month = n.month;
             dt.day = n.day;
@@ -294,6 +307,8 @@ impl CronExpression {
 
 const MINUTE_MS: f64 = 60_000.0;
 const MAX_DST_SHIFT_MIN: f64 = 120.0;
+/// UTC noon of +275760-09-13, the day that `MAX_ECMASCRIPT_TIME` starts.
+const LAST_DAY_NOON_MS: f64 = MAX_ECMASCRIPT_TIME + 12.0 * 60.0 * MINUTE_MS;
 
 const ALL_MINUTES: u64 = (1 << 60) - 1;
 const ALL_HOURS: u32 = (1 << 24) - 1;

--- a/test/js/bun/cron/cron-parse.test.ts
+++ b/test/js/bun/cron/cron-parse.test.ts
@@ -39,6 +39,9 @@ describe.concurrent("Bun.cron.parse — algorithm (pinned TZ=UTC)", () => {
   });
 
   test("impossible day/month (Feb 30) returns null quickly", () => {
+    // The first date conversion in a process pays a one-time setup cost
+    // (about 150 ms in a debug build). Pay it before the walk is timed.
+    Bun.cron.parse("* * * * *", 0, { tz: "UTC" });
     const t = performance.now();
     expect(Bun.cron.parse("0 0 30 2 *", new Date("2026-01-01T00:00:00Z"), { tz: "UTC" })).toBeNull();
     expect(performance.now() - t).toBeLessThan(50);
@@ -128,5 +131,94 @@ describe("Bun.cron.parse — invalid `from` argument", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "Invalid date value", stderr: "", exitCode: 0 });
+  });
+});
+
+// 8.64e15 ms is +275760-09-13T00:00:00Z, the last instant a Date holds. JSC
+// converts no time value more than a day past it to a calendar date. A debug
+// build asserts. Newer JSC returns year 0, which made the walk start over and
+// never stop. Both tests spawn, with a kill switch on the child.
+describe("Bun.cron — end of the Date range", () => {
+  test("Bun.cron.parse stops the walk at the last day", async () => {
+    // [tz, schedule for the wall-clock minute of 8.64e15 in that zone, one minute later]
+    const zones = [
+      [null, "0 0 13 9 *", "1 0 13 9 *"], // local time, TZ=UTC
+      ["UTC", "0 0 13 9 *", "1 0 13 9 *"],
+      ["America/New_York", "0 20 12 9 *", "1 20 12 9 *"],
+      ["Pacific/Kiritimati", "0 14 13 9 *", "1 14 13 9 *"],
+    ];
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const max = 8.64e15, day = 86_400_000;
+         const out = {};
+         for (const [tz, lastMinute, oneMinuteLater] of ${JSON.stringify(zones)}) {
+           const next = (expr, from) => Bun.cron.parse(expr, from, tz ? { tz } : undefined)?.getTime() ?? null;
+           const first = next("* * * * *", -max);
+           out[tz ?? "local"] = [
+             // Every minute after max is past the range.
+             next("* * * * *", max),
+             next("0 0 1 1 *", max),
+             // One minute inside the range lands on the end of it.
+             next("* * * * *", max - 60_000),
+             // Feb 30 never exists: the walk runs into the end of the range.
+             next("0 0 30 2 *", max - 400 * day),
+             // The next Jan 1 is in year 275761.
+             next("0 0 1 1 *", max - 10 * day),
+             next("0 0 14 9 *", max - 10 * day),
+             // The last minute of the range still matches. One minute later does not.
+             next(lastMinute, max - 10 * day),
+             next(oneMinuteLater, max - 10 * day),
+             // The walk only moves forward, so the lower end needs no bound.
+             first > -max && first <= -max + 60_000,
+           ];
+         }
+         process.stdout.write(JSON.stringify(out));`,
+      ],
+      env: { ...bunEnv, TZ: "UTC" },
+      stderr: "pipe",
+      timeout: 20_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const expected = [null, null, 8.64e15, null, null, null, 8.64e15, null, true];
+    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+      out: { local: expected, UTC: expected, "America/New_York": expected, "Pacific/Kiritimati": expected },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // Bun.cron.parse rejects a `from` outside the range. The scheduler reads the
+  // clock, and fake timers can set the clock to any number.
+  test("Bun.cron() finds no occurrence when the clock is past the range", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { jest } = Bun.jest();
+         jest.useFakeTimers();
+         jest.setSystemTime(8.64e15 + 2 * 86_400_000);
+         let result;
+         try {
+           Bun.cron("* * * * *", () => {}).stop();
+           result = "scheduled";
+         } catch (e) {
+           result = e.message;
+         }
+         process.stdout.write(result);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      timeout: 20_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "Cron expression '* * * * *' has no future occurrences",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });

--- a/test/js/bun/cron/cron-parse.test.ts
+++ b/test/js/bun/cron/cron-parse.test.ts
@@ -183,10 +183,11 @@ describe("Bun.cron — end of the Date range", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     const expected = [null, null, 8.64e15, null, null, null, 8.64e15, null, true];
-    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
       out: { local: expected, UTC: expected, "America/New_York": expected, "Pacific/Kiritimati": expected },
       stderr: "",
       exitCode: 0,
+      signalCode: null,
     });
   });
 
@@ -220,10 +221,11 @@ describe("Bun.cron — end of the Date range", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     const noOccurrence = "Cron expression '* * * * *' has no future occurrences";
-    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
       out: [noOccurrence, noOccurrence],
       stderr: "",
       exitCode: 0,
+      signalCode: null,
     });
   });
 });

--- a/test/js/bun/cron/cron-parse.test.ts
+++ b/test/js/bun/cron/cron-parse.test.ts
@@ -192,31 +192,36 @@ describe("Bun.cron — end of the Date range", () => {
 
   // Bun.cron.parse rejects a `from` outside the range. The scheduler reads the
   // clock, and fake timers can set the clock to any number.
-  test("Bun.cron() finds no occurrence when the clock is past the range", async () => {
+  test("Bun.cron() finds no occurrence when the clock is at or past the end of the range", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `const { jest } = Bun.jest();
          jest.useFakeTimers();
-         jest.setSystemTime(8.64e15 + 2 * 86_400_000);
-         let result;
-         try {
-           Bun.cron("* * * * *", () => {}).stop();
-           result = "scheduled";
-         } catch (e) {
-           result = e.message;
+         const out = [];
+         // At the last instant the next minute is past the range. Two days later
+         // JSC has no calendar date for the clock itself.
+         for (const now of [8.64e15, 8.64e15 + 2 * 86_400_000]) {
+           jest.setSystemTime(now);
+           try {
+             Bun.cron("* * * * *", () => {}).stop();
+             out.push("scheduled");
+           } catch (e) {
+             out.push(e.message);
+           }
          }
-         process.stdout.write(result);`,
+         process.stdout.write(JSON.stringify(out));`,
       ],
-      env: bunEnv,
+      env: { ...bunEnv, TZ: "UTC" },
       stderr: "pipe",
       timeout: 20_000,
       killSignal: "SIGKILL",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: "Cron expression '* * * * *' has no future occurrences",
+    const noOccurrence = "Cron expression '* * * * *' has no future occurrences";
+    expect({ out: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+      out: [noOccurrence, noOccurrence],
       stderr: "",
       exitCode: 0,
     });


### PR DESCRIPTION
### Problem
- `CronExpression::next()` (`src/runtime/api/cron_parser.rs:250`) converts each candidate day to a calendar date through JSC. Nothing stops the walk at the end of the Date range. JSC converts nothing more than one day past it.
- Before #42319, a debug build of `main` aborted: `Bun.cron.parse("0 0 1 1 *", 8.64e15)` gave `ASSERTION FAILED: year >= minYear && year <= maxYear` at `PlainGregorianDateTime.h(91)`. A release build returned `null`.
- #42319 (merged, 6a92015fc8) moved `main` to a WebKit where the conversion returns an all-zero date. The year goes back to 0, the 8-year bound never trips, and `Bun.cron.parse("0 0 30 2 *", new Date(8.64e15 - 86400000 * 400))` never returns. `main` and the canary hang on this call today.

### Fix
- `next()` returns `None` when the candidate day is past +275760-09-13. Every zone offset is smaller than one day, so no instant on a later wall-clock day fits in a Date.
- `next()` also returns `None` for a `from` outside the Date range (fake timers can set the scheduler's clock to any number). It skips a candidate that resolves past 8.64e15, so `cron_parse` needs no clamp.
- Verified: `test/js/bun/cron/cron-parse.test.ts`. The 2 new tests fail without the fix and pass with it, on `main` before and after #42319 (6b394bfeb0 and 158ff6cdef). Also ran the rest of `test/js/bun/cron/`.
- Self-reviewed: 7 points raised, 4 addressed. 3 are about #42177, #42267 and #36894 and are comments there.

### Background
- `next()` walks wall-clock time forward from `from`, day by day, until all five fields match.
- 8.64e15 ms is +275760-09-13T00:00:00Z, the largest time value a `Date` holds.
- #42319 merged before this PR. `main` has the endless loop until this PR merges.

<details><summary>Notes</summary>

**Upstream change.** WebKit 320788@main (d5ba0ecec9, bug 323443) changed `DateCache::computeGregorianDateTime` in `JSDateMath.cpp` from `if (!std::isfinite(ms)) return { };` to `if (!canNarrowToInt64Milliseconds(ms)) return { };`, where `canNarrowToInt64Milliseconds(ms)` is `isfinite(ms) && abs(ms) <= maxECMAScriptTime + msPerDay`. `Bun__msToGregorianDateTime` passes the empty value through as year 0, month 1, day 0, weekday 0. With year 0 the walk climbs about 100 million day steps back to year 275760, gets year 0 again, and repeats.

**On `main` before #42319 (WebKit dfd696443b, debug+ASAN build).** These calls abort with the `PlainGregorianDateTime` assertion: `Bun.cron.parse("0 0 1 1 *", 8.64e15)`, `Bun.cron.parse("0 0 30 2 *", new Date(8.64e15 - 86400000 * 400))` with and without `{ tz: "UTC" }`, and `Bun.cron.parse("* * * * *", 8.64e15, { tz: "UTC" })`. The assertion fires inside the `ms_to_gregorian_date_time_utc` call that this PR bounds, when the walk reaches year 275761. Bun 1.4.3 (release) returns `null` for all of them. `* * * * *` from 8.64e15 with a named zone takes 1 to 4.6 s there, because it walks 8 years one minute at a time. With this PR the walk ends after at most two days.

**Proof on both WebKit versions.** `bun bd test test/js/bun/cron/cron-parse.test.ts`, with `src/` at the base and then at this commit.
- `main` (6b394bfeb0): 23 pass and 2 fail, then 25 pass. The parse test fails with exit code 134 and the assertion text. The scheduler test prints `scheduled` for both clock values.
- Head of #42177 (676b1684c9, WebKit 4b9ff9959a) with this commit on top: 23 pass and 2 fail, then 25 pass. Both tests time out and bun:test kills the child.
- `main` after #42319 (158ff6cdef, WebKit cf1b36ec8703) with this branch rebased on it: 23 pass and 2 fail, then 25 pass. Both tests time out and bun:test kills the child.

**Probe.** 29 calls, each in a child process with a 20 s limit, on the debug build of 676b1684c9 with and without the day bound, and on bun 1.4.3. Inputs: `* * * * *`, `0 0 1 1 *`, `0 0 30 2 *`, `0 0 13 9 *`, `0 0 14 9 *`, `0 12 13 9 *` from 8.64e15, 8.64e15 - 1 minute, 8.64e15 - 10 days, 8.64e15 - 400 days and -8.64e15, in local time (TZ=UTC), `UTC`, `America/New_York` and `Asia/Tokyo`. Without the bound 10 calls hang. With the bound every result is equal to the 1.4.3 result.

**Every conversion in `next()` is now inside the window that JSC converts.** `from` is inside the Date range. The noon of each day that the walk can reach is at most 8.64e15 + 12 h. `resolve_local_match` probes at most 121 minutes past `from`. The lower end needs no bound, because the walk only moves forward. The bound keeps +275760-09-13 itself, so the last minute of the range still matches in `Pacific/Kiritimati` (UTC+14, test row `0 14 13 9 *`).

**A candidate on the last day can resolve past 8.64e15.** The local path returns a value above 8.64e15. The named-zone path returns NaN. `next()` skips both and continues to the end of that day (at most 1440 more steps). So `next()` never returns a value outside the Date range. Before, `cron_parse` mapped such a value to `null`, but the scheduler armed a timer for it: with the clock at exactly 8.64e15, `Bun.cron("* * * * *", ...)` scheduled a job. Now it throws `has no future occurrences`, the same as a named zone.

**Test design.** Both tests spawn a child, because a walk that does not stop spins in native code and cannot be interrupted. They are not concurrent: bun:test kills the children of a timed-out test only when the test is not concurrent. The `timeout` and `killSignal` on the child are the kill switch for CI, where the per-test timeout is 90 s or more.

**Timing test.** "impossible day/month (Feb 30) returns null quickly" asserts under 50 ms. It fails on a debug+ASAN build without this PR (159 ms). The first date conversion in a process costs about 150 ms there, and a warm call takes 2 ms. The test now makes one call before it starts the clock. #36894 has the same edit.

**Relation to #36894.** #36894 is closed in favor of this PR. It maps a match past 8.64e15 to `None` inside `next()`, removes the clamp in `cron_parse`, and guards the year in `Bun__gregorianDateTimeToMSInZone`. This PR now does the first two. The year guard is not needed, because the walk cannot reach year 275761. #36894 does not bound the day walk, so it does not stop the loop on the new WebKit. Its `{ tz }` boundary rows are part of the new parse test here, and they pass.

**Not changed.** `Cookie.cpp:261` also calls `msToGregorianDateTime`. On the new WebKit `new Bun.Cookie("a", "b", { expires: 1e13 }).toString()` prints `Expires=Sun, 00 Jan 0000 00:00:00 GMT`. With the old WebKit it printed `Sun, 20 May 318857 17:46:40 GMT`. Both are outside the Date range, and neither hangs. `toISOString` in `wtf-bindings.cpp` only receives the time value of a `Date` or the current time.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/cron/cron-parse.test.ts
bun test v1.4.3 (4ff919377)

test/js/bun/cron/cron-parse.test.ts:
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > impossible day/month (Feb 30) returns null quickly [236.60ms]
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > Feb 29 finds next leap year [1659.45ms]
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > weekday matching uses local day-of-week [1741.19ms]
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > strictly-after: from = exact match returns the next occurrence [1887.91ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 1-7 means Mon-Sun (every day) [1758.25ms]
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > DOM/DOW OR semantics when both restricted [1844.78ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 6-7 means Sat-Sun [1565.94ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > scalar 7 still means Sunday [1374.75ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 5-7 means Fri-Sun [1793.66ms]
(pass) Bun.cron.parse — w
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/js/bun/cron/cron-parse.test.ts:
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > impossible day/month (Feb 30) returns null quickly [5.77ms]
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > weekday matching uses local day-of-week [25.21ms]
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > Feb 29 finds next leap year [23.54ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 1-7 means Mon-Sun (every day) [24.17ms]
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > DOM/DOW OR semantics when both restricted [25.06ms]
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > strictly-after: from = exact match returns the next occurrence [35.13ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 5-7 means Fri-Sun [61.49ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 0-7 means every day [63.62ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > scalar 7 still means Sunday [65.85ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 6-7 means Sat-Sun [70.84ms]
(pass) Bun.cron.parse — invalid `from` argument > throws for out-of-range/non-finite ms: 1e+300 [0.20ms]
(pass) Bun
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/cron/cron-parse.test.ts
bun test v1.4.3 (4ff919377)

test/js/bun/cron/cron-parse.test.ts:
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > impossible day/month (Feb 30) returns null quickly [201.36ms]
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > Feb 29 finds next leap year [1469.26ms]
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > strictly-after: from = exact match returns the next occurrence [1652.81ms]
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > DOM/DOW OR semantics when both restricted [1462.10ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 1-7 means Mon-Sun (every day) [1537.11ms]
(pass) Bun.cron.parse — algorithm (pinned TZ=UTC) > weekday matching uses local day-of-week [1977.03ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 5-7 means Fri-Sun [1813.74ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > scalar 7 still means Sunday [1615.41ms]
(pass) Bun.cron.parse — weekday 7 = Sunday in ranges > 6-7 means Sat-Sun [1781.97ms]
(pass) Bun.cron.parse — w
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 840ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
^[[1m^[[92m   Compiling^[[0m bun_collections v0.0.0 (/workspace/bun/src/collections)
^[[1m^[[92m   Compiling
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/cron.rs             |  7 +--
 src/runtime/api/cron_parser.rs      | 25 +++++++---
 test/js/bun/cron/cron-parse.test.ts | 99 +++++++++++++++++++++++++++++++++++++
 3 files changed, 119 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/api/cron.rs                  3      2     30
src/runtime/api/cron_parser.rs           6      7     30
test/js/bun/cron/cron-parse.test.ts      6      8     29
```

</details>

<!-- robobun:evidence:end -->
