### PR TITLE
react-compiler: do not fold a local that holds a different module on each path

### DIFF
--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -1508,6 +1508,45 @@ impl NonLocalBinding {
         }
     }
 
+    /// Whether both load the same value. `name()` cannot tell: two symbols can share one.
+    pub fn loads_same_value(&self, other: &Self) -> bool {
+        use bun_ast::E::Special;
+        use bun_ast::ExprData as Data;
+        let (a, b) = match (&self.kind, &other.kind) {
+            (NonLocalKind::BunOpaque(a), NonLocalKind::BunOpaque(b)) => (a, b),
+            (NonLocalKind::BunOpaque(_), _) | (_, NonLocalKind::BunOpaque(_)) => return false,
+            _ => {
+                return match (self.ref_(), other.ref_()) {
+                    (Some(a), Some(b)) => a == b,
+                    // Synthesized by the compiler: the name is all there is.
+                    (None, None) => self.name() == other.name(),
+                    (Some(_), None) | (None, Some(_)) => false,
+                };
+            }
+        };
+        match (a.data, b.data) {
+            // Each `require()` call site has its own import record.
+            (Data::ERequireString(a), Data::ERequireString(b)) => {
+                a.import_record_index == b.import_record_index
+            }
+            (Data::ERequireResolveString(a), Data::ERequireResolveString(b)) => {
+                a.import_record_index == b.import_record_index
+            }
+            (Data::EImportMetaMain(a), Data::EImportMetaMain(b)) => a.inverted == b.inverted,
+            (
+                Data::ESpecial(Special::ResolvedSpecifierString(a)),
+                Data::ESpecial(Special::ResolvedSpecifierString(b)),
+            ) => a == b,
+            (Data::ERequireCallTarget, Data::ERequireCallTarget)
+            | (Data::ERequireResolveCallTarget, Data::ERequireResolveCallTarget)
+            | (Data::ERequireMain, Data::ERequireMain)
+            | (Data::ESpecial(Special::ModuleExports), Data::ESpecial(Special::ModuleExports)) => {
+                true
+            }
+            _ => false,
+        }
+    }
+
     /// Returns the original Bun `Ref` this binding came from, or `None` if it
     /// was synthesized during lowering without a source identifier.
     pub fn ref_(&self) -> Option<bun_ast::Ref> {

--- a/src/react_compiler/optimization/constant_propagation.rs
+++ b/src/react_compiler/optimization/constant_propagation.rs
@@ -257,7 +257,7 @@ fn evaluate_phi(phi: &Phi, constants: &Constants) -> Option<Constant> {
                     Constant::LoadGlobal { binding: b, .. },
                 ) => {
                     // different global values, can't constant propagate
-                    if a.name() != b.name() {
+                    if !a.loads_same_value(b) {
                         return None;
                     }
                 }

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1980,6 +1980,257 @@ describe("bundler", () => {
     },
     run: { stdout: '{"h":"div","props":{"title":"A"},"children":["hi"]}' },
   });
+
+  // The compiler folds a local that is the same global on every path. It told
+  // two globals apart by name, which in bun does not identify one: a local that
+  // is a different module per path read as the first module on both.
+  const reactStub = {
+    "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+    "/node_modules/react/index.js": /* js */ `
+      export function useEffect() {}
+    `,
+    "/node_modules/react/compiler-runtime.js": /* js */ `
+      export function c(size) {
+        return new Array(size).fill(Symbol.for("react.memo_cache_sentinel"));
+      }
+    `,
+  };
+  // Prints `Form=<flag is true> <flag is false>` for every export of ./forms.
+  const callEveryForm = /* js */ `
+    import * as forms from "./forms";
+    const lines = [];
+    for (const [name, form] of Object.entries(forms)) {
+      try {
+        lines.push(name + "=" + form({ flag: true }) + " " + form({ flag: false }));
+      } catch (e) {
+        lines.push(name + " threw " + e);
+      }
+    }
+    console.log(lines.join("\\n"));
+  `;
+
+  // `require("a")` is one node to the compiler, a global named `require`.
+  itBundled("react-compiler/LocalHoldsADifferentRequirePerPath", {
+    files: {
+      "/entry.js": callEveryForm,
+      "/forms.jsx": /* jsx */ `
+        import { useEffect } from "react";
+
+        export function Ternary({ flag }) {
+          useEffect(() => {});
+          const m = flag ? require("./one.cjs") : require("./two.cjs");
+          return m.name;
+        }
+        export function IfElse({ flag }) {
+          useEffect(() => {});
+          let m;
+          if (flag) m = require("node:path");
+          else m = require("node:util");
+          return typeof m.join + "/" + typeof m.inspect;
+        }
+        export function Switch({ flag }) {
+          useEffect(() => {});
+          let m;
+          switch (flag) {
+            case true:
+              m = require("./one.cjs");
+              break;
+            default:
+              m = require("./two.cjs");
+          }
+          return m.name;
+        }
+        export function NestedArrow({ flag }) {
+          useEffect(() => {});
+          const pick = first => {
+            let m;
+            if (first) m = require("./one.cjs");
+            else m = require("./two.cjs");
+            return m.name;
+          };
+          return pick(flag);
+        }
+        export function Reassign({ flag }) {
+          useEffect(() => {});
+          let m = require("./one.cjs");
+          if (flag) m = require("./two.cjs");
+          return m.name;
+        }
+        export function TwoLocals({ flag }) {
+          useEffect(() => {});
+          const one = require("./one.cjs");
+          const two = require("./two.cjs");
+          const m = flag ? one : two;
+          return m.name;
+        }
+        export function Resolve({ flag }) {
+          useEffect(() => {});
+          const resolved = flag ? require.resolve("node:path") : require.resolve("node:util");
+          return resolved;
+        }
+        export function RequireOrModule({ flag }) {
+          useEffect(() => {});
+          const m = flag ? require : require("./one.cjs");
+          return typeof m;
+        }
+        export function SameModule({ flag }) {
+          useEffect(() => {});
+          const m = flag ? require("./one.cjs") : require("./one.cjs");
+          return m.name;
+        }
+        export function ModuleOrNull({ flag }) {
+          useEffect(() => {});
+          const m = flag ? require("./one.cjs") : null;
+          return m ? m.name : "null";
+        }
+      `,
+      "/one.cjs": `exports.name = "one";`,
+      "/two.cjs": `exports.name = "two";`,
+      ...reactStub,
+    },
+    reactCompiler: true,
+    backend: "cli",
+    target: "bun",
+    run: {
+      stdout: `
+        IfElse=function/undefined undefined/function
+        ModuleOrNull=one null
+        NestedArrow=one two
+        Reassign=two one
+        RequireOrModule=function object
+        Resolve=path util
+        SameModule=one one
+        Switch=one two
+        Ternary=one two
+        TwoLocals=one two
+      `,
+    },
+    onAfterBundle(api) {
+      // Every form compiled: the compiler drops the effect (ssr), so no call
+      // takes `() => {}` any more.
+      expect(api.readFile("/out.js")).not.toMatch(/\(\(\) => \{\s*\}\)/);
+    },
+  });
+
+  // With two ES modules the path that lost its module printed as nothing:
+  // `flag ? __toCommonJS(exports_state) : ;`.
+  itBundled("react-compiler/LocalHoldsADifferentEsModulePerPath", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useEffect } from "react";
+
+        function App({ flag }) {
+          useEffect(() => {});
+          const m = flag ? require("./state") : require("./other");
+          return m.name;
+        }
+        console.log(App({ flag: true }), App({ flag: false }));
+      `,
+      "/state.js": `export const name = "state";`,
+      "/other.js": `export const name = "other";`,
+      ...reactStub,
+    },
+    reactCompiler: true,
+    backend: "cli",
+    target: "bun",
+    run: { stdout: "state other" },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toMatch(/\(\(\) => \{\s*\}\)/);
+    },
+  });
+
+  // The parser turns `ns.member` off `import * as ns` into an import item, a
+  // symbol named after the export: `light.name` and `dark.name` are two
+  // symbols named `name`.
+  itBundled("react-compiler/LocalHoldsTheSameExportOfADifferentModulePerPath", {
+    files: {
+      "/entry.js": callEveryForm,
+      "/forms.jsx": /* jsx */ `
+        import { useEffect } from "react";
+        import * as light from "./light";
+        import * as dark from "./dark";
+
+        export function Ternary({ flag }) {
+          useEffect(() => {});
+          const picked = flag ? dark.name : light.name;
+          return picked;
+        }
+        export function IfElse({ flag }) {
+          useEffect(() => {});
+          let picked;
+          if (flag) picked = dark.name;
+          else picked = light.name;
+          return picked;
+        }
+        export function ReadInClosure({ flag }) {
+          useEffect(() => {});
+          const picked = flag ? dark.name : light.name;
+          const read = () => picked;
+          return read();
+        }
+        export function DifferentExports({ flag }) {
+          useEffect(() => {});
+          const picked = flag ? dark.background : light.name;
+          return picked;
+        }
+        export function SameExport({ flag }) {
+          useEffect(() => {});
+          const picked = flag ? dark.name : dark.name;
+          return picked;
+        }
+      `,
+      "/light.js": /* js */ `
+        export const name = "light";
+        export const background = "#fff";
+      `,
+      "/dark.js": /* js */ `
+        export const name = "dark";
+        export const background = "#000";
+      `,
+      ...reactStub,
+    },
+    reactCompiler: true,
+    backend: "cli",
+    target: "bun",
+    run: {
+      stdout: `
+        DifferentExports=#000 light
+        IfElse=dark light
+        ReadInClosure=dark light
+        SameExport=dark dark
+        Ternary=dark light
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toMatch(/\(\(\) => \{\s*\}\)/);
+    },
+  });
+
+  // `--minify-syntax` turns `!import.meta.main` into an inverted
+  // `import.meta.main` node. Both are named `import.meta.main`.
+  itBundled("react-compiler/LocalHoldsImportMetaMainOrItsNegation", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useEffect } from "react";
+
+        function Main({ flag }) {
+          useEffect(() => {});
+          const main = flag ? import.meta.main : !import.meta.main;
+          return String(main);
+        }
+        console.log(Main({ flag: true }), Main({ flag: false }));
+      `,
+      ...reactStub,
+    },
+    reactCompiler: true,
+    minifySyntax: true,
+    backend: "cli",
+    target: "bun",
+    run: { stdout: "true false" },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toMatch(/\(\(\) => \{\s*\}\)/);
+    },
+  });
 });
 
 // Three passes kept one copy of their work per basic block or per nesting

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -2066,7 +2066,8 @@ describe("bundler", () => {
         export function Resolve({ flag }) {
           useEffect(() => {});
           const resolved = flag ? require.resolve("node:path") : require.resolve("node:util");
-          return resolved;
+          // A bundle for this target resolves these to "path" and "util".
+          return resolved.replace("node:", "");
         }
         export function RequireOrModule({ flag }) {
           useEffect(() => {});


### PR DESCRIPTION
### Problem

- With `bun build --react-compiler`, a local that is one module on one path and another module on the other reads as the first on both. `const m = flag ? require("./st") : require("./ot")` prints `flag ? __toCommonJS(exports_st) : ;` (`SyntaxError: Unexpected token ';'`), or silently uses `./st`. With `import * as light` and `import * as dark`, `isDark ? dark.name : light.name` is always `dark.name`.
- `evaluate_phi` (`src/react_compiler/optimization/constant_propagation.rs:237`) folds a phi when every operand is the same global. It compares them by `NonLocalBinding::name()`. In bun a name does not identify a binding: every `require("...")` is named `require`, and `dark.name` and `light.name` are two symbols named `name`.

### Fix

- New `NonLocalBinding::loads_same_value`, which `evaluate_phi` calls. A binding that came from a symbol compares by that symbol. A `BunOpaque` compares by what it carries: the import record index for `require()` and `require.resolve()`, `inverted` for `import.meta.main`, the node kind for the rest. Only bindings the compiler made up compare by name.
- Correct because it is stricter than the name in every case, and an unfolded phi keeps the local and both assignments. Each `require()` call site has its own import record, so two sites never compare equal.
- Also fixes `require.resolve(a)` / `require.resolve(b)`, `require` / `require("x")`, and `import.meta.main` / `!import.meta.main` (`--minify-syntax`).
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (4 new tests, all fail on main). Also `react-compiler-fixtures.test.ts`.

### Background

- The compiler runs per function, after the parser. By then `require("x")` is one `E::RequireString` node that holds its import record index, kept whole as a global constant (`NonLocalKind::BunOpaque`). `ns.member` off `import * as ns` is an import item: a symbol named after the export.
- A phi merges the values a variable has on different paths. Constant propagation replaces a phi whose operands are one constant with that constant, and drops the assignments.
- Upstream sees a call on the global `require` and a property load on `ns`. Neither is a constant there, so a comparison by name is right upstream.

<details><summary>Notes</summary>

**Forms in the new tests** (`flag` true, then false). "main" is a debug build of 4b5862fd88, "1.4.3-canary" is 6a92015fc.

| form | expected | main | 1.4.3-canary |
| --- | --- | --- | --- |
| `flag ? require(one) : require(two)` | `one two` | `one one` | `one one` |
| `if (flag) m = require("node:path"); else m = require("node:util")` | `function/undefined undefined/function` | `function/undefined` twice | same as main |
| `switch (flag) { case true: m = require(one); break; default: m = require(two) }` | `one two` | `one one` | `one one` |
| the if/else inside a nested arrow | `one two` | `one one` | `one one` |
| `let m = require(one); if (flag) m = require(two)` | `two one` | `two two` | `ReferenceError: m is not defined` |
| `const one = require(one); const two = require(two); flag ? one : two` | `one two` | `one one` | `one one` |
| `flag ? require.resolve("node:path") : require.resolve("node:util")` | `path util` | `path path` | `path path` |
| `flag ? require : require(one)` | `function object` | `function function` | `function function` |
| `flag ? require(one) : require(one)` (control) | `one one` | `one one` | `one one` |
| `flag ? require(one) : null` (control) | `one null` | `one null` | `one null` |
| two ES modules, the form in the first report | `state other` | `SyntaxError: Unexpected token ';'` | same as main |
| `--minify-syntax`, `flag ? import.meta.main : !import.meta.main` | `true false` | `true true` | `true true` |
| `flag ? dark.name : light.name` | `dark light` | `dark dark` | `dark dark` |
| the same with if/else | `dark light` | `dark dark` | `dark dark` |
| the same, then read in a closure | `dark light` | `dark dark` | `dark dark` |
| `flag ? dark.background : light.name` (control) | `#000 light` | `#000 light` | `#000 light` |
| `flag ? dark.name : dark.name` (control) | `dark dark` | `dark dark` | `dark dark` |

`!import.meta.main` only becomes an inverted `E::ImportMetaMain` node when `--minify-syntax` is on (`src/js_parser/visit/visit_expr.rs:1272`), and only in the entry point, so that test puts the component in the entry file.

**Which bindings have a symbol.** `lower_identifier` (`src/react_compiler/lowering/build_hir/helpers.rs:248`) stores the `Ref` of every identifier it lowers. `Ref::NONE` is only on bindings the compiler makes itself: `undefined`, the outlined `_temp` functions, the outlined JSX components, the early return sentinel. Two unbound references to one global (`Math`) resolve to one symbol, so they still fold. An import item for `ns.member` is cached per namespace, so `dark.name` twice is one symbol and still folds.

More forms checked by hand against a build without `--react-compiler` (all equal with this change): a `for` loop that reassigns the local, `m ??= require(two)`, `flag ? a : a` for one `require()` local, `useMemo(() => (flag ? require(one) : require(two)), [flag])`, a closure that reads the local, a closure that reassigns it, `flag ? import(one) : import(two)`, a destructure of the ternary, `flag ? require(one).name : require(two).name`, `flag ? require.main : require(two)`, `try { m = require("missing") } catch { m = null }` with `--external`, default imports, namespaces (`flag ? dark : light`), and the second report as written (`const name = isDark ? dark.name : light.name`, the compiler renames the local to `name$0`).

**The other direction.** Constant propagation could also stop treating a `BunOpaque` as a constant at all. That changes the text the compiler emits for every `const x = require("y")` in a compiled function (the local stays, reads are not replaced by the `require()`), it does nothing for the import items, and it is not needed for this bug. The comparison is the part that was wrong, so this PR changes only that.

**Not changed.** `flag ? 0 : -0` folds to `0`. Upstream compares primitives with `!==` and does the same, so the port matches it.

**Other callers of `name()`.** `rename_variables`, `name_anonymous_functions`, `validate_use_memo`, `validate_no_capitalized_calls`, `validate_no_ref_access_in_render` and `drop_manual_memoization` use the name for display or match it against a fixed string. `validate_exhaustive_dependencies` sorts and dedupes global dependencies by name, which only feeds a diagnostic. None of them decides what code is emitted, so they are unchanged.

**Three other bugs seen on the way, not fixed here.**

1. Without the compiler, `flag ? require("./st") : require("./ot");` as a statement (value unused) prints `flag ? __toCommonJS(exports_st) : ;`. The `EIf` arm of the printer passes `ExprResultIsUnused` to the `no` branch, and `print_require_or_import_expr` then prints nothing for an ES module that has no wrapper. Present since at least 1.2.0. This is why the fold above gave a syntax error and not only a wrong module.
2. With the compiler, a `require("./x")` whose value nothing reads is removed from a compiled function (dead code elimination prunes every `LoadGlobal`), so `./x` never runs.
3. With the compiler, `import { theme as defaultTheme } from "./theme"` and `const theme = custom ?? defaultTheme` in a component prints `let theme = custom ?? theme` (`ReferenceError: Cannot access 'theme' before initialization.`). The compiler registers its new local symbols in the module scope's `generated` list (`src/js_parser/react_compiler_host.rs:83`), where the renamer does not look for nested names. 1.4.0 and later.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [947.61ms]
(pass) bundler > react-compiler/ComponentWithHooks [382.08ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [285.42ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [427.98ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [172.71ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [121.97ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [376.28ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [151.02ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [134.53ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [130.03ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [474.01ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [672.32ms]
(
... (truncated)

release without fix: 19 failed, 1 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [14.56ms]
(pass) bundler > react-compiler/ComponentWithHooks [7.87ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [6.30ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [10.12ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [6.05ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [3.86ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [11.40ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [4.95ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [3.64ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [3.39ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [8.05ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [14.30ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [7.25ms]
(pass) bundler > react-compiler/BranchBooleanFeatureFlagPreservesDCE [5.84ms]
(pass) bundler > react-compiler/Forwa
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [1046.30ms]
(pass) bundler > react-compiler/ComponentWithHooks [378.62ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [412.57ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [444.12ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [362.64ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [205.62ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [557.91ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [193.55ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [206.56ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [186.09ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [417.20ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [702.16ms]

... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1181ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/w
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/react_compiler/hir/mod.rs                      |  39 ++++
 .../optimization/constant_propagation.rs           |   2 +-
 test/bundler/transpiler/react-compiler.test.ts     | 252 +++++++++++++++++++++
 3 files changed, 292 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/react_compiler/hir/mod.rs                                4      5     35
src/react_compiler/optimization/constant_propagation.rs      1      1     35
test/bundler/transpiler/react-compiler.test.ts               6      5     35
```

</details>

<!-- robobun:evidence:end -->