### PR TITLE
util.inspect, Console#table: read Map and Set iterators from storage

### DIFF
--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -143,7 +143,9 @@ export function write(this: Console, input) {
 // TODO: probably could extract `getStringWidth`; probably make that a native function. note how it is copied from `readline.js`
 export function createConsoleConstructor(console: typeof globalThis.console) {
   const { inspect, formatWithOptions } = require("node:util");
-  const { isBuffer } = require("node:buffer");
+  const {
+    Buffer: { isBuffer },
+  } = require("node:buffer");
   const { isMapIterator, isSetIterator } = require("node:util/types");
 
   const { validateObject, validateInteger, validateArray, validateOneOf } = require("internal/validators");
@@ -162,6 +164,8 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
   const kCounts = Symbol("counts");
 
   const internalGetStringWidth = $newCppFunction("stringWidth.cpp", "jsFunctionBunStringWidth", 1);
+  // [entries, isKeyValue, length] for a Map or Set iterator, without running or advancing it.
+  const previewEntries = $newCppFunction("UtilInspect.cpp", "jsFunctionPreviewEntries", 2);
 
   /**
    * Returns the number of columns required to display the given string.
@@ -666,6 +670,11 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
       const mapIter = isMapIterator(tabularData);
       let isKeyValue = false;
       let i = 0;
+      if (mapIter) {
+        const res = previewEntries(tabularData);
+        tabularData = res[0];
+        isKeyValue = res[1];
+      }
 
       if (isKeyValue || $isMap(tabularData)) {
         const keys = [];
@@ -678,7 +687,10 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
             length++;
           }
         } else {
+          // User code can replace the iterator, so it gets `size` steps, like formatMap() in util.inspect.
+          const size = tabularData.size;
           for (const { 0: k, 1: v } of tabularData) {
+            if (length >= size) break;
             ArrayPrototypePush.$call(keys, _inspect(k));
             ArrayPrototypePush.$call(values, _inspect(v));
             length++;
@@ -688,13 +700,16 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
       }
 
       const setIter = isSetIterator(tabularData);
-      // if (setIter) tabularData = previewEntries(tabularData);
+      if (setIter) tabularData = previewEntries(tabularData)[0];
 
       const setlike = setIter || mapIter || $isSet(tabularData);
       if (setlike) {
         const values = [];
         let length = 0;
-        for (const v of tabularData as Set<any>) {
+        // An iterator is an array of its entries by now. A Set is bounded like the Map above.
+        const size = setIter || mapIter ? tabularData.length : tabularData.size;
+        for (const v of tabularData) {
+          if (length >= size) break;
           ArrayPrototypePush.$call(values, _inspect(v));
           length++;
         }

--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -687,10 +687,7 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
             length++;
           }
         } else {
-          // User code can replace the iterator, so it gets `size` steps, like formatMap() in util.inspect.
-          const size = tabularData.size;
           for (const { 0: k, 1: v } of tabularData) {
-            if (length >= size) break;
             ArrayPrototypePush.$call(keys, _inspect(k));
             ArrayPrototypePush.$call(values, _inspect(v));
             length++;
@@ -706,10 +703,7 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
       if (setlike) {
         const values = [];
         let length = 0;
-        // An iterator is an array of its entries by now. A Set is bounded like the Map above.
-        const size = setIter || mapIter ? tabularData.length : tabularData.size;
-        for (const v of tabularData) {
-          if (length >= size) break;
+        for (const v of tabularData as Set<any>) {
           ArrayPrototypePush.$call(values, _inspect(v));
           length++;
         }

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -43,9 +43,7 @@ const {
   TypedArrayPrototypeGetSymbolToStringTag,
 } = primordials;
 
-const ArrayFrom = Array.from;
 const ArrayPrototypeFilter = uncurryThis(Array.prototype.filter);
-const ArrayPrototypeFlat = uncurryThis(Array.prototype.flat);
 const ArrayPrototypeForEach = uncurryThis(Array.prototype.forEach);
 const ArrayPrototypeIncludes = uncurryThis(Array.prototype.includes);
 const ArrayPrototypeIndexOf = uncurryThis(Array.prototype.indexOf);
@@ -67,8 +65,6 @@ const FunctionPrototypeBind = uncurryThis(Function.prototype.bind);
 const FunctionPrototypeToString = uncurryThis(Function.prototype.toString);
 const JSONStringify = JSON.stringify;
 const MapPrototypeEntries = uncurryThis(Map.prototype.entries);
-const MapPrototypeValues = uncurryThis(Map.prototype.values);
-const MapPrototypeKeys = uncurryThis(Map.prototype.keys);
 const MathFloor = Math.floor;
 const MathMax = Math.max;
 const MathRound = Math.round;
@@ -98,7 +94,6 @@ const RegExpPrototypeExec = uncurryThis(RegExp.prototype.exec);
 const RegExpPrototypeSymbolReplace = uncurryThis(RegExp.prototype[Symbol.replace]);
 const RegExpPrototypeSymbolSplit = uncurryThis(RegExp.prototype[Symbol.split]);
 const RegExpPrototypeToString = uncurryThis(RegExp.prototype.toString);
-const SetPrototypeEntries = uncurryThis(Set.prototype.entries);
 const SetPrototypeValues = uncurryThis(Set.prototype.values);
 const StringPrototypeCharCodeAt = uncurryThis(String.prototype.charCodeAt);
 const StringPrototypeIncludes = uncurryThis(String.prototype.includes);
@@ -2256,9 +2251,10 @@ function formatMap(value, ctx, ignored, recurseTimes) {
   return output;
 }
 
-function formatSetIterInner(ctx, recurseTimes, entries, state) {
+// `length` counts every entry there is. `entries` can stop at maxArrayLength of them.
+function formatSetIterInner(ctx, recurseTimes, entries, state, length = entries.length) {
   const maxArrayLength = MathMax(ctx.maxArrayLength, 0);
-  const maxLength = $min(maxArrayLength, entries.length);
+  const maxLength = $min(maxArrayLength, length);
   const output = new Array(maxLength);
   ctx.indentationLvl += 2;
   for (let i = 0; i < maxLength; i++) {
@@ -2271,17 +2267,16 @@ function formatSetIterInner(ctx, recurseTimes, entries, state) {
     // output is not sorted anyway.
     ArrayPrototypeSort(output);
   }
-  const remaining = entries.length - maxLength;
+  const remaining = length - maxLength;
   if (remaining > 0) {
     ArrayPrototypePush.$call(output, remainingText(remaining));
   }
   return output;
 }
 
-function formatMapIterInner(ctx, recurseTimes, entries, state) {
+// Entries exist as [key1, val1, key2, val2, ...]. `len` counts every pair there is.
+function formatMapIterInner(ctx, recurseTimes, entries, state, len = entries.length / 2) {
   const maxArrayLength = MathMax(ctx.maxArrayLength, 0);
-  // Entries exist as [key1, val1, key2, val2, ...]
-  const len = entries.length / 2;
   const remaining = len - maxArrayLength;
   const maxLength = $min(maxArrayLength, len);
   const output = new Array(maxLength);
@@ -2329,15 +2324,15 @@ function formatWeakMap(ctx, value, recurseTimes) {
 }
 
 function formatIterator(braces, ctx, value, recurseTimes) {
-  const { 0: entries, 1: isKeyValue } = previewEntries(value, true);
+  const { 0: entries, 1: isKeyValue, 2: length } = previewEntries(value, true, MathMax(ctx.maxArrayLength, 0));
   if (isKeyValue) {
     // TODO(bun): JSC can also differ between the keys and values iterator, maybe we should also distinguish those in the future?
     // Mark entry iterators as such.
     braces[0] = RegExpPrototypeSymbolReplace(/ Iterator] {$/, braces[0], " Entries] {");
-    return formatMapIterInner(ctx, recurseTimes, entries, kMapEntries);
+    return formatMapIterInner(ctx, recurseTimes, entries, kMapEntries, length);
   }
 
-  return formatSetIterInner(ctx, recurseTimes, entries, kIterator);
+  return formatSetIterInner(ctx, recurseTimes, entries, kIterator, length);
 }
 
 function formatPromise(ctx, value, recurseTimes) {
@@ -2783,28 +2778,11 @@ function getProxyDetails(proxy, withHandler = true) {
   if (withHandler) return [target, handler];
   else return target;
 }
-function previewEntries(val, isIterator = false) {
-  if (isIterator) {
-    // the Map or Set instance this iterator belongs to
-    const iteratedObject = $getInternalField(val, 1 /*iteratorFieldIteratedObject*/);
-    // for Maps: 0 = keys, 1 = values,      2 = entries
-    // for Sets:           1 = keys|values, 2 = entries
-    const kind = $getInternalField(val, 3 /*iteratorFieldKind*/);
-    const isEntries = kind === 2;
-    // TODO(bun): improve performance by not using Array.from and instead using the iterator directly to only get the first
-    // few entries which will actually be displayed (this requires changing some logic in the call sites of this function)
-    if ($isMap(iteratedObject)) {
-      if (isEntries) return [ArrayPrototypeFlat(ArrayFrom(iteratedObject)), true];
-      else if (kind === 1) return [ArrayFrom(MapPrototypeValues(iteratedObject)), false];
-      else return [ArrayFrom(MapPrototypeKeys(iteratedObject)), false];
-    } else if ($isSet(iteratedObject)) {
-      if (isEntries) return [ArrayPrototypeFlat(ArrayFrom(SetPrototypeEntries(iteratedObject))), true];
-      else return [ArrayFrom(iteratedObject), false];
-    }
-    // TODO(bun): This function is currently only called for Map and Set iterators
-    // perhaps we should add support for other iterators in the future? (e.g. ArrayIterator and StringIterator)
-    else throw new Error("previewEntries(): Invalid iterator received");
-  }
+// For a Map or Set iterator: [entries, isKeyValue, length]. `entries` is flat and holds the first
+// `limit` (default: all) of the `length` entries the iterator has left. See UtilInspect.cpp.
+const previewIteratorEntries = $newCppFunction("UtilInspect.cpp", "jsFunctionPreviewEntries", 2);
+function previewEntries(val, isIterator = false, limit) {
+  if (isIterator) return previewIteratorEntries(val, limit);
   // TODO(bun): are there any JSC APIs for viewing the contents of these in JS?
   if (isWeakMap(val)) return [];
   if (isWeakSet(val)) return [];

--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -2778,8 +2778,7 @@ function getProxyDetails(proxy, withHandler = true) {
   if (withHandler) return [target, handler];
   else return target;
 }
-// For a Map or Set iterator: [entries, isKeyValue, length]. `entries` is flat and holds the first
-// `limit` (default: all) of the `length` entries the iterator has left. See UtilInspect.cpp.
+// (iterator, limit) => [flat entries (at most `limit`), isKeyValue, entries left]
 const previewIteratorEntries = $newCppFunction("UtilInspect.cpp", "jsFunctionPreviewEntries", 2);
 function previewEntries(val, isIterator = false, limit) {
   if (isIterator) return previewIteratorEntries(val, limit);

--- a/src/jsc/bindings/UtilInspect.cpp
+++ b/src/jsc/bindings/UtilInspect.cpp
@@ -10,6 +10,8 @@
 #include "JavaScriptCore/PropertyNameArray.h"
 #include "JavaScriptCore/JSArray.h"
 #include "JavaScriptCore/IdentifierInlines.h"
+#include "JavaScriptCore/JSMapIterator.h"
+#include "JavaScriptCore/JSSetIterator.h"
 
 namespace Bun {
 
@@ -116,6 +118,92 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionGetOwnNonIndexProperties, (JSGlobalObject * g
         return {};
     }
     RELEASE_AND_RETURN(scope, JSValue::encode(constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), keys)));
+}
+
+// Walks what a Map or Set iterator has left to yield, in the storage of the collection, the way
+// the iterator's own next() does but without moving the iterator. Copies out at most `limit`
+// entries and returns how many are left in total.
+template<typename Collection, typename Iterator>
+static uint32_t previewRemainingEntries(VM& vm, Iterator* iterator, uint32_t limit, MarkedArgumentBuffer& entries)
+{
+    using Helper = typename Collection::Helper;
+
+    JSCell* storageCell = iterator->tryGetStorage();
+    // An iterator made while the collection had no storage yet picks it up on its first next().
+    if (!storageCell)
+        storageCell = iterator->iteratedObject()->storage();
+    if (!storageCell || storageCell == vm.orderedHashTableSentinel())
+        return 0;
+
+    IterationKind kind = iterator->kind();
+    auto* storage = uncheckedDowncast<typename Collection::Storage>(storageCell);
+    typename Helper::Entry entry = iterator->entry();
+    uint32_t remaining = 0;
+    while (true) {
+        // Follows the tables a rehash or a clear() left behind, then skips deleted entries.
+        auto next = Helper::transitAndNext(vm, *storage, entry);
+        if (!next.storage)
+            break;
+        storage = next.storage;
+        entry = next.entry + 1;
+        if (remaining++ >= limit)
+            continue;
+        // A Set stores keys only. Its entries() pairs each key with itself.
+        JSValue value = std::is_same_v<Collection, JSSet> ? next.key : next.value;
+        if (kind != IterationKind::Values)
+            entries.append(next.key);
+        if (kind != IterationKind::Keys)
+            entries.append(value);
+    }
+    return remaining;
+}
+
+// Port of V8's `internalBinding('util').previewEntries(iterator, true)`, which util.inspect and
+// console.Console#table use to show a Map or Set iterator. No user code runs: a replaced
+// %MapIteratorPrototype%.next or Map.prototype[Symbol.iterator] is never called.
+// Returns [entries, isKeyValue, length]. `entries` is flat ([key, value, key, value, ...] when
+// isKeyValue) and holds the first `limit` (default: all) of the `length` entries that are left.
+JSC_DEFINE_HOST_FUNCTION(jsFunctionPreviewEntries, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue iteratorValue = callFrame->argument(0);
+    JSValue limitValue = callFrame->argument(1);
+    uint32_t limit = std::numeric_limits<uint32_t>::max();
+    if (limitValue.isNumber()) {
+        double number = limitValue.asNumber();
+        // NaN is not > 0.
+        if (!(number > 0))
+            limit = 0;
+        else if (number < limit)
+            limit = static_cast<uint32_t>(number);
+    }
+
+    MarkedArgumentBuffer entries;
+    uint32_t length = 0;
+    bool isKeyValue = false;
+    if (auto* mapIterator = dynamicDowncast<JSMapIterator>(iteratorValue)) {
+        isKeyValue = mapIterator->kind() == IterationKind::Entries;
+        length = previewRemainingEntries<JSMap>(vm, mapIterator, limit, entries);
+    } else if (auto* setIterator = dynamicDowncast<JSSetIterator>(iteratorValue)) {
+        isKeyValue = setIterator->kind() == IterationKind::Entries;
+        length = previewRemainingEntries<JSSet>(vm, setIterator, limit, entries);
+    } else
+        return throwVMTypeError(globalObject, scope, "previewEntries() expects a Map or Set iterator"_s);
+
+    if (entries.hasOverflowed()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return {};
+    }
+    JSArray* entriesArray = constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), entries);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    MarkedArgumentBuffer result;
+    result.append(entriesArray);
+    result.append(jsBoolean(isKeyValue));
+    result.append(jsNumber(length));
+    RELEASE_AND_RETURN(scope, JSValue::encode(constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), result)));
 }
 
 }

