### PR TITLE
node:module: run the file again when the default extension loader is called twice on one module

### DIFF
--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1481,6 +1481,8 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
         RETURN_IF_EXCEPTION(scope, );
         return;
     }
+    // Node's loader runs the file on every call, and `hasEvaluated` survives a body that threw.
+    this->hasEvaluated = false;
     this->evaluate(globalObject, key, source, false);
 }
 

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -162,6 +162,65 @@ test("wrapping an existing extension but it's secretly sync esm", () => {
     require.extensions[".cjs"] = original;
   }
 });
+test("calling the default loader again on the same module runs the file again", () => {
+  using dir = tempDir("extensions-retry", {
+    "throws.js": `
+      exports.first = 1;
+      globalThis.extensionsRetryRuns.push("throws");
+      throw new Error("boom");
+    `,
+    "recovers.js": `
+      exports.first = 1;
+      globalThis.extensionsRetryRuns.push("recovers");
+      if (!globalThis.extensionsRetryFixed) throw new Error("not yet");
+      exports.second = 2;
+    `,
+    "twice.js": `
+      globalThis.extensionsRetryRuns.push("twice");
+      exports.runs = globalThis.extensionsRetryRuns.length;
+    `,
+  });
+  const throws = path.join(String(dir), "throws.js");
+  const recovers = path.join(String(dir), "recovers.js");
+  const twice = path.join(String(dir), "twice.js");
+
+  const original = require.extensions[".js"];
+  const caught: string[] = [];
+  globalThis.extensionsRetryRuns = [];
+  try {
+    require.extensions[".js"] = function (module, filename) {
+      if (filename === twice) {
+        original(module, filename);
+        return original(module, filename);
+      }
+      try {
+        return original(module, filename);
+      } catch (e: any) {
+        caught.push(e.message);
+        globalThis.extensionsRetryFixed = filename === recovers;
+      }
+      return original(module, filename);
+    };
+
+    // Both attempts throw: require() throws and nothing stays in the cache.
+    expect(() => require(throws)).toThrow("boom");
+    expect(throws in require.cache).toBe(false);
+
+    // The second attempt succeeds: require() returns the complete exports.
+    expect(require(recovers)).toEqual({ first: 1, second: 2 });
+    expect(require.cache[recovers].loaded).toBe(true);
+
+    // Two calls that both succeed run the file two times.
+    expect(require(twice)).toEqual({ runs: 6 });
+
+    expect(caught).toEqual(["boom", "not yet"]);
+    expect(globalThis.extensionsRetryRuns).toEqual(["throws", "throws", "recovers", "recovers", "twice", "twice"]);
+  } finally {
+    require.extensions[".js"] = original;
+    delete globalThis.extensionsRetryRuns;
+    delete globalThis.extensionsRetryFixed;
+  }
+});
 test("mutating extensions is banned by some files", () => {
   // vercel is not allowed to mutate require.extensions
   const files = ["node_modules/next/dist/build/next-config-ts/index.js", "node_modules/@meteorjs/babel/index.js"];


### PR DESCRIPTION
### Problem
- A `Module._extensions` hook that retries the previous handler gets a silent no-op. With `try { old(m, f) } catch { old(m, f) }` on a file whose body throws, `require()` returns the half-built exports (`{"first":1}`) and `require.cache[f].loaded` is `true`. Node runs the file again and `require()` throws `boom`.
- The default loader ends in `JSCommonJSModule::evaluate` (`src/jsc/bindings/JSCommonJSModule.cpp`), which returns early when `hasEvaluated` is set. `evaluateCommonJSModuleOnce` sets that flag before the module body runs, so the flag is still set after a body that threw.

### Fix
- `evaluateWithPotentiallyOverriddenCompile` clears `hasEvaluated` before it calls `evaluate`. Only the built-in `Module._extensions` functions reach this code, and only when user code calls them.
- Correct because Node's `Module._extensions['.js']` has no loaded check. It reads the file and calls `module._compile` on every call. A retry through `m._compile(src, f)` already behaved this way in Bun.
- Verified: `test/js/node/module/require-extensions.test.ts` (new test fails on 1.4.3 with `Received function did not throw`). Also ran `test/js/node/module/node-module-module.test.js`.

### Background
- `Module._extensions['.js']` is the function Node calls to load a `.js` file. Libraries wrap it: they store the old function, install their own, and call the old one from inside.
- In Bun the built-in entries are native functions (`jsLoaderJS`, `jsLoaderTS`, `jsLoaderJSON` in `JSCommonJSExtensions.cpp`). They run only when user code calls them. A plain `require()` with no hook never goes through them.
- `hasEvaluated` backs `module.loaded`. It also stops a second evaluation when a module is reached by two paths, for example `import` and `require()` of the same CommonJS file.

<details><summary>Notes</summary>

Repro (same output on 1.4.2, canary, main 6b394bfeb0 before the fix):

```js
const fs = require("fs"), path = require("path"), os = require("os"), Module = require("module");
const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ext-retry-"));
const f = path.join(dir, "half.js");
fs.writeFileSync(f, "exports.first = 1;\nthrow new Error('boom');\nexports.second = 2;\n");
const old = Module._extensions[".js"];
Module._extensions[".js"] = function (mod, filename) {
  try { return old(mod, filename); } catch (e) { console.log("first attempt threw:", e.message); }
  return old(mod, filename);
};
try { console.log("require returned", JSON.stringify(require(f))); } catch (e) { console.log("require threw", e.message); }
console.log("cached:", f in require.cache, "loaded:", require.cache[f] && require.cache[f].loaded);
```

Before: `require returned {"first":1}`, `cached: true loaded: true`. After, and on Node v26.3.0: `require threw boom`, `cached: false loaded: undefined`.

The test also covers a retry that succeeds (complete exports, `loaded` is `true`) and two calls that both succeed (the file runs two times, as in Node).
</details>
