### PR TITLE
react_compiler: fix panic on an assignment in the test of a `?:`

### DIFF
--- a/src/react_compiler/reactive_scopes/prune_non_escaping_scopes.rs
+++ b/src/react_compiler/reactive_scopes/prune_non_escaping_scopes.rs
@@ -145,8 +145,7 @@ struct CollectState {
     identifiers: IdMap<DeclarationId, IdentifierNode>,
     scopes: IdMap<ScopeId, ScopeNode>,
     escaping_values: IndexSet<DeclarationId>,
-    /// The first invariant violation. The visitor callbacks return `()`, so the
-    /// entry point reads it back once the walk ends.
+    /// First invariant violation. The `()` visitor callbacks cannot return it.
     error: Option<CompilerError>,
 }
 

--- a/src/react_compiler/reactive_scopes/prune_non_escaping_scopes.rs
+++ b/src/react_compiler/reactive_scopes/prune_non_escaping_scopes.rs
@@ -12,6 +12,9 @@ use std::collections::HashSet;
 
 use crate::collections::IdMap;
 use crate::collections::IndexSet;
+use crate::diagnostics::CompilerError;
+use crate::diagnostics::SourceLocation;
+use crate::diagnostics::cold_invariant;
 use crate::hir::ArrayPatternElement;
 use crate::hir::DeclarationId;
 use crate::hir::Effect;
@@ -52,7 +55,7 @@ use crate::reactive_scopes::visitors::visit_reactive_function;
 pub(crate) fn prune_non_escaping_scopes(
     func: &mut ReactiveFunction,
     env: &mut Environment,
-) -> Result<(), crate::diagnostics::CompilerError> {
+) -> Result<(), CompilerError> {
     // First build up a map of which instructions are involved in creating which values,
     // and which values are returned.
     let mut state = CollectState::new();
@@ -64,10 +67,13 @@ pub(crate) fn prune_non_escaping_scopes(
     let visitor = CollectDependenciesVisitor::new(env);
     let mut visitor_state = (state, Vec::<ScopeId>::new());
     visit_reactive_function(func, &visitor, &mut visitor_state);
-    let (state, _) = visitor_state;
+    let (mut state, _) = visitor_state;
+    if let Some(err) = state.error.take() {
+        return Err(err);
+    }
 
     // Then walk outward from the returned values and find all captured operands.
-    let memoized = compute_memoized_identifiers(&state);
+    let memoized = compute_memoized_identifiers(&state)?;
 
     // Prune scopes that do not declare/reassign any escaping values
     let mut transform = PruneScopesTransform {
@@ -139,6 +145,9 @@ struct CollectState {
     identifiers: IdMap<DeclarationId, IdentifierNode>,
     scopes: IdMap<ScopeId, ScopeNode>,
     escaping_values: IndexSet<DeclarationId>,
+    /// The first invariant violation. The visitor callbacks return `()`, so the
+    /// entry point reads it back once the walk ends.
+    error: Option<CompilerError>,
 }
 
 impl CollectState {
@@ -148,7 +157,15 @@ impl CollectState {
             identifiers: IdMap::new(),
             scopes: IdMap::new(),
             escaping_values: IndexSet::new(),
+            error: None,
         }
+    }
+
+    /// TS: `CompilerError.invariant(identifierNode !== undefined, ...)`
+    fn identifier_not_initialized(&mut self, loc: Option<SourceLocation>) {
+        self.error.get_or_insert_with(|| {
+            cold_invariant("Expected identifier to be initialized", None, loc)
+        });
     }
 
     /// Declare a new identifier, used for function id and params.
@@ -189,10 +206,10 @@ impl CollectState {
             });
             // Avoid unused variable warning — we needed the entry to exist
             let _ = node;
-            let identifier_node = self
-                .identifiers
-                .get_mut(identifier)
-                .expect("Expected identifier to be initialized");
+            let Some(identifier_node) = self.identifiers.get_mut(identifier) else {
+                self.identifier_not_initialized(place.loc);
+                return;
+            };
             identifier_node.scopes.insert(scope_id);
         }
     }
