### PR TITLE
node:vm: allow a Proxy in the prototype chain of a global object

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "cf1b36ec8703d8e87436094d21d478d358c7d886";
+export const WEBKIT_VERSION = "autobuild-preview-pr-626-f1e23f97";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/BunGlobalScope.cpp
+++ b/src/jsc/bindings/BunGlobalScope.cpp
@@ -18,6 +18,11 @@ void GlobalScope::finishCreation(JSC::VM& vm)
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
 
+    // Every Bun global clears IsImmutablePrototypeExoticObject from its structure, so user
+    // code can put a Proxy in its prototype chain (jsdom does, for its window). V8 runs
+    // programs against such a chain, so JSC must not reject it.
+    setAllowsProxyInPrototypeChain(true);
+
     m_encodeIntoObjectStructure.initLater(
         [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::Structure>::Initializer& init) {
             auto& vm = init.vm;

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 import {
   compileFunction,
   constants,
@@ -1315,6 +1315,63 @@ describe("DONT_CONTEXTIFY", () => {
 
     ctx.fromOutside = 456;
     expect(runInContext("fromOutside", ctx)).toBe(456);
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/42331
+describe("a Proxy in the prototype chain of the context global", () => {
+  // jsdom 28+ puts a Proxy (WindowProperties) in the prototype chain of its
+  // window. V8 runs a program against such a global, so node:vm must too.
+  function installProxy(ctx: object) {
+    const target = { fromProxy: 7 };
+    const g = runInContext("this", ctx);
+    Object.setPrototypeOf(g, Object.create(new Proxy(target, {})));
+    return target;
+  }
+
+  test.each([
+    ["DONT_CONTEXTIFY", () => createContext(constants.DONT_CONTEXTIFY)],
+    ["contextified sandbox", () => createContext({})],
+  ])("%s: programs run and resolve names through the Proxy", (_, makeContext) => {
+    const ctx = makeContext();
+    const target = installProxy(ctx);
+
+    expect(runInContext("1 + 1", ctx)).toBe(2);
+    expect(new Script("2 + 2").runInContext(ctx)).toBe(4);
+    expect(runInContext("fromProxy", ctx)).toBe(7);
+    expect(runInContext("typeof missingName", ctx)).toBe("undefined");
+    expect(runInContext("undeclaredAssign = 9; undeclaredAssign", ctx)).toBe(9);
+    expect(runInContext("fromProxy = 8; fromProxy", ctx)).toBe(8);
+    expect(target.fromProxy).toBe(7);
+  });
+
+  test("contextified sandbox: declarations land on the global, not on the Proxy", () => {
+    const ctx = createContext({});
+    const target = installProxy(ctx);
+
+    expect(runInContext("var declared = 5; function fn() { return 6 } declared + fn()", ctx)).toBe(11);
+    expect(new Script("declared * 2").runInContext(ctx)).toBe(10);
+    expect(target).toEqual({ fromProxy: 7 });
+  });
+
+  test("main realm: runInThisContext and require() run with a Proxy in the chain of globalThis", async () => {
+    using dir = tempDir("vm-proxy-global", { "dep.cjs": "module.exports = 42;" });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const vm = require("node:vm");
+         Object.setPrototypeOf(globalThis, Object.create(new Proxy({ viaProxy: 3 }, {})));
+         console.log(vm.runInThisContext("1 + 1"), vm.runInThisContext("viaProxy"), require("./dep.cjs"));`,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("2 3 42\n");
+    expect(exitCode).toBe(0);
   });
 });
 


### PR DESCRIPTION
### Problem
- `vm.runInContext(code, ctx)` throws `TypeError: Proxy is not allowed in the global prototype chain.` when the context global has a Proxy anywhere in its prototype chain. jsdom 28+ puts one there (`WindowProperties`), so jsdom under `node:vm` and Vitest `pool: 'vmThreads'` fail on Bun. Node prints the result. Fixes #42331.
- The main realm has the same problem. After `Object.setPrototypeOf(globalThis, Object.create(new Proxy({}, {})))`, `vm.runInThisContext()` and CommonJS `require()` throw the same error.
- The check is JavaScriptCore's, in `ProgramExecutable::initializeGlobalProperties`. It runs before every program links. Bun has no hook to skip it, so the fix needs oven-sh/WebKit#626.

### Fix
- oven-sh/WebKit#626 adds `JSGlobalObject::setAllowsProxyInPrototypeChain()`. A global object that opts in skips the check. `Bun::GlobalScope::finishCreation` (`src/jsc/bindings/BunGlobalScope.cpp`) opts in, so every Bun global is covered: main, workers, shadow realms and `node:vm` contexts.
- Correct because every Bun global already clears `IsImmutablePrototypeExoticObject` from its structure (`ZigGlobalObject.cpp:443`, `NodeVM.cpp:941`), so user code can set its prototype. Global declaration instantiation in JSC reads only own properties of the global, so no Proxy trap runs while a program links. Name lookup at run time goes through the ordinary `[[HasProperty]]`, `[[Get]]` and `[[Set]]` paths, which handle a Proxy. That matches V8.
- `WEBKIT_VERSION` points at the preview build of oven-sh/WebKit#626. Repin it to the merged sha before this merges.
- Verified: `test/js/node/vm/vm.test.ts`, block "a Proxy in the prototype chain of the context global" (4 tests, all fail on Bun 1.4.2). Also the rest of `test/js/node/vm`, the 95 vendored `test/js/node/test/parallel/test-vm-*.js`, and jsdom 30 under `vm.runInContext`.

### Background
- A `ProgramExecutable` is what `vm.runInContext`, `vm.runInThisContext`, `new vm.Script().runIn*` and the CommonJS loader evaluate. Modules and `eval` do not go through it, so they never hit the check.
- An immutable prototype exotic object is an object whose `[[SetPrototypeOf]]` refuses a new value. The spec makes `Object.prototype` one, and JSC makes global objects one by default. Bun clears that flag on its globals so jsdom can set `__proto__` on the window.
- WebKit added the check in 2016 (bug 165205) for the web, where `Window.prototype` is mutable and `var` declaration walked the prototype chain at the time. JSC's declaration code is own-property only today.

<details><summary>Notes</summary>

Node behaviour the tests follow: in a `DONT_CONTEXTIFY` context a missing name throws `ReferenceError`. In a contextified context it reads as `undefined` (the sandbox interceptor). Node's `has`/`get`/`set` traps fire on a Proxy in the chain for unresolved names and sloppy assignments, and the Proxy target is never written (the receiver is the global). Bun now produces the same results.

Pre-existing, unrelated: `var` and function declarations in a `DONT_CONTEXTIFY` context do not create bindings in Bun, with or without a Proxy in the chain. The declaration test therefore uses a contextified context.

`test/js/node/vm/script-leak.test.ts` times out at 5 s in the container used here, on main as well as on this branch (16 s of parse time for 10000 scripts in a debug ASAN build).

Self-reviewed: the review found that the first version opted in only the `node:vm` global and missed the main realm, and that the PR body claimed the main global could not get a Proxy in its chain. Both fixed: the opt-in moved to `Bun::GlobalScope`, and a main realm test was added. The review also asked for the preview pin to be replaced by the merged sha, which is the repin step above.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts

<!-- robobun:evidence:end -->