### PR TITLE
Bound libdeflate's emit path so a racing input cannot overrun the output

### DIFF
--- a/patches/libdeflate/bounded-emit.patch
+++ b/patches/libdeflate/bounded-emit.patch
@@ -1,0 +1,49 @@
+Bound the two emit-path writes that only an ASSERT guards.
+
+deflate_flush_block() costs a block from the symbol frequencies of a first
+pass over the input, compares that cost against the space left in the output
+buffer once, then emits the block in a second pass with no further bounds
+check. That is sound only when the input cannot change between the two
+passes. Bun hands libdeflate memory that another thread can write: a view
+over a SharedArrayBuffer, a MAP_SHARED Bun.mmap region, an external buffer
+from bun:ffi or N-API, or a plain buffer that an in-flight fs.read fills. A
+write between the passes makes the emitted block longer than the cost, and
+the emit path then runs off the end of the output buffer.
+
+The word-at-a-time flush is already bounded by out_fast_end, so the hot path
+does not change. The two writes below are reachable only on the slow
+byte-at-a-time tail and on the final partial byte. Both are guarded by
+ASSERT alone, which a release build compiles out. Set the existing overflow
+flag instead, which makes the call return 0. Every caller already treats 0
+as "the output did not fit".
+
+Upstream treats a stable input as the caller's contract, so this is a local
+hardening patch rather than a fix waiting on a release. If upstream ever
+bounds these writes, this patch stops applying and the build fails, which is
+the signal to drop it.
+
+--- a/lib/deflate_compress.c
++++ b/lib/deflate_compress.c
+@@ -742,8 +742,10 @@
+ 	} else {							\
+ 		/* Flush a byte at a time. */				\
+ 		while (bitcount >= 8) {					\
+-			ASSERT(out_next < os->end);			\
+-			*out_next++ = bitbuf;				\
++			if (likely(out_next < os->end))			\
++				*out_next++ = bitbuf;			\
++			else						\
++				os->overflow = true;			\
+ 			bitcount -= 8;					\
+ 			bitbuf >>= 8;					\
+ 		}							\
+@@ -4056,7 +4058,8 @@
+ 	 */
+ 	ASSERT(os.bitcount <= 7);
+ 	if (os.bitcount) {
+-		ASSERT(os.next < os.end);
++		if (unlikely(os.next >= os.end))
++			return 0;
+ 		*os.next++ = os.bitbuf;
+ 	}
+ 

--- a/scripts/build/deps/libdeflate.ts
+++ b/scripts/build/deps/libdeflate.ts
@@ -21,6 +21,8 @@ export const libdeflate: Dependency = {
     commit: LIBDEFLATE_COMMIT,
   }),
 
+  patches: ["patches/libdeflate/bounded-emit.patch"],
+
   build: () => ({
     kind: "direct",
     sources: [

--- a/src/http/compress_body.rs
+++ b/src/http/compress_body.rs
@@ -84,7 +84,7 @@ pub(crate) fn compress_into(
 }
 
 /// libdeflate one-shot fast path into `state.shared_buffer`. Returns `None`
-/// when the bound exceeds the shared buffer or no compressor can be allocated — caller falls back to
+/// when the bound exceeds the shared buffer, no compressor can be allocated, or the output did not fit — caller falls back to
 /// [`compress_zlib_streaming`].
 fn compress_libdeflate_fast(
     state: &mut LibdeflateState,
@@ -121,9 +121,6 @@ fn compress_libdeflate_fast(
     };
 
     let result = compressor.compress(input, shared_buffer, enc);
-    // `InsufficientSpace` means the output outgrew the bound, which an input
-    // another thread rewrote during the call can do. Fall back to streaming
-    // zlib, which bounds every write by `avail_out`.
     (result.status == Status::Success).then_some(result.written)
 }
 

--- a/src/http/compress_body.rs
+++ b/src/http/compress_body.rs
@@ -92,7 +92,7 @@ fn compress_libdeflate_fast(
     enc: bun_libdeflate_sys::libdeflate::Encoding,
     level: Option<i32>,
 ) -> Option<usize> {
-    use bun_libdeflate_sys::libdeflate::{Compressor, OwnedCompressor};
+    use bun_libdeflate_sys::libdeflate::{Compressor, OwnedCompressor, Status};
 
     // Split-borrow so the compressor handle and `shared_buffer` can be used
     // together.
@@ -120,7 +120,11 @@ fn compress_libdeflate_fast(
         _ => cached,
     };
 
-    Some(compressor.compress(input, shared_buffer, enc).written)
+    let result = compressor.compress(input, shared_buffer, enc);
+    // `InsufficientSpace` means the output outgrew the bound, which an input
+    // another thread rewrote during the call can do. Fall back to streaming
+    // zlib, which bounds every write by `avail_out`.
+    (result.status == Status::Success).then_some(result.written)
 }
 
 /// Slow path for gzip/deflate when the libdeflate one-shot bound exceeds the

--- a/src/libdeflate_sys/libdeflate.rs
+++ b/src/libdeflate_sys/libdeflate.rs
@@ -76,11 +76,7 @@ bun_opaque::opaque_ffi! {
     pub struct Compressor;
 }
 
-/// The one-shot compressors return 0 when the output did not fit. Report that
-/// as [`Status::InsufficientSpace`] so a caller cannot read it as an empty
-/// result. Sizing the output with `*_compress_bound` makes 0 unreachable for an
-/// input that holds still, but an input another thread writes during the call
-/// can still outgrow the bound.
+/// libdeflate's one-shot compressors return 0 when the output did not fit.
 #[inline]
 fn compress_result(read: usize, written: usize) -> Result {
     Result {

--- a/src/libdeflate_sys/libdeflate.rs
+++ b/src/libdeflate_sys/libdeflate.rs
@@ -76,6 +76,24 @@ bun_opaque::opaque_ffi! {
     pub struct Compressor;
 }
 
+/// The one-shot compressors return 0 when the output did not fit. Report that
+/// as [`Status::InsufficientSpace`] so a caller cannot read it as an empty
+/// result. Sizing the output with `*_compress_bound` makes 0 unreachable for an
+/// input that holds still, but an input another thread writes during the call
+/// can still outgrow the bound.
+#[inline]
+fn compress_result(read: usize, written: usize) -> Result {
+    Result {
+        read,
+        written,
+        status: if written == 0 {
+            Status::InsufficientSpace
+        } else {
+            Status::Success
+        },
+    }
+}
+
 impl Compressor {
     pub(crate) fn alloc(compression_level: c_int) -> *mut Compressor {
         libdeflate_alloc_compressor(compression_level)
@@ -93,11 +111,7 @@ impl Compressor {
                 output.len(),
             )
         };
-        Result {
-            read: input.len(),
-            written,
-            status: Status::Success,
-        }
+        compress_result(input.len(), written)
     }
 
     pub fn max_bytes_needed(&mut self, input: &[u8], encoding: Encoding) -> usize {
@@ -142,11 +156,7 @@ impl Compressor {
                 Encoding::Gzip => libdeflate_gzip_compress(self, in_ptr, in_len, out_ptr, out_len),
             }
         };
-        Result {
-            read: in_len,
-            written,
-            status: Status::Success,
-        }
+        compress_result(in_len, written)
     }
 
     /// Compress `input` onto the end of `out`, reserving the bound first; `Err` if that allocation fails.
@@ -178,11 +188,7 @@ impl Compressor {
                 output.len(),
             )
         };
-        Result {
-            read: input.len(),
-            written: result,
-            status: Status::Success,
-        }
+        compress_result(input.len(), result)
     }
 
     pub(crate) fn gzip(&mut self, input: &[u8], output: &mut [u8]) -> Result {
@@ -196,11 +202,7 @@ impl Compressor {
                 output.len(),
             )
         };
-        Result {
-            read: input.len(),
-            written: result,
-            status: Status::Success,
-        }
+        compress_result(input.len(), result)
     }
 }
 

