### PR TITLE
markdown: keep emphasis tags balanced around permissive autolinks

### DIFF
--- a/src/md/autolinks.rs
+++ b/src/md/autolinks.rs
@@ -17,58 +17,17 @@ pub struct Autolink {
 
 pub(crate) type AutolinkResult = Option<Autolink>;
 
-/// Check that emphasis chars at autolink boundaries are actually resolved delimiters.
-/// Called when the relaxed (allow_emph) pass found an autolink but the strict pass didn't.
-pub(crate) fn is_emph_boundary_resolved(
-    content: &[u8],
-    al: Autolink,
-    resolved: &[EmphDelim],
-) -> bool {
-    // Check left boundary: if it's an emphasis char, it must be a resolved delimiter
-    if al.beg > 0 {
-        let prev = content[al.beg - 1];
-        if prev == b'*' || prev == b'_' || prev == b'~' {
-            if !check_left_boundary(content, al.beg, false) {
-                // Left boundary failed strict check, emphasis char caused the relaxed match.
-                // Verify it's actually resolved.
-                let mut found_resolved = false;
-                for d in resolved {
-                    if d.pos < al.beg
-                        && al.beg - 1 < d.pos + d.count
-                        && (d.open_count + d.close_count > 0)
-                    {
-                        found_resolved = true;
-                        break;
-                    }
-                }
-                if !found_resolved {
-                    return false;
-                }
-            }
-        }
+/// An emphasis char next to a permissive autolink is a boundary only if its
+/// delimiter run was paired as an opener or closer. `resolved` is sorted by
+/// position.
+fn is_emph_boundary_resolved(content: &[u8], at: usize, resolved: &[EmphDelim]) -> bool {
+    if !EMPH_DELIMS.contains(content[at]) {
+        return true;
     }
-    // Check right boundary: if it's an emphasis char, it must be a resolved delimiter
-    if al.end < content.len() {
-        let next = content[al.end];
-        if next == b'*' || next == b'_' || next == b'~' {
-            if !check_right_boundary(content, al.end, false) {
-                let mut found_resolved = false;
-                for d in resolved {
-                    if d.pos <= al.end
-                        && al.end < d.pos + d.count
-                        && (d.open_count + d.close_count > 0)
-                    {
-                        found_resolved = true;
-                        break;
-                    }
-                }
-                if !found_resolved {
-                    return false;
-                }
-            }
-        }
-    }
-    true
+    let idx = resolved.partition_point(|d| d.pos + d.count <= at);
+    resolved
+        .get(idx)
+        .is_some_and(|d| d.pos <= at && d.open_count + d.close_count > 0)
 }
 
 #[derive(Copy, Clone)]
@@ -78,8 +37,11 @@ pub(crate) struct ScanResult {
 }
 
 /// Scan a URL component (host, path, query, or fragment) following md4c's URL_MAP.
+/// The component ends at `limit` at the latest. Bytes at and after `limit`
+/// still count as the neighbors of the bytes before it.
 fn scan_url_component(
     content: &[u8],
+    limit: usize,
     start: usize,
     start_char: u8,
     delim_char: u8,
@@ -91,7 +53,7 @@ fn scan_url_component(
     let mut n_components: u32 = 0;
     // Check start character
     if start_char != 0 {
-        if pos >= content.len() || content[pos] != start_char {
+        if pos >= limit || content[pos] != start_char {
             return ScanResult {
                 end: pos,
                 ok: min_components == 0,
@@ -108,7 +70,7 @@ fn scan_url_component(
         pos += 1;
     }
 
-    while pos < content.len() {
+    while pos < limit {
         if helpers::is_alpha_num(content[pos]) {
             if n_components == 0 {
                 n_components = 1;
@@ -135,7 +97,7 @@ fn scan_url_component(
         }
     }
 
-    if pos < content.len() && optional_end_char != 0 && content[pos] == optional_end_char {
+    if pos < limit && optional_end_char != 0 && content[pos] == optional_end_char {
         pos += 1;
     }
 
@@ -210,10 +172,74 @@ struct Scheme {
 
 /// Detect permissive autolinks at the given position in content.
 /// `pos` is the position of the trigger character ('@', ':', or '.').
+/// With `allow_emph`, an emphasis char is a boundary too if its run in
+/// `resolved` (the delimiter runs of `content`, sorted by position) was paired.
+///
+/// The inline walk jumps over a link and emits emphasis tags only for the
+/// delimiter runs it lands on, so a link that covers one run of a pair and not
+/// the other leaves a tag unmatched. Such a candidate is cut: it ends before
+/// the first run it may not cover, and `cut_end` receives its uncut end. The
+/// walk starts no autolink before `cut_end`, so no byte is scanned twice.
 pub(crate) fn find_permissive_autolink(
     content: &[u8],
     pos: usize,
     allow_emph: bool,
+    resolved: &[EmphDelim],
+    cut_end: &mut usize,
+) -> AutolinkResult {
+    let mut al = scan_permissive_autolink(content, pos, allow_emph, content.len())?;
+    if allow_emph && al.beg > 0 && !is_emph_boundary_resolved(content, al.beg - 1, resolved) {
+        return None;
+    }
+    // No paired run lies between the start of a link and its trigger
+    // character, so only the runs after `pos` matter.
+    let runs = &resolved[resolved.partition_point(|d| d.pos < pos)..];
+    if let Some(limit) = split_pair_limit(runs, al.end) {
+        *cut_end = al.end;
+        al = scan_permissive_autolink(content, pos, allow_emph, limit)?;
+        debug_assert!(split_pair_limit(runs, al.end).is_none());
+    }
+    if allow_emph && al.end < content.len() && !is_emph_boundary_resolved(content, al.end, resolved)
+    {
+        return None;
+    }
+    Some(al)
+}
+
+/// A permissive autolink whose boundaries do not depend on how the emphasis
+/// delimiters around it resolve.
+pub(crate) fn find_strict_permissive_autolink(content: &[u8], pos: usize) -> AutolinkResult {
+    scan_permissive_autolink(content, pos, false, content.len())
+}
+
+/// Returns where a link that covers the `runs` before `end` has to stop so
+/// that it covers whole emphasis pairs only, or `None` if it already does.
+fn split_pair_limit(runs: &[EmphDelim], end: usize) -> Option<usize> {
+    // Delimiter chars opened inside the link and not closed yet.
+    let mut depth: usize = 0;
+    // The last run that `depth` was zero in front of.
+    let mut zero_at: usize = 0;
+    for d in runs {
+        if d.pos >= end {
+            break;
+        }
+        if depth == 0 {
+            zero_at = d.pos;
+        }
+        if d.close_count > depth {
+            // Closes a span opened before the link.
+            return Some(zero_at);
+        }
+        depth = depth - d.close_count + d.open_count;
+    }
+    (depth > 0).then_some(zero_at)
+}
+
+fn scan_permissive_autolink(
+    content: &[u8],
+    pos: usize,
+    allow_emph: bool,
+    limit: usize,
 ) -> AutolinkResult {
     if pos >= content.len() {
         return None;
@@ -251,19 +277,21 @@ pub(crate) fn find_permissive_autolink(
 
                     let mut end = pos + 1 + suflen;
                     // Scan URL components: host (mandatory), path, query, fragment
-                    let host = scan_url_component(content, end, 0, b'.', b".-_", 2, 0);
+                    let host = scan_url_component(content, limit, end, 0, b'.', b".-_", 2, 0);
                     if !host.ok {
                         continue;
                     }
                     end = host.end;
 
-                    let path = scan_url_component(content, end, b'/', b'/', b"/.-_~*+%", 0, b'/');
+                    let path =
+                        scan_url_component(content, limit, end, b'/', b'/', b"/.-_~*+%", 0, b'/');
                     end = path.end;
 
-                    let query = scan_url_component(content, end, b'?', b'&', b"&.-+_=()~*%", 1, 0);
+                    let query =
+                        scan_url_component(content, limit, end, b'?', b'&', b"&.-+_=()~*%", 1, 0);
                     end = query.end;
 
-                    let frag = scan_url_component(content, end, b'#', 0, b".-+_~*%", 1, 0);
+                    let frag = scan_url_component(content, limit, end, b'#', 0, b".-+_~*%", 1, 0);
                     end = frag.end;
 
                     end = post_process_autolink_end(content, beg, end);
@@ -308,7 +336,7 @@ pub(crate) fn find_permissive_autolink(
         }
 
         // Scan forward for domain (host component only for email)
-        let host = scan_url_component(content, pos + 1, 0, b'.', b".-_", 2, 0);
+        let host = scan_url_component(content, limit, pos + 1, 0, b'.', b".-_", 2, 0);
         if !host.ok {
             return None;
         }
@@ -335,19 +363,19 @@ pub(crate) fn find_permissive_autolink(
 
         // Scan URL components starting from after the '.'
         let mut end = pos + 1;
-        let host = scan_url_component(content, end, 0, b'.', b".-_", 1, 0);
+        let host = scan_url_component(content, limit, end, 0, b'.', b".-_", 1, 0);
         if !host.ok {
             return None;
         }
         end = host.end;
 
-        let path = scan_url_component(content, end, b'/', b'/', b"/.-_~*+%", 0, b'/');
+        let path = scan_url_component(content, limit, end, b'/', b'/', b"/.-_~*+%", 0, b'/');
         end = path.end;
 
-        let query = scan_url_component(content, end, b'?', b'&', b"&.-+_=()~*%", 1, 0);
+        let query = scan_url_component(content, limit, end, b'?', b'&', b"&.-+_=()~*%", 1, 0);
         end = query.end;
 
-        let frag = scan_url_component(content, end, b'#', 0, b".-+_~*%", 1, 0);
+        let frag = scan_url_component(content, limit, end, b'#', 0, b".-+_~*%", 1, 0);
         end = frag.end;
 
         end = post_process_autolink_end(content, beg, end);

--- a/src/md/autolinks.rs
+++ b/src/md/autolinks.rs
@@ -17,13 +17,9 @@ pub struct Autolink {
 
 pub(crate) type AutolinkResult = Option<Autolink>;
 
-/// An emphasis char next to a permissive autolink is a boundary only if its
-/// delimiter run was paired as an opener or closer. `resolved` is sorted by
-/// position.
-fn is_emph_boundary_resolved(content: &[u8], at: usize, resolved: &[EmphDelim]) -> bool {
-    if !EMPH_DELIMS.contains(content[at]) {
-        return true;
-    }
+/// True if the emphasis char at `at` lies in a delimiter run that was paired as
+/// an opener or closer. `resolved` is sorted by position.
+fn is_paired_delimiter(resolved: &[EmphDelim], at: usize) -> bool {
     let idx = resolved.partition_point(|d| d.pos + d.count <= at);
     resolved
         .get(idx)
@@ -146,23 +142,27 @@ const LEFT_BOUNDARY: ByteSet = ByteSet::of(b" \t\n\r\x0B\x0C({[");
 const RIGHT_BOUNDARY: ByteSet = ByteSet::of(b" \t\n\r\x0B\x0C)}]<.!?,;&");
 
 /// Check left boundary for permissive autolinks.
-/// When `allow_emph` is true, emphasis delimiters (*_~) are also valid boundaries.
-fn check_left_boundary(content: &[u8], pos: usize, allow_emph: bool) -> bool {
+/// With `emph`, an emphasis delimiter (*_~) is a boundary too if its run in
+/// `emph` (the delimiter runs of `content`) was paired.
+fn check_left_boundary(content: &[u8], pos: usize, emph: Option<&[EmphDelim]>) -> bool {
     if pos == 0 {
         return true;
     }
     let c = content[pos - 1];
-    LEFT_BOUNDARY.contains(c) || (allow_emph && EMPH_DELIMS.contains(c))
+    LEFT_BOUNDARY.contains(c)
+        || (EMPH_DELIMS.contains(c) && emph.is_some_and(|runs| is_paired_delimiter(runs, pos - 1)))
 }
 
 /// Check right boundary for permissive autolinks.
-/// When `allow_emph` is true, emphasis delimiters (*_~) are also valid boundaries.
-fn check_right_boundary(content: &[u8], pos: usize, allow_emph: bool) -> bool {
+/// With `emph`, an emphasis delimiter (*_~) is a boundary too if its run in
+/// `emph` (the delimiter runs of `content`) was paired.
+fn check_right_boundary(content: &[u8], pos: usize, emph: Option<&[EmphDelim]>) -> bool {
     if pos >= content.len() {
         return true;
     }
     let c = content[pos];
-    RIGHT_BOUNDARY.contains(c) || (allow_emph && EMPH_DELIMS.contains(c))
+    RIGHT_BOUNDARY.contains(c)
+        || (EMPH_DELIMS.contains(c) && emph.is_some_and(|runs| is_paired_delimiter(runs, pos)))
 }
 
 struct Scheme {
@@ -187,29 +187,24 @@ pub(crate) fn find_permissive_autolink(
     resolved: &[EmphDelim],
     cut_end: &mut usize,
 ) -> AutolinkResult {
-    let mut al = scan_permissive_autolink(content, pos, allow_emph, content.len())?;
-    if allow_emph && al.beg > 0 && !is_emph_boundary_resolved(content, al.beg - 1, resolved) {
-        return None;
-    }
+    let emph = allow_emph.then_some(resolved);
+    let al = scan_permissive_autolink(content, pos, emph, content.len())?;
     // No paired run lies between the start of a link and its trigger
     // character, so only the runs after `pos` matter.
     let runs = &resolved[resolved.partition_point(|d| d.pos < pos)..];
-    if let Some(limit) = split_pair_limit(runs, al.end) {
-        *cut_end = al.end;
-        al = scan_permissive_autolink(content, pos, allow_emph, limit)?;
-        debug_assert!(split_pair_limit(runs, al.end).is_none());
-    }
-    if allow_emph && al.end < content.len() && !is_emph_boundary_resolved(content, al.end, resolved)
-    {
-        return None;
-    }
+    let Some(limit) = split_pair_limit(runs, al.end) else {
+        return Some(al);
+    };
+    *cut_end = al.end;
+    let al = scan_permissive_autolink(content, pos, emph, limit)?;
+    debug_assert!(split_pair_limit(runs, al.end).is_none());
     Some(al)
 }
 
 /// A permissive autolink whose boundaries do not depend on how the emphasis
 /// delimiters around it resolve.
 pub(crate) fn find_strict_permissive_autolink(content: &[u8], pos: usize) -> AutolinkResult {
-    scan_permissive_autolink(content, pos, false, content.len())
+    scan_permissive_autolink(content, pos, None, content.len())
 }
 
 /// Returns where a link that covers the `runs` before `end` has to stop so
@@ -238,7 +233,7 @@ fn split_pair_limit(runs: &[EmphDelim], end: usize) -> Option<usize> {
 fn scan_permissive_autolink(
     content: &[u8],
     pos: usize,
-    allow_emph: bool,
+    emph: Option<&[EmphDelim]>,
     limit: usize,
 ) -> AutolinkResult {
     if pos >= content.len() {
@@ -271,7 +266,7 @@ fn scan_permissive_autolink(
                     && &content[pos + 1..pos + 1 + suflen] == scheme.suffix
                 {
                     let beg = pos - slen;
-                    if !check_left_boundary(content, beg, allow_emph) {
+                    if !check_left_boundary(content, beg, emph) {
                         continue;
                     }
 
@@ -296,7 +291,7 @@ fn scan_permissive_autolink(
 
                     end = post_process_autolink_end(content, beg, end);
 
-                    if !check_right_boundary(content, end, allow_emph) {
+                    if !check_right_boundary(content, end, emph) {
                         continue;
                     }
 
@@ -331,7 +326,7 @@ fn scan_permissive_autolink(
             return None; // empty username
         }
 
-        if !check_left_boundary(content, beg, allow_emph) {
+        if !check_left_boundary(content, beg, emph) {
             return None;
         }
 
@@ -342,7 +337,7 @@ fn scan_permissive_autolink(
         }
         let end = host.end;
 
-        if !check_right_boundary(content, end, allow_emph) {
+        if !check_right_boundary(content, end, emph) {
             return None;
         }
 
@@ -357,7 +352,7 @@ fn scan_permissive_autolink(
         }
 
         let beg = pos - 3;
-        if !check_left_boundary(content, beg, allow_emph) {
+        if !check_left_boundary(content, beg, emph) {
             return None;
         }
 
@@ -380,7 +375,7 @@ fn scan_permissive_autolink(
 
         end = post_process_autolink_end(content, beg, end);
 
-        if !check_right_boundary(content, end, allow_emph) {
+        if !check_right_boundary(content, end, emph) {
             return None;
         }
 

--- a/src/md/autolinks.rs
+++ b/src/md/autolinks.rs
@@ -17,8 +17,7 @@ pub struct Autolink {
 
 pub(crate) type AutolinkResult = Option<Autolink>;
 
-/// True if the emphasis char at `at` lies in a delimiter run that was paired as
-/// an opener or closer. `resolved` is sorted by position.
+/// True if `at` lies in a delimiter run of `resolved` (sorted by position) that was paired.
 fn is_paired_delimiter(resolved: &[EmphDelim], at: usize) -> bool {
     let idx = resolved.partition_point(|d| d.pos + d.count <= at);
     resolved
@@ -33,8 +32,7 @@ pub(crate) struct ScanResult {
 }
 
 /// Scan a URL component (host, path, query, or fragment) following md4c's URL_MAP.
-/// The component ends at `limit` at the latest. Bytes at and after `limit`
-/// still count as the neighbors of the bytes before it.
+/// It ends at `limit` at the latest. Bytes from `limit` on still count as neighbors.
 fn scan_url_component(
     content: &[u8],
     limit: usize,
@@ -142,8 +140,7 @@ const LEFT_BOUNDARY: ByteSet = ByteSet::of(b" \t\n\r\x0B\x0C({[");
 const RIGHT_BOUNDARY: ByteSet = ByteSet::of(b" \t\n\r\x0B\x0C)}]<.!?,;&");
 
 /// Check left boundary for permissive autolinks.
-/// With `emph`, an emphasis delimiter (*_~) is a boundary too if its run in
-/// `emph` (the delimiter runs of `content`) was paired.
+/// With `emph`, an emphasis delimiter (*_~) whose run in `emph` was paired is a boundary too.
 fn check_left_boundary(content: &[u8], pos: usize, emph: Option<&[EmphDelim]>) -> bool {
     if pos == 0 {
         return true;
@@ -154,8 +151,7 @@ fn check_left_boundary(content: &[u8], pos: usize, emph: Option<&[EmphDelim]>) -
 }
 
 /// Check right boundary for permissive autolinks.
-/// With `emph`, an emphasis delimiter (*_~) is a boundary too if its run in
-/// `emph` (the delimiter runs of `content`) was paired.
+/// With `emph`, an emphasis delimiter (*_~) whose run in `emph` was paired is a boundary too.
 fn check_right_boundary(content: &[u8], pos: usize, emph: Option<&[EmphDelim]>) -> bool {
     if pos >= content.len() {
         return true;
@@ -172,14 +168,7 @@ struct Scheme {
 
 /// Detect permissive autolinks at the given position in content.
 /// `pos` is the position of the trigger character ('@', ':', or '.').
-/// With `allow_emph`, an emphasis char is a boundary too if its run in
-/// `resolved` (the delimiter runs of `content`, sorted by position) was paired.
-///
-/// The inline walk jumps over a link and emits emphasis tags only for the
-/// delimiter runs it lands on, so a link that covers one run of a pair and not
-/// the other leaves a tag unmatched. Such a candidate is cut: it ends before
-/// the first run it may not cover, and `cut_end` receives its uncut end. The
-/// walk starts no autolink before `cut_end`, so no byte is scanned twice.
+/// A candidate that covers one run of a pair of `resolved` is cut before that run; `cut_end` gets its uncut end.
 pub(crate) fn find_permissive_autolink(
     content: &[u8],
     pos: usize,
@@ -189,8 +178,7 @@ pub(crate) fn find_permissive_autolink(
 ) -> AutolinkResult {
     let emph = allow_emph.then_some(resolved);
     let al = scan_permissive_autolink(content, pos, emph, content.len())?;
-    // No paired run lies between the start of a link and its trigger
-    // character, so only the runs after `pos` matter.
+    // No paired run lies between the start of a link and `pos`.
     let runs = &resolved[resolved.partition_point(|d| d.pos < pos)..];
     let Some(limit) = split_pair_limit(runs, al.end) else {
         return Some(al);
@@ -201,14 +189,12 @@ pub(crate) fn find_permissive_autolink(
     Some(al)
 }
 
-/// A permissive autolink whose boundaries do not depend on how the emphasis
-/// delimiters around it resolve.
+/// A permissive autolink whose boundaries do not depend on emphasis resolution.
 pub(crate) fn find_strict_permissive_autolink(content: &[u8], pos: usize) -> AutolinkResult {
     scan_permissive_autolink(content, pos, None, content.len())
 }
 
-/// Returns where a link that covers the `runs` before `end` has to stop so
-/// that it covers whole emphasis pairs only, or `None` if it already does.
+/// Where to cut a link that ends at `end` so that it covers only whole pairs of `runs`; `None` if it does.
 fn split_pair_limit(runs: &[EmphDelim], end: usize) -> Option<usize> {
     // Delimiter chars opened inside the link and not closed yet.
     let mut depth: usize = 0;

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -9,8 +9,8 @@ pub(crate) const MAX_EMPH_MATCHES: usize = 6;
 
 /// Snapshot of an enclosing slice's walk state while one of its link/image/
 /// wikilink labels is rendered. `base..end` locate the enclosing slice
-/// within the block's inline content; `i`/`text_start`/`delim_cursor`/
-/// `no_autolink_before` are local to that slice. See `process_inline_content`.
+/// within the block's inline content; `i`/`text_start`/`delim_cursor` are
+/// local to that slice. See `process_inline_content`.
 pub(crate) struct LabelFrame {
     base: usize,
     end: usize,
@@ -222,7 +222,7 @@ impl Parser<'_> {
         let mut i: usize = 0;
         let mut text_start: usize = 0;
         let mut delim_cursor: usize = 0;
-        // End of the last permissive autolink candidate that was cut short.
+        // No permissive autolink starts before this offset: a cut candidate already scanned these bytes.
         let mut no_autolink_before: usize = 0;
 
         // Enter the label of a just-parsed link/image/wikilink: snapshot the
@@ -586,8 +586,7 @@ impl Parser<'_> {
         Ok(())
     }
 
-    /// True if `c` can be the trigger character of a permissive autolink here.
-    /// Explicit links suppress them to avoid double-wrapping (md4c issue #152).
+    /// True if `c` can trigger a permissive autolink here; explicit links suppress them (md4c issue #152).
     fn is_permissive_autolink_trigger(&self, c: u8) -> bool {
         let enabled = match c {
             b':' => self.flags.permissive_url_autolinks,
@@ -747,9 +746,7 @@ impl Parser<'_> {
                     continue;
                 }
             }
-            // Skip permissive autolinks that do not need an emphasis delimiter
-            // as a boundary. They are links whatever the delimiters resolve
-            // to, so `*`, `_` and `~` in them belong to the URL (as in GFM).
+            // A permissive autolink with plain boundaries is a link however emphasis resolves: its `*_~` are URL bytes.
             if self.is_permissive_autolink_trigger(c) {
                 if let Some(al) = find_strict_permissive_autolink(content, i) {
                     i = al.end;

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -1,4 +1,4 @@
-use crate::autolinks::{find_permissive_autolink, is_emph_boundary_resolved};
+use crate::autolinks::{find_permissive_autolink, find_strict_permissive_autolink};
 use crate::helpers;
 use crate::links::{BracketMatches, LabelLeave};
 use crate::parser::{self, Parser};
@@ -9,8 +9,8 @@ pub(crate) const MAX_EMPH_MATCHES: usize = 6;
 
 /// Snapshot of an enclosing slice's walk state while one of its link/image/
 /// wikilink labels is rendered. `base..end` locate the enclosing slice
-/// within the block's inline content; `i`/`text_start`/`delim_cursor` are
-/// local to that slice. See `process_inline_content`.
+/// within the block's inline content; `i`/`text_start`/`delim_cursor`/
+/// `no_autolink_before` are local to that slice. See `process_inline_content`.
 pub(crate) struct LabelFrame {
     base: usize,
     end: usize,
@@ -18,6 +18,7 @@ pub(crate) struct LabelFrame {
     text_start: usize,
     resolved: Vec<EmphDelim>,
     delim_cursor: usize,
+    no_autolink_before: usize,
     leave: LabelLeave,
 }
 
@@ -221,6 +222,8 @@ impl Parser<'_> {
         let mut i: usize = 0;
         let mut text_start: usize = 0;
         let mut delim_cursor: usize = 0;
+        // End of the last permissive autolink candidate that was cut short.
+        let mut no_autolink_before: usize = 0;
 
         // Enter the label of a just-parsed link/image/wikilink: snapshot the
         // current walk state and restart the walk on the label slice.
@@ -234,6 +237,7 @@ impl Parser<'_> {
                     text_start: parse.link_end,
                     resolved: core::mem::take(&mut resolved),
                     delim_cursor,
+                    no_autolink_before,
                     leave: parse.leave,
                 });
                 base += parse.label_start;
@@ -244,6 +248,7 @@ impl Parser<'_> {
                 i = 0;
                 text_start = 0;
                 delim_cursor = 0;
+                no_autolink_before = 0;
             }};
         }
 
@@ -469,21 +474,12 @@ impl Parser<'_> {
                 // Note: Strikethrough (~) is handled above via the resolved delimiter system
 
                 // Permissive autolinks: detect URL, email, and WWW autolinks
-                // Suppress inside explicit links to avoid double-wrapping (md4c issue #152)
-                if self.link_nesting_level == 0
-                    && ((c == b':' && self.flags.permissive_url_autolinks)
-                        || (c == b'@' && self.flags.permissive_email_autolinks)
-                        || (c == b'.' && self.flags.permissive_www_autolinks))
-                {
+                if i >= no_autolink_before && self.is_permissive_autolink_trigger(c) {
                     // First try with strict boundaries, then with relaxed (emphasis-aware)
-                    let mut al = find_permissive_autolink(content, i, false);
+                    let cut_end = &mut no_autolink_before;
+                    let mut al = find_permissive_autolink(content, i, false, &resolved, cut_end);
                     if al.is_none() {
-                        al = find_permissive_autolink(content, i, true);
-                        if let Some(a) = al {
-                            if !is_emph_boundary_resolved(content, a, &resolved) {
-                                al = None;
-                            }
-                        }
+                        al = find_permissive_autolink(content, i, true, &resolved, cut_end);
                     }
                     if let Some(a) = al {
                         if a.beg > text_start {
@@ -576,6 +572,7 @@ impl Parser<'_> {
                     text_start = frame.text_start;
                     resolved = frame.resolved;
                     delim_cursor = frame.delim_cursor;
+                    no_autolink_before = frame.no_autolink_before;
                 }
                 None => break 'frames,
             }
@@ -587,6 +584,18 @@ impl Parser<'_> {
         // Hand the bracket-map storage back for reuse by the next block.
         self.bracket_pairs = brackets.into_storage();
         Ok(())
+    }
+
+    /// True if `c` can be the trigger character of a permissive autolink here.
+    /// Explicit links suppress them to avoid double-wrapping (md4c issue #152).
+    fn is_permissive_autolink_trigger(&self, c: u8) -> bool {
+        let enabled = match c {
+            b':' => self.flags.permissive_url_autolinks,
+            b'@' => self.flags.permissive_email_autolinks,
+            b'.' => self.flags.permissive_www_autolinks,
+            _ => return false,
+        };
+        enabled && self.link_nesting_level == 0
     }
 
     pub(crate) fn enter_span(&mut self, span_type: SpanType) -> crate::types::JsResult<()> {
@@ -735,6 +744,15 @@ impl Parser<'_> {
                         }
                     }
                     i = link_result.link_end;
+                    continue;
+                }
+            }
+            // Skip permissive autolinks that do not need an emphasis delimiter
+            // as a boundary. They are links whatever the delimiters resolve
+            // to, so `*`, `_` and `~` in them belong to the URL (as in GFM).
+            if self.is_permissive_autolink_trigger(c) {
+                if let Some(al) = find_strict_permissive_autolink(content, i) {
+                    i = al.end;
                     continue;
                 }
             }

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -904,6 +904,137 @@ describe("pathological autolink inputs", () => {
 });
 
 // ============================================================================
+// Permissive autolinks and emphasis. "_", "*" and "~" are legal URL bytes, so
+// an autolink can run over emphasis delimiters. It used to be able to swallow
+// one delimiter run of a resolved pair ("__a@b.co__" linked "a@b.co_"): the
+// other tag stayed unmatched, and render() returned "" for the whole document.
+// ============================================================================
+
+describe("permissive autolinks and emphasis delimiters", () => {
+  const opts = { autolinks: true };
+
+  // Every tag in `html` is closed, in order.
+  function isWellFormed(html: string): boolean {
+    const open: string[] = [];
+    for (const [, slash, name] of html.matchAll(/<(\/?)([a-z]+)[^>]*>/g)) {
+      if (!slash) open.push(name);
+      else if (open.pop() !== name) return false;
+    }
+    return open.length === 0;
+  }
+
+  test.each([
+    // The link ends in front of the closer of the emphasis around it.
+    ["__a@b.cob__", '<p><strong><a href="mailto:a@b.cob">a@b.cob</a></strong></p>\n'],
+    ["_a@b.co__", '<p><em><a href="mailto:a@b.co">a@b.co</a></em>_</p>\n'],
+    ["**http://example.com/a**", '<p><strong><a href="http://example.com/a">http://example.com/a</a></strong></p>\n'],
+    ["~~www.example.com/a~~", '<p><del><a href="http://www.example.com/a">www.example.com/a</a></del></p>\n'],
+    [
+      "see *http://example.com/path*with*stars for more",
+      '<p>see <em><a href="http://example.com/path">http://example.com/path</a></em>with*stars for more</p>\n',
+    ],
+    [
+      "**Note:** contact __support@example.com__ today.\n\nSecond paragraph.",
+      '<p><strong>Note:</strong> contact <strong><a href="mailto:support@example.com">support@example.com</a></strong> today.</p>\n' +
+        "<p>Second paragraph.</p>\n",
+    ],
+    // The link ends in front of an opener whose closer it does not reach.
+    ["*a*http://a.bc/*y z*", '<p><em>a</em><a href="http://a.bc/">http://a.bc/</a><em>y z</em></p>\n'],
+    // A pair that lies in the URL stays part of the URL.
+    [
+      "**https://example.com/src/__init__.py**",
+      '<p><strong><a href="https://example.com/src/__init__.py">https://example.com/src/__init__.py</a></strong></p>\n',
+    ],
+    [
+      "https://example.com/src/__tests__/a.js",
+      '<p><a href="https://example.com/src/__tests__/a.js">https://example.com/src/__tests__/a.js</a></p>\n',
+    ],
+    // A link between plain boundaries is found before emphasis is resolved:
+    // the delimiters in it do not pair with delimiters outside of it.
+    [
+      "http://example.com/path*with stars*",
+      '<p><a href="http://example.com/path*with">http://example.com/path*with</a> stars*</p>\n',
+    ],
+    ["*a http://x.yz/b*c d*", '<p><em>a <a href="http://x.yz/b*c">http://x.yz/b*c</a> d</em></p>\n'],
+    ["2*3 http://x.yz/a*b", '<p>2*3 <a href="http://x.yz/a*b">http://x.yz/a*b</a></p>\n'],
+    [
+      "https://foo.bar/a*b\nhttps://foo.bar/a*b",
+      '<p><a href="https://foo.bar/a*b">https://foo.bar/a*b</a>\n<a href="https://foo.bar/a*b">https://foo.bar/a*b</a></p>\n',
+    ],
+  ])("html(%j)", (input, expected) => {
+    expect(Markdown.html(input, opts)).toBe(expected);
+  });
+
+  test("render() returns the text of every paragraph", () => {
+    const input = "**Note:** contact __support@example.com__ today.\n\nSecond paragraph.";
+    expect(Markdown.render(input, {}, opts)).toBe("Note: contact support@example.com today.Second paragraph.");
+    expect(
+      Markdown.render(
+        input,
+        {
+          paragraph: (children: string) => `<p>${children}</p>`,
+          strong: (children: string) => `<b>${children}</b>`,
+          link: (children: string) => `[${children}]`,
+        },
+        opts,
+      ),
+    ).toBe("<p><b>Note:</b> contact <b>[support@example.com]</b> today.</p><p>Second paragraph.</p>");
+  });
+
+  test("every mix of delimiters around and in a link renders balanced tags", () => {
+    const links = ["a@b.co", "http://a.bc/d", "http://a.bc/d*e", "www.a.bc/_d_/~e"];
+    const tails = ["", "x", "_x", " x*"];
+    const bad: string[] = [];
+    for (const before of ["", "*", "__", "~~"]) {
+      for (const link of links) {
+        for (const after of ["", "*", "**", "__", "~~"]) {
+          for (const tail of tails) {
+            const input = before + link + after + tail;
+            const html = Markdown.html(input, opts);
+            const text = html.replace(/<[^>]*>/g, "").replace(/\n$/, "");
+            if (!isWellFormed(html) || Markdown.render(input, {}, opts) !== text) bad.push(input);
+          }
+        }
+      }
+    }
+    expect(bad).toEqual([]);
+  });
+
+  test("a flood of links that are cut at emphasis delimiters renders in linear time", async () => {
+    // Each "www." link runs to the end of the token, over the openers of the
+    // links after it. Every one of those openers closes outside of the token.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
+        const n = 30000;
+        const html = Bun.markdown.html(fill(n, "*www.a.bc/") + "x" + fill(n, " y*"), { autolinks: true });
+        const count = tag => html.split(tag).length - 1;
+        if (count("<em>") !== n || count("</em>") !== n) {
+          throw new Error("unbalanced: " + count("<em>") + " <em>, " + count("</em>") + " </em>");
+        }
+        if (!html.startsWith('<p><em><a href="http://www.a.bc/">www.a.bc/</a><em>www.a.bc/<em>')) {
+          throw new Error("unexpected output: " + JSON.stringify(html.slice(0, 120)));
+        }
+        console.log("DONE");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("DONE");
+    expect(exitCode).toBe(0);
+  }, 90_000);
+});
+
+// ============================================================================
 // ANSI renderer: text taken from the markdown document must not be able to
 // smuggle its own terminal control sequences (OSC 52 clipboard writes, title
 // changes, CSI device queries, ...) into the output alongside the renderer's

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1009,7 +1009,7 @@ describe("permissive autolinks and emphasis delimiters", () => {
         "-e",
         `
         const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
-        const n = 30000;
+        const n = 20000;
         const html = Bun.markdown.html(fill(n, "*www.a.bc/") + "x" + fill(n, " y*"), { autolinks: true });
         const count = tag => html.split(tag).length - 1;
         if (count("<em>") !== n || count("</em>") !== n) {
@@ -1031,7 +1031,7 @@ describe("permissive autolinks and emphasis delimiters", () => {
     expect(stderr).toBe("");
     expect(stdout).toContain("DONE");
     expect(exitCode).toBe(0);
-  }, 90_000);
+  });
 });
 
 // ============================================================================

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1000,23 +1000,32 @@ describe("permissive autolinks and emphasis delimiters", () => {
     expect(bad).toEqual([]);
   });
 
-  test("a flood of links that are cut at emphasis delimiters renders in linear time", async () => {
-    // Each "www." link runs to the end of the token, over the openers of the
-    // links after it. Every one of those openers closes outside of the token.
+  test("floods of links next to emphasis delimiters render in linear time", async () => {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `
         const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
+        const count = (html, tag) => html.split(tag).length - 1;
         const n = 20000;
-        const html = Bun.markdown.html(fill(n, "*www.a.bc/") + "x" + fill(n, " y*"), { autolinks: true });
-        const count = tag => html.split(tag).length - 1;
-        if (count("<em>") !== n || count("</em>") !== n) {
-          throw new Error("unbalanced: " + count("<em>") + " <em>, " + count("</em>") + " </em>");
+
+        // Each "www." link runs to the end of the token, over the openers of
+        // the links after it. Every one of those openers closes outside of the
+        // token, so the first link is cut and the rest of the token is text.
+        const cut = Bun.markdown.html(fill(n, "*www.a.bc/") + "x" + fill(n, " y*"), { autolinks: true });
+        if (count(cut, "<em>") !== n || count(cut, "</em>") !== n) {
+          throw new Error("unbalanced: " + count(cut, "<em>") + " <em>, " + count(cut, "</em>") + " </em>");
         }
-        if (!html.startsWith('<p><em><a href="http://www.a.bc/">www.a.bc/</a><em>www.a.bc/<em>')) {
-          throw new Error("unexpected output: " + JSON.stringify(html.slice(0, 120)));
+        if (!cut.startsWith('<p><em><a href="http://www.a.bc/">www.a.bc/</a><em>www.a.bc/<em>')) {
+          throw new Error("unexpected output: " + JSON.stringify(cut.slice(0, 120)));
+        }
+
+        // The closers lie in a link between plain boundaries, so the openers
+        // stay literal. A literal "*" is no boundary: no link starts after it.
+        const literal = Bun.markdown.html(fill(n, "*www.a.bc/") + " www.x.y/" + fill(n, "a*.") + "a", { autolinks: true });
+        if (count(literal, "<em>") !== 0 || count(literal, "<a ") !== 1) {
+          throw new Error("unexpected output: " + JSON.stringify(literal.slice(0, 120)));
         }
         console.log("DONE");
         `,

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -940,6 +940,11 @@ describe("permissive autolinks and emphasis delimiters", () => {
     ],
     // The link ends in front of an opener whose closer it does not reach.
     ["*a*http://a.bc/*y z*", '<p><em>a</em><a href="http://a.bc/">http://a.bc/</a><em>y z</em></p>\n'],
+    // The bytes after the cut still count as neighbors: the closing "_" of the whole pair stays in the link.
+    [
+      "*a*https://example.com/_b_*c d*",
+      '<p><em>a</em><a href="https://example.com/_b_">https://example.com/_b_</a><em>c d</em></p>\n',
+    ],
     // A pair that lies in the URL stays part of the URL.
     [
       "**https://example.com/src/__init__.py**",


### PR DESCRIPTION
### Problem
- With `autolinks: true`, `Bun.markdown.html("__a@b.cob__")` returns `<p><strong><a href="mailto:a@b.cob_">a@b.cob_</a>_</p>`: the `<strong>` is never closed. `Bun.markdown.render()` returns `""` for the whole document.
- `_`, `*` and `~` are legal URL bytes, so a link can run over emphasis delimiters (`src/md/autolinks.rs`). The inline walk (`process_inline_content`, `src/md/inlines.rs`) jumps over a link and emits tags only for the delimiter runs it lands on. A link that covers one run of a pair drops that run's tag.

### Fix
- `collect_emphasis_delimiters` skips a permissive autolink that has plain boundaries, as it does for code spans. The `*_~` bytes in it never pair. cmark-gfm does the same.
- A link next to an emphasis delimiter (`**url**`) ends before the first delimiter run whose partner it does not cover. A pair inside the URL (`__init__.py`) stays in the link.
- After a cut, the walk starts no autolink in the bytes the uncut candidate covered, so the scan work stays linear.
- Verified: `test/js/bun/md/md-edge-cases.test.ts` (new block, 15 of 17 tests fail on 1.4.3). All of `test/js/bun/md/` and `test/cli/run/markdown-entrypoint.test.ts` pass.

### Background
- A permissive autolink is a bare `http://...`, `www....` or `a@b.c`. It needs a boundary on each side. An emphasis delimiter is a boundary only if it was paired.
- A delimiter run is a sequence of one of `*`, `_`, `~`. The parser pairs the runs first, then walks the text and emits tags for the paired runs.
- `render()` keeps one stack entry per open element. A missing close event shifts every later pop, so no text reaches the root buffer.

<details><summary>Notes</summary>

**Output changes.** A differential run against 1.4.3 (100k generated inputs that mix delimiters, links, brackets, code spans and raw HTML, six option sets):
- Without `autolinks`, no output changes.
- With `autolinks`, about 0.7% of the inputs had unbalanced tags on 1.4.3. None has after this change.
- No input that was well formed before changes. A candidate is cut only if the uncut candidate is a valid link, so a candidate that 1.4.3 rejected is still rejected.
- All 2721 markdown files in this repository (docs, test fixtures, vendored READMEs, 7.3 MB) give the same `html()` and `render()` output before and after, with tables, strikethrough, tasklists and autolinks on.

**Why not stop at every resolved delimiter, as md4c does.** md4c (`md_analyze_permissive_autolink`) ends the link at any resolved mark. That splits real URLs: `https://github.com/python/cpython/blob/main/Lib/asyncio/__init__.py` becomes a link to `.../asyncio/` followed by `<strong>init</strong>.py`. Those URLs are one link today (both runs of the pair are skipped), and `gfm-compat.test.ts` section 6 states the intent that delimiters in URLs are not span delimiters. This change keeps that.

**Examples.**
- `**https://example.com/src/__init__.py**` gives `<strong><a href="https://example.com/src/__init__.py">...</a></strong>`.
- `see *http://example.com/path*with*stars for more` gives `see <em><a href="http://example.com/path">...</a></em>with*stars for more`, the same emphasis as without `autolinks`.
- `http://example.com/path*with stars*` gives `<a href="http://example.com/path*with">...</a> stars*`, as cmark-gfm does.
- `https://foo.bar/a*b` two times in one paragraph (the input of md4c issue 294) stays two links.

**The cut.** `split_pair_limit` walks the delimiter runs that the candidate covers and counts the delimiter chars that opened in the link and did not close yet. A run that closes more than that closes a span from before the link. A count above zero at the end means a span that closes after the link. In both cases the link ends at the last run that had a count of zero in front of it. The second scan stops at that run. It takes the same decisions as the first scan up to there, because bytes after the limit still count as neighbors.

**Linear time.**
- Without the `no_autolink_before` mark, `"*www.a.bc/".repeat(n) + "x" + " y*".repeat(n)` scans the rest of the token again for each link: 46 s for 100 KB on the debug build. With the mark it takes 70 ms.
- The boundary checks now know the delimiter runs, so a candidate after an unpaired `*` is dropped before its scan. `"*www.a.bc/".repeat(n)` takes 5 s for 160 KB on 1.4.3 (each link scans to the end of the token and fails afterwards) and is linear now. This also keeps `"*www.a.bc/".repeat(n) + " www.x.y/" + "a*.".repeat(n) + "a"` linear, where the closers are hidden in the plain-boundary link.
- `is_emph_boundary_resolved` walked all delimiter runs for each link next to emphasis. The lookup is a binary search now. `"*a@b.co* ".repeat(n)` was quadratic on 1.4.3 (5, 20, 79 ms for n = 2k, 4k, 8k) and is linear now.
- The new test covers the first two inputs.

**Not changed.** A chain of candidates that start after paired delimiters and fail at their right boundary is still quadratic: `"www.a.bc/" + "*www.a.bc/x*".repeat(n) + "("` takes 7 s for 192 KB on 1.4.3 and the same class of time after. Each candidate scans to the `(`, fails there, and the next `www.` in it scans again. One more input shape reaches this path now: a delimiter whose partner lies in a plain-boundary link does not pair any more, so `"www.x.y/.~a www.a.bc/" + "*www.a.bc/x*".repeat(n) + "~ "` fails at the unpaired `~` (1.4.3 accepted the first candidate and printed unbalanced tags). A memo of the scan ends would fix the whole class. That is a separate change.

**Separate bug, not fixed here.** `john_doe@example.com` renders as `john_<a href="mailto:john_doe@example.com">john_doe@example.com</a>` on 1.4.3 and after this change. The walk flushes text at the literal `_`, and the email link then starts in front of the flushed text.

**Checks.** About 900k generated inputs on the debug build (debug assertions on): every `html()` output is well formed and `render(input, {})` equals the text of `html()`. The only failures need `wikiLinks: true` and emphasis that crosses a `[[...]]` boundary. They are the same on 1.4.3 and without `autolinks` (see #39494). `cargo clippy -p bun_md` is clean.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-edge-cases.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/27] gen cpp.rs (cppbind)
[2/27] gen JS modules (bundle-modules)
Preprocess modules (12465ms)
Bundle modules (149ms)
Postprocesss modules (136ms)
Bundle Functions (638ms)
Generate Code (51ms)

[13.45s] Bundled "src/js" for development
  2792 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/11] cargo bun_runtime → libbun_runtime.a
[4/11] cxx obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o
FAILED: obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -fno-asynchronous-unwind-tables -Wno-c23-extensions -ffunction-sections -fdata-sections -faddrsig -fno-semantic-interposition -fno-delete-null-pointer-checks -fdia
... (truncated)

release without fix: 15 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [1.73ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [0.11ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [0.04ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [0.11ms]
(pass) fuzzer-like edge cases > control characters in input [0.02ms]
(pass) fuzzer-like edge cases > Buffer input works [0.03ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [0.05ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [0.13ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [0.04ms]
(pass) fuzzer-like edge cases > deeply nested lists [0.08ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [7.58ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [6.05ms]
(pass) fuzzer-like edge cases > deeply nested emphasis [0.09ms]
(pass) fuzzer-like edge cases > deeply nested links [0.07ms]
(pass) fuzzer-like edge cases > very long s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-edge-cases.test.ts
bun test v1.4.3 (4ff919377)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [95.02ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [11.11ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [3.02ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [8.24ms]
(pass) fuzzer-like edge cases > control characters in input [2.49ms]
(pass) fuzzer-like edge cases > Buffer input works [2.80ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [6.27ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [9.51ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [3.81ms]
(pass) fuzzer-like edge cases > deeply nested lists [13.19ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [167.26ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [145.34ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     56b4ca6ffc
  features     baseline

23 deps, 131 codegen, 1172 objects in 1532ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (4ff919377)

Checked 22 installs across 61 packages (no changes) [44.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (4ff919377)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (4ff919377)

Checked 111 installs across 104 packages (no changes) [11.00ms]
[4/1244] gen bindgenv2
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[7/1243] gen .bind.ts → GeneratedBindings.cpp
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] gen ErrorCode+*.h
[10/1216] fetch zlib
[zlib] up to date
[11/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h fr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/md/autolinks.rs                  | 161 ++++++++++++++++++-----------------
 src/md/inlines.rs                    |  43 +++++++---
 test/js/bun/md/md-edge-cases.test.ts | 145 +++++++++++++++++++++++++++++++
 3 files changed, 259 insertions(+), 90 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/md/autolinks.rs                       6      4     17
src/md/inlines.rs                         3      1     16
test/js/bun/md/md-edge-cases.test.ts      1      2     16
```

</details>

<!-- robobun:evidence:end -->