### PR TITLE
Escape object keys the same way for Latin-1 and UTF-16 strings in bun:test and Bun.inspect

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -403,10 +403,6 @@ pub fn contains_any(slice: &[u8], chars: &[u8]) -> bool {
     index_of_any(slice, chars).is_some()
 }
 
-pub fn index_of_any16(self_: &[u16], chars: &[u16]) -> Option<usize> {
-    index_of_any_t(self_, chars)
-}
-
 pub fn index_of_any_t<T: crate::NoUninit + Eq>(str: &[T], chars: &[T]) -> Option<usize> {
     if let (Lanes::U8(s), Lanes::U8(c)) = (lanes(str), lanes(chars)) {
         return index_of_any(s, c);

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2970,8 +2970,6 @@ pub mod formatter {
                 } else {
                     writer.add_for_new_line(key.len + 2);
 
-                    // One escaper over the UTF-8 form, so a key prints the same
-                    // whether JSC stores it as Latin-1 or as UTF-16.
                     writer.print(format_args!(
                         "{}{}{}",
                         pfmt!("<r><green>", C),

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2700,19 +2700,6 @@ pub mod formatter {
         pub(crate) fn write_string(&mut self, str: &bun_core::String) {
             self.print(format_args!("{str}"));
         }
-
-        #[inline]
-        pub(crate) fn write_16_bit(&mut self, input: &[u16]) {
-            // `format_utf16_type` requires `impl fmt::Write + Sized`; route through
-            // the `Display` adapter so we go via `bun_io::Write::write_fmt` instead.
-            self.print(format_args!(
-                "{}",
-                bun_core::fmt::FormatUTF16 {
-                    buf: input,
-                    path_fmt_opts: None
-                }
-            ));
-        }
     }
 
     const INDENTATION_BUF: [u8; 64] = [b' '; 64];
@@ -2980,34 +2967,15 @@ pub mod formatter {
                         key,
                         pfmt!("<d>:<r> ", C),
                     ));
-                } else if key.is_16bit() {
-                    let mut utf16_slice = key.utf16_slice();
-
-                    writer.add_for_new_line(utf16_slice.len() + 2);
-
-                    if C {
-                        writer.write_all(pfmt!("<r><green>", true).as_bytes());
-                    }
-
-                    writer.write_all(b"\"");
-
-                    const QUOTE_U16: &[u16] = &[b'"' as u16];
-                    while let Some(j) = strings::index_of_any16(utf16_slice, QUOTE_U16) {
-                        writer.write_16_bit(&utf16_slice[0..j]);
-                        writer.write_all(b"\"");
-                        utf16_slice = &utf16_slice[j + 1..];
-                    }
-
-                    writer.write_16_bit(utf16_slice);
-
-                    writer.print(format_args!("{}", pfmt!("\"<r><d>:<r> ", C)));
                 } else {
                     writer.add_for_new_line(key.len + 2);
 
+                    // One escaper over the UTF-8 form, so a key prints the same
+                    // whether JSC stores it as Latin-1 or as UTF-16.
                     writer.print(format_args!(
                         "{}{}{}",
                         pfmt!("<r><green>", C),
-                        bun_core::fmt::format_json_string_latin1(key.slice()),
+                        bun_core::fmt::format_json_string_utf8(&key.to_utf8(), Default::default()),
                         pfmt!("<r><d>:<r> ", C),
                     ));
                 }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3877,7 +3877,7 @@ impl BunXFastPath {
 
         // Trigger quoting only on
         // space/tab/quote — compare the FULL u16, not the truncated low byte.
-        let needs_quote = strings::index_of_any16(warg, bun_core::w!(" \t\"")).is_some();
+        let needs_quote = strings::index_of_any_t(warg, bun_core::w!(" \t\"")).is_some();
 
         if !needs_quote {
             buffer[..warg.len()].copy_from_slice(warg);
@@ -3885,7 +3885,7 @@ impl BunXFastPath {
         }
 
         // Fast path: no embedded `"`/`\` → simple wrap.
-        let has_quote_or_backslash = strings::index_of_any16(warg, bun_core::w!("\"\\")).is_some();
+        let has_quote_or_backslash = strings::index_of_any_t(warg, bun_core::w!("\"\\")).is_some();
         if !has_quote_or_backslash {
             buffer[0] = b'"' as u16;
             buffer[1..1 + warg.len()].copy_from_slice(warg);

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -707,21 +707,6 @@ impl<'w, W: bun_io::Write> WrappedWriter<'w, W> {
     pub(crate) fn write_string(&mut self, str: &bun_core::String) {
         self.print(format_args!("{}", str));
     }
-
-    #[inline]
-    pub(crate) fn write_16_bit(&mut self, input: &[u16]) {
-        // `format_utf16_type` writes through `fmt::Write`; buffer to a `String`
-        // and forward bytes (UTF-16 → UTF-8 conversion is the point, so the
-        // intermediate allocation is unavoidable without a `bun_io::Write` overload).
-        let mut buf = String::new();
-        if bun_fmt::format_utf16_type(input, &mut buf).is_err() {
-            self.failed = true;
-            return;
-        }
-        if self.ctx.write_all(buf.as_bytes()).is_err() {
-            self.failed = true;
-        }
-    }
 }
 
 use bun_io::AsFmt;
@@ -967,29 +952,15 @@ impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
                     pretty_fmt_const!(ENABLE_ANSI_COLORS, "<d>"),
                     pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r>"),
                 ));
-            } else if key.is_16bit() {
-                let utf16_slice = key.utf16_slice();
-
-                this.add_for_new_line(utf16_slice.len() + 2);
-
-                if ENABLE_ANSI_COLORS {
-                    writer.write_all(pretty_fmt_const!(true, "<r><green>").as_bytes());
-                }
-
-                writer.write_all(b"\"");
-                writer.write_16_bit(utf16_slice);
-                writer.print(format_args!(
-                    "\"{}:{} ",
-                    pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r><d>"),
-                    pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r>"),
-                ));
             } else {
                 this.add_for_new_line(key.len + 2);
 
+                // One escaper over the UTF-8 form, so a key prints the same
+                // whether JSC stores it as Latin-1 or as UTF-16.
                 writer.print(format_args!(
                     "{}{}{}:{} ",
                     pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r><green>"),
-                    bun_fmt::format_json_string_latin1(key.slice()),
+                    bun_fmt::format_json_string_utf8(&key.to_utf8(), Default::default()),
                     pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r><d>"),
                     pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r>"),
                 ));

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -955,8 +955,6 @@ impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
             } else {
                 this.add_for_new_line(key.len + 2);
 
-                // One escaper over the UTF-8 form, so a key prints the same
-                // whether JSC stores it as Latin-1 or as UTF-16.
                 writer.print(format_args!(
                     "{}{}{}:{} ",
                     pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r><green>"),

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -40,15 +40,18 @@ test("object keys get the same escapes in Latin-1 and UTF-16 strings", () => {
   const value = {
     [utf16(["ascii in utf16 ", special].join(""))]: 1,
     ["latin1 " + special]: 2,
-    ["日本 " + special]: 3,
-    ["😀 " + special]: 4,
+    // A Latin-1 string cannot hold these three characters.
+    ["utf16 only \u2028\u2029\ufeff"]: 3,
+    ["日本 " + special]: 4,
+    ["😀 " + special]: 5,
   };
   expect(value).toMatchInlineSnapshot(`
     {
       "ascii in utf16 \\"\\\\\\n\\u001B": 1,
       "latin1 \\"\\\\\\n\\u001B": 2,
-      "日本 \\"\\\\\\n\\u001B": 3,
-      "😀 \\"\\\\\\n\\u001B": 4,
+      "utf16 only \\u2028\\u2029\\uFEFF": 3,
+      "日本 \\"\\\\\\n\\u001B": 4,
+      "😀 \\"\\\\\\n\\u001B": 5,
     }
   `);
 
@@ -67,12 +70,13 @@ test("object keys get the same escapes in Latin-1 and UTF-16 strings", () => {
     + {
     +   "ascii in utf16 \\"\\\\\\n\\u001B": 1,
     +   "latin1 \\"\\\\\\n\\u001B": 2,
-    +   "日本 \\"\\\\\\n\\u001B": 3,
-    +   "😀 \\"\\\\\\n\\u001B": 4,
+    +   "utf16 only \\u2028\\u2029\\uFEFF": 3,
+    +   "日本 \\"\\\\\\n\\u001B": 4,
+    +   "😀 \\"\\\\\\n\\u001B": 5,
     + }
 
     - Expected  - 1
-    + Received  + 6
+    + Received  + 7
     "
   `);
   expect(failure(() => expect(value).toBe(0))).toMatchInlineSnapshot(`
@@ -82,8 +86,9 @@ test("object keys get the same escapes in Latin-1 and UTF-16 strings", () => {
     Received: {
       "ascii in utf16 \\"\\\\\\n\\u001B": 1,
       "latin1 \\"\\\\\\n\\u001B": 2,
-      "日本 \\"\\\\\\n\\u001B": 3,
-      "😀 \\"\\\\\\n\\u001B": 4,
+      "utf16 only \\u2028\\u2029\\uFEFF": 3,
+      "日本 \\"\\\\\\n\\u001B": 4,
+      "😀 \\"\\\\\\n\\u001B": 5,
     }
     "
   `);

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -33,6 +33,62 @@ test("ArrayBuffer values are serialized like typed arrays", () => {
   `);
 });
 
+test("object keys get the same escapes in Latin-1 and UTF-16 strings", () => {
+  // A string decoded from UTF-16 bytes keeps 16-bit storage, even when every character is ASCII.
+  const utf16 = (s: string) => Buffer.from(s, "utf16le").toString("utf16le");
+  const special = '"\\\n\x1b';
+  const value = {
+    [utf16(["ascii in utf16 ", special].join(""))]: 1,
+    ["latin1 " + special]: 2,
+    ["日本 " + special]: 3,
+    ["😀 " + special]: 4,
+  };
+  expect(value).toMatchInlineSnapshot(`
+    {
+      "ascii in utf16 \\"\\\\\\n\\u001B": 1,
+      "latin1 \\"\\\\\\n\\u001B": 2,
+      "日本 \\"\\\\\\n\\u001B": 3,
+      "😀 \\"\\\\\\n\\u001B": 4,
+    }
+  `);
+
+  // A matcher failure prints the value too. toEqual uses the snapshot formatter. toBe uses the console formatter.
+  const failure = (fn: () => void) => {
+    try {
+      fn();
+    } catch (e) {
+      return Bun.stripANSI((e as Error).message);
+    }
+  };
+  expect(failure(() => expect(value).toEqual(0))).toMatchInlineSnapshot(`
+    "expect(received).toEqual(expected)
+
+    - 0
+    + {
+    +   "ascii in utf16 \\"\\\\\\n\\u001B": 1,
+    +   "latin1 \\"\\\\\\n\\u001B": 2,
+    +   "日本 \\"\\\\\\n\\u001B": 3,
+    +   "😀 \\"\\\\\\n\\u001B": 4,
+    + }
+
+    - Expected  - 1
+    + Received  + 6
+    "
+  `);
+  expect(failure(() => expect(value).toBe(0))).toMatchInlineSnapshot(`
+    "expect(received).toBe(expected)
+
+    Expected: 0
+    Received: {
+      "ascii in utf16 \\"\\\\\\n\\u001B": 1,
+      "latin1 \\"\\\\\\n\\u001B": 2,
+      "日本 \\"\\\\\\n\\u001B": 3,
+      "😀 \\"\\\\\\n\\u001B": 4,
+    }
+    "
+  `);
+});
+
 describe("toMatchSnapshot errors", () => {
   it("should throw if property matchers exist and received is not an object", () => {
     expect(() => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -168,15 +168,18 @@ it("property keys get the same escapes in Latin-1 and UTF-16 strings", () => {
     Bun.inspect({
       [utf16(["ascii in utf16 ", special].join(""))]: 1,
       ["latin1 " + special]: 2,
-      ["日本 " + special]: 3,
-      ["😀 " + special]: 4,
+      // A Latin-1 string cannot hold these three characters.
+      ["utf16 only \u2028\u2029\ufeff"]: 3,
+      ["日本 " + special]: 4,
+      ["😀 " + special]: 5,
     }),
   ).toMatchInlineSnapshot(`
     "{
       "ascii in utf16 \\"\\\\\\n\\u001B": 1,
       "latin1 \\"\\\\\\n\\u001B": 2,
-      "日本 \\"\\\\\\n\\u001B": 3,
-      "😀 \\"\\\\\\n\\u001B": 4,
+      "utf16 only \\u2028\\u2029\\uFEFF": 3,
+      "日本 \\"\\\\\\n\\u001B": 4,
+      "😀 \\"\\\\\\n\\u001B": 5,
     }"
   `);
 });

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -160,6 +160,27 @@ it("utf16 property name", () => {
   expect(Bun.inspect(db.prepare("select '😀' as 笑").all())).toBe(output);
 });
 
+it("property keys get the same escapes in Latin-1 and UTF-16 strings", () => {
+  // A string decoded from UTF-16 bytes keeps 16-bit storage, even when every character is ASCII.
+  const utf16 = s => Buffer.from(s, "utf16le").toString("utf16le");
+  const special = '"\\\n\x1b';
+  expect(
+    Bun.inspect({
+      [utf16(["ascii in utf16 ", special].join(""))]: 1,
+      ["latin1 " + special]: 2,
+      ["日本 " + special]: 3,
+      ["😀 " + special]: 4,
+    }),
+  ).toMatchInlineSnapshot(`
+    "{
+      "ascii in utf16 \\"\\\\\\n\\u001B": 1,
+      "latin1 \\"\\\\\\n\\u001B": 2,
+      "日本 \\"\\\\\\n\\u001B": 3,
+      "😀 \\"\\\\\\n\\u001B": 4,
+    }"
+  `);
+});
+
 it("latin1", () => {
   expect(Bun.inspect("English")).toBe('"English"');
   expect(Bun.inspect("Français")).toBe('"Français"');


### PR DESCRIPTION
> **Superseded by #42320.** That PR now carries this change together with the console printer fix, so the key escaping is defined in one place. Both PRs rewrote the same `key.is_16bit()` branch of `write_property_key`.

### Problem

- `bun:test` and `Bun.inspect` escape an object key in two ways, by how JSC stores the key string. A Latin-1 key goes through the JSON string escaper. A UTF-16 key is written raw: `"`, `\`, and control characters stay as-is.
- JSC can store ASCII text as UTF-16, for example from `TextDecoder("utf-16le")`. So two equal keys can print as `"k\"a": 1` and `"k"a": 1`.
- The cause is the `key.is_16bit()` branch in both copies of the key printer: `src/runtime/test_runner/pretty_format.rs:970` and `write_property_key` (`src/jsc/ConsoleObject.rs:2983`).

### Fix

- Both printers drop that branch and call `format_json_string_utf8(&key.to_utf8(), ..)`: one escaper over the UTF-8 form. Latin-1 key output does not change.
- Behavior change: a stored snapshot changes if it holds a UTF-16 key with `"`, `\`, a control character, U+2028, U+2029, or U+FEFF. `bun test -u` updates it. #23390 set the precedent.
- Verified: new tests in `test/js/bun/test/snapshot-tests/bun-snapshots.test.ts` and `test/js/bun/util/inspect.test.js` fail on 1.4.3-canary. Also ran `expect.test.js` and the console tests.
- Self-reviewed: 15 concerns raised. Main one addressed: the console printer is in this PR, because `toBe` and `Bun.inspect` print with it. Excluded: the `String` object printer (#42296) and string values.

### Background

- JSC stores a string as Latin-1 (8-bit) or UTF-16 (16-bit). JavaScript cannot observe which. A character above U+00FF forces 16-bit.
- `pretty_format.rs` prints `toEqual` diffs and snapshots. `ConsoleObject.rs` prints `console.log`, `Bun.inspect`, and the `Received:` value of other matchers such as `toBe`.
- Both print an ASCII identifier key with no escaper. Every other key takes the changed branch.
- The escaper (`write_pre_quoted_string`, `src/bun_core/string/mod.rs`) writes `\"`, `\\`, `\n`, and `\uXXXX`.

<details><summary>Notes</summary>

No user reported this. A code read found it. The closest report is #23382 (a UTF-16 key printed as `key"`), fixed in #23390 on the same branch of `pretty_format`.

Repro on 1.4.3-canary.1+4ff919377:

```js
import { test, expect } from "bun:test";
test("keys", () => {
  // The text k"a with 16-bit storage.
  const wide = new TextDecoder("utf-16le").decode(new Uint16Array([0x6b, 0x22, 0x61]));
  expect({ [wide]: 1 }).toMatchInlineSnapshot(); // writes  "k"a": 1,
  expect({ ['k"b']: 1 }).toMatchInlineSnapshot(); // writes  "k\"b": 1,
});
```

The repro builds the key from char codes on purpose. A property key is an atom. If the same text is already an 8-bit atom (for example a string literal with that text is in the file), JSC uses that atom for the key and the output is the escaped form. So before this PR the output also depended on which form of a text became a key first.

Why both printers: with only `pretty_format.rs` fixed, one failing test run shows the same UTF-16 key escaped in a `toEqual` diff and raw in a `toBe` message. Today both are raw, so a fix to one file makes bun:test less consistent.

History: keys always went through `JSPrinter.formatJSONString` until fd4a210b84 (2022, a non-ASCII fix for `console.log`). That commit added the 16-bit branch as a raw write. `pretty_format` is a fork of that formatter (4792abdb7f) and kept the split. So the JSON escaper is the original behavior for a quoted key.

Direction: Jest's `pretty-format` escapes only `"` and `\` in keys, and Jest 29 snapshots escape nothing. Bun's Latin-1 path has JSON-escaped keys from the start, and most keys are Latin-1. This PR keeps that output and moves the less common UTF-16 case to it. The other direction changes the stored snapshots of each user that has a Latin-1 key with a backslash (for example a Windows path). Parity with Jest for keys is a separate question (#40656 is the open report for string values).

The escape runs over `to_utf8()` and not over the UTF-16 mode of the escaper. That mode works per code unit and prints an emoji as two `\uXXXX` escapes.

The escaper also writes `\u2028`, `\u2029`, and `\uFEFF` for those three characters. A Latin-1 string cannot hold them, so this does not make the two forms disagree. A lone surrogate still prints as U+FFFD, as before (`to_utf8` replaces it).

#36615 changes which strings get 16-bit storage (UTF-8 decode of text in the Latin-1 range becomes 8-bit). Before this PR that change moves such keys from the raw form to the escaped form. After this PR the storage width does not matter.

Sites that this PR does not change:

- The `String` object arm of `pretty_format.rs` reads a 16-bit string through the 8-bit view. It prints wrong characters in release and panics in debug. That is a different defect: #42296.
- String values. `pretty_format.rs` prints them raw in both forms. The console printer sends a 16-bit value through `JSON.stringify` and an 8-bit value through the JSON escaper, so the hex case of `\u` escapes differs (uppercase from the JSON escaper, lowercase from `JSON.stringify`).

Each file had a `write_16_bit` helper with no other caller. The PR removes both.

`index_of_any16` (`src/bun_core/string/immutable.rs`) lost its last caller outside Windows-only code, and the `mordant` lint reported it as an unused public function. The PR removes it. It was a one-line wrapper for `index_of_any_t`. The two Windows callers in `src/runtime/cli/run_command.rs` now call `index_of_any_t`. `cargo check -p bun_runtime --target x86_64-pc-windows-msvc` passes.

`test/js/bun/test/pretty-format-overflow.test.ts` exits with 139 on a debug ASAN build with and without this change (500 levels of nesting).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->
