### PR TITLE
node:tls: send the FIN when end() runs before a TLSSocket wrap's native handle attaches

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1323,6 +1323,8 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     self.connecting = false;
     if (callback) {
       const writeChunk = self._pendingData;
+      // A write parked while the socket this one wraps was connecting reaches the engine here, not through _write.
+      if (self.secureConnecting) self[kPreHandshakeWrite] = true;
       const res = socket.$write(writeChunk || "", self._pendingEncoding || "utf8");
       if (res < 0) {
         // The retried send failed for good (peer gone): $write returned -errno.
@@ -2113,6 +2115,9 @@ Socket.prototype.connect = function connect(...args) {
                   this.once("end", this[kCloseRawConnection]);
                   raw.connecting = false;
                   this._handle = tls;
+                  // The native open callback ran inside upgradeTLSDeferred: a write parked
+                  // for this connect completed there, before the handle was assigned.
+                  this.emit(kUpgradeAttached);
                 } else {
                   this._handle = null;
                   throw new Error("Invalid socket");
@@ -2280,6 +2285,12 @@ Socket.prototype._final = function _final(callback) {
     return this.once("connect", this._final.bind(this, callback));
   }
   const socket = this._handle;
+
+  // See _write: a TLS wrap attaches its native handle after the wrap itself.
+  // kclosed: that handle already closed and detached, nothing is left to attach.
+  if (!socket && this[kupgraded] && !this.destroyed && !this[kclosed]) {
+    return this.once(kUpgradeAttached, this._final.bind(this, callback));
+  }
 
   // already closed call destroy
   if (!socket) return callback();

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -897,9 +897,11 @@ TLSSocket.prototype._start = function _start() {
 };
 
 TLSSocket.prototype._final = function _final(callback) {
-  if (!this._handle) return callback();
+  const handle = this._handle;
+  // A socket that wraps a connecting one emits no 'connect' for NetSocket.prototype._final to wait for.
+  if (!handle && this.connecting) return callback();
   // https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1119-L1133
-  if (this.secureConnecting && this[kPreHandshakeWrite]) {
+  if (handle && this.secureConnecting && this[kPreHandshakeWrite]) {
     return this.once(kSecureConnectDone, NetSocket.prototype._final.bind(this, callback));
   }
   // https://github.com/nodejs/node/blob/v26.3.0/src/crypto/crypto_tls.cc#L1203-L1213

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1992,4 +1992,47 @@ describe.each([
       clientSawFin: true,
     });
   });
+
+  it.skipIf(!exe)("a server-side TLSSocket end()s in the tick that wrapped the connection", async () => {
+    expect(await run("server-end-same-tick")).toEqual({
+      log: ["end secureConnecting=true", "finish"],
+      clientSawFin: true,
+    });
+  });
+
+  it.skipIf(!exe)("end('') on a client over a socket that is still connecting follows the handshake", async () => {
+    expect(await run("end-over-connecting-socket")).toEqual({
+      log: ["end connecting=true", "secureConnect", "finish", "close"],
+      serverSawEnd: true,
+    });
+  });
+});
+
+// end() waits for a server-side wrap's native handle only while that handle is
+// still to attach. One that attached and then closed leaves nothing to wait
+// for: the stream ends itself from the close, and that end() has to finish.
+it("a server-side TLSSocket wrap finishes and closes after its native handle was closed", async () => {
+  const events: string[] = [];
+  const closed = Promise.withResolvers<void>();
+  let wrapped: TLSSocket | undefined;
+  const server = net.createServer(raw => {
+    raw.on("error", () => {});
+    wrapped = new TLSSocket(raw, { isServer: true, ...COMMON_CERT_ });
+    wrapped.on("error", closed.reject);
+    wrapped.on("secure", () => (wrapped as any)._handle.close());
+    for (const event of ["finish", "close"]) wrapped.on(event, () => events.push(event));
+    wrapped.on("close", () => closed.resolve());
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+  const client = tls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+  client.on("error", () => {});
+  try {
+    await closed.promise;
+    expect(events).toEqual(["finish", "close"]);
+  } finally {
+    client.destroy();
+    wrapped?.destroy();
+    server.close();
+  }
 });

--- a/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
+++ b/test/js/node/tls/tls-shutdown-before-handshake-fixture.mjs
@@ -60,7 +60,7 @@ if (mode === "end" || mode === "destroySoon") {
   client.destroy();
   peer.close();
   report({ peerSawFin: true, writableFinished, readyState, destroyed });
-} else if (mode === "server-end") {
+} else if (mode === "server-end" || mode === "server-end-same-tick") {
   const clientSawFin = Promise.withResolvers();
   let serverSocket;
   const server = net.createServer(raw => {
@@ -72,13 +72,15 @@ if (mode === "end" || mode === "destroySoon") {
     socket.on("error", () => {});
     raw.on("error", () => {});
     socket.on("finish", () => log.push("finish"));
-    // bun's wrap adopts the connection's handle on a later turn, so end() from
-    // the turn after the wrap is the reported shape: the engine runs and waits
-    // for a client flight that never arrives.
-    setImmediate(() => {
+    const end = () => {
       log.push(`end secureConnecting=${socket.secureConnecting}`);
       socket.end();
-    });
+    };
+    // bun's wrap adopts the connection's handle on a later turn. end() from the
+    // turn after the wrap finds the engine waiting for a client flight that
+    // never arrives. end() in the wrap's own tick finds no handle yet.
+    if (mode === "server-end") setImmediate(end);
+    else end();
   });
   await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
 
@@ -93,6 +95,31 @@ if (mode === "end" || mode === "destroySoon") {
   serverSocket?.destroy();
   server.close();
   report({ clientSawFin: true });
+} else if (mode === "end-over-connecting-socket") {
+  // The zero-length chunk is parked until the wrapped socket connects. It then
+  // reaches the engine ahead of the handshake, so the close_notify and the FIN
+  // follow the handshake and the server sees a clean end.
+  const serverSawEnd = Promise.withResolvers();
+  const server = tls.createServer({ key: process.env.TLS_KEY, cert: process.env.TLS_CERT }, socket => {
+    socket.on("error", () => {});
+    socket.on("data", () => {});
+    socket.on("end", () => serverSawEnd.resolve());
+  });
+  server.on("tlsClientError", serverSawEnd.reject);
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+  const raw = net.connect({ port: server.address().port, host: "127.0.0.1" });
+  const client = tls.connect({ socket: raw, rejectUnauthorized: false });
+  for (const event of ["secureConnect", "finish", "close"]) client.on(event, () => log.push(event));
+  client.on("error", error => log.push(`error:${error.code}`));
+  client.on("data", () => {});
+  log.push(`end connecting=${client.connecting}`);
+  client.end("");
+
+  await Promise.all([once(client, "close"), serverSawEnd.promise]);
+
+  server.close();
+  report({ serverSawEnd: true });
 } else {
   throw new Error(`unknown mode ${mode}`);
 }


### PR DESCRIPTION
### Problem
- `new tls.TLSSocket(socket, { isServer: true })` then `end()` in the same tick emits `'finish'` and sends no close_notify and no FIN. The connection stays open. Node sends the FIN at once.
- The server wrap attaches its native TLS handle from a `process.nextTick` (`src/js/node/net.ts:2409`). `_final` runs first, and `TLSSocket.prototype._final` (`src/js/node/tls.ts:900`) calls back when there is no handle.
- `tls.connect({ socket })` over a connecting socket has the same gap for `end("")`. The native `open` callback completes the parked write inside `upgradeTLSDeferred`, before `_handle` is assigned.

### Fix
- `Socket.prototype._final` waits for `kUpgradeAttached`, as `_write` does (`net.ts:2797`), unless the attached handle already closed (`kclosed`). `TLSSocket.prototype._final` sends the no-handle case there.
- The client path emits `kUpgradeAttached` after it assigns the handle. `drain` sets `kPreHandshakeWrite` for the parked chunk, so the FIN follows the handshake.
- Node wraps the handle in the constructor, so its `_final` always has a handle. The wait gives `_final` here the same view.
- Verified: `test/js/node/tls/node-tls-connect.test.ts` (3 new tests, 2 time out on main, node v26.3.0 agrees). Also `test/js/node/{tls,net,http2}/`, `test/js/bun/net/`, vendored `test-{tls,https,http2,net}-*.js`.

### Background
- `_final` is the shutdown hook of the writable side. It runs after every queued write completes. `'finish'` follows its callback.
- A TLS wrap is a `TLSSocket` over an existing socket. Bun adopts the fd of that socket into a native TLS handle. `kupgraded` holds the wrapped socket. `kUpgradeAttached` says the handle is now in `_handle`.
- `kPreHandshakeWrite` records a write that reached the TLS engine before the handshake completed. `_final` then holds the FIN until the handshake settles (#42181).

<details><summary>Notes</summary>

Reference runs, node v26.3.0 against this branch and main (`6a92015fc8`). A server-side wrap that calls `end()` in the wrap tick, with a `tls.connect` client:

| | server events | client events |
| --- | --- | --- |
| node v26.3.0 | `finish, end, close` | `end, error:ECONNRESET, close` |
| main | `finish, secure` (connection stays open) | `secureConnect` |
| this branch | `finish, end, close` | `end, error:ECONNRESET, close` |

`tls.connect({ socket: net.connect(port) })` followed by `end("")` before the connect, against a live TLS server:

| | client events | server events |
| --- | --- | --- |
| node v26.3.0 | `connect, secureConnect, finish, end, close` | `secureConnection, end, close` |
| main | `finish, secureConnect` (connection stays open) | `secureConnection` |
| this branch | `secureConnect, finish, end, close` | `secureConnection, end, close` |

The missing `'connect'` in the last row is a separate gap: a `TLSSocket` that wraps a connecting socket emits no `'connect'` on main.

Each part of the change is needed. Without the `drain` line the client sends a bare FIN in the middle of the handshake and the server reports `tlsClientError: ECONNRESET`. Without the client `kUpgradeAttached` emit the parked `_final` never resumes. Without the `kclosed` check, a server-side wrap whose handle was closed directly (`socket._handle.close()`) parks its own `end()` and never emits `'finish'` or `'close'`. The third new test pins that case. It passes on main and on this branch.

Not changed on purpose:
- `tls.connect({ socket })` over a connecting socket followed by `end()` with no data still finishes at once with no FIN. That wrapper emits no `'connect'` on main, so `Socket.prototype._final` has nothing to wait for. `TLSSocket.prototype._final` keeps the early callback for that one case (`!handle && this.connecting`). A change that makes the wrapper emit `'connect'` can delete that line.
- `end("")` in the wrap tick on a server-side wrap still waits for the handshake (`secure, finish, end, close`). Node sends the FIN at once. This is the zero-length write rule that #42181 describes.
- `end()` followed by `raw.destroy()` in the wrap tick now gives `close` with no `'finish'`. Main and node give `finish, close`. The wrap is destroyed before its handle attaches, so nothing was shut down.
- `end()` followed by `destroy()` in the wrap tick now gives `close`, the same as node. Main gave `finish, close`.

This PR and #42330 both edit the first lines of `TLSSocket.prototype._final`. The two changes are independent. The second one to merge has a small conflict there.

Failures seen in the listed suites that are not from this change (each fails the same way with main's `net.ts` and `tls.ts`): `node-tls-server.test.ts` "SNICallback runs even when the requested servername matches the bind hostname" (ECONNREFUSED in this container), 10 tests in `test/js/node/net/` (`net.Socket read`, `unref should exit`, `#13126`), `test/js/bun/net/socket.test.ts` "should not call drain before handshake", vendored `test-https-timeout.js` (times out on the debug build) and `test-tls-client-allow-partial-trust-chain.js` (needs the test runner).

</details>
