### PR TITLE
node:module: add ES modules, user-made require.cache entries and new Module() to parent.children

### DIFF
--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -137,7 +137,13 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
       }
     }
 
-    return (mod.exports = moduleExports ?? namespace);
+    const exports = (mod.exports = moduleExports ?? namespace);
+    // There is no CommonJS source to evaluate. This adds `mod` to `this.children`.
+    const c = $evaluateCommonJSModule(mod, this);
+    if (c && c.indexOf(mod) === -1) {
+      c.push(mod);
+    }
+    return exports;
   }
 
   const c = $evaluateCommonJSModule(mod, this);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -279,32 +279,54 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionEvaluateCommonJSModule, (JSGlobalObject * lex
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    // These casts are jsDynamicCast because require.cache pollution + invalid
-    // this calls can put arbitrary values here instead of JSCommonJSModule*
+    // require.cache pollution and an invalid `this` can put any value in either argument.
     ASSERT(callframe->argumentCount() == 2);
-    JSCommonJSModule* moduleObject = dynamicDowncast<JSCommonJSModule>(callframe->uncheckedArgument(0));
-    JSCommonJSModule* referrer = dynamicDowncast<JSCommonJSModule>(callframe->uncheckedArgument(1));
-    if (!moduleObject) [[unlikely]] {
-        RELEASE_AND_RETURN(throwScope, JSValue::encode(jsUndefined()));
-    }
+    JSValue child = callframe->uncheckedArgument(0);
+    JSValue referrer = callframe->uncheckedArgument(1);
 
+    // Node adds whatever object require.cache holds to `children`, module or not.
     JSValue returnValue = jsNull();
-    if (referrer) [[likely]] {
-        if (referrer->m_childrenValue) [[unlikely]] {
-            // It's too hard to append from native code:
-            // referrer.children.indexOf(moduleObject) === -1 && referrer.children.push(moduleObject)
-            returnValue = referrer->m_childrenValue.get();
-        } else {
-            WTF::Locker locker { referrer->cellLock() };
-            referrer->m_children.append(WriteBarrier<Unknown>());
-            referrer->m_children.last().set(vm, referrer, moduleObject);
-        }
+    if (child.isObject()) [[likely]] {
+        // JS does the push: referrer.children.indexOf(child) === -1 && referrer.children.push(child)
+        JSValue children = JSCommonJSModule::updateChildren(globalObject, referrer, child);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (children) [[unlikely]]
+            returnValue = children;
     }
 
-    moduleObject->load(vm, globalObject);
-    RETURN_IF_EXCEPTION(throwScope, {});
+    if (auto* moduleObject = dynamicDowncast<JSCommonJSModule>(child)) [[likely]] {
+        moduleObject->load(vm, globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+    }
 
     RELEASE_AND_RETURN(throwScope, JSValue::encode(returnValue));
+}
+
+JSValue JSCommonJSModule::updateChildren(JSGlobalObject* globalObject, JSValue parent, JSValue child)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    ASSERT(child.isObject());
+
+    JSValue children;
+    if (auto* parentModule = dynamicDowncast<JSCommonJSModule>(parent)) [[likely]] {
+        children = parentModule->m_childrenValue.get();
+        if (!children) [[likely]] {
+            WTF::Locker locker { parentModule->cellLock() };
+            parentModule->m_children.append(WriteBarrier<Unknown>());
+            parentModule->m_children.last().set(vm, parentModule, child);
+            return {};
+        }
+    } else if (JSObject* parentObject = parent.getObject()) {
+        // `Module.prototype.require.call({ children: [] }, id)` and `new Module(id, { children: [] })`
+        children = parentObject->get(globalObject, Identifier::fromString(vm, "children"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    // `children` can be assigned any value. Only an array gets the child.
+    if (children && children.inherits<JSArray>())
+        return children;
+    return {};
 }
 
 JSC_DEFINE_HOST_FUNCTION(requireResolvePathsFunction, (JSGlobalObject * globalObject, CallFrame* callframe))
@@ -585,10 +607,10 @@ JSC_DEFINE_CUSTOM_GETTER(getterChildren, (JSC::JSGlobalObject * globalObject, JS
         children.ensureCapacity(mod->m_children.size());
 
         // Deduplicate children while preserving insertion order.
-        JSCommonJSModule* last = nullptr;
+        JSCell* last = nullptr;
         int n = -1;
         for (WriteBarrier<Unknown> childBarrier : mod->m_children) {
-            JSCommonJSModule* child = uncheckedDowncast<JSCommonJSModule>(childBarrier.get());
+            JSCell* child = childBarrier.get().asCell();
             // Check the last module since duplicate imports, if any, will
             // probably be adjacent. Then just do a linear scan.
             if (last == child) [[unlikely]]

--- a/src/jsc/bindings/JSCommonJSModule.h
+++ b/src/jsc/bindings/JSCommonJSModule.h
@@ -58,7 +58,7 @@ public:
     // `m_childrenValue` can be set to any value via the user-exposed setter,
     // but Bun does not test that behavior besides ensuring it does not crash.
     mutable JSC::WriteBarrier<Unknown> m_childrenValue;
-    // This must be WriteBarrier<Unknown> to compile; always JSCommonJSModule
+    // Objects. Almost always JSCommonJSModule, but any object in `require.cache` becomes a child too.
     WTF::Vector<WriteBarrier<Unknown>> m_children;
 
     // Visited by the GC. When the module is assigned a non-JSCommonJSModule
@@ -125,6 +125,9 @@ public:
     JSValue filename() { return m_filename.get(); }
 
     bool load(JSC::VM& vm, Zig::GlobalObject* globalObject);
+
+    // Node's updateChildren(parent, child). Returns `parent.children` when the caller has to push onto that JSArray, else empty.
+    static JSValue updateChildren(JSC::JSGlobalObject* globalObject, JSValue parent, JSValue child);
 
     DECLARE_INFO;
     DECLARE_VISIT_CHILDREN;

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -183,6 +183,14 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionNodeModuleModuleConstructor,
     out->putDirect(vm, JSC::Identifier::fromString(vm, "exports"_s),
         JSC::constructEmptyObject(globalObject), 0);
 
+    JSValue children = Bun::JSCommonJSModule::updateChildren(globalObject, parentValue, out);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (children) {
+        // A new object cannot be in the array yet, so there is nothing to scan for.
+        uncheckedDowncast<JSArray>(children)->push(globalObject, out);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
     return JSValue::encode(out);
 }
 

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -924,6 +924,86 @@ console.log("survived", require("./late.js"));`,
     expect(await proc.exited).toBe(0);
   });
 
+  test.each(["no args", "--access-early"])("children that are not loaded as CommonJS, %s", async arg => {
+    using dir = tempDir("module-children", {
+      "a.js": "module.exports = 1;",
+      "b.mjs": "export default 2;",
+      "c.ts": "export const x: number = 3;",
+      "virt.js": "module.exports = 'real';",
+      "d.js": "module.exports = 'd';",
+      "main.cjs": `
+        const path = require("path");
+        const Module = require("module");
+        const p = f => path.join(__dirname, f);
+        const names = children => children.map(c => path.basename(c.id));
+        if (process.argv.includes("--access-early")) module.children;
+
+        // require() of an ES module, two times each
+        for (const f of ["a.js", "b.mjs", "c.ts", "b.mjs", "c.ts"]) require(p(f));
+
+        // require() served from an entry that user code put in require.cache
+        const stub = { id: p("virt.js"), filename: p("virt.js"), loaded: true, exports: "stub", children: [] };
+        require.cache[p("virt.js")] = stub;
+        const stubExports = [require(p("virt.js")), require(p("virt.js"))];
+
+        // the Module constructor
+        const made = new Module(p("made.js"), module);
+        const orphan = new Module(p("orphan.js"));
+        const fakeParent = { id: "fake", filename: p("fake.js"), children: [] };
+        const madeForFake = new Module(p("made2.js"), fakeParent);
+        Module.prototype.require.call(fakeParent, p("a.js"));
+        const weird = new Module(p("weird.js"), module);
+        weird.children = 5;
+        new Module(p("weird-child.js"), weird);
+
+        const before = names(module.children);
+        // what the require-from-string package does
+        const fromString = new Module(p("from-string.js"), module);
+        fromString._compile("module.exports = 42", p("from-string.js"));
+        module.children.splice(module.children.indexOf(fromString), 1);
+
+        const result = {
+          before,
+          afterRequireFromString: names(module.children),
+          stubIsChild: module.children.includes(stub),
+          stubExports,
+          madeIsChild: module.children.includes(made),
+          orphanChildren: orphan.children,
+          fakeChildren: names(fakeParent.children),
+          madeForFakeIsChild: fakeParent.children.includes(madeForFake),
+          weirdChildren: weird.children,
+        };
+
+        // a "children" that is not an array is left alone
+        module.children = 5;
+        result.loadedWithoutChildrenArray = [require(p("d.js")), require(p("b.mjs")).default];
+        console.log(JSON.stringify(result));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.cjs", arg],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const children = ["a.js", "b.mjs", "c.ts", "virt.js", "made.js", "weird.js"];
+    expect(JSON.parse(stdout)).toEqual({
+      before: children,
+      afterRequireFromString: children,
+      loadedWithoutChildrenArray: ["d", 2],
+      stubIsChild: true,
+      stubExports: ["stub", "stub"],
+      madeIsChild: true,
+      orphanChildren: [],
+      fakeChildren: ["made2.js", "a.js"],
+      madeForFakeIsChild: true,
+      weirdChildren: 5,
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test("new Module().exports survives object spread", async () => {
     // exports was built with inline capacity 0, so spreading it hit JSC's
     // tryCreateObjectViaCloning hasInlineStorage() debug assert. Run in a


### PR DESCRIPTION
### Problem
- `module.children` only gains a child when Bun evaluates CommonJS source. The script in the notes prints `children: ["a.js"]` on Bun and `children: ["a.js","b.mjs","c.ts","virt.js","made.js"]` on Node v26.3.0.
- Three Node paths do nothing in Bun. `overridableRequire` (`src/js/builtins/CommonJS.ts`) returns from its ES module branch (`out === -1`) before it registers the child. `jsFunctionEvaluateCommonJSModule` returns early when the `require.cache` entry is not a `JSCommonJSModule` (mock-require and proxyquire stubs). `jsFunctionNodeModuleModuleConstructor` only stores `parent`.
- Tools that walk `children` (decache, clear-module) miss those subtrees. `require-from-string` does `parent.children.splice(parent.children.indexOf(m), 1)` after `new Module(filename, parent)`. On Bun `indexOf` is `-1`, so it removes the last, unrelated child.

### Fix
- New `JSCommonJSModule::updateChildren(globalObject, parent, child)`, the same job as Node's `updateChildren(parent, child)`. A module parent appends to its native list until `module.children` is first read or assigned. After that, or for a plain-object parent, it returns `children` if that is an array, and the caller pushes.
- `$evaluateCommonJSModule` registers any object as a child and loads it only if it is a real module. The ES module branch of `overridableRequire` now calls it. The `Module` constructor calls `updateChildren` and pushes natively.
- `getterChildren` compares `JSCell*`, because a child can now be any object.
- Verified: `test/js/node/module/node-module-module.test.js` (new test, two modes, fails on 1.4.3). Also ran `test/js/node/module/` (has the concurrent GC test), `plugins.test.ts`, `mock-module.test.ts`.

### Background
- `module.children` lists the modules that a module loaded first. Node reads `parent?.children`, so any object can be the parent.
- Bun keeps `m_children` as a native vector. The first read of `module.children` removes duplicates, builds the JS array (`m_childrenValue`) and clears the vector.

<details><summary>Notes</summary>

Repro:

```js
const fs = require("fs"), path = require("path"), os = require("os"), Module = require("module");
const dir = fs.mkdtempSync(path.join(os.tmpdir(), "children-"));
const w = (n, s) => (fs.writeFileSync(path.join(dir, n), s), path.join(dir, n));
const cjs = w("a.js", "module.exports = 1;\n"), esm = w("b.mjs", "export default 2;\n"), ts = w("c.ts", "export const x: number = 3;\n");
const virt = path.join(dir, "virt.js"); fs.writeFileSync(virt, "module.exports='real';\n");
require(cjs); require(esm); try { require(ts); } catch (e) { }
require.cache[virt] = { id: virt, filename: virt, loaded: true, exports: "stub", children: [] }; require(virt);
const m = new Module(path.join(dir, "made.js"), module);
console.log("children:", JSON.stringify(module.children.map(c => path.basename(c.id))));
```

The test runs a larger script with and without an early read of `module.children` (the native list and the JS array are different code paths). Its output is the same as Node v26.3.0 in both modes. It also covers a second `require()` of the same ES module (no duplicate), a parent that is a plain object (`new Module(id, fake)` and `Module.prototype.require.call(fake, cachedId)`), a `Module` with no parent, the `require-from-string` splice, and a `children` that is not an array.

`children` that is not an array: `module.children = 5; require("./x.js")` threw `TypeError: c.indexOf is not a function` before this PR. Node does not throw there. Now `updateChildren` only hands an array back to JS, so the load succeeds and `children` stays `5`, as in Node.

One odd thing on 1.4.3: the second `require()` of an ES module did register the child, because it takes the cache-hit path. Only the first one did not.

Self-review: checked that the append keeps the old locking and write barrier (`cellLock()`, owner is the parent), that nothing else in `src/` reads `m_children` or assumes its entries are modules, that `JSValue::inherits<JSArray>()` and `getObject()` are safe for non-cells, that each call that can throw has its exception check before the next one, and ran the scenarios with `BUN_JSC_validateExceptionChecks=1`.

Not changed: `.node` addons (`$internalRequire`) still do not appear in `children`. `require.cache[esm].loaded` is still `false` after `require()` of an ES module (Node: `true`). Both are separate from this change.
</details>
