### PR TITLE
node:http2: validate inbound ALTSVC and ORIGIN frames on the client like node

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -5322,20 +5322,14 @@ class ClientHttp2Session extends Http2Session {
       // node.js emits value, origin, streamId
       self.emit("altsvc", value, origin, streamId);
     },
-    origin(self: ClientHttp2Session, origin: string | Array<string> | undefined) {
-      if (!self) return;
-      if (self.encrypted) {
-        const originSet = initOriginSet(self);
-        if ($isArray(origin)) {
-          for (const item of origin) {
-            originSet.add(item);
-          }
-          self.emit("origin", origin);
-        } else if (origin) {
-          originSet.add(origin);
-          self.emit("origin", [origin]);
-        }
+    origin(self: ClientHttp2Session, origins: string[]) {
+      if (!self || !self.encrypted) return;
+      const originSet = initOriginSet(self);
+      for (let i = 0; i < origins.length; i++) {
+        originSet.add(origins[i]);
       }
+      // An ORIGIN frame without origins still emits, with an empty array.
+      self.emit("origin", origins);
     },
     write(self: ClientHttp2Session, buffer: Buffer) {
       if (!self) return -1;

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -206,8 +206,7 @@ pub trait Sink {
     fn on_push_promise(&self, _parent_id: u32, _promised_id: u32) {}
     /// RFC 7838 ALTSVC.
     fn on_altsvc(&self, _stream_id: u32, _origin: &[u8], _value: &[u8]) {}
-    /// RFC 8336 ORIGIN: the origins of one well-formed frame (possibly none), delivered once per
-    /// frame so the embedder can surface them as a single event.
+    /// RFC 8336 ORIGIN: the origins of one well-formed frame (possibly none), once per frame.
     fn on_origin(&self, _origins: wire::OriginEntries<'_>) {}
     /// The peer exceeded the session's invalid-frame allowance (node's maxSessionInvalidFrames):
     /// the embedder should destroy the session with ERR_HTTP2_TOO_MANY_INVALID_FRAMES.
@@ -222,10 +221,7 @@ pub trait Sink {
     fn is_local_stream(&self, _stream_id: u32) -> bool {
         false
     }
-    /// Whether `stream_id` is still open on the embedder's side: `Some(false)` once both halves
-    /// closed or the embedder reset it. `None` if the embedder keeps no record of the stream (a
-    /// stream the peer pushed): then this engine's own entry decides. For any other stream this
-    /// engine only sees the inbound half, so it cannot tell on its own.
+    /// `Some(open)` if the embedder tracks both halves of the stream, `None` if not (a pushed one).
     fn is_stream_open(&self, _stream_id: u32) -> Option<bool> {
         None
     }
@@ -417,9 +413,7 @@ impl Connection {
         self.local_connection_error(sink, code, wire::lib_error::PROTO, debug);
     }
 
-    /// node (Http2Session::OnInvalidFrame): every locally-rejected invalid frame counts against
-    /// maxSessionInvalidFrames (same post-increment comparison as node). Returns true once the
-    /// allowance is exceeded: the session is then torn down with ERR_HTTP2_TOO_MANY_INVALID_FRAMES.
+    /// node's OnInvalidFrame count. True: past maxSessionInvalidFrames, the session is torn down.
     fn count_invalid_frame(&mut self, sink: &impl Sink) -> bool {
         let count = self.invalid_frame_count;
         self.invalid_frame_count = count.saturating_add(1);
@@ -431,12 +425,9 @@ impl Connection {
         false
     }
 
-    /// A frame nghttp2 reports to on_invalid_frame_recv_callback with NGHTTP2_ERR_PROTO and then
-    /// drops, without terminating the session. node counts it, then destroys the session with
-    /// NghttpError("Protocol error"). That destroy writes the only GOAWAY (INTERNAL_ERROR), so
-    /// none is written here. Always returns true: the connection is closing.
-    /// https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1128-L1175
+    /// node counts the frame, then destroys the session. That destroy writes the only GOAWAY.
     fn invalid_frame(&mut self, sink: &impl Sink, debug: &[u8]) -> bool {
+        // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1128-L1175
         if self.count_invalid_frame(sink) {
             return true;
         }
@@ -1792,10 +1783,7 @@ impl Connection {
         })
     }
 
-    /// RFC 7838 §4 ALTSVC: 2-byte origin length, origin, then the Alt-Svc field value. Follows
-    /// nghttp2, whose verdicts node turns into session errors where RFC 7838 says to ignore the
-    /// frame (see `invalid_frame`).
-    /// https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L4816-L4852
+    /// RFC 7838 §4 ALTSVC, with node's session errors where the RFC says to ignore the frame.
     fn handle_altsvc(&mut self, sink: &impl Sink, hdr: &FrameHeader, payload: &[u8]) -> bool {
         // A server never accepts ALTSVC, whatever its shape.
         if self.is_server {
@@ -1805,12 +1793,11 @@ impl Connection {
             .split_first_chunk::<2>()
             .and_then(|(len, rest)| rest.split_at_checked(usize::from(u16::from_be_bytes(*len))));
         let Some((origin, value)) = parsed else {
-            // RFC 9113 §4.2: too small for its origin length, or for the origin that it announces.
-            // https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L5957-L5961
             // https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L6347-L6351
             self.send_go_away(sink, ErrorCode::FrameSizeError, b"ALTSVC frame too short");
             return true;
         };
+        // https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L4816-L4852
         if hdr.stream_id == 0 {
             if origin.is_empty() {
                 return self.invalid_frame(sink, b"ALTSVC on stream 0 without an origin");
@@ -1834,13 +1821,14 @@ impl Connection {
     /// RFC 8336 §2 ORIGIN: a sequence of (2-byte length + origin) entries on stream 0.
     fn handle_origin(&mut self, sink: &impl Sink, hdr: &FrameHeader, payload: &[u8]) -> bool {
         // §2.1: ORIGIN on a non-zero stream is ignored, and like ALTSVC it is server-to-client
-        // only - a server receiving it must ignore it. nghttp2 also ignores a frame with any of
-        // the high four flag bits set.
-        // https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L5990-L6006
-        if hdr.stream_id != 0 || self.is_server || hdr.flags & 0xf0 != 0 {
+        // only - a server receiving it must ignore it.
+        if hdr.stream_id != 0 || self.is_server {
             return false;
         }
-        // A frame that does not parse is dropped whole; it is not an invalid frame.
+        // https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L5990-L6006
+        if hdr.flags & 0xf0 != 0 {
+            return false;
+        }
         // https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L4952-L4960
         if let Some(origins) = wire::OriginEntries::parse(payload) {
             sink.on_origin(origins);

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -206,9 +206,9 @@ pub trait Sink {
     fn on_push_promise(&self, _parent_id: u32, _promised_id: u32) {}
     /// RFC 7838 ALTSVC.
     fn on_altsvc(&self, _stream_id: u32, _origin: &[u8], _value: &[u8]) {}
-    /// RFC 8336 ORIGIN — the full frame payload (a sequence of 2-byte-length-prefixed origins),
-    /// delivered once per frame so the embedder can surface them as a single event.
-    fn on_origin(&self, _payload: &[u8]) {}
+    /// RFC 8336 ORIGIN: the origins of one well-formed frame (possibly none), delivered once per
+    /// frame so the embedder can surface them as a single event.
+    fn on_origin(&self, _origins: wire::OriginEntries<'_>) {}
     /// The peer exceeded the session's invalid-frame allowance (node's maxSessionInvalidFrames):
     /// the embedder should destroy the session with ERR_HTTP2_TOO_MANY_INVALID_FRAMES.
     fn on_too_many_invalid_frames(&self) {}
@@ -221,6 +221,13 @@ pub trait Sink {
     /// inbound frames for it are not treated as frames on an idle stream.
     fn is_local_stream(&self, _stream_id: u32) -> bool {
         false
+    }
+    /// Whether `stream_id` is still open on the embedder's side: `Some(false)` once both halves
+    /// closed or the embedder reset it. `None` if the embedder keeps no record of the stream (a
+    /// stream the peer pushed): then this engine's own entry decides. For any other stream this
+    /// engine only sees the inbound half, so it cannot tell on its own.
+    fn is_stream_open(&self, _stream_id: u32) -> Option<bool> {
+        None
     }
     /// Highest stream id the embedder has ever registered, in either direction. Monotonic across
     /// stream eviction: ids at or below it have existed (closed at worst, never idle), which the
@@ -408,6 +415,35 @@ impl Connection {
     /// specific callback (node's `internal_goaway_sent_` path in OnFrameSent/SendPendingData).
     pub fn send_go_away(&mut self, sink: &impl Sink, code: ErrorCode, debug: &[u8]) {
         self.local_connection_error(sink, code, wire::lib_error::PROTO, debug);
+    }
+
+    /// node (Http2Session::OnInvalidFrame): every locally-rejected invalid frame counts against
+    /// maxSessionInvalidFrames (same post-increment comparison as node). Returns true once the
+    /// allowance is exceeded: the session is then torn down with ERR_HTTP2_TOO_MANY_INVALID_FRAMES.
+    fn count_invalid_frame(&mut self, sink: &impl Sink) -> bool {
+        let count = self.invalid_frame_count;
+        self.invalid_frame_count = count.saturating_add(1);
+        if count > self.max_invalid_frames {
+            self.terminated = true;
+            sink.on_too_many_invalid_frames();
+            return true;
+        }
+        false
+    }
+
+    /// A frame nghttp2 reports to on_invalid_frame_recv_callback with NGHTTP2_ERR_PROTO and then
+    /// drops, without terminating the session. node counts it, then destroys the session with
+    /// NghttpError("Protocol error"). That destroy writes the only GOAWAY (INTERNAL_ERROR), so
+    /// none is written here. Always returns true: the connection is closing.
+    /// https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1128-L1175
+    fn invalid_frame(&mut self, sink: &impl Sink, debug: &[u8]) -> bool {
+        if self.count_invalid_frame(sink) {
+            return true;
+        }
+        self.going_away = true;
+        self.terminated = true;
+        sink.on_error(wire::lib_error::PROTO, self.last_stream_id, debug);
+        true
     }
 
     fn send_window_update(&mut self, sink: &impl Sink, stream_id: u32, increment: u32) {
@@ -1294,14 +1330,7 @@ impl Connection {
             }
         }
         if malformed && !rejected {
-            // node (Http2Session::OnInvalidFrame): every locally-rejected invalid frame counts
-            // against maxSessionInvalidFrames; exceeding it tears the session down with
-            // ERR_HTTP2_TOO_MANY_INVALID_FRAMES (same post-increment comparison as node).
-            let count = self.invalid_frame_count;
-            self.invalid_frame_count = count.saturating_add(1);
-            if count > self.max_invalid_frames {
-                self.terminated = true;
-                sink.on_too_many_invalid_frames();
+            if self.count_invalid_frame(sink) {
                 return true;
             }
             // RFC 9113 §8.2: a malformed header block gets a stream error of type PROTOCOL_ERROR and
@@ -1496,16 +1525,12 @@ impl Connection {
         }
 
         // An empty DATA frame that does not end the stream carries no information and is only
-        // useful for flooding: count it against the session's invalid-frame allowance (node's
-        // maxSessionInvalidFrames; same post-increment comparison as node).
-        if payload.is_empty() && !wire::flags::has(hdr.flags, wire::flags::END_STREAM) {
-            let count = self.invalid_frame_count;
-            self.invalid_frame_count = count.saturating_add(1);
-            if count > self.max_invalid_frames {
-                self.terminated = true;
-                sink.on_too_many_invalid_frames();
-                return true;
-            }
+        // useful for flooding: count it against the session's invalid-frame allowance.
+        if payload.is_empty()
+            && !wire::flags::has(hdr.flags, wire::flags::END_STREAM)
+            && self.count_invalid_frame(sink)
+        {
+            return true;
         }
 
         // Per-stream flow control + state check, decided under a scoped borrow so the self.* calls
@@ -1758,24 +1783,49 @@ impl Connection {
         self.finish_or_park_header_block(sink, hdr, meta)
     }
 
-    /// RFC 7838 §4 ALTSVC: optional 2-byte origin-length + origin, then the Alt-Svc field value.
+    /// nghttp2_session_get_stream: the stream exists and is neither idle nor closed.
+    fn is_stream_open(&self, sink: &impl Sink, stream_id: u32) -> bool {
+        sink.is_stream_open(stream_id).unwrap_or_else(|| {
+            self.streams
+                .get(&stream_id)
+                .is_some_and(|s| !matches!(s.state, State::Idle | State::Closed))
+        })
+    }
+
+    /// RFC 7838 §4 ALTSVC: 2-byte origin length, origin, then the Alt-Svc field value. Follows
+    /// nghttp2, whose verdicts node turns into session errors where RFC 7838 says to ignore the
+    /// frame (see `invalid_frame`).
+    /// https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L4816-L4852
     fn handle_altsvc(&mut self, sink: &impl Sink, hdr: &FrameHeader, payload: &[u8]) -> bool {
-        if payload.len() < 2 {
-            return false; // malformed ALTSVC is ignored (§4)
-        }
-        let origin_len = u16::from_be_bytes([payload[0], payload[1]]) as usize;
-        if 2 + origin_len > payload.len() {
+        // A server never accepts ALTSVC, whatever its shape.
+        if self.is_server {
             return false;
         }
-        let origin = &payload[2..2 + origin_len];
-        let value = &payload[2 + origin_len..];
-        // RFC 7838 4 MUST-ignore rules: a server never accepts ALTSVC; on stream 0 the origin
-        // must be present; on a request stream it must be empty (the stream's own origin applies).
-        if self.is_server
-            || (hdr.stream_id == 0 && origin.is_empty())
-            || (hdr.stream_id != 0 && !origin.is_empty())
-        {
-            return false;
+        let parsed = payload
+            .split_first_chunk::<2>()
+            .and_then(|(len, rest)| rest.split_at_checked(usize::from(u16::from_be_bytes(*len))));
+        let Some((origin, value)) = parsed else {
+            // RFC 9113 §4.2: too small for its origin length, or for the origin that it announces.
+            // https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L5957-L5961
+            // https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L6347-L6351
+            self.send_go_away(sink, ErrorCode::FrameSizeError, b"ALTSVC frame too short");
+            return true;
+        };
+        if hdr.stream_id == 0 {
+            if origin.is_empty() {
+                return self.invalid_frame(sink, b"ALTSVC on stream 0 without an origin");
+            }
+        } else {
+            if !origin.is_empty() {
+                return self.invalid_frame(sink, b"ALTSVC on a stream with an origin");
+            }
+            // An idle, closed or unknown stream drops the frame. This is not an invalid frame.
+            if !self.is_stream_open(sink, hdr.stream_id) {
+                return false;
+            }
+        }
+        if value.is_empty() {
+            return self.invalid_frame(sink, b"ALTSVC without a field value");
         }
         sink.on_altsvc(hdr.stream_id, origin, value);
         false
@@ -1784,12 +1834,17 @@ impl Connection {
     /// RFC 8336 §2 ORIGIN: a sequence of (2-byte length + origin) entries on stream 0.
     fn handle_origin(&mut self, sink: &impl Sink, hdr: &FrameHeader, payload: &[u8]) -> bool {
         // §2.1: ORIGIN on a non-zero stream is ignored, and like ALTSVC it is server-to-client
-        // only - a server receiving it must ignore it. The whole payload is delivered once; the
-        // embedder iterates the (2-byte length, origin) entries and surfaces a single event.
-        if hdr.stream_id != 0 || self.is_server {
+        // only - a server receiving it must ignore it. nghttp2 also ignores a frame with any of
+        // the high four flag bits set.
+        // https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L5990-L6006
+        if hdr.stream_id != 0 || self.is_server || hdr.flags & 0xf0 != 0 {
             return false;
         }
-        sink.on_origin(payload);
+        // A frame that does not parse is dropped whole; it is not an invalid frame.
+        // https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L4952-L4960
+        if let Some(origins) = wire::OriginEntries::parse(payload) {
+            sink.on_origin(origins);
+        }
         false
     }
 
@@ -2028,7 +2083,8 @@ mod tests {
         resets: RefCell<Vec<(u32, u32)>>,
         pushes: RefCell<Vec<(u32, u32)>>,
         altsvc: RefCell<Vec<(u32, Vec<u8>, Vec<u8>)>>,
-        origins: RefCell<Vec<Vec<u8>>>,
+        /// One entry per delivered ORIGIN frame.
+        origins: RefCell<Vec<Vec<Vec<u8>>>>,
     }
     impl Sink for CaptureSink {
         fn write(&self, bytes: &[u8]) -> WriteResult {
@@ -2078,8 +2134,10 @@ mod tests {
                 .borrow_mut()
                 .push((id, origin.to_vec(), value.to_vec()));
         }
-        fn on_origin(&self, origin: &[u8]) {
-            self.origins.borrow_mut().push(origin.to_vec());
+        fn on_origin(&self, origins: wire::OriginEntries<'_>) {
+            self.origins
+                .borrow_mut()
+                .push(origins.map(<[u8]>::to_vec).collect());
         }
     }
 

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -413,7 +413,7 @@ impl Connection {
         self.local_connection_error(sink, code, wire::lib_error::PROTO, debug);
     }
 
-    /// node's OnInvalidFrame count. True: past maxSessionInvalidFrames, the session is torn down.
+    /// node's OnInvalidFrame, post-increment compare included. True: the session is torn down.
     fn count_invalid_frame(&mut self, sink: &impl Sink) -> bool {
         let count = self.invalid_frame_count;
         self.invalid_frame_count = count.saturating_add(1);

--- a/src/runtime/api/bun/h2/wire.rs
+++ b/src/runtime/api/bun/h2/wire.rs
@@ -187,6 +187,54 @@ impl FrameHeader {
     }
 }
 
+/// The Origin-Entry sequence of an ORIGIN frame payload (RFC 8336 §2): each entry is a 2-byte
+/// length followed by that many octets of ASCII-Origin. Only built from a payload in which every
+/// entry is complete. Yields the origins in order and skips zero-length entries.
+/// https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_frame.c#L846-L862
+#[derive(Clone, Debug)]
+pub struct OriginEntries<'a> {
+    rest: &'a [u8],
+    /// Origins left in `rest`, zero-length entries not counted.
+    len: usize,
+}
+
+impl<'a> OriginEntries<'a> {
+    /// `None` when a length prefix or an origin runs past the end of the payload.
+    pub fn parse(payload: &'a [u8]) -> Option<Self> {
+        let mut rest = payload;
+        let mut len = 0;
+        while !rest.is_empty() {
+            let (prefix, tail) = rest.split_first_chunk::<2>()?;
+            let origin_len = usize::from(u16::from_be_bytes(*prefix));
+            rest = tail.get(origin_len..)?;
+            len += usize::from(origin_len != 0);
+        }
+        Some(OriginEntries { rest: payload, len })
+    }
+}
+
+impl<'a> Iterator for OriginEntries<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<&'a [u8]> {
+        loop {
+            let (prefix, tail) = self.rest.split_first_chunk::<2>()?;
+            let (origin, rest) = tail.split_at_checked(usize::from(u16::from_be_bytes(*prefix)))?;
+            self.rest = rest;
+            if !origin.is_empty() {
+                self.len -= 1;
+                return Some(origin);
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
+    }
+}
+
+impl ExactSizeIterator for OriginEntries<'_> {}
+
 /// Outcome of validating an inbound frame header against §4.2/§6 structural rules
 /// (independent of stream state, which the state machine checks separately).
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -332,6 +380,26 @@ mod tests {
             validate_header(&hdr, MAX_FRAME_SIZE_DEFAULT),
             HeaderValidation::ConnectionError(ErrorCode::FrameSizeError)
         );
+    }
+
+    #[test]
+    fn origin_entries_parse_whole_or_not_at_all() {
+        let origins = |payload| {
+            let entries = OriginEntries::parse(payload)?;
+            let len = entries.len();
+            let entries: Vec<_> = entries.collect();
+            assert_eq!(entries.len(), len);
+            Some(entries)
+        };
+        assert_eq!(origins(b""), Some(vec![]));
+        assert_eq!(origins(b"\0\0"), Some(vec![]));
+        assert_eq!(
+            origins(b"\0\x01a\0\0\0\x02bc"),
+            Some(vec![&b"a"[..], &b"bc"[..]])
+        );
+        assert_eq!(origins(b"\0"), None);
+        assert_eq!(origins(b"\0\x01a\0"), None);
+        assert_eq!(origins(b"\0\x01a\0\x05bc"), None);
     }
 
     #[test]

--- a/src/runtime/api/bun/h2/wire.rs
+++ b/src/runtime/api/bun/h2/wire.rs
@@ -187,10 +187,7 @@ impl FrameHeader {
     }
 }
 
-/// The Origin-Entry sequence of an ORIGIN frame payload (RFC 8336 §2): each entry is a 2-byte
-/// length followed by that many octets of ASCII-Origin. Only built from a payload in which every
-/// entry is complete. Yields the origins in order and skips zero-length entries.
-/// https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_frame.c#L846-L862
+/// The entries of an ORIGIN payload in which every entry is complete, zero-length ones skipped.
 #[derive(Clone, Debug)]
 pub struct OriginEntries<'a> {
     rest: &'a [u8],
@@ -201,6 +198,7 @@ pub struct OriginEntries<'a> {
 impl<'a> OriginEntries<'a> {
     /// `None` when a length prefix or an origin runs past the end of the payload.
     pub fn parse(payload: &'a [u8]) -> Option<Self> {
+        // https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_frame.c#L846-L862
         let mut rest = payload;
         let mut len = 0;
         while !rest.is_empty() {

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3947,8 +3947,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     }
 
     fn is_stream_open(&self, stream_id: u32) -> Option<bool> {
-        // On a client the legacy map holds every stream except the ones the peer pushed, until
-        // the read after its teardown. A full close and a local RST_STREAM both set CLOSED first.
+        // A pushed stream has no legacy entry. A full close and a local RST_STREAM both set CLOSED.
         let stream = self.streams.get().get(&stream_id).copied()?;
         // SAFETY: stream is *mut Stream from self.streams; valid while the map entry exists
         Some(unsafe { (*stream).state != StreamState::CLOSED })
@@ -3975,9 +3974,7 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
     }
 
     fn on_origin(&self, origins: crate::api::h2::wire::OriginEntries<'_>) {
-        // One onOrigin dispatch per ORIGIN frame, always with an array. A frame without origins
-        // gives an empty array.
-        // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1673-L1693
+        // Always an array: https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1673-L1693
         if !self.can_dispatch(JSH2FrameParser::Gc::onOrigin) {
             return;
         }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3946,6 +3946,14 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
         self.streams.get().contains_key(&stream_id)
     }
 
+    fn is_stream_open(&self, stream_id: u32) -> Option<bool> {
+        // On a client the legacy map holds every stream except the ones the peer pushed, until
+        // the read after its teardown. A full close and a local RST_STREAM both set CLOSED first.
+        let stream = self.streams.get().get(&stream_id).copied()?;
+        // SAFETY: stream is *mut Stream from self.streams; valid while the map entry exists
+        Some(unsafe { (*stream).state != StreamState::CLOSED })
+    }
+
     fn highest_started_stream_id(&self) -> u32 {
         // handle_received_stream_id raises this for every stream registered on this side
         // (including locally-initiated ones) and eviction never lowers it.
@@ -3966,53 +3974,20 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
         self.rewrite_pending_push.set(promised_id);
     }
 
-    fn on_origin(&self, payload: &[u8]) {
-        // Match the legacy dispatch shape: a single origin is passed as a string, multiple origins
-        // as an array — one onOrigin dispatch per ORIGIN frame.
+    fn on_origin(&self, origins: crate::api::h2::wire::OriginEntries<'_>) {
+        // One onOrigin dispatch per ORIGIN frame, always with an array. A frame without origins
+        // gives an empty array.
+        // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1673-L1693
         if !self.can_dispatch(JSH2FrameParser::Gc::onOrigin) {
             return;
         }
         let g = self.global();
-        let mut origin_value = JSValue::UNDEFINED;
-        let mut count: u32 = 0;
-        let mut rest = payload;
-        while rest.len() >= 2 {
-            let len = u16::from_be_bytes([rest[0], rest[1]]) as usize;
-            if 2 + len > rest.len() {
-                break;
-            }
-            let origin = &rest[2..2 + len];
-            let Some(origin_js) = self.or_stop(self.latin1_to_js(origin)) else {
-                return;
-            };
-            if count == 0 {
-                origin_value = origin_js;
-                origin_value.ensure_still_alive();
-            } else if count == 1 {
-                let Some(array) = self.or_stop(JSValue::create_empty_array(&g, 0)) else {
-                    return;
-                };
-                array.ensure_still_alive();
-                let Some(()) = self.or_stop(
-                    array
-                        .push(&g, origin_value)
-                        .and_then(|()| array.push(&g, origin_js)),
-                ) else {
-                    return;
-                };
-                origin_value = array;
-            } else {
-                let Some(()) = self.or_stop(origin_value.push(&g, origin_js)) else {
-                    return;
-                };
-            }
-            count += 1;
-            rest = &rest[2 + len..];
-        }
-        if count == 0 {
+        let array =
+            JSValue::create_array_from_iter(&g, origins, |origin| self.latin1_to_js(origin));
+        let Some(array) = self.or_stop(array) else {
             return;
-        }
-        self.dispatch(JSH2FrameParser::Gc::onOrigin, origin_value);
+        };
+        self.dispatch(JSH2FrameParser::Gc::onOrigin, array);
     }
 
     fn on_stream_open(&self, stream_id: u32) {

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -8,11 +8,12 @@
 // WINDOW_UPDATE, frame-size and stream-id rules. HPACK/HEADERS cases live in a sibling file.
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, gcTick, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, gcTick, normalizeBunSnapshot, tls as tlsCert } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
 import net from "node:net";
 import { Writable } from "node:stream";
+import tls from "node:tls";
 
 const PREFACE = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "latin1");
 
@@ -27,6 +28,8 @@ const FrameType = {
   GOAWAY: 0x7,
   WINDOW_UPDATE: 0x8,
   CONTINUATION: 0x9,
+  ALTSVC: 0xa, // RFC 7838
+  ORIGIN: 0xc, // RFC 8336
 } as const;
 
 const ErrorCode = {
@@ -681,18 +684,22 @@ class RawH2Server {
   private sawPreface = false;
   frames: Frame[] = [];
   private waiters: Array<{ pred: (f: Frame) => boolean; resolve: (f: Frame) => void }> = [];
+  /** Resolves once the accepted connection has closed: every frame the client wrote is in `frames`. */
+  readonly socketClosed = Promise.withResolvers<void>();
 
   private constructor(server: net.Server) {
     this.server = server;
   }
 
-  static async listen(): Promise<RawH2Server> {
-    const server = net.createServer();
+  /** `secure` serves TLS with ALPN "h2"; connect to `https://localhost:${port}` with `{ ca: tlsCert.cert }`. */
+  static async listen({ secure = false } = {}): Promise<RawH2Server> {
+    const server = secure ? tls.createServer({ ...tlsCert, ALPNProtocols: ["h2"] }) : net.createServer();
     const s = new RawH2Server(server);
-    server.on("connection", socket => {
+    server.on(secure ? "secureConnection" : "connection", (socket: net.Socket) => {
       s.socket = socket;
       socket.on("data", d => s.onData(d));
       socket.on("error", () => {});
+      socket.on("close", () => s.socketClosed.resolve());
     });
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
@@ -731,12 +738,14 @@ class RawH2Server {
     this.socket!.write(encodeFrame(type, flags, streamId, payload));
   }
 
+  /** `timeoutMs: Infinity` leaves the deadline to the test runner. */
   waitFor(pred: (f: Frame) => boolean, timeoutMs = 2000): Promise<Frame> {
     const existing = this.frames.find(pred);
     if (existing) return Promise.resolve(existing);
     return new Promise((resolve, reject) => {
       const w = { pred, resolve };
       this.waiters.push(w);
+      if (timeoutMs === Infinity) return;
       const t = setTimeout(() => {
         const i = this.waiters.indexOf(w);
         if (i !== -1) this.waiters.splice(i, 1);
@@ -925,6 +934,320 @@ describe("SETTINGS ack ordering (RFC 9113 §6.5.3)", () => {
     } finally {
       client.destroy();
       raw.close();
+    }
+  });
+});
+
+// Every expectation below is the output of node v26.3.0 for the same frames. nghttp2 validates
+// the frame (nghttp2_session_on_altsvc_received, nghttp2_frame_unpack_origin_payload). node's
+// Http2Session::OnInvalidFrame destroys the session with NghttpError("Protocol error") for each
+// frame that nghttp2 reports as invalid, also where RFC 7838 says to ignore the frame.
+describe.concurrent("inbound ALTSVC (RFC 7838 §4) and ORIGIN (RFC 8336 §2) frames", () => {
+  const EXAMPLE_ORIGIN = "https://example.org";
+  const lengthPrefixed = (str: string) => {
+    const bytes = Buffer.from(str, "latin1");
+    const prefix = Buffer.alloc(2);
+    prefix.writeUInt16BE(bytes.length);
+    return Buffer.concat([prefix, bytes]);
+  };
+  const altsvcPayload = (origin: string, value: string) =>
+    Buffer.concat([lengthPrefixed(origin), Buffer.from(value, "latin1")]);
+  // Response HEADERS: ":status: 200" (static table index 8) with END_HEADERS.
+  const responseHeaders = (streamId: number, endStream: boolean) =>
+    encodeFrame(FrameType.HEADERS, endStream ? 0x5 : 0x4, streamId, Buffer.from([0x88]));
+
+  type SentFrame = [type: number, flags: number, streamId: number, payload: Buffer] | Buffer;
+  type Scenario = {
+    secure?: boolean;
+    /** Open stream 1 (a request that ended its side) before the frames are sent. */
+    request?: boolean;
+    options?: http2.ClientSessionOptions;
+    frames: SentFrame[];
+  };
+
+  /**
+   * Connects an http2 client to a raw server that sends `frames`. Returns the session events
+   * in order and the error codes of the GOAWAY frames that the client wrote. The run ends
+   * when the client acks a PING that follows `frames`, or when its session closes.
+   */
+  async function run({ secure = false, request = false, options, frames }: Scenario) {
+    const raw = await RawH2Server.listen({ secure });
+    const client = secure
+      ? http2.connect(`https://localhost:${raw.port}`, { ...options, ca: tlsCert.cert })
+      : http2.connect(`http://127.0.0.1:${raw.port}`, options);
+    const events: unknown[] = [];
+    const closed = Promise.withResolvers<void>();
+    client.on("altsvc", (alt, origin, streamId) => events.push({ altsvc: { alt, origin, streamId } }));
+    client.on("origin", origins => events.push({ origin: origins }));
+    client.on("error", err => events.push({ error: { code: (err as any).code, message: err.message } }));
+    client.on("close", () => closed.resolve());
+    client.on("stream", pushed => pushed.on("error", () => {}).resume());
+    try {
+      if (request) {
+        const req = client.request({ ":path": "/" });
+        req.on("error", () => {});
+        req.resume();
+        await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1, Infinity);
+      } else {
+        await raw.waitFor(f => f.type === FrameType.SETTINGS, Infinity);
+      }
+      raw.socket!.write(
+        Buffer.concat([
+          encodeFrame(FrameType.SETTINGS, 0, 0),
+          encodeFrame(FrameType.SETTINGS, 0x1, 0),
+          ...frames.map(f => (Buffer.isBuffer(f) ? f : encodeFrame(...f))),
+          encodeFrame(FrameType.PING, 0, 0, Buffer.alloc(8)),
+        ]),
+      );
+      const pingAcked = raw.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0, Infinity);
+      const sessionClosed = await Promise.race([pingAcked.then(() => false), closed.promise.then(() => true)]);
+      if (sessionClosed) await raw.socketClosed.promise;
+      const originSet = secure && !sessionClosed ? client.originSet : undefined;
+      return {
+        events,
+        sessionClosed,
+        goaway: raw.frames.filter(f => f.type === FrameType.GOAWAY).map(goawayErrorCode),
+        ...(originSet && { originSet: originSet.slice(1) }),
+      };
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  }
+
+  const protocolError = { error: { code: "ERR_HTTP2_ERROR", message: "Protocol error" } };
+  const validOnStream0 = altsvcPayload(EXAMPLE_ORIGIN, 'h2=":443"');
+
+  // nghttp2 terminates the session itself: GOAWAY(FRAME_SIZE_ERROR). RFC 9113 §4.2: the frame is
+  // too small for its mandatory Origin-Len field, or for the origin that the field announces.
+  test.each<[string, Buffer]>([
+    ["an empty payload", Buffer.alloc(0)],
+    ["a 1-byte payload", Buffer.from([0])],
+    ["an origin length past the end of the payload", Buffer.from([0, 0x50, 0x61, 0x62])],
+  ])("ALTSVC with %s is a FRAME_SIZE_ERROR", async (_, payload) => {
+    const { events, sessionClosed, goaway } = await run({ frames: [[FrameType.ALTSVC, 0, 0, payload]] });
+    expect({ events, sessionClosed, firstGoaway: goaway[0] }).toEqual({
+      events: [protocolError],
+      sessionClosed: true,
+      firstGoaway: ErrorCode.FRAME_SIZE_ERROR,
+    });
+  });
+
+  // nghttp2 only reports these frames as invalid. The GOAWAY comes from the destroy of the
+  // session, which has no code of its own: INTERNAL_ERROR.
+  test.each<[string, Scenario]>([
+    ["on stream 0 without an origin", { frames: [[FrameType.ALTSVC, 0, 0, altsvcPayload("", "h2")]] }],
+    ["on stream 0 without a field value", { frames: [[FrameType.ALTSVC, 0, 0, lengthPrefixed(EXAMPLE_ORIGIN)]] }],
+    [
+      "on an open stream with an origin",
+      { request: true, frames: [[FrameType.ALTSVC, 0, 1, altsvcPayload(EXAMPLE_ORIGIN, "h2")]] },
+    ],
+    ["on an idle stream with an origin", { frames: [[FrameType.ALTSVC, 0, 99, altsvcPayload(EXAMPLE_ORIGIN, "h2")]] }],
+    [
+      "on an open stream without a field value",
+      { request: true, frames: [[FrameType.ALTSVC, 0, 1, lengthPrefixed("")]] },
+    ],
+  ])("ALTSVC %s destroys the session with a protocol error", async (_, scenario) => {
+    expect(await run(scenario)).toEqual({
+      events: [protocolError],
+      sessionClosed: true,
+      goaway: [ErrorCode.INTERNAL_ERROR],
+    });
+  });
+
+  test("ALTSVC frames before an invalid one are delivered, frames after it are not", async () => {
+    const { events, sessionClosed } = await run({
+      frames: [
+        [FrameType.ALTSVC, 0, 0, validOnStream0],
+        [FrameType.ALTSVC, 0, 0, altsvcPayload("", "h2")],
+        [FrameType.ALTSVC, 0, 0, altsvcPayload(EXAMPLE_ORIGIN, "h3")],
+      ],
+    });
+    expect({ events, sessionClosed }).toEqual({
+      events: [{ altsvc: { alt: 'h2=":443"', origin: EXAMPLE_ORIGIN, streamId: 0 } }, protocolError],
+      sessionClosed: true,
+    });
+  });
+
+  test("an invalid ALTSVC frame counts against maxSessionInvalidFrames", async () => {
+    // A response with a connection-specific header is the first invalid frame. It only resets
+    // its stream. The ALTSVC frame is the second one.
+    const malformedResponse = Buffer.concat([
+      Buffer.from([0x88, 0x00]), // ":status: 200", then a literal field without indexing
+      hpackLiteral("connection"),
+      hpackLiteral("close"),
+    ]);
+    const secondInvalidFrame = (maxSessionInvalidFrames: number) =>
+      run({
+        request: true,
+        options: { maxSessionInvalidFrames },
+        frames: [
+          [FrameType.HEADERS, 0x5, 1, malformedResponse],
+          [FrameType.ALTSVC, 0, 0, altsvcPayload("", "h2")],
+        ],
+      });
+    const tooManyInvalidFrames = {
+      code: "ERR_HTTP2_TOO_MANY_INVALID_FRAMES",
+      message: "Too many invalid HTTP/2 frames",
+    };
+    expect({ 0: (await secondInvalidFrame(0)).events, 1: (await secondInvalidFrame(1)).events }).toEqual({
+      0: [{ error: tooManyInvalidFrames }],
+      1: [protocolError],
+    });
+  });
+
+  test("ALTSVC on a stream is dropped unless the stream is open", async () => {
+    // Idle odd stream, even stream that nothing promised, idle stream without a field value.
+    // The stream lookup comes before the field value check, so the last one is not an error.
+    const dropped = await run({
+      frames: [
+        [FrameType.ALTSVC, 0, 99, altsvcPayload("", "h2")],
+        [FrameType.ALTSVC, 0, 2, altsvcPayload("", "h2")],
+        [FrameType.ALTSVC, 0, 99, lengthPrefixed("")],
+        [FrameType.ALTSVC, 0xff, 0, validOnStream0], // ALTSVC defines no flags
+      ],
+    });
+    expect(dropped).toEqual({
+      events: [{ altsvc: { alt: 'h2=":443"', origin: EXAMPLE_ORIGIN, streamId: 0 } }],
+      sessionClosed: false,
+      goaway: [],
+    });
+
+    const onStream1 = (response: Buffer[]) =>
+      run({ request: true, frames: [...response, [FrameType.ALTSVC, 0, 1, altsvcPayload("", "h2")]] });
+    const delivered = [{ altsvc: { alt: "h2", origin: "", streamId: 1 } }];
+    expect({
+      beforeTheResponse: (await onStream1([])).events,
+      whileTheResponseIsOpen: (await onStream1([responseHeaders(1, false)])).events,
+      afterTheResponseEnded: (await onStream1([responseHeaders(1, true)])).events,
+    }).toEqual({
+      beforeTheResponse: delivered,
+      whileTheResponseIsOpen: delivered,
+      afterTheResponseEnded: [],
+    });
+
+    // A stream that the server promised is open from its PUSH_PROMISE to the end of the pushed response.
+    const promisedId = Buffer.from([0, 0, 0, 2]);
+    const pushPromise = encodeFrame(
+      FrameType.PUSH_PROMISE,
+      0x4 /* END_HEADERS */,
+      1,
+      Buffer.concat([promisedId, requestHeaderBlock("GET")]),
+    );
+    const onStream2 = (pushedResponse: Buffer[]) =>
+      run({
+        request: true,
+        frames: [pushPromise, ...pushedResponse, [FrameType.ALTSVC, 0, 2, altsvcPayload("", "h2")]],
+      });
+    const deliveredOnStream2 = [{ altsvc: { alt: "h2", origin: "", streamId: 2 } }];
+    expect({
+      reserved: (await onStream2([])).events,
+      whileThePushedResponseIsOpen: (await onStream2([responseHeaders(2, false)])).events,
+      afterThePushedResponseEnded: (await onStream2([responseHeaders(2, true)])).events,
+    }).toEqual({
+      reserved: deliveredOnStream2,
+      whileThePushedResponseIsOpen: deliveredOnStream2,
+      afterThePushedResponseEnded: [],
+    });
+  });
+
+  test("ORIGIN is delivered whole or not at all", async () => {
+    const [a, b, c] = ["https://a.example", "https://b.example", "https://c.example"];
+    const result = await run({
+      secure: true,
+      frames: [
+        // A zero-length entry is skipped.
+        [FrameType.ORIGIN, 0, 0, Buffer.concat([lengthPrefixed(a), lengthPrefixed(""), lengthPrefixed(b)])],
+        // A frame without origins still emits.
+        [FrameType.ORIGIN, 0, 0, Buffer.alloc(0)],
+        [FrameType.ORIGIN, 0, 0, lengthPrefixed("")],
+        // Dropped: an entry cut short, a trailing octet, a lone octet.
+        [
+          FrameType.ORIGIN,
+          0,
+          0,
+          Buffer.concat([lengthPrefixed("https://dropped.example"), Buffer.from([0, 10, 0x78])]),
+        ],
+        [FrameType.ORIGIN, 0, 0, Buffer.concat([lengthPrefixed("https://dropped.example"), Buffer.from([0])])],
+        [FrameType.ORIGIN, 0, 0, Buffer.from([0])],
+        // Dropped: a stream id, one of the high four flag bits (nghttp2 reserves them).
+        [FrameType.ORIGIN, 0, 1, lengthPrefixed("https://dropped.example")],
+        [FrameType.ORIGIN, 0x10, 0, lengthPrefixed("https://dropped.example")],
+        [FrameType.ORIGIN, 0x01, 0, lengthPrefixed(c)],
+      ],
+    });
+    expect(result).toEqual({
+      events: [{ origin: [a, b] }, { origin: [] }, { origin: [] }, { origin: [c] }],
+      sessionClosed: false,
+      goaway: [],
+      originSet: [a, b, c],
+    });
+  });
+
+  test("the 'origin' array is built without a call to a setter on Array.prototype", async () => {
+    // The accessor changes every array of the process, so the scenario runs in a child.
+    const fixture = `
+      const http2 = require("node:http2");
+      const tls = require("node:tls");
+      const cert = ${JSON.stringify(tlsCert)};
+      const frame = (type, flags, payload = Buffer.alloc(0)) => {
+        const header = Buffer.alloc(9);
+        header.writeUIntBE(payload.length, 0, 3);
+        header[3] = type;
+        header[4] = flags;
+        return Buffer.concat([header, payload]);
+      };
+      const entry = str => Buffer.concat([Buffer.from([0, str.length]), Buffer.from(str, "latin1")]);
+      const origins = Buffer.concat([entry("https://a.example"), entry("https://b.example")]);
+      const server = tls.createServer({ ...cert, ALPNProtocols: ["h2"] }, socket => {
+        socket.on("error", () => {});
+        socket.once("data", () => socket.write(Buffer.concat([frame(4, 0), frame(4, 1), frame(0xc, 0, origins)])));
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const client = http2.connect("https://localhost:" + server.address().port, { ca: cert.cert });
+        let setterCalls = 0;
+        client.on("connect", () => {
+          Object.defineProperty(Array.prototype, 0, {
+            configurable: true,
+            get() {},
+            set(value) {
+              if (typeof value === "string" && value.startsWith("https://")) setterCalls++;
+              Object.defineProperty(this, 0, { value, writable: true, enumerable: true, configurable: true });
+            },
+          });
+        });
+        client.on("origin", origins => {
+          delete Array.prototype[0];
+          console.log(JSON.stringify({ setterCalls, origins, originSet: client.originSet.slice(1) }));
+          client.destroy();
+          server.close();
+        });
+      });
+    `;
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const origins = ["https://a.example", "https://b.example"];
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ setterCalls: 0, origins, originSet: origins }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("a server ignores ALTSVC and ORIGIN, well-formed or not", async () => {
+    const c = await RawH2.connect(port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendFrame(FrameType.ALTSVC, 0, 0, Buffer.from([0]));
+      c.sendFrame(FrameType.ALTSVC, 0, 0, altsvcPayload("", "h2"));
+      c.sendFrame(FrameType.ALTSVC, 0, 0, validOnStream0);
+      c.sendFrame(FrameType.ORIGIN, 0, 0, Buffer.from([0, 10, 0x78]));
+      c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      expect(c.frames.filter(f => f.type === FrameType.GOAWAY)).toEqual([]);
+    } finally {
+      c.destroy();
     }
   });
 });

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -987,10 +987,15 @@ describe.concurrent("inbound ALTSVC (RFC 7838 §4) and ORIGIN (RFC 8336 §2) fra
         const req = client.request({ ":path": "/" });
         req.on("error", () => {});
         req.resume();
-        await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1, Infinity);
-      } else {
-        await raw.waitFor(f => f.type === FrameType.SETTINGS, Infinity);
       }
+      const firstFrame = raw.waitFor(
+        request ? f => f.type === FrameType.HEADERS && f.streamId === 1 : f => f.type === FrameType.SETTINGS,
+        Infinity,
+      );
+      const closedEarly = closed.promise.then(() => {
+        throw new Error(`the session closed before its first frame: ${JSON.stringify(events)}`);
+      });
+      await Promise.race([firstFrame, closedEarly]);
       raw.socket!.write(
         Buffer.concat([
           encodeFrame(FrameType.SETTINGS, 0, 0),


### PR DESCRIPTION
### Problem

- The `node:http2` client accepts ALTSVC (RFC 7838) frames that node rejects: too short for the origin, no origin on stream 0, an origin on a stream, no field value. Bun ignores them or emits `'altsvc'`, also on an idle or closed stream. Node v26.3.0 destroys the session with `ERR_HTTP2_ERROR`.
- A malformed ORIGIN (RFC 8336) frame emits the entries before the error. An empty entry becomes `''`. An empty frame emits nothing. Node drops the frame, skips the entry, and emits `[]`.
- Cause: `handle_altsvc` and `handle_origin` (`src/runtime/api/bun/h2/connection.rs:1761`) only bound-check the payload.

### Fix

- `handle_altsvc` follows `nghttp2_session_on_altsvc_received` and node's `OnInvalidFrame`. Too short for its origin: GOAWAY(FRAME_SIZE_ERROR). Invalid for nghttp2: the frame counts against `maxSessionInvalidFrames`, then JS gets `NGHTTP2_ERR_PROTO` and destroys the session. A stream that is not open: the frame is dropped.
- `handle_origin` drops a payload that does not parse (`wire::OriginEntries`). JS always gets an array.
- RFC 7838 says "MUST be ignored" where node destroys the session. This PR ports node on purpose.
- Verified: `test/js/node/http2/h2-conformance.test.ts`, 14 new tests, 13 fail on 1.4.3-canary. Expectations are node v26.3.0 output. Also `node-http2.test.js` and the upstream altsvc and origin tests.

### Background

- ALTSVC (type 0xA): 2-byte origin length, origin, `Alt-Svc` value. Only stream 0 carries an origin.
- ORIGIN (type 0xC): length-prefixed origins on stream 0 of a TLS session. The client adds them to `session.originSet`.
- `h2/connection.rs` is the inbound engine. It calls `H2FrameParser` through the `Sink` trait and sees only inbound frames, so it asks the sink whether a client stream is still open.
- `maxSessionInvalidFrames` (default 1000) is node's allowance of invalid frames per session.

<details><summary>Notes</summary>

**Repro.** A raw h2c (ALTSVC) or TLS (ORIGIN) server sends SETTINGS, SETTINGS ACK, then the frame. The ALTSVC cells are `client GOAWAY codes | session events`.

| frame | node v26.3.0 | bun 1.4.3-canary | this PR |
| --- | --- | --- | --- |
| ALTSVC stream 0, empty origin | `2` \| error ERR_HTTP2_ERROR, close | none \| (none) | `2` \| error ERR_HTTP2_ERROR, close |
| ALTSVC origin length 80 > payload | `6` \| error ERR_HTTP2_ERROR, close | none \| (none) | `6,2` \| error ERR_HTTP2_ERROR, close |
| ALTSVC payload of 0 or 1 byte | `6` \| error ERR_HTTP2_ERROR, close | none \| (none) | `6,2` \| error ERR_HTTP2_ERROR, close |
| ALTSVC stream 99 (idle), empty origin | no event | `altsvc("h2","",99)` | no event |
| ALTSVC stream 2 (even, not promised) | no event | `altsvc("h2","",2)` | no event |
| ALTSVC stream 0, origin, empty value | `2` \| error ERR_HTTP2_ERROR | `altsvc("","https://example.org",0)` | `2` \| error ERR_HTTP2_ERROR |
| ALTSVC stream 1 after its response ended | no event | `altsvc("h2","",1)` | no event |
| ALTSVC stream 2, promised (reserved or open) | `altsvc("h2","",2)` | same | same |
| ORIGIN `[a, "", b]` | `origin([a,b])` | `origin([a,"",b])` | `origin([a,b])` |
| ORIGIN truncated entry or trailing byte | no event | `origin([entries before it])` | no event |
| ORIGIN empty frame, or only a zero-length entry | `origin([])` | no event | `origin([])` |
| ORIGIN with flag 0x10 | no event | `origin([a])` | no event |

**Matrix.** I ran 35 frame sequences (ALTSVC on stream 0, on open, idle, closed, half-closed and promised streams, ORIGIN over TLS) on node v26.3.0 and on this build. 29 rows are identical. The other 6 rows differ only in things that this PR does not own:
- 3 rows: the engine writes GOAWAY(6), then `destroy()` writes a second GOAWAY(2). Every connection error that the engine detects does this today (a PING with a bad length does the same).
- 2 rows: the request `'error'`/`'close'` events come after the session `'error'`/`'close'`, node emits them before. This is the general order of `destroy(error)`. The request gets the same error as in node (`ERR_HTTP2_ERROR`, errno -505, rstCode 2).
- 1 row: `session.originSet` after destroy returns the set, node returns `undefined`. #33792 has that fix.

The node code that this PR follows is the same in v26.8.2 (`OnInvalidFrame`, `nghttp2_session_on_altsvc_received`, `nghttp2_frame_unpack_origin_payload`, `HandleAltSvcFrame`, `HandleOriginFrame`).

**Why the engine writes no GOAWAY for the "invalid" cases.** nghttp2 only reports these frames to `on_invalid_frame_recv_callback` (NGHTTP2_ERR_PROTO) and drops them. Node's `OnInvalidFrame` counts the frame and calls `onSessionInternalError`. `session.destroy(new NghttpError(-505))` then writes the only GOAWAY, with INTERNAL_ERROR because `destroy(error)` has no code of its own. `Connection::invalid_frame` does the same: count, mark the engine terminated, `on_error(PROTO)`.

**Stream state.** `nghttp2_session_get_stream` returns a stream that exists and is neither idle nor closed. `on_altsvc_received` also drops a stream in `NGHTTP2_STREAM_CLOSING`. On the client the legacy stream map (`H2FrameParser::streams`) knows both halves of every stream that the client opened. It sets `CLOSED` on a full close and on a local RST_STREAM. A stream that the server pushed has no legacy entry, so `Sink::is_stream_open` returns `None` for it and the engine's own entry decides.

**Shape changes.** `Sink::on_origin` takes `wire::OriginEntries`: an exact-size iterator that can only be built from a payload that parses, and that skips zero-length entries. The native `onOrigin` dispatch always passes an array (it passed a string for one origin). The array is filled with `put_index`, so an accessor on `Array.prototype[0]` is not called (`push` called it, node does not). `count_invalid_frame` replaces the two copies of the invalid-frame counter (malformed header block, empty DATA).

**Known differences that stay.** Each one needs the stream to go away on the client side in the same socket read that carries the ALTSVC frame for it. Bun 1.4.3 delivers all of these too.
- The application calls `req.close()` or `req.destroy()` in a listener, and an ALTSVC frame for that stream follows in the same read. Node drops it (nghttp2 sets `NGHTTP2_STREAM_CLOSING` when the RST_STREAM is queued). Bun sends the RST_STREAM on a later tick, so the frame is still delivered.
- A GOAWAY refuses a stream (id above its last stream id), and an ALTSVC frame for that stream follows in the same read.
- The client refuses a pushed stream with RST_STREAM, then ALTSVC arrives on it. The engine does not see a local reset of a pushed stream.

**Not in this PR.**
- The `ServerHttp2Session#altsvc()` / `#origin()` argument edges (separate PR).
- The `originSet` getter after destroy (#33792).
- The double GOAWAY.
- node >= 26.4.0 caps `originSet` at `maxOriginSetSize` (CVE-2026-48619). Bun has no cap yet: #42407.
- `framesReceived` of the `perf_hooks` http2 entry counts dropped frames, node does not. This is true for every dropped frame type today.

**Self-review.** I ran probe scripts for the edges above on node and on this build. Two findings changed the diff: ALTSVC on a promised stream was dropped (now `is_stream_open` returns `Option`), and the `'origin'` array was built with `push` (now `put_index`). The other findings are the differences listed above.

**Suites run on the debug build.** `test/js/node/http2/h2-conformance.test.ts` (84 pass), `test/js/node/http2/node-http2.test.js` (387 pass), upstream `test-http2-altsvc.js`, `test-http2-origin.js`, `test-http2-malformed-altsvc.js`, `test-http2-max-invalid-frames.js`, `test-http2-session-cleanup-on-nghttp2-goaway.js`, `test-http2-invalid-last-stream-id.js`, `test-http2-create-client-secure-session.js`, `test-http2-client-http1-server.js`. The `wire.rs` unit tests run standalone with `rustc --test`. The "stream release after a queued END_STREAM" tests in `h2-conformance.test.ts` flake on a debug build with and without this change (`liveCount` 4 > `GC_STRAGGLERS` 3).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [619.82ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [195.18ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [127.37ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [53.36ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [43.70ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [41.66ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [54.72ms]
(pass) PING (checklist §3.7) > a PING on a non-zero st
... (truncated)

release without fix: 13 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [8.56ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [2.33ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [1.84ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [0.97ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [0.76ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [0.78ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [0.75ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [0.65ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [0.71ms]
(pass) WINDOW_UPDATE
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [467.00ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [123.36ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [92.50ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [46.93ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [79.15ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [44.06ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [53.36ms]
(pass) PING (checklist §3.7) > a PING on a non-zero str
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 818ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (9306ms)
Bundle modules (66ms)
Postprocesss modules (155ms)
Bundle Functions (496ms)
Generate Code (49ms)

[10.08s] Bundled "src/js" for production
  2599 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   C
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                      |  22 +-
 src/runtime/api/bun/h2/connection.rs      | 130 ++++++++----
 src/runtime/api/bun/h2/wire.rs            |  66 ++++++
 src/runtime/api/bun/h2_frame_parser.rs    |  56 ++---
 test/js/node/http2/h2-conformance.test.ts | 336 +++++++++++++++++++++++++++++-
 5 files changed, 508 insertions(+), 102 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/http2.ts                           4      2     35
src/runtime/api/bun/h2/connection.rs          11     13     32
src/runtime/api/bun/h2/wire.rs                 2      4     31
src/runtime/api/bun/h2_frame_parser.rs         9      2     31
test/js/node/http2/h2-conformance.test.ts      5      9     31
```

</details>

<!-- robobun:evidence:end -->