### PR TITLE
crypto: compute X509Certificate validFromDate/validToDate from the ASN.1 time

### DIFF
--- a/src/jsc/bindings/JSX509CertificatePrototype.cpp
+++ b/src/jsc/bindings/JSX509CertificatePrototype.cpp
@@ -403,8 +403,6 @@ static JSValue undefinedIfEmpty(JSUint8Array* value)
     return value;
 }
 
-// Built from the ASN.1 time, not from the validFrom / validTo text: that prints
-// the year 30 as "30", which a date parser reads as 2030.
 static JSValue validityDate(VM& vm, JSGlobalObject* globalObject, std::optional<int64_t> seconds)
 {
     double ms = seconds ? static_cast<double>(*seconds) * 1000.0 : PNaN;

--- a/src/jsc/bindings/JSX509CertificatePrototype.cpp
+++ b/src/jsc/bindings/JSX509CertificatePrototype.cpp
@@ -18,7 +18,6 @@
 #include "webcrypto/CryptoKeyRSA.h"
 #include "webcrypto/CryptoKeyOKP.h"
 #include "webcrypto/CryptoKeyAES.h"
-#include "wtf/DateMath.h"
 #include "AsymmetricKeyValue.h"
 #include <JavaScriptCore/DateInstance.h>
 #include "JSKeyObject.h"
@@ -404,6 +403,14 @@ static JSValue undefinedIfEmpty(JSUint8Array* value)
     return value;
 }
 
+// Built from the ASN.1 time, not from the validFrom / validTo text: that prints
+// the year 30 as "30", which a date parser reads as 2030.
+static JSValue validityDate(VM& vm, JSGlobalObject* globalObject, std::optional<int64_t> seconds)
+{
+    double ms = seconds ? static_cast<double>(*seconds) * 1000.0 : PNaN;
+    return DateInstance::create(vm, globalObject->dateStructure(), ms);
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsX509CertificateProtoFuncVerify, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -719,16 +726,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_validToDate, (JSGlobalObject * 
         return {};
     }
 
-    auto* validToDate = thisObject->validTo(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-    auto view = validToDate->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-    Bun::UTF8View validToDateView = Bun::UTF8View(view);
-    if (view->isEmpty())
-        return JSValue::encode(jsUndefined());
-    std::span<const Latin1Character> span = { reinterpret_cast<const Latin1Character*>(validToDateView.span().data()), validToDateView.span().size() };
-    double date = WTF::parseDate(span);
-    return JSValue::encode(JSC::DateInstance::create(vm, globalObject->dateStructure(), date));
+    return JSValue::encode(validityDate(vm, globalObject, thisObject->view().getValidToTime()));
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_validFromDate, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName))
@@ -742,15 +740,6 @@ JSC_DEFINE_CUSTOM_GETTER(jsX509CertificateGetter_validFromDate, (JSGlobalObject 
         return {};
     }
 
-    auto* validFromDate = thisObject->validFrom(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-    auto view = validFromDate->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, {});
-    Bun::UTF8View validFromDateView = Bun::UTF8View(view);
-    if (view->isEmpty())
-        return JSValue::encode(jsUndefined());
-    std::span<const Latin1Character> span = { reinterpret_cast<const Latin1Character*>(validFromDateView.span().data()), validFromDateView.span().size() };
-    double date = WTF::parseDate(span);
-    return JSValue::encode(JSC::DateInstance::create(vm, globalObject->dateStructure(), date));
+    return JSValue::encode(validityDate(vm, globalObject, thisObject->view().getValidFromTime()));
 }
 } // namespace Bun

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -998,6 +998,28 @@ std::optional<std::string> X509View::getSignatureAlgorithmOID() const
     return std::string(buf, static_cast<size_t>(len));
 }
 
+// BoringSSL's X509 parser accepts a UTCTime with a "+hhmm" / "-hhmm" offset,
+// which ASN1_TIME_to_posix refuses. OpenSSL's ASN1_TIME_to_tm, which Node
+// uses, applies the offset, and so does the _nonstandard variant.
+static std::optional<int64_t> asn1TimeToPosix(const ASN1_TIME* time)
+{
+    int64_t seconds;
+    if (time == nullptr || !ASN1_TIME_to_posix_nonstandard(time, &seconds)) return std::nullopt;
+    return seconds;
+}
+
+std::optional<int64_t> X509View::getValidFromTime() const
+{
+    if (cert_ == nullptr) return std::nullopt;
+    return asn1TimeToPosix(X509_get0_notBefore(cert_));
+}
+
+std::optional<int64_t> X509View::getValidToTime() const
+{
+    if (cert_ == nullptr) return std::nullopt;
+    return asn1TimeToPosix(X509_get0_notAfter(cert_));
+}
+
 DataPointer X509View::getSerialNumber() const
 {
     ClearErrorOnReturn clearErrorOnReturn;

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -998,12 +998,10 @@ std::optional<std::string> X509View::getSignatureAlgorithmOID() const
     return std::string(buf, static_cast<size_t>(len));
 }
 
