### PR TITLE
test: deflake the h2 stream-release cases on debug builds

### DIFF
--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1297,8 +1297,13 @@ describe("request pseudo-header requirements (RFC 9113 §8.3.1)", () => {
 const GC_STRAGGLERS = 3;
 
 /**
- * Collects until every one of `refs` is gone, giving up after 50 passes or once the count has not
- * moved for 10 passes, and resolves to how many survived.
+ * Collects until no more than GC_STRAGGLERS of `refs` are left, giving up after 50 passes, or after
+ * 10 that collected nothing at all (the leak itself), and resolves to how many survived.
+ *
+ * A count that holds steady above GC_STRAGGLERS is no reason to stop. A concurrent JIT compile roots
+ * the arguments of the call that started it (a stream, as `this`) until the main thread installs the
+ * result, which it only does at its next tier-up check. On a debug build, where a compile takes
+ * seconds, 4 to 9 streams stay rooted that way for a dozen passes before they go.
  */
 async function liveCount(refs: WeakRef<object>[]): Promise<number> {
   const live = () => refs.filter(ref => ref.deref() !== undefined).length;
@@ -1306,12 +1311,11 @@ async function liveCount(refs: WeakRef<object>[]): Promise<number> {
   // destroy), and a WeakRef target survives the job that dereferenced it, so every pass gets a
   // fresh turn before collecting.
   let last = live();
-  for (let pass = 0, stuck = 0; pass < 50 && last > 0 && stuck < 10; pass++) {
+  for (let pass = 0; pass < 50 && last > GC_STRAGGLERS; pass++) {
+    if (pass === 10 && last === refs.length) break;
     await new Promise(resolve => setImmediate(resolve));
     await gcTick();
-    const now = live();
-    stuck = now === last ? stuck + 1 : 0;
-    last = now;
+    last = live();
   }
   return last;
 }


### PR DESCRIPTION
### Problem
- On a debug build, "stream release after a queued END_STREAM" in `test/js/node/http2/h2-conformance.test.ts` fails with `Expected: <= 3`, `Received: 4` (or 5): 7 of 12 runs with 2 cores.
- A heap snapshot shows each survivor as a direct root with reason `JITWorkList`. It is not a leak and not the stack scan.
- `liveCount()` stops when the count does not move for 10 passes. The streams that a compile plan roots go at about pass 11.

### Fix
- `liveCount()` stops when the count is within `GC_STRAGGLERS`, not on a plateau. The assertion is `<= GC_STRAGGLERS`, so a later pass cannot change the result. The 50-pass limit stays.
- It stops after 10 passes only if nothing at all was collected, which is the leak these cases guard against. Without the release line from #38044, the five cases still fail with `Received: 16`.
- Verified on the debug build: the file passes 12 of 12 runs with 2 cores, 15 of 15 with 12 cores, 8 of 8 under CPU load.

### Background
- JSC compiles hot functions on worker threads. One compile is a plan in `JITWorklist`.
- The plan keeps the arguments of the call that crossed the tier-up threshold (for an `Http2Stream` method, `this` is the stream). The GC marks them as roots until the plan is installed.
- Only a tier-up check on the main thread installs a finished plan. Few such checks run while `liveCount()` polls.
- A debug build needs seconds for one compile, so several plans are pending when the requests end.

<details><summary>Notes</summary>

**Reproduction.** `bun bd`, then `taskset -c <2 cpus> ./build/debug/bun-debug test test/js/node/http2/h2-conformance.test.ts`. Unmodified file: 7 of 12 runs fail (`Received: 4` or `5`). With `BUN_JSC_useConcurrentJIT=0` the unmodified file passes 8 of 8 in the same setup. With all 12 cores about 1 run in 5 to 10 shows a plateau above 3.

**Snapshot.** `generateHeapSnapshotForDebugging()` on a fresh turn, after the count held above 3 for three passes. Reset case (32 streams, 9 alive): 8 `ServerHttp2Stream` cells are direct roots with reason `JITWorkList`, the ninth hangs off a `JITWorkList`-rooted `WritableState` (`Object -[onwrite]-> bound function -> stream`). Compat case: 3 `ServerHttp2Stream` direct `JITWorkList` roots. Client case: 5 `ClientHttp2Stream` direct `JITWorkList` roots. The stalled stream shows `StrongHandles`, as expected. No survivor was without a reported root.

**Mechanism in JSC** (oven-sh/WebKit at `dfd696443b`):
- `operationOptimize` (`jit/JITOperations.cpp`) fills `mustHandleValues` with every parameter of the triggering frame (`numParameters()` includes `this`), also for a compile at function entry, and hands them to `DFG::compile`.
- `DFG::Plan::checkLivenessAndVisitChildren` appends them with `appendUnbarriered`. `JITWorklist::visitWeakReferences` runs that for every plan in `m_plans` (queued, in compilation, ready) from the "JIT Worklist" marking constraint.
- `JITWorklistThread::work` moves a finished plan to `m_readyPlans` and notifies nobody on the main thread. `completeAllReadyPlansForVM` is what finalizes it. Its callers are the tier-up slow paths (`operationOptimize`, `jitCompileAndSetHeuristics` in `llint/LLIntSlowPaths.cpp`, the FTL triggers) and `Heap::completeAllJITPlans` (delete all code).

**Stand-alone demonstration** (debug build): call `function hot(o)` with 400 distinct objects, then only collect. Exactly one object survives (the argument of the call that started the compile, for example #147) while `numberOfDFGCompiles(hot)` is 0. It goes on the pass after the count turns 1. With `BUN_JSC_useConcurrentJIT=0` nothing survives.

**Why pass 11.** Traces of the loop (count logged per pass, loop extended to 400 passes): a group of 4 to 6 holds from pass 0 and goes in one pass at pass 11 to 14, at 1.0 s with 12 cores, 2.4 to 2.8 s with 2 cores, 3.6 s with 1 core. So the release follows the pass count, not the time. The loop's own code makes the tier-up checks: the `filter` callback runs 16 times per pass and reaches the LLInt threshold near pass 6 and the DFG threshold near pass 11. In the 32-stream case the steps start at pass 4 to 6. A single straggler that misses those checks goes at pass 60 to 62 in every run (the `filter` loop's own DFG threshold). Code older than 5 to 15 s is discarded at a full GC, so each case starts this schedule again.

**Second effect.** The old loop tried to reach 0, so a case with 1 to 3 pinned stragglers spent 10 more passes for nothing (about 1 s with 12 cores, 2 s with 2). Under CPU load (24 busy loops on 12 cpus) that alone pushed the unmodified file over the default 5 s timeout in 3 of 8 runs. The new loop returns at once in that state.

**Runs of the fixed file** (debug build, whole file unless noted): 12 of 12 with 2 cores, 6 of 6 with 1 core, 15 of 15 with 12 cores, 8 of 8 with 24 busy loops on 12 cpus, 12 of 12 with `-t "stream release after a queued END_STREAM"` and 2 cores.

**Leak check.** Removed `self.free_resources::<false>(client)` from `Stream::flush_queue` (`h2_frame_parser.rs:1651`), rebuilt: the five queued cases fail with `Expected: <= 3, Received: 16` in 1.0 to 1.6 s each, the reset case passes (other path). Restored, rebuilt: 70 pass.

**Related.** #34640 (with oven-sh/WebKit#308) proposes that JSC stops rooting must-handle values. It is open. It found the same `JITWorkList` roots behind the N-1/N stall in `test-gc-http-client*`. With it no plan would root a stream, and this loop would return after the first pass. This change does not depend on it.

**Not done.** A longer plateau has no bound to derive it from (the release waits for a tier-up check, not for time). `getProtectedObjects()` in place of collection (#39609) and a child process with the concurrent JIT off both remove the JIT from the picture, but they replace the design that #40966 settled on. This change keeps that design.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/http2/h2-conformance.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [379.07ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [113.43ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [88.66ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [45.09ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [39.37ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [38.28ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [44.78ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [35.98ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [68.03ms]
(pass) WINDOW_UPDATE (checklist §6) > a WINDOW_UPDATE with length != 4 is a FRAME_SIZE_ERROR [59.27ms]
(pass) frame structure (checklist §2,§3) > an unknown frame type is ignored, not an error (§2.4) [47.65ms]
(pass) frame structure (checklist §2,§3) > RST_STREAM on an idle stream is a PROTOCOL_ERROR (§4) [42.78ms]
(pass) stream-id rules (checklist §3) > HEADERS on stream 0 is a PROTOCOL_ERROR (§6.2) [44.33ms]
(pass) stream-id rules (checklist §3) > DATA on stream 0 is a PROTOCOL_ERROR (§6.1) [32.26ms]
(pass) fixed-length frames (checklist §3) > PRIORITY with length != 5 is a FRAME_SIZE_ERROR (§6.3) [30.01ms]
(pass) fixed-length frames (checklist §3) > RST_STREAM with length !
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/http2/h2-conformance.test.ts | 16 ++++++++++------
 1 file changed, 10 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
test/js/node/http2/h2-conformance.test.ts      3      2     24
```

</details>

<!-- robobun:evidence:end -->