### PR TITLE
react_compiler: fix panic on an object method shorthand in ssr output mode

### DIFF
--- a/src/react_compiler/inference/align_object_method_scopes.rs
+++ b/src/react_compiler/inference/align_object_method_scopes.rs
@@ -56,10 +56,7 @@ fn find_scopes_to_merge(
                                 (Some(operand_sid), Some(lvalue_sid)) => {
                                     merged_scopes.union(&[operand_sid, lvalue_sid]);
                                 }
-                                // With memoization disabled the pipeline does not run
-                                // InferReactiveScopeVariables on the outermost function,
-                                // so neither identifier has a scope and there is nothing
-                                // to align. Upstream has no such arm and throws here.
+                                // No scopes exist without memoization. Upstream throws here.
                                 (None, None) if !env.enable_memoization() => {}
                                 // TS: CompilerError.invariant(operandScope != null && lvalueScope != null, ...)
                                 _ => {

--- a/src/react_compiler/inference/align_object_method_scopes.rs
+++ b/src/react_compiler/inference/align_object_method_scopes.rs
@@ -12,6 +12,7 @@
 use std::cmp;
 use std::collections::{HashMap, HashSet};
 
+use crate::diagnostics::{CompilerDiagnostic, cold_invariant};
 use crate::hir::environment::Environment;
 use crate::hir::{
     EvaluationOrder, HirFunction, IdentifierId, InstructionValue, ObjectPropertyOrSpread, ScopeId,
@@ -25,7 +26,10 @@ use crate::utils::DisjointSet;
 /// Identifies ObjectMethod lvalue identifiers and then finds ObjectExpression
 /// instructions whose operands reference those methods. Returns a disjoint set
 /// of scopes that must be merged.
-fn find_scopes_to_merge(func: &HirFunction, env: &Environment) -> DisjointSet<ScopeId> {
+fn find_scopes_to_merge(
+    func: &HirFunction,
+    env: &Environment,
+) -> Result<DisjointSet<ScopeId>, CompilerDiagnostic> {
     let mut object_method_decls: HashSet<IdentifierId> = HashSet::new();
     let mut merged_scopes = DisjointSet::<ScopeId>::new();
 
@@ -48,14 +52,25 @@ fn find_scopes_to_merge(func: &HirFunction, env: &Environment) -> DisjointSet<Sc
                             let lvalue_scope =
                                 env.identifiers[instr.lvalue.identifier.0 as usize].scope;
 
-                            // TS: CompilerError.invariant(operandScope != null && lvalueScope != null, ...)
-                            let operand_sid = operand_scope.expect(
-                                "Internal error: Expected all ObjectExpressions and ObjectMethods to have non-null scope.",
-                            );
-                            let lvalue_sid = lvalue_scope.expect(
-                                "Internal error: Expected all ObjectExpressions and ObjectMethods to have non-null scope.",
-                            );
-                            merged_scopes.union(&[operand_sid, lvalue_sid]);
+                            match (operand_scope, lvalue_scope) {
+                                (Some(operand_sid), Some(lvalue_sid)) => {
+                                    merged_scopes.union(&[operand_sid, lvalue_sid]);
+                                }
+                                // With memoization disabled the pipeline does not run
+                                // InferReactiveScopeVariables on the outermost function,
+                                // so neither identifier has a scope and there is nothing
+                                // to align. Upstream has no such arm and throws here.
+                                (None, None) if !env.enable_memoization() => {}
+                                // TS: CompilerError.invariant(operandScope != null && lvalueScope != null, ...)
+                                _ => {
+                                    return Err(cold_invariant(
+                                        "Internal error: Expected all ObjectExpressions and ObjectMethods to have non-null scope.",
+                                        None,
+                                        None,
+                                    )
+                                    .into());
+                                }
+                            }
                         }
                     }
                 }
@@ -64,7 +79,7 @@ fn find_scopes_to_merge(func: &HirFunction, env: &Environment) -> DisjointSet<Sc
         }
     }
 
-    merged_scopes
+    Ok(merged_scopes)
 }
 
 // =============================================================================
@@ -75,7 +90,10 @@ fn find_scopes_to_merge(func: &HirFunction, env: &Environment) -> DisjointSet<Sc
 /// ObjectExpression share the same scope.
 ///
 /// Corresponds to TS `alignObjectMethodScopes(fn: HIRFunction): void`.
-pub(crate) fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment) {
+pub(crate) fn align_object_method_scopes(
+    func: &mut HirFunction,
+    env: &mut Environment,
+) -> Result<(), CompilerDiagnostic> {
     // Handle inner functions first (TS recurses before processing the outer function)
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
@@ -88,7 +106,7 @@ pub(crate) fn align_object_method_scopes(func: &mut HirFunction, env: &mut Envir
                         &mut env.functions[func_id.0 as usize],
                         crate::ssa::enter_ssa::placeholder_function(),
                     );
-                    align_object_method_scopes(&mut inner_func, env);
+                    align_object_method_scopes(&mut inner_func, env)?;
                     env.functions[func_id.0 as usize] = inner_func;
                 }
                 _ => {}
@@ -96,7 +114,7 @@ pub(crate) fn align_object_method_scopes(func: &mut HirFunction, env: &mut Envir
         }
     }
 
