### PR TITLE
usockets: keep a socket paused when the TLS handshake queue drains it

### DIFF
--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -317,6 +317,13 @@ void us_internal_handle_low_priority_sockets(struct us_loop_t *loop) {
         }
 
         us_internal_socket_group_link_socket(s->group, s);
+        if (s->flags.is_paused) {
+            /* us_socket_pause found the reads already off and only set the flag. Hand back an
+             * ordinary paused socket: us_socket_resume arms the reads, and the readable dispatch
+             * gates it again. */
+            s->flags.low_prio_state = 0;
+            continue;
+        }
         us_poll_change(&s->p, s->group->loop, us_poll_events(&s->p) | LIBUS_SOCKET_READABLE);
 
         s->flags.low_prio_state = 2;

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -124,6 +124,38 @@ test.concurrent(
   60_000,
 );
 
+// us_socket_pause on a socket that is parked in the low-priority handshake
+// queue only sets is_paused (parking switched its reads off already), and the
+// queue drain used to switch the reads back on without looking at the flag:
+// the handshake ran, and `handshake` and `data` reached a socket whose pause()
+// had returned. This fixture keeps its clients in its own process, so it needs
+// no grandchild. It parks 27 of 32 accepted sockets, pauses all 32, and turns
+// the loop until the queue has drained several times over.
+// `clientHandshakesWhilePaused` counts the clients that completed their
+// handshake in that time: exactly the 5-per-iteration budget, read before the
+// pause, which also proves that the other 27 were parked. resume() then brings
+// all 32 back.
+test.concurrent(
+  "TLS low-prio queue: the drain does not resume a socket that was paused while parked",
+  async () => {
+    expect(await runFixture("tls-pause-parked-handshake-fixture.ts")).toEqual({
+      summary: {
+        opened: 32,
+        whilePaused: { handshake: 0, data: 0 },
+        clientHandshakesWhilePaused: 5,
+        serverHandshakes: 32,
+        serverData: 32,
+        pongs: 32,
+        errors: 0,
+      },
+      signalCode: null,
+      exitCode: 0,
+      stderrTail: "",
+    });
+  },
+  60_000,
+);
+
 // us_poll_start_rc wraps uv_poll_init_socket on Windows and EPOLL_CTL_ADD /
 // kevent on posix. On Windows the return value was ignored, so an ioctlsocket
 // FIONBIO failure left a never-initialized uv_poll_t that uv_unref/uv_poll_start

