### PR TITLE
worker_threads: answer worker.cpuUsage() and worker.getHeapStatistics() on the parent thread

### DIFF
--- a/src/jsc/bindings/BunClientData.cpp
+++ b/src/jsc/bindings/BunClientData.cpp
@@ -108,6 +108,42 @@ JSVMClientData::~JSVMClientData()
     if (vmHandle)
         Bun__VmHandle__release(std::exchange(vmHandle, nullptr));
 }
+
+namespace {
+// The worker thread holds a ref on its proxy for longer than its VM lives.
+class WorkerHeapStatisticsPublisher final : public JSC::HeapObserver {
+    WTF_MAKE_NONCOPYABLE(WorkerHeapStatisticsPublisher);
+    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(WorkerHeapStatisticsPublisher);
+
+public:
+    WorkerHeapStatisticsPublisher(JSC::Heap& heap, WorkerMessagingProxy& worker)
+        : m_heap(heap)
+        , m_worker(worker)
+    {
+        m_heap.addObserver(this);
+    }
+
+    ~WorkerHeapStatisticsPublisher() final
+    {
+        m_heap.removeObserver(this);
+        m_worker.publishHeapStatistics(std::nullopt);
+    }
+
+private:
+    void willGarbageCollect() final {}
+
+    // The end of a collection, with the mutator stopped. Heap::size() would walk every block.
+    void didGarbageCollect(JSC::CollectionScope scope) final
+    {
+        size_t size = scope == JSC::CollectionScope::Full ? m_heap.sizeAfterLastFullCollection() : m_heap.sizeAfterLastEdenCollection();
+        m_worker.publishHeapStatistics(WorkerMessagingProxy::HeapStatistics { size, m_heap.capacity(), m_heap.extraMemorySize() });
+    }
+
+    JSC::Heap& m_heap;
+    WorkerMessagingProxy& m_worker;
+};
+}
+
 void JSVMClientData::create(VM* vm, void* bunVM, WorkerMessagingProxy* worker)
 {
     auto provider = WebCore::createBuiltinsSourceProvider();
@@ -115,6 +151,8 @@ void JSVMClientData::create(VM* vm, void* bunVM, WorkerMessagingProxy* worker)
     clientData->bunVM = bunVM;
     clientData->m_isWorkerVM = !!worker;
     clientData->m_isNodeWorkerVM = worker && worker->options().kind == WorkerOptions::Kind::Node;
+    if (worker)
+        clientData->m_workerHeapStatistics = makeUnique<WorkerHeapStatisticsPublisher>(vm->heap, *worker);
     clientData->vmHandle = Bun__VmHandle__retain(bunVM);
     clientData->vmHandleState = Bun__VmHandle__stateAddress(clientData->vmHandle);
     vm->deferredWorkTimer->onAddPendingWork = [clientData](Ref<JSC::DeferredWorkTimer::Ticket>&& ticket, JSC::DeferredWorkTimer::WorkType kind) -> void {

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -327,6 +327,8 @@ private:
     WebCore::DOMURLBaseCache m_urlBaseCache;
 
     Bun::HeapSizeAfterLastCollection m_heapSizeAfterLastCollection;
+    // A worker's VM: publishes the heap's counters to the parent (WorkerMessagingProxy::heapStatistics()).
+    std::unique_ptr<JSC::HeapObserver> m_workerHeapStatistics;
 
     SentinelLinkedList<JSVMClientDataClient, BasicRawSentinelNode<JSVMClientDataClient>> m_clients;
     bool m_isWorkerVM { false };

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -23,14 +23,6 @@
 
 #include "ActiveDOMObject.h"
 #include "BunCPUProfiler.h"
-#if OS(WINDOWS)
-#include <uv.h>
-#else
-#include <sys/resource.h>
-#if defined(__APPLE__)
-#include <mach/mach.h>
-#endif
-#endif
 
 #include "EventNames.h"
 #include "ExtendedDOMClientIsoSubspaces.h"
@@ -74,6 +66,9 @@
 #include "BunProcess.h"
 #include "JSEnvironmentVariableMap.h"
 #include <JavaScriptCore/JSMap.h>
+
+// The calling thread's CPU times in microseconds (src/jsc/web_worker.rs). False leaves them alone.
+extern "C" bool WebWorker__currentThreadCpuUsage(double* user, double* system);
 
 namespace WebCore {
 using namespace JSC;
@@ -904,40 +899,12 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_cpuUsageInternalBody
     auto parentId = globalObject->scriptExecutionContext()->identifier();
     auto parentLoopKind = globalObject->scriptExecutionContext()->currentLoopKind();
     bool accepted = worker.contextProxy().postTaskToWorkerGlobalScope([reqId, parentId, parentLoopKind, protectedProxy = Ref { worker.contextProxy() }](ScriptExecutionContext&) mutable {
-        double user = 0;
-        double sys = 0;
-#if OS(WINDOWS)
-        uv_rusage_t ru;
-        if (uv_getrusage_thread(&ru) == 0) {
-            user = static_cast<double>(ru.ru_utime.tv_sec) * 1e6 + static_cast<double>(ru.ru_utime.tv_usec);
-            sys = static_cast<double>(ru.ru_stime.tv_sec) * 1e6 + static_cast<double>(ru.ru_stime.tv_usec);
-        }
-#elif defined(__APPLE__)
-        // Darwin has no RUSAGE_THREAD; RUSAGE_SELF would report whole-process
-        // CPU for every worker. Use mach thread_info for this thread only.
-        mach_port_t machThread = mach_thread_self();
-        thread_basic_info_data_t tinfo;
-        mach_msg_type_number_t tcount = THREAD_BASIC_INFO_COUNT;
-        if (thread_info(machThread, THREAD_BASIC_INFO, reinterpret_cast<thread_info_t>(&tinfo), &tcount) == KERN_SUCCESS) {
-            user = static_cast<double>(tinfo.user_time.seconds) * 1e6 + static_cast<double>(tinfo.user_time.microseconds);
-            sys = static_cast<double>(tinfo.system_time.seconds) * 1e6 + static_cast<double>(tinfo.system_time.microseconds);
-        }
-        mach_port_deallocate(mach_task_self(), machThread);
-#else
-        struct rusage ru;
-        memset(&ru, 0, sizeof(ru));
-#if defined(RUSAGE_THREAD)
-        getrusage(RUSAGE_THREAD, &ru);
-#else
-        getrusage(RUSAGE_SELF, &ru);
-#endif
-        user = static_cast<double>(ru.ru_utime.tv_sec) * 1e6 + static_cast<double>(ru.ru_utime.tv_usec);
-        sys = static_cast<double>(ru.ru_stime.tv_sec) * 1e6 + static_cast<double>(ru.ru_stime.tv_usec);
-#endif
-        ScriptExecutionContext::postTaskTo(parentId, parentLoopKind, [reqId, protectedProxy = WTF::move(protectedProxy), user, sys](ScriptExecutionContext& parentCtx) {
+        WorkerMessagingProxy::CpuUsage measured;
+        WebWorker__currentThreadCpuUsage(&measured.userMicroseconds, &measured.systemMicroseconds);
+        ScriptExecutionContext::postTaskTo(parentId, parentLoopKind, [reqId, protectedProxy = WTF::move(protectedProxy), measured](ScriptExecutionContext& parentCtx) {
             resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, [&](VM& pvm, JSGlobalObject* go) -> JSValue {
                 // One source for every answer, where there is one, so that no answer is below an earlier one.
-                return createCpuUsageObject(pvm, go, protectedProxy->cpuUsage().value_or(WorkerMessagingProxy::CpuUsage { user, sys }));
+                return createCpuUsageObject(pvm, go, protectedProxy->cpuUsage().value_or(measured));
             });
         });
     });

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -705,6 +705,19 @@ static void resolveCrossVMRequest(WorkerMessagingProxy& proxy, uint64_t reqId, S
     handle->resolve(parentCtx.globalObject(), parentCtx.vm(), buildValue(parentCtx.vm(), parentCtx.globalObject()));
 }
 
+// An answer the parent has already. It settles after the loop has polled, as one from the worker does.
+template<typename BuildValue>
+static JSPromise* resolveCrossVMRequestAfterYield(Zig::GlobalObject* globalObject, WorkerMessagingProxy& proxy, BuildValue&& buildValue)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
+    uint64_t reqId = proxy.registerCrossVMRequest(vm, promise);
+    globalObject->scriptExecutionContext()->postTaskAfterYield([reqId, protectedProxy = Ref { proxy }, buildValue = std::forward<BuildValue>(buildValue)](ScriptExecutionContext& context) {
+        resolveCrossVMRequest(protectedProxy.get(), reqId, context, buildValue);
+    });
+    return promise;
+}
+
 static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSWorker>::ClassParameter castedThis)
 {
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
@@ -747,6 +760,7 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
     uint64_t reqId = worker.contextProxy().registerCrossVMRequest(vm, promise);
     auto parentId = globalObject->scriptExecutionContext()->identifier();
     auto parentLoopKind = globalObject->scriptExecutionContext()->currentLoopKind();
+    // Runs on the worker's event loop, as the CPU profile's start and stop do: a worker busy in JavaScript waits (#42354).
     bool accepted = worker.contextProxy().postTaskToWorkerGlobalScope([reqId, parentId, parentLoopKind, protectedProxy = Ref { worker.contextProxy() }](ScriptExecutionContext& workerCtx) mutable {
         auto& vm = workerCtx.vm();
         vm.ensureHeapProfiler();
@@ -799,8 +813,9 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapStatisticsBod
     auto& worker = castedThis->wrapped();
 
     if (auto statistics = worker.contextProxy().heapStatistics()) {
-        auto scope = DECLARE_THROW_SCOPE(vm);
-        RELEASE_AND_RETURN(scope, JSValue::encode(JSC::JSPromise::resolvedPromise(globalObject, createHeapStatisticsObject(vm, globalObject, *statistics))));
+        return JSValue::encode(resolveCrossVMRequestAfterYield(globalObject, worker.contextProxy(), [statistics = *statistics](VM& pvm, JSGlobalObject* go) -> JSValue {
+            return createHeapStatisticsObject(pvm, go, statistics);
+        }));
     }
 
     auto* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
@@ -890,8 +905,9 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_cpuUsageInternalBody
     auto& worker = castedThis->wrapped();
 
     if (auto usage = worker.contextProxy().cpuUsage()) {
-        auto scope = DECLARE_THROW_SCOPE(vm);
-        RELEASE_AND_RETURN(scope, JSValue::encode(JSC::JSPromise::resolvedPromise(globalObject, createCpuUsageObject(vm, globalObject, *usage))));
+        return JSValue::encode(resolveCrossVMRequestAfterYield(globalObject, worker.contextProxy(), [usage = *usage](VM& pvm, JSGlobalObject* go) -> JSValue {
+            return createCpuUsageObject(pvm, go, usage);
+        }));
     }
 
     auto* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
@@ -903,8 +919,7 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_cpuUsageInternalBody
         WebWorker__currentThreadCpuUsage(&measured.userMicroseconds, &measured.systemMicroseconds);
         ScriptExecutionContext::postTaskTo(parentId, parentLoopKind, [reqId, protectedProxy = WTF::move(protectedProxy), measured](ScriptExecutionContext& parentCtx) {
             resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, [&](VM& pvm, JSGlobalObject* go) -> JSValue {
-                // One source for every answer, where there is one, so that no answer is below an earlier one.
-                return createCpuUsageObject(pvm, go, protectedProxy->cpuUsage().value_or(measured));
+                return createCpuUsageObject(pvm, go, protectedProxy->cpuUsage(measured).value_or(measured));
             });
         });
     });

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -773,42 +773,50 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
     return JSValue::encode(promise);
 }
 
+static JSObject* createHeapStatisticsObject(VM& vm, JSGlobalObject* globalObject, const WorkerMessagingProxy::HeapStatistics& statistics)
+{
+    double heapSize = static_cast<double>(statistics.size);
+    double capacity = static_cast<double>(statistics.capacity);
+    JSObject* o = constructEmptyObject(globalObject);
+    auto set = [&](ASCIILiteral k, double v) { o->putDirect(vm, Identifier::fromString(vm, k), jsNumber(v)); };
+    set("total_heap_size"_s, heapSize);
+    set("total_heap_size_executable"_s, heapSize / 2.0);
+    set("total_physical_size"_s, capacity);
+    set("total_available_size"_s, capacity > heapSize ? capacity - heapSize : 0);
+    set("used_heap_size"_s, heapSize);
+    set("heap_size_limit"_s, capacity * 10.0);
+    set("malloced_memory"_s, heapSize);
+    set("peak_malloced_memory"_s, capacity);
+    o->putDirect(vm, Identifier::fromString(vm, "does_zap_garbage"_s), jsBoolean(false));
+    set("number_of_native_contexts"_s, 1);
+    set("number_of_detached_contexts"_s, 0);
+    set("total_global_handles_size"_s, 8192);
+    set("used_global_handles_size"_s, 2208);
+    set("external_memory"_s, static_cast<double>(statistics.extraMemory));
+    set("total_allocated_bytes"_s, heapSize);
+    return o;
+}
+
 static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapStatisticsBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSWorker>::ClassParameter castedThis)
 {
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
     auto& worker = castedThis->wrapped();
 
+    if (auto statistics = worker.contextProxy().heapStatistics()) {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        RELEASE_AND_RETURN(scope, JSValue::encode(JSC::JSPromise::resolvedPromise(globalObject, createHeapStatisticsObject(vm, globalObject, *statistics))));
+    }
+
     auto* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
     uint64_t reqId = worker.contextProxy().registerCrossVMRequest(vm, promise);
     auto parentId = globalObject->scriptExecutionContext()->identifier();
     auto parentLoopKind = globalObject->scriptExecutionContext()->currentLoopKind();
     bool accepted = worker.contextProxy().postTaskToWorkerGlobalScope([reqId, parentId, parentLoopKind, protectedProxy = Ref { worker.contextProxy() }](ScriptExecutionContext& workerCtx) mutable {
-        auto& wvm = workerCtx.vm();
-        double heapSize = static_cast<double>(wvm.heap.size());
-        double capacity = static_cast<double>(wvm.heap.capacity());
-        double extra = static_cast<double>(wvm.heap.extraMemorySize());
-        ScriptExecutionContext::postTaskTo(parentId, parentLoopKind, [reqId, protectedProxy = WTF::move(protectedProxy), heapSize, capacity, extra](ScriptExecutionContext& parentCtx) {
+        auto statistics = WorkerMessagingProxy::HeapStatistics::measure(workerCtx.vm().heap);
+        ScriptExecutionContext::postTaskTo(parentId, parentLoopKind, [reqId, protectedProxy = WTF::move(protectedProxy), statistics](ScriptExecutionContext& parentCtx) {
             resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, [&](VM& pvm, JSGlobalObject* go) -> JSValue {
-                JSObject* o = constructEmptyObject(go);
-                auto set = [&](ASCIILiteral k, double v) { o->putDirect(pvm, Identifier::fromString(pvm, k), jsNumber(v)); };
-                double avail = capacity > heapSize ? capacity - heapSize : 0;
-                set("total_heap_size"_s, heapSize);
-                set("total_heap_size_executable"_s, heapSize / 2.0);
-                set("total_physical_size"_s, capacity);
-                set("total_available_size"_s, avail);
-                set("used_heap_size"_s, heapSize);
-                set("heap_size_limit"_s, capacity * 10.0);
-                set("malloced_memory"_s, heapSize);
-                set("peak_malloced_memory"_s, capacity);
-                o->putDirect(pvm, Identifier::fromString(pvm, "does_zap_garbage"_s), jsBoolean(false));
-                set("number_of_native_contexts"_s, 1);
-                set("number_of_detached_contexts"_s, 0);
-                set("total_global_handles_size"_s, 8192);
-                set("used_global_handles_size"_s, 2208);
-                set("external_memory"_s, extra);
-                set("total_allocated_bytes"_s, heapSize);
-                return o;
+                return createHeapStatisticsObject(pvm, go, statistics);
             });
         });
     });
@@ -872,11 +880,25 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_stopCpuProfileIntern
     return JSValue::encode(promise);
 }
 
+static JSObject* createCpuUsageObject(VM& vm, JSGlobalObject* globalObject, const WorkerMessagingProxy::CpuUsage& usage)
+{
+    JSObject* o = constructEmptyObject(globalObject);
+    o->putDirect(vm, Identifier::fromString(vm, "user"_s), jsNumber(usage.userMicroseconds));
+    o->putDirect(vm, Identifier::fromString(vm, "system"_s), jsNumber(usage.systemMicroseconds));
+    return o;
+}
+
 static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_cpuUsageInternalBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSWorker>::ClassParameter castedThis)
 {
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
     auto& worker = castedThis->wrapped();
+
+    if (auto usage = worker.contextProxy().cpuUsage()) {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        RELEASE_AND_RETURN(scope, JSValue::encode(JSC::JSPromise::resolvedPromise(globalObject, createCpuUsageObject(vm, globalObject, *usage))));
+    }
+
     auto* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
     uint64_t reqId = worker.contextProxy().registerCrossVMRequest(vm, promise);
     auto parentId = globalObject->scriptExecutionContext()->identifier();
@@ -914,10 +936,8 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_cpuUsageInternalBody
 #endif
         ScriptExecutionContext::postTaskTo(parentId, parentLoopKind, [reqId, protectedProxy = WTF::move(protectedProxy), user, sys](ScriptExecutionContext& parentCtx) {
             resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, [&](VM& pvm, JSGlobalObject* go) -> JSValue {
-                JSObject* o = constructEmptyObject(go);
-                o->putDirect(pvm, Identifier::fromString(pvm, "user"_s), jsNumber(user));
-                o->putDirect(pvm, Identifier::fromString(pvm, "system"_s), jsNumber(sys));
-                return o;
+                // One source for every answer, where there is one, so that no answer is below an earlier one.
+                return createCpuUsageObject(pvm, go, protectedProxy->cpuUsage().value_or(WorkerMessagingProxy::CpuUsage { user, sys }));
             });
         });
     });

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -80,9 +80,8 @@ void WebWorker__releaseParentPollRef(void*);
 void WebWorker__join(void*);
 // Drop one ref on the thread object; the last one frees it.
 void WebWorker__deref(void*);