@@ -1027,17 +1044,16 @@ impl<'a> ReactiveFunctionVisitor for CollectDependenciesVisitor<'a> {
         self.traverse_terminal(stmt, state);
 
         // Handle return terminals
-        if let ReactiveTerminal::Return { value, .. } = &stmt.terminal {
+        if let ReactiveTerminal::Return { value, loc, .. } = &stmt.terminal {
             let env = self.env;
             let decl = env.identifiers[value.identifier.0 as usize].declaration_id;
             state.0.escaping_values.insert(decl);
 
             // If the return is within a scope, associate those scopes with the returned value
-            let identifier_node = state
-                .0
-                .identifiers
-                .get_mut(decl)
-                .expect("Expected identifier to be initialized");
+            let Some(identifier_node) = state.0.identifiers.get_mut(decl) else {
+                state.0.identifier_not_initialized(*loc);
+                return;
+            };
             for scope_id in &state.1 {
                 identifier_node.scopes.insert(*scope_id);
             }
@@ -1052,12 +1068,12 @@ impl<'a> ReactiveFunctionVisitor for CollectDependenciesVisitor<'a> {
         // If a scope reassigns any variables, set the chain of active scopes as a dependency
         // of those variables.
         for reassignment_id in &scope_data.reassignments {
-            let decl = env.identifiers[reassignment_id.0 as usize].declaration_id;
-            let identifier_node = state
-                .0
-                .identifiers
-                .get_mut(decl)
-                .expect("Expected identifier to be initialized");
+            let reassignment = &env.identifiers[reassignment_id.0 as usize];
+            let Some(identifier_node) = state.0.identifiers.get_mut(reassignment.declaration_id)
+            else {
+                state.0.identifier_not_initialized(reassignment.loc);
+                return;
+            };
             for s in &state.1 {
                 identifier_node.scopes.insert(*s);
             }
@@ -1083,7 +1099,9 @@ type IdentNodeTuple = (
     bool,
 );
 
-fn compute_memoized_identifiers(state: &CollectState) -> HashSet<DeclarationId> {
+fn compute_memoized_identifiers(
+    state: &CollectState,
+) -> Result<HashSet<DeclarationId>, CompilerError> {
     let mut memoized = HashSet::new();
 
     // We need mutable access to the nodes, so we clone the state into mutable structures
@@ -1112,12 +1130,12 @@ fn compute_memoized_identifiers(state: &CollectState) -> HashSet<DeclarationId> 
         identifier_nodes: &mut IdMap<DeclarationId, IdentNodeTuple>,
         scope_nodes: &mut IdMap<ScopeId, (Vec<DeclarationId>, bool)>,
         memoized: &mut HashSet<DeclarationId>,
-    ) -> bool {
+    ) -> Result<bool, CompilerError> {
         let Some(&(level, _, _, _, seen)) = identifier_nodes.get(id) else {
-            return false;
+            return Ok(false);
         };
         if seen {
-            return identifier_nodes.get(id).unwrap().1;
+            return Ok(identifier_nodes.get(id).unwrap().1);
         }
 
         // Mark as seen, temporarily mark as non-memoized
@@ -1134,7 +1152,7 @@ fn compute_memoized_identifiers(state: &CollectState) -> HashSet<DeclarationId> 
             .collect();
         let mut has_memoized_dependency = false;
         for dep in deps {
-            let is_dep_memoized = visit(dep, false, identifier_nodes, scope_nodes, memoized);
+            let is_dep_memoized = visit(dep, false, identifier_nodes, scope_nodes, memoized)?;
             has_memoized_dependency |= is_dep_memoized;
         }
 
@@ -1153,10 +1171,15 @@ fn compute_memoized_identifiers(state: &CollectState) -> HashSet<DeclarationId> 
                 .copied()
                 .collect();
             for scope_id in scopes {
-                force_memoize_scope_dependencies(scope_id, identifier_nodes, scope_nodes, memoized);
+                force_memoize_scope_dependencies(
+                    scope_id,
+                    identifier_nodes,
+                    scope_nodes,
+                    memoized,
+                )?;
             }
         }
-        identifier_nodes.get(id).unwrap().1
+        Ok(identifier_nodes.get(id).unwrap().1)
     }
 
     fn force_memoize_scope_dependencies(
@@ -1164,20 +1187,21 @@ fn compute_memoized_identifiers(state: &CollectState) -> HashSet<DeclarationId> 
         identifier_nodes: &mut IdMap<DeclarationId, IdentNodeTuple>,
         scope_nodes: &mut IdMap<ScopeId, (Vec<DeclarationId>, bool)>,
         memoized: &mut HashSet<DeclarationId>,
-    ) {
-        let seen = scope_nodes
-            .get(id)
-            .expect("Expected a node for all scopes")
-            .1;
-        if seen {
-            return;
+    ) -> Result<(), CompilerError> {
+        // TS: CompilerError.invariant(node !== undefined, ...)
+        let Some(node) = scope_nodes.get_mut(id) else {
+            return Err(cold_invariant("Expected a node for all scopes", None, None));
+        };
+        if node.1 {
+            return Ok(());
         }
-        scope_nodes.get_mut(id).unwrap().1 = true; // seen = true
+        node.1 = true; // seen = true
 
-        let deps: Vec<DeclarationId> = scope_nodes.get(id).unwrap().0.clone();
+        let deps: Vec<DeclarationId> = node.0.clone();
         for dep in deps {
-            visit(dep, true, identifier_nodes, scope_nodes, memoized);
+            visit(dep, true, identifier_nodes, scope_nodes, memoized)?;
         }
+        Ok(())
     }
 
     // Walk from the "roots" aka returned/escaping identifiers
@@ -1189,10 +1213,10 @@ fn compute_memoized_identifiers(state: &CollectState) -> HashSet<DeclarationId> 
             &mut identifier_nodes,
             &mut scope_nodes,
             &mut memoized,
-        );
+        )?;
     }
 
-    memoized
+    Ok(memoized)
 }
 
 // =============================================================================
@@ -1216,7 +1240,7 @@ impl<'a> ReactiveFunctionTransform for PruneScopesTransform<'a> {
         &mut self,
         scope: &mut ReactiveScopeBlock,
         state: &mut HashSet<DeclarationId>,
-    ) -> Result<Transformed<ReactiveStatement>, crate::diagnostics::CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement>, CompilerError> {
         self.visit_scope(scope, state)?;
 
         let scope_id = scope.scope;
@@ -1252,7 +1276,7 @@ impl<'a> ReactiveFunctionTransform for PruneScopesTransform<'a> {
         &mut self,
         instruction: &mut ReactiveInstruction,
         state: &mut HashSet<DeclarationId>,
-    ) -> Result<Transformed<ReactiveStatement>, crate::diagnostics::CompilerError> {
+    ) -> Result<Transformed<ReactiveStatement>, CompilerError> {
         self.traverse_instruction(instruction, state)?;
 
         match &mut instruction.value {

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1299,6 +1299,22 @@ describe("bundler", () => {
           const r = ((m = p.f()) ? 1 : 0) + 1;
           return [m, r];
         }
+        // https://github.com/facebook/react/issues/37228: the same invariant
+        // with no assignment, from a \`?:\` in a \`try\` in an inlined IIFE.
+        const check = v => v.ok;
+        function useValue() {
+          return { ok: true };
+        }
+        function ConditionalInTryInIife() {
+          const raw = useValue();
+          return (() => {
+            try {
+              return check(raw) ? raw : null;
+            } catch {
+              return null;
+            }
+          })();
+        }
         function AssignedLocalNotMemoized(p) {
           let m;
           const r = (m = p.f()) ? 1 : 0;
@@ -1318,6 +1334,7 @@ describe("bundler", () => {
           ArrayInTest: render(ArrayInTest, { a: 1 }),
           ObjectInTest: render(ObjectInTest, { a: 1, b: 2, c: 3 }),
           useInHook: render(useInHook, { f: () => "y" }),
+          ConditionalInTryInIife: render(ConditionalInTryInIife),
           AssignedLocalNotMemoized: render(AssignedLocalNotMemoized, { f: () => "z" }),
           Plain: render(Plain, { name: "bun" }),
         }));
@@ -1344,6 +1361,7 @@ describe("bundler", () => {
         ArrayInTest: [{ "data-v": [[1]], "data-r": 1 }, 0],
         ObjectInTest: [{ "data-v": { m: { a: 1 }, r: 2 } }, 0],
         useInHook: [["y", 2], 0],
+        ConditionalInTryInIife: [{ ok: true }, 0],
         AssignedLocalNotMemoized: [{ "data-m": "z", "data-r": 1 }, 1],
         Plain: [{ children: ["Hello ", "bun"] }, 1],
       }),

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1265,6 +1265,91 @@ describe("bundler", () => {
     },
   });
 
+  // prune_non_escaping_scopes does not visit the test of a `?:`. A reactive
+  // scope that only the test reaches gets no node, but the local that scope
+  // reassigns still refers to it. Once that local has to be memoized, Babel
+  // raises `Invariant: Expected a node for all scopes` and skips that one
+  // function. The last two functions are the controls.
+  //
+  // A compiled function calls the fake `c` once per render, so the second
+  // number of each pair is 1 for a compiled function and 0 for a skipped one.
+  itBundled("react-compiler/AssignmentInConditionalTestSkipsOnlyThatFunction", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { calls } from "react/compiler-runtime";
+
+        function CallInTest(p) {
+          let m;
+          const r = (m = p.f()) ? 1 : 0;
+          return <div data-v={[m, r]} />;
+        }
+        function ArrayInTest(p) {
+          let m;
+          const r = (m = [p.a]) ? 1 : 0;
+          return <div data-v={[m]} data-r={r} />;
+        }
+        function ObjectInTest(p) {
+          let m = null;
+          const r = (m = { a: p.a }) ? p.b : p.c;
+          return <div data-v={{ m, r }} />;
+        }
+        function useInHook(p) {
+          "use memo";
+          let m;
+          const r = ((m = p.f()) ? 1 : 0) + 1;
+          return [m, r];
+        }
+        function AssignedLocalNotMemoized(p) {
+          let m;
+          const r = (m = p.f()) ? 1 : 0;
+          return <div data-m={m} data-r={r} />;
+        }
+        function Plain({ name }) {
+          return <div>Hello {name}</div>;
+        }
+
+        function render(fn, props) {
+          const before = calls();
+          const result = fn(props);
+          return [result.props ?? result, calls() - before];
+        }
+        console.log(JSON.stringify({
+          CallInTest: render(CallInTest, { f: () => "x" }),
+          ArrayInTest: render(ArrayInTest, { a: 1 }),
+          ObjectInTest: render(ObjectInTest, { a: 1, b: 2, c: 3 }),
+          useInHook: render(useInHook, { f: () => "y" }),
+          AssignedLocalNotMemoized: render(AssignedLocalNotMemoized, { f: () => "z" }),
+          Plain: render(Plain, { name: "bun" }),
+        }));
+      `,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+      "/node_modules/react/index.js": `exports.createElement = () => null;`,
+      "/node_modules/react/jsx-runtime.js": `exports.jsx = exports.jsxs = (type, props) => ({ type, props });`,
+      "/node_modules/react/jsx-dev-runtime.js": `exports.jsxDEV = (type, props) => ({ type, props });`,
+      "/node_modules/react/compiler-runtime.js": `
+        let count = 0;
+        exports.c = size => {
+          count++;
+          return new Array(size).fill(Symbol.for("react.memo_cache_sentinel"));
+        };
+        exports.calls = () => count;
+      `,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    run: {
+      stdout: JSON.stringify({
+        CallInTest: [{ "data-v": ["x", 1] }, 0],
+        ArrayInTest: [{ "data-v": [[1]], "data-r": 1 }, 0],
+        ObjectInTest: [{ "data-v": { m: { a: 1 }, r: 2 } }, 0],
+        useInHook: [["y", 2], 0],
+        AssignedLocalNotMemoized: [{ "data-m": "z", "data-r": 1 }, 1],
+        Plain: [{ children: ["Hello ", "bun"] }, 1],
+      }),
+    },
+  });
+
   // A 0-arg call to an unknown import is non-reactive in InferReactivePlaces
   // (no operand is reactive, callee isn't a hook), so its scope's deps prune
   // to empty and it becomes a sentinel-only block. Babel does the same; this


### PR DESCRIPTION
### Problem
- `bun build --react-compiler --target=browser` aborts on `const r = (m = p.f()) ? 1 : 0; return <div data-v={[m, r]} />`: `panic: Expected a node for all scopes`. `Bun.build` aborts the calling process the same way.
- `CollectDependenciesVisitor` skips the test of a `?:`, so the reactive scope that reassigns `m` gets no scope node. `visit_scope` still attaches that scope to `m`. When `m` is force-memoized, `force_memoize_scope_dependencies` (`src/react_compiler/reactive_scopes/prune_non_escaping_scopes.rs:1170`) calls `.expect()` on the missing node.

### Fix
- That invariant is now a `cold_invariant` error. `program.rs` leaves that one function uncompiled, like upstream's `CompilerError.invariant`.
- The three `Expected identifier to be initialized` invariants in the same pass get the same treatment. Their visitor callbacks return `()`, so they record the first error in `CollectState`, as `assert_scope_instructions_within_scopes` does.
- Correct because babel-plugin-react-compiler 1.0.0 raises the same invariant on the same inputs and skips the same functions. Compiled output does not change.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (new `AssignmentInConditionalTestSkipsOnlyThatFunction`, SIGABRT on 1.4.3 canary). Also `react-compiler-fixtures.test.ts`.

### Background
- The React Compiler groups values that change together into reactive scopes and emits one memo block per scope. PruneNonEscapingScopes removes the scopes whose values never leave the function.
- The pass builds a graph of identifier nodes and scope nodes, then walks it from the returned values.
- Upstream's `CompilerError.invariant` is a caught per-function error in TS. Bun builds with `panic = "abort"`, so a ported `.expect()` ends the process.

<details><summary>Notes</summary>

Repro (any directory, 1.4.2, 1.4.3 canary 6a92015fc and main 4b5862fd8):

```jsx
// a.jsx
export default function App(p) {
  let m;
  const r = (m = p.f()) ? 1 : 0;
  return <div data-v={[m, r]} />;
}
```

```
$ bun build --react-compiler --target=browser --external react a.jsx
panic: Expected a node for all scopes
Crashed while visiting a.jsx
```

Frames: `force_memoize_scope_dependencies` (`prune_non_escaping_scopes.rs:1170`), `compute_memoized_identifiers::visit` (`:1156`), `prune_non_escaping_scopes` (`:70`), `pipeline::run_hir_passes` (`pipeline.rs:622`), `compile_fn` (`:172`).

The smallest shape: an assignment whose value allocates (a call, an array or an object literal) in the test of a `?:`, and the assigned local as an operand of a memoized value (`[m]`, `{ m }`). The result of the conditional does not need to reach that value. `m = p.a` compiles. `&&`, `??`, `?.` or an `if` statement in place of `?:` compile. `<div data-m={m} />` compiles because nothing force-memoizes `m`. `--target=bun` and `--target=node` (ssr mode) create no reactive scopes and compile.

A second shape, with no assignment expression (the input of facebook/react#37228): `return (() => { try { return check(raw) ? raw : null; } catch { return null; } })();`. 1.4.2 aborts with the same panic and this branch skips the function with the same invariant. babel-plugin-react-compiler 1.0.0 skips it one step earlier, with `Todo: Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement`.

Two loop shapes with no `?:` at all, where `identity` is an imported function: `let r; do { r = identity(value); } while (cond()); return r;` and `let r; while (cond()) { r = identity(value); break; } return r;`. 1.4.2 aborts on both with the same panic, this branch skips the function, and babel-plugin-react-compiler 1.0.0 raises the same invariant and leaves the function as written. With `String(value)` in place of `identity(value)` nothing aborts. I ran both by hand on this branch. They are not in the test.

Why the node is missing. `compute_memoization_inputs` returns the rvalues of the consequent and the alternate of a `ConditionalExpression` only (upstream: "Conditionals do not alias their test value"), and `visit_instruction` does not traverse nested values on its own. So nothing calls `visit_operand` for `t = p.f()` or `m = t`, and `visit_operand` is the only place that creates a scope node. The scope is aligned to the whole `const r = ...` statement and lists `m` in `reassignments`, so `visit_scope` adds it to the node of `m`. The array `[m]` is `Memoized`, its scope depends on `m`, `m` is `Unmemoized` (from `let m;`) and forced, and the walk reaches the scope with no node. `(m = p.f()) ? p.a() : p.b()` compiles because the calls in the branches are in the same scope and create the node.

Upstream. `PruneNonEscapingScopes.ts` on facebook/react main still has all four invariants, and `react_compiler_reactive_scopes/src/prune_non_escaping_scopes.rs` there has the same four `.expect()` calls. I ran babel-plugin-react-compiler 1.0.0 on 20 variants of the input. It logs `CompileError: Expected a node for all scopes` and leaves the function as written for exactly the 10 variants that abort 1.4.3 canary. The two agree on the other 10 as well: 8 compile with one memo cache, 1 compiles with none, and 1 fails in both with `Unexpected StoreLocal in codegenInstructionValue`, which Bun already returns as an error. With this change Bun skips the same 10 functions.

Alternative not taken: create the scope node on demand in `force_memoize_scope_dependencies` from `env.scopes[id].dependencies`, which is all `visit_operand` stores. That compiles these functions, but upstream does not compile them, and nothing in that test value has been analysed by this pass.

The three `Expected identifier to be initialized` sites. Upstream never reaches them for the inputs below, but two other bugs of the port do. `visit_operand` (`:195`): a closure above a `let` that it reads and that is reassigned later, for example `const row = () => <Row items={items} />; let items = p.items; if (p.c) items = [];`. The lowering did not declare `items` before the closure there. #42390 fixed that (merged), and upstream compiles and memoizes those functions. `visit_scope` (`:1060`): dead code elimination dropped `let v` but kept a store to it, fixed in #42385 (merged). Those inputs were not parity cases, and they compile on main now. The conversion here is for the next input that reaches one of these sites. To exercise the three paths on their own I also forced each lookup to miss in a local build (one site at a time, selected by an environment variable, not committed). Each time `bun build` exited 0, the debug log showed `compile_fn err: ... "Expected identifier to be initialized"` for the affected functions, and the other functions in the file still compiled.

Not changed here: the other upstream invariants in this crate that are still `.expect()` or `assert!` (`build_reactive_scope_terminals_hir.rs:137/145/173`, `propagate_scope_dependencies_hir.rs:90/1772`, `align_reactive_scopes_to_block_scopes_hir.rs:262`, `eliminate_redundant_phi.rs:75`, `build_reactive_function.rs:216/1388`). No known input reaches them and each needs `Result` plumbing through a different pass. `align_object_method_scopes.rs` is #42375.

What the test checks. It bundles one file with `--target=browser` through the CLI and runs the output against a fake `react/compiler-runtime` whose `c` counts its calls. Four functions have the shape (call, array and object in the test, a `let m = null` initializer, a hook that returns the array, the conditional nested in a binary expression). A fifth is the facebook/react#37228 input, a `?:` in a `try` in an IIFE. Each returns the right value and makes 0 calls to `c`. Two controls (the same `?:` with `m` not memoized, and a plain component) make 1 call each, so the skip is per function and not per file. Each of the five aborts 1.4.2 on its own.

Sweep: built all 1807 source files under `test/bundler/transpiler/react-compiler-fixtures/` with `bun build --react-compiler --target=browser --external '*'` on 1.4.3 canary. None aborts, so no upstream fixture has this shape.

Suites run with the debug build, after the rebase on 7a7cc965bb: `test/bundler/transpiler/react-compiler.test.ts` (58 pass), `test/bundler/transpiler/react-compiler-fixtures.test.ts` (3293 pass, 320 skip). `cargo clippy -p bun_react_compiler` and `cargo fmt --check` are clean.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [1077.04ms]
(pass) bundler > react-compiler/ComponentWithHooks [1018.66ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [466.17ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [677.15ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [586.00ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [413.21ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [963.12ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [227.16ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [1037.88ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [325.23ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [307.01ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [538.68ms]
(pass) bundler > r
... (truncated)

release without fix: 12 failed, 1 skipped
bun test v1.4.3-canary.1 (3c62dfb52)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [63.16ms]
(pass) bundler > react-compiler/ComponentWithHooks [20.36ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [11.72ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [14.43ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [30.53ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [7.03ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [24.77ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [11.01ms]
1031 |       ]);
1032 |       const stdout = Buffer.from(stdoutBytes);
1033 |       const stderr = Buffer.from(stderrBytes);
1034 |       const success = exitCode === 0;
1035 |       if (buildProc.signalCode) {
1036 |         throw new Error(
                         ^
error: [react-compiler/SsrObjectMethodShorthand] 'bun build' subprocess killed by SIGABRT
cmd: /workspace/bun/build/release/bun build /tmp/bun-build-tests/bun-eKoWEm/react-compiler/SsrObjectMethodShorthand/entry.jsx --outfile=/tmp/bun-build-tests
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [984.04ms]
(pass) bundler > react-compiler/ComponentWithHooks [341.71ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [417.08ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [333.24ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [192.84ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [179.22ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [421.84ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [149.25ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [850.95ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [149.08ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [164.78ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [344.39ms]
(pass) bundler > reac
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 814ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
^[[1m^[[92m   Compiling^[[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
^[[1m^[[92m   Compiling^[[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
^[[1m^[[92m   Compiling^[[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
^[[1m^[[92m   Compiling^[[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
^[[1m^[[92m   Compiling^[[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
^[[1m^[[92m   Compiling^[[0m bun_router v0.0.0 (/workspace/bun/src/router)
^[[1m^[[92m   Compiling^[[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
^[[1m^[[92m   Compiling^[[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
^[[1m^[[92m   Compiling^[[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
^[[1m^[[92m   Compiling^[[0m bun_install v0.0.0 (/workspace/bun/src/install)
^[[1m^[[92m   Compiling^[[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
^[[1m^[[92m   Compiling^[[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
^[[1m^[[92m   Compiling^[[0m bun_http_jsc v0.0.0 (/work
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../reactive_scopes/prune_non_escaping_scopes.rs   | 103 +++++++++++++--------
 test/bundler/transpiler/react-compiler.test.ts     | 103 +++++++++++++++++++++
 2 files changed, 166 insertions(+), 40 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…t_compiler/reactive_scopes/prune_non_escaping_scopes.rs      6     12     29
test/bundler/transpiler/react-compiler.test.ts                2      4     29
```

</details>

<!-- robobun:evidence:end -->


