### PR TITLE
fetch, Bun.serve: throw a RangeError for Headers that total 4 GiB or more

### DIFF
--- a/src/http_jsc/headers_jsc.rs
+++ b/src/http_jsc/headers_jsc.rs
@@ -7,7 +7,16 @@ use core::sync::atomic::Ordering;
 use bun_core::{EncodedSlice, StringPointer};
 use bun_http::Headers;
 use bun_http::headers::{EntryList, api};
-use bun_jsc::{CallFrame, FetchHeaders, HTTPHeaderName, JSGlobalObject, JSValue, JsResult};
+use bun_jsc::{
+    CallFrame, FetchHeaders, HTTPHeaderName, JSGlobalObject, JSValue, JsError, JsResult,
+};
+
+fn throw_headers_too_large(global: &JSGlobalObject) -> JsError {
+    global.throw_value(global.create_range_error_instance(format_args!(
+        "Headers exceed the maximum total size of {} bytes",
+        u32::MAX
+    )))
+}
 
 /// Moved up from `bun_http` so it can
 /// name `FetchHeaders` directly instead of dispatching through a vtable.
@@ -15,10 +24,14 @@ use bun_jsc::{CallFrame, FetchHeaders, HTTPHeaderName, JSGlobalObject, JSValue, 
 /// `body_content_type` is `Some(ct)` only when the body has a *user-set*
 /// content-type (callers gate on `has_content_type_from_user()` before passing
 /// `content_type()`); `None` means no body or no user-set content-type.
+///
+/// `Headers` addresses its buffer through `u32` `StringPointer`s. Throws a
+/// `RangeError` when the names and values pass `u32::MAX` bytes in total.
 pub fn from_fetch_headers(
+    global: &JSGlobalObject,
     fetch_headers: Option<&FetchHeaders>,
     body_content_type: Option<&[u8]>,
-) -> Headers {
+) -> JsResult<Headers> {
     // `FetchHeaders::{count,fast_has_,copy_to}` take `&mut self` but
     // are read-only FFI shims; cast through `*mut` (matching the prior
     // `link_interface!` impl which did `from_ref(h).cast_mut()`).
@@ -28,7 +41,9 @@ pub fn from_fetch_headers(
     let mut buf_len: u32 = 0;
     if let Some(h) = h_ptr {
         // SAFETY: `h` is a valid `&FetchHeaders` for the call; FFI is read-only.
-        unsafe { (*h).count(&mut header_count, &mut buf_len) };
+        if !unsafe { (*h).count(&mut header_count, &mut buf_len) } {
+            return Err(throw_headers_too_large(global));
+        }
     }
     let mut headers = Headers {
         entries: EntryList::default(),
@@ -42,8 +57,15 @@ pub fn from_fetch_headers(
                 .map(|h| unsafe { (*h).fast_has_(HTTPHeaderName::ContentType as u8) })
                 .unwrap_or(false);
             if !has_ct_header {
-                header_count += 1;
-                buf_len += u32::try_from(body_ct.len() + b"Content-Type".len()).unwrap();
+                let Some((new_count, new_len)) = header_count.checked_add(1).zip(
+                    u32::try_from(b"Content-Type".len() + body_ct.len())
+                        .ok()
+                        .and_then(|ct_len| buf_len.checked_add(ct_len)),
+                ) else {
+                    return Err(throw_headers_too_large(global));
+                };
+                header_count = new_count;
+                buf_len = new_len;
                 break 'brk true;
             }
         }
@@ -80,7 +102,14 @@ pub fn from_fetch_headers(
     }
     if let Some(h) = h_ptr {
         // SAFETY: `h` is a valid `&FetchHeaders` for the call; columns sized by `count` above.
-        unsafe { (*h).copy_to(names_ptr, values_ptr, headers.buf.as_mut_ptr()) };
+        unsafe {
+            (*h).copy_to(
+                names_ptr,
+                values_ptr,
+                headers.buf.as_mut_ptr(),
+                buf_len_before_content_type,
+            )
+        };
     }
 
     // TODO: maybe we should send Content-Type header first instead of last?
@@ -108,7 +137,7 @@ pub fn from_fetch_headers(
         }
     }
 
-    headers
+    Ok(headers)
 }
 
 /// Build a `WebCore::FetchHeaders` from `bun.http.Headers` storage.

--- a/src/http_jsc/headers_jsc.rs
+++ b/src/http_jsc/headers_jsc.rs
@@ -32,27 +32,25 @@ pub fn from_fetch_headers(
     fetch_headers: Option<&FetchHeaders>,
     body_content_type: Option<&[u8]>,
 ) -> JsResult<Headers> {
-    // `FetchHeaders::{count,fast_has_,copy_to}` take `&mut self` but
-    // are read-only FFI shims; cast through `*mut` (matching the prior
-    // `link_interface!` impl which did `from_ref(h).cast_mut()`).
+    // `FetchHeaders::fast_has_` takes `&mut self` but is a read-only FFI shim;
+    // cast through `*mut` (matching the prior `link_interface!` impl which did
+    // `from_ref(h).cast_mut()`).
     let h_ptr: Option<*mut FetchHeaders> = fetch_headers.map(|h| core::ptr::from_ref(h).cast_mut());
 
-    let mut header_count: u32 = 0;
-    let mut buf_len: u32 = 0;
-    if let Some(h) = h_ptr {
-        // SAFETY: `h` is a valid `&FetchHeaders` for the call; FFI is read-only.
-        if !unsafe { (*h).count(&mut header_count, &mut buf_len) } {
-            return Err(throw_headers_too_large(global));
-        }
-    }
+    let (fetch_header_count, buf_len_before_content_type) =
+        match fetch_headers.map(FetchHeaders::count) {
+            None => (0, 0),
+            Some(Some(counts)) => counts,
+            Some(None) => return Err(throw_headers_too_large(global)),
+        };
+    let (mut header_count, mut buf_len) = (fetch_header_count, buf_len_before_content_type);
     let mut headers = Headers {
         entries: EntryList::default(),
         buf: Vec::new(),
     };
-    let buf_len_before_content_type = buf_len;
     let needs_content_type = 'brk: {
         if let Some(body_ct) = body_content_type {
-            // SAFETY: see `count` above.
+            // SAFETY: `h` is a valid `&FetchHeaders` for the call; FFI is read-only.
             let has_ct_header = h_ptr
                 .map(|h| unsafe { (*h).fast_has_(HTTPHeaderName::ContentType as u8) })
                 .unwrap_or(false);
@@ -100,16 +98,20 @@ pub fn from_fetch_headers(
         core::ptr::write_bytes(names_ptr, 0, header_count as usize);
         core::ptr::write_bytes(values_ptr, 0, header_count as usize);
     }
-    if let Some(h) = h_ptr {
-        // SAFETY: `h` is a valid `&FetchHeaders` for the call; columns sized by `count` above.
-        unsafe {
-            (*h).copy_to(
-                names_ptr,
-                values_ptr,
-                headers.buf.as_mut_ptr(),
-                buf_len_before_content_type,
+    if let Some(h) = fetch_headers {
+        // SAFETY: both columns hold `header_count >= fetch_header_count` slots, zeroed
+        // above, and nothing else borrows them.
+        let (names, values) = unsafe {
+            (
+                core::slice::from_raw_parts_mut(names_ptr, fetch_header_count as usize),
+                core::slice::from_raw_parts_mut(values_ptr, fetch_header_count as usize),
             )
         };
+        h.copy_to(
+            names,
+            values,
+            &mut headers.buf[..buf_len_before_content_type as usize],
+        );
     }
 
     // TODO: maybe we should send Content-Type header first instead of last?

--- a/src/http_jsc/headers_jsc.rs
+++ b/src/http_jsc/headers_jsc.rs
@@ -25,18 +25,12 @@ fn throw_headers_too_large(global: &JSGlobalObject) -> JsError {
 /// content-type (callers gate on `has_content_type_from_user()` before passing
 /// `content_type()`); `None` means no body or no user-set content-type.
 ///
-/// `Headers` addresses its buffer through `u32` `StringPointer`s. Throws a
-/// `RangeError` when the names and values pass `u32::MAX` bytes in total.
+/// Throws a `RangeError` when the total passes `u32::MAX` bytes, the range of a `StringPointer`.
 pub fn from_fetch_headers(
     global: &JSGlobalObject,
     fetch_headers: Option<&FetchHeaders>,
     body_content_type: Option<&[u8]>,
 ) -> JsResult<Headers> {
-    // `FetchHeaders::fast_has_` takes `&mut self` but is a read-only FFI shim;
-    // cast through `*mut` (matching the prior `link_interface!` impl which did
-    // `from_ref(h).cast_mut()`).
-    let h_ptr: Option<*mut FetchHeaders> = fetch_headers.map(|h| core::ptr::from_ref(h).cast_mut());
-
     let (fetch_header_count, buf_len_before_content_type) =
         match fetch_headers.map(FetchHeaders::count) {
             None => (0, 0),
@@ -50,10 +44,8 @@ pub fn from_fetch_headers(
     };
     let needs_content_type = 'brk: {
         if let Some(body_ct) = body_content_type {
-            // SAFETY: `h` is a valid `&FetchHeaders` for the call; FFI is read-only.
-            let has_ct_header = h_ptr
-                .map(|h| unsafe { (*h).fast_has_(HTTPHeaderName::ContentType as u8) })
-                .unwrap_or(false);
+            let has_ct_header =
+                fetch_headers.is_some_and(|h| h.fast_has_(HTTPHeaderName::ContentType as u8));
             if !has_ct_header {
                 let Some((new_count, new_len)) = header_count.checked_add(1).zip(
                     u32::try_from(b"Content-Type".len() + body_ct.len())
@@ -99,8 +91,7 @@ pub fn from_fetch_headers(
         core::ptr::write_bytes(values_ptr, 0, header_count as usize);
     }
     if let Some(h) = fetch_headers {
-        // SAFETY: both columns hold `header_count >= fetch_header_count` slots, zeroed
-        // above, and nothing else borrows them.
+        // SAFETY: each column holds `header_count >= fetch_header_count` zeroed, unborrowed slots.
         let (names, values) = unsafe {
             (
                 core::slice::from_raw_parts_mut(names_ptr, fetch_header_count as usize),

--- a/src/http_jsc/headers_jsc.rs
+++ b/src/http_jsc/headers_jsc.rs
@@ -11,6 +11,7 @@ use bun_jsc::{
     CallFrame, FetchHeaders, HTTPHeaderName, JSGlobalObject, JSValue, JsError, JsResult,
 };
 
+/// `Headers` addresses its buffer with `u32` `StringPointer`s, so it cannot hold a larger total.
 fn throw_headers_too_large(global: &JSGlobalObject) -> JsError {
     global.throw_value(global.create_range_error_instance(format_args!(
         "Headers exceed the maximum total size of {} bytes",
@@ -24,8 +25,6 @@ fn throw_headers_too_large(global: &JSGlobalObject) -> JsError {
 /// `body_content_type` is `Some(ct)` only when the body has a *user-set*
 /// content-type (callers gate on `has_content_type_from_user()` before passing
 /// `content_type()`); `None` means no body or no user-set content-type.
-///
-/// Throws a `RangeError` when the total passes `u32::MAX` bytes, the range of a `StringPointer`.
 pub fn from_fetch_headers(
     global: &JSGlobalObject,
     fetch_headers: Option<&FetchHeaders>,

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -231,7 +231,7 @@ impl FetchHeaders {
         Some(str)
     }
 
-    pub fn fast_has_(&mut self, name_: u8) -> bool {
+    pub fn fast_has_(&self, name_: u8) -> bool {
         WebCore__FetchHeaders__fastHas_(self, name_)
     }
 
@@ -262,8 +262,7 @@ impl FetchHeaders {
         WebCore__FetchHeaders__toJS(self, global_this)
     }
 
-    /// The number of headers, and the bytes in their names and values. `None` when the
-    /// bytes pass `u32::MAX`: the most a `StringPointer` can address.
+    /// Header count and total name + value bytes. `None` when the bytes pass `u32::MAX`.
     pub fn count(&self) -> Option<(u32, u32)> {
         let (mut names, mut buf_len) = (0, 0);
         WebCore__FetchHeaders__count(self, &mut names, &mut buf_len).then_some((names, buf_len))

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -31,8 +31,13 @@ unsafe extern "C" {
         arg1: *mut StringPointer,
         arg2: *mut StringPointer,
         arg3: *mut u8,
+        arg4: u32,
     );
-    safe fn WebCore__FetchHeaders__count(arg0: &FetchHeaders, arg1: &mut u32, arg2: &mut u32);
+    safe fn WebCore__FetchHeaders__count(
+        arg0: &FetchHeaders,
+        arg1: &mut u32,
+        arg2: &mut u32,
+    ) -> bool;
     safe fn WebCore__FetchHeaders__createEmpty() -> *mut FetchHeaders;
     // safe: `arg0`/`arg1` are opaque handles to C++-owned request structs
     // (PicoHeaders / uWS HttpRequest); never dereferenced as Rust data — same
@@ -256,7 +261,10 @@ impl FetchHeaders {
         WebCore__FetchHeaders__toJS(self, global_this)
     }
 
-    pub fn count(&mut self, names: &mut u32, buf_len: &mut u32) {
+    /// Returns `false`, with `names` and `buf_len` unset, when the names and values
+    /// together pass `u32::MAX` bytes: the most a `StringPointer` can address.
+    #[must_use]
+    pub fn count(&mut self, names: &mut u32, buf_len: &mut u32) -> bool {
         WebCore__FetchHeaders__count(self, names, buf_len)
     }
 
@@ -273,9 +281,15 @@ impl FetchHeaders {
         WebCore__FetchHeaders__deref(self)
     }
 
-    pub fn copy_to(&mut self, names: *mut StringPointer, values: *mut StringPointer, buf: *mut u8) {
+    pub fn copy_to(
+        &mut self,
+        names: *mut StringPointer,
+        values: *mut StringPointer,
+        buf: *mut u8,
+        buf_len: u32,
+    ) {
         // SAFETY: caller guarantees names/values/buf are sized per a prior `count()` call
-        unsafe { WebCore__FetchHeaders__copyTo(self, names, values, buf) }
+        unsafe { WebCore__FetchHeaders__copyTo(self, names, values, buf, buf_len) }
     }
 }
 

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -27,11 +27,12 @@ unsafe extern "C" {
         arg1: &JSGlobalObject,
     ) -> *mut FetchHeaders;
     fn WebCore__FetchHeaders__copyTo(
-        arg0: *mut FetchHeaders,
+        arg0: &FetchHeaders,
         arg1: *mut StringPointer,
         arg2: *mut StringPointer,
-        arg3: *mut u8,
-        arg4: u32,
+        arg3: u32,
+        arg4: *mut u8,
+        arg5: u32,
     );
     safe fn WebCore__FetchHeaders__count(
         arg0: &FetchHeaders,
@@ -261,11 +262,11 @@ impl FetchHeaders {
         WebCore__FetchHeaders__toJS(self, global_this)
     }
 
-    /// Returns `false`, with `names` and `buf_len` unset, when the names and values
-    /// together pass `u32::MAX` bytes: the most a `StringPointer` can address.
-    #[must_use]
-    pub fn count(&mut self, names: &mut u32, buf_len: &mut u32) -> bool {
-        WebCore__FetchHeaders__count(self, names, buf_len)
+    /// The number of headers, and the bytes in their names and values. `None` when the
+    /// bytes pass `u32::MAX`: the most a `StringPointer` can address.
+    pub fn count(&self) -> Option<(u32, u32)> {
+        let (mut names, mut buf_len) = (0, 0);
+        WebCore__FetchHeaders__count(self, &mut names, &mut buf_len).then_some((names, buf_len))
     }
 
     pub fn clone_this(
@@ -281,15 +282,27 @@ impl FetchHeaders {
         WebCore__FetchHeaders__deref(self)
     }
 
+    /// Aborts unless `names`, `values` and `buf` hold what `count()` reported.
     pub fn copy_to(
-        &mut self,
-        names: *mut StringPointer,
-        values: *mut StringPointer,
-        buf: *mut u8,
-        buf_len: u32,
+        &self,
+        names: &mut [StringPointer],
+        values: &mut [StringPointer],
+        buf: &mut [u8],
     ) {
-        // SAFETY: caller guarantees names/values/buf are sized per a prior `count()` call
-        unsafe { WebCore__FetchHeaders__copyTo(self, names, values, buf, buf_len) }
+        // A longer slice is valid: C++ addresses `u32::MAX` of it at most.
+        let columns = u32::try_from(names.len().min(values.len())).unwrap_or(u32::MAX);
+        let buf_len = u32::try_from(buf.len()).unwrap_or(u32::MAX);
+        // SAFETY: C++ asserts that it writes at most `columns` entries and `buf_len` bytes.
+        unsafe {
+            WebCore__FetchHeaders__copyTo(
+                self,
+                names.as_mut_ptr(),
+                values.as_mut_ptr(),
+                columns,
+                buf.as_mut_ptr(),
+                buf_len,
+            )
+        }
     }
 }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2420,10 +2420,11 @@ bool WebCore__FetchHeaders__fastHas_(WebCore::FetchHeaders* arg0, unsigned char 
     return arg0->fastHas(static_cast<HTTPHeaderName>(HTTPHeaderName1));
 }
 
-void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* headers, StringPointer* names, StringPointer* values, unsigned char* buf)
+// `buf` holds the `buf_len` bytes that WebCore__FetchHeaders__count reported for these headers.
+void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* headers, StringPointer* names, StringPointer* values, unsigned char* buf, uint32_t buf_len)
 {
     auto iter = headers->createIterator(false);
-    unsigned int i = 0;
+    uint32_t i = 0;
 
     for (auto pair = iter.next(); pair; pair = iter.next()) {
         const auto name = pair->key;
@@ -2431,6 +2432,9 @@ void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* headers, StringPointer
 
         ASSERT_WITH_MESSAGE(name.length(), "Header name must not be empty");
         ASSERT_WITH_MESSAGE(name.containsOnlyASCII(), "Header name must be ASCII. This should already be validated before calling this function.");
+
+        // Each branch below writes one byte per code unit.
+        RELEASE_ASSERT(name.length() <= buf_len - i && value.length() <= buf_len - i - name.length());
 
         if (name.is8Bit()) {
             const auto nameSpan = name.span8();
@@ -2467,7 +2471,9 @@ void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* headers, StringPointer
         values++;
     }
 }
-void WebCore__FetchHeaders__count(WebCore::FetchHeaders* headers, uint32_t* count, uint32_t* buf_len)
+// Returns false when the names and values pass the uint32_t range of a StringPointer,
+// so copyTo cannot address them.
+bool WebCore__FetchHeaders__count(WebCore::FetchHeaders* headers, uint32_t* count, uint32_t* buf_len)
 {
     auto iter = headers->createIterator();
     size_t i = 0;
@@ -2475,10 +2481,13 @@ void WebCore__FetchHeaders__count(WebCore::FetchHeaders* headers, uint32_t* coun
         // copyTo isomorphic-encodes: one byte per code unit.
         i += pair->key.length();
         i += pair->value.length();
+        if (i > std::numeric_limits<uint32_t>::max())
+            return false;
     }
 
     *count = headers->size();
-    *buf_len = i;
+    *buf_len = static_cast<uint32_t>(i);
+    return true;
 }
 
 typedef struct ZigSliceString {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2420,8 +2420,9 @@ bool WebCore__FetchHeaders__fastHas_(WebCore::FetchHeaders* arg0, unsigned char 
     return arg0->fastHas(static_cast<HTTPHeaderName>(HTTPHeaderName1));
 }
 
-// `buf` holds the `buf_len` bytes that WebCore__FetchHeaders__count reported for these headers.
-void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* headers, StringPointer* names, StringPointer* values, unsigned char* buf, uint32_t buf_len)
+// `names` and `values` each hold `count` entries and `buf` holds `buf_len` bytes:
+// what WebCore__FetchHeaders__count reported for these headers.
+void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* headers, StringPointer* names, StringPointer* values, uint32_t count, unsigned char* buf, uint32_t buf_len)
 {
     auto iter = headers->createIterator(false);
     uint32_t i = 0;
@@ -2433,8 +2434,10 @@ void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* headers, StringPointer
         ASSERT_WITH_MESSAGE(name.length(), "Header name must not be empty");
         ASSERT_WITH_MESSAGE(name.containsOnlyASCII(), "Header name must be ASCII. This should already be validated before calling this function.");
 
-        // Each branch below writes one byte per code unit.
+        // Each pair writes one entry per column and one byte per code unit.
+        RELEASE_ASSERT(count > 0);
         RELEASE_ASSERT(name.length() <= buf_len - i && value.length() <= buf_len - i - name.length());
+        count--;
 
         if (name.is8Bit()) {
             const auto nameSpan = name.span8();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2420,8 +2420,7 @@ bool WebCore__FetchHeaders__fastHas_(WebCore::FetchHeaders* arg0, unsigned char 
     return arg0->fastHas(static_cast<HTTPHeaderName>(HTTPHeaderName1));
 }
 
-// `names` and `values` each hold `count` entries and `buf` holds `buf_len` bytes:
-// what WebCore__FetchHeaders__count reported for these headers.
+// `names` and `values` each hold `count` entries. `buf` holds `buf_len` bytes.
 void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* headers, StringPointer* names, StringPointer* values, uint32_t count, unsigned char* buf, uint32_t buf_len)
 {
     auto iter = headers->createIterator(false);
@@ -2474,8 +2473,7 @@ void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* headers, StringPointer
         values++;
     }
 }
-// Returns false when the names and values pass the uint32_t range of a StringPointer,
-// so copyTo cannot address them.
+// Returns false when the names and values pass the uint32_t range of a StringPointer.
 bool WebCore__FetchHeaders__count(WebCore::FetchHeaders* headers, uint32_t* count, uint32_t* buf_len)
 {
     auto iter = headers->createIterator();

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -67,7 +67,7 @@ CPP_DECL WebCore::DOMFormData* _fromJS(JSC::EncodedJSValue JSValue0);
 
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__cast_(JSC::EncodedJSValue JSValue0, JSC::VM* arg1);
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__cloneThis(WebCore::FetchHeaders* arg0, JSC::JSGlobalObject* arg1);
-CPP_DECL void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* arg0, StringPointer* arg1, StringPointer* arg2, unsigned char* arg3, uint32_t arg4);
+CPP_DECL void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* arg0, StringPointer* arg1, StringPointer* arg2, uint32_t arg3, unsigned char* arg4, uint32_t arg5);
 CPP_DECL bool WebCore__FetchHeaders__count(WebCore::FetchHeaders* arg0, uint32_t* arg1, uint32_t* arg2);
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__createEmpty();
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__createFromJS(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1);

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -67,8 +67,8 @@ CPP_DECL WebCore::DOMFormData* _fromJS(JSC::EncodedJSValue JSValue0);
 
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__cast_(JSC::EncodedJSValue JSValue0, JSC::VM* arg1);
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__cloneThis(WebCore::FetchHeaders* arg0, JSC::JSGlobalObject* arg1);
-CPP_DECL void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* arg0, StringPointer* arg1, StringPointer* arg2, unsigned char* arg3);
-CPP_DECL void WebCore__FetchHeaders__count(WebCore::FetchHeaders* arg0, uint32_t* arg1, uint32_t* arg2);
+CPP_DECL void WebCore__FetchHeaders__copyTo(WebCore::FetchHeaders* arg0, StringPointer* arg1, StringPointer* arg2, unsigned char* arg3, uint32_t arg4);
+CPP_DECL bool WebCore__FetchHeaders__count(WebCore::FetchHeaders* arg0, uint32_t* arg1, uint32_t* arg2);
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__createEmpty();
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__createFromJS(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1);
 CPP_DECL WebCore::FetchHeaders* WebCore__FetchHeaders__createFromPicoHeaders_(const void* arg0);

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5400,9 +5400,10 @@ impl DevServer {
                 let global = r.global;
                 let mut any_blob = crate::webcore::blob::Any::from_array_list(buf);
                 let mut headers = bun_http_jsc::headers_jsc::from_fetch_headers(
+                    global,
                     None,
                     crate::webcore::headers_ref::any_blob_content_type(&any_blob),
-                );
+                )?;
                 headers.append(b"Content-Type", &MimeType::HTML.value);
                 if headers.get(b"etag").is_none() && !any_blob.slice().is_empty() {
                     bun_http::headers::append_etag(any_blob.slice(), &mut headers);

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -50,8 +50,12 @@ pub struct InitOptions<'a> {
 use crate::webcore::headers_ref::blob_content_type;
 
 #[inline]
-fn headers_from(fetch_headers: Option<&FetchHeaders>, blob: &Blob) -> Headers {
-    bun_http_jsc::headers_jsc::from_fetch_headers(fetch_headers, blob_content_type(blob))
+fn headers_from(
+    global: &JSGlobalObject,
+    fetch_headers: Option<&FetchHeaders>,
+    blob: &Blob,
+) -> JsResult<Headers> {
+    bun_http_jsc::headers_jsc::from_fetch_headers(global, fetch_headers, blob_content_type(blob))
 }
 
 #[inline]
@@ -124,9 +128,18 @@ impl FileRoute {
         }
     }
 
-    pub(crate) fn init_from_blob(blob: Blob, opts: &InitOptions<'_>) -> RefPtr<FileRoute> {
-        let headers = headers_from(opts.headers, &blob);
-        RefPtr::new(FileRoute::new(blob, headers, opts.server, opts.status_code))
+    pub(crate) fn init_from_blob(
+        global: &JSGlobalObject,
+        blob: Blob,
+        opts: &InitOptions<'_>,
+    ) -> JsResult<RefPtr<FileRoute>> {
+        let headers = headers_from(global, opts.headers, &blob)?;
+        Ok(RefPtr::new(FileRoute::new(
+            blob,
+            headers,
+            opts.server,
+            opts.status_code,
+        )))
     }
 
     pub fn from_js(
@@ -165,7 +178,7 @@ impl FileRoute {
                     "expected blob not to be heap-allocated"
                 );
                 *body_value = BodyValue::Blob(blob.dupe());
-                let headers = headers_from(response.get_init_headers(), &blob);
+                let headers = headers_from(global, response.get_init_headers(), &blob)?;
                 let status_code = response.status_code();
 
                 return Ok(Some(RefPtr::new(FileRoute::new(
@@ -184,7 +197,7 @@ impl FileRoute {
                     !b.is_heap_allocated(),
                     "expected blob not to be heap-allocated"
                 );
-                let headers = headers_from(None, &b);
+                let headers = headers_from(global, None, &b)?;
                 return Ok(Some(RefPtr::new(FileRoute::new(b, headers, None, 200))));
             }
         }

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -102,8 +102,7 @@ impl StaticRoute {
         ))
     }
 
-    /// A route that serves `blob` with the user's `fetch_headers`. Ownership of
-    /// `blob` is transferred to this function.
+    /// Ownership of `blob` is transferred to this function.
     pub(crate) fn init_from_any_blob_with_headers(
         global_this: &JSGlobalObject,
         blob: AnyBlob,

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -43,7 +43,6 @@ pub struct InitFromBytesOptions<'a> {
     pub(crate) server: Option<AnyServer>,
     pub(crate) mime_type: Option<&'a MimeType>,
     pub(crate) status_code: u16,
-    pub(crate) headers: Option<&'a FetchHeaders>,
 }
 
 impl<'a> Default for InitFromBytesOptions<'a> {
@@ -52,7 +51,6 @@ impl<'a> Default for InitFromBytesOptions<'a> {
             server: None,
             mime_type: None,
             status_code: 200,
-            headers: None,
         }
     }
 }
@@ -82,16 +80,11 @@ impl StaticRoute {
         blob: AnyBlob,
         options: InitFromBytesOptions<'_>,
     ) -> RefPtr<StaticRoute> {
-        let mut headers = bun_http_jsc::headers_jsc::from_fetch_headers(
-            options.headers,
-            any_blob_content_type(&blob),
-        );
-        if headers.get_content_type().is_none() {
-            if let Some(mime_type) = options.mime_type {
-                headers.append(b"Content-Type", &mime_type.value);
-            } else if blob.has_content_type_from_user() {
-                headers.append(b"Content-Type", blob.content_type());
-            }
+        let mut headers = Headers::default();
+        if let Some(content_type) = any_blob_content_type(&blob) {
+            headers.append(b"Content-Type", content_type);
+        } else if let Some(mime_type) = options.mime_type {
+            headers.append(b"Content-Type", &mime_type.value);
         }
 
         // Generate ETag if not already present
@@ -107,6 +100,35 @@ impl StaticRoute {
             options.server,
             options.status_code,
         ))
+    }
+
+    /// A route that serves `blob` with the user's `fetch_headers`. Ownership of
+    /// `blob` is transferred to this function.
+    pub(crate) fn init_from_any_blob_with_headers(
+        global_this: &JSGlobalObject,
+        blob: AnyBlob,
+        fetch_headers: Option<&FetchHeaders>,
+        status_code: u16,
+    ) -> JsResult<RefPtr<StaticRoute>> {
+        let mut headers: Headers = bun_http_jsc::headers_jsc::from_fetch_headers(
+            global_this,
+            fetch_headers,
+            any_blob_content_type(&blob),
+        )?;
+
+        // Generate ETag if not already present
+        if headers.get(b"etag").is_none() {
+            if !blob.slice().is_empty() {
+                append_etag(blob.slice(), &mut headers);
+            }
+        }
+
+        Ok(RefPtr::new(StaticRoute::new(
+            blob,
+            headers,
+            None,
+            status_code,
+        )))
     }
 
     /// Create a static route to be used on a single response, freeing the bytes once sent.
@@ -223,24 +245,12 @@ impl StaticRoute {
                 )?;
             }
 
-            let mut headers: Headers = bun_http_jsc::headers_jsc::from_fetch_headers(
-                response.get_init_headers(),
-                any_blob_content_type(&blob),
-            );
-
-            // Generate ETag if not already present
-            if headers.get(b"etag").is_none() {
-                if !blob.slice().is_empty() {
-                    append_etag(blob.slice(), &mut headers);
-                }
-            }
-
-            return Ok(Some(RefPtr::new(StaticRoute::new(
+            return Ok(Some(Self::init_from_any_blob_with_headers(
+                global_this,
                 blob,
-                headers,
-                None,
+                response.get_init_headers(),
                 response.status_code(),
-            ))));
+            )?));
         }
 
         Ok(None)

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -731,23 +731,24 @@ impl AnyRoute {
             }
 
             return Ok(AnyRoute::File(FileRoute::init_from_blob(
+                global,
                 blob,
                 &super::file_route::InitOptions {
                     server: None,
                     status_code: 200,
                     headers,
                 },
-            )));
+            )?));
         }
 
-        Ok(AnyRoute::Static(StaticRoute::init_from_any_blob(
-            AnyBlob::Blob(blob),
-            super::static_route::InitFromBytesOptions {
-                server: None,
+        Ok(AnyRoute::Static(
+            StaticRoute::init_from_any_blob_with_headers(
+                global,
+                AnyBlob::Blob(blob),
                 headers,
-                ..Default::default()
-            },
-        )))
+                200,
+            )?,
+        ))
     }
 
     pub(crate) fn html_route_from_js(

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -916,13 +916,19 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                                             // `cast` returns a live JS-owned FetchHeaders*;
                                             // BackRef invariant holds for this read.
                                             let fetch_hdrs = bun_ptr::BackRef::from(fetch_hdrs);
-                                            proxy_headers =
-                                                Some(from_fetch_headers(Some(&*fetch_hdrs), None));
+                                            proxy_headers = Some(from_fetch_headers(
+                                                global_this,
+                                                Some(&*fetch_hdrs),
+                                                None,
+                                            )?);
                                         } else if let Some(fetch_hdrs) =
                                             HeadersRef::create_from_js(ctx, headers_value)?
                                         {
-                                            proxy_headers =
-                                                Some(from_fetch_headers(Some(&fetch_hdrs), None));
+                                            proxy_headers = Some(from_fetch_headers(
+                                                global_this,
+                                                Some(&fetch_hdrs),
+                                                None,
+                                            )?);
                                         }
                                     }
                                 }
@@ -1166,9 +1172,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             }
 
             Some(from_fetch_headers(
+                global_this,
                 Some(headers_ref),
                 any_blob_content_type_opt(body.get_any_blob().map(|b| &*b)),
-            ))
+            )?)
         } else {
             headers
         };
@@ -1372,9 +1379,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
 
     if headers.is_none() && body.has_body() && body.has_content_type_from_user() {
         headers = Some(from_fetch_headers(
+            global_this,
             None,
             any_blob_content_type_opt(body.get_any_blob().map(|b| &*b)),
-        ));
+        )?);
     }
 
     // `body` is mutated in place for the sendfile/readfile paths and then

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 // Namespace import so a missing binding fails only the kernel tests below
 // (accessing an absent export is `undefined`), not the whole file.
 import * as internalForTesting from "bun:internal-for-testing";
@@ -598,6 +599,68 @@ describe("Headers", () => {
       expect(headers.count).toBe(2);
     });
   });
+
+  // fetch() and the static and file routes of Bun.serve() copy a Headers object into one
+  // buffer that they index with 32-bit offsets. The timeout is for debug builds: they need
+  // more than 10 seconds to validate the 4 GiB of values that the child appends.
+  test("fetch() and Bun.serve() refuse headers that total 4 GiB or more", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        /* js */ `
+          // The 16 values share one 256 MiB string. Names and values total 2 ** 32 - 1 bytes,
+          // the most that fits.
+          const value = Buffer.alloc(2 ** 28, "a").toString("latin1");
+          const headers = new Headers();
+          for (let i = 0; i < 15; i++) headers.append("set-cookie", value);
+          headers.append("set-cookie", value.slice(0, 2 ** 28 - 161));
+
+          async function outcome(fn) {
+            try {
+              await fn();
+              return "no error";
+            } catch (e) {
+              return e.name + ": " + e.message;
+            }
+          }
+          function serve(response) {
+            Bun.serve({ port: 0, routes: { "/": response } }).stop(true);
+          }
+
+          await using server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+          const url = server.url.href;
+          const file = Bun.file(process.execPath);
+
+          // The headers alone fit. The Content-Type that fetch() adds for the body does not.
+          const body = new Blob(["x"], { type: "text/plain" });
+          console.log("content-type:", await outcome(() => fetch(url, { method: "POST", body, headers })));
+
+          // Names and values now total 2 ** 32 + 10 bytes.
+          headers.append("set-cookie", "x");
+          console.log("fetch:", await outcome(() => fetch(url, { headers })));
+          console.log("proxy:", await outcome(() => fetch(url, { proxy: { url, headers } })));
+          console.log("static route:", await outcome(() => serve(new Response("body", { headers }))));
+          console.log("file route:", await outcome(() => serve(new Response(file, { headers }))));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+    const error = "RangeError: Headers exceed the maximum total size of 4294967295 bytes";
+    expect(stdout.split("\n")).toEqual([
+      `content-type: ${error}`,
+      `fetch: ${error}`,
+      `proxy: ${error}`,
+      `static route: ${error}`,
+      `file route: ${error}`,
+      "",
+    ]);
+    expect(exitCode).toBe(0);
+  }, 60_000);
 
   // Header-name lowercasing on iteration (Object.fromEntries / spread / toJSON /
   // keys()) runs through a SIMD kernel on the 8-bit path. Sweep name lengths


### PR DESCRIPTION
### Problem

- A `Headers` object that totals 2^32 bytes or more makes `fetch()` write past a heap buffer. ASAN: `heap-buffer-overflow`, `WRITE of size 268435456` in `WebCore__FetchHeaders__copyTo`. A release build dies with `Segmentation fault`. Sixteen `set-cookie` values that share one 256 MiB string suffice.
- `WebCore__FetchHeaders__count` (`src/jsc/bindings/bindings.cpp`) stores a `size_t` total through a `uint32_t*`. The total wraps. `from_fetch_headers` (`src/http_jsc/headers_jsc.rs`) sizes its buffer with it, and `copyTo` copies every pair at full length.
- Only local JS can build such headers. An audit found this. No issue reports it.

### Fix

- `count()` returns `None` when the total passes `u32::MAX`, the range of a `StringPointer`. `from_fetch_headers` then throws `RangeError: Headers exceed the maximum total size of 4294967295 bytes`. `fetch()` rejects, `Bun.serve()` throws.
- `copy_to` takes slices. C++ receives their lengths and asserts both bounds. The `Content-Type` that `from_fetch_headers` adds wrapped the same way. It now uses checked arithmetic.
- `StaticRoute::init_from_any_blob` no longer accepts `FetchHeaders`, so its seven bake callers stay infallible. `StaticRoute::from_js` and `AnyRoute::from_options` share the new `init_from_any_blob_with_headers`.
- Verified: `test/js/web/fetch/headers.test.ts` covers five entry points. The release build crashes on each. Self-reviewed. The notes list the resulting changes, the other suites, and the abort paths left as they are.

### Background

- `FetchHeaders` is the C++ object behind a JS `Headers`. `Headers` (`src/http_types/ETag.rs`) is the native copy for the HTTP client and the routes: a byte buffer and `StringPointer { offset: u32, length: u32 }` pairs.
- `from_fetch_headers` converts one to the other: `count()` measures, `copyTo()` fills.
- `set-cookie` values are never joined. Many values can share one string, so 4 GiB of values costs little memory.

<details><summary>Notes</summary>

Repro. It crashes bun 1.4.3-canary.1+4ff919377 with exit 139. With this PR it prints the RangeError.

```js
const big = Buffer.alloc(2 ** 28, "a").toString("latin1");
const h = new Headers();
for (let i = 0; i < 16; i++) h.append("set-cookie", big);
await using server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
await fetch(server.url, { headers: h });
```

- `16 * (10 + 2^28) = 2^32 + 160`. The unfixed build allocates 160 bytes. ASAN: `0 bytes after 160-byte region`.
- No network peer can build such headers: request headers into `Bun.serve()` stop at 16 KiB (`--max-http-header-size`) and `fetch()` response headers stop at 1 MiB (`MAX_RESPONSE_HEADER_BUFFER`, `src/http/lib.rs`).
- 15 values (3.75 GiB) work as before: `fetch()` sends them and the server answers 431.
- Each path crashes the unfixed release build on its own: `fetch(url, { headers })`, `fetch(url, { method: "POST", body: typedBlob, headers })` with headers of exactly 2^32 - 1 bytes, `fetch(url, { proxy: { url, headers } })`, `routes: { "/": new Response("body", { headers }) }`, `routes: { "/": new Response(Bun.file(path), { headers }) }`.
- The HTML manifest route shape (`routes: { "/": { index, files: [{ path, headers }] } }`, `AnyRoute::from_options`) throws the same RangeError with this PR. It is not in the test, because it copies and validates the headers again, which doubles the time of the test.
- The test runs all five cases in one child process. The child must validate 4 GiB of header values, which takes about 1.5 s on a release build and about 12 s on a debug build. The per-test timeout exists for debug builds only: the default is 5 s.
- `init_from_any_blob` without `FetchHeaders`: the old code called `from_fetch_headers(None, blob content type)`, then added `options.mime_type` only if no `Content-Type` was present. The `else if blob.has_content_type_from_user()` branch was unreachable, because `from_fetch_headers` had already added that type. The new `if / else if` keeps the same order of precedence.
- Suites run on the debug build: `headers`, `bun-serve-static`, `bun-serve-file`, `bun-serve-html`, `bun-serve-html-manifest`, `proxy`, `fetch-args`, `fetch`, and `test/bake/dev/html`. `fetch.test.ts` has six failures that also occur without this change in this container (IPv6 localhost, four `bad permissions` tests that run as root, one redirect test that also fails on the release build).
- #42214, #42218 and #42250 touch `HTTPHeaderMap` and `FetchHeaders.cpp`. None of them touches `count` or `copyTo`.

Self-review. These changes came from it:

- The test now starts with headers of exactly 2^32 - 1 bytes and checks the `Content-Type` that `fetch()` adds for a typed `Blob` body. That path wrapped too (`buf_len += ...` on a `u32`) and crashes the unfixed release build.
- `FetchHeaders::copy_to` took raw pointers and a length from the caller. It takes slices now. `WebCore__FetchHeaders__copyTo` also receives the number of entries and asserts it, so a count that does not match cannot write past the `StringPointer` columns.
- `count`, `copy_to` and `fast_has_` take `&self`. `from_fetch_headers` no longer casts its `&FetchHeaders` to `*mut`.
- Rejected: to fold the `WebSocket` proxy path into this PR. It does not use `count` or `copyTo`, and a test for it needs a real copy of 4 GiB, which no CI lane can hold.

Not changed in this PR. Each of these is a clean abort (`u32::try_from(..).unwrap()` in `Headers::append`, `src/http_types/ETag.rs:257`), not a memory error. A fallible `Headers::try_append` can close them in a follow-up.

- `new WebSocket(url, { proxy: { url, headers } })`: `Headers8Bit::to_headers` (`src/http_jsc/websocket_client/WebSocketUpgradeClient.rs:1535`) appends pair by pair and aborts for any total of 2^32 or more. It does not use `count` or `copyTo`. It needs a real copy of 4 GiB to reach.
- `fetch()` with `compress`: the `Content-Encoding` append (`src/runtime/webcore/fetch.rs`) aborts if the headers end within a few bytes of `u32::MAX`.
- Static routes: `append_etag` (`src/runtime/server/StaticRoute.rs`) aborts in the same window. It needs a 4 GiB buffer first.
- `headers.get("set-cookie")` joins the values in `HTTPHeaderMap.cpp`. #42218 owns that.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/headers.test.ts
bun test v1.4.3 (4ff919377)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [3.90ms]
(pass) Headers > constructor > cannot create headers from null [3.37ms]
(pass) Headers > constructor > can create headers from empty object [2.68ms]
(pass) Headers > constructor > can create headers from object [1.70ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [2.64ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [5.26ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [6.55ms]
(pass) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [7.99ms]
(pass) Headers > constructor > constructing headers from an object propagates an exception from a getter installed by an earlier value's toString [6.58ms]
(pass) Headers > constructor > construc
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [0.08ms]
(pass) Headers > constructor > cannot create headers from null [0.07ms]
(pass) Headers > constructor > can create headers from empty object [0.03ms]
(pass) Headers > constructor > can create headers from object [0.04ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [0.05ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [0.10ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [0.09ms]
(pass) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [0.19ms]
(pass) Headers > constructor > constructing headers from an object propagates an exception from a getter installed by an earlier value's toString [0.09ms]
(pass) Headers > constructor > constructing headers from an object keeps own-property semantics after setPrototypeOf mid-conversion [0.07ms]
(pass) Headers > constructor > can create headers from 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/headers.test.ts
bun test v1.4.3 (4ff919377)

test/js/web/fetch/headers.test.ts:
(pass) Headers > constructor > can create headers from no arguments [7.10ms]
(pass) Headers > constructor > cannot create headers from null [5.96ms]
(pass) Headers > constructor > can create headers from empty object [3.33ms]
(pass) Headers > constructor > can create headers from object [3.41ms]
(pass) Headers > constructor > deleted key in header constructor is not kept [4.28ms]
(pass) Headers > constructor > constructing headers from an object interleaves Get with value conversion [8.63ms]
(pass) Headers > constructor > constructing headers from an object with a getter interleaves Get with value conversion [11.16ms]
(pass) Headers > constructor > constructing headers from an object observes a getter installed by an earlier value's toString [14.68ms]
(pass) Headers > constructor > constructing headers from an object propagates an exception from a getter installed by an earlier value's toString [9.62ms]
(pass) Headers > constructor > constr
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 716ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[2/22] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[3/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[4/22] cxx obj/src/jsc/bindings/BunObject.cpp.o
[5/22] cxx obj/src/jsc/bindings/BunProcess.cpp.o
[6/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[7/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[8/22] cxx obj/src/jsc/bindings/bindings.cpp.o
[9/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[10/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[11/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[12/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[13/22] cxx obj/src/jsc/bindings/napi.cpp.o
[14/22] cxx obj/codegen/ZigGeneratedClasses.cpp.o
[15/22] cxx obj/codegen/JSSink.cpp.o
[16/22] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[17/22] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, ru
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http_jsc/headers_jsc.rs       | 69 +++++++++++++++++++++++++--------------
 src/jsc/FetchHeaders.rs           | 44 ++++++++++++++++++++-----
 src/jsc/bindings/bindings.cpp     | 18 +++++++---
 src/jsc/bindings/headers.h        |  4 +--
 src/runtime/bake/DevServer.rs     |  3 +-
 src/runtime/server/FileRoute.rs   | 27 +++++++++++----
 src/runtime/server/StaticRoute.rs | 65 ++++++++++++++++++++----------------
 src/runtime/server/server_body.rs | 17 +++++-----
 src/runtime/webcore/fetch.rs      | 20 ++++++++----
 test/js/web/fetch/headers.test.ts | 63 +++++++++++++++++++++++++++++++++++
 10 files changed, 241 insertions(+), 89 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/http_jsc/headers_jsc.rs            6     10     19
src/jsc/FetchHeaders.rs                4      8     19
src/jsc/bindings/bindings.cpp          4      5     19
src/jsc/bindings/headers.h             2      3     19
src/runtime/bake/DevServer.rs          1      1     19
src/runtime/server/FileRoute.rs        2      4     19
src/runtime/server/StaticRoute.rs      4      6     19
src/runtime/server/server_body.rs      3      1     19
src/runtime/webcore/fetch.rs           5      3     19
test/js/web/fetch/headers.test.ts      4      6     19
```

</details>

<!-- robobun:evidence:end -->