### PR TITLE
react-compiler: treat only the last `children` key of a JSX call as the JSX children

### DIFF
--- a/src/react_compiler/lowering/build_hir/jsx.rs
+++ b/src/react_compiler/lowering/build_hir/jsx.rs
@@ -265,13 +265,17 @@ pub(super) fn lower_jsx_call(
             }
         }
 
-        for prop in obj.properties.iter() {
+        let last_index = obj.properties.len().saturating_sub(1);
+        for (index, prop) in obj.properties.iter().enumerate() {
             if matches!(prop.kind, G::PropertyKind::Spread) {
                 let value = prop.value.as_ref().ok_or_else(|| {
                     todo_err("(BuildHIR::lowerJsxCall) spread without value", loc)
                 })?;
                 let argument = lower_expression_to_temporary(builder, value)?;
                 props.push(JsxAttribute::SpreadAttribute { argument });
+                continue;
+            }
+            if record_accessor_prop(builder, prop)? {
                 continue;
             }
             let Some(key_expr) = prop.key.as_ref() else {
@@ -293,7 +297,11 @@ pub(super) fn lower_jsx_call(
                 continue;
             };
 
-            if name == b"children" {
+            // The visit pass appends the JSX children as the last property.
+            // Any earlier `children` key is an attribute (or came from an
+            // inlined `{...{children}}` spread) that a later key overrides at
+            // runtime, so it stays an attribute and keeps its position.
+            if name == b"children" && index == last_index {
                 lower_jsx_children(builder, value_expr, is_static_children, &mut children)?;
                 continue;
             }
@@ -313,6 +321,9 @@ pub(super) fn lower_jsx_call(
                         })?;
                         let argument = lower_expression_to_temporary(builder, value)?;
                         props.push(JsxAttribute::SpreadAttribute { argument });
+                        continue;
+                    }
+                    if record_accessor_prop(builder, prop)? {
                         continue;
                     }
                     let Some(key_expr) = prop.key.as_ref() else {
@@ -406,6 +417,29 @@ fn lower_jsx_children(
     }
     out.push(lower_expression_to_temporary(builder, value)?);
     Ok(())
+}
+
+/// The visit pass inlines `<a {...{ get g() {} }} />` into the props object, so
+/// a getter or setter can reach here. A `JsxAttribute` holds a value, not an
+/// accessor, so the function is left uncompiled, as `lower_object_method` does
+/// for an accessor in an object literal. Returns true when `prop` is one.
+fn record_accessor_prop(
+    builder: &mut HirBuilder,
+    prop: &G::Property,
+) -> Result<bool, CompilerError> {
+    let kind = match prop.kind {
+        G::PropertyKind::Get => "get",
+        G::PropertyKind::Set => "set",
+        _ => return Ok(false),
+    };
+    builder.record_error(CompilerErrorDetail {
+        category: ErrorCategory::Todo,
+        reason: format!("(BuildHIR::lowerJsxCall) Handle {kind} functions in JSX props"),
+        description: None,
+        loc: convert_loc(prop.key.as_ref().map_or(Loc::EMPTY, |key| key.loc)),
+        suggestions: None,
+    })?;
+    Ok(true)
 }
 
 fn todo_err(reason: &str, loc: Option<SourceLocation>) -> CompilerError {

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1139,6 +1139,82 @@ describe("bundler", () => {
     },
   });
 
+  // The parser turns `<div children="x">y</div>` into
+  // `jsx("div", { children: "x", children: "y" })`: the JSX children are the
+  // last property, so they replace every earlier `children` key. It also
+  // inlines `{...{ k: v }}` into that object. The compiler reads the element
+  // back from the call, and has to keep each key in place and keep a getter a
+  // getter.
+  itBundled("react-compiler/ChildrenAttributeIsNotAJsxChild", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        function Attr(p) { return <div children="x">y</div>; }
+        function AttrExpr(p) { return <div children={p.a}>{p.b}</div>; }
+        function TwoAttrs(p) { return <div children="a" children="b" />; }
+        function InlineSpread(p) { return <div {...{ children: "sp" }}>real</div>; }
+        function AttrThenSpread(p) { return <div children="x" {...p} />; }
+        function AttrSpreadChildren(p) { return <div children="x" {...p}>{p.a}{p.b}</div>; }
+        function SpreadThenAttr(p) { return <div {...p} children="x" />; }
+        function Getter(p) { return <i {...{ get g() { return p.a; } }} />; }
+        console.log(JSON.stringify({
+          Attr: Attr({}).p.children,
+          AttrExpr: AttrExpr({ a: 1, b: "x" }).p.children,
+          TwoAttrs: TwoAttrs({}).p.children,
+          InlineSpread: InlineSpread({}).p.children,
+          AttrThenSpread: [AttrThenSpread({ children: "q" }).p.children, AttrThenSpread({}).p.children],
+          AttrSpreadChildren: AttrSpreadChildren({ a: 1, b: 2, children: "q" }).p.children,
+          SpreadThenAttr: SpreadThenAttr({ children: "q" }).p.children,
+          Getter: Getter({ a: 5 }).p.g,
+        }));
+      `,
+      ...stubReact,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "api",
+    run: {
+      stdout: JSON.stringify({
+        Attr: "y",
+        AttrExpr: "x",
+        TwoAttrs: "b",
+        InlineSpread: "real",
+        AttrThenSpread: ["q", "x"],
+        AttrSpreadChildren: [1, 2],
+        SpreadThenAttr: "x",
+        Getter: 5,
+      }),
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      const body = (name: string) => {
+        const start = out.indexOf(`function ${name}(`);
+        return out.slice(start, out.indexOf("\nfunction ", start + 1));
+      };
+      // A compiled component reads its memo cache. The getter has no JSX
+      // attribute form, so that one component is left as written.
+      const compiled = [
+        "Attr",
+        "AttrExpr",
+        "TwoAttrs",
+        "InlineSpread",
+        "AttrThenSpread",
+        "AttrSpreadChildren",
+        "SpreadThenAttr",
+        "Getter",
+      ].filter(name => /\$\[\d+\]/.test(body(name)));
+      expect(compiled).toEqual([
+        "Attr",
+        "AttrExpr",
+        "TwoAttrs",
+        "InlineSpread",
+        "AttrThenSpread",
+        "AttrSpreadChildren",
+        "SpreadThenAttr",
+      ]);
+      expect(body("Getter")).toContain("get g()");
+    },
+  });
+
   // A 0-arg call to an unknown import is non-reactive in InferReactivePlaces
   // (no operand is reactive, callee isn't a hook), so its scope's deps prune
   // to empty and it becomes a sentinel-only block. Babel does the same; this


### PR DESCRIPTION
### Problem
- With `bun build --react-compiler`, `<div children="x">y</div>` renders `["x","y"]`. A plain build renders `"y"`. Two `children` attributes and `<div {...{ children: "sp" }}>real</div>` merge the same way, and `<div children="x" {...p} />` ignores `p.children`.
- The parser lowers the element to `jsx("div", { children: "x", children: "y" })` before the compiler runs. `lower_jsx_call` (`src/react_compiler/lowering/build_hir/jsx.rs:296`) read every `children` key of that object as a JSX child.
- `<i {...{ get g() { return p.a } }} />` passes the getter function as the prop `g`. The parser inlines the spread into the props object, and the lowering ignored `prop.kind`.

### Fix
- Only the last property of the props object is read as the JSX children. The parser always appends them last. An earlier `children` key stays an attribute in its position, so the printed keys keep their source order.
- A getter or setter in the props object records a `Todo` error, so the function is left uncompiled. `lower_object_method` does the same for object literals.
- Verified: `react-compiler/ChildrenAttributeIsNotAJsxChild` in `test/bundler/transpiler/react-compiler.test.ts` (8 components, fails on 1.4.2). Also all of `react-compiler.test.ts` and `react-compiler-fixtures.test.ts`.

### Background
- Bun's visit pass turns JSX into `jsx(tag, props, key)` calls. The compiler runs after it and decodes each call back into a `JsxExpression` instruction with `props` and `children`.
- In an object literal the last duplicate key wins, and a spread after a key can replace it.
- Codegen prints the attributes in order and then the children as a final `children` key.

<details><summary>Notes</summary>

Results of the test components, plain build and compiled build after this change (stub `jsx` runtime that returns `{t, p}`):

| source | `props.children` |
| --- | --- |
| `<div children="x">y</div>` | `"y"` |
| `<div children={p.a}>{p.b}</div>` with `{a: 1, b: "x"}` | `"x"` |
| `<div children="a" children="b" />` | `"b"` |
| `<div {...{ children: "sp" }}>real</div>` | `"real"` |
| `<div children="x" {...p} />` with `{children: "q"}` and `{}` | `"q"`, `"x"` |
| `<div children="x" {...p}>{p.a}{p.b}</div>` | `[1, 2]` |
| `<div {...p} children="x" />` | `"x"` |
| `<i {...{ get g() { return p.a } }} />` with `{a: 5}` | `props.g === 5` |

Before: `["x","y"]`, `[1,"x"]`, `["a","b"]`, `["sp","real"]`, `"x"`/`"x"`, `["x",1,2]`, `"x"`, and `props.g` was a function.

A `children` attribute that is the last property and not a JSX child (`<div {...p} children="x" />`) is still read as a child. The output is the same object, because codegen prints the children last.

The upstream compiler does not have this problem: it sees the JSX element itself and prints it back, and Babel's JSX transform then builds the same duplicate-key object as a plain build.

#42389 rewrites how `lower_jsx_call` tells the `jsx` call shape from the `createElement` one. It does not touch the two property loops this PR changes.
</details>
