### PR TITLE
node:net: drop the undelivered onread tail when the connection ends

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2149,6 +2149,9 @@ Socket.prototype.connect = function connect(...args) {
   }
 
   this.connecting = true;
+  // A live reconnect replaces the native socket, so the undelivered bytes of the old
+  // connection go away with it, as they do in node.
+  dropOnreadTail(this);
 
   const { path } = options;
   const pipe = !!path;
@@ -2186,6 +2189,7 @@ Socket.prototype._destroy = function _destroy(err, callback) {
   $debug("Socket.prototype._destroy");
 
   this.connecting = false;
+  dropOnreadTail(this);
   // Tear down a wrapped generic duplex with this socket: the native handle's
   // close only flushes close_notify and lets the wrapper drain; without an
   // explicit destroy here a late RST on the underlying transport can surface
@@ -2323,6 +2327,15 @@ Object.defineProperty(Socket.prototype, "pending", {
 // ciphertext queues behind the pending writes (order + callbacks preserved).
 function hasUnflushedWrites(connection) {
   return connection.writableLength > 0 || connection[kwriteCallback] != null;
+}
+
+// Node keeps the bytes a paused onread socket has not taken in the kernel, so they go away
+// with the fd. Bun holds them in kOnreadTail, which must not outlive the connection.
+function dropOnreadTail(self) {
+  if (self[kOnreadBuffer] === undefined) return;
+  self[kOnreadTail] = undefined;
+  self[kOnreadPendingEnd] = false;
+  self[kOnreadReadRequested] = false;
 }
 
 function drainOnreadTail(self, fromRead?) {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -2649,6 +2649,58 @@ it("onread: read() redelivers the declined tail without resume()", async () => {
   }
 });
 
+it("onread: a destroyed socket that connects again does not replay the declined tail", async () => {
+  // Node keeps the bytes a false return left behind in the kernel, so they go
+  // away with the fd. The second connection must only see its own bytes.
+  let connections = 0;
+  const server = createServer(c => {
+    c.on("error", () => {});
+    c.end(++connections === 1 ? "AAAABBBBCCCC" : "xxxxyyyy");
+  });
+  const calls: [number, string][] = [];
+  let connection = 1;
+  const first = Promise.withResolvers<void>();
+  let client: Socket | undefined;
+  try {
+    const listening = Promise.withResolvers<void>();
+    server.once("error", listening.reject);
+    server.listen(0, "127.0.0.1", () => listening.resolve());
+    await listening.promise;
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    client = createConnection({
+      port,
+      host: "127.0.0.1",
+      onread: {
+        buffer: Buffer.alloc(4),
+        callback(n: number, buf: Buffer) {
+          calls.push([connection, buf.toString("latin1", 0, n)]);
+          if (connection === 1) {
+            first.resolve();
+            return false; // leaves "BBBBCCCC" undelivered
+          }
+        },
+      },
+    });
+    client.on("error", first.reject);
+    await first.promise;
+    client.destroy();
+    await once(client, "close");
+
+    connection = 2;
+    client.connect({ port, host: "127.0.0.1" });
+    client.resume();
+    await once(client, "close");
+    expect(calls).toEqual([
+      [1, "AAAA"],
+      [2, "xxxx"],
+      [2, "yyyy"],
+    ]);
+  } finally {
+    client?.destroy();
+    server.close();
+  }
+});
+
 it("onread: a buffer factory that never yields a Uint8Array hands the callback `true`", async () => {
   // Node leaves kBuffer as the literal `true` and passes it through:
   // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L332-L342

--- a/test/js/node/net/socket-reconnect-live.test.ts
+++ b/test/js/node/net/socket-reconnect-live.test.ts
@@ -99,6 +99,69 @@ describe.concurrent("socket.connect() on an already-connected socket", () => {
     });
   });
 
+  it("does not replay the declined onread tail of the previous connection", async () => {
+    // The first connection's callback takes one 4-byte slice and returns false. The
+    // rest of that read belongs to the connection that connect() replaces, so the
+    // second connection must only see its own bytes.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { createServer, connect } = require("node:net");
+          const { once } = require("node:events");
+          let connections = 0;
+          const srv = createServer(c => {
+            c.on("error", () => {});
+            c.end(++connections === 1 ? "AAAABBBBCCCC" : "xxxxyyyy");
+          });
+          srv.listen(0, "127.0.0.1", async () => {
+            const port = srv.address().port;
+            const calls = [];
+            let connection = 1;
+            const first = Promise.withResolvers();
+            const s = connect({
+              port,
+              host: "127.0.0.1",
+              onread: {
+                buffer: Buffer.alloc(4),
+                callback(n, buf) {
+                  calls.push([connection, buf.toString("latin1", 0, n)]);
+                  if (connection === 1) {
+                    first.resolve();
+                    return false;
+                  }
+                },
+              },
+            });
+            s.on("error", () => {});
+            await first.promise;
+            connection = 2;
+            s.connect({ port, host: "127.0.0.1" });
+            await once(s, "connect");
+            s.resume();
+            await once(s, "close");
+            srv.close();
+            console.log(JSON.stringify(calls));
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify([
+        [1, "AAAA"],
+        [2, "xxxx"],
+        [2, "yyyy"],
+      ]),
+      stderr,
+      exitCode: 0,
+    });
+  });
+
   it("does not crash when reconnecting while the first connect is still in flight", async () => {
     await using proc = Bun.spawn({
       cmd: [


### PR DESCRIPTION
### Problem
- A `net.Socket` built with the `onread` option keeps the bytes that a `false` return (or `pause()`) left undelivered. `destroy()` does not drop them. When the same socket connects again, `resume()` or `read()` hands the bytes of the old connection to the callback before the bytes of the new connection. Node delivers only the bytes of the new connection.
- The cause: bun's native read can be larger than the `onread` buffer. `kOnreadDeliver` (`src/js/node/net.ts:1715`) stores the rest in `self[kOnreadTail]`. Only the constructor and `drainOnreadTailNT` reset it. `_destroy()` and `connect()` do not.

### Fix
- Add `dropOnreadTail()`. It clears `kOnreadTail`, `kOnreadPendingEnd` and `kOnreadReadRequested`. `_destroy()` calls it, and `connect()` calls it after it sets `connecting`.
- This matches node, where the undelivered bytes stay in the kernel buffer of the fd and go away with the connection. The `connect()` call covers a live reconnect too, since it replaces the native socket.
- The pause state is not touched. A socket that the user paused before `connect()` stays paused.
- Verified: `test/js/node/net/node-net.test.ts` (new test `onread: a destroyed socket that connects again does not replay the declined tail`) and `test/js/node/net/socket-reconnect-live.test.ts` (new test for a live reconnect). Both fail on the released bun and pass with this change. Also ran `handle-leak.test.ts`, `double-connect.test.ts`, `tls/node-tls-connect.test.ts` and the node `test-net-connect-*` parallel tests for socket reuse.

### Background
- The `onread` option of `net.Socket` delivers data into a user buffer through a callback instead of `'data'` events. A `false` return from the callback stops reads until `resume()` or `read()`.
- Node bounds each kernel read to the size of the `onread` buffer. Bun reads a larger chunk natively and slices it in JS. The slice that the callback has not taken yet is the "tail" held in `kOnreadTail`.
- `drainOnreadTailNT` delivers the tail on the next tick after `resume()` or `read()`. It already returns early when the socket is destroyed, so the tail survived `destroy()` and was delivered after the next `connect()`.

<details><summary>Notes</summary>

Repro from the issue on main (6b394bfeb0):

```
[[1,"AAAA"],[2,"BBBB"],[2,"CCCC"],[2,"xxxx"],[2,"yyyy"]]
```

With this change:

```
[[1,"AAAA"],[2,"xxxx"],[2,"yyyy"]]
```

`kOnreadDraining` is left alone. A drain tick that is already queued resets it and finds no tail, so it returns without a delivery.

`node-net.test.ts` has 11 tests that fail in this container both with and without this change (ECONNREFUSED on a shared server, and `unref should exit when no more work pending`). They are not related to this change.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->