--- a/test/js/node/zlib/libdeflate-racing-input-fixture.ts
+++ b/test/js/node/zlib/libdeflate-racing-input-fixture.ts
@@ -22,22 +22,17 @@ if (isMainThread) {
 
   const view = new Uint8Array(shared);
 
-  // The contract is memory safety, not a particular value. A racing input may
-  // outgrow the bound, which reports "insufficient space" rather than writing
-  // past the buffer. Either outcome is fine. A crash is not.
-  let compressed = 0;
-  let refused = 0;
   for (let i = 0; i < CALLS; i++) {
     for (const compress of [Bun.deflateSync, Bun.gzipSync]) {
       try {
-        if (compress(view, { library: "libdeflate" }).length > 0) compressed++;
+        compress(view, { library: "libdeflate" });
       } catch (error) {
+        // A racing input may outgrow the bound. That call is refused, which is fine. A crash is not.
         if (!/insufficient space/.test((error as Error).message)) throw error;
-        refused++;
       }
     }
   }
-  console.log(JSON.stringify({ compressed: compressed > 0, refused: refused > 0 }));
+  console.log("done");
   process.exit(0);
 } else {
   const view = new Uint8Array(workerData as SharedArrayBuffer);

--- a/test/js/node/zlib/libdeflate-racing-input-fixture.ts
+++ b/test/js/node/zlib/libdeflate-racing-input-fixture.ts
@@ -1,0 +1,69 @@
+// Bun.deflateSync and Bun.gzipSync over an input a worker rewrites during the
+// call.
+//
+// libdeflate reads the input twice: it costs the deflate block from the first
+// pass, compares that cost against the output buffer once, then emits the
+// block in a second pass with no further bounds check. Bun sizes the output
+// with libdeflate_deflate_compress_bound, so the cost always fits for an input
+// that holds still. An input another thread rewrites between the two passes
+// can outgrow that bound, and the emit pass then writes past the buffer.
+import { isMainThread, parentPort, Worker, workerData } from "node:worker_threads";
+
+const SIZE = 4096;
+// Unpatched, a sanitizer build aborts well inside this many calls.
+const CALLS = Number(process.env.CALLS || 200);
+const FLIP_BUDGET_MS = 30_000;
+
+if (isMainThread) {
+  const shared = new SharedArrayBuffer(SIZE);
+  const worker = new Worker(new URL(import.meta.url), { workerData: shared });
+  await new Promise(resolve => worker.on("message", resolve));
+  worker.unref();
+
+  const view = new Uint8Array(shared);
+
+  // The contract is memory safety, not a particular value. A racing input may
+  // outgrow the bound, which reports "insufficient space" rather than writing
+  // past the buffer. Either outcome is fine. A crash is not.
+  let compressed = 0;
+  let refused = 0;
+  for (let i = 0; i < CALLS; i++) {
+    for (const compress of [Bun.deflateSync, Bun.gzipSync]) {
+      try {
+        if (compress(view, { library: "libdeflate" }).length > 0) compressed++;
+      } catch (error) {
+        if (!/insufficient space/.test((error as Error).message)) throw error;
+        refused++;
+      }
+    }
+  }
+  console.log(JSON.stringify({ compressed: compressed > 0, refused: refused > 0 }));
+  process.exit(0);
+} else {
+  const view = new Uint8Array(workerData as SharedArrayBuffer);
+
+  // xorshift32, so both patterns are the same on every run. `cheap` holds
+  // bytes 0x00 to 0x7f plus 16 single occurrences of the bytes `costly` is
+  // made of. Those 16 get the longest codewords in the code built from
+  // `cheap`, so re-emitting `costly` through that code needs about twice the
+  // space the cost pass reserved.
+  let state = 88172645;
+  const next = () => ((state ^= state << 13), (state ^= state >>> 17), (state ^= state << 5), state >>> 0);
+  const cheap = new Uint8Array(view.length);
+  const costly = new Uint8Array(view.length);
+  for (let i = 0; i < view.length; i++) {
+    cheap[i] = next() & 0x7f;
+    costly[i] = 0xf0 + (next() & 0x0f);
+  }
+  for (let i = 0; i < 16; i++) cheap[next() % view.length] = 0xf0 + i;
+
+  parentPort!.postMessage("ready");
+
+  const deadline = Date.now() + FLIP_BUDGET_MS;
+  while (Date.now() < deadline) {
+    view.set(cheap);
+    for (let i = next() % 50000; i > 0; i--);
+    view.set(costly);
+    for (let i = next() % 5000; i > 0; i--);
+  }
+}

--- a/test/js/node/zlib/libdeflate-racing-input-fixture.ts
+++ b/test/js/node/zlib/libdeflate-racing-input-fixture.ts
@@ -7,6 +7,9 @@
 // with libdeflate_deflate_compress_bound, so the cost always fits for an input
 // that holds still. An input another thread rewrites between the two passes
 // can outgrow that bound, and the emit pass then writes past the buffer.
+//
+// With the emit path bounded, that same call returns 0 instead. It has to
+// surface as an error, never as an empty result.
 import { isMainThread, parentPort, Worker, workerData } from "node:worker_threads";
 
 const SIZE = 4096;
@@ -24,11 +27,18 @@ if (isMainThread) {
 
   for (let i = 0; i < CALLS; i++) {
     for (const compress of [Bun.deflateSync, Bun.gzipSync]) {
+      let output: Uint8Array;
       try {
-        compress(view, { library: "libdeflate" });
+        output = compress(view, { library: "libdeflate" });
       } catch (error) {
         // A racing input may outgrow the bound. That call is refused, which is fine. A crash is not.
         if (!/insufficient space/.test((error as Error).message)) throw error;
+        continue;
+      }
+      // libdeflate returns 0 for "did not fit". Read as a byte count, that is an empty stream handed back as success.
+      if (output.length === 0) {
+        console.log(`${compress.name} returned an empty result on call ${i}`);
+        process.exit(1);
       }
     }
   }

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -1,6 +1,6 @@
 import { deflateSync, gunzipSync, gzipSync, inflateSync } from "bun";
 import { describe, expect, it } from "bun:test";
-import { tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
 import * as buffer from "node:buffer";
 import { randomFillSync } from "node:crypto";
 import * as fs from "node:fs";
@@ -815,5 +815,54 @@ describe("crc32", () => {
     expect(() => zlib.crc32(undefined)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
     // Omitted second arg defaults to value=0.
     expect(zlib.crc32("hello")).toBe(zlib.crc32("hello", 0));
+  });
+});
+
+describe("libdeflate one-shot", () => {
+  // libdeflate reads the input twice: it costs the deflate block from the
+  // first pass, compares that cost against the output buffer once, then emits
+  // the block in a second pass with no further bounds check. Bun sizes the
+  // output with the compress bound, so the cost always fits for an input that
+  // holds still. An input another thread rewrites between the two passes can
+  // outgrow the bound, and the emit pass then wrote past the buffer. Only a
+  // sanitizer sees that write, so the race test needs one.
+  it.skipIf(!isASAN)("does not overrun the output when a writer races the input", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), resolve(import.meta.dir, "libdeflate-racing-input-fixture.ts")],
+      env: {
+        ...bunEnv,
+        // Symbolizing a sanitizer report costs several seconds, which is
+        // longer than the budget for this test.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Whether the race fires within the call budget is luck, so `refused` is
+    // reported but not asserted. Surviving it is the point.
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toMatchObject({ compressed: true });
+    expect(exitCode).toBe(0);
+    // Booting a worker under a sanitizer costs about 3s before the race even
+    // starts, so this one needs more than the default ceiling.
+  }, 20_000);
+
+  it("compresses an input that holds still", () => {
+    // The bound covers every stable input, so the one-shot path never reports
+    // "insufficient space" here, whatever the data looks like.
+    for (const input of [
+      new Uint8Array(0),
+      new Uint8Array([0]),
+      new Uint8Array(64 * 1024).fill(7),
+      randomFillSync(new Uint8Array(64 * 1024)),
+    ]) {
+      for (const library of ["libdeflate", "zlib"]) {
+        expect(Buffer.from(gunzipSync(gzipSync(input, { library })))).toEqual(Buffer.from(input));
+        expect(Buffer.from(inflateSync(deflateSync(input, { library })))).toEqual(Buffer.from(input));
+      }
+    }
   });
 });

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -821,7 +821,7 @@ describe("crc32", () => {
 describe("libdeflate one-shot", () => {
   // The fixture explains the race. Only a sanitizer sees the stray write.
   it.skipIf(!isASAN)(
-    "does not overrun the output when a writer races the input",
+    "neither overruns the output nor returns an empty result when a writer races the input",
     async () => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), resolve(import.meta.dir, "libdeflate-racing-input-fixture.ts")],

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -819,44 +819,26 @@ describe("crc32", () => {
 });
 
 describe("libdeflate one-shot", () => {
-  // libdeflate reads the input twice: it costs the deflate block from the
-  // first pass, compares that cost against the output buffer once, then emits
-  // the block in a second pass with no further bounds check. Bun sizes the
-  // output with the compress bound, so the cost always fits for an input that
-  // holds still. An input another thread rewrites between the two passes can
-  // outgrow the bound, and the emit pass then wrote past the buffer. Only a
-  // sanitizer sees that write, so the race test needs one.
+  // The fixture explains the race. Only a sanitizer sees the stray write.
   it.skipIf(!isASAN)(
     "does not overrun the output when a writer races the input",
     async () => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), resolve(import.meta.dir, "libdeflate-racing-input-fixture.ts")],
-        env: {
-          ...bunEnv,
-          // Symbolizing a sanitizer report costs several seconds, which is
-          // longer than the budget for this test.
-          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
-        },
+        // symbolize=0: symbolizing a sanitizer report takes longer than the test may run.
+        env: { ...bunEnv, ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":") },
         stdout: "pipe",
         stderr: "pipe",
       });
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      // Whether the race fires within the call budget is luck, so `refused` is
-      // reported but not asserted. Surviving it is the point.
-      expect(stderr).toBe("");
-      expect(JSON.parse(stdout.trim())).toMatchObject({ compressed: true });
-      expect(exitCode).toBe(0);
-      // Booting a worker under a sanitizer costs about 3s before the race even
-      // starts, so this one needs more than the default ceiling.
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "done", stderr: "", exitCode: 0 });
     },