-// BoringSSL's X509 parser accepts a UTCTime with a "+hhmm" / "-hhmm" offset,
-// which ASN1_TIME_to_posix refuses. OpenSSL's ASN1_TIME_to_tm, which Node
-// uses, applies the offset, and so does the _nonstandard variant.
 static std::optional<int64_t> asn1TimeToPosix(const ASN1_TIME* time)
 {
     int64_t seconds;
+    // _nonstandard: the X509 parser accepts a UTCTime "+hhmm" offset, and Node (OpenSSL) applies it.
     if (time == nullptr || !ASN1_TIME_to_posix_nonstandard(time, &seconds)) return std::nullopt;
     return seconds;
 }

--- a/src/jsc/bindings/ncrypto.h
+++ b/src/jsc/bindings/ncrypto.h
@@ -958,6 +958,9 @@ public:
     BIOPointer getValidTo() const;
     std::optional<std::string_view> getSignatureAlgorithm() const;
     std::optional<std::string> getSignatureAlgorithmOID() const;
+    // Seconds since the Unix epoch.
+    std::optional<int64_t> getValidFromTime() const;
+    std::optional<int64_t> getValidToTime() const;
     DataPointer getSerialNumber() const;
     Result<EVPKeyPointer, int> getPublicKey() const;
     StackOfASN1 getKeyUsage() const;

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -161,6 +161,75 @@ describe("X509Certificate.prototype property descriptors", () => {
   });
 });
 
