### PR TITLE
bundler: keep an import() local that a property read still uses under --minify-syntax

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -264,7 +264,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             // imported module end up in the same module group and the namespace
                             // symbol has never been captured, then we don't need to generate
                             // any code for the namespace at all.
-                            p.ignore_usage(id.ref_);
+                            //
+                            // A local holding an `import()` / `require()` namespace is a
+                            // declaration, and an item the linker does not bind prints
+                            // `ns.a`. Its use stays counted, as an accounted-for read, so
+                            // single-use substitution never drops the declaration from
+                            // under it.
+                            if dynamic_record.is_some() {
+                                p.note_tracked_namespace_use(id.ref_);
+                            } else {
+                                p.ignore_usage(id.ref_);
+                            }
 
                             // Track how many times we've referenced this symbol
                             p.record_usage(ref_);

--- a/test/bundler/bundler_dynamic_import_dce.test.ts
+++ b/test/bundler/bundler_dynamic_import_dce.test.ts
@@ -604,6 +604,48 @@ describe("bundler", () => {
     });
   }
 
+  // `q.a` is an import item that prints `q.a` unless the linker binds it, so it
+  // stays a use of `q`: with another use first, single-use substitution must not
+  // inline the declaration into that use and leave the read without it.
+  for (const [name, importee, splitting] of [
+    ["", "./x.js", false],
+    ["Splitting", "./x.js", true],
+    ["CommonJS", "./x.cjs", false],
+  ] as const) {
+    itBundled(`dynamic_import_dce/MinifyKeepsNamespaceLocalForItemRead${name}`, {
+      files: {
+        "/entry.js": /* js */ `
+          async function bare() { const q = await import("${importee}"); return [q, q.a]; }
+          async function copy() { const q = await import("${importee}"); let r = q; return [r, q.a]; }
+          async function test() { const q = await import("${importee}"); return q ? q.a : 0; }
+          async function typeOf() { const q = await import("${importee}"); return [typeof q, q.a]; }
+          function req() { const q = require("${importee}"); return [q, q.a]; }
+          for (const f of [bare, copy, test, typeOf, req]) {
+            let out;
+            try {
+              out = [await f()].flat().map(v => (typeof v === "object" ? "ns" : v)).join();
+            } catch (e) {
+              out = e.name + ": " + e.message;
+            }
+            console.log(f.name, out);
+          }
+        `,
+        "/x.js": `export const a = "A"; export const b = "B";`,
+        "/x.cjs": `exports.a = "A"; exports.b = "B";`,
+      },
+      minifySyntax: true,
+      splitting,
+      target: "bun",
+      format: "esm",
+      outdir: "/out",
+      run: { file: "/out/entry.js", stdout: "bare ns,A\ncopy ns,A\ntest A\ntypeOf object,A\nreq ns,A" },
+      onAfterBundle(api) {
+        // A read the linker can bind still reads the export directly.
+        if (name === "") api.expectFile("/out/entry.js").toContain("? a : 0");
+      },
+    });
+  }
+
   // The minifier substitutes a single-use `const x = cond ? (await import()).a() : b`
   // into its use and re-visits it; the re-visit must not mint a second,
   // untracked record for the same import().


### PR DESCRIPTION
### Problem
- `bun build --minify-syntax` (also `--minify`) turns `const m = await import("./x"); return [m, m.n]` into `return [await …, m.n]`, which throws `ReferenceError: m is not defined`. 1.4.0 is correct. #41186 (1.4.1) added the bug.
- `require()` fails the same way. `m ? m.n : 1` fails when the importee is CommonJS, external, or split.
- `maybe_rewrite_property_access` (`src/js_parser/fold.rs:267`) makes `m.n` an import item and calls `ignore_usage(m)`. The single-use substitution (`src/js_parser/visit/mod.rs:1946`) then sees one use of `m` and moves the declaration into it. An item that the linker does not bind still prints `m.n`.

### Fix
- For a local that holds an `import()` / `require()` namespace, `fold.rs` keeps the read counted and calls `note_tracked_namespace_use`. `import * as ns` still calls `ignore_usage`.
- The escape check (`parse_entry.rs:1268`) compares `use_count_estimate` with `namespace_tracked_uses`. Each read adds one to both, so its result does not change.
- Cost: a local with a truthiness or `typeof` use and bound reads is not inlined now (a few bytes).
- Verified: `test/bundler/bundler_dynamic_import_dce.test.ts` (3 new tests, all fail on 1.4.3-canary). Also the minify, esbuild dce, importstar, splitting, barrel, edgecase, and cjs2esm suites.

### Background
- An import item is a symbol that the linker can bind to an export of another module. A bound item prints the export. An unbound item prints as written: `m.n`.
- `use_count_estimate` is the number of references to a symbol. With `--minify-syntax`, a nested-scope `let` or `const` with a count of 1 moves into its use.
- `namespace_tracked_uses` is how many of those references read named exports only. If all do, the importee drops its other exports.

<details><summary>Notes</summary>

**Repro** (from the report):

```sh
mkdir m && cd m
echo 'export let n = 0;' > counter.ts
cat > entry.ts <<'X'
async function f() {
  const m = await import("./counter.ts");
  return [m, m.n];
}
console.log(await f().then(r => typeof r[0] + " " + r[1], e => e.name + ": " + e.message));
X
bun build --minify-syntax entry.ts --outdir o && bun o/entry.js
```

