### PR TITLE
node:module: hand a file that bun cannot parse to a replaced module._compile

### DIFF
--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -121,7 +121,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:module`](https://nodejs.org/api/module.html)
 
-🟡 Missing `Module#load()`, `registerHooks`, `findPackageJSON`, `stripTypeScriptTypes`, `getSourceMapsSupport`/`setSourceMapsSupport`. Overriding `require.cache`, `require.extensions` and `module._resolveFilename` is supported. `syncBuiltinESMExports`, `module._load`, `module._pathCache` and `module.register` are no-ops (we recommend [`Bun.plugin`](/runtime/plugins) instead). `findSourceMap` always returns `undefined`.
+🟡 Missing `Module#load()`, `registerHooks`, `findPackageJSON`, `stripTypeScriptTypes`, `getSourceMapsSupport`/`setSourceMapsSupport`. Overriding `require.cache`, `require.extensions` and `module._resolveFilename` is supported. A replaced `module._compile` is called for files that Bun loads as CommonJS and for files that Bun cannot parse, not for files that Bun loads as ES modules. `syncBuiltinESMExports`, `module._load`, `module._pathCache` and `module.register` are no-ops (we recommend [`Bun.plugin`](/runtime/plugins) instead). `findSourceMap` always returns `undefined`.
 
 ### [`node:net`](https://nodejs.org/api/net.html)
 

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -228,6 +228,19 @@ export function requireESMFromHijackedExtension(this: JSCommonJSModule, id: stri
   this.exports = moduleExports ?? namespace;
 }
 
