### PR TITLE
node:perf_hooks: do not truncate the monitorEventLoopDelay resolution to int32

### DIFF
--- a/src/js/internal/perf_hooks/monitorEventLoopDelay.ts
+++ b/src/js/internal/perf_hooks/monitorEventLoopDelay.ts
@@ -5,8 +5,8 @@ const { validateObject, validateInteger } = require("internal/validators");
 const cppMonitorEventLoopDelay = $newCppFunction(
   "JSNodePerformanceHooksHistogramPrototype.cpp",
   "jsFunction_monitorEventLoopDelay",
-  1,
-) as (resolution: number) => import("node:perf_hooks").RecordableHistogram;
+  0,
+) as () => import("node:perf_hooks").RecordableHistogram;
 
 const cppEnableEventLoopDelay = $newCppFunction(
   "JSNodePerformanceHooksHistogramPrototype.cpp",
@@ -59,7 +59,7 @@ function monitorEventLoopDelay(options?: { resolution?: number }) {
   }
 
   if (!eventLoopDelayHistogram) {
-    eventLoopDelayHistogram = cppMonitorEventLoopDelay(resolution);
+    eventLoopDelayHistogram = cppMonitorEventLoopDelay();
     $putByValDirect(eventLoopDelayHistogram, "enable", enable);
     $putByValDirect(eventLoopDelayHistogram, "disable", disable);
     $putByValDirect(eventLoopDelayHistogram, Symbol.dispose, disable);

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogramPrototype.cpp
@@ -424,25 +424,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_createHistogram, (JSGlobalObject * globalObj
 }
 
 // Extern declarations for the native timer implementation
-extern "C" void Timer_enableEventLoopDelayMonitoring(void* vm, JSC::EncodedJSValue histogram, int32_t resolution);
+extern "C" void Timer_enableEventLoopDelayMonitoring(void* vm, JSC::EncodedJSValue histogram, double resolution);
 extern "C" void Timer_disableEventLoopDelayMonitoring();
 
 // Create histogram for event loop delay monitoring
-JSC_DEFINE_HOST_FUNCTION(jsFunction_monitorEventLoopDelay, (JSGlobalObject * globalObject, CallFrame* callFrame))
+JSC_DEFINE_HOST_FUNCTION(jsFunction_monitorEventLoopDelay, (JSGlobalObject * globalObject, CallFrame*))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-
-    int32_t resolution = 10; // default 10ms
-    if (callFrame->argumentCount() > 0) {
-        resolution = callFrame->argument(0).toInt32(globalObject);
-        RETURN_IF_EXCEPTION(scope, {});
-
-        if (resolution < 1) {
-            throwRangeError(globalObject, scope, "Resolution must be >= 1"_s);
-            return JSValue::encode(jsUndefined());
-        }
-    }
 
     // Create histogram with range for event loop delays (1ns to 1 hour)
     auto* zigGlobalObject = defaultGlobalObject(globalObject);
@@ -480,7 +469,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_enableEventLoopDelay, (JSGlobalObject * glob
         return JSValue::encode(jsUndefined());
     }
 
-    int32_t resolution = callFrame->argument(1).toInt32(globalObject);
+    double resolution = callFrame->argument(1).toNumber(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
     // Reset histogram data on enable

--- a/src/runtime/timer/EventLoopDelayMonitor.rs
+++ b/src/runtime/timer/EventLoopDelayMonitor.rs
@@ -6,7 +6,7 @@ use bun_jsc::virtual_machine::VirtualMachine;
 extern "C" fn Timer_enableEventLoopDelayMonitoring(
     vm: *mut VirtualMachine,
     histogram: JSValue,
-    resolution_ms: i32,
+    resolution_ms: f64,
 ) {
     // SAFETY: vm is a valid non-null pointer passed from C++.
     let vm = unsafe { &mut *vm };

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -403,7 +403,9 @@ pub struct EventLoopDelayMonitor {
     /// `stop_active_handles` drops it before `~VM` (`All` outlives the heap).
     histogram: bun_jsc::Weak<()>,
     pub(crate) event_loop_timer: EventLoopTimer,
-    pub(crate) resolution_ms: i32,
+    /// Never 0: `on_fire` re-arms at the drain's fixed `now` plus this, and
+    /// `All::drain_timers` pops every node that is not after that `now`.
+    pub(crate) resolution_ms: u32,
     pub(crate) last_fire_ns: u64,
     pub(crate) enabled: bool,
 }
@@ -428,16 +430,17 @@ impl EventLoopDelayMonitor {
         &mut self,
         vm: &mut bun_jsc::virtual_machine::VirtualMachine,
         histogram: JSValue,
-        resolution_ms: i32,
+        resolution_ms: f64,
     ) {
         self.disable();
         self.histogram = bun_jsc::Weak::create_passive(histogram, vm.global());
-        self.resolution_ms = resolution_ms;
+        // `as` saturates and maps NaN to 0.
+        self.resolution_ms = (resolution_ms as u32).max(1);
         self.enabled = true;
 
         // Schedule timer
         let now = Timespec::now(TimespecMockMode::ForceRealTime);
-        let next = now.add_ms(i64::from(resolution_ms));
+        let next = now.add_ms(i64::from(self.resolution_ms));
         self.event_loop_timer.next = ElTimespec {
             sec: next.sec,
             nsec: next.nsec,
@@ -481,9 +484,7 @@ impl EventLoopDelayMonitor {
 
         let now_ns = now.ns();
         if self.last_fire_ns > 0 {
-            let expected_ns = u64::try_from(self.resolution_ms)
-                .expect("int cast")
-                .saturating_mul(1_000_000);
+            let expected_ns = u64::from(self.resolution_ms) * 1_000_000;
             let actual_ns = now_ns - self.last_fire_ns;
 
             if actual_ns > expected_ns {

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import net from "net";
 import perf, { PerformanceObserver } from "perf_hooks";
@@ -277,4 +277,47 @@ test("mark/measure toJSON and inspection include detail without perf_hooks being
   expect(result.indexOption).toBe("PerformanceMark {");
   expect(result.polluted).toBe("PerformanceMark {");
   expect(exitCode).toBe(0);
+});
+
+// `options.resolution` is any safe integer >= 1, so it can be far above the int32 range.
+// Node v26.3.0 accepts every value below, and a timer still runs while the monitor is enabled.
+describe("monitorEventLoopDelay with a resolution above the int32 range", () => {
+  const resolutions = [2 ** 31, 2 ** 32, 2 ** 32 + 1, 2 ** 53 - 1];
+  const cases = resolutions.flatMap(resolution => [
+    { resolution, earlierCall: false, when: "as the first call" },
+    { resolution, earlierCall: true, when: "after an earlier call" },
+  ]);
+
+  test.concurrent.each(cases)("resolution $resolution $when", async ({ resolution, earlierCall }) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { monitorEventLoopDelay } = require("node:perf_hooks");
+         ${earlierCall ? "monitorEventLoopDelay();" : ""}
+         const histogram = monitorEventLoopDelay({ resolution: ${resolution} });
+         console.log("enable", histogram.enable());
+         // The monitor must not fire in these 10 ms. A resolution that wrapped to
+         // 1 ms (2 ** 32 + 1 as an int32) fires about 10 times and records samples.
+         setTimeout(() => {
+           console.log("count", histogram.count);
+           console.log("disable", histogram.disable());
+         }, 10);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      // Kill switch: a monitor that re-arms with a period of 0 ms (2 ** 32 as an int32) spins in
+      // the timer drain forever, and bun:test does not reap the children of a concurrent test.
+      timeout: 4_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, stdout, exitCode, signalCode: proc.signalCode }).toEqual({
+      stderr: "",
+      stdout: "enable true\ncount 0\ndisable true\n",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- After any earlier `monitorEventLoopDelay()` call, `monitorEventLoopDelay({ resolution })` with `2**31` to `2**32-1` (also `2**53-1`) panics in release builds: `panic: int cast: TryFromIntError(NegOverflow)` at `src/runtime/timer/mod.rs:485`. A multiple of `2**32` hangs the event loop at 100 % CPU. As the first call, the same values throw `RangeError: Resolution must be >= 1`. Node v26.3.0 accepts all of them.
- The JS validator accepts any safe integer >= 1, as Node does. Both C++ entry points in `JSNodePerformanceHooksHistogramPrototype.cpp` then run `toInt32()` on it, so `EventLoopDelayMonitor::on_fire` re-arms with a negative or zero period.

### Fix
- `jsFunction_enableEventLoopDelay` passes the number as a `double`. `EventLoopDelayMonitor::enable` saturates it to `1..=u32::MAX` ms and stores a `u32`, so `on_fire` has no cast that can fail.
- `jsFunction_monitorEventLoopDelay` no longer takes the resolution. Its only use was the int32 check that threw the wrong `RangeError`.
- The JS validator does not change.
- Verified: `test/js/node/perf_hooks/perf_hooks.test.ts`, 8 new cases. All 8 fail on canary 4ff919377 (2 panic, 1 hang, 2 wrong period, 3 wrong `RangeError`). Also `test-performance-eventloopdelay.js`, `histogram.test.ts`, `isolation.test.ts`.

### Background
- `monitorEventLoopDelay()` returns a histogram. While it is enabled, a timer fires every `resolution` ms and records how late it fired.
- Bun keeps one histogram per process. Only the first call creates it, so only the first call ran the int32 check.
- `All::drain_timers` reads the clock once and pops every timer that is due at that reading. `on_fire` re-arms at that reading plus the period, so a period of 0 is due again at once and the drain never ends.

<details><summary>Notes</summary>

Repro (from the fuzz ledger, deterministic):

```js
const { monitorEventLoopDelay: m } = require("perf_hooks");
m(); // any earlier call
const h = m({ resolution: 2 ** 31 }); // 2 ** 32 for the hang
h.enable();
setTimeout(() => { console.log("alive"); h.disable(); }, 100);
```

Thresholds before this change, after an earlier call: `2**31-1` ok. `2**31`, `3e9`, `2**32-1`, `2**53-1` panic. `2**32` hangs. `2**32+10` runs as a 10 ms monitor.

- Release dating, `2**31` after an earlier call: 1.3.14 spins at 100 % CPU (killed at 8 s), 1.4.0 panics with the message above. `2**32` spins on both. The bug is older than the Rust port. The port only changed the negative case from a spin to a panic, so this is not a regression test.
- Values above `u32::MAX` ms (49.7 days) saturate. Node has no defined behavior to match here: `IntervalHistogram` stores the interval as `int32_t` and gives it to `uv_timer_start`, so in Node `2**31` never samples and `2**32+10` samples every 10 ms. The histogram tops out at 1 hour.
- `u32` widens without loss to the `i64` that `Timespec::add_ms` takes and to the `u64` that `on_fire` compares against.
- The `.max(1)` floor is not reachable from JS, because the validator rejects values below 1. It is there because a zero period is an endless drain, not an error.
- Alternative that I did not take: bound the JS validator to `2**31-1`. That throws `ERR_OUT_OF_RANGE` where Node does not.
- The validation errors for `0`, `-1`, `1.5`, `2**53`, `Infinity`, `"1"` and `null` are byte-identical to Node v26.3.0 before and after.
- The test child has a 4 s kill switch. `bun:test` does not reap the children of a concurrent test that times out, and the hang case would leave a spinning process behind.
- #33591 (independent histograms per call) is open and touches the same lines. It runs the create check on every call, so on its own it turns the panic into the wrong `RangeError`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [36.32ms]
(pass) doesn't throw [31.84ms]
(pass) Symbol name argument throws V8 wording [13.48ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [10.44ms]
(pass) timerify entry shape [111.07ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [4.22ms]
(pass) export surface matches Node v26.3.0 [16.57ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [471.79ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [492.86ms]
(pass) net entries are instanceof PerformanceEntry [597.08ms]
(pass) re-wrapped native entries, timing and observer keep JS identity [17.99ms]
(pass) mark/measure toJSON and inspection include detail without perf_hooks being loaded [1044.78ms]
311 |       // the timer drain forever, and bun:test does not reap the children of a concurrent test.
312 |       timeout
... (truncated)

release without fix: 8 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [0.08ms]
(pass) doesn't throw [0.25ms]
(pass) Symbol name argument throws V8 wording [0.13ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [0.11ms]
(pass) timerify entry shape [1.38ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [0.03ms]
(pass) export surface matches Node v26.3.0 [0.13ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [11.48ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [10.90ms]
(pass) net entries are instanceof PerformanceEntry [9.43ms]
(pass) re-wrapped native entries, timing and observer keep JS identity [0.36ms]
(pass) mark/measure toJSON and inspection include detail without perf_hooks being loaded [24.09ms]
311 |       // the timer drain forever, and bun:test does not reap the children of a concurrent test.
312 |       timeout: 4_000,
313 |       killSignal: "SIGKILL",
314 |     });
315 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
316
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.3 (4ff919377)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [4.69ms]
(pass) doesn't throw [32.74ms]
(pass) Symbol name argument throws V8 wording [8.89ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [5.58ms]
(pass) timerify entry shape [51.39ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [1.98ms]
(pass) export surface matches Node v26.3.0 [8.07ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [521.71ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [548.95ms]
(pass) net entries are instanceof PerformanceEntry [596.82ms]
(pass) re-wrapped native entries, timing and observer keep JS identity [17.40ms]
(pass) mark/measure toJSON and inspection include detail without perf_hooks being loaded [1203.31ms]
(pass) monitorEventLoopDelay with a resolution above the int32 range > resolution 4294967296 as the first call [448.92ms]
(pas
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 833ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (12108ms)
Bundle modules (56ms)
Postprocesss modules (151ms)
Bundle Functions (656ms)
Generate Code (42ms)

[13.02s] Bundled "src/js" for production
  2599 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/8] cargo bun_runtime → libbun_runtime.a
^[[1m^[[92m   Compiling^[[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
^[[1m^[[92m    Finished^[[0m `release` profile [optimized + debuginfo] target(s) in 5m 36s
[4/8] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[5/8] link bun-profile
[7/8] strip bun
[7/8] bun-profile --revision
1.4.3-canary.1+c69f884e8
[build] done
bun test v1.4.3-canary.1 (c69f884e8)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [0.07ms]
(pass) doesn't throw [0.21ms]
(pass) Symbol name argument throws V8 wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../internal/perf_hooks/monitorEventLoopDelay.ts   |  6 +--
 .../JSNodePerformanceHooksHistogramPrototype.cpp   | 17 ++------
 src/runtime/timer/EventLoopDelayMonitor.rs         |  2 +-
 src/runtime/timer/mod.rs                           | 15 ++++----
 test/js/node/perf_hooks/perf_hooks.test.ts         | 45 +++++++++++++++++++++-
 5 files changed, 59 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/internal/perf_hooks/monitorEventLoopDelay.ts           1      2     11
…c/bindings/JSNodePerformanceHooksHistogramPrototype.cpp      1      2     11
src/runtime/timer/EventLoopDelayMonitor.rs                    1      1     12
src/runtime/timer/mod.rs                                      2      4     12
test/js/node/perf_hooks/perf_hooks.test.ts                    1      1     11
```

</details>

<!-- robobun:evidence:end -->
