### PR TITLE
node:http2: don't track client streams opened by inbound HEADERS

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4937,10 +4937,7 @@ class ClientHttp2Session extends Http2Session {
   #closeCalled: boolean = false;
   /// connected indicates that the connection/socket is connected
   #connected: boolean = false;
-  // Open streams that user code holds, which close() waits for: a request is counted where it
-  // takes its stream id, a push in streamPush. There is no streamStart handler on purpose. The
-  // parser also registers a stream when the peer sends HEADERS on one that this side neither
-  // opened nor reserved, and user code can neither observe nor close that stream.
+  // Open streams that user code holds. Counted in request() and streamPush, never from a parser callback.
   #connections: number = 0;
 
   #socket_proxy: Proxy<TLSSocket | Socket>;
@@ -5888,8 +5885,7 @@ class ClientHttp2Session extends Http2Session {
   }
 
   request(headers: any, options?: any) {
-    // Set once a stream id was allocated and counted in #connections; validation throws before
-    // that point must not decrement.
+    // Set once the stream is counted in #connections: a throw before that must not decrement.
     let connectionsCounted = false;
     try {
       // node validates arguments synchronously and only defers session-state failures

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4937,6 +4937,10 @@ class ClientHttp2Session extends Http2Session {
   #closeCalled: boolean = false;
   /// connected indicates that the connection/socket is connected
   #connected: boolean = false;
+  // Open streams that user code holds, which close() waits for: a request is counted where it
+  // takes its stream id, a push in streamPush. There is no streamStart handler on purpose. The
+  // parser also registers a stream when the peer sends HEADERS on one that this side neither
+  // opened nor reserved, and user code can neither observe nor close that stream.
   #connections: number = 0;
 
   #socket_proxy: Proxy<TLSSocket | Socket>;
@@ -4969,16 +4973,6 @@ class ClientHttp2Session extends Http2Session {
 
   static #Handlers = {
     binaryType: "buffer",
-    streamStart(self: ClientHttp2Session, stream_id: number) {
-      if (!self) return;
-      self.#connections++;
-      if (stream_id % 2 === 0) {
-        // A pushed (even-id) stream announced by the server: its context object must be a stream,
-        // not a session. Returned to the native caller, which stores it as the stream context.
-        const stream = new ClientHttp2Stream(stream_id, self, null);
-        return stream;
-      }
-    },
     streamPush(
       self: ClientHttp2Session,
       pushId: number,
@@ -5894,8 +5888,8 @@ class ClientHttp2Session extends Http2Session {
   }
 
   request(headers: any, options?: any) {
-    // Set once a stream id was allocated (streamStart incremented #connections); validation
-    // throws before that point must not decrement.
+    // Set once a stream id was allocated and counted in #connections; validation throws before
+    // that point must not decrement.
     let connectionsCounted = false;
     try {
       // node validates arguments synchronously and only defers session-state failures
@@ -6229,13 +6223,14 @@ class ClientHttp2Session extends Http2Session {
         return req;
       }
 
-      connectionsCounted = true;
       let stream_id: number = this.#parser.getNextStream();
       if (stream_id < 0) {
         const req = new ClientHttp2Stream(undefined, this, headers);
         process.nextTick(emitOutofStreamErrorNT, req);
         return req;
       }
+      this.#connections++;
+      connectionsCounted = true;
       const req = new ClientHttp2Stream(stream_id, this, headers);
       req.authority = authority;
       req[kHeadRequest] = method === HTTP2_METHOD_HEAD;
@@ -6308,6 +6303,7 @@ class ClientHttp2Session extends Http2Session {
         process.nextTick(emitOutofStreamErrorNT, req);
         continue;
       }
+      this.#connections++;
       req[kSetStreamId](stream_id);
       try {
         if (typeof options === "undefined") {

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -965,6 +965,39 @@ describe.concurrent("HEADERS on a stream the client neither opened nor reserved 
       raw.close();
     }
   });
+
+  // The ordinary cancel race: the response was in flight when the client reset the stream.
+  test("response HEADERS that arrive after the client cancelled the request do not keep a gracefully closed session open", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      const req = client.request({ ":path": "/" });
+      req.on("error", () => {});
+      req.resume();
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      req.close(http2.constants.NGHTTP2_CANCEL);
+      await raw.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 1);
+      // One PING round trip, so the client finishes the read in which it reset the stream.
+      const firstPing = once(client, "ping");
+      raw.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await firstPing;
+      // The late response HEADERS, left open. The second PING tells when the client has read them.
+      const secondPing = once(client, "ping");
+      raw.sendFrame(FrameType.HEADERS, 0x4 /* END_HEADERS */, 1, Buffer.from([0x88]));
+      raw.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await secondPing;
+      const closed = once(client, "close");
+      client.close();
+      await closed;
+      expect(client.destroyed).toBe(true);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
 });
 
 describe("inbound flow control after local end-stream (RFC 9113 §6.9)", () => {

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -800,6 +800,173 @@ describe("push stream states (checklist §5.1, RFC 9113 §6.4/§8.4)", () => {
   });
 });
 
+describe.concurrent("HEADERS on a stream the client neither opened nor reserved (RFC 9113 §5.1.1, §8.4)", () => {
+  // The client never hands such a stream to user code (no 'stream' event for an even id that no
+  // PUSH_PROMISE reserved), so nothing can listen for 'error' on it or close it.
+
+  // The next session-level error must reach the session and the open request only. Run in a
+  // child: the bug is an uncaughtException raised at session teardown. Node v26.3.0 reports the
+  // same four events for both cases.
+  const fixture = (hostileFrames: string) => String.raw`
+    const http2 = require("node:http2");
+    const net = require("node:net");
+    function frame(type, flags, streamId, payload = Buffer.alloc(0)) {
+      const header = Buffer.alloc(9);
+      header.writeUIntBE(payload.length, 0, 3);
+      header[3] = type;
+      header[4] = flags;
+      header.writeUInt32BE(streamId, 5);
+      return Buffer.concat([header, payload]);
+    }
+    const events = [];
+    process.on("uncaughtException", err => events.push("uncaughtException " + err.code));
+    process.on("exit", () => console.log(JSON.stringify(events.sort())));
+    // Raw h2c server: SETTINGS, then the hostile frames once the request HEADERS arrived.
+    const server = net.createServer(socket => {
+      socket.on("error", () => {});
+      socket.write(frame(0x4, 0, 0));
+      let buf = Buffer.alloc(0), sawPreface = false, sent = false;
+      socket.on("data", chunk => {
+        if (sent) return;
+        buf = Buffer.concat([buf, chunk]);
+        if (!sawPreface) {
+          if (buf.length < 24) return;
+          buf = buf.subarray(24);
+          sawPreface = true;
+        }
+        while (buf.length >= 9) {
+          const length = buf.readUIntBE(0, 3);
+          if (buf.length < 9 + length) return;
+          const type = buf[3];
+          buf = buf.subarray(9 + length);
+          if (type === 0x1) {
+            sent = true;
+            socket.write(Buffer.concat([frame(0x4, 0x1, 0), ${hostileFrames}]));
+            return;
+          }
+        }
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const client = http2.connect("http://127.0.0.1:" + server.address().port);
+      client.on("error", () => events.push("session error"));
+      client.on("close", () => {
+        events.push("session close");
+        server.close();
+      });
+      client.on("stream", pushed => {
+        events.push("stream event");
+        pushed.on("error", () => {});
+      });
+      const req = client.request({ ":path": "/" });
+      req.on("error", () => events.push("request error"));
+      req.on("close", () => events.push("request close"));
+      req.resume();
+    });
+  `;
+
+  test.each([
+    {
+      name: "an unfinished header block, then a PING where CONTINUATION is required",
+      hostileFrames: `frame(0x1, 0, 2), frame(0x6, 0, 0, Buffer.alloc(8))`,
+    },
+    {
+      name: "a complete header block, then GOAWAY(PROTOCOL_ERROR)",
+      // HEADERS: END_HEADERS | END_STREAM, ":status: 200". GOAWAY: last-stream-id 0, code 1.
+      hostileFrames: `frame(0x1, 0x5, 2, Buffer.from([0x88])), frame(0x7, 0, 0, Buffer.from([0, 0, 0, 0, 0, 0, 0, 1]))`,
+    },
+  ])(
+    "even stream 2: $name does not raise an uncaughtException",
+    async ({ hostileFrames }) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture(hostileFrames)],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: JSON.stringify(["request close", "request error", "session close", "session error"]) + "\n",
+        stderr: expect.not.stringContaining("ERR_HTTP2"),
+        exitCode: 0,
+      });
+    },
+    30_000,
+  );
+
+  // close() must not wait for such a stream. In both cases below nghttp2 treats the stream as
+  // closed and ignores the frame, and node v26.3.0 finishes the same close().
+
+  // Stream 2 sits below the promised stream 4, so it is not idle.
+  test("even stream 2 left open does not keep a gracefully closed session open", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    client.on("stream", pushed => {
+      pushed.on("error", () => {});
+      pushed.resume();
+    });
+    try {
+      const req = client.request({ ":path": "/" });
+      req.on("error", () => {});
+      req.resume();
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      // A real push on stream 4, start to finish: [:method GET, :scheme http, :path /,
+      // :authority localhost], then ":status: 200" with END_STREAM.
+      const promised = Buffer.alloc(4);
+      promised.writeUInt32BE(4, 0);
+      const block = Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01]), hpackLiteral("localhost")]);
+      raw.sendFrame(FrameType.PUSH_PROMISE, 0x4 /* END_HEADERS */, 1, Buffer.concat([promised, block]));
+      raw.sendFrame(FrameType.HEADERS, 0x5 /* END_HEADERS | END_STREAM */, 4, Buffer.from([0x88]));
+      // HEADERS on stream 2, which nothing promised, left open. Then the response to the request.
+      raw.sendFrame(FrameType.HEADERS, 0x4 /* END_HEADERS */, 2, Buffer.from([0x88]));
+      raw.sendFrame(FrameType.HEADERS, 0x5 /* END_HEADERS | END_STREAM */, 1, Buffer.from([0x88]));
+      await once(req, "close");
+      const closed = once(client, "close");
+      client.close();
+      await closed;
+      expect(client.destroyed).toBe(true);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  // Stream 1 already carried a complete request and response.
+  test("HEADERS on a finished request stream does not keep a gracefully closed session open", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      const first = client.request({ ":path": "/" });
+      first.on("error", () => {});
+      first.resume();
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      raw.sendFrame(FrameType.HEADERS, 0x5 /* END_HEADERS | END_STREAM */, 1, Buffer.from([0x88]));
+      await once(first, "close");
+      const second = client.request({ ":path": "/" });
+      second.on("error", () => {});
+      second.resume();
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 3);
+      // HEADERS on stream 1 again, left open. Then the response to the second request.
+      raw.sendFrame(FrameType.HEADERS, 0x4 /* END_HEADERS */, 1, Buffer.from([0x88]));
+      raw.sendFrame(FrameType.HEADERS, 0x5 /* END_HEADERS | END_STREAM */, 3, Buffer.from([0x88]));
+      await once(second, "close");
+      const closed = once(client, "close");
+      client.close();
+      await closed;
+      expect(client.destroyed).toBe(true);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+});
+
 describe("inbound flow control after local end-stream (RFC 9113 §6.9)", () => {
   // Regression coverage for the test-http2-pipe failure mode: the server responds and ends its
   // side before the request body arrives, the request body is piped into a backpressured


### PR DESCRIPTION
### Problem
- A server sends HEADERS on an even stream that no PUSH_PROMISE reserved. The next session-level error raises `uncaughtException` on the `http2.connect()` client: `error: Protocol error`, `code: "ERR_HTTP2_ERROR"` (or `ERR_HTTP2_GOAWAY_SESSION`). Every stream that user code holds has an `'error'` listener. Bun exits 1, node v26.3.0 exits 0.
- That frame, or HEADERS on a finished request stream, makes `session.close()` wait forever. The second case needs no hostile server: a response that was in flight when the client cancelled the request is enough.
- Cause: the client `streamStart` handler (`src/js/node/http2.ts:4972`). The native parser calls it for every stream id it registers, also one that the peer opens with HEADERS. The handler counted that stream in `#connections`, the count of open streams that `close()` waits on. For an even id it built a `ClientHttp2Stream` that user code never receives. Teardown destroys it with the session error.

### Fix
- Remove the handler. `request()` counts a stream where it takes the id. `streamPush` already creates and counts a real push.
- Correct because a real push never reached the removed branch: the parser reports PUSH_PROMISE through `streamPush`. Every client handler already returns early for a stream with no object.
- Verified: `test/js/node/http2/h2-conformance.test.ts` (5 new tests, all fail on 1.4.3). Also `test/js/node/http2/` and the 261 `test-http2-*` node tests.
- Self-reviewed: 12 concerns raised, none asks for a code change. The description changes they ask for are applied.

### Background
- `streamStart` is the native parser's callback for a new stream id (`handle_received_stream_id`, `h2_frame_parser.rs`). On a client that is a `request()`, or inbound HEADERS on a stream that the parser does not know.
- PUSH_PROMISE reserves an even id for a push. HEADERS on an unreserved even id is a protocol violation.
- The parser still registers that stream. The change that rejects the frame there (#36343, #32987) is not merged, and nghttp2 also ignores it for an id that is not idle. So the JS layer must not react to it.
- #33780 and #33000 (both open) change the same lines inside larger changes.

<details><summary>Notes</summary>

**Repro** (from the report, `bun repro.js`):

```js
const http2 = require('http2'), net = require('net');
const frame = (type, flags, sid, payload) => { const h = Buffer.alloc(9); h.writeUIntBE(payload.length, 0, 3); h[3] = type; h[4] = flags; h.writeUInt32BE(sid, 5); return Buffer.concat([h, payload]); };
const ev = [];
process.on('uncaughtException', e => ev.push('UNCAUGHT ' + e.code)); // remove this line: bun exits 1, node exits 0
const srv = net.createServer(s => {
  s.on('error', () => {}); let rx = 0, sent = false;
  s.write(frame(4, 0, 0, Buffer.alloc(0)));                          // SETTINGS
  s.on('data', d => { rx += d.length; if (!sent && rx > 42) { sent = true; s.write(Buffer.concat([
    frame(4, 1, 0, Buffer.alloc(0)),                                 // SETTINGS ack
    frame(1, 0, 2, Buffer.alloc(0)),                                 // HEADERS on stream 2 (even, never promised), no END_HEADERS
    frame(6, 0, 0, Buffer.alloc(8)),                                 // PING where a CONTINUATION is required -> connection error
  ])); } });
});
srv.listen(0, '127.0.0.1', () => {
  const c = http2.connect('http://127.0.0.1:' + srv.address().port);
  c.on('error', e => ev.push('session error ' + e.code)); c.on('close', () => ev.push('session close'));
  c.on('stream', s => { ev.push('stream event'); s.on('error', () => {}); });
  const rq = c.request({ ':path': '/' }); rq.on('error', e => ev.push('request error ' + e.code)); rq.on('close', () => ev.push('request close')); rq.resume();
  setTimeout(() => { console.log(ev.join(' | ')); process.exit(0); }, 500);
});
```

| | output |
|---|---|
| bun 1.4.3 canary / main 6b394bfeb | `session error ERR_HTTP2_ERROR \| session close \| UNCAUGHT ERR_HTTP2_ERROR \| request error ERR_HTTP2_ERROR \| request close` |
| node v26.3.0 | `request error ERR_HTTP2_ERROR \| request close \| session error ERR_HTTP2_ERROR \| session close` |
| this PR | `session error ERR_HTTP2_ERROR \| session close \| request error ERR_HTTP2_ERROR \| request close` |

**The two paths to the uncaught error.** A connection error or `destroy(err)` runs `emitErrorToAllStreams`. The `streamError` handler then reaches `emitStreamErrorNT` and `Http2Stream._destroy`, which takes the error from `session[kSessionDestroyError]`. A GOAWAY with an error code runs `forEachStream(rejectStreamAboveGoawayLastId)`, which calls `stream.destroy(err)` with `ERR_HTTP2_GOAWAY_SESSION`. Both reached the object that `streamStart` built. Neither reaches a stream that has no object: `for_each_stream` skips it, and every client handler returns early when its stream argument is not an object.

**Why a real push never reached the removed branch.** The parser's inbound engine (`src/runtime/api/bun/h2/connection.rs`) reserves the promised id in `handle_push_promise` and does not call `on_stream_open`. When the block completes, `on_headers_complete` dispatches `streamPush`, which builds the `ClientHttp2Stream`, counts it and stores it with `setStreamContext`. The later response HEADERS find the reserved stream, so `is_new` is false and `on_stream_open` does not run. `handle_received_stream_id` (the only caller of `streamStart`) runs on a client from `getNextStream()` (odd ids) and from `on_stream_open`, which `handle_headers` calls only for a stream the engine does not know: never promised, or closed and evicted.

**`close()` hang.** Before this change (1.4.3): after HEADERS on stream 2 below a promised stream 4, or HEADERS on a finished stream 1 in a later read, `client.close()` never emits `'close'`. Node finishes both. nghttp2 treats both streams as closed and ignores the frame (`session_on_request_headers_received` returns `NGHTTP2_ERR_IGN_HEADER_BLOCK`).

**Tests.** Two child-process tests cover the `uncaughtException`. Three in-process tests cover `close()`: an even stream below a promised one, HEADERS on a request stream that finished, and response HEADERS that arrive after `req.close(NGHTTP2_CANCEL)`. The two child-process tests print the events without error codes. Node raises its connection error at the HEADERS frame itself, so the codes of the GOAWAY case differ from bun until the engine rejects the frame (#36343). The event set is the same in node and bun. The two `close()` tests use streams that are not idle, so a later engine-level idle check does not change them.

**Other suites on the debug build.** `test/js/third_party/grpc-js/test-server`, `test-end-to-end`, `test-idle-timer`, `test-retry`, `test-deadline`, `test-server-errors` pass. `test-client.test.ts` has 3 failures that are identical with main's `http2.ts` (a 100 ms connect deadline under debug+ASAN).

**Source.** Found by frame-mutation fuzzing of a raw h2 server against `http2.connect()`. There is no user report.

**Not in this PR** (same result on 1.4.3 and on this branch, node differs):
- The parser still registers the stream that such a HEADERS frame opens (`handle_headers` in `src/runtime/api/bun/h2/connection.rs`). Each frame leaves one native entry until the session ends. The frame also raises the id that the next `request()` takes, and one frame with a very high id makes later requests fail with `ERR_HTTP2_OUT_OF_STREAMS`. Node answers an idle id with a connection error. #36343 and #32987 (idle ids), #37985 (closed ids on a server) and #37676 (next request id) work on that layer. All are open.
- HEADERS on a finished request stream that arrive in the same read as the END_STREAM that finished it destroy the session with `ERR_HTTP2_ERROR` "Stream was already closed or invalid". Node ignores that block. The new test uses the later-read timing only.
- A real pushed stream that user code refuses with `pushed.close(NGHTTP2_CANCEL)` keeps its count, so a later `session.close()` does not finish. #33000 covers that. #37563 covers a PUSH_PROMISE whose id does not exceed the previous one.
- A pushed stream that is still open when the client session is destroyed never gets `'error'` or `'close'` (node destroys it). That is a separate bug with a separate fix.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [555.12ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [138.81ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [170.21ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [99.93ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [76.57ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [67.16ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [69.88ms]
(pass) PING (checklist §3.7) > a PING on a non-zero st
... (truncated)

release without fix: 5 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [8.17ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [2.35ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [3.16ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [1.15ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [0.91ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [0.89ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [0.93ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [0.73ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [0.83ms]
(pass) WINDOW_UPDATE
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [407.72ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [123.07ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [96.05ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [49.15ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [43.49ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [40.72ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [80.80ms]
(pass) PING (checklist §3.7) > a PING on a non-zero str
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 701ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/650] cc obj/vendor/tinycc/tccrun.c.o
[2/650] cc obj/vendor/tinycc/tccasm.c.o
[3/650] cc obj/vendor/tinycc/x86_64-link.c.o
[4/650] cc obj/vendor/tinycc/libtcc.c.o
[5/650] cc obj/vendor/tinycc/tccdbg.c.o
[6/650] cc obj/vendor/tinycc/tccelf.c.o
[7/650] cc obj/vendor/tinycc/tccgen.c.o
[8/650] cc obj/vendor/tinycc/x86_64-gen.c.o
[9/650] cc obj/vendor/tinycc/tccpp.c.o
[10/650] cc obj/vendor/tinycc/i386-asm.c.o
[11/650] fetch boringssl
[boringssl] up to date
[12/228] fetch lsquic
[lsquic] up to date
[13/159] fetch mimalloc
[mimalloc] up to date
[14/158] fetch WebKit (prebuilt)
[WebKit] up to date
[15/158] fetch lolhtml
[lolhtml] up to date
[16/158] fetch rust-argon2
[rust-argon2] up to date
[17/158] gen cpp.rs (cppbind)
[18/158] check undefined symbols in boringssl
[19/158] gen JS modules (bundle-modules)
Preprocess modules (8236ms)
Bundle modules (54ms)
Postprocesss modules (200ms)
Bundle Functions (510ms)
Generate Code (42ms)

[9.05s] Bundled "src/js" for production
  2599 kb
  197 internal modules
  13 nati
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                      |  18 +--
 test/js/node/http2/h2-conformance.test.ts | 200 ++++++++++++++++++++++++++++++
 2 files changed, 205 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 2 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/http2.ts                          10      9     25
test/js/node/http2/h2-conformance.test.ts      6      8     23
```

</details>

<!-- robobun:evidence:end -->