--- a/src/jsc/bindings/UtilInspect.cpp
+++ b/src/jsc/bindings/UtilInspect.cpp
@@ -120,9 +120,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionGetOwnNonIndexProperties, (JSGlobalObject * g
     RELEASE_AND_RETURN(scope, JSValue::encode(constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), keys)));
 }
 
-// Walks what a Map or Set iterator has left to yield, in the storage of the collection, the way
-// the iterator's own next() does but without moving the iterator. Copies out at most `limit`
-// entries and returns how many are left in total.
+// JSMapIterator::nextWithAdvance in a loop, minus its writes to the iterator. Returns how many entries are left.
 template<typename Collection, typename Iterator>
 static uint32_t previewRemainingEntries(VM& vm, Iterator* iterator, uint32_t limit, MarkedArgumentBuffer& entries)
 {
@@ -158,11 +156,7 @@ static uint32_t previewRemainingEntries(VM& vm, Iterator* iterator, uint32_t lim
     return remaining;
 }
 
-// Port of V8's `internalBinding('util').previewEntries(iterator, true)`, which util.inspect and
-// console.Console#table use to show a Map or Set iterator. No user code runs: a replaced
-// %MapIteratorPrototype%.next or Map.prototype[Symbol.iterator] is never called.
-// Returns [entries, isKeyValue, length]. `entries` is flat ([key, value, key, value, ...] when
-// isKeyValue) and holds the first `limit` (default: all) of the `length` entries that are left.
+// internalBinding('util').previewEntries(iterator, true) plus a limit: [flat entries (at most `limit`), isKeyValue, entries left].
 JSC_DEFINE_HOST_FUNCTION(jsFunctionPreviewEntries, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/UtilInspect.h
+++ b/src/jsc/bindings/UtilInspect.h
@@ -9,4 +9,7 @@ JSC::Structure* createUtilInspectOptionsStructure(JSC::VM& vm, JSC::JSGlobalObje
 // internalBinding('util').getOwnNonIndexProperties(object, filter)
 JSC_DECLARE_HOST_FUNCTION(jsFunctionGetOwnNonIndexProperties);
 
+// internalBinding('util').previewEntries(iterator, true), with a limit on how many entries it copies out
+JSC_DECLARE_HOST_FUNCTION(jsFunctionPreviewEntries);
+
 }

--- a/test/js/node/console/console-table-iterators.test.ts
+++ b/test/js/node/console/console-table-iterators.test.ts
@@ -22,7 +22,7 @@ async function run(script: string) {
 // A broken Console builtin aborts the whole process the moment `node:console`
 // is loaded, so this has to be a spawned fixture: an in-process test in
 // console.test.ts would take the test runner down with it.
-test("console.Console#table renders Map and Set iterators", async () => {
+test.concurrent("console.Console#table renders Map and Set iterators", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     c.table(new Map([["a", 1], ["b", 2]]).entries());
     c.table(new Set([7, 8]).values());
@@ -46,7 +46,7 @@ test("console.Console#table renders Map and Set iterators", async () => {
 });
 
 // Like Node.js: the rows are what the iterator has left, and the iterator does not move.
-test("console.Console#table shows what a Map or Set iterator has left and does not advance it", async () => {
+test.concurrent("console.Console#table shows what a Map or Set iterator has left and does not advance it", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     const entries = new Map([["a", 1], ["b", 2], ["c", 3]]).entries();
     entries.next();
@@ -94,7 +94,7 @@ test("console.Console#table shows what a Map or Set iterator has left and does n
 
 // Every key and value of an iterator is a cell of its own, so an object that is
 // not an array reaches the isBuffer() check of the cell formatter.
-test("console.Console#table formats object keys and values of a Map or Set iterator", async () => {
+test.concurrent("console.Console#table formats object keys and values of a Map or Set iterator", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     c.table(new Map([["a", { x: 1 }], [{ k: 1 }, [1, 2]]]).entries());
     c.table(new Map([["a", { x: 1 }]]).values());
@@ -136,7 +136,7 @@ const guard = /* js */ `
   }
 `;
 
-test("console.Console#table does not run a replaced next() of a Map or Set iterator", async () => {
+test.concurrent("console.Console#table does not run a replaced next() of a Map or Set iterator", async () => {
   const { stdout, exitCode } = await run(
     guard +
       /* js */ `
@@ -171,7 +171,7 @@ test("console.Console#table does not run a replaced next() of a Map or Set itera
 // A Map or a Set itself is read through its own iterator, and every entry the
 // iterator yields is a row, as in Node.js. `size` does not bound it: quick-lru
 // caps `size` at maxSize, and its iterator also yields the older generation.
-test("console.Console#table prints every entry that a Map subclass yields, also past its size", async () => {
+test.concurrent("console.Console#table prints every entry that a Map subclass yields, also past its size", async () => {
   const { stdout, exitCode } = await run(/* js */ `
     class TwoGenerations extends Map {
       #recent = [["d", 4], ["e", 5]];

--- a/test/js/node/console/console-table-iterators.test.ts
+++ b/test/js/node/console/console-table-iterators.test.ts
@@ -168,87 +168,33 @@ test("console.Console#table does not run a replaced next() of a Map or Set itera
   expect(exitCode).toBe(0);
 });
 
-// A Map or a Set is read through its iterator, so that a subclass can keep its
-// entries anywhere. The iterator gets as many steps as the collection has entries.
-test("console.Console#table stops a replaced Symbol.iterator of a Map or Set at its size", async () => {
-  const { stdout, exitCode } = await run(
-    guard +
-      /* js */ `
-    Map.prototype[Symbol.iterator] = function* () {
-      for (;;) {
-        guard();
-        yield ["k", "v"];
-      }
-    };
-    Set.prototype[Symbol.iterator] = function* () {
-      for (;;) {
-        guard();
-        yield "v";
-      }
-    };
-    c.table(new Map([["a", 1], ["b", 2]]));
-    c.table(new Set([7, 8]));
-    c.table(new Map());
-  `,
-  );
-  expect(stdout).toMatchInlineSnapshot(`
-    "┌───────────────────┬─────┬────────┐
-    │ (iteration index) │ Key │ Values │
-    ├───────────────────┼─────┼────────┤
-    │         0         │ 'k' │  'v'   │
-    │         1         │ 'k' │  'v'   │
-    └───────────────────┴─────┴────────┘
-    ┌───────────────────┬────────┐
-    │ (iteration index) │ Values │
-    ├───────────────────┼────────┤
-    │         0         │  'v'   │
-    │         1         │  'v'   │
-    └───────────────────┴────────┘
-    ┌───────────────────┬─────┬────────┐
-    │ (iteration index) │ Key │ Values │
-    ├───────────────────┼─────┼────────┤
-    └───────────────────┴─────┴────────┘
-    "
-  `);
-  expect(exitCode).toBe(0);
-});
-
-// This is why a Map is not read from its storage: a subclass like quick-lru
-// never calls super.set(), so the inherited storage is empty. A size that is
-// not a number (here a method that shadows the getter) sets no bound.
-test("console.Console#table reads a Map subclass through its own iterator", async () => {
+// A Map or a Set itself is read through its own iterator, and every entry the
+// iterator yields is a row, as in Node.js. `size` does not bound it: quick-lru
+// caps `size` at maxSize, and its iterator also yields the older generation.
+test("console.Console#table prints every entry that a Map subclass yields, also past its size", async () => {
   const { stdout, exitCode } = await run(/* js */ `
-    class Lru extends Map {
-      #rows = [["x", 1], ["y", 2], ["z", 3]];
+    class TwoGenerations extends Map {
+      #recent = [["d", 4], ["e", 5]];
+      #old = [["a", 1], ["b", 2], ["c", 3]];
       get size() {
-        return this.#rows.length;
+        return 3;
       }
       *[Symbol.iterator]() {
-        yield* this.#rows;
+        yield* this.#recent;
+        yield* this.#old;
       }
     }
-    c.table(new Lru());
-
-    class JavaStyle extends Map {
-      size() {
-        return 1;
-      }
-    }
-    c.table(new JavaStyle([["a", 1], ["b", 2]]));
+    c.table(new TwoGenerations());
   `);
   expect(stdout).toMatchInlineSnapshot(`
     "┌───────────────────┬─────┬────────┐
     │ (iteration index) │ Key │ Values │
     ├───────────────────┼─────┼────────┤
-    │         0         │ 'x' │   1    │
-    │         1         │ 'y' │   2    │
-    │         2         │ 'z' │   3    │
-    └───────────────────┴─────┴────────┘
-    ┌───────────────────┬─────┬────────┐
-    │ (iteration index) │ Key │ Values │
-    ├───────────────────┼─────┼────────┤
-    │         0         │ 'a' │   1    │
-    │         1         │ 'b' │   2    │
+    │         0         │ 'd' │   4    │
+    │         1         │ 'e' │   5    │
+    │         2         │ 'a' │   1    │
+    │         3         │ 'b' │   2    │
+    │         4         │ 'c' │   3    │
     └───────────────────┴─────┴────────┘
     "
   `);

--- a/test/js/node/console/console-table-iterators.test.ts
+++ b/test/js/node/console/console-table-iterators.test.ts
@@ -1,41 +1,255 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
+const prelude = /* js */ `
+  const { Console } = require("node:console");
+  const c = new Console({ stdout: process.stdout, stderr: process.stderr, colorMode: false });
+`;
+
+async function run(script: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", prelude + script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) {
+    expect(stderr).toBe("");
+  }
+  return { stdout, exitCode };
+}
+
 // A broken Console builtin aborts the whole process the moment `node:console`
 // is loaded, so this has to be a spawned fixture: an in-process test in
 // console.test.ts would take the test runner down with it.
 test("console.Console#table renders Map and Set iterators", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `const { Console } = require("node:console");
-       const c = new Console({ stdout: process.stdout, stderr: process.stderr, colorMode: false });
-       c.table(new Map([["a", 1], ["b", 2]]).entries());
-       c.table(new Set([7, 8]).values());`,
-    ],
-    env: bunEnv,
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  if (exitCode !== 0) {
-    expect(stderr).toBe("");
-  }
+  const { stdout, exitCode } = await run(/* js */ `
+    c.table(new Map([["a", 1], ["b", 2]]).entries());
+    c.table(new Set([7, 8]).values());
+  `);
   expect(stdout).toMatchInlineSnapshot(`
-    "┌───────────────────┬────────────┐
-    │ (iteration index) │   Values   │
-    ├───────────────────┼────────────┤
-    │         0         │ [ 'a', 1 ] │
-    │         1         │ [ 'b', 2 ] │
-    └───────────────────┴────────────┘
+    "┌───────────────────┬─────┬────────┐
+    │ (iteration index) │ Key │ Values │
+    ├───────────────────┼─────┼────────┤
+    │         0         │ 'a' │   1    │
+    │         1         │ 'b' │   2    │
+    └───────────────────┴─────┴────────┘
     ┌───────────────────┬────────┐
     │ (iteration index) │ Values │
     ├───────────────────┼────────┤
     │         0         │   7    │
     │         1         │   8    │
     └───────────────────┴────────┘
+    "
+  `);
+  expect(exitCode).toBe(0);
+});
+
+// Like Node.js: the rows are what the iterator has left, and the iterator does not move.
+test("console.Console#table shows what a Map or Set iterator has left and does not advance it", async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    const entries = new Map([["a", 1], ["b", 2], ["c", 3]]).entries();
+    entries.next();
+    c.table(entries);
+    console.log(JSON.stringify(entries.next()));
+
+    const values = new Set([7, 8, 9]).values();
+    values.next();
+    c.table(values);
+    console.log(JSON.stringify(values.next()));
+
+    c.table(new Map([["a", 1]]).keys());
+    c.table(new Set([7]).entries());
+  `);
+  expect(stdout).toMatchInlineSnapshot(`
+    "┌───────────────────┬─────┬────────┐
+    │ (iteration index) │ Key │ Values │
+    ├───────────────────┼─────┼────────┤
+    │         0         │ 'b' │   2    │
+    │         1         │ 'c' │   3    │
+    └───────────────────┴─────┴────────┘
+    {"value":["b",2],"done":false}
+    ┌───────────────────┬────────┐
+    │ (iteration index) │ Values │
+    ├───────────────────┼────────┤
+    │         0         │   8    │
+    │         1         │   9    │
+    └───────────────────┴────────┘
+    {"value":8,"done":false}
+    ┌───────────────────┬────────┐
+    │ (iteration index) │ Values │
+    ├───────────────────┼────────┤
+    │         0         │  'a'   │
+    └───────────────────┴────────┘
+    ┌───────────────────┬────────┐
+    │ (iteration index) │ Values │
+    ├───────────────────┼────────┤
+    │         0         │   7    │
+    │         1         │   7    │
+    └───────────────────┴────────┘
+    "
+  `);
+  expect(exitCode).toBe(0);
+});
+
+// Every key and value of an iterator is a cell of its own, so an object that is
+// not an array reaches the isBuffer() check of the cell formatter.
+test("console.Console#table formats object keys and values of a Map or Set iterator", async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    c.table(new Map([["a", { x: 1 }], [{ k: 1 }, [1, 2]]]).entries());
+    c.table(new Map([["a", { x: 1 }]]).values());
+    c.table(new Set([{ x: 1 }]).entries());
+  `);
+  expect(stdout).toMatchInlineSnapshot(`
+    "┌───────────────────┬──────────┬──────────┐
+    │ (iteration index) │   Key    │  Values  │
+    ├───────────────────┼──────────┼──────────┤
+    │         0         │   'a'    │ { x: 1 } │
+    │         1         │ { k: 1 } │ [ 1, 2 ] │
+    └───────────────────┴──────────┴──────────┘
+    ┌───────────────────┬──────────┐
+    │ (iteration index) │  Values  │
+    ├───────────────────┼──────────┤
+    │         0         │ { x: 1 } │
+    └───────────────────┴──────────┘
+    ┌───────────────────┬──────────┐
+    │ (iteration index) │  Values  │
+    ├───────────────────┼──────────┤
+    │         0         │ { x: 1 } │
+    │         1         │ { x: 1 } │
+    └───────────────────┴──────────┘
+    "
+  `);
+  expect(exitCode).toBe(0);
+});
+
+// The replaced functions never report done. On a build that lets them run
+// without a bound, the guard ends the child process and the output shows how
+// far it got.
+const guard = /* js */ `
+  let calls = 0;
+  function guard() {
+    if (++calls > 5000) {
+      console.log("RUNAWAY calls=" + calls);
+      process.exit(2);
+    }
+  }
+`;
+
+test("console.Console#table does not run a replaced next() of a Map or Set iterator", async () => {
+  const { stdout, exitCode } = await run(
+    guard +
+      /* js */ `
+    const entries = new Map([["a", 1], ["b", 2]]).entries();
+    const values = new Set([7, 8]).values();
+    Object.getPrototypeOf(entries).next = () => (guard(), { value: ["k", "v"], done: false });
+    Object.getPrototypeOf(values).next = () => (guard(), { value: "v", done: false });
+    c.table(entries);
+    c.table(values);
+    console.log("calls=" + calls);
+  `,
+  );
+  expect(stdout).toMatchInlineSnapshot(`
+    "┌───────────────────┬─────┬────────┐
+    │ (iteration index) │ Key │ Values │
+    ├───────────────────┼─────┼────────┤
+    │         0         │ 'a' │   1    │
+    │         1         │ 'b' │   2    │
+    └───────────────────┴─────┴────────┘
+    ┌───────────────────┬────────┐
+    │ (iteration index) │ Values │
+    ├───────────────────┼────────┤
+    │         0         │   7    │
+    │         1         │   8    │
+    └───────────────────┴────────┘
+    calls=0
+    "
+  `);
+  expect(exitCode).toBe(0);
+});
+
+// A Map or a Set is read through its iterator, so that a subclass can keep its
+// entries anywhere. The iterator gets as many steps as the collection has entries.
+test("console.Console#table stops a replaced Symbol.iterator of a Map or Set at its size", async () => {
+  const { stdout, exitCode } = await run(
+    guard +
+      /* js */ `
+    Map.prototype[Symbol.iterator] = function* () {
+      for (;;) {
+        guard();
+        yield ["k", "v"];
+      }
+    };
+    Set.prototype[Symbol.iterator] = function* () {
+      for (;;) {
+        guard();
+        yield "v";
+      }
+    };
+    c.table(new Map([["a", 1], ["b", 2]]));
+    c.table(new Set([7, 8]));
+    c.table(new Map());
+  `,
+  );
+  expect(stdout).toMatchInlineSnapshot(`
+    "┌───────────────────┬─────┬────────┐
+    │ (iteration index) │ Key │ Values │
+    ├───────────────────┼─────┼────────┤
+    │         0         │ 'k' │  'v'   │
+    │         1         │ 'k' │  'v'   │
+    └───────────────────┴─────┴────────┘
+    ┌───────────────────┬────────┐
+    │ (iteration index) │ Values │
+    ├───────────────────┼────────┤
+    │         0         │  'v'   │
+    │         1         │  'v'   │
+    └───────────────────┴────────┘
+    ┌───────────────────┬─────┬────────┐
+    │ (iteration index) │ Key │ Values │
+    ├───────────────────┼─────┼────────┤
+    └───────────────────┴─────┴────────┘
+    "
+  `);
+  expect(exitCode).toBe(0);
+});
+
+// This is why a Map is not read from its storage: a subclass like quick-lru
+// never calls super.set(), so the inherited storage is empty. A size that is
+// not a number (here a method that shadows the getter) sets no bound.
+test("console.Console#table reads a Map subclass through its own iterator", async () => {
+  const { stdout, exitCode } = await run(/* js */ `
+    class Lru extends Map {
+      #rows = [["x", 1], ["y", 2], ["z", 3]];
+      get size() {
+        return this.#rows.length;
+      }
+      *[Symbol.iterator]() {
+        yield* this.#rows;
+      }
+    }
+    c.table(new Lru());
+
+    class JavaStyle extends Map {
+      size() {
+        return 1;
+      }
+    }
+    c.table(new JavaStyle([["a", 1], ["b", 2]]));
+  `);
+  expect(stdout).toMatchInlineSnapshot(`
+    "┌───────────────────┬─────┬────────┐
+    │ (iteration index) │ Key │ Values │
+    ├───────────────────┼─────┼────────┤
+    │         0         │ 'x' │   1    │
+    │         1         │ 'y' │   2    │
+    │         2         │ 'z' │   3    │
+    └───────────────────┴─────┴────────┘
+    ┌───────────────────┬─────┬────────┐
+    │ (iteration index) │ Key │ Values │
+    ├───────────────────┼─────┼────────┤
+    │         0         │ 'a' │   1    │
+    │         1         │ 'b' │   2    │
+    └───────────────────┴─────┴────────┘
     "
   `);
   expect(exitCode).toBe(0);

--- a/test/js/node/util/node-inspect-tests/internal-inspect.test.js
+++ b/test/js/node/util/node-inspect-tests/internal-inspect.test.js
@@ -1,7 +1,8 @@
 import assert from "assert";
 import { expect, test } from "bun:test";
-import { withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, withoutAggressiveGC } from "harness";
 import util from "util";
+import vm from "vm";
 
 test("no assertion failures", () => {
   // Errors in accessors are not triggered
@@ -155,6 +156,193 @@ test.each([
     // scaled with the length: about 1s for the large one in a release build.
     expect(largeMs).toBeLessThan(smallMs * 20 + 50);
   });
+});
+
+// Map and Set iterators are shown through the native previewEntries
+// (UtilInspect.cpp). It reads what the iterator has left from the storage of
+// the collection and never calls next(). So the iterator stays where it is, and
+// user code that replaces next() or Symbol.iterator does not run. The expected
+// strings are what Node.js prints.
+test("util.inspect shows what a Map or Set iterator has left", () => {
+  const map = new Map([
+    ["a", 1],
+    ["b", 2],
+    ["c", 3],
+  ]);
+  const set = new Set([1, 2, 3]);
+
+  const entries = map.entries();
+  entries.next();
+  expect(util.inspect(entries)).toBe("[Map Entries] { [ 'b', 2 ], [ 'c', 3 ] }");
+  expect(util.inspect(entries)).toBe("[Map Entries] { [ 'b', 2 ], [ 'c', 3 ] }");
+  expect(entries.next()).toEqual({ value: ["b", 2], done: false });
+
+  const keys = map.keys();
+  keys.next();
+  keys.next();
+  expect(util.inspect(keys)).toBe("[Map Iterator] { 'c' }");
+
+  const values = map.values();
+  values.next();
+  expect(util.inspect(values)).toBe("[Map Iterator] { 2, 3 }");
+
+  const setValues = set.values();
+  setValues.next();
+  expect(util.inspect(setValues)).toBe("[Set Iterator] { 2, 3 }");
+
+  const setEntries = set.entries();
+  setEntries.next();
+  expect(util.inspect(setEntries)).toBe("[Set Entries] { [ 2, 2 ], [ 3, 3 ] }");
+
+  // An iterator that reported done stays empty, also when the collection grows.
+  for (const _ of entries);
+  for (const _ of setValues);
+  map.set("d", 4);
+  set.add(4);
+  expect(util.inspect(entries)).toBe("[Map Entries] {  }");
+  expect(util.inspect(setValues)).toBe("[Set Iterator] {  }");
+
+  expect(util.inspect(new Map().entries())).toBe("[Map Entries] {  }");
+  expect(util.inspect(new Set().values())).toBe("[Set Iterator] {  }");
+
+  const fromOtherRealm = vm.runInNewContext("const i = new Map([[1, 2], [3, 4]]).entries(); i.next(); i");
+  expect(util.inspect(fromOtherRealm)).toBe("[Map Entries] { [ 3, 4 ] }");
+});
+
+test("util.inspect of a Map or Set iterator follows delete(), clear() and growth of the collection", () => {
+  const map = new Map([
+    ["a", 1],
+    ["b", 2],
+    ["c", 3],
+    ["d", 4],
+  ]);
+  let iterator = map.entries();
+  iterator.next();
+  map.delete("b");
+  map.set("e", 5);
+  expect(util.inspect(iterator)).toBe("[Map Entries] { [ 'c', 3 ], [ 'd', 4 ], [ 'e', 5 ] }");
+
+  const cleared = new Map([
+    ["a", 1],
+    ["b", 2],
+  ]);
+  iterator = cleared.entries();
+  iterator.next();
+  cleared.clear();
+  cleared.set("z", 26);
+  expect(util.inspect(iterator)).toBe("[Map Entries] { [ 'z', 26 ] }");
+
+  // This iterator exists before the Map has any storage to point at.
+  const late = new Map();
+  iterator = late.entries();
+  late.set("x", 1);
+  expect(util.inspect(iterator)).toBe("[Map Entries] { [ 'x', 1 ] }");
+
+  // Growth and deletes rehash the storage. The iterator still points at the first table.
+  const grown = new Map([
+    [0, 0],
+    [1, 1],
+  ]);
+  iterator = grown.keys();
+  iterator.next();
+  for (let i = 2; i < 40; i++) grown.set(i, i);
+  for (let i = 2; i < 36; i++) grown.delete(i);
+  expect(util.inspect(iterator)).toBe("[Map Iterator] { 1, 36, 37, 38, 39 }");
+  expect([...iterator]).toEqual([1, 36, 37, 38, 39]);
+
+  const set = new Set([1, 2, 3, 4, 5, 6]);
+  iterator = set.values();
+  iterator.next();
+  iterator.next();
+  set.delete(1);
+  set.delete(4);
+  set.add(7);
+  expect(util.inspect(iterator)).toBe("[Set Iterator] { 3, 5, 6, 7 }");
+  expect([...iterator]).toEqual([3, 5, 6, 7]);
+});
+
+test("util.inspect of a Map or Set iterator counts the items it leaves out from where the iterator is", () => {
+  const map = new Map();
+  for (let i = 0; i < 150; i++) map.set(i, i);
+
+  let iterator = map.keys();
+  for (let i = 0; i < 20; i++) iterator.next();
+  expect(util.inspect(iterator, { maxArrayLength: 2 })).toBe("[Map Iterator] { 20, 21, ... 128 more items }");
+  expect(util.inspect(iterator, { breakLength: Infinity })).toEndWith(", 118, 119, ... 30 more items }");
+
+  iterator = map.entries();
+  for (let i = 0; i < 148; i++) iterator.next();
+  expect(util.inspect(iterator, { maxArrayLength: 1 })).toBe("[Map Entries] { [ 148, 148 ], ... 1 more item }");
+  expect(util.inspect(iterator, { maxArrayLength: 0 })).toBe("[Map Entries] { ... 2 more items }");
+  expect(util.inspect(iterator, { maxArrayLength: -1 })).toBe("[Map Entries] { ... 2 more items }");
+  for (const maxArrayLength of [2, 3, Infinity, null]) {
+    expect(util.inspect(iterator, { maxArrayLength })).toBe("[Map Entries] { [ 148, 148 ], [ 149, 149 ] }");
+  }
+
+  iterator = new Set(map.keys()).entries();
+  for (let i = 0; i < 147; i++) iterator.next();
+  expect(util.inspect(iterator, { maxArrayLength: 1 })).toBe("[Set Entries] { [ 147, 147 ], ... 2 more items }");
+});
+
+test("util.inspect of a Map or Set iterator does not run a replaced next() or Symbol.iterator", async () => {
+  // The replaced functions never report done. On a build that calls them, the
+  // guard ends the child process and the output shows how far it got.
+  const fixture = /* js */ `
+    const util = require("node:util");
+    let calls = 0;
+    function guard() {
+      if (++calls > 5000) {
+        console.log("RUNAWAY calls=" + calls);
+        process.exit(2);
+      }
+    }
+    function* endless() {
+      for (;;) {
+        guard();
+        yield ["k", "v"];
+      }
+    }
+    const map = new Map([["a", 1], ["b", 2]]);
+    const set = new Set([1, 2]);
+    const iterators = {
+      "map.entries()": map.entries(),
+      "map.keys()": map.keys(),
+      "map.values()": map.values(),
+      "map[Symbol.iterator]()": map[Symbol.iterator](),
+      "set.entries()": set.entries(),
+      "set.values()": set.values(),
+      "set[Symbol.iterator]()": set[Symbol.iterator](),
+    };
+    Object.getPrototypeOf(map.entries()).next = () => (guard(), { value: ["k", "v"], done: false });
+    Object.getPrototypeOf(set.values()).next = () => (guard(), { value: "v", done: false });
+    for (const method of ["entries", "keys", "values", Symbol.iterator]) {
+      Map.prototype[method] = endless;
+      Set.prototype[method] = endless;
+    }
+    for (const name in iterators) console.log(name, util.inspect(iterators[name]));
+    console.log("calls=" + calls);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) expect(stderr).toBe("");
+  expect(stdout).toBe(
+    [
+      "map.entries() [Map Entries] { [ 'a', 1 ], [ 'b', 2 ] }",
+      "map.keys() [Map Iterator] { 'a', 'b' }",
+      "map.values() [Map Iterator] { 1, 2 }",
+      "map[Symbol.iterator]() [Map Entries] { [ 'a', 1 ], [ 'b', 2 ] }",
+      "set.entries() [Set Entries] { [ 1, 1 ], [ 2, 2 ] }",
+      "set.values() [Set Iterator] { 1, 2 }",
+      "set[Symbol.iterator]() [Set Iterator] { 1, 2 }",
+      "calls=0",
+      "",
+    ].join("\n"),
+  );
+  expect(exitCode).toBe(0);
 });
 
 //! non-standard property, should this be kept?


### PR DESCRIPTION
### Problem
- On bun 1.4.2, `util.inspect` of an advanced Map or Set iterator also prints the entries it already yielded. `new Console(stream).table(map.entries())` prints pairs in one `Values` column and leaves the iterator done. Node.js prints what is left, in `Key` and `Values` columns, and does not move the iterator.
- Both never return when `%MapIteratorPrototype%.next` is replaced by a function that never reports `done`. No user reported this. A code read found it (#42264).
- The cause is `previewEntries` (`src/js/internal/util/inspect.js:2786`): it copies the collection with `Array.from`. `Console#table` (`src/js/builtins/ConsoleObject.ts:697`) ran a `for-of` over the iterator.

### Fix
- `previewEntries` is now native (`src/jsc/bindings/UtilInspect.cpp`). It reads what the iterator has left from the storage of the collection. It calls no user code, does not move the iterator, copies at most `maxArrayLength` entries and counts the rest.
- `Console#table` calls it for iterators, with Node's five lines. Each key and value is now a cell, so this PR carries the `isBuffer` import line of #33452. Without it an object cell throws.
- Scope: `util.inspect` and `new Console()`. The native formatter (`console.log`, `Bun.inspect`) still advances an iterator it prints.
- Verified: `internal-inspect.test.js`, `console-table-iterators.test.ts`. bun 1.4.2 fails 8 of 9 new tests (1 control). Self-reviewed: 14 concerns raised, 6 addressed, the rest in Notes.

### Background
- A Map or Set iterator holds the collection, a pointer to its storage table and an entry index. A rehash or `clear()` links the old table to the new one.
- `JSMap::Helper::transitAndNext` is the read-only step that `next()` uses: follow those links, skip deleted entries, return the next entry. The helper loops over it.
- A Worker uses the JS `Console` class as its global console.

<details><summary>Notes</summary>

**Repro of the hang**

```js
const util = require("node:util");
const m = new Map([["a", 1]]);
let nexts = 0;
Object.getPrototypeOf(m.entries()).next = () => {
  if (++nexts > 5000) { console.log("RUNAWAY nexts=" + nexts); process.exit(2); }
  return { value: ["k", "v"], done: false };
};
console.log(util.inspect(m.entries()));
console.log("nexts=" + nexts);
// bun 1.4.2:  RUNAWAY nexts=5001        (without the guard: spins, memory grows)
// node 26.3:  [Map Entries] { [ 'a', 1 ] }   nexts=0
// this PR:    [Map Entries] { [ 'a', 1 ] }   nexts=0
```

**Without tampering**

```js
const it = new Map([["a", 1], ["b", 2], ["c", 3]]).entries();
it.next();
util.inspect(it);
// bun 1.4.2:         [Map Entries] { [ 'a', 1 ], [ 'b', 2 ], [ 'c', 3 ] }
// node and this PR:  [Map Entries] { [ 'b', 2 ], [ 'c', 3 ] }
new Console(process.stdout).table(it);
// bun 1.4.2:         one Values column with [ 'b', 2 ] and [ 'c', 3 ], then it.next() is { done: true }
// node and this PR:  Key and Values columns, then it.next() is { value: [ 'b', 2 ], done: false }
```

**Comparison with Node.js v26.3.0**

A script of about 50 shapes prints byte-identical `util.inspect` output on this branch and on Node: all four Map and all four Set iterator kinds, advanced and exhausted iterators, `delete()`, `clear()` and a rehash while the iterator is open, an iterator made before the Map had any entry, an iterator from a `node:vm` context, `maxArrayLength` of 0, 1, 2, -1, `Infinity` and `null`, `showHidden`, `sorted`, `compact: false`, nested values and extra own keys. `Console#table` matches Node on the same shapes except for cell alignment, which #32619 covers. Node's own `test-console-table.js` expects the `Key` and `Values` columns for `map.entries()`.

**`isBuffer`**

`Console#table` formats an object cell with `isArray(v) = $isJSArray(v) || $isTypedArrayView(v) || isBuffer(v)`, and `isBuffer` came from `require("node:buffer").isBuffer`, which is `undefined`. So an object cell that is not an array throws `TypeError: isBuffer is not a function`. #33452 fixes that import. Before this PR `table(map.entries())` did not reach it, because each row was the `[key, value]` pair, an array. With Node's code path each key and value is a cell of its own, so this PR needs the same line (`const { Buffer: { isBuffer } } = require("node:buffer")`). The line is identical to #33452, so the PR that lands second rebases without a conflict.

The self-review asked for #33452 to land first, by itself, because the bug is worse than its title says. A Worker uses this JS `Console` as its global console. `console.table([{ createdAt: new Date(0) }])` inside a `node:worker_threads` Worker throws `undefined is not a function` on 1.4.2 and the worker exits with code 1. I agree with that order. I kept the line here because this PR is not correct without it, and I do not set the merge order.

**`Console#table(map)` is unchanged**

The first revision of this PR also stopped the `for-of` over a Map or a Set after `size` steps. The self-review falsified that with quick-lru 7.3.0. It caps `size` at `maxSize`, and its iterator also yields the older generation: `size` is 3 and the iterator yields 5. Node.js and bun 1.4.2 print 5 rows. The bound printed 3. The bound is gone, and those two loops are Node's again. The test `prints every entry that a Map subclass yields, also past its size` pins the two-generation shape.

So `new Console().table(map)` with an endless `Map.prototype[Symbol.iterator]` still never returns, on bun and on Node alike. If a bound is wanted there, one rule has to cover this code and `forEachLimited` in #42264.

**Same class, not fixed here**

- `util.inspect(Object.setPrototypeOf(new Map([[1, 2]]), null))` with a replaced `%MapIteratorPrototype%.next` never returns on bun and on Node. For a null-prototype Map `formatRaw` hands `formatMap` the result of `Map.prototype.entries()`, whose `size` is `undefined`, so there is no bound.
- `console.log(it)`, `console.table(it)` and `Bun.inspect(it)` go through the native formatter, which advances `it`. Node does not. The helper in this PR could serve the native formatter too. That is a follow-up.
- `util.inspect(weakMap, { showHidden: true })` still prints no entries (#28044).

**Overlap with open PRs**

- #35391 (omnibus Node v26 compatibility) wires the old JS `previewEntries` into `Console#table` with the same five lines, changes the same snapshot in `console-table-iterators.test.ts`, and carries the `isBuffer` line too.
- #32619 changes the cell alignment of `Console#table`. The snapshots here use the alignment on main.

**Self-review**

14 concerns survived the review. Removed the `size` bound and its test (2 concerns). Rewrote this description around the differences that need no tampering, the missing user report and the scope (4 concerns). Not taken: move the `isBuffer` line out and stack this PR on #33452 and on the alignment PR (4 concerns), for the reason above. 4 concerns say to keep the design: the native read that does not advance is Node's own, and the `Console#table` lines are the ones #35391 has. 1 concern (WeakMap and WeakSet contents) is a follow-up.

**Other checks**

- The new tests pass with `BUN_JSC_validateExceptionChecks=1`.
- A stress script (60 rounds: 300-entry Map and Set, five iterators at different positions, deletes, a rehash, `clear()`, `Bun.gc(true)` between two `util.inspect` calls of the same iterator) gives stable output under the ASAN debug build, and what `util.inspect` shows equals what the iterator then yields.
- Ran `test/js/node/util/`, `test/js/node/console/`, `test/js/bun/console/` and `test/js/bun/util/inspect.test.js` on the debug build. `util-inspect-long-running` and the `parseArgs` stress test hit the 5 s timeout under ASAN when the host is loaded. Neither reaches this code.
- Also ran `test-util-inspect-*.js`, `test-util.js`, `test-util-types.js`, `test-console-instance.js`, `test-console-methods.js`, `test-console-group.js`, `test-console-with-frozen-intrinsics.js` and `test-repl-inspect-defaults.js` from `test/js/node/test/parallel/`.
- `util.inspect` of an iterator over a large Map no longer copies the Map. It copies `maxArrayLength` entries and counts the rest in native code.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/console/console-table-iterators.test.ts test/js/node/util/node-inspect-tests/internal-inspect.test.js
bun test v1.4.3 (4ff919377)

test/js/node/console/console-table-iterators.test.ts:
25 | test.concurrent("console.Console#table renders Map and Set iterators", async () => {
26 |   const { stdout, exitCode } = await run(/* js */ `
27 |     c.table(new Map([["a", 1], ["b", 2]]).entries());
28 |     c.table(new Set([7, 8]).values());
29 |   `);
30 |   expect(stdout).toMatchInlineSnapshot(`
                      ^
error: expect(received).toMatchInlineSnapshot(expected)

  
- "┌───────────────────┬─────┬────────┐
- │ (iteration index) │ Key │ Values │
- ├───────────────────┼─────┼────────┤
- │         0         │ 'a' │   1    │
- │         1         │ 'b' │   2    │
- └───────────────────┴─────┴─────
... (truncated)

release without fix: 1 skipped
bun test v1.4.3-canary.1 (29be5f2e4)

test/js/node/console/console-table-iterators.test.ts:
(pass) console.Console#table shows what a Map or Set iterator has left and does not advance it [40.58ms]
(pass) console.Console#table renders Map and Set iterators [50.23ms]
(pass) console.Console#table formats object keys and values of a Map or Set iterator [42.52ms]
(pass) console.Console#table prints every entry that a Map subclass yields, also past its size [40.69ms]
(pass) console.Console#table does not run a replaced next() of a Map or Set iterator [52.23ms]

test/js/node/util/node-inspect-tests/internal-inspect.test.js:
(pass) no assertion failures [5.02ms]
(pass) boxed BigInt/Symbol with no prototype are still formatted as boxed primitives [0.29ms]
(pass) util.inspect reports the non-index keys of an array [1.59ms]
(pass) util.inspect reports the non-index keys of a typed array [0.53ms]
(pass) util.inspect of a large Array does not visit every element [12.24ms]
(pass) util.inspect of a large Uint8Array does not visit every element [4.56ms]
(pass) util.inspect shows what a Map or Set iterator has left [5.44ms]
(pass) util.inspect of a Map or Set iterator follows delete
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/console/console-table-iterators.test.ts test/js/node/util/node-inspect-tests/internal-inspect.test.js
bun test v1.4.3 (4ff919377)

test/js/node/console/console-table-iterators.test.ts:
(pass) console.Console#table shows what a Map or Set iterator has left and does not advance it [2222.42ms]
(pass) console.Console#table renders Map and Set iterators [2364.55ms]
(pass) console.Console#table formats object keys and values of a Map or Set iterator [2290.43ms]
(pass) console.Console#table does not run a replaced next() of a Map or Set iterator [2370.29ms]
(pass) console.Console#table prints every entry that a Map subclass yields, also past its size [2366.96ms]

test/js/node/util/node-inspect-tests/internal-inspect.test.js:
(pass) no assertion failures [235.63ms]
(pass) boxed BigInt/Symbol with no prototype are still formatted as boxed primitives [15.86ms]
(pass) util.inspect reports the non-index keys of an array [90.00ms]
(pass) util.inspect reports the non-index keys of a typed array [32.32ms]
(pass) util.inspect of a large Ar
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1016ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/138] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/138] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/138] gen cpp.rs (cppbind)
[4/138] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[5/138] gen JS modules (bundle-modules)
Preprocess modules (13626ms)
Bundle modules (97ms)
Postprocesss modules (172ms)
Bundle Functions (671ms)
Generate Code (61ms)

[14.64s] Bundled "src/js" for production
  2598 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[5/137] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_uws_sys v0.0.0 (/workspace/bun/src/uws_sys)
[1m[92m   Compiling[0m bun_perf v0.0.0 (/works
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/ConsoleObject.ts                   |  13 +-
 src/js/internal/util/inspect.js                    |  49 ++---
 src/jsc/bindings/UtilInspect.cpp                   |  82 +++++++++
 src/jsc/bindings/UtilInspect.h                     |   3 +
 .../node/console/console-table-iterators.test.ts   | 200 ++++++++++++++++++---
 .../node-inspect-tests/internal-inspect.test.js    | 190 +++++++++++++++++++-
 6 files changed, 478 insertions(+), 59 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/builtins/ConsoleObject.ts                              4      5     33
src/js/internal/util/inspect.js                               5      6     33
src/jsc/bindings/UtilInspect.cpp                              3      3     34
src/jsc/bindings/UtilInspect.h                                1      1     27
test/js/node/console/console-table-iterators.test.ts          4      4     23
…s/node/util/node-inspect-tests/internal-inspect.test.js      1      2     16
```

</details>

<!-- robobun:evidence:end -->