### PR TITLE
react-compiler: emit createElement calls for the classic JSX runtime and key after a spread

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5501,6 +5501,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(value)
     }
 
+    /// The classic runtime's `options.jsx.factory` / `options.jsx.fragment` as
+    /// a member expression (`React.createElement`), resolved from the current
+    /// scope. `options.jsx` is dropped when `Parser::parse` returns, but the
+    /// parts live on in symbols and `E::Dot.name` until the printer runs, so
+    /// they are duped into the AST arena.
+    pub(crate) fn jsx_classic_member_expression(
+        &mut self,
+        loc: bun_ast::Loc,
+        members: fn(&options::JSX::Pragma) -> &options::JSX::MemberList,
+    ) -> Expr {
+        let arena = self.arena;
+        let parts: &[&'a [u8]] = arena.alloc_slice_fill_iter(
+            members(&self.options.jsx)
+                .iter()
+                .map(|b| -> &'a [u8] { arena.alloc_slice_copy(b) }),
+        );
+        self.jsx_strings_to_member_expression(loc, parts)
+            .expect("unreachable")
+    }
+
     fn member_expression(
         &mut self,
         loc: bun_ast::Loc,

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -540,6 +540,18 @@ impl JSXImportSymbols {
         }
     }
 
+    pub(crate) fn tag_of(&self, ref_: Ref) -> Option<JSXImport> {
+        [
+            JSXImport::Jsx,
+            JSXImport::JsxDEV,
+            JSXImport::Jsxs,
+            JSXImport::Fragment,
+            JSXImport::CreateElement,
+        ]
+        .into_iter()
+        .find(|&tag| self.get_with_tag(tag) == Some(ref_))
+    }
+
     pub(crate) fn set(&mut self, tag: JSXImport, loc_ref: LocRef) {
         match tag {
             JSXImport::Jsx => self.jsx = Some(loc_ref),

--- a/src/js_parser/react_compiler_host.rs
+++ b/src/js_parser/react_compiler_host.rs
@@ -54,6 +54,26 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
         self.p.options.jsx.development
     }
 
+    fn is_jsx_classic(&self) -> bool {
+        self.p.options.jsx.runtime != crate::parser::options::JSX::Runtime::Automatic
+    }
+
+    fn jsx_classic_factory(&mut self, loc: bun_ast::Loc) -> js_ast::Expr {
+        self.p
+            .jsx_classic_member_expression(loc, |jsx| &jsx.factory)
+    }
+
+    fn jsx_import_kind(&self, ref_: js_ast::Ref) -> Option<bun_react_compiler::JsxImportKind> {
+        use bun_react_compiler::JsxImportKind as K;
+        Some(match self.p.jsx_imports.tag_of(ref_)? {
+            JSXImport::Jsx => K::Jsx,
+            JSXImport::Jsxs => K::Jsxs,
+            JSXImport::JsxDEV => K::JsxDEV,
+            JSXImport::Fragment => K::Fragment,
+            JSXImport::CreateElement => K::CreateElement,
+        })
+    }
+
     fn jsx_import(&mut self, kind: bun_react_compiler::JsxImportKind) -> js_ast::Ref {
         use bun_react_compiler::JsxImportKind as K;
         let kind = match kind {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -361,25 +361,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         break 'tagger _tag;
                     }
                     if p.options.jsx.runtime == options::JSX::Runtime::Classic {
-                        // `jsx_strings_to_member_expression` wants `&[&'a [u8]]`.
-                        // `options.jsx.fragment: Box<[Box<[u8]>]>` is OWNED by
-                        // `P` and dropped when `Parser::parse` returns — but the parts are
-                        // stored in symbols / `E::Dot.name` and read later by the printer.
-                        // Dupe each part into the arena (which backs the AST) so they
-                        // outlive the parse. Build the `&[&'a [u8]]` slice
-                        // directly in the AST arena instead of a throwaway global-heap
-                        // `Vec` — keeps the visitor off the `#[global_allocator]`.
-                        let arena = p.arena;
-                        let parts: &[&'a [u8]] = arena.alloc_slice_fill_iter(
-                            p.options
-                                .jsx
-                                .fragment
-                                .iter()
-                                .map(|b| -> &'a [u8] { arena.alloc_slice_copy(b) }),
-                        );
                         break 'tagger p
-                            .jsx_strings_to_member_expression(expr.loc, parts)
-                            .expect("unreachable");
+                            .jsx_classic_member_expression(expr.loc, |jsx| &jsx.fragment);
                     }
                     break 'tagger p.jsx_import(JSXImport::Fragment, expr.loc);
                 };
@@ -441,20 +424,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
 
                     let target: Expr = if runtime == options::JSX::Runtime::Classic {
-                        // see fragment note above — `options.jsx.factory` is
-                        // owned by `P` and freed when the parser drops; dupe each part
-                        // into the arena so the symbol/E::Dot names outlive the printer.
-                        // Build the parts slice in the AST arena (no global-heap `Vec`).
-                        let arena = p.arena;
-                        let parts: &[&'a [u8]] = arena.alloc_slice_fill_iter(
-                            p.options
-                                .jsx
-                                .factory
-                                .iter()
-                                .map(|b| -> &'a [u8] { arena.alloc_slice_copy(b) }),
-                        );
-                        p.jsx_strings_to_member_expression(expr.loc, parts)
-                            .expect("unreachable")
+                        p.jsx_classic_member_expression(expr.loc, |jsx| &jsx.factory)
                     } else {
                         // jsxStringsToMemberExpression(factory) must run
                         // unconditionally before the runtime check; it has the side-effect of

--- a/src/react_compiler/DESIGN.md
+++ b/src/react_compiler/DESIGN.md
@@ -145,3 +145,6 @@ runtime, and the automatic runtime when `key` follows a spread, calls
 overlap in arity, so lowering tells them apart by the callee
 (`Host::jsx_import_kind`), and codegen picks the shape the visit pass would
 (`Host::is_jsx_classic`, and whether the HIR `key` attribute follows a spread).
+The callee is not an operand of the HIR `JsxExpression`: codegen resolves the
+classic factory again (`Host::jsx_classic_factory`). Lowering rejects a factory
+that is a local of the function, because the compiler would drop it as unused.

--- a/src/react_compiler/DESIGN.md
+++ b/src/react_compiler/DESIGN.md
@@ -137,3 +137,11 @@ as React Fast Refresh). At that point the visit pass has already consumed all
 resolved `RefTag::Symbol`, and JSX has been lowered to
 `E::Call { was_jsx_element: true }`. Lowering reads that call shape and
 codegen emits it, so the compiled body needs no further visiting.
+
+The visit pass emits two call shapes. The automatic runtime calls
+`jsx(type, {...props, children}, key)` (or `jsxs` / `jsxDEV`). The classic
+runtime, and the automatic runtime when `key` follows a spread, calls
+`factory(type, props | null, ...children)` with `key` left in `props`. The two
+overlap in arity, so lowering tells them apart by the callee
+(`Host::jsx_import_kind`), and codegen picks the shape the visit pass would
+(`Host::is_jsx_classic`, and whether the HIR `key` attribute follows a spread).

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -2227,6 +2227,9 @@ fn codegen_base_instruction_value(
             closing_loc,
         } => codegen_jsx_expression(cx, tag, props, children, *loc, *closing_loc),
         InstructionValue::JsxFragment { children, .. } => {
+            // Lowering only makes a `JsxFragment` of the automatic runtime's
+            // `Fragment` import; the classic `React.Fragment` is a plain tag.
+            debug_assert!(!cx.cg.host.is_jsx_classic());
             let mut child_elems: ExprNodeList = AstAlloc::vec_with_capacity(children.len());
             for child in children {
                 child_elems.push(codegen_jsx_element(cx, child)?);
@@ -2568,6 +2571,31 @@ fn codegen_jsx_expression(
         }
     }
 
+    // Same shape choice as `visit_expr.rs::e_jsx_element`: the classic runtime,
+    // and `key` after a spread in the automatic one, is a `createElement` call
+    // whose `key` stays in the props.
+    let is_key_after_spread = props
+        .iter()
+        .skip_while(|attr| !matches!(attr, JsxAttribute::SpreadAttribute { .. }))
+        .any(|attr| match attr {
+            JsxAttribute::Attribute { name, .. } => name.slice() == b"key",
+            JsxAttribute::SpreadAttribute { .. } => false,
+        });
+    if cx.cg.host.is_jsx_classic() || is_key_after_spread {
+        let mut properties: G::PropertyList = AstAlloc::vec_with_capacity(props.len());
+        for attr in props {
+            properties.push(codegen_jsx_attribute(cx, attr)?);
+        }
+        return Ok(codegen_create_element_call(
+            cx,
+            tag_value,
+            properties,
+            child_nodes,
+            elem_loc,
+            close_loc,
+        ));
+    }
+
     let mut properties: G::PropertyList = AstAlloc::vec_with_capacity(props.len() + 1);
     let mut key_value: Option<Expr> = None;
     for attr in props {
@@ -2589,6 +2617,54 @@ fn codegen_jsx_expression(
         elem_loc,
         close_loc,
     ))
+}
+
+/// Build the `createElement(type, props | null, ...children)` call shape —
+/// mirrors `bun_js_parser::visit::visit_expr::e_jsx_element`: the callee is
+/// `options.jsx.factory` for the classic runtime and the auto-imported
+/// `createElement` for the automatic one.
+fn codegen_create_element_call(
+    cx: &mut Context,
+    tag_value: Expr,
+    properties: G::PropertyList,
+    children: ExprNodeList,
+    loc: Loc,
+    close_loc: Loc,
+) -> Expr {
+    let target = if cx.cg.host.is_jsx_classic() {
+        cx.cg.host.jsx_classic_factory(loc)
+    } else {
+        let target_ref = cx.cg.host.jsx_import(JsxImportKind::CreateElement);
+        cx.cg.host.record_usage(target_ref);
+        Expr::init(E::ImportIdentifier::new(target_ref, true), loc)
+    };
+
+    let mut args: ExprNodeList = AstAlloc::vec_with_capacity(2 + children.len());
+    args.push(tag_value);
+    args.push(if properties.is_empty() {
+        Expr::init(E::Null {}, loc)
+    } else {
+        Expr::init(
+            E::Object {
+                properties,
+                ..Default::default()
+            },
+            loc,
+        )
+    });
+    args.extend(children);
+
+    Expr::init(
+        E::Call {
+            target,
+            args,
+            can_be_unwrapped_if_unused: E::CallUnwrap::IfUnused,
+            was_jsx_element: true,
+            close_paren_loc: close_loc,
+            ..Default::default()
+        },
+        loc,
+    )
 }
 
 /// Build the automatic-runtime `jsx(type, props, key?)` / `jsxDEV(...)` call

--- a/src/react_compiler/lowering/build_hir/jsx.rs
+++ b/src/react_compiler/lowering/build_hir/jsx.rs
@@ -15,6 +15,7 @@ use bun_ast::{E, Expr, G, Loc, Ref};
 use super::expr::lower_expression;
 use super::helpers::{lower_expression_to_temporary, lower_identifier, lower_value_to_temporary};
 use crate::lowering::hir_builder::{HirBuilder, convert_loc};
+use crate::program::JsxImportKind;
 
 fn estring_to_store_str(s: &E::EString) -> StoreStr {
     if s.is_utf16 {
@@ -175,8 +176,10 @@ fn lower_tag_identifier(
 ///     jsxDEV(tag, props, key|undefined, isStatic, undefined, this) — 6 args
 ///     where `props` is always an `E::Object` and `children` (if any) is one of
 ///     its properties (single expr or `E::Array`).
-///   Classic runtime:
+///   Classic runtime, and the automatic runtime when `key` follows a spread:
 ///     createElement(tag, propsOrNull, ...children)
+///     where `key` stays in `props` and the callee is `options.jsx.factory`
+///     or the auto-imported `createElement`.
 pub(super) fn lower_jsx_call(
     builder: &mut HirBuilder,
     call: &E::Call,
@@ -208,32 +211,29 @@ pub(super) fn lower_jsx_call(
     // identifier as a scope dependency. Detect that symbol and emit
     // `JsxFragment` to match — otherwise every fragment costs an extra memo
     // slot for the never-changing `$[n] !== Fragment` guard.
-    let is_fragment = is_jsx_runtime_fragment(builder, tag_expr);
+    let is_fragment = jsx_import_kind(builder, tag_expr) == Some(JsxImportKind::Fragment);
     let tag = if is_fragment {
         None
     } else {
         Some(lower_jsx_element_name(builder, tag_expr)?)
     };
 
-    // Detect automatic vs classic runtime by the shape of args[1] and arity.
-    // Automatic always passes an E::Object as args[1] with children packed inside;
-    // classic passes E::Object|E::Null as args[1] and children as args[2..].
+    // Only the callee tells the two shapes apart: `createElement(tag, {..}, child)`
+    // has the arity and the E::Object args[1] of `jsx(tag, {..}, key)`.
+    let callee = jsx_import_kind(builder, &call.target);
     let props_arg = args.get(1);
-    let is_automatic = match props_arg {
-        Some(p) if matches!(p.data, ExprData::EObject(_)) => {
-            matches!(args.len(), 2 | 3 | 6)
-        }
-        _ => false,
+    let automatic_props = match (callee, props_arg.map(|p| &p.data)) {
+        (
+            Some(JsxImportKind::Jsx | JsxImportKind::Jsxs | JsxImportKind::JsxDEV),
+            Some(ExprData::EObject(obj)),
+        ) => Some(obj),
+        _ => None,
     };
 
     let mut props: HirVec<JsxAttribute> = AstAlloc::vec();
     let mut children: HirVec<Place> = AstAlloc::vec();
 
-    if is_automatic {
-        let ExprData::EObject(obj) = &props_arg.unwrap().data else {
-            unreachable!()
-        };
-
+    if let Some(obj) = automatic_props {
         // visit_expr.rs only wraps `children` in a synthetic E::Array when
         // `is_static_jsx` is true; for a single non-spread child the child
         // expression (which may itself be a user-authored array) is passed
@@ -242,13 +242,7 @@ pub(super) fn lower_jsx_call(
         let is_static_children = if args.len() == 6 {
             matches!(args[3].data, ExprData::EBoolean(b) if b.value)
         } else {
-            match &call.target.data {
-                ExprData::EIdentifier(id) => builder.host().ref_name(id.ref_).starts_with(b"jsxs"),
-                ExprData::EImportIdentifier(id) => {
-                    builder.host().ref_name(id.ref_).starts_with(b"jsxs")
-                }
-                _ => false,
-            }
+            callee == Some(JsxImportKind::Jsxs)
         };
 
         // `key` was hoisted out of the props object into args[2] by the visit
@@ -303,7 +297,7 @@ pub(super) fn lower_jsx_call(
         }
         // args[3..6] (isStatic, source, self) are dev-only metadata; ignore.
     } else {
-        // Classic: createElement(tag, propsOrNull, ...children)
+        // createElement(tag, propsOrNull, ...children)
         if let Some(p) = props_arg {
             if let ExprData::EObject(obj) = &p.data {
                 for prop in obj.properties.iter() {
@@ -364,20 +358,17 @@ pub(super) fn lower_jsx_call(
     })
 }
 
-/// True when `tag` is the auto-imported jsx-runtime `Fragment` symbol minted by
-/// the parser's visit pass for `<>...</>`. A user-written
-/// `import { Fragment } from "react"` is a real import (present in
-/// `import_bindings`, absent from `module_scope().generated`) and stays a
-/// regular component tag — matching upstream, which only special-cases the
-/// `JSXFragment` syntax form.
-fn is_jsx_runtime_fragment(builder: &HirBuilder, tag: &Expr) -> bool {
-    let ref_ = match tag.data {
+/// The JSX runtime symbol `expr` refers to, if it is one the parser's visit
+/// pass auto-imported. A user-written `import { Fragment } from "react"` is a
+/// real import, not one of these, and stays a regular component tag: upstream
+/// only special-cases the `JSXFragment` syntax form.
+fn jsx_import_kind(builder: &HirBuilder, expr: &Expr) -> Option<JsxImportKind> {
+    let ref_ = match expr.data {
         ExprData::EIdentifier(id) => id.ref_,
         ExprData::EImportIdentifier(id) => id.ref_,
-        _ => return false,
+        _ => return None,
     };
-    let host = builder.host();
-    host.ref_name(ref_) == b"Fragment" && host.module_scope().generated.contains(&ref_)
+    builder.host().jsx_import_kind(ref_)
 }
 
 /// The visit pass packs children into the props object as either a single

--- a/src/react_compiler/lowering/build_hir/jsx.rs
+++ b/src/react_compiler/lowering/build_hir/jsx.rs
@@ -298,6 +298,22 @@ pub(super) fn lower_jsx_call(
         // args[3..6] (isStatic, source, self) are dev-only metadata; ignore.
     } else {
         // createElement(tag, propsOrNull, ...children)
+        //
+        // The callee is not an operand of `JsxExpression`: codegen resolves
+        // `options.jsx.factory` again. A factory that is a local of this
+        // function would look unused to the compiler and be dropped.
+        if let Some(ref_) = member_expression_root(&call.target)
+            && let VariableBinding::Identifier { .. } = builder.resolve_identifier(ref_, loc)?
+        {
+            builder.record_error(CompilerErrorDetail {
+                category: ErrorCategory::Todo,
+                reason: "(BuildHIR::lowerJsxCall) Handle a JSX factory that is a local binding"
+                    .to_string(),
+                description: None,
+                loc: convert_loc(call.target.loc),
+                suggestions: None,
+            })?;
+        }
         if let Some(p) = props_arg {
             if let ExprData::EObject(obj) = &p.data {
                 for prop in obj.properties.iter() {
@@ -369,6 +385,16 @@ fn jsx_import_kind(builder: &HirBuilder, expr: &Expr) -> Option<JsxImportKind> {
         _ => return None,
     };
     builder.host().jsx_import_kind(ref_)
+}
+
+/// The identifier `a` of an `a.b.c` callee. An import is not a local, so an
+/// `EImportIdentifier` root is of no interest.
+fn member_expression_root(expr: &Expr) -> Option<Ref> {
+    match expr.data {
+        ExprData::EIdentifier(id) => Some(id.ref_),
+        ExprData::EDot(dot) => member_expression_root(&dot.target),
+        _ => None,
+    }
 }
 
 /// The visit pass packs children into the props object as either a single

--- a/src/react_compiler/program.rs
+++ b/src/react_compiler/program.rs
@@ -79,11 +79,23 @@ pub trait Host {
     /// post-visit JSX-import emission picks it up.
     fn jsx_import(&mut self, kind: JsxImportKind) -> Ref;
 
+    /// Which JSX runtime symbol `ref_` is, if the visit pass or
+    /// [`Host::jsx_import`] declared it on the parser's `jsx_imports` table.
+    fn jsx_import_kind(&self, ref_: Ref) -> Option<JsxImportKind>;
+
     /// Whether JSX is being compiled in development mode (selects `jsxDEV`
     /// over `jsx`/`jsxs` and emits the trailing dev-only call args).
     fn is_jsx_dev(&self) -> bool {
         false
     }
+
+    /// Whether this file uses the classic JSX runtime: every element is a
+    /// `factory(type, props, ...children)` call and nothing is auto-imported.
+    fn is_jsx_classic(&self) -> bool;
+
+    /// The classic runtime's factory (`React.createElement`, `h`, ...),
+    /// resolved from the current scope the way the visit pass resolves it.
+    fn jsx_classic_factory(&mut self, loc: Loc) -> Expr;
 
     fn new_generated(&mut self, name: &[u8]) -> Ref;
 

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1602,6 +1602,31 @@ describe("bundler", () => {
       },
     },
   });
+
+  // The classic factory is not an operand the compiler sees: it is resolved
+  // again when the call is rebuilt. A factory that is a local of the component
+  // would look unused and be dropped, so such a component stays uncompiled.
+  itBundled("react-compiler/ClassicRuntimeLocalFactoryIsNotCompiled", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        /** @jsxRuntime classic */
+        /** @jsx h */
+        export function App({ h, a }) {
+          return <div title={a}>hi</div>;
+        }
+        const createElement = (type, props, ...children) => ({ h: type, props, children });
+        console.log(JSON.stringify(App({ h: createElement, a: "A" })));
+      `,
+      ...jsxCallShapeRuntime,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toContain("compiler-runtime");
+    },
+    run: { stdout: '{"h":"div","props":{"title":"A"},"children":["hi"]}' },
+  });
 });
 
 // validate_locals_not_reassigned_after_render (src/react_compiler/validation)

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { isASAN, isDebug, tempDir } from "harness";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
-import { itBundled } from "../expectBundled";
+import { itBundled, type BundlerTestInput } from "../expectBundled";
 
 // The React Compiler emits `import { c as _c } from "react/compiler-runtime"` and
 // rewrites component bodies to call `_c(n)` to allocate a memo cache of `n` slots.
@@ -1480,6 +1480,128 @@ describe("bundler", () => {
       });
     }
   }
+
+  // The compiler lowers the call the visit pass made of each JSX element into
+  // HIR and builds a new call from that. Both steps have to use the call shape
+  // of the file's JSX runtime. The classic runtime, and `key` after a spread in
+  // the automatic one, calls `factory(type, props, ...children)`: the third
+  // argument is a child and not a key, `key` stays in `props`, and no
+  // `jsx`/`jsxDEV` is imported.
+  const jsxCallShapeEntry = (prelude: string, jsx: string) => /* jsx */ `
+    ${prelude}
+    export function App({ a, k, rest }) {
+      const o = { a };
+      return (${jsx});
+    }
+    console.log(JSON.stringify(App({ a: "A", k: "K", rest: { id: "r" } })));
+  `;
+  const jsxCallShapeRuntime = {
+    "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+    "/node_modules/react/index.js": /* js */ `
+      exports.Fragment = "React.Fragment";
+      exports.createElement = (type, props, ...children) => ({ createElement: type, props, children });
+    `,
+    "/node_modules/react/jsx-dev-runtime.js": /* js */ `
+      exports.Fragment = "Fragment";
+      exports.jsxDEV = (type, props, key) => ({ jsxDEV: type, props, key });
+    `,
+    "/node_modules/react/compiler-runtime.js": /* js */ `
+      exports.c = size => new Array(size).fill(Symbol.for("react.memo_cache_sentinel"));
+    `,
+  };
+  // `App` was compiled when its memo cache is in the bundle.
+  const expectCompiled = (api: { readFile(file: string): string }) =>
+    expect(api.readFile("/out.js")).toContain("// node_modules/react/compiler-runtime.js");
+
+  const classicRuntimes: Record<string, { prelude: string; tsconfig?: string; jsx?: BundlerTestInput["jsx"] }> = {
+    Pragma: { prelude: `/** @jsxRuntime classic */ import React from "react";` },
+    Tsconfig: { prelude: `import React from "react";`, tsconfig: `{ "compilerOptions": { "jsx": "react" } }` },
+    Flags: {
+      prelude: `import { createElement as h, Fragment as Frag } from "react";`,
+      jsx: { runtime: "classic", factory: "h", fragment: "Frag" },
+    },
+  };
+  for (const [name, { prelude, tsconfig, jsx }] of Object.entries(classicRuntimes)) {
+    itBundled(`react-compiler/ClassicRuntime-${name}`, {
+      files: {
+        "/entry.jsx": jsxCallShapeEntry(
+          prelude,
+          /* jsx */ `
+            <>
+              <div title={o.a}>hi</div>
+              <p key={k} {...rest}>{a}<b>x</b></p>
+              <ul id="u"><li>1</li><li>2</li><li>3</li><li>4</li></ul>
+              <span />
+            </>
+          `,
+        ),
+        ...(tsconfig && { "/tsconfig.json": tsconfig }),
+        ...jsxCallShapeRuntime,
+      },
+      jsx,
+      reactCompiler: true,
+      target: "browser",
+      backend: "cli",
+      onAfterBundle: expectCompiled,
+      run: {
+        validate({ stdout }) {
+          expect(JSON.parse(stdout)).toEqual({
+            createElement: "React.Fragment",
+            props: null,
+            children: [
+              { createElement: "div", props: { title: "A" }, children: ["hi"] },
+              {
+                createElement: "p",
+                props: { key: "K", id: "r" },
+                children: ["A", { createElement: "b", props: null, children: ["x"] }],
+              },
+              {
+                createElement: "ul",
+                props: { id: "u" },
+                children: ["1", "2", "3", "4"].map(n => ({ createElement: "li", props: null, children: [n] })),
+              },
+              { createElement: "span", props: null, children: [] },
+            ],
+          });
+        },
+      },
+    });
+  }
+
+  itBundled("react-compiler/AutomaticRuntimeKeyAfterSpread", {
+    files: {
+      "/entry.jsx": jsxCallShapeEntry(
+        "",
+        /* jsx */ `
+          <div>
+            <p {...rest} key={k}>{a}</p>
+            <i key={k} {...rest}>{o.a}</i>
+          </div>
+        `,
+      ),
+      ...jsxCallShapeRuntime,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    bundleWarnings: {
+      "/entry.jsx": ['"key" prop after a {...spread} is deprecated in JSX. Falling back to classic runtime.'],
+    },
+    onAfterBundle: expectCompiled,
+    run: {
+      validate({ stdout }) {
+        expect(JSON.parse(stdout)).toEqual({
+          jsxDEV: "div",
+          props: {
+            children: [
+              { createElement: "p", props: { id: "r", key: "K" }, children: ["A"] },
+              { jsxDEV: "i", props: { id: "r", children: "A" }, key: "K" },
+            ],
+          },
+        });
+      },
+    },
+  });
 });
 
 // validate_locals_not_reassigned_after_render (src/react_compiler/validation)

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1506,12 +1506,14 @@ describe("bundler", () => {
       exports.jsxDEV = (type, props, key) => ({ jsxDEV: type, props, key });
     `,
     "/node_modules/react/compiler-runtime.js": /* js */ `
-      exports.c = size => new Array(size).fill(Symbol.for("react.memo_cache_sentinel"));
+      exports.c = function useMemoCache(size) {
+        return new Array(size).fill(Symbol.for("react.memo_cache_sentinel"));
+      };
     `,
   };
   // `App` was compiled when its memo cache is in the bundle.
   const expectCompiled = (api: { readFile(file: string): string }) =>
-    expect(api.readFile("/out.js")).toContain("// node_modules/react/compiler-runtime.js");
+    expect(api.readFile("/out.js")).toContain("useMemoCache");
 
   const classicRuntimes: Record<string, { prelude: string; tsconfig?: string; jsx?: BundlerTestInput["jsx"] }> = {
     Pragma: { prelude: `/** @jsxRuntime classic */ import React from "react";` },
@@ -1623,7 +1625,7 @@ describe("bundler", () => {
     target: "browser",
     backend: "cli",
     onAfterBundle(api) {
-      expect(api.readFile("/out.js")).not.toContain("compiler-runtime");
+      expect(api.readFile("/out.js")).not.toContain("useMemoCache");
     },
     run: { stdout: '{"h":"div","props":{"title":"A"},"children":["hi"]}' },
   });


### PR DESCRIPTION
### Problem
- `bun build --react-compiler` on a file with the classic JSX runtime (`@jsxRuntime classic`, tsconfig `"jsx": "react"`, `--jsx-runtime=classic`) prints `jsxDEV(...)` calls that nothing imports. The first render throws `ReferenceError: jsxDEV is not defined`.
- `lower_jsx_call` (`src/react_compiler/lowering/build_hir/jsx.rs:218`) guessed the runtime from the arity and an object `args[1]`. `createElement("div", {title}, "hi")` looks like `jsx(tag, props, key)`, so `"hi"` became the key. `codegen_jsx_call` (`src/react_compiler/codegen.rs:2597`) always emitted the automatic shape.
- The guess also breaks the automatic runtime: `<div {...props} key={k}>hi</div>` compiled to `jsxDEV("div", {...props}, k, ...)` with no child.

### Fix
- Lowering asks the parser's `jsx_imports` table which symbol the callee is (`Host::jsx_import_kind`). Only `jsx`, `jsxs` and `jsxDEV` decode as the automatic shape.
- Codegen emits `factory(type, props | null, ...children)`, with `key` left in `props`, for the classic runtime and for `key` after a spread in the automatic runtime. `visit_expr.rs::e_jsx_element` makes the same choice.
- `P::jsx_classic_member_expression` replaces two copies of the factory lookup in `visit_expr.rs`, so the compiler host shares it.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (5 new cases, all fail on 1.4.3-canary). Also `react-compiler-fixtures.test.ts`, `bundler_jsx.test.ts`, `transpiler.test.js`.

### Background
- The visit pass turns each JSX element into a call before the React Compiler runs. The compiler lowers that call into its IR (tag, attributes, children) and builds a new call from it.
- Automatic runtime: `jsx(type, {...props, children}, key)` from `react/jsx-runtime`, or `createElement` from `react` when `key` follows a spread.
- Classic runtime: `React.createElement(type, props, ...children)`. Nothing is imported and `key` is a prop.
- `Host` is the compiler crate's view of parser state.

<details><summary>Notes</summary>

Repro (1.4.2, 1.4.3-canary.1+6a92015fc, main 4b5862fd88):

```jsx
// a.jsx
/** @jsxRuntime classic */
import React from "react";
export function App({ a }) {
  const o = { a };
  return <div title={o.a}>hi</div>;
}
```

```
$ bun build --react-compiler --target=browser --external react --external 'react/*' a.jsx
...
    t2 = /* @__PURE__ */ jsxDEV("div", {
      title: o.a
    }, "hi", false, undefined, this), $[2] = o.a, $[3] = t2;
```

No `react/jsx-dev-runtime` import is printed, and `"hi"` sits in the key position. With this change the same line is `React.createElement("div", { title: o.a }, "hi")`.

The automatic runtime case:

```jsx
export function App({ props, k }) {
  return <div {...props} key={k}>hi</div>;
}
```

Before: `jsxDEV("div", { ...props }, k, false, undefined, this)`. After: `createElement("div", { ...props, key: k }, "hi")`, the same as the function the compiler does not touch.

Why the arity guess cannot work: the visit pass emits `createElement(tag, propsOrNull, ...children)` for the classic runtime and for the fallback. One child gives 3 arguments, four children give 6. Both collide with `jsx(tag, props, key)` and `jsxDEV(tag, props, key, isStatic, source, self)` when the element has at least one attribute.

What lowering keeps: the automatic shape pushes the hoisted `key` first, so it never follows a spread. The `createElement` shape keeps `key` where the source has it. Codegen recomputes "key after spread" from that order, the same test `parse_jsx.rs` uses (last `key` index greater than first spread index).

When codegen picks the `createElement` shape in the automatic runtime: only when a `key` attribute follows a spread in the IR. That cannot happen for an element the visit pass hoisted a `key` out of. A `key` left inside the props after a spread means a later `key` exists, and then the parser already chose the fallback. The one other source is the spread-collapse of the visit pass: `<div {...{ ...x, key: k }}>` becomes `jsxDEV("div", { ...x, key: k })`. The compiled output used to hoist that `key` (`jsxDEV("div", { ...x }, k)`), which lets `x.key` win. It is now `createElement("div", { ...x, key: k })`, where `k` wins as in the source.

Classic fragments: `<>...</>` arrives as a call whose tag is `React.Fragment` (from `options.jsx.fragment`). It lowers as a plain member-expression tag, so `JsxFragment` only exists for the automatic runtime's `Fragment` import. Slot counts are the same as for the automatic runtime.

A factory that is a local of the component (`function App({ h })` with `@jsx h`) is not an operand of the IR instruction. Codegen resolves `options.jsx.factory` again when it rebuilds the call, so the compiler saw the local as unused and dropped it. Lowering now records a `Todo` for that case and the component stays uncompiled (`ClassicRuntimeLocalFactoryIsNotCompiled`). Babel after the upstream compiler has the same blind spot, because the factory only appears when the JSX transform runs.

Other checks with the debug build: `import * as React`, `--target=bun` (ssr output mode), `--minify`, `NODE_ENV=production` (`jsx(type, props, key)` with 3 arguments still decodes as automatic), `esbuild/default.test.ts -t JSX`, `esbuild/tsconfig.test.ts -t jsx`, `jsx-production.test.ts`, `jsx-tsconfig-react-jsx.test.ts`.

</details>