--- a/test/js/bun/net/tls-pause-parked-handshake-fixture.ts
+++ b/test/js/bun/net/tls-pause-parked-handshake-fixture.ts
@@ -1,0 +1,161 @@
+// Regression fixture: pause() on a TLS socket that is parked in the low-priority handshake queue.
+//
+// uSockets runs at most 5 TLS handshake reads per loop iteration. A handshaking socket that
+// becomes readable after the budget is spent is PARKED: unlinked from its group, linked into
+// loop->data.low_prio_head, and its readable poll is switched off. The start of every later
+// iteration takes 5 sockets out of the queue and switches their readable poll back on.
+//
+// us_socket_pause on a parked socket finds the reads off already and only sets is_paused. The
+// queue drain did not look at is_paused, so it switched the reads of a paused socket back on: its
+// handshake ran, and `handshake` and `data` were delivered to a socket whose pause() had returned.
+//
+// Server and clients share this process, so a loop iteration is one step for both sides and the
+// iteration counter is an exact clock:
+//   1. N clients connect. The server pauses each accepted socket in `open`, so every ClientHello
+//      stays unread in the kernel.
+//   2. The server resumes all N at once. The next iteration reads 5 ClientHellos (their clients
+//      complete the TLS 1.3 handshake on the flight they get back) and parks the other N - 5.
+//   3. An immediate of that same iteration pauses all N again. From here on no server handler may
+//      run, and no other client may complete its handshake.
+//   4. The loop runs long enough to drain the queue several times over.
+//   5. The server resumes all N. Every handshake completes and every ping is answered, so a socket
+//      that the drain left paused comes back.
+import type { Socket } from "bun";
+import { getEventLoopStats } from "bun:internal-for-testing";
+import { tls as certs } from "harness";
+
+const N = 32;
+// MAX_LOW_PRIO_SOCKETS_PER_LOOP_ITERATION in packages/bun-usockets/src/loop.c.
+const BUDGET = 5;
+// Well inside the test's own timeout, so a stalled step still prints the summary.
+const STEP_DEADLINE_MS = 20_000;
+
+const iteration = () => getEventLoopStats().iteration;
+
+const summary = {
+  opened: 0,
+  // Server handlers that ran between the pause of step 3 and the resume of step 5.
+  whilePaused: { handshake: 0, data: 0 },
+  // Clients whose handshake completed before the resume of step 5.
+  clientHandshakesWhilePaused: -1,
+  serverHandshakes: 0,
+  serverData: 0,
+  pongs: 0,
+  errors: 0,
+};
+
+function report(extra: Record<string, unknown> = {}): never {
+  console.log(JSON.stringify({ ...summary, ...extra }));
+  process.exit(extra.error ? 1 : 0);
+}
+
+// One turn of the immediate queue is one loop iteration. The turns also keep the low-priority
+// queue moving, which drains only when the loop iterates.
+async function until(step: string, done: () => boolean) {
+  const deadline = Date.now() + STEP_DEADLINE_MS;
+  while (!done()) {
+    if (Date.now() > deadline) report({ error: `timed out waiting for ${step}` });
+    await new Promise(r => setImmediate(r));
+  }
+}
+function afterIterations(n: number) {
+  const target = iteration() + n;
+  return until(`${n} loop iterations`, () => iteration() >= target);
+}
+
+type State = { paused: boolean };
+const accepted: Socket<State>[] = [];
+let clientOpens = 0;
+let clientHandshakes = 0;
+
+const server = Bun.listen<State>({
+  hostname: "127.0.0.1",
+  port: 0,
+  tls: { key: certs.key, cert: certs.cert },
+  socket: {
+    open(s) {
+      summary.opened++;
+      s.data = { paused: true };
+      s.pause();
+      accepted.push(s);
+    },
+    handshake(s, success) {
+      if (s.data.paused) summary.whilePaused.handshake++;
+      if (success) summary.serverHandshakes++;
+    },
+    data(s) {
+      if (s.data.paused) summary.whilePaused.data++;
+      summary.serverData++;
+      s.write("pong");
+    },
+    error() {
+      summary.errors++;
+    },
+  },
+});
+
+const clients: Socket[] = [];
+try {
+  for (let i = 0; i < N; i++) {
+    clients.push(
+      await Bun.connect({
+        hostname: "127.0.0.1",
+        port: server.port,
+        tls: { rejectUnauthorized: false },
+        socket: {
+          // The ClientHello goes out as soon as this returns.
+          open() {
+            clientOpens++;
+          },
+          handshake(c, success) {
+            if (!success) return;
+            clientHandshakes++;
+            c.write("ping");
+          },
+          data() {
+            summary.pongs++;
+          },
+          error() {
+            summary.errors++;
+          },
+        },
+      }),
+    );
+  }
+  await until(`${N} connections`, () => accepted.length === N && clientOpens === N);
+  // One more turn and every ClientHello is in the server's receive queue.
+  await afterIterations(2);
+
+  // Step 2.
+  for (const s of accepted) {
+    s.data.paused = false;
+    s.resume();
+  }
+  // Immediates run after an iteration's dispatch: the first one that sees the counter advance runs
+  // with the budget spent and N - 5 sockets parked.
+  await afterIterations(1);
+
+  // Step 3.
+  for (const s of accepted) {
+    s.pause();
+    s.data.paused = true;
+  }
+
+  // Step 4. The queue holds the N - 5 parked server sockets and, for an iteration each, the 5
+  // clients that got a flight back. It drains 5 per iteration.
+  await afterIterations(4 * Math.ceil(N / BUDGET) + 8);
+  summary.clientHandshakesWhilePaused = clientHandshakes;
+
+  // Step 5.
+  for (const s of accepted) {
+    s.data.paused = false;
+    s.resume();
+  }
+  await until(`${N} pongs`, () => summary.pongs === N);
+} catch (e) {
+  report({ error: String(e) });
+} finally {
+  for (const c of clients) c.terminate();
+  server.stop(true);
+}
+report();


### PR DESCRIPTION
### Problem

- `Bun.listen({ tls })`: `socket.pause()` on a connection that waits in the TLS handshake queue does not hold. The queue drain arms the reads again, and `handshake` and `data` fire on a socket whose `pause()` returned. In a burst of 32 connections, all 27 queued sockets get both callbacks (1.4.2, canary, main).
- The cause is `us_internal_handle_low_priority_sockets` (`packages/bun-usockets/src/loop.c:320`). It calls `us_poll_change(events | LIBUS_SOCKET_READABLE)` for each socket it takes out of the queue and does not check `s->flags.is_paused`.