+describe("X509Certificate validFromDate / validToDate", () => {
+  // Self-signed, CN=localhost. Both times are GeneralizedTime, so another four-digit year can be
+  // written over them without changing any DER length. That breaks the signature, which
+  // X509Certificate does not check.
+  const notBefore = "00200101000000Z";
+  const notAfter = "00751231235959Z";
+  const templatePem = `-----BEGIN CERTIFICATE-----
+MIIBPTCB46ADAgECAgIQADAKBggqhkjOPQQDAjAUMRIwEAYDVQQDDAlsb2NhbGhv
+c3QwIhgPMDAyMDAxMDEwMDAwMDBaGA8wMDc1MTIzMTIzNTk1OVowFDESMBAGA1UE
+AwwJbG9jYWxob3N0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJC2RuReWuXPw
+IXWc22JNB/Jwkm4uGiaO1cRhQh6gF7kTLflBzbp6vAnZIB3ukIRPh1syrqVuEPuB
+ugLCAXxsoqMhMB8wHQYDVR0OBBYEFDYYVTNtjOn8v4bS9+yhJX5DS0A1MAoGCCqG
+SM49BAMCA0kAMEYCIQDgLDP/kZnwdTEpvTsMQKhLWg4NeiH62qkajleA8tWF8QIh
+AJSCZhtcwld0QcIt8+FsNj13xry7oItjmw9/n1dicxIW
+-----END CERTIFICATE-----`;
+
+  // The same certificate with the validity rewritten as UTCTime "200101000000-0530" and
+  // "301231235959+0100". RFC 5280 forbids the offset, but BoringSSL and OpenSSL both parse it.
+  const utcOffsetPem = `-----BEGIN CERTIFICATE-----
+MIIBQTCB56ADAgECAgIQADAKBggqhkjOPQQDAjAUMRIwEAYDVQQDDAlsb2NhbGhv
+c3QwJhcRMjAwMTAxMDAwMDAwLTA1MzAXETMwMTIzMTIzNTk1OSswMTAwMBQxEjAQ
+BgNVBAMMCWxvY2FsaG9zdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABCQtkbkX
+lrlz8CF1nNtiTQfycJJuLhomjtXEYUIeoBe5Ey35Qc26erwJ2SAd7pCET4dbMq6l
+bhD7gboCwgF8bKKjITAfMB0GA1UdDgQWBBQ2GFUzbYzp/L+G0vfsoSV+Q0tANTAK
+BggqhkjOPQQDAgNJADBGAiEA4Cwz/5GZ8HUxKb07DECoS1oODXoh+tqpGo5XgPLV
+hfECIQCUgmYbXMJXdEHCLfPhbDY9d8a8u6CLY5sPf59XYnMSFg==
+-----END CERTIFICATE-----`;
+
+  function certForYear(year: string) {
+    const der = Buffer.from(new X509Certificate(templatePem).raw);
+    der.write(year, der.indexOf(notBefore), "latin1");
+    der.write(year, der.indexOf(notAfter), "latin1");
+    return new X509Certificate(der);
+  }
+
+  // The printed year "30" used to be parsed back as 2030, so a certificate that expired in the
+  // year 30 looked valid to `cert.validToDate > new Date()`.
+  test("a year below 100 is not moved to 1950-2049", () => {
+    const cert = new X509Certificate(templatePem);
+    expect({
+      validFrom: cert.validFrom,
+      validFromDate: cert.validFromDate.toISOString(),
+      validTo: cert.validTo,
+      validToDate: cert.validToDate.toISOString(),
+    }).toEqual({
+      validFrom: "Jan  1 00:00:00 20 GMT",
+      validFromDate: "0020-01-01T00:00:00.000Z",
+      validTo: "Dec 31 23:59:59 75 GMT",
+      validToDate: "0075-12-31T23:59:59.000Z",
+    });
+    expect(certForYear("0030").validToDate < new Date()).toBe(true);
+  });
+
+  test.each(["0000", "0049", "0050", "0099", "0100", "1601", "1969", "1970", "2038", "2049", "2050", "9999"])(
+    "GeneralizedTime year %s",
+    year => {
+      const cert = certForYear(year);
+      expect(cert.validFromDate.toISOString()).toBe(`${year}-01-01T00:00:00.000Z`);
+      expect(cert.validToDate.toISOString()).toBe(`${year}-12-31T23:59:59.000Z`);
+    },
+  );
+
+  test("a UTCTime timezone offset is applied", () => {
+    const cert = new X509Certificate(utcOffsetPem);
+    expect(cert.validFromDate.toISOString()).toBe("2020-01-01T05:30:00.000Z");
+    expect(cert.validToDate.toISOString()).toBe("2030-12-31T22:59:59.000Z");
+  });
+});
+
 describe("X509Certificate with an empty subject/issuer DN", () => {
   // Self-signed, `openssl req -x509 -subj "/"`: both names are empty sequences.
   const emptyDN = `-----BEGIN CERTIFICATE-----


### PR DESCRIPTION
### Problem
- `X509Certificate` `validToDate` / `validFromDate` move a validity year 0000-0099 to 1950-2049. A certificate that expired in the year 30 reports `validToDate = 2030-12-31T23:59:59.000Z`, so `cert.validToDate > new Date()` is `true`. Node v26.3.0 reports `0030-12-31T23:59:59.000Z`.
- The cause is `src/jsc/bindings/JSX509CertificatePrototype.cpp:722-731` (`validFromDate` has the same code). The getter parses the `validTo` text (`Dec 31 23:59:59 30 GMT`) with `WTF::parseDate`, which reads the year `30` as 2030.
- The same round trip gives `Invalid Date` for a UTCTime with a `+hhmm` offset (the text is `Bad time value`). Node returns the instant.

### Fix
- New ncrypto functions `X509View::getValidFromTime` / `getValidToTime` convert the `ASN1_TIME` to POSIX seconds. The getters build the `Date` from `seconds * 1000`, as Node does ([crypto_x509.cc](https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_x509.cc#L226-L234), [ncrypto.cc](https://github.com/nodejs/node/blob/v26.3.0/deps/ncrypto/ncrypto.cc#L1171-L1197)).
- The conversion is `ASN1_TIME_to_posix_nonstandard`. BoringSSL's X509 parser accepts the `+hhmm` form and the strict `ASN1_TIME_to_posix` refuses it. OpenSSL's `ASN1_TIME_to_tm`, which Node uses, applies the offset.
- A failed conversion gives `Invalid Date`, as before.
- Verified: `test/js/node/crypto/x509.test.ts` (new block: bun 1.4.3 fails 6 of 14, Node v26.3.0 passes the same assertions). Also `test-crypto-x509.js`, `test-tls-getcertificate-x509.js`, `test/regression/issue/21274.test.ts`.

### Background
- An X.509 validity time is an `ASN1_TIME`: a UTCTime (`YYMMDDHHMMSSZ`, years 1950-2049) or a GeneralizedTime (`YYYYMMDDHHMMSSZ`). RFC 5280 has no encoding for a year before 1950, but a GeneralizedTime year 0000-0099 parses in BoringSSL and in OpenSSL.
- `ASN1_TIME_print` does not pad the year, so the year 30 prints as `30`.
- `validFrom` / `validTo`, `toLegacyObject()` and TLS verification do not use the Date getters. This change does not touch them.

<details><summary>Notes</summary>

Repro (mints a certificate that is valid from the year 20 to the year 30):

```sh
d=$(mktemp -d); cd "$d"
printf '[ca]\ndefault_ca=c\n[c]\ndir=.\ndatabase=./index.txt\nnew_certs_dir=./n\nserial=./serial\ndefault_md=sha256\npolicy=p\nunique_subject=no\n[p]\ncommonName=supplied\n[req]\ndistinguished_name=dn\nprompt=no\n[dn]\nCN=localhost\n' > ca.cnf
mkdir n; : > index.txt; echo 1000 > serial
openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -out key.pem
openssl req -new -key key.pem -config ca.cnf -out csr.pem
openssl ca -batch -config ca.cnf -selfsign -keyfile key.pem -in csr.pem -startdate 00200101000000Z -enddate 00301231235959Z -out c.pem -notext
cat > t.js <<'EOF'
const c = new (require("crypto").X509Certificate)(require("fs").readFileSync("c.pem"));
console.log(c.validTo, "|", c.validToDate.toISOString(), "|", c.validToDate > new Date());
EOF
bun t.js
node t.js
```

| | `validTo` | `validToDate` | `validToDate > new Date()` |
| --- | --- | --- | --- |
| bun 1.4.3 | `Dec 31 23:59:59 30 GMT` | `2030-12-31T23:59:59.000Z` | `true` |
| this branch | `Dec 31 23:59:59 30 GMT` | `0030-12-31T23:59:59.000Z` | `false` |
| node v26.3.0 | `Dec 31 23:59:59 30 GMT` | `0030-12-31T23:59:59.000Z` | `false` |

The old parser moved the years 0-49 to 2000-2049 and the years 50-99 to 1950-1999. A year of 100 or later was already exact. The new test writes the years 0000, 0049, 0050, 0099, 0100, 1601, 1969, 1970, 2038, 2049, 2050 and 9999 over one GeneralizedTime template. The 1949 / 1950 / 2049 / 2050 UTCTime boundary is already in `test-crypto-x509.js`.

UTCTime offset. The test certificate has notBefore `200101000000-0530` and notAfter `301231235959+0100`.

| | `validFrom` | `validFromDate` | `validTo` | `validToDate` |
| --- | --- | --- | --- | --- |
| bun 1.4.3 | `Bad time value` | `Invalid Date` | `Bad time value` | `Invalid Date` |
| this branch | `Bad time value` | `2020-01-01T05:30:00.000Z` | `Bad time value` | `2030-12-31T22:59:59.000Z` |
| node v26.3.0 | `Jan  1 05:30:00 2020 GMT` | `2020-01-01T05:30:00.000Z` | `Dec 31 22:59:59 2030 GMT` | `2030-12-31T22:59:59.000Z` |

The `validFrom` / `validTo` strings for that form still differ from Node. BoringSSL's `ASN1_TIME_print` parses with `allow_timezone_offset=0`. That is a different getter with a different cause, and this PR leaves it alone.

Why a failed conversion is not reachable after a successful parse: `x_x509.cc` validates both times with `allow_utc_timezone_offset=1`, which is what `ASN1_TIME_to_posix_nonstandard` accepts. `OPENSSL_tm_to_posix` covers the years 0000-9999, which is all a GeneralizedTime can hold. The `std::optional` is there because Node's version ignores the return code and reads an uninitialized `int64_t` on failure.

The conversion does not touch the OpenSSL error queue, so the new functions have no `ClearErrorOnReturn`.

The old getters returned `undefined` when the printed text was empty. `ASN1_TIME_print` always prints something, so that branch was not reachable. Node always returns a `Date`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/crypto/x509.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/crypto/x509.test.ts:
(pass) X509Certificate.checkHost() > "sub.wildcard.example.com" returns the subjectAltName entry that matched [4.25ms]
(pass) X509Certificate.checkHost() > "SUB.WILDCARD.EXAMPLE.COM" returns the subjectAltName entry that matched [0.71ms]
(pass) X509Certificate.checkHost() > "exact.example.com" returns the subjectAltName entry that matched [0.42ms]
(pass) X509Certificate.checkHost() > "EXACT.EXAMPLE.COM" returns the subjectAltName entry that matched [0.39ms]
(pass) X509Certificate.checkHost() > "a.b.wildcard.example.com" does not match [2.27ms]
(pass) X509Certificate.checkHost() > "wildcard.example.com" does not match [0.60ms]
(pass) X509Certificate.checkHost() > "wildcard-san.example.com" does not match [0.35ms]
(pass) X509Certificate.checkHost() > "nomatch.example.org" does not match [0.33ms]
(pass) X509Certificate.checkHost() > wildcards: false only disables the wildcard entry [5.42ms]
(pass) X509Certificate.checkHost() > "agent1" falls b
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (b1cb69ec6)

test/js/node/crypto/x509.test.ts:
(pass) X509Certificate.checkHost() > "sub.wildcard.example.com" returns the subjectAltName entry that matched [0.09ms]
(pass) X509Certificate.checkHost() > "SUB.WILDCARD.EXAMPLE.COM" returns the subjectAltName entry that matched [0.01ms]
(pass) X509Certificate.checkHost() > "exact.example.com" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "EXACT.EXAMPLE.COM" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "a.b.wildcard.example.com" does not match [0.03ms]
(pass) X509Certificate.checkHost() > "wildcard.example.com" does not match
(pass) X509Certificate.checkHost() > "wildcard-san.example.com" does not match
(pass) X509Certificate.checkHost() > "nomatch.example.org" does not match
(pass) X509Certificate.checkHost() > wildcards: false only disables the wildcard entry [0.04ms]
(pass) X509Certificate.checkHost() > "agent1" falls back to the subject CN and returns it [0.02ms]
(pass) X509Certificate.checkHost() > "AGENT1" falls back to the subject CN and returns it
(pass) X509Certificate.checkHost() > "AgEnT1" falls back to the sub
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/crypto/x509.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/crypto/x509.test.ts:
(pass) X509Certificate.checkHost() > "sub.wildcard.example.com" returns the subjectAltName entry that matched [3.35ms]
(pass) X509Certificate.checkHost() > "SUB.WILDCARD.EXAMPLE.COM" returns the subjectAltName entry that matched [0.67ms]
(pass) X509Certificate.checkHost() > "exact.example.com" returns the subjectAltName entry that matched [0.34ms]
(pass) X509Certificate.checkHost() > "EXACT.EXAMPLE.COM" returns the subjectAltName entry that matched [0.33ms]
(pass) X509Certificate.checkHost() > "a.b.wildcard.example.com" does not match [2.62ms]
(pass) X509Certificate.checkHost() > "wildcard.example.com" does not match [0.52ms]
(pass) X509Certificate.checkHost() > "wildcard-san.example.com" does not match [0.32ms]
(pass) X509Certificate.checkHost() > "nomatch.example.org" does not match [0.31ms]
(pass) X509Certificate.checkHost() > wildcards: false only disables the wildcard entry [5.66ms]
(pass) X509Certificate.checkHost() > "agent1" falls b
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 764ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/16] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[2/16] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[3/16] cxx obj/src/jsc/bindings/webcore/SerializedScriptValue.cpp.o
[4/16] cxx obj/src/jsc/bindings/webcrypto/SubtleCrypto.cpp.o
[5/16] cxx obj/src/jsc/bindings/BunProcess.cpp.o
[6/16] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[7/16] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-0.cpp.o
[8/16] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[9/16] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[10/16] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-1.cpp.o
[11/16] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[12/16] gen cpp.rs (cppbind)
[12/16] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 6m 21s
[13/16] link bun-profile
[15/16] strip bun
[15/16] bun-profile --revision
1.4.3-canary.1+13f
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSX509CertificatePrototype.cpp | 29 +++--------
 src/jsc/bindings/ncrypto.cpp                    | 20 +++++++
 src/jsc/bindings/ncrypto.h                      |  3 ++
 test/js/node/crypto/x509.test.ts                | 69 +++++++++++++++++++++++++
 4 files changed, 100 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/jsc/bindings/JSX509CertificatePrototype.cpp      3      4      9
src/jsc/bindings/ncrypto.cpp                         3      3      9
src/jsc/bindings/ncrypto.h                           1      2      9
test/js/node/crypto/x509.test.ts                     1      1      9
```

</details>

<!-- robobun:evidence:end -->