### PR TITLE
bundler: check receivers on the Bun.build plugin object and freeze its filters during a build

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -791,8 +791,7 @@ pub mod bv2_impl {
                     JSBundlerPlugin__hasOnBeforeParsePlugins(self) != 0
                 }
 
-                /// JS thread, before a bundle pass takes this plugin. The pass and its parse workers read
-                /// the filter lists with no lock, so `addFilter` / `onBeforeParse` refuse from here on.
+                /// JS thread, before a bundle pass takes this plugin: `addFilter` / `onBeforeParse` throw from here on.
                 pub fn freeze_filters(&self) {
                     JSBundlerPlugin__freezeFilters(self)
                 }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -756,6 +756,8 @@ pub mod bv2_impl {
                 safe fn JSBundlerPlugin__drainDeferred(this: &mut Plugin, rejected: bool);
                 #[link_name = "JSBundlerPlugin__hasOnBeforeParsePlugins"]
                 safe fn JSBundlerPlugin__hasOnBeforeParsePlugins(this: &Plugin) -> i32;
+                #[link_name = "JSBundlerPlugin__freezeFilters"]
+                safe fn JSBundlerPlugin__freezeFilters(this: &Plugin);
                 // `ctx`/`args`/`result` are opaque cookies the C++ side round-trips
                 // to Rust-registered native-plugin callbacks without dereferencing
                 // in `JSBundlerPlugin.cpp` itself (same posture as `matchOnLoad`
@@ -787,6 +789,12 @@ pub mod bv2_impl {
                 #[inline]
                 pub(crate) fn has_on_before_parse_plugins(&self) -> bool {
                     JSBundlerPlugin__hasOnBeforeParsePlugins(self) != 0
+                }
+
+                /// JS thread, before a bundle pass takes this plugin. The pass and its parse workers read
+                /// the filter lists with no lock, so `addFilter` / `onBeforeParse` refuse from here on.
+                pub fn freeze_filters(&self) {
+                    JSBundlerPlugin__freezeFilters(self)
                 }
 
                 #[inline]
@@ -2990,6 +2998,10 @@ pub mod bv2_impl {
                 this.framework = Some(bo.framework);
                 this.linker.framework = this.framework.as_ref().map(bun_ptr::BackRef::new);
                 this.plugins = bo.plugins;
+                // A bake pass is built on the JS thread, which is where the plugin wants this call.
+                if let Some(plugins) = this.plugins_ref() {
+                    plugins.freeze_filters();
+                }
                 if this.transpiler.options.server_components {
                     debug_assert!(
                         this.client_transpiler_ref()

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -215,10 +215,25 @@ DEFINE_VISIT_OUTPUT_CONSTRAINTS(JSBundlerPlugin);
 
 const JSC::ClassInfo JSBundlerPlugin::s_info = { "BundlerPlugin"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSBundlerPlugin) };
 
+// The host functions below are reachable only from the builtins in BundlerPlugin.ts, which always
+// call them with the plugin object as the receiver. The receiver is checked anyway: each one reads
+// C++ fields off `this`, so a receiver of another type is a type confusion and not a bad argument.
+// Returns nullptr with an exception pending.
+static JSBundlerPlugin* pluginReceiver(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
+{
+    auto* thisObject = dynamicDowncast<JSBundlerPlugin>(callFrame->thisValue());
+    if (!thisObject) [[unlikely]]
+        Bun::throwInvalidThisCallError(globalObject, callFrame, "BundlerPlugin"_s);
+    return thisObject;
+}
+
 /// `BundlerPlugin.prototype.addFilter(filter: RegExp, namespace: string, isOnLoad: 0 | 1): void`
 JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_addFilter, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    JSBundlerPlugin* thisObject = uncheckedDowncast<JSBundlerPlugin>(callFrame->thisValue());
+    JSBundlerPlugin* thisObject = pluginReceiver(globalObject, callFrame);
+    if (!thisObject) [[unlikely]]
+        return {};
+
     if (thisObject->plugin.tombstoned) {
         return JSC::JSValue::encode(JSC::jsUndefined());
     }
@@ -340,9 +355,12 @@ int BundlerPlugin::NativePluginList::call(JSC::VM& vm, BundlerPlugin* plugin, in
 }
 JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_onBeforeParse, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
+    JSBundlerPlugin* thisObject = pluginReceiver(globalObject, callFrame);
+    if (!thisObject) [[unlikely]]
+        return {};
+
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSBundlerPlugin* thisObject = uncheckedDowncast<JSBundlerPlugin>(callFrame->thisValue());
     if (thisObject->plugin.tombstoned) {
         return JSC::JSValue::encode(JSC::jsUndefined());
     }
@@ -423,7 +441,10 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_onBeforeParse, (JSC::JSGlobalOb
 
 JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_addError, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    JSBundlerPlugin* thisObject = uncheckedDowncast<JSBundlerPlugin>(callFrame->thisValue());
+    JSBundlerPlugin* thisObject = pluginReceiver(globalObject, callFrame);
+    if (!thisObject) [[unlikely]]
+        return {};
+
     void* context = UNWRAP_BUNDLER_PLUGIN(callFrame);
     if (auto kind = thisObject->plugin.takeRequest(context))
         thisObject->plugin.addError(context, thisObject, JSValue::encode(callFrame->argument(1)), static_cast<uint8_t>(*kind));
@@ -432,7 +453,10 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_addError, (JSC::JSGlobalObject 
 }
 JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_onLoadAsync, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    JSBundlerPlugin* thisObject = uncheckedDowncast<JSBundlerPlugin>(callFrame->thisValue());
+    JSBundlerPlugin* thisObject = pluginReceiver(globalObject, callFrame);
+    if (!thisObject) [[unlikely]]
+        return {};
+
     if (thisObject->plugin.takeRequest(BundlerPlugin::RequestKind::Load, UNWRAP_BUNDLER_PLUGIN(callFrame))) {
         thisObject->plugin.onLoadAsync(
             UNWRAP_BUNDLER_PLUGIN(callFrame),
@@ -445,7 +469,10 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_onLoadAsync, (JSC::JSGlobalObje
 }
 JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_onResolveAsync, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    JSBundlerPlugin* thisObject = uncheckedDowncast<JSBundlerPlugin>(callFrame->thisValue());
+    JSBundlerPlugin* thisObject = pluginReceiver(globalObject, callFrame);
+    if (!thisObject) [[unlikely]]
+        return {};
+
     if (thisObject->plugin.takeRequest(BundlerPlugin::RequestKind::Resolve, UNWRAP_BUNDLER_PLUGIN(callFrame))) {
         thisObject->plugin.onResolveAsync(
             UNWRAP_BUNDLER_PLUGIN(callFrame),
@@ -471,7 +498,10 @@ extern "C" JSC::EncodedJSValue JSBundlerPlugin__appendDeferPromise(Bun::JSBundle
 
 JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_generateDeferPromise, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
-    JSBundlerPlugin* thisObject = uncheckedDowncast<JSBundlerPlugin>(callFrame->thisValue());
+    JSBundlerPlugin* thisObject = pluginReceiver(globalObject, callFrame);
+    if (!thisObject) [[unlikely]]
+        return {};
+
     void* context = UNWRAP_BUNDLER_PLUGIN(callFrame);
     // Only a request the plugins still hold can defer: once answered it is the bundle thread's again.
     if (!thisObject->plugin.holdsRequest(BundlerPlugin::RequestKind::Load, context)) {
@@ -513,8 +543,12 @@ void JSBundlerPlugin::finishCreation(JSC::VM& vm)
                 JSC::JSFunction::create(vm, globalObject, WebCore::bundlerPluginRunSetupFunctionCodeGenerator(vm), globalObject));
         });
 
+    // Every property the builtins in BundlerPlugin.ts read off this object exists from the start, so
+    // a read before the first write finds an own property instead of walking the prototype chain.
     this->putDirect(vm, Identifier::fromString(vm, String("onLoad"_s)), jsUndefined(), 0);
     this->putDirect(vm, Identifier::fromString(vm, String("onResolve"_s)), jsUndefined(), 0);
+    this->putDirect(vm, Identifier::fromString(vm, String("onEndCallbacks"_s)), jsUndefined(), 0);
+    this->putDirect(vm, Identifier::fromString(vm, String("promises"_s)), jsUndefined(), 0);
     Bun::reifyStaticPropertyTable(vm, JSBundlerPlugin::info(), JSBundlerPluginHashTable, *this);
 }
 
@@ -598,7 +632,10 @@ extern "C" Bun::JSBundlerPlugin* JSBundlerPlugin__create(Zig::GlobalObject* glob
         JSBundlerPlugin::createStructure(
             globalObject->vm(),
             globalObject,
-            globalObject->objectPrototype()),
+            // The prototype is null. The builtins in BundlerPlugin.ts read properties off this object
+            // by name. With Object.prototype in the chain, a user accessor planted under one of those
+            // names runs with this private object as its receiver, which hands the object to user code.
+            jsNull()),
         nullptr,
         target);
 }

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -215,10 +215,7 @@ DEFINE_VISIT_OUTPUT_CONSTRAINTS(JSBundlerPlugin);
 
 const JSC::ClassInfo JSBundlerPlugin::s_info = { "BundlerPlugin"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSBundlerPlugin) };
 
-// The host functions below read C++ fields off the receiver. The builtins in BundlerPlugin.ts call
-// them with the plugin object, and the object is a gcProtect'ed cell that bun:jsc's
-// getProtectedObjects() hands to JS, so the receiver is checked: any other type would be read as a
-// plugin. Returns nullptr with an exception pending.
+// nullptr means it threw. Checked, not assumed: bun:jsc's getProtectedObjects() hands this cell to JS.
 static JSBundlerPlugin* pluginReceiver(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
 {
     auto* thisObject = dynamicDowncast<JSBundlerPlugin>(callFrame->thisValue());
@@ -543,8 +540,7 @@ void JSBundlerPlugin::finishCreation(JSC::VM& vm)
                 JSC::JSFunction::create(vm, globalObject, WebCore::bundlerPluginRunSetupFunctionCodeGenerator(vm), globalObject));
         });
 
-    // Every property the builtins in BundlerPlugin.ts read off this object exists from the start, so
-    // a read before the first write finds an own property instead of walking the prototype chain.
+    // Every name the builtins in BundlerPlugin.ts read off this object is an own property from here.
     this->putDirect(vm, Identifier::fromString(vm, String("onLoad"_s)), jsUndefined(), 0);
     this->putDirect(vm, Identifier::fromString(vm, String("onResolve"_s)), jsUndefined(), 0);
     this->putDirect(vm, Identifier::fromString(vm, String("onEndCallbacks"_s)), jsUndefined(), 0);
@@ -632,9 +628,7 @@ extern "C" Bun::JSBundlerPlugin* JSBundlerPlugin__create(Zig::GlobalObject* glob
         JSBundlerPlugin::createStructure(
             globalObject->vm(),
             globalObject,
-            // The prototype is null. The builtins in BundlerPlugin.ts read properties off this object
-            // by name. With Object.prototype in the chain, a user accessor planted under one of those
-            // names runs with this private object as its receiver, which hands the object to user code.
+            // Null prototype: an accessor on Object.prototype would otherwise receive this object.
             jsNull()),
         nullptr,
         target);
@@ -686,8 +680,7 @@ extern "C" JSC::EncodedJSValue JSBundlerPlugin__runSetupFunction(
     arguments.append(JSValue::decode(encodedOnstartPromisesArray));
     arguments.append(JSValue::decode(encodedIsLast));
     arguments.append(JSValue::decode(encodedIsBake));
-    // The setup function is any callable the user gave, not always a JSFunction: a callable Proxy
-    // and a native function are objects of another class.
+    // setup() is any callable, and a callable Proxy is not a JSFunction.
     auto* setupObject = JSValue::decode(encodedSetupFunction).getObject();
     auto* lexicalGlobalObject = setupObject ? setupObject->globalObject() : plugin->globalObject();
 

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -253,7 +253,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_addFilter, (JSC::JSGlobalObject
     RETURN_IF_EXCEPTION(scope, {});
 
     // Checked after the last conversion that can run user code, so nothing runs between this and the append.
-    if (thisObject->plugin.filtersAreFrozen()) [[unlikely]]
+    if (thisObject->plugin.filtersFrozen) [[unlikely]]
         return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE, "addFilter() called after the build started"_s);
 
     unsigned index = 0;
@@ -435,7 +435,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_onBeforeParse, (JSC::JSGlobalOb
     }
 
     // Checked after the last conversion that can run user code, so nothing runs between this and the appends.
-    if (thisObject->plugin.filtersAreFrozen()) [[unlikely]]
+    if (thisObject->plugin.filtersFrozen) [[unlikely]]
         return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE, "onBeforeParse() called after the build started"_s);
 
     if (externalPtr)
@@ -736,6 +736,11 @@ void BundlerPlugin::tombstone()
 extern "C" void JSBundlerPlugin__tombstone(Bun::JSBundlerPlugin* plugin)
 {
     plugin->plugin.tombstone();
+}
+
+extern "C" void JSBundlerPlugin__freezeFilters(Bun::JSBundlerPlugin* plugin)
+{
+    plugin->plugin.filtersFrozen = true;
 }
 
 extern "C" JSC::EncodedJSValue JSBundlerPlugin__runOnEndCallbacks(Bun::JSBundlerPlugin* plugin, JSC::EncodedJSValue encodedBuildPromise, JSC::EncodedJSValue encodedBuildResult, JSC::EncodedJSValue encodedRejection)

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -252,6 +252,10 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_addFilter, (JSC::JSGlobalObject
     uint32_t isOnLoad = callFrame->argument(2).toUInt32(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
+    // Checked after the last conversion that can run user code, so nothing runs between this and the append.
+    if (thisObject->plugin.filtersAreFrozen()) [[unlikely]]
+        return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE, "addFilter() called after the build started"_s);
+
     unsigned index = 0;
     if (isOnLoad) {
         thisObject->plugin.onLoad.append(vm, regExp->regExp(), namespaceStr, index);
@@ -428,8 +432,14 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_onBeforeParse, (JSC::JSGlobalOb
             Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "Expected external (3rd argument) to be a NAPI external"_s);
             return {};
         }
-        thisObject->plugin.onBeforeParseExternals.append(vm, thisObject, externalPtr);
     }
+
+    // Checked after the last conversion that can run user code, so nothing runs between this and the appends.
+    if (thisObject->plugin.filtersAreFrozen()) [[unlikely]]
+        return Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE, "onBeforeParse() called after the build started"_s);
+
+    if (externalPtr)
+        thisObject->plugin.onBeforeParseExternals.append(vm, thisObject, externalPtr);
 
     thisObject->plugin.onBeforeParse.append(vm, newRegexp, namespaceStr, callback, native_plugin_name ? *native_plugin_name : nullptr, externalPtr);
 

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -215,10 +215,10 @@ DEFINE_VISIT_OUTPUT_CONSTRAINTS(JSBundlerPlugin);
 
 const JSC::ClassInfo JSBundlerPlugin::s_info = { "BundlerPlugin"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSBundlerPlugin) };
 
-// The host functions below are reachable only from the builtins in BundlerPlugin.ts, which always
-// call them with the plugin object as the receiver. The receiver is checked anyway: each one reads
-// C++ fields off `this`, so a receiver of another type is a type confusion and not a bad argument.
-// Returns nullptr with an exception pending.
+// The host functions below read C++ fields off the receiver. The builtins in BundlerPlugin.ts call
+// them with the plugin object, and the object is a gcProtect'ed cell that bun:jsc's
+// getProtectedObjects() hands to JS, so the receiver is checked: any other type would be read as a
+// plugin. Returns nullptr with an exception pending.
 static JSBundlerPlugin* pluginReceiver(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
 {
     auto* thisObject = dynamicDowncast<JSBundlerPlugin>(callFrame->thisValue());
@@ -686,7 +686,10 @@ extern "C" JSC::EncodedJSValue JSBundlerPlugin__runSetupFunction(
     arguments.append(JSValue::decode(encodedOnstartPromisesArray));
     arguments.append(JSValue::decode(encodedIsLast));
     arguments.append(JSValue::decode(encodedIsBake));
-    auto* lexicalGlobalObject = uncheckedDowncast<JSFunction>(JSValue::decode(encodedSetupFunction))->globalObject();
+    // The setup function is any callable the user gave, not always a JSFunction: a callable Proxy
+    // and a native function are objects of another class.
+    auto* setupObject = JSValue::decode(encodedSetupFunction).getObject();
+    auto* lexicalGlobalObject = setupObject ? setupObject->globalObject() : plugin->globalObject();
 
     auto result = JSC::profiledCall(lexicalGlobalObject, ProfilingReason::API, setupFunction, callData, plugin, arguments);
     RETURN_IF_EXCEPTION(scope, {}); // should be able to use RELEASE_AND_RETURN, no? observed it returning undefined with exception active

--- a/src/jsc/bindings/JSBundlerPlugin.h
+++ b/src/jsc/bindings/JSBundlerPlugin.h
@@ -145,8 +145,6 @@ public:
     // From here the plugin object answers nothing itself: what it still holds is answered as cancelled now,
     // and whatever its JS side delivers later is dropped.
     void tombstone();
-    // `config` is set as a build takes this plugin to the bundle thread, which reads the filter lists unlocked.
-    bool filtersAreFrozen() const { return config; }
 
     BundlerPlugin(void* config, BunPluginTarget target, JSBundlerPluginAddErrorCallback addError, JSBundlerPluginOnLoadAsyncCallback onLoadAsync, JSBundlerPluginOnResolveAsyncCallback onResolveAsync)
         : addError(addError)
@@ -172,6 +170,8 @@ public:
     JSBundlerPluginOnResolveAsyncCallback onResolveAsync;
     void* config { nullptr };
     bool tombstoned { false };
+    // Set on the JS thread before a bundle pass takes this plugin: other threads then read the filter lists unlocked.
+    bool filtersFrozen { false };
 
 private:
     WTF::HashMap<void*, RequestKind> held;

--- a/src/jsc/bindings/JSBundlerPlugin.h
+++ b/src/jsc/bindings/JSBundlerPlugin.h
@@ -145,6 +145,8 @@ public:
     // From here the plugin object answers nothing itself: what it still holds is answered as cancelled now,
     // and whatever its JS side delivers later is dropped.
     void tombstone();
+    // `config` is set as a build takes this plugin to the bundle thread, which reads the filter lists unlocked.
+    bool filtersAreFrozen() const { return config; }
 
     BundlerPlugin(void* config, BunPluginTarget target, JSBundlerPluginAddErrorCallback addError, JSBundlerPluginOnLoadAsyncCallback onLoadAsync, JSBundlerPluginOnResolveAsyncCallback onResolveAsync)
         : addError(addError)

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -165,7 +165,9 @@ impl JSBundleCompletionTask {
         let plugins = self.plugins;
         let completion = RefPtr::new(self).into_raw();
         if let Some(plugin) = plugins {
-            Plugin::opaque_mut(plugin.as_ptr()).set_config(completion.cast());
+            let plugin = Plugin::opaque_mut(plugin.as_ptr());
+            plugin.set_config(completion.cast());
+            plugin.freeze_filters();
         }
 
         // Ensure this exists before we spawn the thread to prevent any race

--- a/test/bake/serve-plugins-dev-server.test.ts
+++ b/test/bake/serve-plugins-dev-server.test.ts
@@ -137,3 +137,83 @@ test.concurrent("DevServer is notified when [serve.static] plugin setup resolves
   expect(out).toEqual({ status: 200, fromPlugin: true });
   expect(exitCode).toBe(0);
 });
+
+// The DevServer's parse workers read the plugin object's filter lists with no lock, so nothing may
+// append to them once a bundle pass has the plugin. The private plugin object is a gcProtect'ed
+// cell, so bun:jsc.getProtectedObjects() returns it.
+test.concurrent("DevServer's [serve.static] plugin object refuses a new filter once it bundles", async () => {
+  using dir = tempDir("serve-plugins-devserver-late-filter", {
+    "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+    "plugin.ts": `
+      import { getProtectedObjects } from "bun:jsc";
+
+      const hasOwn = Object.prototype.hasOwnProperty;
+      function findPlugin() {
+        for (const object of getProtectedObjects()) {
+          // The list holds raw protected cells. Some of them are internal and reject a property
+          // lookup, so skip whatever throws.
+          try {
+            if (object && typeof object === "object" && hasOwn.call(object, "addFilter") && hasOwn.call(object, "generateDeferPromise")) {
+              return object;
+            }
+          } catch {}
+        }
+        return undefined;
+      }
+
+      let plugin: any;
+      function addFilter() {
+        try {
+          plugin.addFilter(/never-matches/, "probe", 1);
+          return "accepted";
+        } catch (e: any) {
+          return e.code ?? e.name;
+        }
+      }
+
+      globalThis.outcomes = {};
+      export default {
+        name: "late-filter-plugin",
+        setup(build) {
+          plugin = findPlugin();
+          globalThis.outcomes.duringSetup = addFilter();
+          build.onLoad({ filter: /entry\\.ts$/ }, () => {
+            globalThis.outcomes.duringBundle = addFilter();
+            return undefined;
+          });
+        },
+      };
+    `,
+    "index.html": indexHtml,
+    "entry.ts": `console.log("ORIGINAL_MARKER");`,
+    "server.ts": `
+      import html from "./index.html";
+      const server = Bun.serve({
+        port: 0,
+        development: true,
+        routes: { "/": html },
+        fetch() { return new Response("fallback"); },
+      });
+      const res = await fetch(server.url, { signal: AbortSignal.timeout(10_000) });
+      await res.text();
+      await server.stop(true);
+      console.log(JSON.stringify({ status: res.status, outcomes: globalThis.outcomes }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "server.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const line = stdout.split("\n").find(l => l.startsWith("{"));
+  expect(line ? JSON.parse(line) : { stdout, stderr }).toEqual({
+    status: 200,
+    outcomes: { duringSetup: "accepted", duringBundle: "ERR_INVALID_STATE" },
+  });
+  expect(exitCode).toBe(0);
+});

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1893,4 +1893,79 @@ describe("bundler", () => {
       }).toEqual({ success: true, logs: [], outputs: ["second-name.js"] });
     });
   }
+
+  // The builtins in BundlerPlugin.ts read properties off a private plugin object by name. An
+  // accessor planted on Object.prototype under one of those names used to run with that object as
+  // its receiver, which handed it to user code. Its native methods then read any receiver as a
+  // plugin.
+  test.concurrent("plugin/the private plugin object is not reachable from Object.prototype", async () => {
+    using dir = tempDir("plugin-private-object", {
+      "entry.js": `export default 1;`,
+      "probe-fixture.mjs": /* js */ `
+        const names = ["promises", "onEndCallbacks", "onLoad", "onResolve"];
+        const leaked = [];
+        let plugin;
+        function record(name, receiver) {
+          if (!Object.prototype.hasOwnProperty.call(receiver, "addFilter")) return;
+          plugin ??= receiver;
+          if (!leaked.includes(name)) leaked.push(name);
+        }
+        for (const name of names) {
+          Object.defineProperty(Object.prototype, name, {
+            configurable: true,
+            get() {
+              record(name, this);
+              return undefined;
+            },
+            // Define an own property, so the build still behaves as it does without the accessor.
+            set(value) {
+              record(name, this);
+              Object.defineProperty(this, name, { value, writable: true, enumerable: true, configurable: true });
+            },
+          });
+        }
+        const result = await Bun.build({
+          entrypoints: ["./entry.js"],
+          throw: false,
+          plugins: [
+            {
+              name: "probe",
+              setup(build) {
+                build.onResolve({ filter: /entry/ }, () => undefined);
+                build.onLoad({ filter: /entry/ }, () => undefined);
+                build.onStart(() => {});
+                build.onEnd(() => {});
+              },
+            },
+          ],
+        });
+        for (const name of names) delete Object.prototype[name];
+        // If the object ever leaks again, its native methods must refuse a receiver that is not a
+        // plugin instead of reading one out of it.
+        let receiver = "not reachable";
+        if (plugin) {
+          try {
+            plugin.addFilter.call(undefined, /x/, "a", 1);
+            receiver = "accepted";
+          } catch (e) {
+            receiver = e.code ?? "threw";
+          }
+        }
+        console.log(JSON.stringify({ success: result.success, leaked, receiver }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "probe-fixture.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout || "null")).toEqual({ success: true, leaked: [], receiver: "not reachable" });
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1940,18 +1940,7 @@ describe("bundler", () => {
           ],
         });
         for (const name of names) delete Object.prototype[name];
-        // If the object ever leaks again, its native methods must refuse a receiver that is not a
-        // plugin instead of reading one out of it.
-        let receiver = "not reachable";
-        if (plugin) {
-          try {
-            plugin.addFilter.call(undefined, /x/, "a", 1);
-            receiver = "accepted";
-          } catch (e) {
-            receiver = e.code ?? "threw";
-          }
-        }
-        console.log(JSON.stringify({ success: result.success, leaked, receiver }));
+        console.log(JSON.stringify({ success: result.success, leaked, plugin: plugin === undefined }));
       `,
     });
 
@@ -1965,7 +1954,132 @@ describe("bundler", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout || "null")).toEqual({ success: true, leaked: [], receiver: "not reachable" });
+    expect(JSON.parse(stdout || "null")).toEqual({ success: true, leaked: [], plugin: true });
+    expect(exitCode).toBe(0);
+  });
+
+  // The private plugin object is a gcProtect'ed cell, so bun:jsc.getProtectedObjects() returns it.
+  // Its native methods read C++ fields off the receiver. They used to cast any receiver to a plugin,
+  // which segfaults at 0x132 on a release build.
+  test.concurrent("plugin/the private plugin object refuses a receiver that is not a plugin", async () => {
+    using dir = tempDir("plugin-foreign-receiver", {
+      "entry.js": `export default 1;`,
+      "receiver-fixture.mjs": /* js */ `
+        const { getProtectedObjects } = require("bun:jsc");
+        const hasOwn = Object.prototype.hasOwnProperty;
+        function findPlugin() {
+          for (const object of getProtectedObjects()) {
+            // The list holds raw protected cells. Some of them are internal and reject a property
+            // lookup, so skip whatever throws.
+            try {
+              if (object && typeof object === "object" && hasOwn.call(object, "addFilter") && hasOwn.call(object, "generateDeferPromise")) {
+                return object;
+              }
+            } catch {}
+          }
+          return undefined;
+        }
+        let plugin;
+        await Bun.build({
+          entrypoints: ["./entry.js"],
+          throw: false,
+          plugins: [
+            {
+              name: "probe",
+              setup(build) {
+                build.onLoad({ filter: /entry/ }, () => undefined);
+                plugin ??= findPlugin();
+              },
+            },
+          ],
+        });
+        plugin ??= findPlugin();
+        if (!plugin) {
+          console.log(JSON.stringify({ found: false }));
+          process.exit(0);
+        }
+        const calls = {
+          addFilter: [/x/, "a", 1],
+          addError: [0, new Error("x")],
+          onLoadAsync: [0, null, null],
+          onResolveAsync: [0, null, null, null],
+          onBeforeParse: [/x/, "a", {}, "symbol"],
+          generateDeferPromise: [0],
+        };
+        const outcomes = {};
+        for (const [name, args] of Object.entries(calls)) {
+          try {
+            plugin[name].apply(undefined, args);
+            outcomes[name] = "accepted";
+          } catch (e) {
+            outcomes[name] = e.code ?? e.name;
+          }
+        }
+        console.log(JSON.stringify({ found: true, prototype: Object.getPrototypeOf(plugin), outcomes }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "receiver-fixture.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout || "null")).toEqual({
+      found: true,
+      prototype: null,
+      outcomes: {
+        addFilter: "ERR_INVALID_THIS",
+        addError: "ERR_INVALID_THIS",
+        onLoadAsync: "ERR_INVALID_THIS",
+        onResolveAsync: "ERR_INVALID_THIS",
+        onBeforeParse: "ERR_INVALID_THIS",
+        generateDeferPromise: "ERR_INVALID_THIS",
+      },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // setup() is any callable, and a callable Proxy is not a JSFunction. Reading it as one gave the
+  // setup call a garbage global object, which aborts an assert build.
+  test.concurrent("plugin/setup can be a callable that is not a plain function", async () => {
+    using dir = tempDir("plugin-callable-setup", {
+      "entry.js": `export default 1;`,
+      "setup-fixture.mjs": /* js */ `
+        const result = await Bun.build({
+          entrypoints: ["./entry.js"],
+          throw: false,
+          plugins: [
+            {
+              name: "proxy-setup",
+              setup: new Proxy(
+                build => {
+                  build.onLoad({ filter: /entry/ }, () => ({ contents: "export default 2;" }));
+                },
+                {},
+              ),
+            },
+          ],
+        });
+        console.log(JSON.stringify({ success: result.success, output: await result.outputs[0].text() }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "setup-fixture.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout || "null")).toEqual({ success: true, output: "// entry.js\nvar entry_default = 2;\nexport {\n  entry_default as default\n};\n" });
     expect(exitCode).toBe(0);
   });
 });

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1960,7 +1960,7 @@ describe("bundler", () => {
 
   // The private plugin object is a gcProtect'ed cell, so bun:jsc.getProtectedObjects() returns it.
   const findPluginSource = /* js */ `
-    const { getProtectedObjects } = require("bun:jsc");
+    import { getProtectedObjects } from "bun:jsc";
     const hasOwn = Object.prototype.hasOwnProperty;
     function findPlugin() {
       for (const object of getProtectedObjects()) {

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -2079,7 +2079,10 @@ describe("bundler", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toBe("");
-    expect(JSON.parse(stdout || "null")).toEqual({ success: true, output: "// entry.js\nvar entry_default = 2;\nexport {\n  entry_default as default\n};\n" });
+    expect(JSON.parse(stdout || "null")).toEqual({
+      success: true,
+      output: "// entry.js\nvar entry_default = 2;\nexport {\n  entry_default as default\n};\n",
+    });
     expect(exitCode).toBe(0);
   });
 });

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1959,26 +1959,30 @@ describe("bundler", () => {
   });
 
   // The private plugin object is a gcProtect'ed cell, so bun:jsc.getProtectedObjects() returns it.
-  // Its native methods read C++ fields off the receiver. They used to cast any receiver to a plugin,
-  // which segfaults at 0x132 on a release build.
+  const findPluginSource = /* js */ `
+    const { getProtectedObjects } = require("bun:jsc");
+    const hasOwn = Object.prototype.hasOwnProperty;
+    function findPlugin() {
+      for (const object of getProtectedObjects()) {
+        // The list holds raw protected cells. Some of them are internal and reject a property
+        // lookup, so skip whatever throws.
+        try {
+          if (object && typeof object === "object" && hasOwn.call(object, "addFilter") && hasOwn.call(object, "generateDeferPromise")) {
+            return object;
+          }
+        } catch {}
+      }
+      return undefined;
+    }
+  `;
+
+  // The plugin object's native methods read C++ fields off the receiver. They used to cast any
+  // receiver to a plugin, which segfaults at 0x132 on a release build.
   test.concurrent("plugin/the private plugin object refuses a receiver that is not a plugin", async () => {
     using dir = tempDir("plugin-foreign-receiver", {
       "entry.js": `export default 1;`,
       "receiver-fixture.mjs": /* js */ `
-        const { getProtectedObjects } = require("bun:jsc");
-        const hasOwn = Object.prototype.hasOwnProperty;
-        function findPlugin() {
-          for (const object of getProtectedObjects()) {
-            // The list holds raw protected cells. Some of them are internal and reject a property
-            // lookup, so skip whatever throws.
-            try {
-              if (object && typeof object === "object" && hasOwn.call(object, "addFilter") && hasOwn.call(object, "generateDeferPromise")) {
-                return object;
-              }
-            } catch {}
-          }
-          return undefined;
-        }
+        ${findPluginSource}
         let plugin;
         await Bun.build({
           entrypoints: ["./entry.js"],
@@ -2040,6 +2044,62 @@ describe("bundler", () => {
         onBeforeParse: "ERR_INVALID_THIS",
         generateDeferPromise: "ERR_INVALID_THIS",
       },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // Once a build is on the bundle thread, that thread reads the filter lists with no lock. A late
+  // addFilter with the genuine plugin as the receiver used to append to them anyway, which
+  // segfaults the bundle thread under load.
+  test.concurrent("plugin/the private plugin object refuses a new filter once the build runs", async () => {
+    using dir = tempDir("plugin-late-filter", {
+      "entry.js": `export default 1;`,
+      "late-filter-fixture.mjs": /* js */ `
+        ${findPluginSource}
+        let plugin;
+        function addFilter() {
+          try {
+            plugin.addFilter(/never-matches/, "probe", 1);
+            return "accepted";
+          } catch (e) {
+            return e.code ?? e.name;
+          }
+        }
+        const outcomes = {};
+        const result = await Bun.build({
+          entrypoints: ["./entry.js"],
+          throw: false,
+          plugins: [
+            {
+              name: "probe",
+              setup(build) {
+                plugin = findPlugin();
+                outcomes.duringSetup = addFilter();
+                build.onLoad({ filter: /entry/ }, () => {
+                  outcomes.duringBuild = addFilter();
+                  return undefined;
+                });
+              },
+            },
+          ],
+        });
+        console.log(JSON.stringify({ success: result.success, outcomes }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "late-filter-fixture.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout || "null")).toEqual({
+      success: true,
+      outcomes: { duringSetup: "accepted", duringBuild: "ERR_INVALID_STATE" },
     });
     expect(exitCode).toBe(0);
   });

--- a/test/bundler/native-plugin.test.ts
+++ b/test/bundler/native-plugin.test.ts
@@ -631,6 +631,80 @@ const many_foo = ["foo","foo","foo","foo","foo","foo","foo"]
     expect(exitCode).toBe(0);
   });
 
+  it("refuses a native onBeforeParse registration on the private plugin object once the build runs", async () => {
+    // The parse workers read the onBeforeParse list with no lock, so nothing may append to it after
+    // the build starts. The private plugin object is a gcProtect'ed cell, so
+    // bun:jsc.getProtectedObjects() returns it.
+    await Bun.write(path.join(tempdir, "late_registration_index.ts"), `export const v = "foo";\n`);
+
+    const buildScript = /* ts */ `
+      import * as path from "path";
+      import { getProtectedObjects } from "bun:jsc";
+      const tempdir = process.env.BUN_TEST_TEMP_DIR!;
+      const napiModule = require(path.join(tempdir, "build/Release/xXx123_foo_counter_321xXx.node"));
+
+      const hasOwn = Object.prototype.hasOwnProperty;
+      function findPlugin() {
+        for (const object of getProtectedObjects()) {
+          try {
+            if (object && typeof object === "object" && hasOwn.call(object, "onBeforeParse") && hasOwn.call(object, "generateDeferPromise")) {
+              return object;
+            }
+          } catch {}
+        }
+        return undefined;
+      }
+
+      let plugin: any;
+      function onBeforeParse() {
+        try {
+          plugin.onBeforeParse(/never-matches/, "probe", napiModule, "plugin_impl", undefined);
+          return "accepted";
+        } catch (e: any) {
+          return e.code ?? e.name;
+        }
+      }
+      const outcomes: Record<string, string> = {};
+      const result = await Bun.build({
+        outdir: path.join(tempdir, "dist-late-registration"),
+        entrypoints: [path.join(tempdir, "late_registration_index.ts")],
+        throw: false,
+        plugins: [
+          {
+            name: "late-registration",
+            setup(build) {
+              plugin = findPlugin();
+              outcomes.duringSetup = onBeforeParse();
+              build.onLoad({ filter: /late_registration_index\\.ts$/ }, () => {
+                outcomes.duringBuild = onBeforeParse();
+                return undefined;
+              });
+            },
+          },
+        ],
+      });
+      console.log(JSON.stringify({ success: result.success, outcomes }));
+    `;
+    await Bun.write(path.join(tempdir, "late_registration_build.ts"), buildScript);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", path.join(tempdir, "late_registration_build.ts")],
+      env: { ...bunEnv, BUN_TEST_TEMP_DIR: tempdir },
+      cwd: tempdir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const resultLine = stdout.split("\n").find(line => line.startsWith('{"success"'));
+    const parsed = resultLine ? JSON.parse(resultLine) : { stderr, stdout };
+    expect(parsed).toEqual({
+      success: true,
+      outcomes: { duringSetup: "accepted", duringBuild: "ERR_INVALID_STATE" },
+    });
+    expect(exitCode).toBe(0);
+  });
+
   it("should use result of the first plugin that runs and doesn't execute the others", async () => {
     const filter = /\.ts/;
 


### PR DESCRIPTION
### Problem

- The private plugin object behind `Bun.build` plugins reads any receiver as a plugin. `p.addFilter.call(undefined, /x/, "a", 1)` is `panic(main thread): Segmentation fault at address 0x132`.
- With the genuine object, an `addFilter` during the build is `panic: Segmentation fault at address 0x10` on the bundle thread. `NamespaceList::append` (`JSBundlerPlugin.cpp:63`) grows a `Vector` that `anyMatchesForNamespace` (`:79`) iterates with no lock.
- JS gets the object two ways: an `Object.prototype` accessor named `promises` or `onEndCallbacks` (the builtins read both before the object owns them), and `bun:jsc`'s `getProtectedObjects()`.

### Fix

- The six host functions check the receiver with `dynamicDowncast` and throw `ERR_INVALID_THIS`.
- `addFilter` and `onBeforeParse` throw `ERR_INVALID_STATE` once `filtersFrozen` is set. Every path that starts a bundle pass sets it on the JS thread, after every `setup()` settled: `JSBundleCompletionTask::schedule` and, for bake, `BundleV2::init`.
- The structure gets a null prototype and owns all four names the builtins read. `setup` is read as a `JSObject`: a callable `Proxy` is not a `JSFunction`, and it aborted assert builds.
- Verified: 6 new cases (`test/bundler/bundler_plugin.test.ts`, `native-plugin.test.ts`, `test/bake/serve-plugins-dev-server.test.ts`), each red on the released build. The plugin, serve-html and bake suites pass.

### Background

- One `Bun.build` creates one plugin object, which holds the filter lists. The builtins in `src/js/builtins/BundlerPlugin.ts` run with it as `this` and call `addFilter` once per filter when `setup()` returns. It is not public API.
- `Bun.build` and production HTML routes bundle on a dedicated bundle thread, which reads the filter lists. The dev server bundles on the JS thread. Parse workers read the onBeforeParse list on every path.
- `uncheckedDowncast` is a `static_cast` with a debug assertion.

<details><summary>Notes</summary>

Reported repro for the receiver, which prints the object's property names and then crashes:

```js
let p;
Object.defineProperty(Object.prototype, "promises", { configurable: true, set() {},
  get() { if (!p && Object.prototype.hasOwnProperty.call(this, "addFilter")) p = this; } });
await Bun.build({ entrypoints: [import.meta.path], plugins: [{ name: "x", setup() {} }] });
delete Object.prototype.promises;
console.log(Object.getOwnPropertyNames(p).join());
p.addFilter.call(undefined, /x/, "a", 1);
```

`addError`, `onLoadAsync`, `onResolveAsync` and `generateDeferPromise` crash the same way at `0x13A`. An assert build stops earlier, at `ASSERTION FAILED: isCell()` under `WTF::uncheckedDowncast<Bun::JSBundlerPlugin>`.

How the accessor reached the object. The structure used `globalObject->objectPrototype()`, and `runSetupFunction` reads `this.promises` (`src/js/builtins/BundlerPlugin.ts:165`) and `self.onEndCallbacks` (`:274`). The object owned neither name, so the read walked to `Object.prototype`, and an accessor receives the object it was reached through. `onLoad` and `onResolve` were already own properties.

Probe of the receiver check, on a local build that keeps the check and restores both leak conditions: all six functions, eight receiver shapes (`undefined`, `null`, `{}`, `42`, `"str"`, `Object.create(null)`, `[]`, a `Proxy`), under `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1`. 48 of 48 throw `ERR_INVALID_THIS`, exit code 0, and the verifier reports nothing. `throwInvalidThisCallError` declares its own throw scope, and each host function returns the empty value before it declares one.

Probe of the late `addFilter`: 801 files, 50 `addFilter` calls per onLoad callback and 20 per onResolve callback, with the object taken from `getProtectedObjects()`. Canary: `panic: Segmentation fault at address 0x10`, 3 of 3. This branch: `build ok: true | attempts: 28000 | accepted: 0 | refused: 28000`, 3 of 3. On an assert build the crash is `ASSERTION FAILED: m_ptr` in `RefPtr<JSC::Yarr::RegularExpression::Private>::operator*`.

Where the flag is set. `JSBundleCompletionTask::schedule` (`src/runtime/api/js_bundle_completion_task.rs:168`) sets it next to `config`, on the line before it enqueues the build to the bundle thread. That covers `Bun.build` and a production HTML route (`src/runtime/server/HTMLBundle.rs:477`). `BundleV2::init` sets it where a bake pass takes `bo.plugins`, which covers the dev server (`src/runtime/bake/DevServer.rs:3190`) and the bake production build (`src/runtime/bake/production.rs:632`). Both points run on the JS thread. Every legitimate `addFilter` comes from `processSetupResult`, and every path waits for all `setup()` calls to settle first: `Bun.build` waits in `JSBundlerConfig::from_js`, a production route waits for the plugins to load, the dev server defers its first pass until `on_plugins_resolved`, and bake parses both plugin arrays before it starts.

Which list each path shares. All three `has_any_matches` callers in `bundle_v2.rs` are `&mut BundleV2` methods, so they run on the thread that owns the pass: the bundle thread for the first two paths, the JS thread for the bake paths. So only the first two paths have a second reader of the onLoad and onResolve lists. The parse workers read the onBeforeParse list on every path. An earlier version of this branch keyed the freeze on `config`, which left the bake paths out. One flag that every consumer sets does not depend on which thread a path bundles on.

The check sits after the last argument conversion that can run user code (`toWTFString`, `toUInt32`, the `get` on the addon object). Nothing runs between the check and the append.

A hostile `Promise` species on the value `setup()` returns makes `runSetupFunction` hand Rust a thenable that is not a `JSPromise`. Rust then does not wait, schedules the build, and `processSetupResult` runs late. That late `addFilter` used to race with a legitimate receiver. It now throws.

Receiver casts left unchecked after this change: `BunAsyncIterableSource.cpp:437`, `:463` and `:510`. Those three host functions belong to `JSAsyncIteratorSourceOperation`, an internal cell that is never installed on an object JS can name.

The tests do not rest on prototype pollution. They take the cell from `getProtectedObjects()` during `setup()`. The late-filter cases call the function once during `setup()` (accepted) and once from an onLoad callback (`ERR_INVALID_STATE`), so they fail on the released build by outcome and need no crash. The `onBeforeParse` case lives in `native-plugin.test.ts` because the check sits after the addon validation. The dev server case runs a `[serve.static]` plugin under `development: true` and calls `addFilter` from its onLoad callback.

Suites run with the debug build: `bundler_plugin` (69 pass), `bundler_defer`, `bundler_plugin_chain`, `plugin-error-nested-throw`, `plugin-sync-exception-fallback`, `test/js/bun/plugin/plugins.test.ts`, `native-plugin` (20 pass), `test/js/bun/http/bun-serve-html.test.ts` (30 pass), `bun-serve-html-entry.test.ts` (7 pass), `test/bake/serve-plugins-dev-server.test.ts` (3 pass), `test/bake/dev/plugins.test.ts` (3 pass) and `test/bake/deinitialization.test.ts`.

`native-plugin.test.ts` runs `bun install` in `beforeAll`. Under the debug build in a cold container that exceeds the 5 s hook timeout on the first run and passes from then on. `bun bd test test/bundler/bun-build-api.test.ts` fails two `bytecode:` cases at the 5 s timeout in the same container. Neither touches plugin code.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/native-plugin.test.ts, test/bundler/bundler_plugin.test.ts

<!-- robobun:evidence:end -->