### PR TITLE
process.execve: throw instead of aborting for a string past the string limits

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1896,6 +1896,16 @@ struct ExecveCloexecRestorer {
             fcntl(entry.first, F_SETFD, entry.second);
     }
 };
+
+// `String::utf8()` asserts that the conversion worked. It fails when the UTF-8 form can pass 2^31 - 1 bytes: a Latin-1 string of 2^30 characters or more.
+static bool appendUTF8(WTF::Vector<WTF::CString>& storage, const WTF::String& string)
+{
+    auto utf8 = string.tryGetUTF8();
+    if (!utf8) [[unlikely]]
+        return false;
+    storage.append(WTF::move(utf8.value()));
+    return true;
+}
 #endif
 
 JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionExecve, __attribute__((minsize)), (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
@@ -1973,7 +1983,10 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionExecve, __attribute__((
             return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, makeString("args["_s, i, "]"_s),
                 item, "must be a string without null bytes"_s);
         }
-        argvStorage.append(str.utf8());
+        if (!appendUTF8(argvStorage, str)) [[unlikely]] {
+            JSC::throwOutOfMemoryError(globalObject, scope);
+            return {};
+        }
     }
 
     // Node declares env = process.env as the default, so an omitted env
@@ -2016,11 +2029,21 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionExecve, __attribute__((
                 return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "env"_s,
                     envValue, "must be an object with string keys and values without null bytes"_s);
             }
-            envStorage.append(makeString(keyStr, '=', valueStr).utf8());
+            // The key and the value come from JS. Past `String::MaxLength`, `makeString` calls `CRASH()` and `tryMakeString` returns null.
+            WTF::String entry = tryMakeString(keyStr, '=', valueStr);
+            if (entry.isNull() || !appendUTF8(envStorage, entry)) [[unlikely]] {
+                JSC::throwOutOfMemoryError(globalObject, scope);
+                return {};
+            }
         }
     }
 
-    CString execPathUtf8 = execPath.utf8();
+    auto execPathConversion = execPath.tryGetUTF8();
+    if (!execPathConversion) [[unlikely]] {
+        JSC::throwOutOfMemoryError(globalObject, scope);
+        return {};
+    }
+    CString execPathUtf8 = WTF::move(execPathConversion.value());
 
     // Build the null-terminated argv/envp pointer arrays only after the
     // backing storage is fully populated so there is no risk of pointers