### Fix

- The drain links a paused socket back into its group, leaves its reads off, and sets `low_prio_state` to 0. It is an ordinary paused socket again.
- `us_socket_resume` arms the reads. The readable dispatch then limits the socket like any other handshaking socket, so a burst of `resume()` calls cannot run all the delayed handshakes in one iteration.
- Verified: new test in `test/js/bun/net/socket-syscall-fault.test.ts` (fixture `tls-pause-parked-handshake-fixture.ts`). Also `socket.test.ts` and the `node:tls` suites.

### Background

- uSockets reads at most 5 handshaking TLS sockets per loop iteration. A socket over the budget is parked: unlinked from its group, linked into `loop->data.low_prio_head`, reads off. Each later iteration starts with a drain that takes 5 sockets out and switches their reads on.
- `low_prio_state`: 0 is normal, 1 is parked, 2 is taken out by the drain. State 2 is read on its next readable event with no charge to the budget.
- `us_socket_pause` switches the readable poll off and sets `is_paused`. On a parked socket the poll is off already, so only the flag changes. `us_socket_resume` undoes both.

<details><summary>Notes</summary>

Reported from a fuzz run as a two-process script: N TCP connections, then all ClientHellos in one tick, and a control byte in that same tick that makes the server pause every accepted socket. N=40 gave 12 to 30 sockets with callbacks after `pause()` on 1.4.2, 23 on canary d316760e8, 15 to 72 of 200 on main 6b394bfeb0 (ASAN). N=5 (nothing queues) gave 0 in every run. With this change the same script gives 0 for N=5, 40 and 200.

`resume()` on a parked socket was handled already: the "already parked" arm in the readable dispatch (`loop.c:627`). This is the `pause()` direction.

The fixture is deterministic because server and clients share one loop, so the loop iteration counter (`getEventLoopStats().iteration`, the counter of `us_internal_loop_pre`) is an exact clock. It parks sockets with the recipe of `tls-close-all-sibling-fixture.ts`: pause every accepted socket in `open`, then resume all of them at once, so the next iteration reads 5 ClientHellos and parks the rest. An immediate of that iteration pauses all 32 again. The loop then turns 36 iterations, several times what the queue needs to drain.

Fixture output, release 1.4.3-canary.1 and a debug+ASAN build of main without the change:

```
{"opened":32,"whilePaused":{"handshake":27,"data":27},"clientHandshakesWhilePaused":32,"serverHandshakes":32,"serverData":32,"pongs":32,"errors":0}
```

With the change (20 of 20 runs, 4 at a time):

```
{"opened":32,"whilePaused":{"handshake":0,"data":0},"clientHandshakesWhilePaused":5,"serverHandshakes":32,"serverData":32,"pongs":32,"errors":0}
```

`clientHandshakesWhilePaused: 5` is the budget: the 5 ClientHellos read before the pause. It also proves that the other 27 sockets were parked when `pause()` ran. The last three numbers are taken after `resume()`: every socket that the drain left paused comes back.

A paused socket still pays one unit of the iteration's budget when the drain takes it out, the same as a closed socket in that loop. Other handshakes are then parked for one more iteration and go first in the next drain (the queue is LIFO), so nothing starves.

Related open PRs do not touch the drain: #42285 (`App::closeIdle` marks parked sockets), #36403 (timeout sweep for parked sockets), #37099 (`pause()` arms writable interest).

Suites run on a debug+ASAN build: `socket-syscall-fault.test.ts`, `socket.test.ts`, `tcp-server.test.ts`, `node-tls-server.test.ts`, `node-tls-connect.test.ts`, `node-net-server.test.ts`, `fetch.tls.test.ts`, `tls-keepalive.test.ts`, and the 245 vendored `test-tls-*.js` and `test-https-*.js` files. Failures that are the same without the change: `socket.test.ts` "should not call drain before handshake" (needs DNS for `www.example.com`), "an unref'd Bun.listen() ... across GC" (over 5 s on a debug build), `node-tls-server.test.ts` "SNICallback runs even when..." (`localhost` resolution in this container), vendored `test-https-timeout.js` (hangs on a debug build of main as well) and `test-tls-client-allow-partial-trust-chain.js` (uses `describe` outside the test runner).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/net/socket-syscall-fault.test.ts

<!-- robobun:evidence:end -->