### PR TITLE
react-compiler: walk each nested function once in RenameVariables

### DIFF
--- a/src/react_compiler/reactive_scopes/visitors.rs
+++ b/src/react_compiler/reactive_scopes/visitors.rs
@@ -9,8 +9,8 @@
 
 use crate::diagnostics::CompilerError;
 use crate::hir::{
-    EvaluationOrder, FunctionId, InstructionValue, Place, PrunedReactiveScopeBlock, ReactiveBlock,
-    ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock, ReactiveStatement, ReactiveTerminal,
+    EvaluationOrder, FunctionId, Place, PrunedReactiveScopeBlock, ReactiveBlock, ReactiveFunction,
+    ReactiveInstruction, ReactiveScopeBlock, ReactiveStatement, ReactiveTerminal,
     ReactiveTerminalStatement, ReactiveValue, environment::Environment,
 };
 
@@ -41,8 +41,13 @@ pub(crate) trait ReactiveFunctionVisitor {
     fn visit_param(&self, _place: &Place, _state: &mut Self::State) {}
 
     /// Walk an inner HIR function, visiting params, instructions (with lvalues,
-    /// value-lvalues, operands, and nested functions), and terminal operands.
+    /// value-lvalues and operands), and terminal operands.
     /// TS: `visitHirFunction`
+    ///
+    /// Nested functions are not walked here. A visitor reaches them through
+    /// its `visit_value` override, which fires for each instruction below and
+    /// calls this method again. Upstream also recurses here, so with the
+    /// override a function at depth `d` is walked 2^d times.
     fn visit_hir_function(&self, func_id: FunctionId, state: &mut Self::State) {
         let inner_func = &self.env().functions[func_id.0 as usize];
         for param in &inner_func.params {
@@ -70,14 +75,6 @@ pub(crate) trait ReactiveFunctionVisitor {
                     loc: instr.loc,
                 };
                 self.visit_instruction(&reactive_instr, state);
-                // Recurse into nested functions
-                match &instr.value {
-                    InstructionValue::FunctionExpression { lowered_func, .. }
-                    | InstructionValue::ObjectMethod { lowered_func, .. } => {
-                        self.visit_hir_function(lowered_func.func, state);
-                    }
-                    _ => {}
-                }
             }
             for operand in &terminal_operands {
                 self.visit_place(terminal_id, operand, state);

--- a/src/react_compiler/reactive_scopes/visitors.rs
+++ b/src/react_compiler/reactive_scopes/visitors.rs
@@ -43,11 +43,7 @@ pub(crate) trait ReactiveFunctionVisitor {
     /// Walk an inner HIR function, visiting params, instructions (with lvalues,
     /// value-lvalues and operands), and terminal operands.
     /// TS: `visitHirFunction`
-    ///
-    /// Nested functions are not walked here. A visitor reaches them through
-    /// its `visit_value` override, which fires for each instruction below and
-    /// calls this method again. Upstream also recurses here, so with the
-    /// override a function at depth `d` is walked 2^d times.
+    /// Nested functions are left to the visitor's `visit_value` override; upstream also recurses here, which walks depth `d` 2^d times.
     fn visit_hir_function(&self, func_id: FunctionId, state: &mut Self::State) {
         let inner_func = &self.env().functions[func_id.0 as usize];
         for param in &inner_func.params {

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isASAN, isDebug, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { itBundled } from "../expectBundled";
@@ -1578,4 +1578,39 @@ test.skipIf(!isDebug && !isASAN)("react-compiler reports which kind of function 
       Object.entries(localReassignmentCases).map(([name, { error }]) => [name, { error, memoized: error === null }]),
     ),
   );
+});
+
+// RenameVariables reaches a nested function expression through its
+// `visit_value` override. The shared walker for a function body recursed into
+// it a second time, so a function at depth d was walked 2^d times: depth 25
+// took 5 seconds and depth 30 did not finish.
+test("react-compiler compile time is not exponential in the function nesting depth", async () => {
+  const depth = 40;
+  const open = "(() => ";
+  const close = ")()";
+  using dir = tempDir("react-compiler-nesting", {
+    "entry.jsx": `
+      import { useState } from "react";
+      export default function App(p) {
+        const [s] = useState(0);
+        const v = ${Buffer.alloc(open.length * depth, open)}p.a + s${Buffer.alloc(close.length * depth, close)};
+        return <div>{v}</div>;
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--react-compiler", "--target=browser", "--external=*", "entry.jsx"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  // The outermost call is inlined. The other arrows stay, in one memoized scope.
+  expect(stdout).toContain("p.a + s");
+  expect(stdout).toMatch(/\b_c\(\d+\)/);
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem
- `bun build --react-compiler` takes twice as long for each extra level of nested function expressions in one component. 20 levels take 0.18 s, 25 take 5.3 s, 30 do not finish. A plain build takes 0.02 s. The `RenameVariables` pass is 97% of that time.
- `ReactiveFunctionVisitor::visit_hir_function` (`src/react_compiler/reactive_scopes/visitors.rs:46`) visits each instruction of an inner function and then recurses into every `FunctionExpression` and `ObjectMethod`. The `visit_value` override in `rename_variables.rs:184` runs for those same instructions and calls `visit_hir_function` too. A function at depth `d` is walked 2^d times.

### Fix
- `visit_hir_function` no longer recurses by itself. The `visit_value` override reaches each nested function once.
- Correct because the second walk did nothing: `Scopes::visit_identifier` returns early for a declaration it has seen. The names and their order do not change. `RenameVariables` is the only caller.
- The TypeScript `visitors.ts` has the same double walk, so this method now differs from upstream. Its doc comment says why.
- Verified: the new test in `test/bundler/transpiler/react-compiler.test.ts` compiles 40 levels. It times out on 1.4.2 and takes 0.6 s on a debug build. Also all of `react-compiler.test.ts` and `react-compiler-fixtures.test.ts`.

### Background
- The compiler turns a component into a `ReactiveFunction` tree. A nested function expression stays in HIR form (basic blocks) in `env.functions`, and a `FunctionExpression` instruction refers to it by id.
- `ReactiveFunctionVisitor` is the shared walker over that tree. `visit_hir_function` is its helper for one HIR function.
- `RenameVariables` gives every identifier its final name before codegen.

<details><summary>Notes</summary>

Repro (`node gen.mjs 25 > n.jsx`, then `bun build --react-compiler --target=browser --external react n.jsx --outfile=o.js`):

```js
const N = +process.argv[2];
console.log(`import { useState } from "react";
export default function App(p) { const [s] = useState(0); const v = ${"(() => ".repeat(N)}p.a + s${")()".repeat(N)}; return <div>{v}</div>; }`);
```

Per-pass timing on a debug build (`BUN_REACT_COMPILER_TIMING=1`), `RenameVariables` only: depth 12 76 ms, 14 287 ms, 16 856 ms, 18 3803 ms. After the change depth 40 compiles in 0.54 s in total on the same debug build.

The output for depth 16 is byte-identical before and after.

`PromoteUsedTemporaries` has its own walker (`visit_hir_function_for_promotion`) that already visits each nested function once.

Only the outermost call is inlined by `InlineImmediatelyInvokedFunctionExpressions`. The other arrows stay function expressions, which is why `RenameVariables` sees the nesting.
</details>
