### PR TITLE
node:tls: clear connecting on a TLSSocket that wraps a connected socket

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1442,6 +1442,13 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
       req.errno = error.errno || uv().UV_ECANCELED;
       return;
     }
+    // The TLS engine over a wrapped stream failed before it opened. No connect
+    // is pending on that socket, so afterConnect has nothing to settle and
+    // would drop the failure when `connecting` is already false.
+    if (self[kupgraded]) {
+      if (!self.destroyed) self.destroy(new ExceptionWithHostPort(error.errno, "connect"));
+      return;
+    }
     req!.oncomplete(error.errno, self._handle, req, true, true);
   },
 };
@@ -1945,7 +1952,7 @@ Socket.prototype.connect = function connect(...args) {
       else this.readableFlowing = false;
     } else {
       process.nextTick(() => {
-        // An already-open handle (fd, wrapped duplex) starts reading here unless
+        // An already-open handle (fd, wrapped stream) starts reading here unless
         // the user paused; read(0) does that without switching to flowing mode.
         // A pending connect gets this from afterConnect instead, so a pause()
         // that lands before then is still honored:
@@ -2010,12 +2017,13 @@ Socket.prototype.connect = function connect(...args) {
     }
     // start using existing connection
     if (connection) {
-      // A generic duplex transport is already established, so this socket is
-      // not "connecting" - only the TLS layer is pending, which
-      // secureConnecting tracks. Node reports false here. A provided
-      // net.Socket keeps its existing accounting (its own connect lifecycle
-      // drives this flag).
-      if (!(connection instanceof Socket)) {
+      // Node: `connecting = socket.connecting || !socket._handle` for a wrapped
+      // net.Socket, and false for any other stream. Only the TLS layer is
+      // pending, which secureConnecting tracks. Nothing emits 'connect' for a
+      // socket wrapped after it connected, so a flag left set would strand
+      // whatever waits for that event.
+      // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973
+      if (!(connection instanceof Socket) || (connection._handle && !connection.connecting)) {
         this.connecting = false;
       }
       if (connectListener != null) this.once("secureConnect", connectListener);
@@ -3381,11 +3389,9 @@ function afterConnect(status, handle, req, readable, writable) {
 
   $debug("afterConnect", status, readable, writable);
 
-  // A pre-open error on a user-supplied duplex (tls.connect({ socket })) can
-  // clear `connecting` before the queued StartTLS task fires this callback.
-  // The socket is already being torn down, so bail out instead of asserting:
-  // this both avoids the debug $assert abort and stops the late callback from
-  // proceeding to touch a handle that the error path already freed.
+  // Node asserts `connecting` here. A callback for a connect that something
+  // else already settled has nothing left to do. A TLS engine over a wrapped
+  // stream never gets here: connectError reports its failure directly.
   if (!self.connecting) return;
   self.connecting = false;
   self._sockname = null;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1442,9 +1442,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
       req.errno = error.errno || uv().UV_ECANCELED;
       return;
     }
-    // The TLS engine over a wrapped stream failed before it opened. No connect
-    // is pending on that socket, so afterConnect has nothing to settle and
-    // would drop the failure when `connecting` is already false.
+    // A TLS engine that failed before it opened has no connect pending, so afterConnect would drop the failure.
     if (self[kupgraded]) {
       if (!self.destroyed) self.destroy(new ExceptionWithHostPort(error.errno, "connect"));
       return;
@@ -2017,12 +2015,7 @@ Socket.prototype.connect = function connect(...args) {
     }
     // start using existing connection
     if (connection) {
-      // Node: `connecting = socket.connecting || !socket._handle` for a wrapped
-      // net.Socket, and false for any other stream. Only the TLS layer is
-      // pending, which secureConnecting tracks. Nothing emits 'connect' for a
-      // socket wrapped after it connected, so a flag left set would strand
-      // whatever waits for that event.
-      // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973
+      // Node's rule (no 'connect' follows for a socket wrapped after it connected): https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973
       if (!(connection instanceof Socket) || (connection._handle && !connection.connecting)) {
         this.connecting = false;
       }
@@ -3389,9 +3382,7 @@ function afterConnect(status, handle, req, readable, writable) {
 
   $debug("afterConnect", status, readable, writable);
 
-  // Node asserts `connecting` here. A callback for a connect that something
-  // else already settled has nothing left to do. A TLS engine over a wrapped
-  // stream never gets here: connectError reports its failure directly.
+  // Node asserts `connecting` here. A connect that was settled some other way has nothing left to do.
   if (!self.connecting) return;
   self.connecting = false;
   self._sockname = null;

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1031,6 +1031,154 @@ describe("application data written over a Duplex transport before the handshake 
   });
 });
 
+// A connected net.Socket that cannot hand its fd over (here another TLSSocket,
+// as in an HTTPS proxy tunnel) gets the same engine as a Duplex transport. It
+// starts on a later task and nothing emits 'connect' for it, so the wrapper
+// must not report `connecting` in between: whatever parks on 'connect' would
+// never resume. Node's rule is `connecting = socket.connecting || !socket._handle`:
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973
+//
+// Each connection the server accepts gets a second, server-side TLS layer on top of it.
+async function listenTLSInTLS(onInner: (inner: TLSSocket) => void) {
+  const secureContext = tls.createSecureContext(COMMON_CERT_);
+  const server = tls.createServer(COMMON_CERT_, outer => {
+    outer.on("error", () => {});
+    const inner = new TLSSocket(outer, { isServer: true, secureContext });
+    inner.on("error", () => {});
+    onInner(inner);
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const outer = tls.connect({ port: (server.address() as AddressInfo).port, rejectUnauthorized: false });
+  await once(outer, "secureConnect");
+  return { server, outer };
+}
+
+describe("tls.connect({ socket }) over an established TLSSocket", () => {
+  it("is not connecting, and end() in the same tick emits 'finish'", async () => {
+    const { server, outer } = await listenTLSInTLS(inner => inner.resume());
+    let client: TLSSocket | undefined;
+    try {
+      client = tls.connect({ socket: outer, rejectUnauthorized: false });
+      const state = { connecting: client.connecting, pending: client.pending, readyState: client.readyState };
+      client.end();
+      expect(state).toEqual({ connecting: false, pending: false, readyState: "open" });
+      await once(client, "finish");
+      expect(client.writableFinished).toBe(true);
+    } finally {
+      client?.destroy();
+      outer.destroy();
+      server.close();
+    }
+  });
+
+  it("delivers end(data) issued in the same tick once the handshake completes", async () => {
+    // Several TLS records, and more than the stream buffers before it asks for 'drain'.
+    const payload = Buffer.alloc(100_000, "0123456789abcdef");
+    const received = Promise.withResolvers<Buffer>();
+    const { server, outer } = await listenTLSInTLS(inner => {
+      const chunks: Buffer[] = [];
+      inner.on("data", (chunk: Buffer) => chunks.push(chunk));
+      inner.on("end", () => {
+        received.resolve(Buffer.concat(chunks));
+        inner.end();
+      });
+    });
+    let client: TLSSocket | undefined;
+    try {
+      client = tls.connect({ socket: outer, rejectUnauthorized: false });
+      const log: string[] = [];
+      for (const event of ["connect", "secureConnect", "finish", "end", "close"]) {
+        client.on(event, () => log.push(event));
+      }
+      client.resume();
+      client.end(payload);
+      await once(client, "close");
+      const bytes = await received.promise;
+      expect({ log, bytes: bytes.length, intact: bytes.equals(payload) }).toEqual({
+        log: ["secureConnect", "finish", "end", "close"],
+        bytes: payload.length,
+        intact: true,
+      });
+    } finally {
+      client?.destroy();
+      outer.destroy();
+      server.close();
+    }
+  });
+});
+
+// The other half of node's rule: a socket that is still connecting keeps the flag until it connects.
+it("tls.connect({ socket }) stays connecting over a net.Socket that has yet to connect", async () => {
+  const server = tls.createServer(COMMON_CERT_, socket => {
+    socket.on("error", () => {});
+    socket.resume();
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const raw = net.connect((server.address() as AddressInfo).port);
+  const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+  try {
+    const whileConnecting = client.connecting;
+    await once(client, "secureConnect");
+    expect({ whileConnecting, afterHandshake: client.connecting }).toEqual({
+      whileConnecting: true,
+      afterHandshake: false,
+    });
+  } finally {
+    client.destroy();
+    raw.destroy();
+    server.close();
+  }
+});
+
+// The engine cannot take a string chunk, and a transport with a decoder hands
+// it one before the engine's start task runs. No connect is pending on such a
+// socket, so the failure must not depend on `connecting` to be reported.
+describe("a TLS engine over a wrapped stream that fails before it starts", () => {
+  function outcomeOf(client: TLSSocket) {
+    const { promise, resolve } = Promise.withResolvers<{ reported: boolean; hadError: boolean; destroyed: boolean }>();
+    let reported = false;
+    client.on("error", () => (reported = true));
+    client.on("close", hadError => resolve({ reported, hadError, destroyed: client.destroyed }));
+    return promise;
+  }
+  const failed = { reported: true, hadError: true, destroyed: true };
+
+  it("destroys a TLSSocket over an established TLSSocket with the error", async () => {
+    const { server, outer } = await listenTLSInTLS(inner => inner.resume());
+    let client: TLSSocket | undefined;
+    try {
+      outer.setEncoding("utf8");
+      outer.unshift("not a TLS record");
+      client = tls.connect({ socket: outer, rejectUnauthorized: false });
+      expect(await outcomeOf(client)).toEqual(failed);
+    } finally {
+      client?.destroy();
+      outer.destroy();
+      server.close();
+    }
+  });
+
+  it("destroys a TLSSocket over a Duplex with the error", async () => {
+    const transport = new Duplex({
+      read() {},
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    transport.setEncoding("utf8");
+    transport.push("not a TLS record");
+    const client = tls.connect({ socket: transport, rejectUnauthorized: false });
+    try {
+      expect(await outcomeOf(client)).toEqual(failed);
+    } finally {
+      client.destroy();
+      transport.destroy();
+    }
+  });
+});
+
 it("delivers 'session' even when the data handler destroys the socket immediately", async () => {
   // The TLS1.3 NewSessionTickets ride in the same read pass as the response
   // bytes. If the parked session were only flushed after the data dispatch,

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1083,6 +1083,8 @@ describe("tls.connect({ socket }) over an established TLSSocket", () => {
         received.resolve(Buffer.concat(chunks));
         inner.end();
       });
+      inner.on("error", received.reject);
+      inner.on("close", () => received.reject(new Error("the server side closed before 'end'")));
     });
     let client: TLSSocket | undefined;
     try {
@@ -1093,8 +1095,7 @@ describe("tls.connect({ socket }) over an established TLSSocket", () => {
       }
       client.resume();
       client.end(payload);
-      await once(client, "close");
-      const bytes = await received.promise;
+      const [bytes] = await Promise.all([received.promise, once(client, "close")]);
       expect({ log, bytes: bytes.length, intact: bytes.equals(payload) }).toEqual({
         log: ["secureConnect", "finish", "end", "close"],
         bytes: payload.length,

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -222,7 +222,10 @@ describe("tls.connect({ socket }) over a named pipe that is already connected", 
         received.resolve(Buffer.concat(chunks).toString());
         socket.end();
       });
+      socket.on("error", received.reject);
+      socket.on("close", () => received.reject(new Error("the server side closed before 'end'")));
     });
+    server.on("tlsClientError", received.reject);
     let client: TLSSocket | undefined;
     try {
       client = connect({ socket: pipe, rejectUnauthorized: false });
@@ -232,8 +235,8 @@ describe("tls.connect({ socket }) over a named pipe that is already connected", 
       }
       client.resume();
       client.end("hello");
-      await once(client, "close");
-      expect({ log, received: await received.promise }).toEqual({
+      const [data] = await Promise.all([received.promise, once(client, "close")]);
+      expect({ log, received: data }).toEqual({
         log: ["secureConnect", "finish", "end", "close"],
         received: "hello",
       });

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -3,7 +3,7 @@ import { expectMaxObjectTypeCount, isWindows, tls } from "harness";
 import { randomUUID } from "node:crypto";
 import { once } from "node:events";
 import net from "node:net";
-import { connect, createServer } from "node:tls";
+import { connect, createServer, type TLSSocket } from "node:tls";
 
 it.if(isWindows)("should work with named pipes and tls", async () => {
   await expectMaxObjectTypeCount(expect, "TLSSocket", 0);
@@ -175,4 +175,72 @@ it.if(isWindows)("should be able to upgrade a named pipe connection to TLS", asy
   }
   await test(`\\\\.\\pipe\\test\\${randomUUID()}`);
   await expectMaxObjectTypeCount(expect, "TLSSocket", 3);
+});
+
+// Same contract as "tls.connect({ socket }) over an established TLSSocket" in
+// node-tls-connect.test.ts: the pipe is connected, so the TLSSocket is not
+// `connecting` while its engine starts, and nothing waits on a 'connect' event
+// that a socket wrapped after it connected never emits.
+describe("tls.connect({ socket }) over a named pipe that is already connected", () => {
+  async function connectedPipe(onConnection: (socket: TLSSocket) => void) {
+    const server = createServer(tls, socket => {
+      socket.on("error", () => {});
+      onConnection(socket);
+    });
+    server.on("tlsClientError", () => {});
+    const pipeName = `\\\\.\\pipe\\test\\${randomUUID()}`;
+    server.listen(pipeName);
+    await once(server, "listening");
+    const pipe = net.connect(pipeName);
+    await once(pipe, "connect");
+    return { server, pipe };
+  }
+
+  it.if(isWindows)("is not connecting, and end() in the same tick emits 'finish'", async () => {
+    const { server, pipe } = await connectedPipe(socket => socket.resume());
+    let client: TLSSocket | undefined;
+    try {
+      client = connect({ socket: pipe, rejectUnauthorized: false });
+      const state = { connecting: client.connecting, pending: client.pending, readyState: client.readyState };
+      client.end();
+      expect(state).toEqual({ connecting: false, pending: false, readyState: "open" });
+      await once(client, "finish");
+      expect(client.writableFinished).toBe(true);
+    } finally {
+      client?.destroy();
+      pipe.destroy();
+      server.close();
+    }
+  });
+
+  it.if(isWindows)("delivers end(data) issued in the same tick once the handshake completes", async () => {
+    const received = Promise.withResolvers<string>();
+    const { server, pipe } = await connectedPipe(socket => {
+      const chunks: Buffer[] = [];
+      socket.on("data", (chunk: Buffer) => chunks.push(chunk));
+      socket.on("end", () => {
+        received.resolve(Buffer.concat(chunks).toString());
+        socket.end();
+      });
+    });
+    let client: TLSSocket | undefined;
+    try {
+      client = connect({ socket: pipe, rejectUnauthorized: false });
+      const log: string[] = [];
+      for (const event of ["connect", "secureConnect", "finish", "end", "close"]) {
+        client.on(event, () => log.push(event));
+      }
+      client.resume();
+      client.end("hello");
+      await once(client, "close");
+      expect({ log, received: await received.promise }).toEqual({
+        log: ["secureConnect", "finish", "end", "close"],
+        received: "hello",
+      });
+    } finally {
+      client?.destroy();
+      pipe.destroy();
+      server.close();
+    }
+  });
 });


### PR DESCRIPTION
### Problem
- `tls.connect({ socket })` over a connected `net.Socket` that cannot give up its fd reports `connecting: true, pending: true, readyState: "opening"` for one event-loop task. Such a socket is another `TLSSocket`, a Windows named pipe, or a socket with a queued write.
- Nothing emits `'connect'` for a socket wrapped after it connected. Since #42181, `end()` or `destroySoon()` in that task waits for `'connect'` forever: no `'finish'`, no `'close'`.
- The cause is `Socket.prototype.connect` (`src/js/node/net.ts:2018`). It clears `connecting` only for a transport that is not a `net.Socket`. For these sockets the stream-level TLS engine clears it one task later.

### Fix
- Clear `connecting` when the wrapped `net.Socket` has a handle and is not connecting. Node's rule: `connecting = socket.connecting || !socket._handle` ([wrap.js#L964-L973](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L964-L973)).
- `connectError` now destroys a wrapped socket with the error, because `afterConnect` drops a failure when `connecting` is false. A generic Duplex already lost engine failures that way.
- Not fixed: an `end()` before the handshake completes now emits `'finish'`, but the FIN never goes out. That needs a second follow-up to #42181 (see Notes).
- Verified: `test/js/node/tls/node-tls-connect.test.ts` (2 of 5 new tests fail on main). `test/js/node/tls/node-tls-namedpipes.test.ts` fails on the Windows canary and passes on a Windows build of this branch. Also the tls, https, net and http2 suites (Notes).

### Background
- `tls.connect({ socket })` has two engines. A plain connected TCP socket gives its fd to a native TLS socket, synchronously. Any other transport gets the stream-level engine (`upgradeDuplexToTLS`), which runs BoringSSL on the stream's events.
- That engine starts from an event-loop task, after all pending `process.nextTick` callbacks.
- `connecting` covers the transport. `secureConnecting` covers the TLS handshake.

<details><summary>Notes</summary>

**Repro** (Linux, TLS in TLS): wrap an established `TLSSocket` with `tls.connect({ socket })` and call `end()` in the same tick. Events on the inner client socket:

| | state after `tls.connect()` | events | peer sees the end |
| --- | --- | --- | --- |
| node v26.3.0 | `connecting=false pending=false readyState=open` | `finish, secureConnect, end, close` | yes |
| bun 1.4.2 (before #42181) | `connecting=true pending=true readyState=opening` | `secureConnect, finish, end, close` | yes |
| main | `connecting=true pending=true readyState=opening` | `secureConnect` | no |
| this branch | `connecting=false pending=false readyState=open` | `finish, secureConnect` | no |

The same rows hold on Windows for a connected named pipe (canary 81f97bb02 against a Windows build of this branch), and on Linux for a connected socket with a corked write. `destroySoon()` gives `finish, close` on this branch and on node, and nothing on main.

**Which part is old and which is new.** The wrong `connecting`, `pending` and `readyState` values are in every release. Anything that tests `connecting` and then waits for `'connect'` never resumes: `resetAndDestroy()`, and `setSocketTimeout` in `_http_client.ts`, so a request timeout never arms over TLS in TLS. The `'finish'` hang is new. Until #42181 `_final` always waited for the handshake, and by then the flag was clear. #42181 lets `_final` run at once when no write is queued, and `Socket.prototype._final` then waits for `'connect'`.

**What is still wrong after this PR (second follow-up to #42181).** `end()` with no data, issued before the handshake completes, now emits `'finish'` on these routes, but the transport never sees a FIN, so `'end'` and `'close'` do not follow. This covers the whole window before the handshake completes, not only the first task. A generic Duplex transport has been in this state on main since #42181 (it never reported `connecting`). Bun 1.4.2 closed cleanly here, because it waited for the handshake. The cause is native and outside this diff. `UpgradedDuplex::shutdown` (`src/runtime/socket/UpgradedDuplex.rs:551`) does nothing before the engine starts. Once the engine runs, `SSL_shutdown` during the handshake returns 1 without a close_notify, `SSLWrapper::shutdown` (`src/uws/lib.rs:591`) records the shutdown as sent, and nothing ends the stream. The fd path has the matching fallback already: `us_internal_ssl_shutdown` sends a bare FIN when the handshake is not done. The stream-level engine needs the same: end the transport when a shutdown arrives while the SSL is in init, and remember a shutdown that arrives before the engine starts. No PR exists for it yet.

**The `connectError` change.** A transport that has a string decoder and a buffered chunk hands the engine a string before its start task runs. The native side reports that as a connect error (`ECONNREFUSED`). On main the three `net.Socket` routes reported `'error'` and `'close'` only because `connecting` was still set. A generic Duplex reported nothing and stayed open. With the flag clear, all routes would report nothing. Now all routes report `'error'` and `'close'`. The error is the same `connect ECONNREFUSED` as before. The `connectionAttemptFailed` event that `afterConnect` emitted with `undefined` address and port is gone for wrapped sockets.

**Writes in the same tick.** `end(data)` worked before and still works (`secureConnect, finish, end, close`, the peer receives the data). Before, the write parked on `connecting` and the `open` handler drained it. Now it goes to the native handle, which buffers it until the handshake completes. A generic Duplex already used that path. Measured intact from 5 B to 4 MiB, with `end(data)` and with `write(data)`, `'drain'`, `end()`.

**Related.** #42181 is the origin of the hang. #42240 and #42235 deliver a transport's `'error'` to the TLS socket. This PR does not change that delivery on any route. #36534 uses the same predicate to choose the upgrade path. #38122 and #38028 cover a wrapped socket that fails to connect and the teardown of the wrapped socket. A `net.Socket` that is still connecting when it is wrapped keeps `connecting` until its own `'connect'`. A test pins that.

**Tests.** In `node-tls-connect.test.ts`: the state and `'finish'` test fails on main. The Duplex case of the pre-open failure fails on main (timeout, nothing is reported). The other three pass on main and guard the new paths: a 100 kB `end(data)` in the same tick, a socket that is still connecting, and the pre-open failure over a `TLSSocket`. In `node-tls-namedpipes.test.ts`: the state and `'finish'` test fails on the Windows canary.

**Suites.** `test/js/node/tls/` (318 pass), vendored `test-tls-*` (185 of 186), `test-https-*` (58 of 59), `test-net-*` (139 of 139), `test-http2-*` (256 of 256), and the ws, WebSocket and fetch proxy tests. The failures are the same with and without the change: `node-tls-server.test.ts` "SNICallback runs even when the requested servername matches the bind hostname" (`ECONNREFUSED` in this container), `test-https-timeout.js` (hangs), `test-tls-client-allow-partial-trust-chain.js` (needs the `node:test` runner). On the Windows debug build, "should work with named pipes and tls" (400 connections) exceeds its 5 s timeout with and without the change.

Self-reviewed: kept the one-line rule as it is. Added the `connectError` branch and its tests, the test for a socket that is still connecting, and a multi-record payload. Rewrote the code comment around node's rule.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tls/node-tls-namedpipes.test.ts

<!-- robobun:evidence:end -->