### PR TITLE
node:worker_threads: answer getHeapSnapshot() and startCpuProfile() while the worker runs synchronous JavaScript

### DIFF
--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -124,10 +124,8 @@ impl VM {
         JSC__VM__notifyNeedTermination(self)
     }
 
-    /// Fires the NeedShellTimeoutCheck trap. Thread safe. JSC services it by
-    /// calling the process-wide callback bun installs at startup
-    /// (`Bun::VMInterrupts::serviceTrap`) on the VM's thread at its next
-    /// safepoint, also in the middle of synchronous script.
+    /// Fires the NeedShellTimeoutCheck trap, serviced by `Bun::VMInterrupts::serviceTrap`
+    /// on the VM's thread at its next safepoint. Thread safe.
     pub(crate) fn notify_need_interrupt(&self) {
         JSC__VM__notifyNeedShellTimeoutCheck(self)
     }

--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -126,8 +126,8 @@ impl VM {
 
     /// Fires the NeedShellTimeoutCheck trap. Thread safe. JSC services it by
     /// calling the process-wide callback bun installs at startup
-    /// (`WorkerMessagingProxy::serviceInterruptTrap`) on the VM's thread at
-    /// its next safepoint, also in the middle of synchronous script.
+    /// (`Bun::VMInterrupts::serviceTrap`) on the VM's thread at its next
+    /// safepoint, also in the middle of synchronous script.
     pub(crate) fn notify_need_interrupt(&self) {
         JSC__VM__notifyNeedShellTimeoutCheck(self)
     }

--- a/src/jsc/VM.rs
+++ b/src/jsc/VM.rs
@@ -33,6 +33,7 @@ unsafe extern "C" {
     safe fn JSC__VM__setStartupJITDeferralScale(vm: &VM, scale: f64);
     safe fn JSC__VM__executionForbidden(vm: &VM) -> bool;
     safe fn JSC__VM__notifyNeedTermination(vm: &VM);
+    safe fn JSC__VM__notifyNeedShellTimeoutCheck(vm: &VM);
     safe fn JSC__VM__isEntered(vm: &VM) -> bool;
     safe fn JSC__VM__terminationException(vm: &VM) -> JSValue;
     safe fn JSC__VM__throwError(vm: &VM, global_object: &JSGlobalObject, value: JSValue);
@@ -121,6 +122,14 @@ impl VM {
     /// Fires NeedTermination Trap. Thread safe. See jsc's "VMTraps.h" for explaination on traps.
     pub(crate) fn notify_need_termination(&self) {
         JSC__VM__notifyNeedTermination(self)
+    }
+
+    /// Fires the NeedShellTimeoutCheck trap. Thread safe. JSC services it by
+    /// calling the process-wide callback bun installs at startup
+    /// (`WorkerMessagingProxy::serviceInterruptTrap`) on the VM's thread at
+    /// its next safepoint, also in the middle of synchronous script.
+    pub(crate) fn notify_need_interrupt(&self) {
+        JSC__VM__notifyNeedShellTimeoutCheck(self)
     }
 
     /// A script frame is on this VM's stack (JSC::VM::isEntered — a VMEntryScope is live).

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -414,7 +414,10 @@ impl VmHandle {
     /// only ask) and have the VM's thread run its queue at its next safepoint:
     /// a VM trap for running script, a loop task for an idle VM. Any thread;
     /// once closed the work is dropped unrun.
-    pub fn request_interrupt(&self, work: *mut c_void) {
+    ///
+    /// # Safety
+    /// `work` is null or a heap `Bun::VMInterrupts::Work` the caller hands over.
+    pub unsafe fn request_interrupt(&self, work: *mut c_void) {
         if let Some(_a) = self.enter() {
             // SAFETY: inside the gate before `Closed` ⇒ the VM and its
             // JSC::VM are alive; the queue is locked on the C++ side and
@@ -796,11 +799,12 @@ pub unsafe extern "C" fn Bun__VmHandle__scriptAllowed(r: *const Shared) -> bool 
 /// Any thread: [`VmHandle::request_interrupt`].
 ///
 /// # Safety
-/// `r` is a live reference its holder keeps for the duration of the call.
+/// `r` is a live reference its holder keeps for the duration of the call;
+/// `work` as for [`VmHandle::request_interrupt`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn Bun__VmHandle__requestInterrupt(r: *const Shared, work: *mut c_void) {
     // SAFETY: fn contract.
-    unsafe { VmHandle::borrow_ref(r) }.request_interrupt(work);
+    unsafe { VmHandle::borrow_ref(r).request_interrupt(work) };
 }
 
 /// The address of this handle's state byte, for C++ to test

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -31,6 +31,7 @@
 //! set of call sites and of `unsafe impl Send/Sync` in the VM crates so a new
 //! path around the door needs a justification rather than a reviewer's luck.
 
+use core::ffi::c_void;
 #[cfg(debug_assertions)]
 use core::panic::Location;
 use core::ptr::NonNull;
@@ -44,6 +45,14 @@ use crate::virtual_machine::VirtualMachine;
 use bun_event_loop::ConcurrentTask::ConcurrentTask as ConcurrentTaskItem;
 
 pub use bun_event_loop::Posted;
+
+// src/jsc/bindings/VMInterrupts.cpp
+unsafe extern "C" {
+    /// Append `work` to the VM's interrupt queue. The VM is alive.
+    fn Bun__VMInterrupts__enqueue(vm: &crate::VM, work: *mut c_void);
+    /// Delete `work` unrun.
+    pub(crate) fn Bun__VMInterrupts__drop(work: *mut c_void);
+}
 
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
@@ -396,6 +405,30 @@ impl VmHandle {
             // read, no `&VirtualMachine` formed off-thread.
             unsafe { (*(*self.0.hot.vm).jsc_vm.cast_const()).notify_need_termination() };
             self.0.loop_of(LoopKind::Regular).wakeup();
+        }
+    }
+
+    /// Queue `work` (a heap C++ `Bun::VMInterrupts::Work`, handed over; null
+    /// to only fire the trap) for the VM's thread and ask it to run its queue
+    /// at its next safepoint, even in the middle of synchronous script
+    /// (Node's `RequestInterrupt`). Any thread (a parent's
+    /// `worker.getHeapSnapshot()`); once closed the work is dropped unrun.
+    pub fn request_interrupt(&self, work: *mut c_void) {
+        if let Some(_a) = self.enter() {
+            // SAFETY: inside the gate before `Closed` ⇒ the VM and its
+            // JSC::VM are alive; the queue is locked on the C++ side and
+            // `notify_need_interrupt` is thread-safe (VMTraps). Raw field
+            // read, no `&VirtualMachine` formed off-thread.
+            unsafe {
+                let jsc_vm = &*(*self.0.hot.vm).jsc_vm.cast_const();
+                if !work.is_null() {
+                    Bun__VMInterrupts__enqueue(jsc_vm, work);
+                }
+                jsc_vm.notify_need_interrupt();
+            }
+        } else if !work.is_null() {
+            // SAFETY: `work` is ours to give up (fn contract).
+            unsafe { Bun__VMInterrupts__drop(work) };
         }
     }
 
@@ -755,6 +788,17 @@ pub unsafe extern "C" fn Bun__VmHandle__refKeepAlive(
 pub unsafe extern "C" fn Bun__VmHandle__scriptAllowed(r: *const Shared) -> bool {
     // SAFETY: fn contract.
     unsafe { VmHandle::borrow_ref(r) }.script_allowed()
+}
+
+/// Any thread: [`VmHandle::request_interrupt`].
+///
+/// # Safety
+/// `r` is a live reference its holder keeps for the duration of the call;
+/// `work` is a heap `Bun::VMInterrupts::Work` handed over, or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Bun__VmHandle__requestInterrupt(r: *const Shared, work: *mut c_void) {
+    // SAFETY: fn contract.
+    unsafe { VmHandle::borrow_ref(r) }.request_interrupt(work);
 }
 
 /// The address of this handle's state byte, for C++ to test

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -410,13 +410,10 @@ impl VmHandle {
         }
     }
 
-    /// Queue `work` (a heap C++ `Bun::VMInterrupts::Work`, handed over; null
-    /// to only ask) for the VM's thread and ask it to run its queue at its
-    /// next safepoint, even in the middle of synchronous script (Node's
-    /// `RequestInterrupt`): a VM trap for script that does not return to the
-    /// loop, and a loop task for a VM idle in its loop. Any thread (a
-    /// parent's `worker.getHeapSnapshot()`); once closed the work is dropped
-    /// unrun.
+    /// Queue `work` (a heap C++ `Bun::VMInterrupts::Work`, handed over; null to
+    /// only ask) and have the VM's thread run its queue at its next safepoint:
+    /// a VM trap for running script, a loop task for an idle VM. Any thread;
+    /// once closed the work is dropped unrun.
     pub fn request_interrupt(&self, work: *mut c_void) {
         if let Some(_a) = self.enter() {
             // SAFETY: inside the gate before `Closed` ⇒ the VM and its
@@ -799,8 +796,7 @@ pub unsafe extern "C" fn Bun__VmHandle__scriptAllowed(r: *const Shared) -> bool 
 /// Any thread: [`VmHandle::request_interrupt`].
 ///
 /// # Safety
-/// `r` is a live reference its holder keeps for the duration of the call;
-/// `work` is a heap `Bun::VMInterrupts::Work` handed over, or null.
+/// `r` is a live reference its holder keeps for the duration of the call.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn Bun__VmHandle__requestInterrupt(r: *const Shared, work: *mut c_void) {
     // SAFETY: fn contract.

--- a/src/jsc/VmHandle.rs
+++ b/src/jsc/VmHandle.rs
@@ -52,6 +52,8 @@ unsafe extern "C" {
     fn Bun__VMInterrupts__enqueue(vm: &crate::VM, work: *mut c_void);
     /// Delete `work` unrun.
     pub(crate) fn Bun__VMInterrupts__drop(work: *mut c_void);
+    /// A new heap `WebCore::EventLoopTask` that services the VM's queue.
+    fn Bun__VMInterrupts__createServiceTask() -> *mut crate::cpp_task::CppTask;
 }
 
 #[repr(u8)]
@@ -409,10 +411,12 @@ impl VmHandle {
     }
 
     /// Queue `work` (a heap C++ `Bun::VMInterrupts::Work`, handed over; null
-    /// to only fire the trap) for the VM's thread and ask it to run its queue
-    /// at its next safepoint, even in the middle of synchronous script
-    /// (Node's `RequestInterrupt`). Any thread (a parent's
-    /// `worker.getHeapSnapshot()`); once closed the work is dropped unrun.
+    /// to only ask) for the VM's thread and ask it to run its queue at its
+    /// next safepoint, even in the middle of synchronous script (Node's
+    /// `RequestInterrupt`): a VM trap for script that does not return to the
+    /// loop, and a loop task for a VM idle in its loop. Any thread (a
+    /// parent's `worker.getHeapSnapshot()`); once closed the work is dropped
+    /// unrun.
     pub fn request_interrupt(&self, work: *mut c_void) {
         if let Some(_a) = self.enter() {
             // SAFETY: inside the gate before `Closed` ⇒ the VM and its
@@ -425,6 +429,8 @@ impl VmHandle {
                     Bun__VMInterrupts__enqueue(jsc_vm, work);
                 }
                 jsc_vm.notify_need_interrupt();
+                // SAFETY: a fresh heap task, handed over.
+                self.post_cpp_task(LoopKind::Regular, Bun__VMInterrupts__createServiceTask());
             }
         } else if !work.is_null() {
             // SAFETY: `work` is ours to give up (fn contract).

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -30,6 +30,9 @@ extern "C" void Bun__VmHandle__postAndRelease(const BunVmHandleRef*, WebCore::Ev
 extern "C" void Bun__VmHandle__refKeepAlive(const BunVmHandleRef*, BunLoopKind, int delta);
 // Node's can_call_into_js(): false once the VM's stop was requested (terminate()/exit/teardown). Any thread.
 extern "C" bool Bun__VmHandle__scriptAllowed(const BunVmHandleRef*);
+// Queue `work` (a heap `Bun::VMInterrupts::Work`, handed over; may be null) on the VM's interrupts and have its
+// thread service them at its next safepoint. Dropped unrun once the VM is closed. Any thread.
+extern "C" void Bun__VmHandle__requestInterrupt(const BunVmHandleRef*, void* work);
 // The handle's state byte, so hot paths test it inline (BUN_VM_HANDLE_STATE_OPEN == bun_jsc::vm_handle::State::Open).
 extern "C" const unsigned char* Bun__VmHandle__stateAddress(const BunVmHandleRef*);
 #define BUN_VM_HANDLE_STATE_OPEN 0
@@ -58,6 +61,7 @@ class DOMWrapperWorld;
 #include "ExtendedDOMIsoSubspaces.h"
 #include "DOMIsoSubspaces.h"
 #include "BunBuiltinNames.h"
+#include "VMInterrupts.h"
 // #include "WebCoreJSBuiltins.h"
 // #include "WorkerThreadType.h"
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
@@ -257,6 +261,8 @@ public:
     // this thread and JSC forbids execution. Either way no script may be entered on this VM.
     ALWAYS_INLINE bool isStoppingOrStopped(const JSC::VM& vm) const { return !scriptAllowed() || vm.executionForbidden(); }
     Bun::JSCTaskScheduler deferredWorkTimer;
+    // Native work for this VM's thread at its next safepoint (Bun__VmHandle__requestInterrupt).
+    Bun::VMInterrupts interrupts;
 
     // One slot per string of the executable's module-info string table,
     // filled on first use so each name is atomized once however many chunks

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -30,8 +30,7 @@ extern "C" void Bun__VmHandle__postAndRelease(const BunVmHandleRef*, WebCore::Ev
 extern "C" void Bun__VmHandle__refKeepAlive(const BunVmHandleRef*, BunLoopKind, int delta);
 // Node's can_call_into_js(): false once the VM's stop was requested (terminate()/exit/teardown). Any thread.
 extern "C" bool Bun__VmHandle__scriptAllowed(const BunVmHandleRef*);
-// Queue `work` (a heap `Bun::VMInterrupts::Work`, handed over; may be null) on the VM's interrupts and have its
-// thread service them at its next safepoint. Dropped unrun once the VM is closed. Any thread.
+// Queue `work` (a heap `Bun::VMInterrupts::Work`, handed over, or null) and have the VM's thread service its queue. Any thread.
 extern "C" void Bun__VmHandle__requestInterrupt(const BunVmHandleRef*, void* work);
 // The handle's state byte, so hot paths test it inline (BUN_VM_HANDLE_STATE_OPEN == bun_jsc::vm_handle::State::Open).
 extern "C" const unsigned char* Bun__VmHandle__stateAddress(const BunVmHandleRef*);

--- a/src/jsc/bindings/EventLoopTask.h
+++ b/src/jsc/bindings/EventLoopTask.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "root.h"
 #include "ScriptExecutionContext.h"
 

--- a/src/jsc/bindings/VMInterrupts.cpp
+++ b/src/jsc/bindings/VMInterrupts.cpp
@@ -1,6 +1,8 @@
 #include "root.h"
 #include "VMInterrupts.h"
 #include "BunClientData.h"
+#include "EventLoopTask.h"
+#include "ScriptExecutionContext.h"
 #include <JavaScriptCore/Heap.h>
 #include <JavaScriptCore/VM.h>
 #include <JavaScriptCore/VMTraps.h>
@@ -26,8 +28,8 @@ void VMInterrupts::service(JSC::VM& vm)
     }
     // A trap is also serviced from the runtime's exception checks, which can sit inside a DeferGC
     // scope (a cell allocated but not yet reachable from a root). A collection there is the one
-    // DeferGC exists to prevent, and a heap snapshot is a full collection. The trap cannot be fired
-    // again from here (handleTraps loops while a trap bit is set), so a timer fires it.
+    // DeferGC exists to prevent, and a heap snapshot is a full collection. The request cannot be
+    // made again from here (handleTraps loops while a trap bit is set), so a timer makes it.
     if (vm.heap.isDeferred()) {
         JSC::VMTraps::queue().dispatchAfter(1_ms, [vmHandle = Bun__VmHandle__retainRef(clientData.vmHandle)] {
             Bun__VmHandle__requestInterrupt(vmHandle, nullptr);
@@ -61,4 +63,19 @@ extern "C" void Bun__VMInterrupts__enqueue(JSC::VM* vm, Bun::VMInterrupts::Work*
 extern "C" void Bun__VMInterrupts__drop(Bun::VMInterrupts::Work* work)
 {
     delete work;
+}
+
+// The loop task the handle posts beside the trap: the way to a VM idle in its loop, where no script
+// services the trap.
+extern "C" WebCore::EventLoopTask* Bun__VMInterrupts__createServiceTask()
+{
+    return new WebCore::EventLoopTask([](WebCore::ScriptExecutionContext& context) {
+        auto& vm = context.vm();
+        // Once the queue is empty the trap has no script left to service it, and an unserviced trap
+        // keeps JSC's signal sender suspending this thread every 1ms for as long as the VM holds its
+        // API lock, which a worker does for its whole life. Cleared before the drain: a request that
+        // lands after this sets it again and is either drained below or serviced later.
+        vm.traps().clearTrap(JSC::VMTraps::NeedShellTimeoutCheck);
+        WebCore::clientData(vm)->interrupts.service(vm);
+    });
 }

--- a/src/jsc/bindings/VMInterrupts.cpp
+++ b/src/jsc/bindings/VMInterrupts.cpp
@@ -1,0 +1,64 @@
+#include "root.h"
+#include "VMInterrupts.h"
+#include "BunClientData.h"
+#include <JavaScriptCore/Heap.h>
+#include <JavaScriptCore/VM.h>
+#include <JavaScriptCore/VMTraps.h>
+
+namespace Bun {
+
+void VMInterrupts::enqueue(std::unique_ptr<Work> work)
+{
+    Locker locker { m_lock };
+    m_queue.append(WTF::move(work));
+}
+
+void VMInterrupts::service(JSC::VM& vm)
+{
+    ASSERT(vm.currentThreadIsHoldingAPILock());
+    auto& clientData = *WebCore::clientData(vm);
+    // Asked to stop: nothing more is answered from this VM (Node's is_stopping). A worker's parent
+    // rejects its requests once the thread is gone.
+    if (clientData.isStoppingOrStopped(vm)) {
+        Locker locker { m_lock };
+        m_queue.clear();
+        return;
+    }
+    // A trap is also serviced from the runtime's exception checks, which can sit inside a DeferGC
+    // scope (a cell allocated but not yet reachable from a root). A collection there is the one
+    // DeferGC exists to prevent, and a heap snapshot is a full collection. The trap cannot be fired
+    // again from here (handleTraps loops while a trap bit is set), so a timer fires it.
+    if (vm.heap.isDeferred()) {
+        JSC::VMTraps::queue().dispatchAfter(1_ms, [vmHandle = Bun__VmHandle__retainRef(clientData.vmHandle)] {
+            Bun__VmHandle__requestInterrupt(vmHandle, nullptr);
+            Bun__VmHandle__release(vmHandle);
+        });
+        return;
+    }
+    Deque<std::unique_ptr<Work>> queue;
+    {
+        Locker locker { m_lock };
+        queue = std::exchange(m_queue, {});
+    }
+    for (auto& work : queue)
+        (*work)(vm);
+}
+
+void VMInterrupts::serviceTrap(JSC::VM& vm)
+{
+    WebCore::clientData(vm)->interrupts.service(vm);
+}
+
+} // namespace Bun
+
+// The VM's handle (src/jsc/VmHandle.rs) enqueues inside its gate, where the VM is alive, and drops
+// what it refuses once the VM is closed.
+extern "C" void Bun__VMInterrupts__enqueue(JSC::VM* vm, Bun::VMInterrupts::Work* work)
+{
+    WebCore::clientData(*vm)->interrupts.enqueue(std::unique_ptr<Bun::VMInterrupts::Work>(work));
+}
+
+extern "C" void Bun__VMInterrupts__drop(Bun::VMInterrupts::Work* work)
+{
+    delete work;
+}

--- a/src/jsc/bindings/VMInterrupts.cpp
+++ b/src/jsc/bindings/VMInterrupts.cpp
@@ -19,17 +19,14 @@ void VMInterrupts::service(JSC::VM& vm)
 {
     ASSERT(vm.currentThreadIsHoldingAPILock());
     auto& clientData = *WebCore::clientData(vm);
-    // Asked to stop: nothing more is answered from this VM (Node's is_stopping). A worker's parent
-    // rejects its requests once the thread is gone.
+    // Asked to stop: nothing more is answered (Node's is_stopping).
     if (clientData.isStoppingOrStopped(vm)) {
         Locker locker { m_lock };
         m_queue.clear();
         return;
     }
-    // A trap is also serviced from the runtime's exception checks, which can sit inside a DeferGC
-    // scope (a cell allocated but not yet reachable from a root). A collection there is the one
-    // DeferGC exists to prevent, and a heap snapshot is a full collection. The request cannot be
-    // made again from here (handleTraps loops while a trap bit is set), so a timer makes it.
+    // A trap is also serviced from exception checks inside DeferGC scopes, where the work's full
+    // collection is unsafe. handleTraps loops while a trap bit is set, so a timer asks again.
     if (vm.heap.isDeferred()) {
         JSC::VMTraps::queue().dispatchAfter(1_ms, [vmHandle = Bun__VmHandle__retainRef(clientData.vmHandle)] {
             Bun__VmHandle__requestInterrupt(vmHandle, nullptr);
@@ -53,8 +50,7 @@ void VMInterrupts::serviceTrap(JSC::VM& vm)
 
 } // namespace Bun
 
-// The VM's handle (src/jsc/VmHandle.rs) enqueues inside its gate, where the VM is alive, and drops
-// what it refuses once the VM is closed.
+// Called by the VM's handle (src/jsc/VmHandle.rs) inside its gate, where the VM is alive.
 extern "C" void Bun__VMInterrupts__enqueue(JSC::VM* vm, Bun::VMInterrupts::Work* work)
 {
     WebCore::clientData(*vm)->interrupts.enqueue(std::unique_ptr<Bun::VMInterrupts::Work>(work));
@@ -65,16 +61,14 @@ extern "C" void Bun__VMInterrupts__drop(Bun::VMInterrupts::Work* work)
     delete work;
 }
 
-// The loop task the handle posts beside the trap: the way to a VM idle in its loop, where no script
-// services the trap.
+// The loop task the handle posts beside the trap, for a VM idle in its loop.
 extern "C" WebCore::EventLoopTask* Bun__VMInterrupts__createServiceTask()
 {
     return new WebCore::EventLoopTask([](WebCore::ScriptExecutionContext& context) {
         auto& vm = context.vm();
-        // Once the queue is empty the trap has no script left to service it, and an unserviced trap
-        // keeps JSC's signal sender suspending this thread every 1ms for as long as the VM holds its
-        // API lock, which a worker does for its whole life. Cleared before the drain: a request that
-        // lands after this sets it again and is either drained below or serviced later.
+        // An unserviced trap keeps JSC's signal sender suspending this thread every 1ms while it
+        // holds the API lock, which a worker does for life. Cleared before the drain, so a request
+        // that lands after this is still serviced.
         vm.traps().clearTrap(JSC::VMTraps::NeedShellTimeoutCheck);
         WebCore::clientData(vm)->interrupts.service(vm);
     });

--- a/src/jsc/bindings/VMInterrupts.h
+++ b/src/jsc/bindings/VMInterrupts.h
@@ -11,18 +11,11 @@ class VM;
 
 namespace Bun {
 
-// Native work for a VM's thread that runs at its next safepoint, also in the middle of synchronous
-// script: Node's Environment::RequestInterrupt. A safepoint is where JSC services a VM trap: a JIT or
-// LLInt function entry or loop back edge, or a runtime exception check. The work runs with the API
-// lock held. It is native only: it may collect and read the heap, it enters no script and throws
-// nothing.
-//
-// Any thread enqueues through the VM's handle (Bun__VmHandle__requestInterrupt). The handle reaches
-// the thread two ways: it fires the trap, for script that does not return to the loop, and posts a
-// loop task that calls service(), for a VM idle in its loop (a trap is serviced only by running
-// script). Whichever arrives first runs the queue and the other finds it empty. Work still queued
-// when the VM is destroyed is dropped unrun. One queue per VM (JSVMClientData::interrupts), so
-// every user of the trap shares the process-wide callback slot without conflict.
+// Native work for a VM's thread, run at its next safepoint also in the middle of synchronous script
+// (Node's Environment::RequestInterrupt). The work runs with the API lock held; it may collect and
+// read the heap, it enters no script and throws nothing. Any thread enqueues through the VM's handle
+// (Bun__VmHandle__requestInterrupt), which fires the NeedShellTimeoutCheck trap for running script
+// and posts a loop task for an idle VM; the first to arrive runs the queue. One queue per VM.
 class VMInterrupts {
     WTF_MAKE_NONCOPYABLE(VMInterrupts);
 
@@ -33,8 +26,7 @@ public:
 
     // Any thread, while the VM is alive (inside its handle's gate).
     void enqueue(std::unique_ptr<Work>);
-    // VM thread. Drops the queue once the VM has been asked to stop. Inside a DeferGC scope it runs
-    // nothing and makes the request again from a timer, so that a later safepoint services it.
+    // VM thread.
     void service(JSC::VM&);
 
     // JSC's NeedShellTimeoutCheck handler for the whole process, installed by JSCInitialize().

--- a/src/jsc/bindings/VMInterrupts.h
+++ b/src/jsc/bindings/VMInterrupts.h
@@ -17,12 +17,12 @@ namespace Bun {
 // lock held. It is native only: it may collect and read the heap, it enters no script and throws
 // nothing.
 //
-// Any thread enqueues through the VM's handle (Bun__VmHandle__requestInterrupt), which also fires
-// the trap. A trap is serviced only by running script, so a caller that must also reach a VM idle
-// in its loop posts a loop task that calls service() (WorkerMessagingProxy). Whichever arrives
-// first runs the queue and the other finds it empty. Work still queued when the VM is destroyed is
-// dropped unrun. One queue per VM (JSVMClientData::interrupts), so every user of the trap shares
-// the process-wide callback slot without conflict.
+// Any thread enqueues through the VM's handle (Bun__VmHandle__requestInterrupt). The handle reaches
+// the thread two ways: it fires the trap, for script that does not return to the loop, and posts a
+// loop task that calls service(), for a VM idle in its loop (a trap is serviced only by running
+// script). Whichever arrives first runs the queue and the other finds it empty. Work still queued
+// when the VM is destroyed is dropped unrun. One queue per VM (JSVMClientData::interrupts), so
+// every user of the trap shares the process-wide callback slot without conflict.
 class VMInterrupts {
     WTF_MAKE_NONCOPYABLE(VMInterrupts);
 
@@ -34,7 +34,7 @@ public:
     // Any thread, while the VM is alive (inside its handle's gate).
     void enqueue(std::unique_ptr<Work>);
     // VM thread. Drops the queue once the VM has been asked to stop. Inside a DeferGC scope it runs
-    // nothing and asks for the trap again from a timer, so that a later safepoint services it.
+    // nothing and makes the request again from a timer, so that a later safepoint services it.
     void service(JSC::VM&);
 
     // JSC's NeedShellTimeoutCheck handler for the whole process, installed by JSCInitialize().

--- a/src/jsc/bindings/VMInterrupts.h
+++ b/src/jsc/bindings/VMInterrupts.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "root.h"
+#include <wtf/Deque.h>
+#include <wtf/Function.h>
+#include <wtf/Lock.h>
+
+namespace JSC {
+class VM;
+}
+
+namespace Bun {
+
+// Native work for a VM's thread that runs at its next safepoint, also in the middle of synchronous
+// script: Node's Environment::RequestInterrupt. A safepoint is where JSC services a VM trap: a JIT or
+// LLInt function entry or loop back edge, or a runtime exception check. The work runs with the API
+// lock held. It is native only: it may collect and read the heap, it enters no script and throws
+// nothing.
+//
+// Any thread enqueues through the VM's handle (Bun__VmHandle__requestInterrupt), which also fires
+// the trap. A trap is serviced only by running script, so a caller that must also reach a VM idle
+// in its loop posts a loop task that calls service() (WorkerMessagingProxy). Whichever arrives
+// first runs the queue and the other finds it empty. Work still queued when the VM is destroyed is
+// dropped unrun. One queue per VM (JSVMClientData::interrupts), so every user of the trap shares
+// the process-wide callback slot without conflict.
+class VMInterrupts {
+    WTF_MAKE_NONCOPYABLE(VMInterrupts);
+
+public:
+    using Work = WTF::Function<void(JSC::VM&)>;
+
+    VMInterrupts() = default;
+
+    // Any thread, while the VM is alive (inside its handle's gate).
+    void enqueue(std::unique_ptr<Work>);
+    // VM thread. Drops the queue once the VM has been asked to stop. Inside a DeferGC scope it runs
+    // nothing and asks for the trap again from a timer, so that a later safepoint services it.
+    void service(JSC::VM&);
+
+    // JSC's NeedShellTimeoutCheck handler for the whole process, installed by JSCInitialize().
+    static void serviceTrap(JSC::VM&);
+
+private:
+    Lock m_lock;
+    Deque<std::unique_ptr<Work>> m_queue WTF_GUARDED_BY_LOCK(m_lock);
+};
+
+} // namespace Bun

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -151,6 +151,8 @@
 #include <JavaScriptCore/WebAssemblyCompileOptions.h>
 #include "JSWebSocket.h"
 #include "JSWorker.h"
+#include "VMInterrupts.h"
+#include "JavaScriptCore/JSCConfig.h"
 #include "streams/JSWritableStream.h"
 #include "streams/JSWritableStreamDefaultController.h"
 #include "streams/JSWritableStreamDefaultWriter.h"
@@ -378,6 +380,11 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
             }
             JSC::Options::assertOptionsAreCoherent();
         }); // end JSC::initialize lambda
+
+        // The one VM trap that calls back into the embedder: how another thread runs native work on a
+        // VM's thread in the middle of script (Bun::VMInterrupts). Set before the first VM's
+        // constructor freezes g_jscConfig; JSC asserts it is set when the trap is serviced.
+        g_jscConfig.shellTimeoutCheckCallback = Bun::VMInterrupts::serviceTrap;
 
 #if OS(WINDOWS) && (CPU(X86_64) || CPU(ARM64))
         // JSC::initialize() registered unwind info + a language-specific SEH

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -381,9 +381,7 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
             JSC::Options::assertOptionsAreCoherent();
         }); // end JSC::initialize lambda
 
-        // The one VM trap that calls back into the embedder: how another thread runs native work on a
-        // VM's thread in the middle of script (Bun::VMInterrupts). Set before the first VM's
-        // constructor freezes g_jscConfig; JSC asserts it is set when the trap is serviced.
+        // Before the first VM's constructor freezes g_jscConfig.
         g_jscConfig.shellTimeoutCheckCallback = Bun::VMInterrupts::serviceTrap;
 
 #if OS(WINDOWS) && (CPU(X86_64) || CPU(ARM64))

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -737,12 +737,11 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
 
     // No up-front isOnline() gate: a worker can post to its parent (e.g. from
     // a microtask the entry module scheduled while it was still loading) while
-    // m_state is still Pending. postTaskToWorkerGlobalScope queues into
-    // m_pendingTasks for Pending and returns false only for Closing/Closed,
-    // which the !accepted reject below handles. If the worker never reaches
-    // Running (entry threw or failed to load), workerGlobalScopeDestroyedInternal
-    // clears m_pendingTasks on the parent thread and rejectAllCrossVMRequests()
-    // rejects + frees the Strong<>.
+    // m_state is still Pending. postInterruptToWorkerGlobalScope returns false
+    // only for Closing/Closed, which the !accepted reject below handles. If the
+    // worker never reaches Running (entry threw or failed to load), the work is
+    // dropped unrun with its VM and workerGlobalScopeDestroyedInternal's
+    // rejectAllCrossVMRequests() rejects + frees the Strong<>.
     auto* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
 
     // The promise is registered in a parent-side map keyed by reqId; only the id
@@ -752,8 +751,9 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
     uint64_t reqId = worker.contextProxy().registerCrossVMRequest(vm, promise);
     auto parentId = globalObject->scriptExecutionContext()->identifier();
     auto parentLoopKind = globalObject->scriptExecutionContext()->currentLoopKind();
-    bool accepted = worker.contextProxy().postTaskToWorkerGlobalScope([reqId, parentId, parentLoopKind, protectedProxy = Ref { worker.contextProxy() }](ScriptExecutionContext& workerCtx) mutable {
-        auto& vm = workerCtx.vm();
+    // An interrupt, not a loop task: the snapshot is what a parent asks for when the worker does not
+    // return to its loop. The full collection it runs is safe at a trap (Bun::VMInterrupts::service).
+    bool accepted = worker.contextProxy().postInterruptToWorkerGlobalScope([reqId, parentId, parentLoopKind, protectedProxy = Ref { worker.contextProxy() }](JSC::VM& vm) mutable {
         vm.ensureHeapProfiler();
         auto& heapProfiler = *vm.heapProfiler();
         heapProfiler.clearSnapshots();
@@ -766,7 +766,7 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
             });
     });
     if (!accepted) {
-        // postTaskToWorkerGlobalScope returns false only for Closing/Closed.
+        // postInterruptToWorkerGlobalScope returns false only for Closing/Closed.
         worker.contextProxy().takeCrossVMRequest(reqId);
         rejectWorkerNotRunning(vm, globalObject, promise);
     }
@@ -828,9 +828,9 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_startCpuProfileInter
     uint64_t reqId = worker.contextProxy().registerCrossVMRequest(vm, promise);
     auto parentId = globalObject->scriptExecutionContext()->identifier();
     auto parentLoopKind = globalObject->scriptExecutionContext()->currentLoopKind();
-    bool accepted = worker.contextProxy().postTaskToWorkerGlobalScope([reqId, parentId, parentLoopKind, protectedProxy = Ref { worker.contextProxy() }](ScriptExecutionContext& workerCtx) mutable {
+    bool accepted = worker.contextProxy().postInterruptToWorkerGlobalScope([reqId, parentId, parentLoopKind, protectedProxy = Ref { worker.contextProxy() }](JSC::VM& vm) mutable {
         if (!Bun::isCPUProfilerRunning())
-            Bun::startCPUProfiler(workerCtx.vm());
+            Bun::startCPUProfiler(vm);
         ScriptExecutionContext::postTaskTo(parentId, parentLoopKind, [reqId, protectedProxy = WTF::move(protectedProxy)](ScriptExecutionContext& parentCtx) {
             resolveCrossVMRequest(protectedProxy.get(), reqId, parentCtx, [](VM&, JSGlobalObject*) -> JSValue { return jsUndefined(); });
         });
@@ -853,10 +853,10 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_stopCpuProfileIntern
     uint64_t reqId = worker.contextProxy().registerCrossVMRequest(vm, promise);
     auto parentId = globalObject->scriptExecutionContext()->identifier();
     auto parentLoopKind = globalObject->scriptExecutionContext()->currentLoopKind();
-    bool accepted = worker.contextProxy().postTaskToWorkerGlobalScope([reqId, parentId, parentLoopKind, protectedProxy = Ref { worker.contextProxy() }](ScriptExecutionContext& workerCtx) mutable {
+    bool accepted = worker.contextProxy().postInterruptToWorkerGlobalScope([reqId, parentId, parentLoopKind, protectedProxy = Ref { worker.contextProxy() }](JSC::VM& vm) mutable {
         WTF::String result;
         if (Bun::isCPUProfilerRunning())
-            Bun::stopCPUProfiler(workerCtx.vm(), &result, nullptr);
+            Bun::stopCPUProfiler(vm, &result, nullptr);
         if (result.isEmpty())
             result = kEmptyCpuProfileJSON;
         ScriptExecutionContext::postTaskTo(parentId, parentLoopKind, [reqId, protectedProxy = WTF::move(protectedProxy), result = result.isolatedCopy()](ScriptExecutionContext& parentCtx) {

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -735,13 +735,8 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
         }
     }
 
-    // No up-front isOnline() gate: a worker can post to its parent (e.g. from
-    // a microtask the entry module scheduled while it was still loading) while
-    // m_state is still Pending. postInterruptToWorkerGlobalScope returns false
-    // only for Closing/Closed, which the !accepted reject below handles. If the
-    // worker never reaches Running (entry threw or failed to load), the work is
-    // dropped unrun with its VM and workerGlobalScopeDestroyedInternal's
-    // rejectAllCrossVMRequests() rejects + frees the Strong<>.
+    // No up-front isOnline() gate: a request while Pending is kept. A worker that never
+    // reaches Running rejects it from workerGlobalScopeDestroyedInternal.
     auto* promise = JSC::JSPromise::create(vm, globalObject->promiseStructure());
 
     // The promise is registered in a parent-side map keyed by reqId; only the id
@@ -751,8 +746,6 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_getHeapSnapshotBody(
     uint64_t reqId = worker.contextProxy().registerCrossVMRequest(vm, promise);
     auto parentId = globalObject->scriptExecutionContext()->identifier();
     auto parentLoopKind = globalObject->scriptExecutionContext()->currentLoopKind();
-    // An interrupt, not a loop task: the snapshot is what a parent asks for when the worker does not
-    // return to its loop. The full collection it runs is safe at a trap (Bun::VMInterrupts::service).
     bool accepted = worker.contextProxy().postInterruptToWorkerGlobalScope([reqId, parentId, parentLoopKind, protectedProxy = Ref { worker.contextProxy() }](JSC::VM& vm) mutable {
         vm.ensureHeapProfiler();
         auto& heapProfiler = *vm.heapProfiler();

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -39,6 +39,7 @@
 #include "Worker.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/JSPromise.h>
+#include <JavaScriptCore/VMTraps.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -71,6 +72,9 @@ void* WebWorker__create(
     size_t preloadModulesLen);
 // Raise a TerminationException in the worker VM at its next safepoint and wake its loop. Any thread.
 void WebWorker__requestTermination(void*);
+// Queue `work` (a heap Bun::VMInterrupts::Work, handed over) for the worker VM and have it run at its
+// next safepoint; kept until its entry module starts if the thread is still starting. Any thread.
+void WebWorker__requestInterrupt(void*, Bun::VMInterrupts::Work*);
 // Toggle the keep-alive this worker holds on the parent event loop. Parent thread.
 void WebWorker__setRef(void*, bool);
 // Release that keep-alive. Parent thread.
@@ -237,6 +241,27 @@ bool WorkerMessagingProxy::postTaskToWorkerGlobalScope(Function<void(ScriptExecu
         }
     }
     return ScriptExecutionContext::postTaskTo(m_workerContextIdentifier, BunLoopKind::Regular, WTF::move(task));
+}
+
+bool WorkerMessagingProxy::postInterruptToWorkerGlobalScope(Bun::VMInterrupts::Work&& work)
+{
+    if (isClosingOrClosed() || !m_workerThread)
+        return false;
+    // Two ways to the worker thread; the first to arrive runs the VM's queue and the other finds it
+    // empty. The trap reaches script that does not return to the loop. The task reaches a worker
+    // that is idle in its loop (a trap is serviced only by running script) or still Pending (queued
+    // until its entry module has evaluated, like any task).
+    WebWorker__requestInterrupt(m_workerThread, new Bun::VMInterrupts::Work(WTF::move(work)));
+    postTaskToWorkerGlobalScope([](ScriptExecutionContext& context) {
+        auto& vm = context.vm();
+        // The trap this request fired has no script left to service it once the queue is empty, and an
+        // unserviced trap keeps JSC's signal sender suspending this thread every 1ms for as long as the
+        // VM holds its API lock, which a worker does for its whole life. Cleared before the drain: a
+        // request that lands after this sets it again and is either drained below or serviced later.
+        vm.traps().clearTrap(JSC::VMTraps::NeedShellTimeoutCheck);
+        WebCore::clientData(vm)->interrupts.service(vm);
+    });
+    return true;
 }
 
 uint64_t WorkerMessagingProxy::registerCrossVMRequest(JSC::VM& vm, JSC::JSPromise* promise)

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -71,8 +71,7 @@ void* WebWorker__create(
     size_t preloadModulesLen);
 // Raise a TerminationException in the worker VM at its next safepoint and wake its loop. Any thread.
 void WebWorker__requestTermination(void*);
-// Queue `work` (a heap Bun::VMInterrupts::Work, handed over) for the worker VM and have it run at its
-// next safepoint; kept until its entry module starts if the thread is still starting. Any thread.
+// Queue `work` (a heap Bun::VMInterrupts::Work, handed over) for the worker VM. Any thread.
 void WebWorker__requestInterrupt(void*, Bun::VMInterrupts::Work*);
 // Toggle the keep-alive this worker holds on the parent event loop. Parent thread.
 void WebWorker__setRef(void*, bool);

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.cpp
@@ -39,7 +39,6 @@
 #include "Worker.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/JSPromise.h>
-#include <JavaScriptCore/VMTraps.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -247,20 +246,7 @@ bool WorkerMessagingProxy::postInterruptToWorkerGlobalScope(Bun::VMInterrupts::W
 {
     if (isClosingOrClosed() || !m_workerThread)
         return false;
-    // Two ways to the worker thread; the first to arrive runs the VM's queue and the other finds it
-    // empty. The trap reaches script that does not return to the loop. The task reaches a worker
-    // that is idle in its loop (a trap is serviced only by running script) or still Pending (queued
-    // until its entry module has evaluated, like any task).
     WebWorker__requestInterrupt(m_workerThread, new Bun::VMInterrupts::Work(WTF::move(work)));
-    postTaskToWorkerGlobalScope([](ScriptExecutionContext& context) {
-        auto& vm = context.vm();
-        // The trap this request fired has no script left to service it once the queue is empty, and an
-        // unserviced trap keeps JSC's signal sender suspending this thread every 1ms for as long as the
-        // VM holds its API lock, which a worker does for its whole life. Cleared before the drain: a
-        // request that lands after this sets it again and is either drained below or serviced later.
-        vm.traps().clearTrap(JSC::VMTraps::NeedShellTimeoutCheck);
-        WebCore::clientData(vm)->interrupts.service(vm);
-    });
     return true;
 }
 

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.h
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "MessageWithMessagePorts.h"
+#include "VMInterrupts.h"
 #include "ScriptExecutionContext.h"
 #include "WorkerOptions.h"
 #include <JavaScriptCore/Strong.h>
@@ -84,6 +85,11 @@ public:
     void postMessageToWorkerGlobalScope(MessageWithMessagePorts&&);
     // Queued while Pending, posted while Running, refused (false) once Closing.
     bool postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&&);
+    // Run native work on the worker thread as soon as it reaches a safepoint, also in the middle of
+    // synchronous script (Bun::VMInterrupts; Node's Environment::RequestInterrupt). Kept while the
+    // thread starts, refused (false) once Closing; a worker that stops first drops the work unrun
+    // (workerGlobalScopeDestroyedInternal settles the request). Parent thread.
+    bool postInterruptToWorkerGlobalScope(Bun::VMInterrupts::Work&&);
     void setKeepAlive(bool);
     void workerObjectDestroyed();
     // The parent context is exiting: the thread has been asked to stop; wait for it and release what

--- a/src/jsc/bindings/webcore/WorkerMessagingProxy.h
+++ b/src/jsc/bindings/webcore/WorkerMessagingProxy.h
@@ -85,10 +85,8 @@ public:
     void postMessageToWorkerGlobalScope(MessageWithMessagePorts&&);
     // Queued while Pending, posted while Running, refused (false) once Closing.
     bool postTaskToWorkerGlobalScope(Function<void(ScriptExecutionContext&)>&&);
-    // Run native work on the worker thread as soon as it reaches a safepoint, also in the middle of
-    // synchronous script (Bun::VMInterrupts; Node's Environment::RequestInterrupt). Kept while the
-    // thread starts, refused (false) once Closing; a worker that stops first drops the work unrun
-    // (workerGlobalScopeDestroyedInternal settles the request). Parent thread.
+    // Run native work on the worker thread at its next safepoint, also in the middle of synchronous
+    // script (Bun::VMInterrupts). Kept while the thread starts, refused (false) once Closing. Parent thread.
     bool postInterruptToWorkerGlobalScope(Bun::VMInterrupts::Work&&);
     void setKeepAlive(bool);
     void workerObjectDestroyed();

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -573,13 +573,17 @@ impl WebWorker {
 
     /// [`VmHandle::request_interrupt`] for the worker's VM; kept until its
     /// entry module starts. Any thread that holds a ref (the proxy).
+    ///
+    /// # Safety
+    /// `work` is a heap `Bun::VMInterrupts::Work` the caller hands over.
     #[unsafe(export_name = "WebWorker__requestInterrupt")]
-    pub(crate) extern "C" fn request_interrupt(this: *mut WebWorker, work: *mut c_void) {
+    pub(crate) unsafe extern "C" fn request_interrupt(this: *mut WebWorker, work: *mut c_void) {
         let this = bun_ptr::ParentRef::from(NonNull::new(this).expect("WebWorker FFI ptr"));
         let handle = this.vm_handle.lock();
         match &*handle {
             Some(handle) if this.entry_started.load(Ordering::Relaxed) => {
-                handle.request_interrupt(work)
+                // SAFETY: fn contract.
+                unsafe { handle.request_interrupt(work) }
             }
             _ => this.pending_interrupts.lock().push(work),
         }
@@ -888,7 +892,8 @@ impl WebWorker {
             let pending = core::mem::take(&mut *self.pending_interrupts.lock());
             let handle = handle.as_ref().expect("published by start_vm");
             for work in pending {
-                handle.request_interrupt(work);
+                // SAFETY: `work` was handed over to `request_interrupt`.
+                unsafe { handle.request_interrupt(work) };
             }
         }
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -96,12 +96,9 @@ pub struct WebWorker {
     /// ancestor) asks it to terminate. `None` before `start_vm()` publishes it
     /// and after `shutdown()` unpublishes it.
     vm_handle: bun_threading::Guarded<Option<crate::VmHandle>>,
-    /// `spin()` has started loading the entry module: from here on the VM
-    /// runs user code and `request_interrupt()` reaches it. Before that
-    /// (thread startup, the node bootstrap) the work waits in
-    /// `pending_interrupts` and is made here, so that a worker that never
-    /// reaches user code answers nothing, like one that has not started.
-    /// Both touched under the `vm_handle` lock.
+    /// `spin()` has started loading the entry module. Interrupts requested
+    /// before that wait in `pending_interrupts`, so a worker that never reaches
+    /// user code answers none. Both touched under the `vm_handle` lock.
     entry_started: AtomicBool,
     pending_interrupts: bun_threading::Guarded<Vec<*mut c_void>>,
 
@@ -218,8 +215,6 @@ extern "C" fn WebWorker__getMessagingProxy(vm: &VirtualMachine) -> *mut c_void {
 impl Drop for WebWorker {
     fn drop(&mut self) {
         log!("[{}] destroy", self.execution_context_id);
-        // Interrupts the worker never got to (it failed to start, or the
-        // request came after its VM went away) are dropped unrun.
         for work in self.pending_interrupts.lock().drain(..) {
             // SAFETY: `work` was handed over to `request_interrupt`.
             unsafe { crate::vm_handle::Bun__VMInterrupts__drop(work) };
@@ -576,12 +571,8 @@ impl WebWorker {
         }
     }
 
-    /// Queue `work` (a heap C++ `Bun::VMInterrupts::Work`, handed over) for
-    /// the worker's VM and have it run at its next safepoint, even in the
-    /// middle of synchronous script ([`VmHandle::request_interrupt`]). Until
-    /// the entry module starts the work is kept and made then, so a request
-    /// made while the thread starts still reaches an entry module that never
-    /// returns. Any thread that holds a ref (the proxy) may call this.
+    /// [`VmHandle::request_interrupt`] for the worker's VM; kept until its
+    /// entry module starts. Any thread that holds a ref (the proxy).
     #[unsafe(export_name = "WebWorker__requestInterrupt")]
     pub(crate) extern "C" fn request_interrupt(this: *mut WebWorker, work: *mut c_void) {
         let this = bun_ptr::ParentRef::from(NonNull::new(this).expect("WebWorker FFI ptr"));
@@ -890,7 +881,7 @@ impl WebWorker {
             }
         }
 
-        // User code from here on: interrupts requested so far are made now.
+        // User code from here on.
         {
             let handle = self.vm_handle.lock();
             self.entry_started.store(true, Ordering::Relaxed);

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -96,6 +96,14 @@ pub struct WebWorker {
     /// ancestor) asks it to terminate. `None` before `start_vm()` publishes it
     /// and after `shutdown()` unpublishes it.
     vm_handle: bun_threading::Guarded<Option<crate::VmHandle>>,
+    /// `spin()` has started loading the entry module: from here on the VM
+    /// runs user code and `request_interrupt()` reaches it. Before that
+    /// (thread startup, the node bootstrap) the work waits in
+    /// `pending_interrupts` and is made here, so that a worker that never
+    /// reaches user code answers nothing, like one that has not started.
+    /// Both touched under the `vm_handle` lock.
+    entry_started: AtomicBool,
+    pending_interrupts: bun_threading::Guarded<Vec<*mut c_void>>,
 
     // ---- Parent-thread only ---------------------------------------------------
     /// Keep-alive on the parent's event loop: taken in `create()`, toggled by
@@ -210,6 +218,12 @@ extern "C" fn WebWorker__getMessagingProxy(vm: &VirtualMachine) -> *mut c_void {
 impl Drop for WebWorker {
     fn drop(&mut self) {
         log!("[{}] destroy", self.execution_context_id);
+        // Interrupts the worker never got to (it failed to start, or the
+        // request came after its VM went away) are dropped unrun.
+        for work in self.pending_interrupts.lock().drain(..) {
+            // SAFETY: `work` was handed over to `request_interrupt`.
+            unsafe { crate::vm_handle::Bun__VMInterrupts__drop(work) };
+        }
         debug_assert!(
             self.join_handle.with_mut(|h| h.is_none()),
             "worker thread was never joined"
@@ -422,6 +436,8 @@ impl WebWorker {
             ref_count: bun_ptr::ThreadSafeRefCount::init(),
             requested_terminate: AtomicBool::new(false),
             vm_handle: bun_threading::Guarded::new(None),
+            entry_started: AtomicBool::new(false),
+            pending_interrupts: bun_threading::Guarded::new(Vec::new()),
             vm: Cell::new(core::ptr::null_mut()),
             parent_poll_ref: JsCell::new(KeepAlive::init()),
             join_handle: JsCell::new(None),
@@ -557,6 +573,24 @@ impl WebWorker {
             // thread notices; a TerminationException is raised at its next
             // safepoint and its loop woken.
             handle.request_termination();
+        }
+    }
+
+    /// Queue `work` (a heap C++ `Bun::VMInterrupts::Work`, handed over) for
+    /// the worker's VM and have it run at its next safepoint, even in the
+    /// middle of synchronous script ([`VmHandle::request_interrupt`]). Until
+    /// the entry module starts the work is kept and made then, so a request
+    /// made while the thread starts still reaches an entry module that never
+    /// returns. Any thread that holds a ref (the proxy) may call this.
+    #[unsafe(export_name = "WebWorker__requestInterrupt")]
+    pub(crate) extern "C" fn request_interrupt(this: *mut WebWorker, work: *mut c_void) {
+        let this = bun_ptr::ParentRef::from(NonNull::new(this).expect("WebWorker FFI ptr"));
+        let handle = this.vm_handle.lock();
+        match &*handle {
+            Some(handle) if this.entry_started.load(Ordering::Relaxed) => {
+                handle.request_interrupt(work)
+            }
+            _ => this.pending_interrupts.lock().push(work),
         }
     }
 
@@ -853,6 +887,17 @@ impl WebWorker {
                 self.flush_logs(vm);
                 WebWorker__entrySettled(global);
                 return self.shutdown();
+            }
+        }
+
+        // User code from here on: interrupts requested so far are made now.
+        {
+            let handle = self.vm_handle.lock();
+            self.entry_started.store(true, Ordering::Relaxed);
+            let pending = core::mem::take(&mut *self.pending_interrupts.lock());
+            let handle = handle.as_ref().expect("published by start_vm");
+            for work in pending {
+                handle.request_interrupt(work);
             }
         }
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -830,6 +830,73 @@ describe("getHeapSnapshot", () => {
   });
 });
 
+// Node services these from Environment::RequestInterrupt: they settle while the worker runs
+// synchronous JavaScript and never returns to its event loop. The worker spins on a shared flag
+// that only the parent sets, so each call can settle only if it runs without the loop's help.
+// (cpuUsage() and getHeapStatistics() need nothing from the worker thread and are covered apart.)
+describe("introspection while the worker runs synchronous JavaScript", () => {
+  async function expectToSettleWhileBusy(worker: Worker, flag: Int32Array, calledBeforeOnline?: Promise<unknown>) {
+    if (calledBeforeOnline) await expect(calledBeforeOnline).resolves.toBeDefined();
+
+    const handle = await worker.startCpuProfile();
+    const profile = JSON.parse(await handle.stop());
+    expect(profile.nodes[0].callFrame.functionName).toBe("(root)");
+
+    const stream = await worker.getHeapSnapshot();
+    expect(stream).toBeInstanceOf(Readable);
+    const json = JSON.parse(
+      await new Promise<string>(resolve => {
+        let text = "";
+        stream.on("data", chunk => (text += chunk));
+        stream.on("end", () => resolve(text));
+      }),
+    );
+    expect(json.nodes.length).toBeGreaterThan(0);
+
+    // Everything above settled while the worker still spun: it leaves the loop only now.
+    expect(Atomics.load(flag, 0)).toBe(0);
+    Atomics.store(flag, 0, 1);
+    const [exitCode] = await once(worker, "exit");
+    expect(exitCode).toBe(0);
+  }
+
+  test("while the entry module runs", async () => {
+    const flag = new Int32Array(new SharedArrayBuffer(4));
+    const worker = new Worker(
+      /* js */ `
+        const flag = new Int32Array(require("node:worker_threads").workerData);
+        while (Atomics.load(flag, 0) === 0) {}
+      `,
+      { eval: true, workerData: flag.buffer },
+    );
+    // Requested before the worker's entry module starts: kept and made once it does.
+    const early = worker.startCpuProfile();
+    await once(worker, "online");
+    await expectToSettleWhileBusy(worker, flag, early);
+  });
+
+  test("while a message handler runs", async () => {
+    const flag = new Int32Array(new SharedArrayBuffer(4));
+    const worker = new Worker(
+      /* js */ `
+        const { parentPort, workerData } = require("node:worker_threads");
+        const flag = new Int32Array(workerData);
+        parentPort.once("message", () => {
+          while (Atomics.load(flag, 0) === 0) {}
+          process.exit(0);
+        });
+      `,
+      { eval: true, workerData: flag.buffer },
+    );
+    await once(worker, "online");
+    worker.postMessage("spin");
+    await expectToSettleWhileBusy(worker, flag);
+  });
+
+  // A thread parked in Atomics.wait services no VM trap; Node answers there too.
+  test.todo("while the worker is parked in Atomics.wait");
+});
+
 test("failed Worker construction restores transferred FileHandles", async () => {
   const dir = tmpdirSync("worker-fh-transfer");
   const file = join(dir, "x.txt");

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -831,8 +831,9 @@ describe("getHeapSnapshot", () => {
 });
 
 // Node services these from Environment::RequestInterrupt: they settle while the worker runs
-// synchronous JavaScript and never returns to its event loop. The worker spins on a shared flag
-// that only the parent sets, so each call can settle only if it runs without the loop's help.
+// synchronous JavaScript and never returns to its event loop. The worker spins until the parent
+// sets flag[0], so each call can settle only if it runs without the loop's help, and sets flag[1]
+// once it has left the loop.
 // (cpuUsage() and getHeapStatistics() need nothing from the worker thread and are covered apart.)
 describe("introspection while the worker runs synchronous JavaScript", () => {
   async function expectToSettleWhileBusy(worker: Worker, flag: Int32Array, calledBeforeOnline?: Promise<unknown>) {
@@ -856,8 +857,8 @@ describe("introspection while the worker runs synchronous JavaScript", () => {
       );
       expect(json.nodes.length).toBeGreaterThan(0);
 
-      // Everything above settled while the worker still spun: it leaves the loop only now.
-      expect(Atomics.load(flag, 0)).toBe(0);
+      // Everything above settled while the worker still spun.
+      expect(Atomics.load(flag, 1)).toBe(0);
     } finally {
       Atomics.store(flag, 0, 1);
     }
@@ -866,11 +867,12 @@ describe("introspection while the worker runs synchronous JavaScript", () => {
   }
 
   test("while the entry module runs", async () => {
-    const flag = new Int32Array(new SharedArrayBuffer(4));
+    const flag = new Int32Array(new SharedArrayBuffer(8));
     const worker = new Worker(
       /* js */ `
         const flag = new Int32Array(require("node:worker_threads").workerData);
         while (Atomics.load(flag, 0) === 0) {}
+        Atomics.store(flag, 1, 1);
       `,
       { eval: true, workerData: flag.buffer },
     );
@@ -881,7 +883,7 @@ describe("introspection while the worker runs synchronous JavaScript", () => {
   });
 
   test("while a message handler runs", async () => {
-    const flag = new Int32Array(new SharedArrayBuffer(4));
+    const flag = new Int32Array(new SharedArrayBuffer(8));
     const worker = new Worker(
       /* js */ `
         const { parentPort, workerData } = require("node:worker_threads");
@@ -889,6 +891,7 @@ describe("introspection while the worker runs synchronous JavaScript", () => {
         parentPort.once("message", () => {
           parentPort.postMessage("spinning");
           while (Atomics.load(flag, 0) === 0) {}
+          Atomics.store(flag, 1, 1);
           process.exit(0);
         });
       `,

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -836,26 +836,30 @@ describe("getHeapSnapshot", () => {
 // (cpuUsage() and getHeapStatistics() need nothing from the worker thread and are covered apart.)
 describe("introspection while the worker runs synchronous JavaScript", () => {
   async function expectToSettleWhileBusy(worker: Worker, flag: Int32Array, calledBeforeOnline?: Promise<unknown>) {
-    if (calledBeforeOnline) await expect(calledBeforeOnline).resolves.toBeDefined();
+    try {
+      if (calledBeforeOnline) await expect(calledBeforeOnline).resolves.toBeDefined();
 
-    const handle = await worker.startCpuProfile();
-    const profile = JSON.parse(await handle.stop());
-    expect(profile.nodes[0].callFrame.functionName).toBe("(root)");
+      const handle = await worker.startCpuProfile();
+      const profile = JSON.parse(await handle.stop());
+      expect(profile.nodes[0].callFrame.functionName).toBe("(root)");
 
-    const stream = await worker.getHeapSnapshot();
-    expect(stream).toBeInstanceOf(Readable);
-    const json = JSON.parse(
-      await new Promise<string>(resolve => {
-        let text = "";
-        stream.on("data", chunk => (text += chunk));
-        stream.on("end", () => resolve(text));
-      }),
-    );
-    expect(json.nodes.length).toBeGreaterThan(0);
+      const stream = await worker.getHeapSnapshot();
+      expect(stream).toBeInstanceOf(Readable);
+      const json = JSON.parse(
+        await new Promise<string>((resolve, reject) => {
+          let text = "";
+          stream.on("data", chunk => (text += chunk));
+          stream.on("end", () => resolve(text));
+          stream.on("error", reject);
+        }),
+      );
+      expect(json.nodes.length).toBeGreaterThan(0);
 
-    // Everything above settled while the worker still spun: it leaves the loop only now.
-    expect(Atomics.load(flag, 0)).toBe(0);
-    Atomics.store(flag, 0, 1);
+      // Everything above settled while the worker still spun: it leaves the loop only now.
+      expect(Atomics.load(flag, 0)).toBe(0);
+    } finally {
+      Atomics.store(flag, 0, 1);
+    }
     const [exitCode] = await once(worker, "exit");
     expect(exitCode).toBe(0);
   }

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -836,6 +836,7 @@ describe("getHeapSnapshot", () => {
 // (cpuUsage() and getHeapStatistics() need nothing from the worker thread and are covered apart.)
 describe("introspection while the worker runs synchronous JavaScript", () => {
   async function expectToSettleWhileBusy(worker: Worker, flag: Int32Array, calledBeforeOnline?: Promise<unknown>) {
+    const exited = once(worker, "exit");
     try {
       if (calledBeforeOnline) await expect(calledBeforeOnline).resolves.toBeDefined();
 
@@ -860,7 +861,7 @@ describe("introspection while the worker runs synchronous JavaScript", () => {
     } finally {
       Atomics.store(flag, 0, 1);
     }
-    const [exitCode] = await once(worker, "exit");
+    const [exitCode] = await exited;
     expect(exitCode).toBe(0);
   }
 
@@ -886,6 +887,7 @@ describe("introspection while the worker runs synchronous JavaScript", () => {
         const { parentPort, workerData } = require("node:worker_threads");
         const flag = new Int32Array(workerData);
         parentPort.once("message", () => {
+          parentPort.postMessage("spinning");
           while (Atomics.load(flag, 0) === 0) {}
           process.exit(0);
         });
@@ -893,7 +895,9 @@ describe("introspection while the worker runs synchronous JavaScript", () => {
       { eval: true, workerData: flag.buffer },
     );
     await once(worker, "online");
+    const spinning = once(worker, "message");
     worker.postMessage("spin");
+    await spinning;
     await expectToSettleWhileBusy(worker, flag);
   });
 


### PR DESCRIPTION
### Problem
- `worker.getHeapSnapshot()`, `worker.startCpuProfile()` and its `stop()` stay pending while the worker runs synchronous JavaScript. With `while (true) {}` they never settle. Node settles them in milliseconds. Fixes #42354.
- Each call posted an ordinary task to the worker's loop (`JSWorker.cpp`). Nothing interrupted the worker's VM. Both calls need the worker thread: a snapshot is a full collection, the profiler samples it.

### Fix
- `Bun::VMInterrupts` (new, one per VM on `JSVMClientData`) is a queue of native work that the VM's thread runs at its next safepoint, in the middle of script. Any thread enqueues through the VM's handle, which also fires JSC's `NeedShellTimeoutCheck` trap. The one process-wide trap callback, installed in `JSCInitialize`, services the queue of the VM it fired on, so a later user (the inspector, #32549) shares the slot.
- The worker proxy enqueues the snapshot and profiler work and also posts a loop task. The trap reaches script that never returns to the loop, the task reaches an idle or Pending worker. The first to arrive runs the queue.
- The trap fires only once the entry module starts. A worker that never reaches user code still rejects with `ERR_WORKER_NOT_RUNNING`. A worker asked to stop drops the queue. Inside a `DeferGC` scope the queue waits for a later safepoint.
- Verified: two new tests in `test/js/node/worker_threads/worker_threads.test.ts` (a worker spinning on a shared flag, in its entry module and in a message handler; both time out on bun 1.4.3). Also the worker and web worker suites (Notes).

### Background
- A VM trap (`VMTraps.h`) is a bit another thread sets on a VM. The VM's thread services it at its next safepoint: a function entry, a loop back edge, or a runtime exception check. `terminate()` uses one. `NeedShellTimeoutCheck` is the one trap that calls an embedder callback.
- `DeferGC` marks runtime code where a collection is unsafe; `Heap::isDeferred()` exposes it.
- A worker holds its API lock for life. While a trap bit is set under the lock, JSC's signal sender suspends the thread every 1ms. The loop task clears the bit before it drains.
- `cpuUsage()` and `getHeapStatistics()` need nothing from the worker thread: #42360 answers them on the parent thread.

<details><summary>Notes</summary>

Timing on the issue's script, debug ASAN build of this branch (bun 1.4.3 release: 5.7 s for each, the rest of the worker's 6 s loop):

```
snapshot 2884 ms
startCpuProfile 9 ms
stop 7 ms
```

The snapshot time is the debug heap walk itself, not waiting. A request made during the worker's bootstrap (between `online` and the entry module) waits for the bootstrap, about 600 ms on a debug build.

Stress under ASAN: a worker running a JIT-hot allocation loop answered five `startCpuProfile` + `stop` rounds (2 to 10 ms each after the first), a snapshot, and a `terminate()` with a snapshot in flight (rejects `ERR_WORKER_NOT_RUNNING`). Clean under `BUN_JSC_validateExceptionChecks=1`.

Why not a WebKit fork change: the issue asks for a per-VM trap callback. `NeedShellTimeoutCheck` already carries the VM, and `Bun::VMInterrupts` keys the work by VM, so the single callback slot is not a limit. The safepoint set is the one JSC's own Watchdog callback runs at (`VMTraps::handleTraps`, reached from JIT/LLInt trap checks and from `VM::hasExceptionsAfterHandlingTraps` under `RETURN_IF_EXCEPTION`). The extra hazard a full collection adds there is `DeferGC`, which `service()` checks; the DFG already models `CheckTraps` as a node that can collect. A fork primitive serviced only at JIT/LLInt safepoints, and one that wakes a thread parked in `Atomics.wait`, would remove the `DeferGC` re-arm, the `clearTrap` in the loop task, and the `test.todo` for `Atomics.wait`. The bun-side queue and call sites stay the same on top of it.

Suites run: `test/js/node/worker_threads/worker_threads.test.ts` (144 pass, 1 todo), `worker_heap_snapshot_gc`, `worker-transfer-terminate-stress`, `worker_destruction`, `worker-shutdown-post-leak`, `test/js/web/workers/` (459 pass before the rework, `worker.test.ts` and `worker-terminate-lifetime.test.ts` after), `test/internal/source-lints/`, and `test/js/node/test/parallel/test-worker-{terminate-*,cpu-profile,cpu-usage,exit-heapsnapshot,heap-profile,heap-snapshot,heap-statistics,heapdump-failure,message-port-close*}.js`.

`test/js/web/workers/worker-terminate-lifetime.test.ts` ("dns.lookup() in flight") and `worker.test.ts` ("fs.readFile completions keep arriving") fail the same way on main without this change in this container.

Self-reviewed: the review asked to drop the `cpuUsage()`/`getHeapStatistics()` hunks (#42360 owns them), to make the trap dispatcher per-VM instead of worker-only, and to record the `Atomics.wait` gap. All three done. It also asked for a fork primitive first; kept as the interim shape above.

</details>
