### PR TITLE
test(bundler): run bundler_compile_prelinked.test.ts three links at a time and assert stderr

### DIFF
--- a/test/bundler/bundler_compile_prelinked.test.ts
+++ b/test/bundler/bundler_compile_prelinked.test.ts
@@ -1,42 +1,34 @@
-import { describe, expect } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { afterEach, beforeEach, describe, expect } from "bun:test";
+import { isASAN, isDebug, isWindows } from "harness";
 import { BundlerTestInput, BundlerTestRunOptions, itBundled as itBundledBase } from "./expectBundled";
 
 // `bun build --compile --bytecode --format=esm` embeds a pre-resolved module graph that JSC's loader consumes instead
 // of resolving every import by name at startup. These cases pin ES module linking semantics (cycles, live bindings,
 // star exports, namespaces, TLA, CJS interop) for compiled executables: each executable runs with the graph in use,
 // with the graph cross-checked against the specification's ResolveExport, and with the graph disabled, and all three
-// must print the same thing. Without --splitting the bundle is one module record, so only the entry's own record
-// (its exports, TLA and import.meta flags, dynamic-import roots) comes from the graph; the +splitting variants make
-// every listed entry and every import() target a chunk of its own whose bindings are wired across records.
-// GeneratedGraph+splitting also checks the loader log to prove the graph, not by-name resolution, linked the chunks.
+// must print the same thing and nothing on stderr. Without --splitting the bundle is one module record, so only the
+// entry's own record (its exports, TLA and import.meta flags, dynamic-import roots) comes from the graph; the
+// +splitting variants make every listed entry and every import() target a chunk of its own whose bindings are wired
+// across records. GeneratedGraph+splitting also checks the loader log to prove the graph, not by-name resolution,
+// linked the chunks.
 const itBundled = (id: string, opts: BundlerTestInput) => itBundledBase(id, { backend: "cli", ...opts });
 
-const hasPrelinkOptions =
-  Bun.spawnSync({
-    cmd: [bunExe(), "-p", "'probe'"],
-    env: { ...bunEnv, BUN_JSC_usePrelinkedModuleInfo: "1" },
-    stdout: "pipe",
-    stderr: "ignore",
-  })
-    .stdout.toString()
-    .trim() === "probe";
-
 type LoaderMode = "graph" | "graph+validate" | "by-name";
-// A bun without the options (an older release run against this file) gets the "graph" expectations only, which the
-// loader-log check in GeneratedGraph+splitting then fails.
-const loaderModes: { mode: LoaderMode; env: Record<string, string> }[] = hasPrelinkOptions
-  ? [
-      { mode: "graph", env: {} },
-      { mode: "graph+validate", env: { BUN_JSC_validatePrelinkedModuleInfo: "1" } },
-      { mode: "by-name", env: { BUN_JSC_usePrelinkedModuleInfo: "0" } },
-    ]
-  : [{ mode: "graph", env: {} }];
+const loaderModes: { mode: LoaderMode; env: Record<string, string> }[] = [
+  { mode: "graph", env: {} },
+  { mode: "graph+validate", env: { BUN_JSC_validatePrelinkedModuleInfo: "1" } },
+  { mode: "by-name", env: { BUN_JSC_usePrelinkedModuleInfo: "0" } },
+];
+
+// Windows looks up a new executable's reputation inside its first CreateProcess (seconds under Smart App Control), and
+// Bun.spawn makes that call on the JS thread, where it stalls every other case in flight. Started through cmd.exe, the
+// wait is cmd.exe's. expectBundled puts bunArgs in front of the executable's path.
+const launcher = isWindows ? ["cmd.exe", "/d", "/c"] : [];
 
 function eachMode(run: (mode: LoaderMode) => BundlerTestRunOptions): BundlerTestRunOptions[] {
   return loaderModes.map(({ mode, env }) => {
     const options = run(mode);
-    return { ...options, env: { ...options.env, ...env } };
+    return { ...options, bunArgs: launcher, env: { ...options.env, ...env } };
   });
 }
 