+    // A debug sanitizer build needs about 3s to boot the worker, before the race starts.
     20_000,
   );
 
   it("compresses an input that holds still", () => {
-    // The bound covers every stable input, so the one-shot path never reports
-    // "insufficient space" here, whatever the data looks like.
     for (const input of [
       new Uint8Array(0),
       new Uint8Array([0]),

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -826,29 +826,33 @@ describe("libdeflate one-shot", () => {
   // holds still. An input another thread rewrites between the two passes can
   // outgrow the bound, and the emit pass then wrote past the buffer. Only a
   // sanitizer sees that write, so the race test needs one.
-  it.skipIf(!isASAN)("does not overrun the output when a writer races the input", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), resolve(import.meta.dir, "libdeflate-racing-input-fixture.ts")],
-      env: {
-        ...bunEnv,
-        // Symbolizing a sanitizer report costs several seconds, which is
-        // longer than the budget for this test.
-        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+  it.skipIf(!isASAN)(
+    "does not overrun the output when a writer races the input",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), resolve(import.meta.dir, "libdeflate-racing-input-fixture.ts")],
+        env: {
+          ...bunEnv,
+          // Symbolizing a sanitizer report costs several seconds, which is
+          // longer than the budget for this test.
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Whether the race fires within the call budget is luck, so `refused` is
-    // reported but not asserted. Surviving it is the point.
-    expect(stderr).toBe("");
-    expect(JSON.parse(stdout.trim())).toMatchObject({ compressed: true });
-    expect(exitCode).toBe(0);
-    // Booting a worker under a sanitizer costs about 3s before the race even
-    // starts, so this one needs more than the default ceiling.
-  }, 20_000);
+      // Whether the race fires within the call budget is luck, so `refused` is
+      // reported but not asserted. Surviving it is the point.
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout.trim())).toMatchObject({ compressed: true });
+      expect(exitCode).toBe(0);
+      // Booting a worker under a sanitizer costs about 3s before the race even
+      // starts, so this one needs more than the default ceiling.
+    },
+    20_000,
+  );
 
   it("compresses an input that holds still", () => {
     // The bound covers every stable input, so the one-shot path never reports

--- a/test/js/web/websocket/websocket-permessage-deflate.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate.test.ts
@@ -607,26 +607,30 @@ test("every ServerWebSocket send method delivers the bytes of a SharedArrayBuffe
 // Both memory kinds race. Sharing is not the property that matters, so
 // "mmap" (a plain Uint8Array over a MAP_SHARED region) must hold too.
 describe.each(["sab", "mmap"])("ws.send() of %s memory a writer races", mode => {
-  test.skipIf(!isASAN)("does not overrun the deflate buffer", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), path.join(import.meta.dir, "websocket-shared-buffer-deflate-fixture.ts")],
-      env: {
-        ...bunEnv,
-        MODE: mode,
-        // Symbolizing a sanitizer report costs several seconds, which is
-        // longer than the budget for this test. Raw frames still say it failed.
-        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+  test.skipIf(!isASAN)(
+    "does not overrun the deflate buffer",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), path.join(import.meta.dir, "websocket-shared-buffer-deflate-fixture.ts")],
+        env: {
+          ...bunEnv,
+          MODE: mode,
+          // Symbolizing a sanitizer report costs several seconds, which is
+          // longer than the budget for this test. Raw frames still say it failed.
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout.trim()).toBe("done");
-    expect(stderr).toBe("");
-    expect(exitCode).toBe(0);
-    // Booting a worker under a sanitizer costs about 3s before the race even
-    // starts, so this one needs more than the default ceiling.
-  }, 20_000);
+      expect(stdout.trim()).toBe("done");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      // Booting a worker under a sanitizer costs about 3s before the race even
+      // starts, so this one needs more than the default ceiling.
+    },
+    20_000,
+  );
 });

