### PR TITLE
node:net: drop native reads for a socket whose readable side has ended

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -456,8 +456,7 @@ function pushDataToSocket(self, socket, buffer) {
     self.destroy();
     return;
   }
-  // Node never reads for `readable: false`: only _read() reaches readStart(), and an ended Readable never calls it (https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L779-L792).
-  // Our handle is paused for that too, but a reset drains the kernel's unread bytes through a pause (loop.c, drain_for_error). Node leaves them to the kernel.
+  // `readable: false` never reads (node never reaches readStart(): https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L779-L792), but a reset drains unread bytes through the pause.
   if (self.readableEnded) return;
   let full;
   try {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -456,8 +456,7 @@ function pushDataToSocket(self, socket, buffer) {
     self.destroy();
     return;
   }
-  // A reset makes the native layer drain the kernel's unread bytes, also into a stopped handle. A socket built with
-  // `readable: false` takes none, as in node, where it never reads: push() would replace the reset with ERR_STREAM_PUSH_AFTER_EOF.
+  // `readable: false` takes no data, but a reset drains the kernel's unread bytes into a stopped handle too.
   if (self.readableEnded) return;
   let full;
   try {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -456,6 +456,9 @@ function pushDataToSocket(self, socket, buffer) {
     self.destroy();
     return;
   }
+  // A reset makes the native layer drain the kernel's unread bytes, also into a stopped handle. A socket built with
+  // `readable: false` takes none, as in node, where it never reads: push() would replace the reset with ERR_STREAM_PUSH_AFTER_EOF.
+  if (self.readableEnded) return;
   let full;
   try {
     full = self.push(buffer) === false;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -456,7 +456,8 @@ function pushDataToSocket(self, socket, buffer) {
     self.destroy();
     return;
   }
-  // `readable: false` takes no data, but a reset drains the kernel's unread bytes into a stopped handle too.
+  // Node never reads for `readable: false`: only _read() reaches readStart(), and an ended Readable never calls it (https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L779-L792).
+  // Our handle is paused for that too, but a reset drains the kernel's unread bytes through a pause (loop.c, drain_for_error). Node leaves them to the kernel.
   if (self.readableEnded) return;
   let full;
   try {

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1317,6 +1317,39 @@ it("a client dialed with readable: false never reads and keeps writing", async (
   }
 });
 
+// A reset is reported to a stopped handle too, and the native layer first drains
+// what the kernel still holds so that the tail of a stream is not lost. A
+// `readable: false` socket takes none of it. Pushing it into the ended Readable
+// replaced the reset with ERR_STREAM_PUSH_AFTER_EOF. (node's handle is not polled
+// at all, so node finds the reset at the next write, also as ECONNRESET.)
+it("a client dialed with readable: false reports a reset that follows unread data as ECONNRESET", async () => {
+  const accepted = Promise.withResolvers<Socket>();
+  const server = createServer(socket => {
+    socket.on("error", () => {});
+    accepted.resolve(socket);
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  try {
+    const client = connect({
+      port: (server.address() as import("node:net").AddressInfo).port,
+      host: "127.0.0.1",
+      readable: false,
+    });
+    const events: string[] = [];
+    client.on("data", chunk => events.push(`data:${chunk.length}`));
+    client.on("end", () => events.push("end"));
+    client.on("error", err => events.push(`error:${(err as NodeJS.ErrnoException).code}`));
+    const closed = Promise.withResolvers<boolean>();
+    client.on("close", closed.resolve);
+    const [peer] = await Promise.all([accepted.promise, once(client, "connect")]);
+    // The banner sits unread in the client's kernel buffer when the reset arrives.
+    peer.write("banner", () => peer.resetAndDestroy());
+    expect({ hadError: await closed.promise, events }).toEqual({ hadError: true, events: ["error:ECONNRESET"] });
+  } finally {
+    server.close();
+  }
+});
+
 // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L830-L845
 it("an onread client dialed with readable: false still reads into its buffer", async () => {
   const server = createServer(socket => socket.end("banner"));


### PR DESCRIPTION
### Problem
- A `net.Socket` built with `readable: false` fails with `ERR_STREAM_PUSH_AFTER_EOF` ("stream.push() after EOF") when the peer resets the connection while unread data is queued. Without queued data the same reset reports `ECONNRESET`. Present since #42213.
- Cause: on an error event, usockets drains the kernel's receive queue before it closes the socket, also for a paused handle (`packages/bun-usockets/src/loop.c:591-603`, #39860). The bytes reach `pushDataToSocket` (`src/js/node/net.ts:451`), which pushes them into the Readable that `readable: false` left ended.
- #42265 fixed the same push for a socket that TLS wraps, with a check on the adopted raw handle. A plain socket does not match it.

### Fix
- `pushDataToSocket` returns early when `self.readableEnded`. The reset then arrives through the close handler as `ECONNRESET`.
- Correct because node never reads on such a socket: it never calls `readStart()`, and the kernel frees the bytes at close. No data can follow `'end'`, so a socket that reads sees no change.
- Verified: new test in `test/js/node/net/node-net.test.ts`, red 3/3 on main (`error:ERR_STREAM_PUSH_AFTER_EOF`), green with the fix. No new failures in the `node:net` and `node:tls` suites (list in the notes).

### Background
- A Duplex built with `readable: false` starts with `ended` and `endEmitted` set. `push(chunk)` on it raises `ERR_STREAM_PUSH_AFTER_EOF` and destroys the stream.
- Bun's native sockets read as soon as they open. For a `readable: false` socket, `afterConnect` pauses the handle (`readStop()`), so the peer's bytes stay in the kernel.
- A paused handle still receives error events (`EPOLLERR`; kqueue keeps a read knote for this). `drain_for_error` reads the queued bytes first, so that a reset does not cut a stream short.

<details><summary>Notes</summary>

- Repro:

  ```js
  const net = require("net"); const ev = [];
  const srv = net.createServer(c => { c.on("error", () => {}); c.write("banner"); setTimeout(() => c.resetAndDestroy(), 80); });
  srv.listen(0, "127.0.0.1", () => {
    const s = net.connect({ port: srv.address().port, host: "127.0.0.1", readable: false });
    s.on("connect", () => ev.push("connect")); s.on("data", d => ev.push("data " + d.length)); s.on("end", () => ev.push("end"));
    s.on("error", e => ev.push("error " + e.code)); s.on("close", h => ev.push("close hadError=" + h));
    setTimeout(() => { console.log(ev.join(" | ") + " || destroyed=" + s.destroyed + " readyState=" + s.readyState); process.exit(0); }, 600);
  });
  ```

  - main @158ff6cd: `connect | error ERR_STREAM_PUSH_AFTER_EOF | close hadError=true || destroyed=true readyState=closed`
  - this branch: `connect | error ECONNRESET | close hadError=true || destroyed=true readyState=closed`
  - main and this branch without the `c.write("banner")`: `connect | error ECONNRESET | close hadError=true`
  - 1.4.3 (ignores `readable: false`): `connect | data 6 | error ECONNRESET | close hadError=true`
  - node v26.3.0: `connect || destroyed=false readyState=writeOnly`. A later `write()` fails with `ECONNRESET`, then `'error'` and `'close'` follow.
- The handle is already paused (`readStop()` in `afterConnect`, since #42213). `BUN_DEBUG_Socket=1` on the repro prints `onOpen C`, `pause`, `onClose S`, `onData C (6)`, `onClose C`: the 6 bytes arrive with the reset, through the pause. With no reset nothing is delivered and `bytesRead` stays 0.
- Node has no code that discards such bytes. `readable: false` sets `ended` and `endEmitted` ([duplex.js#L92-L96](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/streams/duplex.js#L92-L96)), `read()` returns before `_read()` ([readable.js#L696-L701](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/streams/readable.js#L696-L701)), and `_read()` is the only caller of `readStart()` without an `onread` buffer ([net.js#L779-L792](https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L779-L792)). libuv reads only while `UV_HANDLE_READING` is set, also on `POLLERR` ([stream.c#L1043-L1045](https://github.com/nodejs/node/blob/v26.3.0/deps/uv/src/unix/stream.c#L1043-L1045)).
- Alternative not taken: a bit on `us_socket_t` that makes `drain_for_error` skip a socket whose owner never reads, set through `handle.pause()` from `readStop()`. Then nothing is read and the guard is not needed. It touches usockets, the Rust binding and the socket handle for the same visible result, so this PR keeps the one-line guard in the layer that knows about `readable: false`.
- Remaining difference from node, not changed here: node does not poll a handle that does not read, so it finds the reset at the next write. Bun reports a reset to a paused socket at once, on every platform. This PR only makes the error the same with and without queued data.
- Unchanged and equal to node: data followed by FIN leaves the `readable: false` socket quiet and writable. A socket with an `onread` buffer delivers to the callback and never pushes, so it was not affected.
- `socket.bytesRead` still counts the dropped bytes (6 in the repro, the handler adds them before the push). The socket is destroyed at that point.
- #42262 (closed in favour of #42265) carried this guard for the TLS case. #42265 replaced it with the raw-handle check, which is why the plain socket was left.
- Suites run with the fix: `node-net.test.ts` (104 pass), `node-net-server.test.ts` (26), `node-tls-upgrade.test.ts` (5), `node-tls-connect.test.ts` (55), `node-http-agent-free-socket.test.ts` (9), 340 of 343 vendored `test-net-*` / `test-tls-*` files.
- Failures seen locally that also fail on the unchanged 1.4.3 canary in this container (`localhost` resolves to `::1` first): 10 tests in `node-net.test.ts` (`net.Socket read > ... .connect(port)`, `unref should exit when no more work pending`, `should trigger error when aborted even if connection failed #13126`). 3 vendored files use `node:test` and need the test runner.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->
