### PR TITLE
Escape 16-bit strings and object keys like 8-bit ones (console.log, bun:test, JS printer)

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -403,10 +403,6 @@ pub fn contains_any(slice: &[u8], chars: &[u8]) -> bool {
     index_of_any(slice, chars).is_some()
 }
 
-pub fn index_of_any16(self_: &[u16], chars: &[u16]) -> Option<usize> {
-    index_of_any_t(self_, chars)
-}
-
 pub fn index_of_any_t<T: crate::NoUninit + Eq>(str: &[T], chars: &[T]) -> Option<usize> {
     if let (Lanes::U8(s), Lanes::U8(c)) = (lanes(str), lanes(chars)) {
         return index_of_any(s, c);

--- a/src/bun_core/string/mod.rs
+++ b/src/bun_core/string/mod.rs
@@ -1861,9 +1861,17 @@ pub mod printer {
         let mut i: usize = 0;
 
         while i < n {
+            // A well-formed surrogate pair is one code point; a lone surrogate is escaped below.
+            let utf16_pair: Option<u32> = match encoding {
+                StrEncoding::Utf16 if i + 1 < n => {
+                    strings::decode_surrogate_pair(text16[i], text16[i + 1])
+                }
+                _ => None,
+            };
             let width: u8 = match encoding {
-                StrEncoding::Latin1 | StrEncoding::Ascii | StrEncoding::Utf16 => 1,
+                StrEncoding::Latin1 | StrEncoding::Ascii => 1,
                 StrEncoding::Utf8 => strings::wtf8_byte_sequence_length_with_invalid(text_in[i]),
+                StrEncoding::Utf16 => 1 + u8::from(utf16_pair.is_some()),
             };
             let clamped_width = (width as usize).min(n.saturating_sub(i));
             let c: i32 = match encoding {
@@ -1886,7 +1894,10 @@ pub mod printer {
                     text_in[i] as i32
                 }
                 StrEncoding::Latin1 => text_in[i] as i32,
-                StrEncoding::Utf16 => text16[i] as i32,
+                StrEncoding::Utf16 => match utf16_pair {
+                    Some(cp) => cp as i32,
+                    None => text16[i] as i32,
+                },
             };
 
             if c == MALFORMED {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1265,8 +1265,7 @@ pub fn write_json_string<W: Write + ?Sized, const ENCODING: Encoding>(
     Ok(())
 }
 
-/// `write_json_string` for a string whose encoding is known only at run time, such as a JS string.
-/// Equal strings print the same in every encoding.
+/// `write_json_string` for a string whose encoding is known only at run time. Equal strings print the same.
 pub fn write_json_string_encoded<W: Write + ?Sized>(
     input: bun_core::EncodedSlice<'_>,
     writer: &mut W,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1265,6 +1265,22 @@ pub fn write_json_string<W: Write + ?Sized, const ENCODING: Encoding>(
     Ok(())
 }
 
+/// `write_json_string` for a string whose encoding is known only at run time, such as a JS string.
+/// Equal strings print the same in every encoding.
+pub fn write_json_string_encoded<W: Write + ?Sized>(
+    input: bun_core::EncodedSlice<'_>,
+    writer: &mut W,
+) -> crate::Result<()> {
+    let bytes = input.byte_slice();
+    if input.is_16bit() {
+        write_json_string::<_, { Encoding::Utf16 }>(bytes, writer)
+    } else if input.is_utf8() {
+        write_json_string::<_, { Encoding::Utf8 }>(bytes, writer)
+    } else {
+        write_json_string::<_, { Encoding::Latin1 }>(bytes, writer)
+    }
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // SourceMapHandler / Options — gated on bun_sourcemap::Chunk::Builder and the
 // real bun_js_parser::{runtime, Ast::*} surface.

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1073,10 +1073,17 @@ where
     }
 
     while i < n {
+        // A well-formed surrogate pair is one code point; a lone surrogate is escaped below.
+        let utf16_pair: Option<u32> = match ENCODING {
+            Encoding::Utf16 if i + 1 < n => {
+                strings::decode_surrogate_pair(code_unit_at!(i) as u16, code_unit_at!(i + 1) as u16)
+            }
+            _ => None,
+        };
         let width: u8 = match ENCODING {
             Encoding::Latin1 | Encoding::Ascii => 1,
             Encoding::Utf8 => strings::wtf8_byte_sequence_length_with_invalid(text[i]),
-            Encoding::Utf16 => 1,
+            Encoding::Utf16 => 1 + u8::from(utf16_pair.is_some()),
         };
         let clamped_width = (width as usize).min(n.saturating_sub(i));
         let c: i32 = match ENCODING {
@@ -1095,12 +1102,10 @@ where
                 text[i] as i32
             }
             Encoding::Latin1 => text[i] as i32,
-            Encoding::Utf16 => {
-                // TODO: if this is a part of a surrogate pair, we could parse the whole codepoint in order
-                // to emit it as a single \u{result} rather than two paired \uLOW\uHIGH.
-                // eg: "\u{10334}" will convert to "𐌴" without this.
-                code_unit_at!(i)
-            }
+            Encoding::Utf16 => match utf16_pair {
+                Some(cp) => cp as i32,
+                None => code_unit_at!(i),
+            },
         };
 
         if can_print_without_escape(c, ascii_only) {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2701,17 +2701,18 @@ pub mod formatter {
             self.print(format_args!("{str}"));
         }
 
-        #[inline]
-        pub(crate) fn write_16_bit(&mut self, input: &[u16]) {
-            // `format_utf16_type` requires `impl fmt::Write + Sized`; route through
-            // the `Display` adapter so we go via `bun_io::Write::write_fmt` instead.
-            self.print(format_args!(
-                "{}",
-                bun_core::fmt::FormatUTF16 {
-                    buf: input,
-                    path_fmt_opts: None
-                }
-            ));
+        /// Writes `str` as a quoted JSON string, the same way for every encoding.
+        pub(crate) fn write_json_string(&mut self, str: EncodedSlice<'_>) {
+            let encoding = if str.is_16bit() {
+                JSPrinter::Encoding::Utf16
+            } else if str.is_utf8() {
+                JSPrinter::Encoding::Utf8
+            } else {
+                JSPrinter::Encoding::Latin1
+            };
+            if JSPrinter::write_json_string(str.byte_slice(), self.ctx, encoding).is_err() {
+                self.failed = true;
+            }
         }
     }
 
@@ -2980,36 +2981,14 @@ pub mod formatter {
                         key,
                         pfmt!("<d>:<r> ", C),
                     ));
-                } else if key.is_16bit() {
-                    let mut utf16_slice = key.utf16_slice();
-
-                    writer.add_for_new_line(utf16_slice.len() + 2);
+                } else {
+                    writer.add_for_new_line(key.len + 2);
 
                     if C {
                         writer.write_all(pfmt!("<r><green>", true).as_bytes());
                     }
-
-                    writer.write_all(b"\"");
-
-                    const QUOTE_U16: &[u16] = &[b'"' as u16];
-                    while let Some(j) = strings::index_of_any16(utf16_slice, QUOTE_U16) {
-                        writer.write_16_bit(&utf16_slice[0..j]);
-                        writer.write_all(b"\"");
-                        utf16_slice = &utf16_slice[j + 1..];
-                    }
-
-                    writer.write_16_bit(utf16_slice);
-
-                    writer.print(format_args!("{}", pfmt!("\"<r><d>:<r> ", C)));
-                } else {
-                    writer.add_for_new_line(key.len + 2);
-
-                    writer.print(format_args!(
-                        "{}{}{}",
-                        pfmt!("<r><green>", C),
-                        bun_core::fmt::format_json_string_latin1(key.slice()),
-                        pfmt!("<r><d>:<r> ", C),
-                    ));
+                    writer.write_json_string(*key);
+                    writer.print(format_args!("{}", pfmt!("<r><d>:<r> ", C)));
                 }
             } else if cfg!(debug_assertions) && is_private_symbol {
                 writer.add_for_new_line(1 + "$:".len() + key.len);
@@ -3539,21 +3518,7 @@ pub mod formatter {
                 if C {
                     writer.write_all(pfmt!("<r><green>", true).as_bytes());
                 }
-
-                if str.is_utf16() {
-                    if writer.failed {
-                        self.failed = true;
-                    }
-                    self.print_as::<C>(Tag::JSON, writer_, value, jsc::JSType::StringObject)?;
-                    if C {
-                        let _ = writer_.write_all(pfmt!("<r>", true).as_bytes());
-                    }
-                    return Ok(());
-                }
-
-                JSPrinter::write_json_string(str.latin1(), writer.ctx, JSPrinter::Encoding::Latin1)
-                    .expect("unreachable");
-
+                writer.write_json_string(str.to_encoded_slice());
                 if C {
                     writer.write_all(pfmt!("<r>", true).as_bytes());
                 }
@@ -3568,26 +3533,7 @@ pub mod formatter {
                     writer.print(format_args!("{}", pfmt!("<r><green>", C)));
                 }
                 writer.print(format_args!("[String: "));
-
-                if str.is_utf16() {
-                    if writer.failed {
-                        self.failed = true;
-                    }
-                    self.print_as::<C>(Tag::JSON, writer_, value, jsc::JSType::StringObject)?;
-                    writer = WrappedWriter {
-                        ctx: writer_,
-                        failed: false,
-                        estimated_line_length: &mut self.estimated_line_length,
-                    };
-                } else {
-                    JSPrinter::write_json_string(
-                        str.latin1(),
-                        writer.ctx,
-                        JSPrinter::Encoding::Latin1,
-                    )
-                    .expect("unreachable");
-                }
-
+                writer.write_json_string(str.to_encoded_slice());
                 writer.print(format_args!("]"));
                 if C {
                     writer.write_all(pfmt!("<r>", true).as_bytes());

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -14,11 +14,9 @@ use bun_collections::HashMap;
 use bun_core::{EncodedSlice, String as BunString, strings};
 use bun_core::{Output, StackCheck};
 
-/// Thin facade over `bun_js_parser::lexer` / `bun_js_printer` so the call
-/// sites below can use the `JSLexer.isLatin1Identifier` /
-/// `JSPrinter.writeJsonString` spelling while the underlying crates expose
-/// slightly different shapes (single generic identifier predicate; const-generic
-/// encoding on `write_json_string`).
+/// Thin facade over `bun_js_parser::lexer` so the call sites below can use the
+/// `JSLexer.isLatin1Identifier` spelling while the underlying crate exposes a
+/// slightly different shape (single generic identifier predicate).
 mod JSLexer {
     #[inline]
     pub(super) fn is_latin1_identifier_u8(name: &[u8]) -> bool {
@@ -29,32 +27,6 @@ mod JSLexer {
     #[inline]
     pub(super) fn is_latin1_identifier_u16(name: &[u16]) -> bool {
         bun_ast::lexer_tables::is_latin1_identifier_u16(name)
-    }
-}
-mod JSPrinter {
-    pub(super) use bun_js_printer::Encoding;
-    /// Runtime-encoding adapter over `bun_js_printer::write_json_string`,
-    /// which takes `Encoding` as a const generic.
-    #[inline]
-    pub(super) fn write_json_string(
-        input: &[u8],
-        writer: &mut (impl bun_io::Write + ?Sized),
-        encoding: Encoding,
-    ) -> bun_js_printer::Result<()> {
-        match encoding {
-            Encoding::Latin1 => {
-                bun_js_printer::write_json_string::<_, { Encoding::Latin1 }>(input, writer)
-            }
-            Encoding::Utf8 => {
-                bun_js_printer::write_json_string::<_, { Encoding::Utf8 }>(input, writer)
-            }
-            Encoding::Ascii => {
-                bun_js_printer::write_json_string::<_, { Encoding::Ascii }>(input, writer)
-            }
-            Encoding::Utf16 => {
-                bun_js_printer::write_json_string::<_, { Encoding::Utf16 }>(input, writer)
-            }
-        }
     }
 }
 
@@ -5411,11 +5383,7 @@ pub mod formatter {
                 if C {
                     writer.write_all(pfmt!("<r><green>", true).as_bytes());
                 }
-                let _ = JSPrinter::write_json_string(
-                    slice,
-                    &mut *writer.ctx,
-                    JSPrinter::Encoding::Utf8,
-                );
+                writer.write_json_string(EncodedSlice::utf8(slice));
                 if C {
                     writer.write_all(pfmt!("<r>", true).as_bytes());
                 }

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2703,14 +2703,7 @@ pub mod formatter {
 
         /// Writes `str` as a quoted JSON string, the same way for every encoding.
         pub(crate) fn write_json_string(&mut self, str: EncodedSlice<'_>) {
-            let encoding = if str.is_16bit() {
-                JSPrinter::Encoding::Utf16
-            } else if str.is_utf8() {
-                JSPrinter::Encoding::Utf8
-            } else {
-                JSPrinter::Encoding::Latin1
-            };
-            if JSPrinter::write_json_string(str.byte_slice(), self.ctx, encoding).is_err() {
+            if bun_js_printer::write_json_string_encoded(str, self.ctx).is_err() {
                 self.failed = true;
             }
         }

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -14,9 +14,7 @@ use bun_collections::HashMap;
 use bun_core::{EncodedSlice, String as BunString, strings};
 use bun_core::{Output, StackCheck};
 
-/// Thin facade over `bun_js_parser::lexer` so the call sites below can use the
-/// `JSLexer.isLatin1Identifier` spelling while the underlying crate exposes a
-/// slightly different shape (single generic identifier predicate).
+/// Thin facade so the call sites below keep the `JSLexer.isLatin1Identifier` spelling.
 mod JSLexer {
     #[inline]
     pub(super) fn is_latin1_identifier_u8(name: &[u8]) -> bool {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -3877,7 +3877,7 @@ impl BunXFastPath {
 
         // Trigger quoting only on
         // space/tab/quote — compare the FULL u16, not the truncated low byte.
-        let needs_quote = strings::index_of_any16(warg, bun_core::w!(" \t\"")).is_some();
+        let needs_quote = strings::index_of_any_t(warg, bun_core::w!(" \t\"")).is_some();
 
         if !needs_quote {
             buffer[..warg.len()].copy_from_slice(warg);
@@ -3885,7 +3885,7 @@ impl BunXFastPath {
         }
 
         // Fast path: no embedded `"`/`\` → simple wrap.
-        let has_quote_or_backslash = strings::index_of_any16(warg, bun_core::w!("\"\\")).is_some();
+        let has_quote_or_backslash = strings::index_of_any_t(warg, bun_core::w!("\"\\")).is_some();
         if !has_quote_or_backslash {
             buffer[0] = b'"' as u16;
             buffer[1..1 + warg.len()].copy_from_slice(warg);

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -708,17 +708,9 @@ impl<'w, W: bun_io::Write> WrappedWriter<'w, W> {
         self.print(format_args!("{}", str));
     }
 
-    #[inline]
-    pub(crate) fn write_16_bit(&mut self, input: &[u16]) {
-        // `format_utf16_type` writes through `fmt::Write`; buffer to a `String`
-        // and forward bytes (UTF-16 → UTF-8 conversion is the point, so the
-        // intermediate allocation is unavoidable without a `bun_io::Write` overload).
-        let mut buf = String::new();
-        if bun_fmt::format_utf16_type(input, &mut buf).is_err() {
-            self.failed = true;
-            return;
-        }
-        if self.ctx.write_all(buf.as_bytes()).is_err() {
+    /// Writes `str` as a quoted JSON string, the same way for every encoding.
+    pub(crate) fn write_json_string(&mut self, str: EncodedSlice<'_>) {
+        if bun_js_printer::write_json_string_encoded(str, self.ctx).is_err() {
             self.failed = true;
         }
     }
@@ -967,29 +959,15 @@ impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
                     pretty_fmt_const!(ENABLE_ANSI_COLORS, "<d>"),
                     pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r>"),
                 ));
-            } else if key.is_16bit() {
-                let utf16_slice = key.utf16_slice();
-
-                this.add_for_new_line(utf16_slice.len() + 2);
+            } else {
+                this.add_for_new_line(key.len + 2);
 
                 if ENABLE_ANSI_COLORS {
                     writer.write_all(pretty_fmt_const!(true, "<r><green>").as_bytes());
                 }
-
-                writer.write_all(b"\"");
-                writer.write_16_bit(utf16_slice);
+                writer.write_json_string(key);
                 writer.print(format_args!(
-                    "\"{}:{} ",
-                    pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r><d>"),
-                    pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r>"),
-                ));
-            } else {
-                this.add_for_new_line(key.len + 2);
-
-                writer.print(format_args!(
-                    "{}{}{}:{} ",
-                    pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r><green>"),
-                    bun_fmt::format_json_string_latin1(key.slice()),
+                    "{}:{} ",
                     pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r><d>"),
                     pretty_fmt_const!(ENABLE_ANSI_COLORS, "<r>"),
                 ));

--- a/test/bundler/bundler_string.test.ts
+++ b/test/bundler/bundler_string.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { dedent, itBundled } from "./expectBundled";
 
 interface TemplateStringTest {
@@ -218,4 +218,31 @@ describe("bundler", () => {
       true`,
     },
   });
+
+  // A string literal with non-ASCII characters is UTF-16 in the AST. A text or
+  // JSON import is UTF-8. The printer must escape both the same way.
+  for (const target of ["browser", "bun"] as const) {
+    itBundled(`string/SurrogatePairs_${target}`, {
+      files: {
+        "/entry.js": `
+          import text from "./text.txt";
+          import json from "./data.json";
+          console.log(JSON.stringify([text, json.k, "é 𐌴 \\u{10334} \\uD800\\uDF34", "a\\uD800b", "\\uDF34\\uD800"]));
+        `,
+        "/text.txt": "é 𐌴 𐌴 𐌴",
+        "/data.json": `{"k":"é 𐌴 𐌴 𐌴"}`,
+      },
+      target,
+      onAfterBundle(api) {
+        // --target=bun output is ASCII-only. Other targets print non-ASCII as-is,
+        // a well-formed surrogate pair included. Lone surrogates are always escaped.
+        const wellFormed = target === "bun" ? '"\\xE9 \\uD800\\uDF34 \\uD800\\uDF34 \\uD800\\uDF34"' : '"é 𐌴 𐌴 𐌴"';
+        const out = api.readFile("/out.js");
+        // The text import, the JSON import and the string literal.
+        expect(out.split(wellFormed).length - 1).toBe(3);
+        expect(out).toContain(wellFormed + ', "a\\uD800b", "\\uDF34\\uD800"]');
+      },
+      run: { stdout: '["é 𐌴 𐌴 𐌴","é 𐌴 𐌴 𐌴","é 𐌴 𐌴 𐌴","a\\ud800b","\\udf34\\ud800"]' },
+    });
+  }
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3131,9 +3131,13 @@ console.log(<div {...obj} key="after" />);`),
     });
 
     it("unicode surrogates", () => {
-      expectPrinted_(`console.log("𐌴")`, 'console.log("\\uD800\\uDF34")');
-      expectPrinted_(`console.log("\\u{10334}")`, 'console.log("\\uD800\\uDF34")');
-      expectPrinted_(`console.log("\\uD800\\uDF34")`, 'console.log("\\uD800\\uDF34")');
+      // Bun.Transpiler prints non-ASCII as-is; a well-formed surrogate pair is one character.
+      expectPrinted_(`console.log("𐌴")`, 'console.log("𐌴")');
+      expectPrinted_(`console.log("\\u{10334}")`, 'console.log("𐌴")');
+      expectPrinted_(`console.log("\\uD800\\uDF34")`, 'console.log("𐌴")');
+      expectPrinted_(`console.log("a\\uD800b\\uDF34c")`, 'console.log("a\\uD800b\\uDF34c")');
+      expectPrinted_(`console.log("\\uDF34\\uD800")`, 'console.log("\\uDF34\\uD800")');
+      expectPrinted_(`console.log("\\uD83D\\uDE0E\\uDE0E\\uD83D\\uD83D\\uDE0E")`, 'console.log("😎\\uDE0E\\uD83D😎")');
       expectPrinted_(`console.log("\\u{10334}" === "\\uD800\\uDF34")`, "console.log(true)");
       expectPrinted_(`console.log("\\u{10334}" === "\\uDF34\\uD800")`, "console.log(false)");
       expectPrintedMin_(`console.log("abc" + "def")`, 'console.log("abcdef")');

--- a/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/bun-snapshots.test.ts
@@ -33,6 +33,71 @@ test("ArrayBuffer values are serialized like typed arrays", () => {
   `);
 });
 
+test("object keys get the same escapes in Latin-1 and UTF-16 strings", () => {
+  // A string decoded from UTF-16 bytes keeps 16-bit storage, even when every character is ASCII.
+  const utf16 = (s: string) => Buffer.from(s, "utf16le").toString("utf16le");
+  const special = '"\\\n\x1b';
+  const value = {
+    [utf16(["ascii in utf16 ", special].join(""))]: 1,
+    ["latin1 " + special]: 2,
+    ["lone surrogates \ud800 \udc00"]: 3,
+    // A Latin-1 string cannot hold these three characters.
+    ["utf16 only \u2028\u2029\ufeff"]: 4,
+    ["日本 " + special]: 5,
+    ["😀 " + special]: 6,
+  };
+  expect(value).toMatchInlineSnapshot(`
+    {
+      "ascii in utf16 \\"\\\\\\n\\u001B": 1,
+      "latin1 \\"\\\\\\n\\u001B": 2,
+      "lone surrogates \\uD800 \\uDC00": 3,
+      "utf16 only \\u2028\\u2029\\uFEFF": 4,
+      "日本 \\"\\\\\\n\\u001B": 5,
+      "😀 \\"\\\\\\n\\u001B": 6,
+    }
+  `);
+
+  // A matcher failure prints the value too. toEqual uses the snapshot formatter. toBe uses the console formatter.
+  const failure = (fn: () => void) => {
+    try {
+      fn();
+    } catch (e) {
+      return Bun.stripANSI((e as Error).message);
+    }
+  };
+  expect(failure(() => expect(value).toEqual(0))).toMatchInlineSnapshot(`
+    "expect(received).toEqual(expected)
+
+    - 0
+    + {
+    +   "ascii in utf16 \\"\\\\\\n\\u001B": 1,
+    +   "latin1 \\"\\\\\\n\\u001B": 2,
+    +   "lone surrogates \\uD800 \\uDC00": 3,
+    +   "utf16 only \\u2028\\u2029\\uFEFF": 4,
+    +   "日本 \\"\\\\\\n\\u001B": 5,
+    +   "😀 \\"\\\\\\n\\u001B": 6,
+    + }
+
+    - Expected  - 1
+    + Received  + 8
+    "
+  `);
+  expect(failure(() => expect(value).toBe(0))).toMatchInlineSnapshot(`
+    "expect(received).toBe(expected)
+
+    Expected: 0
+    Received: {
+      "ascii in utf16 \\"\\\\\\n\\u001B": 1,
+      "latin1 \\"\\\\\\n\\u001B": 2,
+      "lone surrogates \\uD800 \\uDC00": 3,
+      "utf16 only \\u2028\\u2029\\uFEFF": 4,
+      "日本 \\"\\\\\\n\\u001B": 5,
+      "😀 \\"\\\\\\n\\u001B": 6,
+    }
+    "
+  `);
+});
+
 describe("toMatchSnapshot errors", () => {
   it("should throw if property matchers exist and received is not an object", () => {
     expect(() => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, jest } from "bun:test";
 import {
   bunEnv,
   bunExe,
@@ -167,6 +167,114 @@ it("latin1", () => {
   expect(Bun.inspect("日本語")).toBe('"日本語"');
   expect(Bun.inspect("Emoji😎")).toBe('"Emoji😎"');
   expect(Bun.inspect("Français / Ελληνική")).toBe('"Français / Ελληνική"');
+});
+
+describe("quoted strings do not depend on the string's internal representation", () => {
+  // Same characters, but backed by 16-bit storage (what a UTF-16 decoder produces).
+  // A string used as a property key can be swapped for an equal 8-bit atom, for
+  // example one made by a string literal in this file, so each test asserts the
+  // representation it depends on.
+  const to16Bit = s => Buffer.from(s, "utf16le").toString("utf16le");
+
+  it("arrays of 8-bit and 16-bit strings wrap at the same place", () => {
+    const row8 = ["a", "b", "c", "d", "e"].map(c => Buffer.alloc(20, c).toString());
+    const row16 = row8.map(to16Bit);
+    expect(row16).toEqual(row8);
+    for (const s of row8) expect(s).toBeLatin1String();
+    for (const s of row16) expect(s).toBeUTF16String();
+    const expected =
+      '[ "aaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbb", "cccccccccccccccccccc", "dddddddddddddddddddd",\n' +
+      '  "eeeeeeeeeeeeeeeeeeee"\n' +
+      "]";
+    expect(Bun.inspect(row8)).toBe(expected);
+    expect(Bun.inspect(row16)).toBe(expected);
+  });
+
+  it("8-bit and 16-bit strings with the same characters print the same", () => {
+    const s8 = '\x1b[31m \x00\x0b\x0e\x1f "q" \\';
+    const s16 = to16Bit(s8);
+    expect(s16).toBe(s8);
+    expect(s8).toBeLatin1String();
+    expect(s16).toBeUTF16String();
+    const expected = '"\\u001B[31m \\u0000\\u000B\\u000E\\u001F \\"q\\" \\\\"';
+    expect(Bun.inspect(s8)).toBe(expected);
+    expect(Bun.inspect(s16)).toBe(expected);
+    expect(Bun.inspect([s16])).toBe(Bun.inspect([s8]));
+    expect(Bun.inspect({ k: s16 })).toBe(Bun.inspect({ k: s8 }));
+    expect(Bun.inspect(new String(s16))).toBe(Bun.inspect(new String(s8)));
+    expect(Bun.inspect(new Map([[s16, s16]]))).toBe(Bun.inspect(new Map([[s8, s8]])));
+    // Nothing above swapped the 16-bit string for the 8-bit one.
+    expect(s16).toBeUTF16String();
+  });
+
+  it("strings that need 16 bits", () => {
+    expect(Bun.inspect("\x1b é 日本 😎 \u{10334}")).toBe('"\\u001B é 日本 😎 𐌴"');
+    expect(Bun.inspect(new String("\x1b😎"))).toBe('"\\u001B😎"');
+    // Lone surrogates and invisible separators are escaped.
+    expect(Bun.inspect(["\ud800", "\udc00x", "a\u2028b\u2029c\ufeffd"])).toBe(
+      '[ "\\uD800", "\\uDC00x", "a\\u2028b\\u2029c\\uFEFFd" ]',
+    );
+    // A surrogate pair is one character only when a high half is directly followed by a low half.
+    expect(Bun.inspect("\ud83d\ude0e\ude0e\ud83d\ud83d\ude0e")).toBe('"😎\\uDE0E\\uD83D😎"');
+  });
+
+  it("console.log of a String object", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.log(new String("\\x1b😎!")); console.log(new String("\\x1b!"));`],
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: '[String: "\\u001B😎!"]\n[String: "\\u001B!"]\n',
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("a String object's toJSON is not called", () => {
+    const toJSON = jest.fn(() => "from toJSON");
+    class Tagged extends String {
+      toJSON() {
+        return toJSON();
+      }
+    }
+    const own = new String("😎");
+    own.toJSON = toJSON;
+    String.prototype.toJSON = toJSON;
+    try {
+      expect(Bun.inspect([new String("😎"), new String("x"), own, new Tagged("😎"), new Tagged("x")])).toBe(
+        '[ "😎", "x", "😎", "😎", "x" ]',
+      );
+    } finally {
+      delete String.prototype.toJSON;
+    }
+    expect(toJSON).not.toHaveBeenCalled();
+  });
+
+  it("property keys", () => {
+    expect(Bun.inspect({ 'k"\x1b\\': 1, 'k"\x1b\\ 日本 😎': 2 })).toBe(
+      '{\n  "k\\"\\u001B\\\\": 1,\n  "k\\"\\u001B\\\\ 日本 😎": 2,\n}',
+    );
+    // URLSearchParams and FormData print their names the same way.
+    expect(Bun.inspect(new URLSearchParams([['k"\x1b\\ 日本 😎', "v"]]))).toBe(
+      'URLSearchParams {\n  "k\\"\\u001B\\\\ 日本 😎": "v",\n}',
+    );
+  });
+
+  it("16-bit property keys that hold only Latin-1 characters", () => {
+    // Built from parts, so no string literal in this file makes an equal 8-bit atom.
+    const key = to16Bit(["dyn", "k", '"', "\x1b", "\\"].join(""));
+    const path = to16Bit(["C:", "Users", "José", "new.js"].join("\\"));
+    expect(key).toBeUTF16String();
+    expect(path).toBeUTF16String();
+    expect(Bun.inspect({ [key]: 1, [path]: path })).toBe(
+      '{\n  "dynk\\"\\u001B\\\\": 1,\n  "C:\\\\Users\\\\José\\\\new.js": "C:\\\\Users\\\\José\\\\new.js",\n}',
+    );
+    // Still 16-bit, so the line above went through the 16-bit branch.
+    expect(key).toBeUTF16String();
+    expect(path).toBeUTF16String();
+  });
 });
 
 it("Request object", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -256,6 +256,10 @@ describe("quoted strings do not depend on the string's internal representation",
     expect(Bun.inspect({ 'k"\x1b\\': 1, 'k"\x1b\\ 日本 😎': 2 })).toBe(
       '{\n  "k\\"\\u001B\\\\": 1,\n  "k\\"\\u001B\\\\ 日本 😎": 2,\n}',
     );
+    // Invisible separators and lone surrogates are escaped, as in a string value.
+    expect(Bun.inspect({ "a\n\u2028\u2029\ufeff": 1, "\ud800b\udc00": 2 })).toBe(
+      '{\n  "a\\n\\u2028\\u2029\\uFEFF": 1,\n  "\\uD800b\\uDC00": 2,\n}',
+    );
     // URLSearchParams and FormData print their names the same way.
     expect(Bun.inspect(new URLSearchParams([['k"\x1b\\ 日本 😎', "v"]]))).toBe(
       'URLSearchParams {\n  "k\\"\\u001B\\\\ 日本 😎": "v",\n}',

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -190,21 +190,35 @@ describe("quoted strings do not depend on the string's internal representation",
     expect(Bun.inspect(row16)).toBe(expected);
   });
 
-  it("8-bit and 16-bit strings with the same characters print the same", () => {
+  describe("8-bit and 16-bit strings with the same characters print the same", () => {
     const s8 = '\x1b[31m \x00\x0b\x0e\x1f "q" \\';
     const s16 = to16Bit(s8);
-    expect(s16).toBe(s8);
-    expect(s8).toBeLatin1String();
-    expect(s16).toBeUTF16String();
-    const expected = '"\\u001B[31m \\u0000\\u000B\\u000E\\u001F \\"q\\" \\\\"';
-    expect(Bun.inspect(s8)).toBe(expected);
-    expect(Bun.inspect(s16)).toBe(expected);
-    expect(Bun.inspect([s16])).toBe(Bun.inspect([s8]));
-    expect(Bun.inspect({ k: s16 })).toBe(Bun.inspect({ k: s8 }));
-    expect(Bun.inspect(new String(s16))).toBe(Bun.inspect(new String(s8)));
-    expect(Bun.inspect(new Map([[s16, s16]]))).toBe(Bun.inspect(new Map([[s8, s8]])));
-    // Nothing above swapped the 16-bit string for the 8-bit one.
-    expect(s16).toBeUTF16String();
+
+    it("as a value", () => {
+      expect(s16).toBe(s8);
+      expect(s8).toBeLatin1String();
+      expect(s16).toBeUTF16String();
+      const expected = '"\\u001B[31m \\u0000\\u000B\\u000E\\u001F \\"q\\" \\\\"';
+      expect(Bun.inspect(s8)).toBe(expected);
+      expect(Bun.inspect(s16)).toBe(expected);
+    });
+
+    // Each row is a place where the printer writes a quoted string that is not a property key.
+    // A new branch on the storage width in one of them fails its row.
+    it.each([
+      ["an array element", s => [s]],
+      ["an array that wraps", s => [s, s, s, s, s]],
+      ["an object value", s => ({ k: s })],
+      ["a nested value", s => ({ a: [{ b: [s] }] })],
+      ["a String object", s => new String(s)],
+      ["a Map key and value", s => new Map([[s, s]])],
+      ["a Set element", s => new Set([s])],
+    ])("as %s", (_, build) => {
+      expect(Bun.inspect(build(s16))).toBe(Bun.inspect(build(s8)));
+      // Nothing above swapped the 16-bit string for the 8-bit one.
+      expect(s8).toBeLatin1String();
+      expect(s16).toBeUTF16String();
+    });
   });
 
   it("strings that need 16 bits", () => {


### PR DESCRIPTION
### Problem
- `console.log`, `Bun.inspect` and `bun:test` write a 16-bit object key raw. `console.log(JSON.parse('{"日本\\n[INFO] forged":1}'))` prints a real line break, so untrusted JSON can forge a log line. An 8-bit key prints `\n`, as Node does. A snapshot with such a key can pass in a full run and fail under `-t` (Notes). Values differ too: a vertical tab prints as `"\u000B"` when 8-bit and `"\u000b"` when 16-bit.
- Cause: `print_string` and `write_property_key` (`src/jsc/ConsoleObject.rs`) and the key printer at `src/runtime/test_runner/pretty_format.rs:970` branch on `is_16bit()`. A fuzzer and a code read found this. No issue exists.

### Fix
- Both printers call one new function, `bun_js_printer::write_json_string_encoded`, for keys, values and `[String: ...]`. A snapshot, a `toEqual` diff, a `toBe` message and `Bun.inspect` print the same key text.
- `write_pre_quoted_string_inner` escaped each half of a surrogate pair in UTF-16 input. It now reads a well-formed pair as one code point, as its UTF-8 path does.
- Two output changes need a maintainer decision. `bun build --target=browser|node` prints an astral character in a string literal as-is (`--target=bun` is byte-identical). A stored snapshot changes if a 16-bit key has `"`, `\`, a control character, U+2028, U+2029, U+FEFF or a lone surrogate. Jest prints keys raw. `bun:test` has always escaped 8-bit keys. This PR extends that form (precedent: #23390).
- Verified: 14 new tests in `inspect.test.js`, one in `bun-snapshots.test.ts`, `bundler_string.test.ts`, `transpiler.test.js`. All fail on 1.4.3-canary.1. This PR includes #42299.

### Background
- JSC stores a string as Latin-1 bytes (8-bit) or UTF-16 code units (16-bit). JavaScript cannot see which.
- `ConsoleObject.rs` prints `console.log`, `Bun.inspect` and the `Received:` value of `toBe`. `pretty_format.rs` is a fork that prints snapshots and `toEqual` diffs.
- `write_pre_quoted_string_inner` (`src/js_printer/lib.rs`) is the shared JS/JSON string escaper. With `ascii_only` it escapes all non-ASCII. The bundler sets that for `--target=bun` only.

<details><summary>Notes</summary>

**This PR and #42299.** #42299 fixed the same `key.is_16bit()` branch of `write_property_key`, and its copy in `pretty_format.rs`, with `format_json_string_utf8(&key.to_utf8(), ..)`. This PR fixed the branch in `ConsoleObject.rs` only, with a helper that also prints values. I built both and printed 20 keys with each (quotes, backslashes, C0 and C1 controls, DEL, U+2028, U+2029, U+FEFF, astral characters, lone and reversed surrogates). The two escapers agree on every key except one with a lone surrogate: `to_utf8()` replaces it with U+FFFD, this PR writes `\uD800`. `pretty_format.rs` cannot print `\uD800` without the surrogate pair fix in this PR, so the two changes are one PR now. What moved here from #42299: the `pretty_format.rs` hunk, the test in `bun-snapshots.test.ts` (plus a lone surrogate key), its key cases for `inspect.test.js`, and the removal of `index_of_any16`.

If the snapshot change is not wanted, the carve-out is mechanical: drop the hunk in `pretty_format.rs` and the test in `bun-snapshots.test.ts`. The rest does not depend on them.

`write_json_string_encoded` takes an `EncodedSlice` and picks `Encoding::Utf16`, `Utf8` or `Latin1`. It is in `bun_js_printer` next to `write_json_string`, because both printer crates already depend on that crate. The `WrappedWriter` of each printer has a one-line `write_json_string` that calls it and sets `failed` on a write error. The `JSPrinter` facade in `ConsoleObject.rs` (a runtime-encoding adapter) had one caller left, the `Uint8Array` as text arm of the error printer. That arm now calls the same helper, and the facade is gone.

The snapshot repro (fails on 1.4.3-canary.1, passes with this PR). `keys.txt` is UTF-8. Line 1 is `café say "hi"`, line 2 is `日本`, so the decoded file is a 16-bit string and so is each line cut from it.

```ts
import { test, expect } from "bun:test";
import { readFileSync } from "node:fs";
const line = readFileSync(import.meta.dir + "/keys.txt", "utf8").split("\n")[0];
const seen: Record<string, number> = {};
test("first", () => {
  seen[line] = 1; // used as a key first: JSC makes an 8-bit atom, and `line` is 8-bit from here on
  expect(Object.keys(seen)).toHaveLength(1);
});
test("second", () => {
  expect(Bun.inspect(line)).toContain("caf"); // printed first (when `first` did not run): `line` stays 16-bit
  expect({ [line]: 1 }).toMatchSnapshot();
});
```

`bun test` writes `"café say \"hi\"": 1` and passes again. `bun test -t second` prints `"café say "hi"": 1` and fails.

More examples of the old behavior (bun 1.4.3):

- A path key: `const p = path.win32.join("C:\\Users\\José", "new.js"); console.log({ [p]: p })` prints `"C:\Users\José\new.js": "C:\\Users\\José\\new.js"`. The key has single backslashes, the value has doubled ones.
- The same JS string changes its output within one program: `const v = "日本,a\x1b[31m".split(",")[1]; Bun.inspect([v])` prints the escape for ESC with lowercase hex digits. After `seen[v] = true` it prints uppercase hex digits, because the property lookup swaps the 16-bit substring for an 8-bit atom. Whether an equal 8-bit atom exists depends on file order, on the thread (each Worker has its own atom table) and on GC.
- `String.prototype.toJSON = () => "x"; Bun.inspect(new String("😎"))` prints `"x"`, and a throwing `toJSON` makes `Bun.inspect` throw. An 8-bit `new String("a")` never calls `toJSON`.
- `URLSearchParams`, `FormData` and `Bun.CookieMap` print their names through the same `write_property_key`, so they had the same raw 16-bit keys.

Other visible output changes:

- A lone surrogate in a key prints as `\uD800` in both printers. Before, both printed U+FFFD, so two different keys could print the same text.
- Array wrapping. The old 16-bit path added the string length to the line length estimate twice (once in `print_string`, once in `print_json`), so an array of 16-bit strings wrapped about twice as early as the same array of 8-bit strings. Both now wrap at the same place. Arrays of CJK or emoji strings therefore get longer lines than before.
- `Bun.inspect` of a 16-bit string now escapes U+2028, U+2029, U+FEFF and lone surrogates with uppercase hex (`"\uD800"`, was `"\ud800"` from `JSON.stringify`; the separators and the BOM printed raw before). 8-bit strings cannot contain these, so there was no 8-bit behavior to match.
- `bun build` / `Bun.Transpiler`: `"👋"` instead of `"\uD83D\uDC4B"` for targets other than bun. On bun 1.4.3 `import t from "./t.txt"` with `👋` in the file already bundles to `"👋"` for `--target=browser` (the UTF-8 path), while the literal `"👋"` bundles to `"\uD83D\uDC4B"` (the UTF-16 path). `string/SurrogatePairs_*` asserts that the two paths agree. The change busts content hashes once for chunks that hold an astral character in a string literal. With `ascii_only`, the combined code point goes to `surrogate_pair_escape`, which emits the same `\uD83D\uDC4B` as before, so `--target=bun` output and the runtime transpiler output (and its cache) do not change. Source map columns already count a code point above U+FFFF as two UTF-16 units (`update_generated_line_and_column_slow`).
- `%j` still uses `JSON.stringify` on purpose and keeps its lowercase escapes.
- A failed write in these paths now sets `failed` instead of `.expect("unreachable")`.

Snapshot direction. Jest's `pretty-format` escapes only `"` and `\` in keys, and Jest 29 and Vitest snapshots print keys raw. `bun:test` has JSON-escaped 8-bit keys since `toMatchSnapshot()` shipped (4792abdb7f, 2023), and most keys are 8-bit. So 16-bit keys match Jest today only by accident. This PR keeps the 8-bit output and moves the less common 16-bit case to it. The other direction changes the stored snapshots of each user that has an 8-bit key with a backslash (for example a Windows path). Parity with Jest for keys is a separate question (#40656 is the open report for string values). With one escaper call for keys, a later change of direction is a change in one place.

History: keys always went through `JSPrinter.formatJSONString` until fd4a210b84 (2022, a non-ASCII fix for `console.log`). That commit added the 16-bit branch as a raw write. `pretty_format` is a fork of that formatter and kept the split. So the JSON escaper is the original behavior for a quoted key.

Order against open PRs:

- #31998 folds the two copies of the escaper into `bun_core::printer::write_pre_quoted_string_inner` with the body of the `js_printer` copy. This PR gives both copies the same two hunks (`bun_core::string::printer::write_pre_quoted_string` has no UTF-16 caller today, the hunks keep the copies in sync). If #31998 lands first, this PR keeps the two hunks on that one function and drops the comment there that says a pair prints as `\uD800\uDF34`. If this PR lands first, #31998 takes the hunks with the body it copies.
- #41789 changes the `Encoding::Utf8` arm of the same `match` in `write_pre_quoted_string_inner`. This PR changes the `Encoding::Utf16` arm. The second one to land rebases over a near hunk. Neither changes the other's output.
- #36404 edits the two `print_as(Tag::JSON, ..)` lines of `print_string` that this PR deletes. After this PR it passes its inner string to `writer.write_json_string(str.to_encoded_slice())`.
- #37303 measures an array element with `json_stringify` for a 16-bit string and with the `JSPrinter` facade for an 8-bit one. After this PR it measures both with `write_json_string_encoded` and a counting writer.
- #39965 (`src/telemetry/db.rs`) and #39745 (a Windows-only shim reader) add callers of `index_of_any16`. There is no textual conflict. After this PR they call `index_of_any_t`, which it wrapped.
- #36615 changes which strings get 16-bit storage (UTF-8 decode of text in the Latin-1 range becomes 8-bit). After this PR the storage width does not change the output.
- #42298 (#42296) fixes the `String` object arm of `pretty_format.rs`. It is a different hunk of that file.

Not in this PR:

- String values in `pretty_format.rs`. It prints them raw in both widths, so the width does not change the output.
- One shared `write_property_key` for both printers. The two copies differ in more than the escaper.
- `format_json_string_latin1` still has callers that pass UTF-8 bytes (`init_command.rs`, `jsc_hooks.rs`). That is a different defect.

Dead code that this PR removes: `write_16_bit` in both printers, the `JSPrinter` facade, and `index_of_any16` (`src/bun_core/string/immutable.rs`). The console key printer was the last caller of `index_of_any16` outside Windows-only code, and the `mordant` lint reports an unused public function. It was a one-line wrapper for `index_of_any_t`. The two Windows callers in `src/runtime/cli/run_command.rs` now call `index_of_any_t`. `cargo check -p bun_runtime --target x86_64-pc-windows-msvc` passes, and a local `cargo dylint` run reports nothing over the baseline.

Self-reviewed before opening, and again after the consolidation. The first review asked for the bundler output change stated up front, the note on #31998, and stronger tests (representation guards with `toBeUTF16String()`, a path-shaped key, a text and JSON import next to the string literal, adjacent lone surrogates, `toJSON`). It also asked to move the runtime-encoding adapter out of `ConsoleObject.rs` so that `pretty_format.rs` can call it. That is `write_json_string_encoded`. The second review raised the points above (the repros first, the Jest difference, the carve-out, the order against open PRs, the `index_of_any16` callers in flight, the facade, one table of positions in `inspect.test.js`). All are in this PR.

Also ran on the consolidated branch: `expect.test.js`, `test/js/bun/test/snapshot-tests/`, `test/js/web/console`, `test/js/bun/console`, `test/js/node/util/*inspect*`, `test/internal/source-lints`, and the new tests under `BUN_JSC_validateExceptionChecks=1`. Two tests fail in those runs on a local debug ASAN build. `error snapshots` in `snapshot.test.ts` fails the same way on 1.4.3-canary.1: its stored snapshot has ANSI colors and a piped run has none. `util-inspect-long-running.test.mjs` hits the 5 s timeout: it calls the JS `util.inspect`, which this PR does not touch. The first version of this PR also ran `es-decorators.test.ts`, `invalid-escape-sequences.test.ts`, `bundler_minify.test.ts` and `bundler_edgecase.test.ts` on the same `js_printer` change.

Throughput: on a release build the old 16-bit path (`JSON.stringify` plus a transcode) formatted 2M CJK characters in about 12 ms. The per-character path that 16-bit strings now share with Latin-1 takes about 21 ms for 2M non-ASCII characters. Small strings skip a JS call and two allocations.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->