--- a/test/js/web/websocket/websocket-permessage-deflate.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate.test.ts
@@ -1,5 +1,7 @@
 import { serve, type ServerWebSocket } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN } from "harness";
+import path from "node:path";
 
 test("WebSocket client negotiates permessage-deflate", async () => {
   let serverReceivedExtensions = "";
@@ -539,4 +541,92 @@ test("server enforces maxPayloadLength on compressed messages inflated through t
   expect(events[1]).toBe("close");
 
   expect(serverReceived).toEqual([900]);
+});
+
+test("every ServerWebSocket send method delivers the bytes of a SharedArrayBuffer view", async () => {
+  const shared = new SharedArrayBuffer(4000);
+  const payload = new Uint8Array(shared);
+  for (let i = 0; i < payload.length; i++) payload[i] = (i * 7) & 0xff;
+  // A control frame carries at most 125 bytes.
+  const control = new Uint8Array(shared, 100, 125);
+
+  using server = serve({
+    port: 0,
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response("Not found", { status: 404 });
+    },
+    websocket: {
+      perMessageDeflate: true,
+      // The one client is also the one subscriber, so it has to see its own publishes.
+      publishToSelf: true,
+      open(ws) {
+        ws.subscribe("topic");
+        ws.send(payload, true);
+        ws.sendBinary(payload, true);
+        ws.publish("topic", payload, true);
+        ws.publishBinary("topic", payload, true);
+        server.publish("topic", payload, true);
+        ws.ping(control);
+        ws.pong(control);
+      },
+      message() {},
+    },
+  });
+
+  const received = { message: [] as Buffer[], ping: [] as Buffer[], pong: [] as Buffer[] };
+  const all = Promise.withResolvers<void>();
+  const client = new WebSocket(`ws://localhost:${server.port}`);
+  for (const kind of ["message", "ping", "pong"] as const) {
+    client.addEventListener(kind, ({ data }) => {
+      received[kind].push(data);
+      if (received.message.length === 5 && received.ping.length === 1 && received.pong.length === 1) all.resolve();
+    });
+  }
+  client.addEventListener("error", all.reject);
+  client.addEventListener("close", all.reject);
+
+  await all.promise;
+  expect(client.extensions).toContain("permessage-deflate");
+  expect(received).toEqual({
+    message: Array(5).fill(Buffer.from(payload)),
+    ping: [Buffer.from(control)],
+    pong: [Buffer.from(control)],
+  });
+  client.close();
+});
+
+// libdeflate reads the input twice in one call: it costs the deflate block from
+// the first pass, compares that cost against the room left in the 4 KiB
+// uWS::DeflationStream::reset_buffer once, then emits the block in a second
+// pass with no further bounds check. A worker that rewrites the input between
+// the two passes made the emitted block longer than the cost, so the second
+// pass wrote past that buffer. Only a sanitizer sees that write: without one
+// the stray bytes land in a neighbouring allocation and the run exits 0.
+//
+// Both memory kinds race. Sharing is not the property that matters, so
+// "mmap" (a plain Uint8Array over a MAP_SHARED region) must hold too.
+describe.each(["sab", "mmap"])("ws.send() of %s memory a writer races", mode => {
+  test.skipIf(!isASAN)("does not overrun the deflate buffer", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "websocket-shared-buffer-deflate-fixture.ts")],
+      env: {
+        ...bunEnv,
+        MODE: mode,
+        // Symbolizing a sanitizer report costs several seconds, which is
+        // longer than the budget for this test. Raw frames still say it failed.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.trim()).toBe("done");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    // Booting a worker under a sanitizer costs about 3s before the race even
+    // starts, so this one needs more than the default ceiling.
+  }, 20_000);
 });

