### PR TITLE
Keep require() and import() locals working in functions the React Compiler compiles

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -472,9 +472,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// Compiled args/flags written by the `visit_stmts` hook for `visit_func` /
     /// arrow-visit to apply to the original `G::Fn` / `E::Arrow`.
     pub(crate) react_compiler_result: Option<bun_react_compiler::CompileResult>,
-    /// The visit is inside a function the React Compiler may compile. A
-    /// compile re-declares every local in there as a new symbol and can drop
-    /// the declaration, so nothing that outlives the visit may hold one.
+    /// Visiting a function the React Compiler may compile. It re-declares the locals as new symbols.
     pub(crate) react_compiler_may_replace_body: bool,
 
     /// only applicable when `.options.features.server_components` is
@@ -1165,8 +1163,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// The import record `ns.name` reads an export of, when `ns` holds that one
     /// module's namespace, so the read can become an import item.
     pub(crate) fn dynamic_import_item_record(&self, ns: Ref, name: &[u8]) -> Option<u32> {
-        // An unbound item prints `ns.name`, which needs the `ns` declared here
-        // in the output. The React Compiler re-declares or drops it.
         if !self.options.bundle
             || self.options.output_format == options::Format::InternalBakeDev
             || self.react_compiler_may_replace_body
@@ -1195,8 +1191,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// export.
     pub(crate) fn note_destructured_locals(&mut self, properties: &[bun_ast::B::Property]) {
         // The dev server does not link, so nothing would bind them. A bound
-        // name leaves the pattern, and `...rest` would then collect it. The
-        // React Compiler re-declares the pattern with new symbols.
+        // name leaves the pattern, and `...rest` would then collect it.
         if !self.options.bundle
             || self.options.output_format == options::Format::InternalBakeDev
             || self.react_compiler_may_replace_body

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -472,6 +472,10 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// Compiled args/flags written by the `visit_stmts` hook for `visit_func` /
     /// arrow-visit to apply to the original `G::Fn` / `E::Arrow`.
     pub(crate) react_compiler_result: Option<bun_react_compiler::CompileResult>,
+    /// The visit is inside a function the React Compiler may compile. A
+    /// compile re-declares every local in there as a new symbol and can drop
+    /// the declaration, so nothing that outlives the visit may hold one.
+    pub(crate) react_compiler_may_replace_body: bool,
 
     /// only applicable when `.options.features.server_components` is
     /// configured to wrap exports. populated before visit pass starts.
@@ -1161,8 +1165,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// The import record `ns.name` reads an export of, when `ns` holds that one
     /// module's namespace, so the read can become an import item.
     pub(crate) fn dynamic_import_item_record(&self, ns: Ref, name: &[u8]) -> Option<u32> {
+        // An unbound item prints `ns.name`, which needs the `ns` declared here
+        // in the output. The React Compiler re-declares or drops it.
         if !self.options.bundle
             || self.options.output_format == options::Format::InternalBakeDev
+            || self.react_compiler_may_replace_body
             || self.dynamic_import_copied_locals.contains_key(&ns)
         {
             return None;
@@ -1188,9 +1195,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// export.
     pub(crate) fn note_destructured_locals(&mut self, properties: &[bun_ast::B::Property]) {
         // The dev server does not link, so nothing would bind them. A bound
-        // name leaves the pattern, and `...rest` would then collect it.
+        // name leaves the pattern, and `...rest` would then collect it. The
+        // React Compiler re-declares the pattern with new symbols.
         if !self.options.bundle
             || self.options.output_format == options::Format::InternalBakeDev
+            || self.react_compiler_may_replace_body
             || properties
                 .iter()
                 .any(|p| p.flags.contains(bun_ast::flags::Property::IsSpread))
@@ -9793,6 +9802,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             react_compiler_in_react_hoc: false,
             react_compiler_pending: None,
             react_compiler_result: None,
+            react_compiler_may_replace_body: false,
             server_components_wrap_ref: Ref::NONE,
             jest: Jest::default(),
             import_records_for_current_part: BumpVec::new_in(arena),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1165,7 +1165,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub(crate) fn dynamic_import_item_record(&self, ns: Ref, name: &[u8]) -> Option<u32> {
         if !self.options.bundle
             || self.options.output_format == options::Format::InternalBakeDev
-            || self.react_compiler_may_replace_body
             || self.dynamic_import_copied_locals.contains_key(&ns)
         {
             return None;
@@ -1259,6 +1258,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .insert(local, ImportItemForNamespaceMap::default());
         self.dynamic_import_namespace_locals
             .insert(local, records.to_vec());
+        if self.react_compiler_may_replace_body {
+            self.dynamic_import_copied_locals.insert(local, ());
+        }
         for &import_record_id in records {
             self.imports_to_convert_from_dynamic_import
                 .push(DeferredImportNamespace {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -472,7 +472,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// Compiled args/flags written by the `visit_stmts` hook for `visit_func` /
     /// arrow-visit to apply to the original `G::Fn` / `E::Arrow`.
     pub(crate) react_compiler_result: Option<bun_react_compiler::CompileResult>,
-    /// Visiting a function the React Compiler may compile. It re-declares the locals as new symbols.
+    /// Visiting a function that is handed to the React Compiler, which re-declares its locals as new symbols.
     pub(crate) react_compiler_may_replace_body: bool,
 
     /// only applicable when `.options.features.server_components` is

--- a/src/js_parser/react_compiler_host.rs
+++ b/src/js_parser/react_compiler_host.rs
@@ -130,10 +130,7 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
 }
 
 impl<'a, const TS: bool, const SCAN_ONLY: bool> P<'a, TS, SCAN_ONLY> {
-    /// Called by `visit_func` / arrow-visit before anything of the function is
-    /// visited. Sets `react_compiler_may_replace_body` if the function is the
-    /// candidate `react_compiler_candidate_name` announces and the compiler
-    /// may take it. Returns the value to restore after the visit.
+    /// Sets `react_compiler_may_replace_body` for the visit of the pending candidate. Returns the old value.
     pub(crate) fn enter_react_compiler_candidate(
         &mut self,
         name: Option<js_ast::Ref>,

--- a/src/js_parser/react_compiler_host.rs
+++ b/src/js_parser/react_compiler_host.rs
@@ -130,6 +130,36 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
 }
 
 impl<'a, const TS: bool, const SCAN_ONLY: bool> P<'a, TS, SCAN_ONLY> {
+    /// Called by `visit_func` / arrow-visit before anything of the function is
+    /// visited. Sets `react_compiler_may_replace_body` if the function is the
+    /// candidate `react_compiler_candidate_name` announces and the compiler
+    /// may take it. Returns the value to restore after the visit.
+    pub(crate) fn enter_react_compiler_candidate(
+        &mut self,
+        name: Option<js_ast::Ref>,
+        has_react_hooks_suppression: bool,
+        body: &[js_ast::Stmt],
+    ) -> bool {
+        let prev = self.react_compiler_may_replace_body;
+        if !prev
+            && let Some(candidate) = self.react_compiler_candidate_name
+            && let Some(rc) = self.react_compiler.as_deref()
+        {
+            let name = name
+                .filter(|r| r.is_valid())
+                .or(Some(candidate))
+                .filter(|r| *r != js_ast::Ref::NONE)
+                .map(|r| self.load_name_from_ref(r));
+            self.react_compiler_may_replace_body = rc.may_compile(
+                name,
+                self.react_compiler_in_react_hoc,
+                has_react_hooks_suppression,
+                body,
+            );
+        }
+        prev
+    }
+
     /// Port of upstream `findFunctionDeclarationOrExpression` for the
     /// expression positions (decl init / `export default` / expression
     /// statement). Returns `Some(in_react_hoc)` only for the shapes the

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -115,6 +115,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let body_loc = func.body.loc;
         let body_stmts: &'a [Stmt] = func.body.stmts.slice();
+        let prev_may_replace_body = self.enter_react_compiler_candidate(
+            func.name.map(|n| n.ref_),
+            func.flags
+                .contains(flags::Function::HasReactHooksSuppression),
+            body_stmts,
+        );
 
         self.push_scope_for_visit_pass(ScopeKind::FunctionArgs, open_parens_loc)
             .expect("unreachable");
@@ -204,6 +210,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.pop_scope();
         self.pop_scope();
 
+        self.react_compiler_may_replace_body = prev_may_replace_body;
         self.fn_or_arrow_data_visit = old_fn_or_arrow_data;
         self.fn_only_data_visit = old_fn_only_data;
 
@@ -1782,6 +1789,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             };
             p.react_compiler = Some(rc);
             if let Some((new_body, result)) = compiled {
+                debug_assert!(
+                    p.react_compiler_may_replace_body,
+                    "ReactCompilerState::may_compile said no for a function that compiled"
+                );
                 stmts.clear();
                 stmts.extend(new_body);
                 p.react_compiler_result = Some(result);

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1771,6 +1771,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         debug_assert!(p.current_scope == initial_scope);
 
         if let Some(pending) = rc_pending
+            && p.react_compiler_may_replace_body
             && let Some(mut rc) = p.react_compiler.take()
         {
             let name = pending
@@ -1789,10 +1790,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             };
             p.react_compiler = Some(rc);
             if let Some((new_body, result)) = compiled {
-                debug_assert!(
-                    p.react_compiler_may_replace_body,
-                    "ReactCompilerState::may_compile said no for a function that compiled"
-                );
                 stmts.clear();
                 stmts.extend(new_body);
                 p.react_compiler_result = Some(result);

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2599,6 +2599,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.push_scope_for_visit_pass(js_ast::scope::Kind::FunctionArgs, expr.loc)
             .expect("unreachable");
         let dupe: &'a mut [Stmt] = p.arena.alloc_slice_copy(e_.body.stmts.slice());
+        let prev_may_replace_body =
+            p.enter_react_compiler_candidate(None, e_.has_react_hooks_suppression, dupe);
 
         let args_mut: &mut [G::Arg] = e_.args.slice_mut();
         p.visit_args(
@@ -2661,6 +2663,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.pop_scope();
         p.pop_scope();
 
+        p.react_compiler_may_replace_body = prev_may_replace_body;
         p.fn_or_arrow_data_visit = old_fn_or_arrow_data;
 
         // Restore before any further `p.*` call so the stack-local pointer

--- a/src/react_compiler/program.rs
+++ b/src/react_compiler/program.rs
@@ -982,6 +982,11 @@ fn get_component_or_hook_like(
     None
 }
 
+/// The part of [`get_component_or_hook_like`] that the binding decides.
+fn is_component_or_hook_like_name(name: Option<&[u8]>, in_react_hoc: bool) -> bool {
+    name.is_some_and(|name| is_component_name(name) || is_hook_name(name)) || in_react_hoc
+}
+
 // -----------------------------------------------------------------------
 // Error handling
 // -----------------------------------------------------------------------
@@ -1165,6 +1170,49 @@ impl ReactCompilerState {
             if let Some(fatal) = handle_error(err, &mut self.diagnostics, &self.options) {
                 self.fatal = Some(fatal);
             }
+        }
+    }
+
+    /// Whether [`maybe_compile_pending`] can replace the body of this
+    /// function, from what is known before the parser visits that body. It is
+    /// `true` for every function that gets compiled. The statements of the
+    /// body and the compile itself then decide.
+    pub fn may_compile(
+        &self,
+        name: Option<&[u8]>,
+        in_react_hoc: bool,
+        has_react_hooks_suppression: bool,
+        body: &[Stmt],
+    ) -> bool {
+        if self.fatal.is_some()
+            || self.context.has_module_scope_opt_out
+            || has_react_hooks_suppression
+        {
+            return false;
+        }
+        let directives = collect_body_directives(body);
+        if find_directive_disabling_memoization(&directives).is_some() {
+            return false;
+        }
+        // Fixture pragmas set the mode when `lazy_init` reads them.
+        if self.options.parse_test_pragmas && !self.did_lazy_init {
+            return true;
+        }
+        if self.options.output_mode.as_deref() == Some("lint") {
+            return false;
+        }
+        if find_directive_enabling_memoization(&directives).is_some()
+            || (self.options.dynamic_gating.is_some()
+                && directives
+                    .iter()
+                    .any(|d| d.starts_with(DYNAMIC_GATING_DIRECTIVE_PREFIX)))
+        {
+            return true;
+        }
+        match self.options.compilation_mode.as_deref().unwrap_or("infer") {
+            "all" => true,
+            "infer" => is_component_or_hook_like_name(name, in_react_hoc),
+            _ => false,
         }
     }
 }

--- a/src/react_compiler/program.rs
+++ b/src/react_compiler/program.rs
@@ -1173,10 +1173,7 @@ impl ReactCompilerState {
         }
     }
 
-    /// Whether [`maybe_compile_pending`] can replace the body of this
-    /// function, from what is known before the parser visits that body. It is
-    /// `true` for every function that gets compiled. The statements of the
-    /// body and the compile itself then decide.
+    /// Whether [`maybe_compile_pending`] can take this function, decided before its body is visited.
     pub fn may_compile(
         &self,
         name: Option<&[u8]>,

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1229,6 +1229,197 @@ describe("bundler", () => {
       expect([...used].sort()).toEqual(["T0", "t0", "t1", "t2", "t3"]);
     },
   });
+
+  // Outside the compiler, the bundler binds a local that holds a `require()` /
+  // `import()` export to the export itself: `const { a } = require("./m")`
+  // declares nothing, and `ns.a` off `const ns = require("./m")` is an import
+  // that prints `ns.a` when it can't be bound. A compiled function gets new
+  // symbols for its locals, and the compiler drops a `const ns` it sees no
+  // read of. So in there the reads have to stay reads of the namespace object.
+  for (const target of ["bun", "browser"] as const) {
+    for (const minifyIdentifiers of [false, true]) {
+      itBundled(`react-compiler/RequireAndImportLocals-${target}-identifiers=${minifyIdentifiers}`, {
+        files: {
+          "/entry.ts": /* ts */ `
+            import { setFlag } from "./state";
+            import * as forms from "./forms";
+            setFlag(true);
+            const lines: string[] = [];
+            for (const [name, form] of Object.entries(forms)) {
+              try {
+                lines.push(name + "=" + (await form({})));
+              } catch (e) {
+                lines.push(name + " threw " + e);
+              }
+            }
+            console.log(lines.join("\\n"));
+          `,
+          "/forms.tsx": /* tsx */ `
+            import { useEffect, memo } from "react";
+            import { keep } from "./keep";
+
+            export function RequireDestructure() {
+              useEffect(() => {});
+              const { isFlag } = require("./state") as typeof import("./state");
+              return String(isFlag());
+            }
+            export function RequireDestructureRenamed() {
+              useEffect(() => {});
+              let { isFlag: read } = require("./state");
+              return String(read());
+            }
+            export function useRequireDestructure() {
+              useEffect(() => {});
+              const { isFlag } = require("./state");
+              return String(isFlag());
+            }
+            export const MemoRequireDestructure = memo(() => {
+              useEffect(() => {});
+              const { isFlag } = require("./state");
+              return String(isFlag());
+            });
+            export function AwaitDestructure() {
+              useEffect(() => {});
+              const load = async () => {
+                const { isFlag } = await import("./state");
+                return String(isFlag());
+              };
+              return load();
+            }
+            export function ThenDestructure() {
+              useEffect(() => {});
+              return import("./state").then(({ isFlag }) => String(isFlag()));
+            }
+            export function NamespaceDestructure() {
+              useEffect(() => {});
+              const ns = require("./state");
+              const { isFlag } = ns;
+              return String(isFlag());
+            }
+            export function NamespaceEscapes() {
+              useEffect(() => {});
+              const ns = require("./state");
+              keep(ns);
+              return String(ns.isFlag());
+            }
+            export function NamespaceOfLazyModule() {
+              useEffect(() => {});
+              const lazy = require("./lazy");
+              return lazy.doubled();
+            }
+            export function NamespaceOfCommonJS() {
+              useEffect(() => {});
+              const cjs = require("./cjs.cjs");
+              return cjs.hello() + cjs.suffix;
+            }
+            export function NamespaceOfBuiltin() {
+              useEffect(() => {});
+              const path = require("node:path");
+              return path.posix.join("a", "b");
+            }
+            export function AwaitNamespaceOfBuiltin() {
+              useEffect(() => {});
+              const load = async () => {
+                const path = await import("node:path");
+                return path.posix.join("a", "b");
+              };
+              return load();
+            }
+            export function ThenNamespaceOfCommonJS() {
+              useEffect(() => {});
+              return import("./cjs.cjs").then(cjs => cjs.hello());
+            }
+            export function ThenNamespaceTwice() {
+              useEffect(() => {});
+              return import("./cjs.cjs")
+                .then(cjs => import("./lazy").then(lazy => cjs.hello() + lazy.doubled()))
+                .then(text => import("./cjs.cjs").then(cjs => text + cjs.suffix));
+            }
+            export function plainFunction() {
+              const { onlyPlain } = require("./only-plain");
+              return onlyPlain();
+            }
+          `,
+          "/state.ts": /* ts */ `
+            let flag = false;
+            export function setFlag(value: boolean) {
+              flag = value;
+            }
+            export function isFlag() {
+              return flag;
+            }
+          `,
+          "/lazy.ts": /* ts */ `
+            const table = [1, 2, 3].map(n => n * 2);
+            export function doubled() {
+              return table.join(",");
+            }
+          `,
+          "/only-plain.ts": /* ts */ `
+            export function onlyPlain() {
+              return "plain";
+            }
+            export const notRead = "NOT_READ_SENTINEL";
+          `,
+          "/cjs.cjs": /* js */ `
+            exports.hello = function () {
+              return "hello";
+            };
+            exports.suffix = "!";
+          `,
+          "/keep.ts": /* ts */ `
+            export function keep(value: unknown) {
+              (globalThis as any).kept = value;
+            }
+          `,
+          "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+          "/node_modules/react/index.js": /* js */ `
+            export function useEffect() {}
+            export function memo(component) {
+              return component;
+            }
+          `,
+          "/node_modules/react/compiler-runtime.js": /* js */ `
+            export function c(size) {
+              return new Array(size).fill(Symbol.for("react.memo_cache_sentinel"));
+            }
+          `,
+        },
+        reactCompiler: true,
+        backend: "cli",
+        target,
+        minifyIdentifiers,
+        run: {
+          stdout: `
+            AwaitDestructure=true
+            AwaitNamespaceOfBuiltin=a/b
+            MemoRequireDestructure=true
+            NamespaceDestructure=true
+            NamespaceEscapes=true
+            NamespaceOfBuiltin=a/b
+            NamespaceOfCommonJS=hello!
+            NamespaceOfLazyModule=2,4,6
+            RequireDestructure=true
+            RequireDestructureRenamed=true
+            ThenDestructure=true
+            ThenNamespaceOfCommonJS=hello
+            ThenNamespaceTwice=hello2,4,6!
+            plainFunction=plain
+            useRequireDestructure=true
+          `,
+        },
+        onAfterBundle(api) {
+          const out = api.readFile("/out.js");
+          // Every component and hook above compiled: the compiler outlines the
+          // empty effect callback (client) or drops the effect (ssr).
+          expect(out).not.toContain("useEffect(() =>");
+          // A function the compiler leaves alone still reads the export
+          // without a namespace object, so tree shaking drops the other one.
+          expect(out).not.toContain("NOT_READ_SENTINEL");
+        },
+      });
+    }
+  }
 });
 
 // validate_locals_not_reassigned_after_render (src/react_compiler/validation)

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1411,8 +1411,9 @@ describe("bundler", () => {
         onAfterBundle(api) {
           const out = api.readFile("/out.js");
           // Every component and hook above compiled: the compiler outlines the
-          // empty effect callback (client) or drops the effect (ssr).
-          expect(out).not.toContain("useEffect(() =>");
+          // empty effect callback (client) or drops the effect (ssr), so no
+          // call takes `() => {}` any more. The callee name can be minified.
+          expect(out).not.toMatch(/\(\(\) => \{\s*\}\)/);
           // A function the compiler leaves alone still reads the export
           // without a namespace object, so tree shaking drops the other one.
           expect(out).not.toContain("NOT_READ_SENTINEL");

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1339,6 +1339,43 @@ describe("bundler", () => {
               const { onlyPlain } = require("./only-plain");
               return onlyPlain();
             }
+
+            // Declared outside the compiled function: the compiler keeps
+            // these symbols, so the reads stay bound to the exports.
+            const moduleNs = require("./module-ns");
+            const { isFlag: moduleIsFlag } = require("./state");
+            export function ModuleNamespace() {
+              useEffect(() => {});
+              return moduleNs.value();
+            }
+            export function ModuleDestructure() {
+              useEffect(() => {});
+              return String(moduleIsFlag());
+            }
+            export function NestedDeclaration() {
+              useEffect(() => {});
+              function inner() {
+                const { isFlag } = require("./state");
+                return isFlag();
+              }
+              return String(inner());
+            }
+            // A component name, but no hook call and no JSX: not compiled.
+            export function ComponentNameNotCompiled() {
+              const { isFlag } = require("./state");
+              return String(isFlag());
+            }
+            export function OptOut() {
+              "use no memo";
+              useEffect(keep);
+              const { onlyOptOut } = require("./only-opt-out");
+              return onlyOptOut();
+            }
+            export function optIn() {
+              "use memo";
+              const { isFlag } = require("./state");
+              return String(isFlag());
+            }
           `,
           "/state.ts": /* ts */ `
             let flag = false;
@@ -1359,7 +1396,19 @@ describe("bundler", () => {
             export function onlyPlain() {
               return "plain";
             }
-            export const notRead = "NOT_READ_SENTINEL";
+            export const notRead = "PLAIN_NOT_READ_SENTINEL";
+          `,
+          "/only-opt-out.ts": /* ts */ `
+            export function onlyOptOut() {
+              return "opt-out";
+            }
+            export const notRead = "OPT_OUT_NOT_READ_SENTINEL";
+          `,
+          "/module-ns.ts": /* ts */ `
+            export function value() {
+              return "module-ns";
+            }
+            export const notRead = "MODULE_NS_NOT_READ_SENTINEL";
           `,
           "/cjs.cjs": /* js */ `
             exports.hello = function () {
@@ -1393,17 +1442,23 @@ describe("bundler", () => {
           stdout: `
             AwaitDestructure=true
             AwaitNamespaceOfBuiltin=a/b
+            ComponentNameNotCompiled=true
             MemoRequireDestructure=true
+            ModuleDestructure=true
+            ModuleNamespace=module-ns
             NamespaceDestructure=true
             NamespaceEscapes=true
             NamespaceOfBuiltin=a/b
             NamespaceOfCommonJS=hello!
             NamespaceOfLazyModule=2,4,6
+            NestedDeclaration=true
+            OptOut=opt-out
             RequireDestructure=true
             RequireDestructureRenamed=true
             ThenDestructure=true
             ThenNamespaceOfCommonJS=hello
             ThenNamespaceTwice=hello2,4,6!
+            optIn=true
             plainFunction=plain
             useRequireDestructure=true
           `,
@@ -1416,7 +1471,11 @@ describe("bundler", () => {
           expect(out).not.toMatch(/\(\(\) => \{\s*\}\)/);
           // A function the compiler leaves alone still reads the export
           // without a namespace object, so tree shaking drops the other one.
-          expect(out).not.toContain("NOT_READ_SENTINEL");
+          expect(out).not.toContain("PLAIN_NOT_READ_SENTINEL");
+          // So does one that opts out of the compiler.
+          expect(out).not.toContain("OPT_OUT_NOT_READ_SENTINEL");
+          // And a read, in a compiled function, of a local declared outside it.
+          expect(out).not.toContain("MODULE_NS_NOT_READ_SENTINEL");
         },
       });
     }


### PR DESCRIPTION
### Problem

- With `bun build --react-compiler`, a component or hook that reads a local bound to `require()` or `import()` breaks when it runs. `const { isFlag } = require("./state")` prints as `let { isFlag } = ({})`: `TypeError: isFlag is not a function`. `const path = require("node:path"); path.join(...)` prints with no `path` declared: `ReferenceError: path is not defined`.
- #41186 binds such a local to the export, by the local's symbol (`note_destructured_locals`, `dynamic_import_item_record` in `src/js_parser/p.rs`). The React Compiler gives every local of a compiled function a new symbol and drops a declaration it sees no read of (`Codegen::ref_for_name`, `src/react_compiler/codegen.rs`). The bound symbols are then not in the output. 1.4.1 and 1.4.2 have the bug, 1.4.0 does not.

### Fix

- Before the parser visits a compile candidate, `ReactCompilerState::may_compile` says if the compiler can take it, from its name, its directives and the mode.
- A local declared inside such a function (destructured name, namespace local, `.then` parameter) is not made an import item. It reads the namespace object, as in 1.4.0. Everything else keeps the #41186 output.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (4 new tests, 21 forms each, 13 of them fail on 1.4.3-canary). Also `bundler_dynamic_import_dce.test.ts`, `react-compiler-fixtures.test.ts`.

### Background

- The React Compiler runs per function, after the parser visited the body. It generates new statements from its own IR.
- An import item is a symbol that the linker binds to an export of another module. The printer prints the export's name for it. An unbound item prints `ns.a`.
- When every read of a `require()` is bound, the printer prints the call as `({})`.

<details><summary>Notes</summary>

**Forms that break on 1.4.1, 1.4.2 and canary.** All need `--react-compiler` and a function that the compiler compiles: a component, a hook, a `memo()` / `forwardRef()` callback, or any closure nested in one. Both output modes (`--target=bun` ssr, `--target=browser` client) are affected. Minified or not.

1. A destructured local: `const|let { a } = require(x)`, `const { a } = await import(x)`, `import(x).then(({ a }) => ...)`, `const ns = require(x); const { a } = ns`. It breaks when the importee is a bundled ES module (direct, through a barrel, or a polyfilled `node:` builtin for the browser target). `a` reads `undefined`. A `var` pattern, a pattern with `...rest`, a default value, or a name the importee does not export keeps the namespace object and works.
2. A namespace local: `const ns = require(x)`, `const ns = await import(x)`, `import(x).then(ns => ...)`, then `ns.a`.
   - Importee is CommonJS, `--external`, or a runtime builtin: `ReferenceError: ns is not defined`.
   - `ns` also escapes (`f(ns)`, `ns[key]`): the same ReferenceError for every importee kind.
   - Importee is a bundled ES module that only this `require()` loads: the output reads the exports but never calls the module's init. Silent.
   - `import(x).then(m => m.a)` with an external importee prints correctly by accident when the names are not minified, because the new parameter has the same name as the old symbol. `--minify-identifiers` breaks it. So does a second parameter of the same name, which the compiler renames to `m_0`.

With `--splitting`, nothing binds across chunks, so the namespace local of an `import()` breaks for every importee kind: `const ns = await import(x); ns.a` prints `ns.a` with no `ns`. The destructured forms work there.

Forms that work: `require(x).a` and `(await import(x)).a` with no local, `ns?.a`, `const ns = cond ? require(x) : null`, array patterns off `Promise.all`, and every form in a function that the compiler does not compile.

**Matrix.** 43 access forms, 8 function shapes, 7 importee kinds, compiler off / ssr / client, minify on / off: 13,344 bundle-and-run cases, each compared with the run of the unbundled source. 1.4.0: 0 failures. 1.4.3-canary: 3,282 failures, all of them with the compiler on. This branch: 0 failures. The same holds with `--splitting` (4,448 cases: 1.4.0 has 0 failures, canary 517, this branch 0).

**`may_compile`.** It repeats the checks of `get_react_function_type` and `maybe_compile_node` that do not read the statements of the body: a component or hook name or a `memo()` / `forwardRef()` callback in `infer` mode, every function in `all` mode, the `use memo` / `use no memo` directives, a module-level opt-out, an eslint suppression, lint mode.

**Guard.** `visit_stmts` hands a function to the compiler only when `may_compile` said yes for it. So a function cannot compile with the flag unset, and the flag and the compile decision cannot disagree. If `may_compile` is ever too strict, the cost is a function that stays uncompiled, not a wrong bundle.

**Precision.** `may_compile` is decided before the body is visited, so it cannot know if the body calls a hook or creates JSX, or if the compile fails later. A function with a component or hook name that is then left uncompiled reads the namespace object too. That costs the #41186 size win for that function. It does not change behavior.

**Existing tests.** `react-compiler/RequireStringPreservesImportRecord` and `react-compiler/DynamicImportInEffectClosure` in the same file have the broken shapes. They only read the output text and do not run it, so they passed.

</details>
