### PR TITLE
install: treat --concurrent-scripts=0 as the default instead of spinning forever

### DIFF
--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -1601,7 +1601,11 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
         }
 
         if let Some(concurrency) = args.option(b"--concurrent-scripts") {
-            cli.concurrent_scripts = strings::parse_int::<usize>(concurrency, 10).ok();
+            // 0 means the default, like `[install] concurrentScripts = 0` in bunfig.toml.
+            // With a limit of 0 no script can start and the wait loops spin.
+            cli.concurrent_scripts = strings::parse_int::<usize>(concurrency, 10)
+                .ok()
+                .filter(|&n| n != 0);
         }
 
         if let Some(cwd_) = args.option(b"--cwd") {

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -2171,6 +2171,55 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
     });
 
+    test("--concurrent-scripts=0 still runs the scripts", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+      const [trusted, untrusted] = await createPackagesWithScripts(packageDir, packageJson, 2, {
+        "postinstall": "touch postinstall.txt",
+      });
+      await writeFile(
+        packageJson,
+        JSON.stringify({ ...(await file(packageJson).json()), trustedDependencies: [trusted] }),
+      );
+
+      // With a limit of 0 both commands used to wait forever for a free script slot.
+      async function run(...args: string[]) {
+        await using proc = spawn({
+          cmd: [bunExe(), ...args, "--concurrent-scripts=0"],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "ignore",
+          stderr: "pipe",
+          env: testEnv,
+          // Only matters if the command never returns.
+          timeout: 30_000,
+          killSignal: "SIGKILL",
+        });
+        const [err, out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+        return { err, out, signalCode: proc.signalCode, exitCode };
+      }
+      const postinstallRan = () =>
+        Promise.all([trusted, untrusted].map(dep => exists(join(packageDir, "node_modules", dep, "postinstall.txt"))));
+
+      expect(await run("install")).toEqual({
+        err: expect.stringContaining("Saved lockfile"),
+        out: expect.stringContaining("Blocked 1 postinstall"),
+        signalCode: null,
+        exitCode: 0,
+      });
+      expect(await postinstallRan()).toEqual([true, false]);
+
+      expect(await run("pm", "trust", "--all")).toEqual({
+        err: expect.not.stringContaining("error:"),
+        out: expect.stringContaining("1 script ran across 1 package"),
+        signalCode: null,
+        exitCode: 0,
+      });
+      expect(await postinstallRan()).toEqual([true, true]);
+    });
+
     test("stress test", async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;


### PR DESCRIPTION
### Problem
- `bun install --concurrent-scripts=0` never exits once a dependency lifecycle script is queued. One core spins until the process is killed. `bun pm trust --concurrent-scripts=0` does the same.
- The CLI parser keeps the `0` (`src/install/PackageManager/CommandLineArguments.rs:1604`). With a limit of 0 no script can start, so each one is deferred. `complete_remaining_scripts` (`src/install/PackageInstaller.rs:920`) then loops on `while alive_count >= max_concurrent_lifecycle_scripts { manager.sleep() }`. That is `0 >= 0`, and `sleep()` returns at once because nothing is alive. `src/runtime/cli/pm_trusted_command.rs:472` has the same loop.

### Fix
- The CLI parser maps `0` to `None`. The limit then falls back to the default, 2x the CPU count.
- bunfig.toml already does this for `[install] concurrentScripts = 0` (`src/bunfig/bunfig.rs:1364`), and the docs call the two settings equivalent. The flag already falls back to the default for a value it cannot parse, for example `abc`.
- Verified: a new case in `test/cli/install/bun-install-lifecycle-scripts.test.ts` runs `bun install` and `bun pm trust --all` with the flag. Release 6a92015fc fails it (killed at the 30 s spawn timeout). The fixed debug build passes in about 1 s.

### Background
- A lifecycle script is a `preinstall`, `install`, or `postinstall` command from a dependency's package.json. Bun runs them for trusted dependencies only.
- `--concurrent-scripts` caps how many of these child processes run at once. `LifecycleScriptSubprocess::alive_count()` counts the live ones.
- The hoisted installer starts a script when a slot is free. It defers the others to `complete_remaining_scripts`, which waits for a slot with `manager.sleep()` (one event loop tick).

<details><summary>Notes</summary>

- Alternative: reject `0` with an error, the way `--network-concurrency` rejects a value that is not a number. This PR picks parity with bunfig.toml. An error is a one-line change if that is preferred.
- After this change no input sets the limit to 0. The default is at least 4, because `get_thread_count()` is clamped to a minimum of 2.
- Repro without a registry (`file:` dependency):
  ```sh
  d=$(mktemp -d); cd "$d"; mkdir dep
  echo '{"name":"dep","version":"1.0.0","scripts":{"postinstall":"echo postinstall-ran"}}' > dep/package.json
  echo '{"name":"app","version":"1.0.0","dependencies":{"dep":"file:./dep"},"trustedDependencies":["dep"]}' > package.json
  timeout -s KILL 15 bun install --concurrent-scripts=0; echo "exit=$?"   # exit=137 before, exit=0 after
  ```
- `bun pm trust dep --concurrent-scripts=0` on release 6a92015fc: also killed by the timeout (exit=137). The new test runs it after the install, so on an unfixed build the test stops at the install.
- The isolated linker does not read this limit. `--linker=isolated --concurrent-scripts=0` did not hang before.
- `bun bd test` on the whole file: 121 pass, 3 fail ("node -p should work in postinstall scripts" and "ensureTempNodeGypScript works" x2). Those 3 fail the same way on main under `bun bd test`, because `bun run` exports `NODE` to the test process. #37384 covers them. They pass with a release build.
- Found on the way, not part of this PR: `[install] concurrentScripts` in bunfig.toml overrides the `--concurrent-scripts` flag (`src/install/PackageManager/PackageManagerOptions.rs:569`).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts

<!-- robobun:evidence:end -->