### PR TITLE
node:http2: submit a request's frames after request() returns

### DIFF
--- a/src/event_loop/DeferredTaskQueue.rs
+++ b/src/event_loop/DeferredTaskQueue.rs
@@ -33,7 +33,9 @@
 //! started; that cap is a livelock bound, not a strict "no new entries this pass" frontier, because
 //! a swap-remove can pull a freshly appended entry forward. Every callback flushes its own object's
 //! buffer to its own fd or socket, so relative order within a pass has no correctness effect, and
-//! anything a pass skips runs on the next one.
+//! anything a pass skips runs on the next one. `take_unrun()` tells the event loop that such an
+//! entry may exist, so that it keeps itself alive for the pass that runs it (an entry posted from a
+//! flush into a JS transport has no fd or timer of its own holding the loop open).
 
 use core::ffi::c_void;
 use core::ptr::NonNull;
@@ -50,6 +52,8 @@ pub type DeferredRepeatingTask = unsafe extern "C" fn(*mut c_void) -> bool;
 #[derive(Default)]
 pub struct DeferredTaskQueue {
     pub(crate) map: ArrayHashMap<Option<NonNull<c_void>>, DeferredRepeatingTask>,
+    /// An entry was posted since the last pass started, so it may not have run yet.
+    unrun: bool,
 }
 
 impl DeferredTaskQueue {
@@ -60,9 +64,20 @@ impl DeferredTaskQueue {
             bun_collections::hash_map::Entry::Occupied(_) => true,
             bun_collections::hash_map::Entry::Vacant(v) => {
                 v.insert(task);
+                self.unrun = true;
                 false
             }
         }
+    }
+
+    /// Whether an entry posted since the last pass started is still registered, and so may be
+    /// waiting for its first run. Clears the mark: the caller takes over the job of giving the
+    /// queue another pass. Entries that a pass ran and kept (they returned `true`) do not count;
+    /// they wait for whatever checkpoint comes next, as before.
+    pub fn take_unrun(&mut self) -> bool {
+        let unrun = self.unrun && !self.map.is_empty();
+        self.unrun = false;
+        unrun
     }
 
     pub fn unregister_task(&mut self, ctx: Option<NonNull<c_void>>) -> bool {
@@ -72,6 +87,8 @@ impl DeferredTaskQueue {
     }
 
     pub fn run(&mut self) {
+        // Every entry present now gets its turn in this pass; only ones posted during it can miss.
+        self.unrun = false;
         // Callbacks may re-entrantly mutate `self.map` (see the re-entrancy
         // note in the file doc), so re-read `len()` every iteration and
         // re-check slot `i` after each callback. `remaining` is a livelock bound.

--- a/src/event_loop/DeferredTaskQueue.rs
+++ b/src/event_loop/DeferredTaskQueue.rs
@@ -87,7 +87,8 @@ impl DeferredTaskQueue {
     }
 
     pub fn run(&mut self) {
-        // Every entry present now gets its turn in this pass; only ones posted during it can miss.
+        // Every entry present now runs in this pass. Only an entry posted during the pass can
+        // miss it.
         self.unrun = false;
         // Callbacks may re-entrantly mutate `self.map` (see the re-entrancy
         // note in the file doc), so re-read `len()` every iteration and

--- a/src/event_loop/DeferredTaskQueue.rs
+++ b/src/event_loop/DeferredTaskQueue.rs
@@ -33,9 +33,7 @@
 //! started; that cap is a livelock bound, not a strict "no new entries this pass" frontier, because
 //! a swap-remove can pull a freshly appended entry forward. Every callback flushes its own object's
 //! buffer to its own fd or socket, so relative order within a pass has no correctness effect, and
-//! anything a pass skips runs on the next one. `take_unrun()` tells the event loop that such an
-//! entry may exist, so that it keeps itself alive for the pass that runs it (an entry posted from a
-//! flush into a JS transport has no fd or timer of its own holding the loop open).
+//! anything a pass skips runs on the next one.
 
 use core::ffi::c_void;
 use core::ptr::NonNull;
@@ -52,7 +50,7 @@ pub type DeferredRepeatingTask = unsafe extern "C" fn(*mut c_void) -> bool;
 #[derive(Default)]
 pub struct DeferredTaskQueue {
     pub(crate) map: ArrayHashMap<Option<NonNull<c_void>>, DeferredRepeatingTask>,
-    /// An entry was posted since the last pass started, so it may not have run yet.
+    /// An entry was posted since the last pass started.
     unrun: bool,
 }
 
@@ -70,10 +68,7 @@ impl DeferredTaskQueue {
         }
     }
 
-    /// Whether an entry posted since the last pass started is still registered, and so may be
-    /// waiting for its first run. Clears the mark: the caller takes over the job of giving the
-    /// queue another pass. Entries that a pass ran and kept (they returned `true`) do not count;
-    /// they wait for whatever checkpoint comes next, as before.
+    /// Whether an entry may still be waiting for its first run. Clears the mark.
     pub fn take_unrun(&mut self) -> bool {
         let unrun = self.unrun && !self.map.is_empty();
         self.unrun = false;
@@ -87,8 +82,6 @@ impl DeferredTaskQueue {
     }
 
     pub fn run(&mut self) {
-        // Every entry present now runs in this pass. Only an entry posted during the pass can
-        // miss it.
         self.unrun = false;
         // Callbacks may re-entrantly mutate `self.map` (see the re-entrancy
         // note in the file doc), so re-read `len()` every iteration and

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2729,11 +2729,6 @@ class Http2Stream extends Duplex {
             } else {
               this.emit("wantTrailers");
             }
-            // Hand the END_STREAM (or trailer) frame to the socket now: with deferred write
-            // completion, _final can run on the program's last live turn and a frame left in
-            // the cork for the auto-flusher would strand a generic-streams (duplexPair) peer
-            // waiting for 'end'.
-            native.flush();
             if (this[bunHTTP2StreamFinal] !== callback) {
               // markWritableDone already consumed and invoked the callback during the
               // synchronous streamEnd dispatch above.
@@ -2745,9 +2740,6 @@ class Http2Stream extends Duplex {
           return;
         }
         const settled = native.writeStream(this.#id, "", "ascii", true, callback);
-        // Same as above: don't leave the END_STREAM frame in the cork on what may be the
-        // program's last live turn.
-        native.flush();
         if (settled === 5) {
           // HALF_CLOSED_LOCAL settled synchronously; the dispatch was suppressed.
           markWritableDone(this);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3080,6 +3080,16 @@ extern "C" uint8_t JSC__JSGlobalObject__drainMicrotasks(Zig::GlobalObject* globa
     return globalObject->drainMicrotasks();
 }
 
+// Whether a drain would run anything: either queue a checkpoint drains holds work.
+extern "C" bool JSC__JSGlobalObject__hasPendingMicrotasks(Zig::GlobalObject* globalObject)
+{
+    auto& vm = globalObject->vm();
+    if (!vm.defaultMicrotaskQueue().isEmpty())
+        return true;
+    auto* nextTickQueue = globalObject->m_nextTickQueue.get();
+    return nextTickQueue && !nextTickQueue->isEmpty();
+}
+
 template<class Visitor, class T> static void visitGlobalObjectMember(Visitor& visitor, T& anything)
 {
     anything.visit(visitor);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3080,8 +3080,6 @@ extern "C" uint8_t JSC__JSGlobalObject__drainMicrotasks(Zig::GlobalObject* globa
     return globalObject->drainMicrotasks();
 }
 
-// True when drainMicrotasks() above would run something: the microtask queue or the
-// process.nextTick queue is not empty.
 extern "C" bool JSC__JSGlobalObject__hasPendingMicrotasks(Zig::GlobalObject* globalObject)
 {
     auto& vm = globalObject->vm();

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3080,7 +3080,8 @@ extern "C" uint8_t JSC__JSGlobalObject__drainMicrotasks(Zig::GlobalObject* globa
     return globalObject->drainMicrotasks();
 }
 
-// Whether a drain would run anything: either queue a checkpoint drains holds work.
+// True when drainMicrotasks() above would run something: the microtask queue or the
+// process.nextTick queue is not empty.
 extern "C" bool JSC__JSGlobalObject__hasPendingMicrotasks(Zig::GlobalObject* globalObject)
 {
     auto& vm = globalObject->vm();

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -157,8 +157,7 @@ unsafe extern "C" {
     safe fn JSC__JSGlobalObject__hasPendingMicrotasks(global: &JSGlobalObject) -> bool;
 }
 
-/// The yield task `drain_microtasks_with_global` queues. It has nothing to do itself: the tick
-/// that runs it ends in a checkpoint, and that checkpoint runs the deferred queue.
+/// No-op yield task: the tick that runs it ends in a checkpoint, which runs the deferred queue.
 fn deferred_task_checkpoint(_queue: *mut DeferredTaskQueue::DeferredTaskQueue) -> JsResult<()> {
     Ok(())
 }
@@ -438,10 +437,7 @@ impl EventLoop {
         self.deferred_tasks.run();
         vm.is_inside_deferred_task_queue.set(false);
 
-        // A deferred task writes its buffer to its transport, and a JS-backed transport (an http2
-        // session over a user Duplex) runs user code for that write, which queues microtasks and
-        // nextTicks. They belong to this checkpoint: the loop can find no work left right after
-        // it and exit, and a timer or I/O callback must not run ahead of them either.
+        // A deferred flush into a JS transport runs user code: drain what it queued.
         if JSC__JSGlobalObject__hasPendingMicrotasks(global_object) {
             match JSC__JSGlobalObject__drainMicrotasks(global_object) {
                 drain_result::SUCCESS => {}
@@ -451,10 +447,7 @@ impl EventLoop {
             }
         }
 
-        // That user code can also post deferred tasks of its own (the peer end of an in-process
-        // transport answering the frame it was just handed). Those run at the next checkpoint,
-        // the way node submits them from a fresh immediate. A yield task keeps the loop alive,
-        // and keeps its poll from blocking, until that checkpoint has run.
+        // A deferred task posted too late for the pass: keep the loop alive for one more.
         if self.deferred_tasks.take_unrun() {
             let task = ManagedTask::ManagedTask::new(
                 core::ptr::from_mut(&mut self.deferred_tasks),

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -154,6 +154,13 @@ mod drain_result {
 // the microtask queue through it is interior mutation invisible to Rust.
 unsafe extern "C" {
     safe fn JSC__JSGlobalObject__drainMicrotasks(global: &JSGlobalObject) -> u8;
+    safe fn JSC__JSGlobalObject__hasPendingMicrotasks(global: &JSGlobalObject) -> bool;
+}
+
+/// The yield task `drain_microtasks_with_global` queues. It has nothing to do itself: the tick
+/// that runs it ends in a checkpoint, and that checkpoint runs the deferred queue.
+fn deferred_task_checkpoint(_queue: *mut DeferredTaskQueue::DeferredTaskQueue) -> JsResult<()> {
+    Ok(())
 }
 
 impl JSGlobalObject {
@@ -430,6 +437,31 @@ impl EventLoop {
         vm.is_inside_deferred_task_queue.set(true);
         self.deferred_tasks.run();
         vm.is_inside_deferred_task_queue.set(false);
+
+        // A deferred task writes its buffer to its transport, and a JS-backed transport (an http2
+        // session over a user Duplex) runs user code for that write, which queues microtasks and
+        // nextTicks. They belong to this checkpoint: the loop can find no work left right after
+        // it and exit, and a timer or I/O callback must not run ahead of them either.
+        if JSC__JSGlobalObject__hasPendingMicrotasks(global_object) {
+            match JSC__JSGlobalObject__drainMicrotasks(global_object) {
+                drain_result::SUCCESS => {}
+                drain_result::STOPPED => return Err(Stopped),
+                drain_result::PENDING_EXCEPTION => return Ok(()),
+                _ => unreachable!(),
+            }
+        }
+
+        // That user code can also post deferred tasks of its own (the peer end of an in-process
+        // transport answering the frame it was just handed). Those run at the next checkpoint,
+        // the way node submits them from a fresh immediate; a yield task makes sure the loop
+        // stays alive and does not block until there has been one.
+        if self.deferred_tasks.take_unrun() {
+            let task = ManagedTask::ManagedTask::new(
+                core::ptr::from_mut(&mut self.deferred_tasks),
+                deferred_task_checkpoint,
+            );
+            self.enqueue_task_after_yield(task);
+        }
 
         // Guard on `event_loop_handle` being set, but drain via `uws_loop_mut()`:
         // on Windows the uSockets loop (`uws::Loop::get()`) is NOT

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -453,8 +453,8 @@ impl EventLoop {
 
         // That user code can also post deferred tasks of its own (the peer end of an in-process
         // transport answering the frame it was just handed). Those run at the next checkpoint,
-        // the way node submits them from a fresh immediate; a yield task makes sure the loop
-        // stays alive and does not block until there has been one.
+        // the way node submits them from a fresh immediate. A yield task keeps the loop alive,
+        // and keeps its poll from blocking, until that checkpoint has run.
         if self.deferred_tasks.take_unrun() {
             let task = ManagedTask::ManagedTask::new(
                 core::ptr::from_mut(&mut self.deferred_tasks),

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2967,8 +2967,6 @@ impl H2FrameParser {
         }
     }
 
-    /// Whether this parser owns the thread's cork slot, and with it an auto-flush registration
-    /// that `uncork()` releases.
     fn holds_cork(&self) -> bool {
         Self::corked().is_some_and(|corked| std::ptr::eq(corked, self.as_ctx_ptr()))
     }
@@ -3004,23 +3002,21 @@ impl H2FrameParser {
 
     pub(crate) fn on_auto_flush(&self) -> bool {
         let _keepalive = self.keepalive();
-        if self.transport_write_fatal.get() {
-            if self.has_backpressure() {
-                // Returning `false` makes DeferredTaskQueue::run remove the entry
-                // itself, so only the registration's flag and ref are released here
-                // - never a re-entrant map mutation from inside run(). The flag is
-                // cleared before the close so the teardown paths the close re-enters
-                // (detach -> unregister_auto_flush) see an unregistered flusher and
-                // early-return instead of removing a map entry run() still owns.
-                self.auto_flusher.get().registered.set(false);
-                self.deref();
-                self.close_transport_after_fatal_write();
-                return false;
-            }
-            // An empty write buffer here means a later write already drained the bytes
-            // the failing send left behind - the transport recovered. This tick is still
-            // the only flush the cork is registered for, so carry on with it.
+        if self.transport_write_fatal.get() && !self.has_backpressure() {
+            // A later write drained the buffer: the transport recovered, so this tick flushes.
             self.transport_write_fatal.set(false);
+        }
+        if self.transport_write_fatal.get() {
+            // Returning `false` makes DeferredTaskQueue::run remove the entry
+            // itself, so only the registration's flag and ref are released here
+            // - never a re-entrant map mutation from inside run(). The flag is
+            // cleared before the close so the teardown paths the close re-enters
+            // (detach -> unregister_auto_flush) see an unregistered flusher and
+            // early-return instead of removing a map entry run() still owns.
+            self.auto_flusher.get().registered.set(false);
+            self.deref();
+            self.close_transport_after_fatal_write();
+            return false;
         }
         if self.pending_header_compression_error.get() {
             // Keep the pending latch set across dispatch+flush: re-entrant detach() ->
@@ -3044,14 +3040,11 @@ impl H2FrameParser {
             return false;
         }
         let _ = self.flush();
-        // A registration waits for one of three things: the cork (uncork() releases it), a
-        // write-fatal latch, or a pending compression error. That flush can have set either
-        // of the last two, and they get their tick at the next checkpoint.
         let still_owed = self.holds_cork()
             || self.transport_write_fatal.get()
             || self.pending_header_compression_error.get();
         if self.auto_flusher.get().registered.get() && !still_owed {
-            // Left over from a latch this tick cleared: nothing else releases it.
+            // Only uncork() releases a registration, and nothing is corked.
             self.auto_flusher.get().registered.set(false);
             self.deref();
             return false;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2967,6 +2967,12 @@ impl H2FrameParser {
         }
     }
 
+    /// Whether this parser owns the thread's cork slot, and with it an auto-flush registration
+    /// that `uncork()` releases.
+    fn holds_cork(&self) -> bool {
+        Self::corked().is_some_and(|corked| std::ptr::eq(corked, self.as_ctx_ptr()))
+    }
+
     /// Runs from the deferred tick (never under a write): closes the native socket so the
     /// normal socket-close teardown runs (native callback detach, JS 'close', session
     /// destroy) - the same path a peer disconnect takes. Closes WITHOUT detaching: a
@@ -2999,23 +3005,22 @@ impl H2FrameParser {
     pub(crate) fn on_auto_flush(&self) -> bool {
         let _keepalive = self.keepalive();
         if self.transport_write_fatal.get() {
-            // Returning `false` makes DeferredTaskQueue::run remove the entry
-            // itself, so only the registration's flag and ref are released here
-            // - never a re-entrant map mutation from inside run(). The flag is
-            // cleared before the close so the teardown paths the close re-enters
-            // (detach -> unregister_auto_flush) see an unregistered flusher and
-            // early-return instead of removing a map entry run() still owns.
-            self.auto_flusher.get().registered.set(false);
-            self.deref();
-            // An empty write buffer here means a later write in the same flush()
-            // cycle already drained the bytes the failing send left behind (racy
-            // one-off errnos, e.g. macOS EPROTOTYPE) - the transport recovered.
             if self.has_backpressure() {
+                // Returning `false` makes DeferredTaskQueue::run remove the entry
+                // itself, so only the registration's flag and ref are released here
+                // - never a re-entrant map mutation from inside run(). The flag is
+                // cleared before the close so the teardown paths the close re-enters
+                // (detach -> unregister_auto_flush) see an unregistered flusher and
+                // early-return instead of removing a map entry run() still owns.
+                self.auto_flusher.get().registered.set(false);
+                self.deref();
                 self.close_transport_after_fatal_write();
-            } else {
-                self.transport_write_fatal.set(false);
+                return false;
             }
-            return false;
+            // An empty write buffer here means a later write already drained the bytes
+            // the failing send left behind - the transport recovered. This tick is still
+            // the only flush the cork is registered for, so carry on with it.
+            self.transport_write_fatal.set(false);
         }
         if self.pending_header_compression_error.get() {
             // Keep the pending latch set across dispatch+flush: re-entrant detach() ->
@@ -3039,7 +3044,18 @@ impl H2FrameParser {
             return false;
         }
         let _ = self.flush();
-        // we will unregister ourselves when the buffer is empty
+        // A registration waits for one of three things: the cork (uncork() releases it), a
+        // write-fatal latch, or a pending compression error. That flush can have set either
+        // of the last two, and they get their tick at the next checkpoint.
+        let still_owed = self.holds_cork()
+            || self.transport_write_fatal.get()
+            || self.pending_header_compression_error.get();
+        if self.auto_flusher.get().registered.get() && !still_owed {
+            // Left over from a latch this tick cleared: nothing else releases it.
+            self.auto_flusher.get().registered.set(false);
+            self.deref();
+            return false;
+        }
         true
     }
 

--- a/test/js/node/http2/node-http2-syscall-fault.test.ts
+++ b/test/js/node/http2/node-http2-syscall-fault.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tls as certs, isASAN, isWindows } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
+import net from "node:net";
+import { constants as osConstants } from "node:os";
 import path from "node:path";
 
 const skip = !fault.available() || isWindows;
@@ -20,7 +22,7 @@ async function makeServer(handler: (stream: http2.ServerHttp2Stream, headers: ht
   server.on("sessionError", () => {});
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
-  const port = (server.address() as import("node:net").AddressInfo).port;
+  const port = (server.address() as net.AddressInfo).port;
   return {
     port,
     url: `http://127.0.0.1:${port}`,
@@ -183,6 +185,49 @@ describe.skipIf(skip)("node:http2 under injected syscall faults", () => {
     } finally {
       fault.clear();
       client.close();
+    }
+  });
+
+  // A send the kernel rejects latches the parser's fatal-write flag, and a deferred tick decides
+  // what to do about it. When the next send goes through, the transport has recovered and the
+  // tick only clears the latch. It used to return right there, although it is the same tick the
+  // corked HEADERS frame was registered for, so the frame stayed in the cork. macOS hit this on
+  // every connect while the preface was still written to a connecting socket (ENOTCONN there,
+  // EAGAIN on Linux). The peer below stays silent until it has the HEADERS, so nothing else
+  // pushes them out.
+  test.each([
+    ["a request that ends with its HEADERS", {}, undefined],
+    ["a request that stays open", { ":method": "POST" }, { endStream: false }],
+  ])("send → one ENOTCONN, then recovery: HEADERS of %s still reach the peer", async (_, headers, options) => {
+    const gotHeaders = Promise.withResolvers<void>();
+    let received = Buffer.alloc(0);
+    const server = net.createServer(socket => {
+      socket.on("error", () => {});
+      socket.on("data", chunk => {
+        received = Buffer.concat([received, chunk]);
+        // Skip the 24-byte preface, then walk the frames looking for HEADERS (type 1) on stream 1.
+        for (let at = 24; at + 9 <= received.length; at += 9 + received.readUIntBE(at, 3)) {
+          if (received[at + 3] === 1 && (received.readUInt32BE(at + 5) & 0x7fffffff) === 1) gotHeaders.resolve();
+        }
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const port = (server.address() as net.AddressInfo).port;
+    // The first send is the preface, flushed when the socket connects. The session flushes again
+    // right after, and that send drains what the first one left buffered.
+    fault.set({ syscall: "send", action: "errno", errno: osConstants.errno.ENOTCONN, repeat: 1 });
+    const client = http2.connect(`http://127.0.0.1:${port}`);
+    client.on("error", gotHeaders.reject);
+    client.on("close", () => gotHeaders.reject(new Error("session closed before its HEADERS left")));
+    try {
+      const req = client.request({ ":path": "/", ...headers }, options);
+      req.on("error", () => {});
+      await gotHeaders.promise;
+    } finally {
+      fault.clear();
+      client.destroy();
+      server.close();
     }
   });
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6329,3 +6329,171 @@ describe("frames issued from inside a user-supplied Duplex transport's _write", 
     },
   );
 });
+
+describe.concurrent("session.request() over a transport that delivers synchronously", () => {
+  // An in-memory transport pair that hands every write to the other side from inside
+  // socket.write(), the way a mock socket in a unit test does.
+  function synchronousDuplexPair() {
+    class Side extends Duplex {
+      _read() {}
+      _write(chunk, _encoding, callback) {
+        this.peer.push(chunk);
+        callback();
+      }
+    }
+    const a = new Side();
+    const b = new Side();
+    a.peer = b;
+    b.peer = a;
+    return [a, b];
+  }
+
+  function frame(type, flags, streamId, payload = Buffer.alloc(0)) {
+    const header = Buffer.alloc(9);
+    header.writeUIntBE(payload.length, 0, 3);
+    header[3] = type;
+    header[4] = flags;
+    header.writeUInt32BE(streamId, 5);
+    return Buffer.concat([header, Buffer.from(payload)]);
+  }
+
+  // A peer that answers every HEADERS frame from inside its own 'data' handler: 200 with the
+  // body "ok". 0x88 is the static-table HPACK index for :status 200.
+  function replyToEveryRequestSynchronously(socket, onRequestFrame) {
+    const FRAME_HEADERS = 1;
+    const FRAME_DATA = 0;
+    const FRAME_SETTINGS = 4;
+    const PREFACE_LENGTH = 24;
+    let buffered = Buffer.alloc(0);
+    let prefaceSeen = false;
+    socket.write(frame(FRAME_SETTINGS, 0, 0));
+    socket.on("data", chunk => {
+      buffered = Buffer.concat([buffered, chunk]);
+      if (!prefaceSeen) {
+        if (buffered.length < PREFACE_LENGTH) return;
+        buffered = buffered.subarray(PREFACE_LENGTH);
+        prefaceSeen = true;
+      }
+      while (buffered.length >= 9) {
+        const length = buffered.readUIntBE(0, 3);
+        if (buffered.length < 9 + length) break;
+        const type = buffered[3];
+        const flags = buffered[4];
+        const streamId = buffered.readUInt32BE(5);
+        buffered = buffered.subarray(9 + length);
+        if (type === FRAME_SETTINGS && !(flags & 1)) socket.write(frame(FRAME_SETTINGS, 1, 0));
+        if (type === FRAME_HEADERS) {
+          onRequestFrame(streamId);
+          socket.write(frame(FRAME_HEADERS, 4, streamId, [0x88]));
+          socket.write(frame(FRAME_DATA, 1, streamId, "ok"));
+        }
+      }
+    });
+  }
+
+  // Node submits a session's frames from a scheduled write, so request() never reaches the
+  // transport itself. Bun flushed the HEADERS frame from inside request() (through the
+  // stream's _final), so over a transport that delivers synchronously the response came back
+  // before the caller could attach a 'response' listener: the status was lost while the body
+  // and 'close' still arrived.
+  it("submits nothing while request() is on the stack, so 'response' is never missed", async () => {
+    const [clientSide, peerSide] = synchronousDuplexPair();
+    let insideRequestCall = false;
+    const peerSawRequestInsideCall = [];
+    replyToEveryRequestSynchronously(peerSide, () => peerSawRequestInsideCall.push(insideRequestCall));
+
+    const client = http2.connect("http://localhost", { createConnection: () => clientSide });
+    try {
+      const results = [];
+      // The first request connects the session (its submit is deferred to 'connect' anyway);
+      // every later one runs on a session that is already connected.
+      for (const path of ["/1", "/2", "/3"]) {
+        insideRequestCall = true;
+        const req = client.request({ ":path": path });
+        insideRequestCall = false;
+
+        let status = 0;
+        let body = "";
+        req.setEncoding("utf8");
+        req.on("response", headers => (status = headers[":status"]));
+        req.on("data", chunk => (body += chunk));
+        await new Promise((resolve, reject) => {
+          req.on("close", resolve);
+          req.on("error", reject);
+        });
+        results.push({ status, body });
+      }
+
+      expect(results).toEqual([
+        { status: 200, body: "ok" },
+        { status: 200, body: "ok" },
+        { status: 200, body: "ok" },
+      ]);
+      expect(peerSawRequestInsideCall).toEqual([false, false, false]);
+    } finally {
+      client.destroy();
+    }
+  });
+
+  // A session writes the frames it owes its transport at the end of the microtask checkpoint.
+  // Over a JS transport that write runs user code: the peer end parses the bytes, and its handlers
+  // queue nextTicks and cork frames of their own. Nothing else holds the event loop open for an
+  // in-process pair, so all of that has to be seen through before the loop can call the process
+  // done. It used to exit with the response written but never reported to the stream.
+  it.each([
+    [
+      "from inside the 'stream' handler",
+      `stream.respond({ ":status": 200 }); stream.write("he"); stream.end("llo");`,
+      ["response:200", "end:hello", "close"],
+    ],
+    [
+      "from a nextTick queued by the 'stream' handler",
+      `process.nextTick(() => process.nextTick(() => stream.respond({ ":status": 204 }, { endStream: true })));`,
+      ["response:204", "end:", "close"],
+    ],
+    [
+      "from a nextTick, with trailers sent from another",
+      `process.nextTick(() => {
+         stream.respond({ ":status": 200 }, { waitForTrailers: true });
+         stream.on("wantTrailers", () => process.nextTick(() => stream.sendTrailers({ "x-trailer": "1" })));
+         stream.end("hello");
+       });`,
+      ["response:200", "end:hello", "close"],
+    ],
+  ])("the whole response arrives before the process exits when the server answers %s", async (_, respond, expected) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const http2 = require("node:http2");
+        const { duplexPair } = require("node:stream");
+        const events = [];
+        process.on("exit", () => console.log(JSON.stringify(events)));
+
+        const server = http2.createServer();
+        server.on("stream", stream => {
+          ${respond}
+        });
+        const [clientSide, serverSide] = duplexPair();
+        server.emit("connection", serverSide);
+
+        const client = http2.connect("http://localhost", { createConnection: () => clientSide });
+        const req = client.request({ ":path": "/" });
+        req.setEncoding("utf8");
+        let body = "";
+        req.on("response", headers => events.push("response:" + headers[":status"]));
+        req.on("data", chunk => (body += chunk));
+        req.on("end", () => events.push("end:" + body));
+        req.on("close", () => events.push("close"));
+        `,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(expected);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- `session.request()` on a connected `node:http2` client writes HEADERS while it is on the stack. Over a transport that delivers synchronously (an in-memory `Duplex` from `createConnection`), the response comes back inside `request()`, so `'response'` fires before a listener exists.
- Cause: `Http2Stream._final` calls `native.flush()`, and `request()` runs `req.end()` before it returns. Node schedules every session write ([`MaybeScheduleWrite`](https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1832-L1860)).
- Those calls hide two ways a corked frame is never flushed.

### Fix
- Remove both `native.flush()` calls. Frames leave at the microtask checkpoint through the session's auto-flush entry, where node writes too.
- `drain_microtasks_with_global`: after the deferred queue runs, drain pending microtasks again. If a deferred task was posted too late for the pass, a yield task gives the loop one more checkpoint before it can exit.
- `H2FrameParser::on_auto_flush`: a tick that finds a write-fatal latch the transport recovered from clears it and flushes. It used to return, and the frames corked for that tick stayed corked.
- Verified: `node-http2.test.js` (four new, main fails the first), `node-http2-syscall-fault.test.ts` (two new, main fails one), all 278 node `test-http2-*` tests.

### Background
- A session serializes frames into a cork buffer and registers an entry in the `DeferredTaskQueue`, which runs once per microtask checkpoint, after the drain.
- `is_event_loop_alive()` does not count pending microtasks or deferred entries, and an in-process pair owns no handle.
- A yield task runs on the next loop iteration and counts toward liveness.
- The write-fatal latch marks a send the kernel rejected. A deferred tick closes the transport, or clears the latch when a later send went through.

<details><summary>Notes</summary>

**The latch tick, and the darwin lanes.** The first CI run of this PR failed `h2-conformance.test.ts` and `h2-push-refusal-staged.test.ts` on both darwin lanes, every attempt, with the tape `preface -> recv:SETTINGS#0` and no client HEADERS. At that base the session still wrote its preface to a connecting socket. macOS fails that `send()` with ENOTCONN (Linux says EAGAIN), `us_socket_write_check_error` classifies ENOTCONN as peer-gone, and the parser latched `transport_write_fatal`. The next auto-flush tick, the one the request's HEADERS were corked for, cleared the latch and returned without flushing. The `_final` flush hid this. #40048 (now in the base) stopped the connect-time write, so darwin no longer latches there, but the tick still must not be spent. Reproduced on Linux with `socketFaultInjection` (one ENOTCONN on the first send after connect): main strands the HEADERS of a request that stays open, this PR delivers them.

**Repro.** Three sequential requests on one session over an in-memory `Duplex` pair that delivers synchronously, against a hand-written peer that answers every HEADERS frame with `:status 200` and `ok`. bun 1.4.3: the peer sees the HEADERS for streams 3 and 5 while `session.request()` is on the stack, and those two requests get `'close'` with the body but no `'response'`. node v26.3.0 and this PR: `on the stack: false` and `'response' 200` for all three. Over a kernel socket nothing can be delivered inside `request()`, so `http2.connect(url)` never showed the symptom.

**Why the event-loop change is in this PR.** Removing only the two `flush()` calls regresses cases that pass today (the "flushes removed only" column below): the frames are written, but the process exits before the client stream reports them. The flushes were a workaround for that strand, and the strand is reachable on main without them (the 112 failing cases in the second matrix).

**Why the fix is in the checkpoint and not in the http2 parser.** The `DeferredTaskQueue` already documents that a callback can reach user JS. Every other user of the queue avoids resolving promises inside its callback by posting a task (`FlushPendingFileSinkTask`, `StreamPending`), which is the same constraint worked around per call site. With the drain and the yield task in the checkpoint, the queue's contract holds for any callback.

**Self-review.** Checked: `take_unrun()` can report a late entry that a pass did run (a swap-remove pulled it forward). The cost is one empty loop iteration. It cannot miss one, because only `post_task` of a new key sets the mark and `run()` clears it before the first callback. An entry that returns `true` and stays registered never sets the mark, so a sink waiting on a writable poll does not spin the loop. On a loop that is closed for tasks, `enqueue_task_after_yield` releases the task at once. Native-socket sessions post from inside a pass only when a flush dispatches a write callback that writes again. Those frames used to wait for the next unrelated checkpoint and now get one on the next iteration.

**Measured against node v26.3.0 over `duplexPair`.** Two matrices, each run as a separate process per case, checking that `'response'`, `'end'` (with the full body), `'close'`, and the server's `'close'` all fire before exit.

| matrix | node | bun 1.4.3 | flushes removed only | this PR |
| --- | --- | --- | --- | --- |
| 42 cases: request issued from top level, `'connect'`, `setImmediate`, `setTimeout`, or after a previous stream closed, times 7 server response shapes | 42 | 27 | 25 | 42 |
| 448 cases: same entry points plus `nextTick` and microtask, times a server that answers from 1 to 5 nested `nextTick` / microtask / promise hops, times 4 response shapes | 448 | 336 | 258 | 448 |

The 112 cases stock bun fails in the second matrix are all "trailers sent from a deferred callback": the pre-existing strand, which the synchronous flush never covered.

**Why a yield task and not a second pass in the same checkpoint.** Looping the deferred queue until it is quiet would run a whole in-process conversation inside one checkpoint, ahead of timers and I/O, and two chatty in-process peers could starve the loop. Node submits each side's frames from its own immediate, so I/O interleaves. One checkpoint per loop iteration gives the same fairness.

**Cost.** The second drain is guarded by `JSC__JSGlobalObject__hasPendingMicrotasks` (two loads), and the yield task is only queued when a deferred callback posted a new entry during the pass, which native-socket flushes do not do. A deferred-task-heavy loop (200k `FileSink` writes, one per `setImmediate`, debug+ASAN, interleaved runs): 27.3 / 26.9 / 27.5 / 26.9 s on main, 26.8 / 27.4 / 27.7 / 27.1 s with the change. An unguarded second drain cost about 9% on the same loop. 1500 sequential h2 requests over TCP, same build with and without the event-loop change: 5.45 / 5.60 / 5.62 s and 5.55 / 5.54 / 5.65 s.

**Reset sockets.** A peer that resets the connection after answering is reported the same way before and after (`session error: ECONNRESET`): the same write path runs, from the scheduled flush instead of from `request()`.

**Other suites, each compared with a build of main:** `test/js/web/fetch`, `test/js/web/streams`, `test/js/node/stream`, `test/js/bun/http`, `test/js/bun/io`, `test/js/third_party/grpc-js`, `test/js/third_party/http2-wrapper`, and 1347 node tests matching `test-{stream,net,timers,process-next,http-,https-,tls-,worker,child-process}*`. Failures are identical with and without the change (IPv6, proxy, and CA-store tests that need network or host setup, ASAN leak thresholds, and files that exceed a 60 s cap under debug+ASAN and pass serially).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/http2/node-http2-syscall-fault.test.ts

<!-- robobun:evidence:end -->