### PR TITLE
tls: report a rejected send() as a write error instead of a clean close

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -117,6 +117,15 @@ struct loop_ssl_data {
   char *ssl_spill;
   unsigned int ssl_spill_len;
   unsigned int ssl_spill_off;
+
+  /* Set only while us_internal_ssl_write_check_error runs: the socket it
+   * writes to, and the platform error code of a raw send to that socket that
+   * the kernel rejected outright (the peer is gone). The raw sends of a TLS
+   * write run inside the write BIO and the batch/spill flushes, whose return
+   * values mean "bytes taken, 0 = the wire blocked" to BoringSSL and to the
+   * spill bookkeeping, so the code cannot travel up through them. */
+  struct us_socket_t *ssl_send_error_owner;
+  int ssl_send_error;
 };
 
 enum {
@@ -657,6 +666,14 @@ void us_internal_ssl_loop_state_restore(void **saved) {
   d->ssl_write_batching = (int)(uintptr_t)saved[5];
 }
 
+/* Send ciphertext for `s`. A send the kernel rejected outright still returns 0
+ * like a blocked wire. Its error code goes to the write that is in progress
+ * for `s`, if there is one (see ssl_send_error_owner). */
+static int ssl_raw_write(struct loop_ssl_data *loop_ssl_data, struct us_socket_t *s, const char *data, int length) {
+  return us_internal_socket_raw_write(s, data, length,
+                                      loop_ssl_data->ssl_send_error_owner == s ? &loop_ssl_data->ssl_send_error : NULL);
+}
+
 static int BIO_s_custom_write(BIO *bio, const char *data, int length) {
   struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)BIO_get_data(bio);
 
@@ -720,7 +737,7 @@ static int BIO_s_custom_write(BIO *bio, const char *data, int length) {
     BIO_clear_retry_flags(bio);
     return length;
   }
-  int written = us_socket_raw_write(loop_ssl_data->ssl_socket, data, length);
+  int written = ssl_raw_write(loop_ssl_data, loop_ssl_data->ssl_socket, data, length);
 
   BIO_clear_retry_flags(bio);
   if (!written) {
@@ -746,7 +763,7 @@ static int ssl_flush_write_batch(struct loop_ssl_data *loop_ssl_data, struct us_
   }
   loop_ssl_data->ssl_write_batch_len = 0;
   loop_ssl_data->ssl_write_batch_owner = NULL;
-  int written = us_socket_raw_write(s, loop_ssl_data->ssl_write_batch, (int)len);
+  int written = ssl_raw_write(loop_ssl_data, s, loop_ssl_data->ssl_write_batch, (int)len);
   if (written < 0) written = 0;
   if ((unsigned int)written < len) {
     unsigned int remainder = len - (unsigned int)written;
@@ -791,7 +808,7 @@ static void ssl_release_batch(struct us_loop_t *loop, struct us_socket_t *s) {
 static int ssl_drain_spill(struct loop_ssl_data *loop_ssl_data, struct us_socket_t *s) {
   if (loop_ssl_data->ssl_spill_owner != s) return 1;
   unsigned int pending = loop_ssl_data->ssl_spill_len - loop_ssl_data->ssl_spill_off;
-  int written = us_socket_raw_write(s, loop_ssl_data->ssl_spill + loop_ssl_data->ssl_spill_off, (int)pending);
+  int written = ssl_raw_write(loop_ssl_data, s, loop_ssl_data->ssl_spill + loop_ssl_data->ssl_spill_off, (int)pending);
   if (written < 0) written = 0;
   loop_ssl_data->ssl_spill_off += (unsigned int)written;
   if (loop_ssl_data->ssl_spill_off == loop_ssl_data->ssl_spill_len) {
@@ -805,21 +822,26 @@ static int ssl_drain_spill(struct loop_ssl_data *loop_ssl_data, struct us_socket
   return 0;
 }
 
+/* Free the spill slot if `s` owns it, without another attempt to send it. */
+static void ssl_discard_spill(struct loop_ssl_data *loop_ssl_data, struct us_socket_t *s) {
+  if (loop_ssl_data->ssl_spill_owner != s) return;
+  us_free(loop_ssl_data->ssl_spill);
+  loop_ssl_data->ssl_spill = NULL;
+  loop_ssl_data->ssl_spill_len = 0;
+  loop_ssl_data->ssl_spill_off = 0;
+  loop_ssl_data->ssl_spill_owner = NULL;
+}
+
 /* Release the spill slot when its owner dies (close path). */
 static void ssl_release_spill(struct us_loop_t *loop, struct us_socket_t *s) {
   struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)loop->data.ssl_data;
-  if (loop_ssl_data && loop_ssl_data->ssl_spill_owner == s) {
+  if (!loop_ssl_data) return;
+  if (loop_ssl_data->ssl_spill_owner == s) {
     /* Hard close with ciphertext still spilled: give the kernel one last
      * chance to take it (it usually can - the spill is bounded small). */
     ssl_drain_spill(loop_ssl_data, s);
   }
-  if (loop_ssl_data && loop_ssl_data->ssl_spill_owner == s) {
-    us_free(loop_ssl_data->ssl_spill);
-    loop_ssl_data->ssl_spill = NULL;
-    loop_ssl_data->ssl_spill_len = 0;
-    loop_ssl_data->ssl_spill_off = 0;
-    loop_ssl_data->ssl_spill_owner = NULL;
-  }
+  ssl_discard_spill(loop_ssl_data, s);
 }
 
 void us_internal_ssl_socket_relocated(struct us_loop_t *loop, struct us_socket_t *old_s,
@@ -2867,6 +2889,45 @@ int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
     }
   }
   return 0;
+}
+
+/* us_internal_ssl_write for a caller that wants to know when the kernel
+ * rejected one of the write's raw sends outright (us_socket_write_check_error).
+ * That send is the only report of the failure. SSL_write has already taken the
+ * plaintext, and on Linux the failed send() consumes the socket's pending
+ * error, so the read side sees a plain EOF afterwards. Without the report the
+ * caller counts the bytes as written and the connection ends as a clean close. */
+int us_internal_ssl_write_check_error(struct us_socket_t *s, const char *data, int length, int *fatal_write_error) {
+  struct us_loop_t *loop = s->group->loop;
+  struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)loop->data.ssl_data;
+  /* JS that runs from inside SSL_write (a keylog callback while the write
+   * drives the handshake) can write to another TLS socket on this loop. Keep
+   * the outer write's record across that nested call. */
+  struct us_socket_t *outer_owner = loop_ssl_data->ssl_send_error_owner;
+  int outer_send_error = loop_ssl_data->ssl_send_error;
+  loop_ssl_data->ssl_send_error_owner = s;
+  loop_ssl_data->ssl_send_error = 0;
+
+  int written = us_internal_ssl_write(s, data, length);
+
+  int send_error = loop_ssl_data->ssl_send_error;
+  loop_ssl_data->ssl_send_error_owner = outer_owner;
+  loop_ssl_data->ssl_send_error = outer_send_error;
+  /* Before the handshake has been reported, the handshake dispatch carries
+   * the failure and its reason. */
+  if (send_error && fatal_write_error && us_internal_ssl_handshake_callback_has_fired(s)) {
+    /* The writer is told that this write failed, so the records SSL_write
+     * sealed for it must not reach the peer later: a writer that retries
+     * (node:net keeps the chunk, the h2 parser keeps its frames) would put
+     * the same plaintext on the stream twice if the wire came back. Without
+     * them the stream has a gap, which the peer rejects: that fails the
+     * connection instead of corrupting it. A close that follows also has
+     * nothing undeliverable to wait for. */
+    ssl_release_batch(loop, s);
+    ssl_discard_spill(loop_ssl_data, s);
+    *fatal_write_error = send_error;
+  }
+  return written;
 }
 
 void us_internal_ssl_shutdown(struct us_socket_t *s) {

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -857,6 +857,9 @@ void us_internal_ssl_socket_relocated(struct us_loop_t *loop, struct us_socket_t
   if (loop_ssl_data->ssl_last_fatal_error_owner == (void *)old_s) {
     loop_ssl_data->ssl_last_fatal_error_owner = (void *)new_s;
   }
+  if (loop_ssl_data->ssl_send_error_owner == old_s) {
+    loop_ssl_data->ssl_send_error_owner = new_s;
+  }
 }
 
 static int BIO_s_custom_read(BIO *bio, char *dst, int length) {
@@ -2913,6 +2916,7 @@ int us_internal_ssl_write_check_error(struct us_socket_t *s, const char *data, i
   int send_error = loop_ssl_data->ssl_send_error;
   loop_ssl_data->ssl_send_error_owner = outer_owner;
   loop_ssl_data->ssl_send_error = outer_send_error;
+  s = us_internal_socket_follow_adopted(s);
   /* Before the handshake has been reported, the handshake dispatch carries
    * the failure and its reason. */
   if (send_error && fatal_write_error && us_internal_ssl_handshake_callback_has_fired(s)) {

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -244,6 +244,7 @@ int us_internal_ssl_handshake_callback_has_fired(us_socket_r s);
 int us_internal_ssl_is_shut_down(us_socket_r s);
 void us_internal_ssl_shutdown(us_socket_r s);
 int us_internal_ssl_write(us_socket_r s, const char *data, int length);
+int us_internal_ssl_write_check_error(us_socket_r s, const char *data, int length, int *fatal_write_error);
 unsigned int us_internal_ssl_spill_pending(us_socket_r s);
 void *us_internal_ssl_get_native_handle(us_socket_r s);
 struct us_bun_verify_error_t us_internal_ssl_verify_error(us_socket_r s);
@@ -255,6 +256,10 @@ void us_internal_ssl_ctx_up_ref(struct ssl_ctx_st *ssl_ctx);
 void us_internal_ssl_ctx_unref(struct ssl_ctx_st *ssl_ctx);
 /* TCP-level FIN, bypassing the SSL layer (used by ssl_on_end). */
 void us_internal_socket_raw_shutdown(us_socket_r s);
+/* us_socket_raw_write that also classifies a failed send(). When the kernel
+ * rejected the send outright, *fatal_send_error (may be NULL) receives the
+ * platform error code. The return value is the same either way. */
+int us_internal_socket_raw_write(us_socket_r s, const char *data, int length, int *fatal_send_error);
 
 int us_internal_handle_dns_results(us_loop_r loop);
 

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -657,8 +657,8 @@ int us_socket_raw_writev(us_socket_r s, const struct us_iovec_t *iov, int count)
 int us_socket_raw_write(us_socket_r s, const char *data, int length);
 /* Like us_socket_write, but additionally reports a fatal (non-would-block)
  * send error through *fatal_write_error so opted-in callers can fail the
- * write instead of retrying forever. TLS sockets fall back to
- * us_socket_write (their errors propagate through the SSL layer). */
+ * write instead of retrying forever. For a TLS socket that is a raw send of
+ * the write's ciphertext, once the handshake has been reported. */
 int us_socket_write_check_error(us_socket_r s, const char *data, int length, int *fatal_write_error);
 
 void us_socket_timeout(us_socket_r s, unsigned int seconds) nonnull_fn_decl;

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -545,6 +545,56 @@ static int us_internal_send_errno_is_peer_gone(int e) {
 #define US_UNCLASSIFIED_SEND_RETRY_LIMIT 32
 #endif
 
+/* Classify the failure of a send() that just returned < 0 on `s`. Returns 0
+ * when the write is to be retried from a writable event, or the platform
+ * error code (errno on POSIX, a WSA code on Windows) when no retry can
+ * succeed. */
+static int us_internal_classify_failed_send(struct us_socket_t *s) {
+    /* bsd_send already retries EINTR; bsd_would_block() reads errno on
+     * POSIX and WSAGetLastError() on Windows. ENOBUFS/ENOMEM are
+     * transient kernel resource exhaustion on a healthy connection -
+     * classifying them as fatal made the node:net drain path drop the
+     * buffered bytes on a socket that kept flowing. */
+    if (bsd_would_block() || bsd_send_is_transient_error()) {
+        return 0;
+    }
+#ifndef _WIN32
+    /* Anything else that is not a known peer-gone errno gets a BOUNDED
+     * retry through the same rearm/writable machinery as would-block.
+     * Kernels return racy, non-terminal errnos from send() on sockets
+     * that are still perfectly usable - macOS EPROTOTYPE while the
+     * connection is concurrently mutating is the canonical case, and
+     * libuv retries it (RETRY_ON_WRITE_ERROR,
+     * https://github.com/libuv/libuv/blob/v1.x/src/unix/stream.c) -
+     * so failing the write on first sight killed live connections.
+     * But the retry must not be unbounded: an errno that persists across
+     * many consecutive writable dispatches with no successful send in
+     * between means the transport is dead in a way the kernel will not
+     * name on the write side, and silently re-arming forever jams the
+     * connection (buffered bytes never drain and no error ever
+     * surfaces). After the limit, report the errno like the peer-gone
+     * class so the caller can fail the write. */
+    if (!us_internal_send_errno_is_peer_gone(errno) &&
+        s->unclassified_send_failures < US_UNCLASSIFIED_SEND_RETRY_LIMIT) {
+        s->unclassified_send_failures++;
+        return 0;
+    }
+    return errno;
+#else
+    /* Windows: report the raw (positive) WSA code. The JS layer already
+     * traffics in raw negative WSA values on this platform (see
+     * SocketEmitEndNT / failWrite, which shape unnameable ones as
+     * ECONNRESET), and a real code keeps fatal sends distinguishable from
+     * the legacy -1 closed/shutdown sentinel so the h2 parser can latch
+     * them (flood tests hung on Windows because a fatal send looked like
+     * backpressure). Keep 1 as the floor for a zero/garbage WSA value.
+     * See a5e7ba5905 before widening what counts as fatal
+     * (drain-into-RST on test-http-no-content-length). */
+    int wsa_send_error = WSAGetLastError();
+    return wsa_send_error > 1 ? wsa_send_error : 1;
+#endif
+}
+
 int us_socket_write_check_error(struct us_socket_t *s, const char *data, int length, int *fatal_write_error) {
     if (fatal_write_error) *fatal_write_error = 0;
     if (us_socket_is_closed(s) || us_socket_is_shut_down(s)) {
@@ -557,57 +607,15 @@ int us_socket_write_check_error(struct us_socket_t *s, const char *data, int len
 
     int written = bsd_send(us_poll_fd(&s->p), data, length);
     if (written < 0) {
-        /* bsd_send already retries EINTR; bsd_would_block() reads errno on
-         * POSIX and WSAGetLastError() on Windows. ENOBUFS/ENOMEM are
-         * transient kernel resource exhaustion on a healthy connection -
-         * classifying them as fatal made the node:net drain path drop the
-         * buffered bytes on a socket that kept flowing. */
-        if (bsd_would_block() || bsd_send_is_transient_error()) {
+        int fatal_send_error = us_internal_classify_failed_send(s);
+        if (!fatal_send_error) {
             s->flags.last_write_failed = 1;
             us_internal_rearm_writable(s);
             return 0;
         }
-#ifndef _WIN32
-        /* Anything else that is not a known peer-gone errno gets a BOUNDED
-         * retry through the same rearm/writable machinery as would-block.
-         * Kernels return racy, non-terminal errnos from send() on sockets
-         * that are still perfectly usable - macOS EPROTOTYPE while the
-         * connection is concurrently mutating is the canonical case, and
-         * libuv retries it (RETRY_ON_WRITE_ERROR,
-         * https://github.com/libuv/libuv/blob/v1.x/src/unix/stream.c) -
-         * so failing the write on first sight killed live connections.
-         * But the retry must not be unbounded: an errno that persists across
-         * many consecutive writable dispatches with no successful send in
-         * between means the transport is dead in a way the kernel will not
-         * name on the write side, and silently re-arming forever jams the
-         * connection (buffered bytes never drain and no error ever
-         * surfaces). After the limit, report the errno like the peer-gone
-         * class so the caller can fail the write. */
-        if (!us_internal_send_errno_is_peer_gone(errno) &&
-            s->unclassified_send_failures < US_UNCLASSIFIED_SEND_RETRY_LIMIT) {
-            s->unclassified_send_failures++;
-            s->flags.last_write_failed = 1;
-            us_internal_rearm_writable(s);
-            return 0;
-        }
-        /* Fatal send error: report the errno to callers that opt in and stop
+        /* Fatal send error: report the code to callers that opt in and stop
          * polling writable - retrying can never succeed. */
-        if (fatal_write_error) *fatal_write_error = errno;
-#else
-        /* Windows: report the raw (positive) WSA code. The JS layer already
-         * traffics in raw negative WSA values on this platform (see
-         * SocketEmitEndNT / failWrite, which shape unnameable ones as
-         * ECONNRESET), and a real code keeps fatal sends distinguishable from
-         * the legacy -1 closed/shutdown sentinel so the h2 parser can latch
-         * them (flood tests hung on Windows because a fatal send looked like
-         * backpressure). Keep 1 as the floor for a zero/garbage WSA value.
-         * See a5e7ba5905 before widening what counts as fatal
-         * (drain-into-RST on test-http-no-content-length). */
-        if (fatal_write_error) {
-            int wsa_send_error = WSAGetLastError();
-            *fatal_write_error = wsa_send_error > 1 ? wsa_send_error : 1;
-        }
-#endif
+        if (fatal_write_error) *fatal_write_error = fatal_send_error;
         return 0;
     }
     s->unclassified_send_failures = 0;

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -601,8 +601,9 @@ int us_socket_write_check_error(struct us_socket_t *s, const char *data, int len
         return 0;
     }
     if (s->ssl) {
-        /* TLS writes have their own error propagation; keep the existing path. */
-        return us_socket_write(s, data, length);
+        /* The raw sends of a TLS write happen inside the SSL layer, which
+         * reports a fatal one through the same out-parameter. */
+        return us_internal_ssl_write_check_error(s, data, length, fatal_write_error);
     }
 
     int written = bsd_send(us_poll_fd(&s->p), data, length);
@@ -644,7 +645,7 @@ int us_socket_raw_writev(struct us_socket_t *s, const struct us_iovec_t *iov, in
     return written < 0 ? 0 : (int)written;
 }
 
-int us_socket_raw_write(struct us_socket_t *s, const char *data, int length) {
+int us_internal_socket_raw_write(struct us_socket_t *s, const char *data, int length, int *fatal_send_error) {
     /* Bypass-TLS path: openssl.c uses this to flush close_notify *after*
      * SSL_shutdown() has marked the SSL layer shut down, so checking
      * us_socket_is_shut_down() here would deadlock the alert in userspace.
@@ -655,12 +656,24 @@ int us_socket_raw_write(struct us_socket_t *s, const char *data, int length) {
     }
 
     int written = bsd_send(us_poll_fd(&s->p), data, length);
+    if (written < 0) {
+        if (fatal_send_error) {
+            int send_error = us_internal_classify_failed_send(s);
+            if (send_error) *fatal_send_error = send_error;
+        }
+    } else {
+        s->unclassified_send_failures = 0;
+    }
     if (written != length) {
         s->flags.last_write_failed = 1;
         us_internal_rearm_writable(s);
     }
 
     return written < 0 ? 0 : written;
+}
+
+int us_socket_raw_write(struct us_socket_t *s, const char *data, int length) {
+    return us_internal_socket_raw_write(s, data, length, NULL);
 }
 
 #if !defined(_WIN32)

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3291,9 +3291,15 @@ pub(crate) trait NativeSocketWrite {
 }
 impl NativeSocketWrite for &TLSSocket {
     fn write_maybe_corked(&mut self, buf: &[u8]) -> i32 {
-        // Forward to the inherent NewSocket<true>::write_maybe_corked (R-2: now
-        // takes `&self`). UFCS to avoid resolving back to this trait impl.
-        TLSSocket::write_maybe_corked(*self, buf)
+        // A TLS transport keeps a send the kernel rejected as backpressure. The
+        // parser's reaction to a fatal write is to close the transport on its
+        // deferred tick (`close_transport_after_fatal_write`), and over TLS
+        // that would discard what the peer sent before it went away: a
+        // complete response that is still in the receive buffer. The read side
+        // delivers it, and then its EOF or error ends the session, which is
+        // also what node does (its http2 session does not act on a failed
+        // write). UFCS to avoid resolving back to this trait impl.
+        TLSSocket::write_maybe_corked_without_fatal_report(*self, buf)
     }
 }
 impl NativeSocketWrite for &TCPSocket {

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3291,14 +3291,7 @@ pub(crate) trait NativeSocketWrite {
 }
 impl NativeSocketWrite for &TLSSocket {
     fn write_maybe_corked(&mut self, buf: &[u8]) -> i32 {
-        // A TLS transport keeps a send the kernel rejected as backpressure. The
-        // parser's reaction to a fatal write is to close the transport on its
-        // deferred tick (`close_transport_after_fatal_write`), and over TLS
-        // that would discard what the peer sent before it went away: a
-        // complete response that is still in the receive buffer. The read side
-        // delivers it, and then its EOF or error ends the session, which is
-        // also what node does (its http2 session does not act on a failed
-        // write). UFCS to avoid resolving back to this trait impl.
+        // No fatal-send report: the parser's immediate close would drop unread peer data.
         TLSSocket::write_maybe_corked_without_fatal_report(*self, buf)
     }
 }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2945,7 +2945,7 @@ impl H2FrameParser {
     /// produced them owns the lifecycle. Latch the fatal and let the deferred tick
     /// close the transport - the failing write can be deep inside frame emission, so
     /// the close must not run under the caller's stack.
-    /// Errno classification lives in `us_socket_write_check_error` (socket.c):
+    /// Errno classification lives in `us_internal_classify_failed_send` (socket.c):
     /// would-block/transient errnos re-arm writable and are never reported
     /// here, known peer-gone errnos are reported immediately, and every other
     /// errno gets a bounded retry window through the same rearm machinery

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2387,9 +2387,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         Ok(
             match this.write_or_end::<false>(global, args.mut_(), false) {
                 WriteResult::Fail => JSValue::ZERO,
-                // `wrote < -1` is the errno of a fatal send, which only the
-                // node:net path (`write_buffered`) hands to JS. This API
-                // documents -1 for a socket that cannot be written to.
+                // A fatal send's errno (< -1) is for node:net only. This API documents -1.
                 WriteResult::Success { wrote, .. } => JSValue::js_number_from_int32(wrote.max(-1)),
             },
         )
@@ -2542,12 +2540,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         self.write_maybe_corked_impl::<true>(buffer)
     }
 
-    /// `write_maybe_corked` that keeps a send the kernel rejected as
-    /// backpressure (0 bytes now, retried from the writable event) instead of
-    /// returning its errno. For a writer whose only reaction to the errno is
-    /// to close the transport at once, when the connection has to end through
-    /// its read side instead: that delivers what the peer sent before it went
-    /// away, and then reports the EOF or the error.
+    /// Like `write_maybe_corked`, but a send the kernel rejected stays backpressure (no errno).
     pub(crate) fn write_maybe_corked_without_fatal_report(&self, buffer: &[u8]) -> i32 {
         self.write_maybe_corked_impl::<false>(buffer)
     }

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2387,7 +2387,10 @@ impl<const SSL: bool> NewSocket<SSL> {
         Ok(
             match this.write_or_end::<false>(global, args.mut_(), false) {
                 WriteResult::Fail => JSValue::ZERO,
-                WriteResult::Success { wrote, .. } => JSValue::js_number_from_int32(wrote),
+                // `wrote < -1` is the errno of a fatal send, which only the
+                // node:net path (`write_buffered`) hands to JS. This API
+                // documents -1 for a socket that cannot be written to.
+                WriteResult::Success { wrote, .. } => JSValue::js_number_from_int32(wrote.max(-1)),
             },
         )
     }
@@ -2536,6 +2539,20 @@ impl<const SSL: bool> NewSocket<SSL> {
     }
 
     pub(crate) fn write_maybe_corked(&self, buffer: &[u8]) -> i32 {
+        self.write_maybe_corked_impl::<true>(buffer)
+    }
+
+    /// `write_maybe_corked` that keeps a send the kernel rejected as
+    /// backpressure (0 bytes now, retried from the writable event) instead of
+    /// returning its errno. For a writer whose only reaction to the errno is
+    /// to close the transport at once, when the connection has to end through
+    /// its read side instead: that delivers what the peer sent before it went
+    /// away, and then reports the EOF or the error.
+    pub(crate) fn write_maybe_corked_without_fatal_report(&self, buffer: &[u8]) -> i32 {
+        self.write_maybe_corked_impl::<false>(buffer)
+    }
+
+    fn write_maybe_corked_impl<const REPORT_FATAL_SEND: bool>(&self, buffer: &[u8]) -> i32 {
         let socket = self.socket.get();
         if socket.is_shutdown() || socket.is_closed() {
             return -1;
@@ -2547,8 +2564,7 @@ impl<const SSL: bool> NewSocket<SSL> {
 
         // The raw [raw, tls] upgrade twin shares the TLS half's us_socket_t
         // (`s->ssl` is set) but must write raw bytes: write_check_error would
-        // route it through the SSL-encrypting us_socket_write, and its fatal
-        // signal is never set for TLS sockets anyway.
+        // route it through the SSL-encrypting write.
         if flags.contains(Flags::BYPASS_TLS) {
             let res = self.do_socket_write(buffer);
             let uwrote: usize = usize::try_from(res.max(0)).expect("int cast");
@@ -2558,7 +2574,11 @@ impl<const SSL: bool> NewSocket<SSL> {
             return res;
         }
 
-        let (res, fatal_errno) = socket.write_check_error(buffer);
+        let (res, fatal_errno) = if REPORT_FATAL_SEND {
+            socket.write_check_error(buffer)
+        } else {
+            (socket.write(buffer), 0)
+        };
         if fatal_errno != 0 {
             // Kernel rejected the send (peer gone): return the negative errno so
             // JS fails the write; never close from under the caller's stack, and
@@ -3053,8 +3073,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             // the initial write does: once the peer is gone the kernel rejects
             // every retry (EPIPE/ECONNRESET), and treating that as would-block
             // kept this buffer parked forever (the FIN-terminated-response hang).
-            // BYPASS_TLS twins keep the raw write path; TLS errors propagate
-            // through the SSL layer.
+            // BYPASS_TLS twins keep the raw write path.
             let res: i32 = if self.flags.get().contains(Flags::BYPASS_TLS) {
                 self.do_socket_write(self.buffered_data_for_node_net.get().slice())
             } else {
@@ -3238,7 +3257,7 @@ impl<const SSL: bool> NewSocket<SSL> {
                 if wrote >= 0 && usize::try_from(wrote).expect("int cast") == total {
                     let _ = this.internal_flush();
                 }
-                JSValue::js_number(wrote as f64)
+                JSValue::js_number(f64::from(wrote.max(-1)))
             }
         };
         Ok(result)

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -255,9 +255,10 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
 
     // ── state queries ───────────────────────────────────────────────────────
 
-    /// Raw-TCP write that also reports a fatal send error as the positive
-    /// errno of the failed `send()` (0 = none); non-Connected and TLS-wrapped
-    /// sockets fall back to the plain write (no fatal signal).
+    /// Write that also reports a fatal send error as the positive errno of
+    /// the failed `send()` (0 = none). Sockets that are not connected native
+    /// sockets (a duplex, a pipe) fall back to the plain write (no fatal
+    /// signal).
     pub fn write_check_error(&self, data: &[u8]) -> (i32, i32) {
         on_socket!(self.socket;
             connected s => s.write_check_error(data),

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -255,10 +255,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
 
     // ── state queries ───────────────────────────────────────────────────────
 
-    /// Write that also reports a fatal send error as the positive errno of
-    /// the failed `send()` (0 = none). Sockets that are not connected native
-    /// sockets (a duplex, a pipe) fall back to the plain write (no fatal
-    /// signal).
+    /// Write that also returns the errno of a fatal send (0 = none, always 0 for a duplex or pipe).
     pub fn write_check_error(&self, data: &[u8]) -> (i32, i32) {
         on_socket!(self.socket;
             connected s => s.write_check_error(data),

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4783,6 +4783,7 @@ describe.concurrent("write() that is the first to observe the peer's reset retur
       stdout: "pipe",
       stderr: "pipe",
     });
+    const stderrText = proc.stderr.text();
     let stdout = "";
     let reset = false;
     for await (const chunk of proc.stdout) {
@@ -4795,7 +4796,7 @@ describe.concurrent("write() that is the first to observe the peer's reset retur
         await Bun.write(resetDoneFile, "");
       }
     }
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stderr, exitCode] = await Promise.all([stderrText, proc.exited]);
     const lines = stdout.trim().split("\n");
     // Debug builds may write benign diagnostics to stderr, so it is only shown
     // when the fixture failed.

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4744,6 +4744,15 @@ describe.concurrent("write() that is the first to observe the peer's reset retur
     const script = `
       const fs = require("node:fs");
       const writes = [];
+      let reported = false;
+      function report(closed) {
+        if (reported) return;
+        reported = true;
+        fs.writeSync(1, JSON.stringify({ writes, closed }) + "\\n");
+        process.exit(0);
+      }
+      // Report whatever happened if close() never runs.
+      setTimeout(report, 20000, false);
       Bun.connect({
         hostname: "127.0.0.1",
         port: Number(process.env.PEER_PORT),
@@ -4762,8 +4771,7 @@ describe.concurrent("write() that is the first to observe the peer's reset retur
           },
           error() {},
           close() {
-            fs.writeSync(1, JSON.stringify({ writes }) + "\\n");
-            process.exit(0);
+            report(true);
           },
         },
       });
@@ -4795,7 +4803,7 @@ describe.concurrent("write() that is the first to observe the peer's reset retur
       reset,
       result: JSON.parse(lines[lines.length - 1]),
       failureDetail: exitCode === 0 ? "" : stderr,
-    }).toEqual({ reset: true, result: { writes: [-1, -1] }, failureDetail: "" });
+    }).toEqual({ reset: true, result: { writes: [-1, -1], closed: true }, failureDetail: "" });
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4706,3 +4706,96 @@ it("concurrent end() on two allowHalfOpen TLS peers closes both sockets", async 
 
   await Promise.all([serverClosed.promise, clientClosed.promise]);
 });
+
+// The peer resets the connection while the client's loop is blocked, so the
+// client's write() is the first operation that observes the reset and the
+// kernel rejects its send(). write() documents -1 for a socket that cannot be
+// written to. A TLS socket used to count the dropped bytes as written (it
+// returned their length), and the errno of the failed send, which only the
+// node:net write path hands to JS, leaked out of a plain TCP socket as a raw
+// negative number (-104).
+describe.concurrent("write() that is the first to observe the peer's reset returns -1", () => {
+  it.each([["tcp"], ["tls"]])("%s", async kind => {
+    using dir = tempDir("socket-write-sees-reset", {});
+    const resetDoneFile = join(String(dir), "reset-done");
+
+    const opened = Promise.withResolvers<Socket>();
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls: kind === "tls" ? { key: tls.key, cert: tls.cert } : undefined,
+      socket: {
+        open(s) {
+          if (kind === "tcp") {
+            s.write("hello");
+            opened.resolve(s);
+          }
+        },
+        handshake(s) {
+          s.write("hello");
+          opened.resolve(s);
+        },
+        data() {},
+        error() {},
+        close() {},
+      },
+    });
+
+    const script = `
+      const fs = require("node:fs");
+      const writes = [];
+      Bun.connect({
+        hostname: "127.0.0.1",
+        port: Number(process.env.PEER_PORT),
+        tls: process.env.PEER_KIND === "tls" ? { rejectUnauthorized: false } : undefined,
+        socket: {
+          data(socket) {
+            // Block the loop until the parent has reset the connection.
+            // Nothing is polled in between, so write() meets the reset first.
+            fs.writeSync(1, "busy\\n");
+            const cell = new Int32Array(new SharedArrayBuffer(4));
+            const deadline = Date.now() + 30000;
+            while (!fs.existsSync(process.env.RESET_DONE_FILE) && Date.now() < deadline) {
+              Atomics.wait(cell, 0, 0, 5);
+            }
+            writes.push(socket.write("ping"), socket.write("ping"));
+          },
+          error() {},
+          close() {
+            fs.writeSync(1, JSON.stringify({ writes }) + "\\n");
+            process.exit(0);
+          },
+        },
+      });
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, PEER_PORT: String(server.port), PEER_KIND: kind, RESET_DONE_FILE: resetDoneFile },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    let stdout = "";
+    let reset = false;
+    for await (const chunk of proc.stdout) {
+      stdout += Buffer.from(chunk).toString();
+      if (!reset && stdout.includes("busy\n")) {
+        reset = true;
+        // terminate() closes the fd with SO_LINGER 0, so the RST is on the wire
+        // when it returns.
+        (await opened.promise).terminate();
+        await Bun.write(resetDoneFile, "");
+      }
+    }
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const lines = stdout.trim().split("\n");
+    // Debug builds may write benign diagnostics to stderr, so it is only shown
+    // when the fixture failed.
+    expect({
+      reset,
+      result: JSON.parse(lines[lines.length - 1]),
+      failureDetail: exitCode === 0 ? "" : stderr,
+    }).toEqual({ reset: true, result: { writes: [-1, -1] }, failureDetail: "" });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6407,6 +6407,7 @@ it("a session over TLS whose peer reset is first seen by a write ends without a 
       stdout: "pipe",
       stderr: "pipe",
     });
+    const stderrText = proc.stderr.text();
     let stdout = "";
     let reset = false;
     for await (const chunk of proc.stdout) {
@@ -6419,7 +6420,7 @@ it("a session over TLS whose peer reset is first seen by a write ends without a 
         fs.writeFileSync(resetDoneFile, "");
       }
     }
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stderr, exitCode] = await Promise.all([stderrText, proc.exited]);
     const lines = stdout.trim().split("\n");
     const state = JSON.parse(lines[lines.length - 1]);
     // Debug builds may write benign diagnostics to stderr, so it is only shown

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6333,14 +6333,15 @@ describe("frames issued from inside a user-supplied Duplex transport's _write", 
 it("a session over TLS whose peer reset is first seen by a write ends without a hang", async () => {
   // An idle connected https session whose peer resets the connection while the
   // client's event loop is blocked: the HEADERS write of the next request() is
-  // the first operation that observes the reset, and its send() fails. The TLS
-  // transport reports that failed send to the frame parser, as a plain TCP
-  // transport does. How the reset then reaches JS differs by kernel, in Node as
-  // well: on Linux the failed send() consumes the socket's pending error, the
-  // read side sees a plain EOF, and the request ends clean (rstCode 8); on
-  // Windows the reset stays readable and both the stream and the session get
-  // ECONNRESET. So this asserts what holds everywhere: the stream and the
-  // session both close, no response appears, and any error is the reset.
+  // the first operation that observes the reset, and its send() fails. Over TLS
+  // the frame parser is not told about that failed send (it keeps it as
+  // backpressure), so the reset reaches JS through the read side. How it looks
+  // there differs by kernel, in Node as well: on Linux the failed send()
+  // consumes the socket's pending error, the read side sees a plain EOF, and
+  // the request ends clean (rstCode 8); on Windows the reset stays readable and
+  // both the stream and the session get ECONNRESET. So this asserts what holds
+  // everywhere: the stream and the session both close, no response appears,
+  // and any error is the reset.
   using dir = tempDir("h2-tls-write-sees-reset", {});
   const resetDoneFile = path.join(String(dir), "reset-done");
   const fixture = `

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1,5 +1,5 @@
 import { jscDescribe } from "bun:jsc";
-import { bunEnv, bunExe, isASAN, isCI, isDebug, nodeExe } from "harness";
+import { bunEnv, bunExe, isASAN, isCI, isDebug, nodeExe, tempDir } from "harness";
 import { createTest } from "node-harness";
 import { AsyncLocalStorage } from "node:async_hooks";
 import dc from "node:diagnostics_channel";
@@ -6328,4 +6328,118 @@ describe("frames issued from inside a user-supplied Duplex transport's _write", 
       }
     },
   );
+});
+
+it("a session over TLS whose peer reset is first seen by a write ends without a hang", async () => {
+  // An idle connected https session whose peer resets the connection while the
+  // client's event loop is blocked: the HEADERS write of the next request() is
+  // the first operation that observes the reset, and its send() fails. The TLS
+  // transport reports that failed send to the frame parser, as a plain TCP
+  // transport does. How the reset then reaches JS differs by kernel, in Node as
+  // well: on Linux the failed send() consumes the socket's pending error, the
+  // read side sees a plain EOF, and the request ends clean (rstCode 8); on
+  // Windows the reset stays readable and both the stream and the session get
+  // ECONNRESET. So this asserts what holds everywhere: the stream and the
+  // session both close, no response appears, and any error is the reset.
+  using dir = tempDir("h2-tls-write-sees-reset", {});
+  const resetDoneFile = path.join(String(dir), "reset-done");
+  const fixture = `
+    const http2 = require("node:http2");
+    const fs = require("node:fs");
+    const state = { requested: false, sawResponse: false, streamClosed: false, sessionClosed: false, errors: [] };
+    let reported = false;
+    function report() {
+      if (reported) return;
+      reported = true;
+      fs.writeSync(1, JSON.stringify(state) + "\\n");
+      process.exit(0);
+    }
+    function closed() {
+      if (state.streamClosed && state.sessionClosed) report();
+    }
+    const session = http2.connect("https://127.0.0.1:" + process.env.H2_PEER_PORT, { rejectUnauthorized: false });
+    session.on("error", err => state.errors.push(err.code));
+    session.on("close", () => {
+      state.sessionClosed = true;
+      closed();
+    });
+    session.on("remoteSettings", () => {
+      // Block the loop until the parent has reset the connection. Nothing is
+      // polled in between, so the request's write meets the reset first.
+      fs.writeSync(1, "busy\\n");
+      const cell = new Int32Array(new SharedArrayBuffer(4));
+      const deadline = Date.now() + 30000;
+      while (!fs.existsSync(process.env.RESET_DONE_FILE) && Date.now() < deadline) {
+        Atomics.wait(cell, 0, 0, 5);
+      }
+      const req = session.request({ ":path": "/" });
+      state.requested = true;
+      req.on("response", () => (state.sawResponse = true));
+      req.on("error", err => state.errors.push(err.code));
+      req.on("close", () => {
+        state.streamClosed = true;
+        closed();
+      });
+      req.resume();
+      req.end();
+    });
+    // Report whatever happened if the teardown never completes.
+    setTimeout(report, 20000);
+  `;
+  const frame = (type, flags) => Buffer.from([0, 0, 0, type, flags, 0, 0, 0, 0]);
+  // The raw TCP socket under the server's TLSSocket: resetting it sends the RST
+  // with no TLS alert in front of it.
+  let raw = null;
+  const server = tls.createServer({ ...TLS_CERT, ALPNProtocols: ["h2"] }, socket => {
+    socket.on("error", () => {});
+    socket.write(frame(4, 0)); // empty SETTINGS
+    socket.once("data", () => socket.write(frame(4, 1))); // ACK the client's SETTINGS
+  });
+  server.on("connection", socket => {
+    raw = socket;
+    socket.on("error", () => {});
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  try {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, H2_PEER_PORT: String(server.address().port), RESET_DONE_FILE: resetDoneFile },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    let stdout = "";
+    let reset = false;
+    for await (const chunk of proc.stdout) {
+      stdout += Buffer.from(chunk).toString();
+      if (!reset && stdout.includes("busy\n")) {
+        reset = true;
+        const rawClosed = new Promise(resolve => raw.once("close", resolve));
+        raw.resetAndDestroy();
+        await rawClosed;
+        fs.writeFileSync(resetDoneFile, "");
+      }
+    }
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const lines = stdout.trim().split("\n");
+    const state = JSON.parse(lines[lines.length - 1]);
+    // Debug builds may write benign diagnostics to stderr, so it is only shown
+    // when the fixture failed.
+    expect({
+      reset,
+      ...state,
+      errors: state.errors.filter(code => code !== "ECONNRESET" && code !== "EPIPE"),
+      failureDetail: exitCode === 0 ? "" : stderr,
+    }).toEqual({
+      reset: true,
+      requested: true,
+      sawResponse: false,
+      streamClosed: true,
+      sessionClosed: true,
+      errors: [],
+      failureDetail: "",
+    });
+    expect(exitCode).toBe(0);
+  } finally {
+    server.close();
+  }
 });

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1993,3 +1993,123 @@ describe.each([
     });
   });
 });
+
+// The peer resets the connection while the client's event loop is blocked, so
+// the client's next write is the first operation that observes the reset. On
+// Linux that send() returns ECONNRESET and consumes the socket's pending error,
+// so the read side only ever sees a plain EOF afterwards: the failed send is the
+// one report of the reset. The TLS write path dropped its errno and the socket
+// ended as a clean close (no write error, 'end', 'close' with hadError false).
+// Node fails the write: the callback and 'error' get `write ECONNRESET` (EPIPE
+// on BSD kernels), then 'close' with hadError true. Verified against node
+// v26.3.0 on Linux and Windows, for both ways to connect.
+describe.concurrent("a write that is the first to observe the peer's reset fails with a write error", () => {
+  it.each([
+    ["tls.connect({ port })", "0"],
+    ["tls.connect({ socket })", "1"],
+  ])("%s", async (_name, overSocket) => {
+    using dir = tempDir("tls-write-sees-reset", {});
+    const resetDoneFile = join(String(dir), "reset-done");
+
+    // The raw TCP socket under the server's TLSSocket: resetting it sends the
+    // RST with no TLS alert in front of it.
+    let raw: net.Socket | undefined;
+    const server = tls.createServer({ key: COMMON_CERT_.key, cert: COMMON_CERT_.cert }, socket => {
+      socket.on("error", () => {});
+      socket.write("hello");
+    });
+    server.on("connection", socket => {
+      raw = socket;
+      socket.on("error", () => {});
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+
+    const script = `
+      const tlsMod = require("node:tls");
+      const netMod = require("node:net");
+      const fs = require("node:fs");
+      const port = Number(process.env.TLS_PEER_PORT);
+      const events = [];
+      let write;
+      function run(socket) {
+        socket.on("error", function onError(err) {
+          events.push("error:" + err.code + ":" + err.syscall);
+        });
+        socket.on("end", function onEnd() {
+          events.push("end");
+        });
+        socket.on("close", function onClose(hadError) {
+          fs.writeSync(1, JSON.stringify({ write, events, hadError }) + "\\n");
+          process.exit(0);
+        });
+        socket.once("data", function onData() {
+          // Block the loop until the parent has reset the connection. Nothing
+          // is polled in between, so the write below meets the reset first.
+          fs.writeSync(1, "busy\\n");
+          const cell = new Int32Array(new SharedArrayBuffer(4));
+          const deadline = Date.now() + 30000;
+          while (!fs.existsSync(process.env.RESET_DONE_FILE) && Date.now() < deadline) {
+            Atomics.wait(cell, 0, 0, 5);
+          }
+          socket.write("ping", function onWritten(err) {
+            write = err ? { code: err.code, syscall: err.syscall } : "ok";
+          });
+        });
+      }
+      if (process.env.TLS_OVER_SOCKET === "1") {
+        const transport = netMod.connect({ port, host: "127.0.0.1" }, function onConnect() {
+          run(tlsMod.connect({ socket: transport, rejectUnauthorized: false }));
+        });
+      } else {
+        run(tlsMod.connect({ port, host: "127.0.0.1", rejectUnauthorized: false }));
+      }
+    `;
+
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: {
+          ...bunEnv,
+          TLS_PEER_PORT: String((server.address() as AddressInfo).port),
+          TLS_OVER_SOCKET: overSocket,
+          RESET_DONE_FILE: resetDoneFile,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      let stdout = "";
+      let reset = false;
+      for await (const chunk of proc.stdout) {
+        stdout += Buffer.from(chunk).toString();
+        if (!reset && stdout.includes("busy\n")) {
+          reset = true;
+          const rawClosed = once(raw!, "close");
+          raw!.resetAndDestroy();
+          await rawClosed;
+          await Bun.write(resetDoneFile, "");
+        }
+      }
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const lines = stdout.trim().split("\n");
+      // Debug builds may write benign diagnostics to stderr, so it is only
+      // shown when the fixture failed.
+      expect({
+        reset,
+        result: JSON.parse(lines[lines.length - 1]),
+        failureDetail: exitCode === 0 ? "" : stderr,
+      }).toEqual({
+        reset: true,
+        result: {
+          write: { code: expect.stringMatching(/^(ECONNRESET|EPIPE)$/), syscall: "write" },
+          events: [expect.stringMatching(/^error:(ECONNRESET|EPIPE):write$/)],
+          hadError: true,
+        },
+        failureDetail: "",
+      });
+      expect(exitCode).toBe(0);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -2032,6 +2032,15 @@ describe.concurrent("a write that is the first to observe the peer's reset fails
       const port = Number(process.env.TLS_PEER_PORT);
       const events = [];
       let write;
+      let reported = false;
+      function report(hadError) {
+        if (reported) return;
+        reported = true;
+        fs.writeSync(1, JSON.stringify({ write, events, hadError }) + "\\n");
+        process.exit(0);
+      }
+      // Report whatever happened if 'close' never fires.
+      setTimeout(report, 20000, "no close");
       function run(socket) {
         socket.on("error", function onError(err) {
           events.push("error:" + err.code + ":" + err.syscall);
@@ -2039,10 +2048,7 @@ describe.concurrent("a write that is the first to observe the peer's reset fails
         socket.on("end", function onEnd() {
           events.push("end");
         });
-        socket.on("close", function onClose(hadError) {
-          fs.writeSync(1, JSON.stringify({ write, events, hadError }) + "\\n");
-          process.exit(0);
-        });
+        socket.on("close", report);
         socket.once("data", function onData() {
           // Block the loop until the parent has reset the connection. Nothing
           // is polled in between, so the write below meets the reset first.

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -2084,6 +2084,7 @@ describe.concurrent("a write that is the first to observe the peer's reset fails
         stdout: "pipe",
         stderr: "pipe",
       });
+      const stderrText = proc.stderr.text();
       let stdout = "";
       let reset = false;
       for await (const chunk of proc.stdout) {
@@ -2096,7 +2097,7 @@ describe.concurrent("a write that is the first to observe the peer's reset fails
           await Bun.write(resetDoneFile, "");
         }
       }
-      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      const [stderr, exitCode] = await Promise.all([stderrText, proc.exited]);
       const lines = stdout.trim().split("\n");
       // Debug builds may write benign diagnostics to stderr, so it is only
       // shown when the fixture failed.

--- a/test/js/node/tls/tls-syscall-fault.test.ts
+++ b/test/js/node/tls/tls-syscall-fault.test.ts
@@ -93,6 +93,36 @@ describe.skipIf(skip)("node:tls under injected syscall faults", () => {
     expect(p.client.destroyed).toBe(true);
   });
 
+  test("send → ECONNRESET on an established session fails the write", async () => {
+    // A TLS write reaches the wire from inside the write BIO, where a send the
+    // kernel rejected is folded into "the wire blocked". The code was dropped
+    // there, so the write was buffered as backpressure, nothing reported the
+    // peer's reset, and the connection ended as a clean close. Node reports
+    // `write ECONNRESET` on the write callback and on the socket.
+    using p = await connectedTLSPair();
+    const events: string[] = [];
+    // `once(socket, "close")` would reject on the socket's 'error', so collect
+    // both events by hand.
+    const closed = Promise.withResolvers<boolean>();
+    p.client.on("error", (err: NodeJS.ErrnoException) => events.push(`error:${err.code}:${err.syscall}`));
+    p.client.on("end", () => events.push("end"));
+    p.client.on("close", hadError => closed.resolve(hadError));
+    const written = Promise.withResolvers<NodeJS.ErrnoException | null | undefined>();
+
+    fault.set({ syscall: "send", action: "errno", errno: "ECONNRESET", repeat: -1 });
+    p.client.write("hello", err => written.resolve(err as NodeJS.ErrnoException | null | undefined));
+    const writeError = await written.promise;
+    const hadError = await closed.promise;
+    fault.clear();
+
+    expect({
+      code: writeError?.code,
+      syscall: writeError?.syscall,
+      events,
+      hadError,
+    }).toEqual({ code: "ECONNRESET", syscall: "write", events: ["error:ECONNRESET:write"], hadError: true });
+  });
+
   test("recv → short reads (1 byte) still decrypt complete payload", async () => {
     using p = await connectedTLSPair();
     // The TLS record layer must reassemble across many tiny BIO reads.


### PR DESCRIPTION
### Problem
- A `node:tls` socket whose write is the first to see the peer's reset ends as a clean close: no write error, `'end'`, `hadError` false. Node fails the write with `write ECONNRESET`.
- The cause is `us_socket_write_check_error` (`packages/bun-usockets/src/socket.c:548`). For an SSL socket it never set `*fatal_write_error`. TLS ciphertext goes out through `us_socket_raw_write`, which folds a rejected `send()` to 0. On Linux that `send()` also consumes the pending socket error, so the next `recv()` returns 0 and the reset is lost.

### Fix
- The raw sends of a TLS write classify a failed `send()`. The code travels up through per-loop scratch (`loop_ssl_data`, no socket state) and out of the `fatal_write_error` channel that plain TCP already uses.
- The records `SSL_write` sealed for the failed write are discarded, so a retry cannot send the same plaintext twice.
- `Bun.connect` `write()`/`end()` return the documented `-1` for a fatal send (TCP leaked `-104`). HTTP/2 over TLS is unchanged: it already ends as in Node.
- Verified: four test files on linux-x64 and Windows x64, the Node-compatible fixtures also on node v26.3.0. Self-reviewed: 10 concerns raised, 9 addressed (Notes).

### Background
- `SSL_write` seals records into a custom write BIO, which sends them in one batch. A short send parks the rest in a per-loop spill slot.
- `socket_body.rs` writes node:net and node:tls data through `us_socket_write_check_error`. Its `fatal_write_error` out-parameter carries a peer-gone `send()` up to `net.ts` `failWrite`, which fails the write like Node.
- The classification existed for TCP. The first commit only moves it into `us_internal_classify_failed_send`.

<details><summary>Notes</summary>

**How it was found.** By inspection during work on #42182, not from a tracker report.

**Reach.** `tls.connect({ socket })`, `https.request` and `Bun.connect({ tls })` go through the same write path and change with it, as the table shows.

**Repro** (the peer resets while the client's loop is blocked, then the client writes. The peer runs under node in every row):

```
node:tls socket
  node v26.3.0, linux + windows:  write()->false | writecb:ECONNRESET | error:ECONNRESET:write | close(hadError=true)
  bun 1.4.3, linux:               write()->true  | writecb:ok | end | close(hadError=false)
  bun canary, windows:            write()->true  | writecb:ok | error:ECONNRESET:read | close(hadError=true)
  this branch, linux + windows:   write()->true  | writecb:ECONNRESET | error:ECONNRESET:write | close(hadError=true)
tls.connect({ socket }): the same three results.
https.request (100-continue, then the reset, then req.write)
  node, linux + windows:          req.writecb:ECONNRESET | req.error: write ECONNRESET
  bun 1.4.3, linux:               req.writecb:ok | req.error: socket hang up
  bun canary, windows:            req.writecb:ok | req.error: read ECONNRESET
  this branch, linux + windows:   req.writecb:ECONNRESET | req.error: write ECONNRESET
Bun.connect({ tls }) write(), twice
  bun 1.4.3 / canary:             4, 0
  this branch:                    -1, -1      (TCP: -104, -32 before, -1, -1 now)
```

`write()` returning true is pre-existing and shared with the TCP path.

**Why HTTP/2 over TLS is left alone.** The report that started this said an `https` h2 session ends clean where Node reports `ECONNRESET`. Node's answer depends on the kernel. With #42182's own fixture, node v26.3.0 on linux-x64 ends the request clean, 6 of 6 runs (`stream.end`, `rstCode` 8, `session.close`, no `'error'`), because the failed `send()` consumed the socket error and Node's `Http2Session::OnStreamAfterWrite` does not act on the write status. On Windows the reset stays readable and Node reports `ECONNRESET` on the stream and the session. bun over TLS already gives exactly those two results, through the read side, and it also delivers a response that arrived before the reset, as Node does. The parser's reaction to a fatal write is `close_transport_after_fatal_write` on its deferred tick. Over TLS that close discards the unread response and the session gets `EBADF` from the write that follows (what plain TCP does on main). So `NativeSocketWrite for &TLSSocket` calls `write_maybe_corked_without_fatal_report`, and h2 over TLS is byte for byte what it was. The new h2 test pins that. #42182 owns what the parser does with a fatal write over TCP.

**Why the sealed records are discarded.** When the raw send fails, `SSL_write` has already taken the plaintext and the sealed records sit in the batch or the spill. node:net keeps the failed chunk for `internal_flush`, and a `Bun.connect` user can call `write()` again. If the wire came back (the classification also reports an unclassified errno after 32 consecutive failures), the spill would drain and the retry would put the same plaintext on the stream again. Without the records the stream has a gap, which the peer rejects (bad record MAC), so the connection fails instead of being corrupted. A close that follows also no longer waits behind bytes that cannot drain. `ssl_fatal_error` is not set: it would stop the read side.

**Relation to other open PRs.**
- #34510 (Jarred asked there whether a send errno has to be stored on the socket): nothing is stored here. The code lives in `loop_ssl_data` for one `us_internal_ssl_write_check_error` call, with an owner, like `ssl_last_fatal_error_owner`. That PR also extracts the classifier. The extraction is the first commit here and can be taken alone. It is not a separate PR because it has no failing test to show. The writable spin (#24845) is that PR's and is unchanged.
- #38176 reports `EPROTO` through the same out-parameter when `SSL_write` itself fails. The two conditions do not overlap. The `if (s->ssl)` block in `socket.c` is one call now, so that PR's check goes after it, or into `us_internal_ssl_write_check_error` as the `else`.
- #36422 clamps `write()`/`end()` with the same line and goes further (the close reports the errno).

**Self-review.** Ten concerns came out of it and nine are addressed: no socket field, the false size comment is gone with it, the `Bun.connect` return value, the h2 decision and its test, Windows verified on a Windows x64 machine, tests that run on release lanes, on Windows and on Node, the stale comments in `socket_body.rs`, `socket.rs` and `libusockets.h`, the retry hazard above (found while doing this), and this section. Not done: a stack of separate PRs, for the reason given under #34510.

**Review follow-ups.** The send-error owner in `loop_ssl_data` follows a socket relocation like the other owner slots. The two child fixtures that report from their close handler also report on a 20 s deadline. The new comments under `src/` are one line each.

**Tests.**
- `test/js/node/tls/tls-syscall-fault.test.ts`: fault injection, `send` fails with `ECONNRESET`. Times out on stock bun.
- `test/js/node/tls/node-tls-connect.test.ts`: real reset, `tls.connect({ port })` and `tls.connect({ socket })`. The child blocks its loop until the parent confirms the reset. Fails on stock bun on Linux and on the Windows canary. Passes on node v26.3.0 on both.
- `test/js/bun/net/socket.test.ts`: `Bun.connect` `write()` returns `-1`, TCP and TLS. Stock bun returns `-104, -32` and `4, 0`.
- `test/js/node/http2/node-http2.test.js`: h2 over TLS, real reset. Passes before and after by design. Passes on node v26.3.0 on both platforms.

**Suites**, linux-x64 debug+ASAN: `test/js/node/tls/` 316 pass, `test/js/node/http2/` 521 pass, `test/js/bun/net/` 143 pass, `test/js/node/net/` 266 pass, `bun-serve-ssl` + `serve.test.ts` 315 pass, `test/js/node/http/` 372 pass, node's parallel `test-tls-*` 185/186, `test-https-*` 58/59, `test-net-*` 139/139, `test-http2-*` 256/256. Every failure is also there without this change in the same container (tests that need localhost name resolution or the public internet, `test-https-timeout` on a debug build, a 5 s limit around a 5.09 s debug run). Windows x64 debug: `test/js/node/tls/` 315 pass (2 named-pipe timeouts that fail identically without the change), `test/js/node/http2/` 511 pass, `test/js/node/net/` 252 pass, `test/js/bun/net/` 120 pass.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tls/tls-syscall-fault.test.ts, test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->
