### PR TITLE
node:tls: send the FIN when end() runs before the TLS handle is attached

### DIFF
--- a/src/js/internal/net/symbols.ts
+++ b/src/js/internal/net/symbols.ts
@@ -7,5 +7,7 @@ export default {
   // Internal handshake-settled signal: server-side sockets emit no user
   // 'secureConnect' (node parity), so internal deferrals park on this instead.
   kSecureConnectDone: Symbol("kSecureConnectDone"),
+  // Set while a TLS socket waits to adopt its transport's handle.
+  kUpgradePending: Symbol("kUpgradePending"),
   kVerifyError: Symbol("kVerifyError"),
 };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2075,7 +2075,6 @@ Socket.prototype.connect = function connect(...args) {
             // wait to be connected
             this[kUpgradePending] = true;
             const onConnect = () => {
-              connection.removeListener("close", onClose);
               // The TLS socket may have been destroyed before the underlying
               // socket connected (e.g. tls.connect({ socket }).destroy()); don't
               // start a handshake on a dead socket.
@@ -2123,6 +2122,8 @@ Socket.prototype.connect = function connect(...args) {
                   throw new Error("Invalid socket");
                 }
               }
+              // destroyWhenUpgradedCloses took over above. An upgrade that threw keeps onClose.
+              connection.removeListener("close", onClose);
               this[kUpgradePending] = false;
               this.emit(kUpgradeAttached);
             };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -187,6 +187,9 @@ function onUpgradeWriteClose(callback) {
   callback($ERR_SOCKET_CLOSED());
 }
 const kUpgradeAttached = Symbol("kUpgradeAttached");
+// True while a TLS socket has no handle because it adopts one later: when the transport it was given
+// connects, or one tick after a server-side wrap. kUpgradeAttached is emitted once it has the handle.
+const kUpgradePending = Symbol("kUpgradePending");
 const kOnreadTail = Symbol("kOnreadTail");
 const kOnreadDraining = Symbol("kOnreadDraining");
 const kOnreadBuffer = Symbol("kOnreadBuffer");
@@ -2003,6 +2006,7 @@ Socket.prototype.connect = function connect(...args) {
       this.authorized = false;
       this.secureConnecting = true;
       this[kPreHandshakeWrite] = false;
+      this[kUpgradePending] = false;
       this._secureEstablished = false;
       this._securePending = true;
       this[kConnectOptions] = options;
@@ -2070,6 +2074,7 @@ Socket.prototype.connect = function connect(...args) {
             }
           } else {
             // wait to be connected
+            this[kUpgradePending] = true;
             connection.once("connect", () => {
               // The TLS socket may have been destroyed before the underlying
               // socket connected (e.g. tls.connect({ socket }).destroy()); don't
@@ -2118,6 +2123,8 @@ Socket.prototype.connect = function connect(...args) {
                   throw new Error("Invalid socket");
                 }
               }
+              this[kUpgradePending] = false;
+              this.emit(kUpgradeAttached);
             });
           }
         }
@@ -2276,6 +2283,10 @@ Socket.prototype._destroy = function _destroy(err, callback) {
 
 Socket.prototype._final = function _final(callback) {
   $debug("Socket.prototype._final");
+  // No TLS handle to shut down yet. Node has one from the constructor and waits on `connecting`: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973
+  if (this[kUpgradePending]) {
+    return this.once(kUpgradeAttached, this._final.bind(this, callback));
+  }
   if (this.connecting) {
     return this.once("connect", this._final.bind(this, callback));
   }
@@ -2406,6 +2417,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
     return;
   }
   this[kupgraded] = connection;
+  this[kUpgradePending] = true;
   process.nextTick(() => {
     if (this.destroyed || connection.destroyed) {
       this.destroy();
@@ -2432,6 +2444,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
       connection.on("close", events[3]);
       destroyWhenUpgradedCloses(this, connection);
       this._handle = result;
+      this[kUpgradePending] = false;
       this.emit(kUpgradeAttached);
       return;
     }
@@ -2458,6 +2471,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
     this.once("end", this[kCloseRawConnection]);
     raw.connecting = false;
     this._handle = tlsHandle;
+    this[kUpgradePending] = false;
     this.emit(kUpgradeAttached);
   });
 };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2075,7 +2075,8 @@ Socket.prototype.connect = function connect(...args) {
           } else {
             // wait to be connected
             this[kUpgradePending] = true;
-            connection.once("connect", () => {
+            const onConnect = () => {
+              connection.removeListener("close", onClose);
               // The TLS socket may have been destroyed before the underlying
               // socket connected (e.g. tls.connect({ socket }).destroy()); don't
               // start a handshake on a dead socket.
@@ -2125,7 +2126,14 @@ Socket.prototype.connect = function connect(...args) {
               }
               this[kUpgradePending] = false;
               this.emit(kUpgradeAttached);
-            });
+            };
+            // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L739-L741
+            const onClose = () => {
+              connection.removeListener("connect", onConnect);
+              this.destroy();
+            };
+            connection.once("connect", onConnect);
+            connection.once("close", onClose);
           }
         }
       } catch (error) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -188,6 +188,11 @@ function onUpgradeWriteClose(callback) {
   callback($ERR_SOCKET_CLOSED());
 }
 const kUpgradeAttached = Symbol("kUpgradeAttached");
+// The deferred TLS upgrade has assigned `_handle`: resume the _write and the _final that waited for it.
+function upgradeAttached(self) {
+  self[kUpgradePending] = false;
+  self.emit(kUpgradeAttached);
+}
 const kOnreadTail = Symbol("kOnreadTail");
 const kOnreadDraining = Symbol("kOnreadDraining");
 const kOnreadBuffer = Symbol("kOnreadBuffer");
@@ -1447,6 +1452,11 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
       req.errno = error.errno || uv().UV_ECANCELED;
       return;
     }
+    // A TLS engine that failed before it opened has no connect pending, so afterConnect would drop the failure.
+    if (self[kupgraded]) {
+      if (!self.destroyed) self.destroy(new ExceptionWithHostPort(error.errno, "connect"));
+      return;
+    }
     req!.oncomplete(error.errno, self._handle, req, true, true);
   },
 };
@@ -2130,8 +2140,7 @@ Socket.prototype.connect = function connect(...args) {
               connection.removeListener("close", onClose);
               // The transport is connected. The stream-level engine opens on a later task and emits no 'connect' for _final to wait for.
               this.connecting = false;
-              this[kUpgradePending] = false;
-              this.emit(kUpgradeAttached);
+              upgradeAttached(this);
             };
             // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L739-L741
             const onClose = () => {
@@ -2432,7 +2441,8 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
     return;
   }
   this[kupgraded] = connection;
