### PR TITLE
Parse a private copy of a shared or resizable buffer in Bun.Transpiler, Bun.markdown, Bun.YAML and Bun.TOML

### DIFF
--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -159,6 +159,20 @@ impl ArrayBuffer {
         }
     }
 
+    /// True for a `SharedArrayBuffer`, which another thread writes during the call, and for a resizable buffer, whose `resize()` unmaps pages as soon as the call runs JS.
+    pub fn can_change_under_borrow(&self) -> bool {
+        self.shared || self.resizable
+    }
+
+    /// A private copy of the bytes. `None` if it cannot be allocated.
+    pub fn try_copy_bytes(&self) -> Option<Vec<u8>> {
+        let bytes = self.byte_slice();
+        let mut copy = Vec::new();
+        copy.try_reserve_exact(bytes.len()).ok()?;
+        copy.extend_from_slice(bytes);
+        Some(copy)
+    }
+
     // require('buffer').kMaxLength.
     // keep in sync with Bun::Buffer::kMaxLength
     pub const MAX_SIZE: c_uint = c_uint::MAX;
@@ -698,12 +712,9 @@ impl PinnedArrayBuffer {
         {
             return true;
         }
-        let bytes = self.buffer.byte_slice();
-        let mut copy = Vec::new();
-        if copy.try_reserve_exact(bytes.len()).is_err() {
+        let Some(mut copy) = self.buffer.try_copy_bytes() else {
             return false;
-        }
-        copy.extend_from_slice(bytes);
+        };
         global.vm().report_extra_memory(copy.len());
         self.buffer.ptr = copy.as_mut_ptr();
         self.copy = Some(copy);

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -270,7 +270,7 @@ fn with_text_format_source_encoded<R>(
     let mut encoding = SourceEncoding::Utf8Text;
     let bytes: &[u8] = 'bytes: {
         if blob_or_buffer_input == BlobOrBufferInput::Bytes && !input_value.is_string() {
-            if let Some(v) = BlobOrStringOrBuffer::from_js(global, input_value)? {
+            if let Some(v) = BlobOrStringOrBuffer::from_js_stable(global, input_value)? {
                 _blob_hold = v;
                 encoding = SourceEncoding::Bytes;
                 break 'bytes _blob_hold.slice();

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -131,6 +131,24 @@ fn level_from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<bun
 
 /// Deep-clone a [`MacroMap`]. The keys are `Box<[u8]>`, so an owned copy
 /// is needed wherever the map is assigned by value.
+/// The `code` of `scan` and `transformSync`, with a buffer copied: a macro runs in the middle of the parse and can write, shrink or detach it. No parser reads a source over [`bun_ast::Source::MAX_PARSEABLE_LEN`], so that one stays borrowed.
+fn code_from_js(
+    global: &JSGlobalObject,
+    value: JSValue,
+) -> JsResult<Option<StringOrBuffer<'static>>> {
+    let parsed = StringOrBuffer::from_js(global, value)?;
+    let Some(StringOrBuffer::Buffer(buffer)) = &parsed else {
+        return Ok(parsed);
+    };
+    if buffer.slice().len() > bun_ast::Source::MAX_PARSEABLE_LEN {
+        return Ok(parsed);
+    }
+    match buffer.buffer.try_copy_bytes() {
+        Some(copy) => Ok(Some(StringOrBuffer::owned(copy))),
+        None => Err(global.throw_out_of_memory()),
+    }
+}
+
 fn clone_macro_map(src: &MacroMap) -> MacroMap {
     let mut out = MacroMap::default();
     bun_core::handle_oom(out.ensure_unused_capacity(src.count()));
@@ -1271,7 +1289,7 @@ impl JSTranspiler {
             return Err(global.throw_invalid_argument_type("scan", "code", "string or Uint8Array"));
         };
 
-        let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
+        let Some(code_holder) = code_from_js(global, code_arg)? else {
             return Err(global.throw_invalid_argument_type("scan", "code", "string or Uint8Array"));
         };
         let code = code_holder.slice();
@@ -1412,7 +1430,7 @@ impl JSTranspiler {
         };
 
         let arena = Arena::new();
-        let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
+        let Some(code_holder) = code_from_js(global, code_arg)? else {
             return Err(global.throw_invalid_argument_type(
                 "transformSync",
                 "code",
@@ -1615,7 +1633,7 @@ impl JSTranspiler {
             ));
         };
 
-        let Some(code_holder) = StringOrBuffer::from_js(global, code_arg)? else {
+        let Some(code_holder) = StringOrBuffer::from_js_stable(global, code_arg)? else {
             return Err(global.throw_invalid_argument_type(
                 "scanImports",
                 "code",

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -123,7 +123,7 @@ pub(crate) fn render_to_ansi(
             .throw_invalid_arguments(format_args!("Expected a string or buffer to render")));
     }
 
-    let Some(buffer) = StringOrBuffer::from_js(global_this, input_value)? else {
+    let Some(buffer) = StringOrBuffer::from_js_stable(global_this, input_value)? else {
         return Err(global_this
             .throw_invalid_arguments(format_args!("Expected a string or buffer to render")));
     };
@@ -191,7 +191,7 @@ fn render_to_html(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResu
             .throw_invalid_arguments(format_args!("Expected a string or buffer to render")));
     }
 
-    let Some(buffer) = StringOrBuffer::from_js(global_this, input_value)? else {
+    let Some(buffer) = StringOrBuffer::from_js_stable(global_this, input_value)? else {
         return Err(global_this
             .throw_invalid_arguments(format_args!("Expected a string or buffer to render")));
     };
@@ -294,7 +294,7 @@ fn render(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSVal
             .throw_invalid_arguments(format_args!("Expected a string or buffer to render")));
     }
 
-    let Some(buffer) = StringOrBuffer::from_js(global_this, input_value)? else {
+    let Some(buffer) = StringOrBuffer::from_js_stable(global_this, input_value)? else {
         return Err(global_this
             .throw_invalid_arguments(format_args!("Expected a string or buffer to render")));
     };
@@ -387,7 +387,7 @@ fn render_ast(
             .throw_invalid_arguments(format_args!("Expected a string or buffer to render")));
     }
 
-    let Some(buffer) = StringOrBuffer::from_js(global_this, input_value)? else {
+    let Some(buffer) = StringOrBuffer::from_js_stable(global_this, input_value)? else {
         return Err(global_this
             .throw_invalid_arguments(format_args!("Expected a string or buffer to render")));
     };

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -151,6 +151,20 @@ impl BlobOrStringOrBuffer {
         Self::from_js_maybe_file(global, value, FileBlobs::Reject)
     }
 
+    /// [`from_js`](Self::from_js), with a buffer copied if [`StringOrBuffer::copy_if_can_change`] says so. A `Blob` owns its bytes.
+    pub(crate) fn from_js_stable(
+        global: &JSGlobalObject,
+        value: JSValue,
+    ) -> JsResult<Option<BlobOrStringOrBuffer>> {
+        let mut parsed = Self::from_js(global, value)?;
+        if let Some(Self::StringOrBuffer(input)) = &mut parsed
+            && !input.copy_if_can_change()
+        {
+            return Err(global.throw_out_of_memory());
+        }
+        Ok(parsed)
+    }
+
     /// Like [`from_js_with_encoding_value_allow_request_response`] but takes an
     /// already-parsed [`Encoding`], so callers that must inspect the encoding
     /// first (e.g. to validate odd-length hex) don't coerce `encoding_value`
@@ -315,6 +329,22 @@ impl<'a> StringOrBuffer<'a> {
 }
 
 impl StringOrBuffer<'_> {
+    /// Replaces a borrowed buffer that [`can_change_under_borrow`](jsc::ArrayBuffer::can_change_under_borrow) with a private copy of its bytes. `false` if the copy cannot be allocated.
+    #[must_use]
+    pub(crate) fn copy_if_can_change(&mut self) -> bool {
+        let Self::Buffer(buffer) = self else {
+            return true;
+        };
+        if !buffer.buffer.can_change_under_borrow() {
+            return true;
+        }
+        let Some(copy) = buffer.buffer.try_copy_bytes() else {
+            return false;
+        };
+        *self = Self::owned(copy);
+        true
+    }
+
     pub fn into_js(self, ctx: &JSGlobalObject) -> JsResult<JSValue> {
         match self {
             Self::ThreadIsolatedString(str) | Self::String(str) => str.into_js(ctx),
@@ -452,6 +482,21 @@ impl StringOrBuffer<'static> {
     #[inline]
     pub fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<Self>> {
         Self::from_js_maybe_async(global, value, Flavor::Sync, StringObjects::Allow)
+    }
+
+    /// [`from_js`](Self::from_js), with a buffer copied if [`copy_if_can_change`](Self::copy_if_can_change) says so.
+    #[inline]
+    pub(crate) fn from_js_stable(
+        global: &JSGlobalObject,
+        value: JSValue,
+    ) -> JsResult<Option<Self>> {
+        let mut parsed = Self::from_js(global, value)?;
+        if let Some(input) = &mut parsed
+            && !input.copy_if_can_change()
+        {
+            return Err(global.throw_out_of_memory());
+        }
+        Ok(parsed)
     }
 
     /// [`from_js`](Self::from_js) for a work-pool job that reads the bytes itself: strings thread-isolated, buffers pinned and GC-rooted, a resizable buffer copied ([`PinnedArrayBuffer::copy_if_resizable`]).

--- a/src/runtime/webcore/TextDecoder.rs
+++ b/src/runtime/webcore/TextDecoder.rs
@@ -301,8 +301,10 @@ impl TextDecoder {
 
             if let Some(ab) = arguments[0].as_array_buffer(global_this) {
                 array_buffer = ab;
-                if array_buffer.shared || array_buffer.resizable {
-                    owned_input = Box::<[u8]>::from(array_buffer.slice());
+                if array_buffer.can_change_under_borrow() {
+                    owned_input = array_buffer
+                        .try_copy_bytes()
+                        .ok_or_else(|| global_this.throw_out_of_memory())?;
                     break 'input_slice &owned_input;
                 }
                 break 'input_slice array_buffer.slice();

--- a/test/js/bun/md/md-render-callback.test.ts
+++ b/test/js/bun/md/md-render-callback.test.ts
@@ -426,4 +426,72 @@ describe("Bun.markdown buffer input", () => {
     input.buffer.transfer();
     expect((input.buffer as ArrayBuffer).detached).toBe(true);
   });
+
+  // A pin stops a detach but not a shrink: `resize()` gives the trimmed pages
+  // back. Option getters and render callbacks run after the call took its
+  // input, so a resizable input renders from the bytes that were passed in.
+  describe("a resizable input that shrinks while the call runs", () => {
+    const source = "# Hello\n\nworld **bold**\n";
+
+    function resizableInput() {
+      const bytes = new TextEncoder().encode(source);
+      const buffer = new ArrayBuffer(bytes.length, { maxByteLength: bytes.length });
+      const view = new Uint8Array(buffer);
+      view.set(bytes);
+      return { buffer, view };
+    }
+
+    test("html: an option getter shrinks it", () => {
+      const { buffer, view } = resizableInput();
+      const options = {
+        get autolinks() {
+          buffer.resize(0);
+          return true;
+        },
+      };
+      expect(Markdown.html(view, options)).toBe(Markdown.html(source, { autolinks: true }));
+      expect(buffer.byteLength).toBe(0);
+    });
+
+    test("ansi: a theme getter shrinks it", () => {
+      const { buffer, view } = resizableInput();
+      const theme = {
+        get colors() {
+          buffer.resize(0);
+          return false;
+        },
+      };
+      expect(Markdown.ansi(view, theme)).toBe(Markdown.ansi(source, { colors: false }));
+      expect(buffer.byteLength).toBe(0);
+    });
+
+    test("render: a callback shrinks it", () => {
+      const { buffer, view } = resizableInput();
+      const result = Markdown.render(view, {
+        heading: (children: string) => {
+          buffer.resize(0);
+          return `<h1>${children}</h1>`;
+        },
+        paragraph: (children: string) => `<p>${children}</p>`,
+        strong: (children: string) => `<b>${children}</b>`,
+      });
+      expect(result).toBe("<h1>Hello</h1><p>world <b>bold</b></p>");
+      expect(buffer.byteLength).toBe(0);
+    });
+
+    test("react: an option getter shrinks it", () => {
+      const { buffer, view } = resizableInput();
+      const options = {
+        reactVersion: 18,
+        get autolinks() {
+          buffer.resize(0);
+          return true;
+        },
+      };
+      expect(Markdown.react(view, undefined, options)).toEqual(
+        Markdown.react(source, undefined, { reactVersion: 18, autolinks: true }),
+      );
+      expect(buffer.byteLength).toBe(0);
+    });
+  });
 });

--- a/test/js/bun/util/parse-shared-buffer-fixture.ts
+++ b/test/js/bun/util/parse-shared-buffer-fixture.ts
@@ -1,0 +1,115 @@
+// Fixture for parse-shared-buffer.test.ts.
+//
+//   bun parse-shared-buffer-fixture.ts <api> <calls>
+//
+// The main thread parses a SharedArrayBuffer while a worker flips a few of its
+// bytes back and forth. Each flipped byte is one the parser reads twice, and
+// the second value contradicts what the parser concluded from the first. A
+// parser that reads the shared bytes in place aborts the process. One that
+// reads a private copy sees one value per byte. Prints "ok" after <calls>
+// calls that ran while the worker wrote. A call can return or throw.
+import { isMainThread, Worker, workerData } from "node:worker_threads";
+
+type Case = {
+  text: string;
+  /** The value the worker flips the byte at `at` to, or `byte` to leave it. */
+  flip: (byte: number, at: number) => number;
+};
+
+// The block parser sees `#`, starts the heading text after it, then scans for
+// the end of the line from the `#` again. A newline there ends the line before
+// the text starts.
+const heading: Case = { text: "# heading\n\nparagraph\n", flip: (byte, at) => (at === 0 ? 0x0a : byte) };
+
+const CASES: Record<string, Case> = {
+  // The lexer counts the `_` separators of a numeric literal, allocates
+  // `length - count` bytes, then copies every byte that is not a `_`.
+  transpiler: { text: "let a = 1_000_000_000_000_000;\n", flip: byte => (byte === 0x5f ? 0x30 : byte) },
+  markdown: heading,
+  ansi: heading,
+  // The scanner reads a byte of a plain scalar, then asserts that the input
+  // still holds it when it appends it to the string.
+  yaml: { text: "key: value value value value\n", flip: byte => (byte === 0x76 ? 0x77 : byte) },
+  // A string is measured in UTF-16 units, then converted in a second pass. A
+  // 3-byte sequence that turns into three ASCII letters is three units, not one.
+  toml: { text: 'a = "€€€€€€€€€€€€€€€€"\n', flip: byte => (byte > 0x7f ? 0x61 : byte) },
+};
+
+const api = process.argv[2];
+const calls = Number(process.argv[3]);
+const base = new TextEncoder().encode(CASES[api].text);
+
+if (isMainThread) {
+  const bytes = new SharedArrayBuffer(base.length);
+  // The number of passes the worker has made over the bytes it flips.
+  const passes = new Int32Array(new SharedArrayBuffer(4));
+  const worker = new Worker(new URL(import.meta.url), {
+    workerData: { bytes, passes },
+    argv: [api, String(calls)],
+  });
+  worker.unref();
+
+  const input = new Uint8Array(bytes);
+  input.set(base);
+
+  // The worker's events cannot reach this thread while it parses in a loop, so
+  // a worker that stopped shows only as a pass count that stands still.
+  const workerStopped = (): never => {
+    console.error("the worker made no pass over the bytes for 10 s");
+    process.exit(1);
+  };
+
+  if (Atomics.wait(passes, 0, 0, 10_000) === "timed-out") workerStopped();
+
+  const transpiler = new Bun.Transpiler({ loader: "ts" });
+  const parse: Record<string, () => unknown> = {
+    transpiler: () => transpiler.transformSync(input),
+    markdown: () => Bun.markdown.html(input),
+    ansi: () => Bun.markdown.ansi(input),
+    yaml: () => Bun.YAML.parse(input),
+    toml: () => Bun.TOML.parse(input),
+  };
+
+  // Count a call only when the worker made a pass while it ran. A debug build
+  // is slow enough that every call counts. A release build can make a thousand
+  // calls before the worker's thread gets a core of its own.
+  let seen = Atomics.load(passes, 0);
+  let progressAt = performance.now();
+  for (let overlapped = 0; overlapped < calls; ) {
+    try {
+      parse[api]();
+    } catch {}
+    const now = Atomics.load(passes, 0);
+    if (now !== seen) {
+      seen = now;
+      overlapped++;
+      progressAt = performance.now();
+    } else if (performance.now() - progressAt > 10_000) {
+      workerStopped();
+    }
+  }
+
+  console.log("ok");
+  process.exit(0);
+} else {
+  const { bytes, passes } = workerData as { bytes: SharedArrayBuffer; passes: Int32Array };
+  const input = new Uint8Array(bytes);
+
+  const at: number[] = [];
+  const to: number[] = [];
+  for (let i = 0; i < base.length; i++) {
+    const other = CASES[api].flip(base[i], i);
+    if (other !== base[i]) {
+      at.push(i);
+      to.push(other);
+    }
+  }
+
+  // `Atomics.store` so that the compiler keeps every store and the other
+  // thread sees each one.
+  for (;;) {
+    for (let k = 0; k < at.length; k++) Atomics.store(input, at[k], to[k]);
+    for (let k = 0; k < at.length; k++) Atomics.store(input, at[k], base[at[k]]);
+    if (Atomics.add(passes, 0, 1) === 0) Atomics.notify(passes, 0);
+  }
+}

--- a/test/js/bun/util/parse-shared-buffer.test.ts
+++ b/test/js/bun/util/parse-shared-buffer.test.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "node:path";
+
+const fixture = path.join(import.meta.dir, "parse-shared-buffer-fixture.ts");
+
+// Each parser reads a byte more than once: the TypeScript lexer re-reads the
+// digits of a numeric literal after it counts the separators, the markdown
+// block parser scans a heading line twice, YAML asserts the byte its scanner
+// read, and TOML measures a string before it converts it. A worker that writes
+// the SharedArrayBuffer between the two reads aborted the process.
+//
+// The call counts: a debug build that parses the shared bytes in place aborts
+// within 200 calls, and within 50 of `transformSync`, which costs the most.
+test.concurrent.each([
+  ["transpiler", 300],
+  ["markdown", 1000],
+  ["ansi", 1000],
+  ["yaml", 1000],
+  ["toml", 1000],
+])("%s parses a SharedArrayBuffer a worker writes", async (api, calls) => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture, api, String(calls)],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout: stdout.trim(), stderr: stderr.trim() }).toEqual({ stdout: "ok", stderr: "" });
+  expect(exitCode).toBe(0);
+});
+
+// A macro runs in the middle of the parse. `transformSync` and `scan` read the
+// rest of the source after it returns, and read names and string literals back
+// from the source when they print. The macro is user code, so it can take the
+// bytes away: `resize()` gives the trimmed pages of a resizable ArrayBuffer
+// back, a write changes a fixed-length one in place, and `transfer()` moves its
+// bytes to a buffer nothing holds. `Bun.markdown` has the resizable cases next
+// to its other buffer input tests, in test/js/bun/md/md-render-callback.test.ts.
+test.concurrent.each([
+  {
+    macro: "shrinks the resizable input",
+    buffer: "new ArrayBuffer(bytes.length, { maxByteLength: bytes.length })",
+    takeAway: "globalThis.input.resize(0);",
+  },
+  {
+    macro: "overwrites the input and detaches it",
+    buffer: "new ArrayBuffer(bytes.length)",
+    takeAway: "new Uint8Array(globalThis.input).fill(0x20); globalThis.input.transfer(); Bun.gc(true);",
+  },
+])("transformSync and scan parse the bytes they were given when a macro $macro", async ({ buffer, takeAway }) => {
+  using dir = tempDir("transpiler-macro-takes-input", {
+    "macro.ts": `
+      export function takeAway() {
+        ${takeAway}
+        return "from the macro";
+      }
+    `,
+    "index.ts": `
+      import { join } from "node:path";
+
+      const macro = join(import.meta.dir, "macro.ts");
+      const source =
+        "import { takeAway } from " + JSON.stringify(macro) + ' with { type: "macro" };\\n' +
+        "export const fromTheMacro = takeAway();\\n" +
+        "export const filler = " + JSON.stringify(Buffer.alloc(100_000, "x").toString()) + ";\\n" +
+        "export const afterTheMacro = 'after the macro';\\n";
+
+      function input() {
+        const bytes = new TextEncoder().encode(source);
+        globalThis.input = ${buffer};
+        const view = new Uint8Array(globalThis.input);
+        view.set(bytes);
+        return view;
+      }
+
+      const transpiler = new Bun.Transpiler({ loader: "ts" });
+      const code = transpiler.transformSync(input());
+      const { exports, imports } = transpiler.scan(input());
+      console.log(
+        JSON.stringify({
+          byteLength: globalThis.input.byteLength,
+          transformSync: [
+            code.includes('fromTheMacro = "from the macro"'),
+            code.includes('afterTheMacro = "after the macro"'),
+          ],
+          exports: exports.sort(),
+          imports: imports.map(({ path }) => path === macro),
+        }),
+      );
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // A debug build logs each macro call to stdout first.
+  expect({ result: stdout.trim().split("\n").at(-1), stderr: stderr.trim() }).toEqual({
+    result: JSON.stringify({
+      byteLength: 0,
+      transformSync: [true, true],
+      exports: ["afterTheMacro", "filler", "fromTheMacro"],
+      imports: [true],
+    }),
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- `Bun.Transpiler#transformSync`/`scan`/`scanImports`, `Bun.markdown.*`, `Bun.YAML.parse` and `Bun.TOML.parse` parse a `SharedArrayBuffer` view in place. A Worker that writes it mid-call aborts: `panic: index out of bounds: the len is 1 but the index is 1` (`src/js_parser/lexer.rs:3287`), `called Option::unwrap() on a None value` (`src/md/html_renderer.rs:463`), `assertion failed: self.input[pos.cast()] == unit` (`src/parsers/yaml.rs:792`). TOML is a SIGSEGV on release, `heap-buffer-overflow` in `to_utf16_alloc` under ASAN.
- Each parser reads a byte twice: the lexer counts `_` separators, allocates `len - count`, then re-reads the digits.
- On one thread, a callback or macro that shrinks a resizable input SEGVs. A macro that writes or `transfer()`s a fixed input makes `transformSync`/`scan` print garbage.

### Fix
- Add `ArrayBuffer::can_change_under_borrow` (`shared || resizable`) and `try_copy_bytes`. `StringOrBuffer::from_js_stable` copies such a view, so only this thread writes what the parser reads. Other input stays borrowed. `TextDecoder.decode` and `copy_if_resizable` use them too.
- Call it in the three transpiler sync methods, the four `Bun.markdown` renderers, and the `Bun.YAML`/`TOML`/`JSON5`/`XML` scaffold. `transformSync` and `scan` run macros, so they copy every buffer, as the async `transform()` does.
- Scope: these entry points only. The parsers still expect stable bytes.
- Verified: `test/js/bun/util/parse-shared-buffer.test.ts` and new cases in `test/js/bun/md/md-render-callback.test.ts` fail unfixed, pass fixed. Also `test/js/bun/{md,transpiler,yaml,toml,json5,jsonc,xml}`, `text-decoder*`.

### Background
- Another thread can write a `SharedArrayBuffer` during a native call.
- `resize()` gives a resizable `ArrayBuffer`'s trimmed pages back to the OS. A pin stops a detach, not a shrink.
- `StringOrBuffer` is the parsed "string or BufferSource" argument: `Buffer` borrows the JS bytes, `Utf8(Owned)` holds a copy.

<details><summary>Notes</summary>

**Self-review.** 3 concerns raised, 3 addressed: the `resizable` arm had no test (added the single-thread cases), the copy and its predicate duplicated `PinnedArrayBuffer::copy_if_resizable` and `TextDecoder.rs:304` (moved both onto `bun_jsc::ArrayBuffer`), and the text implied the lexers are closed (see "Still open").

**The race test.** The fixture's worker flips only the bytes the parser reads twice, with `Atomics.store`. The main thread counts a call only when the worker made a pass while it ran, so a release build that finishes 1000 calls before the worker gets a core still overlaps.
- transpiler: every `_` of `1_000_000_000_000_000` flips to `0`.
- markdown and ansi: byte 0 of `# heading` flips to a newline. The block parser starts the heading text after the `#`, then scans for the end of the line from the `#` again (`src/md/blocks.rs:602`, `attempt to subtract with overflow` on debug, `index out of bounds: the len is 21 but the index is 4294967295` on release).
- yaml: each `v` of a plain scalar flips to `w`.
- toml: each byte of `€` flips to `a`.

Calibration on the unfixed debug+ASAN build: every mode aborts 3/3 at 200 calls, and all but markdown 3/3 at 50. With `src/` at `origin/main` the file fails 6/6 in 2/2 runs. With the fix it passes 6/6 in 3/3 runs (0.5 to 3.1 s per test on a loaded host). The released 1.4.3 binary fails 6/6 in 5/5 runs.

**Release dating.** This is a regression in 1.4.0. With the same fixture, 1.3.14 survives all five modes (0 of 5 runs abort at 1000 calls, 0 of 3 at 100000 calls). 1.4.0 aborts at 1000 calls: transpiler 5/5, markdown 4/5, ansi 5/5, yaml 5/5, toml 5/5 (`Segmentation fault at address 0x47700610061`). The current canary (`b99371011`) still aborts.

**The single-thread tests.** `md-render-callback.test.ts`: an option getter (`html`, `ansi`, `react`) or a render callback (`render`) calls `resize(0)` on the input. `parse-shared-buffer.test.ts`: a macro calls `resize(0)` on the `transformSync` input. Without the fix these are `SEGV ... in bun_md::helpers::skip_utf8_bom` and a lexer SEGV. A second macro case fills a fixed-length input with spaces and then calls `transfer()` on it. Without the fix, `transformSync` prints `export const              = ...` and `scan` returns exports of spaces. `scanImports` runs no macros and keeps `from_js_stable`. A source over `Source::MAX_PARSEABLE_LEN` (2 GiB) is not copied: the parser rejects it by its length and does not read it (`test/js/bun/transpiler/source-too-large.test.ts`). #31730 fixes the markdown half for `resizable && !shared`. This PR covers that case too.

**Predicate.** The text-format scaffold runs no JS between the borrow and the parse, so `resizable` alone cannot change its bytes there. It shares the one predicate anyway. The cost is one copy on a rare input shape. #42192 adds `ArrayBuffer::pin_cannot_hold` (`!shared && (resizable || wasm_memory)`). Once both land, `can_change_under_borrow` is `shared || pin_cannot_hold()`, a one-line change.

**Not affected.** `Bun.Transpiler#transform` (async) already copies its input before it schedules the job. `Bun.XML.parse` and `Bun.JSON5.parse` share the scaffold and now get the copy too. Neither aborted in 200k calls on the same rig without the fix. `Bun.JSONC.parse` stringifies a buffer argument. A `Blob` argument owns its bytes.

**Still open.**
- A `Bun.markdown` render callback that overwrites a fixed input in place still changes what the rest of the render reads. The pin keeps the memory valid. The output then reflects the overwrite.
- `Bun.plugin` `onLoad` `contents` over a `SharedArrayBuffer` borrows `view->vector()` (`src/jsc/bindings/ModuleLoader.cpp:307`) and reaches the same lexer. It aborts 3/3 on 1.4.3 with the same panic. Filed as a separate follow-up.
- The other sync callers of `StringOrBuffer::from_js` keep the borrow on purpose. `CryptoHasher` reads each byte once, and `digest(into)` writes through the borrow. `Bun.password`, socket, TLS, HTTP/2 and `Bun.Terminal` writes make one pass to a syscall or a codec. `Bun.build` `files` copies at once. `Bun.gzipSync`/`deflateSync` read twice in libdeflate: #42249.
- `StringOrBuffer::from_js_async` (node:fs, zlib, crypto work-pool jobs) still hands a pool thread a live `SharedArrayBuffer`. #41574 covers the UTF-8 decoders.

Two failures seen locally are timeouts on the debug+ASAN build and are not related: `XML.stringify > deep values are a catchable error` (builds 1M nested objects, 190 ms on release) and `Bun.JSONC.parse matches JSON.parse on generated documents` (4.99 s alone against the 5 s default).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-render-callback.test.ts test/js/bun/util/parse-shared-buffer.test.ts
bun test v1.4.3 (b99371011)

test/js/bun/md/md-render-callback.test.ts:
(pass) Bun.markdown.render > returns a string [11.74ms]
(pass) Bun.markdown.render > without callbacks, children pass through unchanged [1.92ms]
(pass) Bun.markdown.render > heading callback with level metadata [4.77ms]
(pass) Bun.markdown.render > heading levels 1-6 [27.13ms]
(pass) Bun.markdown.render > paragraph callback [3.39ms]
(pass) Bun.markdown.render > strong callback [4.40ms]
(pass) Bun.markdown.render > emphasis callback [4.44ms]
(pass) Bun.markdown.render > link callback with href metadata [5.23ms]
(pass) Bun.markdown.render > link callback with title metadata [4.77ms]
(pass) Bun.markdown.render > image callback with src metadata [4.73ms]
(pass) Bun.markdown.render > link callback with href/title from reference-style link [4.84ms]
(pass) Bun.markdown.render > link callback with href from shortcut reference link [4.59ms]
(pass) Bun.markdown.render > image callback with 
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.3-canary.1 (b99371011)

test/js/bun/md/md-render-callback.test.ts:
(pass) Bun.markdown.render > returns a string [0.07ms]
(pass) Bun.markdown.render > without callbacks, children pass through unchanged [0.02ms]
(pass) Bun.markdown.render > heading callback with level metadata [0.04ms]
(pass) Bun.markdown.render > heading levels 1-6 [0.12ms]
(pass) Bun.markdown.render > paragraph callback [0.03ms]
(pass) Bun.markdown.render > strong callback [0.04ms]
(pass) Bun.markdown.render > emphasis callback [0.03ms]
(pass) Bun.markdown.render > link callback with href metadata [0.04ms]
(pass) Bun.markdown.render > link callback with title metadata [0.04ms]
(pass) Bun.markdown.render > image callback with src metadata [0.03ms]
(pass) Bun.markdown.render > link callback with href/title from reference-style link [0.04ms]
(pass) Bun.markdown.render > link callback with href from shortcut reference link [0.03ms]
(pass) Bun.markdown.render > image callback with src/title from reference-style image [0.04ms]
(pass) Bun.markdown.render > code block callback with language metadata [0.03ms]
(pass) Bun.markdown.render > code block without language [0.03ms]
(pass) Bun.markdown
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-render-callback.test.ts test/js/bun/util/parse-shared-buffer.test.ts
bun test v1.4.3 (b99371011)

test/js/bun/md/md-render-callback.test.ts:
(pass) Bun.markdown.render > returns a string [11.01ms]
(pass) Bun.markdown.render > without callbacks, children pass through unchanged [1.79ms]
(pass) Bun.markdown.render > heading callback with level metadata [15.09ms]
(pass) Bun.markdown.render > heading levels 1-6 [13.59ms]
(pass) Bun.markdown.render > paragraph callback [3.31ms]
(pass) Bun.markdown.render > strong callback [4.23ms]
(pass) Bun.markdown.render > emphasis callback [4.76ms]
(pass) Bun.markdown.render > link callback with href metadata [4.51ms]
(pass) Bun.markdown.render > link callback with title metadata [4.52ms]
(pass) Bun.markdown.render > image callback with src metadata [4.80ms]
(pass) Bun.markdown.render > link callback with href/title from reference-style link [4.79ms]
(pass) Bun.markdown.render > link callback with href from shortcut reference link [4.33ms]
(pass) Bun.markdown.render > image callback with
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     d2047efb99
  features     baseline

23 deps, 131 codegen, 1176 objects in 731ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] install /workspace/bun
bun install v1.4.3-canary.1 (b99371011)

Checked 22 installs across 61 packages (no changes) [6.00ms]
[2/1248] gen ErrorCode+*.h
[3/1248] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (b99371011)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1248] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (b99371011)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[5/1248] fetch tinycc
[tinycc] up to date
[6/1247] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 KB  (entry point)

[7/1247] fetch zlib
[zlib] up to date
[8/1247] gen bindgenv2
[9/1247] gen .bind.ts → GeneratedBindings.cpp
[10/1247] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1247] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/buil
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/array_buffer.rs                         |  21 +++-
 src/runtime/api.rs                              |   2 +-
 src/runtime/api/JSTranspiler.rs                 |  10 +-
 src/runtime/api/MarkdownObject.rs               |  31 ++----
 src/runtime/node/types.rs                       |  56 +++++++++++
 src/runtime/webcore/TextDecoder.rs              |   6 +-
 test/js/bun/md/md-render-callback.test.ts       |  68 +++++++++++++
 test/js/bun/util/parse-shared-buffer-fixture.ts | 104 ++++++++++++++++++++
 test/js/bun/util/parse-shared-buffer.test.ts    | 122 ++++++++++++++++++++++++
 9 files changed, 388 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/jsc/array_buffer.rs                              2      2     36
src/runtime/api.rs                                   2      3     36
src/runtime/api/JSTranspiler.rs                      1      0     36
src/runtime/api/MarkdownObject.rs                    2      2     36
src/runtime/node/types.rs                            5      6     36
src/runtime/webcore/TextDecoder.rs                   1      1     36
test/js/bun/md/md-render-callback.test.ts            1      1     13
test/js/bun/util/parse-shared-buffer-fixture.ts      4     12     60
test/js/bun/util/parse-shared-buffer.test.ts         6     10     33
```

</details>

<!-- robobun:evidence:end -->


