### PR TITLE
tls: select the certificate by server name for connections accepted before close() / graceful stop()

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -365,8 +365,7 @@ static void us_internal_init_listen_socket(struct us_listen_socket_t *ls,
     ls->accept_kind = kind;
     ls->ssl_ctx = ssl_ctx;
     if (ssl_ctx) us_internal_ssl_ctx_up_ref(ssl_ctx);
-    ls->sni = NULL;
-    ls->on_server_name = NULL;
+    ls->server_names = NULL;
     ls->socket_ext_size = socket_ext_size;
     ls->deferred_accept = 0;
     ls->accept_paused = (options & LIBUS_SOCKET_OPEN_PAUSED) && !ssl_ctx;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -3044,14 +3044,12 @@ static void sni_node_destructor(void *user) {
   us_free(node);
 }
 
-/* The server names of a TLS listen socket: the static SNI tree and the dynamic
- * resolver. A connection selects its certificate when its ClientHello is
- * processed, and that can be after the listen socket closed: server.close()
- * and a graceful server.stop() keep accepted connections, and a handshake can
- * still be parked in the low-priority queue or waiting for its ClientHello.
- * So the listen socket does not own this alone. It holds one reference, and
+/* A TLS listen socket's static SNI tree and dynamic resolver. A connection
+ * selects its certificate when its ClientHello is processed, which can be
+ * after the listen socket closed (server.close() and a graceful server.stop()
+ * keep accepted connections). So the listen socket holds one reference and
  * every SSL it accepted holds one (us_ssl_server_names_ex_idx) until SSL_free.
- * Loop-thread only, like the listen socket. */
+ * Loop-thread only. */
 struct us_server_names_t {
   unsigned int refs;
   /* NULL once the listen socket closed. */
@@ -3444,10 +3442,8 @@ void us_internal_listen_socket_ssl_free(struct us_listen_socket_t *ls) {
     ls->ssl_ctx = NULL;
   }
   if (ls->server_names) {
-    /* Accepted sockets may outlive the listener (server.close() keeps existing
-     * connections per Node semantics), and the ones that have not processed
-     * their ClientHello yet still have to select a certificate. They hold
-     * their own reference, and none of them holds `ls`. */
+    /* Accepted SSLs that have not selected a certificate yet keep their own
+     * reference. None of them holds `ls`. */
     ls->server_names->ls = NULL;
     us_server_names_unref(ls->server_names);
     ls->server_names = NULL;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -151,10 +151,10 @@ long us_ssl_ctx_live_count(void) {
  *   - us_sni_ex_idx (SSL_CTX): per-domain userdata (uWS HttpRouter*).
  *   - us_ssl_reneg_state_idx (SSL): per-connection reneg counter, malloc'd on
  *     first reneg attempt only — never on the hot path.
- *   - us_ssl_listener_ex_idx (SSL): the accepting us_listen_socket_t*. The
- *     SSL_CTX is shared and can outlive any one listener, so storing ls as the
- *     CTX-level servername_arg is a UAF after listener close (and overwritten
- *     on multi-listen).
+ *   - us_ssl_server_names_ex_idx (SSL): one reference to the accepting listen
+ *     socket's us_server_names_t, released on SSL_free. Per SSL and not the
+ *     CTX-level servername_arg because the SSL_CTX is shared across listeners
+ *     and outlives them.
  *
  * SSL_CTX creation runs from both the JS thread (SecureContext, Bun.connect/
  * listen) and the HTTP-client thread (HTTPContext.initWithOpts). A racy `<0`
@@ -172,7 +172,7 @@ static int us_ctx_user_ca_ex_idx = -1;
 static int us_ssl_reneg_state_idx = -1;
 /* Per-connection async-SNI suspension state (select_certificate_cb retry). */
 static int us_ssl_sni_pending_idx = -1;
-static int us_ssl_listener_ex_idx = -1;
+static int us_ssl_server_names_ex_idx = -1;
 /* Per-SSL socket-level SNI resolver (us_socket_sni_resolver_t), used when the
  * SSL has no listen socket behind it. */
 static int us_ssl_socket_sni_ex_idx = -1;
@@ -249,6 +249,17 @@ static void us_socket_sni_resolver_free(void *parent, void *ptr, CRYPTO_EX_DATA 
                                         int index, long argl, void *argp) {
   (void)parent; (void)ad; (void)index; (void)argl; (void)argp;
   if (ptr) us_free(ptr);
+}
+
+/* us_server_names_t lives in the SNI section below. */
+struct us_server_names_t;
+static struct us_server_names_t *us_server_names_ref(struct us_listen_socket_t *ls);
+static void us_server_names_unref(struct us_server_names_t *names);
+
+static void us_ssl_server_names_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
+                                     int index, long argl, void *argp) {
+  (void)parent; (void)ad; (void)index; (void)argl; (void)argp;
+  if (ptr) us_server_names_unref(ptr);
 }
 
 struct us_ssl_reneg_state_t {
@@ -453,7 +464,7 @@ static void us_ex_idx_init(void) {
   us_ctx_sni_policy_ex_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
   us_ssl_reneg_state_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_reneg_state_free);
   us_ssl_sni_pending_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_sni_pending_free);
-  us_ssl_listener_ex_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+  us_ssl_server_names_ex_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, us_ssl_server_names_free);
   us_ssl_socket_sni_ex_idx =
       SSL_get_ex_new_index(0, NULL, NULL, NULL, us_socket_sni_resolver_free);
   us_ssl_is_socket_ex_idx = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
@@ -1799,9 +1810,13 @@ void us_internal_ssl_attach(struct us_socket_t *s, SSL_CTX *ctx,
   } else {
     SSL_set_accept_state(ssl);
     SSL_set_renegotiate_mode(ssl, ssl_renegotiate_never);
-    /* sni_cb recovers ls per-SSL — never via the shared SSL_CTX. */
+    /* sni_cb recovers the listener's server names per-SSL — never via the
+     * shared SSL_CTX. */
     us_ex_idx_ensure();
-    SSL_set_ex_data(ssl, us_ssl_listener_ex_idx, listener);
+    struct us_server_names_t *names = listener ? us_server_names_ref(listener) : NULL;
+    if (names && !SSL_set_ex_data(ssl, us_ssl_server_names_ex_idx, names)) {
+      us_server_names_unref(names);
+    }
   }
 
   s->ssl = ssl;
@@ -3029,9 +3044,51 @@ static void sni_node_destructor(void *user) {
   us_free(node);
 }
 
-static struct sni_node_t *resolve_listener_ctx(struct us_listen_socket_t *ls, const char *hostname) {
-  if (!ls->sni) return NULL;
-  return (struct sni_node_t *)sni_find(ls->sni, hostname);
+/* The server names of a TLS listen socket: the static SNI tree and the dynamic
+ * resolver. A connection selects its certificate when its ClientHello is
+ * processed, and that can be after the listen socket closed: server.close()
+ * and a graceful server.stop() keep accepted connections, and a handshake can
+ * still be parked in the low-priority queue or waiting for its ClientHello.
+ * So the listen socket does not own this alone. It holds one reference, and
+ * every SSL it accepted holds one (us_ssl_server_names_ex_idx) until SSL_free.
+ * Loop-thread only, like the listen socket. */
+struct us_server_names_t {
+  unsigned int refs;
+  /* NULL once the listen socket closed. */
+  struct us_listen_socket_t *ls;
+  /* hostname -> sni_node_t. NULL until the first name is added. */
+  void *tree;
+  /* Returns the SSL_CTX to serve for `hostname` on the in-flight handshake
+   * only (the caller does not cache it), or NULL to fall through to the tree. */
+  struct ssl_ctx_st *(*on_server_name)(struct us_listen_socket_t *, const char *hostname, int *abort_handshake, struct us_socket_t *socket);
+};
+
+static struct us_server_names_t *us_listen_socket_server_names(struct us_listen_socket_t *ls) {
+  if (!ls->server_names && ls->ssl_ctx) {
+    struct us_server_names_t *names = us_calloc(1, sizeof(*names));
+    if (!names) return NULL;
+    names->refs = 1;
+    names->ls = ls;
+    ls->server_names = names;
+  }
+  return ls->server_names;
+}
+
+static struct us_server_names_t *us_server_names_ref(struct us_listen_socket_t *ls) {
+  struct us_server_names_t *names = us_listen_socket_server_names(ls);
+  if (names) names->refs++;
+  return names;
+}
+
+static void us_server_names_unref(struct us_server_names_t *names) {
+  if (--names->refs) return;
+  if (names->tree) sni_free(names->tree, sni_node_destructor);
+  us_free(names);
+}
+
+static struct sni_node_t *us_server_names_find(struct us_server_names_t *names, const char *hostname) {
+  if (!names || !names->tree) return NULL;
+  return (struct sni_node_t *)sni_find(names->tree, hostname);
 }
 
 #define US_SNI_POLICY_REQUEST_CERT ((uintptr_t)1)
@@ -3127,7 +3184,11 @@ static size_t us_client_hello_servername(const SSL_CLIENT_HELLO *hello, char *ou
  * through to the default context. us_socket_sni_resolve() resumes it. */
 static enum ssl_select_cert_result_t us_select_cert_cb(const SSL_CLIENT_HELLO *hello) {
   SSL *ssl = hello->ssl;
-  if (!ssl || us_ssl_listener_ex_idx < 0) return ssl_select_cert_success;
+  if (!ssl || us_ssl_server_names_ex_idx < 0) return ssl_select_cert_success;
+
+  /* NULL on an SSL with no listen socket behind it. Valid whether or not that
+   * listen socket is still open: this SSL holds a reference. */
+  struct us_server_names_t *names = SSL_get_ex_data(ssl, us_ssl_server_names_ex_idx);
 
   /* A previous suspension being resumed: consume the stored result. */
   struct us_ssl_sni_pending_t *pending =
@@ -3144,16 +3205,14 @@ static enum ssl_select_cert_result_t us_select_cert_cb(const SSL_CLIENT_HELLO *h
      * through to the static SNI tree below, exactly like a synchronous
      * resolver returning null - the resume must not skip the tree fallback
      * the sync path gets. */
-    struct us_listen_socket_t *resumed_ls =
-        (struct us_listen_socket_t *)SSL_get_ex_data(ssl, us_ssl_listener_ex_idx);
-    if (resumed_ls) {
+    if (names) {
       /* Read the servername from the raw ClientHello, same as the first-call
        * path below: that is the read the early-callback contract guarantees
        * (SSL_get_servername happens to be populated by the resume re-drive
        * today, but the raw parse does not depend on that). */
       char resumed_host[256];
       if (us_client_hello_servername(hello, resumed_host, sizeof(resumed_host))) {
-        struct sni_node_t *resumed_node = resolve_listener_ctx(resumed_ls, resumed_host);
+        struct sni_node_t *resumed_node = us_server_names_find(names, resumed_host);
         if (resumed_node) {
           us_ssl_apply_selected_ctx(ssl, resumed_node->ctx);
         }
@@ -3170,11 +3229,9 @@ static enum ssl_select_cert_result_t us_select_cert_cb(const SSL_CLIENT_HELLO *h
     return ssl_select_cert_retry;
   }
 
-  struct us_listen_socket_t *ls =
-      (struct us_listen_socket_t *)SSL_get_ex_data(ssl, us_ssl_listener_ex_idx);
   /* With no listener resolver, the SSL may still carry a socket-level one: a
    * server-side socket adopted into TLS with its own SNICallback. */
-  const int no_listener_resolver = (!ls || !ls->on_server_name);
+  const int no_listener_resolver = (!names || !names->on_server_name);
   struct us_socket_sni_resolver_t *socket_resolver = NULL;
   if (no_listener_resolver && us_ssl_socket_sni_ex_idx >= 0) {
     socket_resolver = SSL_get_ex_data(ssl, us_ssl_socket_sni_ex_idx);
@@ -3205,9 +3262,11 @@ static enum ssl_select_cert_result_t us_select_cert_cb(const SSL_CLIENT_HELLO *h
   void *saved_loop_state[US_SSL_LOOP_STATE_SLOTS];
   us_internal_ssl_loop_state_save(ssl, saved_loop_state);
   int abort_handshake = 0;
+  /* names->ls is NULL once the listen socket closed: the listener resolver
+   * then resolves from cb_socket alone. */
   SSL_CTX *dyn =
       socket_resolver ? socket_resolver->cb(cb_socket, hostname, &abort_handshake)
-                      : ls->on_server_name(ls, hostname, &abort_handshake, cb_socket);
+                      : names->on_server_name(names->ls, hostname, &abort_handshake, cb_socket);
   us_internal_ssl_loop_state_restore(saved_loop_state);
 
   if (abort_handshake == 1) {
@@ -3239,24 +3298,21 @@ static enum ssl_select_cert_result_t us_select_cert_cb(const SSL_CLIENT_HELLO *h
 
   /* No dynamic selection: fall back to the static SNI tree (the bind
    * hostname and addContext() entries). An adopted socket has no tree. */
-  if (ls) {
-    struct sni_node_t *node = resolve_listener_ctx(ls, hostname);
-    if (node) {
-      us_ssl_apply_selected_ctx(ssl, node->ctx);
-    }
+  struct sni_node_t *node = us_server_names_find(names, hostname);
+  if (node) {
+    us_ssl_apply_selected_ctx(ssl, node->ctx);
   }
   return ssl_select_cert_success;
 }
 
 static int sni_cb(SSL *ssl, int *al, void *arg) {
   (void)al; (void)arg;
-  if (!ssl || us_ssl_listener_ex_idx < 0) return SSL_TLSEXT_ERR_NOACK;
-  /* The listener is per-SSL (set at accept), not the CTX-level arg — the
-   * SSL_CTX is shared and may outlive any one listener. */
-  struct us_listen_socket_t *ls =
-      (struct us_listen_socket_t *)SSL_get_ex_data(ssl, us_ssl_listener_ex_idx);
-  if (!ls) return SSL_TLSEXT_ERR_OK;
-  if (ls->on_server_name) {
+  if (!ssl || us_ssl_server_names_ex_idx < 0) return SSL_TLSEXT_ERR_NOACK;
+  /* The listener's server names are per-SSL (set at accept), not the CTX-level
+   * arg — the SSL_CTX is shared and may outlive any one listener. */
+  struct us_server_names_t *names = SSL_get_ex_data(ssl, us_ssl_server_names_ex_idx);
+  if (!names) return SSL_TLSEXT_ERR_OK;
+  if (names->on_server_name) {
     /* A dynamic resolver (user SNICallback) exists: us_select_cert_cb already
      * ran it - and the static-tree fallback - at the earlier
      * select-certificate stage. Consulting the tree again here would
@@ -3269,7 +3325,7 @@ static int sni_cb(SSL *ssl, int *al, void *arg) {
   if (hostname && hostname[0]) {
     /* Static SNI tree only (no dynamic resolver registered for this
      * listener). */
-    struct sni_node_t *node = resolve_listener_ctx(ls, hostname);
+    struct sni_node_t *node = us_server_names_find(names, hostname);
     if (node) {
       us_ssl_apply_selected_ctx(ssl, node->ctx);
     }
@@ -3283,10 +3339,12 @@ int us_listen_socket_add_server_name(struct us_listen_socket_t *ls,
   SSL_CTX *default_ctx = ls->ssl_ctx;
   if (!default_ctx) return -1;
 
-  if (!ls->sni) {
-    ls->sni = sni_new();
+  struct us_server_names_t *names = us_listen_socket_server_names(ls);
+  if (!names) return -1;
+  if (!names->tree) {
+    names->tree = sni_new();
     /* Idempotent across listeners sharing this SSL_CTX — the callback reads
-     * the listener off the SSL, not the arg. */
+     * the listener's server names off the SSL, not the arg. */
     SSL_CTX_set_tlsext_servername_callback(default_ctx, sni_cb);
   }
 
@@ -3299,7 +3357,7 @@ int us_listen_socket_add_server_name(struct us_listen_socket_t *ls,
   us_ex_idx_ensure();
   SSL_CTX_set_ex_data(ctx, us_sni_ex_idx, user);
 
-  if (sni_add(ls->sni, hostname_pattern, node)) {
+  if (sni_add(names->tree, hostname_pattern, node)) {
     /* Duplicate hostname — propagate so App.h's `if (result != 0)` rollback
      * (which frees the per-domain HttpRouter it just built) actually fires. */
     sni_node_destructor(node);
@@ -3310,15 +3368,14 @@ int us_listen_socket_add_server_name(struct us_listen_socket_t *ls,
 
 void us_listen_socket_remove_server_name(struct us_listen_socket_t *ls,
                                          const char *hostname_pattern) {
-  if (!ls->sni) return;
-  struct sni_node_t *node = (struct sni_node_t *)sni_remove(ls->sni, hostname_pattern);
+  if (!ls->server_names || !ls->server_names->tree) return;
+  struct sni_node_t *node = (struct sni_node_t *)sni_remove(ls->server_names->tree, hostname_pattern);
   sni_node_destructor(node);
 }
 
 void *us_listen_socket_find_server_name_userdata(struct us_listen_socket_t *ls,
                                                  const char *hostname_pattern) {
-  if (!ls->sni) return NULL;
-  struct sni_node_t *node = (struct sni_node_t *)sni_find(ls->sni, hostname_pattern);
+  struct sni_node_t *node = us_server_names_find(ls->server_names, hostname_pattern);
   return node ? node->user : NULL;
 }
 
@@ -3329,8 +3386,7 @@ void *us_listen_socket_find_server_name_userdata(struct us_listen_socket_t *ls,
  * tree's reference must not be handed out as a borrow. */
 struct ssl_ctx_st *us_listen_socket_find_server_name_ctx(struct us_listen_socket_t *ls,
                                                          const char *hostname_pattern) {
-  if (!ls->sni) return NULL;
-  struct sni_node_t *node = (struct sni_node_t *)sni_find(ls->sni, hostname_pattern);
+  struct sni_node_t *node = us_server_names_find(ls->server_names, hostname_pattern);
   if (!node || !node->ctx) return NULL;
   SSL_CTX_up_ref(node->ctx);
   return node->ctx;
@@ -3338,15 +3394,15 @@ struct ssl_ctx_st *us_listen_socket_find_server_name_ctx(struct us_listen_socket
 
 void us_listen_socket_on_server_name(struct us_listen_socket_t *ls,
                                      struct ssl_ctx_st *(*cb)(struct us_listen_socket_t *, const char *, int *, struct us_socket_t *)) {
-  ls->on_server_name = cb;
+  struct us_server_names_t *names = us_listen_socket_server_names(ls);
+  if (!names) return;
+  names->on_server_name = cb;
   /* The dynamic resolver may need to suspend the handshake (async
    * SNICallback); only the early select-certificate callback supports retry,
    * so register it on the listener's default context. The servername-stage
    * sni_cb stays registered for the static SNI tree (it is a no-op when the
    * early callback already installed a context). */
-  if (ls->ssl_ctx) {
-    SSL_CTX_set_select_certificate_cb(ls->ssl_ctx, us_select_cert_cb);
-  }
+  SSL_CTX_set_select_certificate_cb(ls->ssl_ctx, us_select_cert_cb);
 }
 
 /* Register a socket-level SNI resolver on an already-attached server-side SSL.
@@ -3383,37 +3439,18 @@ const char *us_internal_ssl_sni_servername(struct us_socket_t *s) {
 }
 
 void us_internal_listen_socket_ssl_free(struct us_listen_socket_t *ls) {
-  /* Accepted sockets carry `ls` in per-SSL ex_data so sni_cb can reach the
-   * listener's SNI tree. Those sockets may outlive the listener (server.close()
-   * keeps existing connections per Node semantics), so wipe the back-ref now —
-   * sni_cb returns OK on NULL. Walk only sockets accepted INTO this listener's
-   * group; uWS apps with multiple listeners on one group are scoped by the
-   * `== ls` check. */
-  if (us_ssl_listener_ex_idx >= 0 && ls->accept_group) {
-    for (struct us_socket_t *s = ls->accept_group->head_sockets; s; s = s->next) {
-      if (s->ssl && SSL_get_ex_data((SSL *)s->ssl, us_ssl_listener_ex_idx) == ls) {
-        SSL_set_ex_data((SSL *)s->ssl, us_ssl_listener_ex_idx, NULL);
-      }
-    }
-    /* Mid-handshake sockets (SSL_in_init → low_prio) are *unlinked* from
-     * head_sockets while parked in loop->data.low_prio_head, and they're
-     * exactly the population that will run sni_cb on the next tick. Miss them
-     * here and sni_cb dereferences `ls` after it's freed. Same group-filter as
-     * close_all's drain. */
-    for (struct us_socket_t *s = ls->accept_group->loop->data.low_prio_head; s; s = s->next) {
-      if (s->group == ls->accept_group && s->ssl &&
-          SSL_get_ex_data((SSL *)s->ssl, us_ssl_listener_ex_idx) == ls) {
-        SSL_set_ex_data((SSL *)s->ssl, us_ssl_listener_ex_idx, NULL);
-      }
-    }
-  }
   if (ls->ssl_ctx) {
     us_internal_ssl_ctx_unref(ls->ssl_ctx);
     ls->ssl_ctx = NULL;
   }
-  if (ls->sni) {
-    sni_free(ls->sni, sni_node_destructor);
-    ls->sni = NULL;
+  if (ls->server_names) {
+    /* Accepted sockets may outlive the listener (server.close() keeps existing
+     * connections per Node semantics), and the ones that have not processed
+     * their ClientHello yet still have to select a certificate. They hold
+     * their own reference, and none of them holds `ls`. */
+    ls->server_names->ls = NULL;
+    us_server_names_unref(ls->server_names);
+    ls->server_names = NULL;
   }
 }
 

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -248,7 +248,8 @@ unsigned int us_internal_ssl_spill_pending(us_socket_r s);
 void *us_internal_ssl_get_native_handle(us_socket_r s);
 struct us_bun_verify_error_t us_internal_ssl_verify_error(us_socket_r s);
 const char *us_internal_ssl_sni_servername(us_socket_r s);
-/* SSL_CTX_free(ls->ssl_ctx) + sni_free(ls->sni). Called from us_listen_socket_close. */
+/* Drops the listen socket's references to ls->ssl_ctx and ls->server_names.
+ * Called from us_listen_socket_close. */
 void us_internal_listen_socket_ssl_free(struct us_listen_socket_t *ls);
 /* Opaque SSL_CTX_up_ref/SSL_CTX_free so context.c needn't include OpenSSL. */
 void us_internal_ssl_ctx_up_ref(struct ssl_ctx_st *ssl_ctx);
@@ -451,12 +452,10 @@ struct us_listen_socket_t {
   /* SSL_CTX for accepted sockets. Borrowed; up_ref'd on listen, freed on
    * close. NULL → plain TCP. */
   struct ssl_ctx_st *ssl_ctx;
-  /* SNI hostname → {SSL_CTX*, user*} tree. Owned. */
-  void *sni;
-  /* Dynamic SNI resolver: returns the SSL_CTX to serve for `hostname` on the
-   * in-flight handshake only (the caller does not cache it), or NULL to fall
-   * through to the default context. */
-  struct ssl_ctx_st *(*on_server_name)(struct us_listen_socket_t *, const char *hostname, int *abort_handshake, struct us_socket_t *socket);
+  /* Static SNI tree + dynamic resolver, shared with every SSL this listener
+   * accepted. Defined in crypto/openssl.c. NULL until the first name, resolver
+   * or TLS accept. */
+  struct us_server_names_t *server_names;
   unsigned int socket_ext_size;
   /* kind to stamp on accepted sockets. */
   unsigned char accept_kind;

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -399,8 +399,10 @@ struct us_listen_socket_t *us_socket_group_listen_fd(us_socket_group_r group,
     __attribute__((nonnull(1, 8)));  /* ssl_ctx nullable */
 void us_listen_socket_close(struct us_listen_socket_t *ls) nonnull_fn_decl;
 
-/* SNI: tree hangs off the listen socket. ssl_ctx is up_ref'd; user is opaque
- * (uWS stores a per-domain HttpRouter*). user may be NULL. */
+/* SNI: the listen socket shares its server names with the connections it
+ * accepted, so one that selects its certificate after us_listen_socket_close()
+ * still sees them. ssl_ctx is up_ref'd; user is opaque (uWS stores a
+ * per-domain HttpRouter*). user may be NULL. */
 int us_listen_socket_add_server_name(struct us_listen_socket_t *ls,
     const char *hostname_pattern, struct ssl_ctx_st *ssl_ctx, void *user)
     __attribute__((nonnull(1, 2, 3)));
@@ -416,6 +418,9 @@ struct ssl_ctx_st *us_listen_socket_find_server_name_ctx(struct us_listen_socket
 int us_ssl_parse_pkcs12(const char *data, size_t len, const char *pass,
     char **out_key, size_t *out_key_len, char **out_cert, size_t *out_cert_len,
     char **out_ca, size_t *out_ca_len, const char **err_reason);
+/* Dynamic SNI resolver. It keeps running for the connections `ls` accepted
+ * after us_listen_socket_close(ls), and then receives NULL in place of `ls`:
+ * resolve from `socket`. */
 void us_listen_socket_on_server_name(struct us_listen_socket_t *ls,
     struct ssl_ctx_st *(*cb)(struct us_listen_socket_t *, const char *hostname, int *abort_handshake, struct us_socket_t *socket)) nonnull_fn_decl;
 /* Resume a handshake suspended by an async SNICallback (the dynamic resolver

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -325,6 +325,8 @@ private:
          * default serve the request - it never aborts or suspends the handshake. */
         (void) abort_handshake;
         (void) socket;
+        /* The listener closed before this ClientHello: nowhere left to register a name. */
+        if (!ls) return nullptr;
         auto *httpContext = (HttpContext<SSL> *) us_socket_group_ext(us_listen_socket_group(ls));
         httpContext->getSocketContextData()->missingServerNameHandler(hostname);
         /* The handler is expected to have registered the name via

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -2058,14 +2058,10 @@ fn decode_sni_result(result: JSValue, abort_handshake: *mut core::ffi::c_int) ->
 /// (select-certificate retry) until the JS resolution calls
 /// `handle.resumeSNI(...)` -> `us_socket_sni_resolve()`.
 ///
-/// Node keeps calling the SNICallback for the connections `server.close()`
-/// left open, so this also runs after the listen socket closed, with a null
-/// `_ls`. Everything is resolved from the accepted socket, which shares its
-/// `Handlers` with the listener that accepted it.
+/// `_ls` is null once the listen socket closed (Node still calls SNICallback).
 ///
 /// # Safety
-/// `socket` is the live us_socket_t processing this ClientHello and `hostname`
-/// is a NUL-terminated string valid for the call. JS-thread only.
+/// `socket` is live and `hostname` NUL-terminated for the call. JS-thread only.
 extern "C" fn us_dispatch_server_name(
     _ls: *mut uws_sys::ListenSocket,
     hostname: *const core::ffi::c_char,
@@ -2084,8 +2080,6 @@ extern "C" fn us_dispatch_server_name(
         Some(tls) => tls,
         None => return core::ptr::null_mut(),
     };
-    // An idle socket can drop its Handlers while the us_socket_t lives on;
-    // `get_handlers()` would panic. Same guard as `select_alpn_callback`.
     if !tls.has_handlers() {
         return core::ptr::null_mut();
     }
@@ -2099,15 +2093,14 @@ extern "C" fn us_dispatch_server_name(
         return core::ptr::null_mut();
     };
     // No `Handlers::enter`/`exit` scope here: that protocol tracks the
-    // accepted-socket callback lifecycle, and running it from inside the
-    // handshake corrupts `active_connections` for every subsequent accept.
-    // The socket, its handlers and the listener are structurally alive for
-    // this synchronous dispatch.
+    // accepted-socket callback lifecycle, and running it against the listener's
+    // own handlers from inside the handshake corrupts `active_connections` for
+    // every subsequent accept.
     let global = handlers.global_object;
     // Pass the listener's `data` (the owning net.Server) rather than minting a
     // JS wrapper for the Listener itself - `to_js` here would create a second
     // cell owning the same Rust struct and whichever is collected first frees
-    // it out from under the other. `stop()` keeps it while connections remain.
+    // it out from under the other.
     let this_value = listener
         .strong_data
         .get()
@@ -2116,10 +2109,10 @@ extern "C" fn us_dispatch_server_name(
     // SAFETY: `hostname` is NUL-terminated per the fn contract.
     let name = unsafe { core::ffi::CStr::from_ptr(hostname) };
     let js_name = EncodedSlice::latin1(name.to_bytes()).to_js(&global);
-    // The socket's JS wrapper is the resume handle an asynchronous SNICallback
-    // uses (`handle.resumeSNI(...)`) to complete the suspended handshake. The
-    // wrapper's lifecycle is GC-managed, so a resume after the socket died is
-    // a safe no-op.
+    // The accepted socket processing this ClientHello: its JS wrapper is the
+    // resume handle an asynchronous SNICallback uses (`handle.resumeSNI(...)`)
+    // to complete the suspended handshake. The wrapper's lifecycle is
+    // GC-managed, so a resume after the socket died is a safe no-op.
     let socket_handle = tls.get_this_value(&global);
     let result = match callback.call(&global, this_value, &[this_value, js_name, socket_handle]) {
         Ok(v) => v,

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -2058,8 +2058,6 @@ fn decode_sni_result(result: JSValue, abort_handshake: *mut core::ffi::c_int) ->
 /// (select-certificate retry) until the JS resolution calls
 /// `handle.resumeSNI(...)` -> `us_socket_sni_resolve()`.
 ///
-/// `_ls` is null once the listen socket closed (Node still calls SNICallback).
-///
 /// # Safety
 /// `socket` is live and `hostname` NUL-terminated for the call. JS-thread only.
 extern "C" fn us_dispatch_server_name(

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -2058,45 +2058,56 @@ fn decode_sni_result(result: JSValue, abort_handshake: *mut core::ffi::c_int) ->
 /// (select-certificate retry) until the JS resolution calls
 /// `handle.resumeSNI(...)` -> `us_socket_sni_resolve()`.
 ///
+/// Node keeps calling the SNICallback for the connections `server.close()`
+/// left open, so this also runs after the listen socket closed, with a null
+/// `_ls`. Everything is resolved from the accepted socket, which shares its
+/// `Handlers` with the listener that accepted it.
+///
 /// # Safety
-/// `ls` is a live listen socket whose accept-group ext holds a `*mut Listener`
-/// and `hostname` is a NUL-terminated string valid for the call. JS-thread
-/// only.
+/// `socket` is the live us_socket_t processing this ClientHello and `hostname`
+/// is a NUL-terminated string valid for the call. JS-thread only.
 extern "C" fn us_dispatch_server_name(
-    ls: *mut uws_sys::ListenSocket,
+    _ls: *mut uws_sys::ListenSocket,
     hostname: *const core::ffi::c_char,
     abort_handshake: *mut core::ffi::c_int,
     socket: *mut c_void,
 ) -> *mut c_void {
     jsc::mark_binding!();
-    if ls.is_null() || hostname.is_null() {
+    if socket.is_null() || hostname.is_null() {
         return core::ptr::null_mut();
     }
-    // The accept group's ext holds the owning `*mut Listener` for the lifetime
-    // of the listen socket. S008: `ListenSocket` is an `opaque_ffi!` ZST.
-    let listener_ptr: *mut Listener = bun_opaque::opaque_deref_mut(ls).group().owner::<Listener>();
-    if listener_ptr.is_null() {
+    let s_ref = uws_sys::us_socket_t::opaque_mut(socket.cast());
+    if s_ref.kind() != uws_sys::SocketKind::BunSocketTls {
         return core::ptr::null_mut();
     }
-    // SAFETY: see above — the listen socket keeps the `Listener` alive for the
-    // duration of this synchronous handshake dispatch.
-    let listener = unsafe { bun_ptr::ThisPtr::new(listener_ptr) };
-    let handlers = &listener.handlers;
+    let tls = match *s_ref.ext::<Option<bun_ptr::ThisPtr<TLSSocket>>>() {
+        Some(tls) => tls,
+        None => return core::ptr::null_mut(),
+    };
+    // An idle socket can drop its Handlers while the us_socket_t lives on;
+    // `get_handlers()` would panic. Same guard as `select_alpn_callback`.
+    if !tls.has_handlers() {
+        return core::ptr::null_mut();
+    }
+    let handlers = tls.get_handlers();
     let callback = handlers.on_server_name();
     if callback.is_empty() {
         return core::ptr::null_mut();
     }
+    // Cleared only by `Listener::deinit`, not by `stop()`.
+    let Some(listener) = handlers.listener() else {
+        return core::ptr::null_mut();
+    };
     // No `Handlers::enter`/`exit` scope here: that protocol tracks the
-    // accepted-socket callback lifecycle, and running it against the listener's
-    // own handlers from inside the handshake corrupts `active_connections` for
-    // every subsequent accept. The listener and its handlers are structurally
-    // alive for this synchronous dispatch - the listen socket cannot be freed
-    // mid-handshake.
+    // accepted-socket callback lifecycle, and running it from inside the
+    // handshake corrupts `active_connections` for every subsequent accept.
+    // The socket, its handlers and the listener are structurally alive for
+    // this synchronous dispatch.
     let global = handlers.global_object;
     // Pass the listener's `data` (the owning net.Server) rather than minting a
     // JS wrapper for the Listener itself - `to_js` here would create a second
     // cell owning the same Rust struct and whichever is collected first frees
-    // it out from under the other.
+    // it out from under the other. `stop()` keeps it while connections remain.
     let this_value = listener
         .strong_data
         .get()
@@ -2105,26 +2116,11 @@ extern "C" fn us_dispatch_server_name(
     // SAFETY: `hostname` is NUL-terminated per the fn contract.
     let name = unsafe { core::ffi::CStr::from_ptr(hostname) };
     let js_name = EncodedSlice::latin1(name.to_bytes()).to_js(&global);
-    // The accepted socket processing this ClientHello: its JS wrapper is the
-    // resume handle an asynchronous SNICallback uses (`handle.resumeSNI(...)`)
-    // to complete the suspended handshake. The wrapper's lifecycle is
-    // GC-managed, so a resume after the socket died is a safe no-op.
-    let socket_handle: JSValue = if socket.is_null() {
-        JSValue::UNDEFINED
-    } else {
-        // SAFETY: the C caller passes the live us_socket_t processing this
-        // ClientHello; for BunSocketTls sockets the ext slot holds the
-        // TLSSocket wrapper.
-        let s_ref = uws_sys::us_socket_t::opaque_mut(socket.cast());
-        if s_ref.kind() == uws_sys::SocketKind::BunSocketTls {
-            match *s_ref.ext::<Option<bun_ptr::ThisPtr<TLSSocket>>>() {
-                Some(tls) => tls.get_this_value(&global),
-                None => JSValue::UNDEFINED,
-            }
-        } else {
-            JSValue::UNDEFINED
-        }
-    };
+    // The socket's JS wrapper is the resume handle an asynchronous SNICallback
+    // uses (`handle.resumeSNI(...)`) to complete the suspended handshake. The
+    // wrapper's lifecycle is GC-managed, so a resume after the socket died is
+    // a safe no-op.
+    let socket_handle = tls.get_this_value(&global);
     let result = match callback.call(&global, this_value, &[this_value, js_name, socket_handle]) {
         Ok(v) => v,
         Err(err) => global.take_exception(err),

--- a/src/uws_sys/ListenSocket.rs
+++ b/src/uws_sys/ListenSocket.rs
@@ -70,6 +70,8 @@ impl ListenSocket {
         unsafe { us_listen_socket_remove_server_name(self, hostname.as_ptr()) }
     }
 
+    /// C keeps calling `cb` for connections accepted before `close()` whose
+    /// ClientHello arrives after it, and then passes a null `ListenSocket`.
     pub fn on_server_name(
         &mut self,
         cb: extern "C" fn(*mut ListenSocket, *const c_char, *mut c_int, *mut c_void) -> *mut c_void,

--- a/src/uws_sys/ListenSocket.rs
+++ b/src/uws_sys/ListenSocket.rs
@@ -64,8 +64,7 @@ impl ListenSocket {
         unsafe { us_listen_socket_remove_server_name(self, hostname.as_ptr()) }
     }
 
-    /// C keeps calling `cb` for connections accepted before `close()` whose
-    /// ClientHello arrives after it, and then passes a null `ListenSocket`.
+    /// `cb` receives a null `ListenSocket` once this listen socket closed.
     pub fn on_server_name(
         &mut self,
         cb: extern "C" fn(*mut ListenSocket, *const c_char, *mut c_int, *mut c_void) -> *mut c_void,

--- a/src/uws_sys/ListenSocket.rs
+++ b/src/uws_sys/ListenSocket.rs
@@ -1,6 +1,6 @@
 use core::ffi::{c_char, c_int, c_void};
 
-use crate::{SocketGroup, SslCtx, us_socket_t};
+use crate::{SslCtx, us_socket_t};
 
 bun_opaque::opaque_ffi! {
     /// Opaque FFI handle for a uSockets listen socket.
@@ -32,12 +32,6 @@ impl ListenSocket {
         crate::socket::NewSocketHandler::<IS_SSL>::from(std::ptr::from_mut::<us_socket_t>(
             self.get_socket(),
         ))
-    }
-
-    /// Group accepted sockets are linked into.
-    pub fn group(&mut self) -> &mut SocketGroup {
-        // SAFETY: self is a valid listen socket; C returns a non-null group.
-        unsafe { &mut *us_listen_socket_group(self) }
     }
 
     /// `ssl_ctx` is `SSL_CTX_up_ref`'d for the SNI node; the listener drops
@@ -86,7 +80,6 @@ impl ListenSocket {
 // `safe fn`. Shims with nullable raw / ctx ptr stay unsafe.
 unsafe extern "C" {
     safe fn us_listen_socket_close(ls: &mut ListenSocket);
-    safe fn us_listen_socket_group(ls: &mut ListenSocket) -> *mut SocketGroup;
     fn us_listen_socket_add_server_name(
         ls: *mut ListenSocket,
         hostname: *const c_char,

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
+import { once } from "node:events";
+import net from "node:net";
 import tls from "node:tls";
 import { join } from "path";
 import privateKey from "../../third_party/jsonwebtoken/priv.pem" with { type: "text" };
@@ -252,5 +254,61 @@ describe("Bun.serve per-serverName client certificate policy", () => {
       defaultResumed: "HTTP/1.1 200 OK",
       gatedResumed: "connection closed without a response",
     });
+  });
+
+  test("a handshake still queued at a graceful stop() is served under its serverName entry", async () => {
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls: [
+        { key: serverKey, cert: serverCert },
+        {
+          serverName: "admin.example.com",
+          // A certificate of its own (CN=agent1), so the client can tell which entry answered.
+          ...untrustedClient,
+          ca: clientCa,
+          requestCert: true,
+          rejectUnauthorized: true,
+        },
+      ],
+      fetch: () => new Response("members only"),
+    });
+    try {
+      // The loop runs a few handshakes per iteration and queues the rest, so
+      // ClientHellos sent in one go are not all processed when the first
+      // handshake completes.
+      const raws = Array.from({ length: 32 }, () => net.connect({ host: "127.0.0.1", port: server.port }));
+      for (const raw of raws) raw.on("error", () => {});
+      await Promise.all(raws.map(raw => once(raw, "connect")));
+
+      const firstHandshake = Promise.withResolvers<void>();
+      // No client presents a certificate.
+      const outcomes = raws.map(raw => {
+        const { promise, resolve } = Promise.withResolvers<{ certificate: string; status: string }>();
+        let certificate = "no handshake";
+        let received = "";
+        const socket = tls.connect({ socket: raw, servername: "admin.example.com", rejectUnauthorized: false }, () => {
+          certificate = socket.getPeerCertificate().subject.CN;
+          firstHandshake.resolve();
+          socket.write("GET / HTTP/1.1\r\nHost: admin.example.com\r\nConnection: close\r\n\r\n");
+        });
+        socket.on("data", chunk => (received += chunk));
+        socket.on("error", () => {});
+        socket.on("close", () => resolve({ certificate, status: received.split("\r\n")[0] || "no response" }));
+        return promise;
+      });
+      await firstHandshake.promise;
+      server.stop();
+
+      const settled = await Promise.all(outcomes);
+      // Graceful stop may close a connection that has not started its
+      // handshake ("no handshake"). It must not answer one under another entry.
+      expect(
+        settled.filter(o => o.status !== "no response" || !["agent1", "no handshake"].includes(o.certificate)),
+      ).toEqual([]);
+      expect(settled.filter(o => o.certificate === "agent1").length).toBeGreaterThan(0);
+    } finally {
+      server.stop(true);
+    }
   });
 });

--- a/test/js/bun/http/bun-serve-ssl.test.ts
+++ b/test/js/bun/http/bun-serve-ssl.test.ts
@@ -273,11 +273,12 @@ describe("Bun.serve per-serverName client certificate policy", () => {
       ],
       fetch: () => new Response("members only"),
     });
+    const raws: net.Socket[] = [];
     try {
       // The loop runs a few handshakes per iteration and queues the rest, so
       // ClientHellos sent in one go are not all processed when the first
       // handshake completes.
-      const raws = Array.from({ length: 32 }, () => net.connect({ host: "127.0.0.1", port: server.port }));
+      for (let i = 0; i < 32; i++) raws.push(net.connect({ host: "127.0.0.1", port: server.port }));
       for (const raw of raws) raw.on("error", () => {});
       await Promise.all(raws.map(raw => once(raw, "connect")));
 
@@ -297,7 +298,8 @@ describe("Bun.serve per-serverName client certificate policy", () => {
         socket.on("close", () => resolve({ certificate, status: received.split("\r\n")[0] || "no response" }));
         return promise;
       });
-      await firstHandshake.promise;
+      // If no handshake completes, every outcome settles and the assertions report them.
+      await Promise.race([firstHandshake.promise, Promise.all(outcomes)]);
       server.stop();
 
       const settled = await Promise.all(outcomes);
@@ -309,6 +311,7 @@ describe("Bun.serve per-serverName client certificate policy", () => {
       expect(settled.filter(o => o.certificate === "agent1").length).toBeGreaterThan(0);
     } finally {
       server.stop(true);
+      for (const raw of raws) raw.destroy();
     }
   });
 });

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -398,41 +398,48 @@ describe("tls.Server", () => {
       server.on("connection", () => {
         if (++accepted === servernames.length) allAccepted.resolve();
       });
-      server.listen(0, "127.0.0.1");
-      await once(server, "listening");
-      const port = (server.address() as AddressInfo).port;
-      const raws = servernames.map(() => net.connect({ host: "127.0.0.1", port }));
-      for (const raw of raws) raw.on("error", () => {});
-      await Promise.all(raws.map(raw => once(raw, "connect")));
-      await allAccepted.promise;
+      server.on("error", allAccepted.reject);
+      const raws: net.Socket[] = [];
+      try {
+        server.listen(0, "127.0.0.1");
+        await once(server, "listening");
+        const port = (server.address() as AddressInfo).port;
+        for (const _ of servernames) raws.push(net.connect({ host: "127.0.0.1", port }));
+        for (const raw of raws) raw.on("error", () => {});
+        await Promise.all(raws.map(raw => once(raw, "connect")));
+        await allAccepted.promise;
 
-      // No TLS byte has been sent yet.
-      server.close();
+        // No TLS byte has been sent yet.
+        server.close();
 
-      const outcomes = await Promise.all(
-        raws.map((raw, i) => {
-          const { promise, resolve } = Promise.withResolvers<{ certificate: string; received: string }>();
-          let certificate = "no handshake";
-          let received = "";
-          const socket = tls.connect(
-            { socket: raw, servername: servernames[i], rejectUnauthorized: false, key: agent3Key, cert: agent3Cert },
-            () => (certificate = socket.getPeerCertificate().subject.CN),
-          );
-          socket.on("data", chunk => (received += chunk));
-          socket.on("error", () => {});
-          socket.on("close", () => resolve({ certificate, received }));
-          return promise;
-        }),
-      );
+        const outcomes = await Promise.all(
+          raws.map((raw, i) => {
+            const { promise, resolve } = Promise.withResolvers<{ certificate: string; received: string }>();
+            let certificate = "no handshake";
+            let received = "";
+            const socket = tls.connect(
+              { socket: raw, servername: servernames[i], rejectUnauthorized: false, key: agent3Key, cert: agent3Cert },
+              () => (certificate = socket.getPeerCertificate().subject.CN),
+            );
+            socket.on("data", chunk => (received += chunk));
+            socket.on("error", () => {});
+            socket.on("close", () => resolve({ certificate, received }));
+            return promise;
+          }),
+        );
 
-      const tenantOutcome = { certificate: "agent1", received: "a.example.com authorized=false" };
-      expect(outcomes.slice(0, 3)).toEqual([tenantOutcome, tenantOutcome, tenantOutcome]);
-      if (mode === "SNICallback") {
-        // The callback is the allow-list: a name it rejects gets no session.
-        expect(outcomes[3]).toEqual({ certificate: "no handshake", received: "" });
-        expect(names.toSorted()).toEqual(servernames.toSorted());
-      } else {
-        expect(outcomes[3].certificate).toBe("agent2");
+        const tenantOutcome = { certificate: "agent1", received: "a.example.com authorized=false" };
+        expect(outcomes.slice(0, 3)).toEqual([tenantOutcome, tenantOutcome, tenantOutcome]);
+        if (mode === "SNICallback") {
+          // The callback is the allow-list: a name it rejects gets no session.
+          expect(outcomes[3]).toEqual({ certificate: "no handshake", received: "" });
+          expect(names.toSorted()).toEqual(servernames.toSorted());
+        } else {
+          expect(outcomes[3].certificate).toBe("agent2");
+        }
+      } finally {
+        if (server.listening) server.close();
+        for (const raw of raws) raw.destroy();
       }
     });
   });

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -361,7 +361,7 @@ describe("tls.Server", () => {
 
   // server.close() keeps the connections it already accepted. One that starts
   // its handshake afterwards still selects its context by server name.
-  describe.each(["addContext"] as ("addContext" | "SNICallback")[])("a handshake that starts after close() resolves %s", mode => {
+  describe.each(["addContext", "SNICallback"] as const)("a handshake that starts after close() resolves %s", mode => {
     it("like one that starts before it", async () => {
       // agent1 chains to ca1, the client's agent3 to ca2: the default context
       // authorizes the client, the a.example.com context does not.

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -5,8 +5,9 @@ import { describe, expect, it } from "bun:test";
 
 import { bunEnv, bunExe, tempDir } from "harness";
 import { X509Certificate } from "node:crypto";
+import { once } from "node:events";
 import { readFileSync } from "node:fs";
-import { AddressInfo } from "node:net";
+import net, { AddressInfo } from "node:net";
 import { join } from "node:path";
 import tls from "node:tls";
 
@@ -356,6 +357,84 @@ describe("tls.Server", () => {
       true,
       "chain.example.com",
     );
+  });
+
+  // server.close() keeps the connections it already accepted. One that starts
+  // its handshake afterwards still selects its context by server name.
+  describe.each(["addContext"] as ("addContext" | "SNICallback")[])("a handshake that starts after close() resolves %s", mode => {
+    it("like one that starts before it", async () => {
+      // agent1 chains to ca1, the client's agent3 to ca2: the default context
+      // authorizes the client, the a.example.com context does not.
+      const tenant = { key: agent1Key, cert: agent1Cert, ca: [ca1] };
+      const names: string[] = [];
+      const server = tls.createServer(
+        {
+          key: agent2Key,
+          cert: agent2Cert,
+          ca: [ca2],
+          requestCert: true,
+          rejectUnauthorized: false,
+          SNICallback:
+            mode === "SNICallback"
+              ? (name, cb) => {
+                  names.push(name);
+                  if (name === "a.example.com") cb(null, tls.createSecureContext(tenant));
+                  else cb(new Error("unknown tenant"));
+                }
+              : undefined,
+        },
+        socket => {
+          socket.on("error", () => {});
+          //@ts-ignore
+          socket.end(`${socket.servername} authorized=${socket.authorized}`);
+        },
+      );
+      server.on("tlsClientError", () => {});
+      if (mode === "addContext") server.addContext("a.example.com", tenant);
+
+      const servernames = ["a.example.com", "a.example.com", "a.example.com", "unknown.example.com"];
+      let accepted = 0;
+      const allAccepted = Promise.withResolvers<void>();
+      server.on("connection", () => {
+        if (++accepted === servernames.length) allAccepted.resolve();
+      });
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const port = (server.address() as AddressInfo).port;
+      const raws = servernames.map(() => net.connect({ host: "127.0.0.1", port }));
+      for (const raw of raws) raw.on("error", () => {});
+      await Promise.all(raws.map(raw => once(raw, "connect")));
+      await allAccepted.promise;
+
+      // No TLS byte has been sent yet.
+      server.close();
+
+      const outcomes = await Promise.all(
+        raws.map((raw, i) => {
+          const { promise, resolve } = Promise.withResolvers<{ certificate: string; received: string }>();
+          let certificate = "no handshake";
+          let received = "";
+          const socket = tls.connect(
+            { socket: raw, servername: servernames[i], rejectUnauthorized: false, key: agent3Key, cert: agent3Cert },
+            () => (certificate = socket.getPeerCertificate().subject.CN),
+          );
+          socket.on("data", chunk => (received += chunk));
+          socket.on("error", () => {});
+          socket.on("close", () => resolve({ certificate, received }));
+          return promise;
+        }),
+      );
+
+      const tenantOutcome = { certificate: "agent1", received: "a.example.com authorized=false" };
+      expect(outcomes.slice(0, 3)).toEqual([tenantOutcome, tenantOutcome, tenantOutcome]);
+      if (mode === "SNICallback") {
+        // The callback is the allow-list: a name it rejects gets no session.
+        expect(outcomes[3]).toEqual({ certificate: "no handshake", received: "" });
+        expect(names.toSorted()).toEqual(servernames.toSorted());
+      } else {
+        expect(outcomes[3].certificate).toBe("agent2");
+      }
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- A TLS connection accepted before `server.close()` or a graceful `server.stop()`, whose ClientHello is processed after it, gets the default certificate. Its `serverName` or `addContext` entry's `requestCert`, `rejectUnauthorized` and `ca` do not apply. A user `SNICallback` is not called. Node v26.3.0 selects by name in each case.
- Static names regressed in 1.3.14 (#29932). Across `stop()`, 1.3.13 serves 40 of 40 queued handshakes the `a.test` certificate. 1.4.3 serves 35 of 40 the default one.
- Cause: the listen socket owned the SNI tree and the resolver. `us_internal_listen_socket_ssl_free()` (`packages/bun-usockets/src/crypto/openssl.c`) freed the tree and cleared each accepted SSL's back-reference. `sni_cb` and `us_select_cert_cb` return OK on NULL.

### Fix
- The tree and the resolver move into a reference-counted `us_server_names_t`. The listen socket holds one reference. Each accepted SSL holds one (`us_ssl_server_names_ex_idx`) until `SSL_free`. Close no longer walks the accepted sockets.
- After close the resolver receives NULL for the listen socket. `us_dispatch_server_name` finds the `Listener` through the accepted socket's `Handlers`, so `SNICallback` runs after close. The callback ABI does not change.
- Correct because a handshake reads the same state before and after close, and no SSL points at the listen socket.
- Verified: new tests in `bun-serve-ssl.test.ts` and `node-tls-context.test.ts` (3 fail on 1.4.3). Other suites: see Notes.

### Background
- The ClientHello names a host (SNI). The server selects an `SSL_CTX` for it: `sni_cb` reads a static tree (`tls: [...]`, `addContext`), `us_select_cert_cb` asks a resolver first (`SNICallback`).
- `close()` and graceful `stop()` keep accepted connections. The loop runs 5 handshakes per iteration and parks the rest.
- BoringSSL ex_data: per-`SSL` slots. A slot can run a function in `SSL_free`.

<details><summary>Notes</summary>

Self-reviewed: 5 concerns raised, 5 addressed. The first shape of this change passed the accept group to the resolver. The review preferred to keep the callback ABI and resolve from the accepted socket, to rename the slot and the field, to leave the unused `missingServerName` path alone, to split the C change into its own commit, and to state the regression window.

Two commits. The first is the C change and works alone: with it, a closed listener's `SNICallback` is skipped (the resolver sees NULL) and the static tree still applies. The second is the Rust resolver change.

`Bun.serve` face (certificates in cwd: `for n in default a client; do openssl req -x509 -newkey rsa:2048 -nodes -keyout $n.key -out $n.crt -days 2 -subj /CN=$n.test; done`). 40 raw sockets connect, all send a ClientHello for `a.test` with no client certificate, `server.stop()` runs one tick later. `a.test` has `requestCert: true, rejectUnauthorized: true`.

| build | result |
| --- | --- |
| 1.3.13 | 40 x `a.test` certificate (per-name `requestCert` did not exist yet) |
| 1.3.14 | 5 x `a.test`, 35 x `default.test` |
| 1.4.3 | 5 x `server-cert=a.test response=none`, 35 x `server-cert=default.test response=HTTP/1.1 200 OK` |
| this branch | 40 x `server-cert=a.test response=none` |

`tls.createServer` face: connect 20 raw sockets, wait for 20 `'connection'` events, `server.close()`, then start the handshakes with a client certificate that only the default context trusts. No race.

| build | `SNICallback` | `addContext` |
| --- | --- | --- |
| 1.4.3 | 0 callback calls, 20 x default certificate, `authorized=true` | 20 x default certificate, `authorized=true` |
| this branch | 20 calls, 20 x `a.test` certificate, not authorized | 20 x `a.test` certificate, not authorized |
| Node v26.3.0 | 20 calls, 20 x `a.test` certificate, not authorized | 20 x `a.test` certificate, not authorized |

A name the `SNICallback` rejects (`cb(new Error(...))`): 1.4.3 serves it on the default context, this branch and Node reset the connection.

An asynchronous `SNICallback` that is pending at `close()` and then answers `cb(null, undefined)`: 1.4.3 lost the `addContext` fallback in that window, this branch keeps it, the same as with no `close()`.

ASAN runs with no report: `close()` from inside the first `SNICallback`, `close()` then drop the server and force GC with 16 handshakes pending, 50 rounds of `addContext` / `setSecureContext` under 16 suspended handshakes then `close()` then resolve, `Bun.serve` `stop()` then `stop(true)` with 30 handshakes parked.

Design points:
- The state object is created on the first name, resolver, or TLS accept, so a connection accepted before the first `addContext()` still sees names added later, as before.
- An accepted SSL keeps its reference until `SSL_free`, not until the handshake ends. The tree of a closed listener therefore lives as long as the last connection it accepted. Node keeps `server._contexts` alive the same way through `socket.server`.
- The slot and the field are renamed (`us_ssl_listener_ex_idx` to `us_ssl_server_names_ex_idx`, `ls->sni` to `ls->server_names`) because what they hold changed type. Code written against the old meaning fails to compile.
- `sni_cb` still returns early when the listener has a resolver, before and after close, so a static entry does not overwrite the choice of the `SNICallback`.
- `Handlers::listener()` is cleared only by `Listener::deinit`, and `stop()` keeps `strong_data` (the `net.Server`) while connections remain. A socket that is mid-handshake counts as a connection.
- `TemplatedApp::onMissingServerName` gets a NULL guard. Bun does not call `missingServerName()`, so that path stays unused.
- HTTP/3 keeps its own SNI table in `quic.c` and is not changed.

Related, not changed here:
- #37196 / #37197: a request whose `Host` names another `serverName` entry than the one the handshake selected. #37197 resolves `Host` through the listener's tree, which this change keeps reachable after close.
- #42285: graceful `stop()` does not mark parked handshakes `HTTP_CLOSE_WHEN_IDLE`. Independent of which certificate they get.
- #40236 replaces `us_dispatch_server_name` with a thunk that also ignores the listen socket argument, so it needs no change for this.
- #40294 deletes the unused `missingServerName` path.
- #37896: names added with `addContext()` while listening do not survive `close()` + `listen()`.

Suites run on the debug ASAN build: `test/js/bun/http/bun-serve-ssl.test.ts`, `test/js/node/tls/node-tls-context.test.ts`, `node-tls-server.test.ts`, `ssl-ctx-cache.test.ts`, `tls-connect-socket-churn.test.ts`, `node-tls-upgrade.test.ts`, `node-tls-connect.test.ts`, `test/js/bun/http/tls-keepalive.test.ts`, `serve-http2.test.ts`, `test/js/web/fetch/fetch.tls.test.ts`, and the Node tests `test-tls-sni-*`, `test-tls-add-context`, `test-tls-snicallback-error`, `test-tls-empty-sni-context`, `test-https-agent-sni`.

Not related to this change, seen in this container on both the release build and this branch: `node-tls-server.test.ts` "SNICallback runs even when the requested servername matches the bind hostname" fails with `ECONNREFUSED` because `localhost` resolves to `::1` first.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-ssl.test.ts test/js/node/tls/node-tls-context.test.ts
bun test v1.4.3 (4ff919377)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [9.81ms]
(pass) Bun.serve SSL validations > invalid key #2 development [2.17ms]
(pass) Bun.serve SSL validations > invalid cert development [2.28ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [29.84ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [2.47ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [2.20ms]
(pass) Bun.serve SSL validations > invalid key production [2.21ms]
(pass) Bun.serve SSL validations > invalid key #2 production [2.12ms]
(pass) Bun.serve SSL validations > invalid cert production [2.03ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [6.06ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [2.06ms]
(pass) Bun.serve SSL validations > invalid serverName: empty se
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [0.30ms]
(pass) Bun.serve SSL validations > invalid key #2 development [0.06ms]
(pass) Bun.serve SSL validations > invalid cert development [0.02ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [2.90ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [0.03ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [0.01ms]
(pass) Bun.serve SSL validations > invalid key production [0.04ms]
(pass) Bun.serve SSL validations > invalid key #2 production [0.03ms]
(pass) Bun.serve SSL validations > invalid cert production [0.02ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [0.33ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [0.01ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName production [0.01ms]
(pass) Bun.serve SSL validations > valid development [4.39ms]
(pass) Bun.serve SSL validations > valid 2 development [2.54ms]
(pass) Bun.serve SSL validations > valid productio
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/http/bun-serve-ssl.test.ts test/js/node/tls/node-tls-context.test.ts
bun test v1.4.3 (4ff919377)

test/js/bun/http/bun-serve-ssl.test.ts:
(pass) Bun.serve SSL validations > invalid key development [9.63ms]
(pass) Bun.serve SSL validations > invalid key #2 development [2.44ms]
(pass) Bun.serve SSL validations > invalid cert development [2.14ms]
(pass) Bun.serve SSL validations > invalid cert #2 development [29.73ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName development [2.42ms]
(pass) Bun.serve SSL validations > invalid serverName: empty serverName development [2.42ms]
(pass) Bun.serve SSL validations > invalid key production [2.27ms]
(pass) Bun.serve SSL validations > invalid key #2 production [1.75ms]
(pass) Bun.serve SSL validations > invalid cert production [2.01ms]
(pass) Bun.serve SSL validations > invalid cert #2 production [5.48ms]
(pass) Bun.serve SSL validations > invalid serverName: missing serverName production [1.99ms]
(pass) Bun.serve SSL validations > invalid serverName: empty se
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 665ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/27] cc obj/packages/bun-usockets/src/bsd.c.o
[2/27] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[3/27] cc obj/packages/bun-usockets/src/context.c.o
[4/27] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[5/27] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[6/27] cxx obj/src/jsc/bindings/bindings.cpp.o
[7/27] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[8/27] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[9/27] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[10/27] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[11/27] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[12/27] cc obj/packages/bun-usockets/src/fault_inject.c.o
[13/27] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[14/27] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[15/27] cc obj/packages/bun-usockets/src/loop.c.o
[16/27] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[17/27] cc obj/packages/bun-usockets/src/socket.c.o
[18/27] cc obj/pac
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/context.c           |   3 +-
 packages/bun-usockets/src/crypto/openssl.c    | 181 +++++++++++++++-----------
 packages/bun-usockets/src/internal/internal.h |  13 +-
 packages/bun-usockets/src/libusockets.h       |   9 +-
 packages/bun-uws/src/App.h                    |   2 +
 src/runtime/socket/Listener.rs                |  51 +++-----
 src/uws_sys/ListenSocket.rs                   |  10 +-
 test/js/bun/http/bun-serve-ssl.test.ts        |  61 +++++++++
 test/js/node/tls/node-tls-context.test.ts     |  88 ++++++++++++-
 9 files changed, 292 insertions(+), 126 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
packages/bun-usockets/src/context.c                2      1     20
packages/bun-usockets/src/crypto/openssl.c        11     13     23
packages/bun-usockets/src/internal/internal.h      2      3     20
packages/bun-usockets/src/libusockets.h            2      3     20
packages/bun-uws/src/App.h                         3      2     20
src/runtime/socket/Listener.rs                     7      2     20
src/uws_sys/ListenSocket.rs                        3      2     20
test/js/bun/http/bun-serve-ssl.test.ts             2      1     15
test/js/node/tls/node-tls-context.test.ts          3      1     14
```

</details>

<!-- robobun:evidence:end -->