--- a/test/js/web/websocket/websocket-permessage-deflate.test.ts
+++ b/test/js/web/websocket/websocket-permessage-deflate.test.ts
@@ -1,6 +1,6 @@
 import { serve, type ServerWebSocket } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 import path from "node:path";
 
 test("WebSocket client negotiates permessage-deflate", async () => {
@@ -577,46 +577,42 @@ test("every ServerWebSocket send method delivers the bytes of a SharedArrayBuffe
   const received = { message: [] as Buffer[], ping: [] as Buffer[], pong: [] as Buffer[] };
   const all = Promise.withResolvers<void>();
   const client = new WebSocket(`ws://localhost:${server.port}`);
-  for (const kind of ["message", "ping", "pong"] as const) {
-    client.addEventListener(kind, ({ data }) => {
-      received[kind].push(data);
-      if (received.message.length === 5 && received.ping.length === 1 && received.pong.length === 1) all.resolve();
-    });
-  }
-  client.addEventListener("error", all.reject);
-  client.addEventListener("close", all.reject);
+  try {
+    for (const kind of ["message", "ping", "pong"] as const) {
+      client.addEventListener(kind, ({ data }) => {
+        received[kind].push(data);
+        if (received.message.length === 5 && received.ping.length === 1 && received.pong.length === 1) all.resolve();
+      });
+    }
+    client.addEventListener("error", all.reject);
+    client.addEventListener("close", all.reject);
 
-  await all.promise;
-  expect(client.extensions).toContain("permessage-deflate");
-  expect(received).toEqual({
-    message: Array(5).fill(Buffer.from(payload)),
-    ping: [Buffer.from(control)],
-    pong: [Buffer.from(control)],
-  });
-  client.close();
+    await all.promise;
+    expect(client.extensions).toContain("permessage-deflate");
+    expect(received).toEqual({
+      message: Array(5).fill(Buffer.from(payload)),
+      ping: [Buffer.from(control)],
+      pong: [Buffer.from(control)],
+    });
+  } finally {
+    client.close();
+  }
 });
 
-// libdeflate reads the input twice in one call: it costs the deflate block from
-// the first pass, compares that cost against the room left in the 4 KiB
-// uWS::DeflationStream::reset_buffer once, then emits the block in a second
-// pass with no further bounds check. A worker that rewrites the input between
-// the two passes made the emitted block longer than the cost, so the second
-// pass wrote past that buffer. Only a sanitizer sees that write: without one
-// the stray bytes land in a neighbouring allocation and the run exits 0.
-//
-// Both memory kinds race. Sharing is not the property that matters, so
-// "mmap" (a plain Uint8Array over a MAP_SHARED region) must hold too.
+// The fixture explains the race. Only a sanitizer sees the stray write. "mmap" is a
+// plain Uint8Array over a MAP_SHARED region: a SharedArrayBuffer is not the only racing input.
 describe.each(["sab", "mmap"])("ws.send() of %s memory a writer races", mode => {
   test.skipIf(!isASAN)(
     "does not overrun the deflate buffer",
     async () => {
+      using dir = tempDir("ws-deflate-race", { "bytes.bin": Buffer.alloc(4000) });
       await using proc = Bun.spawn({
         cmd: [bunExe(), path.join(import.meta.dir, "websocket-shared-buffer-deflate-fixture.ts")],
         env: {
           ...bunEnv,
           MODE: mode,
-          // Symbolizing a sanitizer report costs several seconds, which is
-          // longer than the budget for this test. Raw frames still say it failed.
+          FILE: path.join(String(dir), "bytes.bin"),
+          // symbolize=0: symbolizing a sanitizer report takes longer than the test may run.
           ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
         },
         stdout: "pipe",
@@ -624,13 +620,9 @@ describe.each(["sab", "mmap"])("ws.send() of %s memory a writer races", mode => 
       });
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stdout.trim()).toBe("done");
-      expect(stderr).toBe("");
-      expect(exitCode).toBe(0);
-      // Booting a worker under a sanitizer costs about 3s before the race even
-      // starts, so this one needs more than the default ceiling.
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "done", stderr: "", exitCode: 0 });
     },
+    // A debug sanitizer build needs about 3s to boot the worker, before the race starts.
     20_000,
   );
 });

