### PR TITLE
node:tls: shut the wrapped stream down when a client-side TLSSocket wrap ends or is destroyed

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4328,11 +4328,11 @@ function closeSocketHandle(self, isException, isCleanupPending = false) {
   const handle = self._handle;
   $debug("closeSocketHandle", isException, isCleanupPending, !!handle);
   if (handle) {
-    if (typeof handle.close === "function") {
+    if (handle instanceof Duplex) {
+      // A client-side TLSSocket wrap holds the stream it wraps as its handle until connect() upgrades it.
+      handle.destroy();
+    } else {
       handle.close(onSocketHandleClosed);
-    } else if (!handle.destroyed) {
-      // tls.ts stores the wrapped Duplex directly as _handle; it has destroy(), not close().
-      handle.destroy?.();
     }
     setImmediate(() => {
       $debug("emit close", isCleanupPending);

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4328,7 +4328,12 @@ function closeSocketHandle(self, isException, isCleanupPending = false) {
   const handle = self._handle;
   $debug("closeSocketHandle", isException, isCleanupPending, !!handle);
   if (handle) {
-    handle.close(onSocketHandleClosed);
+    if (typeof handle.close === "function") {
+      handle.close(onSocketHandleClosed);
+    } else if (!handle.destroyed) {
+      // tls.ts stores the wrapped Duplex directly as _handle; it has destroy(), not close().
+      handle.destroy?.();
+    }
     setImmediate(() => {
       $debug("emit close", isCleanupPending);
       self.emit("close", isException);

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -708,6 +708,11 @@ const kSharedCreds = Symbol.for("::buntlssharedcreds::");
 // the unwrapped native context).
 const kNativeSecureContextCtor = Symbol.for("::buntlsnativesecurecontextctor::");
 
+// One tick after the transport's 'close', so a 'finish' that is already queued is emitted first.
+function destroyWithTransportNT(self, transport) {
+  if (self._handle === transport) self.destroy();
+}
+
 function TLSSocket(socket?, options?) {
   this[ksecureContext] = undefined;
   this.ALPNProtocols = undefined;
@@ -809,6 +814,8 @@ function TLSSocket(socket?, options?) {
       this._handle = socket;
       // keep compatibility with http2-wrapper or other places that try to grab JSStreamSocket in node.js, with here is just the TLSSocket
       this._handle._parentWrap = this;
+      // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L739-L741
+      socket.once("close", () => process.nextTick(destroyWithTransportNT, this, socket));
     }
     // For the server wrap, _handle is assigned the upgraded TLS handle by the
     // server-upgrade method below; leaving it unset until then means a synchronous

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -897,10 +897,20 @@ TLSSocket.prototype._start = function _start() {
 };
 
 TLSSocket.prototype._final = function _final(callback) {
-  if (!this._handle) return callback();
+  const handle = this._handle;
+  if (!handle) return callback();
   // https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1119-L1133
   if (this.secureConnecting && this[kPreHandshakeWrite]) {
     return this.once(kSecureConnectDone, NetSocket.prototype._final.bind(this, callback));
+  }
+  // A client-side wrap holds the stream it wraps as its handle until connect() upgrades it.
+  if (handle instanceof Duplex) {
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973
+    if (handle instanceof NetSocket && handle.pending) {
+      return handle.once("connect", this._final.bind(this, callback));
+    }
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L155-L160
+    return handle.end(() => callback());
   }
   // https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1203-L1213
   return NetSocket.prototype._final.$call(this, callback);

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1952,9 +1952,9 @@ describe.each([
   ["bun", bunExe()],
   ["node", nodeExe()],
 ])("end() and destroySoon() before the handshake completes (%s)", (_runtime, exe) => {
-  async function run(mode: string) {
+  async function run(...args: string[]) {
     await using proc = Bun.spawn({
-      cmd: [exe!, join(import.meta.dir, "tls-shutdown-before-handshake-fixture.mjs"), mode],
+      cmd: [exe!, join(import.meta.dir, "tls-shutdown-before-handshake-fixture.mjs"), ...args],
       env: { ...bunEnv, TLS_KEY: COMMON_CERT_.key, TLS_CERT: COMMON_CERT_.cert },
       stdout: "pipe",
       stderr: "pipe",
@@ -1990,6 +1990,40 @@ describe.each([
     expect(await run("server-end")).toEqual({
       log: ["end secureConnecting=true", "finish"],
       clientSawFin: true,
+    });
+  });
+
+  // new tls.TLSSocket(stream) without isServer: nothing starts a handshake on
+  // it, and until connect() upgrades it the wrapped stream stands in for the
+  // native handle. Node shuts that stream down, a net.Socket once it is connected:
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L155-L160
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973
+  describe.concurrent.each([
+    ["a connected net.Socket", "connected", []],
+    ["a net.Socket that is still connecting", "connecting", ["transport connect"]],
+    ["a net.Socket that connects later", "unconnected", ["transport connect"]],
+    ["a Duplex", "duplex", ["transport final"]],
+  ])("a client-side wrap of %s", (_name, transport, before) => {
+    it.skipIf(!exe)("end() finishes the writable side and ends the stream", async () => {
+      expect(await run("wrap-end", transport)).toEqual({
+        log: [...before, "finish"],
+        peerSawFin: transport !== "duplex",
+        writableFinished: true,
+        readyState: "readOnly",
+        destroyed: false,
+        transportDestroyed: false,
+      });
+    });
+
+    it.skipIf(!exe)("destroySoon() closes the socket and destroys the stream", async () => {
+      expect(await run("wrap-destroySoon", transport)).toEqual({
+        log: [...before, "finish", "close"],
+        peerSawFin: transport !== "duplex",
+        writableFinished: true,
+        readyState: "closed",
+        destroyed: true,
+        transportDestroyed: true,
+      });
     });
   });
 });

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -208,6 +208,7 @@ it("should be able to grab the JSStreamSocket constructor", () => {
   expect(socket._handle._parentWrap).not.toBeNull();
   //@ts-ignore
   expect(socket._handle._parentWrap.constructor).toBeFunction();
+  socket.destroy();
 });
 for (const { name, connect } of tests) {
   describe(name, () => {
@@ -1356,14 +1357,13 @@ it("TLSSocket._requestCert follows Node's _init rule", () => {
   // Clients always request the peer certificate; servers only when asked.
   // Must be decided in the constructor, before a server wrap starts its
   // upgrade: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L845-L848
-  // Like the JSStreamSocket test above, the detached wrappers are not
-  // destroyed: tearing down a never-connected duplex wrap is its own quirk.
   const cases = [
     new TLSSocket(new stream.PassThrough()), // client
     new TLSSocket(new stream.PassThrough(), { isServer: true }),
     new TLSSocket(new stream.PassThrough(), { isServer: true, requestCert: true }),
   ];
   expect(cases.map(s => (s as any)._requestCert)).toEqual([true, false, true]);
+  for (const s of cases) s.destroy();
 });
 
 it("socket.ssl is assignable like Node's plain own property", async () => {
@@ -1999,30 +1999,38 @@ describe.each([
   // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L155-L160
   // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973
   describe.concurrent.each([
-    ["a connected net.Socket", "connected", []],
-    ["a net.Socket that is still connecting", "connecting", ["transport connect"]],
-    ["a net.Socket that connects later", "unconnected", ["transport connect"]],
-    ["a Duplex", "duplex", ["transport final"]],
-  ])("a client-side wrap of %s", (_name, transport, before) => {
-    it.skipIf(!exe)("end() finishes the writable side and ends the stream", async () => {
-      expect(await run("wrap-end", transport)).toEqual({
-        log: [...before, "finish"],
-        peerSawFin: transport !== "duplex",
-        writableFinished: true,
-        readyState: "readOnly",
-        destroyed: false,
-        transportDestroyed: false,
-      });
-    });
-
-    it.skipIf(!exe)("destroySoon() closes the socket and destroys the stream", async () => {
-      expect(await run("wrap-destroySoon", transport)).toEqual({
-        log: [...before, "finish", "close"],
-        peerSawFin: transport !== "duplex",
-        writableFinished: true,
-        readyState: "closed",
-        destroyed: true,
-        transportDestroyed: true,
+    ["a connected net.Socket", "connected", [], true],
+    ["a net.Socket that is still connecting", "connecting", ["transport connect"], true],
+    ["a net.Socket that connects later", "unconnected", ["transport connect"], true],
+    ["a Duplex", "duplex", ["transport final"], false],
+    ["a Duplex that has a close(code, callback) of its own", "duplex-with-close", ["transport final"], false],
+  ])("a client-side wrap of %s", (_name, transport, before, peerSawFin) => {
+    it.skipIf(!exe)("end(), destroySoon() and destroy() shut the stream down", async () => {
+      expect(await run("wrap", transport)).toEqual({
+        end: {
+          log: [...before, "finish"],
+          peerSawFin,
+          writableFinished: true,
+          readyState: "readOnly",
+          destroyed: false,
+          transportDestroyed: false,
+        },
+        destroySoon: {
+          log: [...before, "finish", "close"],
+          peerSawFin,
+          writableFinished: true,
+          readyState: "closed",
+          destroyed: true,
+          transportDestroyed: true,
+        },
+        destroy: {
+          log: ["close"],
+          peerSawFin: false,
+          writableFinished: false,
+          readyState: "closed",
+          destroyed: true,
+          transportDestroyed: true,
+        },
       });
     });
   });

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -2034,4 +2034,27 @@ describe.each([
       });
     });
   });
+
+  // The wrap closes when the stream under it does:
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L739-L741
+  describe.concurrent("a client-side wrap whose stream closes under it", () => {
+    const closed = { readyState: "closed", destroyed: true, transportDestroyed: true };
+
+    it.skipIf(!exe)("a peer that closes on the FIN closes the wrap after end()", async () => {
+      expect(await run("wrap", "peer-closes")).toEqual({
+        end: { log: ["finish", "close"], peerSawFin: true, writableFinished: true, ...closed },
+        destroySoon: { log: ["finish", "close"], peerSawFin: true, writableFinished: true, ...closed },
+        destroy: { log: ["close"], peerSawFin: false, writableFinished: false, ...closed },
+      });
+    });
+
+    it.skipIf(!exe)("a refused connection closes a wrap whose end() waits for 'connect'", async () => {
+      const refused = ["transport error:ECONNREFUSED", "close"];
+      expect(await run("wrap", "refused")).toEqual({
+        end: { log: refused, peerSawFin: false, writableFinished: false, ...closed },
+        destroySoon: { log: refused, peerSawFin: false, writableFinished: false, ...closed },
+        destroy: { log: ["close"], peerSawFin: false, writableFinished: false, ...closed },
+      });
+    });
+  });
 });

--- a/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
+++ b/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
@@ -7,6 +7,7 @@
 // reproduces on a plain net.Socket, tracked separately).
 import { once } from "node:events";
 import net from "node:net";
+import { Duplex } from "node:stream";
 import tls, { TLSSocket } from "node:tls";
 
 const mode = process.argv[2];
@@ -16,6 +17,12 @@ function report(extra) {
   console.log(JSON.stringify({ log, ...extra }));
   process.exit(0);
 }
+
+// Ends the run at once, also while a top-level await below is still pending.
+process.on("uncaughtException", error => {
+  console.error(error);
+  process.exit(1);
+});
 
 // Accepts the TCP connection, reads, and never answers the ClientHello: a dead
 // TLS backend, a plaintext service on a TLS port, a middlebox. allowHalfOpen
@@ -93,6 +100,49 @@ if (mode === "end" || mode === "destroySoon") {
   serverSocket?.destroy();
   server.close();
   report({ clientSawFin: true });
+} else if (mode === "wrap-end" || mode === "wrap-destroySoon") {
+  // new TLSSocket(stream) without isServer: a client-side wrap that nothing
+  // starts a handshake on. Shutting it down shuts the wrapped stream down.
+  const method = mode.slice("wrap-".length);
+  const transport = process.argv[3];
+  const peer = transport === "duplex" ? undefined : await stalledPeer();
+
+  let raw;
+  if (transport === "duplex") {
+    raw = new Duplex({
+      read() {},
+      write(chunk, encoding, callback) {
+        callback();
+      },
+      final(callback) {
+        log.push("transport final");
+        callback();
+      },
+    });
+  } else if (transport === "unconnected") {
+    raw = new net.Socket();
+  } else {
+    raw = net.connect(peer.port, "127.0.0.1");
+    if (transport === "connected") await once(raw, "connect");
+  }
+  raw.on("connect", () => log.push("transport connect"));
+
+  const socket = new TLSSocket(raw, { rejectUnauthorized: false });
+  socket.on("finish", () => log.push("finish"));
+  socket.on("error", error => log.push(`error:${error.code ?? error.message}`));
+  socket.on("close", () => log.push("close"));
+
+  socket[method]();
+  if (transport === "unconnected") raw.connect(peer.port, "127.0.0.1");
+
+  await Promise.all([once(socket, method === "end" ? "finish" : "close"), peer?.sawFin]);
+
+  const { writableFinished, readyState, destroyed } = socket;
+  const transportDestroyed = raw.destroyed;
+  socket.destroy();
+  raw.destroy();
+  peer?.close();
+  report({ peerSawFin: peer !== undefined, writableFinished, readyState, destroyed, transportDestroyed });
 } else {
   throw new Error(`unknown mode ${mode}`);
 }

--- a/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
+++ b/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
@@ -28,10 +28,10 @@ process.on("uncaughtException", error => {
 // TLS backend, a plaintext service on a TLS port, a middlebox. allowHalfOpen
 // keeps it from closing when our FIN arrives, so the client's event list stays
 // independent of the peer's teardown.
-async function stalledPeer() {
+async function stalledPeer(allowHalfOpen = true) {
   const sawFin = Promise.withResolvers();
   let accepted;
-  const server = net.createServer({ allowHalfOpen: true }, socket => {
+  const server = net.createServer({ allowHalfOpen }, socket => {
     accepted = socket;
     socket.on("data", () => {});
     socket.on("error", () => {});
@@ -105,13 +105,24 @@ if (mode === "end" || mode === "destroySoon") {
   // starts a handshake on. Shutting it down shuts the wrapped stream down. One
   // report per method, each on a wrap and a stream of its own.
   const transport = process.argv[3];
+  // "peer-closes": the peer closes when the FIN arrives. "refused": nothing listens.
+  // Both close the stream under the wrap, and the wrap closes with it.
+  const peerCloses = transport === "peer-closes";
+  const refused = transport === "refused";
 
   async function shutDown(method) {
     const log = [];
-    const peer = transport.startsWith("duplex") ? undefined : await stalledPeer();
+    const peer = transport.startsWith("duplex") || refused ? undefined : await stalledPeer(!peerCloses);
 
     let raw;
-    if (peer === undefined) {
+    if (refused) {
+      const server = net.createServer();
+      await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+      const { port } = server.address();
+      await new Promise(resolve => server.close(resolve));
+      raw = net.connect(port, "127.0.0.1");
+      raw.on("error", error => log.push(`transport error:${error.code}`));
+    } else if (peer === undefined) {
       raw = new Duplex({
         read() {},
         write(chunk, encoding, callback) {
@@ -129,7 +140,7 @@ if (mode === "end" || mode === "destroySoon") {
       raw = new net.Socket();
     } else {
       raw = net.connect(peer.port, "127.0.0.1");
-      if (transport === "connected") await once(raw, "connect");
+      if (transport === "connected" || peerCloses) await once(raw, "connect");
     }
     raw.on("connect", () => log.push("transport connect"));
 
@@ -143,7 +154,8 @@ if (mode === "end" || mode === "destroySoon") {
     const peerSawFin = peer !== undefined && method !== "destroy";
     if (transport === "unconnected" && peerSawFin) raw.connect(peer.port, "127.0.0.1");
 
-    await Promise.all([once(socket, method === "end" ? "finish" : "close"), peerSawFin && peer.sawFin]);
+    const settled = method === "end" && !peerCloses && !refused ? "finish" : "close";
+    await Promise.all([once(socket, settled), peerSawFin && peer.sawFin]);
 
     const { writableFinished, readyState, destroyed } = socket;
     const result = { log: [...log], peerSawFin, writableFinished, readyState, destroyed, transportDestroyed: raw.destroyed };

--- a/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
+++ b/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
@@ -100,49 +100,62 @@ if (mode === "end" || mode === "destroySoon") {
   serverSocket?.destroy();
   server.close();
   report({ clientSawFin: true });
-} else if (mode === "wrap-end" || mode === "wrap-destroySoon") {
+} else if (mode === "wrap") {
   // new TLSSocket(stream) without isServer: a client-side wrap that nothing
-  // starts a handshake on. Shutting it down shuts the wrapped stream down.
-  const method = mode.slice("wrap-".length);
+  // starts a handshake on. Shutting it down shuts the wrapped stream down. One
+  // report per method, each on a wrap and a stream of its own.
   const transport = process.argv[3];
-  const peer = transport === "duplex" ? undefined : await stalledPeer();
 
-  let raw;
-  if (transport === "duplex") {
-    raw = new Duplex({
-      read() {},
-      write(chunk, encoding, callback) {
-        callback();
-      },
-      final(callback) {
-        log.push("transport final");
-        callback();
-      },
-    });
-  } else if (transport === "unconnected") {
-    raw = new net.Socket();
-  } else {
-    raw = net.connect(peer.port, "127.0.0.1");
-    if (transport === "connected") await once(raw, "connect");
+  async function shutDown(method) {
+    const log = [];
+    const peer = transport.startsWith("duplex") ? undefined : await stalledPeer();
+
+    let raw;
+    if (peer === undefined) {
+      raw = new Duplex({
+        read() {},
+        write(chunk, encoding, callback) {
+          callback();
+        },
+        final(callback) {
+          log.push("transport final");
+          callback();
+        },
+      });
+      // A stream's own close() is not the close(callback) of a handle: an
+      // http2 stream takes close(code, callback).
+      if (transport === "duplex-with-close") raw.close = code => log.push(`transport close(${typeof code})`);
+    } else if (transport === "unconnected") {
+      raw = new net.Socket();
+    } else {
+      raw = net.connect(peer.port, "127.0.0.1");
+      if (transport === "connected") await once(raw, "connect");
+    }
+    raw.on("connect", () => log.push("transport connect"));
+
+    const socket = new TLSSocket(raw, { rejectUnauthorized: false });
+    socket.on("finish", () => log.push("finish"));
+    socket.on("error", error => log.push(`error:${error.code ?? error.message}`));
+    socket.on("close", () => log.push("close"));
+
+    socket[method]();
+    // Only the graceful shapes owe the peer a FIN, and destroy() leaves nothing to connect.
+    const peerSawFin = peer !== undefined && method !== "destroy";
+    if (transport === "unconnected" && peerSawFin) raw.connect(peer.port, "127.0.0.1");
+
+    await Promise.all([once(socket, method === "end" ? "finish" : "close"), peerSawFin && peer.sawFin]);
+
+    const { writableFinished, readyState, destroyed } = socket;
+    const result = { log: [...log], peerSawFin, writableFinished, readyState, destroyed, transportDestroyed: raw.destroyed };
+    socket.destroy();
+    raw.destroy();
+    peer?.close();
+    return result;
   }
-  raw.on("connect", () => log.push("transport connect"));
 
-  const socket = new TLSSocket(raw, { rejectUnauthorized: false });
-  socket.on("finish", () => log.push("finish"));
-  socket.on("error", error => log.push(`error:${error.code ?? error.message}`));
-  socket.on("close", () => log.push("close"));
-
-  socket[method]();
-  if (transport === "unconnected") raw.connect(peer.port, "127.0.0.1");
-
-  await Promise.all([once(socket, method === "end" ? "finish" : "close"), peer?.sawFin]);
-
-  const { writableFinished, readyState, destroyed } = socket;
-  const transportDestroyed = raw.destroyed;
-  socket.destroy();
-  raw.destroy();
-  peer?.close();
-  report({ peerSawFin: peer !== undefined, writableFinished, readyState, destroyed, transportDestroyed });
+  const [end, destroySoon, destroy] = await Promise.all(["end", "destroySoon", "destroy"].map(shutDown));
+  console.log(JSON.stringify({ end, destroySoon, destroy }));
+  process.exit(0);
 } else {
   throw new Error(`unknown mode ${mode}`);
 }


### PR DESCRIPTION
### Problem
- `new tls.TLSSocket(stream)` without `isServer`, then `end()` or `destroySoon()`, kills the process: `TypeError: socket.shutdown is not a function. (In 'socket.shutdown()', 'socket.shutdown' is undefined)` at `endNT (node:net)`, thrown from a nextTick. Bun 1.4.2 did nothing. Unreleased regression from #42181, found by a fuzz run.
- This wrap keeps the wrapped stream as `_handle` until `connect()` upgrades it (`src/js/node/tls.ts:814`). `TLSSocket.prototype._final` used to park on the handshake, which never starts here. Since #42181 it reaches `endNT` (`src/js/node/net.ts:245`), which calls `_handle.shutdown()`. A JS stream has none.

### Fix
- `_final` ends the wrapped stream with `stream.end(cb)`, as node's `JSStreamSocket.doShutdown` does. A wrapped `net.Socket` that is not connected yet waits for its `'connect'` first, as in node.
- `closeSocketHandle` destroys a handle that is a stream, as `JSStreamSocket.doClose` does. The `destroy()` that `destroySoon()` issues on `'finish'` threw `handle.close is not a function` here. Supersedes #35842, with `instanceof Duplex` for `typeof close`: an http2 stream has its own `close(code, callback)`.
- The wrap closes when its stream closes, as node's `_wrapHandle` does. That ends an `end()` that waits on a refused connection, and closes the wrap once the peer answers the FIN.
- Verified: `test/js/node/tls/node-tls-connect.test.ts`, 7 new tests (21 cells) that run the same fixture on node v26.3.0 with the same expected report. All 7 fail on main with the TypeError. Also vendored `test-tls-*`, `test-https-*`, `test-http2-*`, `test-net-*`, `test/js/node/tls/`, `test/js/node/net/`.

### Background
- `_final` is the shutdown hook of the writable side. `'finish'` follows its callback. `destroySoon()` is `end()` plus `destroy()` on `'finish'`.
- `_handle` is normally a native socket with `shutdown()` and `close()`. Only the client-side wrap holds a JS stream there (#37664 changes that).
- Node puts such a stream in a `JSStreamSocket`. Its `doShutdown` calls `stream.end()`, its `doClose` calls `stream.destroy()`.

<details><summary>Notes</summary>

Reproduction (no certificates needed), from the report:

```js
const net = require("net"), tls = require("tls");
const how = process.argv[2] || "end";
const srv = net.createServer(c => { c.on("data", () => {}); c.on("end", () => console.log("peer: got FIN")); c.on("error", () => {}); });
srv.listen(0, "127.0.0.1", () => {
  const raw = net.connect(srv.address().port, "127.0.0.1", () => {
    const s = new tls.TLSSocket(raw, { rejectUnauthorized: false });
    s.on("error", e => console.log("tls 'error':", e.code || e.message));
    s.on("finish", () => console.log("tls 'finish'"));
    s.on("close", () => console.log("tls 'close'"));
    setTimeout(() => { console.log("calling", how + "()"); how === "end" ? s.end() : s.destroySoon(); }, 50);
    setTimeout(() => { console.log("exit: destroyed=" + s.destroyed, "writableFinished=" + s.writableFinished); process.exit(0); }, 500);
  });
});
```

| call | node v26.3.0 | bun 1.4.2 | main (97c191b7c0) | this branch |
| --- | --- | --- | --- | --- |
| `end()` | `finish`, FIN, `close`, `destroyed=true` | nothing | uncaught TypeError, exit 1 | same as node |
| `destroySoon()` | `finish`, FIN, `close`, `destroyed=true` | nothing | uncaught TypeError, exit 1 | same as node |

Twelve cells throw on main: a connected, a connecting, and a never-connected `net.Socket`, and a user `Duplex`, each with `end()`, `end(cb)`, and `destroySoon()`. With this branch all twelve match node in the `'finish'`, `'error'` and `'close'` events of the TLS socket.

What the first five new tests pin, per transport (connected, still connecting, connected later, `Duplex`, `Duplex` with a `close(code, callback)` of its own), identical on node v26.3.0 and this branch. The peer keeps its side open (`allowHalfOpen`), so the stream stays open under the wrap:
- `end()`: `'finish'`, the peer sees the FIN, the wrap is `readOnly`, nothing is destroyed. A socket that is not connected yet gets its `'connect'` first.
- `destroySoon()`: `'finish'`, `'close'`, the peer sees the FIN, the wrap and the stream are destroyed.
- `destroy()`: `'close'`, the wrap and the stream are destroyed. The stream's own `close()` is never called. With the `typeof close` form of the check that cell fails: `close()` receives the completion callback and the stream survives.

The last two tests close the stream under the wrap, again identical on node v26.3.0 and this branch:
- A peer that closes when the FIN arrives: `end()` gives `'finish'`, `'close'`, and the wrap and the stream are destroyed.
- A refused connection: `end()` and `destroySoon()` wait for `'connect'`, the stream reports `ECONNREFUSED` and closes, and the wrap closes with it (`'close'`, no `'finish'`).

The wrap follows the `'close'` of its stream one tick later, and only while that stream is still its handle. One tick later, because the stream machinery emits `'finish'` one tick after the `_final` callback: a stream that fails in its own `final` calls back and closes in the same turn, and node reports `'finish'` and then `'close'` for it (measured, and the same here). Only while it is the handle, because after `connect({ socket })` the native handle reports the close.

This PR guards 2 of the 6 places where `node:net` calls the wrapped stream as if it were a native handle. The other four are older than #42181, throw from the call itself (so the caller can catch them), and are unchanged here:
- `_write` calls `_handle.$write()`: `write()`, `end(data)`, `end('')` and `uncork()` throw `socket.@write is not a function`.
- `ref()` and `unref()` call `_handle.ref()` / `_handle.unref()`: they throw over a generic `Duplex` (a wrapped `net.Socket` has both).
- `resetAndDestroy()` calls `_handle.terminate()`.

The wrap exists in this form so that `_handle._parentWrap` works for http2-wrapper. #37664 removes all four sites, because the wrap then has a native handle. When the `_handle = socket` assignment in the constructor goes away, the two branches added here are dead code and can go with it.

Found on the way, handed off separately:
- `end()` before the TLS handle is attached emits `'finish'` and sends no FIN: `tls.connect({ socket: stillConnecting }).end()`, and `new TLSSocket(sock, { isServer: true }).end()` in the same tick. Both are older than #42181.
- `endNT` calls `shutdown()` with no guard, so any throw there is an uncaught exception.

Differences from node that remain:
- Node also forwards the `'error'` of the stream: the constructor adds `wrap.on('error', err => this._emitTLSError(err))`, so the TLS socket emits `'_tlsError'` (and `'error'` once control is released), and the stream's error never counts as unhandled. Bun's client-side wrap does not listen for it until `connect()` upgrades it, so a wrapped socket that fails with no `'error'` listener of its own is still an uncaught exception. That is older than this PR. #37664 closes it.
- The wrap does not read its transport, so after the peer's FIN it emits `'close'` but no `'end'`.
- Node shuts the TCP handle down below the wrapped `net.Socket`, so that socket has `writableEnded === false` and emits no `'finish'`. Here the wrapped socket ends through its own `end()`, so it reports both. For a wrapped `Duplex` node calls `end()` too, and the reports are identical.

The order of the checks in `_final`: a write that happened before the handshake still parks on the handshake signal first, as #42181 left it. The stream branch applies only while `_handle instanceof Duplex`, which only the client-side constructor branch produces. After `connect({ socket })` the handle is native and the old path runs.

On the fixture: an uncaught exception does not end a bun process while the top-level await of the entry module is pending (open #34627). The process prints the error and keeps running. The fixture installs an `uncaughtException` handler that prints and exits 1, so the new tests fail in about 2 s with the TypeError in the assertion, and do not time out.

Review findings: two reviewers asked `_final` to settle when a wrapped socket fails before `'connect'`, and one asked it to forward the error of `stream.end()`. Node does neither (measured on v26.3.0: the `end()` callback of a wrap over a stream whose `final` fails gets no error, and a refused connection leaves `_final` unsettled). What node does have is the close path above, which is now in.

Suites run with a debug build of this branch, compared with a debug build of main:
- `test/js/node/tls/node-tls-connect.test.ts`: 69 pass, 18 skip, 0 fail.
- `test/js/node/test/parallel/test-tls-*.js` (186 files): 185 pass. `test-tls-client-allow-partial-trust-chain.js` needs the `node:test` runner.
- `test-https-*`, `test-http2-*`, `test-net-*` (473 files): 461 pass. The 12 that fail (`test-https-proxy-request*.mjs`, `test-https-request-proxy-post.mjs`, `test-https-timeout.js`, two `node:test` files) fail the same way on main in this environment.
- `test/js/node/tls/*.test.ts`, `test/js/node/net/*.test.ts`: no new failure. `node-tls-server.test.ts` (2) and `node-net.test.ts` (11) have failures that need DNS or more than 5 s on a debug build, identical on main.

Self-reviewed: 3 changes requested, 3 made. `closeSocketHandle` tests `instanceof Duplex`. A cell covers a stream with its own `close()`. The `destroy()` cells from #35842 are in.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [3.64ms]
(pass) should thow ECONNRESET if FIN is received before handshake [363.04ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [7.97ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [131.51ms]
(pass) should be able to grab the JSStreamSocket constructor [53.25ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [202.13ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [136.10ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port 
... (truncated)

release without fix: 10 failed, 18 skipped
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.16ms]
(pass) should thow ECONNRESET if FIN is received before handshake [7.01ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [0.16ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [3.90ms]
(pass) should be able to grab the JSStreamSocket constructor [0.36ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [6.74ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [4.75ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls.c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [3.48ms]
(pass) should thow ECONNRESET if FIN is received before handshake [385.07ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [14.70ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [158.23ms]
(pass) should be able to grab the JSStreamSocket constructor [23.63ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [136.61ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [111.03ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1101ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (10780ms)
Bundle modules (268ms)
Postprocesss modules (36ms)
Bundle Functions (648ms)
Generate Code (37ms)

[11.78s] Bundled "src/js" for production
  2599 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                                 |  7 +-
 src/js/node/tls.ts                                 | 19 +++++-
 test/js/node/tls/node-tls-connect.test.ts          | 73 ++++++++++++++++++--
 .../tls/tls-shutdown-before-handshake-fixture.mjs  | 79 +++++++++++++++++++++-
 4 files changed, 170 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/net.ts                                            6      2     28
src/js/node/tls.ts                                            4      3     26
test/js/node/tls/node-tls-connect.test.ts                     4      6     22
…t/js/node/tls/tls-shutdown-before-handshake-fixture.mjs      4      9     23
```

</details>

<!-- robobun:evidence:end -->