### PR TITLE
Upgrade WebKit to cf1b36ec8703

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "dfd696443b9ba87c4f516d1c724f0abacdd8768a";
+export const WEBKIT_VERSION = "cf1b36ec8703d8e87436094d21d478d358c7d886";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/bundler_jsc/analyze_jsc.rs
+++ b/src/bundler_jsc/analyze_jsc.rs
@@ -16,6 +16,7 @@ use bun_bundler::analyze_transpiled_module as analyze;
 extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
     global_object: &JSGlobalObject,
     vm: &VM,
+    module_loader: *mut JSModuleLoader,
     module_key: &IdentifierArray,
     source_code: &SourceCode,
     res: &ModuleInfoDeserialized,
@@ -24,8 +25,15 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
     // The caller (BunAnalyzeTranspiledModule.cpp) decides whether to free
     // immediately or keep it alive on the SourceProvider for the isolation
     // SourceProvider cache.
-    to_js_module_record(global_object, vm, module_key, source_code, res)
-        .unwrap_or(core::ptr::null_mut())
+    to_js_module_record(
+        global_object,
+        vm,
+        module_loader,
+        module_key,
+        source_code,
+        res,
+    )
+    .unwrap_or(core::ptr::null_mut())
 }
 
 /// Walks the serialized body in place (layout documented on the printer's