--- a/test/js/node/process/process-execve.test.ts
+++ b/test/js/node/process/process-execve.test.ts
@@ -367,6 +367,9 @@ describe.concurrent("process.execve", () => {
   // (exit code 134) instead of throwing. The length is what is under test, so
   // the child needs a string of about 2 GiB and the test skips on small machines.
   // It is serial so that it does not hold 4.4 GB next to the concurrent tests.
+  // `repeat` and not `Buffer.alloc(n, fill).toString()`: for one character at
+  // this size it is faster in a debug build (1.6 s against 2.9 s), and it does
+  // not hold a second 2 GiB.
   test.serial.skipIf(isWindows || totalmem() < 10 * 1024 ** 3)(
     "throws instead of aborting for a string past the string limits",
     async () => {
@@ -397,8 +400,8 @@ describe.concurrent("process.execve", () => {
         stderr: "pipe",
       });
 
-      // stderr has the ExperimentalWarning for process.execve.
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      // stderr has the ExperimentalWarning for process.execve, so it is read but not compared.
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stdout.trim().split("\n")).toEqual([
         "env entry longer than a string: RangeError: Out of memory",

--- a/test/js/node/process/process-execve.test.ts
+++ b/test/js/node/process/process-execve.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
+import { totalmem } from "node:os";
 import { join } from "node:path";
 
 describe.concurrent("process.execve", () => {
@@ -359,6 +360,56 @@ describe.concurrent("process.execve", () => {
     ]);
     expect(exitCode).toBe(0);
   });
+
+  // Each string that execve takes comes from JS. One that does not fit in a
+  // WTF::String ("KEY=VALUE" past 2**31 - 1 characters), or whose UTF-8 form does
+  // not fit in a buffer (2**30 Latin-1 characters or more), aborted the process
+  // (exit code 134) instead of throwing. The length is what is under test, so
+  // the child needs a string of about 2 GiB and the test skips on small machines.
+  // It is serial so that it does not hold 4.4 GB next to the concurrent tests.
+  test.serial.skipIf(isWindows || totalmem() < 10 * 1024 ** 3)(
+    "throws instead of aborting for a string past the string limits",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const long = "q".repeat(2 ** 31 - 10);
+            const cases = {
+              "env entry longer than a string": () => process.execve("/bin/true", [], { ["K".repeat(20)]: long }),
+              "env entry too long for UTF-8": () => process.execve("/bin/true", [], { A: long }),
+              "argument too long for UTF-8": () => process.execve("/bin/true", ["true", long], {}),
+              "path too long for UTF-8": () => process.execve(long, [], {}),
+            };
+            for (const [name, run] of Object.entries(cases)) {
+              try {
+                run();
+                console.log(name + ": did not throw");
+              } catch (e) {
+                console.log(name + ": " + e.name + ": " + e.message);
+              }
+            }
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      // stderr has the ExperimentalWarning for process.execve.
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+      expect(stdout.trim().split("\n")).toEqual([
+        "env entry longer than a string: RangeError: Out of memory",
+        "env entry too long for UTF-8: RangeError: Out of memory",
+        "argument too long for UTF-8: RangeError: Out of memory",
+        "path too long for UTF-8: RangeError: Out of memory",
+      ]);
+      expect(exitCode).toBe(0);
+    },
+    30_000,
+  );
 
   test.skipIf(!isWindows)("throws ERR_FEATURE_UNAVAILABLE_ON_PLATFORM on Windows", () => {
     expect(() => process.execve(process.execPath, [process.execPath], {})).toThrow(


### PR DESCRIPTION
### Problem

- `process.execve` aborts the process for a very long string, also inside `try`/`catch`: `panic(main thread): abort() called`, exit code 134. Example: `bun -e 'try { process.execve("/bin/true", [], { A: "q".repeat(2**31-10) }) } catch {}'`.
- Two conversions in `Process_functionExecve` (`src/jsc/bindings/BunProcess.cpp`) crash on a long input. `makeString(keyStr, '=', valueStr)` at :2019 calls `CRASH()` when the `KEY=VALUE` entry passes `String::MaxLength`. `String::utf8()` asserts that the conversion worked, at :1976 (arguments), :2019 (environment) and :2023 (path).

### Fix

- Build the entry with `tryMakeString`, and convert every string with `tryGetUTF8`. A failure throws `RangeError: Out of memory`.
- Correct because that is what JSC reports for a string it cannot create, and what Bun reports at its other string limits. Nothing changes for a string under the limits. `execve(2)` is never reached for these inputs, so the stdio flags are not touched yet.
- Verified: `test/js/node/process/process-execve.test.ts`, one new test with four cases in one child (the concatenation, then the environment, argument and path conversions). Each case aborts alone on 1.4.3. Also the six `test-process-execve*.js` node tests.

### Background

- `String::MaxLength` is 2^31 - 1 code units. `makeString` crashes past it. `tryMakeString` returns a null string.
- `String::utf8()` is `tryGetUTF8()` plus `RELEASE_ASSERT`. `tryGetUTF8` fails when the UTF-8 form can pass the `Vector` capacity limit of 2^31 - 1 bytes. A Latin-1 character can take 2 bytes, so the limit is 2^30 characters.
- The kernel rejects a single argument over 128 KiB with `E2BIG` anyway, so no input that reaches these limits could have worked.

<details><summary>Notes</summary>

This is split out of #42202, which is now only about error messages. The `makeString` site was in that PR's brief. The `utf8()` assert is the next line, so fixing one without the other leaves the same call aborting.

`RangeError: Out of memory` or `E2BIG`: the failure happens in Bun's string conversion, before `execve(2)` is called. `E2BIG` would say that the kernel rejected the call. So this reports what failed. If a maintainer prefers the system error, the four `throwOutOfMemoryError` calls are the only places to change.

Not in this PR: `String::utf8()` has the same assert at many other call sites under `src/jsc/bindings` (`process.setuid`, `setgid`, `initgroups`, `process.title`, and more). That is a wider change with a shared helper. This PR only touches the `execve` path.

The test needs a string of about 2 GiB, because the length is what is under test. It runs the four cases in one child, so the string is allocated once. Peak RSS is 4.4 GB. It skips below 10 GiB of total memory and on Windows, where `process.execve` is not available. It is `test.serial` because the rest of the file is `describe.concurrent`. It takes about 6 s in a debug ASAN build, so it carries a 30 s ceiling.

</details>