@@ -71,6 +63,7 @@ function graphCase(id: string, c: GraphCase) {
       ...(entries ? { entryPointsRaw: entries.map(e => "./" + e.replace(/^\//, "")), outfile: "dist/out" } : {}),
       run: eachMode(mode => ({
         stdout: variant(c.stdout, splitting),
+        stderr: "",
         ...(entries ? { file: "dist/out" } : {}),
         ...(splitting ? c.splitRun?.(mode) : {}),
       })),
@@ -78,7 +71,23 @@ function graphCase(id: string, c: GraphCase) {
   }
 }
 
-describe("bundler", () => {
+describe.concurrent("bundler", () => {
+  // Every case links an executable: `bun build --compile` copies the bun binary and writes it again with the bundle
+  // patched in. The 20 links describe.concurrent would start at once ran CI out of memory in bundler_compile.test.ts,
+  // so a case takes a slot first, in beforeEach, where its own timeout is not running yet. An ASAN or debug binary is
+  // about a gigabyte and its link is bound by disk writeback, so those run one at a time.
+  let freeSlots = isASAN || isDebug ? 1 : 3;
+  const waiting: (() => void)[] = [];
+  beforeEach(async () => {
+    if (freeSlots > 0) freeSlots--;
+    else await new Promise<void>(resolve => waiting.push(resolve));
+  }, Infinity);
+  afterEach(() => {
+    const next = waiting.shift();
+    if (next) next();
+    else freeSlots++;
+  });
+
   // (1) cycles: b evaluates before a (entry -> a -> b), calls a hoisted function of a while a is unevaluated, and
   // later reads a's live `counter` binding.
   graphCase("CycleTwoModules", {
@@ -462,16 +471,20 @@ describe("bundler", () => {
       files: { "/entry.ts": files["/entry.ts"], ...files },
       entries: ["/entry.ts", ...Array.from({ length: N }, (_, i) => `/m${i}.ts`)],
       stdout: [value[0], value[30], exportsOf(0).size, exportsOf(12).size, exportsOf(24).size, sum].join(" "),
-      // JSC logs one line per host-hook call. All 63 records (entry chunk, 60 module chunks, the shared chunk and
-      // runtime chunk) evaluate either way; with the graph in use only the roots (bun:main, the entry, the import()
-      // of m24) go through the host's resolve, without it every cross-chunk import does.
+      // JSC logs one line per host-hook call, and nothing else may be on stderr. All 63 records (entry chunk, 60 module
+      // chunks, the shared chunk and runtime chunk) evaluate either way, and only the roots (bun:main, the entry, the
+      // import() of m24) are fetched. With the graph in use only those roots go through the host's resolve (bun:main
+      // and m24 twice each), without it every cross-chunk import statement does too.
       splitRun: mode => ({
         env: { BUN_JSC_dumpModuleLoadingState: "1" },
+        stderr: undefined, // the log, checked line by line below
         validate({ stderr }) {
-          const count = (kind: string) => stderr.split("\n").filter(l => l.startsWith(`Loader [${kind}] `)).length;
-          expect(count("evaluate")).toBe(63);
-          if (mode === "by-name") expect(count("resolve")).toBeGreaterThan(63);
-          else expect(count("resolve")).toBeLessThanOrEqual(6);
+          const hookCalls: Record<string, number> = {};
+          for (const line of stderr.trim().split("\n")) {
+            const hook = /^Loader \[(\w+)\] /.exec(line)?.[1] ?? `not a loader line: ${line}`;
+            hookCalls[hook] = (hookCalls[hook] ?? 0) + 1;
+          }
+          expect(hookCalls).toEqual({ resolve: mode === "by-name" ? 252 : 5, fetch: 3, evaluate: 63, import: 1 });
         },
       }),
     });


### PR DESCRIPTION
### Problem
- `test/bundler/bundler_compile_prelinked.test.ts` takes 81 s on the Windows 11 aarch64 lane (build 114078). It links 26 executables one after the other and runs each one 3 times.
- About 62 s of that is Smart App Control: the first `CreateProcess` of a new executable blocks about 2.4 s. `Bun.spawn` makes that call on the JS thread, so `describe.concurrent` alone cannot overlap it (74.5 s to 69 s).

### Fix
- The block is `describe.concurrent`. A `beforeEach`/`afterEach` pair lets 3 cases link at once on release builds and 1 on ASAN and debug builds (the split #39649 measured).
- On Windows the executables start through `cmd.exe /d /c`. The wait happens in `cmd.exe`, and the cases overlap it.
- Every run asserts an empty stderr (75 new checks). `GeneratedGraph+splitting` pins each loader hook count: `resolve` is 5 with the graph, 252 without (was `<= 6`, `> 63`). The module-load `Bun.spawnSync` probe is gone.
- Verified, main to branch: Windows 11 arm64 74.5 s to 27 s, Windows Server 2019 x64 11.9 s to 5.8 s, Linux x64 release 6.5 s to 2.9 s. `bun bd test` is unchanged (1 slot). All 27 tests and 3 loader modes still run.

### Background
- Smart App Control is a Windows 11 code integrity policy, in evaluation mode by default. #41550 (open) turns it off on the runners.
- Bun runs concurrent tests 20 at a time with no per-describe limit. 20 links at once ran CI out of memory before.
- A loader mode is one environment for the same executable: graph in use, graph cross-checked, graph off.

<details><summary>Notes</summary>

**Where the time goes.** Probe on a Windows 11 arm64 VM with Smart App Control in evaluation mode (`Get-MpComputerStatus` reports `SmartAppControlState: Eval`, the same as the CI image): `bun build --compile --bytecode` 260 to 330 ms, first launch of each new executable 2.4 to 2.7 s, second and third launch 16 ms. The `Bun.spawn()` call itself returns after 2.3 to 4.0 s for a new executable and after 2 to 3 ms for a known one. Eight cases started at once take 22.0 s with a direct spawn (the same as serial) and 5.8 s through `cmd.exe /d /c`, where the `Bun.spawn()` call returns in 7 ms. During one first launch `MsMpEng` uses about 1.7 s of CPU. Pinning the test process tree to 4 or to 2 cores does not change the file's time (28.0 s and 27.2 s), so the 4 vCPU runners should see a similar gain.

**Whole file, `bun test` with a release build, main to this branch.**

| machine | main | branch |
| --- | ---: | ---: |
| Windows 11 arm64, 16 vCPU, Smart App Control in evaluation mode | 74.5 s | 26.2 to 35.2 s (7 runs, median 28.0 s) |
| the same, without the `cmd.exe` launcher | | 69.0 s |
| Windows Server 2019 x64, 16 vCPU | 11.9 s | 5.8 s (6.4 s without the launcher) |
| Linux x64, release, 5 interleaved pairs | 6.3 to 6.9 s | 2.4 to 3.4 s |
| Linux x64, `bun bd test` (debug + ASAN, 1 slot) | 107.5 s, 127.8 s | 114.0 s, 99.4 s, 99.0 s |

Slot count on the Windows 11 VM: 2 slots 38.3 s, 3 slots 27 s, 4 slots 22.9 s, 6 slots 17.0 s. The file uses 3 on every release build, the number #39649 checked on the 4 vCPU, 8 GB Linux lanes.

**Per lane in build 114078** (all in the parallel bucket): windows 11 aarch64 80.55 s, darwin x64 44.52 s, debian x64-asan 37.19 s, windows 2019 x64 17.27 s, debian x64 9.68 s, ubuntu x64 9.60 s, ubuntu aarch64 7.20 s, alpine x64 7.18 s, debian aarch64 7.08 s, alpine aarch64 5.00 s, darwin aarch64 4.31 s. In that batch of 189 files (91 s) this file was the critical path on Windows 11.

**ASAN and debug stay serial.** Locally the link is 2.5 to 2.9 s of a 3.5 s case with the 812 MB debug binary, and each run is about 0.3 s. #39649 tried 3 links at once on the x64-asan lane: the file got slower there (170 s against 107 s), because the link is three passes over the binary and the lane is bound by writeback. One slot under `describe.concurrent` behaves like today.

**The three runs of one executable do not overlap.** After the first launch a run takes 5 ms on Linux and 16 ms on Windows, so there is nothing to gain on release builds. On debug builds it would save about 0.6 s per case, and it needs a change to the run loop in `expectBundled.ts`, which every bundler test file shares.

**`bunArgs`.** `expectBundled` builds the command as `[...bunArgs, file, ...args]` for a compiled executable, so the launcher needs no change to the helper. `cmd.exe /d /c <path>` passes stdio and the exit code through. It works for paths with spaces and `+` (probed). It does not work for a temp directory whose path contains `&`, `(`, `)`, `^` or `%VAR%`.

**Loader counts.** With `BUN_JSC_dumpModuleLoadingState=1` JSC prints one `Loader [hook] key` line per host hook call. Linux x64 release, Linux x64 debug, Windows 11 arm64 and Windows Server 2019 x64 all print the same table: `resolve` 5 (bun:main twice, the entry, m24 twice) with the graph, 252 without it, `fetch` 3, `evaluate` 63, `import` 1, and no other line on stderr.

**The probe.** `hasPrelinkOptions` let an older bun fail only in the loader log check. That was for the fail-before run of #42002. A bun without the options now fails the second and third run of every case with `invalid JSC environment variable`, which is also a clear failure.

**Slots.** 45 concurrent tests with 3 slots, one test that throws and one that times out: 45 ran, at most 3 held a slot, no slot leaked. `afterEach` runs after a failed or timed out test. The per-test timeout starts when the test callback starts (`on_entry_started` in `src/runtime/test_runner/Execution.rs`), so the wait in `beforeEach` does not count against it. The reported duration of a test does include the wait.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_compile_prelinked.test.ts

<!-- robobun:evidence:end -->