### PR TITLE
webview: report a failed Chrome load from its error page, once

### DIFF
--- a/src/runtime/webview/ChromeBackend.cpp
+++ b/src/runtime/webview/ChromeBackend.cpp
@@ -654,6 +654,14 @@ static void settle(JSGlobalObject* g, JSWebView* view, PendingSlot slot, bool ok
     settleSlot(g, view, slotFor(view, slot), ok, v);
 }
 
+static void fireOnNavigationFailed(JSGlobalObject* g, JSWebView* view, JSValue errValue)
+{
+    if (JSObject* cb = view->m_onNavigationFailed.get()) {
+        Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
+            JSValue::encode(errValue), JSValue::encode(jsUndefined()));
+    }
+}
+
 // Reject one op's slot on a CDP failure. A Navigate-slot failure also fires
 // onNavigationFailed and clears loading, like WebKit's NavFailEvent, except
 // for PageTitle: that is the post-load title fetch, and its failure (for
@@ -665,12 +673,7 @@ static void settleFailure(JSGlobalObject* g, JSWebView* view, PendingSlot slot, 
     bool navigationFailed = slot == PendingSlot::Navigate && method != Method::PageTitle;
     if (navigationFailed) view->m_loading = false;
     settle(g, view, slot, false, errValue);
-    if (navigationFailed) {
-        if (JSObject* cb = view->m_onNavigationFailed.get()) {
-            Bun__EventLoop__runCallback2(g, JSValue::encode(cb), JSValue::encode(jsUndefined()),
-                JSValue::encode(errValue), JSValue::encode(jsUndefined()));
-        }
-    }
+    if (navigationFailed) fireOnNavigationFailed(g, view, errValue);
 }
 
 // Slots, not m_pending: a navigation that Chrome has already answered is
@@ -869,6 +872,8 @@ void Transport::handleResponse(uint32_t id, std::span<const char> result, std::s
         // net::ERR_* resolved before commit). Reject now.
         auto err = jsonString(jsonField(result, { "errorText", 9 }));
         if (!err.empty()) {
+            // Chrome commits its error page for this failure next. An aborted navigation (a download, a 204) shows none.
+            view->m_chromeErrorPageDue = !(err.size() == 16 && memcmp(err.data(), "net::ERR_ABORTED", 16) == 0);
             settleFailure(g, view, entry.slot, entry.method, createError(g, WTF::String::fromUTF8(err)));
             return;
         }
@@ -1161,16 +1166,26 @@ static void fireOnNavigated(JSGlobalObject* g, JSWebView* view, const WTF::Strin
     }
 }
 
