### PR TITLE
YAML, JSON5, XML stringify: throw instead of aborting when the output passes the string length limit

### DIFF
--- a/src/jsc/bindings/StringBuilderBinding.cpp
+++ b/src/jsc/bindings/StringBuilderBinding.cpp
@@ -5,6 +5,9 @@
 static_assert(sizeof(WTF::StringBuilder) == 24, "src/jsc/StringBuilder.rs assumes WTF::StringBuilder is 24 bytes");
 static_assert(alignof(WTF::StringBuilder) == 8, "src/jsc/StringBuilder.rs assumes WTF::StringBuilder is 8-byte aligned");
 
+// RecordOverflow: an append past String::MaxLength, or a failed allocation, marks the builder
+// instead of crashing, and StringBuilder__toString throws for it. length() and capacity()
+// release-assert !hasOverflowed(), so a function below that can reach them checks it first.
 extern "C" void StringBuilder__init(WTF::StringBuilder* ptr)
 {
     new (ptr) WTF::StringBuilder(OverflowPolicy::RecordOverflow);
@@ -42,6 +45,9 @@ extern "C" void StringBuilder__appendUsize(WTF::StringBuilder* builder, size_t n
 
 extern "C" void StringBuilder__appendString(WTF::StringBuilder* builder, const BunString* str)
 {
+    // A 16-bit string makes an 8-bit builder upconvert, and that reads capacity().
+    if (builder->hasOverflowed()) [[unlikely]]
+        return;
     str->appendToBuilder(*builder);
 }
 
@@ -77,5 +83,7 @@ extern "C" JSC::EncodedJSValue StringBuilder__toString(WTF::StringBuilder* build
 
 extern "C" void StringBuilder__ensureUnusedCapacity(WTF::StringBuilder* builder, size_t additional)
 {
+    if (builder->hasOverflowed()) [[unlikely]]
+        return;
     builder->reserveCapacity(builder->length() + additional);
 }

--- a/src/jsc/bindings/StringBuilderBinding.cpp
+++ b/src/jsc/bindings/StringBuilderBinding.cpp
@@ -5,9 +5,6 @@
 static_assert(sizeof(WTF::StringBuilder) == 24, "src/jsc/StringBuilder.rs assumes WTF::StringBuilder is 24 bytes");
 static_assert(alignof(WTF::StringBuilder) == 8, "src/jsc/StringBuilder.rs assumes WTF::StringBuilder is 8-byte aligned");
 
-// RecordOverflow: an append past String::MaxLength, or a failed allocation, marks the builder
-// instead of crashing, and StringBuilder__toString throws for it. length() and capacity()
-// release-assert !hasOverflowed(), so a function below that can reach them checks it first.
 extern "C" void StringBuilder__init(WTF::StringBuilder* ptr)
 {
     new (ptr) WTF::StringBuilder(OverflowPolicy::RecordOverflow);
@@ -45,7 +42,7 @@ extern "C" void StringBuilder__appendUsize(WTF::StringBuilder* builder, size_t n
 
 extern "C" void StringBuilder__appendString(WTF::StringBuilder* builder, const BunString* str)
 {
-    // A 16-bit string makes an 8-bit builder upconvert, and that reads capacity().
+    // Upconverting an 8-bit builder for a 16-bit string reads capacity(), which asserts !hasOverflowed().
     if (builder->hasOverflowed()) [[unlikely]]
         return;
     str->appendToBuilder(*builder);
@@ -83,6 +80,7 @@ extern "C" JSC::EncodedJSValue StringBuilder__toString(WTF::StringBuilder* build
 
 extern "C" void StringBuilder__ensureUnusedCapacity(WTF::StringBuilder* builder, size_t additional)
 {
+    // length() asserts !hasOverflowed().
     if (builder->hasOverflowed()) [[unlikely]]
         return;
     builder->reserveCapacity(builder->length() + additional);

--- a/test/js/bun/util/stringify-string-limit.test.ts
+++ b/test/js/bun/util/stringify-string-limit.test.ts
@@ -1,0 +1,83 @@
+// Bun.YAML, Bun.JSON5, Bun.TOML and Bun.XML write their output into one string
+// builder (src/jsc/StringBuilder.rs, a WTF::StringBuilder). A string holds at
+// most 2**31 - 1 characters. The builder records an overflow when an append
+// passes that limit, and also when it cannot grow its buffer, and stringify
+// has to throw an out-of-memory error for it, the same as JSON.stringify. Two
+// calls asserted on an overflowed builder and aborted the process instead: the
+// capacity that block-style YAML reserves before indentation, and the append
+// of a UTF-16 string, which YAML, JSON5 and XML make for keys, names and indents.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { totalmem } from "node:os";
+
+// `big` overflows the builder, and what follows it makes one of the two calls.
+const fixture = (big: string, expression: string) => `
+  const big = ${big};
+  try {
+    console.log("returned", ${expression}.length);
+  } catch (e) {
+    console.log("threw", e.name, e.message);
+  }
+`;
+const threw = "threw RangeError Out of memory\n";
+
+// The overflow comes from a failed allocation. With Malloc=1 WebKit allocates
+// through the system allocator, so ASAN's per-allocation cap covers the
+// builder's buffer. `big` is 3/4 of the cap: the string itself fits, and the
+// buffer cannot double to get past it.
+describe.concurrent.skipIf(!isASAN)("stringify throws when the string builder cannot grow", () => {
+  const CAP_MIB = 4;
+  test.each([
+    ["block-style YAML reserves capacity", `Bun.YAML.stringify([big, 1], null, 2)`],
+    ["block-style YAML appends a UTF-16 key", `Bun.YAML.stringify({ a: big, "日本": 1 }, null, 2)`],
+    ["block-style YAML appends a UTF-16 indent", `Bun.YAML.stringify([[big, 1]], null, "\\u3000")`],
+    ["flow-style YAML appends a UTF-16 key", `Bun.YAML.stringify({ a: big, "日本": 1 })`],
+    ["JSON5 appends a UTF-16 key", `Bun.JSON5.stringify({ a: big, "日本": 1 })`],
+    ["XML appends a UTF-16 element name", `Bun.XML.stringify({ a: { b: big, "日本": "1" } })`],
+  ])("%s", async (_name, expression) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture(`"x".repeat(${0.75 * CAP_MIB} * 1024 * 1024)`, expression)],
+      env: {
+        ...bunEnv,
+        Malloc: "1",
+        ASAN_OPTIONS: [
+          bunEnv.ASAN_OPTIONS,
+          "allocator_may_return_null=1",
+          `max_allocation_size_mb=${CAP_MIB}`,
+          "detect_leaks=0",
+        ]
+          .filter(Boolean)
+          .join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // ASAN reports the allocation it refused on stderr, so stderr is not compared.
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    expect(stdout).toBe(threw);
+    expect(exitCode).toBe(0);
+  });
+});
+
+// The overflow comes from the length: `a: ` and a string of the maximum length
+// are three characters past the limit. The key after it needs both calls. The
+// child holds 2 GiB and reads it once to decide on quoting, about 80 ns per
+// character in a debug build, so this runs on release builds with enough memory.
+test.skipIf(isASAN || isDebug || totalmem() < 10 * 1024 ** 3)(
+  "stringify throws when the output passes the maximum string length",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture(`"x".repeat(2 ** 31 - 1)`, `Bun.YAML.stringify({ a: big, "日本": 1 }, null, 2)`)],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: threw, stderr: "", exitCode: 0 });
+  },
+  120_000,
+);

--- a/test/js/bun/util/stringify-string-limit.test.ts
+++ b/test/js/bun/util/stringify-string-limit.test.ts
@@ -35,8 +35,10 @@ describe.concurrent.skipIf(!isASAN)("stringify throws when the string builder ca
     ["JSON5 appends a UTF-16 key", `Bun.JSON5.stringify({ a: big, "日本": 1 })`],
     ["XML appends a UTF-16 element name", `Bun.XML.stringify({ a: { b: big, "日本": "1" } })`],
   ])("%s", async (_name, expression) => {
+    // "latin1" makes `big` an 8-bit string, so the builder is still 8-bit when the UTF-16 string arrives.
+    const big = `Buffer.alloc(${0.75 * CAP_MIB} * 1024 * 1024, "x").toString("latin1")`;
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", fixture(`"x".repeat(${0.75 * CAP_MIB} * 1024 * 1024)`, expression)],
+      cmd: [bunExe(), "-e", fixture(big, expression)],
       env: {
         ...bunEnv,
         Malloc: "1",
@@ -50,13 +52,13 @@ describe.concurrent.skipIf(!isASAN)("stringify throws when the string builder ca
           .join(":"),
       },
       stdout: "pipe",
+      // ASAN logs a warning for every refused allocation; drained, not asserted on.
       stderr: "pipe",
     });
 
-    // ASAN reports the allocation it refused on stderr, so stderr is not compared.
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout).toBe(threw);
+    expect(stdout, `the child exited with ${exitCode}\nstderr:\n${stderr}`).toBe(threw);
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `Bun.YAML.stringify`, `Bun.JSON5.stringify` and `Bun.XML.stringify` abort the process when the output does not fit in a string: `panic(main thread): abort() called`, exit code 134. An assertions build prints `ASSERTION FAILED: !hasOverflowed()` in `WTF::StringBuilder::length()` (`wtf/text/StringBuilder.h(288)`). `JSON.stringify` throws `RangeError: Out of memory`.
- `length()` release-asserts on an overflowed builder, and two functions in `src/jsc/bindings/StringBuilderBinding.cpp` reach it. `StringBuilder__ensureUnusedCapacity` (:78) reads it. Block-style YAML calls that before each indentation run. `StringBuilder__appendString` (:43) reaches it when a 16-bit key or name goes into an 8-bit builder.

### Fix
- Both functions return early for an overflowed builder. It drops every append, and `StringBuilder__toString` already throws the error.
- Not in this PR: the text sink of a direct `ReadableStream` (`BunStandaloneTextSink.h:35`) aborts the same way after a `write()` error that the caller caught. See Notes.
- Verified: `test/js/bun/util/stringify-string-limit.test.ts` (new, seven tests). With `src/` at main the six ASAN tests abort with the assertion above. The release test fails on bun 1.4.3-canary. Also ran the YAML, TOML, JSON5 and XML suites.
- Self-reviewed: 8 concerns raised, 6 addressed. Rejected: deleting YAML's four capacity hints. It is an unmeasured performance change in code #39925 rewrites.

### Background
- `wtf::StringBuilder` (`src/jsc/StringBuilder.rs`) is the Rust handle for a C++ `WTF::StringBuilder`. The YAML, JSON5, TOML and XML stringifiers write into it.
- It uses `OverflowPolicy::RecordOverflow`: an append past 2^31 - 1 characters, or a failed allocation, makes `hasOverflowed()` true. The failed reallocation has already freed the buffer.
- A builder is 8-bit until it gets a character above U+00FF. Then it copies itself into a 16-bit buffer. That copy reads `capacity()`, which is `length()` once the buffer is gone.

<details><summary>Notes</summary>

**Reproduction** on bun 1.4.3-canary (5f554969b). Each exits with code 134.

```js
// Block-style YAML, the reservation. About 3 GB and 7 s.
let o = new Array(108000).fill(1);
for (let i = 0; i < 2000; i++) o = { a: o };
Bun.YAML.stringify(o, null, 10);

// The 16-bit append. No space argument, so no reservation is involved. About 2.2 GB.
Bun.YAML.stringify({ a: "x".repeat(2 ** 31 - 1), "日本": 1 });
```

**Where the second abort comes from.** `BunString::appendToBuilder` passes a `StringImpl*` to the variadic `StringBuilder::append`. `appendFromAdapters` does not check `hasOverflowed()`. For a 16-bit string and an 8-bit builder it calls `extendBufferForAppendingWithUpconvert`, which computes `expandedCapacity(capacity(), requiredLength)`. `capacity()` is `m_buffer ? m_buffer->length() : length()`, and a failed `tryReallocate` has already released `m_buffer`. The `append(std::span<...>)` overloads, `append(char16_t)`, `append(Latin1Character)`, the number adapters (8-bit, so they take the checked `extendBufferForAppending` path), `appendQuotedJSONString` and `reserveCapacity` all check first. `Bun.TOML.stringify` writes non-ASCII keys and values one character at a time, so it did not abort.

**The tests.**

- A run that appends 2^31 characters is too slow for a debug build. The quoting check reads each character of a string value at about 80 ns there (about 3 minutes for 2 GiB), and the deep-indentation value above needs about 2e8 append calls at about 10 µs each.
- The six ASAN tests record the overflow through a failed allocation. `max_allocation_size_mb=4` with `Malloc=1` makes the builder's next doubling fail, which calls the same `didOverflow()` and leaves the same state. `text-encoder-stream.test.ts`, `buffer-oom.test.ts` and `zstd.test.ts` use the same ASAN options. bun boots with a cap as low as 1 MiB. Each child takes about 1 s on a debug build, and the six run concurrently.
- One row covers the reservation. Five rows put a 16-bit string after the overflow: a key and an indent in block-style YAML, a key in flow-style YAML, a key in JSON5, an element name in XML. With only the `ensureUnusedCapacity` check, those five still abort.
- The release test passes the real limit with a string of 2^31 - 1 characters, then a 16-bit key, so it needs both checks. It needs 2 GiB, so it skips below 10 GB of RAM, and it skips debug and ASAN builds. The same fixture prints `threw RangeError Out of memory` on the fixed debug build when run by hand (220 s).
- The tests have their own file because the builder is shared by four APIs, like `streams-string-limit.test.ts` and `source-too-large.test.ts`. The file takes about 4 s on a debug build.
- Two existing tests go past the 5 s default timeout on my loaded debug build: `XML.stringify > deep values are a catchable error` (7.7 s) and `stack overflow protection in the write pass` in `yaml.test.ts` (4.4 to 5.8 s). The XML one does the same with `src/` at main. Both build a 1,000,000-deep value and neither reaches an overflowed builder. Everything else in the four suites passes.

**Self-review, by concern.**

- The first version of this change only fixed `ensureUnusedCapacity`. The review found that a 16-bit key or indent after the overflow still aborted, in YAML with and without a space argument, in JSON5 and in XML. That is the `appendString` check and the five rows (2 concerns).
- The first version also made block-style YAML stop at the first value after an overflow, through a new `has_overflowed()` accessor. It had no test of its own and it touched the same lines as #39925. It is gone. The diff is now the two checks and nothing on the Rust side (2 concerns).
- The four `ensure_unused_capacity` calls in `YAMLObject.rs` stay as they are. `WTF::StringBuilder::reserveCapacity` reallocates to the exact size, so they probably do not help, and JSON5 and XML have the same `newline()` without them. Removing them is a performance change with no measurement behind it, and #39925 rewrites those functions and keeps the calls, so it is not part of this crash fix (rejected). The first version also refused a reservation above `String::MaxLength`. That is gone too: such a request makes the builder record an overflow, and the result is the same catchable error (2 concerns).
- The stream text sink, below (2 concerns).

**The stream text sink (not fixed here).** `BunTextAccumulator::rope` is the only other `RecordOverflow` builder in `src/`. `writeToTextSink` (`JSDirectStreamController.cpp:405`) throws `RangeError: Out of memory` when an append overflows it, but leaves it overflowed. If the caller catches that and writes a typed array, line 431 calls `rope.toString()`, which asserts in `reifyString()`. `BunStreamConsumers.cpp:679`, `:709` and `:744` read `rope.length()` the same way. Under `Malloc=1` and `max_allocation_size_mb=4` on a debug build:

```js
const s = "x".repeat(1024 * 1024);
const rs = new ReadableStream({
  type: "direct",
  pull(c) {
    c.write(s);
    c.write(s);
    try { c.write(s); } catch {}      // RangeError: Out of memory
    c.write(new Uint8Array(1));       // ASSERTION FAILED: !hasOverflowed()  StringBuilder.cpp(52) reifyString()
    c.end();
  },
});
await Bun.readableStreamToText(rs);
```

The fix has to decide what a write after a failed write does (throw again, or error the stream), in two write arms and two end arms. It belongs with the stream code and its tests.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/stringify-string-limit.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/util/stringify-string-limit.test.ts:
56 |       stderr: "pipe",
57 |     });
58 | 
59 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
60 | 
61 |     expect(stdout, `the child exited with ${exitCode}\nstderr:\n${stderr}`).toBe(threw);
                                                                                 ^
