### PR TITLE
Drop the frames instead of aborting when a stack trace passes the string length limit

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -32,6 +32,19 @@ using namespace WebCore;
 
 namespace Bun {
 
+// What `.stack` is when the frames do not fit in one string. It cannot throw: `formatStackTrace` also runs in a GC finalizer.
+static WTF::String stackTraceHeaderOnly(const WTF::String& name, const WTF::String& message)
+{
+    if (name.isEmpty())
+        return message;
+    if (message.isEmpty())
+        return name;
+    WTF::String header = tryMakeString(name, ": "_s, message);
+    if (header.isNull()) [[unlikely]]
+        return message;
+    return header;
+}
+
 static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalObject, JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* errorObject, JSC::JSArray* callSites)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -39,8 +52,10 @@ static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalO
     // default formatting
     size_t framesCount = callSites->length();
 
-    WTF::StringBuilder sb;
+    // The message and the frames come from JS. Past `String::MaxLength` a default `StringBuilder` calls `CRASH()`.
+    WTF::StringBuilder sb { WTF::OverflowPolicy::RecordOverflow };
 
+    JSC::JSString* messageString = nullptr;
     auto errorMessage = errorObject->getIfPropertyExists(lexicalGlobalObject, vm.propertyNames->message);
     RETURN_IF_EXCEPTION(scope, {});
     if (errorMessage) {
@@ -49,6 +64,7 @@ static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalO
         if (str->length() > 0) {
             auto value = str->view(lexicalGlobalObject);
             RETURN_IF_EXCEPTION(scope, {});
+            messageString = str;
             sb.append("Error: "_s);
             sb.append(value.data);
         } else {
@@ -76,6 +92,14 @@ static JSValue formatStackTraceToJSValue(JSC::VM& vm, Zig::GlobalObject* globalO
             RETURN_IF_EXCEPTION(scope, {});
             sb.append(value.data);
         }
+    }
+
+    if (sb.hasOverflowed()) [[unlikely]] {
+        if (!messageString)
+            return jsNontrivialString(vm, "Error"_s);
+        auto message = messageString->value(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        return jsString(vm, stackTraceHeaderOnly("Error"_s, message.data));
     }
 
     return jsString(vm, sb.toString());
@@ -151,7 +175,8 @@ WTF::String formatStackTrace(
     JSC::JSObject* errorInstance)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    WTF::StringBuilder sb;
+    // The message and each frame's source URL come from JS. Past `String::MaxLength` a default `StringBuilder` calls `CRASH()`.
+    WTF::StringBuilder sb { WTF::OverflowPolicy::RecordOverflow };
 
     if (!name.isEmpty()) {
         sb.append(name);
@@ -233,6 +258,8 @@ WTF::String formatStackTrace(
 
     if (framesCount == 0) {
         ASSERT(stackTrace.isEmpty());
+        if (sb.hasOverflowed()) [[unlikely]]
+            return stackTraceHeaderOnly(name, message);
         return sb.toString();
     }
 
@@ -388,6 +415,9 @@ WTF::String formatStackTrace(
             sb.append("\n"_s);
         }
     }
+
+    if (sb.hasOverflowed()) [[unlikely]]
+        return stackTraceHeaderOnly(name, message);
 
     return sb.toString();
 }

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1231,6 +1231,9 @@ test.concurrent.each([[{}], [{ BUN_JSC_useSourceProviderCache: "0" }]])(
 // the frames. The length is what is under test, so the child needs a string of
 // about 2 GiB, and the test skips on small machines. The child touches about
 // 6 GB of pages, which takes longer than the default limit in a debug build.
+// `repeat` and not `Buffer.alloc(n, fill).toString()`: for one character at this
+// size it is faster in a debug build (1.6 s against 3.3 s), and it does not hold
+// a second 2 GiB.
 test.skipIf(totalmem() < 10 * 1024 ** 3)(
   "a stack trace past the string length limit drops its frames instead of aborting the process",
   async () => {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -2,6 +2,7 @@ import { nativeFrameForTesting } from "bun:internal-for-testing";
 import { noInline } from "bun:jsc";
 import { afterEach, expect, mock, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { totalmem } from "node:os";
 const origPrepareStackTrace = Error.prepareStackTrace;
 afterEach(() => {
   Error.prepareStackTrace = origPrepareStackTrace;
@@ -1222,4 +1223,41 @@ test.concurrent.each([[{}], [{ BUN_JSC_useSourceProviderCache: "0" }]])(
     expect(stdout.trim()).toEndWith("[eval]:5:14)"); // 2:18 when the lexer resumed on the template literal's first line
     expect(exitCode).toBe(0);
   },
+);
+
+// The message and the frames of a stack trace come from JS. A trace past
+// `WTF::String::MaxLength` (2**31 - 1 characters) aborted the process (exit code
+// 134) while it was formatted. It now keeps the "name: message" header and drops
+// the frames. The length is what is under test, so the child needs a string of
+// about 2 GiB, and the test skips on small machines. The child touches about
+// 6 GB of pages, which takes longer than the default limit in a debug build.
+test.skipIf(totalmem() < 10 * 1024 ** 3)(
+  "a stack trace past the string length limit drops its frames instead of aborting the process",
+  async () => {
+    const length = 2 ** 31 - 10;
+    const src = `
+      const long = "q".repeat(${length});
+      const describe = stack => typeof stack + " " + stack.length + " " + JSON.stringify(stack.slice(0, 9));
+      console.log(".stack: " + describe(new Error(long).stack));
+      Bun.gc(true);
+      const frames = [{ toString: () => "frame" }];
+      console.log("default Error.prepareStackTrace: " + describe(Error.prepareStackTrace(new Error(long), frames)));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim().split("\n"), stderr, exitCode }).toEqual({
+      stdout: [
+        `.stack: string ${"Error: ".length + length} "Error: qq"`,
+        `default Error.prepareStackTrace: string ${"Error: ".length + length} "Error: qq"`,
+      ],
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+  30_000,
 );


### PR DESCRIPTION
### Problem

- Reading `.stack` of an error with a very long message aborts the process: `panic(main thread): abort() called`, exit code 134. Example: `bun -e 'new Error("q".repeat(2**31-10)).stack'`. The default `Error.prepareStackTrace`, which also runs before a user-defined one, aborts the same way.
- Both formatters in `src/jsc/bindings/FormatStackTraceForJS.cpp` (`formatStackTrace` at :154, `formatStackTraceToJSValue` at :42) use a default-constructed `WTF::StringBuilder`. It calls `CRASH()` on the append that passes `String::MaxLength`. The message and each frame's source URL come from JS.

### Fix

- Both builders record the overflow (`OverflowPolicy::RecordOverflow`). A trace that did not fit becomes the `name: message` header without the frames, or the message alone if the header does not fit either.
- It degrades and does not throw, because `formatStackTrace` also runs from `ErrorInstance::finalizeUnconditionally`, inside a GC, where nothing can throw. `.stack` is then the same whether the GC or the getter computes it.
- A trace under the limit is unchanged. A user `Error.prepareStackTrace` still runs and still gets the call sites.
- Verified: `test/js/node/v8/capture-stack-trace.test.js`, one new test with both paths in one child. Each path aborts alone on 1.4.3. Also `stack.test.ts`, three stack-trace regression tests and `test-error-prepare-stack-trace.js`.

### Background

- `String::MaxLength` is 2^31 - 1 code units. An error message can be that long.
- `.stack` is computed lazily: `ErrorInstance::materializeErrorInfoIfNeeded` calls Bun's hook on the first read. If the GC finds dead frames first, `finalizeUnconditionally` calls the string variant of the same hook.
- `RecordOverflow` makes the builder set a flag that `hasOverflowed()` reports. Later appends do nothing.

<details><summary>Notes</summary>

This is split out of #42202, which is now only about error messages.

Other policies for a trace that does not fit, and why this PR does not take them:
- Throw, like Node. Node v26.3.0 throws `RangeError: Invalid string length` from the `.stack` read for the same input. In Bun the same text is also produced inside a GC, where a throw is not possible, so the two paths would differ. The getter runs under many operations on the error object (`Object.keys`, a property write), which would all start to throw.
- Keep the frames and cut the message. That keeps more information, because the frames are small. It needs the header and the frames built apart, which is a larger change to a function that #40354 and #33584 also edit.

The change is small on purpose: the builder policy and three return sites. It does not touch the parts of the file that #40354 and #33584 change, so any merge order works.

Seen while testing, not caused by this change: `stack.test.ts > Async functions frame should be included in stack trace` fails when it runs in one process after the three regression files (two extra frames). It fails the same way with `src/` at `origin/main`, and it passes alone.

Cost of the test: the length is what is under test, so the child needs a string of about 2 GiB. Both paths run in one child, so the string is allocated once. Each path copies the header once, so the child touches about 6 GB of pages. It takes about 5 s in a debug ASAN build, so it carries a 30 s ceiling. It skips below 10 GiB of total memory, the gate `test/js/bun/transpiler/source-too-large.test.ts` uses.

</details>
