### PR TITLE
react_compiler: hoist a context variable that a closure reads before its declaration

### DIFF
--- a/src/react_compiler/lowering/build_hir/stmt.rs
+++ b/src/react_compiler/lowering/build_hir/stmt.rs
@@ -155,7 +155,10 @@ fn lower_block_statement_inner(
         while h < hoist.len() && hoist[h].0 == i {
             let (_, target, loc, kind) = hoist[h];
             h += 1;
-            if builder.is_context_identifier(target) {
+            if builder
+                .environment()
+                .is_hoisted_identifier(target.inner_index())
+            {
                 continue;
             }
             let id_loc = convert_loc(loc);

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1168,6 +1168,94 @@ describe("bundler", () => {
     },
   });
 
+  // A closure reads a `let` that is declared below it (or by its own statement)
+  // and reassigned later. Babel declares such a local with `DeclareContext
+  // HoistedLet` in front of the closure, also when the local is already a
+  // context variable because it is captured and reassigned.
+  //
+  // The fake `c` records the size of every memo cache, so the second element of
+  // each pair is the `_c(n)` of that function. The sizes are the ones
+  // babel-plugin-react-compiler 1.0.0 emits. A function that the compiler
+  // skips has `[]` there.
+  itBundled("react-compiler/ClosureAboveReassignedLet", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { sizes } from "react/compiler-runtime";
+
+        const Row = "row";
+        const wrap = fn => fn;
+
+        function DeclarationReadsLetBelow(p) {
+          function label() {
+            return \`\${n} items\`;
+          }
+          let n = 0;
+          for (const it of p.items) {
+            n += it.qty;
+          }
+          return <b>{label()}</b>;
+        }
+        function ArrowReadsLetBelow(p) {
+          const renderRow = () => <Row items={items} />;
+          let items = p.items;
+          if (p.onlyActive) {
+            items = items.filter(i => i.active);
+          }
+          return <ul>{renderRow()}</ul>;
+        }
+        function ArrowReadsItself(p) {
+          let render = () => <Row again={render} x={p.x} />;
+          render = wrap(render);
+          return <div>{render()}</div>;
+        }
+        function TernaryOnLetBelow(p) {
+          const pick = () => (flag ? p.a : p.b);
+          let flag = p.flag;
+          flag = !flag;
+          return <i>{pick()}</i>;
+        }
+
+        function render(fn, props) {
+          const before = sizes().length;
+          const result = fn(props);
+          return [result.props.children, sizes().slice(before)];
+        }
+        console.log(JSON.stringify({
+          DeclarationReadsLetBelow: render(DeclarationReadsLetBelow, { items: [{ qty: 2 }, { qty: 3 }] }),
+          ArrowReadsLetBelow: render(ArrowReadsLetBelow, {
+            items: [{ id: 1, active: true }, { id: 2, active: false }],
+            onlyActive: true,
+          }),
+          ArrowReadsItself: render(ArrowReadsItself, { x: 7 }),
+          TernaryOnLetBelow: render(TernaryOnLetBelow, { flag: true, a: "a", b: "b" }),
+        }, (key, value) => (typeof value === "function" ? "function" : value)));
+      `,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+      "/node_modules/react/index.js": `exports.createElement = () => null;`,
+      "/node_modules/react/jsx-runtime.js": `exports.jsx = exports.jsxs = (type, props) => ({ type, props });`,
+      "/node_modules/react/jsx-dev-runtime.js": `exports.jsxDEV = (type, props) => ({ type, props });`,
+      "/node_modules/react/compiler-runtime.js": `
+        const sizes = [];
+        exports.c = size => {
+          sizes.push(size);
+          return new Array(size).fill(Symbol.for("react.memo_cache_sentinel"));
+        };
+        exports.sizes = () => sizes;
+      `,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    run: {
+      stdout: JSON.stringify({
+        DeclarationReadsLetBelow: ["5 items", [4]],
+        ArrowReadsLetBelow: [{ type: "row", props: { items: [{ id: 1, active: true }] } }, [3]],
+        ArrowReadsItself: [{ type: "row", props: { again: "function", x: 7 } }, [4]],
+        TernaryOnLetBelow: ["b", [6]],
+      }),
+    },
+  });
+
   // A temporary that has to survive as a variable is "promoted": the compiler
   // names it `#t<n>` (or `#T<n>` for a JSX tag, which has to be capitalised to
   // read as a component) after its declaration id, and the printer drops the


### PR DESCRIPTION
### Problem
- `bun build --react-compiler --target=browser` aborts on a component with a helper above a `let` that the helper reads and that is reassigned later: `panic: Expected identifier to be initialized` (`prune_non_escaping_scopes.rs:195`). With other helper bodies the compiler skips the function instead (`Invariant: [InferMutationAliasingEffects] Expected value kind to be initialized`), so it is not memoized.
- The block hoisting pass (`src/react_compiler/lowering/build_hir/stmt.rs:158`) skipped every binding that `is_context_identifier`. `FindContextIdentifiers` marks a captured and reassigned local before lowering starts, so that local got no `DeclareContext HoistedLet`. The closure then captured a variable that no instruction had declared.

### Fix
- Skip a binding only if it was already hoisted (`is_hoisted_identifier`), like `BuildHIR.ts` and the upstream Rust crate.
- Correct because the HIR now has the `DeclareContext HoistedLet` that upstream prints in front of the closure. On 119 probe variants the outcome and every `_c(n)` size equal babel-plugin-react-compiler 1.0.0. Before: 41 abort, 50 skipped, 28 equal.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (new `ClosureAboveReassignedLet`, SIGABRT on 1.4.2 and main). Also `react-compiler-fixtures.test.ts` (3293 pass).

### Background
- A context variable is a local that a closure captures and that something reassigns. The compiler accesses it with `LoadContext` and `StoreContext` and declares it with `DeclareContext`.
- A closure can name a `let` that is declared below it. Lowering emits `DeclareContext HoistedLet x` in front of the first statement that has such a closure, so every pass sees a declaration before the capture. `PruneHoistedContexts` removes it before codegen.
- `FindContextIdentifiers` is the pass before lowering that finds those locals.

<details><summary>Notes</summary>

Repro (any directory, 1.4.2 and main 471b5868b6):

```jsx
// g.jsx
export function List(p) {
  const renderRow = () => <Row items={items} />;
  let items = p.items;
  if (p.onlyActive) {
    items = items.filter((i) => i.active);
  }
  return <ul>{renderRow()}</ul>;
}
```

```
$ bun build --react-compiler --target=browser --external '*' g.jsx
panic: Expected identifier to be initialized
Crashed while visiting g.jsx
```

Frames: `CollectState::visit_operand` (`prune_non_escaping_scopes.rs:195`), `visit_value_for_memoization` (`:896`), `prune_non_escaping_scopes` (`:66`), `pipeline::run_hir_passes` (`pipeline.rs:622`). The operand is the context operand `items` of the `FunctionExpression`. It is in a reactive scope that is active at that instruction, and no earlier instruction has it as an lvalue, so it has no identifier node.

The same cause with a self reference: `let render = () => <Row again={render} />; render = wrap(render);`.

Upstream HIR for `g.jsx` (babel-plugin-react-compiler 1.0.0, `debugLogIRs`), first instructions:

```
[1] $2 = DeclareContext HoistedLet items$1
[2] $8 = Function @context[items$1] ...
[3] $10 = StoreLocal Const renderRow$9 = $8
...
[6] $13 = StoreContext Let items$1 = $12
```

`items` is a context identifier from `FindContextIdentifiers` there too (captured and reassigned), and upstream still hoists it. `BuildHIR.ts` has `if (builder.environment.isHoistedIdentifier(binding.identifier)) continue; // Already hoisted`, and `react_compiler_lowering/src/build_hir.rs` on facebook/react main has `is_hoisted_identifier(info.binding_id.0)`. The `is_context_identifier` check is in the port since #32504.

Why only some helper bodies abort. Without the declaration, `InferMutationAliasingEffects` fails when the closure captures or aliases the variable (`items.length`, `[items]`, `foo(items)`, a bare `items`): the value kind of `items` is not initialized, and that invariant is already a per-function error. When the closure only reads or freezes it (a JSX attribute or child, a template literal, `items + 1`, `items ? 1 : 2`), inference passes and PruneNonEscapingScopes is the first pass that needs the declaration. That one is an `.expect()`.

Probes. Matrix 1 is 104 files: helper as arrow or function declaration, 13 helper bodies, the `let` reassigned in an `if`, in a loop, in a plain statement, or never. Matrix 2 is 15 files: function declaration reassigned after a closure calls it, destructured `let`, `let` in a nested block, two closures, a closure that reassigns, a closure in a closure, `useEffect`, an object method, `for`, `switch`, `try`, the self reference. For each file I compared the compile event and the list of `_c(n)` sizes with babel-plugin-react-compiler 1.0.0.

| | equal to upstream | skipped (invariant) | abort |
| --- | --- | --- | --- |
| main (debug build of 6a92015fc) | 28 | 50 | 41 |
| this branch | 119 | 0 | 0 |

One of the 119 is a function declaration that names itself in JSX and is reassigned. Upstream skips it with `Todo: [PruneHoistedContexts] Rewrite hoisted function references`. This branch reports the same error. Main aborts.

The fixture `hoisting-reassigned-let-declaration.js` has this shape with a bare `() => x`. It passes before and after: the port reached the same output without the declaration.

Relation to #42378. That PR turns the `.expect()` at `prune_non_escaping_scopes.rs:195` into a per-function error. The two are independent. With only #42378 these functions are skipped and not memoized. With only this PR they compile.

What the test checks. It bundles four functions with `--target=browser` through the CLI and runs the output against a fake `react/compiler-runtime` whose `c` records every cache size. Each function returns the right value (the closure sees the reassigned value) and allocates the cache size that upstream emits: 4, 3, 4, 6. Each of the four aborts 1.4.2 on its own. On a build that has only #42378 the test also fails, with `[]` in place of each size.

ssr mode (`--target=bun`) compiled these before and still does.

Suites run with the debug build: `test/bundler/transpiler/react-compiler.test.ts` (46 pass), `test/bundler/transpiler/react-compiler-fixtures.test.ts` (3293 pass, 320 skip). `cargo clippy -p bun_react_compiler` and `cargo fmt --check` are clean.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [813.34ms]
(pass) bundler > react-compiler/ComponentWithHooks [324.73ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [395.04ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [301.18ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [183.68ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [144.15ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [452.98ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [178.42ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [142.44ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [136.16ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [423.84ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [518.09ms]
(
... (truncated)

release without fix: 1 failed, 1 skipped
bun test v1.4.3-canary.1 (402e05b8c)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [39.44ms]
(pass) bundler > react-compiler/ComponentWithHooks [19.94ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [14.48ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [15.89ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [16.02ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [8.57ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [20.83ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [6.15ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [7.18ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [14.42ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [15.26ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [55.56ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [27.79ms]
(pass) bundler > react-compiler/BranchBooleanFeatureFlagPreservesDCE [15.03ms]
(pass) bundler > react-compile
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [806.81ms]
(pass) bundler > react-compiler/ComponentWithHooks [296.53ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [300.84ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [365.91ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [274.89ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [140.96ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [401.46ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [126.19ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [130.72ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [131.59ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [317.37ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [518.86ms]
(
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 793ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/works
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/react_compiler/lowering/build_hir/stmt.rs  |  5 +-
 test/bundler/transpiler/react-compiler.test.ts | 88 ++++++++++++++++++++++++++
 2 files changed, 92 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/react_compiler/lowering/build_hir/stmt.rs       2      2     20
test/bundler/transpiler/react-compiler.test.ts      2      4     19
```

</details>

<!-- robobun:evidence:end -->