### PR TITLE
tls: end the wrapped Duplex on end(), also before the handshake completes

### DIFF
--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -64,6 +64,11 @@ pub(crate) struct UpgradedDuplex {
     /// Replayed by [`Self::drain_pending`] after the staged bytes, preserving
     /// the original data-then-EOF order.
     pub pending_end: Cell<bool>,
+    /// [`Self::shutdown`] was called before the TLS engine existed. Same window
+    /// as [`Self::pending_data`]: `end()` in the turn that created the socket
+    /// reaches here first. Replayed by [`Self::drain_pending`] once the engine
+    /// has started, so the transport sees the first flight, then the end().
+    pub pending_shutdown: Cell<bool>,
     /// The transport delivered EOF (its 'end' event fired). Teardown payloads
     /// (close_notify) are dropped after this; see [`Self::call_write_or_end`].
     pub transport_eof: Cell<bool>,
@@ -310,10 +315,10 @@ impl UpgradedDuplex {
         self.pending_data.with_mut(|p| p.extend_from_slice(data));
     }
 
-    /// Replay bytes that arrived before the engine existed. Called by
-    /// `DuplexUpgradeContext::run_event` once the `StartTLS` branch has
-    /// finished its bookkeeping, so the replay is indistinguishable from an
-    /// ordinary post-start delivery.
+    /// Replay what arrived before the engine existed: bytes, then an EOF, then
+    /// a shutdown. Called by `DuplexUpgradeContext::run_event` once the
+    /// `StartTLS` branch has finished its bookkeeping, so the replay is
+    /// indistinguishable from an ordinary post-start delivery.
     pub(super) fn drain_pending(&self) {
         // Nothing to replay, or the engine never came up (the socket died
         // before `StartTLS`). Bail before taking so the bytes are not
@@ -321,8 +326,18 @@ impl UpgradedDuplex {
         if self.wrapper_ref().is_none() {
             return;
         }
+        self.drain_pending_data();
+        self.drain_pending_end();
+        // Last: the staged input arrived first, so the engine answers it
+        // first. A server handed a staged ClientHello writes its flight ahead
+        // of the end().
+        if self.pending_shutdown.replace(false) {
+            self.shutdown();
+        }
+    }
+
+    fn drain_pending_data(&self) {
         if self.pending_data.get().is_empty() {
-            self.drain_pending_end();
             return;
         }
         // Taking ownership is load-bearing: a re-entrant `teardown()` clears
@@ -343,12 +358,11 @@ impl UpgradedDuplex {
                 _ => break,
             }
         }
-        self.drain_pending_end();
     }
 
-    /// Replay an EOF that landed before the engine came up. Split out so both
-    /// `drain_pending` exits report it, and kept after the staged bytes so the
-    /// engine sees data-then-EOF in the order the peer sent it.
+    /// Replay an EOF that landed before the engine came up. Kept after the
+    /// staged bytes so the engine sees data-then-EOF in the order the peer
+    /// sent it.
     fn drain_pending_end(&self) {
         if !self.pending_end.get() {
             return;
@@ -408,6 +422,7 @@ impl UpgradedDuplex {
             current_timeout: Cell::new(0),
             pending_data: JsCell::new(Vec::new()),
             pending_end: Cell::new(false),
+            pending_shutdown: Cell::new(false),
             transport_eof: Cell::new(false),
         }
     }
@@ -547,11 +562,18 @@ impl UpgradedDuplex {
         }
     }
 
+    /// Half-close (node's `end()`): the close_notify, then the end of the
+    /// transport's write side, like `us_internal_ssl_shutdown` on an fd. The
+    /// engine keeps reading. Mid-handshake there is no close_notify to send
+    /// (`SSL_shutdown` succeeds silently) and the transport is ended bare.
     #[uws_callback(export = "UpgradedDuplex__shutdown")]
     pub(crate) fn shutdown(&self) {
-        if let Some(w) = self.wrapper_ref() {
-            let _ = w.shutdown(false);
-        }
+        let Some(w) = self.wrapper_ref() else {
+            self.pending_shutdown.set(true);
+            return;
+        };
+        let _ = w.shutdown(false);
+        self.call_write_or_end(None, false);
     }
 
     #[uws_callback(export = "UpgradedDuplex__shutdown_read")]
@@ -679,6 +701,7 @@ impl UpgradedDuplex {
         self.ssl_error.set(CertError::default());
         self.pending_data.set(Vec::new());
         self.pending_end.set(false);
+        self.pending_shutdown.set(false);
         self.transport_eof.set(false);
     }
 }

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -64,10 +64,7 @@ pub(crate) struct UpgradedDuplex {
     /// Replayed by [`Self::drain_pending`] after the staged bytes, preserving
     /// the original data-then-EOF order.
     pub pending_end: Cell<bool>,
-    /// [`Self::shutdown`] was called before the TLS engine existed. Same window
-    /// as [`Self::pending_data`]: `end()` in the turn that created the socket
-    /// reaches here first. Replayed by [`Self::drain_pending`] once the engine
-    /// has started, so the transport sees the first flight, then the end().
+    /// [`Self::shutdown`] arrived before the engine existed. [`Self::drain_pending`] replays it.
     pub pending_shutdown: Cell<bool>,
     /// The transport delivered EOF (its 'end' event fired). Teardown payloads
     /// (close_notify) are dropped after this; see [`Self::call_write_or_end`].
@@ -315,10 +312,10 @@ impl UpgradedDuplex {
         self.pending_data.with_mut(|p| p.extend_from_slice(data));
     }
 
-    /// Replay what arrived before the engine existed: bytes, then an EOF, then
-    /// a shutdown. Called by `DuplexUpgradeContext::run_event` once the
-    /// `StartTLS` branch has finished its bookkeeping, so the replay is
-    /// indistinguishable from an ordinary post-start delivery.
+    /// Replay bytes that arrived before the engine existed. Called by
+    /// `DuplexUpgradeContext::run_event` once the `StartTLS` branch has
+    /// finished its bookkeeping, so the replay is indistinguishable from an
+    /// ordinary post-start delivery.
     pub(super) fn drain_pending(&self) {
         // Nothing to replay, or the engine never came up (the socket died
         // before `StartTLS`). Bail before taking so the bytes are not
@@ -326,18 +323,9 @@ impl UpgradedDuplex {
         if self.wrapper_ref().is_none() {
             return;
         }
-        self.drain_pending_data();
-        self.drain_pending_end();
-        // Last: the staged input arrived first, so the engine answers it
-        // first. A server handed a staged ClientHello writes its flight ahead
-        // of the end().
-        if self.pending_shutdown.replace(false) {
-            self.shutdown();
-        }
-    }
-
-    fn drain_pending_data(&self) {
         if self.pending_data.get().is_empty() {
+            self.drain_pending_end();
+            self.drain_pending_shutdown();
             return;
         }
         // Taking ownership is load-bearing: a re-entrant `teardown()` clears
@@ -358,11 +346,13 @@ impl UpgradedDuplex {
                 _ => break,
             }
         }
+        self.drain_pending_end();
+        self.drain_pending_shutdown();
     }
 
-    /// Replay an EOF that landed before the engine came up. Kept after the
-    /// staged bytes so the engine sees data-then-EOF in the order the peer
-    /// sent it.
+    /// Replay an EOF that landed before the engine came up. Split out so both
+    /// `drain_pending` exits report it, and kept after the staged bytes so the
+    /// engine sees data-then-EOF in the order the peer sent it.
     fn drain_pending_end(&self) {
         if !self.pending_end.get() {
             return;
@@ -375,6 +365,13 @@ impl UpgradedDuplex {
             return;
         }
         (self.handlers.on_end)(self.handlers.ctx);
+    }
+
+    /// After the staged input: a server answers a staged ClientHello before the end().
+    fn drain_pending_shutdown(&self) {
+        if self.pending_shutdown.replace(false) {
+            self.shutdown();
+        }
     }
 
     pub(crate) fn on_timeout(&self) {
@@ -562,10 +559,7 @@ impl UpgradedDuplex {
         }
     }
 
-    /// Half-close (node's `end()`): the close_notify, then the end of the
-    /// transport's write side, like `us_internal_ssl_shutdown` on an fd. The
-    /// engine keeps reading. Mid-handshake there is no close_notify to send
-    /// (`SSL_shutdown` succeeds silently) and the transport is ended bare.
+    /// Half-close like `us_internal_ssl_shutdown`: close_notify (none mid-handshake), then end().
     #[uws_callback(export = "UpgradedDuplex__shutdown")]
     pub(crate) fn shutdown(&self) {
         let Some(w) = self.wrapper_ref() else {

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1957,9 +1957,9 @@ async function runShutdownFixture(exe: string, ...mode: string[]) {
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  const report = JSON.parse(stdout);
+  // The report is the fixture's last line before exit(0): no exit 0, nothing to parse.
   expect(exitCode).toBe(0);
-  return report;
+  return JSON.parse(stdout);
 }
 describe.each([
   ["bun", bunExe()],

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1948,23 +1948,24 @@ it.skipIf(!nodeExe())(
 // still finish its writable side and send the FIN, as node does:
 // https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1203-L1213
 // The fixture runs on both runtimes so the expected reports are pinned to node.
+async function runShutdownFixture(exe: string, ...mode: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [exe, join(import.meta.dir, "tls-shutdown-before-handshake-fixture.mjs"), ...mode],
+    env: { ...bunEnv, TLS_KEY: COMMON_CERT_.key, TLS_CERT: COMMON_CERT_.cert },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const report = JSON.parse(stdout);
+  expect(exitCode).toBe(0);
+  return report;
+}
 describe.each([
   ["bun", bunExe()],
   ["node", nodeExe()],
-])("end() and destroySoon() before the handshake completes (%s)", (_runtime, exe) => {
-  async function run(mode: string) {
-    await using proc = Bun.spawn({
-      cmd: [exe!, join(import.meta.dir, "tls-shutdown-before-handshake-fixture.mjs"), mode],
-      env: { ...bunEnv, TLS_KEY: COMMON_CERT_.key, TLS_CERT: COMMON_CERT_.cert },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    const report = JSON.parse(stdout);
-    expect(exitCode).toBe(0);
-    return report;
-  }
+])("end() and destroySoon() before the handshake completes (%s)", (runtime, exe) => {
+  const run = (...mode: string[]) => runShutdownFixture(exe!, ...mode);
 
   it.skipIf(!exe)("end() finishes the writable side and sends the FIN", async () => {
     expect(await run("end")).toEqual({
@@ -1990,6 +1991,106 @@ describe.each([
     expect(await run("server-end")).toEqual({
       log: ["end secureConnecting=true", "finish"],
       clientSawFin: true,
+    });
+  });
+
+  // tls.connect({ socket: duplex }) and new TLSSocket(duplex): the engine has no
+  // fd to shut down, so the FIN is the transport's own end(), which runs its
+  // final(). Node: TLSWrap::DoShutdown -> JSStreamSocket.doShutdown -> stream.end().
+  describe("over a Duplex transport", () => {
+    const clientEnded = {
+      log: ["end secureConnecting=true", "finish"],
+      transportFinalCalled: true,
+      peerSawFin: true,
+      peerSawHandshakeRecord: true,
+      writableFinished: true,
+      readyState: "readOnly",
+      destroyed: false,
+    };
+    const clientDestroyed = {
+      ...clientEnded,
+      log: ["destroySoon secureConnecting=true", "finish", "close"],
+      readyState: "closed",
+      destroyed: true,
+    };
+
+    it.skipIf(!exe)(
+      "end() in the turn that created the socket sends the ClientHello, then ends the transport",
+      async () => {
+        expect(await run("duplex-end", "same-turn")).toEqual(clientEnded);
+      },
+    );
+
+    it.skipIf(!exe)("end() while the engine waits for the server's flight ends the transport", async () => {
+      expect(await run("duplex-end", "after-first-flight")).toEqual(clientEnded);
+    });
+
+    it.skipIf(!exe)("destroySoon() ends the transport, then closes the socket", async () => {
+      expect(await run("duplex-destroySoon", "after-first-flight")).toEqual(clientDestroyed);
+    });
+
+    // Known gap in bun: 'finish' does not wait for the transport's end(). In
+    // the turn that created the socket it fires before the engine exists, so
+    // destroySoon()'s destroy() runs first and destroys the transport: no
+    // ClientHello and no final(), the peer only sees the connection close.
+    (!exe ? it.skip : runtime === "bun" ? it.failing : it)(
+      "destroySoon() in the turn that created the socket ends the transport, then closes the socket",
+      async () => {
+        expect(await run("duplex-destroySoon", "same-turn")).toEqual(clientDestroyed);
+      },
+    );
+
+    // A healthy server. Without the FIN its handshake completes and the
+    // session stays open with nothing left to close it.
+    it.skipIf(!exe)("end() makes a healthy server give up on the handshake", async () => {
+      expect(await run("duplex-end-live-server")).toEqual({
+        log: ["end secureConnecting=true", "finish"],
+        transportFinalCalled: true,
+        server: "tlsClientError:ECONNRESET",
+        destroyed: true,
+      });
+    });
+
+    it.skipIf(!exe)("a server-side TLSSocket end()s while it waits for the client's first flight", async () => {
+      expect(await run("duplex-server-end", "same-turn")).toEqual({
+        log: ["end secureConnecting=true", "finish"],
+        transportFinalCalled: true,
+        transportWroteHandshakeRecord: false,
+        clientSawFin: true,
+        clientSawHandshakeRecord: false,
+      });
+    });
+  });
+});
+
+// The ClientHello is already in the stream's readable buffer when the server
+// wraps it and ends in the same turn. The engine answers what arrived first, so
+// the client gets the server's flight and then the FIN. Bun only: node v26.3.0
+// aborts here (ERR_INTERNAL_ASSERTION in JSStreamSocket.doWrite).
+it("a server-side TLSSocket over a Duplex answers a buffered ClientHello before its end()", async () => {
+  expect(await runShutdownFixture(bunExe(), "duplex-server-end", "buffered-client-hello")).toEqual({
+    log: ["end secureConnecting=true", "finish"],
+    transportFinalCalled: true,
+    transportWroteHandshakeRecord: true,
+    clientSawFin: true,
+    clientSawHandshakeRecord: true,
+  });
+});
+
+// The half-close is the close_notify and then the end of the transport, whatever
+// the peer does next: this server reads the close_notify and does not answer it.
+// https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1203-L1213
+describe.each([
+  ["bun", bunExe()],
+  ["node", nodeExe()],
+])("end() after the handshake over a Duplex transport (%s)", (_runtime, exe) => {
+  it.skipIf(!exe)("ends the transport without waiting for the peer's close_notify", async () => {
+    expect(await runShutdownFixture(exe!, "duplex-end-established")).toEqual({
+      log: ["secureConnect", "finish"],
+      transportFinalCalled: true,
+      writableFinished: true,
+      readyState: "readOnly",
+      destroyed: false,
     });
   });
 });

--- a/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
+++ b/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
@@ -1,12 +1,14 @@
 // Shutdown shapes issued before a TLS handshake completes, as one report per
 // mode. Runs on bun and on node, so node-tls-connect.test.ts can assert the
-// same report for both.
+// same report for both. "duplex-end-established" is the one shape issued after
+// the handshake: it shares the stream transport below.
 //
 // The readable side's 'end' is not part of these shapes, so the log does not
 // subscribe to it: bun emits an extra one after destroy() (pre-existing, it
 // reproduces on a plain net.Socket, tracked separately).
 import { once } from "node:events";
 import net from "node:net";
+import { Duplex } from "node:stream";
 import tls, { TLSSocket } from "node:tls";
 
 const mode = process.argv[2];
@@ -23,10 +25,11 @@ function report(extra) {
 // independent of the peer's teardown.
 async function stalledPeer() {
   const sawFin = Promise.withResolvers();
+  const received = [];
   let accepted;
   const server = net.createServer({ allowHalfOpen: true }, socket => {
     accepted = socket;
-    socket.on("data", () => {});
+    socket.on("data", chunk => received.push(chunk));
     socket.on("error", () => {});
     socket.on("end", () => sawFin.resolve());
   });
@@ -34,11 +37,53 @@ async function stalledPeer() {
   return {
     port: server.address().port,
     sawFin: sawFin.promise,
+    // 0x16 is the TLS record type of a handshake message.
+    sawHandshakeRecord: () => Buffer.concat(received)[0] === 0x16,
     close() {
       accepted?.destroy();
       server.close();
     },
   };
+}
+
+// A generic stream between the TLS socket and the TCP connection, so the TLS
+// engine runs over a stream and not over an fd. Only final() sends a FIN while
+// the stream stays open. destroy() closes the connection, as a real transport
+// does.
+function transportOver(raw) {
+  const wrote = Promise.withResolvers();
+  const received = Promise.withResolvers();
+  const state = {
+    finalCalled: false,
+    // 0x16 is the TLS record type of a handshake message.
+    wroteHandshakeRecord: false,
+    wrote: wrote.promise,
+    received: received.promise,
+  };
+  state.stream = new Duplex({
+    read() {},
+    write(chunk, encoding, callback) {
+      state.wroteHandshakeRecord ||= chunk[0] === 0x16;
+      wrote.resolve();
+      raw.write(chunk, encoding, callback);
+    },
+    final(callback) {
+      state.finalCalled = true;
+      raw.end(callback);
+    },
+    destroy(error, callback) {
+      raw.destroy();
+      callback(error);
+    },
+  });
+  state.stream.on("error", () => {});
+  raw.on("data", chunk => {
+    state.stream.push(chunk);
+    received.resolve();
+  });
+  raw.on("end", () => state.stream.push(null));
+  raw.on("error", () => {});
+  return state;
 }
 
 if (mode === "end" || mode === "destroySoon") {
@@ -60,6 +105,39 @@ if (mode === "end" || mode === "destroySoon") {
   client.destroy();
   peer.close();
   report({ peerSawFin: true, writableFinished, readyState, destroyed });
+} else if (mode === "duplex-end" || mode === "duplex-destroySoon") {
+  // "same-turn": bun creates the engine for a stream transport on a later
+  // event-loop turn, so this call arrives before the engine exists.
+  // "after-first-flight": the engine wrote its ClientHello and waits for an
+  // answer that never comes.
+  const method = mode.slice("duplex-".length);
+  const when = process.argv[3];
+  const peer = await stalledPeer();
+  const raw = net.connect(peer.port, "127.0.0.1");
+  await once(raw, "connect");
+  const transport = transportOver(raw);
+  const client = tls.connect({ socket: transport.stream, rejectUnauthorized: false });
+  for (const event of ["secureConnect", "finish", "error", "close"]) {
+    client.on(event, arg => log.push(arg?.code ? `${event}:${arg.code}` : event));
+  }
+  if (when === "after-first-flight") await transport.wrote;
+  log.push(`${method} secureConnecting=${client.secureConnecting}`);
+  client[method]();
+
+  await Promise.all([once(client, method === "end" ? "finish" : "close"), peer.sawFin]);
+
+  const { writableFinished, readyState, destroyed } = client;
+  client.destroy();
+  raw.destroy();
+  peer.close();
+  report({
+    transportFinalCalled: transport.finalCalled,
+    peerSawFin: true,
+    peerSawHandshakeRecord: peer.sawHandshakeRecord(),
+    writableFinished,
+    readyState,
+    destroyed,
+  });
 } else if (mode === "server-end") {
   const clientSawFin = Promise.withResolvers();
   let serverSocket;
@@ -93,6 +171,121 @@ if (mode === "end" || mode === "destroySoon") {
   serverSocket?.destroy();
   server.close();
   report({ clientSawFin: true });
+} else if (mode === "duplex-end-live-server") {
+  // The server is healthy. A FIN in the middle of the handshake must make it
+  // give up: without the FIN the handshake completes and the session stays
+  // open with nothing left to close it.
+  const serverOutcome = Promise.withResolvers();
+  const server = tls.createServer({ key: process.env.TLS_KEY, cert: process.env.TLS_CERT }, socket => {
+    socket.on("error", () => {});
+    serverOutcome.resolve("secureConnection");
+  });
+  server.on("tlsClientError", error => serverOutcome.resolve(`tlsClientError:${error.code}`));
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+  const raw = net.connect(server.address().port, "127.0.0.1");
+  await once(raw, "connect");
+  const transport = transportOver(raw);
+  const client = tls.connect({ socket: transport.stream, rejectUnauthorized: false });
+  // node's engine also completes its side of the handshake and then fails the
+  // write of its last flight to the ended stream. Neither is part of this shape.
+  client.on("error", () => {});
+  const closed = Promise.withResolvers();
+  client.on("close", () => closed.resolve());
+  client.on("finish", () => log.push("finish"));
+  log.push(`end secureConnecting=${client.secureConnecting}`);
+  client.end();
+
+  const outcome = await serverOutcome.promise;
+  if (outcome !== "secureConnection") await closed.promise;
+
+  const { destroyed } = client;
+  client.destroy();
+  raw.destroy();
+  server.close();
+  report({ transportFinalCalled: transport.finalCalled, server: outcome, destroyed });
+} else if (mode === "duplex-end-established") {
+  // After the handshake, against a server that reads the close_notify and
+  // does not answer it (allowHalfOpen). The transport must be ended anyway.
+  const serverSawCloseNotify = Promise.withResolvers();
+  const server = tls.createServer(
+    { key: process.env.TLS_KEY, cert: process.env.TLS_CERT, allowHalfOpen: true },
+    socket => {
+      socket.on("error", () => {});
+      socket.on("end", () => serverSawCloseNotify.resolve());
+      socket.resume();
+    },
+  );
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+  const raw = net.connect(server.address().port, "127.0.0.1");
+  await once(raw, "connect");
+  const transport = transportOver(raw);
+  const client = tls.connect({ socket: transport.stream, rejectUnauthorized: false, allowHalfOpen: true });
+  for (const event of ["secureConnect", "finish", "close"]) client.on(event, () => log.push(event));
+  client.on("error", error => log.push(`error:${error.code}`));
+  await once(client, "secureConnect");
+  client.end();
+  await serverSawCloseNotify.promise;
+
+  const { writableFinished, readyState, destroyed } = client;
+  const transportFinalCalled = transport.finalCalled;
+  client.destroy();
+  raw.destroy();
+  server.close();
+  report({ transportFinalCalled, writableFinished, readyState, destroyed });
+} else if (mode === "duplex-server-end") {
+  // A server-side TLSSocket over a stream that ends in the turn that created it.
+  // "same-turn": the client sends nothing.
+  // "buffered-client-hello": the ClientHello already sits in the stream's
+  // readable buffer, so the server's flight is due before the end().
+  const when = process.argv[3];
+  const clientSawFin = Promise.withResolvers();
+  const serverFinished = Promise.withResolvers();
+  let serverSocket;
+  let transport;
+  const server = net.createServer(async raw => {
+    transport = transportOver(raw);
+    if (when === "buffered-client-hello") await transport.received;
+    const socket = (serverSocket = new TLSSocket(transport.stream, {
+      isServer: true,
+      key: process.env.TLS_KEY,
+      cert: process.env.TLS_CERT,
+    }));
+    socket.on("error", () => {});
+    socket.on("finish", () => {
+      log.push("finish");
+      serverFinished.resolve();
+    });
+    log.push(`end secureConnecting=${socket.secureConnecting}`);
+    socket.end();
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+  const received = [];
+  const raw = net.connect({ port: server.address().port, host: "127.0.0.1", allowHalfOpen: true });
+  raw.on("data", chunk => received.push(chunk));
+  raw.on("error", () => {});
+  raw.on("end", () => clientSawFin.resolve());
+  let client;
+  if (when === "buffered-client-hello") {
+    await once(raw, "connect");
+    client = tls.connect({ socket: transportOver(raw).stream, rejectUnauthorized: false });
+    client.on("error", () => {});
+  }
+
+  await Promise.all([clientSawFin.promise, serverFinished.promise]);
+
+  client?.destroy();
+  raw.destroy();
+  serverSocket?.destroy();
+  server.close();
+  report({
+    transportFinalCalled: transport.finalCalled,
+    transportWroteHandshakeRecord: transport.wroteHandshakeRecord,
+    clientSawFin: true,
+    clientSawHandshakeRecord: Buffer.concat(received)[0] === 0x16,
+  });
 } else {
   throw new Error(`unknown mode ${mode}`);
 }

--- a/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
+++ b/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
@@ -224,9 +224,14 @@ if (mode === "end" || mode === "destroySoon") {
   const client = tls.connect({ socket: transport.stream, rejectUnauthorized: false, allowHalfOpen: true });
   for (const event of ["secureConnect", "finish", "close"]) client.on(event, () => log.push(event));
   client.on("error", error => log.push(`error:${error.code}`));
+  const finished = Promise.withResolvers();
+  client.on("finish", () => finished.resolve());
   await once(client, "secureConnect");
   client.end();
-  await serverSawCloseNotify.promise;
+  // 'finish' is the client's own last step here, and it is the sampling point:
+  // node runs the transport's final() before it, bun inside the same shutdown.
+  // The server's 'end' can come before or after it.
+  await Promise.all([finished.promise, serverSawCloseNotify.promise]);
 
   const { writableFinished, readyState, destroyed } = client;
   const transportFinalCalled = transport.finalCalled;


### PR DESCRIPTION
### Problem
- Regression from #42181, not released. `tls.connect({ socket: duplex })`, then `end()` before the handshake completes: `'finish'` fires, but the Duplex's `final()` never runs, so the peer sees no FIN. A healthy server then completes the handshake and the session stays open forever. Node v26.3.0 ends the Duplex at once.
- `UpgradedDuplex::shutdown` (`src/runtime/socket/UpgradedDuplex.rs:551`) ran `SSL_shutdown` and nothing else. Only the close callback ended the transport, which needs the peer's close_notify or a `destroy()`. Mid-handshake, BoringSSL's `SSL_shutdown` returns 1 and does nothing.

### Fix
- `shutdown()` sends the close_notify (none mid-handshake), then ends the write side of the transport. `us_internal_ssl_shutdown` does this on an fd, node's `TLSWrap::DoShutdown` on a stream.
- `end()` in the turn that created the socket arrives before the engine exists and was dropped. It now sets `pending_shutdown`. `drain_pending` replays it after the staged input: first flight, then `end()`.
- Correct because the engine keeps reading, and the `writableEnded` probe in `call_write_or_end` drops handshake output that follows.
- Verified: `test/js/node/tls/node-tls-connect.test.ts`. 7 new cells fail on main, 6 assert the same report on node v26.3.0. Self-reviewed: 16 concerns raised, 13 addressed, 3 need no change. Remaining gaps: notes.

### Background
- Bun has three TLS engines. `openssl.c` drives a socket on its fd. `UpgradedDuplex` runs an `SSLWrapper` over a `stream.Duplex` through `duplex.write()` and `duplex.end()`. `WindowsNamedPipe` does the same over a pipe. Only `UpgradedDuplex` changes.
- node:net's `_final`, the shutdown hook of the writable side, calls `handle.shutdown()`: `UpgradedDuplex::shutdown` here. `'finish'` follows its callback.
- The engine for a Duplex starts on a later event-loop turn. `drain_pending` replays what arrived before.

<details><summary>Notes</summary>

**Reports.** The fixture `test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs` runs on both runtimes. "same turn" means the call is made in the turn that created the socket, before bun's engine exists. "after first flight" means the engine wrote its ClientHello and waits.

| cell | node v26.3.0 | main | this branch |
| --- | --- | --- | --- |
| `end()`, stalled peer, same turn | ClientHello, `final()`, FIN, `finish` | `finish`, no FIN (times out) | same as node |
| `end()`, stalled peer, after first flight | same | `finish`, no FIN (times out) | same as node |
| `destroySoon()`, after first flight | `final()`, FIN, `finish`, `close` | transport destroyed, no `final()` | same as node |
| `destroySoon()`, same turn | ClientHello, `final()`, FIN, `finish`, `close` | transport destroyed, no ClientHello, no `final()` | unchanged, see below |
| `end()`, healthy TLS server, same turn | server: `tlsClientError ECONNRESET`, client closes | server: `secureConnection`, session left open | same as node |
| server-side `TLSSocket` over a Duplex, `end()` same turn | `final()`, FIN | no FIN (times out) | same as node |
| server-side, ClientHello already buffered | aborts: `ERR_INTERNAL_ASSERTION` in `JSStreamSocket.doWrite` | no FIN | server flight, then FIN (bun-only cell) |
| `end()` after the handshake, server does not answer the close_notify | `final()` at once | `final()` never runs | same as node |

The healthy-server cell on bun 1.4.3 (before #42181): `_final` waited for the handshake, so the log is `secureConnect`, `finish`, close_notify, `final()`, `close`. Late, but closed. #42181 removed that wait for the case with no queued write, which is right for the fd engine, where `us_internal_ssl_shutdown` sends the FIN. The stream engine had no equivalent.

**Behaviour change after the handshake.** `end()` now ends the transport right after the close_notify. Before, the transport was ended only when the peer's close_notify arrived. With a peer that does not answer (a server with `allowHalfOpen`), the transport was never ended. Node ends it at once. Cell: `duplex-end-established`.

**Against a healthy server, client side.** Node's engine also completes its half of the handshake after the FIN and writes its last flight into the ended stream, so node's client emits `secureConnect` and then `ERR_STREAM_WRITE_AFTER_END`. Bun drops that write (the `writableEnded` probe) and emits neither. The cell does not assert those two events. The server side is identical.

**Not covered here.**
- `destroySoon()` in the creating turn over a Duplex. Committed as an `it.failing` cell for bun. `endNT` (`src/js/node/net.ts:245`) calls the `_final` callback right after `shutdown()`, so `'finish'` fires before the engine exists, `destroySoon()`'s `destroy()` runs, and `_destroy` destroys the transport. Node completes the shutdown in the `stream.end()` callback, so `'finish'` comes after the transport's `final()`. Same on 1.4.3. The same cause puts `'finish'` ahead of the transport's `'finish'` when the transport's write is asynchronous. Gating `'finish'` on the transport is a separate change in `net.ts`.
- `WindowsNamedPipe::shutdown` with TLS (`tls.connect({ path: pipe })`) has the same shape: `SSL_shutdown` only. `writer.end()` there closes the whole pipe, read side included, so it needs the `uv_shutdown` half-close from #39727 first.
- `tlsSocketFinal` in `src/js/node/_http2_upgrade.ts` ends its engine with `handle.end()`, a full close, not `shutdown()`. Not changed.
- `end()` in the creating turn when the transport is a `net.Socket` (unflushed writes, named pipe): `Socket.prototype._final` parks on `'connect'`, which an upgraded socket never emits, so `shutdown()` is never reached. #42343 clears `connecting` for such a transport and #42340 emits the event. `end()` before the fd handle is attached is #42339. #42343 names the missing FIN on this engine as its open follow-up: that is this change. With the engine started, those transports get the FIN from this change (checked by hand with a net.Socket that has 4 MB of unflushed writes).

**Replay order.** The pending shutdown runs after the staged bytes and EOF. A server-side socket that was handed a buffered ClientHello answers it first, so the client gets the server's flight and then the FIN. The first version replayed the shutdown first and dropped that flight.

**Suites run with the debug build:** all of `test/js/node/tls/`, `test/js/node/net/`, `test/js/node/http2/`, `test/js/bun/net/socket.test.ts`, `socket-retention.test.ts`, `node-http-connect.test.ts`, `ws.test.ts`, `websocket-proxy.test.ts`, and 223 vendored `test-tls-*`, `test-https-*`, `test-http2-generic-streams*` scripts (222 exit 0). Every failure also fails on a debug build of main: tests that need public DNS or an IPv4 `localhost`, `test-https-timeout.js` (hangs on debug builds with and without this change), and `test-tls-client-allow-partial-trust-chain.js` (a `node:test` file).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [2.90ms]
(pass) should thow ECONNRESET if FIN is received before handshake [362.75ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [12.06ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [173.06ms]
(pass) should be able to grab the JSStreamSocket constructor [21.30ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [120.40ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [140.18ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port
... (truncated)

release without fix: 11 failed, 18 skipped
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.04ms]
(pass) should thow ECONNRESET if FIN is received before handshake [6.73ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [0.18ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [4.02ms]
(pass) should be able to grab the JSStreamSocket constructor [0.22ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [6.15ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [4.22ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port and host correctly
(skip) tls.connect > should process port, host, and callback correctly
(skip) tls.connect > should handle the absence of a callback gracefully
(skip) tls.c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/tls/node-tls-connect.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [3.28ms]
(pass) should thow ECONNRESET if FIN is received before handshake [318.81ms]
(pass) initializes authorizationError to null in the TLSSocket constructor [8.05ms]
(pass) setMaxSendFragment mirrors OpenSSL's [512, 16384] acceptance without throwing [104.40ms]
(pass) should be able to grab the JSStreamSocket constructor [13.33ms]
(skip) tls.connect > should work with alpnProtocols
(pass) tls.connect > Bun.serve() should work with tls and Bun.file() [79.45ms]
(pass) tls.connect > should have peer certificate when using self asign certificate [88.70ms]
(skip) tls.connect > should have peer certificate
(skip) tls.connect > getCipher, getProtocol, getEphemeralKeyInfo, getSharedSigalgs, getSession, exportKeyingMaterial and isSessionReused should work
(skip) tls.connect > should process options correctly when connect is called with only options
(skip) tls.connect > should process port an
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 612ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (7686ms)
Bundle modules (44ms)
Postprocesss modules (18ms)
Bundle Functions (516ms)
Generate Code (28ms)

[8.30s] Bundled "src/js" for production
  2599 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 38s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.3-canary.1+75fa7a27d
[build] done
bun test v1.4.3-canary.1 (75fa7a27d)

test/js/node/tls/node-tls-connect.test.ts:
(pass) should have checkServerIdentity [0.03ms]
(pass) should thow ECONNRESET if FIN is received before handshake [6.16ms]
(pass) initializes authorizationError to null in the TLSSocket 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/socket/UpgradedDuplex.rs               |  23 ++-
 test/js/node/tls/node-tls-connect.test.ts          | 129 +++++++++++--
 .../tls/tls-shutdown-before-handshake-fixture.mjs  | 202 ++++++++++++++++++++-
 3 files changed, 335 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/socket/UpgradedDuplex.rs                          2      8     20
test/js/node/tls/node-tls-connect.test.ts                     3      5     18
…t/js/node/tls/tls-shutdown-before-handshake-fixture.mjs      3      3     23
```

</details>

<!-- robobun:evidence:end -->