### PR TITLE
node:tls: emit 'connect' on a TLSSocket that wraps a connecting socket

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -276,6 +276,12 @@ function onUpgradedClose(self, connection) {
 function destroyWhenUpgradedCloses(self, connection) {
   connection.once("close", (self[kOnUpgradedClose] = onUpgradedClose.bind(null, self, connection)));
 }
+// Node's parent 'connect' -> 'connect': https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973
+function onUpgradedConnect(self, connection) {
+  if (self.destroyed || self[kupgraded] !== connection) return;
+  self.connecting = false;
+  self.emit("connect");
+}
 let addAbortListener;
 function destroyWhenAborted(err) {
   if (!this.destroyed) {
@@ -2043,6 +2049,9 @@ Socket.prototype.connect = function connect(...args) {
           connection.on("close", events[3]);
           destroyWhenUpgradedCloses(this, connection);
           this._handle = result;
+          if (connection instanceof Socket && connection.connecting) {
+            connection.once("connect", onUpgradedConnect.bind(null, this, connection));
+          }
         } else {
           // upgradeTLS requires an established socket; a socket that is still
           // connecting (e.g. tls.connect({ socket: net.connect(port) })) must be
@@ -2118,6 +2127,7 @@ Socket.prototype.connect = function connect(...args) {
                   throw new Error("Invalid socket");
                 }
               }
+              onUpgradedConnect(this, connection);
             });
           }
         }
@@ -2788,6 +2798,8 @@ Socket.prototype._write = function _write(chunk, encoding, callback) {
     }
     this.once("connect", function connect() {
       this.off("close", onClose);
+      // tls.connect({ socket }): the open handler's drain sends this chunk before 'connect' is emitted.
+      if (this._pendingData !== chunk) return;
       this._write(chunk, encoding, callback);
     });
     this.once("close", onClose);

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -897,9 +897,8 @@ TLSSocket.prototype._start = function _start() {
 };
 
 TLSSocket.prototype._final = function _final(callback) {
-  if (!this._handle) return callback();
   // https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1119-L1133
-  if (this.secureConnecting && this[kPreHandshakeWrite]) {
+  if (this._handle && this.secureConnecting && this[kPreHandshakeWrite]) {
     return this.once(kSecureConnectDone, NetSocket.prototype._final.bind(this, callback));
   }
   // https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1203-L1213

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1993,3 +1993,249 @@ describe.each([
     });
   });
 });
