### PR TITLE
fix(node:fs): preserve POSIX locks in realpath

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -323,7 +323,7 @@ const exports = {
     return _writeFile(fileHandleOrFdOrPath, ...args);
   },
   readlink: asyncWrap(fs.readlink, "readlink"),
-  realpath: asyncWrap(fs.realpath, "realpath"),
+  realpath: asyncWrap(fs.realpathNative, "realpath"),
   rename: asyncWrap(fs.rename, "rename"),
   stat: asyncWrap(fs.stat, "stat"),
   symlink: asyncWrap(fs.symlink, "symlink"),

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -218,8 +218,6 @@ pub use super::node_fs_binding::Binding;
 use bun_jsc::JSPromiseStrong;
 
 use super::dir_iterator as DirIterator;
-#[cfg(not(windows))]
-use bun_resolver::fs::FileSystem;
 
 // On POSIX the libuv-backed code paths (`UVFSRequest`, `uv_fs_*`) are absent:
 // `UVFSRequest` aliases `AsyncFSTask` and every `uv::*` reference is gated
@@ -7385,40 +7383,19 @@ impl NodeFS {
         {
             let mut outbuf = bun_paths::path_buffer_pool::get();
             let inbuf = &mut self.sync_error_buf;
-            // SAFETY: single-threaded init flag (resolver/fs.rs).
-            debug_assert!(
-                bun_resolver::fs::INSTANCE_LOADED.load(core::sync::atomic::Ordering::Relaxed)
-            );
-
             let path_slice = args.path.slice();
-            // SAFETY: instance() returns the leaked singleton; INSTANCE_LOADED checked above.
-            let fs = FileSystem::get();
-            let parts = [fs.top_level_dir, path_slice];
-            let inbuf_len = inbuf.len();
-            let Some(joined) = fs.abs_buf_checked(&parts, &mut inbuf[..inbuf_len - 1]) else {
+            if path_slice.len() >= inbuf.len() {
                 return Err(sys::Error {
                     errno: E::ENAMETOOLONG as _,
                     syscall: sys::Tag::realpath,
                     path: args.path.slice().into(),
                     ..Default::default()
                 });
-            };
-            let path_len = joined.len();
-            inbuf[path_len] = 0;
-            let path = ZStr::from_buf(&inbuf[..], path_len);
-
-            #[cfg(any(target_os = "linux", target_os = "android"))]
-            let flags = sys::O::PATH; // O_PATH is faster
-            #[cfg(not(any(target_os = "linux", target_os = "android")))]
-            let flags = sys::O::RDONLY | sys::O::NONBLOCK | sys::O::NOCTTY;
-
-            let fd = match sys::open(path, flags, 0) {
-                Err(err) => return Err(err.with_path(path)),
-                Ok(fd_) => fd_,
-            };
-            let _close = scopeguard::guard(fd, |fd| fd.close());
-
-            let buf = match Syscall::get_fd_path(fd, &mut outbuf) {
+            }
+            // Let realpath walk the original components without opening and
+            // closing the target, which would release process-owned POSIX locks.
+            let path = args.path.slice_z(inbuf);
+            let buf = match Syscall::realpath(path, &mut outbuf) {
                 Err(err) => return Err(err.with_path(path)),
                 Ok(buf_) => buf_,
             };

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -218,6 +218,8 @@ pub use super::node_fs_binding::Binding;
 use bun_jsc::JSPromiseStrong;
 
 use super::dir_iterator as DirIterator;
+#[cfg(not(windows))]
+use bun_resolver::fs::FileSystem;
 
 // On POSIX the libuv-backed code paths (`UVFSRequest`, `uv_fs_*`) are absent:
 // `UVFSRequest` aliases `AsyncFSTask` and every `uv::*` reference is gated
@@ -7384,23 +7386,42 @@ impl NodeFS {
             let mut outbuf = bun_paths::path_buffer_pool::get();
             let inbuf = &mut self.sync_error_buf;
             let path_slice = args.path.slice();
-            if path_slice.len() >= inbuf.len() {
-                return Err(sys::Error {
-                    errno: E::ENAMETOOLONG as _,
-                    syscall: sys::Tag::realpath,
-                    path: args.path.slice().into(),
-                    ..Default::default()
-                });
-            }
-            // Let realpath walk the original components without opening and
-            // closing the target, which would release process-owned POSIX locks.
-            let path = args.path.slice_z(inbuf);
+            let path = if variant == RealpathVariant::Emulated {
+                debug_assert!(
+                    bun_resolver::fs::INSTANCE_LOADED.load(core::sync::atomic::Ordering::Relaxed)
+                );
+                // SAFETY: instance() returns the process-lifetime resolver singleton.
+                let fs = FileSystem::get();
+                let parts = [fs.top_level_dir, path_slice];
+                let inbuf_len = inbuf.len();
+                let Some(joined) = fs.abs_buf_checked(&parts, &mut inbuf[..inbuf_len - 1]) else {
+                    return Err(sys::Error {
+                        errno: E::ENAMETOOLONG as _,
+                        syscall: sys::Tag::realpath,
+                        path: args.path.slice().into(),
+                        ..Default::default()
+                    });
+                };
+                let path_len = joined.len();
+                inbuf[path_len] = 0;
+                ZStr::from_buf(&inbuf[..], path_len)
+            } else {
+                if path_slice.len() >= inbuf.len() {
+                    return Err(sys::Error {
+                        errno: E::ENAMETOOLONG as _,
+                        syscall: sys::Tag::realpath,
+                        path: args.path.slice().into(),
+                        ..Default::default()
+                    });
+                }
+                args.path.slice_z(inbuf)
+            };
+            // Resolve without opening and closing the target, which would
+            // release process-owned POSIX locks.
             let buf = match Syscall::realpath(path, &mut outbuf) {
                 Err(err) => return Err(err.with_path(path)),
                 Ok(buf_) => buf_,
             };
-
-            let _ = variant;
             if args.encoding == Encoding::Utf8 {
                 if let PathLike::String(s) = &args.path {
                     if strings::eql_long(s.slice(), buf, true) {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3248,10 +3248,10 @@ it.if(isPosix)("realpath resolves a symlink before a following parent traversal"
   symlinkSync(nestedDir, linkPath);
   const input = `${linkPath}${path.sep}..${path.sep}target.txt`;
 
-  expect(realpathSync(input)).toBe(expected);
+  expect(realpathSync(input)).toBe(collision);
   expect(realpathSync.native(input)).toBe(expected);
   expect(await promises.realpath(input)).toBe(expected);
-  expect(await promisify(fs.realpath)(input)).toBe(expected);
+  expect(await promisify(fs.realpath)(input)).toBe(collision);
   expect(await promisify(fs.realpath.native)(input)).toBe(expected);
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3219,9 +3219,7 @@ it.if(isPosix)("realpathSync doesn't block on FIFO", () => {
   unlinkSync(path);
 });
 
-// Regression guard for realpathSync on POSIX hosts. On Linux, getFdPath has
-// a /dev/fd fallback for environments where /proc is broken (FreeBSD
-// Linuxulator) or absent (minimal containers).
+// Regression guard for realpathSync on POSIX hosts.
 it.if(isPosix)("realpathSync resolves root, regular files, and symlinks", () => {
   expect(realpathSync("/")).toBe("/");
 
@@ -3235,13 +3233,105 @@ it.if(isPosix)("realpathSync resolves root, regular files, and symlinks", () => 
   expect(realpathSync(linkPath)).toBe(self);
 });
 
-// src/sys/sys.zig getFdPath has an exhaustive per-OS switch: .windows
-// (GetFinalPathNameByHandle), .mac (F_GETPATH), .linux (/proc/self/fd, also
-// covers Android), .freebsd (fcntl F_KINFO + struct_kinfo_file). On every
-// non-Windows target Bun ships, fd→path resolution is implemented — there is
-// no platform that falls through to ENOSYS. realpathSync on POSIX is
-// open() → getFdPath(fd), so an ENOSYS here means the per-OS arm is missing.
-it.skipIf(isWindows)("realpathSync (getFdPath) is implemented on every POSIX target — never ENOSYS", () => {
+it.if(isPosix)("realpath resolves a symlink before a following parent traversal", async () => {
+  using dir = tempDir("fs-realpath-symlink-parent", {});
+  const root = String(dir);
+  const actualDir = join(root, "actual");
+  const nestedDir = join(actualDir, "nested");
+  const expected = join(actualDir, "target.txt");
+  const collision = join(root, "target.txt");
+  const linkPath = join(root, "link");
+  mkdirSync(nestedDir, { recursive: true });
+  writeFileSync(expected, "expected");
+  writeFileSync(collision, "collision");
+  symlinkSync(nestedDir, linkPath);
+  const input = `${linkPath}${path.sep}..${path.sep}target.txt`;
+
+  expect(realpathSync(input)).toBe(expected);
+  expect(realpathSync.native(input)).toBe(expected);
+  expect(await promises.realpath(input)).toBe(expected);
+  expect(await promisify(fs.realpath)(input)).toBe(expected);
+  expect(await promisify(fs.realpath.native)(input)).toBe(expected);
+});
+
+const darwinCc = process.platform === "darwin" ? Bun.which("cc") || Bun.which("gcc") || Bun.which("clang") : null;
+it.skipIf(!darwinCc)("realpath preserves process-owned POSIX locks", async () => {
+  using dir = tempDir("fs-realpath-posix-lock", {
+    "lock.c": `
+      #include <fcntl.h>
+      int lock_file(int fd) {
+        struct flock lock = { .l_start = 0, .l_len = 0, .l_pid = 0, .l_type = F_WRLCK, .l_whence = SEEK_SET };
+        return fcntl(fd, F_SETLK, &lock);
+      }
+    `,
+  });
+  const dylibPath = join(String(dir), "lock.dylib");
+  const compile = spawnSync({
+    cmd: [darwinCc!, "-dynamiclib", "-o", dylibPath, join(String(dir), "lock.c")],
+    env: bunEnv,
+  });
+  expect(compile.stderr.toString()).toBe("");
+  expect(compile.exitCode).toBe(0);
+  const { dlopen, FFIType } = await import("bun:ffi");
+  const library = dlopen(dylibPath, {
+    lock_file: { args: [FFIType.i32], returns: FFIType.i32 },
+  });
+  const implementations = [
+    realpathSync,
+    realpathSync.native,
+    promises.realpath,
+    promisify(fs.realpath),
+    promisify(fs.realpath.native),
+  ];
+
+  const probeWriter = (filePath: string) => {
+    const result = spawnSync({
+      cmd: [
+        bunExe(),
+        "--eval",
+        `
+          const { closeSync, openSync } = require("node:fs");
+          const { dlopen, FFIType } = require("bun:ffi");
+          const library = dlopen(process.argv[1], {
+            lock_file: { args: [FFIType.i32], returns: FFIType.i32 },
+          });
+          const fd = openSync(process.argv[2], "r+");
+          console.log(library.symbols.lock_file(fd) === 0 ? "acquired" : "busy");
+          closeSync(fd);
+          library.close();
+        `,
+        dylibPath,
+        filePath,
+      ],
+      env: bunEnv,
+    });
+    expect(result.stderr.toString()).toBe("");
+    expect(result.exitCode).toBe(0);
+    return result.stdout.toString().trim();
+  };
+
+  try {
+    for (const [index, impl] of implementations.entries()) {
+      const filePath = join(String(dir), `${index}.lock`);
+      writeFileSync(filePath, "lock target");
+      const fd = openSync(filePath, "r+");
+      try {
+        expect(library.symbols.lock_file(fd)).toBe(0);
+        expect(probeWriter(filePath)).toBe("busy");
+        expect(await impl(filePath)).toBe(filePath);
+        expect(probeWriter(filePath)).toBe("busy");
+      } finally {
+        closeSync(fd);
+      }
+    }
+  } finally {
+    library.close();
+  }
+});
+
+// The POSIX syscall layer supports every non-Windows target Bun ships, so an
+// ENOSYS result means a platform implementation was dropped.
+it.skipIf(isWindows)("realpathSync is implemented on every POSIX target — never ENOSYS", () => {
   using dir = tempDir("fs-getfdpath-platform-arm", { "probe.txt": "x" });
   const probe = join(String(dir), "probe.txt");
 
@@ -3249,9 +3339,6 @@ it.skipIf(isWindows)("realpathSync (getFdPath) is implemented on every POSIX tar
   try {
     resolved = realpathSync(probe);
   } catch (e: any) {
-    // The Zig spec never returns ENOSYS from getFdPath: every Environment.os
-    // value has a real implementation. If this fires, a target (FreeBSD's
-    // F_KINFO arm, or Android via the .linux /proc/self/fd arm) was dropped.
     expect(e?.code).not.toBe("ENOSYS");
     expect(e?.errno).not.toBe(-os.constants.errno.ENOSYS);
     throw e;
@@ -6894,8 +6981,8 @@ it("sync fs calls read a Buffer path captured at call time when an option getter
 it.if(isPosix)("realpathSync reports ENAMETOOLONG when cwd plus the path exceeds the system path limit", async () => {
   using dir = tempDir("fs-realpath-too-long", {});
 
-  // The relative path argument is within the per-argument limit, but joining
-  // it onto the (non-root) cwd overflows the internal fixed-size path buffer.
+  // The relative path argument is within the per-argument limit, but resolving
+  // it against the (non-root) cwd exceeds the system path limit.
   // Both realpath variants must surface this as a clean ENAMETOOLONG error
   // instead of aborting the process.
   const script = `

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -65,6 +65,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { spawnSync } from "bun";
+import { dlopen, FFIType } from "bun:ffi";
 import { mkfifo } from "mkfifo";
 import { ReadStream as ReadStream_, WriteStream as WriteStream_ } from "./export-from.js";
 import { ReadStream as ReadStreamStar_, WriteStream as WriteStreamStar_ } from "./export-star-from.js";
@@ -3272,7 +3273,6 @@ it.skipIf(!darwinCc)("realpath preserves process-owned POSIX locks", async () =>
   });
   expect(compile.stderr.toString()).toBe("");
   expect(compile.exitCode).toBe(0);
-  const { dlopen, FFIType } = await import("bun:ffi");
   const library = dlopen(dylibPath, {
     lock_file: { args: [FFIType.i32], returns: FFIType.i32 },
   });


### PR DESCRIPTION
### What does this PR do?

Bun's POSIX `realpath` implementation opened the target, looked up its descriptor path, then closed it. Closing any descriptor for an inode releases that process's traditional POSIX record locks, so resolving a SQLite database path could silently release a live connection's lock. Opening the target also wrongly required read permission on macOS, rejecting valid unreadable files and search-only directories.

The path first passed through Bun's loose lexical normalizer. That could erase a symlink before a following `..`, or interpret literal POSIX backslashes as separators and resolve a different existing file.

This change uses Bun's existing `Syscall::realpath` implementation on POSIX, without opening and closing the target. Native and promise APIs pass the original component sequence to the OS. Ordinary `fs.realpath` and `fs.realpathSync` retain Node's lexical dot-segment normalization, using the existing POSIX-specific normalizer so backslashes remain literal. Filesystem policy stays with the OS canonicalizer.

It supersedes closed #42277. The locking defect was found while validating OpenClaw under Bun; the permission and backslash cases were reproduced through fs-safe's public APIs and then reduced to direct Node-compatible filesystem tests.

### How did you verify your code works?

- Added a Darwin regression that holds a real POSIX `fcntl` lock and checks sync, native, promise, and callback realpath variants. Released Bun 1.4.2 loses the lock; the patched implementation preserves it.
- Retained the symlink-before-`..` collision test, including Node's intentional ordinary/native API distinction.
- Added ten regression cases across all five API variants: literal-backslash collisions, symlinks, relative paths, string/Buffer input and output, unreadable files, and search-only directories. Released Bun 1.4.2 fails all ten. The earlier PR head passed eight; this follow-up fixes the remaining two ordinary-API backslash failures.
- Patched debug+ASAN Bun: complete `test/js/node/fs/fs.test.ts` passed **567 tests**, with **16 platform/capability skips**.
- Vendored Node conformance files passed: `test-fs-realpath.js` (18 subtests), `test-fs-realpath-native.js`, `test-fs-realpath-buffer-encoding.js`, and `test-fs-realpath-pipe.js`.
- `rust:check-all` passed all **12 targets**, with no failed or skipped targets, on the final source. Actual build/runtime proof was macOS arm64; cross-target checks are compilation checks.
- Rustfmt, Prettier, `git diff --check`, and independent P0–P2 review passed.

The current host's macOS 27 SDK is incompatible with the pinned LLVM 21 headers. The debug+ASAN build used an installed macOS 26.5 SDK through a task-local developer-directory view; no global Xcode configuration, source warning checks, or installed Bun runtime changed.

Earlier proof on this PR also ran OpenClaw's managed-update writer-exclusion suite with patched release Bun: 44 tests passed, with one unrelated #40005 qualification skipped.