-// The thread's CPU times in microseconds, read from the parent thread. False before its VM exists
-// and once it has begun shutting down.
-bool WebWorker__threadCpuUsage(void*, double* user, double* system);
+// One worker.cpuUsage() answer, read by the parent thread; `measured` offers the worker's own reading.
+bool WebWorker__cpuUsage(void*, bool measured, double* userMicroseconds, double* systemMicroseconds);
 
 } // extern "C"
 
@@ -258,26 +257,32 @@ JSC::Strong<JSC::JSPromise> WorkerMessagingProxy::takeCrossVMRequest(uint64_t id
 
 WorkerMessagingProxy::HeapStatistics WorkerMessagingProxy::HeapStatistics::measure(JSC::Heap& heap)
 {
-    // Heap::size() counts what the last collection marked: nothing before the first one, when
-    // nothing has been freed either and every block counts as used (as process.memoryUsage() does).
+    // Heap::size() counts what the last collection marked. Before the first one every block counts as used.
     size_t size = heap.size();
     return { size ? size : heap.blockBytesAllocated(), heap.capacity(), heap.extraMemorySize() };
 }
 
+bool WorkerMessagingProxy::answersOnParentThread() const
+{
+    return m_sawThreadStart && !m_askedToTerminate && !isClosingOrClosed();
+}
+
 std::optional<WorkerMessagingProxy::HeapStatistics> WorkerMessagingProxy::heapStatistics()
 {
-    if (!m_sawThreadStart || m_askedToTerminate || isClosingOrClosed())
+    if (!answersOnParentThread())
         return std::nullopt;
     Locker locker { m_heapStatisticsLock };
     return m_heapStatistics;
 }
 
-std::optional<WorkerMessagingProxy::CpuUsage> WorkerMessagingProxy::cpuUsage()
+std::optional<WorkerMessagingProxy::CpuUsage> WorkerMessagingProxy::cpuUsage(std::optional<CpuUsage> measuredByWorker)
 {
-    if (!m_sawThreadStart || m_askedToTerminate || isClosingOrClosed() || !m_workerThread)
+    if (!measuredByWorker && !answersOnParentThread())
         return std::nullopt;
-    CpuUsage usage;
-    if (!WebWorker__threadCpuUsage(m_workerThread, &usage.userMicroseconds, &usage.systemMicroseconds))
+    if (!m_workerThread)
+        return measuredByWorker;
+    CpuUsage usage = measuredByWorker.value_or(CpuUsage {});
+    if (!WebWorker__cpuUsage(m_workerThread, measuredByWorker.has_value(), &usage.userMicroseconds, &usage.systemMicroseconds))
         return std::nullopt;
     return usage;
 }
@@ -421,7 +426,7 @@ void WorkerMessagingProxy::workerThreadStarted()
         if (m_state.load() != State::Pending)
             return;
     }
