### PR TITLE
bun test: name the hook kind and its timeout when a hook times out

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1013,7 +1013,11 @@ impl CommandLineReporter {
             match sequence.timed_out_hook {
                 Some(hook) => {
                     let name: &'static str = hook.tag.map_or("hook", Into::into);
-                    let article = if name.starts_with(['a', 'e', 'i', 'o', 'u']) { "an" } else { "a" };
+                    let article = if name.starts_with(['a', 'e', 'i', 'o', 'u']) {
+                        "an"
+                    } else {
+                        "a"
+                    };
                     let label = if hook.tag.is_some_and(|tag| tag.is_per_test()) {
                         format!("{article} {name} hook for this test")
                     } else {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1006,7 +1006,24 @@ impl CommandLineReporter {
         }
 
         let scopes: &[*const bun_test::DescribeScope] = scopes_stack.as_slice();
-        let display_label: &[u8] = test_entry.base.name.as_deref().unwrap_or(b"(unnamed)");
+        let display_label: &[u8] = test_entry.display_label();
+        // For a hook timeout: "a beforeEach hook for this test" / "a beforeAll hook", plus
+        // the hook's own timeout. `*All` hooks belong to no test.
+        let timed_out_hook = || -> (String, u32) {
+            match sequence.timed_out_hook {
+                Some(hook) => {
+                    let name: &'static str = hook.tag.map_or("hook", Into::into);
+                    let article = if name.starts_with(['a', 'e', 'i', 'o', 'u']) { "an" } else { "a" };
+                    let label = if hook.tag.is_some_and(|tag| tag.is_per_test()) {
+                        format!("{article} {name} hook for this test")
+                    } else {
+                        format!("{article} {name} hook")
+                    };
+                    (label, hook.timeout)
+                }
+                None => ("a hook".to_owned(), test_entry.timeout),
+            }
+        };
 
         // Quieter output when claude code is in use.
         if !Output::is_ai_agent() || !status.is_pass(bun_test::PendingMode::PendingIsFail) {
@@ -1049,14 +1066,25 @@ impl CommandLineReporter {
                     Output::flush();
                 }
                 bun_test::Execution::Result::FailBecauseTimeout
-                | bun_test::Execution::Result::FailBecauseHookTimeout
-                | bun_test::Execution::Result::FailBecauseTimeoutWithDoneCallback
-                | bun_test::Execution::Result::FailBecauseHookTimeoutWithDoneCallback => {
+                | bun_test::Execution::Result::FailBecauseTimeoutWithDoneCallback => {
                     if Output::is_github_action() {
                         Output::print_error(format_args!(
                             "::error title=error: Test \"{}\" timed out after {}ms::\n",
                             bun_fmt::github_action_property(display_label),
                             test_entry.timeout
+                        ));
+                        Output::flush();
+                    }
+                }
+                bun_test::Execution::Result::FailBecauseHookTimeout
+                | bun_test::Execution::Result::FailBecauseHookTimeoutWithDoneCallback => {
+                    if Output::is_github_action() {
+                        let (hook_label, hook_timeout) = timed_out_hook();
+                        Output::print_error(format_args!(
+                            "::error title=error: Test \"{}\": {} timed out after {}ms::\n",
+                            bun_fmt::github_action_property(display_label),
+                            hook_label,
+                            hook_timeout
                         ));
                         Output::flush();
                     }
@@ -1176,10 +1204,13 @@ impl CommandLineReporter {
                     );
                 }
                 R::FailBecauseHookTimeout => {
+                    let (hook_label, hook_timeout) = timed_out_hook();
                     let _ = bun_core::write_pretty!(
                         writer,
                         colors,
-                        "  <d>^<r> <red>a beforeEach/afterEach hook timed out for this test.<r>\n"
+                        "  <d>^<r> <red>{s} timed out after {d}ms.<r>\n",
+                        hook_label,
+                        hook_timeout
                     );
                 }
                 R::FailBecauseTimeoutWithDoneCallback => {
@@ -1191,10 +1222,13 @@ impl CommandLineReporter {
                     );
                 }
                 R::FailBecauseHookTimeoutWithDoneCallback => {
+                    let (hook_label, hook_timeout) = timed_out_hook();
                     let _ = bun_core::write_pretty!(
                         writer,
                         colors,
-                        "  <d>^<r> <red>a beforeEach/afterEach hook timed out before its done callback was called.<r> <d>If a done callback was not intended, remove the last parameter from the hook callback function<r>\n"
+                        "  <d>^<r> <red>{s} timed out after {d}ms, before its done callback was called.<r> <d>If a done callback was not intended, remove the last parameter from the hook callback function<r>\n",
+                        hook_label,
+                        hook_timeout
                     );
                 }
             }
@@ -1243,7 +1277,7 @@ impl CommandLineReporter {
         TestCaseReport {
             file,
             scopes,
-            name: test_entry.base.name.as_deref().unwrap_or(b"(unnamed)"),
+            name: test_entry.display_label(),
             status,
             assertions: sequence.expect_call_count,
             elapsed_ns,

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1007,24 +1007,9 @@ impl CommandLineReporter {
 
         let scopes: &[*const bun_test::DescribeScope] = scopes_stack.as_slice();
         let display_label: &[u8] = test_entry.display_label();
-        // For a hook timeout: "a beforeEach hook for this test" / "a beforeAll hook", plus
-        // the hook's own timeout. `*All` hooks belong to no test.
         let timed_out_hook = || -> (String, u32) {
             match sequence.timed_out_hook {
-                Some(hook) => {
-                    let name: &'static str = hook.tag.map_or("hook", Into::into);
-                    let article = if name.starts_with(['a', 'e', 'i', 'o', 'u']) {
-                        "an"
-                    } else {
-                        "a"
-                    };
-                    let label = if hook.tag.is_some_and(|tag| tag.is_per_test()) {
-                        format!("{article} {name} hook for this test")
-                    } else {
-                        format!("{article} {name} hook")
-                    };
-                    (label, hook.timeout)
-                }
+                Some(hook) => (hook.label(), hook.timeout),
                 None => ("a hook".to_owned(), test_entry.timeout),
             }
         };

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1055,25 +1055,14 @@ impl CommandLineReporter {
                     Output::flush();
                 }
                 bun_test::Execution::Result::FailBecauseTimeout
-                | bun_test::Execution::Result::FailBecauseTimeoutWithDoneCallback => {
+                | bun_test::Execution::Result::FailBecauseHookTimeout
+                | bun_test::Execution::Result::FailBecauseTimeoutWithDoneCallback
+                | bun_test::Execution::Result::FailBecauseHookTimeoutWithDoneCallback => {
                     if Output::is_github_action() {
                         Output::print_error(format_args!(
                             "::error title=error: Test \"{}\" timed out after {}ms::\n",
                             bun_fmt::github_action_property(display_label),
                             test_entry.timeout
-                        ));
-                        Output::flush();
-                    }
-                }
-                bun_test::Execution::Result::FailBecauseHookTimeout
-                | bun_test::Execution::Result::FailBecauseHookTimeoutWithDoneCallback => {
-                    if Output::is_github_action() {
-                        let (hook_label, hook_timeout) = timed_out_hook();
-                        Output::print_error(format_args!(
-                            "::error title=error: Test \"{}\": {} timed out after {}ms::\n",
-                            bun_fmt::github_action_property(display_label),
-                            hook_label,
-                            hook_timeout
                         ));
                         Output::flush();
                     }

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -160,6 +160,23 @@ pub struct TimedOutHook {
     pub(crate) timeout: u32,
 }
 
+impl TimedOutHook {
+    /// "a beforeAll hook" or "an afterEach hook for this test".
+    pub(crate) fn label(&self) -> String {
+        let name: &'static str = self.tag.map_or("hook", Into::into);
+        let article = if name.starts_with(['a', 'e', 'i', 'o', 'u']) {
+            "an"
+        } else {
+            "a"
+        };
+        if self.tag.is_some_and(|tag| tag.is_per_test()) {
+            format!("{article} {name} hook for this test")
+        } else {
+            format!("{article} {name} hook")
+        }
+    }
+}
+
 pub struct ExecutionSequence {
     pub(crate) first_entry: Option<NonNull<ExecutionEntry>>,
     /// Index into ExecutionSequence.entries() for the entry that is not started or currently running

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -155,7 +155,7 @@ pub enum ExpectAssertions {
 /// Which hook entry set `FailBecauseHookTimeout*` on its sequence.
 #[derive(Clone, Copy)]
 pub struct TimedOutHook {
-    pub(crate) tag: Option<GenericHookTag>,
+    pub(crate) tag: GenericHookTag,
     /// The hook's own timeout in ms, not the test's.
     pub(crate) timeout: u32,
 }
@@ -163,13 +163,13 @@ pub struct TimedOutHook {
 impl TimedOutHook {
     /// "a beforeAll hook" or "an afterEach hook for this test".
     pub(crate) fn label(&self) -> String {
-        let name: &'static str = self.tag.map_or("hook", Into::into);
+        let name: &'static str = self.tag.into();
         let article = if name.starts_with(['a', 'e', 'i', 'o', 'u']) {
             "an"
         } else {
             "a"
         };
-        if self.tag.is_some_and(|tag| tag.is_per_test()) {
+        if self.tag.is_per_test() {
             format!("{article} {name} hook for this test")
         } else {
             format!("{article} {name} hook")

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -45,7 +45,7 @@ use bun_core::scoped_log;
 
 use super::debug::group as group_log; // bun_test.debug.group
 use super::bun_test::{
-    group_begin, AddedInPhase, BunTest, BunTestPtr, EntryData, ExecutionEntry,
+    group_begin, AddedInPhase, BunTest, BunTestPtr, EntryData, ExecutionEntry, GenericHookTag,
     HandleUncaughtExceptionResult, Order, RefDataValue, ScopeMode, StepResult,
 };
 use crate::cli::test_command;
@@ -152,6 +152,14 @@ pub enum ExpectAssertions {
     Exact(u32),
 }
 
+/// Which hook entry set `FailBecauseHookTimeout*` on its sequence.
+#[derive(Clone, Copy)]
+pub struct TimedOutHook {
+    pub(crate) tag: Option<GenericHookTag>,
+    /// The hook's own timeout in ms, not the test's.
+    pub(crate) timeout: u32,
+}
+
 pub struct ExecutionSequence {
     pub(crate) first_entry: Option<NonNull<ExecutionEntry>>,
     /// Index into ExecutionSequence.entries() for the entry that is not started or currently running
@@ -167,6 +175,8 @@ pub struct ExecutionSequence {
     /// Expectation set by expect.hasAssertions() or expect.assertions(n).
     pub(crate) expect_assertions: ExpectAssertions,
     pub(crate) maybe_skip: bool,
+    /// Set when `result` is `FailBecauseHookTimeout*`.
+    pub(crate) timed_out_hook: Option<TimedOutHook>,
 }
 
 impl ExecutionSequence {
@@ -189,6 +199,7 @@ impl ExecutionSequence {
             expect_call_count: 0,
             expect_assertions: ExpectAssertions::NotSet,
             maybe_skip: false,
+            timed_out_hook: None,
         }
     }
 

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -114,45 +114,6 @@ pub mod js_fns {
         Ok(bun_test)
     }
 
-    /// Tags accepted by `generic_hook`. Superset of `DescribeScope::HookTag`
-    /// (adds `OnTestFinished`).
-    // was a const-generic param (`adt_const_params` is unstable);
-    // reshaped to runtime dispatch with per-tag thin host_fn wrappers below.
-    #[derive(Copy, Clone, PartialEq, Eq, strum::IntoStaticStr)]
-    pub enum GenericHookTag {
-        #[strum(serialize = "beforeAll")]
-        BeforeAll,
-        #[strum(serialize = "beforeEach")]
-        BeforeEach,
-        #[strum(serialize = "afterEach")]
-        AfterEach,
-        #[strum(serialize = "afterAll")]
-        AfterAll,
-        #[strum(serialize = "onTestFinished")]
-        OnTestFinished,
-    }
-    impl GenericHookTag {
-        const fn as_hook_tag(self) -> Option<HookTag> {
-            match self {
-                Self::BeforeAll => Some(HookTag::BeforeAll),
-                Self::BeforeEach => Some(HookTag::BeforeEach),
-                Self::AfterEach => Some(HookTag::AfterEach),
-                Self::AfterAll => Some(HookTag::AfterAll),
-                Self::OnTestFinished => None,
-            }
-        }
-        /// Per-variant signature string: the tag name plus `"()"`.
-        const fn sig(self) -> &'static [u8] {
-            match self {
-                Self::BeforeAll => b"beforeAll()",
-                Self::BeforeEach => b"beforeEach()",
-                Self::AfterEach => b"afterEach()",
-                Self::AfterAll => b"afterAll()",
-                Self::OnTestFinished => b"onTestFinished()",
-            }
-        }
-    }
-
     // `adt_const_params` is unstable, so the body takes `tag` at runtime and
     // 5 thin `#[host_fn]` wrappers below supply the per-tag entry points
     // (one fn per JS function so JSFunction::create gets a distinct address).
@@ -292,6 +253,7 @@ pub mod js_fns {
 
                     let new_item = ExecutionEntry::create(
                         None,
+                        Some(tag),
                         args.callback,
                         cfg,
                         None,
@@ -1808,7 +1770,7 @@ impl DescribeScope {
         base: BaseScopeCfg,
         phase: AddedInPhase,
     ) -> JsResult<&mut ExecutionEntry> {
-        let mut entry = ExecutionEntry::create(name_not_owned, callback, cfg, Some(std::ptr::from_mut(self)), base, phase);
+        let mut entry = ExecutionEntry::create(name_not_owned, None, callback, cfg, Some(std::ptr::from_mut(self)), base, phase);
         let has_cb = entry.callback.is_some();
         entry.base.propagate(has_cb);
         self.entries.push(TestScheduleEntry::TestCallback(entry));
@@ -1837,7 +1799,7 @@ impl DescribeScope {
         base: BaseScopeCfg,
         phase: AddedInPhase,
     ) -> JsResult<&mut ExecutionEntry> {
-        let entry = ExecutionEntry::create(None, callback, cfg, Some(std::ptr::from_mut(self)), base, phase);
+        let entry = ExecutionEntry::create(None, Some(tag.into()), callback, cfg, Some(std::ptr::from_mut(self)), base, phase);
         let list = self.get_hook_entries(tag);
         list.push(entry);
         Ok(&mut **list.last_mut().unwrap())
@@ -1850,6 +1812,61 @@ pub enum HookTag {
     BeforeEach,
     AfterEach,
     AfterAll,
+}
+
+/// Tags accepted by `generic_hook`. Superset of `DescribeScope::HookTag`
+/// (adds `OnTestFinished`). Also recorded on every hook `ExecutionEntry` so
+/// the reporter can name the hook kind.
+#[derive(Copy, Clone, PartialEq, Eq, strum::IntoStaticStr)]
+pub enum GenericHookTag {
+    #[strum(serialize = "beforeAll")]
+    BeforeAll,
+    #[strum(serialize = "beforeEach")]
+    BeforeEach,
+    #[strum(serialize = "afterEach")]
+    AfterEach,
+    #[strum(serialize = "afterAll")]
+    AfterAll,
+    #[strum(serialize = "onTestFinished")]
+    OnTestFinished,
+}
+impl GenericHookTag {
+    const fn as_hook_tag(self) -> Option<HookTag> {
+        match self {
+            Self::BeforeAll => Some(HookTag::BeforeAll),
+            Self::BeforeEach => Some(HookTag::BeforeEach),
+            Self::AfterEach => Some(HookTag::AfterEach),
+            Self::AfterAll => Some(HookTag::AfterAll),
+            Self::OnTestFinished => None,
+        }
+    }
+    /// Per-variant signature string: the tag name plus `"()"`.
+    const fn sig(self) -> &'static [u8] {
+        match self {
+            Self::BeforeAll => b"beforeAll()",
+            Self::BeforeEach => b"beforeEach()",
+            Self::AfterEach => b"afterEach()",
+            Self::AfterAll => b"afterAll()",
+            Self::OnTestFinished => b"onTestFinished()",
+        }
+    }
+    /// `true` for the hooks that run as part of one test's sequence.
+    pub(crate) const fn is_per_test(self) -> bool {
+        match self {
+            Self::BeforeEach | Self::AfterEach | Self::OnTestFinished => true,
+            Self::BeforeAll | Self::AfterAll => false,
+        }
+    }
+}
+impl From<HookTag> for GenericHookTag {
+    fn from(tag: HookTag) -> Self {
+        match tag {
+            HookTag::BeforeAll => Self::BeforeAll,
+            HookTag::BeforeEach => Self::BeforeEach,
+            HookTag::AfterEach => Self::AfterEach,
+            HookTag::AfterAll => Self::AfterAll,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Default)]
@@ -1873,6 +1890,8 @@ pub enum AddedInPhase {
 pub struct ExecutionEntry {
     pub(crate) base: BaseScope,
     pub callback: Option<Strong>,
+    /// `Some` for a hook entry, `None` for a test entry.
+    pub(crate) hook: Option<GenericHookTag>,
     /// 0 = unlimited timeout
     pub(crate) timeout: u32,
     pub(crate) has_done_parameter: bool,
@@ -1893,6 +1912,7 @@ pub struct ExecutionEntry {
 impl ExecutionEntry {
     fn create(
         name_not_owned: Option<&[u8]>,
+        hook: Option<GenericHookTag>,
         cb: Option<JSValue>,
         cfg: ExecutionEntryCfg,
         parent: Option<*mut DescribeScope>,
@@ -1902,6 +1922,7 @@ impl ExecutionEntry {
         let mut entry = Box::new(ExecutionEntry {
             base: BaseScope::init(base, name_not_owned, parent, cb.is_some()),
             callback: None,
+            hook,
             timeout: cfg.timeout,
             has_done_parameter: cfg.has_done_parameter,
             added_in_phase: phase,
@@ -1925,6 +1946,17 @@ impl ExecutionEntry {
         entry
     }
 
+    /// The label the reporter prints: the test name, or the hook kind for a hook entry.
+    pub(crate) fn display_label(&self) -> &[u8] {
+        if let Some(name) = self.base.name.as_deref() {
+            return name;
+        }
+        match self.hook {
+            Some(hook) => <&'static str>::from(hook).as_bytes(),
+            None => b"(unnamed)",
+        }
+    }
+
     pub(crate) fn evaluate_timeout(
         &self,
         sequence: &mut Execution::ExecutionSequence,
@@ -1942,10 +1974,16 @@ impl ExecutionEntry {
                 } else {
                     Execution::Result::FailBecauseTimeout
                 }
-            } else if self.has_done_parameter {
-                Execution::Result::FailBecauseHookTimeoutWithDoneCallback
             } else {
-                Execution::Result::FailBecauseHookTimeout
+                sequence.timed_out_hook = Some(Execution::TimedOutHook {
+                    tag: self.hook,
+                    timeout: self.timeout,
+                });
+                if self.has_done_parameter {
+                    Execution::Result::FailBecauseHookTimeoutWithDoneCallback
+                } else {
+                    Execution::Result::FailBecauseHookTimeout
+                }
             };
             sequence.maybe_skip = true;
             return true;

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1814,9 +1814,7 @@ pub enum HookTag {
     AfterAll,
 }
 
-/// Tags accepted by `generic_hook`. Superset of `DescribeScope::HookTag`
-/// (adds `OnTestFinished`). Also recorded on every hook `ExecutionEntry` so
-/// the reporter can name the hook kind.
+/// `HookTag` plus `OnTestFinished`: every hook kind a JS hook function can register.
 #[derive(Copy, Clone, PartialEq, Eq, strum::IntoStaticStr)]
 pub enum GenericHookTag {
     #[strum(serialize = "beforeAll")]

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -253,7 +253,7 @@ pub mod js_fns {
 
                     let new_item = ExecutionEntry::create(
                         None,
-                        Some(tag),
+                        EntryKind::Hook(tag),
                         args.callback,
                         cfg,
                         None,
@@ -1770,7 +1770,15 @@ impl DescribeScope {
         base: BaseScopeCfg,
         phase: AddedInPhase,
     ) -> JsResult<&mut ExecutionEntry> {
-        let mut entry = ExecutionEntry::create(name_not_owned, None, callback, cfg, Some(std::ptr::from_mut(self)), base, phase);
+        let mut entry = ExecutionEntry::create(
+            name_not_owned,
+            EntryKind::Test,
+            callback,
+            cfg,
+            Some(std::ptr::from_mut(self)),
+            base,
+            phase,
+        );
         let has_cb = entry.callback.is_some();
         entry.base.propagate(has_cb);
         self.entries.push(TestScheduleEntry::TestCallback(entry));
@@ -1799,7 +1807,15 @@ impl DescribeScope {
         base: BaseScopeCfg,
         phase: AddedInPhase,
     ) -> JsResult<&mut ExecutionEntry> {
-        let entry = ExecutionEntry::create(None, Some(tag.into()), callback, cfg, Some(std::ptr::from_mut(self)), base, phase);
+        let entry = ExecutionEntry::create(
+            None,
+            EntryKind::Hook(tag.into()),
+            callback,
+            cfg,
+            Some(std::ptr::from_mut(self)),
+            base,
+            phase,
+        );
         let list = self.get_hook_entries(tag);
         list.push(entry);
         Ok(&mut **list.last_mut().unwrap())
@@ -1885,11 +1901,16 @@ pub enum AddedInPhase {
     Execution,
 }
 
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum EntryKind {
+    Test,
+    Hook(GenericHookTag),
+}
+
 pub struct ExecutionEntry {
     pub(crate) base: BaseScope,
     pub callback: Option<Strong>,
-    /// `Some` for a hook entry, `None` for a test entry.
-    pub(crate) hook: Option<GenericHookTag>,
+    pub(crate) kind: EntryKind,
     /// 0 = unlimited timeout
     pub(crate) timeout: u32,
     pub(crate) has_done_parameter: bool,
@@ -1910,7 +1931,7 @@ pub struct ExecutionEntry {
 impl ExecutionEntry {
     fn create(
         name_not_owned: Option<&[u8]>,
-        hook: Option<GenericHookTag>,
+        kind: EntryKind,
         cb: Option<JSValue>,
         cfg: ExecutionEntryCfg,
         parent: Option<*mut DescribeScope>,
@@ -1920,7 +1941,7 @@ impl ExecutionEntry {
         let mut entry = Box::new(ExecutionEntry {
             base: BaseScope::init(base, name_not_owned, parent, cb.is_some()),
             callback: None,
-            hook,
+            kind,
             timeout: cfg.timeout,
             has_done_parameter: cfg.has_done_parameter,
             added_in_phase: phase,
@@ -1949,9 +1970,9 @@ impl ExecutionEntry {
         if let Some(name) = self.base.name.as_deref() {
             return name;
         }
-        match self.hook {
-            Some(hook) => <&'static str>::from(hook).as_bytes(),
-            None => b"(unnamed)",
+        match self.kind {
+            EntryKind::Hook(tag) => <&'static str>::from(tag).as_bytes(),
+            EntryKind::Test => b"(unnamed)",
         }
     }
 
@@ -1962,25 +1983,24 @@ impl ExecutionEntry {
     ) -> bool {
         if !self.timespec.eql(&Timespec::EPOCH) && self.timespec.order(now) == core::cmp::Ordering::Less {
             // timed out
-            // SAFETY: pointer-identity comparison only — no deref, no provenance laundering.
-            let is_test_entry = sequence
-                .test_entry
-                .is_some_and(|p| core::ptr::eq(p.as_ptr().cast_const(), self));
-            sequence.result = if is_test_entry {
-                if self.has_done_parameter {
-                    Execution::Result::FailBecauseTimeoutWithDoneCallback
-                } else {
-                    Execution::Result::FailBecauseTimeout
+            sequence.result = match self.kind {
+                EntryKind::Test => {
+                    if self.has_done_parameter {
+                        Execution::Result::FailBecauseTimeoutWithDoneCallback
+                    } else {
+                        Execution::Result::FailBecauseTimeout
+                    }
                 }
-            } else {
-                sequence.timed_out_hook = Some(Execution::TimedOutHook {
-                    tag: self.hook,
-                    timeout: self.timeout,
-                });
-                if self.has_done_parameter {
-                    Execution::Result::FailBecauseHookTimeoutWithDoneCallback
-                } else {
-                    Execution::Result::FailBecauseHookTimeout
+                EntryKind::Hook(tag) => {
+                    sequence.timed_out_hook = Some(Execution::TimedOutHook {
+                        tag,
+                        timeout: self.timeout,
+                    });
+                    if self.has_done_parameter {
+                        Execution::Result::FailBecauseHookTimeoutWithDoneCallback
+                    } else {
+                        Execution::Result::FailBecauseHookTimeout
+                    }
                 }
             };
             sequence.maybe_skip = true;

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -755,24 +755,6 @@ describe("bun test", () => {
       });
       expect(stderr).toMatch(/::error title=error: Test \"time out\" timed out after \d+ms::/);
     });
-    test("should annotate a hook timeout with the hook kind and its timeout", () => {
-      const stderr = runTest({
-        input: `
-          import { beforeEach, test } from "bun:test";
-          beforeEach(async () => {
-            await Bun.sleep(1000);
-          }, 10);
-          test("time out", () => {}, { timeout: 5000 });
-        `,
-        env: {
-          FORCE_COLOR: "1",
-          GITHUB_ACTIONS: "true",
-        },
-      });
-      expect(stderr).toContain(
-        '::error title=error: Test "time out": a beforeEach hook for this test timed out after 10ms::',
-      );
-    });
     test("should annotate an error thrown from a source whose URL is longer than a path buffer", () => {
       // Longer than a path buffer on every platform (98302 bytes on Windows).
       const padding = 100_000;

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -403,6 +403,40 @@ describe("bun test", () => {
       });
       expect(stderr).toHaveTestTimedOutAfter(5000);
     }, 10000);
+    // https://github.com/oven-sh/bun/issues/42361
+    test.concurrent.each([
+      ["beforeAll", "(fail) beforeAll", "a beforeAll hook timed out after 10ms."],
+      ["afterAll", "(fail) afterAll", "an afterAll hook timed out after 10ms."],
+      ["beforeEach", "(fail) runs", "a beforeEach hook for this test timed out after 10ms."],
+      ["afterEach", "(fail) runs", "an afterEach hook for this test timed out after 10ms."],
+    ])("a timed out %s hook names the hook kind", (hook, label, message) => {
+      const stderr = runTest({
+        input: `
+          import { ${hook}, test } from "bun:test";
+          ${hook}(async () => {
+            await Bun.sleep(1000);
+          }, 10);
+          test("runs", () => {});
+        `,
+        expectExitCode: 1,
+      });
+      expect(stderr).toContain(label);
+      expect(stderr).toContain(`^ ${message}`);
+      expect(stderr).not.toContain("beforeEach/afterEach");
+      expect(stderr).not.toContain("(unnamed)");
+    });
+    test.concurrent("a timed out hook with a done callback names the hook kind", () => {
+      const stderr = runTest({
+        input: `
+          import { afterAll, test } from "bun:test";
+          afterAll(done => {}, 10);
+          test("runs", () => {});
+        `,
+        expectExitCode: 1,
+      });
+      expect(stderr).toContain("(fail) afterAll");
+      expect(stderr).toContain("^ an afterAll hook timed out after 10ms, before its done callback was called.");
+    });
   });
   describe("support for Github Actions", () => {
     test("should not group logs by default", () => {
@@ -718,6 +752,24 @@ describe("bun test", () => {
         },
       });
       expect(stderr).toMatch(/::error title=error: Test \"time out\" timed out after \d+ms::/);
+    });
+    test("should annotate a hook timeout with the hook kind and its timeout", () => {
+      const stderr = runTest({
+        input: `
+          import { beforeEach, test } from "bun:test";
+          beforeEach(async () => {
+            await Bun.sleep(1000);
+          }, 10);
+          test("time out", () => {}, { timeout: 5000 });
+        `,
+        env: {
+          FORCE_COLOR: "1",
+          GITHUB_ACTIONS: "true",
+        },
+      });
+      expect(stderr).toContain(
+        '::error title=error: Test "time out": a beforeEach hook for this test timed out after 10ms::',
+      );
     });
     test("should annotate an error thrown from a source whose URL is longer than a path buffer", () => {
       // Longer than a path buffer on every platform (98302 bytes on Windows).

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -404,28 +404,30 @@ describe("bun test", () => {
       expect(stderr).toHaveTestTimedOutAfter(5000);
     }, 10000);
     // https://github.com/oven-sh/bun/issues/42361
-    test.concurrent.each([
+    describe.each([
       ["beforeAll", "(fail) beforeAll", "a beforeAll hook timed out after 10ms."],
       ["afterAll", "(fail) afterAll", "an afterAll hook timed out after 10ms."],
       ["beforeEach", "(fail) runs", "a beforeEach hook for this test timed out after 10ms."],
       ["afterEach", "(fail) runs", "an afterEach hook for this test timed out after 10ms."],
-    ])("a timed out %s hook names the hook kind", (hook, label, message) => {
-      const stderr = runTest({
-        input: `
-          import { ${hook}, test } from "bun:test";
-          ${hook}(async () => {
-            await Bun.sleep(1000);
-          }, 10);
-          test("runs", () => {});
-        `,
-        expectExitCode: 1,
+    ])("%s", (hook, label, message) => {
+      test("a timed out hook names the hook kind", () => {
+        const stderr = runTest({
+          input: `
+            import { ${hook}, test } from "bun:test";
+            ${hook}(async () => {
+              await Bun.sleep(1000);
+            }, 10);
+            test("runs", () => {});
+          `,
+          expectExitCode: 1,
+        });
+        expect(stderr).toContain(label);
+        expect(stderr).toContain(`^ ${message}`);
+        expect(stderr).not.toContain("beforeEach/afterEach");
+        expect(stderr).not.toContain("(unnamed)");
       });
-      expect(stderr).toContain(label);
-      expect(stderr).toContain(`^ ${message}`);
-      expect(stderr).not.toContain("beforeEach/afterEach");
-      expect(stderr).not.toContain("(unnamed)");
     });
-    test.concurrent("a timed out hook with a done callback names the hook kind", () => {
+    test("a timed out hook with a done callback names the hook kind", () => {
       const stderr = runTest({
         input: `
           import { afterAll, test } from "bun:test";

--- a/test/regression/issue/12782.test.ts
+++ b/test/regression/issue/12782.test.ts
@@ -31,7 +31,7 @@ test("12782", async () => {
                                                                          ^
     error: Environment variable FOO is not set
         at <anonymous> (file:NN:NN)
-    (fail) (unnamed)
+    (fail) beforeAll
 
     test/regression/issue/12782.bar.fixture.ts:
     (pass) bar > should not run


### PR DESCRIPTION
Fixes #42361

### Problem
- A `beforeAll` or `afterAll` hook that exceeds its timeout is reported as `(fail) (unnamed)` with the note `a beforeEach/afterEach hook timed out for this test.` The file may contain no `beforeEach` or `afterEach`.
- The two `FailBecauseHookTimeout*` arms in `src/runtime/cli/test_command.rs` hardcode that text. `ExecutionEntry::evaluate_timeout` (`src/runtime/test_runner/bun_test.rs`) picks the hook result for every entry that is not the sequence's test entry, and `*All` hooks run in a sequence with no test entry. The entry does not record which hook kind it is, and hook entries have no name, so the label falls back to `(unnamed)`.

### Fix
- Each `ExecutionEntry` now carries `kind: EntryKind`, either `Test` or `Hook(GenericHookTag)`. `append_hook` sets it from the `HookTag`, and hooks added during execution (`afterEach` inside a test, `onTestFinished`) set it from the tag they were called with.
- When a hook times out, `evaluate_timeout` records the hook kind and the hook's own timeout on the sequence (`ExecutionSequence::timed_out_hook`). `reset_sequence` clears it because it rebuilds the sequence with `init`.
- The reporter prints `a beforeAll hook timed out after 50ms.` for `*All` hooks and `an afterEach hook for this test timed out after 50ms.` for per-test hooks. The done-callback variant uses the same label. A `*All` hook entry with no name now prints its kind as the label (`(fail) beforeAll`) in the test line and in the JUnit report.
- Verified: `test/cli/test/bun-test.test.ts` (five new tests, all fail on stock bun). Also `test/regression/issue/12782.test.ts` (snapshot updated from `(fail) (unnamed)` to `(fail) beforeAll`), `test/js/bun/test/jest-hooks.test.ts`, `test/js/bun/test/test-test.test.ts`, `test/cli/test/test-timeout-behavior.test.ts`, `test/cli/test/parallel.test.ts`.

### Background
- `bun test` runs each test as an `ExecutionSequence`: a linked list of `ExecutionEntry` values (`beforeEach` hooks, the test, `afterEach` hooks). `sequence.test_entry` points at the test. A `beforeAll` or `afterAll` hook runs in its own sequence whose `test_entry` is `None` and whose only entry is the hook.
- `HookTag` is the four-variant kind used to pick a `DescribeScope` hook list. `GenericHookTag` is the five-variant kind the JS-facing `beforeAll()`, `onTestFinished()` and friends dispatch on. It already has the display names (`beforeAll`, ...). This PR moves it next to `HookTag` so `EntryKind` can hold it.
- The reporter (`print_test_line`) receives the sequence and either the test entry or, for a `*All` sequence, the hook entry itself. Under `--parallel` the worker formats the line and sends the text to the coordinator, so no wire format changes.
- Related: #41876 and #39234 also touch the hook timeout strings in this reporter. This PR is the one that records the hook kind on the entry. The others can read `EntryKind` and `timed_out_hook` after a rebase instead of deriving the kind from `sequence.test_entry`.

<details><summary>Notes</summary>

Output after the change for the issue's repro:

```
repro.test.ts:
(fail) beforeAll [50.16ms]
  ^ a beforeAll hook timed out after 50ms.
```

Other cases checked by hand with the debug build: `afterAll` with a done callback, `beforeEach`, `afterEach`, `onTestFinished` (reports as the `beforeEach` hook that timed out first in that sequence), a throwing `beforeAll` inside a describe (`(fail) outer > beforeAll`), `--parallel`, and `--reporter=junit` (testcase name is now `beforeAll`).

The GitHub Actions `::error` annotation is unchanged. An earlier revision of this PR added the hook label to its title. That hunk was dropped because #41876 rewrites the annotation code as a whole.

Two `beforeAll` hooks in one scope share the JUnit testcase name `beforeAll`. They shared `(unnamed)` before this change. Each testcase still carries the file and line of the hook.

`test/cli/test/parallel.test.ts` has one failure, `each worker has a unique JEST_WORKER_ID and BUN_TEST_WORKER_ID`, that fails the same way on main without this diff.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->