### PR TITLE
inspect: count a hole run before the 101st array element once

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4327,6 +4327,8 @@ pub mod formatter {
                         continue;
                     }
                     if nonempty_count >= 100 {
+                        // A pending hole run is part of the elided tail, not trailing holes.
+                        let elided_from = empty_start.take().unwrap_or(i);
                         writer.print_comma::<C>();
                         writer.write_all(b"\n"); // we want the line break to be unconditional here
                         *writer.estimated_line_length = 0;
@@ -4336,7 +4338,7 @@ pub mod formatter {
                             format_args!(
                                 "{}... {} more items{}",
                                 pf!("<r><d>"),
-                                len - u64::from(i),
+                                len - u64::from(elided_from),
                                 pf!("<r>")
                             ),
                         );

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -557,6 +557,54 @@ it("Bun.inspect array with non-indexed properties", () => {
 ]`);
 });
 
+// After 100 elements the rest of the array is one "... N more items" summary. A run of holes right
+// before the 101st element is part of that rest, not a second "N x empty items" entry.
+it("Bun.inspect array counts a hole run before the 101st element once", () => {
+  const hundred = () => Array.from({ length: 100 }, (_, i) => i);
+  const afterThe100th = value => {
+    const out = Bun.inspect(value);
+    return out.slice(out.lastIndexOf("99,"));
+  };
+
+  const holesThenElement = hundred();
+  holesThenElement[105] = "x";
+
+  const holesOnBothSides = hundred();
+  holesOnBothSides[105] = "x";
+  holesOnBothSides.length = 200;
+
+  const withNamedProperty = hundred();
+  withNamedProperty[105] = "x";
+  withNamedProperty.potato = "hello";
+
+  const args = (function () {
+    arguments[105] = "x";
+    arguments.length = 106;
+    return arguments;
+  })(...hundred());
+
+  // Controls: no hole run is pending when the cap is reached. This records their current output.
+  const dense = Array.from({ length: 106 }, (_, i) => i);
+  const trailingHolesOnly = hundred();
+  trailingHolesOnly.length = 106;
+
+  expect({
+    holesThenElement: afterThe100th(holesThenElement),
+    holesOnBothSides: afterThe100th(holesOnBothSides),
+    withNamedProperty: afterThe100th(withNamedProperty),
+    args: afterThe100th(args),
+    dense: afterThe100th(dense),
+    trailingHolesOnly: afterThe100th(trailingHolesOnly),
+  }).toEqual({
+    holesThenElement: "99,\n  ... 6 more items\n]",
+    holesOnBothSides: "99,\n  ... 100 more items\n]",
+    withNamedProperty: '99,\n  ... 6 more items, potato: "hello"\n]',
+    args: "99,\n  ... 6 more items\n]",
+    dense: "99,\n  ... 6 more items\n]",
+    trailingHolesOnly: "99, 6 x empty items\n]",
+  });
+});
+
 // Printing a sparse array must never iterate index-by-index over the holes:
 // `length` can be up to 2^32 - 1 with no elements in the array at all.
 // Run it in a child so a regression times this test out instead of hanging the runner.


### PR DESCRIPTION
### Problem
- `Bun.inspect` and `console.log` count one region of an array two times. `const a = Array.from({ length: 100 }, (_, i) => i); a[105] = "x"; Bun.inspect(a)` ends with `... 1 more items, 6 x empty items`. Only 6 entries remain: 5 holes and 1 element. Node prints `... 6 more items`.
- The cause is `print_array` (`src/jsc/ConsoleObject.rs:4329`). At the 100-element cap the loop prints `len - i` and breaks while `empty_start` still holds the start of the hole run. The block after the loop (line 4408) then prints `len - empty_start` as `x empty items`.

### Fix
- At the cap, count the summary from the start of the pending hole run: `empty_start.take().unwrap_or(i)`. `take()` clears `empty_start`, so the block after the loop prints nothing.
- The repro now ends with `... 6 more items`, as `util.inspect` does in Node 26.3 and in Bun. Other output does not change.
- Verified: `test/js/bun/util/inspect.test.js` (the new test fails on 1.4.3-canary.1). Also `test/js/web/console/` and `test/js/bun/console/`.
- Self-reviewed: 2 concerns raised, 1 addressed. Rejected: a seeded random check that parses the output text, which three open PRs change. See Notes.

### Background
- `print_array` is the native printer for arrays and `arguments` objects behind `console.log` and `Bun.inspect`. `node:util` has a separate JS `inspect`, which is correct already.
- A hole is an index with no own property. The printer collapses a run of holes into `N x empty items`. `empty_start` holds the first index of a run that is not printed yet.
- After 100 elements that are not holes, the printer prints `... N more items` for the rest.

<details><summary>Notes</summary>

- Reproduced on the released 1.4.3, on canary 1.4.3-canary.1 (4ff919377) and on main. Plain arrays and `arguments` objects both show it.
- With a large length the two numbers add up to almost two times the length. 100 elements plus one element at index 4294967290 printed `... 1 more items, 4294967191 x empty items`. It now prints `... 4294967191 more items`.
- Differential run, released bun against this branch, 25 array shapes. The 16 shapes with a hole run pending at the cap changed to one count equal to `length - start of the hole run`. The other 9 shapes are byte-identical: dense arrays of 100, 101 and 250, a leading hole, a hole at index 99, holes spread over the first elements, trailing holes only, and a hole run that ends at the 100th element.
- Seeded check, not in the test file: 100 random arrays of length 101 to 260 with alternating runs of elements and holes, every fourth one an `arguments` object. The printed elements, the `x empty items` counts and the `more items` count add up to `length` for 94 of 100 on the released bun, and for 100 of 100 on this branch.
- `empty_start == Some(0)` cannot occur at the cap. A leading hole run is printed at the first element, and the cap needs 99 more elements after that. So the comma before the summary always follows printed content.
- #31809 (`maxArrayLength` for the native formatter) has the same change at the cap, written against the loop before #33158. It conflicts with main and waits for a rework. This PR does not depend on it.
- #42247, #37303 and #36693 edit other parts of `print_array`. The nearest hunk (#42247) ends 3 unchanged lines above the cap block.
- Not changed here: Bun counts only elements that are not holes toward the cap, and Node counts each collapsed hole run as one entry. That is why `100 elements + 6 trailing holes` prints `99, 6 x empty items` in Bun and `... 6 more items` in Node. Bun also prints `1 more items` where Node prints `1 more item`. Both differences are older than this bug.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->