### PR TITLE
react-compiler: keep the declaration of a local when dead code elimination keeps a store to it

### DIFF
--- a/src/react_compiler/optimization/dead_code_elimination.rs
+++ b/src/react_compiler/optimization/dead_code_elimination.rs
@@ -123,6 +123,33 @@ fn is_id_used(state: &State, identifier_id: IdentifierId) -> bool {
     state.identifiers.contains(&identifier_id)
 }
 
+/// Keep the declaration of each variable that a retained reassignment assigns.
+///
+/// Not in upstream, which prunes a declaration once nothing reads the variable. A store
+/// to such a variable can still be retained: as the last instruction of a non-`Block`
+/// block (a catch handler, a `for..of` test), or for its own value (`f(v = 1)`).
+/// `rewrite_instruction_kinds_based_on_reassignment` then makes the first store left
+/// the declaration, in a scope that need not enclose the other stores.
+fn reference_reassigned_variables(
+    state: &mut State,
+    identifiers: &[crate::hir::Identifier],
+    value: &InstructionValue,
+) {
+    match value {
+        InstructionValue::StoreLocal { lvalue, .. } if lvalue.kind == InstructionKind::Reassign => {
+            reference(state, identifiers, lvalue.place.identifier);
+        }
+        InstructionValue::Destructure { lvalue, .. }
+            if lvalue.kind == InstructionKind::Reassign =>
+        {
+            for place in visitors::each_pattern_operand(&lvalue.pattern) {
+                reference(state, identifiers, place.identifier);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Phase 1: Find all referenced identifiers via fixed-point iteration.
 fn find_referenced_identifiers(func: &HirFunction, env: &Environment) -> State {
     let has_loop = has_back_edge(func);
@@ -157,6 +184,8 @@ fn find_referenced_identifiers(func: &HirFunction, env: &Environment) -> State {
                     for place in visitors::each_instruction_value_operand(&instr.value, env) {
                         reference(&mut state, &env.identifiers, place.identifier);
                     }
+                    // Nor is it rewritten, so every variable it reassigns stays assigned.
+                    reference_reassigned_variables(&mut state, &env.identifiers, &instr.value);
                 } else if is_id_or_name_used(&state, &env.identifiers, instr.lvalue.identifier)
                     || !pruneable_value(&instr.value, &state, env)
                 {
@@ -170,6 +199,9 @@ fn find_referenced_identifiers(func: &HirFunction, env: &Environment) -> State {
                         {
                             reference(&mut state, &env.identifiers, value.identifier);
                         }
+                        // A Destructure is left to rewrite_instruction, which prunes the
+                        // pattern entries that nothing reads.
+                        reference_reassigned_variables(&mut state, &env.identifiers, &instr.value);
                     } else {
                         for place in visitors::each_instruction_value_operand(&instr.value, env) {
                             reference(&mut state, &env.identifiers, place.identifier);

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1230,6 +1230,193 @@ describe("bundler", () => {
     },
   });
 
+  // Dead code elimination keeps some stores to a local that nothing reads: the
+  // last instruction of a catch handler or of a `for..of` head, and a store
+  // whose own value is used (`f(v = 2)`). It pruned `let v` all the same. The
+  // first store left then became the declaration, in a scope that did not
+  // enclose the other stores: `ReferenceError: v is not defined`.
+  const stubReactWithEffect = { ...stubReact, "/node_modules/react/index.js": `exports.useEffect = () => {};` };
+  const deadStoreForms = {
+    "/entry.js": /* js */ `
+      import * as forms from "./forms";
+      const props = { bad: "{bad", items: [1, 2], call() {} };
+      const lines = [];
+      for (const [name, form] of Object.entries(forms)) {
+        try {
+          lines.push(name + "=" + JSON.stringify(form(props).p));
+        } catch (e) {
+          lines.push(name + " threw " + e);
+        }
+      }
+      console.log(lines.join("\\n"));
+    `,
+    "/forms.jsx": /* jsx */ `
+      import { useEffect } from "react";
+
+      export function NestedTry(p) {
+        useEffect(() => {});
+        let v;
+        try {
+          try {
+            JSON.parse(p.bad);
+          } catch {
+            v = 1;
+          }
+          JSON.parse(p.bad);
+        } catch {
+          v = 2;
+        }
+        return <div />;
+      }
+      export function SequentialTry(p) {
+        useEffect(() => {});
+        let v;
+        try {
+          JSON.parse(p.bad);
+        } catch {
+          v = 1;
+        }
+        try {
+          JSON.parse(p.bad);
+        } catch {
+          v = 2;
+        }
+        return <div />;
+      }
+      export function DestructureInHandler(p) {
+        useEffect(() => {});
+        let v;
+        try {
+          JSON.parse(p.bad);
+        } catch {
+          [v] = p.items;
+        }
+        try {
+          JSON.parse(p.bad);
+        } catch {
+          [v] = p.items;
+        }
+        return <div />;
+      }
+      export function HandlerThenArgument(p) {
+        useEffect(() => {});
+        let v;
+        try {
+          JSON.parse(p.bad);
+        } catch {
+          v = 1;
+        }
+        p.call((v = 2));
+        return <div />;
+      }
+      export function HandlerThenLogical(p) {
+        useEffect(() => {});
+        let v;
+        if (p.items) {
+          try {
+            JSON.parse(p.bad);
+          } catch {
+            v = 1;
+          }
+        }
+        p.items && (v = 2);
+        return <div />;
+      }
+      // The one read of \`v\` folds to "final".
+      export function EveryReadFolded(p) {
+        useEffect(() => {});
+        let v = "init";
+        try {
+          try {
+            JSON.parse(p.bad);
+          } catch {
+            v = "a";
+          }
+          JSON.parse(p.bad);
+        } catch {
+          v = "b";
+        }
+        v = "final";
+        return <div>{v}</div>;
+      }
+      // With \`let v\` kept, the compiler leaves these two alone: it does not
+      // take a \`for..of\` or \`for..in\` that assigns an outer local.
+      export function ForOfThenArgument(p) {
+        let v;
+        for (v of p.items) p.call();
+        p.call((v = 2));
+        return <div />;
+      }
+      export function ForInThenHandler(p) {
+        let v;
+        for (v in p.items) p.call();
+        try {
+          JSON.parse(p.bad);
+        } catch {
+          v = 2;
+        }
+        return <div />;
+      }
+    `,
+    ...stubReactWithEffect,
+  };
+  for (const target of ["browser", "bun"] as const) {
+    itBundled(`react-compiler/DeadStoreKeepsItsDeclaration-${target}`, {
+      files: deadStoreForms,
+      reactCompiler: true,
+      backend: "cli",
+      target,
+      run: {
+        stdout: `
+          DestructureInHandler={}
+          EveryReadFolded={"children":"final"}
+          ForInThenHandler={}
+          ForOfThenArgument={}
+          HandlerThenArgument={}
+          HandlerThenLogical={}
+          NestedTry={}
+          SequentialTry={}
+        `,
+      },
+      onAfterBundle(api) {
+        // Every form that calls useEffect compiled: the compiler outlines the
+        // empty effect callback (client) or drops the effect (ssr), so no
+        // call takes `() => {}` any more.
+        expect(api.readFile("/out.js")).not.toMatch(/\(\(\) => \{\s*\}\)/);
+      },
+    });
+  }
+
+  // Same cause. In client mode the store left in the `for` update was then a
+  // reassignment, inside a memo scope, of a local with no declaration:
+  // `panic: Expected identifier to be initialized`.
+  itBundled("react-compiler/DeadStoreInForUpdateKeepsItsDeclaration", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useEffect } from "react";
+
+        function App(p) {
+          useEffect(() => {});
+          let v;
+          for (let i = 0; i < 2; v = i++) p.call(i);
+          for (let j = 0; j < 2; v = j++) p.call(j);
+          return <div />;
+        }
+        const calls = [];
+        App({ call: i => calls.push(i) });
+        console.log(calls.join());
+      `,
+      ...stubReactWithEffect,
+    },
+    reactCompiler: true,
+    backend: "cli",
+    target: "browser",
+    run: { stdout: "0,1,0,1" },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toMatch(/\(\(\) => \{\s*\}\)/);
+    },
+  });
+
   // Outside the compiler, the bundler binds a local that holds a `require()` /
   // `import()` export to the export itself: `const { a } = require("./m")`
   // declares nothing, and `ns.a` off `const ns = require("./m")` is an import


### PR DESCRIPTION
### Problem

- `bun build --react-compiler` can print an assignment to a local with no declaration: `ReferenceError: v is not defined`. With `v` never read, `try { try {..} catch { v = 1 } .. } catch { v = 2 }` prints `let v = 1` in the inner handler and a bare `v = 2` in the outer one. In client mode the same cause can crash the build: `panic: Expected identifier to be initialized`.
- Dead code elimination (`src/react_compiler/optimization/dead_code_elimination.rs`) keeps some stores to a local that nothing reads, but prunes `let v`: nothing marks the name. `rewrite_instruction_kinds_based_on_reassignment` then makes the first store left the declaration, in a scope that need not enclose the others. Upstream prints the same text.

### Fix

- A `Reassign` store that the pass retains now marks its variable, so `let v` stays. A `Destructure` retained as a block value marks each variable of its pattern.
- Correct because a retained assignment needs its binding, whatever retained it. Unretained stores are still pruned.
- Verified: three new tests in `test/bundler/transpiler/react-compiler.test.ts` fail without the fix. All 1806 upstream fixtures print byte-identical output before and after, in both output modes. Also ran `react-compiler-fixtures.test.ts` and the react tests in `bundler_jsx.test.ts`.

### Background

- The compiler lowers a function to HIR: basic blocks of SSA instructions. `let v` is a `DeclareLocal`, `v = 1` a `StoreLocal` of kind `Reassign`.
- The pass marks what is referenced and sweeps the rest. A declaration stays while the variable's name is marked. A `Reassign` store stays while its own SSA value is read.
- Two more things keep a store: its own result is used (`f(v = 2)`), or it ends a block whose kind is not `Block`. That rule protects value blocks (a ternary branch, a `for..of` test). It also covers a catch handler, kind `Catch`.

<details><summary>Notes</summary>

**Shapes probed** (`v` is never read in each). Before: main 4b5862fd88 and 1.4.3-canary.1+6a92015fc. After: this branch. "Left alone" means the compiler skips the function and the source runs as written.

| shape | before | after |
| --- | --- | --- |
| nested `try`, a store ends each handler (the report) | `let v = 1` / bare `v = 2`, ReferenceError | `let v` kept, compiled |
| two `try` in sequence, a store ends each handler | same | same |
| `[v] = p.items` ends two handlers | `let [v] = ..` / bare `[v] = ..`, ReferenceError | compiled |
| handler store, then `f(v = 2)` or `c && (v = 2)` | ReferenceError | compiled |
| `let v = "init"`, handler stores, `v = "final"`, `<div>{v}</div>` (the read folds to `"final"`) | ReferenceError | compiled |
| `for (v of xs) {}` or `for (v in xs) {}`, then `f(v = 2)` or a handler store | `for (let v of xs)` / bare `v = 2`, ReferenceError | left alone |
| `for (..; ..; v = i++)` twice, client mode | `panic: Expected identifier to be initialized` (`prune_non_escaping_scopes.rs:1060`, a scope reassigns a local that was never declared) | compiled |
| `f(v = 1); f(v = 2)`, `c ? (v = 1) : (v = 2)`, `a && (v = 1); b && (v = 2)` | left alone (`Const declaration cannot be referenced as an expression`) | compiled |

**Nesting is not needed.** In a handler nested in a `try`, every instruction ends its own `Catch` block (each one can throw to the outer handler), so every store there is kept. In a plain handler only the last instruction is.

**Upstream.** `babel-plugin-react-compiler@1.0.0` prints `let v = 1` / bare `v = 2` for the two-`try`-in-sequence form. For the nested form it raises `Expected a break target` and skips the function, an older limit on nested `try`. `0.0.0-experimental-a1856f3-20260507` compiles the nested form and prints the same broken text. It also prints `for (let v of p.items) {..} foo(v = 2)`. `DeadCodeElimination.ts` and the Rust port on facebook/react main have the same logic as `UPSTREAM_PORTED`.

**Why not narrow the block-value rule to expression blocks.** Upstream's `isStatementBlockKind` calls `catch` a statement kind, so the rule covers handlers by accident. Narrowing it removes the handler cases only. A `for..of` test is a real value block, and `let v; for (v of xs) {}; f(v = 2)` breaks the same way.

**Why not fail in `rewrite_instruction_kinds_based_on_reassignment`.** An invariant there for a `Reassign` store with no declaration also stops the bad output, but it leaves every such function uncompiled.

**Cost.** The dead stores stay in the output, as in the source. `let v; for (v of xs) {}` with `v` never read used to compile as `for (const v of xs)`. It is now left alone, like any `for (v of xs)` over an outer local that is read later (`Unexpected Reassign variable in for..of collection`).

**Not changed here.** The `panic` above is an upstream invariant that the port writes as `.expect()`. Other invariants written that way also end the build where upstream skips the function.

</details>
