### PR TITLE
js_parser: build one cross-module enum value map per merged enum

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -9459,6 +9459,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut map = bun_ast::ast_result::TsEnumsMap::default();
         map.ensure_total_capacity(self.top_level_enums.len())?;
         for r#ref in self.top_level_enums.iter() {
+            // Each block of a merged `enum E {} enum E {}` has its own symbol. An older
+            // symbol links to the newest one and all of them share one member map. The
+            // linker and the printer look up the newest symbol only.
+            if self.symbols[r#ref.inner_index() as usize].has_link() {
+                continue;
+            }
             let Some(js_ast::ts::Data::Namespace(namespace)) =
                 self.ref_to_ts_namespace_member.get(r#ref)
             else {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -9459,9 +9459,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut map = bun_ast::ast_result::TsEnumsMap::default();
         map.ensure_total_capacity(self.top_level_enums.len())?;
         for r#ref in self.top_level_enums.iter() {
-            // Each block of a merged `enum E {} enum E {}` has its own symbol. An older
-            // symbol links to the newest one and all of them share one member map. The
-            // linker and the printer look up the newest symbol only.
+            // Only the newest symbol of a merged `enum E {} enum E {}` is looked up. It has no link.
             if self.symbols[r#ref.inner_index() as usize].has_link() {
                 continue;
             }

--- a/test/bundler/bundler_merged_enum.test.ts
+++ b/test/bundler/bundler_merged_enum.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { emptyProcessMaxRSS, isASAN, isDebug, runFixtureMaxRSS, tempDir } from "harness";
+import { join } from "node:path";
+import { itBundled } from "./expectBundled";
+
+describe("bundler", () => {
+  // Each `enum E {}` block of a merged enum has its own symbol. An older symbol
+  // links to the newest one, and all of them share one member table. Every way
+  // to import the enum resolves to the newest symbol, so the linker gets the
+  // inlinable values for that symbol only.
+  itBundled("ts/EnumCrossModuleInliningMergedDeclarations", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { drop_a, drop_b, c, d as dd } from './enums'
+        import { ra } from './re-export'
+        import { drop_b as sb } from './re-export-star'
+        import * as ns from './enums'
+        globalThis["captu" + "re"] = x => x;
+        console.log(JSON.stringify([
+          capture(drop_a.first),
+          capture(drop_a.second),
+          capture(drop_a.third),
+          capture(drop_b.x),
+          capture(drop_b.y),
+          capture(c.p),
+          capture(c.q),
+          capture(c.r),
+          capture(dd.m),
+          capture(dd.n),
+          capture(ra.first),
+          capture(ra.third),
+          capture(sb.x),
+          capture(sb.y),
+          capture(ns.drop_a.second),
+          capture(ns.c.r),
+        ]))
+      `,
+      "/re-export.ts": `export { drop_a as ra } from './enums'`,
+      "/re-export-star.ts": `export * from './enums'`,
+      "/enums.ts": /* ts */ `
+        export enum drop_a { first = 1 }
+        export enum drop_a { second = 'two' }
+        export enum drop_a { third = first + 2 }
+
+        enum drop_b { x = 10 }
+        export { drop_b }
+        enum drop_b { y = 20 }
+
+        export enum c { p = 5 }
+        export namespace c { export const q = 6 }
+        export enum c { r = 7 }
+
+        namespace d { export const m = 'ns' }
+        enum d { n = 8 }
+        export { d }
+      `,
+    },
+    // Every use of drop_a and drop_b inlines, so no block of them stays.
+    dce: true,
+    minifySyntax: false, // intentionally disabled. enum inlining always happens
+    onAfterBundle(api) {
+      expect(api.captureFile("/out.js").map(x => x.replace(/\/\*.*\*\//g, "").trim())).toEqual([
+        "1",
+        '"two"',
+        "3",
+        "10",
+        "20",
+        "5",
+        "c.q",
+        "7",
+        "d.m",
+        "8",
+        "1",
+        "3",
+        "10",
+        "20",
+        '"two"',
+        "7",
+      ]);
+    },
+    run: { stdout: '[1,"two",3,10,20,5,6,7,"ns",8,1,3,10,20,"two",7]' },
+  });
+
+  // The parser used to give the linker one full copy of the shared member table
+  // per block, and the linker copied each of those again: n blocks cost n^2
+  // entries. 8192 blocks of 1 member (100 KB of source) took 8.6 GB.
+  test("merged enum blocks do not each get a copy of the shared member table", async () => {
+    const blocks = 256;
+    const membersPerBlock = 32;
+    const count = blocks * membersPerBlock;
+    let enums = "";
+    for (let block = 0; block < blocks; block++) {
+      const first = block * membersPerBlock;
+      enums += `export enum E { M${first} = ${first}`;
+      for (let i = first + 1; i < first + membersPerBlock; i++) enums += `, M${i}`;
+      enums += " }\n";
+    }
+    const [head, middle, tail] = [0, count / 2, count - 1];
+    using dir = tempDir("bundler-merged-enum", {
+      "enums.ts": enums,
+      "entry.ts": `import { E } from "./enums";\nconsole.log(E.M${head}, E.M${middle}, E.M${tail});\n`,
+    });
+
+    const fixture = /* js */ `
+      const build = await Bun.build({ entrypoints: [${JSON.stringify(join(String(dir), "entry.ts"))}] });
+      const code = await build.outputs[0].text();
+      console.log(JSON.stringify({ log: code.split("\\n").find(line => line.startsWith("console.log(")) }));
+    `;
+    const [fixtureMaxRSS, baselineMaxRSS] = await Promise.all([
+      // A member of the first, of a middle and of the last block still inlines.
+      runFixtureMaxRSS(fixture, {
+        log: `console.log(${head} /* M${head} */, ${middle} /* M${middle} */, ${tail} /* M${tail} */);`,
+      }),
+      emptyProcessMaxRSS(),
+    ]);
+    // Peak RSS over an empty process for this 51 KB input. Before the fix:
+    // 220 MB in release, 320 MB in a debug ASAN build. After: 50 MB in debug.
+    expect((fixtureMaxRSS - baselineMaxRSS) / 1024 / 1024).toBeLessThan(isASAN || isDebug ? 150 : 100);
+  });
+});


### PR DESCRIPTION
### Problem
- Bundling a file that declares one top-level enum n times (`enum E {A} enum E {B} ...`) costs O(n^2) memory. 8192 blocks (100 KB of source) reach 8.6 GB RSS in `Bun.build`. With 8192 different names: 70 MB.
- The cause is `compute_ts_enums_map` (`src/js_parser/p.rs:9448`). `s_enum` pushes one ref per block to `top_level_enums`. Every ref maps to the one member map that all blocks share, and the function copies that map once per ref: n maps of n entries. `LinkerGraph::load` then clones each copy.

### Fix
- `compute_ts_enums_map` skips a ref whose symbol has a link. Only the newest symbol of a merged enum has no link, so each enum gets one map.
- Correct because both readers of `ts_enums` look up the newest symbol only. The printer calls `symbols.follow()` first. Linker step 5 uses the ref of the named export, which is the newest symbol for `export enum E` and for `export { E }`.
- 8192 blocks now take 1.1 GB. The rest is not specific to enums (see Notes).
- Verified: `test/bundler/bundler_merged_enum.test.ts` (stock bun: 220 MB, bound 100 MB). Also ran `test/bundler/esbuild/{ts,dce,importstar_ts,splitting}.test.ts`.

### Background
- `ts_enums` maps an enum symbol to its constant members. The linker and the printer use it to replace `E.A` in another file with the value.
- Each declaration of a name gets a symbol. For `enum` + `enum`, `declare_symbol` sets `older.link = newer`, and the scope keeps the newer symbol. Readers follow the links.
- All blocks of a merged enum share one `TSNamespaceMemberMap`.

<details><summary>Notes</summary>

Release build, linux x64, `Bun.build` of n lines `enum E{M<i>}` plus `console.log(E)`. Time and RSS after the build:

| n | main | this branch | n lines `var x = x \|\| <i>;` (main and branch) |
| --- | --- | --- | --- |
| 2048 | 420 ms, 640 MB | 207 ms, 137 MB | |
| 4096 | 1678 ms, 2203 MB | 811 ms, 312 MB | 370 ms, 391 MB |
| 8192 | 9205 ms, 8588 MB | 2332 ms, 1099 MB | 1705 ms, 1461 MB |

- What remains is the part dependency fan-out in the linker. Every block is a part that declares `E` and uses `E`. Step 5 gives each of the n parts a dependency on all n parts, and tree shaking visits each of them. n merged `var x = x || i;` statements cost the same on main and on this branch (last column). esbuild has the same model. This PR does not change it.
- #42242 makes the link chain walks in the parser linear for the same input. It does not touch `compute_ts_enums_map`. The two changes are independent.
- The new test bundles 256 blocks of 32 members (51 KB). That makes the map copies large and the part fan-out small. Peak RSS over an empty process: 220 to 250 MB before and 15 MB after in release, 320 MB before and 50 MB after in a debug ASAN build. A debug ASAN build without the fix needs 16 s for this input, so there the test fails on the default timeout and not on the bound.
- The bundle of the files of `ts/EnumCrossModuleInliningMergedDeclarations` is byte-identical before and after, with and without `--minify`.
- A symbol of kind `TsEnum` only gets a link from a newer `enum` of the same name in the same scope (`Scope::can_merge_symbol_kinds`). A `namespace` after an `enum` keeps the enum symbol. Symbol hoisting only links hoisted kinds. So the end of each chain is a top-level enum and is in `top_level_enums`.
- Self-review: checked every writer of `Symbol::link`, every `record_export` caller and both readers of `ts_enums`. No input makes a reader look up a linked symbol. If one did, step 5 would keep the enum object (larger output) and the printer would still inline the value, so it fails safe. With the condition inverted (keep only the linked symbols) `ts/EnumCrossModuleInliningMergedDeclarations` fails its DCE check, so that test is sensitive to which symbol keeps the map.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_merged_enum.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_merged_enum.test.ts:
(pass) bundler > ts/EnumCrossModuleInliningMergedDeclarations [994.67ms]
killed 1 dangling process
(fail) bundler > merged enum blocks do not each get a copy of the shared member table [5006.20ms]
  ^ this test timed out after 5000ms.

 1 pass
 1 fail
 2 expect() calls
Ran 2 tests across 1 file. [9.15s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (1f89da512)

test/bundler/bundler_merged_enum.test.ts:
(pass) bundler > ts/EnumCrossModuleInliningMergedDeclarations [30.83ms]
113 |       }),
114 |       emptyProcessMaxRSS(),
115 |     ]);
116 |     // Peak RSS over an empty process for this 51 KB input. Before the fix:
117 |     // 220 MB in release, 320 MB in a debug ASAN build. After: 50 MB in debug.
118 |     expect((fixtureMaxRSS - baselineMaxRSS) / 1024 / 1024).toBeLessThan(isASAN || isDebug ? 150 : 100);
                                                                 ^
error: expect(received).toBeLessThan(expected)

Expected: < 100
Received: 222.87890625

      at <anonymous> (/workspace/bun/test/bundler/bundler_merged_enum.test.ts:118:60)
(fail) bundler > merged enum blocks do not each get a copy of the shared member table [276.69ms]

 1 pass
 1 fail
 7 expect() calls
Ran 2 tests across 1 file. [444.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_merged_enum.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_merged_enum.test.ts:
(pass) bundler > ts/EnumCrossModuleInliningMergedDeclarations [911.75ms]
(pass) bundler > merged enum blocks do not each get a copy of the shared member table [1756.98ms]

 2 pass
 0 fail
 7 expect() calls
Ran 2 tests across 1 file. [5.70s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 690ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (8120ms)
Bundle modules (50ms)
Postprocesss modules (166ms)
Bundle Functions (502ms)
Generate Code (44ms)

[8.89s] Bundled "src/js" for production
  2599 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/worksp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                       |   6 ++
 test/bundler/bundler_merged_enum.test.ts | 120 +++++++++++++++++++++++++++++++
 2 files changed, 126 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js_parser/p.rs                            8      3     14
test/bundler/bundler_merged_enum.test.ts      1      2     14
```

</details>

<!-- robobun:evidence:end -->