### PR TITLE
node:tls: test bytesRead on the sockets that a TLS upgrade wraps

### DIFF
--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -148,3 +148,75 @@ test("a STARTTLS exchange hands no TLS bytes to the 'data' listeners of the wrap
     server.close();
   }
 });
+
+// node's handle counts a read before TLSWrap consumes it: https://github.com/nodejs/node/blob/v26.3.0/src/stream_base-inl.h#L75-L80
+test.each([
+  ["no reader", {}],
+  ["readable: false", { readable: false }],
+  ["an onread buffer", { onread: { buffer: Buffer.alloc(64), callback() {} } }],
+])(
+  "a net.Socket with %s that tls.connect({ socket }) wraps counts the TLS records in bytesRead",
+  async (_, options) => {
+    const server = tls.createServer(certs, socket => {
+      socket.on("error", () => {});
+      socket.end("banner");
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const raw = net.connect({ port: (server.address() as net.AddressInfo).port, host: "127.0.0.1", ...options });
+      await once(raw, "connect");
+      const tlsSocket = tls.connect({ socket: raw, ca: certs.cert, servername: "localhost" });
+      let got = "";
+      tlsSocket.on("data", data => (got += data));
+      await once(tlsSocket, "close");
+      expect(got).toBe("banner");
+      // The TLS socket counts plaintext. The wrapped socket counts the handshake and the records.
+      expect(tlsSocket.bytesRead).toBe(6);
+      expect(raw.bytesRead).toBeGreaterThan(tlsSocket.bytesRead);
+    } finally {
+      server.close();
+    }
+  },
+);
+
+// Values observed under node v26.3.0: the upgrade keeps the handle, so the count goes on.
+test("bytesRead of the wrapped sockets keeps the bytes read before a STARTTLS upgrade", async () => {
+  const serverSide = Promise.withResolvers<{ before: number; after: number; raw: number; tls: number }>();
+  const server = net.createServer(socket => {
+    socket.on("error", serverSide.reject);
+    socket.once("data", () => {
+      socket.write("GO", () => {
+        const before = socket.bytesRead;
+        const tlsSocket = new tls.TLSSocket(socket, { isServer: true, secureContext: tls.createSecureContext(certs) });
+        const after = socket.bytesRead;
+        tlsSocket.on("error", serverSide.reject);
+        tlsSocket.on("data", data => tlsSocket.end("echo:" + data));
+        tlsSocket.on("close", () =>
+          serverSide.resolve({ before, after, raw: socket.bytesRead, tls: tlsSocket.bytesRead }),
+        );
+      });
+    });
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  try {
+    const raw = net.connect({ port: (server.address() as net.AddressInfo).port, host: "127.0.0.1" });
+    raw.write("STARTTLS");
+    expect(String((await once(raw, "data"))[0])).toBe("GO");
+    const before = raw.bytesRead;
+    const tlsSocket = tls.connect({ socket: raw, ca: certs.cert, servername: "localhost" });
+    const after = raw.bytesRead;
+    tlsSocket.on("secureConnect", () => tlsSocket.write("hi"));
+    let got = "";
+    tlsSocket.on("data", data => (got += data));
+    await once(tlsSocket, "close");
+    expect(got).toBe("echo:hi");
+    expect({ before, after, tls: tlsSocket.bytesRead }).toEqual({ before: 2, after: 2, tls: 7 });
+    expect(raw.bytesRead).toBeGreaterThan(before + tlsSocket.bytesRead);
+
+    const peer = await serverSide.promise;
+    expect({ before: peer.before, after: peer.after, tls: peer.tls }).toEqual({ before: 8, after: 8, tls: 2 });
+    expect(peer.raw).toBeGreaterThan(peer.before + peer.tls);
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
Follow-up to #42304 (closed in favor of #42313). Stacked on #42313. Tests only.

### Problem

- #42313 moves `bytesRead` to a counter on the native socket. Its TLS upgrade path has no test: the `raw` half of the `[raw, tls]` pair inherits the count of the handle it replaces.
- On main one case of that path is wrong. A `net.Socket` with an `onread` buffer that `tls.connect({ socket })` wraps reports `bytesRead === 0`. Node v26.3.0 reports 3055, the TLS records.

### Fix

- 4 tests in `test/js/node/tls/node-tls-upgrade.test.ts`. Three rows (`no reader`, `readable: false`, `an onread buffer`) check that the wrapped socket counts the TLS records: `tlsSocket.bytesRead` is 6, `raw.bytesRead` is greater.
- One STARTTLS test checks both wrapped sockets. The count right after the upgrade equals the count before it (2 on the client, 8 on the server). Then it grows.
- Verified on a debug build, expected values from node v26.3.0. With #42313's `src/` all 9 tests of the file pass. With main's `src/` (4b5862fd88) the `an onread buffer` row fails with `Expected: > 6, Received: 0`.

### Background

- `tls.connect({ socket })` and `new tls.TLSSocket(socket, { isServer: true })` run TLS over an existing `net.Socket`. Bun's native `upgradeTLS` turns the TCP handle into a `[raw, tls]` pair over one fd. The wrapped socket keeps `raw`, which sees the ciphertext.
- In node the upgrade keeps the handle, and the handle counts each read before `TLSWrap` consumes it. So `socket.bytesRead` goes on from its value before the upgrade.
- `onread: { buffer, callback }` makes a socket read into `buffer` and call `callback(nread, buffer)`.

<details><summary>Notes</summary>

**Why a separate PR.** #42313 had a CI run in progress and no human review yet. A push there restarts the run. If the tests are wanted inside #42313, cherry-pick a6cbad99a1.

**After #42313 merges** I rebase this branch on main, so that it holds the one test commit only.

**Why the `onread` row is 0 on main.** The `data` handler that the `onread` option installs never added to `bytesRead` (#42304 was the JS fix for that). #42265 then added an early return for the wrapped socket to that handler, before the deliver loop. #42313 counts on the handle before any JS handler runs, so the row passes there.

**Probe numbers** (`tls.connect({ socket: raw })`, the server sends `"banner"`):

| | node v26.3.0 | main (4b5862fd88) | #42313 (d2dd882b47) |
|---|---|---|---|
| `raw.bytesRead`, no `onread` | 3055 | 2813 | 2813 |
| `raw.bytesRead`, `raw` has `onread` | 3055 | 0 | 2813 |
| calls of the `onread` callback | 0 | 0 | 0 |

STARTTLS probe (plaintext `greeting\n`, `go`, `ok\n`, then TLS in both directions). Client `raw.bytesRead`: 12 before, 12 right after the upgrade, at the end 3027 in node and 2821 in bun. Server: 2, 2, then 1720 in node and 1588 in bun. Bun 1.4.3, main and #42313 print the same numbers for this probe. Node and bun differ in the size of the handshake, so the tests compare against the plaintext count and not against a fixed number.

</details>
