### PR TITLE
node:net: count bytesRead on a socket built with the onread option

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1718,6 +1718,7 @@ function Socket(options?) {
       while (offset < total) {
         const dest = self[kOnreadBuffer];
         if (dest === true) {
+          self.bytesRead += total - offset;
           let ret;
           try {
             ret = onreadCallback(total - offset, true);
@@ -1749,6 +1750,8 @@ function Socket(options?) {
         const n = MathMin(dest.length, total - offset);
         dest.set(buffer.subarray(offset, offset + n));
         offset += n;
+        // Counted here per slice, not per native read in data(): node's handle reads into the onread buffer and counts before the callback, https://github.com/nodejs/node/blob/v26.3.0/src/stream_base-inl.h#L75-L80
+        self.bytesRead += n;
         let ret;
         try {
           ret = onreadCallback(n, dest);

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -30,7 +30,7 @@ import {
   Stream,
 } from "node:net";
 import { join } from "node:path";
-import { TLSSocket } from "node:tls";
+import { connect as tlsConnect, createServer as createTLSServer, TLSSocket } from "node:tls";
 
 const socket_domain = tmpdirSync();
 
@@ -2737,6 +2737,108 @@ it("onread: `false` from a callback holding the `true` sentinel still pauses unt
     client?.destroy();
     server.close();
   }
+});
+
+// Node counts on the handle, one onread-buffer-sized read at a time, before the callback runs:
+// https://github.com/nodejs/node/blob/v26.3.0/src/stream_base-inl.h#L75-L80
+// Expected values observed under node v26.3.0.
+describe.concurrent("net.Socket onread bytesRead", () => {
+  async function listen(server: Server) {
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    return (server.address() as import("node:net").AddressInfo).port;
+  }
+
+  it.each(["net", "tls"] as const)("%s: counts each slice as it reaches the callback", async kind => {
+    const onConnection = (c: Socket) => {
+      c.on("error", () => {});
+      c.end("abcdefghij");
+    };
+    const server = kind === "tls" ? createTLSServer(tlsCert, onConnection) : createServer(onConnection);
+    let client: Socket | undefined;
+    try {
+      const seen: number[][] = [];
+      let delivered = 0;
+      const options = {
+        port: await listen(server),
+        host: "127.0.0.1",
+        onread: {
+          buffer: Buffer.alloc(4),
+          callback(n: number) {
+            delivered += n;
+            seen.push([delivered, client!.bytesRead]);
+          },
+        },
+      };
+      client =
+        kind === "tls" ? tlsConnect({ ...options, ca: tlsCert.cert, servername: "localhost" }) : connect(options);
+      await once(client, "close");
+      // The last slice is shorter than the buffer.
+      expect(seen).toEqual([
+        [4, 4],
+        [8, 8],
+        [10, 10],
+      ]);
+      expect(client.bytesRead).toBe(10);
+    } finally {
+      client?.destroy();
+      server.close();
+    }
+  });
+
+  it("does not count the bytes a false return holds back", async () => {
+    const server = createServer(c => c.end("abcdefghij"));
+    let client: Socket | undefined;
+    try {
+      const paused = Promise.withResolvers<void>();
+      let delivered = 0;
+      client = connect({
+        port: await listen(server),
+        host: "127.0.0.1",
+        onread: {
+          buffer: Buffer.alloc(4),
+          callback(n: number) {
+            delivered += n;
+            if (delivered !== 4) return;
+            paused.resolve();
+            return false;
+          },
+        },
+      });
+      const closed = once(client, "close");
+      await paused.promise;
+      expect(client.bytesRead).toBe(4);
+      client.resume();
+      await closed;
+      expect({ delivered, bytesRead: client.bytesRead }).toEqual({ delivered: 10, bytesRead: 10 });
+    } finally {
+      client?.destroy();
+      server.close();
+    }
+  });
+
+  it("counts a read that reaches the callback as the `true` sentinel", async () => {
+    const server = createServer(c => c.end("hello"));
+    let client: Socket | undefined;
+    try {
+      const seen: unknown[][] = [];
+      client = connect({
+        port: await listen(server),
+        host: "127.0.0.1",
+        onread: {
+          buffer: () => null as any,
+          callback(n: number, buf: unknown) {
+            seen.push([n, buf, client!.bytesRead]);
+          },
+        },
+      });
+      await once(client, "close");
+      expect(seen).toEqual([[5, true, 5]]);
+      expect(client.bytesRead).toBe(5);
+    } finally {
+      client?.destroy();
+      server.close();
+    }
+  });
 });
 
 // node lets a throwing onread callback escape as an uncaught exception:

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -30,7 +30,7 @@ import {
   Stream,
 } from "node:net";
 import { join } from "node:path";
-import { connect as tlsConnect, createServer as createTLSServer, TLSSocket } from "node:tls";
+import { createServer as createTLSServer, connect as tlsConnect, TLSSocket } from "node:tls";
 
 const socket_domain = tmpdirSync();
 


### PR DESCRIPTION
### Problem

- `socket.bytesRead` stays `0` on a `net.Socket` or `tls.TLSSocket` built with the `onread` option. A server sends `"banner"` to a client that connects with `onread: { buffer: Buffer.alloc(64), callback() {} }`. Node v26.3.0 reports `6`. Bun 1.4.3 and main report `0`.
- The `data` handler that `onread` installs (`src/js/node/net.ts:1780`) never updates `bytesRead`. The three other `data` handlers (`net.ts:482`, `:802`, `:1316`) add `buffer.length`.

### Fix

- The deliver loop (`net.ts:1715`) adds each slice to `bytesRead` before it calls the callback.
- The count is per slice, not per native read, because node never shows `bytesRead` ahead of the callback. Node's handle reads into the `onread` buffer and adds `nread` before the callback runs ([stream_base-inl.h#L75-L80](https://github.com/nodejs/node/blob/v26.3.0/src/stream_base-inl.h#L75-L80)). Bytes that a `false` return leaves unread are counted when the callback gets them.
- Verified: `test/js/node/net/node-net.test.ts`, new block `net.Socket onread bytesRead` (4 tests, stock bun fails all 4, expected values from node v26.3.0).
- Self-reviewed: 13 concerns raised, 11 addressed, 2 deferred (the wrapped-socket test, see the #42265 note). #42313 also covers this case with a native counter, so only one of the two PRs needs to land (see the #42313 note).

### Background

- `onread: { buffer, callback }` makes the socket read into `buffer` and call `callback(nread, buffer)`. A `false` return stops reads until `resume()`.
- Bun's native read can be larger than `buffer`. `kOnreadDeliver` copies it in slices of at most `buffer.length` bytes, one callback per slice. After a `false` return the rest waits in `kOnreadTail`.
- In node `bytesRead` reads a native counter on the handle. In bun the JS `data` handlers update a plain property.

<details><summary>Notes</summary>

**No user report.** I found this by a read of the `onread` handler while #42265 was in work. I found no package that reads `bytesRead` on an `onread` socket. The change is parity with a documented `node:net` property.

**Why not `self.bytesRead += buffer.length` in the `data` handler, like the other three handlers.** That counts a whole native read before the first callback. Node never shows that state. Probes against node v26.3.0, a 1024-byte write into a 256-byte `onread` buffer:

| probe | node v26.3.0 | count in `data` handler | this PR |
|---|---|---|---|
| `bytesRead` in callbacks 1 to 4 | 256, 512, 768, 1024 | 1024, 1024, 1024, 1024 | 256, 512, 768, 1024 |
| `bytesRead` 200 ms after callback 1 returned `false` | 256 | 1024 | 256 |
| `bytesRead` after `resume()` and `'close'` | 1024 | 1024 | 1024 |
| `buffer` is a function that never returns a `Uint8Array` (node passes `true` in place of a buffer), 5-byte read | 5 | 5 | 5 |
| `tls.connect({ onread })`, 1024 bytes of plaintext, in callbacks 1 to 4 | 256, 512, 768, 1024 | 1024 each | 256, 512, 768, 1024 |
| zero-length buffer (`ENOBUFS`) | 0 | length of the read | 0 |

Code that derives a stream offset from `socket.bytesRead - nread` inside the callback is correct in node and with this PR. With the per-read count it is wrong whenever the native read is larger than the user buffer.

**Interplay with #42265.** That PR adds `if (socket[kAdoptedTLSRaw]) return;` to the same `onread` `data` handler, so the raw socket under `tls.connect({ socket })` stops handing TLS records to its `onread` callback. In node that raw socket still counts the TLS records in `bytesRead` (3055 in my probe, with or without `onread`), because the handle counts before `TLSWrap` consumes the read. On main with this PR the raw socket also counts them (2813, equal to a raw socket without `onread`), because the records still reach the deliver loop. After #42265 they do not. Its early return then needs `self.bytesRead += buffer.length;` before `return`. The two diffs do not overlap, so git does not flag this. A test for the wrapped case passes on this branch, but it fails on main as soon as both PRs are in without that line, whichever lands first. So the test is not in this PR. #42265 has green CI and will probably land first: I then rebase, add the line and the test here. I left a note on #42265 for the other order.

**Interplay with #42313.** That PR came out of #42302 and #42303, which this PR's review filed. It counts on the native socket, and `net.Socket.prototype.bytesRead` becomes a getter with no setter, as in node. For an `onread` socket it subtracts the bytes that the callback has not received yet, so it shows the same numbers as the table above. It also covers the wrapped socket, the h2 session and the reused socket. This PR is the small version: 3 lines of JS, the `onread` case only.
- If #42313 lands first, this PR is not needed and I close it.
- If this PR lands first, #42313 drops the two `self.bytesRead +=` lines when it rebases. An assignment to a getter with no setter throws in the strict-mode builtins, so the lines cannot stay.
- The two PRs conflict in git in the deliver loop (both insert after `offset += n;` and after `if (dest === true) {`). GitHub blocks the second one until someone resolves the conflict by hand, so the two cannot both land by accident.

**Interplay with #41495.** That PR adds a second caller of `kOnreadDeliver`, `onStreamRead` for fd-adopted stream handles. It runs `self.bytesRead += nread` before it calls deliver. On top of this PR that counts an `onread` socket twice on that path. When #41495 rebases, its count must move into the branch that calls `push()`.

**Read paths that still do not count.** These are outside this diff. Each has a tracker:
- `req.socket.bytesRead` in a `node:http` server is `0`: #28709, with #28710 open.
- `session.socket.bytesRead` of a `node:http2` session is `0`, because the native h2 consumer takes the bytes before the JS `data` handler: #42302, with #42313 open.
- `bytesRead` adds up over the connections of a reused socket (node: one connection): #42303, with #42313 and #42306 open.
- An `onread` socket that connects again replays the undelivered bytes of the old connection to the callback: #42301, with #42305 open. This PR counts what the callback gets, so it counts those bytes too until #42301 is fixed.

**Related PR #33382.** It is an older and larger rewrite of the `onread` path (open since July, conflicts with main). Main got a different implementation of the same contract in #32630 (`kOnreadDeliver`, `kOnreadTail`). #33382 also counted `bytesRead` per delivered slice.

**Other suites.** The other `onread` tests in `node-net.test.ts`, `node-tls-connect.test.ts`, `node-tls-upgrade.test.ts`, `socket-reconnect-live.test.ts`, `test-net-bytes-read.js`, `test-net-bytes-stats.js` and `test-net-bytes-written-large.js` pass. The 4 new tests pass 15 runs in a row on the debug build.

**Local test run.** In my container 10 tests in `node-net.test.ts` fail with and without this change: 8 in `net.Socket read` with `connect ECONNREFUSED 127.0.0.1:<port>`, `unref should exit when no more work pending`, and `should trigger error when aborted even if connection failed #13126`. The failing `net.Socket read` tests listen with `Bun.listen({ hostname: "localhost" })`, and `localhost` there gives the listener and the client different addresses. The released build fails the same 10.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->
