### PR TITLE
Add tests for the WebKit cf1b36ec8703 upgrade: no tail calls in generator and async bodies

### DIFF
--- a/test/js/bun/jsc/webkit-upgrade-cf1b36ec8703.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-cf1b36ec8703.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "bun:test";
+
+// Coverage for the WebKit cf1b36ec8703 sync (oven-sh/WebKit#614). Each case pins
+// an observable behavior difference between the previous JSC and the new one.
+//
+// WebKit/WebKit#73407: a generator, async function, async arrow or async
+// generator body has no tail position
+// (https://tc39.es/ecma262/#sec-static-semantics-isintailposition), so
+// `return f()` there is an ordinary call. The previous engine emitted a tail
+// call, which replaces the frame of the body with the frame of `f`.
+
+describe.concurrent("WebKit cf1b36ec8703 upgrade", () => {
+  // `return x` in an async generator awaits `x` before the generator completes.
+  // The tail call returned the promise to the caller and skipped that await.
+  describe("an async generator awaits the call it returns (oven-sh/bun#33185)", () => {
+    const f = () => Promise.resolve(42);
+    const object = { f };
+    const tag = (_: TemplateStringsArray) => f();
+    // Destructured so that the transpiler cannot fold `yes ? f() : 0` to `f()`.
+    const [yes, no, nothing] = [true, false, null];
+
+    const shapes: Record<string, () => AsyncGenerator<unknown, unknown>> = {
+      "Promise.resolve(v)": async function* () {
+        return Promise.resolve(42);
+      },
+      "f()": async function* () {
+        return f();
+      },
+      "object.f()": async function* () {
+        return object.f();
+      },
+      "f?.()": async function* () {
+        return f?.();
+      },
+      "f(...[])": async function* () {
+        return f(...[]);
+      },
+      "f.call()": async function* () {
+        return f.call(null);
+      },
+      "f.apply()": async function* () {
+        return f.apply(null, []);
+      },
+      "a tagged template": async function* () {
+        return tag`x`;
+      },
+      "an async arrow call": async function* () {
+        return (async () => 42)();
+      },
+      "c ? f() : 0": async function* () {
+        return yes ? f() : 0;
+      },
+      "a && f()": async function* () {
+        return yes && f();
+      },
+      "a || f()": async function* () {
+        return no || f();
+      },
+      "a ?? f()": async function* () {
+        return nothing ?? f();
+      },
+      "in nested statements": async function* () {
+        if (yes) {
+          for (;;) {
+            switch (0) {
+              default:
+                return f();
+            }
+          }
+        }
+      },
+      "in a catch block": async function* () {
+        try {
+          throw 0;
+        } catch {
+          return f();
+        }
+      },
+      "in a finally block": async function* () {
+        try {
+        } finally {
+          return f();
+        }
+      },
+      "after a yield": async function* () {
+        yield 1;
+        return f();
+      },
+      "in an object method": {
+        async *method() {
+          return f();
+        },
+      }.method,
+      "in a class method": new (class {
+        async *method() {
+          return f();
+        }
+      })().method,
+    };
+
+    test.each(Object.keys(shapes))("%s", async name => {
+      const generator = shapes[name]();
+      let result = await generator.next();
+      while (!result.done) result = await generator.next();
+      expect(result).toEqual({ value: 42, done: true });
+    });
+
+    test("a rejected promise rejects next()", async () => {
+      // The previous engine resolved next() with the rejected promise. Nothing
+      // handled that promise, so it was also reported as an unhandled rejection.
+      async function* generator() {
+        return Promise.reject(new Error("boom"));
+      }
+      await expect(generator().next()).rejects.toThrow("boom");
+    });
+  });
+
+  // The body keeps its frame, so the stack that `f` sees names the function
+  // that contains the `return f()`.
+  describe("`return f()` keeps the frame of the body", () => {
+    // The name of the function that called the function that called this one.
+    function callerName() {
+      const frame = new Error().stack!.split("\n")[2] ?? "no frame";
+      return /^\s*at (?:async )?(\S+) \(/.exec(frame)?.[1] ?? frame;
+    }
+
+    test("generator body", () => {
+      function* generatorBody() {
+        return callerName();
+      }
+      expect(generatorBody().next().value).toBe("generatorBody");
+    });
+
+    test("async function body", async () => {
+      async function asyncFunctionBody() {
+        await 0;
+        return callerName();
+      }
+      expect(await asyncFunctionBody()).toBe("asyncFunctionBody");
+    });
+
+    test("async generator body", async () => {
+      async function* asyncGeneratorBody() {
+        return callerName();
+      }
+      expect((await asyncGeneratorBody().next()).value).toBe("asyncGeneratorBody");
+    });
+
+    test("async arrow body", async () => {
+      // The body of an async arrow has no name. `frameCount() + 0` is not a
+      // tail call in either engine, so both bodies see the same number of frames.
+      const frameCount = () => new Error().stack!.split("\n").length;
+      const returnsCall = async () => {
+        await 0;
+        return frameCount();
+      };
+      const returnsSum = async () => {
+        await 0;
+        return frameCount() + 0;
+      };
+      expect(await returnsCall()).toBe(await returnsSum());
+    });
+
+    test("an error that an async function returns after an await has a stack", async () => {
+      // The runtime transpiler prints `new Error(m)` as `Error(m)`. As a tail
+      // call from a resumed body it ran with no JavaScript frame left on the
+      // stack, and `stack` was undefined.
+      async function loadUser(id: number) {
+        await 0;
+        return new Error("no user " + id);
+      }
+      expect((await loadUser(1)).stack).toContain("at loadUser (");
+    });
+
+    test("Error.captureStackTrace(error, helper) keeps the async caller of the helper", async () => {
+      function fail(message: string) {
+        const error = new Error(message);
+        Error.captureStackTrace(error, fail);
+        return error;
+      }
+      async function validate(input: unknown) {
+        if (!input) return fail("invalid");
+        await 0;
+      }
+      expect((await validate(0))!.stack).toContain("at validate (");
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- #42319 upgraded WebKit to `cf1b36ec8703` with no test for one behavior change. WebKit/WebKit#73407 stops generator, async function, async arrow and async generator bodies from emitting a tail call for `return f()`.
- Before the upgrade, an async generator skipped the await on `return f()`. `async function* g() { return Promise.resolve("x") }` gave `{ value: Promise { <resolved> }, done: true }` (#33185).
- The tail call also removed the body frame from `Error.stack`. An `Error` returned from an async function after an `await` had `stack === undefined`.

### Fix
- Add `test/js/bun/jsc/webkit-upgrade-cf1b36ec8703.test.ts`, in the form of the other `webkit-upgrade-*.test.ts` files. There is no source change.
- Block 1: an async generator returns a call in 19 shapes. Each `next()` must give `{ value: 42, done: true }`. A returned rejected promise must reject `next()`.
- Block 2: the stack must name the body for each of the four body kinds. Two user idioms are included: `return new Error()` after an `await`, and `Error.captureStackTrace(error, helper)`.
- Verified: 26 of 26 fail with bun `1.4.3-canary.1+4ff919377` (old engine). 26 of 26 pass with a debug build of main at 6a92015fc8.

### Background
- A tail call reuses the frame of the caller for the callee. JavaScriptCore does this for `return f()` in strict code, so the caller is not in the stack trace.
- The specification gives these four body kinds no tail position.
- In an async generator, `return x` awaits `x`. The tail call left the body before that await.

Closes #33185. #42319 fixed it. This PR adds the regression test.

<details><summary>Notes</summary>

Repro (save as `f.mjs`):

```js
const one = s => String(s).split("\n").map(x => x.trim()).join(" | ");
async function loadUser(id) { await 0; return new Error("no user " + id); }
console.log("1", one((await loadUser(1)).stack));
function fail(m) { const e = new Error(m); Error.captureStackTrace(e, fail); return e; }
async function validate(x) { if (!x) return fail("invalid"); await 0; }
console.log("2", one((await validate(0)).stack));
function* gen() { return mk(); } function mk() { const e = new Error("gen"); void e.stack; return e; }
console.log("3", one(gen().next().value.stack));
async function* ag() { return Promise.resolve("awaited"); }
console.log("4", await ag().next());
```

bun `1.4.3-canary.1+4ff919377` (old engine):

```
1 undefined
2 Error: invalid | at f.mjs:6:29
3 Error: gen | at mk (f.mjs:7:64) | at f.mjs:8:28
4 { value: Promise { <resolved> }, done: true }
```

Debug build of main at 6a92015fc8:

```
1 Error: no user 1 | at loadUser (f.mjs:2:51)
2 Error: invalid | at validate (f.mjs:5:45) | at f.mjs:6:29
3 Error: gen | at mk (f.mjs:7:64) | at gen (f.mjs:7:26) | at generatorResume (native:10:89) | at f.mjs:8:28
4 { value: "awaited", done: true }
```

`BUN_JSC_useTailCalls=0` on the old engine prints the new lines. Node v26 agrees with the new lines.

- An async function with no `await` in its body compiles to a plain function with a try/finally. `return f()` was never a tail call there. The async function cases have an `await` for this reason.
- The runtime transpiler prints `new Error(m)` as `Error(m)`. This is why case 1 was a tail call. It also folds `(0, f())` to `f()`, so the table has no comma shape. Checked with `Function.prototype.toString`.
- The body of an async arrow has no name in the stack. That case compares the frame count of `return f()` with the frame count of `return f() + 0`.
- Sync strict functions still make tail calls. The test does not pin that.
- The test asserts function names and frame counts only. It does not assert positions or builtin frames, which differ between debug and release builds.
- #42177 (closed, superseded by #42319) had one case for this change in `webkit-upgrade-ccdcb8a026.test.ts`. That file is not on main. #42267 still carries it.
- `prettier --check` and `tsc --noEmit` pass on the new file.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/webkit-upgrade-cf1b36ec8703.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/bun/jsc/webkit-upgrade-cf1b36ec8703.test.ts"
bun test v1.4.3 (4ff919377)

test/js/bun/jsc/webkit-upgrade-cf1b36ec8703.test.ts:
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > Promise.resolve(v) [18.25ms]
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > f() [7.61ms]
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > object.f() [6.03ms]
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > f?.() [5.77ms]
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > f(...[]) [5.88ms]
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > f.call() [6.12ms]
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > f.apply() [6.23ms]
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > a tagged template [7.88ms]
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > an async arrow call [8.66ms]
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > c ? f() : 0 [7.52ms]
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > a && f() [6.13ms]
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > a || f() [5.72ms]
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > a ?? f() [5.51ms]
(pass) WebKit cf1b36ec8703 upgrade > an async generator awaits the call it returns (oven-sh/bun#33185) > in nested statements [6.11ms]
(pass) Web
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../js/bun/jsc/webkit-upgrade-cf1b36ec8703.test.ts | 188 +++++++++++++++++++++
 1 file changed, 188 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
test/js/bun/jsc/webkit-upgrade-cf1b36ec8703.test.ts      1      3      6
```

</details>

<!-- robobun:evidence:end -->