### PR TITLE
node:module: load the file when Module.prototype.require is called on something that is not a module

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -294,6 +294,7 @@ declare function $evaluateCommonJSModule(
   sourceModule: JSCommonJSModule,
 ): JSCommonJSModule[];
 declare function $evictIsolationSourceProviderCache(key?: string): void;
+declare function $requireNativeModule(id: string): any;
 
 declare function $overridableRequire(this: JSCommonJSModule, id: string): any;
 

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -16,7 +16,9 @@ export function require(this: JSCommonJSModule, _: string) {
 $overriddenName = "require";
 $visibility = "Private";
 export function overridableRequire(this: JSCommonJSModule, originalId: string, options?: { paths?: string[] }) {
-  const id = $resolveSync(originalId, this.filename, false, false, options ? options.paths : undefined, this, options);
+  // Like Node, only read properties off `this`: it can be a plain object or undefined.
+  const parentFilename = this?.filename;
+  const id = $resolveSync(originalId, parentFilename, false, false, options ? options.paths : undefined, this, options);
   if (id.startsWith("node:")) {
     if (id !== originalId) {
       // A terrible special case where Node.js allows non-prefixed built-ins to
@@ -31,7 +33,7 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
       }
     }
 
-    return this.$requireNativeModule(id);
+    return $requireNativeModule(id);
   } else {
     const existing = $requireMap.$get(id);
     if (existing) {
@@ -68,7 +70,7 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
   }
 
   if (id === "bun:test") {
-    return Bun.jest(this.filename);
+    return Bun.jest(parentFilename);
   }
 
   // To handle import/export cycles, we need to create a module object and put
@@ -87,9 +89,9 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
   if (IS_BUN_DEVELOPMENT) {
     $assert(mod.id === id);
     try {
-      out = this.$require(
+      out = mod.$require(
         id,
-        mod,
+        parentFilename,
         // did they pass a { type } object?
         $argumentCount(),
         // the object containing a "type" attribute, if they passed one
@@ -101,7 +103,7 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
       throw E;
     }
   } else {
-    out = this.$require(id, mod, $argumentCount(), $argument(1));
+    out = mod.$require(id, parentFilename, $argumentCount(), $argument(1));
   }
 
   // -1 means we need to lookup the module from the ESM registry.

--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -67,8 +67,8 @@ declare interface Error {
 }
 
 interface JSCommonJSModule {
-  $require(id: string, mod: any, args_count: number, args: Array): any;
-  $requireNativeModule(id: string): any;
+  /** Called on the module being loaded. `parentFilename` is the `filename` of what `require` was called on. */
+  $require(id: string, parentFilename: unknown, args_count: number, args: Array): any;
   children: JSCommonJSModule[];
   exports: any;
   id: string;

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -87,7 +87,6 @@ namespace Bun {
 using namespace JSC;
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionRequireCommonJS);
-JSC_DECLARE_HOST_FUNCTION(jsFunctionRequireNativeModule);
 
 static bool canPerformFastEnumeration(Structure* s)
 {
@@ -848,12 +847,6 @@ public:
             clientData(vm)->builtinNames().requirePrivateName(),
             2,
             jsFunctionRequireCommonJS, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete);
-        this->putDirectNativeFunction(
-            vm,
-            globalObject,
-            clientData(vm)->builtinNames().requireNativeModulePrivateName(),
-            0,
-            jsFunctionRequireNativeModule, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete);
     }
 };
 
@@ -1300,27 +1293,24 @@ ALWAYS_INLINE EncodedJSValue finishRequireWithError(Zig::GlobalObject* globalObj
     if (throwScope.exception()) [[unlikely]] \
     return finishRequireWithError(globalObject, throwScope, specifierValue)
 
-// JSCommonJSModule.$require(resolvedId, newModule, userArgumentCount, userOptions)
+// newModule.$require(resolvedId, parentFilename, userArgumentCount, userOptions)
 JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireCommonJS, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
 {
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     ASSERT(callframe->argumentCount() == 4);
-    // If overriddenRequire is called with invalid this, execution could potentially reach here.
-    JSCommonJSModule* referrerModule = dynamicDowncast<JSCommonJSModule>(callframe->thisValue());
-    if (!referrerModule)
+    JSCommonJSModule* child = dynamicDowncast<JSCommonJSModule>(callframe->thisValue());
+    if (!child)
         return throwVMTypeError(globalObject, throwScope);
     JSValue specifierValue = callframe->uncheckedArgument(0);
     // If Module._resolveFilename is overridden, this could cause this to be a non-string
     WTF::String specifier = specifierValue.toWTFString(globalObject);
     REQUIRE_CJS_RETURN_IF_EXCEPTION;
-    // If this.filename is overridden, this could cause this to be a non-string
-    WTF::String referrer = referrerModule->filename().toWTFString(globalObject);
+    // The parent's `filename` can be any value, and is missing when the parent is not a module.
+    JSValue referrerValue = callframe->uncheckedArgument(1);
+    WTF::String referrer = referrerValue.isUndefinedOrNull() ? emptyString() : referrerValue.toWTFString(globalObject);
     REQUIRE_CJS_RETURN_IF_EXCEPTION;
-
-    // This is always a new JSCommonJSModule object; cast cannot fail.
-    JSCommonJSModule* child = uncheckedDowncast<JSCommonJSModule>(callframe->uncheckedArgument(1));
 
     BunString referrerStr = Bun::toString(referrer);
     BunString typeAttributeStr = { BunStringTag::Dead };
@@ -1368,10 +1358,6 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireNativeModule, (JSGlobalObject * lexica
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-
-    JSCommonJSModule* thisObject = dynamicDowncast<JSCommonJSModule>(callframe->thisValue());
-    if (!thisObject)
-        return throwVMTypeError(globalObject, throwScope);
 
     JSValue specifierValue = callframe->argument(0);
     WTF::String specifier = specifierValue.toWTFString(globalObject);

--- a/src/jsc/bindings/JSCommonJSModule.h
+++ b/src/jsc/bindings/JSCommonJSModule.h
@@ -27,6 +27,7 @@ static constexpr ASCIILiteral commonJSDefaultWrapperEnd = "})"_s;
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionCreateCommonJSModule);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionEvaluateCommonJSModule);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionRequireNativeModule);
 JSC_DECLARE_HOST_FUNCTION(functionJSCommonJSModule_compile);
 
 void populateESMExports(

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2865,6 +2865,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
         { BuiltinName::k_esmRegistryDelete, 1, functionEsmRegistryDelete },
         { BuiltinName::k_esmRegistryEvaluatedKeys, 0, functionEsmRegistryEvaluatedKeys },
         { BuiltinName::k_esmLoadSync, 1, functionEsmLoadSync },
+        { BuiltinName::k_requireNativeModule, 1, Bun::jsFunctionRequireNativeModule },
         { BuiltinName::k_makeErrorWithCode, 2, jsFunctionMakeErrorWithCode },
         { BuiltinName::k_toClass, 1, jsFunctionToClass },
         { BuiltinName::k_inherits, 1, jsFunctionInherits },

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -760,6 +760,78 @@ console.log("survived", require("./late.js"));`,
     expect(await proc.exited).toBe(0);
   });
 
+  test("Module.prototype.require called on something that is not a module", async () => {
+    using dir = tempDir("require-plain-parent", {
+      "dep.js": "module.exports = { ok: true, parentIsFake: module.parent === globalThis.fakeParent };",
+      "sub/rel.js": "module.exports = 'relative to sub';",
+      "bare.js": "module.exports = 'no receiver';",
+      "throws.js": "throw new Error('boom');",
+      "main.cjs": `
+        const path = require("node:path");
+        const Module = require("node:module");
+        const dep = path.join(__dirname, "dep.js");
+        const bare = path.join(__dirname, "bare.js");
+        const throws = path.join(__dirname, "throws.js");
+        const fakeParent = (globalThis.fakeParent = {
+          id: path.join(__dirname, "sub", "virtual.js"),
+          filename: path.join(__dirname, "sub", "virtual.js"),
+          paths: Module._nodeModulePaths(path.join(__dirname, "sub")),
+          children: [],
+        });
+        const caught = fn => {
+          try {
+            return fn();
+          } catch (e) {
+            return "threw " + e.name + ": " + e.message;
+          }
+        };
+        const unbound = Module.prototype.require;
+
+        const first = caught(() => Module.prototype.require.call(fakeParent, dep));
+        const cached = require.cache[dep];
+        console.log(
+          JSON.stringify({
+            first,
+            loaded: cached?.loaded,
+            parentIsFakeParent: cached?.parent === fakeParent,
+            second: require(dep),
+            relative: caught(() => Module.prototype.require.call(fakeParent, "./rel.js")),
+            builtin: caught(() => Module.prototype.require.call(fakeParent, "fs") === require("fs")),
+            noReceiver: caught(() => unbound(bare)),
+            noReceiverRelative: caught(() => unbound("./bare.js")),
+            noReceiverBuiltin: caught(() => unbound("node:path") === path),
+            primitiveReceiver: caught(() => Module.prototype.require.call(5, bare)),
+            throwing: caught(() => Module.prototype.require.call(fakeParent, throws)),
+            throwingCached: throws in require.cache,
+          }),
+        );
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      first: { ok: true, parentIsFake: true },
+      loaded: true,
+      parentIsFakeParent: true,
+      second: { ok: true, parentIsFake: true },
+      relative: "relative to sub",
+      builtin: true,
+      noReceiver: "no receiver",
+      noReceiverRelative: "no receiver",
+      noReceiverBuiltin: true,
+      primitiveReceiver: "no receiver",
+      throwing: "threw Error: boom",
+      throwingCached: false,
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test.each([
     "/file/name/goes/here.js",
     "file/here.js",


### PR DESCRIPTION
### Problem
- `Module.prototype.require.call(plainParentObject, id)` throws `TypeError: this.@require is not a function` (1.4.2: `undefined is not a function`). The module that never ran stays in `require.cache`, so the next ordinary `require(id)` returns `{}`. Node loads the file. A call with no receiver (`const r = Module.prototype.require; r(id)`) also throws on Bun only.
- `overridableRequire` (`src/js/builtins/CommonJS.ts`) does `$requireMap.$set(id, mod)` and then calls the native loader as `this.$require(...)`. `$require` is a private method on the CommonJS module prototype, so a plain object does not have it. The throw happens in JS, outside the native cleanup (`finishRequireWithError`).

### Fix
- The native loader is called on the new module: `mod.$require(id, parentFilename, argc, options)`. `overridableRequire` creates `mod`, so the lookup cannot fail. The native side only needed the parent's filename.
- `$requireNativeModule` (builtin module lookup) is now a private global function. It never used its receiver.
- `overridableRequire` reads `this?.filename` one time. A missing or primitive receiver resolves relative to the cwd, as in Node.
- Verified: `test/js/node/module/node-module-module.test.js` (new test fails on 1.4.3). Also ran `test/js/node/module/`, `plugins.test.ts`, `mock-module.test.ts`, `run-cjs.test.ts`.

### Background
- `Module.prototype.require` is the function behind every CommonJS `require()`. In Bun it is the JS builtin `overridableRequire`. `this` is the module that asked (the parent).
- Node only reads plain properties from the parent (`filename`, `paths`, `children`). Sandbox helpers use this and pass a plain object.
- `$requireMap` is the `Map` behind `require.cache`. A new module goes in before its file runs, so that cycles see it. Native code removes it again if the load fails.

<details><summary>Notes</summary>

Repro:

```js
const fs = require("fs"), path = require("path"), os = require("os"), Module = require("module");
const dir = fs.mkdtempSync(path.join(os.tmpdir(), "req-this-"));
const f = path.join(dir, "dep.js");
fs.writeFileSync(f, "module.exports = { ok: true };\n");
const fakeParent = { id: path.join(dir, "virtual.js"), filename: path.join(dir, "virtual.js"), paths: Module._nodeModulePaths(dir), children: [] };
try { console.log("1st (fake parent):", JSON.stringify(Module.prototype.require.call(fakeParent, f))); }
catch (e) { console.log("1st (fake parent) threw:", e.name, e.message.slice(0, 60)); }
console.log("in cache after 1st:", f in require.cache, "loaded:", require.cache[f] && require.cache[f].loaded);
console.log("2nd (ordinary require):", JSON.stringify(require(f)));
```

Before (1.4.2, canary, main 6b394bfeb0):

```
1st (fake parent) threw: TypeError undefined is not a function
in cache after 1st: true loaded: false
2nd (ordinary require): {}
```

After, and on Node v26.3.0:

```
1st (fake parent): {"ok":true}
in cache after 1st: true loaded: true
2nd (ordinary require): {"ok":true}
```

A debug build of main also fails the `$assert` in `overridableRequire`: `Module "..." should no longer be in the map`.

The test covers: a plain object parent (absolute id, relative id resolved from the parent's `filename`, a builtin id), `module.parent` of the loaded module is the plain object, no receiver (absolute id, id relative to the cwd, builtin id), a primitive receiver, and a file that throws (the error is the file's own error and `require.cache` has no entry).

Self-review: checked that nothing else under `src/` uses `$require` or `$requireNativeModule`, that every exit of `jsFunctionRequireCommonJS` after the specifier is read still goes through `finishRequireWithError`, that every `Zig::GlobalObject` runs `addBuiltinGlobals` (workers, ShadowRealm, test isolation), and ran the scenarios with `BUN_JSC_validateExceptionChecks=1`. No problems found.

One visible side effect: when the parent has no `filename`, the referrer string that the transpiler gets for error text is now empty. It was the text `undefined` or `null`.

`fakeParent.children` is still not updated by this PR. That is part of the `module.children` change, a separate PR.
</details>
