### PR TITLE
fix(sqlite): allow workers to reuse custom library

### DIFF
--- a/docs/runtime/sqlite.mdx
+++ b/docs/runtime/sqlite.mdx
@@ -649,6 +649,8 @@ const db = new Database();
 db.loadExtension("myext");
 ```
 
+Workers can repeat `setCustomSQLite()` with the exact same path. Bun rejects a different path after SQLite loads.
+
 </Note>
 
 ### `.fileControl(cmd: number, value: any)`

--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -341,11 +341,10 @@ declare module "bun:sqlite" {
      *
      * @note macOS-only
      *
-     * This only works before SQLite is loaded, that is,
-     * before you call `new Database()`.
-     *
-     * It can only be run once because it loads
-     * the SQLite library into the process.
+     * The initial call only works before SQLite is loaded, that is,
+     * before you call `new Database()`. Later calls with the exact same path
+     * are idempotent so workers can adopt the process-wide selection.
+     * A different path is rejected after SQLite loads.
      *
      * @param path The path to the SQLite library
      */

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1219,9 +1219,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementSetCustomSQLite, (JSC::JSGlobalObject * l
             // Keep the selected path alive for the process-global SQLite handle.
             sqlite3_lib_path_storage = requestedPathUTF8;
             sqlite3_lib_path = sqlite3_lib_path_storage.data();
-            if (lazyLoadSQLiteUnlocked() == -1) {
-                sqlite3_handle = nullptr;
-                WTF::String msg = WTF::String::fromUTF8(dlerror());
+            WTF::String msg;
+            if (lazyLoadSQLiteUnlocked(&msg) == -1) {
                 throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, msg));
                 return {};
             }
@@ -1277,8 +1276,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementDeserialize, (JSC::JSGlobalObject * lexic
     }
 
 #if LAZY_LOAD_SQLITE
-    if (lazyLoadSQLite() < 0) [[unlikely]] {
-        WTF::String msg = WTF::String::fromUTF8(dlerror());
+    WTF::String msg;
+    if (lazyLoadSQLite(&msg) < 0) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, msg));
         return {};
     }
@@ -1775,8 +1774,8 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementOpenStatementFunction, (JSC::JSGlobalObje
     }
 
 #if LAZY_LOAD_SQLITE
-    if (lazyLoadSQLite() < 0) [[unlikely]] {
-        WTF::String msg = WTF::String::fromUTF8(dlerror());
+    WTF::String msg;
+    if (lazyLoadSQLite(&msg) < 0) [[unlikely]] {
         throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, msg));
         return {};
     }

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -1202,22 +1202,31 @@ JSC_DEFINE_HOST_FUNCTION(jsSQLStatementSetCustomSQLite, (JSC::JSGlobalObject * l
     }
 
 #if LAZY_LOAD_SQLITE
-    if (sqlite3_handle) {
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "SQLite already loaded\nThis function can only be called before SQLite has been loaded and exactly once. SQLite auto-loads when the first time you open a Database."_s));
-        return {};
-    }
-
-    // Use a static CString to keep the string alive for the lifetime of the process
-    static CString sqlite3_lib_path_storage;
-    sqlite3_lib_path_storage = sqliteStrValue.toWTFString(lexicalGlobalObject).utf8();
+    auto requestedPath = sqliteStrValue.toWTFString(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    sqlite3_lib_path = sqlite3_lib_path_storage.data();
-
-    if (lazyLoadSQLite() == -1) {
-        sqlite3_handle = nullptr;
-        WTF::String msg = WTF::String::fromUTF8(dlerror());
-        throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, msg));
-        return {};
+    static CString sqlite3_lib_path_storage;
+    static String selectedSQLitePath;
+    auto requestedPathUTF8 = requestedPath.utf8();
+    RETURN_IF_EXCEPTION(scope, {});
+    {
+        WTF::Locker locker { sqlite3_handle_lock };
+        if (sqlite3_handle) {
+            if (selectedSQLitePath.isNull() || selectedSQLitePath != requestedPath) {
+                throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, "SQLite already loaded\nA custom SQLite path can only be selected before SQLite is loaded. Repeating a path is allowed only when that path selected the loaded library."_s));
+                return {};
+            }
+        } else {
+            // Keep the selected path alive for the process-global SQLite handle.
+            sqlite3_lib_path_storage = requestedPathUTF8;
+            sqlite3_lib_path = sqlite3_lib_path_storage.data();
+            if (lazyLoadSQLiteUnlocked() == -1) {
+                sqlite3_handle = nullptr;
+                WTF::String msg = WTF::String::fromUTF8(dlerror());
+                throwException(lexicalGlobalObject, scope, createError(lexicalGlobalObject, msg));
+                return {};
+            }
+            selectedSQLitePath = requestedPath;
+        }
     }
 #endif
 

--- a/src/jsc/bindings/sqlite/NodeSqlite.cpp
+++ b/src/jsc/bindings/sqlite/NodeSqlite.cpp
@@ -1041,8 +1041,9 @@ bool JSDatabaseSync::open(JSGlobalObject* globalObject, ThrowScope& scope)
     }
 
 #if LAZY_LOAD_SQLITE
-    if (lazyLoadSQLite() < 0) [[unlikely]] {
-        scope.throwException(globalObject, createError(globalObject, WTF::String::fromUTF8(dlerror())));
+    WTF::String msg;
+    if (lazyLoadSQLite(&msg) < 0) [[unlikely]] {
+        scope.throwException(globalObject, createError(globalObject, msg));
         return false;
     }
 #endif

--- a/src/jsc/bindings/sqlite/lazy_sqlite3.h
+++ b/src/jsc/bindings/sqlite/lazy_sqlite3.h
@@ -340,7 +340,17 @@ inline WTF::Lock sqlite3_handle_lock;
 // APIs must be runtime-gated on this instead of compiled out.
 inline bool lazy_sqlite3_has_session = false;
 
-inline int lazyLoadSQLiteUnlocked()
+inline void unloadSQLiteHandleUnlocked()
+{
+#if OS(WINDOWS)
+    FreeLibrary(sqlite3_handle);
+#else
+    dlclose(sqlite3_handle);
+#endif
+    sqlite3_handle = nullptr;
+}
+
+inline int lazyLoadSQLiteUnlocked(WTF::String* errorMessage = nullptr)
 {
     if (sqlite3_handle)
         return 0;
@@ -351,10 +361,17 @@ inline int lazyLoadSQLiteUnlocked()
 #endif
 
     if (!sqlite3_handle) {
+        if (errorMessage)
+            *errorMessage = WTF::String::fromUTF8(dlerror());
         return -1;
     }
     lazy_sqlite3_open_v2 = (lazy_sqlite3_open_v2_type)dlsym(sqlite3_handle, "sqlite3_open_v2");
-    if (!lazy_sqlite3_open_v2) return -1;
+    if (!lazy_sqlite3_open_v2) {
+        if (errorMessage)
+            *errorMessage = WTF::String::fromUTF8(dlerror());
+        unloadSQLiteHandleUnlocked();
+        return -1;
+    }
     lazy_sqlite3_bind_blob = (lazy_sqlite3_bind_blob_type)dlsym(sqlite3_handle, "sqlite3_bind_blob");
     lazy_sqlite3_bind_blob64 = (lazy_sqlite3_bind_blob64_type)dlsym(sqlite3_handle, "sqlite3_bind_blob64");
     lazy_sqlite3_bind_double = (lazy_sqlite3_bind_double_type)dlsym(sqlite3_handle, "sqlite3_bind_double");
@@ -493,10 +510,10 @@ inline int lazyLoadSQLiteUnlocked()
     return 0;
 }
 
-inline int lazyLoadSQLite()
+inline int lazyLoadSQLite(WTF::String* errorMessage = nullptr)
 {
     WTF::Locker locker { sqlite3_handle_lock };
-    return lazyLoadSQLiteUnlocked();
+    return lazyLoadSQLiteUnlocked(errorMessage);
 }
 
 #if OS(WINDOWS)

--- a/src/jsc/bindings/sqlite/lazy_sqlite3.h
+++ b/src/jsc/bindings/sqlite/lazy_sqlite3.h
@@ -340,9 +340,8 @@ inline WTF::Lock sqlite3_handle_lock;
 // APIs must be runtime-gated on this instead of compiled out.
 inline bool lazy_sqlite3_has_session = false;
 
-inline int lazyLoadSQLite()
+inline int lazyLoadSQLiteUnlocked()
 {
-    WTF::Locker locker { sqlite3_handle_lock };
     if (sqlite3_handle)
         return 0;
 #if OS(WINDOWS)
@@ -492,6 +491,12 @@ inline int lazyLoadSQLite()
     }
 
     return 0;
+}
+
+inline int lazyLoadSQLite()
+{
+    WTF::Locker locker { sqlite3_handle_lock };
+    return lazyLoadSQLiteUnlocked();
 }
 
 #if OS(WINDOWS)

--- a/test/js/node/sqlite/node-sqlite.test.ts
+++ b/test/js/node/sqlite/node-sqlite.test.ts
@@ -2508,6 +2508,60 @@ test.skipIf(process.platform !== "darwin")("setCustomSQLite() sees a library nod
   void stderr;
 });
 
+test.skipIf(process.platform !== "darwin")("setCustomSQLite() accepts the selected path from a worker", async () => {
+  const workerSource = `
+    const { parentPort, workerData } = require("node:worker_threads");
+    try {
+      const { Database } = require("bun:sqlite");
+      Database.setCustomSQLite(workerData);
+      const db = new Database(":memory:");
+      const version = db.query("SELECT sqlite_version() AS version").get().version;
+      db.close();
+      let differentPathRejected = false;
+      try {
+        Database.setCustomSQLite("libsqlite3.dylib");
+      } catch (error) {
+        differentPathRejected = /already loaded/.test(String(error));
+      }
+      parentPort.postMessage({ version, differentPathRejected });
+    } catch (error) {
+      parentPort.postMessage({ error: String(error) });
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { Worker } = require("node:worker_threads");
+        const path = "/usr/lib/libsqlite3.dylib";
+        const { Database } = require("bun:sqlite");
+        Database.setCustomSQLite(path);
+        const db = new Database(":memory:");
+        const parentVersion = db.query("SELECT sqlite_version() AS version").get().version;
+        db.close();
+        const worker = new Worker(${JSON.stringify(workerSource)}, { eval: true, workerData: path });
+        const message = await new Promise((resolve, reject) => {
+          worker.once("message", resolve);
+          worker.once("error", reject);
+          worker.once("exit", code => {
+            if (code !== 0) reject(new Error("worker exited with " + code));
+          });
+        });
+        if (message.error) throw new Error(message.error);
+        if (message.version !== parentVersion) throw new Error("worker loaded a different SQLite library");
+        if (!message.differentPathRejected) throw new Error("worker accepted a different SQLite path");
+        console.log("idempotent");
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr }).toEqual({ stdout: "idempotent", stderr: "" });
+  expect(exitCode).toBe(0);
+});
+
 // process.versions.sqlite must not force-dlopen the system SQLite: that
 // would defeat setCustomSQLite() for anyone whose imports read
 // process.versions before opening a database.


