### PR TITLE
Bump WebKit (oven-sh/WebKit#629 preview): DFG keeps for-of state alive across adjacent try ranges in --bytecode builds

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "cf1b36ec8703d8e87436094d21d478d358c7d886";
+export const WEBKIT_VERSION = "autobuild-preview-pr-629-79647d9f";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-629-79647d9f";
+export const WEBKIT_VERSION = "autobuild-preview-pr-629-c3d11c07";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -77,6 +77,71 @@ describe("bundler", () => {
     },
     run: { stdout: "RedisClient\nRedisClient\nRedisClient\n" },
   });
+  // The build-time bytecode optimizer deletes the jmp that ends a try body whose catch block is empty. When the try
+  // body ends by leaving a for-of loop, its try range then falls through into the try range of the loop's iterator
+  // close. The DFG kept the wrong handler's locals alive across that boundary (oven-sh/WebKit#629), so once the
+  // callee threw in DFG code the loop went on with `next` undefined:
+  // TypeError: undefined is not a function (near '...d of ["objects", "refs"]...')
+  itBundled("bun/bytecode-for-of-exit-from-try-with-empty-catch", {
+    target: "bun",
+    format: "cjs",
+    bytecode: true,
+    outdir: "/out",
+    files: {
+      "/entry.ts": /* js */ `
+        import { numberOfDFGCompiles } from "bun:jsc";
+
+        // The call throws for every element, except for the last element when c is "repo".
+        function returnFromTry(c: string) {
+          for (const d of ["objects", "refs"])
+            try {
+              return JSON.parse(c === "repo" && d === "refs" ? "1" : "{bad"), true;
+            } catch {}
+          return false;
+        }
+        function breakToOuterLabel(c: string) {
+          let found = false;
+          outer: for (const once of [0]) {
+            for (const d of ["objects", "refs"]) {
+              try {
+                JSON.parse(c === "repo" && d === "refs" ? "1" : "{bad");
+                found = true;
+                break outer;
+              } catch (e) {}
+            }
+          }
+          return found;
+        }
+        const map = new Map([["objects", 1], ["refs", 2]]);
+        function overMapEntries(c: string) {
+          for (const [d, n] of map)
+            try {
+              return JSON.parse(c === "repo" && d === "refs" ? "1" : "{bad"), n === 2;
+            } catch {}
+          return false;
+        }
+
+        // Calls fn until the DFG has compiled it, then 100 more times, so that the callee throws into DFG code.
+        function check(fn: (c: string) => boolean) {
+          for (let i = 0, callsAfterDFG = 0; callsAfterDFG < 100; i++) {
+            if (i === 100_000) return console.log(fn.name, "never reached the DFG");
+            const expected = i % 3 === 0;
+            let result;
+            try {
+              result = fn(expected ? "repo" : "x");
+            } catch (e) {
+              return console.log(fn.name, "threw at call", i, String(e));
+            }
+            if (result !== expected) return console.log(fn.name, "returned", result, "at call", i);
+            if (numberOfDFGCompiles(fn) > 0) callsAfterDFG++;
+          }
+          console.log(fn.name, "ok");
+        }
+        for (const fn of [returnFromTry, breakToOuterLabel, overMapEntries]) check(fn);
+      `,
+    },
+    run: { stdout: "returnFromTry ok\nbreakToOuterLabel ok\noverMapEntries ok\n" },
+  });
   itBundled("bun/embedded-sqlite-file", {
     target: "bun",
     outfile: "",


### PR DESCRIPTION
### Problem
- A `--bytecode` build throws `TypeError: undefined is not a function (near '...d of ["objects", "refs"]...')` from a `for…of` loop in DFG code. The loop body is `try { …return or break… } catch {}`, and a callee in the try throws.
- The bytecode optimizer (#42002) deletes the `jmp` that ends a try body when the catch block is empty. The try range then falls through into the iterator close's range.
- There, DFG's `LiveCatchVariablePreservationPhase` flushes the next handler's live locals, not those of the handler it leaves. The exception OSR exit restores the for-of state (`iterable`, `next`) as `undefined`.

### Fix
- Engine fix: oven-sh/WebKit#629 (by @dylan-conway). This PR pins `WEBKIT_VERSION` to the preview build of its current head, `autobuild-preview-pr-629-c3d11c07` (`cf1b36ec8703` plus the two commits of that PR).
- The preview tag goes away when oven-sh/WebKit#629 merges. Move the pin to the `autobuild-<merge sha>` release before you merge this PR.
- Verified: new case `bun/bytecode-for-of-exit-from-try-with-empty-catch` in `test/bundler/bundler_bun.test.ts`. bun 1.4.3 canary (`6a92015fc`) fails it. The pinned build passes. More suites: see Notes.

### Background
- An exception handler covers a bytecode range `[start, end)`. JSC's generator always ends a try body with a `jmp` inside the range. Nothing requires that.
- When a call in DFG code throws into a handler of the same function, DFG takes an OSR exit to the Baseline `catch`. A local that is dead in DFG comes back as `undefined`. The phase inserts `Flush` nodes to keep the needed locals alive.
- For an array, `iterator_next` expects the empty value in `next`. With `undefined` it calls `next`.

<details><summary>Notes</summary>

Repro (from the report), `entry.ts`:

```js
function y(c){for(let d of["objects","refs"])try{return JSON.parse(c==="repo"&&d==="refs"?"1":"{bad"),!0}catch{}return!1}
for(let i=0;i<20000;i++){try{y(i%3===0?"repo":"x")}catch(e){console.log("THREW at",i,String(e));process.exit(1)}}
console.log("ok")
```

- `bun build --compile --bytecode --format=esm --target=bun entry.ts --outfile app && ./app` throws at about call 1,100 to 1,600 on current main. `bun build --bytecode --format=cjs --target=bun --outdir out && bun out/entry.js` and `BUN_JSC_useBytecodeOptimizer=1 bun run entry.ts` throw too. With `BUN_JSC_useConcurrentJIT=0` every path throws at call 672, in release and in debug.
- On the pinned build all three paths print `ok` for 20,000 calls, with and without `BUN_JSC_useConcurrentJIT=0`.
- The pin first pointed at `autobuild-preview-pr-629-79647d9f`. oven-sh/WebKit#629 then gained a second commit (`c3d11c07a9`), which keys the live set on the (handler, inline call frame) pair. The pin moved to that head, and every check in these Notes ran again on it.

Optimized bytecode of `y` (`BUN_JSC_dumpGeneratedBytecodes=1`). The user catch covers `[44, 93)`. The iterator close handler covers `[93, 121)`. Stock bytecode has `jmp ->114` between `[105]` and the iterator close, inside the first range:

```
[  82] call_ignore_result callee:loc12, argc:2, argv:22      ; JSON.parse
[  87] mov                dst:loc9, src:Int32: 2
[  90] mov                dst:loc10, src:True
[  93] get_by_id          dst:loc12, base:loc8, property:3   ; iterator.return
...
[ 145] catch              exception:loc13, thrownValue:loc12
[ 149] jmp                targetLabel:-124(->25)             ; back to loop_hint
Exception Handlers:
	 1: { start: [  44] end: [  93] target: [ 145] } catch
	 2: { start: [  44] end: [  93] target: [ 151] } synthesized finally
	 3: { start: [  93] end: [ 121] target: [ 160] } synthesized catch
```

- Bytecode liveness is correct: `{loc4, loc6, loc7, loc8}` are live at `[145]` (`BUN_JSC_dumpBytecodeLivenessResults=1`).
- The DFG block for `bc#82` ends in a fall-through `Jump` whose origin is `bc#93`. The phase flushed `loc9`, `loc10` and `this` there (live at catch `[160]`), twice, and never `loc4`, `loc6`, `loc7`, `loc8`.
- `BUN_JSC_printEachOSRExit=1`: `DFG OSR exit #17 (D@129, bc#145, GenericUnwind) ... loc4:[Undefined] ... loc6:[Undefined] loc7:[Undefined] loc8:*cell(loc8)`. `BUN_JSC_poisonDeadOSRExitVariables=1` does not change the symptom, because these operands have no value source at all in the block.
- A statement in the catch body keeps the catch body between the try and the iterator close, so the `jmp` stays. That is why any non-empty catch is correct.

Test:
- The new `itBundled` case builds three functions with `bytecode: true, format: "cjs"`: `return` from the try, `break` to an outer label with `catch (e) {}`, and `for (const [d, n] of map)`. Each function runs until `numberOfDFGCompiles(fn) > 0`, then 100 more calls. It takes about 2.5 s under debug ASAN.
- The fix lives in the WebKit pin under `scripts/`, so a fail-before run that restores only `src/` and `packages/` cannot show the failing side. Fail-before was checked by hand: `USE_SYSTEM_BUN=1 bun test test/bundler/bundler_bun.test.ts -t bytecode-for-of`.
- Also ran on the pinned debug build: all of `test/bundler/bundler_bun.test.ts`, the `optimize` group of `test/bundler/bun-build-compile.test.ts`, `test/js/bun/compile/jit-policy.test.ts`, and the `exception|try-catch` fixtures of `test/js/bun/jsc-stress/jsc-stress.test.ts` (23 fixtures).

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 2 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bundler/bundler_bun.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bundler/bundler_bun.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/bundler_bun.test.ts:
(pass) bundler > bun/bytecode-depth-cli [1202.93ms]
(pass) bundler > bun/bytecode-depth-api [570.97ms]
(pass) bundler > bun/import-bun-format-cjs [623.51ms]
(pass) bundler > bun/bytecode-for-of-exit-from-try-with-empty-catch [1922.18ms]
(pass) bundler > bun/embedded-sqlite-file [458.23ms]
(pass) bundler > bun/sqlite-file [432.41ms]
(pass) bundler > bun/TargetBunNoSourcemapMessage [589.76ms]
(pass) bundler > bun/TargetBunSourcemapInline [575.14ms]
(pass) bundler > bun/unicode comment [422.55ms]
(pass) bundler > bun/ExportsConditionsDevelopmentAPI [364.11ms]
(pass) bundler > bun/ExportsConditionsDevelopmentInProductionAPI [426.59ms]
(pass) bundler > bun/ExportsConditionsDevelopmentCLI [488.32ms]
(pass) bundler > bun/ExportsConditionsDevelopmentInProductionCLI [503.66ms]

 13 pass
 0 fail
 23 expect() calls
Ran 13 tests across 1 file. [11.66s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts     |  2 +-
 test/bundler/bundler_bun.test.ts | 65 ++++++++++++++++++++++++++++++++++++++++
 2 files changed, 66 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
scripts/build/deps/webkit.ts          2      3     12
test/bundler/bundler_bun.test.ts      2      1     11
```

</details>

<!-- robobun:evidence:end -->