@@ -35,6 +43,7 @@ extern "C" fn zig__ModuleInfoDeserialized__toJSModuleRecord(
 fn to_js_module_record(
     global_object: &JSGlobalObject,
     vm: &VM,
+    module_loader: *mut JSModuleLoader,
     module_key: &IdentifierArray,
     source_code: &SourceCode,
     res: &ModuleInfoDeserialized,
@@ -87,6 +96,7 @@ fn to_js_module_record(
     let module_record = JSModuleRecord::create(
         global_object,
         vm,
+        module_loader,
         module_key,
         source_code,
         res.flags.contains_import_meta(),
@@ -330,11 +340,13 @@ impl IdentifierArray {
 bun_opaque::opaque_ffi! {
     pub(crate) struct SourceCode;
     pub(crate) struct JSModuleRecord;
+    pub(crate) struct JSModuleLoader;
 }
 unsafe extern "C" {
     fn JSC_JSModuleRecord__create(
         global_object: *const JSGlobalObject,
         vm: *const VM,
+        module_loader: *mut JSModuleLoader,
         module_key: *const IdentifierArray,
         source_code: *const SourceCode,
         has_import_meta: bool,
@@ -443,6 +455,7 @@ impl JSModuleRecord {
     fn create(
         global_object: &JSGlobalObject,
         vm: &VM,
+        module_loader: *mut JSModuleLoader,
         module_key: &IdentifierArray,
         source_code: &SourceCode,
         has_import_meta: bool,
@@ -457,6 +470,7 @@ impl JSModuleRecord {
             JSC_JSModuleRecord__create(
                 global_object,
                 vm,
+                module_loader,
                 module_key,
                 source_code,
                 has_import_meta,

--- a/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
+++ b/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
@@ -41,7 +41,7 @@ Identifier getFromIdentifierArray(VM& vm, Identifier* identifierArray, uint32_t 
     return identifierArray[n];
 }
 
-extern "C" JSModuleRecord* zig__ModuleInfoDeserialized__toJSModuleRecord(JSGlobalObject* globalObject, VM& vm, const Identifier& module_key, const SourceCode& source_code, bun_ModuleInfoDeserialized* module_info);
+extern "C" JSModuleRecord* zig__ModuleInfoDeserialized__toJSModuleRecord(JSGlobalObject* globalObject, VM& vm, JSModuleLoader*, const Identifier& module_key, const SourceCode& source_code, bun_ModuleInfoDeserialized* module_info);
 extern "C" void zig__renderDiff(const char* expected_ptr, size_t expected_len, const char* received_ptr, size_t received_len);
 
 // AtomStringImpl::add copies the characters; the record they came from is freed once the JSModuleRecord is built.
@@ -93,9 +93,9 @@ extern "C" void JSC__IdentifierArray__destroy(Identifier* identifiers, size_t co
     WTF::fastFree(identifiers);
 }
 
-extern "C" JSModuleRecord* JSC_JSModuleRecord__create(JSGlobalObject* globalObject, VM& vm, const Identifier* moduleKey, const SourceCode& sourceCode, bool hasImportMeta, bool isTypescript, bool hasTLA, uint32_t requestedModuleCount, uint32_t importCount, uint32_t exportCount)
+extern "C" JSModuleRecord* JSC_JSModuleRecord__create(JSGlobalObject* globalObject, VM& vm, JSModuleLoader* moduleLoader, const Identifier* moduleKey, const SourceCode& sourceCode, bool hasImportMeta, bool isTypescript, bool hasTLA, uint32_t requestedModuleCount, uint32_t importCount, uint32_t exportCount)
 {
-    JSModuleRecord* result = JSModuleRecord::create(globalObject, vm, globalObject->moduleRecordStructure(), *moduleKey, sourceCode, hasImportMeta ? ImportMetaFeature : 0);
+    JSModuleRecord* result = JSModuleRecord::create(globalObject, vm, globalObject->moduleRecordStructure(), moduleLoader, *moduleKey, sourceCode, hasImportMeta ? ImportMetaFeature : 0);
     result->reserveCapacity(requestedModuleCount, importCount, exportCount);
     result->m_isTypeScript = isTypescript;
     result->setHasTLA(hasTLA);
@@ -197,10 +197,10 @@ extern "C" void JSC_JSModuleRecord__addImportEntryNamespaceDefer(JSModuleRecord*
     });
 }
 
-extern "C" JSModuleRecord* Bun__createPrelinkedModuleRecordForPipeline(Zig::GlobalObject*, const Identifier& key, const SourceCode&);
+extern "C" JSModuleRecord* Bun__createPrelinkedModuleRecordForPipeline(Zig::GlobalObject*, JSModuleLoader*, const Identifier& key, const SourceCode&);
 
-static EncodedJSValue fallbackParse(JSGlobalObject* globalObject, const Identifier& moduleKey, const SourceCode& sourceCode, JSPromise* promise, JSModuleRecord* resultValue = nullptr);
-extern "C" EncodedJSValue Bun__analyzeTranspiledModule(JSGlobalObject* globalObject, const Identifier& moduleKey, const SourceCode& sourceCode, JSPromise* promise)
+static EncodedJSValue fallbackParse(JSGlobalObject* globalObject, JSModuleLoader*, const Identifier& moduleKey, const SourceCode& sourceCode, JSPromise* promise, JSModuleRecord* resultValue = nullptr);
+extern "C" EncodedJSValue Bun__analyzeTranspiledModule(JSGlobalObject* globalObject, JSModuleLoader* moduleLoader, const Identifier& moduleKey, const SourceCode& sourceCode, JSPromise* promise)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -214,18 +214,18 @@ extern "C" EncodedJSValue Bun__analyzeTranspiledModule(JSGlobalObject* globalObj
 
     if (provider->m_moduleInfo == nullptr) {
         // A module of the executable's pre-resolved graph carries no module_info of its own: the graph is its record.
-        JSModuleRecord* prelinked = Bun__createPrelinkedModuleRecordForPipeline(uncheckedDowncast<Zig::GlobalObject>(globalObject), moduleKey, sourceCode);
+        JSModuleRecord* prelinked = Bun__createPrelinkedModuleRecordForPipeline(uncheckedDowncast<Zig::GlobalObject>(globalObject), moduleLoader, moduleKey, sourceCode);
         RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(vm, scope)));
         if (prelinked) {
             promise->resolve(globalObject, vm, prelinked);
             RELEASE_AND_RETURN(scope, JSValue::encode(promise));
         }
         // Neither: analyze the source text.
-        RELEASE_AND_RETURN(scope, fallbackParse(globalObject, moduleKey, sourceCode, promise));
+        RELEASE_AND_RETURN(scope, fallbackParse(globalObject, moduleLoader, moduleKey, sourceCode, promise));
     }
 
     auto* moduleInfo = provider->m_moduleInfo;
-    auto moduleRecord = zig__ModuleInfoDeserialized__toJSModuleRecord(globalObject, vm, moduleKey, sourceCode, moduleInfo);
+    auto moduleRecord = zig__ModuleInfoDeserialized__toJSModuleRecord(globalObject, vm, moduleLoader, moduleKey, sourceCode, moduleInfo);
     // Under --isolate the same SourceProvider is reused across globals via the
     // IsolatedModuleCache, so module_info must remain alive on the provider;
     // ~SourceProvider frees it. Otherwise, free now.
@@ -238,13 +238,13 @@ extern "C" EncodedJSValue Bun__analyzeTranspiledModule(JSGlobalObject* globalObj
     }
 
 #if BUN_DEBUG
-    RELEASE_AND_RETURN(scope, fallbackParse(globalObject, moduleKey, sourceCode, promise, moduleRecord));
+    RELEASE_AND_RETURN(scope, fallbackParse(globalObject, moduleLoader, moduleKey, sourceCode, promise, moduleRecord));
 #else
     promise->resolve(globalObject, vm, moduleRecord);
     RELEASE_AND_RETURN(scope, JSValue::encode(promise));
 #endif
 }
-static EncodedJSValue fallbackParse(JSGlobalObject* globalObject, const Identifier& moduleKey, const SourceCode& sourceCode, JSPromise* promise, JSModuleRecord* resultValue)
+static EncodedJSValue fallbackParse(JSGlobalObject* globalObject, JSModuleLoader* moduleLoader, const Identifier& moduleKey, const SourceCode& sourceCode, JSPromise* promise, JSModuleRecord* resultValue)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -261,7 +261,7 @@ static EncodedJSValue fallbackParse(JSGlobalObject* globalObject, const Identifi
         RELEASE_AND_RETURN(scope, JSValue::encode(rejectWithError(error.toErrorObject(globalObject, sourceCode))));
     ASSERT(moduleProgramNode);
 
-    ModuleAnalyzer moduleAnalyzer(globalObject, moduleKey, sourceCode, moduleProgramNode->features());
+    ModuleAnalyzer moduleAnalyzer(globalObject, moduleLoader, moduleKey, sourceCode, moduleProgramNode->features());
     RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(vm, scope)));
 
     auto result = moduleAnalyzer.analyze(*moduleProgramNode);

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -958,6 +958,7 @@ const JSC::GlobalObjectMethodTable& NodeVMGlobalObject::globalObjectMethodTable(
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // shouldInterruptScriptBeforeTimeout,
+        nullptr, // moduleTypeIsAllowed
         &moduleLoaderImportModule,
         nullptr, // moduleLoaderResolve
         nullptr, // moduleLoaderFetch

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -810,7 +810,7 @@ const JSC::ClassInfo NodeVMModuleConstructor::s_info = { "Module"_s, &Base::s_in
 JSC::JSModuleLoader* NodeVMModule::moduleLoader(JSGlobalObject* globalObject)
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    NodeVMGlobalObject* contextGlobalObject = getGlobalObjectFromContext(globalObject, m_context.get(), false);
+    NodeVMGlobalObject* contextGlobalObject = NodeVM::getGlobalObjectFromContext(globalObject, m_context.get(), false);
     RETURN_IF_EXCEPTION(scope, nullptr);
     return (contextGlobalObject ? contextGlobalObject : globalObject)->moduleLoader();
 }

--- a/src/jsc/bindings/NodeVMModule.cpp
+++ b/src/jsc/bindings/NodeVMModule.cpp
@@ -807,4 +807,12 @@ const JSC::ClassInfo NodeVMModule::s_info = { "NodeVMModule"_s, &Base::s_info, n
 const JSC::ClassInfo NodeVMModulePrototype::s_info = { "NodeVMModule"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(NodeVMModulePrototype) };
 const JSC::ClassInfo NodeVMModuleConstructor::s_info = { "Module"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(NodeVMModuleConstructor) };
 
+JSC::JSModuleLoader* NodeVMModule::moduleLoader(JSGlobalObject* globalObject)
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+    NodeVMGlobalObject* contextGlobalObject = getGlobalObjectFromContext(globalObject, m_context.get(), false);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    return (contextGlobalObject ? contextGlobalObject : globalObject)->moduleLoader();
+}
+
 } // namespace Bun

--- a/src/jsc/bindings/NodeVMModule.h
+++ b/src/jsc/bindings/NodeVMModule.h
@@ -41,6 +41,9 @@ public:
     static NodeVMModule* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, ArgList args);
 
     const WTF::String& identifier() const { return m_identifier; }
+    // The context's own module loader (its global object's), or `globalObject`'s without a context: the
+    // loader this module's record is created against.
+    JSC::JSModuleLoader* moduleLoader(JSC::JSGlobalObject*);
 
     Status status() const { return m_status; }
     void status(Status value) { m_status = value; }

--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
+++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
@@ -165,7 +165,9 @@ JSValue NodeVMSourceTextModule::createModuleRecord(JSGlobalObject* globalObject)
         return {};
     }
 
-    ModuleAnalyzer analyzer(globalObject, Identifier::fromString(vm, m_identifier), m_sourceCode, AllFeatures);
+    JSModuleLoader* loader = moduleLoader(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    ModuleAnalyzer analyzer(globalObject, loader, Identifier::fromString(vm, m_identifier), m_sourceCode, AllFeatures);
 
     RETURN_IF_EXCEPTION(scope, {});
     ASSERT(node != nullptr);

--- a/src/jsc/bindings/NodeVMSyntheticModule.cpp
+++ b/src/jsc/bindings/NodeVMSyntheticModule.cpp
@@ -90,10 +90,14 @@ void NodeVMSyntheticModule::destroy(JSCell* cell)
 void NodeVMSyntheticModule::createModuleRecord(JSGlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
+    JSModuleLoader* loader = moduleLoader(globalObject);
+    RETURN_IF_EXCEPTION(scope, void());
     // The source type only feeds AbstractModuleRecord::moduleType(), which the loader attaches to
     // errors as the failing module's kind; a vm.SyntheticModule is a JavaScript module in that sense.
-    SyntheticModuleRecord* moduleRecord = SyntheticModuleRecord::create(globalObject, vm, globalObject->syntheticModuleRecordStructure(), Identifier::fromString(vm, identifier()), SourceProviderSourceType::Module);
+    SyntheticModuleRecord* moduleRecord = SyntheticModuleRecord::create(globalObject, vm, globalObject->syntheticModuleRecordStructure(), loader, Identifier::fromString(vm, identifier()), SourceProviderSourceType::Module);
+    RETURN_IF_EXCEPTION(scope, void());
 
     m_moduleRecord.set(vm, this, moduleRecord);
 
@@ -113,6 +117,7 @@ void NodeVMSyntheticModule::createModuleRecord(JSGlobalObject* globalObject)
     // before setExport() yields undefined), unlike TDZ which would throw.
     JSModuleEnvironment* moduleEnvironment = JSModuleEnvironment::create(vm, globalObject, nullptr, exportSymbolTable, jsUndefined(), moduleRecord);
     moduleRecord->setModuleEnvironment(globalObject, moduleEnvironment);
+    RELEASE_AND_RETURN(scope, void());
 }
 
 void NodeVMSyntheticModule::ensureModuleRecord(JSGlobalObject* globalObject)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -954,6 +954,7 @@ const JSC::GlobalObjectMethodTable& GlobalObject::globalObjectMethodTable()
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // &shouldInterruptScriptBeforeTimeout,
+        nullptr, // moduleTypeIsAllowed
         &moduleLoaderImportModule, // moduleLoaderImportModule
         &moduleLoaderResolve, // moduleLoaderResolve
         &moduleLoaderFetch, // moduleLoaderFetch
@@ -982,6 +983,7 @@ const JSC::GlobalObjectMethodTable& EvalGlobalObject::globalObjectMethodTable()
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // &shouldInterruptScriptBeforeTimeout,
+        nullptr, // moduleTypeIsAllowed
         &moduleLoaderImportModule, // moduleLoaderImportModule
         &moduleLoaderResolve, // moduleLoaderResolve
         &moduleLoaderFetch, // moduleLoaderFetch
@@ -1010,6 +1012,7 @@ const JSC::GlobalObjectMethodTable& StandaloneGlobalObject::globalObjectMethodTa
         &shouldInterruptScript,
         &javaScriptRuntimeFlags,
         nullptr, // &shouldInterruptScriptBeforeTimeout,
+        nullptr, // moduleTypeIsAllowed
         &moduleLoaderImportModule, // moduleLoaderImportModule
         &StandaloneGlobalObject::moduleLoaderResolve,
         &StandaloneGlobalObject::moduleLoaderFetch,
@@ -3521,7 +3524,7 @@ JSC::Identifier StandaloneGlobalObject::moduleLoaderResolve(JSGlobalObject* glob
 }
 
 JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalObject,
-    JSModuleLoader*,
+    JSModuleLoader* loader,
     JSString* moduleNameValue,
     RefPtr<JSC::ScriptFetchParameters> parameters,
     const SourceOrigin& sourceOrigin,
@@ -3558,7 +3561,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
         auto referrerKey = query.isEmpty()
             ? JSC::Identifier::fromString(vm, sourceOriginStringHolder)
             : JSC::Identifier::fromString(vm, makeString(sourceOriginStringHolder, query));
-        referrerAsyncOrder = globalObject->moduleLoader()->asyncEvaluationOrderForKey(referrerKey);
+        referrerAsyncOrder = loader->asyncEvaluationOrderForKey(referrerKey);
     } else if (sourceURL.protocol() == "builtin"_s) {
         ASSERT(sourceURL.string().startsWith("builtin://"_s));
         sourceOriginStringHolder = sourceURL.string().substringSharingImpl(10 /* builtin:// */);
@@ -3570,7 +3573,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
         if (auto resolution = globalObject->onLoadPlugins.resolveVirtualModule(moduleName, sourceURL.protocolIsFile() ? sourceOriginStringHolder : String())) {
             resolvedIdentifier = JSC::Identifier::fromString(vm, resolution.value());
 
-            auto result = JSC::importModule(globalObject, resolvedIdentifier, JSC::Identifier(), parameters, nullptr, /* deferred */ false, referrerAsyncOrder);
+            auto result = loader->requestImportModule(globalObject, resolvedIdentifier, JSC::Identifier(), parameters, nullptr, /* deferred */ false, referrerAsyncOrder);
             if (scope.exception()) [[unlikely]] {
                 return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
             }
@@ -3609,7 +3612,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
     // The C++ module loader now extracts `with.type` into a
     // ScriptFetchParameters before calling this hook, so `parameters` is
     // already the parsed RefPtr (or null). Just forward it.
-    auto result = JSC::importModule(globalObject, resolvedIdentifier,
+    auto result = loader->requestImportModule(globalObject, resolvedIdentifier,
         JSC::Identifier(), WTF::move(parameters), nullptr, /* deferred */ false, referrerAsyncOrder);
     if (scope.exception()) [[unlikely]] {
         return JSC::JSPromise::rejectedPromiseWithCaughtException(globalObject, scope);
@@ -3709,7 +3712,7 @@ JSC::JSPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject,
     return rejectedInternalPromise(globalObject, result);
 }
 
-extern "C" JSModuleRecord* zig__ModuleInfoDeserialized__toJSModuleRecord(JSGlobalObject*, VM&, const Identifier&, const SourceCode&, bun_ModuleInfoDeserialized*);
+extern "C" JSModuleRecord* zig__ModuleInfoDeserialized__toJSModuleRecord(JSGlobalObject*, VM&, JSModuleLoader*, const Identifier&, const SourceCode&, bun_ModuleInfoDeserialized*);
 extern "C" void zig__ModuleInfoDeserialized__deinit(bun_ModuleInfoDeserialized*);
 
 // Synchronous fetch through Bun's loader (embedded modules are bytecode-backed and builtins are in-process, so neither
@@ -3779,16 +3782,16 @@ static Identifier prelinkedModuleKey(VM& vm, PrelinkedModuleGraph& graph, uint32
 // build without parsing, from its serialized module_info or, for a module of the pre-resolved graph, with its entries
 // copied out of the graph (that path wires [[LoadedModules]] by specifier, not by index). Null for anything else
 // (CommonJS wrappers, JSON, ... take JSC's normal path).
-static JSModuleRecord* createEmbeddedModuleRecord(Zig::GlobalObject* globalObject, const Identifier& key, JSSourceCode* source)
+static JSModuleRecord* createEmbeddedModuleRecord(Zig::GlobalObject* globalObject, JSModuleLoader* loader, const Identifier& key, JSSourceCode* source)
 {
     VM& vm = globalObject->vm();
     if (auto* provider = transpiledModuleProvider(source))
-        return zig__ModuleInfoDeserialized__toJSModuleRecord(globalObject, vm, key, source->sourceCode(), provider->m_moduleInfo);
+        return zig__ModuleInfoDeserialized__toJSModuleRecord(globalObject, vm, loader, key, source->sourceCode(), provider->m_moduleInfo);
     uint32_t moduleIndex = PrelinkedModuleGraph::noModule;
     PrelinkedModuleGraph* graph = prelinkedGraphFor(globalObject, key.string(), moduleIndex);
     if (!graph || source->sourceCode().provider()->sourceType() != JSC::SourceProviderSourceType::BunTranspiledModule)
         return nullptr;
-    JSModuleRecord* record = JSModuleRecord::createPrelinked(globalObject, vm, globalObject->moduleRecordStructure(), key, source->sourceCode(), *graph, moduleIndex);
+    JSModuleRecord* record = JSModuleRecord::createPrelinked(globalObject, vm, globalObject->moduleRecordStructure(), loader, key, source->sourceCode(), *graph, moduleIndex);
     if (record->isPrelinked())
         record->convertPrelinkedToEager();
     return record;
@@ -3852,7 +3855,7 @@ static void registerPrelinkedSubgraph(Zig::GlobalObject* globalObject, JSModuleL
                             complete = false;
                             continue;
                         }
-                        JSModuleRecord* dependency = JSModuleRecord::createPrelinked(globalObject, vm, globalObject->moduleRecordStructure(), key, source->sourceCode(), graph, request.moduleIndex);
+                        JSModuleRecord* dependency = JSModuleRecord::createPrelinked(globalObject, vm, globalObject->moduleRecordStructure(), loader, key, source->sourceCode(), graph, request.moduleIndex);
                         entry = loader->ensureRegistered(globalObject, key, ScriptFetchParameters::Type::JavaScript);
                         RETURN_IF_EXCEPTION(scope, void());
                         entry->provideModule(vm, dependency);
@@ -3890,7 +3893,7 @@ static void registerPrelinkedSubgraph(Zig::GlobalObject* globalObject, JSModuleL
                         complete = false;
                         continue;
                     }
-                    JSPromise* made = JSModuleLoader::makeModule(globalObject, key, source);
+                    JSPromise* made = loader->makeModule(globalObject, key, source);
                     RETURN_IF_EXCEPTION(scope, void());
                     auto* builtin = made && made->status() == JSPromise::Status::Fulfilled ? dynamicDowncast<AbstractModuleRecord>(made->result()) : nullptr;
                     if (!builtin) {
@@ -3930,7 +3933,7 @@ static void registerPrelinkedSubgraph(Zig::GlobalObject* globalObject, JSModuleL
 
 // makeModule for a graph module JSC fetched through its own pipeline (a static edge from a module outside the graph):
 // the record is prelinked all the same, and its subgraph registered by index.
-extern "C" JSModuleRecord* Bun__createPrelinkedModuleRecordForPipeline(Zig::GlobalObject* globalObject, const Identifier& key, const SourceCode& sourceCode)
+extern "C" JSModuleRecord* Bun__createPrelinkedModuleRecordForPipeline(Zig::GlobalObject* globalObject, JSModuleLoader* loader, const Identifier& key, const SourceCode& sourceCode)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -3938,10 +3941,9 @@ extern "C" JSModuleRecord* Bun__createPrelinkedModuleRecordForPipeline(Zig::Glob
     PrelinkedModuleGraph* graph = prelinkedGraphFor(globalObject, key.string(), moduleIndex);
     if (!graph)
         return nullptr;
-    JSModuleRecord* record = JSModuleRecord::createPrelinked(globalObject, vm, globalObject->moduleRecordStructure(), key, sourceCode, *graph, moduleIndex);
+    JSModuleRecord* record = JSModuleRecord::createPrelinked(globalObject, vm, globalObject->moduleRecordStructure(), loader, key, sourceCode, *graph, moduleIndex);
     if (!record->isPrelinked())
         return record; // Options::usePrelinkedModuleInfo() is off: an ordinary record
-    JSModuleLoader* loader = globalObject->moduleLoader();
     if (loader->prelinkedModuleGraph() && loader->prelinkedModuleGraph() != graph)
         return record;
     loader->setPrelinkedModuleGraph(*graph);
@@ -4027,10 +4029,10 @@ static void collectStandaloneClosure(Zig::GlobalObject* globalObject, JSModuleLo
 
             AbstractModuleRecord* record = nullptr;
             if (embedded) {
-                record = createEmbeddedModuleRecord(globalObject, key, source);
+                record = createEmbeddedModuleRecord(globalObject, loader, key, source);
                 RETURN_IF_EXCEPTION(scope, void());
             } else if (builtin && source->sourceCode().provider()->sourceType() == JSC::SourceProviderSourceType::Synthetic) {
-                JSPromise* made = JSModuleLoader::makeModule(globalObject, key, source);
+                JSPromise* made = loader->makeModule(globalObject, key, source);
                 RETURN_IF_EXCEPTION(scope, void());
                 if (made && made->status() == JSPromise::Status::Fulfilled)
                     record = dynamicDowncast<AbstractModuleRecord>(made->result());
@@ -4112,7 +4114,7 @@ JSC::JSPromise* StandaloneGlobalObject::moduleLoaderFetch(JSGlobalObject* jsGlob
             // When HostLoadImportedModule already created the root's entry it drives fetch -> makeModule itself once this
             // hook returns; makeModule (Bun__analyzeTranspiledModule) then builds the root prelinked and registers its subgraph.
             if (!loader->getRegisteredMayBeNull(rootKey, ScriptFetchParameters::Type::JavaScript) && !loader->prelinkedRecord(rootIndex) && rootSource->sourceCode().provider()->sourceType() == JSC::SourceProviderSourceType::BunTranspiledModule) {
-                JSModuleRecord* rootRecord = JSModuleRecord::createPrelinked(globalObject, vm, globalObject->moduleRecordStructure(), rootKey, rootSource->sourceCode(), *graph, rootIndex);
+                JSModuleRecord* rootRecord = JSModuleRecord::createPrelinked(globalObject, vm, globalObject->moduleRecordStructure(), loader, rootKey, rootSource->sourceCode(), *graph, rootIndex);
                 auto* rootEntry = loader->ensureRegistered(globalObject, rootKey, ScriptFetchParameters::Type::JavaScript);
                 RETURN_IF_EXCEPTION(scope, rejectedInternalPromise(globalObject, scope.exception()->value()));
                 rootEntry->provideModule(vm, rootRecord);
@@ -4126,7 +4128,7 @@ JSC::JSPromise* StandaloneGlobalObject::moduleLoaderFetch(JSGlobalObject* jsGlob
 
     MarkedArgumentBuffer keepAlive;
     keepAlive.append(rootSource);
-    JSModuleRecord* rootRecord = createEmbeddedModuleRecord(globalObject, rootKey, rootSource);
+    JSModuleRecord* rootRecord = createEmbeddedModuleRecord(globalObject, loader, rootKey, rootSource);
     RETURN_IF_EXCEPTION(scope, rejectedInternalPromise(globalObject, scope.exception()->value()));
     if (!rootRecord)
         RELEASE_AND_RETURN(scope, resolvedInternalPromise(globalObject, rootSource));

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -218,6 +218,7 @@ const JSC::GlobalObjectMethodTable& GlobalObject::globalObjectMethodTable()
         INHERIT_HOOK_METHOD(shouldInterruptScript),
         INHERIT_HOOK_METHOD(javaScriptRuntimeFlags),
         INHERIT_HOOK_METHOD(shouldInterruptScriptBeforeTimeout),
+        INHERIT_HOOK_METHOD(moduleTypeIsAllowed),
         bakeModuleLoaderImportModule,
         bakeModuleLoaderResolve,
         bakeModuleLoaderFetch,

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -499,8 +499,8 @@ describe("bytecode cache portability", () => {
         "bun build --bytecode happy-dom/lib/index.js": {
           "js": "75d2ad2bc252c916f90f8ca85f53f0883ca46049c2700e3c1fe2337ec42d1142",
           "jsc": {
-            "bytes": 2337296,
-            "sha256": "28afc82679782e8effeb749b20556093facb376d7d1e92de50888230412ec0e2",
+            "bytes": 2337264,
+            "sha256": "49a83aca1ac5dcf9a7a20d64259fcb39aaec3a6c47afce6254cefb2bc89dde8e",
           },
         },
         "bun build --bytecode immutable/dist/immutable.es.js": {
@@ -513,8 +513,8 @@ describe("bytecode cache portability", () => {
         "bun build --bytecode libraries.js": {
           "js": "493bab674ff49b287f26be3f356a3ad6681afb0c7eeffaa590f10cdcd8b58724",
           "jsc": {
-            "bytes": 22009464,
-            "sha256": "3107a462fc955913d0c5b93633c450d3aa6b8cccf8e10ef763efdfee9da4cf6d",
+            "bytes": 22009576,
+            "sha256": "c80a5a57ff0d1a5daa37670a6df5f35fc4578edc29603c3e06fee0634f28695f",
           },
         },
         "bun build --bytecode lodash/lodash.js": {
@@ -555,8 +555,8 @@ describe("bytecode cache portability", () => {
         "bun build --bytecode undici/index.js": {
           "js": "e1c4f1494711ecaae57a6d63dfb8ac6096629582f55cc42530ff5a156b70c9de",
           "jsc": {
-            "bytes": 874752,
-            "sha256": "80b3b63ecb885d41b285861b0a64e121f2586edb065ed170775bcf985df49db0",
+            "bytes": 874736,
+            "sha256": "20fc4d7f3f1deec97bbd18574f07e4c58426ba4a94596299640e2362b8fdfe66",
           },
         },
         "vm.Script big.js": {
@@ -588,12 +588,12 @@ describe("bytecode cache portability", () => {
           "sha256": "e5c42d10d1ecb91872abf9ce5b58b84f28de58cacf16bed19d528f90074f6641",
         },
         "vm.SourceTextModule acorn.mjs": {
-          "bytes": 257136,
-          "sha256": "6ea80770a81b15d47460df859791040f75425d713692c9dcdd5c6226447e364f",
+          "bytes": 257168,
+          "sha256": "a02fde5c6bbe50919370fe150cf487e1c01ea2f8b8bcacdf8419869f8b205303",
         },
         "vm.SourceTextModule module.js": {
-          "bytes": 9280,
-          "sha256": "f1e09d13f75e9ab052d0904b31f11df9893655f711a5c9fd2ab100f647681d7b",
+          "bytes": 9336,
+          "sha256": "c84ce82c137686f4972fb4a1a128fbeade717ed89f7d7d71045f0ceba5f9846c",
         },
       }
     `);

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -513,8 +513,8 @@ describe("bytecode cache portability", () => {
         "bun build --bytecode libraries.js": {
           "js": "493bab674ff49b287f26be3f356a3ad6681afb0c7eeffaa590f10cdcd8b58724",
           "jsc": {
-            "bytes": 22009576,
-            "sha256": "c80a5a57ff0d1a5daa37670a6df5f35fc4578edc29603c3e06fee0634f28695f",
+            "bytes": 22009472,
+            "sha256": "c5c3d5417c955434debefb6053e2a7abaa63dd0e1495686b805fd030d04c8f3b",
           },
         },
         "bun build --bytecode lodash/lodash.js": {


### PR DESCRIPTION
### What does this PR do?

Upgrades WebKit to oven-sh/WebKit@`cf1b36ec8703` (current `main`: the upstream merge from oven-sh/WebKit#614 plus oven-sh/WebKit#522). Supersedes #42177, which pins the pre-#522 commit.

Bun-side changes the new JSC needs:

- `GlobalObjectMethodTable` has a new `moduleTypeIsAllowed` hook; the five tables pass `nullptr` (default behaviour).
- Module records are created against a specific `JSModuleLoader`: the loader JSC passes to the fetch hook is threaded through `Bun__analyzeTranspiledModule` and the prelinked-record helpers, `moduleLoaderImportModule` uses the loader it is given, and `node:vm` `SourceTextModule` / `SyntheticModule` records are created against their context's loader (the same global they already link and evaluate in).
- `bundler_bytecode_portable`: the serialized bytecode changes uniformly with the engine (module programs declare `@moduleLoader`; async/generator bodies per #614), so the affected snapshot entries move.

### How did you verify your code works?

Builds and runs against the `autobuild-cf1b36ec8703d8e87436094d21d478d358c7d886` prebuilt; `bundler_bytecode_portable.test.ts`, `test/js/node/vm`, the `test-vm-module-*` node tests and `import-meta.test.js` pass locally. Full matrix in CI.