-    let mut merged_scopes = find_scopes_to_merge(func, env);
+    let mut merged_scopes = find_scopes_to_merge(func, env)?;
 
     // Step 1: Merge affected scopes to their canonical root.
     // Use a HashMap to accumulate min/max across all scopes mapping to the same root,
@@ -165,4 +183,6 @@ pub(crate) fn align_object_method_scopes(func: &mut HirFunction, env: &mut Envir
             }
         }
     }
+
+    Ok(())
 }

--- a/src/react_compiler/pipeline.rs
+++ b/src/react_compiler/pipeline.rs
@@ -562,7 +562,7 @@ fn run_hir_passes(
     timed!(
         "AlignObjectMethodScopes",
         crate::inference::align_object_method_scopes(hir, env)
-    );
+    )?;
 
     timed!(
         "PruneUnusedLabelsHIR",

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -253,6 +253,56 @@ describe("bundler", () => {
     },
   });
 
+  // With memoization off (ssr mode) the pipeline infers no reactive scopes for
+  // the compiled function itself, so an object literal and its method
+  // shorthands reach AlignObjectMethodScopes with no scope to align.
+  //
+  // The fake useState never returns its argument. The ssr pass inlines useState
+  // to its initial value, so a function prints that value only when the
+  // compiler compiled it and did not skip it.
+  itBundled("react-compiler/SsrObjectMethodShorthand", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useState } from "react";
+
+        function InJsxAttribute() {
+          const [n] = useState(1);
+          return <div data-v={{ m() { return n; } }} />;
+        }
+        function InBody({ label }) {
+          const [n] = useState(2);
+          const v = {
+            m() { return label + n; },
+            async am() { return n; },
+            [label]() { return n; },
+            nested() { return { inner() { return n; } }; },
+          };
+          return <div data-v={v} />;
+        }
+        function useApi(value) {
+          const [n] = useState(3);
+          return { get() { return value + n; } };
+        }
+
+        const a = InJsxAttribute().props["data-v"];
+        const b = InBody({ label: "x" }).props["data-v"];
+        console.log(JSON.stringify({
+          InJsxAttribute: a.m(),
+          InBody: [b.m(), await b.am(), b.x(), b.nested().inner()],
+          useApi: useApi("v").get(),
+        }));
+      `,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+      "/node_modules/react/index.js": `exports.useState = () => ["not inlined", () => {}];`,
+      "/node_modules/react/jsx-runtime.js": `exports.jsx = exports.jsxs = (type, props) => ({ type, props });`,
+      "/node_modules/react/jsx-dev-runtime.js": `exports.jsxDEV = (type, props) => ({ type, props });`,
+    },
+    reactCompiler: true,
+    target: "bun",
+    backend: "cli",
+    run: { stdout: '{"InJsxAttribute":1,"InBody":["x2",2,2,2],"useApi":"v3"}' },
+  });
+
   // https://github.com/oven-sh/bun/pull/32504#discussion_r3447488111
   itBundled("react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client", {
     files: {


### PR DESCRIPTION
### Problem
- `bun build --react-compiler --target=bun` aborts on a component that contains an object literal with a method shorthand, for example `<div data-v={{ m() {} }} />`: `panic: Internal error: Expected all ObjectExpressions and ObjectMethods to have non-null scope.` `--target=node` and `reactCompilerOutputMode: "ssr"` do the same.
- `pipeline.rs` runs `infer_reactive_scope_variables` only if `env.enable_memoization()`, which is false in ssr mode. So no identifier gets a reactive scope. `align_object_method_scopes.rs:52` runs in every mode and calls `.expect()` on the scope of each object method and its object literal.

### Fix
- With memoization disabled, `find_scopes_to_merge` skips a pair with no scope on either side. The sibling pass `align_method_call_scopes` already has this `(None, None)` arm.
- Any other mismatch returns the invariant as an error. `program.rs` then leaves that one function uncompiled, like upstream's `CompilerError.invariant`.
- Correct because without scopes no memo block can separate a method from its object.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (new `SsrObjectMethodShorthand`, SIGABRT on 1.4.3). Also `react-compiler-fixtures.test.ts`, and all 1806 upstream fixtures with `--target=bun`: 5 abort before, 0 after.

### Background
- The React Compiler groups values that change together into reactive scopes and emits one memo block per scope.
- The build target selects the output mode: `browser` is client (memoize), `bun` and `node` are ssr (no memoization, `useState` inlined).
- A method shorthand is a separate instruction from its object literal. Codegen prints it inline, so this pass merges the two scopes.
- Upstream main has the same invariant in TS and Rust. In TS it is a caught per-function error. Bun builds with `panic = "abort"`.

<details><summary>Notes</summary>

Repro (any directory, 1.4.2 and main 4b5862fd8):

```jsx
// a.jsx
export function App() {
  return <div data-v={{ m() {} }} />;
}
```

```
$ bun build --react-compiler --target=bun a.jsx --external react --external 'react/*'
panic: Internal error: Expected all ObjectExpressions and ObjectMethods to have non-null scope.
Crashed while visiting a.jsx
```

Frames: `find_scopes_to_merge` (`src/react_compiler/inference/align_object_method_scopes.rs:52`), `align_object_method_scopes` (`:99`), `pipeline::run_hir_passes` (`pipeline.rs:564`), `compile_fn` (`:172`), `program::maybe_compile_node` (`program.rs:1363`).

Why the guard is on `enable_memoization()` and the arm is not unconditional: with memoization enabled, `infer_reactive_scope_variables` gives every `ObjectMethod` and `ObjectExpression` a scope (`may_allocate` is true for both), so a missing scope there is a real invariant violation. That case keeps upstream's behavior, as an error and not as a panic. Inner functions always have scopes, in every mode: `analyse_functions` runs `infer_reactive_scope_variables` on them without the gate.

Alternative not taken: gate the two alignment passes in `pipeline.rs` on `enable_memoization()`. The header of `pipeline.rs` says the pass sequence and the gating predicates stay identical with upstream, and the in-pass arm mirrors the sibling pass.

What the test checks: it bundles with `--target=bun` through the CLI and runs the output. The fake `useState` never returns its argument. The ssr pass inlines `useState` to its initial value, so each function prints that value only if the compiler compiled it. Shapes covered: the object literal as a JSX attribute value, `const v = { ... }` in the body with plain, `async`, computed-key and nested methods, and a hook that returns an object with a method. A generator method is not in the test: upstream does not lower `yield`, so that function is skipped in every mode.

Sweep: built each of the 1806 files under `test/bundler/transpiler/react-compiler-fixtures/` with `bun build --react-compiler --target=bun --external '*'`. On 1.4.3 canary five abort with this panic (`infer-nested-object-method.jsx`, `object-method-shorthand-hook-dep.js`, `object-shorthand-method-nested.js`, `infer-object-method-uncond-access.tsx`, `infer-objectmethod-cond-access.js`). With this change none abort, and the output of those five keeps each method inline in its object.

Codegen does not depend on the scopes here: it stores each `ObjectMethod` in a map that lives for the whole function (`cx.object_methods`, `codegen.rs:1418`) and reads it back at the `ObjectExpression`. A missing entry there is already an error return.

Upstream: `AlignObjectMethodScopes.ts` and `react_compiler_inference/src/align_object_method_scopes.rs` on facebook/react main both still have the invariant, and `Pipeline.ts` gates `inferReactiveScopeVariables` on `env.enableMemoization` the same way.

Suites run with the debug build: `test/bundler/transpiler/react-compiler.test.ts` (46 pass), `test/bundler/transpiler/react-compiler-fixtures.test.ts` (3293 pass, 320 skip). `cargo clippy -p bun_react_compiler` is clean.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [689.67ms]
(pass) bundler > react-compiler/ComponentWithHooks [309.24ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [300.71ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [306.43ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [133.03ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [90.31ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [304.08ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [118.98ms]
1031 |       ]);
1032 |       const stdout = Buffer.from(stdoutBytes);
1033 |       const stderr = Buffer.from(stderrBytes);
1034 |       const success = exitCode === 0;
1035 |       if (buildProc.signalCode) {
1036 |         throw new Error(
                         ^
error: [react-compiler/SsrObjectMethodShorthand] 'bun build' subproc
... (truncated)

release without fix: 1 skipped
bun test v1.4.3-canary.1 (7af2e7c7e)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [14.70ms]
(pass) bundler > react-compiler/ComponentWithHooks [5.41ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [5.75ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [5.21ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [4.93ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [3.04ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [7.41ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [3.31ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [11.42ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [3.83ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [2.93ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [6.28ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [8.26ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [5.08ms]
(pass) bundler > react-compiler/BranchBooleanFeatur
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [704.04ms]
(pass) bundler > react-compiler/ComponentWithHooks [235.64ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [220.78ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [249.55ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [124.66ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [92.83ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [409.55ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [125.37ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [605.33ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [104.66ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [98.85ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [260.57ms]
(pass) bundler > react-
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 621ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/w
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../inference/align_object_method_scopes.rs        | 43 +++++++++++++------
 src/react_compiler/pipeline.rs                     |  2 +-
 test/bundler/transpiler/react-compiler.test.ts     | 50 ++++++++++++++++++++++
 3 files changed, 81 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…/react_compiler/inference/align_object_method_scopes.rs      4      7     10
src/react_compiler/pipeline.rs                                1      1     10
test/bundler/transpiler/react-compiler.test.ts                4      1     10
```

</details>

<!-- robobun:evidence:end -->