### PR TITLE
react-compiler: stop three passes from using memory quadratic in the size of a component

### DIFF
--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -1732,11 +1732,12 @@ fn codegen_instruction_value(
             value,
             ..
         } => {
-            let block_items: Vec<ReactiveStatement> = instructions
-                .iter()
-                .map(|i| ReactiveStatement::Instruction(i.clone()))
-                .collect();
-            let body = codegen_block_no_reset(cx, &block_items)?;
+            let mut body: Vec<Stmt> = Vec::with_capacity(instructions.len());
+            for instr in instructions {
+                if let Some(stmt) = codegen_instruction_nullable(cx, instr)? {
+                    body.push(stmt);
+                }
+            }
             let mut expressions: Vec<Expr> = Vec::new();
             for stmt in body {
                 match stmt.data {

--- a/src/react_compiler/collections.rs
+++ b/src/react_compiler/collections.rs
@@ -376,6 +376,11 @@ impl<K: Copy + Into<u32>, V> IdMap<K, V> {
     pub(crate) fn remove(&mut self, k: K) -> Option<V> {
         self.0.remove(&k.into())
     }
+    /// O(1) remove; does not preserve order.
+    #[inline]
+    pub(crate) fn swap_remove(&mut self, k: K) -> Option<V> {
+        self.0.swap_remove(&k.into())
+    }
     #[inline]
     pub(crate) fn iter(&self) -> impl Iterator<Item = (K, &V)>
     where

--- a/src/react_compiler/hir/dominator.rs
+++ b/src/react_compiler/hir/dominator.rs
@@ -160,7 +160,9 @@ fn build_reverse_graph(
     let mut nodes = Vec::with_capacity(postorder.len());
     let mut node_index = IdMap::default();
     for (idx, id) in postorder.into_iter().enumerate() {
-        let mut node = raw_nodes.remove(id).unwrap();
+        // `remove` keeps the order of the other entries: it shifts them and
+        // rebuilds the map's index, in the arena, on every call.
+        let mut node = raw_nodes.swap_remove(id).unwrap();
         node.index = idx;
         node_index.insert(id, idx);
         nodes.push(node);

--- a/src/react_compiler/inference/infer_mutation_aliasing_effects.rs
+++ b/src/react_compiler/inference/infer_mutation_aliasing_effects.rs
@@ -171,6 +171,8 @@ pub(crate) fn infer_mutation_aliasing_effects(
         fallback_value_ids: HashMap::default(),
     };
 
+    let revisitable = blocks_reachable_from_back_edges(func);
+
     let mut iteration_count = 0;
 
     while !queued_states.is_empty() {
@@ -192,8 +194,13 @@ pub(crate) fn infer_mutation_aliasing_effects(
                 None => continue,
             };
 
-            let mut state = incoming_state.clone();
-            states_by_block.insert(block_id, incoming_state);
+            let mut state = if revisitable.contains(&block_id) {
+                let state = incoming_state.clone();
+                states_by_block.insert(block_id, incoming_state);
+                state
+            } else {
+                incoming_state
+            };
 
             infer_block(&mut context, &mut state, block_id, func, env)?;
 
@@ -237,6 +244,43 @@ pub(crate) fn infer_mutation_aliasing_effects(
     }
 
     Ok(())
+}
+
+/// Blocks that the fixpoint loop can queue again after it processed them.
+///
+/// A block is queued only when one of its predecessors is processed, and each
+/// sweep processes blocks in `func.body.blocks` order. So a block is queued
+/// after its own turn only if it is the target of an edge from the same or a
+/// later block, or if such a target reaches it. Every other block is processed
+/// exactly once and `states_by_block` never reads its incoming state back. A
+/// dense state is `env.identifiers.len()` cells, so keeping one per block of a
+/// long loop-free function is quadratic.
+fn blocks_reachable_from_back_edges(func: &HirFunction) -> HashSet<BlockId> {
+    let position: HashMap<BlockId, usize> = func
+        .body
+        .blocks
+        .keys()
+        .enumerate()
+        .map(|(index, id)| (*id, index))
+        .collect();
+    let mut worklist: Vec<BlockId> = Vec::new();
+    for (index, block) in func.body.blocks.values().enumerate() {
+        for successor in terminal_successors(&block.terminal) {
+            if position.get(&successor).is_some_and(|&p| p <= index) {
+                worklist.push(successor);
+            }
+        }
+    }
+    let mut reachable: HashSet<BlockId> = HashSet::default();
+    while let Some(block_id) = worklist.pop() {
+        if !reachable.insert(block_id) {
+            continue;
+        }
+        if let Some(block) = func.body.blocks.get(&block_id) {
+            worklist.extend(terminal_successors(&block.terminal));
+        }
+    }
+    reachable
 }
 
 // =============================================================================

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isASAN, isDebug, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
 import { itBundled } from "../expectBundled";
@@ -1480,6 +1480,69 @@ describe("bundler", () => {
       });
     }
   }
+});
+
+// Three passes kept one copy of their work per basic block or per nesting
+// level of a value, so memory grew with the square of the size of a component
+// that has no loop at all. The fixpoint in InferMutationAliasingEffects kept
+// the incoming state of every block. Codegen cloned the instructions of a
+// sequence expression at each level of a `||` chain. The post-dominator graph
+// rebuilt a hash index for each block it took out of a map. A chain of 400
+// terms took 979 MB, and an array pattern of 300 elements with defaults 1 GB.
+test("react-compiler memory does not grow with the square of the size of a component", async () => {
+  // A debug build is 20 times slower, and its larger frames overflow the stack
+  // on a longer chain.
+  const small = isDebug || isASAN;
+  const terms = small ? 100 : 400;
+  const elements = small ? 120 : 300;
+  using dir = tempDir("react-compiler-memory", {
+    "empty.jsx": `export default function App() { return null; }`,
+    "chain.jsx": `
+      import { useState } from "react";
+      export default function App(p) {
+        const [s] = useState(0);
+        const v = ${Array.from({ length: terms }, (_, i) => `(p.a === ${i})`).join(" || ")} || "f";
+        return <div>{v}{s}</div>;
+      }
+    `,
+    "pattern.jsx": `
+      import { useState } from "react";
+      export default function App(p) {
+        const [s] = useState(0);
+        const [${Array.from({ length: elements }, (_, i) => `e${i} = ${i}`).join(", ")}] = p.items;
+        return <div>{e0 + e${elements - 1}}{s}</div>;
+      }
+    `,
+  });
+
+  const peakMB = async (entry: string) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--react-compiler", "--target=browser", "--external=*", entry],
+      env: {
+        ...bunEnv,
+        // ASAN's quarantine keeps freed blocks resident, which hides the difference.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "thread_local_quarantine_size_kb=0"]
+          .filter(Boolean)
+          .join(":"),
+      },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // The component compiled, or there is no component.
+    expect(stdout.includes("react/compiler-runtime")).toBe(entry !== "empty.jsx");
+    expect(exitCode).toBe(0);
+    return proc.resourceUsage()!.maxRSS / 1024 / 1024;
+  };
+
+  const [empty, chain, pattern] = await Promise.all([peakMB("empty.jsx"), peakMB("chain.jsx"), peakMB("pattern.jsx")]);
+  // Above the empty build, without the fixes: 110 MB and 125 MB for the small
+  // inputs, 940 MB and 1050 MB for the large ones.
+  const bound = small ? 70 : 300;
+  expect(chain - empty).toBeLessThan(bound);
+  expect(pattern - empty).toBeLessThan(bound);
 });
 
 // validate_locals_not_reassigned_after_render (src/react_compiler/validation)


### PR DESCRIPTION
### Problem
- `bun build --react-compiler` uses memory quadratic in the size of one loop-free component. A `||` chain of 400 terms takes 979 MB, an array pattern of 300 elements with defaults 1 GB. 800 terms or 500 elements are OOM-killed at 3 GB. A plain build takes 14 MB.
- Three places keep one copy of their work per basic block or nesting level. `InferMutationAliasingEffects` keeps the incoming state of every block (`infer_mutation_aliasing_effects.rs:196`), at 16 bytes per identifier of the function. Codegen deep-clones the instructions of each nested `SequenceExpression` (`codegen.rs:1735`). `build_reverse_graph` (`hir/dominator.rs:163`) rebuilds the hash index of an `IdMap` on every `remove`.

### Fix
- A block that no back edge reaches is never queued twice. The fixpoint moves its state and keeps no copy.
- Codegen generates the instructions of a sequence in place. `build_reverse_graph` uses `swap_remove`, because nothing reads the map afterwards.
- The output is byte-identical. After: 400 terms 49 MB, 800 terms 78 MB, 300 elements 84 MB, 500 elements 194 MB.
- Verified: a new peak-RSS test in `test/bundler/transpiler/react-compiler.test.ts` (fails on 1.4.2). Also all of `react-compiler.test.ts` and `react-compiler-fixtures.test.ts`.

### Background
- `InferMutationAliasingEffects` is a forward dataflow pass. It sweeps the blocks in order until none is queued. `queue()` merges a new state into the one the block last saw.
- `HirVec`, `IndexMap` and `IdMap` allocate in the per-file AST arena. Its `deallocate` is a no-op, so transient copies stay resident.
- `ValidateHooksUsage`, `ValidateNoSetStateInRender` and `InferReactivePlaces` each build the post-dominator graph.

<details><summary>Notes</summary>

Why a block that no back edge reaches is never queued twice. A block is queued only when a predecessor is processed, and a sweep processes blocks in `func.body.blocks` order. If block `X` is queued after its own turn, the predecessor `P` that queued it was processed after `X`. Either `P` is at the same or a later position, so `P -> X` is an edge to the same or an earlier block and `X` is such a target itself. Or `P` is earlier and ran in a later sweep, so `P` was itself processed after its first turn and the same argument applies to `P`, and `X` is reachable from `P`. `blocks_reachable_from_back_edges` computes that set from the same successor function the fixpoint uses, and it does not assume the blocks are in reverse postorder.

Where the memory went, from a breakpoint on every pass entry that reads `VmRSS` (release build with symbols):

- 400 terms: 60 MB before `InferMutationAliasingEffects`, 289 MB after it, 172 MB at codegen entry, peak 959 MB in codegen.
- 200 elements: 45 MB before `InferMutationAliasingEffects`, 389 MB after it. 7179 identifiers and about 400 blocks at 100 elements.
- 800 terms after the first two fixes: 494 MB, of which about 135 MB each in `ValidateHooksUsage`, `ValidateNoSetStateInRender` and `InferReactivePlaces`. 3200 blocks times a 40 KB index per `remove`.

Peak RSS, 1.4.2 then this branch:

| input | 1.4.2 | this branch |
| --- | --- | --- |
| 100 terms | 80 MB | 26 MB |
| 400 terms | 959 MB | 49 MB |
| 800 terms | killed at 3 GB | 78 MB |
| 100 elements | 77 MB | 31 MB |
| 300 elements | 1064 MB | 84 MB |
| 500 elements | killed at 3 GB | 194 MB |
| 2000 statements + 400 `if`s | 1569 MB | 226 MB |

What is left at 500 elements is `EnterSSA` (115 MB): it caches a definition in every block between a use and its definition, as upstream does. `InferReactivePlaces` is still quadratic in time, because `post_dominators_of` walks every ancestor of every block, also as upstream does.

The test uses 100 terms and 120 elements on debug and ASAN builds, because a debug build overflows its stack in `lower_logical` at about 150 terms and is 20 times slower. It disables the ASAN quarantine for the child, like `expectRssDeltaBelow` in `harness.ts`. Measured above an empty build on a debug build: 25 MB and 28 MB with the fix, 112 MB and about 125 MB without.

`codegen_for_init` has the same clone, but it is not nested, so it is linear. It is not changed here.
</details>