error: the child exited with 134
stderr:
==255766==WARNING: AddressSanitizer failed to allocate 0x600018 bytes
ASSERTION FAILED: !hasOverflowed()
/root/.bun/build-cache/webkit-dfd696443b9ba87c-debug-asan/include/wtf/text/StringBuilder.h(288) : unsigned int WTF::StringBuilder::length() const
no stacktrace available

- "threw RangeError Out of memory
- "
+ ""

- Expected  - 2
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/util/stringify-string-limit.test.ts:61:77)
(fail) stringify throws when the string builder cannot grow > block-style YAML reserves capac
... (truncated)

release without fix: 1 failed, 6 skipped
bun test v1.4.3-canary.1 (5f554969b)

test/js/bun/util/stringify-string-limit.test.ts:
(skip) stringify throws when the string builder cannot grow > block-style YAML reserves capacity
(skip) stringify throws when the string builder cannot grow > block-style YAML appends a UTF-16 key
(skip) stringify throws when the string builder cannot grow > block-style YAML appends a UTF-16 indent
(skip) stringify throws when the string builder cannot grow > flow-style YAML appends a UTF-16 key
(skip) stringify throws when the string builder cannot grow > JSON5 appends a UTF-16 key
(skip) stringify throws when the string builder cannot grow > XML appends a UTF-16 element name
77 |       stderr: "pipe",
78 |     });
79 | 
80 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
81 | 
82 |     expect({ stdout, stderr, exitCode }).toEqual({ stdout: threw, stderr: "", exitCode: 0 });
                                              ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stderr": "",