Expected `object 0`. 1.4.1, 1.4.2 and main print `ReferenceError: m is not defined`. 1.4.0 and this branch print `object 0`, and emit the same text for `f`:

```js
async function f() {
  let m = await Promise.resolve().then(() => exports_counter);
  return [m, m.n];
}
```

**Shapes** (`const m = await import("./counter.ts")`, then `return <shape>`). Each one was built with no flags, `--minify-syntax`, `--minify-syntax --splitting` and `--minify`, on 1.4.3-canary and on this branch. This branch prints the unminified result in every cell.

| shape | 1.4.3-canary |
|---|---|
| `[m, m.n]`, `[m, m["n"]]`, `[m === ns, m.n]` | ReferenceError with each minify flag set |
| `[typeof m, m.n]`, `m ? m.n : 1` | ReferenceError with `--minify-syntax --splitting` |
| `[m.n, m]`, `[m.n, m.n]`, `[m?.n, m]`, `[m["n"], m]`, `[Object.keys(m).length, m.n]` | correct |

The second row also fails without `--splitting` when the importee is CommonJS (`exports.n = 5`) or external (`node:fs`), because the linker binds no item of those records. `--format=cjs`, `--format=iife` and `--compile --bytecode --format=esm --minify` fail on 1.4.3-canary and pass on this branch.

**Why the first use decides.** The substitution only moves an initializer with side effects into the first expression that the next statement evaluates. So `[m.n, m]` was never inlined: the item `m.n` comes first and `await import()` cannot move past it.

**Why the count is the right place.** The doc comment on `namespace_tracked_uses` (`src/js_parser/p.rs:351`) says that the tracked count is kept beside the real count "so the minifier's single-use substitution still sees every use". #32557 added that rule and the `TrackedAccessThenEscape` test for it. #41186 sent `ns.a` through the `import * as ns` rewrite, which removes the use from the count. That test still passes only because its read comes before its escaping use. `ignore_usage` is correct for `import * as ns`, because no declaration of `ns` exists for the minifier to remove.

**Other readers of the count.** `use_count_estimate` of such a local has three readers, all in the parser: the single-use substitution, the escape check, and the character frequency pass for minified names (`src/js_parser/p.rs:1893`, a naming heuristic). Every other reader looks at a fixed symbol (`module`, `exports`, `require`, `arguments`, a function or class expression name), at a static import namespace, or runs only for the dev server, where `ns.a` does not become an item. The part-level `symbol_uses` entry for `ns` now stays in a part that reads `ns.a`. That part then depends on the part that declares `ns`. The declaration is an `await import()` or a `require()`, which tree shaking never removes, so no output changes. #41158 (open) rewrites the substitution loop and adds removal of unused locals. It reads the same count, and this change does not touch its files.

**Suites run with the debug build:** `bundler_dynamic_import_dce` (277 pass), `bundler_minify`, `bundler_promiseall_deadcode`, `bundler_bytecode_portable`, `bundler_barrel`, `bundler_edgecase`, `bundler_splitting`, `bundler_cjs2esm`, `esbuild/dce`, `esbuild/importstar`, `esbuild/splitting`, `regression/issue/cyclic-imports-async-bundler`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_dynamic_import_dce.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [902.48ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [512.01ms]
(pass) bundler > dynamic_import_dce/AwaitDot [643.22ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [515.97ms]
(pass) bundler > dynamic_import_dce/LetBinding [459.23ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [579.70ms]
(pass) bundler > dynamic_import_dce/BailoutRest [559.78ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [646.59ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [557.98ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [467.12ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [889.36ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [508.32ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [444.26ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [464.94ms]
(pass) bundler > dynam
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [27.90ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [12.72ms]
(pass) bundler > dynamic_import_dce/AwaitDot [13.96ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [14.04ms]
(pass) bundler > dynamic_import_dce/LetBinding [14.01ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [11.21ms]
(pass) bundler > dynamic_import_dce/BailoutRest [14.35ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [16.05ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [14.31ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [11.98ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [21.69ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [17.29ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [18.10ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [15.74ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllDestructure [14.33ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllThenDestructure [18.47ms]
(pass) bundler > dynamic_import_dce/SplittingProm
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_dynamic_import_dce.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [885.80ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [364.74ms]
(pass) bundler > dynamic_import_dce/AwaitDot [460.50ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [390.85ms]
(pass) bundler > dynamic_import_dce/LetBinding [357.10ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [382.78ms]
(pass) bundler > dynamic_import_dce/BailoutRest [469.81ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [384.53ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [458.47ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [467.46ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [790.15ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [485.59ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [410.37ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [496.15ms]
(pass) bundler > dynam
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 687ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (10129ms)
Bundle modules (56ms)
Postprocesss modules (165ms)
Bundle Functions (667ms)
Generate Code (41ms)

[11.06s] Bundled "src/js" for production
  2599 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/work
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/fold.rs                           | 12 ++++++-
 test/bundler/bundler_dynamic_import_dce.test.ts | 42 +++++++++++++++++++++++++
 2 files changed, 53 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/js_parser/fold.rs                                3      2     14
test/bundler/bundler_dynamic_import_dce.test.ts      3      2     14
```

</details>

<!-- robobun:evidence:end -->