-  this[kUpgradePending] = true;
+  // Not over a socket that is still connecting: a shutdown of the handle adopted from it underflows the native connection count.
+  this[kUpgradePending] = !connection.connecting;
   process.nextTick(() => {
     if (this.destroyed || connection.destroyed) {
       this.destroy();
@@ -2459,8 +2469,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
       connection.on("close", events[3]);
       destroyWhenUpgradedCloses(this, connection);
       this._handle = result;
-      this[kUpgradePending] = false;
-      this.emit(kUpgradeAttached);
+      upgradeAttached(this);
       return;
     }
     // Bytes that already arrived before the wrap were pulled off the fd into
@@ -2486,8 +2495,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
     this.once("end", this[kCloseRawConnection]);
     raw.connecting = false;
     this._handle = tlsHandle;
-    this[kUpgradePending] = false;
-    this.emit(kUpgradeAttached);
+    upgradeAttached(this);
   });
 };
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -47,6 +47,7 @@ const {
   kDestroyOnRead,
   kPreHandshakeWrite,
   kSecureConnectDone,
+  kUpgradePending,
   kVerifyError,
 } = require("internal/net/symbols");
 
@@ -187,8 +188,6 @@ function onUpgradeWriteClose(callback) {
   callback($ERR_SOCKET_CLOSED());
 }
 const kUpgradeAttached = Symbol("kUpgradeAttached");
-// Set while a TLS socket waits to adopt its transport's handle; kUpgradeAttached is emitted when it has it.
-const kUpgradePending = Symbol("kUpgradePending");
 const kOnreadTail = Symbol("kOnreadTail");
 const kOnreadDraining = Symbol("kOnreadDraining");
 const kOnreadBuffer = Symbol("kOnreadBuffer");

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -187,8 +187,7 @@ function onUpgradeWriteClose(callback) {
   callback($ERR_SOCKET_CLOSED());
 }
 const kUpgradeAttached = Symbol("kUpgradeAttached");