--- a/test/js/web/websocket/websocket-shared-buffer-deflate-fixture.ts
+++ b/test/js/web/websocket/websocket-shared-buffer-deflate-fixture.ts
@@ -1,0 +1,99 @@
+// A Bun.serve WebSocket sends the same bytes with permessage-deflate on while
+// a worker rewrites them. MODE picks the memory another thread can write:
+// "sab" a SharedArrayBuffer view, "mmap" a MAP_SHARED Bun.mmap region.
+//
+// uWS hands the payload straight to libdeflate_deflate_compress, which reads
+// the input twice: the first pass costs the deflate block against the space
+// left in the 4 KiB uWS::DeflationStream::reset_buffer, and the second pass
+// emits the block with no further bounds check. The worker flips the bytes
+// between a pattern that costs little and a pattern whose symbols are rare in
+// the other pattern's Huffman code. A flip between the two passes makes the
+// emitted block longer than the cost, which writes past that buffer.
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isMainThread, parentPort, Worker, workerData } from "node:worker_threads";
+
+const SIZE = 4000;
+// Unpatched, a sanitizer build aborts within the first 30 sends.
+const SENDS = 500;
+// The main thread ends the process as soon as the sends finish. This bound
+// only stops the worker spinning forever if it ever outlives its parent.
+const FLIP_BUDGET_MS = 30_000;
+
+/** xorshift32, so both patterns are the same on every run. */
+function patterns(length: number) {
+  let state = 88172645;
+  const next = () => ((state ^= state << 13), (state ^= state >>> 17), (state ^= state << 5), state >>> 0);
+
+  // `cheap` holds bytes 0x00 to 0x7f, plus 16 single occurrences of the bytes
+  // `costly` is made of. Those 16 get the longest codewords in the code built
+  // from `cheap`, so re-emitting `length` `costly` bytes through that code
+  // needs about twice the space the cost pass reserved.
+  const cheap = new Uint8Array(length);
+  const costly = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    cheap[i] = next() & 0x7f;
+    costly[i] = 0xf0 + (next() & 0x0f);
+  }
+  for (let i = 0; i < 16; i++) cheap[next() % length] = 0xf0 + i;
+  return { cheap, costly, next };
+}
+
+if (isMainThread) {
+  const mode = process.env.MODE === "mmap" ? "mmap" : "sab";
+  let view: Uint8Array;
+  let handle: SharedArrayBuffer | string;
+  if (mode === "mmap") {
+    const file = join(mkdtempSync(join(tmpdir(), "ws-deflate-")), "bytes.bin");
+    writeFileSync(file, new Uint8Array(SIZE));
+    handle = file;
+    view = Bun.mmap(file, { shared: true });
+  } else {
+    const shared = new SharedArrayBuffer(SIZE);
+    handle = shared;
+    view = new Uint8Array(shared);
+  }
+
+  const worker = new Worker(new URL(import.meta.url), { workerData: { mode, handle } });
+  await new Promise(resolve => worker.on("message", resolve));
+  worker.unref();
+
+  const sent = Promise.withResolvers<void>();
+  const server = Bun.serve({
+    port: 0,
+    fetch(request, server) {
+      if (server.upgrade(request)) return;
+      return new Response("expected an upgrade", { status: 400 });
+    },
+    websocket: {
+      perMessageDeflate: true,
+      open(ws) {
+        for (let i = 0; i < SENDS; i++) ws.send(view, true);
+        sent.resolve();
+      },
+      message() {},
+    },
+  });
+
+  const client = new WebSocket(`ws://localhost:${server.port}/`);
+  client.onmessage = () => {};
+  await sent.promise;
+  console.log("done");
+  process.exit(0);
+} else {
+  const { mode, handle } = workerData as { mode: string; handle: SharedArrayBuffer | string };
+  const view: Uint8Array =
+    mode === "mmap" ? Bun.mmap(handle as string, { shared: true }) : new Uint8Array(handle as SharedArrayBuffer);
+  const { cheap, costly, next } = patterns(view.length);
+
+  parentPort!.postMessage("ready");
+
+  const deadline = Date.now() + FLIP_BUDGET_MS;
+  while (Date.now() < deadline) {
+    view.set(cheap);
+    for (let i = next() % 50000; i > 0; i--);
+    view.set(costly);
+    for (let i = next() % 5000; i > 0; i--);
+  }
+}

--- a/test/js/web/websocket/websocket-shared-buffer-deflate-fixture.ts
+++ b/test/js/web/websocket/websocket-shared-buffer-deflate-fixture.ts
@@ -1,6 +1,6 @@
 // A Bun.serve WebSocket sends the same bytes with permessage-deflate on while
 // a worker rewrites them. MODE picks the memory another thread can write:
