### PR TITLE
fix(npm): preserve optional bun executable on postinstall reruns

### DIFF
--- a/packages/bun-release/scripts/npm-postinstall.test.ts
+++ b/packages/bun-release/scripts/npm-postinstall.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+import { buildSync } from "esbuild";
+import { copyFileSync, mkdirSync, readFileSync } from "fs";
+import { dirname, join } from "path";
+import { bunEnv, bunExe, tempDir } from "../../../test/harness";
+import { supportedPlatforms } from "../src/platform";
+
+test("npm postinstall preserves the optional executable across repeated runs", async () => {
+  using dir = tempDir("bun-npm-postinstall", {
+    "package.json": JSON.stringify({ name: "bun", version: "0.0.0" }),
+    "bin/bun.exe": "postinstall has not run",
+    "bin/bunx.exe": "postinstall has not run",
+  });
+  const root = String(dir);
+  const platform = supportedPlatforms[0];
+  expect(platform).toBeDefined();
+  const source = join(root, "node_modules", "@oven", platform.bin, platform.exe);
+  mkdirSync(dirname(source), { recursive: true });
+  copyFileSync(bunExe(), source);
+  const original = readFileSync(source);
+  const script = join(root, "install.cjs");
+  buildSync({
+    entryPoints: [join(import.meta.dir, "npm-postinstall.ts")],
+    outfile: script,
+    bundle: true,
+    treeShaking: true,
+    keepNames: true,
+    minifySyntax: true,
+    pure: ["console.debug"],
+    platform: "node",
+    target: "es6",
+    format: "cjs",
+    define: { version: '"0.0.0"', module: '"bun"', owner: '"@oven"' },
+  });
+  for (let run = 0; run < 3; run++) {
+    const proc = Bun.spawn({ cmd: [bunExe(), script], cwd: root, env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    expect(readFileSync(source).toString("base64")).toBe(original.toString("base64"));
+    expect(readFileSync(join(root, "bin/bun.exe")).toString("base64")).toBe(original.toString("base64"));
+    expect(readFileSync(join(root, "bin/bunx.exe")).toString("base64")).toBe(original.toString("base64"));
+  }
+});

--- a/packages/bun-release/src/npm/install.ts
+++ b/packages/bun-release/src/npm/install.ts
@@ -129,7 +129,8 @@ export function optimizeBun(path: string): void {
   const installScript =
     os === "win32" ? 'powershell -c "irm bun.sh/install.ps1 | iex"' : "curl -fsSL https://bun.com/install | bash";
   try {
-    rename(path, join(__dirname, "bin", "bun.exe"));
+    // Preserve the optional executable for postinstall reruns (https://github.com/oven-sh/bun/pull/25303).
+    link(path, join(__dirname, "bin", "bun.exe"));
     link(join(__dirname, "bin", "bun.exe"), join(__dirname, "bin", "bunx.exe"));
     return;
   } catch (error) {

--- a/test/integration/bun-release/npm-postinstall-rerun.test.ts
+++ b/test/integration/bun-release/npm-postinstall-rerun.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "bun:test";
 import { buildSync } from "esbuild";
-import { copyFileSync, mkdirSync, readFileSync } from "fs";
+import { chmodSync, copyFileSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
-import { bunEnv, bunExe, tempDir } from "../../../test/harness";
-import { supportedPlatforms } from "../src/platform";
+import { supportedPlatforms } from "../../../packages/bun-release/src/platform";
+import { bunEnv, bunExe, isWindows, tempDir } from "../../../test/harness";
 
 test("npm postinstall preserves the optional executable across repeated runs", async () => {
   using dir = tempDir("bun-npm-postinstall", {
@@ -16,11 +16,15 @@ test("npm postinstall preserves the optional executable across repeated runs", a
   expect(platform).toBeDefined();
   const source = join(root, "node_modules", "@oven", platform.bin, platform.exe);
   mkdirSync(dirname(source), { recursive: true });
-  copyFileSync(bunExe(), source);
+  if (!isWindows) {
+    writeFileSync(join(root, "fixture.sh"), "#!/bin/sh\nexit 0\n");
+  }
+  copyFileSync(isWindows ? bunExe() : join(root, "fixture.sh"), source);
+  if (!isWindows) chmodSync(source, 0o755);
   const original = readFileSync(source);
   const script = join(root, "install.cjs");
   buildSync({
-    entryPoints: [join(import.meta.dir, "npm-postinstall.ts")],
+    entryPoints: [join(import.meta.dir, "../../../packages/bun-release/scripts/npm-postinstall.ts")],
     outfile: script,
     bundle: true,
     treeShaking: true,


### PR DESCRIPTION
## Problem

Repeated `npm install` runs can move the optional platform executable out of `node_modules/@oven/bun-*`, causing later installs to fail.

## Fix

`optimizeBun()` now hard-links the optional executable into `bin/bun.exe` and links `bunx.exe` from that destination. The existing destination is unlinked first, so reruns work. If the source and destination are on different filesystems, the fallback creates one copy and links `bunx.exe` to it.

Fixes #25031

## Verification

The integration regression test at `test/integration/bun-release/npm-postinstall-rerun.test.ts` bundles the shipped postinstall script and runs it three times. POSIX uses a tiny executable fixture to avoid copying the approximately 800 MB debug Bun binary; Windows uses the real executable. Each run must exit 0 with no output, and the optional source plus both installed executables must retain their original bytes.

Local result: `bun test test/integration/bun-release/npm-postinstall-rerun.test.ts` — 1 pass, 13 assertions.

## Continuation of #42236

This PR carries the same implementation, regression coverage, review context, and validation as #42236. That PR was unintentionally closed when its temporary fork branch was renamed during rebase. The branch was restored and force-updated, but GitHub does not allow reopening the closed PR with the available permissions, so this replacement uses the contributor-owned branch `LilMGenius/npm-postinstall-preserve-optional`.
