### PR TITLE
bun-types: correct the tail call note in the callerSourceOrigin JSDoc

### DIFF
--- a/packages/bun-types/jsc.d.ts
+++ b/packages/bun-types/jsc.d.ts
@@ -201,7 +201,32 @@ declare module "bun:jsc" {
    *
    * JavaScriptCore performs proper tail calls in strict mode code, which
    * includes every ES module, so a helper that does `return callerSourceOrigin()`
-   * reports the file of the helper's caller rather than its own.
+   * reports the file of the helper's caller rather than its own. A generator
+   * or async function never makes a tail call, so a helper of that kind
+   * reports its own file.
+   *
+   * @example
+   * ```ts
+   * // helper.ts
+   * import { callerSourceOrigin } from "bun:jsc";
+   *
+   * export function origin() {
+   *   return callerSourceOrigin();
+   * }
+   *
+   * export async function originAsync() {
+   *   return callerSourceOrigin();
+   * }
+   *
+   * // index.ts
+   * import { origin, originAsync } from "./helper.ts";
+   *
+   * console.log(origin());
+   * // file:///home/me/app/index.ts
+   *
+   * console.log(await originAsync());
+   * // file:///home/me/app/helper.ts
+   * ```
    */
   function callerSourceOrigin(): string | null;
 

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -24,7 +24,8 @@ import {
   totalCompileTime,
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBuildKite, isWindows } from "harness";
+import { bunEnv, bunExe, isBuildKite, isWindows, tempDir } from "harness";
+import * as helper from "./caller-source-origin-fixture";
 
 describe("bun:jsc", () => {
   function count() {
@@ -80,6 +81,71 @@ describe("bun:jsc", () => {
   });
   it("callerSourceOrigin", () => {
     expect(callerSourceOrigin()).toBe(import.meta.url);
+  });
+  // JavaScriptCore decides which `return f()` is a tail call, so an engine upgrade can change these
+  // results. packages/bun-types/jsc.d.ts documents them: keep its JSDoc in step with this test.
+  it("callerSourceOrigin from a helper in another module", async () => {
+    const helperUrl = new URL("./caller-source-origin-fixture.ts", import.meta.url).href;
+    expect({
+      plain: helper.plain(),
+      arrow: helper.arrow(),
+      generator: helper.generator().next().value,
+      asyncFunction: await helper.asyncFunction(),
+      asyncFunctionAfterAwait: await helper.asyncFunctionAfterAwait(),
+      asyncArrowAfterAwait: await helper.asyncArrowAfterAwait(),
+      asyncGenerator: (await helper.asyncGenerator().next()).value,
+    }).toEqual({
+      // A tail call: the helper has left the stack, so the caller is this file.
+      plain: import.meta.url,
+      arrow: import.meta.url,
+      // Not a tail call: the helper is the caller.
+      generator: helperUrl,
+      asyncFunction: helperUrl,
+      asyncFunctionAfterAwait: helperUrl,
+      asyncArrowAfterAwait: helperUrl,
+      asyncGenerator: helperUrl,
+    });
+  });
+  it("callerSourceOrigin: the @example in bun-types prints what its comments say", async () => {
+    const dts = await Bun.file(new URL("../../../../packages/bun-types/jsc.d.ts", import.meta.url)).text();
+    const declaration = dts.indexOf("\n  function callerSourceOrigin(");
+    expect(declaration).not.toBe(-1);
+    const end = dts.lastIndexOf("*/", declaration);
+    const jsdoc = dts.slice(dts.lastIndexOf("/**", end), end).replace(/^[ \t]*\* ?/gm, "");
+    const example = /^@example\n```ts\n([\s\S]*?)\n```/m.exec(jsdoc)?.[1];
+    if (example === undefined) throw new Error("the JSDoc of callerSourceOrigin has no @example fence");
+
+    // A `// name.ts` line starts a file.
+    const files: Record<string, string> = {};
+    let name: string | undefined;
+    for (const line of example.split("\n")) {
+      const header = /^\/\/ (\w+\.ts)$/.exec(line);
+      if (header) files[(name = header[1])] = "";
+      else if (name) files[name] += line + "\n";
+    }
+    expect(Object.keys(files)).toEqual(["helper.ts", "index.ts"]);
+
+    // The `//` line after each `console.log(...);` is the output the example documents.
+    const lines = files["index.ts"].split("\n");
+    const documented = lines
+      .filter((line, i) => line.startsWith("// ") && lines[i - 1].startsWith("console.log("))
+      .map(line => line.slice(3) + "\n")
+      .join("");
+    expect(documented).not.toBe("");
+
+    using dir = tempDir("caller-source-origin-example", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.replaceAll(Bun.pathToFileURL(String(dir)).href, "file:///home/me/app")).toBe(documented);
+    expect(exitCode).toBe(0);
   });
   it("noFTL", () => {});
   it("noOSRExitFuzzing", () => {});

--- a/test/js/bun/jsc/caller-source-origin-fixture.ts
+++ b/test/js/bun/jsc/caller-source-origin-fixture.ts
@@ -1,0 +1,31 @@
+// Imported by bun-jsc.test.ts. Each helper does `return callerSourceOrigin()` from its own module.
+import { callerSourceOrigin } from "bun:jsc";
+
+export function plain() {
+  return callerSourceOrigin();
+}
+
+export const arrow = () => callerSourceOrigin();
+
+export function* generator() {
+  return callerSourceOrigin();
+}
+
+export async function asyncFunction() {
+  return callerSourceOrigin();
+}
+
+// After an `await` the body runs from the microtask queue, with no other JavaScript frame below it.
+export async function asyncFunctionAfterAwait() {
+  await 0;
+  return callerSourceOrigin();
+}
+
+export const asyncArrowAfterAwait = async () => {
+  await 0;
+  return callerSourceOrigin();
+};
+
+export async function* asyncGenerator() {
+  return callerSourceOrigin();
+}


### PR DESCRIPTION
### Problem
- The JSDoc of `callerSourceOrigin` (`packages/bun-types/jsc.d.ts:202`) says JavaScriptCore performs proper tail calls in all strict mode code. It concludes that a helper that does `return callerSourceOrigin()` reports the file of its caller.
- #42319 upgraded WebKit to `cf1b36ec8703`. Since then, generator, async function and async generator bodies emit no tail call for `return f()` (WebKit/WebKit#73407, `BytecodeGenerator.cpp:463`). A helper of that kind now reports its own file.

### Fix
- The JSDoc names the exception. A new `@example` shows a plain helper and an async helper in `helper.ts`, called from `index.ts`.
- Comments only. No declaration changes.
- `test/js/bun/jsc/bun-jsc.test.ts` gets two tests. One runs the `@example` and compares stdout with the comments in the example. It fails with the old JSDoc. The other checks seven kinds of helper from a fixture module. Four of them fail on the engine before #42319.
- Verified: both pass on a debug build of main (Linux x64) and on canary `6a92015fc` (Windows x64). All 40 tests of the file pass.

### Background
- `callerSourceOrigin()` walks the stack from its own frame. It skips builtin functions and returns the source URL of the first other JavaScript frame, or `null` if there is none.
- A tail call reuses the frame of the calling function. After a tail call to `callerSourceOrigin()` the helper is not on the stack, so the first frame is the caller of the helper.
- The ECMAScript specification gives generator and async bodies no tail position. JavaScriptCore now follows that.

<details><summary>Notes</summary>

Probe: each helper lives in `helper.mjs` and does `return callerSourceOrigin()`. `main.mjs` calls it. The columns are bun `1.4.3-canary.1+4ff919377` (WebKit `dfd696443b9b`) and a debug build of main at 6a92015fc8 (WebKit `cf1b36ec8703`).

```
helper                              before #42319   main
plain function, arrow, method       main.mjs        main.mjs
function*, generator method         main.mjs        helper.mjs
async function, no await            helper.mjs      helper.mjs
async function, after an await      null            helper.mjs
async arrow, after an await         null            helper.mjs
async function*                     main.mjs        helper.mjs
async function*, after an await     null            helper.mjs
```

- Before the upgrade, an async helper with no `await` already reported its own file. After an `await`, the body ran from the microtask queue and made the tail call with no other JavaScript frame on the stack, so the result was `null`.
- The result does not depend on the JIT tier. On the debug build of main, 300000 calls of the plain helper and 300000 calls of the generator helper each give one answer.
- The other sentences of the JSDoc hold on main. `eval`, indirect `eval` and `new Function` report the file that created the code. `Promise.resolve().then(callerSourceOrigin)` gives `null`.
- `docs/` does not mention `callerSourceOrigin`, and no other doc sentence makes a claim about tail calls.
- `test/integration/bun-types/bun-types.test.ts` gives the same result with and without this diff (11 pass, 10 fail). #42230 has the cause (the `latest` dist-tag of `@types/node`) and the fix.
- #42335 adds engine-level tests for the same WebKit change (`Error.stack` frames, the await in an async generator `return`). It does not touch `bun:jsc` or the JSDoc.
- #42257 adds `test/integration/bun-types/jsdoc-examples.test.ts` for examples in `bun.d.ts`. This PR keeps its test in `bun-jsc.test.ts`, so the two do not conflict.
- `prettier --check` passes on the three files.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/jsc/bun-jsc.test.ts

<!-- robobun:evidence:end -->