### PR TITLE
node:http2: match node for invalid origins in session.altsvc() and session.origin()

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3927,17 +3927,15 @@ function getOrigin(origin: any, isAltSvc: boolean): string {
     try {
       origin = new URL(origin).origin;
     } catch (e) {
-      if (isAltSvc) {
-        throw $ERR_HTTP2_ALTSVC_INVALID_ORIGIN();
-      } else {
-        throw $ERR_INVALID_URL(origin);
-      }
+      throw $ERR_INVALID_URL(origin);
     }
   } else if (origin != null && typeof origin === "object") {
     origin = origin.origin;
   }
   validateString(origin, "origin");
-  if (!origin || origin === "null") {
+  // Only "null" is rejected. origin() sends an empty string as a zero-length entry.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1779-L1786
+  if (origin === "null") {
     if (isAltSvc) {
       throw $ERR_HTTP2_ALTSVC_INVALID_ORIGIN();
     } else {
@@ -4408,6 +4406,12 @@ class ServerHttp2Session extends Http2Session {
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1760
     if (origin.length + alt.length > MAX_LENGTH) {
       throw $ERR_HTTP2_ALTSVC_LENGTH();
+    }
+    // altsvc(alt) names neither an origin nor a stream. RFC 7838 section 4 makes that frame
+    // invalid. Node gives no error to match: it aborts the process on a CHECK.
+    // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L3227-L3229
+    if (stream === 0 && origin === "") {
+      throw $ERR_HTTP2_ALTSVC_INVALID_ORIGIN();
     }
     parser.altsvc(origin, alt, stream);
   }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3933,8 +3933,7 @@ function getOrigin(origin: any, isAltSvc: boolean): string {
     origin = origin.origin;
   }
   validateString(origin, "origin");
-  // Only "null" is rejected. origin() sends an empty string as a zero-length entry.
-  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1779-L1786
+  // Only "null", not "": https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L1784-L1786
   if (origin === "null") {
     if (isAltSvc) {
       throw $ERR_HTTP2_ALTSVC_INVALID_ORIGIN();
@@ -4407,9 +4406,7 @@ class ServerHttp2Session extends Http2Session {
     if (origin.length + alt.length > MAX_LENGTH) {
       throw $ERR_HTTP2_ALTSVC_LENGTH();
     }
-    // altsvc(alt) names neither an origin nor a stream. RFC 7838 section 4 makes that frame
-    // invalid. Node gives no error to match: it aborts the process on a CHECK.
-    // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L3227-L3229
+    // Node aborts here (CHECK): https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L3227-L3229
     if (stream === 0 && origin === "") {
       throw $ERR_HTTP2_ALTSVC_INVALID_ORIGIN();
     }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3136,6 +3136,80 @@ it("http2 session.altsvc() sends an object origin unchanged, like Node", async (
   ]);
 });
 
+it("http2 session.altsvc() and session.origin() reject an origin with the same error as Node", async () => {
+  // A string origin goes through URL parsing first, and its ERR_INVALID_URL is
+  // not replaced. After that only the origin "null" is invalid. The outcomes
+  // are those of node v26.3.0, except for the last two calls.
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const alt = 'h2=":8000"';
+  const calls = {
+    'altsvc(alt, "")': session => session.altsvc(alt, ""),
+    'altsvc(alt, "not a url")': session => session.altsvc(alt, "not a url"),
+    'altsvc(alt, "null")': session => session.altsvc(alt, "null"),
+    'altsvc(alt, "1")': session => session.altsvc(alt, "1"),
+    'altsvc(alt, "file:///x")': session => session.altsvc(alt, "file:///x"),
+    'origin("")': session => session.origin(""),
+    'origin("not a url")': session => session.origin("not a url"),
+    'origin("file:///x")': session => session.origin("file:///x"),
+    'origin({ origin: "null" })': session => session.origin({ origin: "null" }),
+    "origin({ origin: 1 })": session => session.origin({ origin: 1 }),
+    // An empty origin is not "null": the entry is sent with a length of zero.
+    'origin({ origin: "" })': session => session.origin({ origin: "" }),
+    // Neither an origin nor a stream: RFC 7838 section 4 makes that frame
+    // invalid. Node aborts the process here (a CHECK in Http2Session::AltSvc),
+    // so there is no error to match.
+    "altsvc(alt)": session => session.altsvc(alt),
+    "altsvc(alt, undefined)": session => session.altsvc(alt, undefined),
+  };
+  const outcomes = {};
+
+  const server = http2.createServer();
+  server.on("session", session => {
+    for (const [name, call] of Object.entries(calls)) {
+      try {
+        call(session);
+        outcomes[name] = "sent";
+      } catch (err) {
+        outcomes[name] = `${err.name} ${err.code}`;
+      }
+    }
+  });
+  server.on("stream", stream => {
+    stream.respond({ ":status": 200 });
+    stream.end("ok");
+  });
+  server.on("error", reject);
+  server.listen(0, "127.0.0.1", () => {
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    client.on("error", reject);
+    const req = client.request({ ":path": "/" });
+    req.resume();
+    req.on("close", () => {
+      client.close();
+      server.close();
+      resolve();
+    });
+    req.end();
+  });
+
+  await promise;
+  expect(outcomes).toEqual({
+    'altsvc(alt, "")': "TypeError ERR_INVALID_URL",
+    'altsvc(alt, "not a url")': "TypeError ERR_INVALID_URL",
+    'altsvc(alt, "null")': "TypeError ERR_INVALID_URL",
+    'altsvc(alt, "1")': "TypeError ERR_INVALID_URL",
+    'altsvc(alt, "file:///x")': "TypeError ERR_HTTP2_ALTSVC_INVALID_ORIGIN",
+    'origin("")': "TypeError ERR_INVALID_URL",
+    'origin("not a url")': "TypeError ERR_INVALID_URL",
+    'origin("file:///x")': "TypeError ERR_HTTP2_INVALID_ORIGIN",
+    'origin({ origin: "null" })': "TypeError ERR_HTTP2_INVALID_ORIGIN",
+    "origin({ origin: 1 })": "TypeError ERR_INVALID_ARG_TYPE",
+    'origin({ origin: "" })': "sent",
+    "altsvc(alt)": "TypeError ERR_HTTP2_ALTSVC_INVALID_ORIGIN",
+    "altsvc(alt, undefined)": "TypeError ERR_HTTP2_ALTSVC_INVALID_ORIGIN",
+  });
+});
+
 it("http2 client.request() propagates a throwing header-value toString() instead of masking it", async () => {
   // Node calls `${value}` and lets the user's exception escape; it must not be
   // replaced with ERR_HTTP2_INVALID_HEADER_VALUE.
@@ -3734,6 +3808,22 @@ describe("http2 ALTSVC and ORIGIN frame strings are latin-1", () => {
     try {
       const frames = await framesBeforePingAck(server.address().port, ORIGIN);
       expect(frames.map(originEntries)).toEqual([[origin], [origin, "https://b.example"]]);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("server writes an empty object origin as a zero-length ORIGIN entry", async () => {
+    const server = http2.createServer();
+    server.on("session", session => {
+      session.origin({ origin: "" });
+      session.origin({ origin: "" }, "https://b.example");
+      session.origin("https://a.example", { origin: "" });
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    try {
+      const frames = await framesBeforePingAck(server.address().port, ORIGIN);
+      expect(frames.map(originEntries)).toEqual([[""], ["", "https://b.example"], ["https://a.example", ""]]);
     } finally {
       server.close();
     }


### PR DESCRIPTION
### Problem

- Two calls of `ServerHttp2Session` differ from node v26.3.0. `altsvc(alt, origin)` with a string that is not a URL (`""`, `"not a url"`, `"null"`, `"1"`) throws `ERR_HTTP2_ALTSVC_INVALID_ORIGIN`, node throws `ERR_INVALID_URL`. `origin({ origin: "" })` throws `ERR_HTTP2_INVALID_ORIGIN`, node sends a zero-length ORIGIN entry because it rejects only `"null"`.
- `altsvc(alt)` with no origin and no stream id writes an ALTSVC frame with an empty origin on stream 0. RFC 7838 section 4 makes that frame invalid. A node client answers it with a session error.
- Cause: `getOrigin` (`src/js/node/http2.ts:3925`) replaces the URL error for `altsvc` and rejects every falsy origin. `altsvc()` does not check the call without a second argument.

### Fix

- `getOrigin` rethrows `ERR_INVALID_URL` for both callers and rejects only `"null"`, like `getURLOrigin()` and the loop in node's `origin()`.
- `altsvc(alt)` with neither an origin nor a stream id throws `ERR_HTTP2_ALTSVC_INVALID_ORIGIN`, after every other argument check. Node has no error to match here: it aborts the process (`CHECK` in `Http2Session::AltSvc`, `node_http2.cc:3229`). The code is the one node uses for an empty object origin.
- Verified: two new tests in `test/js/node/http2/node-http2.test.js`, both fail on 1.4.3-canary. All of `node-http2.test.js` and the upstream `test-http2-altsvc.js` and `test-http2-origin.js` pass.

### Background

- `ServerHttp2Session#altsvc(alt, originOrStream)` sends an ALTSVC frame (RFC 7838): on stream 0 with an origin, or on a stream without one.
- `ServerHttp2Session#origin(...origins)` sends an ORIGIN frame (RFC 8336): a list of length-prefixed origins.
- For both, a string argument goes through URL parsing and is replaced by its origin. An object's `origin` property is sent as is.

<details><summary>Notes</summary>

**Outcomes.** Same script on node v26.3.0, bun 1.4.3-canary and this PR. The calls run in the `'session'` listener of an h2c server. A raw client reads the ALTSVC and ORIGIN frames that arrive.

| call | node v26.3.0 | bun 1.4.3-canary | this PR |
| --- | --- | --- | --- |
| `altsvc(alt, "")`, `"not a url"`, `"null"`, `"1"` | TypeError ERR_INVALID_URL | TypeError ERR_HTTP2_ALTSVC_INVALID_ORIGIN | TypeError ERR_INVALID_URL |
| `altsvc(alt, "file:///x")` | ERR_HTTP2_ALTSVC_INVALID_ORIGIN | same | same |
| `origin({ origin: "" })` | sent, payload `0000` | ERR_HTTP2_INVALID_ORIGIN | sent, payload `0000` |
| `origin({ origin: "" }, "https://b.example")` | sent, `0000` + entry | ERR_HTTP2_INVALID_ORIGIN | sent, `0000` + entry |
| `origin({ origin: "null" })` | ERR_HTTP2_INVALID_ORIGIN | same | same |
| `altsvc(alt)`, `altsvc(alt, undefined)` | process abort: `Assertion failed: (origin_len != 0 && id == 0) \|\| (origin_len == 0 && id != 0)` | frame `0000` + alt on stream 0 | ERR_HTTP2_ALTSVC_INVALID_ORIGIN |

The other 28 rows of the matrix are identical in all three: number arguments (`0`, `1.5`, `-1`, `2**32`, a stream that does not exist), `null`, `true`, `{}`, `{ origin: 1 }`, a non-string `alt`, an `alt` with a character above U+00FF, `origin()` with no arguments, `origin("")`, `origin("not a url")`, `origin("file:///x")`.

**Why throw for `altsvc(alt)`.** The choices are: keep the invalid frame, drop the call in silence, or throw. A client that follows nghttp2 (node, and bun after #42391) destroys the session when it gets that frame. A throw tells the caller what is wrong at the call site. No program that runs on node can depend on the old behavior, because node aborts.

**Not matched.**
- Node's `ERR_INVALID_URL` from `getURLOrigin()` comes from C++ and has no `input` property. Bun's has `input`, as `new URL()` does in both runtimes. `origin()` already behaved this way.
- An object origin with a code unit above U+00FF is written as UTF-8. Node writes the low byte of each code unit. #41254 left that open on purpose (`header_value_bytes`).

</details>