-// Page.frameNavigated {frame: {id, parentId?, url, urlFragment?}, type}: a document committed.
+// Page.frameNavigated {frame: {id, parentId?, url, urlFragment?, unreachableUrl?}, type}: a document committed.
 void Transport::onFrameNavigated(JSWebView* view, std::span<const char> params)
 {
     auto frame = jsonField(params, { "frame", 5 });
     if (!jsonField(frame, { "parentId", 8 }).empty()) return; // an <iframe>'s own navigation
     view->m_mainFrameId = WTF::String::fromUTF8(jsonString(jsonField(frame, { "id", 2 })));
-    if (commitIsNavigations(view)) {
+    // navigate() reported this failure from its reply already: its error page ends nothing and reports nothing.
+    auto unreachable = jsonString(jsonField(frame, { "unreachableUrl", 14 }));
+    bool reported = !unreachable.empty() && view->m_chromeErrorPageDue;
+    view->m_chromeErrorPageDue = false;
+    if (!reported && commitIsNavigations(view)) {
         view->m_chromeNavigationCommitted = true;
         view->m_chromeNavigationKind = ChromeNavigationKind::CrossDocument;
     }
+
+    // unreachableUrl: this is Chrome's error page for a load that failed. view.url keeps the last real page.
+    view->m_chromeOnErrorPage = !unreachable.empty();
+    // Reported once the error page has loaded and the tab takes commands again.
+    view->m_chromeUnreportedFailure = unreachable.empty() || reported ? WTF::String() : WTF::String::fromUTF8(unreachable);
+    if (view->m_chromeOnErrorPage) return;
 
     // frame.url omits the fragment; frame.urlFragment ("#x") carries it.
     auto url = jsonString(jsonField(frame, { "url", 3 }));
@@ -1207,7 +1222,23 @@ void Transport::onNavigatedWithinDocument(JSWebView* view, std::span<const char>
 // Page.loadEventFired (page-level: no frame, no loader): the live document loaded. Title fetch, then settle.
 void Transport::onLoadEventFired(JSWebView* view)
 {
+    auto* g = m_global;
     bool endsNavigation = view->m_pendingNavigate && view->m_chromeNavigationCommitted;
+
+    if (view->m_chromeOnErrorPage) {
+        // No title fetch: view.title keeps the last real page's, like view.url.
+        auto failedUrl = std::exchange(view->m_chromeUnreportedFailure, WTF::String());
+        if (failedUrl.isNull()) return;
+        JSValue err = createError(g, makeString("Navigation to "_s, failedUrl, " failed"_s));
+        if (endsNavigation) {
+            navigationConsumed(view);
+            settleFailure(g, view, PendingSlot::Navigate, Method::PageNavigate, err);
+        } else {
+            fireOnNavigationFailed(g, view, err);
+        }
+        return;
+    }
+
     // For a load that is not the view's navigation, the fetch only updates m_title.
     sendTitleFetch(view, endsNavigation);
     if (endsNavigation) navigationConsumed(view);

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -114,6 +114,12 @@ public:
     bool m_chromeNavigationCommitted = false;
     // Chrome: counts navigation commands, so a title reply settles only the navigation it was fetched for.
     uint32_t m_chromeNavigationSeq = 0;
+    // Chrome: the live main frame document is Chrome's error page for a load that failed.
+    bool m_chromeOnErrorPage = false;
+    // Chrome: navigate() reported a failure from Page.navigate's errorText. The next error page to commit is that failure's.
+    bool m_chromeErrorPageDue = false;
+    // Chrome: the URL whose error page committed. Reported as a failure once that page has loaded.
+    WTF::String m_chromeUnreportedFailure;
     // clickSelector stash — the actionability eval chains into a
     // dispatchMouseEvent that needs these. WebViewHost has the same fields
     // on its side (m_selButton etc.) for the same chain.

--- a/test/js/bun/webview/fake-chrome-fixture.ts
+++ b/test/js/bun/webview/fake-chrome-fixture.ts
@@ -76,6 +76,13 @@ Object.assign(globalThis, {
       type: "Navigation",
     });
   },
+  // Chrome's error page for `url` commits and loads. For a URL the runtime did
+  // not ask for, this is a load the page started itself (a link, `location.href
+  // = ...`) and that failed.
+  __fake_error_page(url: string) {
+    if (history[historyIndex]?.url !== url) pushEntry(url);
+    commitErrorPage(url);
+  },
   // The load event of the document that is live, the way one arrives for a
   // document the page itself navigated to. It names no frame and no loader.
   __fake_load_event() {
@@ -129,10 +136,15 @@ const fragmentOf = (url: string) => (url.includes("#") ? url.slice(url.indexOf("
 // server that accepts the connection and then says nothing looks. One with
 // "stall-on-return" loads when navigated to, but a history traversal back to
 // it starts and never commits. One with "bfcached" in it comes back whole
-// from the back-forward cache when a history traversal returns to it.
+// from the back-forward cache when a history traversal returns to it. One
+// with "unreachable" in it fails to load, the way a refused connection does:
+// Chrome commits its error page instead, at once, or with "unreachable-late"
+// only when __fake_error_page() says so.
 const neverLoads = (url: string) => url.includes("never-load");
 const stallsOnReturn = (url: string) => url.includes("stall-on-return");
 const bfcached = (url: string) => url.includes("bfcached");
+const failsToLoad = (url: string) => url.includes("unreachable");
+const errorPageLater = (url: string) => url.includes("unreachable-late");
 
 function pushEntry(url: string) {
   history.length = historyIndex + 1;
@@ -153,6 +165,15 @@ function commitDocument(url: string, type: "Navigation" | "BackForwardCacheResto
     const subframe = { id: "SUB", parentId: "F", loaderId: "S" + loads, url: "http://fake/subframe" };
     event("Page.frameNavigated", { frame: { ...subframe, mimeType: "text/html" }, type });
   }
+  event("Page.loadEventFired", { timestamp: loads });
+}
+
+// Chrome's error page standing in for a document that failed to load. It names
+// the URL it replaces, and it loads. Chromium 139 and older commit it under a
+// loader of its own, not the failed navigation's, and so does this.
+function commitErrorPage(unreachableUrl: string) {
+  const frame = { id: "F", loaderId: "E" + ++loads, url: "chrome-error://chromewebdata/", mimeType: "text/html" };
+  event("Page.frameNavigated", { frame: { ...frame, unreachableUrl }, type: "Navigation" });
   event("Page.loadEventFired", { timestamp: loads });
 }
 
@@ -190,11 +211,24 @@ async function handle(command: { id: number; method: string; params?: any; sessi
       const current = history[historyIndex]?.url;
       const sameDocument = current !== undefined && documentOf(current) === documentOf(url) && fragmentOf(url) !== "";
       if (!sameDocument) loads++;
+      if (failsToLoad(url)) {
+        // The failure is known before anything commits, so the reply carries it.
+        reply({ frameId: "F", loaderId: "L" + loads, errorText: "net::ERR_CONNECTION_REFUSED" });
+        pushEntry(url);
+        return errorPageLater(url) ? undefined : commitErrorPage(url);
+      }
       // The reply names a loaderId only for a navigation that loads a document.
       reply(sameDocument ? { frameId: "F" } : { frameId: "F", loaderId: "L" + loads });
       if (neverLoads(url)) return;
       pushEntry(url);
       return sameDocument ? commitSameDocument(url) : commitDocument(url, "Navigation");
+    }
+    case "Page.reload": {
+      const url = history[historyIndex]?.url;
+      reply({});
+      if (url === undefined) return;
+      loads++;
+      return failsToLoad(url) ? commitErrorPage(url) : commitDocument(url, "Navigation");
     }
     case "Page.getNavigationHistory":
       return reply({ currentIndex: historyIndex, entries: history });

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -330,6 +330,100 @@ test.concurrent("goBack() onto a page restored from the back-forward cache settl
   });
 });
 
+// After a load fails, Chrome commits its own error page
+// (chrome-error://chromewebdata/, with frame.unreachableUrl naming the page it
+// stands in for) and fires that page's load event. Neither is a navigation of
+// the view's: navigate() already rejected with the errorText of its reply, so
+// the error page reports nothing more, and view.url and view.title keep the
+// last real page.
+test.concurrent("a failed navigate() reports one failure and Chrome's error page changes nothing", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/before");
+    const events = [];
+    view.onNavigated = url => events.push("navigated:" + url);
+    view.onNavigationFailed = error => events.push("failed:" + error.message);
+    const failed = await outcome(view.navigate("http://fake/unreachable"));
+    // The fake sent the error page's commit and load event behind the reply,
+    // and it answers in order, so both are handled once this resolves.
+    await view.evaluate("1");
+    print({ failed, events, url: view.url, title: view.title, loading: view.loading });
+    view.close();
+  `);
+  expect(result).toEqual({
+    failed: { rejected: "net::ERR_CONNECTION_REFUSED" },
+    events: ["failed:net::ERR_CONNECTION_REFUSED"],
+    url: "http://fake/before",
+    title: "fake chrome",
+    loading: false,
+  });
+});
+
+// That error page can land after a retry from onNavigationFailed was answered.
+// It commits under a loader that no reply named (Chromium 139 and older), so
+// only the order says whose it is: the next error page behind a failed
+// navigate() is that failure's. It is not the retry's commit, its load event
+// does not end the retry, and it is not a second failure. The retry's page
+// never loads here, so the retry has to stay pending.
+test.concurrent("the error page of a failed navigate() ends nothing for the retry behind it", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/before");
+    const events = [];
+    let retry;
+    view.onNavigated = url => events.push("navigated:" + url);
+    view.onNavigationFailed = error => {
+      events.push("failed:" + error.message);
+      retry ??= view.navigate("http://fake/never-load");
+    };
+    await outcome(view.navigate("http://fake/unreachable-late"));
+    // This evaluate is behind the retry's command, so the fake has answered
+    // the retry by the time it commits the error page.
+    await view.evaluate("__fake_error_page('http://fake/unreachable-late')");
+    const first = await Promise.race([
+      retry.then(() => "retry settled", () => "retry rejected"),
+      view.evaluate("'retry still pending'"),
+    ]);
+    print({ first, events, url: view.url, loading: view.loading });
+    view.close();
+  `);
+  expect(result).toEqual({
+    first: "retry still pending",
+    events: ["failed:net::ERR_CONNECTION_REFUSED"],
+    url: "http://fake/before",
+    loading: true,
+  });
+});
+
+// A load the page starts itself can fail too. Its error page is the only sign:
+// onNavigationFailed fires once that page has loaded. reload() then loads the
+// failed URL again, fails again, and rejects instead of resolving on the error
+// page's load event.
+test.concurrent("a failed load the page started fires onNavigationFailed, and reload() of it rejects", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/start");
+    const events = [];
+    view.onNavigated = url => events.push("navigated:" + url);
+    view.onNavigationFailed = error => events.push("failed:" + error.message);
+    await view.evaluate("__fake_error_page('http://fake/unreachable-link')");
+    const afterLink = { events: [...events], url: view.url };
+    const reloaded = await outcome(view.reload());
+    print({ afterLink, reloaded, events, url: view.url, loading: view.loading });
+    view.close();
+  `);
+  expect(result).toEqual({
+    afterLink: { events: ["failed:Navigation to http://fake/unreachable-link failed"], url: "http://fake/start" },
+    reloaded: { rejected: "Navigation to http://fake/unreachable-link failed" },
+    events: [
+      "failed:Navigation to http://fake/unreachable-link failed",
+      "failed:Navigation to http://fake/unreachable-link failed",
+    ],
+    url: "http://fake/start",
+    loading: false,
+  });
+});
+
 test.concurrent("a reply larger than the read buffer is reassembled", async () => {
   const result = await runScenario(`
     const view = newView();

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -1090,6 +1090,62 @@ it("chrome: view.url keeps the #fragment", async () => {
   expect(await view.evaluate("location.href")).toBe(srv.base + "/page#frag");
 });
 
+// Chrome commits its internal error page (chrome-error://chromewebdata/) after
+// a load fails and fires that page's load event. Resolves once the page says
+// it has loaded: every event it produces has been handled by then.
+async function errorPageLoaded(view: InstanceType<typeof Bun.WebView>) {
+  while (
+    (await view.evaluate("location.href + ' ' + document.readyState")) !== "chrome-error://chromewebdata/ complete"
+  )
+    await Bun.sleep(5);
+}
+
+it("chrome: a failed navigate() reports one failure and no navigation, and leaves view.url alone", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/before");
+  const events: string[] = [];
+  view.onNavigated = (url: string) => events.push("navigated:" + url);
+  view.onNavigationFailed = (err: Error) => events.push("failed:" + err.message);
+  // Port 9 is on Chrome's unsafe-port list: fails before any connection.
+  await expect(view.navigate("http://127.0.0.1:9/")).rejects.toThrow("net::ERR_UNSAFE_PORT");
+  // Neither the error page's commit nor its load event may surface as a
+  // navigation or as a second failure.
+  await errorPageLoaded(view);
+  expect(events).toEqual(["failed:net::ERR_UNSAFE_PORT"]);
+  expect({ url: view.url, title: view.title, loading: view.loading }).toEqual({
+    url: srv.base + "/before",
+    title: "T/before",
+    loading: false,
+  });
+  // The view still navigates afterwards.
+  await view.navigate(srv.base + "/after");
+  expect({ url: view.url, title: view.title }).toEqual({ url: srv.base + "/after", title: "T/after" });
+});
+
+it("chrome: a navigation the page starts and that fails fires onNavigationFailed", async () => {
+  using srv = navServer();
+  await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });
+  await view.navigate(srv.base + "/start");
+  const events: string[] = [];
+  const failed = Promise.withResolvers<void>();
+  view.onNavigated = (url: string) => events.push("navigated:" + url);
+  view.onNavigationFailed = (err: Error) => {
+    events.push("failed:" + err.message);
+    failed.resolve();
+  };
+  // No navigate() of the view's is pending, so Chrome's error page for the
+  // failed load is the only notice of the failure.
+  await view.evaluate("location.href = 'http://127.0.0.1:9/gone'");
+  await failed.promise;
+  expect(events).toEqual(["failed:Navigation to http://127.0.0.1:9/gone failed"]);
+  expect({ url: view.url, title: view.title, loading: view.loading }).toEqual({
+    url: srv.base + "/start",
+    title: "T/start",
+    loading: false,
+  });
+});
+
 it("chrome: same-document navigations settle and update view.url", async () => {
   using srv = navServer();
   await using view = new Bun.WebView({ backend: chrome, width: 200, height: 200 });


### PR DESCRIPTION
### Problem

- After a load fails, Chrome commits its own error page (`chrome-error://chromewebdata/`). `Transport::onFrameNavigated` (`src/runtime/webview/ChromeBackend.cpp`) does not read `frame.unreachableUrl`, so that page becomes `view.url`, fires `onNavigated`, and its load event resolves a pending `reload()` or `goBack()` as a success.
- A load that the page starts itself and that fails is not reported at all. Only a failed `navigate()` fires `onNavigationFailed`, from the `errorText` of its reply.

### Fix

- A commit with `frame.unreachableUrl` leaves `view.url` and `view.title` on the last real page and fires no `onNavigated`. The failure is reported when that error page has loaded. A pending `reload()` or `goBack()` rejects with `Navigation to <url> failed`, and a load the page started fires `onNavigationFailed`.
- `navigate()` already reports its failure from `errorText`. The backend counts those failures, and each error page that commits takes one: it reports nothing, and it is not the commit of a retry that follows.
- The order decides that, not the `loaderId`: Chromium 139 and older commit the error page under a loader that no reply named. `net::ERR_ABORTED` (a download, a 204) expects no error page, because Chrome shows none.
- Verified: 4 new blocks in `webview-chrome-pipe.test.ts` and 2 in `webview-chrome.test.ts`. All 6 fail on the base branch. The real-Chrome blocks pass on Chromium 132, 138, 143, 152 and Chrome 153.

### Background

- This PR is stacked on #42162: its base is that PR's branch, so the diff shows only the failed-load handling. It carries the part of #42168 that #42162 left out.
- `Page.navigate` replies `{frameId, loaderId?, errorText?}`. `errorText` means the load failed before anything committed.
- `Page.frameNavigated` carries `frame.unreachableUrl` when the committed document is Chrome's error page for that URL.

<details><summary>Notes</summary>

What Chrome sends for a failed `Page.navigate`, from a raw CDP probe:

```
Chromium 132
  reply  {"frameId":"174A…","loaderId":"86E7383F…","errorText":"net::ERR_UNSAFE_PORT"}
  event  Page.frameNavigated {"url":"chrome-error://chromewebdata/","unreachableUrl":"http://127.0.0.1:1/","loaderId":"5A6889E1…"}
  event  Page.loadEventFired
Chrome 153
  reply  {"frameId":"0313…","loaderId":"E2D14E7B…","errorText":"net::ERR_UNSAFE_PORT"}
  event  Page.frameNavigated {"url":"chrome-error://chromewebdata/","unreachableUrl":"http://127.0.0.1:9/","loaderId":"E2D14E7B…"}
  event  Page.loadEventFired
```

The reply and the error page share a `loaderId` on Chromium 143 and newer. On 132 and 138 the error page has a fresh one. #42168 matched the two by `loaderId`, and so did the first fold of it into #42162. On 132 and 138 that match missed: `onNavigationFailed` fired twice for one failed `navigate()`, and a retry from inside the callback threw `Invalid state: a navigation is already pending` on the second call. This version keeps a count instead (`m_chromeErrorPagesDue`): a failed `navigate()` with an `errorText` other than `net::ERR_ABORTED` adds one, each error page that commits takes one, and a real document's commit clears it. It is a count and not a flag because a retry from `onNavigationFailed` can fail too, and Chrome can answer it before the first error page commits. Two error pages are due then (`two failed navigate() calls in a row report two failures, not three`).

The same flow against five browsers, with a retry that starts inside `onNavigationFailed` (the pattern `onNavigationFailed can retry navigate() immediately` in `webview-chrome-pipe.test.ts` treats as supported):

```
132, 138, 143, 152, 153:
  failed#1:net::ERR_CONNECTION_REFUSED
  retry#1:started
  navigate(dead) rejected: net::ERR_CONNECTION_REFUSED
  navigated:http://127.0.0.1:<good>/slow
  retry#1:resolved url=http://127.0.0.1:<good>/slow title=T/slow
```

On main the same flow reports `navigated:chrome-error://chromewebdata/`, and the error page's load event can resolve the retry before its own page loads.

A navigation to a `204` rejects with `net::ERR_ABORTED` and no error page follows it (checked on 132 and 153). A page-started failure after it is still reported, and `reload()` of that failed page rejects.

The fake browser commits its error page under a loader of its own, the shape that broke, so `the error page of a failed navigate() ends nothing for the retry behind it` covers it on every lane.

The limit of the count: if Chrome answers a `navigate()` with an `errorText` other than `net::ERR_ABORTED` and then commits no error page, the next error page is taken for it. Chrome sends that reply when it hands the failed request over to commit its error page, so I found no way to produce that. The next commit of a real document clears the count.

The real-Chrome blocks wait for the error page with `location.href + ' ' + document.readyState`, polled through `evaluate()`. They do not depend on the delivery of `Page.loadEventFired` to `addEventListener()`, which #42222 owns.

The WebKit backend reports a page-started failure already: its navigation delegate (`ObjCRuntime.cpp`) forwards `didFailProvisionalNavigation` and `didFailNavigation`, and `WebViewHost::onNavigationFailed` sends `NavFailEvent` for each, whoever started the navigation.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome.test.ts, test/js/bun/webview/webview-chrome-pipe.test.ts

<!-- robobun:evidence:end -->