-// "sab" a SharedArrayBuffer view, "mmap" a MAP_SHARED Bun.mmap region.
+// "sab" a SharedArrayBuffer view, "mmap" a MAP_SHARED Bun.mmap region over FILE.
 //
 // uWS hands the payload straight to libdeflate_deflate_compress, which reads
 // the input twice: the first pass costs the deflate block against the space
@@ -9,9 +9,6 @@
 // between a pattern that costs little and a pattern whose symbols are rare in
 // the other pattern's Huffman code. A flip between the two passes makes the
 // emitted block longer than the cost, which writes past that buffer.
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { isMainThread, parentPort, Worker, workerData } from "node:worker_threads";
 
 const SIZE = 4000;
@@ -45,10 +42,8 @@ if (isMainThread) {
   let view: Uint8Array;
   let handle: SharedArrayBuffer | string;
   if (mode === "mmap") {
-    const file = join(mkdtempSync(join(tmpdir(), "ws-deflate-")), "bytes.bin");
-    writeFileSync(file, new Uint8Array(SIZE));
-    handle = file;
-    view = Bun.mmap(file, { shared: true });
+    handle = process.env.FILE!;
+    view = Bun.mmap(handle, { shared: true });
   } else {
     const shared = new SharedArrayBuffer(SIZE);
     handle = shared;


### PR DESCRIPTION
### Problem
- A `Bun.serve` WebSocket sending bytes another thread writes, with `perMessageDeflate` on, overruns a heap buffer. ASAN reports `heap-buffer-overflow`, `WRITE of size 1` in `deflate_flush_block` (`deflate_compress.c:1982`), through `uWS::DeflationStream::deflate` (`PerMessageDeflate.h:120`). `Bun.gzipSync` and `Bun.deflateSync` overrun the same way.
- `deflate_flush_block` checks a block's cost against the output buffer once, after a first pass, then emits it in a second pass with no bounds check (`deflate_compress.c:1816`). A write between the passes makes the block longer than the cost.

### Fix
- `patches/libdeflate/bounded-emit.patch` bounds the two emit writes that only an `ASSERT` guards (compiled out in release). They set the existing overflow flag, so the call returns 0.
- The word-at-a-time flush is already bounded by `out_fast_end`: the hot path is untouched and stable input gives byte-identical output. A 0 return now reports `InsufficientSpace`, not success. Before, about 8% of racing one-shot calls returned an empty result silently.
- Self-reviewed: my first shape (copy when `ArrayBuffer::shared` is set) was rejected, because a `Bun.mmap` view still overflowed. This is the rework. The review's release-crash claim did not reproduce.
- Verified in `websocket-permessage-deflate.test.ts` and `zlib.test.js`. Three races fail 3 of 3 without the patch. With the patch but not the `src/` change, the one-shot race fails 5 of 5 on an empty result.

### Background
- libdeflate treats a stable input as the caller's contract.
- uWS compresses into a fixed 4 KiB buffer and already falls back to zlib on a 0 return (`PerMessageDeflate.h:122`).
- Bun sizes the one-shot output with `libdeflate_deflate_compress_bound`, so 0 is unreachable for input that holds still.

<details><summary>Notes</summary>

**Why not copy the input at the binding instead.** The first version of this change copied the payload in `ServerWebSocket` when `ArrayBuffer::shared` was set. That is the wrong invariant. On that build the same overflow still fired 3 of 3 with a `Bun.mmap` view, which is a plain `Uint8Array` with `isShared()` false, symbolized through the patched line itself. Sharing is not the property that matters. What matters is that another thread can write the bytes during the call. The same holds for a `bun:ffi` or N-API external buffer, and for a plain buffer an in-flight `fs.read` is filling. Copying would also need a guard at every binding that reaches the compressor, plus a copy on every send. Bounding the sink is about 10 lines, costs no copy, and cannot be forgotten at a new call site.

**Verification matrix.** Debug ASAN build, 5 runs each. "overflow" is an ASAN `heap-buffer-overflow` in `deflate_flush_block`.

| Race | unpatched | patched |
| --- | --- | --- |
| `ws.send` of a SharedArrayBuffer view | 5/5 overflow | 5/5 clean |
| `ws.send` of a `Bun.mmap` region | 5/5 overflow | 5/5 clean |
| `Bun.deflateSync` / `Bun.gzipSync` | 5/5 overflow | 5/5 clean |

Through the test files, 3 runs each: all three race tests fail 3 of 3 with the patch removed, and pass 3 of 3 with it.

**Output is unchanged.** Gzip and deflate of a fixed input hash identically on the patched build and on stock 1.4.3. Round-trips pass for empty, single-byte, incompressible and highly compressible inputs, under both `library: "libdeflate"` and `library: "zlib"`.

**Behaviour change.** A racing input that outgrows the bound now makes `Bun.gzipSync` and `Bun.deflateSync` throw `libdeflate error: insufficient space` instead of corrupting the heap. The throw is the `src/` half of the change. With only the patch, the wrapper read the 0 return as a byte count: in 10 of 10 runs, 25 to 38 of 400 racing calls returned an empty `Uint8Array` as success. The HTTP request-body path had the same reading and now falls back to streaming zlib. It cannot fire for an input that holds still, because the bound covers those. The WebSocket path never throws: uWS already falls back to zlib on a 0 return, so the message still goes out.

**Release builds.** I could not get a stock release build to crash on these fixtures: 16 runs across 3 shapes all exited 0. The overflow is real there, but the stray bytes land in a neighbouring allocation and nothing observed them. That is why the three race tests are `skipIf(!isASAN)`.

**Patch upkeep.** 13 vendored deps already carry patches, and libdeflate is bumped by `.github/workflows/update-libdeflate.yml`, as are cares, highway, libarchive and hdrhistogram, which are patched too. If upstream ever bounds these writes, the patch stops applying and the build fails, which is the signal to drop it.

**Overlap with #42249.** That PR fixes the `Bun.gzipSync` and `Bun.deflateSync` case by copying a shared input in `BunObject.rs`. This change fixes the same case at the sink, and also the `Bun.mmap` input that approach does not reach. The two do not conflict. Its author should decide whether to keep it for the snapshot semantics, which this change does not provide: here a racing one-shot throws instead of compressing a snapshot.

**Review round.** Four findings fixed (two long comments in `src/`, a temp directory the mmap test left behind, a WebSocket client closed after the assertions). Two kept with reasons in the threads: the empty-stderr check and the `20_000` per-test timeout. Both test files also pass under the sanitizer lane's environment (`detect_leaks=1`, `abort_on_error=1`, `BUN_DESTRUCT_VM_ON_EXIT=1`).

**Other suites.** `test/js/web/websocket/`, `test/js/node/zlib/`, `fetch-compress.test.ts` and `fetch-gzip.test.ts`. Every failure I saw reproduces on `main` without this change: two `websocket.test.js` tests need `ws.postman-echo.com`, and `zlib/leak.test.ts` plus three slow tests time out under parallel load and pass when run alone.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:dep]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/zlib/zlib.test.js test/js/web/websocket/websocket-permessage-deflate.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/42] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/42] gen cpp.rs (cppbind)
[3/42] gen JS modules (bundle-modules)
Preprocess modules (7897ms)
Bundle modules (42ms)
Postprocesss modules (27ms)
Bundle Functions (570ms)
Generate Code (40ms)

