### PR TITLE
Bump WebKit (oven-sh/WebKit#625 preview): stop assert-enabled builds aborting on a ToInt32 that B3 hoists out of a loop

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "cf1b36ec8703d8e87436094d21d478d358c7d886";
+export const WEBKIT_VERSION = "autobuild-preview-pr-625-fe20753d";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc/ftl-to-int32-loop-invariant-double.test.ts
+++ b/test/js/bun/jsc/ftl-to-int32-loop-invariant-double.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// On x86_64 the FTL converts a double to int32 with cvttsd2siq and calls a C++
+// operation only when that fails (NaN, the infinities, |x| >= 2^63). B3 sees no
+// side effects in the call, so when the double is the same in every iteration
+// of a loop, B3 moves the call to the loop pre-header. There it runs with a
+// double that the fast path accepts. The operation asserted that it never gets
+// one, so a build with assertions on died with
+//
+//   ASSERTION FAILED: exp >= 63
+//   JavaScriptCore/runtime/MathCommon.h(155) : int32_t JSC::toInt32AfterFailedTruncation(double)
+//
+// A release build runs the call and drops its result. oven-sh/WebKit#625.
+
+const iterations = 200_000;
+
+// [name, program, what it prints]
+const programs: [string, string, string][] = [
+  [
+    "(zero + 0.5) | 0 in a function inlined into the loop",
+    `
+      function convert(i) { const zero = i - i; return (zero + 0.5) | 0; }
+      let sum = 0;
+      for (let i = 0; i < ${iterations}; i++) sum = (sum + convert(i)) | 0;
+      console.log(sum);
+    `,
+    "0",
+  ],
+  [
+    "(zero + 5.5) | 0 in a function inlined into the loop",
+    `
+      function convert(i) { const zero = i - i; return (zero + 5.5) | 0; }
+      let sum = 0;
+      for (let i = 0; i < ${iterations}; i++) sum = (sum + convert(i)) | 0;
+      console.log(sum);
+    `,
+    String(5 * iterations),
+  ],
+  [
+    "(zero ** 2) >> 0 and ~(zero ** 2)",
+    `
+      function sumInLoop(count) {
+        let sum = 0;
+        for (let i = 0; i < count; i++) {
+          const zero = Math.imul(0, i);
+          sum = (sum + ((zero ** 2) >> 0) + ~(zero ** 2)) | 0;
+        }
+        return sum;
+      }
+      console.log(sumInLoop(${iterations}));
+    `,
+    String(-iterations),
+  ],
+  [
+    "(zero + 4294967301.5) >>> 0",
+    `
+      function sumInLoop(count) {
+        let sum = 0;
+        for (let i = 0; i < count; i++) {
+          const zero = (i * 0) | 0;
+          sum = (sum + ((zero + 4294967301.5) >>> 0)) | 0;
+        }
+        return sum;
+      }
+      console.log(sumInLoop(${iterations}));
+    `,
+    String(5 * iterations),
+  ],
+  [
+    "int32Array[j] = 1.5 in a function inlined into the loop",
+    `
+      const int32Array = new Int32Array(8);
+      function store(j) { int32Array[j] = 1.5; return int32Array[j]; }
+      let sum = 0;
+      for (let i = 0; i < ${iterations}; i++) sum = (sum + store(i & 7)) | 0;
+      console.log(sum);
+    `,
+    String(iterations),
+  ],
+  [
+    "uint8Array[i & 7] = 255.5",
+    `
+      const uint8Array = new Uint8Array(8);
+      for (let i = 0; i < ${iterations}; i++) uint8Array[i & 7] = 255.5;
+      console.log(uint8Array.join());
+    `,
+    "255,255,255,255,255,255,255,255",
+  ],
+  [
+    "uint32Array[i & 7] = -1.5 and int16Array[i & 7] = 65537.5",
+    `
+      const uint32Array = new Uint32Array(8);
+      const int16Array = new Int16Array(8);
+      function storeInLoop(count) {
+        for (let i = 0; i < count; i++) {
+          uint32Array[i & 7] = -1.5;
+          int16Array[i & 7] = 65537.5;
+        }
+      }
+      storeInLoop(${iterations});
+      console.log(uint32Array[7], int16Array[7]);
+    `,
+    "4294967295 1",
+  ],
+  [
+    // Here the slow path does run, so the value of the call that B3 moved is the result.
+    "doubles that only the slow path converts",
+    `
+      const int32Array = new Int32Array(8);
+      function sumInLoop(count) {
+        let sum = 0;
+        for (let i = 0; i < count; i++) {
+          const zero = Math.imul(0, i);
+          int32Array[i & 7] = -(2 ** 63 + 2048);
+          sum = (sum + ((zero + 2 ** 63 + 2048) | 0) + ((zero / zero) | 0) + ((1 / zero) | 0) + int32Array[i & 7]) | 0;
+        }
+        return sum;
+      }
+      console.log(sumInLoop(${iterations}));
+    `,
+    "0",
+  ],
+];
+
+describe.concurrent("ToInt32 of a loop-invariant double in the FTL", () => {
+  test.each(programs)("%s", async (_, program, expected) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", program],
+      // Without the concurrent JIT the FTL code is in place after a fixed number of
+      // iterations. With it, a slow build can finish the loop before the compile does.
+      env: { ...bunEnv, BUN_JSC_useConcurrentJIT: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe(expected);
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- Since the WebKit upgrade in #42319, every build with assertions on (`bun-debug`, `bun-asan`, the ASAN CI lanes) aborts on ordinary numeric code on x64 once the FTL compiles it. Release builds are not affected. Example: `for (let i = 0; i < 3000000; i++) uint8Array[i & 7] = 255.5;`

```
ASSERTION FAILED: exp >= 63
JavaScriptCore/runtime/MathCommon.h(155) : int32_t JSC::toInt32AfterFailedTruncation(double)
```

- The FTL emits the slow path call of the x64 double to int32 conversion as a call without side effects. When the double is the same in every iteration of a loop, B3 moves the call to the loop pre-header, where it runs with a double that the fast path accepts. Upstream 320644@main made the callee assert that it never gets one.

### Fix
- Pin WebKit to `autobuild-preview-pr-625-fe20753d`, the preview build of oven-sh/WebKit#625 on top of the current pin `cf1b36ec8703`. There the FTL slow path calls `operationToInt32`, which accepts every double.
- The pin is a preview tag, not a merge commit. Do not merge before oven-sh/WebKit#625 lands. I move the pin to the `autobuild-<sha>` release of the merge commit then.
- Verified: `test/js/bun/jsc/ftl-to-int32-loop-invariant-double.test.ts` fails 7 of 8 tests on a debug build of `main` and passes on a debug build with the new pin. The eighth test covers doubles that do take the slow path and passes on both.

### Background
- ToInt32 is the conversion behind `|`, `>>`, `~` and stores into integer typed arrays. On x64 JSC truncates with `cvttsd2siq` and keeps the low 32 bits. Only NaN, the infinities and `|x| >= 2^63` fail that and take a call into C++.
- The FTL is the top JIT tier of JSC. B3 is its backend. B3 may move a call that is marked as free of side effects out of a loop when its arguments do not change in the loop, even from a branch that never runs.
- A release build also runs the moved call, but nothing reads its result, so the values were always right.

<details><summary>Notes</summary>

- Source: fuzz-ledger #47504, a JIT tier differential on `release-asan` `main` @6a92015f.
- The canary release build `1.4.3-canary.1+6a92015fc` prints 15000000 for `function hot(i) { const t0 = i - i; return (t0 + 5.5) | 0; }` summed over 3e6 iterations, with the FTL compile confirmed by `BUN_JSC_reportFTLCompileTimes=1`. Its B3 dump shows the four unrolled `CCall`s in the pre-header after `hoistLoopInvariantValues`.
- `BUN_JSC_useB3HoistLoopInvariantValues=0` hides the abort on the unfixed build.
- The test sets `BUN_JSC_useConcurrentJIT=0`. A debug build is slow enough to finish a 200000 iteration loop before a concurrent FTL compile lands, and the test would then pass without the fix.
- The JSC reasoning, the list of shapes that reach it, and the alternatives are in oven-sh/WebKit#625.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/ftl-to-int32-loop-invariant-double.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/bun/jsc/ftl-to-int32-loop-invariant-double.test.ts"
bun test v1.4.3 (4ff919377)

test/js/bun/jsc/ftl-to-int32-loop-invariant-double.test.ts:
(pass) ToInt32 of a loop-invariant double in the FTL > (zero + 4294967301.5) >>> 0 [921.35ms]
(pass) ToInt32 of a loop-invariant double in the FTL > (zero + 0.5) | 0 in a function inlined into the loop [1146.70ms]
(pass) ToInt32 of a loop-invariant double in the FTL > (zero + 5.5) | 0 in a function inlined into the loop [1078.46ms]
(pass) ToInt32 of a loop-invariant double in the FTL > (zero ** 2) >> 0 and ~(zero ** 2) [1111.74ms]
(pass) ToInt32 of a loop-invariant double in the FTL > int32Array[j] = 1.5 in a function inlined into the loop [1266.80ms]
(pass) ToInt32 of a loop-invariant double in the FTL > uint8Array[i & 7] = 255.5 [880.81ms]
(pass) ToInt32 of a loop-invariant double in the FTL > uint32Array[i & 7] = -1.5 and int16Array[i & 7] = 65537.5 [769.79ms]
(pass) ToInt32 of a loop-invariant double in the FTL > doubles that only the slow path converts [1762.37ms]

 8 pass
 0 fail
 32 expect() calls
Ran 8 tests across 1 file. [6.37s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |   2 +-
 .../jsc/ftl-to-int32-loop-invariant-double.test.ts | 142 +++++++++++++++++++++
 2 files changed, 143 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                  3      1      6
…t/js/bun/jsc/ftl-to-int32-loop-invariant-double.test.ts      0      1      6
```

</details>

<!-- robobun:evidence:end -->