### PR TITLE
inspector: check the type of process.argv in getModuleGraph

### DIFF
--- a/src/jsc/bindings/InspectorLifecycleAgent.cpp
+++ b/src/jsc/bindings/InspectorLifecycleAgent.cpp
@@ -171,15 +171,19 @@ Protocol::ErrorStringOr<ModuleGraph> InspectorLifecycleAgent::getModuleGraph()
 
     Ref<JSON::ArrayOf<String>> argv = JSON::ArrayOf<String>::create();
     {
-
-        auto* array = uncheckedDowncast<JSC::JSArray>(process->getArgv(global));
+        // process.argv is writable, so this slot holds whatever the program
+        // last assigned to it. Report an empty argv for a value that is not an
+        // array.
+        auto argvValue = process->getArgv(global);
         RETURN_IF_EXCEPTION(scope, fail("Failed to get argv"_s));
-        for (size_t i = 0, length = array->length(); i < length; i++) {
-            auto value = array->getIndex(global, i);
-            RETURN_IF_EXCEPTION(scope, fail("Failed to get value at index"_s));
-            auto string = value.toWTFString(global);
-            RETURN_IF_EXCEPTION(scope, fail("Failed to convert value to string"_s));
-            argv->addItem(string);
+        if (auto* array = dynamicDowncast<JSC::JSArray>(argvValue)) {
+            for (size_t i = 0, length = array->length(); i < length; i++) {
+                auto value = array->getIndex(global, i);
+                RETURN_IF_EXCEPTION(scope, fail("Failed to get value at index"_s));
+                auto string = value.toWTFString(global);
+                RETURN_IF_EXCEPTION(scope, fail("Failed to convert value to string"_s));
+                argv->addItem(string);
+            }
         }
     }
 

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -603,3 +603,82 @@ test("error.stack doesnt lose frames", () => {
   // We allow it to differ by the existence of <anonymous> as a string. But that's it.
   expect(no.split("\n").slice(0, -2).join("\n").trim()).toBe(yes.split("\n").slice(0, -2).join("\n").trim());
 });
+
+// process.argv is a writable property, so a program can store any value in it.
+// LifecycleReporter.getModuleGraph read that slot with uncheckedDowncast<JSArray>:
+// an attached inspector client that called getModuleGraph crashed the process
+// (SIGSEGV) when the value was not a cell, and read a bogus length off an
+// unrelated cell otherwise.
+test("LifecycleReporter.getModuleGraph survives a process.argv that is not an array", async () => {
+  await using child = spawn({
+    cmd: [bunExe(), "--inspect=ws://127.0.0.1:0/", "-e", "setInterval(() => {}, 1000);"],
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+
+  let stderr = "";
+  let url: string | undefined;
+  const decoder = new TextDecoder();
+  for await (const chunk of child.stderr as ReadableStream) {
+    stderr += decoder.decode(chunk);
+    url = stderr.match(/(ws:\/\/[^\s]+)/)?.[1];
+    if (url) break;
+  }
+  if (!url) throw new Error(`Unable to find the inspector URL in:\n${stderr}`);
+
+  type Reply = { result?: any; error?: { message: string } };
+  const pending = new Map<number, (reply: Reply) => void>();
+  // A crash closes the socket. Resolving instead of rejecting keeps the failure
+  // in the snapshot below.
+  const closed = Promise.withResolvers<Reply>();
+  const opened = Promise.withResolvers<Reply>();
+  const webSocket = new WebSocket(url);
+  webSocket.addEventListener("open", () => opened.resolve({}));
+  webSocket.addEventListener("close", () => closed.resolve({ error: { message: "the inspector closed the socket" } }));
+  webSocket.addEventListener("error", () => closed.resolve({ error: { message: "the inspector socket failed" } }));
+  webSocket.addEventListener("message", ({ data }) => {
+    const reply: Reply & { id: number } = JSON.parse(data.toString());
+    pending.get(reply.id)?.(reply);
+    pending.delete(reply.id);
+  });
+
+  let nextId = 1;
+  function send(method: string, params: object = {}): Promise<Reply> {
+    const id = nextId++;
+    const { promise, resolve } = Promise.withResolvers<Reply>();
+    pending.set(id, resolve);
+    webSocket.send(JSON.stringify({ id, method, params }));
+    return Promise.race([promise, closed.promise]);
+  }
+
+  expect(await Promise.race([opened.promise, closed.promise])).toEqual({});
+
+  const argv: Record<string, unknown> = {};
+  for (const expression of ["undefined", "null", "0", "NaN", "true", `"abc"`, "{}", "Symbol()", `["a", "b"]`]) {
+    const assigned = await send("Runtime.evaluate", { expression: `process.argv = ${expression}` });
+    const graph = assigned.error ? assigned : await send("LifecycleReporter.getModuleGraph");
+    argv[expression] = graph.error?.message ?? graph.result.argv;
+  }
+
+  expect(argv).toMatchInlineSnapshot(`
+    {
+      "\\"abc\\"": [],
+      "0": [],
+      "NaN": [],
+      "Symbol()": [],
+      "[\\"a\\", \\"b\\"]": [
+        "a",
+        "b",
+      ],
+      "null": [],
+      "true": [],
+      "undefined": [],
+      "{}": [],
+    }
+  `);
+
+  // The process is still running. A crash would have ended it before the replies.
+  expect(child.exitCode).toBe(null);
+  webSocket.close();
+});


### PR DESCRIPTION
### Problem
- An attached inspector client that sends `LifecycleReporter.getModuleGraph` kills the process when `process.argv` holds a non-array: `panic(main thread): Segmentation fault at address 0x0`, exit code 139. One message is enough, and no `enable` is needed.
- The cause is `uncheckedDowncast<JSC::JSArray>(process->getArgv(global))` in `src/jsc/bindings/InspectorLifecycleAgent.cpp:175`. `process.argv` is writable, and `setProcessArgv` (`src/jsc/bindings/BunProcess.cpp:3198`) stores any `JSValue` in the slot. A non-cell value (`undefined`, `null`, a number, a boolean) becomes a bogus `JSCell*`. A cell that is not an array (a string, an object) reads a length off an unrelated field and answers `"argv":[]`.

### Fix
- Read the slot into a local, then use `dynamicDowncast<JSC::JSArray>`. Report an empty argv when the value is not an array. A real array still reports its elements.
- The exception check now runs before the cast. `JSValue::isCell()` is true for the empty value, so a `getArgv` that throws also reached `asCell()`.
- `util.parseArgs` reads the same slot and already checks `is_array()` first (`src/runtime/node/util/parse_args.rs:191`).
- Verified: `test/cli/inspect/inspect.test.ts`, a new test that drives one inspector session through 9 values of `process.argv`. Stock bun crashes on the first one and the socket closes. Also ran `test/cli/inspect/bun-inspector-protocol.test.ts` and `test/cli/inspect/BunFrontendDevServer.test.ts`, which snapshot the argv of a normal run, plus the rest of `test/cli/inspect/inspect.test.ts`.

### Background
- `LifecycleReporter` is one of the inspector domains bun adds to JavaScriptCore's own set. `getModuleGraph` answers with the ESM and CJS module lists, the cwd, the main file, and argv. `test/cli/inspect` and the VS Code extension are the in-tree callers.
- `process.argv` is a custom accessor over a single `WriteBarrier<Unknown>` slot on the `Process` object. The getter fills the slot with a real array on the first read. The setter replaces it with whatever the program assigns.
- `uncheckedDowncast<T>` performs no type check. A release build compiles it to a `static_cast` after `JSValue::asCell()`. An assert build reports `ASSERTION FAILED: isCell()`.

<details><summary>Notes</summary>

Repro (loopback only, the inspector port is unauthenticated):

```
bun --inspect=127.0.0.1:6499/x -e 'process.argv = 5; setInterval(() => {}, 1000)' &
sleep 1
node -e 'const ws = new WebSocket("ws://127.0.0.1:6499/x"); ws.onopen = () => ws.send(JSON.stringify({ id: 1, method: "LifecycleReporter.getModuleGraph" })); ws.onmessage = (m) => { console.log(String(m.data).slice(0, 200)); process.exit(0) }; ws.onclose = () => { console.log("inspector socket closed"); process.exit(0) }'
```

Observed before this change, 3 of 3 runs each, on 1.4.2 (744846f84) and 1.4.3-canary.1:

- `undefined`, `null`, `0`, `5`, `NaN`, `true`, `false`: exit code 139.
- a string, a symbol, a bigint, `{}`, a class, a `Proxy`, a function, a typed array: the process survives and answers `"argv":[]`.
- a real array: the elements.

On an assert build the same call reports `ASSERTION FAILED: isCell()` at `JSCJSValue.h(766)` for `5`, and aborts in the downcast for a string or an object.

The reader site is confirmed with a breakpoint on `WTFReportAssertionFailure`:

```
#1 WTF::uncheckedDowncast<JSC::JSArray>(JSC::JSValue const&)
#2 Inspector::InspectorLifecycleAgent::getModuleGraph()
#4 Inspector::LifecycleReporterBackendDispatcher::getModuleGraph(...)
#7 Inspector::JSGlobalObjectInspectorController::dispatchMessageFromFrontend
#9 Bun::BunInspectorConnection::receiveMessagesOnInspectorThread
```

Two shapes were considered and rejected. A protocol error for the whole command drops the module graph, the cwd, and the main file, which are all still correct. Generic array-like iteration (`length` plus indexed `get`) would let a user getter run during inspector dispatch, which `getModuleGraph` does not do today.

The protocol describes the field as "argv that launched the process" (`packages/bun-inspector-protocol/src/protocol/jsc/protocol.json`). The agent has always reported the live `process.argv` value instead, and this change keeps that. Reporting the launch argv from `Bun__Process__createArgv` would change what a client sees for a program that edits `process.argv`, so it is left alone.

The real-world reach is small. It needs an attached frontend that issues `getModuleGraph` and a program that assigns a non-object to `process.argv`, for example a test helper that clears argv with `process.argv = undefined`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/inspect/inspect.test.ts
bun test v1.4.3 (4ff919377)

test/cli/inspect/inspect.test.ts:
(pass) websocket > bun --inspect [960.64ms]
(pass) websocket > bun --inspect=0 [742.77ms]
(pass) websocket > bun --inspect=21042 [835.43ms]
(pass) websocket > bun --inspect=localhost [672.18ms]
(pass) websocket > bun --inspect=localhost/ [732.38ms]
(pass) websocket > bun --inspect=localhost:0 [835.06ms]
(pass) websocket > bun --inspect=localhost:0/ [694.24ms]
(pass) websocket > bun --inspect=localhost/foo/bar [709.93ms]
(pass) websocket > bun --inspect=127.0.0.1 [795.89ms]
(pass) websocket > bun --inspect=127.0.0.1/ [813.13ms]
(pass) websocket > bun --inspect=127.0.0.1:0/ [851.23ms]
(pass) websocket > bun --inspect=[::1] [717.60ms]
(pass) websocket > bun --inspect=[::1]:0 [743.03ms]
(pass) websocket > bun --inspect=[::1]:0/ [803.74ms]
(pass) websocket > bun --inspect=/ [724.44ms]
(pass) websocket > bun --inspect=/foo [791.75ms]
(pass) websocket > bun --inspect=/foo/baz/ [725.93ms]
(pass) websocket > bun --inspect=:0 [746.26ms]
(pass) websocke
... (truncated)

release without fix: 1 failed, 2 skipped
bun test v1.4.3-canary.1 (4ff919377)

test/cli/inspect/inspect.test.ts:
(pass) websocket > bun --inspect [16.49ms]
(pass) websocket > bun --inspect=0 [15.74ms]
(pass) websocket > bun --inspect=54964 [18.81ms]
(pass) websocket > bun --inspect=localhost [15.70ms]
(pass) websocket > bun --inspect=localhost/ [15.34ms]
(pass) websocket > bun --inspect=localhost:0 [18.44ms]
(pass) websocket > bun --inspect=localhost:0/ [19.63ms]
(pass) websocket > bun --inspect=localhost/foo/bar [15.32ms]
(pass) websocket > bun --inspect=127.0.0.1 [16.20ms]
(pass) websocket > bun --inspect=127.0.0.1/ [15.23ms]
(pass) websocket > bun --inspect=127.0.0.1:0/ [15.54ms]
(pass) websocket > bun --inspect=[::1] [16.63ms]
(pass) websocket > bun --inspect=[::1]:0 [15.07ms]
(pass) websocket > bun --inspect=[::1]:0/ [14.42ms]
(pass) websocket > bun --inspect=/ [14.90ms]
(pass) websocket > bun --inspect=/foo [15.99ms]
(pass) websocket > bun --inspect=/foo/baz/ [15.01ms]
(pass) websocket > bun --inspect=:0 [14.42ms]
(pass) websocket > bun --inspect=:0/ [14.24ms]
(pass) websocket > bun --inspect=ws://localhost/ [13.81ms]
(pass) websocket > bun --inspect=ws://localhost:0/ [16.34ms]
(pass) websocket > bun
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/inspect/inspect.test.ts
bun test v1.4.3 (4ff919377)

test/cli/inspect/inspect.test.ts:
(pass) websocket > bun --inspect [931.69ms]
(pass) websocket > bun --inspect=0 [886.92ms]
(pass) websocket > bun --inspect=13131 [743.97ms]
(pass) websocket > bun --inspect=localhost [836.83ms]
(pass) websocket > bun --inspect=localhost/ [849.94ms]
(pass) websocket > bun --inspect=localhost:0 [870.17ms]
(pass) websocket > bun --inspect=localhost:0/ [887.28ms]
(pass) websocket > bun --inspect=localhost/foo/bar [708.83ms]
(pass) websocket > bun --inspect=127.0.0.1 [679.25ms]
(pass) websocket > bun --inspect=127.0.0.1/ [855.00ms]
(pass) websocket > bun --inspect=127.0.0.1:0/ [785.30ms]
(pass) websocket > bun --inspect=[::1] [779.63ms]
(pass) websocket > bun --inspect=[::1]:0 [879.77ms]
(pass) websocket > bun --inspect=[::1]:0/ [858.23ms]
(pass) websocket > bun --inspect=/ [676.19ms]
(pass) websocket > bun --inspect=/foo [652.52ms]
(pass) websocket > bun --inspect=/foo/baz/ [650.14ms]
(pass) websocket > bun --inspect=:0 [892.17ms]
(pass) websocke
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 706ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 6m 06s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.3-canary.1+47aa7cda5
[build] done
bun test v1.4.3-canary.1 (47aa7cda5)

test/cli/inspect/inspect.test.ts:
(pass) websocket > bun --inspect [15.18ms]
(pass) websocket > bun --inspect=0 [11.68ms]
(pass) websocket > bun --inspect=45139 [12.14ms]
(pass) websocket > bun --inspect=localhost [13.48ms]
(pass) websocket > bun --inspect=localhost/ [11.46ms]
(pass) websocket > bun --inspect=localhost:0 [14.35ms]
(pass) websocket > bun --inspect=localhost:0/ [13.82ms]
(pass) websocket > bun --inspect=localhost/foo/bar [12.71ms]
(pass) websocket > bun --inspect=127.0.0.1 [12.12ms]
(pass) websocket > bun --inspect=127.0.0.1/ [13.78ms]
(pass) websocket > bun --
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/InspectorLifecycleAgent.cpp | 20 ++++---
 test/cli/inspect/inspect.test.ts             | 79 ++++++++++++++++++++++++++++
 2 files changed, 91 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/bindings/InspectorLifecycleAgent.cpp      1      1     12
test/cli/inspect/inspect.test.ts                  2      1     12
```

</details>

<!-- robobun:evidence:end -->