[8.59s] Bundled "src/js" for development
  2791 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/29] cargo bun_runtime → libbun_runtime.a
[22/29] cxx obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o
FAILED: obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inl
... (truncated)

release without fix: 6 skipped
bun test v1.4.3-canary.1 (f44306468)

test/js/web/websocket/websocket-permessage-deflate.test.ts:
(pass) WebSocket client negotiates permessage-deflate [3.85ms]
(pass) WebSocket client handles compressed text messages [101.95ms]
(pass) WebSocket client handles compressed binary messages [102.19ms]
(pass) WebSocket client handles fragmented compressed messages [1.78ms]
(pass) WebSocket client handles context takeover options [101.23ms]
(skip) WebSocket client rejects compressed control frames
(pass) clients on one thread share the inflater without mixing up their messages [6.46ms]
(pass) a message that outgrows the libdeflate buffer does not disturb later messages [3.98ms]
(pass) server with decompress: 'dedicated' inflates a client context-takeover stream (every message fits the fast-path buffer) [2.14ms]
(pass) server with decompress: 'dedicated' inflates a client context-takeover stream (message 1 overflows the fast-path buffer) [1.05ms]
(pass) server enforces maxPayloadLength on compressed messages inflated through the fast path [1.70ms]
(pass) every ServerWebSocket send method delivers the bytes of a SharedArrayBuffer view [2.47ms]
(skip) ws.send() of sab memory
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 3 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/zlib/zlib.test.js test/js/web/websocket/websocket-permessage-deflate.test.ts
bun test v1.4.3 (4ff919377)

test/js/web/websocket/websocket-permessage-deflate.test.ts:
(pass) WebSocket client negotiates permessage-deflate [85.59ms]
(pass) WebSocket client handles compressed text messages [149.13ms]
(pass) WebSocket client handles compressed binary messages [153.63ms]
(pass) WebSocket client handles fragmented compressed messages [31.43ms]
(pass) WebSocket client handles context takeover options [137.06ms]
(skip) WebSocket client rejects compressed control frames
(pass) clients on one thread share the inflater without mixing up their messages [141.67ms]
(pass) a message that outgrows the libdeflate buffer does not disturb later messages [95.35ms]
(pass) server with decompress: 'dedicated' inflates a client context-takeover stream (every message fits the fast-path buffer) [50.02ms]
(pass) server with decompress: 'dedicated' inflates a client context-takeover stream (message 1 overflows the fast-path buffer) [23.38ms]
(pass) ser
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 646ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/31] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/31] gen cpp.rs (cppbind)
[3/31] gen JS modules (bundle-modules)
Preprocess modules (9174ms)
Bundle modules (47ms)
Postprocesss modules (18ms)
Bundle Functions (575ms)
Generate Code (29ms)

[9.85s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/23] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_libdeflate_sys v0.0.0 (/workspace/bun/src/libdeflate_sys)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/worksp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
patches/libdeflate/bounded-emit.patch              | 49 +++++++++++
 scripts/build/deps/libdeflate.ts                   |  2 +
 src/http/compress_body.rs                          |  7 +-
 src/libdeflate_sys/libdeflate.rs                   | 38 +++++----
 .../node/zlib/libdeflate-racing-input-fixture.ts   | 74 +++++++++++++++++
 test/js/node/zlib/zlib.test.js                     | 37 ++++++++-
 .../websocket/websocket-permessage-deflate.test.ts | 88 +++++++++++++++++++-
 .../websocket-shared-buffer-deflate-fixture.ts     | 94 ++++++++++++++++++++++
 8 files changed, 364 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
patches/libdeflate/bounded-emit.patch                         1      2     36
scripts/build/deps/libdeflate.ts                              1      2     37
src/http/compress_body.rs                                     2      4     35
src/libdeflate_sys/libdeflate.rs                              2      2     35
test/js/node/zlib/libdeflate-racing-input-fixture.ts          1      6     38
test/js/node/zlib/zlib.test.js                                2      4     18
…t/js/web/websocket/websocket-permessage-deflate.test.ts      3      9     26
…eb/websocket/websocket-shared-buffer-deflate-fixture.ts      1      3     38
```

</details>

<!-- robobun:evidence:end -->