### PR TITLE
react-compiler: lower the member target of an assignment before its right-hand side

### DIFF
--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -668,9 +668,7 @@ fn lower_simple_assignment(
         Data::EImportIdentifier(ident) => {
             lower_simple_assignment_identifier(builder, ident.ref_, &bin.right, bin.left.loc)
         }
-        // Upstream lowers the right-hand side before the member target. JS
-        // evaluates the target's object and key first, and `a.b = a = c` or
-        // `a[i] = i++` reads a different value when the order is swapped.
+        // Unlike upstream: JS evaluates the target's object and key before the right-hand side.
         Data::EDot(d) => {
             let left_loc = convert_loc(bin.left.loc);
             let object = lower_expression_to_temporary(builder, &d.target)?;

--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -668,10 +668,13 @@ fn lower_simple_assignment(
         Data::EImportIdentifier(ident) => {
             lower_simple_assignment_identifier(builder, ident.ref_, &bin.right, bin.left.loc)
         }
+        // Upstream lowers the right-hand side before the member target. JS
+        // evaluates the target's object and key first, and `a.b = a = c` or
+        // `a[i] = i++` reads a different value when the order is swapped.
         Data::EDot(d) => {
-            let right = lower_expression_to_temporary(builder, &bin.right)?;
             let left_loc = convert_loc(bin.left.loc);
             let object = lower_expression_to_temporary(builder, &d.target)?;
+            let right = lower_expression_to_temporary(builder, &bin.right)?;
             let temp = lower_value_to_temporary(
                 builder,
                 InstructionValue::PropertyStore {
@@ -687,10 +690,10 @@ fn lower_simple_assignment(
             })
         }
         Data::EIndex(i) => {
-            let right = lower_expression_to_temporary(builder, &bin.right)?;
             let left_loc = convert_loc(bin.left.loc);
             let object = lower_expression_to_temporary(builder, &i.target)?;
             let temp = if let Data::ENumber(num) = &i.index.data {
+                let right = lower_expression_to_temporary(builder, &bin.right)?;
                 lower_value_to_temporary(
                     builder,
                     InstructionValue::PropertyStore {
@@ -702,6 +705,7 @@ fn lower_simple_assignment(
                 )?
             } else {
                 let prop = lower_expression_to_temporary(builder, &i.index)?;
+                let right = lower_expression_to_temporary(builder, &bin.right)?;
                 lower_value_to_temporary(
                     builder,
                     InstructionValue::ComputedStore {

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1980,6 +1980,142 @@ describe("bundler", () => {
     },
     run: { stdout: '{"h":"div","props":{"title":"A"},"children":["hi"]}' },
   });
+
+  // `a.b = a = c` and `a[i] = i++` read `a` and `i` for the member target
+  // before the right-hand side runs. The compiler removes assignments and
+  // propagates constants by the order of its own instructions, so it has to
+  // lower the target's object and key first too.
+  for (const target of ["bun", "browser"] as const) {
+    itBundled(`react-compiler/MemberAssignmentReadsTargetBeforeRightHandSide-${target}`, {
+      files: {
+        "/entry.ts": /* ts */ `
+          import * as forms from "./forms";
+          const props = { items: [1, 2, 3], key: "next", flag: true };
+          const lines: string[] = [];
+          for (const [name, Form] of Object.entries(forms)) {
+            try {
+              lines.push(name + "=" + Form(props).props.children);
+            } catch (e) {
+              lines.push(name + " threw " + e);
+            }
+          }
+          console.log(lines.join("\\n"));
+        `,
+        "/forms.jsx": /* jsx */ `
+          function values(head, next = "next") {
+            const out = [];
+            for (let node = head; node; node = node[next]) out.push(node.v);
+            return out.join();
+          }
+
+          export function AppendInLoop(p) {
+            const head = { v: 0, next: null };
+            let tail = head;
+            for (const x of p.items) {
+              tail.next = tail = { v: x, next: null };
+            }
+            return <div>{values(head)}</div>;
+          }
+          export function AppendTwice(p) {
+            const head = { v: 0, next: null };
+            let tail = head;
+            tail.next = tail = { v: p.items[0], next: null };
+            tail.next = tail = { v: p.items[1], next: null };
+            return <div>{values(head)}</div>;
+          }
+          export function AppendInCallback(p) {
+            const list = items => {
+              const head = { v: 0, next: null };
+              let tail = head;
+              for (const x of items) {
+                tail.next = tail = { v: x, next: null };
+              }
+              return values(head);
+            };
+            return <div>{list(p.items)}</div>;
+          }
+          export function AppendWithComputedKey(p) {
+            const head = { v: 0, next: null };
+            let tail = head;
+            for (const x of p.items) {
+              tail[p.key] = tail = { v: x, next: null };
+            }
+            return <div>{values(head)}</div>;
+          }
+          export function AppendWithNumericKey(p) {
+            const head = { v: 0, 0: null };
+            let tail = head;
+            for (const x of p.items) {
+              tail[0] = tail = { v: x, 0: null };
+            }
+            return <div>{values(head, 0)}</div>;
+          }
+          export function ConstantOnTheRight(p) {
+            let v = {};
+            const first = v;
+            if (p.flag) {
+              v.z = v = 80;
+            }
+            return <div>{JSON.stringify([first, v])}</div>;
+          }
+          export function KeyIsReassignedOnTheRight(p) {
+            let key = "a";
+            const o = {};
+            if (p.flag) {
+              o[key] = key = "b";
+            }
+            return <div>{JSON.stringify([o, key])}</div>;
+          }
+          export function KeyIsIncrementedOnTheRight() {
+            const arr = [];
+            let i = 0;
+            arr[i] = i++;
+            arr[i] = i++;
+            return <div>{JSON.stringify([arr, i])}</div>;
+          }
+          // The right-hand side is the member assignment here, so it already ran first.
+          export function MemberAssignmentOnTheRight(p) {
+            const head = { v: 0, next: null };
+            let tail = head;
+            for (const x of p.items) {
+              tail = tail.next = { v: x, next: null };
+            }
+            return <div>{values(head)}</div>;
+          }
+        `,
+        "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+        "/node_modules/react/index.js": ``,
+        "/node_modules/react/jsx-runtime.js": /* js */ `
+          export const jsx = (type, props) => ({ type, props });
+          export const jsxs = jsx;
+        `,
+        "/node_modules/react/jsx-dev-runtime.js": /* js */ `
+          export const jsxDEV = (type, props) => ({ type, props });
+        `,
+        "/node_modules/react/compiler-runtime.js": /* js */ `
+          export function c(size) {
+            return new Array(size).fill(Symbol.for("react.memo_cache_sentinel"));
+          }
+        `,
+      },
+      reactCompiler: true,
+      backend: "cli",
+      target,
+      run: {
+        stdout: `
+          AppendInCallback=0,1,2,3
+          AppendInLoop=0,1,2,3
+          AppendTwice=0,1,2
+          AppendWithComputedKey=0,1,2,3
+          AppendWithNumericKey=0,1,2,3
+          ConstantOnTheRight=[{"z":80},80]
+          KeyIsIncrementedOnTheRight=[[0,1],2]
+          KeyIsReassignedOnTheRight=[{"a":"b"},"b"]
+          MemberAssignmentOnTheRight=0,1,2,3
+        `,
+      },
+    });
+  }
 });
 
 // Three passes kept one copy of their work per basic block or per nesting


### PR DESCRIPTION
### Problem

- With `bun build --react-compiler`, `tail.next = tail = node` (list append) throws `TypeError: undefined is not an object (evaluating 'tail.next = tail = {...}')`: the output declares `let tail;` without `= head`. `v.z = v = 80` prints as `80 .z = v = 80`. `arr[i] = i++` stores at the wrong index. Both output modes, 1.4.2 and main.
- `lower_simple_assignment` (`src/react_compiler/lowering/build_hir/expr.rs:671`) lowers the right-hand side before the object and key of a member target. JS evaluates the object and key first. So the target reads the value that the right-hand side assigned, and the old value has no reader left. Upstream has the same order.

### Fix

- Lower the object, then a computed key, then the right-hand side, then the store. `a.b += c` and `a.b++` already lower in this order.
- Correct because codegen prints `object[key] = value`, which JS evaluates in this order.
- The upstream fixtures (1,587 in client mode, 1,734 in ssr mode) print the same text before and after.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (2 new tests, 9 forms each, 8 fail on 1.4.3-canary). Also `react-compiler-fixtures.test.ts`, `bundler_jsx.test.ts`.

### Background

- The compiler lowers a function to HIR: instructions in evaluation order, each result in a temporary. `a.b = c` becomes a load of `a`, the instructions of `c`, and a `PropertyStore`.
- SSA, constant propagation and dead code elimination decide from that order which assignment a read sees.
- Codegen puts each temporary back where it is used, so the output has the shape of the source. A wrong order shows only when a pass acted on it.

<details><summary>Notes</summary>

**Upstream.** babel-plugin-react-compiler 1.0.0 prints the same `let tail;` for the first form. The same order is in `compiler/crates/react_compiler_lowering/src/build_hir.rs` at the ported commit (560db514, "Member expression assignment" arm) and on facebook/react main (019019be). It is also in `BuildHIR.ts`: the `AssignmentExpression` case passes `lowerExpressionToTemporary(builder, expr.get('right'))` as an argument to `lowerAssignment`, and the `MemberExpression` case of `lowerAssignment` lowers the object after that. The new comment in `lower_simple_assignment` records that the port differs here on purpose.

**Forms.** 44 forms. Each was built without the compiler, in ssr mode (`--target=bun`) and in client mode (`--target=browser`). Each output then rendered five times with a memo cache that persists between renders: the same props twice, two other prop sets, then the first props again. The compiled outputs must print what the uncompiled output prints. On 1.4.3-canary (6a92015fc) 17 forms differ. On this branch none differ, and client mode memoizes 42 of the 44 (the other two break a rule of React on purpose and are left uncompiled on both builds). Canary is two commits behind main and neither commit touches the lowering. A debug build of main (4b5862fd88) fails the same way on the 31 forms I also ran there.

| form | expected | 1.4.3-canary |
| --- | --- | --- |
| `tail.next = tail = {...}` in `for of`, `for`, `while`, and in the update clause of a `for` | `0,1,2,3` | `TypeError: undefined is not an object` |
| the same twice with no loop | the list `0,5,1` | the same TypeError |
| `tail[p.key] = tail = {...}` and `tail[0] = tail = {...}` | `0,1,2,3` | the same TypeError |
| `tail.next = tail = p.make(x)` | `0,1,2,3` | the same TypeError |
| the same inside `try`/`catch` | `0,1,2,3` | the `catch` branch renders |
| the `for of` form inside an arrow function | `0,1,2,3` | the same TypeError |
| `box.child = box = { el: <span/> }`, `box.fn = box = { get: () => p.a }` | the old `box` gets the key | the same TypeError |
| `v.z = v = 80` in an `if`, in a loop, at the top level | `[{"z":80},80]` | `TypeError: Attempted to assign to readonly property.` |
| `o[key] = key = "b"` with `let key = "a"` | `[{"a":"b"},"b"]` | `[{"b":"b"},"b"]` |
| `arr[i] = i++; arr[i] = i++; arr[i++] = i` with `let i = 0` | `[[0,1,3],3]` | `[[null,0,2],3]` |
| `let a = {name: "a"}; if (p.flag) a.other = a = b;` | with `flag` false: `{"name":"a"}` | client mode, after a render with `flag` true: `{"name":"a","other":{"name":"b"}}` |

The last row is the second effect in the report. The compiler saw no write to the first object, cached it behind a sentinel check, and the store then changed the cached object for every later render.

27 forms already matched on canary and still match: `v.z = v = p.a` and `v.z = v = {...}` at the top level, the `arr[i] = i++` forms inside a loop (no constant to propagate), `arr[0] = arr = [...]`, `a.b.c = a = {...}`, `o.x = o.y = o = {...}`, a sequence, conditional, logical, nullish or optional chain on the right, `(a = {...}).x = a.name`, `tail = tail.next = {...}`, a call as the object and as the key (the calls run in source order), `useState()` on the right, a local that a closure captures, `reduce((tail, x) => (tail.next = tail = {...}), head)`, `v.z += (v = {...}).z`, `seen.push(v, (v = {...}))`, and destructuring targets (`[a.x, a] = ...`, `[a, a.y] = ...`).

**Why many forms already worked.** With the instructions in the wrong order the printed text is still `tail.next = tail = {...}`, in source order, because codegen puts the temporaries back at their place of use. The output is wrong only when a pass used the order: dead code elimination (the removed `= head`), constant propagation (`80 .z`, `o["b"]`, `arr[1] = i++`), or the mutation analysis (the last row of the table).

**One form now compiles.** At the top level of a component, `let v = {}; const o = v; v.z = v = p.a;` was left uncompiled in client mode. With the wrong order the store looked like a write to the prop `p.a`, which the compiler rejects. Now the store goes to the local object and the component is memoized.

**Other assignment lowerings.** A member target inside a destructuring pattern (`[a.b] = c`) or in `for (a.b of c)` goes through `lower_member_store` with a value that already exists. JS also produces that value before it evaluates the target, so those stay as they are. Calls, compound assignment and update expressions lower their operands in source order.

**Fixture corpus.** I compiled every upstream fixture that builds (1,587 in one `Bun.build` call in client mode, 1,734 with one `bun build` per file in ssr mode) with a debug build of main and with a debug build of this branch, and compared the output files. No file differs. So the memo slot counts and scope boundaries of the corpus are unchanged. Five fixtures panic in ssr mode on both builds (`Expected all ObjectExpressions and ObjectMethods to have non-null scope`), which #42375 fixes.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [949.44ms]
(pass) bundler > react-compiler/ComponentWithHooks [341.77ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [454.80ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [526.88ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [178.43ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [156.04ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [548.32ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [156.65ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [226.14ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [156.10ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [384.19ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [742.38ms]
(
... (truncated)

release without fix: 11 failed, 1 skipped
bun test v1.4.3-canary.1 (c800ac881)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [37.06ms]
(pass) bundler > react-compiler/ComponentWithHooks [13.21ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [14.65ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [15.81ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [10.81ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [9.10ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [29.97ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [11.46ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [26.57ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [12.37ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [14.27ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [30.20ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [18.43ms]
(pass) bundler > react-compiler/BranchBooleanFeatureFlagPreservesDCE [10.10ms]
(pass) bundler > react-compi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [1041.63ms]
(pass) bundler > react-compiler/ComponentWithHooks [316.85ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [368.95ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [367.44ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [193.38ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [152.07ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [520.79ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [146.70ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [148.27ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [137.77ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [485.46ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [656.34ms]

... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 815ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/react_compiler/lowering/build_hir/expr.rs  |   6 +-
 test/bundler/transpiler/react-compiler.test.ts | 136 +++++++++++++++++++++++++
 2 files changed, 140 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/react_compiler/lowering/build_hir/expr.rs       3      2     20
test/bundler/transpiler/react-compiler.test.ts      3      1     20
```

</details>

<!-- robobun:evidence:end -->