### PR TITLE
usockets: resume a paused TLS socket when its graceful close waits for the peer

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2194,6 +2194,9 @@ struct us_socket_t *us_internal_ssl_close(struct us_socket_t *s, int code, void 
   if (code != LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN || ssl_handle_shutdown(s)) {
     return us_internal_socket_close_raw(s, code, reason);
   }
+  /* Only a read delivers the reply this close now waits for, and the owner that paused the
+   * socket let go of it with this close, so nobody is left to call resume(). */
+  us_socket_resume(s);
   return s;
 }
 #define ssl_close us_internal_ssl_close

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4463,6 +4463,54 @@ it("a paused socket with a backpressured write still closes when its peer resets
   expect(error?.code).toBe("ECONNRESET");
 });
 
+// end() on a TLS socket sends close_notify and keeps the fd until it has read the peer's reply
+// (the peer's own close_notify, or its FIN). end() also detaches the socket, so a resume() after
+// it does nothing. A socket that was paused at that point kept its reads off for good: it never
+// saw the reply, never reported `close`, and held its fd for the life of the process.
+describe.concurrent.each(["end", "close"] as const)(
+  "tls socket that is paused when it ends, peer answers with %s()",
+  answer => {
+    it("reads the peer's reply and closes", async () => {
+      const closed = Promise.withResolvers<void>();
+      using server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        tls,
+        socket: {
+          data(socket) {
+            socket.write("pong");
+            socket.pause();
+            socket.end();
+          },
+          close() {
+            closed.resolve();
+          },
+        },
+      });
+
+      const peerClosed = Promise.withResolvers<void>();
+      await Bun.connect({
+        hostname: "127.0.0.1",
+        port: server.port,
+        tls: { ca: tls.cert },
+        socket: {
+          handshake(socket, success, authorizationError) {
+            if (success) socket.write("ping");
+            else peerClosed.reject(authorizationError ?? new Error("client handshake failed"));
+          },
+          // end() replies with close_notify and a FIN, close() with the FIN alone.
+          data: socket => void socket[answer](),
+          error: (_socket, error) => peerClosed.reject(error),
+          connectError: (_socket, error) => peerClosed.reject(error),
+          close: () => peerClosed.resolve(),
+        },
+      });
+      await peerClosed.promise;
+      await closed.promise;
+    });
+  },
+);
+
 // A close that the event loop initiated passes the read error to close(). usockets
 // reports that error in the platform's own numbering (an errno on POSIX, a WSA code
 // such as WSAECONNRESET = 10054 on Windows) and on_close has to map it: unmapped, a


### PR DESCRIPTION
### Problem

- `Bun.listen({ tls })` and `Bun.connect({ tls })`: `socket.pause(); socket.end();` never closes. `close` does not fire and the fd stays open for the life of the process, also after the peer closed (1.4.2, canary, main). Plain TCP and `end(); pause()` close.
- `end()` reaches `us_internal_ssl_close(s, 0)` (`packages/bun-usockets/src/crypto/openssl.c:2194`). It sends close_notify and keeps the fd open until it reads the peer's close_notify or FIN. A paused socket does not read.
- `end()` also detaches the JS socket (`close_and_detach`, `src/runtime/socket/socket_body.rs:1324`), so a later `resume()` returns early and cannot arm the reads.

### Fix

- When `us_internal_ssl_close` defers for the peer's reply, it calls `us_socket_resume`, which clears `is_paused` and arms the readable poll.
- Correct because the close is the owner's last word on the socket, and only a read can complete it. Data that arrives ahead of the reply is dropped, as after an `end()` with no pause.
- The change is in uSockets, where the wait is. Any owner that closes a paused TLS socket with code 0 has the same wait, not only a `Bun.listen` socket.
- Verified: two new tests in `test/js/bun/net/socket.test.ts`. Also the `node:tls`, `fetch` TLS and WebSocket suites.

### Background

- Close code 0 on a TLS socket is the graceful close: send close_notify, then wait for the peer's reply before `close(2)`, so that the peer can read everything that was sent.
- `us_socket_pause` removes the readable interest from the poll and sets `is_paused`.
- `close_and_detach` clears the JS object's native socket. `close` still fires later, from the native close.

