### PR TITLE
bun:test: print String objects with 16-bit storage correctly

### DIFF
--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1117,8 +1117,13 @@ impl<'a> Formatter<'a> {
                         self.reset_line();
                         self.write_indent(writer.ctx).expect("unreachable");
                         let length = str.len;
-                        for (i, c) in str.slice().iter().enumerate() {
-                            writer.print(format_args!("\"{}\": \"{}\",\n", i, *c as char));
+                        for i in 0..length {
+                            let unit = [str.char_at(i)];
+                            writer.print(format_args!(
+                                "\"{}\": \"{}\",\n",
+                                i,
+                                bun_fmt::utf16(&unit)
+                            ));
                             if i != length - 1 {
                                 self.write_indent(writer.ctx).expect("unreachable");
                             }

--- a/test/js/bun/test/snapshot-tests/snapshots/__snapshots__/snapshot.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/snapshots/__snapshots__/snapshot.test.ts.snap
@@ -297,6 +297,20 @@ String {
 }
 `;
 
+exports[`most types: String with 16-bit storage 1`] = `
+String {
+  "0": "日",
+  "1": "本",
+}
+`;
+
+exports[`most types: String with ASCII text in 16-bit storage 1`] = `
+String {
+  "0": "a",
+  "1": "b",
+}
+`;
+
 exports[`most types: String with property 1`] = `String {}`;
 
 exports[`most types: Uint8Array 1`] = `Uint8Array []`;

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -57,6 +57,10 @@ test("most types", () => {
   expect({ a: s }).toMatchSnapshot("Object with String with property");
   expect({ a: new String() }).toMatchSnapshot("Object with empty String");
   expect(new String("hello")).toMatchSnapshot("String");
+  expect(new String("日本")).toMatchSnapshot("String with 16-bit storage");
+  expect(new String(new TextDecoder("utf-16le").decode(new Uint16Array([0x61, 0x62])))).toMatchSnapshot(
+    "String with ASCII text in 16-bit storage",
+  );
 
   expect(new Number(7)).toMatchSnapshot("Number");
   expect({ a: {} }).toMatchSnapshot("Object with empty object");


### PR DESCRIPTION
### Problem
- `bun:test` prints wrong characters for a `String` object when the backing string has 16-bit storage (any character above U+00FF). `expect(new String("日本")).toEqual(0)` prints `"0": "å", "1": "e"`. A debug build panics with `EncodedSlice::slice() on UTF-16; use to_utf8()`. The same output goes into `toMatchSnapshot` and `toMatchInlineSnapshot`.
- The cause is the `StringObject` branch of `Tag::String` in `src/runtime/test_runner/pretty_format.rs:1120`. It loops over `str.slice()`, the 8-bit view of an `EncodedSlice`. For a 16-bit string that view is the raw UTF-16 buffer, so the loop prints the first `len` bytes of it as Latin-1.

### Fix
- Loop over `0..str.len` and read each code unit with `EncodedSlice::char_at(i)`. It returns a `u16` for both widths. Format the unit with `bun_core::fmt::utf16`, which transcodes to UTF-8.
- An 8-bit string prints the same as before: `char_at` widens the Latin-1 byte, and the UTF-16 formatter maps it to the same code point. A lone surrogate prints as U+FFFD, the same as the plain string path.
- Verified: `test/js/bun/test/snapshot-tests/snapshots/more.test.ts` (two new snapshots). The released bun prints `"å"` and `"e"` for them, and a debug build of main panics. Also `snapshot.test.ts` and `test/js/bun/test/expect.test.js`.

### Background
- `EncodedSlice` is a borrowed `{ptr, len}` view of a string with encoding bits in the pointer (Latin-1, UTF-8, or UTF-16). `slice()` returns the 8-bit bytes and asserts the string is not 16-bit. `utf16_slice()` and `char_at(i)` are the width-aware accessors.
- JSC stores a string as 8-bit (Latin-1) when every character fits in one byte, and as 16-bit (UTF-16) otherwise. A `TextDecoder("utf-16le")` result is 16-bit even for ASCII text, so the test covers that case too.

Fixes #42296