+// For a file Bun could not load: like Node, hand the replaced `module._compile` the file as it is on disk.
+export function compileFromHijackedExtension(this: JSCommonJSModule, filename: string, loadError: unknown) {
+  $assert(this);
+  let source: string;
+  try {
+    source = require("node:fs").readFileSync(filename, "utf8");
+  } catch {
+    // Missing, a directory, a `blob:` id: nothing to hand over, so keep the first error.
+    throw loadError;
+  }
+  this._compile(source, filename);
+}
+
 $visibility = "Private";
 export function createRequireCache() {
   var moduleMap = new Map();

--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -78,6 +78,7 @@ interface JSCommonJSModule {
   paths: string[];
   require: typeof require;
   filename: string;
+  _compile(source: string, filename: string): void;
 }
 
 /**

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -831,6 +831,18 @@ JSValue fetchCommonJSModuleNonBuiltin(
     }
 
     if (!res->success) {
+        if constexpr (isExtension) {
+            // A replaced `module._compile` gets the file from disk. Node's JSON loader does not call `_compile`.
+            if (target->m_overriddenCompile && forceLoaderType != BunLoaderTypeJSON && !scope.exception()) {
+                JSC::JSFunction* compileFromDisk = globalObject->compileFromHijackedExtension();
+                JSC::MarkedArgumentBuffer args;
+                args.append(specifierValue);
+                args.append(JSC::JSValue::decode(res->result.err));
+                JSC::profiledCall(globalObject, JSC::ProfilingReason::API, compileFromDisk, JSC::getCallData(compileFromDisk), target, args);
+                RETURN_IF_EXCEPTION(scope, {});
+                RELEASE_AND_RETURN(scope, target);
+            }
+        }
         throwException(scope, res->result.err, globalObject);
         RELEASE_AND_RETURN(scope, {});
     }

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -281,6 +281,7 @@ public:
     Bun::JSCommonJSExtensions* lazyRequireExtensionsObject() const { return m_lazyRequireExtensionsObject.getInitializedOnMainThread(this); }
     JSC::JSFunction* modulePrototypeUnderscoreCompileFunction() const { return m_modulePrototypeUnderscoreCompileFunction.getInitializedOnMainThread(this); }
     JSC::JSFunction* requireESMFromHijackedExtension() const { return m_commonJSRequireESMFromHijackedExtensionFunction.getInitializedOnMainThread(this); }
+    JSC::JSFunction* compileFromHijackedExtension() const { return m_commonJSCompileFromHijackedExtensionFunction.getInitializedOnMainThread(this); }
 
     Structure* NodeVMGlobalObjectStructure() const { return m_cachedNodeVMGlobalObjectStructure.getInitializedOnMainThread(this); }
     JSObject* lazyTestModuleObject() const { return m_lazyTestModuleObject.getInitializedOnMainThread(this); }
@@ -491,6 +492,7 @@ public:
     V(public, LazyPropertyOfGlobalObject<JSCell>, m_moduleRunMainFunction)                                   \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_modulePrototypeUnderscoreCompileFunction)            \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_commonJSRequireESMFromHijackedExtensionFunction)     \
+    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_commonJSCompileFromHijackedExtensionFunction)        \
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_nodeModuleConstructor)                                 \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_nodeModuleSourceMapEntryStructure)                    \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_nodeModuleSourceMapOriginStructure)                   \

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -1157,6 +1157,11 @@ void addNodeModuleConstructorProperties(JSC::VM& vm,
             init.set(requireESM);
         });
 
+    globalObject->m_commonJSCompileFromHijackedExtensionFunction.initLater(
+        [](const Zig::GlobalObject::Initializer<JSFunction>& init) {
+            init.set(JSC::JSFunction::create(init.vm, init.owner, commonJSCompileFromHijackedExtensionCodeGenerator(init.vm), init.owner));
+        });
+
     globalObject->m_lazyRequireCacheObject.initLater(
         [](const Zig::GlobalObject::Initializer<JSObject>& init) {
             JSC::VM& vm = init.vm;

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { expect, mock, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
 test("require.extensions shape makes sense", () => {
@@ -139,6 +139,93 @@ test("wrapping an existing extension with mutated compile function ts", () => {
   } finally {
     require.extensions[".js"] = original;
   }
+});
+test("a replaced module._compile gets the file from disk when bun cannot parse it", async () => {
+  // Spawned because the other tests in this file leave ".js" mapped to the TypeScript loader.
+  const flow = `// @flow\nconst x: number = 1;\nmodule.exports = { kind: "flow", x };\n`;
+  using dir = tempDir("extensions-unparseable", {
+    "flow.js": flow,
+    "flow2.js": flow,
+    "flow3.js": flow,
+    // Parses as TSX, not as JavaScript.
+    "generic.tsx": `type Props = { name: string };\nconst greet = <T extends Props>(p: T): string => "hello " + p.name;\nexport const out = greet({ name: "bun" });\n`,
+    "broken.json": `{ not json`,
+    "main.cjs": `
+      const path = require("path");
+      const fs = require("fs");
+      const originalJS = require.extensions[".js"];
+      const originalJSON = require.extensions[".json"];
+      const seen = [];
+      // What pirates.addHook() does. @babel/register, sucrase/register, esbuild-register and ts-node share it.
+      const addHook = old =>
+        function (module, filename) {
+          const compile = module._compile;
+          module._compile = function (code) {
+            module._compile = compile;
+            seen.push([path.basename(filename), code]);
+            return module._compile("module.exports = 'transformed " + path.basename(filename) + "';", filename);
+          };
+          old(module, filename);
+        };
+      const caught = fn => {
+        try {
+          return fn();
+        } catch (e) {
+          return "threw " + e.name + ": " + String(e.message).split("\\n")[0].replaceAll(__dirname + path.sep, "");
+        }
+      };
+
+      require.extensions[".js"] = addHook(originalJS);
+      // Bun has no ".tsx" entry, so those packages wrap the ".js" loader for it, as they do in Node.
+      require.extensions[".tsx"] = addHook(originalJS);
+      require.extensions[".json"] = addHook(originalJSON);
+      const flow = caught(() => require("./flow.js"));
+      const tsx = caught(() => require("./generic.tsx"));
+      const sawFileFromDisk = seen.map(([name, code]) => [name, code === fs.readFileSync(path.join(__dirname, name), "utf8")]);
+      // The JSON loader does not use module._compile, in Node too.
+      const json = caught(() => require("./broken.json"));
+
+      // A file that cannot be read keeps the error from the loader.
+      require.extensions[".js"] = function (module, filename) {
+        module._compile = () => {
+          throw new Error("should not be called");
+        };
+        originalJS(module, path.join(__dirname, "missing.js"));
+      };
+      const unreadable = caught(() => require("./flow2.js"));
+
+      // Without a replaced module._compile nothing changes.
+      require.extensions[".js"] = function (module, filename) {
+        originalJS(module, filename);
+      };
+      const noReplacement = caught(() => require("./flow3.js"));
+
+      console.log(JSON.stringify({ flow, tsx, sawFileFromDisk, json, unreadable, noReplacement, calls: seen.length }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.cjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    flow: "transformed flow.js",
+    tsx: "transformed generic.tsx",
+    sawFileFromDisk: [
+      ["flow.js", true],
+      ["generic.tsx", true],
+    ],
+    json: "threw SyntaxError: JSON Parse error: Expected '}'",
+    unreadable: 'threw BuildMessage: ENOENT reading "missing.js"',
+    noReplacement: 'threw AggregateError: 2 errors building "flow3.js"',
+    calls: 2,
+  });
+  expect(exitCode).toBe(0);
 });
 test("wrapping an existing extension but it's secretly sync esm", () => {
   const original = require.extensions[".ts"];


### PR DESCRIPTION
### Problem
- With `sucrase/register` or `esbuild-register` installed, `require("./comp.tsx")` of a file that Bun loads fine with no hook throws `AggregateError: 2 errors building "/…/comp.tsx"`. A Flow-typed `.js` file fails the same way. Node loads both.
- These packages use the pirates shape: they wrap `Module._extensions[ext]`, replace `module._compile` with their transform, and call the previous loader. For `.tsx` and `.jsx` they wrap the `.js` loader (`Module._extensions[ext] || originalJSLoader`), which forces Bun's JavaScript loader on a TSX file.
- The built-in loader (`fetchCommonJSModuleNonBuiltin<true>`, `src/jsc/bindings/ModuleLoader.cpp`) throws the build error at `if (!res->success)`. It only consults the replaced `_compile` after a successful transpile.

### Fix
- In that failure branch, when `module._compile` was replaced, the loader reads the file from disk and calls the replacement with the text (new builtin `compileFromHijackedExtension` in `CommonJS.ts`). Node's loader does the same: it reads the file and calls `module._compile(source, filename)` without parsing first.
- If the file cannot be read, the first error is thrown unchanged. The JSON loader is excluded, because it does not use `_compile` in Node either.
- Only a path that throws today changes. Files that Bun loads as ES modules still skip a replaced `_compile`, by design (`require-extensions.test.ts`, "secretly sync esm"). `docs/runtime/nodejs-compat.mdx` now says so.
- Verified: `test/js/node/module/require-extensions.test.ts` (new test fails on 1.4.3). Also ran all of `test/js/node/module/`.

### Background
- `Module._extensions['.js']` is the function Node calls to load a `.js` file. Bun's built-in entries are native and run only when user code calls them.
- `m_overriddenCompile` holds the value user code assigned to `module._compile` on one module object.

<details><summary>Notes</summary>

Installed-package repro (`bun add sucrase esbuild-register esbuild`):

```tsx
// comp.tsx
type Props = { name: string };
const greet = <T extends Props>(p: T): string => "hello " + p.name;
export const kind = "tsx";
export const out = greet({ name: "bun" });
```

```js
// flow.js
// @flow
const x: number = 1;
module.exports = { kind: "flow", x };
```

```js
// main.cjs
const caught = fn => { try { return fn(); } catch (e) { return "THROW " + e.name + ": " + String(e.message).split("\n")[0].slice(0, 60); } };
console.log("no hook      tsx ->", JSON.stringify(caught(() => require("./comp.tsx"))));
delete require.cache[require.resolve("./comp.tsx")];
require(process.argv[2]);
console.log("with hook    tsx ->", JSON.stringify(caught(() => require("./comp.tsx"))));
console.log("with hook   flow ->", JSON.stringify(caught(() => require("./flow.js"))));
```

`bun main.cjs sucrase/register` on 1.4.3 (same with `esbuild-register`):

```
no hook      tsx -> {"kind":"tsx","out":"hello bun"}
with hook    tsx -> "THROW AggregateError: 2 errors building \"/tmp/t19/comp.tsx\""
with hook   flow -> "THROW AggregateError: 2 errors building \"/tmp/t19/flow.js\""
```

This branch, and Node v26.3.0 with the hook:

```
with hook    tsx -> {"kind":"tsx","out":"hello bun"}
with hook   flow -> {"kind":"flow","x":1}
```

(`esbuild-register` still rejects `flow.js` on both runtimes. esbuild has no Flow support, and the error is esbuild's own.)

The test uses a hand-written 10 line copy of `pirates.addHook()`, because tests cannot install from npm. It checks that the hook receives the exact bytes on disk, that a `.tsx` file routed through the wrapped `.js` loader works, that broken JSON still throws `JSON Parse error` and never calls `_compile`, that a file that cannot be read keeps `BuildMessage: ENOENT reading "missing.js"`, and that a hook that does not replace `_compile` still gets the build error. It runs in a subprocess because other tests in that file leave `.js` mapped to the TypeScript loader.

Scope decision: the other half of the original report (call the replaced `_compile` for files that Bun classifies as ES modules) is not in this PR and is not planned. #18686 chose the skip on purpose, a test pins it, and `drizzle-kit` <= 0.31.9 with `esbuild-register` works on Bun only because of it.

Self-review: checked every `return null` arm of `Bun__transpileFile` for an empty error value with no pending exception (none reachable on this path), that the new lazy function is GC-visited and initialised before `builtinLoader` is reachable, that `fetchCommonJSModuleNonBuiltin<true>` has one caller, and ran the scenario with `BUN_JSC_validateExceptionChecks=1`.
</details>
