### PR TITLE
Drain the CPU profiler while it runs so sampled callees are not pinned until exit

### DIFF
--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -29,6 +29,8 @@ unsafe extern "C" {
     /// `VM` is an opaque `UnsafeCell`-backed ZST handle; `&mut VM` is
     /// ABI-identical to a non-null `VM*`.
     safe fn Bun__startCPUProfiler(vm: &mut VM);
+    /// Same `&mut VM` contract as `Bun__startCPUProfiler`.
+    safe fn Bun__drainCPUProfilerIfNeeded(vm: &mut VM);
     /// `Option<&mut BunString>` is ABI-identical to a nullable `*mut BunString`
     /// via the guaranteed null-pointer optimization; the C++ side writes a +1
     /// ref into each non-null out-param and ignores nulls.
@@ -50,6 +52,13 @@ pub fn set_sampling_interval(interval: u32) {
 
 pub fn start_cpu_profiler(vm: &mut VM) {
     Bun__startCPUProfiler(vm);
+}
+
+/// Folds the samples taken since the last drain into the profile and releases
+/// the JS objects they reference. Cheap when the profiler is off or was
+/// drained recently, so the event loop calls it every tick.
+pub fn drain_cpu_profiler_if_needed(vm: &mut VM) {
+    Bun__drainCPUProfilerIfNeeded(vm);
 }
 
 pub(crate) fn stop_and_write_profile(

--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -56,8 +56,7 @@ pub fn start_cpu_profiler(vm: &mut VM, collect_markdown: bool) {
     Bun__startCPUProfiler(vm, collect_markdown);
 }
 
-/// Stops a profiler that `node:inspector` or `Worker.startCpuProfile` started
-/// and never stopped, and frees its profile data. No output is written.
+/// Stops a profiler that was never stopped (inspector or worker sessions) and frees its data.
 pub(crate) fn stop_cpu_profiler_if_running(vm: &mut VM) {
     Bun__stopCPUProfilerIfRunning(vm);
 }

--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -28,9 +28,11 @@ pub struct CPUProfilerConfig {
 unsafe extern "C" {
     /// `VM` is an opaque `UnsafeCell`-backed ZST handle; `&mut VM` is
     /// ABI-identical to a non-null `VM*`.
-    safe fn Bun__startCPUProfiler(vm: &mut VM);
+    safe fn Bun__startCPUProfiler(vm: &mut VM, collect_markdown: bool);
     /// Same `&mut VM` contract as `Bun__startCPUProfiler`.
     safe fn Bun__drainCPUProfilerIfNeeded(vm: &mut VM);
+    /// Same `&mut VM` contract as `Bun__startCPUProfiler`.
+    safe fn Bun__stopCPUProfilerIfRunning(vm: &mut VM);
     /// `Option<&mut BunString>` is ABI-identical to a nullable `*mut BunString`
     /// via the guaranteed null-pointer optimization; the C++ side writes a +1
     /// ref into each non-null out-param and ignores nulls.
@@ -50,13 +52,17 @@ pub fn set_sampling_interval(interval: u32) {
     Bun__setSamplingInterval(clamped as c_int);
 }
 
-pub fn start_cpu_profiler(vm: &mut VM) {
-    Bun__startCPUProfiler(vm);
+pub fn start_cpu_profiler(vm: &mut VM, collect_markdown: bool) {
+    Bun__startCPUProfiler(vm, collect_markdown);
 }
 
-/// Folds the samples taken since the last drain into the profile and releases
-/// the JS objects they reference. Cheap when the profiler is off or was
-/// drained recently, so the event loop calls it every tick.
+/// Stops a profiler that `node:inspector` or `Worker.startCpuProfile` started
+/// and never stopped, and frees its profile data. No output is written.
+pub(crate) fn stop_cpu_profiler_if_running(vm: &mut VM) {
+    Bun__stopCPUProfilerIfRunning(vm);
+}
+
+/// Folds pending samples into the profile and releases the JS objects they reference.
 pub fn drain_cpu_profiler_if_needed(vm: &mut VM) {
     Bun__drainCPUProfilerIfNeeded(vm);
 }

--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -28,7 +28,7 @@ pub struct CPUProfilerConfig {
 unsafe extern "C" {
     /// `VM` is an opaque `UnsafeCell`-backed ZST handle; `&mut VM` is
     /// ABI-identical to a non-null `VM*`.
-    safe fn Bun__startCPUProfiler(vm: &mut VM, collect_markdown: bool);
+    safe fn Bun__startCPUProfiler(vm: &mut VM);
     /// Same `&mut VM` contract as `Bun__startCPUProfiler`.
     safe fn Bun__drainCPUProfilerIfNeeded(vm: &mut VM);
     /// Same `&mut VM` contract as `Bun__startCPUProfiler`.
@@ -43,6 +43,8 @@ unsafe extern "C" {
     );
     /// Plain by-value `c_int`; sets a global sampler interval, no pointer invariants.
     safe fn Bun__setSamplingInterval(interval_microseconds: c_int);
+    /// Plain by-value `bool`; sets a thread-local flag.
+    safe fn Bun__setCPUProfilerCollectMarkdown(collect: bool);
 }
 
 pub fn set_sampling_interval(interval: u32) {
@@ -52,8 +54,13 @@ pub fn set_sampling_interval(interval: u32) {
     Bun__setSamplingInterval(clamped as c_int);
 }
 
-pub fn start_cpu_profiler(vm: &mut VM, collect_markdown: bool) {
-    Bun__startCPUProfiler(vm, collect_markdown);
+pub fn start_cpu_profiler(vm: &mut VM) {
+    Bun__startCPUProfiler(vm);
+}
+
+/// Whether profiles on this thread also build the per-function stats for `--cpu-prof-md`.
+pub fn set_collect_markdown(collect: bool) {
+    Bun__setCPUProfilerCollectMarkdown(collect);
 }
 
 /// Stops a profiler that was never stopped (inspector or worker sessions) and frees its data.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1862,6 +1862,7 @@ impl VirtualMachine {
                 bun_core::Output::err(<&'static str>::from(e), "Failed to write CPU profile", ());
             }
         }
+        crate::bun_cpu_profiler::stop_cpu_profiler_if_running(self.jsc_vm_mut());
         // Write heap profile if profiling was enabled - do this after CPU
         // profile but before shutdown.
         if let Some(config) = self.heap_profiler_config.take() {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1862,7 +1862,6 @@ impl VirtualMachine {
                 bun_core::Output::err(<&'static str>::from(e), "Failed to write CPU profile", ());
             }
         }
-        crate::bun_cpu_profiler::stop_cpu_profiler_if_running(self.jsc_vm_mut());
         // Write heap profile if profiling was enabled - do this after CPU
         // profile but before shutdown.
         if let Some(config) = self.heap_profiler_config.take() {
@@ -1883,6 +1882,9 @@ impl VirtualMachine {
         }
 
         self.is_shutting_down = true;
+
+        // After exit handlers, so a `Profiler.stop` in one still gets its profile.
+        crate::bun_cpu_profiler::stop_cpu_profiler_if_running(self.jsc_vm_mut());
 
         if self.exit_tears_down_napi_envs() {
             self.run_cleanup_hooks();

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -19,8 +19,9 @@
 #include <limits>
 #include <memory>
 
-extern "C" void Bun__startCPUProfiler(JSC::VM* vm);
+extern "C" void Bun__startCPUProfiler(JSC::VM* vm, bool collectMarkdown);
 extern "C" void Bun__drainCPUProfilerIfNeeded(JSC::VM* vm);
+extern "C" void Bun__stopCPUProfilerIfRunning(JSC::VM* vm);
 extern "C" void Bun__stopCPUProfiler(JSC::VM* vm, BunString* outJSON, BunString* outText);
 extern "C" void Bun__setSamplingInterval(int intervalMicroseconds);
 
@@ -252,12 +253,7 @@ static WTF::String generateEmptyProfileJSON()
     return sb.toString();
 }
 
-// Everything the .cpuprofile JSON and the markdown report need, folded in one
-// batch of samples at a time. Samples are drained from the SamplingProfiler
-// while it runs (see drainCPUProfilerIfNeeded) so that its StackFrame objects,
-// whose `callee` and `executable` pointers the profiler marks as GC roots,
-// are released long before the profile is written. Only names, URLs, line
-// numbers and counts live here, never JS objects.
+// Profile output folded in one batch of samples at a time. Holds no JS objects.
 struct ProfileData {
     // Chrome DevTools format: call tree keyed by parent id + function identity.
     WTF::HashMap<WTF::String, int> nodeMap;
@@ -266,17 +262,16 @@ struct ProfileData {
     WTF::Vector<int> samples;
     WTF::Vector<long long> timeDeltas;
 
-    // Markdown format: per-function aggregates.
+    // Markdown format: per-function aggregates. Only built when requested.
+    bool collectMarkdown { false };
     WTF::HashMap<WTF::String, FunctionStats> functionStatsMap;
     long long totalTimeUs { 0 };
     int totalSamples { 0 };
 
-    // Wall clock time (microseconds since the Unix epoch) of the last sample
-    // folded in. Both formats measure deltas from it.
+    // Wall clock microseconds of the last sample folded in.
     double lastTime { 0.0 };
 
-    // URL parsing dominates the per-frame cost. A profile sees few distinct
-    // URLs, so memoize the two conversions by input string.
+    // URL parsing dominates the per-frame cost, so both conversions are memoized.
     WTF::HashMap<WTF::String, WTF::String> normalizedURLs;
     WTF::HashMap<WTF::String, WTF::String> fileSystemPaths;
 };
@@ -285,14 +280,14 @@ static thread_local ProfileData* s_profileData = nullptr;
 static thread_local WTF::MonotonicTime s_lastDrainTime;
 static constexpr WTF::Seconds kDrainInterval = WTF::Seconds::fromMilliseconds(100);
 
-void startCPUProfiler(JSC::VM& vm)
+void startCPUProfiler(JSC::VM& vm, bool collectMarkdown)
 {
-    // Capture the wall clock time when profiling starts (before creating stopwatch)
-    // This will be used as the profile's startTime
+    // The profile's startTime.
     s_profilingStartTime = MonotonicTime::now().approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
 
     delete s_profileData;
     s_profileData = new ProfileData();
+    s_profileData->collectMarkdown = collectMarkdown;
     s_profileData->lastTime = s_profilingStartTime;
 
     ProfileNode rootNode;
@@ -342,9 +337,7 @@ static WTF::String formatLocation(ProfileData& data, const WTF::String& url, int
     return path;
 }
 
-// Absolute file path → `file://` URL. Chrome DevTools expects `callFrame.url`
-// to be a proper URL; leaving the raw path breaks source-view resolution.
-// See #29240.
+// Absolute file path to `file://` URL, as Chrome DevTools expects (#29240).
 static void normalizeURL(ProfileData& data, WTF::String& u)
 {
     if (u.isEmpty())
@@ -370,9 +363,7 @@ static void normalizeURL(ProfileData& data, WTF::String& u)
     data.normalizedURLs.add(input, u);
 }
 
-// Fold one batch of stack traces into `data`. The caller holds the JSLock
-// and defers GC: the frames carry raw pointers into the heap that nothing
-// marks once releaseStackTraces() has cleared the profiler's live cell set.
+// The caller holds the JSLock and defers GC: the frames carry raw heap pointers.
 static void appendStackTraces(JSC::VM& vm, ProfileData& data, WTF::Vector<JSC::SamplingProfiler::StackTrace>&& stackTraces)
 {
     // Sort traces by timestamp once for both formats
@@ -401,15 +392,13 @@ static void appendStackTraces(JSC::VM& vm, ProfileData& data, WTF::Vector<JSC::S
             continue;
         }
 
-        // displayName() looks up properties on the callee. Both walks below
-        // need it, so resolve it once per frame.
+        // displayName() reads properties on the callee, so resolve it once per frame.
         WTF::Vector<WTF::String> frameNames;
         frameNames.reserveInitialCapacity(stackTrace.frames.size());
         for (auto& frame : stackTrace.frames)
             frameNames.append(frame.displayName(vm));
 
-        // JSON format: walk the stack from the outermost frame and place each
-        // frame under its parent in the call tree.
+        // JSON format: call tree from the outermost frame.
         {
             int currentParentId = 1;
 
@@ -433,11 +422,7 @@ static void appendStackTraces(JSC::VM& vm, ProfileData& data, WTF::Vector<JSC::S
                         scriptId = static_cast<int>(provider->asID());
                     }
 
-                    // normalizeURL runs AFTER the sourcemap callbacks below
-                    // because the callback (see FormatStackTraceForJS.cpp)
-                    // unconditionally rewrites its out-param back to the raw
-                    // provider URL when no sourcemap is found, which would
-                    // undo an earlier normalization. See #29240.
+                    // The sourcemap callback resets `url` to the raw provider URL, so normalizeURL runs after it (#29240).
 
                     // Function definition location. JSC returns these 1-based;
                     // Node/Deno/Chrome DevTools emit them 0-based in the JSON.
@@ -561,7 +546,7 @@ static void appendStackTraces(JSC::VM& vm, ProfileData& data, WTF::Vector<JSC::S
         }
 
         // Markdown format: per-function self/total time and caller/callee counts.
-        {
+        if (data.collectMarkdown) {
             WTF::String previousKey;
 
             for (int i = stackTrace.frames.size() - 1; i >= 0; i--) {
@@ -646,13 +631,14 @@ void drainCPUProfilerIfNeeded(JSC::VM& vm)
     JSC::JSLockHolder locker(vm);
     JSC::DeferGC deferGC(vm);
 
-    auto& lock = profiler->getLock();
-    WTF::Locker profilerLocker { lock };
-
-    // releaseStackTraces() calls processUnverifiedStackTraces() internally
-    // and clears the profiler's live cell set, so the sampled callees and
-    // executables stop being GC roots here.
-    auto stackTraces = profiler->releaseStackTraces();
+    WTF::Vector<JSC::SamplingProfiler::StackTrace> stackTraces;
+    {
+        // The sampling thread takes the same lock, so hold it only for the release.
+        auto& lock = profiler->getLock();
+        WTF::Locker profilerLocker { lock };
+        // releaseStackTraces() clears the profiler's live cell set: the sampled callees stop being GC roots here.
+        stackTraces = profiler->releaseStackTraces();
+    }
     if (!stackTraces.isEmpty())
         appendStackTraces(vm, *s_profileData, WTF::move(stackTraces));
 }
@@ -996,9 +982,15 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
 
 } // namespace Bun
 
-extern "C" void Bun__startCPUProfiler(JSC::VM* vm)
+extern "C" void Bun__startCPUProfiler(JSC::VM* vm, bool collectMarkdown)
 {
-    Bun::startCPUProfiler(*vm);
+    Bun::startCPUProfiler(*vm, collectMarkdown);
+}
+
+extern "C" void Bun__stopCPUProfilerIfRunning(JSC::VM* vm)
+{
+    if (Bun::isCPUProfilerRunning())
+        Bun::stopCPUProfiler(*vm, nullptr, nullptr);
 }
 
 extern "C" void Bun__drainCPUProfilerIfNeeded(JSC::VM* vm)

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -104,28 +104,6 @@ static WTF::String formatFunctionName(const WTF::String& name, const JSC::Sampli
     return displayName;
 }
 
-// Helper to format a location string from URL and line number
-static WTF::String formatLocation(const WTF::String& url, int lineNumber)
-{
-    if (url.isEmpty())
-        return "[native code]"_s;
-
-    // Extract path from file:// URL using WTF::URL
-    WTF::String path = url;
-    WTF::URL parsedUrl { url };
-    if (parsedUrl.isValid() && parsedUrl.protocolIsFile())
-        path = parsedUrl.fileSystemPath();
-
-    if (lineNumber >= 0) {
-        WTF::StringBuilder sb;
-        sb.append(path);
-        sb.append(':');
-        sb.append(lineNumber);
-        return sb.toString();
-    }
-    return path;
-}
-
 // Helper to format time in human-readable form
 static WTF::String formatTime(double microseconds)
 {
@@ -296,6 +274,11 @@ struct ProfileData {
     // Wall clock time (microseconds since the Unix epoch) of the last sample
     // folded in. Both formats measure deltas from it.
     double lastTime { 0.0 };
+
+    // URL parsing dominates the per-frame cost. A profile sees few distinct
+    // URLs, so memoize the two conversions by input string.
+    WTF::HashMap<WTF::String, WTF::String> normalizedURLs;
+    WTF::HashMap<WTF::String, WTF::String> fileSystemPaths;
 };
 
 static thread_local ProfileData* s_profileData = nullptr;
@@ -334,13 +317,44 @@ void startCPUProfiler(JSC::VM& vm)
     s_isProfilerRunning = true;
 }
 
+// Helper to format a location string from URL and line number
+static WTF::String formatLocation(ProfileData& data, const WTF::String& url, int lineNumber)
+{
+    if (url.isEmpty())
+        return "[native code]"_s;
+
+    // Extract path from file:// URL using WTF::URL
+    auto cached = data.fileSystemPaths.ensure(url, [&] {
+        WTF::URL parsedUrl { url };
+        if (parsedUrl.isValid() && parsedUrl.protocolIsFile())
+            return parsedUrl.fileSystemPath();
+        return url;
+    });
+    const WTF::String& path = cached.iterator->value;
+
+    if (lineNumber >= 0) {
+        WTF::StringBuilder sb;
+        sb.append(path);
+        sb.append(':');
+        sb.append(lineNumber);
+        return sb.toString();
+    }
+    return path;
+}
+
 // Absolute file path → `file://` URL. Chrome DevTools expects `callFrame.url`
 // to be a proper URL; leaving the raw path breaks source-view resolution.
 // See #29240.
-static void normalizeURL(WTF::String& u)
+static void normalizeURL(ProfileData& data, WTF::String& u)
 {
     if (u.isEmpty())
         return;
+    auto cached = data.normalizedURLs.find(u);
+    if (cached != data.normalizedURLs.end()) {
+        u = cached->value;
+        return;
+    }
+    WTF::String input = u;
     bool isAbsolutePath = false;
     if (u[0] == '/') {
         isAbsolutePath = true;
@@ -353,6 +367,7 @@ static void normalizeURL(WTF::String& u)
     }
     if (isAbsolutePath)
         u = WTF::URL::fileURLWithFileSystemPath(u).string();
+    data.normalizedURLs.add(input, u);
 }
 
 // Fold one batch of stack traces into `data`. The caller holds the JSLock
@@ -456,7 +471,7 @@ static void appendStackTraces(JSC::VM& vm, ProfileData& data, WTF::Vector<JSC::S
 
                     // Normalize `url` to a `file://` URL now that any
                     // sourcemap rewriting is done.
-                    normalizeURL(url);
+                    normalizeURL(data, url);
 
                     if (frame.hasExpressionInfo()) {
                         // Sample position for positionTicks. Use a throwaway
@@ -487,7 +502,7 @@ static void appendStackTraces(JSC::VM& vm, ProfileData& data, WTF::Vector<JSC::S
                             }
 #endif
                         }
-                        normalizeURL(sampleURL);
+                        normalizeURL(data, sampleURL);
                         if (sourceMappedLineColumn.line > 0 && sampleURL == url)
                             sampleLine = static_cast<int>(sourceMappedLineColumn.line);
                     }
@@ -561,7 +576,7 @@ static void appendStackTraces(JSC::VM& vm, ProfileData& data, WTF::Vector<JSC::S
                     auto* provider = std::get<0>(sourceProviderAndID);
                     if (provider) {
                         url = provider->sourceURL();
-                        normalizeURL(url);
+                        normalizeURL(data, url);
                     }
 
                     if (frame.hasExpressionInfo()) {
@@ -577,7 +592,7 @@ static void appendStackTraces(JSC::VM& vm, ProfileData& data, WTF::Vector<JSC::S
                     }
                 }
 
-                WTF::String location = formatLocation(url, lineNumber);
+                WTF::String location = formatLocation(data, url, lineNumber);
                 // Key uses zero-width space separator internally (not shown in output)
                 WTF::StringBuilder keyBuilder;
                 keyBuilder.append(functionName);

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -17,8 +17,10 @@
 #include <wtf/URL.h>
 #include <algorithm>
 #include <limits>
+#include <memory>
 
 extern "C" void Bun__startCPUProfiler(JSC::VM* vm);
+extern "C" void Bun__drainCPUProfilerIfNeeded(JSC::VM* vm);
 extern "C" void Bun__stopCPUProfiler(JSC::VM* vm, BunString* outJSON, BunString* outText);
 extern "C" void Bun__setSamplingInterval(int intervalMicroseconds);
 
@@ -43,23 +45,6 @@ void setSamplingInterval(int intervalMicroseconds)
 bool isCPUProfilerRunning()
 {
     return s_isProfilerRunning;
-}
-
-void startCPUProfiler(JSC::VM& vm)
-{
-    // Capture the wall clock time when profiling starts (before creating stopwatch)
-    // This will be used as the profile's startTime
-    s_profilingStartTime = MonotonicTime::now().approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
-
-    // Create a stopwatch and start it
-    auto stopwatch = WTF::Stopwatch::create();
-    stopwatch->start();
-
-    JSC::SamplingProfiler& samplingProfiler = vm.ensureSamplingProfiler(WTF::move(stopwatch));
-    samplingProfiler.setTimingInterval(WTF::Seconds::fromMicroseconds(s_samplingInterval));
-    samplingProfiler.noticeCurrentThreadAsJSCExecutionThread();
-    samplingProfiler.start();
-    s_isProfilerRunning = true;
 }
 
 struct ProfileNode {
@@ -289,43 +274,92 @@ static WTF::String generateEmptyProfileJSON()
     return sb.toString();
 }
 
-// Unified function that stops the profiler and generates requested output formats
-void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
+// Everything the .cpuprofile JSON and the markdown report need, folded in one
+// batch of samples at a time. Samples are drained from the SamplingProfiler
+// while it runs (see drainCPUProfilerIfNeeded) so that its StackFrame objects,
+// whose `callee` and `executable` pointers the profiler marks as GC roots,
+// are released long before the profile is written. Only names, URLs, line
+// numbers and counts live here, never JS objects.
+struct ProfileData {
+    // Chrome DevTools format: call tree keyed by parent id + function identity.
+    WTF::HashMap<WTF::String, int> nodeMap;
+    WTF::Vector<ProfileNode> nodes;
+    int nextNodeId { 2 };
+    WTF::Vector<int> samples;
+    WTF::Vector<long long> timeDeltas;
+
+    // Markdown format: per-function aggregates.
+    WTF::HashMap<WTF::String, FunctionStats> functionStatsMap;
+    long long totalTimeUs { 0 };
+    int totalSamples { 0 };
+
+    // Wall clock time (microseconds since the Unix epoch) of the last sample
+    // folded in. Both formats measure deltas from it.
+    double lastTime { 0.0 };
+};
+
+static thread_local ProfileData* s_profileData = nullptr;
+static thread_local WTF::MonotonicTime s_lastDrainTime;
+static constexpr WTF::Seconds kDrainInterval = WTF::Seconds::fromMilliseconds(100);
+
+void startCPUProfiler(JSC::VM& vm)
 {
-    s_isProfilerRunning = false;
+    // Capture the wall clock time when profiling starts (before creating stopwatch)
+    // This will be used as the profile's startTime
+    s_profilingStartTime = MonotonicTime::now().approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
 
-    JSC::SamplingProfiler* profiler = vm.samplingProfiler();
-    if (!profiler) {
-        if (outJSON) *outJSON = WTF::String();
-        if (outText) *outText = WTF::String();
+    delete s_profileData;
+    s_profileData = new ProfileData();
+    s_profileData->lastTime = s_profilingStartTime;
+
+    ProfileNode rootNode;
+    rootNode.id = 1;
+    rootNode.functionName = "(root)"_s;
+    rootNode.url = ""_s;
+    rootNode.scriptId = 0;
+    rootNode.lineNumber = -1;
+    rootNode.columnNumber = -1;
+    rootNode.hitCount = 0;
+    s_profileData->nodes.append(WTF::move(rootNode));
+
+    // Create a stopwatch and start it
+    auto stopwatch = WTF::Stopwatch::create();
+    stopwatch->start();
+
+    JSC::SamplingProfiler& samplingProfiler = vm.ensureSamplingProfiler(WTF::move(stopwatch));
+    samplingProfiler.setTimingInterval(WTF::Seconds::fromMicroseconds(s_samplingInterval));
+    samplingProfiler.noticeCurrentThreadAsJSCExecutionThread();
+    samplingProfiler.start();
+    s_lastDrainTime = MonotonicTime::now();
+    s_isProfilerRunning = true;
+}
+
+// Absolute file path → `file://` URL. Chrome DevTools expects `callFrame.url`
+// to be a proper URL; leaving the raw path breaks source-view resolution.
+// See #29240.
+static void normalizeURL(WTF::String& u)
+{
+    if (u.isEmpty())
         return;
+    bool isAbsolutePath = false;
+    if (u[0] == '/') {
+        isAbsolutePath = true;
+    } else if (u.length() >= 2 && u[1] == ':') {
+        char firstChar = u[0];
+        if ((firstChar >= 'A' && firstChar <= 'Z') || (firstChar >= 'a' && firstChar <= 'z'))
+            isAbsolutePath = true;
+    } else if (u.length() >= 2 && u[0] == '\\' && u[1] == '\\') {
+        isAbsolutePath = true;
     }
+    if (isAbsolutePath)
+        u = WTF::URL::fileURLWithFileSystemPath(u).string();
+}
 
-    // JSLock is re-entrant, so always acquiring it handles both JS and shutdown contexts
-    JSC::JSLockHolder locker(vm);
-
-    // Defer GC while we're working with stack traces
-    JSC::DeferGC deferGC(vm);
-
-    // Pause the profiler while holding the lock
-    auto& lock = profiler->getLock();
-    WTF::Locker profilerLocker { lock };
-    profiler->pause();
-
-    // releaseStackTraces() calls processUnverifiedStackTraces() internally
-    auto stackTraces = profiler->releaseStackTraces();
-    profiler->clearData();
-
-    // If neither output is requested, we're done
-    if (!outJSON && !outText)
-        return;
-
-    if (stackTraces.isEmpty()) {
-        if (outJSON) *outJSON = generateEmptyProfileJSON();
-        if (outText) *outText = "No samples collected.\n"_s;
-        return;
-    }
-
+// Fold one batch of stack traces into `data`. The caller holds the JSLock
+// and defers GC: the frames carry raw pointers into the heap that nothing
+// marks once releaseStackTraces() has cleared the profiler's live cell set.
+static void appendStackTraces(JSC::VM& vm, ProfileData& data, WTF::Vector<JSC::SamplingProfiler::StackTrace>&& stackTraces)
+{
     // Sort traces by timestamp once for both formats
     WTF::Vector<size_t> sortedIndices;
     sortedIndices.reserveInitialCapacity(stackTraces.size());
@@ -336,47 +370,38 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
         return stackTraces[a].timestamp < stackTraces[b].timestamp;
     });
 
-    // Generate JSON format if requested
-    if (outJSON) {
-        // Map from stack frame signature to node ID
-        WTF::HashMap<WTF::String, int> nodeMap;
-        WTF::Vector<ProfileNode> nodes;
+    data.totalSamples += static_cast<int>(stackTraces.size());
 
-        // Create root node
-        ProfileNode rootNode;
-        rootNode.id = 1;
-        rootNode.functionName = "(root)"_s;
-        rootNode.url = ""_s;
-        rootNode.scriptId = 0;
-        rootNode.lineNumber = -1;
-        rootNode.columnNumber = -1;
-        rootNode.hitCount = 0;
-        nodes.append(WTF::move(rootNode));
+    for (size_t idx : sortedIndices) {
+        auto& stackTrace = stackTraces[idx];
 
-        int nextNodeId = 2;
-        WTF::Vector<int> samples;
-        WTF::Vector<long long> timeDeltas;
+        double currentTime = stackTrace.timestamp.approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
+        long long deltaUs = static_cast<long long>(std::max(0.0, currentTime - data.lastTime));
+        data.lastTime = currentTime;
+        data.totalTimeUs += deltaUs;
+        data.timeDeltas.append(deltaUs);
 
-        double startTime = s_profilingStartTime;
-        double lastTime = s_profilingStartTime;
+        if (stackTrace.frames.isEmpty()) {
+            data.samples.append(1);
+            continue;
+        }
 
-        for (size_t idx : sortedIndices) {
-            auto& stackTrace = stackTraces[idx];
-            if (stackTrace.frames.isEmpty()) {
-                samples.append(1);
-                double currentTime = stackTrace.timestamp.approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
-                double delta = std::max(0.0, currentTime - lastTime);
-                timeDeltas.append(static_cast<long long>(delta));
-                lastTime = currentTime;
-                continue;
-            }
+        // displayName() looks up properties on the callee. Both walks below
+        // need it, so resolve it once per frame.
+        WTF::Vector<WTF::String> frameNames;
+        frameNames.reserveInitialCapacity(stackTrace.frames.size());
+        for (auto& frame : stackTrace.frames)
+            frameNames.append(frame.displayName(vm));
 
+        // JSON format: walk the stack from the outermost frame and place each
+        // frame under its parent in the call tree.
+        {
             int currentParentId = 1;
 
             for (int i = stackTrace.frames.size() - 1; i >= 0; i--) {
                 auto& frame = stackTrace.frames[i];
 
-                WTF::String functionName = frame.displayName(vm);
+                WTF::String functionName = frameNames[i];
                 WTF::String url;
                 int scriptId = 0;
                 // Function-definition line/column (0-indexed) for callFrame.
@@ -393,30 +418,11 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
                         scriptId = static_cast<int>(provider->asID());
                     }
 
-                    // Absolute file path → `file://` URL. Chrome DevTools
-                    // expects `callFrame.url` to be a proper URL; leaving
-                    // the raw path breaks source-view resolution. We run
-                    // this AFTER the sourcemap callbacks below because the
-                    // callback (see FormatStackTraceForJS.cpp) unconditionally
-                    // rewrites its out-param back to the raw provider URL when
-                    // no sourcemap is found, which would undo an earlier
-                    // normalization. See #29240.
-                    auto normalizeURL = [](WTF::String& u) {
-                        if (u.isEmpty())
-                            return;
-                        bool isAbsolutePath = false;
-                        if (u[0] == '/') {
-                            isAbsolutePath = true;
-                        } else if (u.length() >= 2 && u[1] == ':') {
-                            char firstChar = u[0];
-                            if ((firstChar >= 'A' && firstChar <= 'Z') || (firstChar >= 'a' && firstChar <= 'z'))
-                                isAbsolutePath = true;
-                        } else if (u.length() >= 2 && u[0] == '\\' && u[1] == '\\') {
-                            isAbsolutePath = true;
-                        }
-                        if (isAbsolutePath)
-                            u = WTF::URL::fileURLWithFileSystemPath(u).string();
-                    };
+                    // normalizeURL runs AFTER the sourcemap callbacks below
+                    // because the callback (see FormatStackTraceForJS.cpp)
+                    // unconditionally rewrites its out-param back to the raw
+                    // provider URL when no sourcemap is found, which would
+                    // undo an earlier normalization. See #29240.
 
                     // Function definition location. JSC returns these 1-based;
                     // Node/Deno/Chrome DevTools emit them 0-based in the JSON.
@@ -505,10 +511,10 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
                 WTF::String key = keyBuilder.toString();
 
                 int nodeId;
-                auto it = nodeMap.find(key);
-                if (it == nodeMap.end()) {
-                    nodeId = nextNodeId++;
-                    nodeMap.add(key, nodeId);
+                auto it = data.nodeMap.find(key);
+                if (it == data.nodeMap.end()) {
+                    nodeId = data.nextNodeId++;
+                    data.nodeMap.add(key, nodeId);
 
                     ProfileNode node;
                     node.id = nodeId;
@@ -519,10 +525,10 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
                     node.columnNumber = functionDefColumn;
                     node.hitCount = 0;
 
-                    nodes.append(WTF::move(node));
+                    data.nodes.append(WTF::move(node));
 
                     if (currentParentId > 0)
-                        nodes[currentParentId - 1].children.append(nodeId);
+                        data.nodes[currentParentId - 1].children.append(nodeId);
                 } else {
                     nodeId = it->value;
                 }
@@ -530,28 +536,166 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
                 currentParentId = nodeId;
 
                 if (i == 0) {
-                    nodes[nodeId - 1].hitCount++;
+                    data.nodes[nodeId - 1].hitCount++;
                     if (sampleLine > 0)
-                        nodes[nodeId - 1].positionTicks.add(sampleLine, 0).iterator->value++;
+                        data.nodes[nodeId - 1].positionTicks.add(sampleLine, 0).iterator->value++;
                 }
             }
 
-            samples.append(currentParentId);
-
-            double currentTime = stackTrace.timestamp.approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
-            double delta = std::max(0.0, currentTime - lastTime);
-            timeDeltas.append(static_cast<long long>(delta));
-            lastTime = currentTime;
+            data.samples.append(currentParentId);
         }
 
-        double endTime = lastTime;
+        // Markdown format: per-function self/total time and caller/callee counts.
+        {
+            WTF::String previousKey;
+
+            for (int i = stackTrace.frames.size() - 1; i >= 0; i--) {
+                auto& frame = stackTrace.frames[i];
+
+                WTF::String functionName = formatFunctionName(frameNames[i], frame);
+                WTF::String url;
+                int lineNumber = -1;
+
+                if (frame.frameType == JSC::SamplingProfiler::FrameType::Executable && frame.executable) {
+                    auto sourceProviderAndID = frame.sourceProviderAndID();
+                    auto* provider = std::get<0>(sourceProviderAndID);
+                    if (provider) {
+                        url = provider->sourceURL();
+                        normalizeURL(url);
+                    }
+
+                    if (frame.hasExpressionInfo()) {
+                        JSC::LineColumn sourceMappedLineColumn = frame.semanticLocation.lineColumn;
+                        if (provider) {
+#if USE(BUN_JSC_ADDITIONS)
+                            auto& fn = vm.computeLineColumnWithSourcemap();
+                            if (fn)
+                                fn(vm, provider, sourceMappedLineColumn, url);
+#endif
+                        }
+                        lineNumber = static_cast<int>(sourceMappedLineColumn.line);
+                    }
+                }
+
+                WTF::String location = formatLocation(url, lineNumber);
+                // Key uses zero-width space separator internally (not shown in output)
+                WTF::StringBuilder keyBuilder;
+                keyBuilder.append(functionName);
+                keyBuilder.append(kKeySeparator);
+                keyBuilder.append(location);
+                WTF::String key = keyBuilder.toString();
+
+                auto result = data.functionStatsMap.add(key, FunctionStats());
+                FunctionStats& stats = result.iterator->value;
+                if (result.isNewEntry) {
+                    stats.functionName = functionName;
+                    stats.location = location;
+                }
+
+                stats.totalSamples++;
+                stats.totalTimeUs += deltaUs;
+
+                if (i == 0) {
+                    stats.selfSamples++;
+                    stats.selfTimeUs += deltaUs;
+                }
+
+                if (!previousKey.isEmpty()) {
+                    stats.callers.add(previousKey, 0).iterator->value++;
+
+                    auto prevIt = data.functionStatsMap.find(previousKey);
+                    if (prevIt != data.functionStatsMap.end())
+                        prevIt->value.callees.add(key, 0).iterator->value++;
+                }
+
+                previousKey = key;
+            }
+        }
+    }
+}
+
+void drainCPUProfilerIfNeeded(JSC::VM& vm)
+{
+    if (!s_isProfilerRunning || !s_profileData)
+        return;
+
+    auto now = MonotonicTime::now();
+    if (now - s_lastDrainTime < kDrainInterval)
+        return;
+    s_lastDrainTime = now;
+
+    JSC::SamplingProfiler* profiler = vm.samplingProfiler();
+    if (!profiler)
+        return;
+
+    JSC::JSLockHolder locker(vm);
+    JSC::DeferGC deferGC(vm);
+
+    auto& lock = profiler->getLock();
+    WTF::Locker profilerLocker { lock };
+
+    // releaseStackTraces() calls processUnverifiedStackTraces() internally
+    // and clears the profiler's live cell set, so the sampled callees and
+    // executables stop being GC roots here.
+    auto stackTraces = profiler->releaseStackTraces();
+    if (!stackTraces.isEmpty())
+        appendStackTraces(vm, *s_profileData, WTF::move(stackTraces));
+}
+
+// Unified function that stops the profiler and generates requested output formats
+void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
+{
+    s_isProfilerRunning = false;
+
+    std::unique_ptr<ProfileData> data(s_profileData);
+    s_profileData = nullptr;
+
+    JSC::SamplingProfiler* profiler = vm.samplingProfiler();
+    if (!profiler) {
+        if (outJSON) *outJSON = WTF::String();
+        if (outText) *outText = WTF::String();
+        return;
+    }
+
+    // JSLock is re-entrant, so always acquiring it handles both JS and shutdown contexts
+    JSC::JSLockHolder locker(vm);
+
+    // Defer GC while we're working with stack traces
+    JSC::DeferGC deferGC(vm);
+
+    // Pause the profiler while holding the lock
+    auto& lock = profiler->getLock();
+    WTF::Locker profilerLocker { lock };
+    profiler->pause();
+
+    // releaseStackTraces() calls processUnverifiedStackTraces() internally
+    auto stackTraces = profiler->releaseStackTraces();
+    profiler->clearData();
+
+    // If neither output is requested, we're done
+    if (!outJSON && !outText)
+        return;
+
+    if (data && !stackTraces.isEmpty())
+        appendStackTraces(vm, *data, WTF::move(stackTraces));
+
+    if (!data || data->totalSamples == 0) {
+        if (outJSON) *outJSON = generateEmptyProfileJSON();
+        if (outText) *outText = "No samples collected.\n"_s;
+        return;
+    }
+
+    // Generate JSON format if requested
+    if (outJSON) {
+        double startTime = s_profilingStartTime;
+        double endTime = data->lastTime;
 
         // Build JSON
         using namespace WTF;
         auto json = JSON::Object::create();
 
         auto nodesArray = JSON::Array::create();
-        for (const auto& node : nodes) {
+        for (const auto& node : data->nodes) {
             auto nodeObj = JSON::Object::create();
             nodeObj->setInteger("id"_s, node.id);
 
@@ -603,12 +747,12 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
         json->setDouble("endTime"_s, endTime);
 
         auto samplesArray = JSON::Array::create();
-        for (int sample : samples)
+        for (int sample : data->samples)
             samplesArray->pushInteger(sample);
         json->setValue("samples"_s, samplesArray);
 
         auto timeDeltasArray = JSON::Array::create();
-        for (long long delta : timeDeltas)
+        for (long long delta : data->timeDeltas)
             timeDeltasArray->pushInteger(delta);
         json->setValue("timeDeltas"_s, timeDeltasArray);
 
@@ -618,104 +762,11 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
     // Generate text format if requested
     if (outText) {
         double startTime = s_profilingStartTime;
-        double lastTime = s_profilingStartTime;
-        double endTime = startTime;
+        double endTime = data->lastTime;
 
-        WTF::HashMap<WTF::String, FunctionStats> functionStatsMap;
-
-        long long totalTimeUs = 0;
-        int totalSamples = static_cast<int>(stackTraces.size());
-
-        for (size_t idx : sortedIndices) {
-            auto& stackTrace = stackTraces[idx];
-
-            double currentTime = stackTrace.timestamp.approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
-            long long deltaUs = static_cast<long long>(std::max(0.0, currentTime - lastTime));
-            totalTimeUs += deltaUs;
-            lastTime = currentTime;
-            endTime = currentTime;
-
-            if (stackTrace.frames.isEmpty())
-                continue;
-
-            WTF::String previousKey;
-
-            for (int i = stackTrace.frames.size() - 1; i >= 0; i--) {
-                auto& frame = stackTrace.frames[i];
-
-                WTF::String rawFunctionName = frame.displayName(vm);
-                WTF::String functionName = formatFunctionName(rawFunctionName, frame);
-                WTF::String url;
-                int lineNumber = -1;
-
-                if (frame.frameType == JSC::SamplingProfiler::FrameType::Executable && frame.executable) {
-                    auto sourceProviderAndID = frame.sourceProviderAndID();
-                    auto* provider = std::get<0>(sourceProviderAndID);
-                    if (provider) {
-                        url = provider->sourceURL();
-
-                        bool isAbsolutePath = false;
-                        if (!url.isEmpty()) {
-                            if (url[0] == '/')
-                                isAbsolutePath = true;
-                            else if (url.length() >= 2 && url[1] == ':') {
-                                char firstChar = url[0];
-                                if ((firstChar >= 'A' && firstChar <= 'Z') || (firstChar >= 'a' && firstChar <= 'z'))
-                                    isAbsolutePath = true;
-                            } else if (url.length() >= 2 && url[0] == '\\' && url[1] == '\\')
-                                isAbsolutePath = true;
-                        }
-                        if (isAbsolutePath)
-                            url = WTF::URL::fileURLWithFileSystemPath(url).string();
-                    }
-
-                    if (frame.hasExpressionInfo()) {
-                        JSC::LineColumn sourceMappedLineColumn = frame.semanticLocation.lineColumn;
-                        if (provider) {
-#if USE(BUN_JSC_ADDITIONS)
-                            auto& fn = vm.computeLineColumnWithSourcemap();
-                            if (fn)
-                                fn(vm, provider, sourceMappedLineColumn, url);
-#endif
-                        }
-                        lineNumber = static_cast<int>(sourceMappedLineColumn.line);
-                    }
-                }
-
-                WTF::String location = formatLocation(url, lineNumber);
-                // Key uses zero-width space separator internally (not shown in output)
-                WTF::StringBuilder keyBuilder;
-                keyBuilder.append(functionName);
-                keyBuilder.append(kKeySeparator);
-                keyBuilder.append(location);
-                WTF::String key = keyBuilder.toString();
-
-                auto result = functionStatsMap.add(key, FunctionStats());
-                FunctionStats& stats = result.iterator->value;
-                if (result.isNewEntry) {
-                    stats.functionName = functionName;
-                    stats.location = location;
-                }
-
-                stats.totalSamples++;
-                stats.totalTimeUs += deltaUs;
-
-                if (i == 0) {
-                    stats.selfSamples++;
-                    stats.selfTimeUs += deltaUs;
-                }
-
-                if (!previousKey.isEmpty()) {
-                    stats.callers.add(previousKey, 0).iterator->value++;
-
-                    auto prevIt = functionStatsMap.find(previousKey);
-                    if (prevIt != functionStatsMap.end())
-                        prevIt->value.callees.add(key, 0).iterator->value++;
-                }
-
-                previousKey = key;
-            }
-        }
+        WTF::HashMap<WTF::String, FunctionStats>& functionStatsMap = data->functionStatsMap;
+        long long totalTimeUs = data->totalTimeUs;
+        int totalSamples = data->totalSamples;
 
         // Sort functions by self time
         WTF::Vector<std::pair<WTF::String, FunctionStats*>> sortedBySelf;
@@ -933,6 +984,11 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
 extern "C" void Bun__startCPUProfiler(JSC::VM* vm)
 {
     Bun::startCPUProfiler(*vm);
+}
+
+extern "C" void Bun__drainCPUProfilerIfNeeded(JSC::VM* vm)
+{
+    Bun::drainCPUProfilerIfNeeded(*vm);
 }
 
 extern "C" void Bun__stopCPUProfiler(JSC::VM* vm, BunString* outJSON, BunString* outText)

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -19,15 +19,21 @@
 #include <limits>
 #include <memory>
 
-extern "C" void Bun__startCPUProfiler(JSC::VM* vm, bool collectMarkdown);
+extern "C" void Bun__startCPUProfiler(JSC::VM* vm);
 extern "C" void Bun__drainCPUProfilerIfNeeded(JSC::VM* vm);
 extern "C" void Bun__stopCPUProfilerIfRunning(JSC::VM* vm);
 extern "C" void Bun__stopCPUProfiler(JSC::VM* vm, BunString* outJSON, BunString* outText);
 extern "C" void Bun__setSamplingInterval(int intervalMicroseconds);
+extern "C" void Bun__setCPUProfilerCollectMarkdown(bool collect);
 
 void Bun__setSamplingInterval(int intervalMicroseconds)
 {
     Bun::setSamplingInterval(intervalMicroseconds);
+}
+
+void Bun__setCPUProfilerCollectMarkdown(bool collect)
+{
+    Bun::setCollectMarkdown(collect);
 }
 
 namespace Bun {
@@ -37,10 +43,16 @@ static thread_local double s_profilingStartTime = 0.0;
 // Set sampling interval to 1ms (1000 microseconds) to match Node.js
 static thread_local int s_samplingInterval = 1000;
 static thread_local bool s_isProfilerRunning = false;
+static thread_local bool s_collectMarkdown = false;
 
 void setSamplingInterval(int intervalMicroseconds)
 {
     s_samplingInterval = intervalMicroseconds;
+}
+
+void setCollectMarkdown(bool collect)
+{
+    s_collectMarkdown = collect;
 }
 
 bool isCPUProfilerRunning()
@@ -280,14 +292,14 @@ static thread_local ProfileData* s_profileData = nullptr;
 static thread_local WTF::MonotonicTime s_lastDrainTime;
 static constexpr WTF::Seconds kDrainInterval = WTF::Seconds::fromMilliseconds(100);
 
-void startCPUProfiler(JSC::VM& vm, bool collectMarkdown)
+void startCPUProfiler(JSC::VM& vm)
 {
     // The profile's startTime.
     s_profilingStartTime = MonotonicTime::now().approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
 
     delete s_profileData;
     s_profileData = new ProfileData();
-    s_profileData->collectMarkdown = collectMarkdown;
+    s_profileData->collectMarkdown = s_collectMarkdown;
     s_profileData->lastTime = s_profilingStartTime;
 
     ProfileNode rootNode;
@@ -982,9 +994,9 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
 
 } // namespace Bun
 
-extern "C" void Bun__startCPUProfiler(JSC::VM* vm, bool collectMarkdown)
+extern "C" void Bun__startCPUProfiler(JSC::VM* vm)
 {
-    Bun::startCPUProfiler(*vm, collectMarkdown);
+    Bun::startCPUProfiler(*vm);
 }
 
 extern "C" void Bun__stopCPUProfilerIfRunning(JSC::VM* vm)

--- a/src/jsc/bindings/BunCPUProfiler.h
+++ b/src/jsc/bindings/BunCPUProfiler.h
@@ -13,13 +13,11 @@ namespace Bun {
 void setSamplingInterval(int intervalMicroseconds);
 bool isCPUProfilerRunning();
 
-// Start the CPU profiler
-void startCPUProfiler(JSC::VM& vm);
+// Start the CPU profiler. collectMarkdown also builds the per-function stats for the markdown report.
+void startCPUProfiler(JSC::VM& vm, bool collectMarkdown = false);
 
-// Fold the samples taken since the last drain into the profile and release
-// the JS objects those samples reference. The event loop calls this on the JS
-// thread once per tick. It is a no-op when the profiler is not running or when
-// the last drain was less than 100ms ago.
+// Fold pending samples into the profile and release the JS objects they
+// reference. Called from the event loop tick. Rate limited to once per 100ms.
 void drainCPUProfilerIfNeeded(JSC::VM& vm);
 
 // Stop the CPU profiler and get profile data in requested formats.

--- a/src/jsc/bindings/BunCPUProfiler.h
+++ b/src/jsc/bindings/BunCPUProfiler.h
@@ -16,6 +16,12 @@ bool isCPUProfilerRunning();
 // Start the CPU profiler
 void startCPUProfiler(JSC::VM& vm);
 
+// Fold the samples taken since the last drain into the profile and release
+// the JS objects those samples reference. The event loop calls this on the JS
+// thread once per tick. It is a no-op when the profiler is not running or when
+// the last drain was less than 100ms ago.
+void drainCPUProfilerIfNeeded(JSC::VM& vm);
+
 // Stop the CPU profiler and get profile data in requested formats.
 // Pass non-null pointers for the formats you want. Null pointers are skipped.
 void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText);

--- a/src/jsc/bindings/BunCPUProfiler.h
+++ b/src/jsc/bindings/BunCPUProfiler.h
@@ -16,8 +16,7 @@ bool isCPUProfilerRunning();
 // Start the CPU profiler. collectMarkdown also builds the per-function stats for the markdown report.
 void startCPUProfiler(JSC::VM& vm, bool collectMarkdown = false);
 
-// Fold pending samples into the profile and release the JS objects they
-// reference. Called from the event loop tick. Rate limited to once per 100ms.
+// Folds pending samples into the profile and releases their GC roots. Called from the event loop tick, at most once per 100ms.
 void drainCPUProfilerIfNeeded(JSC::VM& vm);
 
 // Stop the CPU profiler and get profile data in requested formats.

--- a/src/jsc/bindings/BunCPUProfiler.h
+++ b/src/jsc/bindings/BunCPUProfiler.h
@@ -13,8 +13,11 @@ namespace Bun {
 void setSamplingInterval(int intervalMicroseconds);
 bool isCPUProfilerRunning();
 
-// Start the CPU profiler. collectMarkdown also builds the per-function stats for the markdown report.
-void startCPUProfiler(JSC::VM& vm, bool collectMarkdown = false);
+// Whether profiles on this thread also build the per-function stats for the markdown report.
+void setCollectMarkdown(bool collect);
+
+// Start the CPU profiler
+void startCPUProfiler(JSC::VM& vm);
 
 // Folds pending samples into the profile and releases their GC roots. Called from the event loop tick, at most once per 100ms.
 void drainCPUProfilerIfNeeded(JSC::VM& vm);

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -759,6 +759,7 @@ impl EventLoop {
         let ctx = self.vm();
         self.tick_concurrent();
         self.process_gc_timer();
+        crate::bun_cpu_profiler::drain_cpu_profiler_if_needed(self.vm_ref().as_mut().jsc_vm_mut());
 
         // Note: reshaped for borrowck — `vm_ref()` is `&'static`, so the
         // global borrow detaches from `&self` and survives the `&mut self` call.

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1316,7 +1316,10 @@ impl Run<'_> {
             });
             bun_jsc::bun_cpu_profiler::set_sampling_interval(opts.interval);
             // SAFETY: `vm.jsc_vm` set in `init`.
-            bun_jsc::bun_cpu_profiler::start_cpu_profiler(unsafe { &mut *vm.jsc_vm });
+            bun_jsc::bun_cpu_profiler::start_cpu_profiler(
+                unsafe { &mut *vm.jsc_vm },
+                opts.md_format,
+            );
             bun_analytics::features::cpu_profile.fetch_add(1, Ordering::Relaxed);
         }
 

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1315,11 +1315,9 @@ impl Run<'_> {
                 interval: opts.interval,
             });
             bun_jsc::bun_cpu_profiler::set_sampling_interval(opts.interval);
+            bun_jsc::bun_cpu_profiler::set_collect_markdown(opts.md_format);
             // SAFETY: `vm.jsc_vm` set in `init`.
-            bun_jsc::bun_cpu_profiler::start_cpu_profiler(
-                unsafe { &mut *vm.jsc_vm },
-                opts.md_format,
-            );
+            bun_jsc::bun_cpu_profiler::start_cpu_profiler(unsafe { &mut *vm.jsc_vm });
             bun_analytics::features::cpu_profile.fetch_add(1, Ordering::Relaxed);
         }
 

--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -501,8 +501,8 @@ describe.concurrent("--cpu-prof", () => {
     const result = JSON.parse(stdout);
     expect(result.sink).toBe(true);
     // Without the fix, every frame that was sampled through its bound function
-    // stays alive: about 90 of 150 on a debug build.
-    expect(result.alive).toBeLessThan(4);
+    // stays alive: about 60 of 150.
+    expect(result.alive).toBe(0);
     expect(exitCode).toBe(0);
 
     // Draining must not lose samples: the profile still covers the workload.

--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -444,4 +444,72 @@ describe.concurrent("--cpu-prof", () => {
     const mdContent = readFileSync(join(String(dir), mdFiles[0]), "utf-8");
     expect(mdContent).toContain("# CPU Profile");
   });
+
+  // https://github.com/oven-sh/bun/issues/42377
+  // The sampling profiler marks every sampled callee as a GC root until its
+  // samples are released. Bun only released them at exit, so a per-frame bound
+  // function (React's scheduler makes one per render) kept every frame's data
+  // alive for the whole run. The event loop now drains the profiler while it
+  // runs, so the heap after a full GC stays flat.
+  test("sampled callees are released while profiling runs", async () => {
+    using dir = tempDir("cpu-prof-gc-roots", {
+      "test.mjs": `
+        let sink = 0;
+        function work(frame) {
+          let s = 0;
+          for (const op of frame.operations) s += op.x;
+          return s;
+        }
+        function renderFrame(n) {
+          const frame = { operations: [], cells: new Array(50000).fill(n) };
+          for (let i = 0; i < 2000; i++) frame.operations.push({ x: i });
+          const callee = work.bind(null, frame);
+          for (let k = 0; k < 100; k++) sink += callee();
+        }
+        const heapMB = () => {
+          Bun.gc(true);
+          return process.memoryUsage().heapUsed / 1048576;
+        };
+        for (let n = 0; n < 150; n++) {
+          renderFrame(n);
+          if (n % 10 === 9) await Bun.sleep(1);
+        }
+        // The profiler drains on an event loop tick at most once per 100ms.
+        // Poll until the drained samples let the GC free the frames.
+        const deadline = performance.now() + 1000;
+        let heapAfterGC = heapMB();
+        while (heapAfterGC >= 8 && performance.now() < deadline) {
+          await Bun.sleep(20);
+          heapAfterGC = heapMB();
+        }
+        console.log(JSON.stringify({ heapAfterGC: Math.round(heapAfterGC), sink: sink > 0 }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--cpu-prof", "test.mjs"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout);
+    expect(result.sink).toBe(true);
+    // Without the fix this is 25 MB or more: every sampled frame's 50000-element array.
+    expect(result.heapAfterGC).toBeLessThan(8);
+    expect(exitCode).toBe(0);
+
+    // Draining must not lose samples: the profile still covers the workload.
+    const profileFiles = readdirSync(String(dir)).filter(f => f.endsWith(".cpuprofile"));
+    expect(profileFiles.length).toBe(1);
+    const profile = JSON.parse(readFileSync(join(String(dir), profileFiles[0]), "utf-8"));
+    expect(profile.samples.length).toBeGreaterThan(0);
+    expect(profile.samples.length).toBe(profile.timeDeltas.length);
+    const functionNames = profile.nodes.map((n: any) => n.callFrame.functionName);
+    expect(functionNames).toContain("renderFrame");
+    expect(functionNames).toContain("work");
+  });
 });

--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -450,11 +450,12 @@ describe.concurrent("--cpu-prof", () => {
   // samples are released. Bun only released them at exit, so a per-frame bound
   // function (React's scheduler makes one per render) kept every frame's data
   // alive for the whole run. The event loop now drains the profiler while it
-  // runs, so the heap after a full GC stays flat.
+  // runs, so a full GC frees the frames.
   test("sampled callees are released while profiling runs", async () => {
     using dir = tempDir("cpu-prof-gc-roots", {
       "test.mjs": `
         let sink = 0;
+        const frames = [];
         function work(frame) {
           let s = 0;
           for (const op of frame.operations) s += op.x;
@@ -463,12 +464,13 @@ describe.concurrent("--cpu-prof", () => {
         function renderFrame(n) {
           const frame = { operations: [], cells: new Array(50000).fill(n) };
           for (let i = 0; i < 2000; i++) frame.operations.push({ x: i });
+          frames.push(new WeakRef(frame));
           const callee = work.bind(null, frame);
           for (let k = 0; k < 100; k++) sink += callee();
         }
-        const heapMB = () => {
+        const aliveFrames = () => {
           Bun.gc(true);
-          return process.memoryUsage().heapUsed / 1048576;
+          return frames.filter(ref => ref.deref() !== undefined).length;
         };
         for (let n = 0; n < 150; n++) {
           renderFrame(n);
@@ -477,12 +479,12 @@ describe.concurrent("--cpu-prof", () => {
         // The profiler drains on an event loop tick at most once per 100ms.
         // Poll until the drained samples let the GC free the frames.
         const deadline = performance.now() + 1000;
-        let heapAfterGC = heapMB();
-        while (heapAfterGC >= 8 && performance.now() < deadline) {
+        let alive = aliveFrames();
+        while (alive > 0 && performance.now() < deadline) {
           await Bun.sleep(20);
-          heapAfterGC = heapMB();
+          alive = aliveFrames();
         }
-        console.log(JSON.stringify({ heapAfterGC: Math.round(heapAfterGC), sink: sink > 0 }));
+        console.log(JSON.stringify({ alive, sink: sink > 0 }));
       `,
     });
 
@@ -498,8 +500,9 @@ describe.concurrent("--cpu-prof", () => {
     expect(stderr).toBe("");
     const result = JSON.parse(stdout);
     expect(result.sink).toBe(true);
-    // Without the fix this is 25 MB or more: every sampled frame's 50000-element array.
-    expect(result.heapAfterGC).toBeLessThan(8);
+    // Without the fix, every frame that was sampled through its bound function
+    // stays alive: about 90 of 150 on a debug build.
+    expect(result.alive).toBeLessThan(4);
     expect(exitCode).toBe(0);
 
     // Draining must not lose samples: the profile still covers the workload.

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -405,6 +405,36 @@ describe("node:inspector", () => {
       expect(result2.profile.nodes.length).toBeGreaterThanOrEqual(1);
     });
 
+    test("Profiler.stop in a process exit handler still returns the profile", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const inspector = require("node:inspector");
+            const session = new inspector.Session();
+            session.connect();
+            session.post("Profiler.enable");
+            session.post("Profiler.start");
+            let sum = 0;
+            for (let i = 0; i < 100000; i++) sum += i;
+            process.on("exit", () => {
+              const { profile } = session.post("Profiler.stop");
+              console.log(JSON.stringify({ nodes: profile.nodes.length, sum }));
+            });
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const result = JSON.parse(stdout);
+      expect(result.nodes).toBeGreaterThanOrEqual(1);
+      expect(exitCode).toBe(0);
+    });
+
     test("disconnect() stops running profiler", () => {
       session.post("Profiler.enable");
       session.post("Profiler.start");


### PR DESCRIPTION
### Problem
- Under `--cpu-prof`, the heap after a full GC grows without bound, about 65 MB/s in the issue's repro. A React or Ink app leaks every render: the scheduler calls through a fresh bound function each time.
- JSC's `SamplingProfiler` marks every sampled callee and executable as a GC root until `clearData()`. Bun called it once, in `stopCPUProfiler` at exit (`src/jsc/bindings/BunCPUProfiler.cpp`).

### Fix
- The event loop calls `Bun__drainCPUProfilerIfNeeded` once per tick (`src/jsc/event_loop.rs:tick_turn`). At most every 100ms it calls `releaseStackTraces()` under the JSLock with GC deferred, and folds the batch into a thread-local `ProfileData` of names, URLs, line numbers and counts.
- `stopCPUProfiler` folds the last batch and serializes from `ProfileData`. The output shape is unchanged. The per-trace work moves from exit into the run.
- The VM exit path stops a profiler that `node:inspector` or `Worker.startCpuProfile` never stopped, so its data is freed. Markdown stats are built only for `--cpu-prof-md`. URL conversions are memoized.
- Verified: `test/cli/run/cpu-prof.test.ts` (new test: on 1.4.2 about 60 of 150 frames survive a full GC, with the fix 0). Also the inspector profiler, 29240, and `test-cpu-prof-*` suites.

### Background
- `SamplingProfiler` is JSC's sampling thread. It resolves each sample into `StackFrame`s whose `executable` and `callee` are kept alive as GC roots so names can be read later.
- `releaseStackTraces()` returns the resolved traces and clears the root set. After that only `DeferGC` keeps the frames valid, so the caller reads them at once.
- The same start and stop pair serves `node:inspector` `Profiler` and `Worker.startCpuProfile`, so they get the drain too.

<details><summary>Notes</summary>

Repro from the issue, debug build, 15s run with `--expose-gc --cpu-prof`: heap after full GC was 21 MB at 6s and 33 MB at 11s on main. With this change it stays at 0 MB.

Drain cost, debug build, 1ms sampling, fib workload: about 7.5ms per trace before the URL cache, about 3ms per trace with it. A release build is far faster. The drain runs from the event loop outside any VM entry scope, so the sampler does not sample it.

Samples taken in a long synchronous loop are not drained until the loop returns to the event loop. That is the same bound as before for that window, and a drain needs the JS thread.

`src/jsc/bindings/v8/V8CpuProfiler.cpp` (the `v8` shim used by `@datadog/pprof`) has its own consumer of `SamplingProfiler` with the same release-at-stop pattern. Its sessions are short (dd-trace uses about 60s windows), so it is left for a follow-up.

#36017 refactors the same function to share the sampler between `--cpu-prof` and inspector sessions. It does not release roots mid-run. Its per-sample records would need to be built on top of the drain in this PR.

Self-reviewed: 3 concerns raised. The V8 shim and #36017 overlap are noted above as follow-ups. The request to split the refactor from the drain was not taken: the drain needs the fold-per-batch shape to exist.

Review follow-ups: the ASAN lane caught the profile data leak for a worker terminated mid-profile (fixed by the exit-path stop, which runs after the `process.on('exit')` handlers so a `Profiler.stop` in one still gets its profile). The sampler lock is now held only for `releaseStackTraces()`. The markdown flag is a thread-local set by `--cpu-prof-md`, so an inspector restart of the profiler keeps the per-function stats. Running the v8 shim profiler and `--cpu-prof` together was already unsupported on main (`CpuProfilerImpl::stop()` pauses and clears the shared sampler), so that combination is left as is.

</details>
