### PR TITLE
node:http2: end the readable before the event of a HEADERS frame that carries END_STREAM

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2021,6 +2021,16 @@ function pushToStream(stream, data) {
   }
 }
 
+// The peer's half of the stream is over: END_STREAM arrived, or the stream is a server push,
+// which never has one. A HEADERS frame that carries END_STREAM calls this before the event for
+// that frame is emitted (node's onSessionHeaders): the streamEnd dispatch for the same frame only
+// runs after the listener's ticks have drained, too late for a listener that close()s with an
+// error code, which would never see 'end'.
+function endInboundHalf(stream: Http2Stream) {
+  if (!stream.rstCode) stream.rstCode = 0;
+  pushToStream(stream, null);
+}
+
 enum StreamState {
   EndedCalled = 1 << 0, // 00001 = 1
   WantTrailer = 1 << 1, // 00010 = 2
@@ -3266,6 +3276,7 @@ class ServerHttp2Stream extends Http2Stream {
     if (pushedStream && pushedStream[bunHTTP2Headers] == null) {
       pushedStream[bunHTTP2Headers] = headers;
     }
+    if (pushedStream) endInboundHalf(pushedStream);
     if (onServerStreamCreatedChannel.hasSubscribers) {
       onServerStreamCreatedChannel.publish({ stream: pushedStream, headers });
     }
@@ -4057,10 +4068,7 @@ class ServerHttp2Session extends Http2Session {
       }
       if (state == 6 || state == 7) {
         if (stream.readable) {
-          if (!stream.rstCode) {
-            stream.rstCode = 0;
-          }
-          pushToStream(stream, null);
+          endInboundHalf(stream);
 
           // If the user hasn't tried to consume the stream then dump the incoming data so the
           // stream can finish — but at half-close only when nothing is buffered: a consumer may
@@ -4149,7 +4157,9 @@ class ServerHttp2Session extends Http2Session {
         stream[kHeadRequest] = true;
       }
       const status = stream[bunHTTP2StreamStatus];
+      const endOfStream = (flags & constants.NGHTTP2_FLAG_END_STREAM) !== 0;
       if ((status & StreamState.StreamResponded) !== 0) {
+        if (endOfStream) endInboundHalf(stream);
         stream.emit("trailers", headers, flags, rawheaders);
       } else {
         // Set the StreamResponded bit BEFORE dispatching the 'stream' event
@@ -4166,6 +4176,7 @@ class ServerHttp2Session extends Http2Session {
         if (onServerStreamStartChannel.hasSubscribers) {
           onServerStreamStartChannel.publish({ stream, headers });
         }
+        if (endOfStream) endInboundHalf(stream);
         // performServerHandshake() sessions have no owning server.
         self[kServer]?.emit("stream", stream, headers, flags, rawheaders);
         self.emit("stream", stream, headers, flags, rawheaders);
@@ -5056,12 +5067,9 @@ class ClientHttp2Session extends Http2Session {
       }
       if (state == 6 || state == 7) {
         if (stream.readable) {
-          if (!stream.rstCode) {
-            stream.rstCode = 0;
-          }
           // Push a null so the stream can end whenever the client consumes
           // it completely.
-          pushToStream(stream, null);
+          endInboundHalf(stream);
           stream.read(0);
         }
       }
@@ -5129,11 +5137,13 @@ class ClientHttp2Session extends Http2Session {
         }
         const status = stream[bunHTTP2StreamStatus];
         const header_status = headers[HTTP2_HEADER_STATUS];
+        const endOfStream = (flags & constants.NGHTTP2_FLAG_END_STREAM) !== 0;
         if (header_status === HTTP_STATUS_CONTINUE) {
           stream.emit("continue");
         }
 
         if ((status & StreamState.StreamResponded) !== 0) {
+          if (endOfStream) endInboundHalf(stream);
           stream.emit("trailers", headers, flags, rawheaders);
         } else {
           if (header_status >= 100 && header_status < 200) {
@@ -5151,6 +5161,7 @@ class ClientHttp2Session extends Http2Session {
             if (onClientStreamFinishChannel.hasSubscribers) {
               onClientStreamFinishChannel.publish({ stream, headers, flags });
             }
+            if (endOfStream) endInboundHalf(stream);
             if (stream[kPush]) {
               // A pushed stream delivers its response via 'push'; the session 'stream' event already
               // fired (with the promised request headers) when the PUSH_PROMISE arrived.

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2021,11 +2021,8 @@ function pushToStream(stream, data) {
   }
 }
 
-// The peer's half of the stream is over: END_STREAM arrived, or the stream is a server push,
-// which never has one. A HEADERS frame that carries END_STREAM calls this before the event for
-// that frame is emitted (node's onSessionHeaders): the streamEnd dispatch for the same frame only
-// runs after the listener's ticks have drained, too late for a listener that close()s with an
-// error code, which would never see 'end'.
+// Ends the readable. A HEADERS frame with END_STREAM calls this before its event is emitted
+// (node's onSessionHeaders): the frame's streamEnd dispatch only runs a tick drain later.
 function endInboundHalf(stream: Http2Stream) {
   if (!stream.rstCode) stream.rstCode = 0;
   pushToStream(stream, null);

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2021,8 +2021,7 @@ function pushToStream(stream, data) {
   }
 }
 
-// Ends the readable. A HEADERS frame with END_STREAM calls this before its event is emitted
-// (node's onSessionHeaders): the frame's streamEnd dispatch only runs a tick drain later.
+// Like node's onSessionHeaders, a HEADERS frame with END_STREAM ends the readable before its event.
 function endInboundHalf(stream: Http2Stream) {
   if (!stream.rstCode) stream.rstCode = 0;
   pushToStream(stream, null);

--- a/test/js/node/http2/node-http2-client-close.test.ts
+++ b/test/js/node/http2/node-http2-client-close.test.ts
@@ -324,8 +324,14 @@ for (const [site, table] of [
 
 if (typeof Bun !== "undefined") {
   const node = Bun.which("node");
+  // Alpine's node segfaults at a random point of this file (alpine 3.23 aarch64, on main too), and
+  // the CI runner fails a file for any new core dump, whichever process wrote it. The glibc, macOS
+  // and Windows lanes keep the cross-check.
+  const isMusl =
+    process.platform === "linux" &&
+    !(process.report.getReport() as { header: { glibcVersionRuntime?: string } }).header.glibcVersionRuntime;
   describe("Node.js compatibility", () => {
-    test("tests should run on node.js", { skip: !node }, async () => {
+    test("tests should run on node.js", { skip: !node || isMusl }, async () => {
       await using proc = Bun.spawn({
         cmd: [node as string, "--test", import.meta.filename],
         stdout: "inherit",

--- a/test/js/node/http2/node-http2-client-close.test.ts
+++ b/test/js/node/http2/node-http2-client-close.test.ts
@@ -1,7 +1,9 @@
 /**
- * ClientHttp2Stream.close(code) event contract:
+ * Http2Stream.close(code) event contract, client and server, while the peer's half is still open:
  *   NO_ERROR / CANCEL  -> 'end', 'close'             (documented 'error' exemption)
  *   any other code     -> 'error', 'close'           (no 'end': the body was killed by RST_STREAM)
+ * Once the peer's half has ended (END_STREAM on a HEADERS frame, or a server push, which has no
+ * inbound half) the readable already has its EOF, so 'end' comes first for every code.
  *
  * Works with both:
  *   bun bd test test/js/node/http2/node-http2-client-close.test.ts
@@ -182,6 +184,143 @@ describe("ClientHttp2Stream.close(code) while pending", () => {
     });
   }
 });
+
+// The listeners below call close(code) once the peer's half of the stream has ended. Each one is
+// the event of a HEADERS frame that carried END_STREAM (or the pushStream() callback: a server push
+// has no inbound half). "server 'stream', request open" is the contrast: no END_STREAM yet.
+type Site =
+  | "server 'stream'"
+  | "server 'stream' after respond()"
+  | "server 'stream', request open"
+  | "server 'trailers'"
+  | "pushStream() callback"
+  | "client 'response'"
+  | "client 'trailers'";
+
+async function closeIn(site: Site, code: number, defer: boolean): Promise<string[]> {
+  const events: string[] = [];
+  const { promise, resolve, reject } = Promise.withResolvers<string[]>();
+  const watch = (stream: http2.Http2Stream) => {
+    stream.on("end", () => events.push("end"));
+    stream.on("error", e => events.push("error:" + (e as NodeJS.ErrnoException).code));
+    stream.on("close", () => {
+      events.push("close:" + stream.rstCode);
+      resolve(events);
+    });
+    stream.resume();
+  };
+  const close = (stream: http2.Http2Stream) => {
+    if (defer) process.nextTick(() => stream.close(code));
+    else stream.close(code);
+  };
+  const ignoreErrors = (stream: http2.Http2Stream) => stream.on("error", () => {});
+
+  const server = http2.createServer();
+  server.on("stream", stream => {
+    switch (site) {
+      case "server 'stream'":
+      case "server 'stream', request open":
+        watch(stream);
+        close(stream);
+        break;
+      case "server 'stream' after respond()":
+        watch(stream);
+        stream.respond({ ":status": 200 }, { endStream: true });
+        close(stream);
+        break;
+      case "server 'trailers'":
+        watch(stream);
+        stream.respond({ ":status": 200 });
+        stream.on("trailers", () => close(stream));
+        break;
+      case "pushStream() callback":
+        ignoreErrors(stream);
+        stream.pushStream({ ":path": "/pushed" }, (err, pushed) => {
+          if (err) return reject(err);
+          watch(pushed);
+          close(pushed);
+        });
+        stream.respond({ ":status": 200 });
+        stream.end();
+        break;
+      case "client 'response'":
+        ignoreErrors(stream);
+        stream.respond({ ":status": 204 }, { endStream: true });
+        break;
+      case "client 'trailers'":
+        ignoreErrors(stream);
+        stream.respond({ ":status": 200 }, { waitForTrailers: true });
+        stream.on("wantTrailers", () => stream.sendTrailers({ "x-trailer": "1" }));
+        stream.end("body");
+        break;
+    }
+  });
+  const port = await listen(server);
+  const client = http2.connect(`http://127.0.0.1:${port}`);
+  client.on("error", reject);
+  client.on("stream", pushed => ignoreErrors(pushed).resume());
+  try {
+    switch (site) {
+      case "server 'trailers'": {
+        const req = client.request({ ":path": "/", ":method": "POST" }, { waitForTrailers: true });
+        req.on("wantTrailers", () => req.sendTrailers({ "x-trailer": "1" }));
+        ignoreErrors(req).resume();
+        req.end("body");
+        break;
+      }
+      case "client 'response'":
+      case "client 'trailers'": {
+        // The request stays open, so nothing but close(code) can close the stream.
+        const req = client.request({ ":path": "/", ":method": "POST" });
+        watch(req);
+        req.on(site === "client 'response'" ? "response" : "trailers", () => close(req));
+        break;
+      }
+      case "server 'stream', request open":
+        ignoreErrors(client.request({ ":path": "/", ":method": "POST" })).resume();
+        break;
+      default:
+        ignoreErrors(client.request({ ":path": "/" }, { endStream: true })).resume();
+    }
+    return await promise;
+  } finally {
+    client.destroy();
+    server.close();
+  }
+}
+
+const endThenClose = [
+  [NGHTTP2_NO_ERROR, ["end", "close:0"]],
+  [NGHTTP2_CANCEL, ["end", "close:8"]],
+  [NGHTTP2_INTERNAL_ERROR, ["end", "error:ERR_HTTP2_STREAM_ERROR", "close:2"]],
+  [NGHTTP2_ENHANCE_YOUR_CALM, ["end", "error:ERR_HTTP2_STREAM_ERROR", "close:11"]],
+] as const;
+const noEndForErrorCodes = [
+  [NGHTTP2_NO_ERROR, ["end", "close:0"]],
+  [NGHTTP2_CANCEL, ["end", "close:8"]],
+  [NGHTTP2_INTERNAL_ERROR, ["error:ERR_HTTP2_STREAM_ERROR", "close:2"]],
+  [NGHTTP2_ENHANCE_YOUR_CALM, ["error:ERR_HTTP2_STREAM_ERROR", "close:11"]],
+] as const;
+
+for (const [site, table] of [
+  ["server 'stream'", endThenClose],
+  ["server 'stream' after respond()", endThenClose],
+  ["server 'trailers'", endThenClose],
+  ["pushStream() callback", endThenClose],
+  ["client 'response'", endThenClose],
+  ["client 'trailers'", endThenClose],
+  ["server 'stream', request open", noEndForErrorCodes],
+] as const) {
+  for (const defer of [false, true]) {
+    describe(`close(code) ${defer ? "a tick after" : "in"} ${site}`, () => {
+      for (const [code, expected] of table) {
+        test(`close(${code})`, async () => {
+          assert.deepStrictEqual(await closeIn(site, code, defer), expected);
+        });
+      }
+    });
+  }
+}
 
 if (typeof Bun !== "undefined") {
   const node = Bun.which("node");


### PR DESCRIPTION
### Problem

- A `node:http2` stream emits no `'end'` when a listener calls `close(code)` with an error code (2, 7, 11) after the peer's half ended on a HEADERS frame: server `'stream'` and `'trailers'`, client `'response'` and `'trailers'`, the `pushStream()` callback. Node v26.3.0 and Bun 1.4.2 emit `'end'`, `'error'`, `'close'`. Main skips `'end'`.
- Both `streamHeaders` handlers (`src/js/node/http2.ts`) emit the event inside the HEADERS dispatch. The frame's END_STREAM reaches the readable only in the later `streamEnd` dispatch, after the listener's ticks drain. By then the error has destroyed the stream and suppressed `'end'`. A pushed server stream never got an EOF.
- `close()` hid this with an unconditional `push(null)` until #33607 (fc479fb35a) gated it.

### Fix

- `endInboundHalf()` gives the readable its EOF. Both `streamHeaders` handlers call it before the event of a HEADERS frame that carries END_STREAM. `pushStream()` calls it for the new stream. Node's `onSessionHeaders` and `pushStream` do the same.
- The `close()` gate stays. With the peer's half still open, an error code gives no `'end'`, as on Node.
- Verified: `test/js/node/http2/node-http2-client-close.test.ts` (56 new cases, 24 fail on main, all 68 pass on Node v26.3.0). Also `test/js/node/http2/`, Node's `test-http2-*`, grpc-js, `serve-http2`, fetch HTTP/2.

### Background

- The native frame parser calls JS once per event: `streamHeaders` for a header block, then `streamEnd` if the frame carried END_STREAM. The `nextTick` queue drains between the two.
- `push(null)` gives a Readable its EOF. `'end'` fires a tick later, unless the stream has an error by then.
- `close(code)` with a code other than NO_ERROR or CANCEL destroys the stream with `ERR_HTTP2_STREAM_ERROR`.

<details><summary>Notes</summary>

The regression is unreleased. A fuzz ledger found it, no user reported it.

"Before" below is `1.4.3-canary.1+4ff919377`, the last build before #33607. The report measured the same sequences on 1.4.2.

Server-side events for `close(2)` inside the `'stream'` listener. The client sent `request({':path':'/'}).end()` with no body:

| when | Node v26.3.0 | before | main | this PR |
| --- | --- | --- | --- | --- |
| sync | aborted, finish, end, error, close | as Node | aborted, finish, error, close | as Node |
| nextTick | aborted, end, finish, error, close | as Node | aborted, finish, error, close | as Node |
| setImmediate | end, aborted, finish, error, close | as Node | as Node | as Node |
| setTimeout | end, aborted, finish, error, close | as Node | as Node | as Node |

Codes 7 and 11 behave like 2. Codes 0 and 8 agree on all four builds.

The other sites, `close(2)` or `close(11)` in the listener or one tick later. The column says whether `'end'` fires before `'error'`:

| listener | Node v26.3.0 | before | main | this PR |
| --- | --- | --- | --- | --- |
| server `'stream'`, after `respond({endStream: true})` | yes | yes | no | yes |
| server `'trailers'` | yes | yes | no | yes |
| client `'response'`, response ended on HEADERS (204) | yes | yes | no | yes |
| client `'trailers'` | yes | yes | no | yes |
| `pushStream()` callback | yes | yes | no | yes |

Three probe scripts cover these sites with codes 0, 8, 2, 11 (and 7 for the push), sync and nextTick. Their output on this branch is identical to Node v26.3.0 on all 82 cells.

Cells that #33607 moved to Node's sequence and that this PR keeps (`'end'` for `close(2)` on a server stream):

| request | close(2) runs | Node v26.3.0 | before | main and this PR |
| --- | --- | --- | --- | --- |
| `end('hello')` | sync or nextTick in `'stream'` | no `'end'` | `'end'` | no `'end'` |
| `end('hello')` | in `'data'`, or a tick after it | no `'end'` | `'end'` | no `'end'` |
| never ended | sync, nextTick, setImmediate, setTimeout | no `'end'` | `'end'` | no `'end'` |

END_STREAM on a DATA frame is not part of this change. nghttp2 ignores frames for a stream that `close()` already reset, so Node emits no `'end'` in the `'data'` rows above, and main already agrees.

Sites left out on purpose:

- The client `'headers'` event (a 1xx block). A 1xx block with END_STREAM is malformed. Node reports it as `'response'`. Nothing changes there.
- The client `streamPush` handler (PUSH_PROMISE). A PUSH_PROMISE cannot carry END_STREAM.

The two shapes the report proposed, and why this PR uses neither:

- "Apply the gate only to client streams" brings back `'end'` on server streams whose request is still open. Node does not emit it there. It also leaves the client `'response'` and `'trailers'` cells broken.
- "Apply the gate only when the readable has not received END_STREAM": in the failing cells the JS readable has not received it yet when `close()` runs. That is the defect. `close()` would have to ask the native layer, and any other code that looks at the readable inside the listener would still see the stale state.

Related open PRs:

- #33380 (server-side RST_STREAM) is why the client still sees `rstCode=0` and no `'error'` in the no-body cells. It does not touch these hunks. With it, `close()` no longer sends END_STREAM first, so some `'stream'` cells would pass without this change. The `after respond()` cells stay red without it on both main and #33380.
- #41945 gives `rstCode` a default of 0. If it lands, the `rstCode` guard in `endInboundHalf()` is dead and can go.

`endInboundHalf()` also sets `rstCode = 0` when no reset set it, as the `streamEnd` handlers did. Without that, a listener that resumes the stream inside `'stream'` reads `rstCode === undefined` in its `'end'` handler, because `'end'` now fires before the `streamEnd` dispatch. Node reports 0.

The Node cross-check inside the test file is now skipped on musl. Alpine's `node` segfaults at a random point of this file under `node --test` (alpine 3.23 aarch64, also on main in build 114123, before this change). The CI runner fails a file for any new core dump, whichever process wrote it. The glibc, macOS and Windows lanes keep the cross-check.

Suites run on the debug build: `test/js/node/http2/` (576 pass, 6 skip), 261 `test-http2-*` and 18 `test-diagnostics-channel-http2-*` Node tests, `serve-http2`, `serve-http2-protocol`, `serve-http2-lifecycle`, `node-http2-ping-flood-staged`, `fetch-http2-client`, `fetch-http2-adversarial`, `fetch-http2-leak`, `undici-h2`, `wpt-h2`, `grpc-js`, the http2 regression tests (25589, 24924, 26915, 29073).

Local failures that also occur without the change: the `test-outlier-detection.test.ts` ejection tests (5 s timeouts on a loaded debug build, they flip between runs on main too), `test tonic server`, the grpc-js DNS tests (no network), `http2-wrapper.test.ts` (ECONNREFUSED, on the release build too), one `AsyncLocalStorage.test.ts` timing test (debug build timeout).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/http2/node-http2-client-close.test.ts

<!-- robobun:evidence:end -->