-   "stdout": 
- "threw RangeError Out of memory
+   "exitCode": 134,
+   "stderr": 
+ "========================
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/stringify-string-limit.test.ts
bun test v1.4.3 (5f554969b)

test/js/bun/util/stringify-string-limit.test.ts:
(pass) stringify throws when the string builder cannot grow > block-style YAML appends a UTF-16 indent [719.70ms]
(pass) stringify throws when the string builder cannot grow > flow-style YAML appends a UTF-16 key [979.51ms]
(pass) stringify throws when the string builder cannot grow > block-style YAML appends a UTF-16 key [1020.19ms]
(pass) stringify throws when the string builder cannot grow > block-style YAML reserves capacity [1155.71ms]
(pass) stringify throws when the string builder cannot grow > JSON5 appends a UTF-16 key [1575.14ms]
(pass) stringify throws when the string builder cannot grow > XML appends a UTF-16 element name [1096.21ms]
(skip) stringify throws when the output passes the maximum string length

 6 pass
 1 skip
 0 fail
 12 expect() calls
Ran 7 tests across 1 file. [4.86s]
__F:0:S:1

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 931ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/StringBuilderBinding.cpp       |  6 ++
 test/js/bun/util/stringify-string-limit.test.ts | 85 +++++++++++++++++++++++++
 2 files changed, 91 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/jsc/bindings/StringBuilderBinding.cpp            3      7     15
test/js/bun/util/stringify-string-limit.test.ts      2      5     12
```

</details>

<!-- robobun:evidence:end -->