### PR TITLE
tls: do not close the SSL wrapper from a write made during a fatal read

### DIFF
--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -766,6 +766,12 @@ pub mod ssl_wrapper {
             if self.flags.sent_ssl_shutdown() {
                 return Err(WriteDataError::ConnectionClosed);
             }
+            // A callback of the pass that hit a fatal error wrote back. That pass
+            // closes once the callback returns. Closing here instead runs the owner's
+            // `on_close` (fetch's ProxyTunnel frees itself there) under its own frame.
+            if self.flags.fatal_error() {
+                return Err(WriteDataError::ConnectionClosed);
+            }
 
             if data.is_empty() {
                 // just cycle through internal openssl's state

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -766,9 +766,8 @@ pub mod ssl_wrapper {
             if self.flags.sent_ssl_shutdown() {
                 return Err(WriteDataError::ConnectionClosed);
             }
-            // A callback of the pass that hit a fatal error wrote back. That pass
-            // closes once the callback returns. Closing here instead runs the owner's
-            // `on_close` (fetch's ProxyTunnel frees itself there) under its own frame.
+            // The fatal read closes once its callbacks return. A close from here
+            // would run the owner's `on_close` under one of them.
             if self.flags.fatal_error() {
                 return Err(WriteDataError::ConnectionClosed);
             }

--- a/test/js/bun/http/proxy-upgrade-fatal-record-fixture.ts
+++ b/test/js/bun/http/proxy-upgrade-fatal-record-fixture.ts
@@ -20,6 +20,8 @@ const iterations = Number(process.argv[2] ?? "3");
 // How many connections actually got the bad record. A run where the upgrade
 // fails earlier proves nothing, so the test asserts this count.
 let injected = 0;
+// Resolves when the current iteration's body generator has been pulled.
+let bodyPulled = Promise.withResolvers<void>();
 
 // The origin answers the first request with a bare 101 and nothing else.
 using origin = Bun.listen({
@@ -61,14 +63,23 @@ const proxy = net.createServer(client => {
     }
     if (offset !== held.length || !sawResponse) return;
     poisoned = true;
-    // Wait for the body generator's first chunk to be queued, so the 101 arm
-    // has something for flush_stream to write.
-    setTimeout(() => {
-      if (client.destroyed) return;
+    // The 101 arm only writes when the body generator's first chunk is already
+    // queued in the client. JS can see the pull, not the hand-off to the HTTP
+    // thread that follows it, so a short grace covers that hop.
+    let released = false;
+    const release = () => {
+      if (released || client.destroyed) return;
+      released = true;
       client.write(Buffer.concat([held, BAD_RECORD]));
       held = Buffer.alloc(0);
       injected++;
-    }, 500);
+    };
+    // A body that is never pulled must not hang the fixture.
+    const deadline = setTimeout(release, 2000);
+    bodyPulled.promise.then(() => {
+      clearTimeout(deadline);
+      setTimeout(release, 100);
+    });
   }
 
   client.on("error", () => {});
@@ -107,6 +118,9 @@ await new Promise<void>(resolve => proxy.once("listening", () => resolve()));
 const proxyPort = (proxy.address() as net.AddressInfo).port;
 
 for (let i = 0; i < iterations; i++) {
+  bodyPulled = Promise.withResolvers<void>();
+  // Keeps the request stream open until the fetch has settled.
+  const settled = Promise.withResolvers<void>();
   let outcome: string;
   try {
     const res = await fetch(`https://localhost:${origin.port}/`, {
@@ -116,8 +130,9 @@ for (let i = 0; i < iterations; i++) {
       // A generator body keeps the request stream open past the response, so
       // the 101 arm has something to flush.
       async *body() {
+        bodyPulled.resolve();
         yield Buffer.alloc(1024, 0x61);
-        await Bun.sleep(5000);
+        await settled.promise;
       },
     });
     try {
@@ -127,6 +142,8 @@ for (let i = 0; i < iterations; i++) {
     }
   } catch (e: any) {
     outcome = `rejected:${e?.code ?? e?.name ?? String(e)}`;
+  } finally {
+    settled.resolve();
   }
   console.log(outcome);
 }

--- a/test/js/bun/http/proxy-upgrade-fatal-record-fixture.ts
+++ b/test/js/bun/http/proxy-upgrade-fatal-record-fixture.ts
@@ -1,0 +1,134 @@
+// Fixture for proxy.test.ts: fetch with an Upgrade header and a streaming
+// body through a CONNECT proxy to an HTTPS origin, where the origin's 101
+// response and a TLS record that cannot be decrypted reach the client in one
+// packet.
+//
+// The client's SSLWrapper decrypts the 101 and dispatches it; the 101 arm of
+// handle_on_data_headers calls flush_stream, whose write reaches SSL_write on
+// an SSL that the same read already made fatal. write_data then closed the
+// wrapper, ProxyTunnel::on_close freed the HTTPClient, and the 101 arm kept
+// reading it (ASAN: heap-use-after-free in handle_response_metadata).
+//
+// Usage: bun proxy-upgrade-fatal-record-fixture.ts [iterations]
+// Prints one line per iteration, then "probe: <text>" from a fresh request.
+
+import net from "node:net";
+import { tls as tlsCert } from "harness";
+
+const iterations = Number(process.argv[2] ?? "3");
+
+// The origin answers the first request with a bare 101 and nothing else.
+using origin = Bun.listen({
+  hostname: "127.0.0.1",
+  port: 0,
+  tls: tlsCert,
+  socket: {
+    data(socket) {
+      if (socket.data?.answered) return;
+      socket.data = { answered: true };
+      socket.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: foo\r\nConnection: Upgrade\r\n\r\n");
+    },
+    error() {},
+    close() {},
+  },
+});
+
+// application_data, 32 bytes of ciphertext that cannot authenticate.
+const BAD_RECORD = Buffer.concat([Buffer.from([0x17, 0x03, 0x03, 0x00, 0x20]), Buffer.alloc(32, 0x42)]);
+
+const proxy = net.createServer(client => {
+  let upstream: net.Socket | null = null;
+  let head = Buffer.alloc(0);
+  let clientFlights = 0;
+  let held = Buffer.alloc(0);
+  let poisoned = false;
+
+  // Hold the origin's records until the 101 response record is complete, then
+  // send it with the bad record appended, so one read decrypts both.
+  function flushWithBadRecord() {
+    let offset = 0;
+    let sawResponse = false;
+    while (offset + 5 <= held.length) {
+      const len = held.readUInt16BE(offset + 3);
+      if (offset + 5 + len > held.length) return;
+      // The 101 record is ~90 bytes of ciphertext. Session tickets are larger.
+      if (held[offset] === 0x17 && len >= 70 && len <= 140) sawResponse = true;
+      offset += 5 + len;
+    }
+    if (offset !== held.length || !sawResponse) return;
+    poisoned = true;
+    // Wait for the body generator's first chunk to be queued, so the 101 arm
+    // has something for flush_stream to write.
+    setTimeout(() => {
+      client.write(Buffer.concat([held, BAD_RECORD]));
+      held = Buffer.alloc(0);
+    }, 500);
+  }
+
+  client.on("error", () => {});
+  client.on("close", () => upstream?.destroy());
+  client.on("data", chunk => {
+    if (!upstream) {
+      head = Buffer.concat([head, chunk]);
+      const end = head.indexOf("\r\n\r\n");
+      if (end === -1) return;
+      const leftover = head.subarray(end + 4);
+      upstream = net.connect(origin.port, "127.0.0.1", () => {
+        client.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+        if (leftover.length) upstream!.write(leftover);
+      });
+      upstream.on("error", () => {});
+      upstream.on("data", data => {
+        if (poisoned) return;
+        // The first two client flights are the ClientHello and the rest of the
+        // handshake; hold only what follows them.
+        if (clientFlights >= 2) {
+          held = Buffer.concat([held, data]);
+          flushWithBadRecord();
+        } else {
+          client.write(data);
+        }
+      });
+      return;
+    }
+    clientFlights++;
+    upstream.write(chunk);
+  });
+});
+using _proxy = { [Symbol.dispose]: () => proxy.close() };
+proxy.listen(0, "127.0.0.1");
+await new Promise<void>(resolve => proxy.once("listening", () => resolve()));
+const proxyPort = (proxy.address() as net.AddressInfo).port;
+
+for (let i = 0; i < iterations; i++) {
+  let outcome: string;
+  try {
+    const res = await fetch(`https://localhost:${origin.port}/`, {
+      proxy: `http://127.0.0.1:${proxyPort}`,
+      headers: { Upgrade: "foo", Connection: "Upgrade" },
+      tls: { ca: tlsCert.cert, rejectUnauthorized: false },
+      // A generator body keeps the request stream open past the response, so
+      // the 101 arm has something to flush.
+      async *body() {
+        yield Buffer.alloc(1024, 0x61);
+        await Bun.sleep(5000);
+      },
+    });
+    try {
+      outcome = `resolved:${res.status}:${(await res.bytes()).length}`;
+    } catch (e: any) {
+      outcome = `body-rejected:${res.status}:${e?.code ?? e?.name ?? String(e)}`;
+    }
+  } catch (e: any) {
+    outcome = `rejected:${e?.code ?? e?.name ?? String(e)}`;
+  }
+  console.log(outcome);
+}
+
+// A request on a fresh connection proves the process and the HTTP thread are
+// still healthy.
+using probeOrigin = Bun.serve({ port: 0, tls: tlsCert, fetch: () => new Response("probe-ok") });
+const probe = await fetch(`https://localhost:${probeOrigin.port}/`, {
+  tls: { ca: tlsCert.cert, rejectUnauthorized: false },
+});
+console.log("probe:", await probe.text());

--- a/test/js/bun/http/proxy-upgrade-fatal-record-fixture.ts
+++ b/test/js/bun/http/proxy-upgrade-fatal-record-fixture.ts
@@ -10,12 +10,16 @@
 // reading it (ASAN: heap-use-after-free in handle_response_metadata).
 //
 // Usage: bun proxy-upgrade-fatal-record-fixture.ts [iterations]
-// Prints one line per iteration, then "probe: <text>" from a fresh request.
+// Prints one line per iteration, then "injected: <n>" (how many connections
+// got the bad record) and "probe: <text>" from a fresh request.
 
 import net from "node:net";
 import { tls as tlsCert } from "harness";
 
 const iterations = Number(process.argv[2] ?? "3");
+// How many connections actually got the bad record. A run where the upgrade
+// fails earlier proves nothing, so the test asserts this count.
+let injected = 0;
 
 // The origin answers the first request with a bare 101 and nothing else.
 using origin = Bun.listen({
@@ -60,8 +64,10 @@ const proxy = net.createServer(client => {
     // Wait for the body generator's first chunk to be queued, so the 101 arm
     // has something for flush_stream to write.
     setTimeout(() => {
+      if (client.destroyed) return;
       client.write(Buffer.concat([held, BAD_RECORD]));
       held = Buffer.alloc(0);
+      injected++;
     }, 500);
   }
 
@@ -124,6 +130,8 @@ for (let i = 0; i < iterations; i++) {
   }
   console.log(outcome);
 }
+
+console.log("injected:", injected);
 
 // A request on a fresh connection proves the process and the HTTP thread are
 // still healthy.

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1399,7 +1399,7 @@ for (const scheme of ["http", "https"] as const) {
 // closed the wrapper, ProxyTunnel::on_close freed the client, and the 101 arm
 // kept reading it (ASAN: heap-use-after-free in handle_response_metadata).
 test("a bad record delivered with a 101 through a proxy tunnel does not free the client mid-dispatch", async () => {
-  const iterations = 3;
+  const iterations = 2;
   await using proc = Bun.spawn({
     cmd: [bunExe(), require.resolve("./proxy-upgrade-fatal-record-fixture.ts"), String(iterations)],
     env: {
@@ -1425,7 +1425,7 @@ test("a bad record delivered with a 101 through a proxy tunnel does not free the
   expect(stdout).toContain(`injected: ${iterations}\n`);
   expect(stdout).toEndWith("probe: probe-ok\n");
   expect(exitCode).toBe(0);
-}, 30000);
+});
 
 describe.concurrent("proxy object format with headers", () => {
   test("proxy object with url string works same as string proxy", async () => {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1418,9 +1418,11 @@ test("a bad record delivered with a 101 through a proxy tunnel does not free the
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   if (exitCode !== 0) console.error("stderr:", stderr);
   // The request itself may resolve with the 101 or fail on the bad record;
-  // either is fine. What must hold is that the process survives every
-  // iteration and still serves a fresh request.
-  expect(stdout.trim().split("\n")).toHaveLength(iterations + 1);
+  // either is fine. What must hold is that every iteration really received the
+  // bad record, that the process survived it, and that it still serves a fresh
+  // request.
+  expect(stdout.trim().split("\n")).toHaveLength(iterations + 2);
+  expect(stdout).toContain(`injected: ${iterations}\n`);
   expect(stdout).toEndWith("probe: probe-ok\n");
   expect(exitCode).toBe(0);
 }, 30000);

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -1392,6 +1392,39 @@ for (const scheme of ["http", "https"] as const) {
   }, 15000);
 }
 
+// A fatal SSL_read inside a proxy tunnel whose data callback writes back freed
+// the HTTPClient under its own caller. The origin's 101 and a record that
+// cannot be decrypted arrive together: the 101 arm of handle_on_data_headers
+// flushes the request body into the now-fatal SSL, SSLWrapper::write_data
+// closed the wrapper, ProxyTunnel::on_close freed the client, and the 101 arm
+// kept reading it (ASAN: heap-use-after-free in handle_response_metadata).
+test("a bad record delivered with a 101 through a proxy tunnel does not free the client mid-dispatch", async () => {
+  const iterations = 3;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), require.resolve("./proxy-upgrade-fatal-record-fixture.ts"), String(iterations)],
+    env: {
+      ...bunEnv,
+      // Same reason as the fixture above: the per-request proxy must not be
+      // bypassed by ambient proxy configuration (see PROXY_ENV_KEYS).
+      NO_PROXY: undefined,
+      no_proxy: undefined,
+      HTTP_PROXY: undefined,
+      http_proxy: undefined,
+      HTTPS_PROXY: undefined,
+      https_proxy: undefined,
+    },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) console.error("stderr:", stderr);
+  // The request itself may resolve with the 101 or fail on the bad record;
+  // either is fine. What must hold is that the process survives every
+  // iteration and still serves a fresh request.
+  expect(stdout.trim().split("\n")).toHaveLength(iterations + 1);
+  expect(stdout).toEndWith("probe: probe-ok\n");
+  expect(exitCode).toBe(0);
+}, 30000);
+
 describe.concurrent("proxy object format with headers", () => {
   test("proxy object with url string works same as string proxy", async () => {
     const response = await fetch(httpServer.url, {


### PR DESCRIPTION
### Problem
- `fetch()` with an `Upgrade` header and a streaming body, through a CONNECT proxy, frees the `HTTPClient` while a caller still holds it. ASAN on `main`: `heap-use-after-free ... READ of size 1` in `handle_response_metadata` (`src/http/lib.rs:4870`), reached from `handle_on_data_headers` and `proxy_tunnel::on_data`.
- The cause is `SSLWrapper::write_data` (`src/uws/lib.rs:802`). A read that hits a fatal SSL error still delivers the data it decrypted first. The `101` arm of `handle_on_data_headers` calls `flush_stream`, whose write reaches `SSL_write` on the now-fatal SSL. `write_data` then closed the wrapper from inside that callback, and `proxy_tunnel::on_close` freed the client under its own caller.

### Fix
- `write_data` fails the write with `ConnectionClosed` and does not close while `fatal_error` is set. The read that set the flag closes once its callbacks return, so the owner's `on_close` runs in the frame that owns it.
- Correct because every `write_data` caller already treats `Err` as "no bytes went out" and the close still happens, one frame later. It is the same rule as the `sent_ssl_shutdown` guard above it.
- Verified: `test/js/bun/http/proxy.test.ts` ("a bad record delivered with a 101 through a proxy tunnel does not free the client mid-dispatch") with `test/js/bun/http/proxy-upgrade-fatal-record-fixture.ts`. It fails on `main` with the ASAN report and passes with the change. Also all of `proxy.test.ts`, `websocket-proxy.test.ts`, `fetch-proxy-connect-tunnel-split-envelope.test.ts`, `node-tls-connect.test.ts`, and `socket.test.ts`.

### Background
- `SSLWrapper` (`src/uws/lib.rs`) runs BoringSSL over memory BIOs for TLS on a transport that is not a `us_socket_t`: a CONNECT tunnel for fetch and WebSocket, a `Duplex`, a Windows named pipe. It calls its owner back through `Handlers` (`on_data`, `write`, `on_close`).
- A fatal `SSL_read` sets `fatal_error`, flushes the bytes it already decrypted through `on_data`, and then closes. The owner's `on_close` is its teardown: `proxy_tunnel::on_close` fails the request, which frees the `HTTPClient`.
- `flush_stream` exists for the `101` arm, because an upgraded request keeps streaming its body after the response headers arrive.

<details><summary>Notes</summary>

- Repro (the fixture): a CONNECT proxy holds the origin's records until the `101` response record is whole, then writes it with an application_data record of 32 unauthenticated bytes appended, so one `SSL_read` pass decrypts both. The body is an async generator, so the `101` arm has something to flush.
- The fixture clears `NO_PROXY` and the other proxy variables in the child, like the fixture test above it. This container sets `NO_PROXY=localhost,...`, which makes the per-request `proxy:` option a no-op and hides the bug.
- Without the guard the process aborts on the first iteration. With it, both iterations finish, the fixture reports `injected: 2` (every connection really got the bad record), and a fresh request on a new connection still answers.
- The proxy releases the held bytes once the body generator has been pulled, plus a 100 ms grace. The hand-off of the chunk from the JS thread to the HTTP thread is not observable from JS, so that last hop is a fixed wait. If it were too short the test would pass without exercising the write, it could not fail spuriously.
- The ASAN stack: `write_data` (`src/uws/lib.rs:802`) to `trigger_close_callback` to `proxy_tunnel::on_close` (`ProxyTunnel.rs:525`) to `close_and_fail` to `AsyncHTTP::on_async_http_callback_raw` (the free), while frame 19 is `flush_stream` from `handle_on_data_headers`, which reads the client again on return.
- Found while I reviewed the TLS-over-Duplex error reporting in #42324. That PR needs the same guard, because its `'data'` listener case depends on the close carrying the read's error. This PR sends it to `main` on its own, with a fetch-level regression test.
- A fatal `SSL_write` with no read in flight is unchanged: `fatal_error` is only set by the read path before this point, so an ordinary write that fails still closes as before.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/proxy.test.ts
bun test v1.4.3 (4ff919377)

test/js/bun/http/proxy.test.ts:
(pass) GET non-TLS proxy -> non-TLS body type undefined [746.82ms]
(pass) POST non-TLS proxy -> non-TLS body type string [738.65ms]
(pass) GET TLS proxy -> non-TLS body type undefined [843.47ms]
(pass) GET non-TLS proxy -> TLS body type undefined [957.24ms]
(pass) POST non-TLS proxy -> TLS body type string [976.61ms]
(pass) POST TLS proxy -> non-TLS body type string [352.90ms]
(pass) GET TLS proxy -> TLS body type undefined [508.51ms]
(pass) POST TLS proxy -> TLS body type string [484.95ms]
(pass) proxy can handle redirects with non-TLS server > with empty body #12007 [493.61ms]
(pass) proxy can handle redirects with non-TLS server > with body #12007 [747.46ms]
(pass) proxy can handle redirects with TLS server > with empty body #12007 [764.30ms]
(pass) proxy can handle redirects with TLS server > with body #12007 [713.58ms]
(pass) proxy can handle redirects with non-TLS server > with chunked body #12007 [1249.08ms]
(pass) proxy can handle redirec
... (truncated)

release without fix: 1 skipped
bun test v1.4.3-canary.1 (d4f44b9f8)

test/js/bun/http/proxy.test.ts:
(pass) POST non-TLS proxy -> non-TLS body type string [36.97ms]
(pass) GET non-TLS proxy -> non-TLS body type undefined [37.29ms]
(pass) POST TLS proxy -> non-TLS body type string [43.52ms]
(pass) GET TLS proxy -> non-TLS body type undefined [43.56ms]
(pass) POST non-TLS proxy -> TLS body type string [52.68ms]
(pass) GET non-TLS proxy -> TLS body type undefined [52.72ms]
(pass) POST TLS proxy -> TLS body type string [54.88ms]
(pass) GET TLS proxy -> TLS body type undefined [54.91ms]
(pass) proxy can handle redirects with non-TLS server > with empty body #12007 [57.72ms]
(pass) proxy can handle redirects with non-TLS server > with body #12007 [71.35ms]
(pass) proxy can handle redirects with TLS server > with empty body #12007 [76.33ms]
(pass) proxy can handle redirects with TLS server > with body #12007 [75.14ms]
(pass) proxy can handle redirects with non-TLS server > with chunked body #12007 [651.78ms]
(pass) proxy can handle redirects with TLS server > with chunked body #12007 [659.64ms]
(pass) non-TLS origin redirect through HTTPS proxy forwards every hop through the proxy [7.45ms]
(pass) unsupp
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/proxy.test.ts
bun test v1.4.3 (4ff919377)

test/js/bun/http/proxy.test.ts:
(pass) GET non-TLS proxy -> non-TLS body type undefined [818.58ms]
(pass) POST non-TLS proxy -> non-TLS body type string [806.81ms]
(pass) GET TLS proxy -> non-TLS body type undefined [923.01ms]
(pass) GET non-TLS proxy -> TLS body type undefined [1073.78ms]
(pass) POST non-TLS proxy -> TLS body type string [1111.61ms]
(pass) POST TLS proxy -> non-TLS body type string [423.33ms]
(pass) GET TLS proxy -> TLS body type undefined [615.30ms]
(pass) POST TLS proxy -> TLS body type string [587.75ms]
(pass) proxy can handle redirects with non-TLS server > with empty body #12007 [604.16ms]
(pass) proxy can handle redirects with non-TLS server > with body #12007 [841.51ms]
(pass) proxy can handle redirects with TLS server > with empty body #12007 [814.41ms]
(pass) proxy can handle redirects with TLS server > with body #12007 [741.93ms]
(pass) proxy can handle redirects with non-TLS server > with chunked body #12007 [1274.71ms]
(pass) proxy can handle redir
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 768ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/1] reconfigure
[1/173] install /workspace/bun
bun install v1.4.3-canary.1 (d4f44b9f8)

Checked 22 installs across 61 packages (no changes) [6.00ms]
[2/173] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[3/173] gen ErrorCode+*.h
[4/173] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[5/173] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/173] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[7/173] gen bindgenv2
[8/173] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/uws/lib.rs                                     |   5 +
 .../bun/http/proxy-upgrade-fatal-record-fixture.ts | 159 +++++++++++++++++++++
 test/js/bun/http/proxy.test.ts                     |  35 +++++
 3 files changed, 199 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/uws/lib.rs                                              7      8     22
test/js/bun/http/proxy-upgrade-fatal-record-fixture.ts      0      1     23
test/js/bun/http/proxy.test.ts                              1      1     19
```

</details>

<!-- robobun:evidence:end -->