-// True while a TLS socket has no handle because it adopts one later: when the transport it was given
-// connects, or one tick after a server-side wrap. kUpgradeAttached is emitted once it has the handle.
+// Set while a TLS socket waits to adopt its transport's handle; kUpgradeAttached is emitted when it has it.
 const kUpgradePending = Symbol("kUpgradePending");
 const kOnreadTail = Symbol("kOnreadTail");
 const kOnreadDraining = Symbol("kOnreadDraining");

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1326,6 +1326,8 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     self.connecting = false;
     if (callback) {
       const writeChunk = self._pendingData;
+      // A write parked while the socket this one wraps was connecting reaches the engine here, not through _write.
+      if (self.secureConnecting) self[kPreHandshakeWrite] = true;
       const res = socket.$write(writeChunk || "", self._pendingEncoding || "utf8");
       if (res < 0) {
         // The retried send failed for good (peer gone): $write returned -errno.

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2123,6 +2123,8 @@ Socket.prototype.connect = function connect(...args) {
               }
               // destroyWhenUpgradedCloses took over above. An upgrade that threw keeps onClose.
               connection.removeListener("close", onClose);
+              // The transport is connected. The stream-level engine opens on a later task and emits no 'connect' for _final to wait for.
+              this.connecting = false;
               this[kUpgradePending] = false;
               this.emit(kUpgradeAttached);
             };

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -897,7 +897,8 @@ TLSSocket.prototype._start = function _start() {
 };
 
 TLSSocket.prototype._final = function _final(callback) {
-  if (!this._handle) return callback();
+  // net.Socket's _final waits for a handle that is still on its way, and finishes at once when none is.
+  if (!this._handle) return NetSocket.prototype._final.$call(this, callback);
   // https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1119-L1133
   if (this.secureConnecting && this[kPreHandshakeWrite]) {
     return this.once(kSecureConnectDone, NetSocket.prototype._final.bind(this, callback));

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -22,7 +22,13 @@ const {
 } = require("internal/validators");
 
 const { Server: NetServer, Socket: NetSocket } = net;
-const { kArmHandshakeTimeout, kPreHandshakeWrite, kSecureConnectDone, kVerifyError } = require("internal/net/symbols");
+const {
+  kArmHandshakeTimeout,
+  kPreHandshakeWrite,
+  kSecureConnectDone,
+  kUpgradePending,
+  kVerifyError,
+} = require("internal/net/symbols");
 
 const getBundledRootCertificates = $newCppFunction("NodeTLS.cpp", "getBundledRootCertificates", 1);
 const getExtraCACertificates = $newCppFunction("NodeTLS.cpp", "getExtraCACertificates", 1);
@@ -897,8 +903,11 @@ TLSSocket.prototype._start = function _start() {
 };
 
 TLSSocket.prototype._final = function _final(callback) {
-  // net.Socket's _final waits for a handle that is still on its way, and finishes at once when none is.
-  if (!this._handle) return NetSocket.prototype._final.$call(this, callback);
+  if (!this._handle) {
+    // The handle is still on its way: net.Socket's _final waits for it.
+    if (this[kUpgradePending]) return NetSocket.prototype._final.$call(this, callback);
+    return callback();
+  }
   // https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1119-L1133
   if (this.secureConnecting && this[kPreHandshakeWrite]) {
     return this.once(kSecureConnectDone, NetSocket.prototype._final.bind(this, callback));

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1986,6 +1986,41 @@ describe.each([
     });
   });
 
+  // Both shapes shut the socket down before it has its TLS handle. The FIN waits
+  // for the transport, as node's _final does on `connecting`:
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973
+  describe.concurrent("before the TLS handle is attached", () => {
+    it.skipIf(!exe)("end() and destroySoon() wait for a tls.connect({ socket }) transport to connect", async () => {
+      const ended = {
+        log: ["transport connect", "finish"],
+        peerSawFin: true,
+        writableFinished: true,
+        readyState: "readOnly",
+        destroyed: false,
+      };
+      const destroyed = {
+        log: ["transport connect", "finish", "close"],
+        peerSawFin: true,
+        writableFinished: true,
+        readyState: "closed",
+        destroyed: true,
+      };
+      expect(await run("pending-transport")).toEqual({
+        "end connecting": ended,
+        "end unconnected": ended,
+        "destroySoon connecting": destroyed,
+        "destroySoon unconnected": destroyed,
+      });
+    });
+
+    it.skipIf(!exe)("a server-side TLSSocket end()s and destroySoon()s in the tick that wraps the socket", async () => {
+      expect(await run("server-same-tick")).toEqual({
+        end: { log: ["finish"], clientSawFin: true, writableFinished: true, destroyed: false },
+        destroySoon: { log: ["finish", "close"], clientSawFin: true, writableFinished: true, destroyed: true },
+      });
+    });
+  });
+
   it.skipIf(!exe)("a server-side TLSSocket end()s while it waits for the client's first flight", async () => {
     expect(await run("server-end")).toEqual({
       log: ["end secureConnecting=true", "finish"],

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1983,15 +1983,20 @@ it("tls.connect({ socket }).end() finishes after a transport with queued plainte
   const raw = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
   raw.on("error", () => {});
   const client = tls.connect({ socket: raw, rejectUnauthorized: false });
-  client.on("error", () => {});
+  const finished = Promise.withResolvers<void>();
+  client.on("error", finished.reject);
+  client.once("close", () => finished.reject(new Error("closed before 'finish'")));
   try {
     const events: string[] = [];
     raw.on("connect", () => events.push("transport connect"));
-    client.on("finish", () => events.push("finish"));
+    client.on("finish", () => {
+      events.push("finish");
+      finished.resolve();
+    });
     // Still queued when the transport connects, so the upgrade takes the stream-level engine.
     raw.write("plain");
     client.end();
-    await new Promise<void>(resolve => client.once("finish", () => resolve()));
+    await finished.promise;
     expect(events).toEqual(["transport connect", "finish"]);
   } finally {
     client.destroy();

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -2006,6 +2006,35 @@ it("tls.connect({ socket }).end() finishes after a transport with queued plainte
   }
 });
 
+// end() waits for a wrap's native handle only while that handle is still to
+// attach. One that attached and then closed leaves nothing to wait for: the
+// stream ends itself from the close, and that end() has to finish.
+it("a server-side TLSSocket wrap finishes and closes after its native handle was closed", async () => {
+  const events: string[] = [];
+  const closed = Promise.withResolvers<void>();
+  let wrapped: TLSSocket | undefined;
+  const server = net.createServer(raw => {
+    raw.on("error", () => {});
+    wrapped = new TLSSocket(raw, { isServer: true, ...COMMON_CERT_ });
+    wrapped.on("error", closed.reject);
+    wrapped.on("secure", () => (wrapped as any)._handle.close());
+    for (const event of ["finish", "close"]) wrapped.on(event, () => events.push(event));
+    wrapped.on("close", () => closed.resolve());
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+  const client = tls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+  client.on("error", () => {});
+  try {
+    await closed.promise;
+    expect(events).toEqual(["finish", "close"]);
+  } finally {
+    client.destroy();
+    wrapped?.destroy();
+    server.close();
+  }
+});
+
 // The peer accepts the TCP connection and never answers the ClientHello (a dead
 // TLS backend, a plaintext service on a TLS port). A caller that gives up must
 // still finish its writable side and send the FIN, as node does:
@@ -2086,6 +2115,17 @@ describe.each([
           "end destroyed": closed,
           "destroySoon refused": closed,
           "destroySoon destroyed": closed,
+        });
+      },
+    );
+
+    // https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1119-L1133
+    it.skipIf(!exe)(
+      "end('') over a tls.connect({ socket }) transport that is still connecting follows the handshake",
+      async () => {
+        expect(await run("end-over-connecting-socket")).toEqual({
+          log: ["end connecting=true", "secureConnect", "finish", "close"],
+          serverSawEnd: true,
         });
       },
     );

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1972,6 +1972,35 @@ it("tls.connect({ socket }) closes when a 'connect' listener destroys the transp
   }
 });
 
+it("tls.connect({ socket }).end() finishes after a transport with queued plaintext connects", async () => {
+  const accepted: net.Socket[] = [];
+  const server = net.createServer(socket => {
+    accepted.push(socket);
+    socket.on("error", () => {});
+    socket.resume();
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const raw = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
+  raw.on("error", () => {});
+  const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+  client.on("error", () => {});
+  try {
+    const events: string[] = [];
+    raw.on("connect", () => events.push("transport connect"));
+    client.on("finish", () => events.push("finish"));
+    // Still queued when the transport connects, so the upgrade takes the stream-level engine.
+    raw.write("plain");
+    client.end();
+    await new Promise<void>(resolve => client.once("finish", () => resolve()));
+    expect(events).toEqual(["transport connect", "finish"]);
+  } finally {
+    client.destroy();
+    raw.destroy();
+    for (const socket of accepted) socket.destroy();
+    server.close();
+  }
+});
+
 // The peer accepts the TCP connection and never answers the ClientHello (a dead
 // TLS backend, a plaintext service on a TLS port). A caller that gives up must
 // still finish its writable side and send the FIN, as node does:

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1943,96 +1943,134 @@ it.skipIf(!nodeExe())(
   },
 );
 
-it("tls.connect({ socket }) closes when a 'connect' listener destroys the transport before the upgrade", async () => {
-  const accepted: net.Socket[] = [];
-  const server = net.createServer(socket => {
-    accepted.push(socket);
-    socket.on("error", () => {});
-  });
-  await once(server.listen(0, "127.0.0.1"), "listening");
-  try {
+// Guards for paths that only bun's deferred upgrade has: the stream-level engine
+// that takes over when plaintext is still queued, and a native handle closed
+// directly. Node reports other events in these shapes, so they do not run under
+// node. The shapes that both runtimes share are in the fixture further down.
+describe("bun's deferred TLS upgrade", () => {
+  async function connectingTransport() {
+    const accepted: net.Socket[] = [];
+    const server = net.createServer(socket => {
+      accepted.push(socket);
+      socket.on("error", () => {});
+      socket.resume();
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
     const raw = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
     raw.on("error", () => {});
-    // Registered first, so it runs before the listener that upgrades the socket.
-    raw.once("connect", () => raw.destroy());
+    return {
+      raw,
+      [Symbol.dispose]() {
+        raw.destroy();
+        for (const socket of accepted) socket.destroy();
+        server.close();
+      },
+    };
+  }
+
+  it("tls.connect({ socket }).end() finishes after a transport with queued plaintext connects", async () => {
+    using transport = await connectingTransport();
+    const { raw } = transport;
     const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+    const finished = Promise.withResolvers<void>();
+    client.on("error", finished.reject);
+    client.once("close", () => finished.reject(new Error("closed before 'finish'")));
+    try {
+      const events: string[] = [];
+      raw.on("connect", () => events.push("transport connect"));
+      client.on("finish", () => {
+        events.push("finish");
+        finished.resolve();
+      });
+      // Still queued when the transport connects, so the upgrade takes the stream-level engine.
+      raw.write("plain");
+      client.end();
+      await finished.promise;
+      expect(events).toEqual(["transport connect", "finish"]);
+    } finally {
+      client.destroy();
+    }
+  });
+
+  // The engine cannot take a string chunk, and a transport with a decoder hands
+  // it one before the engine's start task runs. The socket is no longer
+  // `connecting` by then, so the report must not depend on that flag.
+  it("tls.connect({ socket }) reports a stream-level engine that fails before it starts", async () => {
+    using transport = await connectingTransport();
+    const { raw } = transport;
+    const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+    const outcome = Promise.withResolvers<{ reported: boolean; hadError: boolean; destroyed: boolean }>();
+    let reported = false;
+    client.on("error", () => (reported = true));
+    client.on("close", hadError => outcome.resolve({ reported, hadError, destroyed: client.destroyed }));
+    try {
+      raw.write("plain");
+      raw.setEncoding("utf8");
+      raw.unshift("not a TLS record");
+      expect(await outcome.promise).toEqual({ reported: true, hadError: true, destroyed: true });
+    } finally {
+      client.destroy();
+    }
+  });
+
+  // Plain writes queued on the connection between the wrap and the next tick send
+  // the server-side upgrade to the stream-level engine as well.
+  it("a server-side TLSSocket end()s in the wrap tick while plain writes are queued on the connection", async () => {
+    const finished = Promise.withResolvers<void>();
+    const sockets: net.Socket[] = [];
+    const server = net.createServer(raw => {
+      raw.on("error", () => {});
+      const wrapped = new TLSSocket(raw, { isServer: true, ...COMMON_CERT_ });
+      sockets.push(wrapped, raw);
+      wrapped.on("error", finished.reject);
+      wrapped.once("close", () => finished.reject(new Error("closed before 'finish'")));
+      wrapped.on("finish", () => finished.resolve());
+      // More than the kernel takes at once, and the client does not read: still queued on the next tick.
+      raw.write(Buffer.alloc(32 * 1024 * 1024));
+      wrapped.end();
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const client = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
     client.on("error", () => {});
-    const events: string[] = [];
-    client.on("finish", () => events.push("finish"));
-    client.end();
-    await new Promise<void>(resolve => client.once("close", () => resolve()));
-    expect({ events, destroyed: client.destroyed, transportDestroyed: raw.destroyed }).toEqual({
-      events: [],
-      destroyed: true,
-      transportDestroyed: true,
-    });
-  } finally {
-    for (const socket of accepted) socket.destroy();
-    server.close();
-  }
-});
-
-it("tls.connect({ socket }).end() finishes after a transport with queued plaintext connects", async () => {
-  const accepted: net.Socket[] = [];
-  const server = net.createServer(socket => {
-    accepted.push(socket);
-    socket.on("error", () => {});
-    socket.resume();
+    client.pause();
+    try {
+      await finished.promise;
+      expect(sockets[0].writableFinished).toBe(true);
+    } finally {
+      client.destroy();
+      for (const socket of sockets) socket.destroy();
+      server.close();
+    }
   });
-  await once(server.listen(0, "127.0.0.1"), "listening");
-  const raw = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
-  raw.on("error", () => {});
-  const client = tls.connect({ socket: raw, rejectUnauthorized: false });
-  const finished = Promise.withResolvers<void>();
-  client.on("error", finished.reject);
-  client.once("close", () => finished.reject(new Error("closed before 'finish'")));
-  try {
-    const events: string[] = [];
-    raw.on("connect", () => events.push("transport connect"));
-    client.on("finish", () => {
-      events.push("finish");
-      finished.resolve();
-    });
-    // Still queued when the transport connects, so the upgrade takes the stream-level engine.
-    raw.write("plain");
-    client.end();
-    await finished.promise;
-    expect(events).toEqual(["transport connect", "finish"]);
-  } finally {
-    client.destroy();
-    raw.destroy();
-    for (const socket of accepted) socket.destroy();
-    server.close();
-  }
-});
 
-// end() waits for a wrap's native handle only while that handle is still to
-// attach. One that attached and then closed leaves nothing to wait for: the
-// stream ends itself from the close, and that end() has to finish.
-it("a server-side TLSSocket wrap finishes and closes after its native handle was closed", async () => {
-  const events: string[] = [];
-  const closed = Promise.withResolvers<void>();
-  let wrapped: TLSSocket | undefined;
-  const server = net.createServer(raw => {
-    raw.on("error", () => {});
-    wrapped = new TLSSocket(raw, { isServer: true, ...COMMON_CERT_ });
-    wrapped.on("error", closed.reject);
-    wrapped.on("secure", () => (wrapped as any)._handle.close());
-    for (const event of ["finish", "close"]) wrapped.on(event, () => events.push(event));
-    wrapped.on("close", () => closed.resolve());
+  // end() waits for a wrap's native handle only while that handle is still to
+  // attach. One that attached and then closed leaves nothing to wait for: the
+  // stream ends itself from the close, and that end() has to finish.
+  it("a server-side TLSSocket wrap finishes and closes after its native handle was closed", async () => {
+    const events: string[] = [];
+    const closed = Promise.withResolvers<void>();
+    let wrapped: TLSSocket | undefined;
+    const server = net.createServer(raw => {
+      raw.on("error", () => {});
+      wrapped = new TLSSocket(raw, { isServer: true, ...COMMON_CERT_ });
+      wrapped.on("error", closed.reject);
+      wrapped.on("secure", () => (wrapped as any)._handle.close());
+      for (const event of ["finish", "close"]) wrapped.on(event, () => events.push(event));
+      wrapped.on("close", () => closed.resolve());
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+    const client = tls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+    client.on("error", () => {});
+    try {
+      await closed.promise;
+      expect(events).toEqual(["finish", "close"]);
+    } finally {
+      client.destroy();
+      wrapped?.destroy();
+      server.close();
+    }
   });
-  await once(server.listen(0, "127.0.0.1"), "listening");
-  const { port } = server.address() as AddressInfo;
-  const client = tls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
-  client.on("error", () => {});
-  try {
-    await closed.promise;
-    expect(events).toEqual(["finish", "close"]);
-  } finally {
-    client.destroy();
-    wrapped?.destroy();
-    server.close();
-  }
 });
 
 // The peer accepts the TCP connection and never answers the ClientHello (a dead
@@ -2110,11 +2148,15 @@ describe.each([
       "a tls.connect({ socket }) transport that closes before it connects closes the socket",
       async () => {
         const closed = { log: ["close"], writableFinished: false, readyState: "closed", destroyed: true };
+        // A 'connect' listener that ran first destroyed the transport: the upgrade finds no handle.
+        const closedOnConnect = { readyState: "closed", destroyed: true, transportDestroyed: true };
         expect(await run("closed-transport")).toEqual({
           "end refused": closed,
           "end destroyed": closed,
+          "end destroyed on connect": closedOnConnect,
           "destroySoon refused": closed,
           "destroySoon destroyed": closed,
+          "destroySoon destroyed on connect": closedOnConnect,
         });
       },
     );

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -2013,6 +2013,20 @@ describe.each([
       });
     });
 
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L739-L741
+    it.skipIf(!exe)(
+      "a tls.connect({ socket }) transport that closes before it connects closes the socket",
+      async () => {
+        const closed = { log: ["close"], writableFinished: false, readyState: "closed", destroyed: true };
+        expect(await run("closed-transport")).toEqual({
+          "end refused": closed,
+          "end destroyed": closed,
+          "destroySoon refused": closed,
+          "destroySoon destroyed": closed,
+        });
+      },
+    );
+
     it.skipIf(!exe)("a server-side TLSSocket end()s and destroySoon()s in the tick that wraps the socket", async () => {
       expect(await run("server-same-tick")).toEqual({
         end: { log: ["finish"], clientSawFin: true, writableFinished: true, destroyed: false },

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1943,6 +1943,35 @@ it.skipIf(!nodeExe())(
   },
 );
 
+it("tls.connect({ socket }) closes when a 'connect' listener destroys the transport before the upgrade", async () => {
+  const accepted: net.Socket[] = [];
+  const server = net.createServer(socket => {
+    accepted.push(socket);
+    socket.on("error", () => {});
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  try {
+    const raw = net.connect((server.address() as AddressInfo).port, "127.0.0.1");
+    raw.on("error", () => {});
+    // Registered first, so it runs before the listener that upgrades the socket.
+    raw.once("connect", () => raw.destroy());
+    const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+    client.on("error", () => {});
+    const events: string[] = [];
+    client.on("finish", () => events.push("finish"));
+    client.end();
+    await new Promise<void>(resolve => client.once("close", () => resolve()));
+    expect({ events, destroyed: client.destroyed, transportDestroyed: raw.destroyed }).toEqual({
+      events: [],
+      destroyed: true,
+      transportDestroyed: true,
+    });
+  } finally {
+    for (const socket of accepted) socket.destroy();
+    server.close();
+  }
+});
+
 // The peer accepts the TCP connection and never answers the ClientHello (a dead
 // TLS backend, a plaintext service on a TLS port). A caller that gives up must
 // still finish its writable side and send the FIN, as node does:

--- a/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
+++ b/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
@@ -138,6 +138,31 @@ if (mode === "end" || mode === "destroySoon") {
   );
   console.log(JSON.stringify(reports));
   process.exit(0);
+} else if (mode === "end-over-connecting-socket") {
+  // The zero-length chunk is parked until the wrapped socket connects. It then
+  // reaches the engine ahead of the handshake, so the close_notify and the FIN
+  // follow the handshake and the server sees a clean end.
+  const serverSawEnd = Promise.withResolvers();
+  const server = tls.createServer({ key: process.env.TLS_KEY, cert: process.env.TLS_CERT }, socket => {
+    socket.on("error", () => {});
+    socket.on("data", () => {});
+    socket.on("end", () => serverSawEnd.resolve());
+  });
+  server.on("tlsClientError", serverSawEnd.reject);
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+  const raw = net.connect({ port: server.address().port, host: "127.0.0.1" });
+  const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+  for (const event of ["secureConnect", "finish", "close"]) client.on(event, () => log.push(event));
+  client.on("error", error => log.push(`error:${error.code}`));
+  client.on("data", () => {});
+  log.push(`end connecting=${client.connecting}`);
+  client.end("");
+
+  await Promise.all([once(client, "close"), serverSawEnd.promise]);
+
+  server.close();
+  report({ serverSawEnd: true });
 } else if (mode === "server-same-tick") {
   // new TLSSocket(socket, { isServer: true }) shut down in the tick that wraps
   // it. One report per method, each on a server and a connection of its own.

--- a/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
+++ b/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
@@ -97,6 +97,47 @@ if (mode === "end" || mode === "destroySoon") {
   );
   console.log(JSON.stringify(reports));
   process.exit(0);
+} else if (mode === "closed-transport") {
+  // The same shapes over a net.Socket that closes before it connects. There is
+  // nothing to shut down: the TLS socket closes with its transport. Node also
+  // reports a refused connect as the TLS socket's 'error'. That report is not
+  // part of these shapes, so the log does not subscribe to it.
+  async function shutDown(method, transport) {
+    const log = [];
+    const peer = await stalledPeer();
+    // The local port of a live connection refuses connections: nothing listens
+    // on it, and no listen(0) can be handed it while the connection is open.
+    const holder = net.connect(peer.port, "127.0.0.1");
+    await once(holder, "connect");
+
+    const raw = net.connect(transport === "refused" ? holder.localPort : peer.port, "127.0.0.1");
+    raw.on("error", () => {});
+    const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+    client.on("error", () => {});
+    for (const event of ["finish", "close"]) client.on(event, () => log.push(event));
+    client[method]();
+    if (transport === "destroyed") raw.destroy();
+
+    // events.once() rejects on the 'error' that node emits first.
+    await new Promise(resolve => client.once("close", resolve));
+
+    const { writableFinished, readyState, destroyed } = client;
+    holder.destroy();
+    raw.destroy();
+    peer.close();
+    return { log, writableFinished, readyState, destroyed };
+  }
+
+  const reports = {};
+  await Promise.all(
+    ["end", "destroySoon"].flatMap(method =>
+      ["refused", "destroyed"].map(async transport => {
+        reports[`${method} ${transport}`] = await shutDown(method, transport);
+      }),
+    ),
+  );
+  console.log(JSON.stringify(reports));
+  process.exit(0);
 } else if (mode === "server-same-tick") {
   // new TLSSocket(socket, { isServer: true }) shut down in the tick that wraps
   // it. One report per method, each on a server and a connection of its own.

--- a/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
+++ b/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
@@ -112,6 +112,8 @@ if (mode === "end" || mode === "destroySoon") {
 
     const raw = net.connect(transport === "refused" ? holder.localPort : peer.port, "127.0.0.1");
     raw.on("error", () => {});
+    // Registered before tls.connect() adds its own, so the transport is gone when that one runs.
+    if (transport === "destroyed on connect") raw.once("connect", () => raw.destroy());
     const client = tls.connect({ socket: raw, rejectUnauthorized: false });
     client.on("error", () => {});
     for (const event of ["finish", "close"]) client.on(event, () => log.push(event));
@@ -122,16 +124,20 @@ if (mode === "end" || mode === "destroySoon") {
     await new Promise(resolve => client.once("close", resolve));
 
     const { writableFinished, readyState, destroyed } = client;
+    const transportDestroyed = raw.destroyed;
     holder.destroy();
     raw.destroy();
     peer.close();
+    // Node runs its shutdown on the closed handle here: 'finish' and an EINVAL follow 'close'.
+    // The report keeps what both runtimes share.
+    if (transport === "destroyed on connect") return { readyState, destroyed, transportDestroyed };
     return { log, writableFinished, readyState, destroyed };
   }
 
   const reports = {};
   await Promise.all(
     ["end", "destroySoon"].flatMap(method =>
-      ["refused", "destroyed"].map(async transport => {
+      ["refused", "destroyed", "destroyed on connect"].map(async transport => {
         reports[`${method} ${transport}`] = await shutDown(method, transport);
       }),
     ),

--- a/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
+++ b/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
@@ -60,6 +60,83 @@ if (mode === "end" || mode === "destroySoon") {
   client.destroy();
   peer.close();
   report({ peerSawFin: true, writableFinished, readyState, destroyed });
+} else if (mode === "pending-transport") {
+  // tls.connect({ socket }) over a net.Socket that is not connected yet, shut
+  // down in the same tick: the FIN has to wait for the transport. One report
+  // per method and transport, each on a socket and a peer of its own.
+  async function shutDown(method, transport) {
+    const log = [];
+    const peer = await stalledPeer();
+    const raw = transport === "connecting" ? net.connect(peer.port, "127.0.0.1") : new net.Socket();
+    raw.on("connect", () => log.push("transport connect"));
+
+    const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+    for (const event of ["secureConnect", "finish", "error", "close"]) {
+      client.on(event, arg => log.push(arg?.code ? `${event}:${arg.code}` : event));
+    }
+    client[method]();
+    if (transport === "unconnected") raw.connect(peer.port, "127.0.0.1");
+
+    await Promise.all([once(client, method === "end" ? "finish" : "close"), peer.sawFin]);
+
+    const { writableFinished, readyState, destroyed } = client;
+    const result = { log: [...log], peerSawFin: true, writableFinished, readyState, destroyed };
+    client.destroy();
+    raw.destroy();
+    peer.close();
+    return result;
+  }
+
+  const reports = {};
+  await Promise.all(
+    ["end", "destroySoon"].flatMap(method =>
+      ["connecting", "unconnected"].map(async transport => {
+        reports[`${method} ${transport}`] = await shutDown(method, transport);
+      }),
+    ),
+  );
+  console.log(JSON.stringify(reports));
+  process.exit(0);
+} else if (mode === "server-same-tick") {
+  // new TLSSocket(socket, { isServer: true }) shut down in the tick that wraps
+  // it. One report per method, each on a server and a connection of its own.
+  async function shutDown(method) {
+    const log = [];
+    const clientSawFin = Promise.withResolvers();
+    const wrapped = Promise.withResolvers();
+    const server = net.createServer(raw => {
+      const socket = new TLSSocket(raw, {
+        isServer: true,
+        key: process.env.TLS_KEY,
+        cert: process.env.TLS_CERT,
+      });
+      socket.on("error", () => {});
+      raw.on("error", () => {});
+      for (const event of ["finish", "close"]) socket.on(event, () => log.push(event));
+      wrapped.resolve({ socket, done: once(socket, method === "end" ? "finish" : "close") });
+      socket[method]();
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+    const client = net.connect({ port: server.address().port, host: "127.0.0.1", allowHalfOpen: true });
+    client.on("data", () => {});
+    client.on("error", () => {});
+    client.on("end", () => clientSawFin.resolve());
+
+    const { socket, done } = await wrapped.promise;
+    await Promise.all([done, clientSawFin.promise]);
+
+    const { writableFinished, destroyed } = socket;
+    const result = { log: [...log], clientSawFin: true, writableFinished, destroyed };
+    client.destroy();
+    socket.destroy();
+    server.close();
+    return result;
+  }
+
+  const [end, destroySoon] = await Promise.all(["end", "destroySoon"].map(shutDown));
+  console.log(JSON.stringify({ end, destroySoon }));
+  process.exit(0);
 } else if (mode === "server-end") {
   const clientSawFin = Promise.withResolvers();
   let serverSocket;


### PR DESCRIPTION
### Problem
- `end()` or `destroySoon()` on a TLSSocket with no native handle yet emits `'finish'` at once and never sends the FIN. Node v26.3.0 sends it (Node parity, no user report). Shapes: `tls.connect({ socket })` over an unconnected `net.Socket`, and `new tls.TLSSocket(socket, { isServer: true })` ended in the same tick.
- Cause: `TLSSocket.prototype._final` (`src/js/node/tls.ts:900`) starts with `if (!this._handle) return callback();`. The client path assigns the handle in the transport's `'connect'` listener (`src/js/node/net.ts:2076`), the server wrap one tick later (`net.ts:2413`).

### Fix
- Both paths set `kUpgradePending` until they assign the handle, then emit `kUpgradeAttached`. `_final` waits for it, then `shutdown()` sends the FIN and `'finish'` fires. Other no-handle states call back at once.
- No wait lasts forever. A transport that closes before it connects destroys the TLS socket, as node's `_wrapHandle` does. `connectError` destroys a wrap whose engine fails before it opens.
- `drain` (`net.ts:1321`) sets `kPreHandshakeWrite` for a write parked while the transport connected, so the FIN of `end("")` follows the handshake, as in node. From #42367, which this PR replaces.
- Verified: eight new tests in `test/js/node/tls/node-tls-connect.test.ts` (five fail on `main`, four also run under node v26.3.0), `test/js/node/tls/`, vendored `test-tls-*`, `test-https-*`. Self-reviewed twice: 11 concerns, 7 addressed, 4 already on `main` (Notes).

### Background
- `_final` is the writable side's shutdown hook. `'finish'` fires when its callback does. `destroySoon()` is `end()` plus `destroy()` on `'finish'`.
- Bun adopts the transport's file descriptor into a native TLS handle. That needs a connected socket, and the server wrap waits one tick for bytes already read.
- `kPreHandshakeWrite` marks a write that reached the TLS engine during the handshake. `_final` then holds the FIN until the handshake settles (#42181).
- Node has its handle from the constructor and defers `_final` on `connecting` ([wrap.js](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973), [net.js](https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L536-L541)).

<details><summary>Notes</summary>

Not a regression: bun 1.4.3 behaves the same. Found while working on #42330, which covers a different path (`new tls.TLSSocket(stream)` without `isServer`, where `_handle` is the wrapped stream, not null). #42181 listed the server shape as out of scope. Reach: a `write()` or an `end(data)` in the same window is already parked until the handle attaches, so only a bare `end()`, `end("")` or `destroySoon()` reaches the early `'finish'`.

This PR also carries the parts of #42367 that it did not have. #42367 fixed the same gap and is closed in favor of this PR. Carried over at db37e4b26f: the `kPreHandshakeWrite` line in `drain`, the `end-over-connecting-socket` fixture mode with its test, and the in-process test for a server-side wrap whose native handle was closed directly. Not carried over: the `server-end-same-tick` fixture mode, because `server-same-tick` here asserts the same shape for `end()` and `destroySoon()`.

**Repros**

The client shape, no certificates needed. The peer is a plain TCP server that never answers:

```js
const net = require("net"), tls = require("tls");
const log = [];
const srv = net.createServer({ allowHalfOpen: true }, c => {
  c.on("data", () => log.push("peer: data"));
  c.on("end", () => log.push("peer: got FIN"));
  c.on("error", () => {});
});
srv.listen(0, "127.0.0.1", () => {
  const raw = net.connect(srv.address().port, "127.0.0.1");
  raw.on("connect", () => log.push("raw connect"));
  const s = tls.connect({ socket: raw, rejectUnauthorized: false });
  s.on("error", e => log.push("tls error:" + (e.code || e.message)));
  s.on("finish", () => log.push("tls finish"));
  s.end();
  setTimeout(() => { console.log(log.join("\n")); process.exit(0); }, 800);
});
```

| runtime | output |
| --- | --- |
| node v26.3.0 | `raw connect`, `tls finish`, `peer: data`, `peer: got FIN` |
| bun 1.4.3 and main | `tls finish`, `raw connect`, `peer: data` |
| this branch | `raw connect`, `tls finish`, `peer: data`, `peer: got FIN` |

The server shape: a `net` server whose `'connection'` handler does `new tls.TLSSocket(sock, { isServer: true, key, cert }).end()`, with a `tls.connect` client.

| | server events | client events |
| --- | --- | --- |
| node v26.3.0 | `finish, end, close` | `end, error:ECONNRESET, close` |
| main (a749e0a9b6, debug build) | `finish, secure` (connection stays open) | `secureConnect` |
| this branch | `finish, close` | `end, error:ECONNRESET, close` |

The missing `'end'` on the server side in the last row is a separate regression on `main` since #42265. It also shows with `setImmediate(() => socket.end())`, a shape that this change does not touch: bun at 6a92015fc8 (before #42265) reports `finish, end, close` there, `main` reports `finish, close`. It has its own report. The tests here do not subscribe to `'end'`.

`tls.connect({ socket: net.connect(port) })` followed by `end("")` before the connect, against a live TLS server:

| | client events | server events |
| --- | --- | --- |
| node v26.3.0 | `connect, secureConnect, finish, end, close` | `secureConnection, end, close` |
| main | `finish, secureConnect` (connection stays open) | `secureConnection` |
| this branch without the `drain` line | FIN in the middle of the handshake | `tlsClientError: ECONNRESET` |
| this branch | `secureConnect, finish, end, close` | `secureConnection, end, close` |

The empty write completes inside the native `open` callback, which runs inside `upgradeTLSDeferred`, before `_handle` is assigned. `_final` runs from that write callback, finds `kUpgradePending`, and waits for `kUpgradeAttached`. On its second run it finds `kPreHandshakeWrite` and waits for the handshake. The missing `'connect'` in the last row is a separate gap (#42340). A non-empty `end(data)` was already correct: the engine holds the plaintext until the handshake ends, so the write callback and `_final` run after it.

Other shapes compared with node v26.3.0 on this branch, all with the same event lists: the client shape against a live TLS server (`tlsClientError: ECONNRESET` on the server, then `end` and `close` on the client), the server shape against a TLS client that sends its ClientHello, `write(); end()` in the same tick in both shapes (the data still arrives before the close), and `end(cb); end(cb)` while the upgrade is pending.

**Why a flag**

The flag is reset at the top of `connect()` with the other per-connection TLS state. One helper, `upgradeAttached`, clears it and emits `kUpgradeAttached` at the three places that assign the handle. Each other exit of the deferred callbacks destroys the socket, and a destroyed stream never runs `_final`. An upgrade that throws inside the client's `'connect'` callback leaves the flag set, but the callback keeps its `'close'` listener on the transport until the upgrade has installed its own. Bun routes that exception to the transport's error handler, the transport closes, and the listener destroys the TLS socket. The `destroyed on connect` shapes in the fixture cover the reachable case: a `'connect'` listener that ran first destroyed the transport. A second reachable case is a transport that two TLS sockets wrap: the second upgrade gets no result and throws `Invalid socket`.

A flag, and not the `_write` condition (`!handle && kupgraded && !destroyed`), marks the wait. That condition stays true after an attached handle closes and detaches (`socket._handle.close()`), so #42367 needed an extra `kclosed` check to keep `end()` from waiting forever there. The flag is already clear at that point. The test "a server-side TLSSocket wrap finishes and closes after its native handle was closed" pins this. It passes on `main` too: it guards the wait, it does not reproduce the bug.

**What stays different from node**, all of it present before this change:
- The TLSSocket does not emit `'connect'` when its transport connects. That is why `_final` waits on an internal signal here.
- Only the writable side's shutdown waits for the handle. `ref()`, `unref()`, `setTimeout()` and `_read()` in the same window still act on no handle, as on `main`. Example: `unref()` in the wrap tick keeps the process alive on bun, node exits. They are out of scope here.
- A transport whose connect fails: node also emits the transport's `'error'` on the TLSSocket. Bun does not yet (#38122). This branch closes the TLSSocket with the transport, so a pending `end()` or `destroySoon()` ends in `'close'` as in node. Before this change `end()` reported `'finish'` and the TLSSocket stayed open.
- A `net.Socket` transport that takes the stream-level engine at wrap time (a connected named pipe, an outer TLSSocket) stays `connecting` until the engine opens, so its `_final` waits for a `'connect'` that is never emitted (#42343, #42340). Checked on Windows: `tls.connect({ socket: net.connect(pipe) }).end()` behaves the same before and after this change.
- `end("")` in the wrap tick on a server-side wrap waits for the handshake (`secure, finish, end, close`). Node sends the FIN at once. This is the zero-length write rule that #42181 describes.
- `new tls.TLSSocket(socket, { isServer: true })` over a socket that is still connecting keeps the early `'finish'` (see the second self-review below).

One difference that this change introduces: `end()` on a server wrap followed by `raw.destroy()` in the same tick. Node reports `'finish'` and then `'close'`, because its cancelled shutdown request still completes. Bun did the same by accident, because `'finish'` fired early. This branch reports `'close'` only. No FIN can be sent in that case on either runtime.

Same as node: a transport that is already destroyed when `tls.connect({ socket })` takes it. Node v26.3.0 keeps the TLSSocket `connecting`, with no `'finish'` and no `'close'`, because `raw.connect()` can connect a destroyed `net.Socket` again. A later `raw.connect()` completes the pending `end()` on node and on this branch (`raw connect`, `tls finish`, `peer: data`, `peer: got FIN`). So the TLSSocket is not destroyed for a transport that is destroyed at wrap time.

**Tests and node**

Four tests run one fixture (`tls-shutdown-before-handshake-fixture.mjs`) under bun and under node v26.3.0 and assert the same report: `pending-transport`, `closed-transport`, `end-over-connecting-socket`, `server-same-tick`. The shape where a `'connect'` listener destroys the transport first is part of `closed-transport`. Node runs its shutdown on the closed handle there and reports `close, finish, error:EINVAL`. Bun reports `close`. The shared report is `readyState: "closed"`, `destroyed: true`, `transportDestroyed: true`.

Four in-process tests pin paths that only bun's deferred upgrade has. They do not run under node. Node's output for the same scripts:
- `end()` with plaintext still queued on a connecting transport: node reports `transport connect, error:EPIPE, finish, close` and the peer gets the FIN. This branch reports `transport connect, finish`. `main` reports `finish` before `transport connect`. The stream-level engine sends no FIN before it starts (#42350).
- A stream-level engine that gets a string chunk before it starts (`setEncoding("utf8")` on the transport): node aborts in `TLSWrap::Receive` (`Assertion failed: buf->IsSharedArrayBuffer()`). `main` and this branch report `'error'` and `'close'`.
- `end()` in the wrap tick with a 32 MB plain write queued on the connection: node emits no `'finish'` until the plain write drains. `main` and this branch emit `'finish'`. The test guards the `upgradeAttached` call on that path: without it `end()` never finishes.
- A server-side wrap whose native handle was closed directly: node reports `secure, close`, bun reports `secure, end, finish, close`.

**Self-reviews**

First version, 5 concerns:
- Addressed (0931c214ef): `TLSSocket.prototype._final` first sent every no-handle case to `net.Socket`'s `_final`. A TLS socket whose upgrade fails synchronously in `connect()` (for example a second `tls.connect({ socket })` over a transport that is already wrapped, `Invalid socket`) has no handle and still reports `connecting`. Its `end()` then waited for a `'connect'` that never comes. `main` reports `'finish'` at once there. Now only a pending upgrade takes the new path, and that case behaves as on `main` again.
- Addressed (481fd608d3): when the transport connects and the upgrade takes the stream-level engine (plaintext still queued on the transport, or a named pipe that was dialed after the wrap), the handle is attached but the socket stayed `connecting` until the engine opened on a later task. The second run of `_final` then waited for a `'connect'` that is never emitted, where bun 1.4.2 reported `'finish'` at once. The deferred callback now clears `connecting` once it has the handle, as node does on the transport's `'connect'`. `'finish'` fires after the transport connects and `destroySoon()` closes. That sub-path still sends no FIN, because `shutdown()` is a no-op before the engine starts (#42350).
- Not changed: node also emits the pending transport's `'error'` on the TLS socket (#38122).
- Not changed: a TLSSocket that is destroyed while its upgrade is pending and then connected again keeps the listeners of its first life. That is already wrong on `main`, where the first transport's `'connect'` still upgrades the socket that was connected again.
- Not changed then, see below: a server-side wrap over a transport that is still connecting (#38076).

Combined diff at db37e4b26f, 6 concerns. The verdict was to merge after changes. Changes are in f111176481:
- Addressed: after 481fd608d3 a stream-level engine that failed before it opened was dropped. `connectError` handed it to `afterConnect`, which returns when nothing is `connecting`. `main` reports `'error'` and `'close'` there, the branch reported nothing and the socket stayed open. `connectError` now destroys an upgraded socket itself. These are the same five lines as in #42343, which fixes the same drop for Duplex and TLS-in-TLS transports on `main`.
- Addressed: `new tls.TLSSocket(socket, { isServer: true })` over a `net.Socket` that is still connecting, then a bare `end()` or `destroySoon()`. The native upgrade adopts that handle before it is connected. With the wait, `_final` then ran `shutdown()` on it, and the close underflowed the native connection count: `panic: attempt to subtract with overflow` in `Handlers::mark_inactive` (`src/runtime/socket/Handlers.rs:244`) on a debug build, a silent wrap of the counter on a release build. `main` only reports the early `'finish'` there. The server wrap no longer sets `kUpgradePending` over a connecting socket, so that shape behaves as on `main`. In a 36-cell matrix (9 operations, 4 kinds of peer) the branch now aborts in the same 7 cells as `main` and in no other. Those 7 are a bug on `main`: the same wrap aborts when it is destroyed while its peer never answers, with or without `end()`. #38076 adopts such a socket only after `'connect'` and can remove the exclusion.
- Addressed: the three places that assign the handle each cleared the flag and emitted the event by hand. A rebase of an open PR that dropped one clear would hang every `end()` on that path. One helper does both now, and each of the three places has a test that hangs without the call.
- Addressed: tests. The bar on #42181 was that new tests pass under node v26.3.0 too. The `'connect'`-listener shape moved into the fixture. The bun-only tests are grouped and node's output for them is listed above.
- Addressed in this description: the merge order below, and the reach of the bug.
- Not changed: `ref()`, `unref()`, `setTimeout()` and `_read()` in the same window (listed above). They need their own handling of the missing handle, not the `_final` wait.

**Merge order with the open PRs on the same lines**

This PR is the narrow fix and can go first.
- #42367: closed, replaced by this PR.
- #42340 emits `'connect'` on a TLSSocket whose transport connects. Rebase onto this PR: keep its `net.ts` part, with `onUpgradedConnect(this, connection)` next to `upgradeAttached(this)`. Drop its `tls.ts` hunk. That hunk deletes the no-handle check in `_final`, and the server shape has no `'connect'` to wait for.
- #42343 clears `connecting` on a wrap of a connected socket. Independent. Its `connectError` lines are identical to the ones here, so git merges them in either order.
- #38076 uses the stream engine for server-side wraps that the native upgrade cannot adopt, and rewrites `::bunUpgradeServerTLS::`. On rebase its two `emit(kUpgradeAttached)` calls become `upgradeAttached(self)`, and each new exit has to clear the flag or destroy the socket. It can then set `kUpgradePending` over a connecting socket as well.
- #38028 destroys the wrapped `net.Socket` with the TLS wrap. It edits the same deferred `'connect'` listener. Line-level conflicts only: keep the named `onConnect` and `onClose` pair.
- #42330 changes the first lines of `TLSSocket.prototype._final` for `new tls.TLSSocket(stream)` without `isServer`, where `_handle` is the stream. Small conflict, both checks stay.
- #36534 reworks the whole upgrade in native code and makes `_final` wait through `_parent`. It is large and has conflicts. If it lands, it replaces this mechanism.

**Suites**, debug build of f111176481 (this branch with `main` at a749e0a9b6 merged in):
- `test/js/node/tls/node-tls-connect.test.ts`: 67 pass, 0 fail. With `net.ts`, `tls.ts` and `symbols.ts` from `main`: 62 pass, 5 fail (the four fixture tests in their bun variant, and the queued-plaintext test).
- All seven fixture modes give the same report under node v26.3.0 and under this branch.
- `test/js/node/tls/`: 328 pass, 2 fail. "SNICallback runs even when the requested servername matches the bind hostname" needs an IPv4 `localhost` and fails the same way on the release binary without this change. "concurrent Workers all see the same CA certificate lists" takes 4.1 to 4.9 s of its 5 s limit on this machine. It passes alone and passed in the run before.
- Vendored `parallel/` and `sequential/` `test-tls-*` and `test-https-*` scripts: 250 of 252 exit 0. `test-tls-client-allow-partial-trust-chain.js` is a `node:test` file and needs `bun test`. `test-https-timeout.js` hangs on the debug build with and without this change and passes on the release binary.
- `test/js/node/http2/node-http2-upgrade.test.mts` and `node-http2-client-close.test.ts`: 84 pass.
- At db37e4b26f: `test/js/node/net/`, 266 pass, 11 fail. Ten fail the same way with `main`'s files (`net.Socket read`, `unref should exit`, `#13126`: public DNS or an IPv4 `localhost`). The eleventh, "should not leak when connect({path}) fails synchronously on a reused handle", is a plain `net.Socket` test with a 60 s limit. Here it takes 58 s with `main`'s files and runs past the limit with this branch's. No line of this change is on that path, and the script alone takes 48 s on this branch and reports `delta: 0`.
- Before the merge of #42367's parts, at ed6872ebb7 and 5ab75591ec: also `test/js/bun/net/`, `test/js/node/http2/`, the vendored `test-net-*` and `test-http2-*` scripts (619 of 621 exit 0 over all four groups), and the new tests on Windows x64 with a local debug build.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [3.89ms]
(pass) should thow ECONNRESET if FIN is received before handshake [355.82ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [8.10ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [108.40ms]
(pass) should be able to grab the JSStreamSocket constructor [13.90ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [81.69ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [88.36ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port an
... (truncated)

release without fix: 18 skipped
bun test v1.4.3-canary.1 (f11117648)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.06ms]
(pass) should thow ECONNRESET if FIN is received before handshake [9.87ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [0.30ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [5.08ms]
(pass) should be able to grab the JSStreamSocket constructor [0.41ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [7.02ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [6.14ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls.c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [3.72ms]
(pass) should thow ECONNRESET if FIN is received before handshake [369.20ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [8.92ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [112.73ms]
(pass) should be able to grab the JSStreamSocket constructor [18.56ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [85.64ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [94.41ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port an
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 630ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/126] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/126] gen cpp.rs (cppbind)
[3/126] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[4/126] gen JS modules (bundle-modules)
Preprocess modules (7529ms)
Bundle modules (49ms)
Postprocesss modules (205ms)
Bundle Functions (476ms)
Generate Code (39ms)

[8.31s] Bundled "src/js" for production
  2601 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[4/125] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/net/symbols.ts                     |   2 +
 src/js/node/net.ts                                 |  41 ++++-
 src/js/node/tls.ts                                 |  14 +-
 test/js/node/tls/node-tls-connect.test.ts          | 194 +++++++++++++++++++++
 .../tls/tls-shutdown-before-handshake-fixture.mjs  | 149 ++++++++++++++++
 5 files changed, 394 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/internal/net/symbols.ts                                1      1     39
src/js/node/net.ts                                           16     14     39
src/js/node/tls.ts                                            1      1     39
test/js/node/tls/node-tls-connect.test.ts                     5      6     39
…t/js/node/tls/tls-shutdown-before-handshake-fixture.mjs      3      5     48
```

</details>

<!-- robobun:evidence:end -->
