### PR TITLE
socket(windows): release the attempt ref when a named-pipe connect fails synchronously

### DIFF
--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1304,7 +1304,13 @@ impl Listener {
                     };
                     let named_pipe = match named_pipe_result {
                         Ok(p) => p,
-                        Err(_) => return Ok(promise_value),
+                        Err(_) => {
+                            // The context's guard already ran `handle_connect_error`
+                            // on the still-detached socket, which releases nothing.
+                            // Balance the attempt `tls_ref.ref_()` above.
+                            TLSSocket::deref(&tls_ref);
+                            return Ok(promise_value);
+                        }
                     };
                     tls_ref.socket.set(uws::NewSocketHandler {
                         socket: uws::InternalSocket::Pipe(named_pipe.cast()),
@@ -1383,7 +1389,11 @@ impl Listener {
                     };
                     let named_pipe = match named_pipe_result {
                         Ok(p) => p,
-                        Err(_) => return Ok(promise_value),
+                        Err(_) => {
+                            // Balance the attempt `tcp_ref.ref_()` above; see the TLS arm.
+                            TCPSocket::deref(&tcp_ref);
+                            return Ok(promise_value);
+                        }
                     };
                     tcp_ref.socket.set(uws::NewSocketHandler {
                         socket: uws::InternalSocket::Pipe(named_pipe.cast()),

--- a/test/js/bun/net/socket-retention.test.ts
+++ b/test/js/bun/net/socket-retention.test.ts
@@ -296,3 +296,54 @@ test("node:net reconnect after connectError does not accumulate wrappers", async
   expect(exitCode).toBe(0);
   void stderr;
 }, 30_000);
+
+// Windows routes `unix:` through WindowsNamedPipeContext. A connect that fails
+// before libuv queues it (here: a TLS config that cannot build a context)
+// reports the error through `handle_connect_error` while the socket is still
+// detached, so that path releases nothing. The attempt ref taken in
+// `connect_inner` must be released by the caller, as the POSIX path does.
+test.skipIf(!isWindows)(
+  "a named-pipe connect that fails synchronously does not leak the native socket",
+  async () => {
+    const script = /* js */ `
+    const { heapStats } = require("bun:jsc");
+    const socket = { open() {}, data() {}, close() {}, error() {}, connectError() {} };
+    const opts = {
+      unix: "\\\\\\\\.\\\\pipe\\\\bun-missing-" + process.pid,
+      tls: { cert: "not a cert", key: "not a key" },
+    };
+    async function run(n) {
+      for (let i = 0; i < n; i += 100) {
+        await Promise.all(Array.from({ length: 100 }, () => Bun.connect({ ...opts, socket }).catch(() => {})));
+      }
+      for (let k = 0; k < 3; k++) {
+        Bun.gc(true);
+        await new Promise(r => setImmediate(r));
+      }
+    }
+    // Live mimalloc pages: allocator bookkeeping, independent of OS reclamation.
+    function pageCount() {
+      return heapStats().mimalloc.page_bins.reduce((a, b) => a + b.current, 0);
+    }
+    await run(4000);
+    const before = pageCount();
+    await run(4000);
+    const after = pageCount();
+    console.log(JSON.stringify({ before, after, delta: after - before }));
+  `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, BUN_GARBAGE_COLLECTOR_LEVEL: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const { before, after, delta } = JSON.parse(stdout.trim().split("\n").pop()!);
+    // Without the balancing deref each run of 4000 leaks about 16 pages
+    // (release) and many more under debug. With it the delta is heap noise.
+    expect(delta, `mimalloc page count: ${before} -> ${after}`).toBeLessThan(10);
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);


### PR DESCRIPTION
### Problem
- On Windows, a `Bun.connect({ unix: "\\\\.\\pipe\\..." })` that fails synchronously leaks the native `NewSocket` and its connection path. The JS wrapper is collected, but live mimalloc pages grow by about 20 for each 5000 failed connects (81, 104, 124, 145 over four rounds). Fixes #42309.
- Cause: the two named-pipe arms of `Listener::connect_inner` (`src/runtime/socket/Listener.rs:1283` and `:1359`) take an attempt reference with `ref_()` and then return on `Err(_)` without a release. The `FailAndRelease` guard in `WindowsNamedPipeContext` runs `handle_connect_error` on a socket that is still `Detached`, so `needs_deref` is false and the teardown releases nothing. The guard only releases the `+1` that `create()` took.

### Fix
- On the `Err(_)` path of both arms, call `NewSocket::deref` to balance the attempt `ref_()`.
- This matches what `connect_finish` does for TCP and unix sockets on its synchronous failure path (added in #30168).
- Verified: `test/js/bun/net/socket-retention.test.ts`, new Windows-only test. On stock bun it fails with a delta of 18 pages. With the fix the delta is 0 to 1. The issue's repro script is flat with the fix (44, 45, 45, 45). Also ran `test/js/bun/net/socket.test.ts` and `named-pipe-listen-error.test.ts` on Windows x64: 93 pass, 0 fail.

### Background
- `NewSocket` is the native struct behind `TCPSocket`/`TLSSocket`. It is intrusively refcounted. The JS wrapper holds one reference. A connect attempt takes one more so the struct outlives the attempt, and the attempt's teardown releases it.
- On POSIX, `connect_finish` owns the attempt. On Windows, a `unix:` path goes through `WindowsNamedPipeContext`, a libuv pipe owner. Its `connect`/`open` can fail before libuv queues anything (`init_tls_wrapper`, `uv_pipe_init`, `uv_pipe_open`, a synchronous `uv_pipe_connect2` error).
- `handle_connect_error` releases the attempt reference only when the socket is attached (`needs_deref`). On the synchronous failure path the socket is attached only after success, so the caller has to release.

<details><summary>Notes</summary>

- The test is skipped on non-Windows. The fail-before run was done on Windows Server 2019 x64 with `USE_SYSTEM_BUN=1 bun test` (1.4.3-canary.1, 81f97bb02): `mimalloc page count: 77 -> 95`, expected `< 10`. The fixed debug build passes the whole file: 5 pass, 1 skip.
- The measurement is the same one as the POSIX test `should not leak when connect({path}) fails synchronously on a reused handle` in `test/js/node/net/node-net.test.ts`.
- The synchronous failure in the test comes from the TLS arm: `tls: { cert: "not a cert", key: "not a key" }` makes `init_tls_wrapper` reject. The TCP arm has the same shape and gets the same fix.
- #42295 touches the same arms (it replaces `get_this_value` with `this_value_for_connect`) but does not change the `Err(_)` path.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/net/socket-retention.test.ts

<!-- robobun:evidence:end -->