-    // The heap as the entry point finds it. From here each collection publishes (JSVMClientData).
+    // The heap as the entry point finds it; from here the end of each collection publishes.
     publishHeapStatistics(HeapStatistics::measure(defaultGlobalObject()->vm().heap));
     ScriptExecutionContext::postTaskTo(m_loaderContextIdentifier, m_loaderLoopKind, [protectedThis = Ref { *this }](ScriptExecutionContext&) {
         protectedThis->m_sawThreadStart = true;
@@ -436,6 +441,7 @@ void WorkerMessagingProxy::workerGlobalScopeStarted(Zig::GlobalObject& workerGlo
 {
     auto& context = *workerGlobalObject.scriptExecutionContext();
     ASSERT(context.identifier() == m_workerContextIdentifier);
+    publishHeapStatistics(HeapStatistics::measure(workerGlobalObject.vm().heap));
 
     // Pending -> Running under the lock postTaskToWorkerGlobalScope() takes: no task is lost.
     Deque<Function<void(ScriptExecutionContext&)>> pendingTasks;

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -80,6 +80,9 @@ void WebWorker__releaseParentPollRef(void*);
 void WebWorker__join(void*);
 // Drop one ref on the thread object; the last one frees it.
 void WebWorker__deref(void*);
+// The thread's CPU times in microseconds, read from the parent thread. False before its VM exists
+// and once it has begun shutting down.
+bool WebWorker__threadCpuUsage(void*, double* user, double* system);
 
 } // extern "C"
 
@@ -253,6 +256,38 @@ JSC::Strong<JSC::JSPromise> WorkerMessagingProxy::takeCrossVMRequest(uint64_t id
     return m_pendingCrossVMRequests.take(id);
 }
 
+WorkerMessagingProxy::HeapStatistics WorkerMessagingProxy::HeapStatistics::measure(JSC::Heap& heap)
+{
+    // Heap::size() counts what the last collection marked: nothing before the first one, when
+    // nothing has been freed either and every block counts as used (as process.memoryUsage() does).
+    size_t size = heap.size();
+    return { size ? size : heap.blockBytesAllocated(), heap.capacity(), heap.extraMemorySize() };
+}
+
+std::optional<WorkerMessagingProxy::HeapStatistics> WorkerMessagingProxy::heapStatistics()
+{
+    if (!m_sawThreadStart || m_askedToTerminate || isClosingOrClosed())
+        return std::nullopt;
+    Locker locker { m_heapStatisticsLock };
+    return m_heapStatistics;
+}
+
+std::optional<WorkerMessagingProxy::CpuUsage> WorkerMessagingProxy::cpuUsage()
+{
+    if (!m_sawThreadStart || m_askedToTerminate || isClosingOrClosed() || !m_workerThread)
+        return std::nullopt;
+    CpuUsage usage;
+    if (!WebWorker__threadCpuUsage(m_workerThread, &usage.userMicroseconds, &usage.systemMicroseconds))
+        return std::nullopt;
+    return usage;
+}
+
+void WorkerMessagingProxy::publishHeapStatistics(std::optional<HeapStatistics> statistics)
+{
+    Locker locker { m_heapStatisticsLock };
+    m_heapStatistics = statistics;
+}
+
 void WorkerMessagingProxy::rejectAllCrossVMRequests()
 {
     HashMap<uint64_t, JSC::Strong<JSC::JSPromise>> pending;
@@ -386,7 +421,10 @@ void WorkerMessagingProxy::workerThreadStarted()
         if (m_state.load() != State::Pending)
             return;
     }
+    // The heap as the entry point finds it. From here each collection publishes (JSVMClientData).
+    publishHeapStatistics(HeapStatistics::measure(defaultGlobalObject()->vm().heap));
     ScriptExecutionContext::postTaskTo(m_loaderContextIdentifier, m_loaderLoopKind, [protectedThis = Ref { *this }](ScriptExecutionContext&) {
+        protectedThis->m_sawThreadStart = true;
         RefPtr workerObject = protectedThis->m_workerObject;
         if (!workerObject || !workerObject->hasEventListeners(eventNames().openEvent))
             return;

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.h
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.h
@@ -36,6 +36,7 @@
 #include <wtf/ThreadSafeRefCounted.h>
 
 namespace JSC {
+class Heap;
 class JSGlobalObject;
 class JSPromise;
 class JSValue;
@@ -97,6 +98,23 @@ public:
     uint64_t registerCrossVMRequest(JSC::VM&, JSC::JSPromise*);
     JSC::Strong<JSC::JSPromise> takeCrossVMRequest(uint64_t id);
 
+    // Answered on the parent thread, so a worker that never returns to its event loop still answers.
+    // Empty until the parent has seen the thread start and once it was asked to stop or has exited:
+    // the caller then goes through postTaskToWorkerGlobalScope().
+    struct HeapStatistics {
+        size_t size { 0 };
+        size_t capacity { 0 };
+        size_t extraMemory { 0 };
+        // The thread that owns `heap`.
+        static HeapStatistics measure(JSC::Heap&);
+    };
+    std::optional<HeapStatistics> heapStatistics();
+    struct CpuUsage {
+        double userMicroseconds { 0 };
+        double systemMicroseconds { 0 };
+    };
+    std::optional<CpuUsage> cpuUsage();
+
     // -- WorkerObjectProxy / WorkerReportingProxy (worker thread) ---------------------------------
     // Before the entry point loads: posts 'online' to the parent, as node does before user code.
     void workerThreadStarted();
@@ -108,6 +126,9 @@ public:
     // stoppedByParent: it stopped because it was asked to and never called process.exit() itself.
     void workerGlobalScopeDestroyed(int32_t exitCode, bool stoppedByParent);
     void drainMessagesToWorkerGlobalScope(ScriptExecutionContext&);
+    // The worker heap's counters as of its last collection (the worker or its collector thread);
+    // nullopt when its VM is going away.
+    void publishHeapStatistics(std::optional<HeapStatistics>);
 
     // -- Either thread ---------------------------------------------------------------------------
     WorkerOptions& options() { return m_options; }
@@ -134,6 +155,8 @@ private:
     Worker* m_workerObject;
     bool m_askedToTerminate { false };
     bool m_keepAliveReleased { false };
+    // The task workerThreadStarted() posted has run.
+    bool m_sawThreadStart { false };
 
     const ScriptExecutionContextIdentifier m_loaderContextIdentifier;
     // The parent loop that was current at `new Worker()`: a macro that creates a worker and awaits
@@ -154,6 +177,9 @@ private:
     Deque<Function<void(ScriptExecutionContext&)>> m_pendingTasks WTF_GUARDED_BY_LOCK(m_pendingTasksLock);
     HashMap<uint64_t, JSC::Strong<JSC::JSPromise>> m_pendingCrossVMRequests WTF_GUARDED_BY_LOCK(m_pendingTasksLock);
     std::atomic<uint64_t> m_nextRequestId { 1 };
+
+    Lock m_heapStatisticsLock;
+    std::optional<HeapStatistics> m_heapStatistics WTF_GUARDED_BY_LOCK(m_heapStatisticsLock);
 
     MessageInbox m_toWorker;
     MessageInbox m_toParent;

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.h
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.h
@@ -98,9 +98,6 @@ public:
     uint64_t registerCrossVMRequest(JSC::VM&, JSC::JSPromise*);
     JSC::Strong<JSC::JSPromise> takeCrossVMRequest(uint64_t id);
 
-    // Answered on the parent thread, so a worker that never returns to its event loop still answers.
-    // Empty until the parent has seen the thread start and once it was asked to stop or has exited:
-    // the caller then goes through postTaskToWorkerGlobalScope().
     struct HeapStatistics {
         size_t size { 0 };
         size_t capacity { 0 };
@@ -108,12 +105,14 @@ public:
         // The thread that owns `heap`.
         static HeapStatistics measure(JSC::Heap&);
     };
-    std::optional<HeapStatistics> heapStatistics();
     struct CpuUsage {
         double userMicroseconds { 0 };
         double systemMicroseconds { 0 };
     };
-    std::optional<CpuUsage> cpuUsage();
+    // What the worker last published; empty when the caller has to ask the worker.
+    std::optional<HeapStatistics> heapStatistics();
+    // Never below an earlier answer. Given the worker's own reading it answers whenever the worker did.
+    std::optional<CpuUsage> cpuUsage(std::optional<CpuUsage> measuredByWorker = std::nullopt);
 
     // -- WorkerObjectProxy / WorkerReportingProxy (worker thread) ---------------------------------
     // Before the entry point loads: posts 'online' to the parent, as node does before user code.
@@ -126,8 +125,7 @@ public:
     // stoppedByParent: it stopped because it was asked to and never called process.exit() itself.
     void workerGlobalScopeDestroyed(int32_t exitCode, bool stoppedByParent);
     void drainMessagesToWorkerGlobalScope(ScriptExecutionContext&);
-    // The worker heap's counters as of its last collection (the worker or its collector thread);
-    // nullopt when its VM is going away.
+    // The worker's heap as of its last collection, or nothing once its VM goes away. Also its collector thread.
     void publishHeapStatistics(std::optional<HeapStatistics>);
 
     // -- Either thread ---------------------------------------------------------------------------
@@ -147,6 +145,8 @@ private:
     void releaseWorkerThread();
     void drainMessagesToWorkerObject(ScriptExecutionContext&, DrainBudget);
     void rejectAllCrossVMRequests();
+    // The parent answers by itself once it has seen the thread start and until it asks it to stop.
+    bool answersOnParentThread() const;
     void postMessageErrorToWorkerObject(String&& message);
     bool postSerializedErrorToWorkerObject(Zig::GlobalObject&, JSC::JSValue error);
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -563,29 +563,30 @@ impl WebWorker {
         }
     }
 
-    /// `worker.cpuUsage()`, answered without the worker thread's help so that a
-    /// worker which never returns to its loop still answers. Parent thread.
-    /// `false` before the VM exists and once the thread is in `shutdown()`.
-    #[unsafe(export_name = "WebWorker__threadCpuUsage")]
-    pub(crate) extern "C" fn thread_cpu_usage(
+    /// One `worker.cpuUsage()` answer in microseconds. `measured`: the worker's own reading is in.
+    #[unsafe(export_name = "WebWorker__cpuUsage")]
+    pub(crate) extern "C" fn cpu_usage(
         this: *mut WebWorker,
+        measured: bool,
         user_micros: &mut f64,
         system_micros: &mut f64,
     ) -> bool {
         let this = bun_ptr::ParentRef::from(NonNull::new(this).expect("WebWorker FFI ptr"));
-        // shutdown() takes this lock to unpublish the handle, so while it is
-        // held and `Some` the thread has not exited.
-        let handle = this.vm_handle.lock();
-        if handle.is_none() {
-            return false;
-        }
-        let Some(now) = this
-            .join_handle
-            .get()
-            .as_ref()
-            .and_then(bun_sys::ThreadCpuUsage::of)
-        else {
-            return false;
+        let read = {
+            // `shutdown()` unpublishes the handle under this lock, so `Some` is a live thread.
+            let handle = this.vm_handle.lock();
+            handle
+                .as_ref()
+                .and(this.join_handle.get().as_ref())
+                .and_then(bun_sys::ThreadCpuUsage::of)
+        };
+        let now = match read {
+            Some(read) => read,
+            None if measured => bun_sys::ThreadCpuUsage {
+                user: *user_micros as u64,
+                system: *system_micros as u64,
+            },
+            None => return false,
         };
         let usage = now.never_below(this.last_cpu_usage.get());
         this.last_cpu_usage.set(usage);
@@ -594,8 +595,7 @@ impl WebWorker {
         true
     }
 
-    /// The calling thread's CPU times, for a `worker.cpuUsage()` that the worker
-    /// itself answers. Worker thread.
+    /// The calling thread's CPU times in microseconds. Worker thread.
     #[unsafe(export_name = "WebWorker__currentThreadCpuUsage")]
     pub(crate) extern "C" fn current_thread_cpu_usage(
         user_micros: &mut f64,

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -103,6 +103,8 @@ pub struct WebWorker {
     parent_poll_ref: JsCell<KeepAlive>,
     /// Taken by the parent to join the OS thread.
     join_handle: JsCell<Option<JoinHandle<()>>>,
+    /// The last `worker.cpuUsage()` answer, which the next one never goes below.
+    last_cpu_usage: Cell<ThreadCpuUsage>,
 
     // ---- Worker-thread only -----------------------------------------------------
     // Mutated only on the worker thread, but through `&self` because other
@@ -130,6 +132,140 @@ struct WorkerVmInit {
     transform_options: bun_options_types::schema::api::TransformOptions,
     env_loader: bun_dotenv::Loader,
     proxy_env_slots: jsc::rare_data::ProxyEnvSlots,
+}
+
+/// One thread's CPU times in microseconds, read from any thread.
+#[derive(Clone, Copy, Default)]
+struct ThreadCpuUsage {
+    user: u64,
+    system: u64,
+}
+
+impl ThreadCpuUsage {
+    /// `thread` must not have exited.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn of(thread: &JoinHandle<()>) -> Option<Self> {
+        use std::os::unix::thread::JoinHandleExt as _;
+        // A thread's three CPU clocks differ in the low two bits of the id
+        // (CPUCLOCK_PROF/VIRT/SCHED, include/linux/posix-timers_types.h).
+        const CLOCK_MASK: libc::clockid_t = 3;
+        const USER_AND_SYSTEM_TICKS: libc::clockid_t = 0;
+        const USER_TICKS: libc::clockid_t = 1;
+        let mut runtime_clock: libc::clockid_t = 0;
+        let pthread = thread.as_pthread_t() as libc::pthread_t;
+        // SAFETY: the thread is alive (fn contract), so its pthread_t is valid.
+        if unsafe { libc::pthread_getcpuclockid(pthread, &raw mut runtime_clock) } != 0 {
+            return None;
+        }
+        let nanos = |clock: libc::clockid_t| -> Option<u64> {
+            let mut ts = libc::timespec {
+                tv_sec: 0,
+                tv_nsec: 0,
+            };
+            // SAFETY: `ts` is a valid out-pointer.
+            (unsafe { libc::clock_gettime(clock, &raw mut ts) } == 0)
+                .then(|| ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64)
+        };
+        let runtime = nanos(runtime_clock)?;
+        let user_ticks = nanos((runtime_clock & !CLOCK_MASK) | USER_TICKS)?;
+        let system_ticks = nanos((runtime_clock & !CLOCK_MASK) | USER_AND_SYSTEM_TICKS)?
+            .saturating_sub(user_ticks);
+        // What getrusage(RUSAGE_THREAD) reports: the exact runtime, split in the
+        // ratio of the tick-sampled times (cputime_adjust(), kernel/sched/cputime.c).
+        let system = match (user_ticks, system_ticks) {
+            (_, 0) => 0,
+            (0, _) => runtime,
+            (user, system) => {
+                (u128::from(runtime) * u128::from(system) / (u128::from(user) + u128::from(system)))
+                    as u64
+            }
+        };
+        Some(Self {
+            user: (runtime - system) / 1000,
+            system: system / 1000,
+        })
+    }
+
+    /// `thread` must not have exited.
+    #[cfg(target_os = "macos")]
+    fn of(thread: &JoinHandle<()>) -> Option<Self> {
+        use std::os::unix::thread::JoinHandleExt as _;
+        // SAFETY: all-zero is a valid `thread_basic_info` (POD C struct).
+        let mut info: libc::thread_basic_info = unsafe { bun_core::ffi::zeroed_unchecked() };
+        let mut count = libc::THREAD_BASIC_INFO_COUNT;
+        // SAFETY: the thread is alive (fn contract), so its mach port is valid;
+        // `info` and `count` are valid out-pointers of the size `count` states.
+        let status = unsafe {
+            libc::thread_info(
+                libc::pthread_mach_thread_np(thread.as_pthread_t() as libc::pthread_t),
+                libc::THREAD_BASIC_INFO as libc::thread_flavor_t,
+                (&raw mut info).cast(),
+                &raw mut count,
+            )
+        };
+        let micros = |t: libc::time_value_t| t.seconds as u64 * 1_000_000 + t.microseconds as u64;
+        (status == libc::KERN_SUCCESS).then(|| Self {
+            user: micros(info.user_time),
+            system: micros(info.system_time),
+        })
+    }
+
+    #[cfg(windows)]
+    fn of(thread: &JoinHandle<()>) -> Option<Self> {
+        use bun_sys::windows::FILETIME;
+        use std::os::windows::io::AsRawHandle as _;
+        // SAFETY: all-zero is a valid FILETIME (POD C struct).
+        let [mut creation, mut exit, mut kernel, mut user]: [FILETIME; 4] =
+            unsafe { bun_core::ffi::zeroed_unchecked() };
+        // SAFETY: the JoinHandle keeps the thread's HANDLE open; valid out-pointers.
+        if unsafe {
+            bun_sys::windows::GetThreadTimes(
+                thread.as_raw_handle().cast(),
+                &raw mut creation,
+                &raw mut exit,
+                &raw mut kernel,
+                &raw mut user,
+            )
+        } == 0
+        {
+            return None;
+        }
+        // FILETIME counts 100 ns units.
+        let micros =
+            |t: FILETIME| ((u64::from(t.dwHighDateTime) << 32) | u64::from(t.dwLowDateTime)) / 10;
+        Some(Self {
+            user: micros(user),
+            system: micros(kernel),
+        })
+    }
+
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "macos",
+        windows
+    )))]
+    fn of(_: &JoinHandle<()>) -> Option<Self> {
+        None
+    }
+
+    /// `self`, adjusted so that neither time is below what `previous` reported
+    /// (the split on Linux is an estimate that can move between readings).
+    fn never_below(self, previous: Self) -> Self {
+        let total = self.user + self.system;
+        if total <= previous.user + previous.system {
+            return previous;
+        }
+        let system = self.system.max(previous.system);
+        let user = total - system;
+        if user < previous.user {
+            return Self {
+                user: previous.user,
+                system: total - previous.user,
+            };
+        }
+        Self { user, system }
+    }
 }
 
 enum EntryOutcome {
@@ -425,6 +561,7 @@ impl WebWorker {
             vm: Cell::new(core::ptr::null_mut()),
             parent_poll_ref: JsCell::new(KeepAlive::init()),
             join_handle: JsCell::new(None),
+            last_cpu_usage: Cell::new(ThreadCpuUsage::default()),
             status: Cell::new(Status::Start),
             arena: JsCell::new(None),
             worker_env_loader: Cell::new(core::ptr::null_mut()),
@@ -558,6 +695,32 @@ impl WebWorker {
             // safepoint and its loop woken.
             handle.request_termination();
         }
+    }
+
+    /// `worker.cpuUsage()`, answered without the worker thread's help so that a
+    /// worker which never returns to its loop still answers. Parent thread.
+    /// `false` before the VM exists and once the thread is in `shutdown()`.
+    #[unsafe(export_name = "WebWorker__threadCpuUsage")]
+    pub(crate) extern "C" fn thread_cpu_usage(
+        this: *mut WebWorker,
+        user_micros: &mut f64,
+        system_micros: &mut f64,
+    ) -> bool {
+        let this = bun_ptr::ParentRef::from(NonNull::new(this).expect("WebWorker FFI ptr"));
+        // shutdown() takes this lock to unpublish the handle, so while it is
+        // held and `Some` the thread has not exited.
+        let handle = this.vm_handle.lock();
+        if handle.is_none() {
+            return false;
+        }
+        let Some(now) = this.join_handle.get().as_ref().and_then(ThreadCpuUsage::of) else {
+            return false;
+        };
+        let usage = now.never_below(this.last_cpu_usage.get());
+        this.last_cpu_usage.set(usage);
+        *user_micros = usage.user as f64;
+        *system_micros = usage.system as f64;
+        true
     }
 
     /// The parent is releasing this thread: drop the keep-alive on the parent's

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -104,7 +104,7 @@ pub struct WebWorker {
     /// Taken by the parent to join the OS thread.
     join_handle: JsCell<Option<JoinHandle<()>>>,
     /// The last `worker.cpuUsage()` answer, which the next one never goes below.
-    last_cpu_usage: Cell<ThreadCpuUsage>,
+    last_cpu_usage: Cell<bun_sys::ThreadCpuUsage>,
 
     // ---- Worker-thread only -----------------------------------------------------
     // Mutated only on the worker thread, but through `&self` because other
@@ -132,140 +132,6 @@ struct WorkerVmInit {
     transform_options: bun_options_types::schema::api::TransformOptions,
     env_loader: bun_dotenv::Loader,
     proxy_env_slots: jsc::rare_data::ProxyEnvSlots,
-}
-
-/// One thread's CPU times in microseconds, read from any thread.
-#[derive(Clone, Copy, Default)]
-struct ThreadCpuUsage {
-    user: u64,
-    system: u64,
-}
-
-impl ThreadCpuUsage {
-    /// `thread` must not have exited.
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    fn of(thread: &JoinHandle<()>) -> Option<Self> {
-        use std::os::unix::thread::JoinHandleExt as _;
-        // A thread's three CPU clocks differ in the low two bits of the id
-        // (CPUCLOCK_PROF/VIRT/SCHED, include/linux/posix-timers_types.h).
-        const CLOCK_MASK: libc::clockid_t = 3;
-        const USER_AND_SYSTEM_TICKS: libc::clockid_t = 0;
-        const USER_TICKS: libc::clockid_t = 1;
-        let mut runtime_clock: libc::clockid_t = 0;
-        let pthread = thread.as_pthread_t() as libc::pthread_t;
-        // SAFETY: the thread is alive (fn contract), so its pthread_t is valid.
-        if unsafe { libc::pthread_getcpuclockid(pthread, &raw mut runtime_clock) } != 0 {
-            return None;
-        }
-        let nanos = |clock: libc::clockid_t| -> Option<u64> {
-            let mut ts = libc::timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
-            // SAFETY: `ts` is a valid out-pointer.
-            (unsafe { libc::clock_gettime(clock, &raw mut ts) } == 0)
-                .then(|| ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64)
-        };
-        let runtime = nanos(runtime_clock)?;
-        let user_ticks = nanos((runtime_clock & !CLOCK_MASK) | USER_TICKS)?;
-        let system_ticks = nanos((runtime_clock & !CLOCK_MASK) | USER_AND_SYSTEM_TICKS)?
-            .saturating_sub(user_ticks);
-        // What getrusage(RUSAGE_THREAD) reports: the exact runtime, split in the
-        // ratio of the tick-sampled times (cputime_adjust(), kernel/sched/cputime.c).
-        let system = match (user_ticks, system_ticks) {
-            (_, 0) => 0,
-            (0, _) => runtime,
-            (user, system) => {
-                (u128::from(runtime) * u128::from(system) / (u128::from(user) + u128::from(system)))
-                    as u64
-            }
-        };
-        Some(Self {
-            user: (runtime - system) / 1000,
-            system: system / 1000,
-        })
-    }
-
-    /// `thread` must not have exited.
-    #[cfg(target_os = "macos")]
-    fn of(thread: &JoinHandle<()>) -> Option<Self> {
-        use std::os::unix::thread::JoinHandleExt as _;
-        // SAFETY: all-zero is a valid `thread_basic_info` (POD C struct).
-        let mut info: libc::thread_basic_info = unsafe { bun_core::ffi::zeroed_unchecked() };
-        let mut count = libc::THREAD_BASIC_INFO_COUNT;
-        // SAFETY: the thread is alive (fn contract), so its mach port is valid;
-        // `info` and `count` are valid out-pointers of the size `count` states.
-        let status = unsafe {
-            libc::thread_info(
-                libc::pthread_mach_thread_np(thread.as_pthread_t() as libc::pthread_t),
-                libc::THREAD_BASIC_INFO as libc::thread_flavor_t,
-                (&raw mut info).cast(),
-                &raw mut count,
-            )
-        };
-        let micros = |t: libc::time_value_t| t.seconds as u64 * 1_000_000 + t.microseconds as u64;
-        (status == libc::KERN_SUCCESS).then(|| Self {
-            user: micros(info.user_time),
-            system: micros(info.system_time),
-        })
-    }
-
-    #[cfg(windows)]
-    fn of(thread: &JoinHandle<()>) -> Option<Self> {
-        use bun_sys::windows::FILETIME;
-        use std::os::windows::io::AsRawHandle as _;
-        // SAFETY: all-zero is a valid FILETIME (POD C struct).
-        let [mut creation, mut exit, mut kernel, mut user]: [FILETIME; 4] =
-            unsafe { bun_core::ffi::zeroed_unchecked() };
-        // SAFETY: the JoinHandle keeps the thread's HANDLE open; valid out-pointers.
-        if unsafe {
-            bun_sys::windows::GetThreadTimes(
-                thread.as_raw_handle().cast(),
-                &raw mut creation,
-                &raw mut exit,
-                &raw mut kernel,
-                &raw mut user,
-            )
-        } == 0
-        {
-            return None;
-        }
-        // FILETIME counts 100 ns units.
-        let micros =
-            |t: FILETIME| ((u64::from(t.dwHighDateTime) << 32) | u64::from(t.dwLowDateTime)) / 10;
-        Some(Self {
-            user: micros(user),
-            system: micros(kernel),
-        })
-    }
-
-    #[cfg(not(any(
-        target_os = "linux",
-        target_os = "android",
-        target_os = "macos",
-        windows
-    )))]
-    fn of(_: &JoinHandle<()>) -> Option<Self> {
-        None
-    }
-
-    /// `self`, adjusted so that neither time is below what `previous` reported
-    /// (the split on Linux is an estimate that can move between readings).
-    fn never_below(self, previous: Self) -> Self {
-        let total = self.user + self.system;
-        if total <= previous.user + previous.system {
-            return previous;
-        }
-        let system = self.system.max(previous.system);
-        let user = total - system;
-        if user < previous.user {
-            return Self {
-                user: previous.user,
-                system: total - previous.user,
-            };
-        }
-        Self { user, system }
-    }
 }
 
 enum EntryOutcome {
@@ -561,7 +427,7 @@ impl WebWorker {
             vm: Cell::new(core::ptr::null_mut()),
             parent_poll_ref: JsCell::new(KeepAlive::init()),
             join_handle: JsCell::new(None),
-            last_cpu_usage: Cell::new(ThreadCpuUsage::default()),
+            last_cpu_usage: Cell::new(bun_sys::ThreadCpuUsage::default()),
             status: Cell::new(Status::Start),
             arena: JsCell::new(None),
             worker_env_loader: Cell::new(core::ptr::null_mut()),
@@ -713,11 +579,31 @@ impl WebWorker {
         if handle.is_none() {
             return false;
         }
-        let Some(now) = this.join_handle.get().as_ref().and_then(ThreadCpuUsage::of) else {
+        let Some(now) = this
+            .join_handle
+            .get()
+            .as_ref()
+            .and_then(bun_sys::ThreadCpuUsage::of)
+        else {
             return false;
         };
         let usage = now.never_below(this.last_cpu_usage.get());
         this.last_cpu_usage.set(usage);
+        *user_micros = usage.user as f64;
+        *system_micros = usage.system as f64;
+        true
+    }
+
+    /// The calling thread's CPU times, for a `worker.cpuUsage()` that the worker
+    /// itself answers. Worker thread.
+    #[unsafe(export_name = "WebWorker__currentThreadCpuUsage")]
+    pub(crate) extern "C" fn current_thread_cpu_usage(
+        user_micros: &mut f64,
+        system_micros: &mut f64,
+    ) -> bool {
+        let Some(usage) = bun_sys::ThreadCpuUsage::current() else {
+            return false;
+        };
         *user_micros = usage.user as f64;
         *system_micros = usage.system as f64;
         true

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -906,6 +906,8 @@ pub mod signal_code;
 pub use signal_code::SignalCode;
 pub mod tmp;
 pub use tmp::Tmpfile;
+pub mod thread_cpu_usage;
+pub use thread_cpu_usage::ThreadCpuUsage;
 // `windows/mod.rs` is `#![cfg(windows)]`-gated internally; on POSIX this
 // declares an empty module so `bun_sys::windows::*` paths still resolve under
 // `#[cfg(windows)]` arms in dependents.

--- a/src/sys/thread_cpu_usage.rs
+++ b/src/sys/thread_cpu_usage.rs
@@ -15,14 +15,12 @@ impl ThreadCpuUsage {
         imp::current()
     }
 
-    /// `thread`'s, read from any thread. `None` once it has exited, and where
-    /// the platform has no way to ask.
+    /// `thread`'s, from any thread. `None` once it has exited or where the platform cannot say.
     pub fn of<T>(thread: &JoinHandle<T>) -> Option<Self> {
         imp::of(thread)
     }
 
-    /// `self` with neither time below what `previous` reported. On Linux the
-    /// split of another thread's time is an estimate that moves between reads.
+    /// Neither time below `previous`: on Linux another thread's split is an estimate that moves.
     #[must_use]
     pub fn never_below(self, previous: Self) -> Self {
         let total = self.user + self.system;
@@ -80,8 +78,7 @@ mod imp {
                 &raw mut runtime_clock,
             )
         };
-        // musl and bionic clear the tid of a thread that has exited and answer with the clock of
-        // tid 0, which is the calling thread's.
+        // For an exited thread musl and bionic give the clock of tid 0, the calling thread's.
         let tid = !(runtime_clock >> 3);
         if status != 0 || tid == 0 {
             return None;
@@ -98,9 +95,7 @@ mod imp {
         let user_ticks = nanos((runtime_clock & !WHICH_MASK) | USER_TICKS)?;
         let system_ticks = nanos((runtime_clock & !WHICH_MASK) | USER_AND_SYSTEM_TICKS)?
             .saturating_sub(user_ticks);
-        // getrusage(RUSAGE_THREAD) only answers for the calling thread. It reports the exact
-        // runtime, split in the ratio of the tick-sampled times (cputime_adjust(),
-        // kernel/sched/cputime.c).
+        // Like getrusage(RUSAGE_THREAD): the exact runtime, split as the tick-sampled times are.
         let system = match (user_ticks, system_ticks) {
             (_, 0) => 0,
             (0, _) => runtime,

--- a/src/sys/thread_cpu_usage.rs
+++ b/src/sys/thread_cpu_usage.rs
@@ -1,0 +1,242 @@
+//! The CPU time one thread has used.
+
+use std::thread::JoinHandle;
+
+/// Microseconds, split as `getrusage(RUSAGE_THREAD)` splits them.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ThreadCpuUsage {
+    pub user: u64,
+    pub system: u64,
+}
+
+impl ThreadCpuUsage {
+    /// The calling thread's.
+    pub fn current() -> Option<Self> {
+        imp::current()
+    }
+
+    /// `thread`'s, read from any thread. `None` once it has exited, and where
+    /// the platform has no way to ask.
+    pub fn of<T>(thread: &JoinHandle<T>) -> Option<Self> {
+        imp::of(thread)
+    }
+
+    /// `self` with neither time below what `previous` reported. On Linux the
+    /// split of another thread's time is an estimate that moves between reads.
+    #[must_use]
+    pub fn never_below(self, previous: Self) -> Self {
+        let total = self.user + self.system;
+        if total <= previous.user + previous.system {
+            return previous;
+        }
+        let system = self.system.max(previous.system);
+        let user = total - system;
+        if user < previous.user {
+            return Self {
+                user: previous.user,
+                system: total - previous.user,
+            };
+        }
+        Self { user, system }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+mod imp {
+    use super::ThreadCpuUsage;
+    use core::ffi::c_int;
+    use std::os::unix::thread::JoinHandleExt as _;
+    use std::thread::JoinHandle;
+
+    unsafe extern "C" {
+        // The out-parameters are references; a clock that does not exist is an errno.
+        safe fn clock_gettime(clock: libc::clockid_t, time: &mut libc::timespec) -> c_int;
+        safe fn getrusage(who: c_int, usage: &mut libc::rusage) -> c_int;
+    }
+
+    // include/uapi/linux/resource.h; the libc crate has no constant for bionic.
+    const RUSAGE_THREAD: c_int = 1;
+
+    pub(super) fn current() -> Option<ThreadCpuUsage> {
+        let mut usage: libc::rusage = bun_core::ffi::zeroed();
+        let micros = |t: libc::timeval| t.tv_sec as u64 * 1_000_000 + t.tv_usec as u64;
+        (getrusage(RUSAGE_THREAD, &mut usage) == 0).then(|| ThreadCpuUsage {
+            user: micros(usage.ru_utime),
+            system: micros(usage.ru_stime),
+        })
+    }
+
+    // `(!tid << 3) | CPUCLOCK_PERTHREAD_MASK | which` (include/linux/posix-timers_types.h).
+    const WHICH_MASK: libc::clockid_t = 3;
+    const USER_AND_SYSTEM_TICKS: libc::clockid_t = 0;
+    const USER_TICKS: libc::clockid_t = 1;
+
+    pub(super) fn of<T>(thread: &JoinHandle<T>) -> Option<ThreadCpuUsage> {
+        let mut runtime_clock: libc::clockid_t = 0;
+        // SAFETY: a thread that is neither joined nor detached keeps its pthread_t valid.
+        let status = unsafe {
+            libc::pthread_getcpuclockid(
+                thread.as_pthread_t() as libc::pthread_t,
+                &raw mut runtime_clock,
+            )
+        };
+        // musl and bionic clear the tid of a thread that has exited and answer with the clock of
+        // tid 0, which is the calling thread's.
+        let tid = !(runtime_clock >> 3);
+        if status != 0 || tid == 0 {
+            return None;
+        }
+        let nanos = |clock: libc::clockid_t| -> Option<u64> {
+            let mut time = libc::timespec {
+                tv_sec: 0,
+                tv_nsec: 0,
+            };
+            (clock_gettime(clock, &mut time) == 0)
+                .then(|| time.tv_sec as u64 * 1_000_000_000 + time.tv_nsec as u64)
+        };
+        let runtime = nanos(runtime_clock)?;
+        let user_ticks = nanos((runtime_clock & !WHICH_MASK) | USER_TICKS)?;
+        let system_ticks = nanos((runtime_clock & !WHICH_MASK) | USER_AND_SYSTEM_TICKS)?
+            .saturating_sub(user_ticks);
+        // getrusage(RUSAGE_THREAD) only answers for the calling thread. It reports the exact
+        // runtime, split in the ratio of the tick-sampled times (cputime_adjust(),
+        // kernel/sched/cputime.c).
+        let system = match (user_ticks, system_ticks) {
+            (_, 0) => 0,
+            (0, _) => runtime,
+            (user, system) => {
+                (u128::from(runtime) * u128::from(system) / (u128::from(user) + u128::from(system)))
+                    as u64
+            }
+        };
+        Some(ThreadCpuUsage {
+            user: (runtime - system) / 1000,
+            system: system / 1000,
+        })
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use super::ThreadCpuUsage;
+    use std::os::unix::thread::JoinHandleExt as _;
+    use std::thread::JoinHandle;
+
+    pub(super) fn current() -> Option<ThreadCpuUsage> {
+        // SAFETY: no preconditions; the calling thread's pthread_t is valid.
+        of_pthread(unsafe { libc::pthread_self() })
+    }
+
+    pub(super) fn of<T>(thread: &JoinHandle<T>) -> Option<ThreadCpuUsage> {
+        of_pthread(thread.as_pthread_t() as libc::pthread_t)
+    }
+
+    /// `pthread` belongs to a thread that is neither joined nor detached.
+    fn of_pthread(pthread: libc::pthread_t) -> Option<ThreadCpuUsage> {
+        // SAFETY: all-zero is a valid `thread_basic_info` (POD C struct).
+        let mut info: libc::thread_basic_info = unsafe { bun_core::ffi::zeroed_unchecked() };
+        let mut count = libc::THREAD_BASIC_INFO_COUNT;
+        // SAFETY: the pthread_t is valid (fn contract) and lends its mach port without a new
+        // right; `info` and `count` are out-pointers of the size `count` states. The port of a
+        // thread that has exited is a dead name, which is an error status.
+        let status = unsafe {
+            libc::thread_info(
+                libc::pthread_mach_thread_np(pthread),
+                libc::THREAD_BASIC_INFO as libc::thread_flavor_t,
+                (&raw mut info).cast(),
+                &raw mut count,
+            )
+        };
+        let micros = |t: libc::time_value_t| t.seconds as u64 * 1_000_000 + t.microseconds as u64;
+        (status == libc::KERN_SUCCESS).then(|| ThreadCpuUsage {
+            user: micros(info.user_time),
+            system: micros(info.system_time),
+        })
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use super::ThreadCpuUsage;
+    use crate::windows::{FILETIME, GetCurrentThread, GetThreadTimes, HANDLE};
+    use std::os::windows::io::AsRawHandle as _;
+    use std::thread::JoinHandle;
+
+    pub(super) fn current() -> Option<ThreadCpuUsage> {
+        // SAFETY: no preconditions; a pseudo handle for the calling thread.
+        of_handle(unsafe { GetCurrentThread() })
+    }
+
+    pub(super) fn of<T>(thread: &JoinHandle<T>) -> Option<ThreadCpuUsage> {
+        of_handle(thread.as_raw_handle().cast())
+    }
+
+    /// `thread` is an open thread handle. A thread that has exited reports its final times.
+    fn of_handle(thread: HANDLE) -> Option<ThreadCpuUsage> {
+        // SAFETY: all-zero is a valid FILETIME (POD C struct).
+        let [mut creation, mut exit, mut kernel, mut user]: [FILETIME; 4] =
+            unsafe { bun_core::ffi::zeroed_unchecked() };
+        // SAFETY: an open handle (fn contract) and four valid out-pointers.
+        let ok = unsafe {
+            GetThreadTimes(
+                thread,
+                &raw mut creation,
+                &raw mut exit,
+                &raw mut kernel,
+                &raw mut user,
+            )
+        };
+        // FILETIME counts 100 ns units.
+        let micros =
+            |t: FILETIME| ((u64::from(t.dwHighDateTime) << 32) | u64::from(t.dwLowDateTime)) / 10;
+        (ok != 0).then(|| ThreadCpuUsage {
+            user: micros(user),
+            system: micros(kernel),
+        })
+    }
+}
+
+#[cfg(target_os = "freebsd")]
+mod imp {
+    use super::ThreadCpuUsage;
+    use core::ffi::c_int;
+    use std::thread::JoinHandle;
+
+    unsafe extern "C" {
+        // The out-parameter is a reference; a `who` that does not exist is an errno.
+        safe fn getrusage(who: c_int, usage: &mut libc::rusage) -> c_int;
+    }
+
+    pub(super) fn current() -> Option<ThreadCpuUsage> {
+        let mut usage: libc::rusage = bun_core::ffi::zeroed();
+        let micros = |t: libc::timeval| t.tv_sec as u64 * 1_000_000 + t.tv_usec as u64;
+        (getrusage(libc::RUSAGE_THREAD, &mut usage) == 0).then(|| ThreadCpuUsage {
+            user: micros(usage.ru_utime),
+            system: micros(usage.ru_stime),
+        })
+    }
+
+    pub(super) fn of<T>(_: &JoinHandle<T>) -> Option<ThreadCpuUsage> {
+        None
+    }
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "freebsd",
+    windows
+)))]
+mod imp {
+    use super::ThreadCpuUsage;
+    use std::thread::JoinHandle;
+
+    pub(super) fn current() -> Option<ThreadCpuUsage> {
+        None
+    }
+
+    pub(super) fn of<T>(_: &JoinHandle<T>) -> Option<ThreadCpuUsage> {
+        None
+    }
+}

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1414,6 +1414,7 @@ pub use bun_windows_sys::externs::DeleteFileW;
 pub use bun_windows_sys::externs::GetCommandLineW;
 pub use bun_windows_sys::externs::GetCurrentThread;
 pub use bun_windows_sys::externs::GetProcessTimes;
+pub use bun_windows_sys::externs::GetThreadTimes;
 pub use bun_windows_sys::externs::SetEndOfFile;
 
 /// `PROCESS_MEMORY_COUNTERS` (`psapi.h`).

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -1831,6 +1831,14 @@ unsafe extern "system" {
         out_lpUserTime: *mut FILETIME,
     ) -> BOOL;
 
+    pub fn GetThreadTimes(
+        in_hThread: HANDLE,
+        out_lpCreationTime: *mut FILETIME,
+        out_lpExitTime: *mut FILETIME,
+        out_lpKernelTime: *mut FILETIME,
+        out_lpUserTime: *mut FILETIME,
+    ) -> BOOL;
+
     /// `RegisterWaitForSingleObject` (`winbase.h`). Queues `Callback` to the
     /// system thread pool once `hObject` is signaled (or `dwMilliseconds`
     /// elapses). Returns non-zero on success; `*phNewWaitObject` receives the

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isDebug, isFreeBSD, tempDir, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -1577,17 +1577,20 @@ describe("a worker that does not return to its event loop", () => {
         expect(statistics.used_heap_size).toBeGreaterThan(0);
         expect(statistics.total_physical_size).toBeGreaterThan(0);
 
-        // The operating system may account CPU time in ticks as long as several milliseconds.
-        let usage = await worker.cpuUsage();
-        while (usage.user + usage.system === 0) usage = await worker.cpuUsage();
-        const since = await worker.cpuUsage(usage);
-        expect(since.user).toBeGreaterThanOrEqual(0);
-        expect(since.system).toBeGreaterThanOrEqual(0);
+        // FreeBSD has no way to read another thread's CPU times, so cpuUsage() still asks the worker there.
+        if (!isFreeBSD) {
+          // The operating system may account CPU time in ticks as long as several milliseconds.
+          let usage = await worker.cpuUsage();
+          while (usage.user + usage.system === 0) usage = await worker.cpuUsage();
+          const since = await worker.cpuUsage(usage);
+          expect(since.user).toBeGreaterThanOrEqual(0);
+          expect(since.system).toBeGreaterThanOrEqual(0);
+        }
 
         // Each answer lets the parent's event loop turn, so a loop that polls does not starve it.
         let turned = false;
         setImmediate(() => (turned = true));
-        while (!turned) await worker.cpuUsage();
+        while (!turned) await worker.getHeapStatistics();
 
         expect(Atomics.load(flag, 0)).toBe(0);
       } finally {
@@ -1598,25 +1601,27 @@ describe("a worker that does not return to its event loop", () => {
   );
 
   test.concurrent("getHeapStatistics() follows the heap as the worker collects", async () => {
-    const flag = new Int32Array(new SharedArrayBuffer(4));
+    // [0] ends the worker's loop. [1] lets it retain what it allocates, up to 64 MB, set once `before` is read.
+    const flags = new Int32Array(new SharedArrayBuffer(8));
     const worker = new Worker(
       `const { parentPort, workerData } = require("node:worker_threads");
       parentPort.postMessage("spinning");
       const retained = [];
       while (Atomics.load(workerData, 0) === 0) {
         const chunk = new Array(1024).fill(retained.length);
-        if (retained.length < 4096) retained.push(chunk);
+        if (Atomics.load(workerData, 1) === 1 && retained.length < 8192) retained.push(chunk);
       }`,
-      { eval: true, workerData: flag },
+      { eval: true, workerData: flags },
     );
     try {
       await once(worker, "message");
       const { used_heap_size: before } = await worker.getHeapStatistics();
+      Atomics.store(flags, 1, 1);
       let after = before;
       while (after < before + 16 * 1024 * 1024) after = (await worker.getHeapStatistics()).used_heap_size;
-      expect(Atomics.load(flag, 0)).toBe(0);
+      expect(Atomics.load(flags, 0)).toBe(0);
     } finally {
-      Atomics.store(flag, 0, 1);
+      Atomics.store(flags, 0, 1);
       await worker.terminate();
     }
   });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1584,6 +1584,11 @@ describe("a worker that does not return to its event loop", () => {
         expect(since.user).toBeGreaterThanOrEqual(0);
         expect(since.system).toBeGreaterThanOrEqual(0);
 
+        // Each answer lets the parent's event loop turn, so a loop that polls does not starve it.
+        let turned = false;
+        setImmediate(() => (turned = true));
+        while (!turned) await worker.cpuUsage();
+
         expect(Atomics.load(flag, 0)).toBe(0);
       } finally {
         Atomics.store(flag, 0, 1);
@@ -1591,6 +1596,30 @@ describe("a worker that does not return to its event loop", () => {
       }
     },
   );
+
+  test.concurrent("getHeapStatistics() follows the heap as the worker collects", async () => {
+    const flag = new Int32Array(new SharedArrayBuffer(4));
+    const worker = new Worker(
+      `const { parentPort, workerData } = require("node:worker_threads");
+      parentPort.postMessage("spinning");
+      const retained = [];
+      while (Atomics.load(workerData, 0) === 0) {
+        const chunk = new Array(1024).fill(retained.length);
+        if (retained.length < 4096) retained.push(chunk);
+      }`,
+      { eval: true, workerData: flag },
+    );
+    try {
+      await once(worker, "message");
+      const { used_heap_size: before } = await worker.getHeapStatistics();
+      let after = before;
+      while (after < before + 16 * 1024 * 1024) after = (await worker.getHeapStatistics()).used_heap_size;
+      expect(Atomics.load(flag, 0)).toBe(0);
+    } finally {
+      Atomics.store(flag, 0, 1);
+      await worker.terminate();
+    }
+  });
 });
 
 test("*Internal introspection methods are DontEnum on Worker.prototype", () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1555,6 +1555,44 @@ test("getHeapStatistics settles when terminated mid-request", async () => {
   ).resolves.toMatch(/^(ok|ERR_WORKER_NOT_RUNNING)$/);
 });
 
+describe("a worker that does not return to its event loop", () => {
+  // The worker spins until the parent sets the flag, and the parent sets it only once the calls have
+  // settled: a call that waits for the worker's event loop never settles.
+  test.concurrent.each(["while its entry module evaluates", "inside a message handler"])(
+    "answers cpuUsage() and getHeapStatistics() %s",
+    async where => {
+      const flag = new Int32Array(new SharedArrayBuffer(4));
+      const spin = `parentPort.postMessage("spinning"); while (Atomics.load(workerData, 0) === 0) {}`;
+      const worker = new Worker(
+        `const { parentPort, workerData } = require("node:worker_threads");
+        ${where === "inside a message handler" ? `parentPort.once("message", () => { ${spin} });` : spin}`,
+        { eval: true, workerData: flag },
+      );
+      try {
+        const spinning = once(worker, "message");
+        if (where === "inside a message handler") worker.postMessage("go");
+        await spinning;
+
+        const statistics = await worker.getHeapStatistics();
+        expect(statistics.used_heap_size).toBeGreaterThan(0);
+        expect(statistics.total_physical_size).toBeGreaterThan(0);
+
+        // The operating system may account CPU time in ticks as long as several milliseconds.
+        let usage = await worker.cpuUsage();
+        while (usage.user + usage.system === 0) usage = await worker.cpuUsage();
+        const since = await worker.cpuUsage(usage);
+        expect(since.user).toBeGreaterThanOrEqual(0);
+        expect(since.system).toBeGreaterThanOrEqual(0);
+
+        expect(Atomics.load(flag, 0)).toBe(0);
+      } finally {
+        Atomics.store(flag, 0, 1);
+        await worker.terminate();
+      }
+    },
+  );
+});
+
 test("*Internal introspection methods are DontEnum on Worker.prototype", () => {
   const enumerable: string[] = [];
   for (const k in globalThis.Worker.prototype) enumerable.push(k);


### PR DESCRIPTION
### Problem
- `worker.cpuUsage()` and `worker.getHeapStatistics()` stay pending while the worker runs synchronous JavaScript. With `while (true) {}` they never settle. Node settles both at once.
- Both post a task to the worker's event loop (`JSWorker.cpp`, `postTaskToWorkerGlobalScope`). While the entry module evaluates, the proxy only appends the task to `m_pendingTasks`.

### Fix
- Once the parent has seen the worker come online, it answers both calls itself. Before that, and after `terminate()`, the old path runs unchanged.
- `cpuUsage()`: the new `bun_sys::ThreadCpuUsage` reads a thread's CPU times by its native handle (Linux per-thread CPU clocks, macOS `thread_info`, Windows `GetThreadTimes`). `WebWorker::cpu_usage` calls it under the `vm_handle` lock, so the thread cannot exit meanwhile.
- `getHeapStatistics()`: the worker publishes its heap counters to the proxy when it comes online and at the end of each collection (a `JSC::HeapObserver`), as `process.memoryUsage()` reports last-collection sizes.
- Verified: three new tests in `test/js/node/worker_threads/worker_threads.test.ts`, all time out on bun 1.4.3. The file passes (145) on linux-x64 debug with ASAN and on windows-x64, with the vendored worker tests.

### Background
- `WorkerMessagingProxy` is the object the parent and the worker thread share. It stays `Pending` until the entry module has evaluated. `online` fires earlier, when the thread's VM exists.
- `vm_handle` is how a parent reaches a worker's VM from another thread. The worker takes it back, under its lock, as the first step of `shutdown()`.
- `getHeapSnapshot()` and `startCpuProfile()` must run on the worker thread where a collection is safe. They are not changed here: #42354.

<details><summary>Notes</summary>

- The promise settles after the parent's loop has polled once (`postTaskAfterYield`), as an answer from the worker does. A loop that polls these calls does not starve timers and I/O.
- Worker in a 6 s synchronous loop: `getHeapStatistics()` 3 ms and `cpuUsage()` 6 ms on the debug build, both about 5710 ms on bun 1.4.3, both 0 ms on Node v26.3.0. The same holds when the loop runs in a `parentPort` message handler.
- The answers need nothing from the worker, so they also settle while it is parked in `Atomics.wait`, in a long regular expression, or in a WebAssembly loop, where a VM trap does not fire.
- Why not a VM trap for all five calls: JSC services `NeedShellTimeoutCheck`, the one trap with an embedder callback, from every C++ `RETURN_IF_EXCEPTION` (`VM::hasExceptionsAfterHandlingTraps`), not only at JIT and LLInt safepoints. A heap snapshot runs a full synchronous collection, which is not safe there. #32549 also claims that single callback slot.
- Linux: `getrusage(RUSAGE_THREAD)` only answers for the calling thread. `pthread_getcpuclockid` gives another thread's exact runtime clock. The same clock id with the low two bits changed gives its tick-sampled user time and user plus system time. `ThreadCpuUsage::of` splits the exact runtime in that ratio, which is what the kernel's `cputime_adjust()` does for `getrusage`. Next to `process.threadCpuUsage()` inside the worker the numbers agree to within the time between the two reads (user 1312626 and 1314875 µs). On Windows they agree to the tick (781000 and 781250 µs).
- The split is an estimate, so `never_below` keeps each answer at or above the previous one, and every answer for one worker goes through it, also one the worker measured itself. `worker.cpuUsage(previous)` is then never negative.
- On musl and bionic `pthread_getcpuclockid` on a thread that has exited gives the clock of tid 0, which is the caller's. `ThreadCpuUsage::of` rejects that id itself.
- The per-OS code that `JSWorker.cpp` carried for the worker-side read is gone. That path now calls `ThreadCpuUsage::current()`.
- Heap numbers are as of the worker's last collection, plus one reading when it comes online and one when its entry point has evaluated. `Heap::size()` already counted only what the last collection marked, so `used_heap_size` means the same as before. Capacity and external memory can lag until the next collection.
- `cargo check -p bun_jsc` passes for linux gnu and musl, android, darwin, windows and freebsd. `cargo clippy` is clean for `bun_sys` and `bun_jsc` on linux gnu and musl, darwin, windows and freebsd. The macOS path has not run locally.
- `test/js/web/workers/worker.test.ts` "terminate() while fs.readFile completions keep arriving" takes 6.2 s on the local debug build against its 5 s default timeout. It creates 48 workers and prints PASS. It does not touch this code.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 6 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/worker_threads/worker_threads.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/164] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/164] gen cpp.rs (cppbind)
[3/164] gen JS modules (bundle-modules)
Preprocess modules (9181ms)
Bundle modules (48ms)
Postprocesss modules (125ms)
Bundle Functions (444ms)
Generate Code (25ms)

[9.83s] Bundled "src/js" for development
  2791 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/164] cargo bun_runtime → libbun_runtime.a
[157/164] cxx obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o
FAILED: obj/unified/UnifiedSource-src_runtime_bake-0.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (8575c3c97)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [17.83ms]
(pass) all worker_threads module properties are present [0.34ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [0.38ms]
(pass) all worker_threads worker instance properties are present [2.49ms]
(pass) threadId module and worker property is consistent [4.95ms]
(pass) receiveMessageOnPort works across threads [17.49ms]
(pass) receiveMessageOnPort works as FIFO [0.24ms]
(pass) you can override globalThis.postMessage [18.44ms]
(pass) support require in eval [14.74ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [21.50ms]
(pass) support require in eval for a file that doesnt exist [13.93ms]
(pass) support worker eval that throws [17.18ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [79.94ms]
(pass) execArgv option > provides empty execArgv when passed an empty array [39.48ms]
(pass) execArgv option > can specify an array of strings [35.52ms]
(pass) eval does not leak source code [2044.04
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1291.39ms]
(pass) all worker_threads module properties are present [22.95ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [23.60ms]
(pass) all worker_threads worker instance properties are present [150.57ms]
(pass) threadId module and worker property is consistent [205.32ms]
(pass) receiveMessageOnPort works across threads [1049.52ms]
(pass) receiveMessageOnPort works as FIFO [14.50ms]
(pass) you can override globalThis.postMessage [1047.32ms]
(pass) support require in eval [1015.41ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1087.57ms]
(pass) support require in eval for a file that doesnt exist [961.50ms]
(pass) support worker eval that throws [1010.61ms]
(pass) execArgv option > inherits the parent's execArgv when falsy or unspecified [4272.02ms]
(pa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 668ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/125] gen cpp.rs (cppbind)
[3/125] gen JS modules (bundle-modules)
Preprocess modules (8057ms)
Bundle modules (45ms)
Postprocesss modules (172ms)
Bundle Functions (511ms)
Generate Code (34ms)

[8.83s] Bundled "src/js" for production
  2599 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/124] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_windows_sys v0.0.0 (/workspace/bun/src/windows_sys)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunClientData.cpp                 |  38 ++++
 src/jsc/bindings/BunClientData.h                   |   2 +
 src/jsc/bindings/webcore/JSWorker.cpp              | 136 ++++++------
 src/jsc/bindings/webcore/WorkerMessagingProxy.cpp  |  44 ++++
 src/jsc/bindings/webcore/WorkerMessagingProxy.h    |  26 +++
 src/jsc/web_worker.rs                              |  49 +++++
 src/sys/lib.rs                                     |   2 +
 src/sys/thread_cpu_usage.rs                        | 237 +++++++++++++++++++++
 src/sys/windows/mod.rs                             |   1 +
 src/windows_sys/externs.rs                         |   8 +
 test/js/node/worker_threads/worker_threads.test.ts |  74 ++++++-
 11 files changed, 549 insertions(+), 68 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/BunClientData.cpp                      1      2     28
src/jsc/bindings/BunClientData.h                        1      2     28
src/jsc/bindings/webcore/JSWorker.cpp                   6      8     28
src/jsc/bindings/webcore/WorkerMessagingProxy.cpp       4      7     28
src/jsc/bindings/webcore/WorkerMessagingProxy.h         2      6     28
src/jsc/web_worker.rs                                  15     21     28
src/sys/lib.rs                                          1      1     28
src/sys/thread_cpu_usage.rs                             0      1     30
src/sys/windows/mod.rs                                  1      1     28
src/windows_sys/externs.rs                              1      1     28
test/js/node/worker_threads/worker_threads.test.ts      3      2     28
```

</details>

<!-- robobun:evidence:end -->