+
+// node re-emits the wrapped socket's 'connect' on the TLSSocket, and whatever a
+// connecting socket defers (a parked write, end()) resumes from that event:
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973
+// The sequences asserted below are the ones node v26.3.0 produces.
+describe("tls.connect({ socket }) over a net.Socket that is still connecting", () => {
+  // A TLS server that reports everything the client sent once the client ends.
+  async function tlsSink() {
+    const received = Promise.withResolvers<string>();
+    const server = tls.createServer(COMMON_CERT_, socket => {
+      let data = "";
+      socket.on("error", received.reject);
+      socket.on("data", chunk => (data += chunk));
+      socket.on("end", () => {
+        received.resolve(data);
+        socket.end();
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    return {
+      port: (server.address() as AddressInfo).port,
+      received: received.promise,
+      [Symbol.asyncDispose]: () => server[Symbol.asyncDispose](),
+    };
+  }
+
+  it("emits 'connect' when the wrapped socket connects, and a write from that listener is delivered", async () => {
+    await using sink = await tlsSink();
+    const raw = net.connect(sink.port, "127.0.0.1");
+    const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+    const log = [`wrapped connecting=${client.connecting}`];
+    // Added after the wrap, so it runs after the TLSSocket's 'connect': the
+    // event is re-emitted inside the wrapped socket's own emit, not later.
+    raw.on("connect", () => log.push("wrapped socket's later 'connect' listener"));
+    client.on("connect", () => {
+      log.push(
+        `connect connecting=${client.connecting} pending=${client.pending} secureConnecting=${client.secureConnecting}`,
+      );
+      client.write("from connect;");
+    });
+    // Only 'connect' is re-emitted: node has no 'ready' on this socket.
+    client.on("ready", () => log.push("ready"));
+    client.on("secureConnect", () => {
+      log.push("secureConnect");
+      client.end("from secureConnect;");
+    });
+
+    const [received] = await Promise.all([sink.received, once(client, "close")]);
+
+    expect({ log, received }).toEqual({
+      log: [
+        "wrapped connecting=true",
+        "connect connecting=false pending=false secureConnecting=true",
+        "wrapped socket's later 'connect' listener",
+        "secureConnect",
+      ],
+      received: "from connect;from secureConnect;",
+    });
+  });
+
+  it("sends a write issued before the wrapped socket connects once, ahead of a write from 'connect'", async () => {
+    await using sink = await tlsSink();
+    const raw = net.connect(sink.port, "127.0.0.1");
+    const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+    const callbacks: string[] = [];
+    client.write("before connect;", () => callbacks.push("before connect"));
+    client.on("connect", () => client.write("from connect;", () => callbacks.push("from connect")));
+    client.on("secureConnect", () => client.end());
+
+    const [received] = await Promise.all([sink.received, once(client, "close")]);
+
+    expect({ received, callbacks }).toEqual({
+      received: "before connect;from connect;",
+      callbacks: ["before connect", "from connect"],
+    });
+  });
+
+  // The wrapped socket sends a plaintext preamble first (a PROXY protocol
+  // header, say). That parked write makes the TLS engine run over the stream
+  // instead of taking over the fd, from either of two places.
+  it.each([
+    [
+      "a preamble written before the wrap",
+      (port: number) => {
+        const raw = net.connect(port, "127.0.0.1");
+        raw.write("preamble;");
+        return { raw, client: tls.connect({ socket: raw, rejectUnauthorized: false }) };
+      },
+    ],
+    [
+      "a socket wrapped before it dials",
+      (port: number) => {
+        const raw = new net.Socket();
+        const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+        raw.connect(port, "127.0.0.1");
+        raw.write("preamble;");
+        return { raw, client };
+      },
+    ],
+  ])("also when the TLS engine runs over the stream: %s", async (_shape, dial) => {
+    // Reads the preamble, then speaks TLS on the same connection.
+    const received = Promise.withResolvers<{ preamble: string; data: string }>();
+    await using server = net.createServer(socket => {
+      socket.once("readable", () => {
+        const preamble = String(socket.read(9));
+        const secure = new tls.TLSSocket(socket, { isServer: true, ...COMMON_CERT_ });
+        let data = "";
+        secure.on("error", received.reject);
+        secure.on("data", chunk => (data += chunk));
+        secure.on("end", () => {
+          received.resolve({ preamble, data });
+          secure.end();
+        });
+      });
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { client } = dial((server.address() as AddressInfo).port);
+    const log = [`wrapped connecting=${client.connecting}`];
+    client.write("before connect;");
+    client.on("connect", () => {
+      log.push(`connect connecting=${client.connecting} pending=${client.pending}`);
+      client.write("from connect;");
+    });
+    client.on("secureConnect", () => {
+      log.push("secureConnect");
+      client.end();
+    });
+
+    const [fromClient] = await Promise.all([received.promise, once(client, "close")]);
+
+    expect({ log, fromClient }).toEqual({
+      log: ["wrapped connecting=true", "connect connecting=false pending=false", "secureConnect"],
+      fromClient: { preamble: "preamble;", data: "before connect;from connect;" },
+    });
+  });
+
+  it("end() issued before the wrapped socket connects waits for 'connect', then sends the FIN", async () => {
+    // The peer never answers the ClientHello, so the handshake cannot settle
+    // first, and allowHalfOpen keeps it from closing when the FIN arrives.
+    const sawFin = Promise.withResolvers<void>();
+    const accepted: net.Socket[] = [];
+    await using peer = net.createServer({ allowHalfOpen: true }, socket => {
+      accepted.push(socket);
+      socket.on("error", () => {});
+      socket.on("data", () => {});
+      socket.on("end", () => sawFin.resolve());
+    });
+    await once(peer.listen(0, "127.0.0.1"), "listening");
+    const raw = net.connect((peer.address() as AddressInfo).port, "127.0.0.1");
+    const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+    try {
+      const log: string[] = [];
+      client.on("connect", () => log.push("connect"));
+      client.on("finish", () => log.push("finish"));
+      client.end();
+
+      await once(client, "finish");
+      expect(log).toEqual(["connect", "finish"]);
+      await sawFin.promise;
+    } finally {
+      client.destroy();
+      raw.destroy();
+      for (const socket of accepted) socket.destroy();
+    }
+  });
+
+  describe("does not emit 'connect'", () => {
+    it("when the wrapped socket had already connected", async () => {
+      await using sink = await tlsSink();
+      const raw = net.connect(sink.port, "127.0.0.1");
+      await once(raw, "connect");
+      const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+      const log = [`wrapped connecting=${client.connecting}`];
+      client.on("connect", () => log.push("connect"));
+      client.on("secureConnect", () => {
+        log.push("secureConnect");
+        client.end();
+      });
+
+      await Promise.all([sink.received, once(client, "close")]);
+
+      expect(log).toEqual(["wrapped connecting=false", "secureConnect"]);
+    });
+
+    it("when the TLSSocket was destroyed before the wrapped socket connects", async () => {
+      await using peer = net.createServer(socket => {
+        socket.on("error", () => {});
+        socket.resume();
+      });
+      await once(peer.listen(0, "127.0.0.1"), "listening");
+      const raw = net.connect((peer.address() as AddressInfo).port, "127.0.0.1");
+      // A parked write: the engine runs over the stream, and that branch does
+      // not tear the wrapped socket down, so the socket still connects.
+      raw.write("preamble;");
+      const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+      try {
+        const connects: string[] = [];
+        client.on("connect", () => connects.push(`connect destroyed=${client.destroyed}`));
+        client.destroy();
+
+        // node destroys the wrapped socket with the TLSSocket.
+        if (!raw.destroyed) await once(raw, "connect");
+
+        expect(connects).toEqual([]);
+      } finally {
+        raw.destroy();
+      }
+    });
+
+    it("for a Duplex that reports connecting and emits its own 'connect'", async () => {
+      // node only follows a net.Socket: a Duplex transport counts as connected.
+      await using sink = await tlsSink();
+      const raw = net.connect(sink.port, "127.0.0.1");
+      const duplex = Object.assign(
+        new Duplex({
+          read() {},
+          write(chunk, encoding, callback) {
+            raw.write(chunk, encoding, callback);
+          },
+          final(callback) {
+            raw.end();
+            callback();
+          },
+        }),
+        { connecting: true },
+      );
+      raw.on("data", chunk => duplex.push(chunk));
+      raw.on("end", () => duplex.push(null));
+      raw.on("connect", () => {
+        duplex.connecting = false;
+        duplex.emit("connect");
+      });
+      const client = tls.connect({ socket: duplex, rejectUnauthorized: false });
+      const log = [`wrapped connecting=${client.connecting}`];
+      client.on("connect", () => log.push("connect"));
+      client.on("secureConnect", () => {
+        log.push("secureConnect");
+        client.end();
+      });
+
+      await Promise.all([sink.received, once(client, "close")]);
+
+      expect(log).toEqual(["wrapped connecting=false", "secureConnect"]);
+    });
+  });
+});

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -176,3 +176,49 @@ it.if(isWindows)("should be able to upgrade a named pipe connection to TLS", asy
   await test(`\\\\.\\pipe\\test\\${randomUUID()}`);
   await expectMaxObjectTypeCount(expect, "TLSSocket", 3);
 });
+
+// A named pipe runs the TLS engine over the stream as soon as it is wrapped,
+// so this is not the wait-for-'connect' branch that the TCP tests in
+// node-tls-connect.test.ts cover. node re-emits the pipe's 'connect':
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973
+it.if(isWindows)("a TLSSocket over a named pipe that is still connecting emits 'connect'", async () => {
+  const received = Promise.withResolvers<string>();
+  let client: ReturnType<typeof connect> | null = null;
+  const server = createServer(tls, socket => {
+    let data = "";
+    socket.on("error", received.reject);
+    socket.on("data", chunk => (data += chunk));
+    socket.on("end", () => {
+      received.resolve(data);
+      socket.end();
+    });
+  });
+  try {
+    const pipeName = `\\\\.\\pipe\\test\\${randomUUID()}`;
+    server.listen(pipeName);
+    await once(server, "listening");
+
+    const socket = connect({ socket: net.connect(pipeName), ca: tls.cert });
+    client = socket;
+    const log = [`wrapped connecting=${socket.connecting}`];
+    socket.write("before connect;");
+    socket.on("connect", () => {
+      log.push(`connect connecting=${socket.connecting} pending=${socket.pending}`);
+      socket.write("from connect;");
+    });
+    socket.on("secureConnect", () => {
+      log.push("secureConnect");
+      socket.end();
+    });
+
+    const [fromClient] = await Promise.all([received.promise, once(socket, "close")]);
+
+    expect({ log, fromClient }).toEqual({
+      log: ["wrapped connecting=true", "connect connecting=false pending=false", "secureConnect"],
+      fromClient: "before connect;from connect;",
+    });
+  } finally {
+    client?.destroy();
+    server.close();
+  }
+});


### PR DESCRIPTION
### Problem
- `tls.connect({ socket })` over a still-connecting `net.Socket` never emits `'connect'` on the TLSSocket, only `'secureConnect'`, so a `'connect'` listener that starts the conversation never runs. Node v26.3.0 emits it when the TCP connect completes.
- `Socket.prototype.connect` (`src/js/node/net.ts:2082`) starts TLS from the wrapped socket's `'connect'` and does not re-emit it.
- `end()` before that connect found no handle: `'finish'` fired at once and no FIN was sent.

### Fix
- Emit `'connect'` from the wrapped socket's `'connect'`, after the TLS handle is attached, as node's `TLSSocket._init` does ([wrap.js#L964-L973](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973)). The branch that runs TLS over the stream at once (connecting named pipe, parked write, TLSSocket) gets the same listener.
- `drain` in the open handler already sends a write parked while connecting. That write's `'connect'` listener now skips a chunk `drain` took. Without the guard it goes out twice.
- `TLSSocket._final` leaves the no-handle case to `net.Socket._final`, which waits for `'connect'` while connecting.
- Verified: 8 new tests in `test/js/node/tls/node-tls-connect.test.ts` (5 fail on main), one Windows test in `node-tls-namedpipes.test.ts`. Self-reviewed: 4 concerns raised, 4 addressed. Suites and exclusions are in the notes.

### Background
- `tls.connect({ socket })` wraps an existing stream. For a connected TCP socket, Bun moves the fd into a native TLS socket (`upgradeTLSDeferred`) and the native `open` callback runs inside that call. Otherwise a TLS engine runs over the stream (`upgradeDuplexToTLS`) and `open` runs a tick later.
- While `connecting` is true, `_write` parks one chunk (`_pendingData`). `_write`, `_final`, `_read`, `ref()` and `unref()` wait on `once('connect')`.
- A direct `tls.connect(port)` emits `'connect'` through `afterConnect`. `SocketHandlers2.open` skips that for a wrapped socket and calls `drain`, which sends the parked write.

<details><summary>Notes</summary>

Repro (from the report), `raw` still connecting when it is wrapped:

```js
const raw = net.connect(port, "127.0.0.1");
const c = tls.connect({ socket: raw, rejectUnauthorized: false });
c.once("connect", () => c.write("first;"));
c.once("secureConnect", () => { c.write("second;"); c.end(); });
```

| | client events | server received |
| --- | --- | --- |
| node v26.3.0 | `connect`, `secureConnect`, write callbacks, `finish`, `close` | `first;second;` |
| bun 1.4.3, main | `secureConnect`, second write callback, `finish`, `close` | `second;` |
| this branch | same as node | `first;second;` |

**What matches node, and where.** Event matrix for the fd branch (`upgradeTLSDeferred`), {wrapped while connecting, wrapped after connect, direct} x first action at {same tick, TLSSocket `'connect'`, wrapped socket's `'connect'`} x {write, write+end, end}, against a TLS server that ends when the client does. Before: the three "TLSSocket `'connect'`" cells of a socket wrapped while connecting do nothing, and "same tick, end" emits `'finish'` and then hangs. After: every cell gives node's event list, except that a bare `end()` before the handshake gives no `'secureConnect'`. That difference is the same for a direct `tls.connect(port)` and is described in #42181. The eight new tests were also run as a plain script on node v26.3.0 and hold there.

**Each added clause has a test that fails without it** (checked by deleting the clause): the emit in the wait branch (tests 1, 2), the listener in the stream branch ("a preamble written before the wrap"), `self.connecting = false` ("a socket wrapped before it dials", where `open` has not run yet), a deferred emit such as `process.nextTick` (test 1 pins that the event runs inside the wrapped socket's own emit), the `_pendingData` guard (test 2 receives `before connect;before connect;from connect;` without it), the `_final` change (the `end()` test), `self.destroyed` and `connection instanceof Socket` (the last two tests). The `self[kupgraded] !== connection` half of the guard mirrors `onUpgradedClose` from #39066. It is reachable by calling `connect({ socket })` again on the same TLSSocket before the first socket connects, and has no test, as in #39066.

**Windows.** Run on a Windows x64 debug build: `tls.connect({ socket: net.connect(pipeName) })` emitted no `'connect'` before and does now (the new test in `node-tls-namedpipes.test.ts` fails without the change and passes with it). `node-tls-connect.test.ts`, `node-tls-upgrade.test.ts` and `node-tls-socket-allow-half-open-option.test.ts` pass there. `should work with named pipes and tls` times out in a debug build with and without the change.

**Not node's behaviour after this change, all of it also true on main:**
- The `end()` claim ("sends the FIN") holds for the fd branch only. In the stream branch (parked write, named pipe) an `end()` before the connect now gives `'connect'`, `'finish'`, and the peer still sees no FIN. main gives nothing at all there. The engine does not end the underlying stream when it is shut down before the handshake. It reproduces on main with a plain `Duplex` transport and is reported separately.
- `end()` before a wrapped connect that is then refused: main emits a spurious `'finish'`, this branch emits nothing (node: `'error'`, `'close'`). Neither emits `'error'` or `'close'` until #38122 lands.
- A zero-length write parked before the connect (`write("")`, `end("")`): its callback runs from `drain` inside the native `open`, before `'connect'` and before the handle is assigned, so `end("")` still finishes with no FIN. node keeps that write pending until the handshake completes. Same root as the next item.
- Excluded on purpose from the `_final` change: `new tls.TLSSocket(raw, { isServer: true }).end()` in the wrap tick (named as out of scope in #42181). It needs a wait on the handle attach (`kUpgradeAttached`), not on `'connect'`. #42339 adds that wait.
- On Windows, `end()` in the same tick as wrapping an already connected named pipe never emits `'finish'`: the TLSSocket reports `connecting` for one tick and nothing emits `'connect'` for it. Unchanged here, reported separately.

**One behaviour change outside tls.** The `_pendingData` guard sits in the shared `_write`. A plain `net.Socket` that is reused after a failed `connect()` with a parked write keeps the stale `'connect'` listener of that write. node, bun 1.4.3 and main then send the stale chunk again on the next connect and emit `ERR_MULTIPLE_CALLBACK`. With the guard the stale listener does nothing and only the current write goes out. Plain `net.connect` and direct `tls.connect` dials with a parked write are unchanged.

**Effect outside tls.** `http.ClientRequest#setTimeout` and `_deferToConnect` (`setNoDelay`, `setSocketKeepAlive`) wait for `'connect'` on a connecting socket. With a `createConnection` that returns such a TLSSocket they never ran.

Adjacent open PRs, none of which emits the event: #38122 (the wrapped socket's connect failure, same callback), #42176, #36534. Two open PRs edit `TLSSocket.prototype._final` too and will need a textual merge with this one. #42330 covers a `new TLSSocket(stream)` wrap that was never connected. #42339 (opened while this was in review) makes `_final` wait for the handle attach, which fixes the same `end()` symptom from the other side and also the server-side wrap. It emits no `'connect'`. Both changes send the no-handle case to `net.Socket._final`, so they compose: with both, `_final` waits for the attach and then finds `connecting` already false.

Suites run with the change (Linux debug build): `test/js/node/tls/`, `test/js/node/net/`, `test/js/node/http2/`, `test/js/bun/net/`, and the vendored `test-tls-*`, `test-https-*`, `test-net-*`, `test-http2-*` files. Local failures that are the same with and without this change: `SNICallback runs even when the requested servername matches the bind hostname`, `socket > should not call drain before handshake`, `net.Socket read > ...` in `node-net.test.ts`, and the vendored `test-https-timeout.js`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tls/node-tls-namedpipes.test.ts

<!-- robobun:evidence:end -->