### PR DESCRIPTION
### What does this PR do?

`Database.setCustomSQLite()` selects one process-wide SQLite library, but each worker has a separate JavaScript global. After a parent selected a custom library, repeating that same selection from a worker threw `SQLite already loaded` even though the requested path matched the library already in use.

This change serializes selection through the existing process-wide SQLite handle lock, records the path that successfully loaded the library, and makes later calls with that exact path idempotent. Calls after Bun loaded its default SQLite library or with a different custom path still fail. A rejected partial library load now preserves its loader error and releases the loader reference before a retry.

This unblocks applications such as OpenClaw that validate a full SQLite build before starting worker-owned state leases and need worker globals to adopt that process-wide selection.

AI assistance: This change was developed and reviewed with Codex.

### How did you verify your code works?

- Confirmed the new worker regression fails on the shipping Bun runtime with `SQLite already loaded`.
- Built Bun from this branch and ran the complete `test/js/node/sqlite/node-sqlite.test.ts` suite: 116 passed, 4 skipped, 0 failed.
- Ran the new worker regression with JavaScriptCore exception validation enabled.
- Repeated a loadable non-SQLite library failure twice, verified the missing-symbol error remained intact, then selected and opened the valid system SQLite library.
- Ran clang-format, Prettier, and `git diff --check`.
