### PR TITLE
node:net: reset socket.bytesRead when a socket connects again

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4310,6 +4310,8 @@ function initSocketHandle(self) {
   self._sockname = null;
   self[kclosed] = false;
   self[kended] = false;
+  // Node reads bytesRead off the handle, so a new connection starts at 0.
+  self.bytesRead = 0;
 
   // Handle creation may be deferred to bind() or connect() time.
   const handle = self._handle;

--- a/test/js/node/net/socket-reconnect-live.test.ts
+++ b/test/js/node/net/socket-reconnect-live.test.ts
@@ -135,4 +135,38 @@ describe.concurrent("socket.connect() on an already-connected socket", () => {
     expect(["connect", "err:EALREADY"]).toContain(stdout);
     expect({ stderr, exitCode }).toEqual({ stderr, exitCode: 0 });
   });
+
+  it("starts bytesRead at 0 for each new connection", async () => {
+    // Node reads bytesRead off the handle, and a reconnect gets a new handle.
+    // The count covers one connection, and stays readable after close.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { createServer, Socket } = require("node:net");
+          const { once } = require("node:events");
+          const srv = createServer(c => c.end("banner"));
+          srv.listen(0, "127.0.0.1", async () => {
+            const port = srv.address().port;
+            const s = new Socket();
+            s.resume();
+            const seen = [];
+            for (let i = 0; i < 3; i++) {
+              s.connect(port, "127.0.0.1");
+              await once(s, "close");
+              seen.push(s.bytesRead);
+            }
+            srv.close();
+            process.stdout.write(JSON.stringify(seen));
+          });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "[6,6,6]", stderr, exitCode: 0 });
+  });
 });


### PR DESCRIPTION
### Problem
- `socket.bytesRead` on a `net.Socket` that calls `connect()` more than once adds up over all its connections. Three connections that each receive 6 bytes report `[6, 12, 18]`. Node reports `[6, 6, 6]`.
- The cause is in `src/js/node/net.ts`. The `Socket` constructor sets `this.bytesRead = 0` and the `data` handlers add to it. Nothing sets it back when `connect()` creates a new handle.

### Fix
- `initSocketHandle` now sets `self.bytesRead = 0`. It runs for every new handle: a `connect()` on a closed socket and the `autoSelectFamily` retry (`kReinitializeHandle`). A retry happens before any data arrives, so the reset there loses nothing.
- This matches node, where `bytesRead` is a getter over `handle.bytesRead` and a new handle starts at 0. The value stays readable after `close`, as before.
- Verified: `test/js/node/net/socket-reconnect-live.test.ts` (new test, stock bun prints `[6,12,18]`). Also `test/js/node/net/node-net.test.ts`. Its failures in my environment are the same without this change (`ECONNREFUSED` on a bound port, and one timing-bound leak test).

### Background
- A `net.Socket` can connect again after it closes. Bun keeps the same JS object and creates a new native handle in `Socket.prototype.connect`, then calls `initSocketHandle` to reset per-connection state (`_sockname`, closed and ended flags).
- `bytesWritten` already handles a reconnect: `kAttach` reads it from the new native socket.

Fixes #42303

<details><summary>Notes</summary>

- Node keeps `bytesRead` as a prototype accessor with no setter. This PR keeps Bun's own data property, since the `data` handlers in `net.ts` assign to it. The shape difference is out of scope here.
- `node-net.test.ts` results in my container: 8 `net.Socket read` tests fail with `ECONNREFUSED` on main and on this branch alike. `should not leak when connect({path}) fails synchronously on a reused handle` runs the same workload in about 41 s with and without the change (delta 0 pages both ways) and sits near its 60 s timeout under the debug build.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/net/socket-reconnect-live.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/net/socket-reconnect-live.test.ts:
(pass) socket.connect() on an already-connected socket > pauses the new connection although the previous one was left paused [1988.30ms]
165 |       env: bunEnv,
166 |       stdout: "pipe",
167 |       stderr: "pipe",
168 |     });
169 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
170 |     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "[6,6,6]", stderr, exitCode: 0 });
                                               ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
-   "stdout": "[6,6,6]",
+   "stdout": "[6,12,18]",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/net/socket-reconnect-live.test.ts:170:42)
(fail) socket.connect() on an already-connected socket > starts bytesRead at 0 for each new connection [2122.39ms]
(pass) socket.connect() on an already-connected
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/net/socket-reconnect-live.test.ts:
165 |       env: bunEnv,
166 |       stdout: "pipe",
167 |       stderr: "pipe",
168 |     });
169 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
170 |     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "[6,6,6]", stderr, exitCode: 0 });
                                               ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
-   "stdout": "[6,6,6]",
+   "stdout": "[6,12,18]",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/net/socket-reconnect-live.test.ts:170:42)
(fail) socket.connect() on an already-connected socket > starts bytesRead at 0 for each new connection [36.42ms]
(pass) socket.connect() on an already-connected socket > pauses the new connection although the previous one was left paused [41.96ms]
(pass) socket.connect() on an already-connected socket > does not crash when reconnecting while the first connect is still in flight [41.90ms]
(pass) socket.connect() on an already-connected socket > does not crash and em
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/net/socket-reconnect-live.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/net/socket-reconnect-live.test.ts:
(pass) socket.connect() on an already-connected socket > does not crash and emits connect for the new connection [1860.65ms]
(pass) socket.connect() on an already-connected socket > does not crash when reconnecting while the first connect is still in flight [1994.10ms]
(pass) socket.connect() on an already-connected socket > starts bytesRead at 0 for each new connection [2075.90ms]
(pass) socket.connect() on an already-connected socket > pauses the new connection although the previous one was left paused [2217.70ms]

 4 pass
 0 fail
 5 expect() calls
Ran 4 tests across 1 file. [4.27s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 755ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (12149ms)
Bundle modules (57ms)
Postprocesss modules (20ms)
Bundle Functions (506ms)
Generate Code (42ms)

[12.78s] Bundled "src/js" for production
  2599 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 6m 42s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.3-canary.1+763c74eff
[build] done
bun test v1.4.3-canary.1 (763c74eff)

test/js/node/net/socket-reconnect-live.test.ts:
(pass) socket.connect() on an already-connected socket > does not crash and emits connect for the new connection [50.49ms]
(pass) socket.connect() on an already-connected socket > starts bytesRead at 0 for each new connection [52.02ms]
(pass) socket.connect() on an already-connected socket > pauses the new connection alth
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                             |  2 ++
 test/js/node/net/socket-reconnect-live.test.ts | 34 ++++++++++++++++++++++++++
 2 files changed, 36 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/js/node/net.ts                                  1      2      5
test/js/node/net/socket-reconnect-live.test.ts      1      1      5
```

</details>

**root cause** · written by the author bot

In Bun, `socket.bytesRead` was an own data property set to zero only in the `Socket` constructor and incremented by the `data` handlers, so a socket that called `connect()` again after closing kept accumulating bytes across connections instead of counting only the current one as Node does. The fix sets `bytesRead` back to zero in `initSocketHandle`, the function that already resets other per-connection state when a handle is created or reused, so each new connection starts from zero while the final count stays readable after close.

<!-- robobun:evidence:end -->