<details><summary>Notes</summary>

Reported from a fuzz run. The script answers `ping` with `s.write("pong")`, then `s.pause(); s.end();`, then `setTimeout(() => s.resume(), 50)`. The client closes when it gets the reply. Result on 1.4.2, canary d316760e8 and main 6b394bfeb0 (ASAN), 10 of 10 runs:

```
{"TLS":true,"ORDER":"pause-end","RESUME":50,"clientsClosed":50,"open":50,"close":0,"stillOpen":50,"fds":50}
{"TLS":true,"ORDER":"end-pause","RESUME":50,"clientsClosed":50,"open":50,"close":50,"stillOpen":0,"fds":0}
{"TLS":false,"ORDER":"pause-end","RESUME":50,"clientsClosed":50,"open":50,"close":50,"stillOpen":0,"fds":0}
```

`strace` from the report, one connection: `pause()` is `epoll_ctl(MOD, fd, EPOLLOUT)`. `end()` writes the 24-byte close_notify, then `epoll_ctl(MOD, fd, EPOLLERR|EPOLLHUP)`. `resume()` makes no `epoll_ctl` at all. The client's close follows. The server never calls `shutdown()` or `close()` on the fd. The graceful close sends no FIN of its own, so the peer's FIN alone does not raise `EPOLLHUP`, and nothing wakes the socket.

With this change, on a debug+ASAN build:

```
{"TLS":true,"ORDER":"pause-end","RESUME":50,"clientsClosed":50,"open":50,"close":50,"stillOpen":0,"fds":0}
{"TLS":true,"ORDER":"pause-end","RESUME":-1,"clientsClosed":50,"open":50,"close":50,"stillOpen":0,"fds":0}
```

`RESUME=-1` never calls `resume()`. `RESUME=0`, `N=3` and `CLIENT=end` (the client sends close_notify and FIN) close as well. The controls are unchanged.

The dispatcher also holds back an EOF for a socket with `is_paused` set (`eof_deferrable` in `loop.c`), so arming the poll alone would not be enough: `us_socket_resume` clears the flag too.

Why not close the fd at once when the socket is paused: `close(2)` with unread data in the receive queue sends an RST, and an RST can discard the reply that the peer has not read yet. The wait for the peer exists to prevent that.

Why `end(); pause()` closes: `end()` detaches first, so `pause()` returns early and the reads stay on.

Why `node:tls` closes: its `end()` is the half-close (`us_internal_ssl_shutdown`: close_notify and FIN), the socket stays attached, and `resume()` works. The peer's FIN then raises `EPOLLHUP` because both directions are down.

The same wait covers a paused socket that the dispatcher took out of epoll after a hangup (`us_poll_stop` in `loop.c`). `us_socket_resume` registers it again through `us_poll_change`, which falls back to `EPOLL_CTL_ADD` on `ENOENT`.

The new tests time out without the change (release 1.4.3-canary.1 and a debug+ASAN build of main) and pass in 35 to 140 ms with it.

Suites run on a debug+ASAN build: `socket.test.ts`, `socket-syscall-fault.test.ts`, `tcp-server.test.ts`, `node-tls-server.test.ts`, `node-tls-connect.test.ts`, `node-tls-socket-allow-half-open-option.test.ts`, `node-tls-upgrade.test.ts`, `renegotiation.test.ts`, `tls-connect-socket-churn.test.ts`, `tls-syscall-fault.test.ts`, `node-http2-client-close.test.ts`, `node-net-server.test.ts`, `fetch.tls.test.ts`, `tls-keepalive.test.ts`, `websocket-pause.test.ts`, `websocket-client.test.ts`, and the 245 vendored `test-tls-*.js` and `test-https-*.js` files. Failures that are the same without the change: `socket.test.ts` "should not call drain before handshake" (needs DNS for `www.example.com`), "an unref'd Bun.listen() ... across GC" (over 5 s on a debug build), `node-tls-server.test.ts` "SNICallback runs even when..." (`localhost` resolution in this container), vendored `test-https-timeout.js` (hangs on a debug build of main as well) and `test-tls-client-allow-partial-trust-chain.js` (uses `describe` outside the test runner).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/net/socket.test.ts

<!-- robobun:evidence:end -->