### PR TITLE
tls: report a fatal post-handshake SSL error over a Duplex or a named pipe

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1912,6 +1912,20 @@ struct us_bun_verify_error_t us_ssl_socket_verify_error_from_ssl(SSL *ssl) {
   return (struct us_bun_verify_error_t){.error = x509_verify_error, .code = code, .reason = reason};
 }
 
+/* The packed error that names a fatal SSL_read failure the way node reports
+ * it: the first SSL-library entry on the thread's queue (for a bad record
+ * BoringSSL queues the cipher's BAD_DECRYPT ahead of the TLS reason), else the
+ * oldest entry, else 0. Shared with the SSLWrapper engine (src/uws/lib.rs). */
+uint32_t us_ssl_take_fatal_error(void) {
+  uint32_t oldest = ERR_peek_error();
+  for (uint32_t queued; (queued = ERR_get_error()) != 0;) {
+    if (ERR_GET_LIB(queued) == ERR_LIB_SSL) {
+      return queued;
+    }
+  }
+  return oldest;
+}
+
 struct us_bun_verify_error_t us_internal_ssl_verify_error(struct us_socket_t *s) {
   if (!s->ssl || !s_ssl(s) || us_socket_is_closed(s) || us_internal_ssl_is_shut_down(s)) {
     return (struct us_bun_verify_error_t){.error = 0, .code = NULL, .reason = NULL};
@@ -2623,16 +2637,8 @@ restart:
            * server that rejects the client certificate sends certificate_required
            * after the client's handshake is done) or a record that does not
            * decrypt. No handshake dispatch reports it, so hand the reason to
-           * the socket before the close, like node's ClearOut calls onerror.
-           * Report the first SSL-library entry: for a bad record BoringSSL
-           * queues the cipher's BAD_DECRYPT ahead of the TLS reason. */
-          uint32_t ssl_err = ERR_peek_error();
-          for (uint32_t queued; (queued = ERR_get_error()) != 0;) {
-            if (ERR_GET_LIB(queued) == ERR_LIB_SSL) {
-              ssl_err = queued;
-              break;
-            }
-          }
+           * the socket before the close, like node's ClearOut calls onerror. */
+          uint32_t ssl_err = us_ssl_take_fatal_error();
           /* Everything that came before the failing record goes first, in wire
            * order, while the socket is not yet fatal: a fatal socket gives the
            * handshake dispatch no verify result, and data handlers assert that

--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -577,6 +577,7 @@ impl ProxyTunnel {
                 write: write_encrypted,
                 // fetch's proxy tunnel surfaces no 'session'/'keylog' events;
                 // opting out keeps its SSL off the parked queues entirely.
+                on_ssl_error: None,
                 on_session: None,
                 on_keylog: None,
                 ctx: this.as_erased_ptr().as_ptr(),

--- a/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
+++ b/src/http_jsc/websocket_client/WebSocketProxyTunnel.rs
@@ -185,6 +185,7 @@ impl WebSocketProxyTunnel {
                 write: Self::write_encrypted,
                 // No JS TLSSocket fronts the tunnel; opting out keeps the
                 // SSL off the parked session/keylog queues entirely.
+                on_ssl_error: None,
                 on_session: None,
                 on_keylog: None,
             },

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -100,6 +100,8 @@ pub struct Handlers {
     pub(crate) on_handshake: fn(*mut (), bool, us_bun_verify_error_t),
     pub(crate) on_data: fn(*mut (), &[u8]),
     pub on_close: fn(*mut ()),
+    /// See `ssl_wrapper::Handlers::on_ssl_error`.
+    pub(crate) on_ssl_error: fn(*mut (), u32),
     pub(crate) on_end: fn(*mut ()),
     pub(crate) on_writable: fn(*mut ()),
     pub(crate) on_error: fn(*mut (), JSValue),
@@ -195,6 +197,13 @@ impl UpgradedDuplex {
         if handshake_success && !this.is_shutdown() {
             (this.handlers.on_writable)(this.handlers.ctx);
         }
+    }
+
+    fn on_ssl_error(this: *mut Self, err: u32) {
+        bun_output::scoped_log!(UpgradedDuplex, "onSslError");
+        // SAFETY: see handler note above.
+        let this = unsafe { &*this };
+        (this.handlers.on_ssl_error)(this.handlers.ctx, err);
     }
 
     fn on_close(this: *mut Self) {
@@ -477,6 +486,7 @@ impl UpgradedDuplex {
             on_handshake: Self::on_handshake,
             on_data: Self::on_data,
             on_close: Self::on_close,
+            on_ssl_error: Some(Self::on_ssl_error),
             write: Self::internal_write,
             on_session: Some(Self::on_session),
             on_keylog: Some(Self::on_keylog),

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -135,6 +135,8 @@ pub struct Handlers {
     pub(crate) on_handshake: fn(*mut c_void, bool, us_bun_verify_error_t),
     pub(crate) on_data: fn(*mut c_void, &[u8]),
     pub on_close: fn(*mut c_void),
+    /// See `ssl_wrapper::Handlers::on_ssl_error`.
+    pub(crate) on_ssl_error: fn(*mut c_void, u32),
     pub(crate) on_end: fn(*mut c_void),
     pub(crate) on_writable: fn(*mut c_void),
     pub(crate) on_error: fn(*mut c_void, bun_sys::Error),
@@ -359,6 +361,11 @@ impl WindowsNamedPipe {
         (self.handlers.on_keylog)(self.handlers.ctx, line);
     }
 
+    fn on_ssl_error(&self, err: u32) {
+        bun_output::scoped_log!(WindowsNamedPipe, "onSslError");
+        (self.handlers.on_ssl_error)(self.handlers.ctx, err);
+    }
+
     // ── SSLWrapper trampolines ───────────────────────────────────────────────
     // `ssl_wrapper::Handlers<*mut Self>` carries `fn(*mut Self, ..)` slots.
     // SAFETY (all): `this` is the `ctx` set in `wrapper_handlers`; the engine
@@ -383,6 +390,10 @@ impl WindowsNamedPipe {
         // SAFETY: see block note above.
         unsafe { &*this }.on_keylog(d)
     }
+    fn ssl_on_ssl_error(this: *mut Self, err: u32) {
+        // SAFETY: see block note above.
+        unsafe { &*this }.on_ssl_error(err)
+    }
     fn ssl_on_close(this: *mut Self) {
         // SAFETY: see block note above.
         unsafe { &*this }.on_close()
@@ -400,6 +411,7 @@ impl WindowsNamedPipe {
             on_handshake: Self::ssl_on_handshake,
             on_data: Self::ssl_on_data,
             on_close: Self::ssl_on_close,
+            on_ssl_error: Some(Self::ssl_on_ssl_error),
             write: Self::ssl_write,
             on_session: Some(Self::ssl_on_session),
             on_keylog: Some(Self::ssl_on_keylog),

--- a/src/runtime/socket/WindowsNamedPipeContext.rs
+++ b/src/runtime/socket/WindowsNamedPipeContext.rs
@@ -213,6 +213,13 @@ impl WindowsNamedPipeContext {
         }
     }
 
+    fn on_ssl_error(this: *mut Self, err: u32) {
+        // SAFETY: see `on_open`.
+        if let SocketType::Tls(s) = unsafe { (*this).socket } {
+            crate::dispatch::fold(TLSSocket::on_ssl_error(s, err));
+        }
+    }
+
     fn on_handshake(this: *mut Self, success: bool, ssl_error: us_bun_verify_error_t) {
         // SAFETY: see `on_open`.
         let (socket, pipe) = unsafe { ((*this).socket, ptr::addr_of_mut!((*this).named_pipe)) };
@@ -391,6 +398,7 @@ impl WindowsNamedPipeContext {
             on_close: |p| Self::on_close(p.cast::<Self>()),
             on_session: |p, d| Self::on_session(p.cast::<Self>(), d),
             on_keylog: |p, d| Self::on_keylog(p.cast::<Self>(), d),
+            on_ssl_error: |p, err| Self::on_ssl_error(p.cast::<Self>(), err),
         };
         #[cfg(not(windows))]
         {

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -4396,6 +4396,12 @@ impl DuplexUpgradeContext {
         }
     }
 
+    fn on_ssl_error(this: bun_ptr::ThisPtr<Self>, err: u32) {
+        if let Some(tls) = this.tls_this_ptr() {
+            crate::dispatch::fold(TLSSocket::on_ssl_error(tls, err));
+        }
+    }
+
     fn on_close(this: bun_ptr::ThisPtr<Self>) {
         let socket = this.duplex_socket();
         if let Some(tls) = this.tls.replace(None) {
@@ -4791,6 +4797,10 @@ pub fn js_upgrade_duplex_to_tls(
                 // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
                 on_close: |c: *mut ()| {
                     DuplexUpgradeContext::on_close(bun_ptr::ThisPtr::new(c.cast()))
+                },
+                // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
+                on_ssl_error: |c: *mut (), err| {
+                    DuplexUpgradeContext::on_ssl_error(bun_ptr::ThisPtr::new(c.cast()), err)
                 },
                 // SAFETY: `c` is `ctx` below — the live `DuplexUpgradeContext` heap allocation.
                 on_end: |c: *mut ()| DuplexUpgradeContext::on_end(bun_ptr::ThisPtr::new(c.cast())),

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -769,8 +769,9 @@ pub mod ssl_wrapper {
             if self.flags.sent_ssl_shutdown() {
                 return Err(WriteDataError::ConnectionClosed);
             }
-            // A fatal read is mid-dispatch (its data callback wrote back): the
-            // error report and the close follow it. Do not close here.
+            // A callback of the pass that hit the fatal error wrote back. That pass
+            // closes once the callback returns. Closing here instead runs the owner's
+            // `on_close` (fetch's ProxyTunnel frees itself there) under its own frame.
             if self.flags.fatal_error() {
                 return Err(WriteDataError::ConnectionClosed);
             }

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -769,9 +769,8 @@ pub mod ssl_wrapper {
             if self.flags.sent_ssl_shutdown() {
                 return Err(WriteDataError::ConnectionClosed);
             }
-            // A callback of the pass that hit the fatal error wrote back. That pass
-            // closes once the callback returns. Closing here instead runs the owner's
-            // `on_close` (fetch's ProxyTunnel frees itself there) under its own frame.
+            // The fatal read closes once its callbacks return. A close from here
+            // would run the owner's `on_close` under one of them.
             if self.flags.fatal_error() {
                 return Err(WriteDataError::ConnectionClosed);
             }

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -348,6 +348,9 @@ pub mod ssl_wrapper {
         pub write: fn(T, &[u8]),
         pub on_data: fn(T, &[u8]),
         pub on_close: fn(T),
+        /// A fatal `SSL_read` failure (a packed BoringSSL error), reported just
+        /// before `on_close`. `None`: the owner only needs the close.
+        pub on_ssl_error: Option<fn(T, u32)>,
         /// A new resumable TLS session arrived (serialized SSL_SESSION bytes)
         /// - node's `'session'` event. `None` opts the SSL out of session
         /// parking entirely (fetch / WebSocket tunnels have no consumer).
@@ -766,6 +769,11 @@ pub mod ssl_wrapper {
             if self.flags.sent_ssl_shutdown() {
                 return Err(WriteDataError::ConnectionClosed);
             }
+            // A fatal read is mid-dispatch (its data callback wrote back): the
+            // error report and the close follow it. Do not close here.
+            if self.flags.fatal_error() {
+                return Err(WriteDataError::ConnectionClosed);
+            }
 
             if data.is_empty() {
                 // just cycle through internal openssl's state
@@ -851,6 +859,16 @@ pub mod ssl_wrapper {
             // trigger the onClose callback
             let handlers = self.handlers.get();
             (handlers.on_close)(handlers.ctx);
+        }
+
+        fn trigger_ssl_error_callback(&self, err: u32) {
+            if self.flags.closed_notified() {
+                return;
+            }
+            let handlers = self.handlers.get();
+            if let Some(on_ssl_error) = handlers.on_ssl_error {
+                on_ssl_error(handlers.ctx, err);
+            }
         }
 
         fn get_verify_error(&self) -> us_bun_verify_error_t {
@@ -989,6 +1007,14 @@ pub mod ssl_wrapper {
                 if just_read <= 0 {
                     // SAFETY: ssl is still valid.
                     let err = unsafe { boring_sys::SSL_get_error(ssl.as_ptr(), just_read) };
+                    let is_fatal =
+                        err == boring_sys::SSL_ERROR_SSL || err == boring_sys::SSL_ERROR_SYSCALL;
+                    // Take the error before the queue is cleared.
+                    let fatal_error = if is_fatal {
+                        us_ssl_take_fatal_error()
+                    } else {
+                        0
+                    };
                     boring_sys::ERR_clear_error();
 
                     if err != boring_sys::SSL_ERROR_WANT_READ
@@ -1038,8 +1064,7 @@ pub mod ssl_wrapper {
                             let _ = self.shutdown(false);
                             self.handle_end_of_renegotiation();
                         }
-                        if err == boring_sys::SSL_ERROR_SSL || err == boring_sys::SSL_ERROR_SYSCALL
-                        {
+                        if is_fatal {
                             self.flags.set_fatal_error(true);
                         }
 
@@ -1053,12 +1078,27 @@ pub mod ssl_wrapper {
                                 return false;
                             }
                         }
+                        if is_fatal {
+                            // Send the alert BoringSSL sealed into the write BIO
+                            // before the close frees it, so the peer gets its error.
+                            self.handle_writing(buffer);
+                            if self.ssl.get().is_none() || self.flags.closed_notified() {
+                                return false;
+                            }
+                        }
                         // A NewSessionTicket/keylog line that rode in ahead of the
                         // peer's close_notify is still parked; deliver it before the
                         // close tears the wrapper down (mirrors the C ZERO_RETURN path).
                         self.flush_pending_events(buffer);
                         if self.ssl.get().is_none() || self.flags.closed_notified() {
                             return false;
+                        }
+                        if fatal_error != 0 {
+                            // Like node's ClearOut: the error goes to the owner, then the close.
+                            self.trigger_ssl_error_callback(fatal_error);
+                            if self.ssl.get().is_none() || self.flags.closed_notified() {
+                                return false;
+                            }
                         }
                         self.trigger_close_callback();
                         return false;
@@ -1274,6 +1314,10 @@ pub mod ssl_wrapper {
         /// Implemented in uSockets C; reads
         /// `SSL_get_verify_result` and maps it onto the C `us_bun_verify_error_t`.
         fn us_ssl_socket_verify_error_from_ssl(ssl: *mut boring_sys::SSL) -> us_bun_verify_error_t;
+        /// Implemented in uSockets C; the packed error that names a fatal
+        /// `SSL_read` failure, taken off the thread's error queue (0 if none).
+        // safe: no args; reads the calling thread's own queue.
+        safe fn us_ssl_take_fatal_error() -> u32;
         /// Opt this SSL into the parked new-session/keylog queues
         /// (openssl.c's `us_ssl_new_session_cb` / `us_ssl_keylog_cb` skip
         /// SSLs without the marker).

--- a/test/js/node/http2/node-http2-upgrade.test.mts
+++ b/test/js/node/http2/node-http2-upgrade.test.mts
@@ -461,6 +461,55 @@ describe("HTTP/2 upgrade — server TLS options", () => {
   });
 });
 
+describe("HTTP/2 upgrade — fatal TLS error after the handshake", () => {
+  test("a record that fails to decrypt reaches the server as sessionError", async () => {
+    const h2Server = http2.createSecureServer(TLS, (_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    h2Server.on("error", () => {});
+    // A clean session 'close' with no error before it is the bug.
+    const outcome = new Promise<{ event: string; code?: string }>(resolve => {
+      h2Server.on("sessionError", (err: NodeJS.ErrnoException) => resolve({ event: "sessionError", code: err.code }));
+      h2Server.on("session", session => session.on("close", () => resolve({ event: "close" })));
+    });
+    const netServer = net.createServer(socket => {
+      socket.on("error", () => {});
+      h2Server.emit("connection", socket);
+    });
+    // A plain proxy in front of the net.Server, to inject bytes toward it.
+    let toServer: net.Socket | undefined;
+    const proxy = net.createServer(c => {
+      toServer = net.connect((netServer.address() as net.AddressInfo).port, "127.0.0.1");
+      c.pipe(toServer);
+      toServer.pipe(c);
+      c.on("error", () => {});
+      toServer.on("error", () => {});
+    });
+    let client: http2.ClientHttp2Session | undefined;
+    try {
+      await once(netServer.listen(0, "127.0.0.1"), "listening");
+      await once(proxy.listen(0, "127.0.0.1"), "listening");
+      client = connectClient((proxy.address() as net.AddressInfo).port);
+      const first = await request(client, "GET", "/");
+      assert.strictEqual(first.status, 200);
+
+      // application_data, 32 bytes of ciphertext that cannot authenticate.
+      toServer!.write(Buffer.concat([Buffer.from([0x17, 0x03, 0x03, 0x00, 0x20]), Buffer.alloc(32, 0x42)]));
+
+      assert.deepStrictEqual(await outcome, {
+        event: "sessionError",
+        code: "ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC",
+      });
+    } finally {
+      client?.destroy();
+      toServer?.destroy();
+      proxy.close();
+      netServer.close();
+    }
+  });
+});
+
 if (typeof Bun !== "undefined") {
   describe("Node.js compatibility", () => {
     test("tests should run on node.js", async () => {

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -584,6 +584,130 @@ for (const { name, connect } of tests) {
   });
 }
 
+// A TLS record that fails after the handshake is a fatal protocol error. Node
+// surfaces it as the socket's ERR_SSL_<REASON> 'error' (and leaves the socket
+// open). Over a generic Duplex the TLS engine is SSLWrapper, a separate
+// SSL_read driver from the uSockets one, so it gets its own coverage. A TCP
+// proxy between the Duplex and the server injects the bytes once the
+// handshake has completed on both sides. Every assertion here also holds on
+// Node.js; only the alert's code name depends on the SSL library.
+describe("tls.connect over a Duplex reports a fatal post-handshake SSL error", () => {
+  // application_data, legacy version TLS 1.2, 32 bytes of ciphertext that
+  // cannot authenticate: the receiver fails the AEAD open and alerts
+  // bad_record_mac.
+  const BAD_RECORD = Buffer.concat([Buffer.from([0x17, 0x03, 0x03, 0x00, 0x20]), Buffer.alloc(32, 0x42)]);
+  // BoringSSL names the bad_record_mac alert SSLV3_ALERT_BAD_RECORD_MAC,
+  // OpenSSL 3 names it SSL/TLS_ALERT_BAD_RECORD_MAC.
+  const ALERT_BAD_RECORD_MAC = (process.features as { openssl_is_boringssl?: boolean }).openssl_is_boringssl
+    ? "ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC"
+    : "ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC";
+
+  type Scenario = {
+    toClient: net.Socket;
+    toServer: net.Socket;
+    serverSocket: TLSSocket;
+    client: TLSSocket;
+    // Append `bytes` to the next chunk the proxy forwards from the server.
+    appendToNextServerChunk(bytes: Buffer): void;
+  };
+
+  async function run(inject: (s: Scenario) => void | Promise<void>) {
+    let toClient: net.Socket | undefined;
+    let toServer: net.Socket | undefined;
+    let raw: net.Socket | undefined;
+    let client: TLSSocket | undefined;
+    let serverSocket: TLSSocket | undefined;
+    let appendOnce: Buffer | undefined;
+    const server = tls.createServer(COMMON_CERT_);
+    server.on("secureConnection", s => s.on("error", () => {}));
+    const proxy = net.createServer(c => {
+      toClient = c;
+      toServer = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
+      c.pipe(toServer);
+      toServer.on("data", chunk => {
+        if (appendOnce) {
+          chunk = Buffer.concat([chunk, appendOnce]);
+          appendOnce = undefined;
+        }
+        c.write(chunk);
+      });
+      toServer.on("end", () => c.end());
+      c.on("error", () => {});
+      toServer.on("error", () => {});
+    });
+    try {
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const serverSecure = once(server, "secureConnection") as Promise<[TLSSocket]>;
+      await once(proxy.listen(0, "127.0.0.1"), "listening");
+
+      raw = net.connect((proxy.address() as AddressInfo).port, "127.0.0.1");
+      await once(raw, "connect");
+      client = tls.connect({ socket: new SocketProxy(raw), rejectUnauthorized: false });
+      // Settle on whichever comes first: the 'error' (expected), or a 'close'
+      // with no 'error' before it (the bug). Node emits no 'close' at all here.
+      const outcome = new Promise<{ event: string; code?: string; library?: string }>(resolve => {
+        client!.once("error", (err: NodeJS.ErrnoException & { library?: string }) =>
+          resolve({ event: "error", code: err.code, library: err.library }),
+        );
+        client!.once("close", () => resolve({ event: "close" }));
+      });
+      await once(client, "secureConnect");
+      [serverSocket] = await serverSecure;
+
+      await inject({
+        toClient: toClient!,
+        toServer: toServer!,
+        serverSocket,
+        client,
+        appendToNextServerChunk: bytes => (appendOnce = bytes),
+      });
+      return await outcome;
+    } finally {
+      for (const s of [client, raw, serverSocket, toClient, toServer]) s?.destroy();
+      proxy.close();
+      server.close();
+    }
+  }
+
+  it("a record that fails to decrypt surfaces as ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC", async () => {
+    const result = await run(({ toClient }) => void toClient.write(BAD_RECORD));
+    expect(result).toEqual({
+      event: "error",
+      code: "ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC",
+      library: "SSL routines",
+    });
+  });
+
+  it("the peer's bad_record_mac alert surfaces as an ERR_SSL_*_ALERT_BAD_RECORD_MAC error", async () => {
+    // The bad record goes to the server, whose SSL_read fails and sends a
+    // bad_record_mac alert back. The client's SSL_read fails on that alert.
+    const result = await run(({ toServer }) => void toServer.write(BAD_RECORD));
+    expect(result).toEqual({
+      event: "error",
+      code: ALERT_BAD_RECORD_MAC,
+      library: "SSL routines",
+    });
+  });
+
+  it("a 'data' listener that writes back does not hide the error", async () => {
+    // Good data and the bad record arrive in one chunk. The engine delivers
+    // the data first, the listener's write hits the now-fatal SSL, and the
+    // read's reason must still be the error that surfaces.
+    const result = await run(async ({ serverSocket, client, appendToNextServerChunk }) => {
+      client.on("data", () => client.write("back"));
+      serverSocket.write("first");
+      await once(client, "data");
+      appendToNextServerChunk(BAD_RECORD);
+      serverSocket.write("second");
+    });
+    expect(result).toEqual({
+      event: "error",
+      code: "ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC",
+      library: "SSL routines",
+    });
+  });
+});
+
 it("setSession() should not leak the SSL_SESSION returned by d2i_SSL_SESSION", async () => {
   // d2i_SSL_SESSION returns an owned SSL_SESSION; SSL_set_session takes its own
   // reference ("the caller retains ownership"), so the caller's reference must

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -176,3 +176,78 @@ it.if(isWindows)("should be able to upgrade a named pipe connection to TLS", asy
   await test(`\\\\.\\pipe\\test\\${randomUUID()}`);
   await expectMaxObjectTypeCount(expect, "TLSSocket", 3);
 });
+
+// Same contract as "tls.connect over a Duplex reports a fatal post-handshake
+// SSL error" in node-tls-connect.test.ts, with both TLS peers on a named pipe.
+// A plain pipe proxy between them injects a record that cannot authenticate
+// once the handshake has completed on both sides.
+describe("a fatal post-handshake SSL error over a named pipe", () => {
+  const BAD_RECORD = Buffer.concat([Buffer.from([0x17, 0x03, 0x03, 0x00, 0x20]), Buffer.alloc(32, 0x42)]);
+  // BoringSSL and OpenSSL 3 name the bad_record_mac alert differently.
+  const ALERT_BAD_RECORD_MAC = (process.features as { openssl_is_boringssl?: boolean }).openssl_is_boringssl
+    ? "ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC"
+    : "ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC";
+
+  type Outcome = { event: string; code?: string; library?: string };
+  // Settles on the 'error' (expected), or on a 'close' with no 'error' before it (the bug).
+  function firstErrorOrClose(socket: net.Socket): Promise<Outcome> {
+    return new Promise(resolve => {
+      socket.once("error", (err: NodeJS.ErrnoException & { library?: string }) =>
+        resolve({ event: "error", code: err.code, library: err.library }),
+      );
+      socket.once("close", () => resolve({ event: "close" }));
+    });
+  }
+
+  async function run(inject: (toClient: net.Socket, toServer: net.Socket) => void) {
+    let toClient: net.Socket | undefined;
+    let toServer: net.Socket | undefined;
+    let client: ReturnType<typeof connect> | undefined;
+    let serverSocket: ReturnType<typeof connect> | undefined;
+    const serverPipe = `\\\\.\\pipe\\test\\${randomUUID()}`;
+    const proxyPipe = `\\\\.\\pipe\\test\\${randomUUID()}`;
+    const server = createServer(tls);
+    const serverOutcome = Promise.withResolvers<Outcome>();
+    server.on("secureConnection", s => firstErrorOrClose(s).then(serverOutcome.resolve));
+    const proxy = net.createServer(c => {
+      toClient = c;
+      toServer = net.connect(serverPipe);
+      c.pipe(toServer);
+      toServer.pipe(c);
+      c.on("error", () => {});
+      toServer.on("error", () => {});
+    });
+    try {
+      await once(server.listen(serverPipe), "listening");
+      const serverSecure = once(server, "secureConnection");
+      await once(proxy.listen(proxyPipe), "listening");
+
+      client = connect({ path: proxyPipe, rejectUnauthorized: false });
+      const clientOutcome = firstErrorOrClose(client);
+      await once(client, "secureConnect");
+      [serverSocket] = await serverSecure;
+
+      inject(toClient!, toServer!);
+      return { client: await clientOutcome, server: await serverOutcome.promise };
+    } finally {
+      for (const s of [client, serverSocket, toClient, toServer]) s?.destroy();
+      proxy.close();
+      server.close();
+    }
+  }
+
+  it.if(isWindows)("a record that fails to decrypt on the client", async () => {
+    expect(await run(toClient => void toClient.write(BAD_RECORD))).toEqual({
+      client: { event: "error", code: "ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC", library: "SSL routines" },
+      // The client's bad_record_mac alert reaches the server as its own error.
+      server: { event: "error", code: ALERT_BAD_RECORD_MAC, library: "SSL routines" },
+    });
+  });
+
+  it.if(isWindows)("a record that fails to decrypt on the server", async () => {
+    expect(await run((_toClient, toServer) => void toServer.write(BAD_RECORD))).toEqual({
+      client: { event: "error", code: ALERT_BAD_RECORD_MAC, library: "SSL routines" },
+      server: { event: "error", code: "ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC", library: "SSL routines" },
+    });
+  });
+});


### PR DESCRIPTION
Stacked on #41272 (merge it first). Replaces #41507, which never reached `main`.

### Problem
- `tls.connect({ socket: <Duplex> })`, node:tls over a Windows named pipe, and the `Http2SecureServer` raw-socket upgrade end cleanly when a TLS record fails after the handshake. Node emits the socket's `ERR_SSL_<REASON>` `'error'`, for example `ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC`.
- The cause is `SSLWrapper::handle_reading` (`src/uws/lib.rs`). On `SSL_ERROR_SSL` it cleared the error queue, dropped the alert BoringSSL had sealed, and closed with no error. #41272 fixes openssl.c, a separate `SSL_read` driver.

### Fix
- `handle_reading` takes the packed error before the queue is cleared, sends the alert, and reports the error through a new optional `Handlers::on_ssl_error` just before `on_close`. `UpgradedDuplex` and `WindowsNamedPipe` forward it to #41272's `TLSSocket::on_ssl_error`.
- #41272's inline error picker is now `us_ssl_take_fatal_error()`. Both drivers call it.
- `write_data` no longer closes the wrapper while a fatal read is mid-dispatch. Before, a `'data'` listener that wrote back hid the error.
- JS gets the same dispatch as a uSockets socket: `'error'`, `'end'`, `'close'`. `net.ts` does not change.
- Verified: `node-tls-connect.test.ts` (3 cases), `node-tls-namedpipes.test.ts` (2, Windows), `node-http2-upgrade.test.mts` (1). All fail on the base and pass on Node.js v26.3.0.

### Background
- `SSLWrapper` runs BoringSSL over memory BIOs for transports that are not a `us_socket_t`. It calls its owner through `Handlers`.
- A fatal `SSL_read` leaves its reason on OpenSSL's per-thread error queue, and its alert in the write BIO. Nothing pumps that BIO after a close.
- `TLSSocket::on_ssl_error` calls the `error` handler with a third `true` argument. node:net then emits the error and keeps the socket.

<details><summary>Notes</summary>

- #41507 was merged into the branch of #41463. #41463 is closed without a merge (withdrawn in favor of #41272), so that merge never reached `main`.
- Other suites run: `test/js/node/tls/`, `test/js/bun/net/socket.test.ts`, `test/js/bun/http/proxy.test.ts`, `test/js/web/websocket/websocket-proxy.test.ts`, `test/js/node/http2/node-http2.test.js`. The fetch and WebSocket proxy tunnels pass `on_ssl_error: None`.
- The picker takes the first SSL-library entry on the queue, because BoringSSL can queue a cipher-layer entry (`BAD_DECRYPT`) ahead of the TLS reason.
- Repro: a TCP proxy between a `Duplex`-wrapped client and `tls.createServer`. After `secureConnect`, write an application_data record (`17 03 03 00 20` plus 32 bytes of `0x42`) toward the client. Node v26.3.0: `error ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC`. Bun 1.4.3: `end`, `close false`. With the fix: the same `error`, then `end`, `close false`.
- The other peer gets the alert as `ERR_SSL_SSLV3_ALERT_BAD_RECORD_MAC` (BoringSSL's name. OpenSSL 3 says `SSL/TLS_ALERT_BAD_RECORD_MAC`). The tests pick the name from `process.features.openssl_is_boringssl`.
- Node leaves the sockets open after the `'error'` in this injected case, because neither peer closes. Bun's engine closes after a fatal read, so `'end'` and `'close'` follow. The tests assert only the first event.
- Named pipes on Windows without the fix: the peer whose read fails gets a clean `close`, the other peer gets `EPIPE` (no alert went out). With the fix both get their `ERR_SSL_*` error. Checked on Node v26.3.0 on Windows too.
- `Http2SecureServer` fed by `emit("connection", rawSocket)`: the server now gets `sessionError` with `ERR_SSL_DECRYPTION_FAILED_OR_BAD_RECORD_MAC`, the same as Node. That test file also runs itself under Node in CI.
- Compared to #41507: no reason string on `on_close`, so the tunnels' `on_close` signatures and the named pipe's deferred close do not change. The error is a `u32`, so nothing borrows a stack buffer.
- Not in this PR:
  - A fatal `SSL_write` or `SSL_shutdown` in `SSLWrapper` still closes with no error. openssl.c does the same (#38176 covers the write side there).
  - The handshake-time exit (`update_handshake_state`) still clears the queue and closes without sending the sealed alert. #32929 owns that exit.
  - `ssl_park_fatal_reason` (the handshake-time park in openssl.c) still reports the oldest queue entry, not the first SSL-library entry. That is noted on #41272.
- The `write_data` guard also fixes a use-after-free that exists on `main` today: fetch with an `Upgrade` header and a streaming body through a CONNECT proxy, when the `101` and a bad record arrive in one packet. `flush_stream` writes into the fatal SSL, `write_data` closes, `proxy_tunnel::on_close` frees the `AsyncHTTP`, and `handle_on_data_headers` reads it after. That guard goes to `main` in its own PR with a regression test.
- Self-reviewed: 7 concerns raised, 5 addressed (stacked on the live base, one picker for both `SSL_read` drivers, the http2 upgrade path covered, the guard's comment names the invariant, exclusions listed above). Not done: the handshake-exit alert flush (left to #32929, which edits the same lines) and a tracking issue for the two mirrored engines.
- Slow under a debug build, not failures of this change: `an unref'd Bun.listen() ... keeps accepting across GC` (4.6 s), `should work with named pipes and tls` on Windows (6.1 s). Both pass with a longer timeout. `should not call drain before handshake` needs www.example.com.
- Cross-checked with `cargo check -p bun_runtime --target x86_64-pc-windows-msvc`, and built and tested on Windows x64.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tls/node-tls-namedpipes.test.ts

<!-- robobun:evidence:end -->