### PR TITLE
Bun.serve http2: close a connection that becomes HTTP/2 after a graceful stop()

### DIFF
--- a/packages/bun-uws/src/Http2Context.h
+++ b/packages/bun-uws/src/Http2Context.h
@@ -650,6 +650,11 @@ struct Http2Context {
     /* Seconds without traffic in either direction before a connection is
      * dropped (streams in flight are aborted); 0 disables. */
     unsigned idleTimeoutS = 10;
+    /* closeIdle(true) has run (graceful stop): every connection we had then
+     * has its GOAWAY. One adopted later (its TLS handshake or cleartext
+     * preface was pending) serves its first stream, as the HTTP/1 socket it
+     * was would serve one request, and sends GOAWAY with it. */
+    bool stopping = false;
 
     /* Output buffer lent to whichever connection is inside a socket event;
      * see Http2Connection::out. */
@@ -799,9 +804,11 @@ struct Http2Context {
 
     /* Close connections with nothing in flight (after a GOAWAY). With
      * `closeWhenIdle`, busy connections also get GOAWAY so no new streams
-     * start and they close once their last stream retires (graceful stop);
-     * without it they are left alone. */
+     * start and they close once their last stream retires (graceful stop;
+     * `stopping` covers connections adopted afterwards); without it they are
+     * left alone. */
     size_t closeIdle(bool closeWhenIdle) {
+        if (closeWhenIdle) stopping = true;
         size_t closedNow = 0;
         forEachConnection([&](Http2Connection *conn) {
             if (!conn->streams.empty() && !closeWhenIdle) return;
@@ -1650,6 +1657,8 @@ inline bool Http2Connection::handleHeaderBlock(uint32_t streamId, uint8_t flags,
         return streamError(streamId, nullptr, http2::ERR_REFUSED_STREAM);
     }
     lastProcessedStreamId = streamId;
+    /* No GOAWAY sent although a graceful stop has run: adopted after it. */
+    if (ctx->stopping) writeGoaway(http2::ERR_NO_ERROR);
     if (tooLarge) {
         Http2Response *stream = new Http2Response(this, streamId, peerInitialWindowSize);
         stream->remoteClosed = endStream;

--- a/test/js/bun/http/serve-http2-fixture.ts
+++ b/test/js/bun/http/serve-http2-fixture.ts
@@ -242,9 +242,12 @@ async function handler(req: Request, server: Bun.Server<undefined>): Promise<Res
     }
     case "/passthrough":
       return new Response(req.body, { headers: { "x-passthrough": "1" } });
-    case "/stop":
-      setTimeout(() => server.stop(), 0);
+    case "/stop": {
+      // ?exit: leave once the stop() promise resolves, that is once every connection is gone.
+      const exit = url.searchParams.has("exit");
+      setTimeout(() => server.stop().then(() => exit && process.exit(0)), 0);
       return new Response("stopping");
+    }
     case "/reload":
       server.reload({
         routes: { ...makeRoutes(), "/reloaded-route": new Response("after-reload") },

--- a/test/js/bun/http/serve-http2-helpers.ts
+++ b/test/js/bun/http/serve-http2-helpers.ts
@@ -224,18 +224,25 @@ export class RawH2 {
   closed = false;
 
   static async connect(port: number, secure: boolean, opts: { sendPreface?: boolean; settings?: Buffer } = {}) {
-    const c = new RawH2();
+    let socket!: net.Socket | tls.TLSSocket;
     await new Promise<void>((resolve, reject) => {
       const onErr = (e: Error) => reject(e);
       if (secure) {
-        c.socket = tls.connect({ port, host: "127.0.0.1", ALPNProtocols: ["h2"], rejectUnauthorized: false }, () =>
+        socket = tls.connect({ port, host: "127.0.0.1", ALPNProtocols: ["h2"], rejectUnauthorized: false }, () =>
           resolve(),
         );
       } else {
-        c.socket = net.connect({ port, host: "127.0.0.1" }, () => resolve());
+        socket = net.connect({ port, host: "127.0.0.1" }, () => resolve());
       }
-      c.socket.once("error", onErr);
+      socket.once("error", onErr);
     });
+    return RawH2.over(socket, opts);
+  }
+
+  /** Speak HTTP/2 over a socket that is already connected (TLS: whose handshake is done). */
+  static over(socket: net.Socket | tls.TLSSocket, opts: { sendPreface?: boolean; settings?: Buffer } = {}) {
+    const c = new RawH2();
+    c.socket = socket;
     c.socket.on("data", (d: Buffer) => c.onData(d));
     c.socket.on("close", () => {
       c.closed = true;

--- a/test/js/bun/http/serve-http2-lifecycle.test.ts
+++ b/test/js/bun/http/serve-http2-lifecycle.test.ts
@@ -182,7 +182,7 @@ describe("Bun.serve http2 lifecycle", () => {
         await secured;
         return RawH2.over(socket);
       });
-    }, 20000);
+    });
 
     test("cleartext preface incomplete", async () => {
       await using fx = await startFixture({ tls: false });
@@ -197,7 +197,7 @@ describe("Bun.serve http2 lifecycle", () => {
         raw.write(frame(T.SETTINGS, 0, 0));
         return raw;
       });
-    }, 20000);
+    });
 
     test("TLS handshakes queued behind the per-iteration budget", async () => {
       // The loop runs five TLS handshakes per iteration and parks the rest of a burst in a queue
@@ -254,6 +254,7 @@ describe("Bun.serve http2 lifecycle", () => {
         answeredWithoutGoaway: 0,
       });
       expect(exitCode).toBe(0);
+      // 40 TLS endpoints handshake in one process: 4 to 6 s on a debug build with ASAN.
     }, 20000);
   });
 

--- a/test/js/bun/http/serve-http2-lifecycle.test.ts
+++ b/test/js/bun/http/serve-http2-lifecycle.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, tempDir, tls as tlsCert } from "harness";
+import { once } from "node:events";
 import http2 from "node:http2";
+import net from "node:net";
+import { Duplex } from "node:stream";
 import tls from "node:tls";
 import {
   F,
+  Fixture,
   H2Result,
+  PREFACE,
   RawH2,
   T,
   baseHeaders,
@@ -123,6 +128,129 @@ describe("Bun.serve http2 lifecycle", () => {
     expect(raw.frames.some(f => f.streamId === 5)).toBe(false);
     expect(raw.frames.filter(f => f.type === T.GOAWAY).every(f => f.payload.readUInt32BE(4) === 0)).toBe(true);
     raw.close();
+  });
+
+  // stop() visits every connection once. One that is still an HTTP/1 socket at that point (its TLS
+  // handshake or its cleartext preface is incomplete) becomes HTTP/2 only afterwards. It is served
+  // one request, as it would be had it stayed HTTP/1, and closed.
+  describe("graceful stop: a connection that becomes HTTP/2 after stop() serves one stream, gets GOAWAY and is closed", () => {
+    // Runs stop() through a second connection, then lets `becomeH2` complete the pending one.
+    async function stopThenComplete(fx: Fixture, secure: boolean, becomeH2: () => Promise<RawH2>) {
+      const session = await connectH2(fx.port, secure);
+      const sessionClosed = new Promise<void>(r => session.once("close", () => r()));
+      expect((await request(session, { ":path": "/stop?exit" })).body.toString()).toBe("stopping");
+      // stop() closes this drained session itself, so by now it has run and has seen the pending connection.
+      await sessionClosed;
+
+      const raw = await becomeH2();
+      // Two requests in one write: the server has read both before it can close.
+      const get = (id: number) =>
+        frame(T.HEADERS, F.END_HEADERS | F.END_STREAM, id, hpackLiteral(baseHeaders("/hello")));
+      raw.write(Buffer.concat([get(1), get(3)]));
+      expect((await raw.body(1)).toString()).toBe("hello");
+      // GOAWAY is written when the first request arrives, ahead of its response.
+      const goaways = raw.frames.filter(f => f.type === T.GOAWAY);
+      expect(goaways.map(f => ({ lastStreamId: f.payload.readUInt32BE(0), code: f.payload.readUInt32BE(4) }))).toEqual([
+        { lastStreamId: 1, code: 0 },
+      ]);
+      // The server hangs up. This client never does.
+      await raw.waitForClose();
+      expect(raw.frames.some(f => f.streamId === 3)).toBe(false);
+      // No connection is left, so the stop() promise resolves and the fixture exits.
+      expect(await fx.proc.exited).toBe(0);
+    }
+
+    test("TLS handshake incomplete", async () => {
+      await using fx = await startFixture({ tls: true });
+      const tcp = net.connect({ port: fx.port, host: "127.0.0.1" });
+      await once(tcp, "connect");
+      // The ClientHello goes out. The server's answer is held back, so the handshake cannot finish yet.
+      let hold = true;
+      const held: Buffer[] = [];
+      const wire = new Duplex({ read() {}, write: (chunk, _encoding, cb) => void tcp.write(chunk, cb) });
+      tcp.on("data", d => void (hold ? held.push(d) : wire.push(d)));
+      tcp.on("close", () => wire.push(null));
+      const socket = tls.connect({ socket: wire, ALPNProtocols: ["h2"], rejectUnauthorized: false });
+      socket.on("error", () => {});
+      await once(tcp, "data");
+
+      await stopThenComplete(fx, true, async () => {
+        // The handshake can finish while the held bytes are pushed, so listen first.
+        const secured = once(socket, "secureConnect");
+        hold = false;
+        for (const d of held) wire.push(d);
+        await secured;
+        return RawH2.over(socket);
+      });
+    }, 20000);
+
+    test("cleartext preface incomplete", async () => {
+      await using fx = await startFixture({ tls: false });
+      const tcp = net.connect({ port: fx.port, host: "127.0.0.1" });
+      await once(tcp, "connect");
+      // Too short to tell HTTP/2 from HTTP/1: the server keeps these bytes and waits for more.
+      tcp.write(PREFACE.subarray(0, 3));
+
+      await stopThenComplete(fx, false, async () => {
+        const raw = RawH2.over(tcp, { sendPreface: false });
+        raw.write(PREFACE.subarray(3));
+        raw.write(frame(T.SETTINGS, 0, 0));
+        return raw;
+      });
+    }, 20000);
+
+    test("TLS handshakes queued behind the per-iteration budget", async () => {
+      // The loop runs five TLS handshakes per iteration and parks the rest of a burst in a queue
+      // that the stop() sweep does not walk. The first request stops the server, so most of the
+      // burst is still mid-handshake at that moment. A client asks again after each answer and
+      // hangs up only after the third, so more than one answer on a connection means the server
+      // kept serving it. No answer means stop() found it already HTTP/2 with no request yet.
+      const src = `
+        const http2 = require("node:http2");
+        let stopped;
+        const server = Bun.serve({
+          port: 0, hostname: "127.0.0.1", tls: ${JSON.stringify(tlsCert)}, http2: true, idleTimeout: 30,
+          fetch() {
+            stopped ??= server.stop();
+            return new Response("ok");
+          },
+        });
+        const conns = [];
+        for (let i = 0; i < 20; i++) {
+          const session = http2.connect("https://127.0.0.1:" + server.port, { rejectUnauthorized: false });
+          const closed = Promise.withResolvers();
+          const conn = { answers: 0, goaway: false, closed: closed.promise };
+          session.on("error", () => {});
+          session.on("goaway", () => (conn.goaway = true));
+          session.on("close", () => closed.resolve());
+          const request = () => {
+            const req = session.request({ ":path": "/" });
+            let body = "";
+            req.on("data", d => (body += d));
+            req.on("error", () => {});
+            req.on("end", () => {
+              if (body !== "ok") return;
+              if (++conn.answers === 3) session.close();
+              else if (!session.closed && !session.destroyed) request();
+            });
+            req.end();
+          };
+          session.on("connect", request);
+          conns.push(conn);
+        }
+        await Promise.all(conns.map(c => c.closed));
+        await stopped;
+        console.log(JSON.stringify({
+          answers: conns.map(c => c.answers).join(""),
+          answeredWithoutGoaway: conns.filter(c => c.answers > 0 && !c.goaway).length,
+        }));
+      `;
+      await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(JSON.parse(stdout)).toEqual({ answers: expect.stringMatching(/^1[01]{19}$/), answeredWithoutGoaway: 0 });
+      expect(exitCode).toBe(0);
+    }, 20000);
   });
 
   test("a paused (slowly read) request body does not idle out the connection", async () => {

--- a/test/js/bun/http/serve-http2-lifecycle.test.ts
+++ b/test/js/bun/http/serve-http2-lifecycle.test.ts
@@ -206,7 +206,7 @@ describe("Bun.serve http2 lifecycle", () => {
       // hangs up only after the third, so more than one answer on a connection means the server
       // kept serving it. No answer means stop() found it already HTTP/2 with no request yet.
       const src = `
-        const http2 = require("node:http2");
+        import http2 from "node:http2";
         let stopped;
         const server = Bun.serve({
           port: 0, hostname: "127.0.0.1", tls: ${JSON.stringify(tlsCert)}, http2: true, idleTimeout: 30,
@@ -248,7 +248,11 @@ describe("Bun.serve http2 lifecycle", () => {
       await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stdout: "pipe", stderr: "pipe" });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).not.toContain("error:");
-      expect(JSON.parse(stdout)).toEqual({ answers: expect.stringMatching(/^1[01]{19}$/), answeredWithoutGoaway: 0 });
+      // The request that called stop() is always answered. Which connection sent it is not fixed.
+      expect(JSON.parse(stdout)).toEqual({
+        answers: expect.stringMatching(/^(?=[01]*1)[01]{20}$/),
+        answeredWithoutGoaway: 0,
+      });
       expect(exitCode).toBe(0);
     }, 20000);
   });


### PR DESCRIPTION
### Problem
- With `Bun.serve({ http2: true })`, a connection that becomes HTTP/2 after a graceful `server.stop()` never gets GOAWAY. The server keeps serving new streams on it. `stop()` resolves only when the client hangs up or is silent for `idleTimeout`.
- `Http2Context::closeIdle(true)` (`packages/bun-uws/src/Http2Context.h:804`) sends GOAWAY once, to the connections it has then. A socket whose TLS handshake or cleartext preface is incomplete joins later through `adopt()` (`:737`). Nothing visits it again.

### Fix
- `closeIdle(true)` sets `Http2Context::stopping`. When a stream arrives on a connection that has sent no GOAWAY and the context is stopping, `handleHeaderBlock` sends GOAWAY (NO_ERROR) that names the stream. Only a connection adopted after the stop is in that state.
- The stream is served, as the HTTP/1 path serves one request in this state. The existing `goawaySent` path ignores later streams. The connection closes when the stream retires. The flag is per context, so it also covers sockets parked in the TLS handshake queue.
- Verified: three new tests in `test/js/bun/http/serve-http2-lifecycle.test.ts`. 1.4.3-canary and a debug build of main fail all three. Also ran the other `serve-http2*` suites and the `stop()` tests in `bun-server.test.ts`.
- Self-reviewed: 3 concerns raised, 3 addressed (see Notes).

### Background
- With `http2: true` a connection starts as an HTTP/1 socket. It moves into the `Http2Context` when ALPN selects `h2`, or when a cleartext connection opens with the HTTP/2 preface.
- GOAWAY carries a last-stream-id. The server still answers streams up to that id. The client retries later streams elsewhere.
- usockets runs 5 TLS handshake reads per loop iteration and parks the rest in a queue.

<details><summary>Notes</summary>

**Policy.** A connection accepted before `stop()` gets one request, whichever protocol it negotiates afterwards. That is what the HTTP/1 path does (`HTTP_CLOSE_WHEN_IDLE`, #37074, and the test "serves a TLS connection whose handshake completes after a graceful stop()" in `serve.test.ts`). The alternative was GOAWAY with last-stream-id 0 at adoption. I tried it first. The server then closes on the first socket event, while the client's preface, SETTINGS and HEADERS are still in flight. With a cleartext client that sends them as separate writes, the client's writes failed with EPIPE or ECONNRESET in 6 of 6 runs, and one run lost the GOAWAY. With GOAWAY on the first stream the server has read the request before it closes.

**Frames on the late connection** (second connection calls `/stop`, then the late one finishes its handshake and sends GET on stream 1, and 300 ms later GET on stream 3):

```
1.4.3-canary (4ff919377), TLS and cleartext alike:
  SETTINGS, WINDOW_UPDATE, SETTINGS ack, HEADERS #1, DATA #1 "hello", HEADERS #3, DATA #3 "hello"
  connection stays open, stop() resolves only after the client destroys the socket
this branch:
  SETTINGS, WINDOW_UPDATE, SETTINGS ack, GOAWAY last=1 code=0, HEADERS #1, DATA #1 "hello"
  server closes, stop() resolves
```

**Burst repro from the report** (40 `node:http2` sessions opened in one tick, the first request handler calls `stop()`, each client asks again after an answer and hangs up after the third). Answers per connection, and GOAWAY seen per connection:

```
1.4.3-canary and debug build of main   1333333333333333333333333333333333333333   1000000000000000000000000000000000000000
this branch (3 of 3 runs)              1111111111111111111111111111111111111111   1111111111111111111111111111111111111111
```

**Self-review.** The first shape carried the per-socket `HTTP_CLOSE_WHEN_IDLE` mark through `onHttp2` into `adopt()`. It depended on the HTTP/1 sweep having marked the socket. That sweep does not walk the TLS low-priority queue (#42285 fixes that for HTTP/1.1), so in the burst repro only 10 of 40 connections got GOAWAY. Concerns raised and addressed: move the fact to the object that owns it (`Http2Context`, which receives `closeIdle(true)`), add a test with a parked population, and state the idle-timeout bound in the problem statement. #42285 stays separate: HTTP/1.1 clients of the same server still need it.

**Not changed.**
- A connection that is already HTTP/2 with no stream when `stop()` runs still gets GOAWAY with last-stream-id 0 and closes at once (`closeIdle`, #40137).
- A late connection that never opens a stream is closed by the idle timeout, like the HTTP/1 socket that never sends a request.
- `closeIdle(false)` (`server.closeIdleConnections()`) does not set the flag. `closeIdle(true)` has one caller, the graceful stop in `src/runtime/server/mod.rs`, and a second `stop()` returns before it.

**Tests.** "TLS handshake incomplete" holds back the server's handshake flight until `stop()` has run. "cleartext preface incomplete" sends the first 3 bytes of the preface, which the server keeps as undecided, and the rest after `stop()`. Both send the first bytes before `stop()` because the listener uses `TCP_DEFER_ACCEPT`: the kernel does not hand over a connection that has sent nothing. Both send GET on streams 1 and 3 in one write and expect GOAWAY (last-stream-id 1), the answer on stream 1, nothing on stream 3, a close from the server, and the fixture to exit when the `stop()` promise resolves. The third test is the burst repro with 20 connections.

Suites run on the debug build: `serve-http2-lifecycle.test.ts` (26 pass), `serve-http2.test.ts` (90), `serve-http2-protocol.test.ts` (193), `serve.test.ts -t "graceful stop"`, `bun-server.test.ts -t stop` (25).

</details>
