### PR TITLE
node:net: do not dispatch a connect after a 'connectionAttempt' listener destroys the socket

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3143,6 +3143,9 @@ function internalConnect(self, options, address, port, addressType, localAddress
 
   $debug("connect: attempting to connect to %s:%d (addressType: %d)", address, port, addressType);
   self.emit("connectionAttempt", address, port, addressType);
+  // A listener may destroy() the socket. _handle is null then, and doConnect
+  // with no handle would open a native socket that nothing owns or closes.
+  if (!self.connecting) return;
 
   if (addressType === 6 || addressType === 4) {
     if (self.blockList?.check(address, `ipv${addressType}`)) {
@@ -3294,6 +3297,8 @@ function internalConnectMultiple(context, canceled?) {
 
   $debug("connect/multiple: attempting to connect to %s:%d (addressType: %d)", address, port, addressType);
   self.emit("connectionAttempt", address, port, addressType);
+  // Same as internalConnect: a listener may destroy() the socket.
+  if (!self.connecting) return;
 
   // const req = new TCPConnectWrap();
   const req = {};
@@ -3321,9 +3326,9 @@ function internalConnectMultiple(context, canceled?) {
     return;
   }
 
-  // The if(err) above covers sync failure; this catches a sync open or a
-  // destroy() from a 'connectionAttempt' listener. Arming the timer now
-  // would capture a stale handle and overwrite the next attempt's kTimeout.
+  // The if(err) above covers sync failure; this catches a sync open. Arming
+  // the timer now would capture a stale handle and overwrite the next
+  // attempt's kTimeout.
   if (!self.connecting || context.current !== current + 1) {
     return;
   }

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3143,8 +3143,7 @@ function internalConnect(self, options, address, port, addressType, localAddress
 
   $debug("connect: attempting to connect to %s:%d (addressType: %d)", address, port, addressType);
   self.emit("connectionAttempt", address, port, addressType);
-  // A listener may destroy() the socket. _handle is null then, and doConnect
-  // with no handle would open a native socket that nothing owns or closes.
+  // A listener may destroy() the socket; doConnect(null) would open a handle nothing owns.
   if (!self.connecting) return;
 
   if (addressType === 6 || addressType === 4) {
@@ -3326,9 +3325,7 @@ function internalConnectMultiple(context, canceled?) {
     return;
   }
 
-  // The if(err) above covers sync failure; this catches a sync open. Arming
-  // the timer now would capture a stale handle and overwrite the next
-  // attempt's kTimeout.
+  // A sync open already moved on; arming the timer now would overwrite the next attempt's kTimeout.
   if (!self.connecting || context.current !== current + 1) {
     return;
   }

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -745,6 +745,69 @@ it.concurrent.each(["s.unref()", "s.pause()"])("%s survives an autoSelectFamily 
   }
 });
 
+// https://github.com/oven-sh/bun/issues/42307 — destroy() from a 'connectionAttempt' listener nulls _handle before the
+// connect is dispatched. The connect must not start on a fresh native socket that no net.Socket owns.
+describe.concurrent("destroy() inside 'connectionAttempt'", () => {
+  async function run(autoSelectFamily: boolean) {
+    const accepted: string[] = [];
+    const server = createServer(c => {
+      accepted.push(`${c.remoteAddress}:${c.remotePort}`);
+      c.on("error", () => {});
+      c.end();
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const port = server.address().port;
+      const lookup = (_host, opts, cb) =>
+        process.nextTick(
+          cb,
+          null,
+          opts.all
+            ? [
+                { address: "127.0.0.1", family: 4 },
+                { address: "127.0.0.1", family: 4 },
+              ]
+            : "127.0.0.1",
+          4,
+        );
+      const closed: Promise<void>[] = [];
+      let attempts = 0;
+      for (let i = 0; i < 10; i++) {
+        const s = connect({ host: "localhost", port, lookup, autoSelectFamily });
+        s.on("error", () => {});
+        s.on("connectionAttempt", () => {
+          attempts++;
+          s.destroy();
+        });
+        closed.push(new Promise<void>(resolve => s.on("close", () => resolve())));
+      }
+      await Promise.all(closed);
+
+      // The kernel completes loopback connects in the order they were issued, so once the control socket is accepted
+      // every connect dispatched before it has been accepted too. Only the control socket may show up.
+      const control = connect(port, "127.0.0.1");
+      control.on("error", () => {});
+      await once(control, "connect");
+      const controlKey = `${control.localAddress}:${control.localPort}`;
+      while (!accepted.includes(controlKey)) await once(server, "connection");
+      await once(control, "close");
+
+      expect(attempts).toBe(10);
+      expect(accepted).toEqual([controlKey]);
+    } finally {
+      server.close();
+    }
+  }
+
+  it("does not open a connection (single address)", async () => {
+    await run(false);
+  });
+
+  it("does not open a connection (autoSelectFamily)", async () => {
+    await run(true);
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/37086 — node's pending uv_connect_t keeps the loop alive even on an
 // unref'd/non-reading handle, so unref()/pause() issued before or while connecting only take effect once connected.
 describe.concurrent("unref()/pause() around connect()", () => {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -758,6 +758,8 @@ describe.concurrent("destroy() inside 'connectionAttempt'", () => {
     await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
     try {
       const port = server.address().port;
+      // Two distinct addresses keep the autoSelectFamily path on internalConnectMultiple: a lookup that resolves to
+      // one address falls back to internalConnect. The first attempt targets the server.
       const lookup = (_host, opts, cb) =>
         process.nextTick(
           cb,
@@ -765,7 +767,7 @@ describe.concurrent("destroy() inside 'connectionAttempt'", () => {
           opts.all
             ? [
                 { address: "127.0.0.1", family: 4 },
-                { address: "127.0.0.1", family: 4 },
+                { address: "::1", family: 6 },
               ]
             : "127.0.0.1",
           4,


### PR DESCRIPTION
### Problem
- `socket.destroy()` from a `'connectionAttempt'` listener closes the `net.Socket`, but the connect still starts. The server accepts a connection that no `net.Socket` owns. It stays open for the life of the process, and its `TCPSocket` wrapper is never collected.
- `internalConnect` (`src/js/node/net.ts:3145`) emits `'connectionAttempt'` and then calls `kConnectTcp` with no check of the socket state. `_destroy()` has set `_handle = null` by then, so `doConnect(null, opts)` opens a fresh native socket whose `data.self` is the destroyed `net.Socket`. `internalConnectMultiple` (`net.ts:3296`) has the same sequence.

### Fix
- After each `'connectionAttempt'` emit, return when `self.connecting` is false. `_destroy()` clears `connecting`, so this is the same guard that `emitLookup` already uses after the `'lookup'` event.
- Node makes no connection in this case either. Its `internalConnect` throws on `null._handle.connect`. Bun returns in silence instead: the socket already emitted `'close'`.
- Verified: `test/js/node/net/node-net.test.ts` (two new tests in `destroy() inside 'connectionAttempt'`, both fail on stock bun with 10 extra accepted connections). Also the rest of that file, `connect-autoselectfamily-stale-timer.test.ts`, `handle-leak.test.ts`, `double-connect.test.ts`, and the `test-net-connect-*` and `test-net-autoselectfamily*` node parallel tests.

### Background
- `net.Socket.connect()` resolves the host, then `internalConnect` (one address) or `internalConnectMultiple` (`autoSelectFamily`, one attempt per address) dispatches the native connect through `kConnectTcp` and `doConnect(self._handle, opts)`.
- `doConnect` with a null handle asks the native side for a new socket. That path exists for a first connect on a socket with no handle. A destroyed socket also has a null handle, so the native side cannot tell the two apart.
- The test checks the server side: after every client emitted `'close'`, a control connect is made. Loopback connects complete in order, so when the server accepts the control socket, every earlier connect has already been accepted. Only the control socket may be in the accepted list.

<details><summary>Notes</summary>

- The issue's repro script on main prints `serverConns: 20, serverCloses: 0`. With this change it prints `serverConns: 0`.
- The comment in `internalConnectMultiple` above the `!self.connecting` check after `kConnectTcp` named a `'connectionAttempt'` destroy as one of the cases it covers. That case now returns earlier, so the comment names only the sync open.
- `node-net.test.ts` has a set of tests that fail in this container with and without the change (`net.Socket read > ... .connect(port)`, `unref should exit`, `#13126`). They connect to a `Bun.listen({ hostname: "localhost" })` server and get ECONNREFUSED on 127.0.0.1. They fail the same way on stock bun here.
- #42295 is related but separate: it lets the GC collect a handle whose socket was destroyed before the connect completes. It does not change the JS dispatch path.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->