### PR TITLE
tls: pause and resume a wrapped Duplex transport with the TLS socket's reads

### DIFF
--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -64,9 +64,10 @@ pub(crate) struct UpgradedDuplex {
     /// Replayed by [`Self::drain_pending`] after the staged bytes, preserving
     /// the original data-then-EOF order.
     pub pending_end: Cell<bool>,
-    /// The transport delivered EOF (its 'end' event fired). Teardown payloads
-    /// (close_notify) are dropped after this; see [`Self::call_write_or_end`].
-    pub transport_eof: Cell<bool>,
+    /// [`Self::pause_stream`] paused `origin` and no [`Self::resume_stream`]
+    /// followed. [`Self::on_close`] resumes such a transport so it can still
+    /// drain to its own EOF once the engine is gone.
+    pub reads_paused: Cell<bool>,
 }
 
 bun_event_loop::impl_timer_owner!(UpgradedDuplex; from_timer_ptr => event_loop_timer);
@@ -209,12 +210,68 @@ impl UpgradedDuplex {
         js_wrapper.ensure_still_alive();
 
         (this.handlers.on_close)(this.handlers.ctx);
+        // A transport left paused would never read its peer's EOF and close.
+        // `teardown` neuters the thunks, so whatever it still delivers is dropped.
+        if this.reads_paused.get() {
+            this.resume_stream();
+        }
         // closes the underlying duplex
         this.call_write_or_end(None, false);
 
         // Early teardown (struct itself is dropped later by parent).
         this.teardown();
         js_wrapper.ensure_still_alive();
+    }
+
+    /// node's `JSStreamSocket.readStop()` / `readStart()`: the transport only
+    /// emits 'data' while the TLS socket wants more. A chunk already handed to
+    /// the engine is still decrypted and delivered in full.
+    /// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L117-L125
+    ///
+    /// A pause before `start_tls` ran is left alone, like a socket that is
+    /// still connecting: `on_open` forgets the owner's paused flag, and the
+    /// handshake needs the reads.
+    #[uws_callback(export = "UpgradedDuplex__pause_stream")]
+    pub(crate) fn pause_stream(&self) -> bool {
+        if self.wrapper_ref().is_none() || !self.call_origin("pause") {
+            return false;
+        }
+        self.reads_paused.set(true);
+        true
+    }
+
+    #[uws_callback(export = "UpgradedDuplex__resume_stream")]
+    pub(crate) fn resume_stream(&self) -> bool {
+        if !self.call_origin("resume") {
+            return false;
+        }
+        self.reads_paused.set(false);
+        true
+    }
+
+    /// Calls `origin[name]()`. False when there is no JS duplex to talk to
+    /// (see [`Self::call_write_or_end`]) or the call threw (routed to `on_error`).
+    fn call_origin(&self, name: &str) -> bool {
+        let duplex = self.origin.get();
+        if duplex.is_empty() {
+            return false;
+        }
+        let Some(global) = self.global else {
+            return false;
+        };
+        let method = match duplex.get(&global, name) {
+            Ok(Some(f)) if f.is_callable() => f,
+            Ok(_) => return false,
+            Err(err) => {
+                (self.handlers.on_error)(self.handlers.ctx, global.take_error(err));
+                return false;
+            }
+        };
+        if let Err(err) = method.call(&global, duplex, &[]) {
+            (self.handlers.on_error)(self.handlers.ctx, global.take_error(err));
+            return false;
+        }
+        true
     }
 
     fn call_write_or_end(&self, data: Option<&[u8]>, msg_more: bool) {
@@ -234,12 +291,12 @@ impl UpgradedDuplex {
         let teardown = data.is_none() || self.wrapper_ref().is_some_and(|w| w.is_shutdown());
         if teardown {
             // A teardown payload (close_notify) after the transport's readable
-            // side ended has no reader behind it: node writes nothing there,
-            // and a transport that forwards into an auto-ended net.Socket
-            // throws writeAfterFIN (EPIPE). The trailing end() is not a write
-            // and still goes through the writableEnded probe below, so a
-            // half-open transport sees our FIN.
-            if data.is_some() && self.transport_eof.get() {
+            // side got its EOF has no reader behind it: node writes nothing
+            // there, and a transport that forwards into an auto-ended
+            // net.Socket throws writeAfterFIN (EPIPE). The trailing end() is
+            // not a write and still goes through the writableEnded probe
+            // below, so a half-open transport sees our FIN.
+            if data.is_some() && Self::readable_got_eof(duplex, &global) {
                 return;
             }
             match duplex.get(&global, "writableEnded") {
@@ -274,6 +331,27 @@ impl UpgradedDuplex {
                 (self.handlers.on_error)(self.handlers.ctx, global.take_error(err));
             }
         }
+    }
+
+    /// `duplex._readableState.ended`. The 'end' event comes too late to tell:
+    /// a paused transport holds it back until the unread bytes are consumed.
+    fn readable_got_eof(duplex: JSValue, global: &JSGlobalObject) -> bool {
+        let probe = || -> JsResult<bool> {
+            let Some(state) = duplex.get(global, "_readableState")? else {
+                return Ok(false);
+            };
+            if !state.is_object() {
+                return Ok(false);
+            }
+            Ok(state
+                .get(global, "ended")?
+                .is_some_and(|ended| ended.to_boolean()))
+        };
+        // Best-effort probe: consume the exception and report no EOF.
+        probe().unwrap_or_else(|err| {
+            let _ = global.take_exception(err);
+            false
+        })
     }
 
     fn internal_write(this: *mut Self, encoded_data: &[u8]) {
@@ -408,7 +486,7 @@ impl UpgradedDuplex {
             current_timeout: Cell::new(0),
             pending_data: JsCell::new(Vec::new()),
             pending_end: Cell::new(false),
-            transport_eof: Cell::new(false),
+            reads_paused: Cell::new(false),
         }
     }
 
@@ -679,7 +757,7 @@ impl UpgradedDuplex {
         self.ssl_error.set(CertError::default());
         self.pending_data.set(Vec::new());
         self.pending_end.set(false);
-        self.transport_eof.set(false);
+        self.reads_paused.set(false);
     }
 }
 
@@ -738,7 +816,6 @@ fn on_end(_global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         // SAFETY: see host-fn note above.
         let this = unsafe { &*self_ptr.cast::<UpgradedDuplex>() };
 
-        this.transport_eof.set(true);
         if this.wrapper_ref().is_some() {
             (this.handlers.on_end)(this.handlers.ctx);
         } else {

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -296,8 +296,15 @@ impl UpgradedDuplex {
             // net.Socket throws writeAfterFIN (EPIPE). The trailing end() is
             // not a write and still goes through the writableEnded probe
             // below, so a half-open transport sees our FIN.
-            if data.is_some() && Self::readable_got_eof(duplex, &global) {
-                return;
+            if data.is_some() {
+                match Self::readable_got_eof(duplex, &global) {
+                    Ok(false) => {}
+                    Ok(true) => return,
+                    Err(err) => {
+                        (self.handlers.on_error)(self.handlers.ctx, global.take_error(err));
+                        return;
+                    }
+                }
             }
             match duplex.get(&global, "writableEnded") {
                 Ok(Some(ended)) if ended.to_boolean() => return,
@@ -335,23 +342,16 @@ impl UpgradedDuplex {
 
     /// `duplex._readableState.ended`. The 'end' event comes too late to tell:
     /// a paused transport holds it back until the unread bytes are consumed.
-    fn readable_got_eof(duplex: JSValue, global: &JSGlobalObject) -> bool {
-        let probe = || -> JsResult<bool> {
-            let Some(state) = duplex.get(global, "_readableState")? else {
-                return Ok(false);
-            };
-            if !state.is_object() {
-                return Ok(false);
-            }
-            Ok(state
-                .get(global, "ended")?
-                .is_some_and(|ended| ended.to_boolean()))
+    fn readable_got_eof(duplex: JSValue, global: &JSGlobalObject) -> JsResult<bool> {
+        let Some(state) = duplex.get(global, "_readableState")? else {
+            return Ok(false);
         };
-        // Best-effort probe: consume the exception and report no EOF.
-        probe().unwrap_or_else(|err| {
-            let _ = global.take_exception(err);
-            false
-        })
+        if !state.is_object() {
+            return Ok(false);
+        }
+        Ok(state
+            .get(global, "ended")?
+            .is_some_and(|ended| ended.to_boolean()))
     }
 
     fn internal_write(this: *mut Self, encoded_data: &[u8]) {

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -64,7 +64,7 @@ pub(crate) struct UpgradedDuplex {
     /// Replayed by [`Self::drain_pending`] after the staged bytes, preserving
     /// the original data-then-EOF order.
     pub pending_end: Cell<bool>,
-    /// [`Self::pause_stream`] paused `origin`; [`Self::on_close`] undoes it.
+    /// [`Self::pause_stream`] called `origin.pause()`; [`Self::on_close`] undoes it.
     pub reads_paused: Cell<bool>,
 }
 
@@ -224,11 +224,12 @@ impl UpgradedDuplex {
     #[uws_callback(export = "UpgradedDuplex__pause_stream")]
     pub(crate) fn pause_stream(&self) -> bool {
         // Before `start_tls` the handshake still needs the reads, and `on_open` clears the owner's paused flag.
-        if self.wrapper_ref().is_none() || !self.call_origin("pause") {
+        if self.wrapper_ref().is_none() {
             return false;
         }
+        // Set first and kept on failure: `pause()` is user code that can close this socket, or throw after it paused.
         self.reads_paused.set(true);
-        true
+        self.call_origin("pause")
     }
 
     #[uws_callback(export = "UpgradedDuplex__resume_stream")]

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -64,9 +64,7 @@ pub(crate) struct UpgradedDuplex {
     /// Replayed by [`Self::drain_pending`] after the staged bytes, preserving
     /// the original data-then-EOF order.
     pub pending_end: Cell<bool>,
-    /// [`Self::pause_stream`] paused `origin` and no [`Self::resume_stream`]
-    /// followed. [`Self::on_close`] resumes such a transport so it can still
-    /// drain to its own EOF once the engine is gone.
+    /// [`Self::pause_stream`] paused `origin`; [`Self::on_close`] undoes it.
     pub reads_paused: Cell<bool>,
 }
 
@@ -210,8 +208,7 @@ impl UpgradedDuplex {
         js_wrapper.ensure_still_alive();
 
         (this.handlers.on_close)(this.handlers.ctx);
-        // A transport left paused would never read its peer's EOF and close.
-        // `teardown` neuters the thunks, so whatever it still delivers is dropped.
+        // Left paused, a net.Socket transport never reads its peer's FIN and stays open.
         if this.reads_paused.get() {
             this.resume_stream();
         }
@@ -223,16 +220,10 @@ impl UpgradedDuplex {
         js_wrapper.ensure_still_alive();
     }
 
-    /// node's `JSStreamSocket.readStop()` / `readStart()`: the transport only
-    /// emits 'data' while the TLS socket wants more. A chunk already handed to
-    /// the engine is still decrypted and delivered in full.
-    /// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L117-L125
-    ///
-    /// A pause before `start_tls` ran is left alone, like a socket that is
-    /// still connecting: `on_open` forgets the owner's paused flag, and the
-    /// handshake needs the reads.
+    /// node's `JSStreamSocket.readStop()`: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L117-L125
     #[uws_callback(export = "UpgradedDuplex__pause_stream")]
     pub(crate) fn pause_stream(&self) -> bool {
+        // Before `start_tls` the handshake still needs the reads, and `on_open` clears the owner's paused flag.
         if self.wrapper_ref().is_none() || !self.call_origin("pause") {
             return false;
         }
@@ -249,8 +240,7 @@ impl UpgradedDuplex {
         true
     }
 
-    /// Calls `origin[name]()`. False when there is no JS duplex to talk to
-    /// (see [`Self::call_write_or_end`]) or the call threw (routed to `on_error`).
+    /// Calls `origin[name]()`. A throw goes to `on_error`; false when the call did not complete.
     fn call_origin(&self, name: &str) -> bool {
         let duplex = self.origin.get();
         if duplex.is_empty() {
@@ -291,11 +281,11 @@ impl UpgradedDuplex {
         let teardown = data.is_none() || self.wrapper_ref().is_some_and(|w| w.is_shutdown());
         if teardown {
             // A teardown payload (close_notify) after the transport's readable
-            // side got its EOF has no reader behind it: node writes nothing
-            // there, and a transport that forwards into an auto-ended
-            // net.Socket throws writeAfterFIN (EPIPE). The trailing end() is
-            // not a write and still goes through the writableEnded probe
-            // below, so a half-open transport sees our FIN.
+            // side ended has no reader behind it: node writes nothing there,
+            // and a transport that forwards into an auto-ended net.Socket
+            // throws writeAfterFIN (EPIPE). The trailing end() is not a write
+            // and still goes through the writableEnded probe below, so a
+            // half-open transport sees our FIN.
             if data.is_some() {
                 match Self::readable_got_eof(duplex, &global) {
                     Ok(false) => {}
@@ -340,8 +330,7 @@ impl UpgradedDuplex {
         }
     }
 
-    /// `duplex._readableState.ended`. The 'end' event comes too late to tell:
-    /// a paused transport holds it back until the unread bytes are consumed.
+    /// `_readableState.ended`, not the 'end' event: a paused transport holds 'end' back.
     fn readable_got_eof(duplex: JSValue, global: &JSGlobalObject) -> JsResult<bool> {
         let Some(state) = duplex.get(global, "_readableState")? else {
             return Ok(false);

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -221,6 +221,8 @@ unsafe extern "C" {
     safe fn UpgradedDuplex__shutdown_read(this: &mut UpgradedDuplex);
     safe fn UpgradedDuplex__close(this: &mut UpgradedDuplex);
     safe fn UpgradedDuplex__abandon_js_side(this: &mut UpgradedDuplex);
+    safe fn UpgradedDuplex__pause_stream(this: &mut UpgradedDuplex) -> bool;
+    safe fn UpgradedDuplex__resume_stream(this: &mut UpgradedDuplex) -> bool;
 }
 impl UpgradedDuplex {
     #[inline]
@@ -281,6 +283,14 @@ impl UpgradedDuplex {
     #[inline]
     pub(crate) fn abandon_js_side(&mut self) {
         UpgradedDuplex__abandon_js_side(self)
+    }
+    #[inline]
+    pub(crate) fn pause_stream(&mut self) -> bool {
+        UpgradedDuplex__pause_stream(self)
+    }
+    #[inline]
+    pub(crate) fn resume_stream(&mut self) -> bool {
+        UpgradedDuplex__resume_stream(self)
     }
 }
 

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -523,7 +523,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
             connected s => if s.is_established() { s.pause(); true } else { false },
             connecting _c => false,
             detached => true,
-            duplex _d => false, // TODO: pause/resume upgraded duplex
+            duplex d => d.pause_stream(),
             pipe p => p.pause_stream(),
         )
     }
@@ -533,7 +533,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
             connected s => if s.is_established() { s.resume(); true } else { false },
             connecting _c => false,
             detached => true,
-            duplex _d => false, // TODO: pause/resume upgraded duplex
+            duplex d => d.resume_stream(),
             pipe p => p.resume_stream(),
         )
     }

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1024,48 +1024,85 @@ describe("a TLS socket over a Duplex transport reads it with backpressure", () =
     });
   });
 
-  it("destroying a paused socket lets a net.Socket transport read its peer's close", async () => {
-    // A server wrap over a net.Socket with unflushed plain writes cannot take
-    // the fd over, so it reads the net.Socket like any other Duplex. Nothing
-    // destroys that net.Socket along with the TLS socket, so one left paused
-    // would never read the client's FIN and would stay open for good.
-    const sockets: { destroy(): unknown }[] = [];
-    const accepted = Promise.withResolvers<{ transport: net.Socket; wrapped: TLSSocket }>();
-    await using listener = net.createServer(transport => {
-      transport.cork();
-      transport.write("!");
-      const wrapped = new TLSSocket(transport, serverContext());
-      transport.uncork();
-      sockets.push(wrapped, transport);
-      accepted.resolve({ transport, wrapped });
+  describe("a server wrap over a net.Socket with unflushed plain writes", () => {
+    // Such a wrap cannot take the fd over, so it reads the net.Socket like any
+    // other Duplex. Nothing destroys that net.Socket along with the TLS
+    // socket, so one left paused would never read the client's FIN and would
+    // stay open for good.
+    async function connectedWrap() {
+      const sockets: { destroy(): unknown }[] = [];
+      const accepted = Promise.withResolvers<{ transport: net.Socket; wrapped: TLSSocket }>();
+      const listener = net.createServer(transport => {
+        transport.cork();
+        transport.write("!");
+        const wrapped = new TLSSocket(transport, serverContext());
+        transport.uncork();
+        sockets.push(wrapped, transport);
+        accepted.resolve({ transport, wrapped });
+      });
+      // close() waits for the connections, so they go first.
+      const dispose = async () => {
+        for (const socket of sockets) socket.destroy();
+        await listener[Symbol.asyncDispose]();
+      };
+      try {
+        await once(listener.listen(0, "127.0.0.1"), "listening");
+        const clientTransport = net.connect((listener.address() as AddressInfo).port, "127.0.0.1");
+        sockets.push(clientTransport);
+        const [{ transport, wrapped }, [greeting]] = await Promise.all([
+          accepted.promise,
+          once(clientTransport, "data"),
+        ]);
+        expect(String(greeting)).toBe("!");
+        const client = tls.connect({ socket: clientTransport, rejectUnauthorized: false });
+        sockets.push(client);
+        const failed = firstErrorOf(wrapped, client);
+        await Promise.race([Promise.all([once(wrapped, "secure"), once(client, "secureConnect")]), failed]);
+        return { transport, wrapped, client, failed, [Symbol.asyncDispose]: dispose };
+      } catch (err) {
+        await dispose();
+        throw err;
+      }
+    }
+
+    it("destroying the paused socket lets the transport read its peer's close", async () => {
+      await using wrap = await connectedWrap();
+      const { transport, wrapped, client, failed } = wrap;
+      wrapped.pause();
+      // Without backpressure the engine takes the whole payload and the
+      // client's close_notify, answers it, and the client closes.
+      const outcome = Promise.race([
+        once(transport, "pause").then(() => "transport paused"),
+        once(client, "close").then(() => "client closed"),
+        failed,
+      ]);
+      client.end(payload);
+      expect(await outcome).toBe("transport paused");
+
+      const closed = once(transport, "close");
+      wrapped.destroy();
+      await Promise.race([closed, failed]);
+      expect(transport.destroyed).toBe(true);
     });
-    // Declared after the listener, so it runs first: close() waits for them.
-    using _ = destroyedOnExit(sockets);
-    await once(listener.listen(0, "127.0.0.1"), "listening");
-    const clientTransport = net.connect((listener.address() as AddressInfo).port, "127.0.0.1");
-    sockets.push(clientTransport);
-    const [{ transport, wrapped }, [greeting]] = await Promise.all([accepted.promise, once(clientTransport, "data")]);
-    expect(String(greeting)).toBe("!");
-    const client = tls.connect({ socket: clientTransport, rejectUnauthorized: false });
-    sockets.push(client);
-    const failed = firstErrorOf(wrapped, client);
-    await Promise.race([Promise.all([once(wrapped, "secure"), once(client, "secureConnect")]), failed]);
 
-    wrapped.pause();
-    // Without backpressure the engine takes the whole payload and the client's
-    // close_notify, answers it, and the client closes.
-    const outcome = Promise.race([
-      once(transport, "pause").then(() => "transport paused"),
-      once(client, "close").then(() => "client closed"),
-      failed,
-    ]);
-    client.end(payload);
-    expect(await outcome).toBe("transport paused");
-
-    const closed = once(transport, "close");
-    wrapped.destroy();
-    await closed;
-    expect(transport.destroyed).toBe(true);
+    it("a destroy from the transport's 'pause' listener does the same", async () => {
+      await using wrap = await connectedWrap();
+      const { transport, wrapped, client, failed } = wrap;
+      wrapped.pause();
+      // The engine is still inside the transport's pause() when the socket closes.
+      let destroyedFromPause = false;
+      transport.once("pause", () => {
+        destroyedFromPause = true;
+        wrapped.destroy();
+      });
+      const closed = once(transport, "close");
+      client.end(payload);
+      await Promise.race([closed, failed]);
+      expect({ destroyedFromPause, transportDestroyed: transport.destroyed }).toEqual({
+        destroyedFromPause: true,
+        transportDestroyed: true,
+      });
+    });
   });
 });
 

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -843,6 +843,232 @@ it("a client and a server TLSSocket connected through a synchronous in-memory du
   });
 });
 
+describe("a TLS socket over a Duplex transport reads it with backpressure", () => {
+  // Node reads such a transport through a JSStreamSocket, whose readStop() and
+  // readStart() pause and resume it, so it only flows while the TLS socket
+  // takes more data:
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L117-L125
+  // Each side's _write pushes straight into the other side and never waits,
+  // so only the reading TLS socket can slow the transport down.
+  function inMemoryPair() {
+    const makeSide = (peer: () => Duplex) =>
+      new Duplex({
+        read() {},
+        write(chunk, _encoding, callback) {
+          peer().push(chunk);
+          callback();
+        },
+        final(callback) {
+          peer().push(null);
+          callback();
+        },
+      });
+    const clientSide: Duplex = makeSide(() => serverSide);
+    const serverSide: Duplex = makeSide(() => clientSide);
+    return { clientSide, serverSide };
+  }
+  const serverContext = () => ({ isServer: true, secureContext: tls.createSecureContext(COMMON_CERT_) });
+  const payload = Buffer.alloc(1024 * 1024, "x");
+  // Rejects with the first 'error' any of `sockets` emits. Meant to be raced.
+  function firstErrorOf(...sockets: TLSSocket[]) {
+    const { promise, reject } = Promise.withResolvers<never>();
+    promise.catch(() => {});
+    for (const socket of sockets) socket.on("error", reject);
+    return promise;
+  }
+  // Destroys every socket in `sockets` when the test leaves its scope.
+  function destroyedOnExit(sockets: { destroy(): unknown }[]) {
+    return {
+      [Symbol.dispose]() {
+        for (const socket of sockets) socket.destroy();
+      },
+    };
+  }
+
+  // Both wraps run the same engine; the reader is the side under test.
+  function securePair(reader: "client" | "server") {
+    const { clientSide, serverSide } = inMemoryPair();
+    const server = new TLSSocket(serverSide, serverContext());
+    const client = tls.connect({ socket: clientSide, rejectUnauthorized: false });
+    const failed = firstErrorOf(server, client);
+    const secured = Promise.all([once(server, "secure"), once(client, "secureConnect")]);
+    const [readerSocket, transport, writerSocket] =
+      reader === "client" ? [client, clientSide, server] : [server, serverSide, client];
+    return { readerSocket, transport, writerSocket, failed, secured, cleanup: destroyedOnExit([client, server]) };
+  }
+
+  describe.each(["client", "server"] as const)("%s reader", reader => {
+    // The writer does not end: what happens to unread data once the peer has
+    // closed is a separate matter from how much the socket takes in.
+    it("a paused socket pauses the transport once its buffer is full", async () => {
+      const { readerSocket, transport, writerSocket, failed, secured, cleanup } = securePair(reader);
+      using _ = cleanup;
+      await Promise.race([secured, failed]);
+      readerSocket.pause();
+      // The pair is synchronous, so the callback runs with every byte handed
+      // to the reader's transport.
+      const written = Promise.withResolvers<void>();
+      writerSocket.write(payload, err => (err ? written.reject(err) : written.resolve()));
+      await Promise.race([written.promise, failed]);
+      // Without backpressure the transport keeps flowing and the paused socket
+      // holds the whole payload.
+      expect({
+        transportFlowing: transport.readableFlowing,
+        socketIsFull: readerSocket.readableLength >= readerSocket.readableHighWaterMark,
+        mostOfItWaitsInTheTransport: transport.readableLength > payload.length / 2,
+      }).toEqual({ transportFlowing: false, socketIsFull: true, mostOfItWaitsInTheTransport: true });
+
+      const chunks: Buffer[] = [];
+      let total = 0;
+      const received = Promise.withResolvers<void>();
+      readerSocket.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+        if ((total += chunk.length) >= payload.length) received.resolve();
+      });
+      readerSocket.resume();
+      await Promise.race([received.promise, failed]);
+      expect(Buffer.concat(chunks).equals(payload)).toBe(true);
+    });
+
+    it("a slow reader gets the whole payload while the transport is paused and resumed under it", async () => {
+      const { readerSocket, transport, writerSocket, failed, secured, cleanup } = securePair(reader);
+      using _ = cleanup;
+      await Promise.race([secured, failed]);
+      let pauses = 0;
+      transport.on("pause", () => pauses++);
+      writerSocket.write(payload);
+
+      const read = (async () => {
+        let total = 0;
+        let mostHeld = 0;
+        for await (const chunk of readerSocket) {
+          total += chunk.length;
+          mostHeld = Math.max(mostHeld, readerSocket.readableLength);
+          if (total >= payload.length) break;
+          // Yield a macrotask per chunk so the socket's buffer fills up.
+          await new Promise<void>(resolve => setImmediate(resolve));
+        }
+        return { total, heldLessThanHalfAtAnyTime: mostHeld < payload.length / 2 };
+      })();
+      expect({ ...(await Promise.race([read, failed])), pausedMoreThanOnce: pauses > 1 }).toEqual({
+        total: payload.length,
+        heldLessThanHalfAtAnyTime: true,
+        pausedMoreThanOnce: true,
+      });
+    });
+  });
+
+  it("does not answer a close_notify that it reads after the transport's EOF", async () => {
+    // A net.Socket that has read its peer's FIN fails a later write with EPIPE
+    // (writeAfterFIN in net.ts), and so does this transport. A paused reader
+    // makes the engine read the peer's close_notify long after that EOF, and
+    // the transport's 'end' event, held back by the pause, comes later still.
+    const transportErrors: string[] = [];
+    const gotEOF = new WeakSet<Duplex>();
+    const makeSide = (peer: () => Duplex) =>
+      new Duplex({
+        read() {},
+        write(chunk, _encoding, callback) {
+          if (gotEOF.has(this))
+            return callback(Object.assign(new Error("write after the peer's FIN"), { code: "EPIPE" }));
+          peer().push(chunk);
+          callback();
+        },
+        final(callback) {
+          gotEOF.add(peer());
+          peer().push(null);
+          callback();
+        },
+      });
+    const clientSide: Duplex = makeSide(() => serverSide);
+    const serverSide: Duplex = makeSide(() => clientSide);
+    clientSide.on("error", (err: NodeJS.ErrnoException) => transportErrors.push(`${err.code}`));
+    const server = new TLSSocket(serverSide, serverContext());
+    const client = tls.connect({ socket: clientSide, rejectUnauthorized: false });
+    using _ = destroyedOnExit([client, server]);
+    const failed = firstErrorOf(server, client);
+    await Promise.race([Promise.all([once(server, "secure"), once(client, "secureConnect")]), failed]);
+
+    client.pause();
+    // Like a TLS server over TCP: the payload, the close_notify, then the FIN.
+    server.end(payload);
+    await Promise.race([once(server, "finish"), failed]);
+    serverSide.end();
+
+    let total = 0;
+    client.on("data", (chunk: Buffer) => (total += chunk.length));
+    const closed = once(client, "close");
+    client.resume();
+    await Promise.race([closed, failed]);
+    expect({ total, transportErrors }).toEqual({ total: payload.length, transportErrors: [] });
+  });
+
+  it("a pause() issued before the engine exists does not stall the handshake", async () => {
+    // The engine is created on a later event-loop turn. A transport paused
+    // ahead of it would never deliver the server's flight.
+    const { clientSide, serverSide } = inMemoryPair();
+    const server = new TLSSocket(serverSide, serverContext());
+    const client = tls.connect({
+      socket: clientSide,
+      rejectUnauthorized: false,
+      // Only an onread socket stops its handle from pause().
+      onread: { buffer: Buffer.alloc(64), callback: () => {} },
+    });
+    using _ = destroyedOnExit([client, server]);
+    client.pause();
+    const secured = Promise.all([once(server, "secure"), once(client, "secureConnect")]);
+    await Promise.race([secured, firstErrorOf(server, client)]);
+    expect({ server: server.getProtocol(), client: client.getProtocol() }).toEqual({
+      server: "TLSv1.3",
+      client: "TLSv1.3",
+    });
+  });
+
+  it("destroying a paused socket lets a net.Socket transport read its peer's close", async () => {
+    // A server wrap over a net.Socket with unflushed plain writes cannot take
+    // the fd over, so it reads the net.Socket like any other Duplex. Nothing
+    // destroys that net.Socket along with the TLS socket, so one left paused
+    // would never read the client's FIN and would stay open for good.
+    const sockets: { destroy(): unknown }[] = [];
+    const accepted = Promise.withResolvers<{ transport: net.Socket; wrapped: TLSSocket }>();
+    await using listener = net.createServer(transport => {
+      transport.cork();
+      transport.write("!");
+      const wrapped = new TLSSocket(transport, serverContext());
+      transport.uncork();
+      sockets.push(wrapped, transport);
+      accepted.resolve({ transport, wrapped });
+    });
+    // Declared after the listener, so it runs first: close() waits for them.
+    using _ = destroyedOnExit(sockets);
+    await once(listener.listen(0, "127.0.0.1"), "listening");
+    const clientTransport = net.connect((listener.address() as AddressInfo).port, "127.0.0.1");
+    sockets.push(clientTransport);
+    const [{ transport, wrapped }, [greeting]] = await Promise.all([accepted.promise, once(clientTransport, "data")]);
+    expect(String(greeting)).toBe("!");
+    const client = tls.connect({ socket: clientTransport, rejectUnauthorized: false });
+    sockets.push(client);
+    const failed = firstErrorOf(wrapped, client);
+    await Promise.race([Promise.all([once(wrapped, "secure"), once(client, "secureConnect")]), failed]);
+
+    wrapped.pause();
+    // Without backpressure the engine takes the whole payload and the client's
+    // close_notify, answers it, and the client closes.
+    const outcome = Promise.race([
+      once(transport, "pause").then(() => "transport paused"),
+      once(client, "close").then(() => "client closed"),
+      failed,
+    ]);
+    client.end(payload);
+    expect(await outcome).toBe("transport paused");
+
+    const closed = once(transport, "close");
+    wrapped.destroy();
+    await closed;
+    expect(transport.destroyed).toBe(true);
+  });
+});
+
 describe("application data written over a Duplex transport before the handshake completes", () => {
   // Node parks such a write (TLSWrap's pending cleartext) and sends it right
   // after the handshake: the write is still pending when 'secureConnect' /


### PR DESCRIPTION
### Problem

- A `node:tls` socket over a `Duplex` transport (a plain stream, or a `net.Socket` that Bun cannot adopt) reads it with no backpressure. A paused reader of a 1 MB body holds all 1048576 bytes and the transport never pauses. Node pauses it at 65536.
- The cause: `pause_stream` / `resume_stream` in `src/uws_sys/socket.rs:526` have `duplex _d => false, // TODO: pause/resume upgraded duplex`, so the `handle.pause()` in `readStop()` (`net.ts`) did nothing.

### Fix

- `UpgradedDuplex` gets `pause_stream` / `resume_stream`. They call `pause()` / `resume()` on the wrapped stream, like Node's [`JSStreamSocket`](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/js_stream_socket.js#L117-L125). `net.ts` does not change.
- A pause before the engine exists returns `false`: the handshake needs the reads. The close callback resumes a transport that it left paused. Otherwise a `net.Socket` transport never reads its peer's FIN.
- A paused transport holds its `'end'` event back. The engine can then read the peer's `close_notify` long after the transport's EOF, and its answer fails with EPIPE. The check that drops the answer now reads `_readableState.ended`, not a flag set by `'end'`.
- Verified: eight tests in `test/js/node/tls/node-tls-connect.test.ts` (seven fail on main). Other suites: notes.

### Background

- A stream with no fd cannot use the kernel TLS path. `upgradeDuplexToTLS` runs a BoringSSL engine over it. Thunks on the stream's `data`, `end`, `drain` and `close` events feed it.
- `readStop()` runs when the readable buffer reaches `highWaterMark`. `_read()` starts the handle again.
- `writeAfterFIN` (`net.ts`): a `net.Socket` that read its peer's FIN fails a later `write()` with EPIPE.

Notes: #42176, #36534, #38028, and what this PR leaves out.

<details><summary>Notes</summary>

No user reported this. The work on #42176 found it. The wraps in question are `tls.connect({ socket })` and `new tls.TLSSocket(stream, { isServer: true })` over a plain `Duplex`, and over a `net.Socket` that Bun cannot adopt: one with unflushed writes, a Windows named pipe, or another TLS socket.

#### Measurements

Paused reader, 1 MB, in-memory duplex pair whose `_write` pushes into the other side. Values at the moment the writer's callback runs.

| | transport flowing | TLS socket `readableLength` | transport `readableLength` |
| --- | --- | --- | --- |
| node v26.3.0 | false | 65536 at the pause | rest |
| bun 1.4.3 / main | true | 1048576 | 0 |
| this branch | false | 114688 (49152 on Windows, `highWaterMark` 16384) | 919298 |

The engine still decrypts and delivers a chunk that it already holds, as Node's `TLSWrap::ClearOut` does. That is why the socket holds more than one `highWaterMark`.

`pipeline(tlsSocket, slowWritable)`, 4 MB, same pair: largest `readableLength` seen was 4145152 on 1.4.3 and 131072 on this branch (4161536 on node, whose peer hands the whole ciphertext over in one chunk).

Server wrap over a `net.Socket` with unflushed writes (the stream engine over a real socket), 4 MB from the client, server paused: 1.4.3 buffers 4194304, this branch 65536. Client over a Windows named pipe `net.Socket`: the canary buffers 4194304, this branch pauses at 49152.

#### What this PR does not change

- The engine ends the transport when it reads the peer's `close_notify`. It has no half-open mode. Since #39066, main destroys the TLS socket when its transport closes, so a reader that is not flowing loses what it has not read at that moment. A slow `for await` reader of a 1 MB body that the peer ends gets 49152 bytes and `ERR_STREAM_PREMATURE_CLOSE` on main (1.4.3 delivers all of it). With this PR it gets 1032192. #42176 gates that destroy and makes it 1048576. For this reason the tests here do not end the writer, except where the case needs the `close_notify`.
- #42176 has a case that pauses the reader and waits for the transport's `'close'`. With backpressure the transport does not close while the reader is paused. Node behaves the same way, so that case waits forever on node too. The PR that lands second has to change it to drain to `'end'`.
- `Socket.prototype.read()` and `resume()` in `net.ts` start the handle again on every call. Node does that only for an `onread` socket and leaves the rest to `_read()`. A reader that calls `read()` for each chunk (`for await`) over a transport fed from TCP lets the engine run ahead again: it held 851968 of 1048576 bytes in the probe, because one restart admits one transport chunk of up to 512 KB. A paused reader and the in-memory cases above are bounded. This belongs in a `net.ts` change of its own, because it changes flow control for every socket.
- The write direction. The engine ignores the return value of `write()` on the transport.
- A transport that is already paused when it is wrapped never handshakes. Node's `JSStreamSocket` constructor calls `read(0)`, which resumes it. Same on 1.4.3.
- `_http2_upgrade.ts` pauses its raw socket from JS because the handle could not. It keeps working and is not touched.

#### Related PRs

- #36534 fills the same two arms for a transport that has a native handle and returns `false` for a plain stream (`Transport::None`). The PR that lands second maps `Transport::None` to `call_origin("pause" | "resume")` and keeps the pre-engine guard.
- #38028 destroys a wrapped `net.Socket` with its TLS socket. Once that is in, the close-time resume has nothing left to do. Until then it prevents a leak: with `transport.resume` stubbed out right before `wrapped.destroy()`, the transport never closed and `server.close()` never returned.

#### Probes

- The EPIPE case: a transport that fails a write once its readable side has its EOF (what `writeAfterFIN` does), a paused reader, a peer that sends the payload, `close_notify` and EOF. Before the change to the check the transport reported EPIPE when the reader resumed. 1.4.3 does not, because it answers at once. Over real TCP with a forwarding `Duplex` and a slow reader the EPIPE showed up from 4 MB on.
- `pause()` or `resume()` on the transport that throws, a getter that throws, a value that is not callable, a `pause()` that destroys the TLS socket: the error reaches the TLS socket's `'error'`, nothing crashes under ASAN. `reads_paused` is set before `pause()` runs and stays set when the call fails, so a `'pause'` listener that destroys the TLS socket still gets the close-time resume (its test timed out with the flag set after the call). `BUN_JSC_validateExceptionChecks=1` is clean on the new tests.
- `tls.connect({ socket, onread }).pause()` in the same tick: the handshake completes (node and 1.4.3 too). Without the pre-engine guard it never did, because `on_open` clears `IS_PAUSED` and no `resume()` reached the transport.

#### Suites

Linux x64, debug + ASAN: `test/js/node/tls/` (the `SNICallback ... bind hostname` case fails the same way on the released binary: `localhost` resolves differently in this container), `test/js/node/net/` (the same 10 failures as the released binary), `node-http2.test.js`, `node-http2-upgrade.test.mts`, `h2-conformance`, `node-http-connect`, `ws.test.ts`, `grpc-js/test-server`, the regression tests 12117, 24374, 25190, 40401, and 186 vendored `test-tls-*` files (184 pass. `test-tls-client-allow-partial-trust-chain.js` needs `bun test`, and `test-tls-get-ca-certificates-extra.js` shares a temp directory with its siblings and passes when it runs alone). Two cases that take more than 5 s on the loaded host pass with a longer timeout and do not use this code path.

Windows x64, debug: `node-tls-connect` (78 pass), `node-tls-server`, `renegotiation`, `node-tls-upgrade`, `node-http2-upgrade`, `node-tls-namedpipes` (the 400-connection case takes 5.9 s on the debug build and passes with a longer timeout, 0.6 s on the release build).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [5.59ms]
(pass) should thow ECONNRESET if FIN is received before handshake [516.67ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [12.92ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [171.95ms]
(pass) should be able to grab the JSStreamSocket constructor [22.64ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [99.84ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [116.18ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port 
... (truncated)

release without fix: 9 failed, 18 skipped
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.06ms]
(pass) should thow ECONNRESET if FIN is received before handshake [8.93ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [0.20ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [5.51ms]
(pass) should be able to grab the JSStreamSocket constructor [0.32ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [7.56ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [4.20ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls.c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [5.70ms]
(pass) should thow ECONNRESET if FIN is received before handshake [547.50ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [12.79ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [173.21ms]
(pass) should be able to grab the JSStreamSocket constructor [22.58ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [130.73ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [164.40ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 829ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_uws_sys v0.0.0 (/workspace/bun/src/uws_sys)
[1m[92m   Compiling[0m bun_io v0.0.0 (/workspace/bun/src/io)
[1m[92m   Compiling[0m bun_uws v0.0.0 (/workspace/bun/src/uws)
[1m[92m   Compiling[0m bun_crash_handler v0.0.0 (/workspace/bun/src/crash_handler)
[1m[92m   Compiling[0m bun_event_loop v0.0.0 (/workspace/bun/src/event_loop)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_spawn v0.0.0 (/workspace/bun/src/spawn)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/socket/UpgradedDuplex.rs      |  83 +++++++++-
 src/uws_sys/lib.rs                        |  10 ++
 src/uws_sys/socket.rs                     |   4 +-
 test/js/node/tls/node-tls-connect.test.ts | 263 ++++++++++++++++++++++++++++++
 4 files changed, 350 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/socket/UpgradedDuplex.rs           6     11     37
src/uws_sys/lib.rs                             1      2     36
src/uws_sys/socket.rs                          1      1     36
test/js/node/tls/node-tls-connect.test.ts      5      6     36
```

</details>

<!-- robobun:evidence:end -->