### PR TITLE
pm diff: compare a folder's workspace: and catalog: versions as pack publishes them

### DIFF
--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -272,7 +272,7 @@ $ bun pm diff react-dom@18.2.0 18.3.1 '*.min.js'
 $ bun pm diff react-dom@18.2.0 18.3.1 'cjs/**/*.production.min.js'
 ```
 
-A local folder that has a `package.json` is read the way `bun pm pack` would publish it — the `files` field, `.npmignore` / `.gitignore`, `bin` — so diffing a checkout against the registry compares what would ship, not `node_modules/`, `vendor/` or build output.
+A local folder that has a `package.json` is read the way `bun pm pack` would publish it — the `files` field, `.npmignore` / `.gitignore`, `bin` — so diffing a checkout against the registry compares what would ship, not `node_modules/`, `vendor/` or build output. In that `package.json`, `workspace:` and `catalog:` dependency versions are compared as the versions `bun pm pack` writes in their place (from `bun.lock`), so a workspace package shows no dependency change against its own published copy.
 
 Piped or with `NO_COLOR`, the output is a plain unified patch of the real file contents (so `bun pm diff a b > changes.patch` applies), and `--raw` turns the re-print off on a terminal too.
 

--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -272,7 +272,7 @@ $ bun pm diff react-dom@18.2.0 18.3.1 '*.min.js'
 $ bun pm diff react-dom@18.2.0 18.3.1 'cjs/**/*.production.min.js'
 ```
 
-A local folder that has a `package.json` is read the way `bun pm pack` would publish it — the `files` field, `.npmignore` / `.gitignore`, `bin` — so diffing a checkout against the registry compares what would ship, not `node_modules/`, `vendor/` or build output. In that `package.json`, `workspace:` and `catalog:` dependency versions are compared as the versions `bun pm pack` writes in their place (from `bun.lock`), so a workspace package shows no dependency change against its own published copy. Two folders that spell such a version the same way keep it as written.
+A local folder that has a `package.json` is read the way `bun pm pack` would publish it — the `files` field, `.npmignore` / `.gitignore`, `bin` — so diffing a checkout against the registry compares what would ship, not `node_modules/`, `vendor/` or build output. Against a tarball or a published version, the `workspace:` and `catalog:` dependency versions in that `package.json` are compared as the versions `bun pm pack` writes in their place (from the folder's `bun.lock`), so a workspace package shows no dependency change against its own published copy. Two folders are compared as written.
 
 Piped or with `NO_COLOR`, the output is a plain unified patch of the real file contents (so `bun pm diff a b > changes.patch` applies), and `--raw` turns the re-print off on a terminal too.
 

--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -272,7 +272,7 @@ $ bun pm diff react-dom@18.2.0 18.3.1 '*.min.js'
 $ bun pm diff react-dom@18.2.0 18.3.1 'cjs/**/*.production.min.js'
 ```
 
-A local folder that has a `package.json` is read the way `bun pm pack` would publish it — the `files` field, `.npmignore` / `.gitignore`, `bin` — so diffing a checkout against the registry compares what would ship, not `node_modules/`, `vendor/` or build output. In that `package.json`, `workspace:` and `catalog:` dependency versions are compared as the versions `bun pm pack` writes in their place (from `bun.lock`), so a workspace package shows no dependency change against its own published copy.
+A local folder that has a `package.json` is read the way `bun pm pack` would publish it — the `files` field, `.npmignore` / `.gitignore`, `bin` — so diffing a checkout against the registry compares what would ship, not `node_modules/`, `vendor/` or build output. In that `package.json`, `workspace:` and `catalog:` dependency versions are compared as the versions `bun pm pack` writes in their place (from `bun.lock`), so a workspace package shows no dependency change against its own published copy. Two folders that spell such a version the same way keep it as written.
 
 Piped or with `NO_COLOR`, the output is a plain unified patch of the real file contents (so `bun pm diff a b > changes.patch` applies), and `--raw` turns the re-print off on a terminal too.
 

--- a/src/parsers/json.rs
+++ b/src/parsers/json.rs
@@ -798,7 +798,8 @@ fn array_next_item(contents: &[u8], item: usize) -> Option<usize> {
     (!matches!(contents[p], b']' | b',')).then_some(p)
 }
 
-fn skip_string_token(contents: &[u8], start: usize) -> Option<usize> {
+/// Offset one past the closing quote of the string token whose opening quote is at `start`.
+pub fn skip_string_token(contents: &[u8], start: usize) -> Option<usize> {
     let quote = *contents.get(start)?;
     if quote != b'"' && quote != b'\'' {
         return None;

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -3353,17 +3353,14 @@ impl UnresolvedVersion {
     }
 }
 
-/// The version the tarball's package.json gets in place of a `workspace:` or `catalog:` dependency version.
-/// `None` when `spec` uses neither protocol and is published as written. Shared with `bun pm diff`, which shows a
-/// local package.json with the versions that would be published.
+/// What the tarball's package.json gets in place of a `workspace:` or `catalog:` version. `None`: `spec` uses neither.
 pub(crate) fn published_version(
     maybe_lockfile: Option<&Lockfile>,
     dependency_name: &[u8],
     spec: &[u8],
 ) -> Option<Result<Vec<u8>, UnresolvedVersion>> {
     if let Some(range) = strings::without_prefix_if_possible_comptime(spec, b"workspace:") {
-        // Only a bare `^`, `~` or `*` stands for the workspace's current version; any other range is published as
-        // written.
+        // Only a bare `^`, `~` or `*` takes the workspace's version. Any other range is published as written.
         let prefix: &[u8] = match range {
             b"^" => b"^",
             b"~" => b"~",

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -3325,6 +3325,83 @@ fn add_archive_entry(
     Ok(entry.clear())
 }
 
+/// Why `published_version` has no version for a `workspace:` or `catalog:` dependency.
+#[derive(Clone, Copy)]
+pub(crate) enum UnresolvedVersion {
+    /// `workspace:^`, `workspace:~` or `workspace:*`, and the lockfile has no version for that workspace.
+    Workspace,
+    /// `catalog:`, and there is no lockfile to read the catalogs from.
+    CatalogWithoutLockfile,
+    /// `catalog:`, and that catalog has no entry for the dependency.
+    CatalogEntry,
+}
+
+impl UnresolvedVersion {
+    /// The error `bun pm pack` stops with. The `{}`s are the dependency's name and its package.json section.
+    fn message(self) -> &'static str {
+        match self {
+            UnresolvedVersion::Workspace => {
+                "Failed to resolve workspace version for \"{}\" in `{}`. Run <cyan>`bun install`<r> and try again."
+            }
+            UnresolvedVersion::CatalogWithoutLockfile => {
+                "Failed to resolve catalog version for \"{}\" in `{}` (catalogs require a lockfile)."
+            }
+            UnresolvedVersion::CatalogEntry => {
+                "Failed to resolve catalog version for \"{}\" in `{}` (no matching catalog dependency)."
+            }
+        }
+    }
+}
+
+/// The version the tarball's package.json gets in place of a `workspace:` or `catalog:` dependency version.
+/// `None` when `spec` uses neither protocol and is published as written. Shared with `bun pm diff`, which shows a
+/// local package.json with the versions that would be published.
+pub(crate) fn published_version(
+    maybe_lockfile: Option<&Lockfile>,
+    dependency_name: &[u8],
+    spec: &[u8],
+) -> Option<Result<Vec<u8>, UnresolvedVersion>> {
+    if let Some(range) = strings::without_prefix_if_possible_comptime(spec, b"workspace:") {
+        // Only a bare `^`, `~` or `*` stands for the workspace's current version; any other range is published as
+        // written.
+        let prefix: &[u8] = match range {
+            b"^" => b"^",
+            b"~" => b"~",
+            b"*" => b"",
+            _ => return Some(Ok(range.to_vec())),
+        };
+        let Some(lockfile) = maybe_lockfile else {
+            return Some(Err(UnresolvedVersion::Workspace));
+        };
+        let Some(workspace_version) = lockfile
+            .workspace_versions
+            .get(&Semver::string::Builder::string_hash(dependency_name))
+        else {
+            return Some(Err(UnresolvedVersion::Workspace));
+        };
+        return Some(Ok(format!(
+            "{}{}",
+            bstr::BStr::new(prefix),
+            workspace_version.fmt(lockfile.buffers.string_bytes.as_slice()),
+        )
+        .into_bytes()));
+    }
+
+    let catalog_name = strings::without_prefix_if_possible_comptime(spec, b"catalog:")?;
+    let Some(lockfile) = maybe_lockfile else {
+        return Some(Err(UnresolvedVersion::CatalogWithoutLockfile));
+    };
+    let map_buf: &[u8] = lockfile.buffers.string_bytes.as_slice();
+    let catalog_name = strings::trim(catalog_name, &strings::WHITESPACE_CHARS);
+    let Some(dep) = lockfile
+        .catalogs
+        .find(map_buf, catalog_name, dependency_name)
+    else {
+        return Some(Err(UnresolvedVersion::CatalogEntry));
+    };
+    Some(Ok(dep.version.literal.slice(map_buf).to_vec()))
+}
+
 /// Strips workspace and catalog protocols from dependency versions then
 /// returns the printed json
 fn edit_root_package_json(
@@ -3344,85 +3421,26 @@ fn edit_root_package_json(
         if let Some(dependencies_expr) = json.root.get(dependency_group) {
             if let ExprData::EObject(mut dependencies) = dependencies_expr.data {
                 for dependency in dependencies.properties.slice_mut() {
-                    if dependency.key.is_none() {
-                        continue;
-                    }
-                    if dependency.value.is_none() {
-                        continue;
-                    }
-
-                    let Some(package_spec) = dependency
-                        .value
-                        .as_ref()
-                        .expect("infallible: prop has value")
-                        .as_utf8_string_literal()
-                    else {
+                    let (Some(dependency_name), Some(package_spec)) = (
+                        dependency
+                            .key
+                            .as_ref()
+                            .and_then(Expr::as_utf8_string_literal),
+                        dependency
+                            .value
+                            .as_ref()
+                            .and_then(Expr::as_utf8_string_literal),
+                    ) else {
                         continue;
                     };
-                    if let Some(without_workspace_protocol) =
-                        strings::without_prefix_if_possible_comptime(package_spec, b"workspace:")
-                    {
-                        // TODO: make semver parsing more strict. `^`, `~` are not valid
 
-                        if without_workspace_protocol.len() == 1 {
-                            // TODO: this might be too strict
-                            let c = without_workspace_protocol[0];
-                            if c == b'^' || c == b'~' || c == b'*' {
-                                let dependency_name = match dependency
-                                    .key
-                                    .as_ref()
-                                    .expect("infallible: prop has key")
-                                    .as_utf8_string_literal()
-                                {
-                                    Some(n) => n,
-                                    None => {
-                                        Output::err_generic(
-                                            "expected string value for dependency name in \"{}\"",
-                                            format_args!("{}", bstr::BStr::new(dependency_group)),
-                                        );
-                                        Global::crash();
-                                    }
-                                };
-
-                                let resolved = 'failed_to_resolve: {
-                                    // find the current workspace version and append to package spec without `workspace:`
-                                    let Some(lockfile) = maybe_lockfile else {
-                                        break 'failed_to_resolve false;
-                                    };
-                                    let Some(workspace_version) = lockfile.workspace_versions.get(
-                                        &Semver::string::Builder::string_hash(dependency_name),
-                                    ) else {
-                                        break 'failed_to_resolve false;
-                                    };
-                                    let prefix: &[u8] = match c {
-                                        b'^' => b"^",
-                                        b'~' => b"~",
-                                        b'*' => b"",
-                                        _ => unreachable!(),
-                                    };
-                                    // Format on the heap then copy into the
-                                    // pack arena; `EString::init` erases the
-                                    // lifetime.
-                                    let tmp = format!(
-                                        "{}{}",
-                                        bstr::BStr::new(prefix),
-                                        workspace_version
-                                            .fmt(lockfile.buffers.string_bytes.as_slice()),
-                                    );
-                                    let data = pack_bump().alloc_slice_copy(tmp.as_bytes());
-                                    dependency.value = Some(Expr::init(
-                                        E::EString::init(data),
-                                        Default::default(),
-                                    ));
-                                    true
-                                };
-                                if resolved {
-                                    continue;
-                                }
-
-                                // only produce this error only when we need to get the workspace version
+                    let version =
+                        match published_version(maybe_lockfile, dependency_name, package_spec) {
+                            None => continue,
+                            Some(Ok(version)) => version,
+                            Some(Err(unresolved)) => {
                                 Output::err_generic(
-                                    "Failed to resolve workspace version for \"{}\" in `{}`. Run <cyan>`bun install`<r> and try again.",
+                                    unresolved.message(),
                                     (
                                         bstr::BStr::new(dependency_name),
                                         bstr::BStr::new(dependency_group),
@@ -3430,55 +3448,11 @@ fn edit_root_package_json(
                                 );
                                 Global::crash();
                             }
-                        }
-
-                        let dup = pack_bump().alloc_slice_copy(without_workspace_protocol);
-                        dependency.value =
-                            Some(Expr::init(E::EString::init(dup), Default::default()));
-                    } else if let Some(catalog_name_str) =
-                        strings::without_prefix_if_possible_comptime(package_spec, b"catalog:")
-                    {
-                        let dep_name_str = dependency
-                            .key
-                            .as_ref()
-                            .expect("infallible: prop has key")
-                            .as_utf8_string_literal()
-                            .expect("infallible: is_string checked");
-
-                        let lockfile = match maybe_lockfile {
-                            Some(l) => l,
-                            None => {
-                                Output::err_generic(
-                                    "Failed to resolve catalog version for \"{}\" in `{}` (catalogs require a lockfile).",
-                                    (
-                                        bstr::BStr::new(dep_name_str),
-                                        bstr::BStr::new(dependency_group),
-                                    ),
-                                );
-                                Global::crash();
-                            }
                         };
 
-                        let map_buf: &[u8] = lockfile.buffers.string_bytes.as_slice();
-                        let catalog_name =
-                            strings::trim(catalog_name_str, &strings::WHITESPACE_CHARS);
-                        let Some(dep) = lockfile.catalogs.find(map_buf, catalog_name, dep_name_str)
-                        else {
-                            Output::err_generic(
-                                "Failed to resolve catalog version for \"{}\" in `{}` (no matching catalog dependency).",
-                                (
-                                    bstr::BStr::new(dep_name_str),
-                                    bstr::BStr::new(dependency_group),
-                                ),
-                            );
-                            Global::crash();
-                        };
-
-                        let literal =
-                            pack_bump().alloc_slice_copy(dep.version.literal.slice(map_buf));
-                        dependency.value =
-                            Some(Expr::init(E::EString::init(literal), Default::default()));
-                    }
+                    // `EString::init` erases the lifetime, so the bytes go into the pack arena.
+                    let data = pack_bump().alloc_slice_copy(&version);
+                    dependency.value = Some(Expr::init(E::EString::init(data), Default::default()));
                 }
             }
         }

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -734,7 +734,7 @@ fn lockfile_for<'a>(
     let dir = strings::without_trailing_slash(join_abs_string_buf::<platform::Auto>(
         dir,
         &mut dir_buf[..],
-        &[],
+        &[b"."],
     ));
     let mut root = dir;
     loop {

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -717,10 +717,7 @@ fn read_dir_tree(pm: &mut PackageManager, root: &[u8]) -> Result<Tree, crate::Er
     Ok(tree)
 }
 
-/// This project's lockfile, loaded into `lockfile`, when `manifest` (the package.json of `dir`) has `workspace:` or
-/// `catalog:` versions and `dir` is a folder whose `bun pm pack` reads that lockfile: the package the command was
-/// run in, the project root, or a workspace the lockfile lists. Any other folder keeps its versions as written, so
-/// a workspace here that happens to share a name never stands in for one of its own.
+/// This project's lockfile, loaded into `lockfile`, when `manifest` (the package.json of `dir`) needs it and it covers `dir`.
 fn project_lockfile<'a>(
     pm: &mut PackageManager,
     lockfile: &'a mut Lockfile,
@@ -755,6 +752,7 @@ fn project_lockfile<'a>(
     let dir = absolute(top_level_dir, &mut dir_buf[..], dir);
     let mut is_dir = |path: &[u8]| absolute(top_level_dir, &mut buf[..], path) == dir;
     let string_buf = lockfile.buffers.string_bytes.as_slice();
+    // `bun pm pack` reads this lockfile in the invoking package, the project root and each workspace it lists. Not elsewhere.
     let covered = is_dir(b"")
         || bun_paths::dirname(pm.original_package_json_path.as_bytes()).is_some_and(&mut is_dir)
         || lockfile.packages.items_resolution().iter().any(|res| {
@@ -763,8 +761,7 @@ fn project_lockfile<'a>(
     covered.then_some(lockfile)
 }
 
-/// The `workspace:` and `catalog:` dependency versions in `manifest` (a package.json, parsed as `json`), each with the
-/// version `bun pm pack` writes into the tarball in its place.
+/// The `workspace:` and `catalog:` versions in `manifest` (parsed as `json`), each with what `bun pm pack` publishes for it.
 fn protocol_versions(
     manifest: &[u8],
     json: &bun_js_parser::Expr,
@@ -811,10 +808,7 @@ fn protocol_versions(
     versions
 }
 
-/// Replaces the `workspace:` and `catalog:` versions in a folder's package.json with the ones `bun pm pack` publishes,
-/// so a workspace package compares equal to its published copy. The rest of the file stays as written. So does a
-/// version that `other`, the folder on the other side, spells the same way: the two already compare equal, and maybe
-/// only one of them has a lockfile that resolves it (two checkouts of one package).
+/// Writes the published versions into `tree`'s package.json. `other` holds the versions of the folder on the other side.
 fn publish_versions(tree: &mut Tree, other: &[ProtocolVersion]) {
     let Some(manifest) = tree.files.get_mut(b"package.json".as_slice()) else {
         return;
@@ -822,6 +816,7 @@ fn publish_versions(tree: &mut Tree, other: &[ProtocolVersion]) {
     let mut edits: Vec<(&core::ops::Range<usize>, &[u8])> = tree
         .protocol_versions
         .iter()
+        // A version both folders spell the same way already compares equal, and maybe only one folder's lockfile resolves it.
         .filter(|v| {
             !other
                 .iter()

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -719,7 +719,11 @@ fn lockfile_for<'a>(
     manifest: &[u8],
 ) -> Option<&'a Lockfile> {
     use bun_paths::resolve_path::{join_abs_string_buf, platform};
-    if !strings::contains(manifest, b"workspace:") && !strings::contains(manifest, b"catalog:") {
+    // A JSON escape can spell either protocol, so a manifest with a backslash in it loads the lockfile too.
+    if !strings::contains(manifest, b"workspace:")
+        && !strings::contains(manifest, b"catalog:")
+        && !strings::contains_char(manifest, b'\\')
+    {
         return None;
     }
     let (mut dir_buf, mut buf) = (
@@ -767,6 +771,17 @@ fn lockfile_for<'a>(
     listed.then_some(lockfile)
 }
 
+/// Whether `token`, a JSON string with its quotes, decodes to `value`. `"workspace:\u005e"` reads as `workspace:^`.
+fn json_string_reads_as(token: &[u8], value: &[u8]) -> bool {
+    let bump = Bump::new();
+    bun_parsers::json::parse_utf8(
+        &bun_ast::Source::init_path_string(b"package.json", token),
+        &mut bun_ast::Log::init(),
+        &bump,
+    )
+    .is_ok_and(|string| string.as_utf8_string_literal() == Some(value))
+}
+
 /// `manifest` (a package.json, parsed as `json`) with its `workspace:` and `catalog:` versions as `bun pm pack` publishes them.
 fn with_published_versions(
     manifest: Vec<u8>,
@@ -798,10 +813,10 @@ fn with_published_versions(
             else {
                 continue;
             };
-            // Only a token that reads exactly as the value the parser gave is replaced.
+            // Only a token that reads as the value the parser gave is replaced.
             let token = usize::try_from(version.loc.start).ok().and_then(|at| {
                 let end = bun_parsers::json::skip_string_token(&manifest, at)?;
-                (manifest[at + 1..end - 1] == *spec).then_some((at, end))
+                json_string_reads_as(&manifest[at..end], spec).then_some((at, end))
             });
             if let Some((at, end)) = token {
                 edits.push((at, end, published));

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -15,7 +15,7 @@ use bun_install::dependency;
 use bun_install::lockfile::LoadResult;
 use bun_install::lockfile::package::PackageColumns as _;
 use bun_install::npm::{self, PackageManifest};
-use bun_install::{PackageManager, resolution};
+use bun_install::{Lockfile, PackageManager, resolution};
 use bun_libarchive::lib::{ArchiveIterator, IteratorResult as ArchiveIterResult};
 use bun_semver as Semver;
 use bun_sys::{Fd, FdExt as _, dir_iterator as DirIterator};
@@ -480,7 +480,7 @@ fn materialize(pm: &mut PackageManager, spec: &Spec) -> Result<Tree, crate::Erro
             read_tarball_into(&bytes, &mut tree)?;
             Ok(tree)
         }
-        Spec::Dir(path) => read_dir_tree(path),
+        Spec::Dir(path) => read_dir_tree(pm, path),
     }
 }
 
@@ -541,7 +541,7 @@ fn read_tarball_into(bytes: &[u8], tree: &mut Tree) -> Result<(), crate::Error> 
     Ok(())
 }
 
-fn read_dir_tree(root: &[u8]) -> Result<Tree, crate::Error> {
+fn read_dir_tree(pm: &mut PackageManager, root: &[u8]) -> Result<Tree, crate::Error> {
     let mut tree = Tree {
         label: root.to_vec(),
         files: BTreeMap::new(),
@@ -569,6 +569,9 @@ fn read_dir_tree(root: &[u8]) -> Result<Tree, crate::Error> {
     // bins — not the whole checkout with its vendor/ and build/.
     'package: {
         if let Ok(pkg) = bun_sys::File::read_from(root_fd, b"package.json") {
+            // Before the parse below: loading a lockfile resets the AST store that parse allocates from.
+            let mut lockfile = Lockfile::default();
+            let lockfile = project_lockfile(pm, &mut lockfile, root, &pkg);
             let bump = Bump::new();
             let src: &[u8] = bump.alloc_slice_copy(&pkg);
             if let Ok(json) = bun_parsers::json::parse_utf8(
@@ -613,7 +616,10 @@ fn read_dir_tree(root: &[u8]) -> Result<Tree, crate::Error> {
                         Err(err) => fail(err, rel),
                     }
                 }
-                tree.files.insert(b"package.json".to_vec(), pkg);
+                tree.files.insert(
+                    b"package.json".to_vec(),
+                    with_published_versions(pkg, &json, lockfile),
+                );
                 root_fd.close();
                 return Ok(tree);
             }
@@ -692,6 +698,114 @@ fn read_dir_tree(root: &[u8]) -> Result<Tree, crate::Error> {
         dir.close();
     }
     Ok(tree)
+}
+
+/// This project's lockfile, loaded into `lockfile`, when `manifest` (the package.json of `dir`) has `workspace:` or
+/// `catalog:` versions and `bun pm pack` run in `dir` would resolve them from it: `dir` is the package the command
+/// was run in, the project root, or a workspace the lockfile lists. Any other folder keeps its versions as written,
+/// so a workspace here that happens to share a name never stands in for one of its own.
+fn project_lockfile<'a>(
+    pm: &mut PackageManager,
+    lockfile: &'a mut Lockfile,
+    dir: &[u8],
+    manifest: &[u8],
+) -> Option<&'a Lockfile> {
+    use bun_paths::resolve_path::{join_abs_string_buf, platform};
+    if !strings::contains(manifest, b"workspace:") && !strings::contains(manifest, b"catalog:") {
+        return None;
+    }
+    let loaded = matches!(
+        lockfile.load_from_cwd::<false>(Some(&mut *pm), &mut bun_ast::Log::init()),
+        LoadResult::Ok(_)
+    );
+    if !loaded {
+        return None;
+    }
+    let lockfile = &*lockfile;
+    // Every path compared goes through the same join, so `./packages/a/` and `packages/a` are one folder.
+    fn absolute<'b>(top_level_dir: &'b [u8], buf: &'b mut [u8], path: &[u8]) -> &'b [u8] {
+        strings::without_trailing_slash(join_abs_string_buf::<platform::Auto>(
+            top_level_dir,
+            buf,
+            &[path],
+        ))
+    }
+    let top_level_dir = bun_resolver::fs::FileSystem::instance().top_level_dir();
+    let (mut dir_buf, mut buf) = (
+        bun_paths::path_buffer_pool::get(),
+        bun_paths::path_buffer_pool::get(),
+    );
+    let dir = absolute(top_level_dir, &mut dir_buf[..], dir);
+    let mut is_dir = |path: &[u8]| absolute(top_level_dir, &mut buf[..], path) == dir;
+    let string_buf = lockfile.buffers.string_bytes.as_slice();
+    let covered = is_dir(b"")
+        || bun_paths::dirname(pm.original_package_json_path.as_bytes()).is_some_and(&mut is_dir)
+        || lockfile.packages.items_resolution().iter().any(|res| {
+            res.tag == resolution::Tag::Workspace && is_dir(res.workspace().slice(string_buf))
+        });
+    covered.then_some(lockfile)
+}
+
+/// `manifest` (a package.json, parsed as `json`) with each `workspace:` and `catalog:` dependency version replaced by
+/// the one `bun pm pack` writes into the tarball, so a workspace package compares equal to its published copy. The
+/// rest of the file stays as written, and so does a version that does not resolve (pack refuses those).
+fn with_published_versions(
+    manifest: Vec<u8>,
+    json: &bun_js_parser::Expr,
+    lockfile: Option<&Lockfile>,
+) -> Vec<u8> {
+    // The string token of each version to replace (its start and end in `manifest`), and what replaces it.
+    let mut edits: Vec<(usize, usize, Vec<u8>)> = Vec::new();
+    for section in bun_install_types::DependencyGroup::FOUR {
+        let Some(section) = json.get_object(section.prop) else {
+            continue;
+        };
+        let Some(dependencies) = section.data.e_object() else {
+            continue;
+        };
+        for dependency in dependencies.properties.slice() {
+            let (Some(name), Some(version)) = (&dependency.key, &dependency.value) else {
+                continue;
+            };
+            let (Some(name), Some(spec)) = (
+                name.as_utf8_string_literal(),
+                version.as_utf8_string_literal(),
+            ) else {
+                continue;
+            };
+            let Some(Ok(published)) =
+                crate::cli::pack_command::published_version(lockfile, name, spec)
+            else {
+                continue;
+            };
+            // Only a token that reads exactly as the value the parser gave is replaced.
+            let token = usize::try_from(version.loc.start).ok().and_then(|at| {
+                let end = bun_parsers::json::skip_string_token(&manifest, at)?;
+                (manifest[at + 1..end - 1] == *spec).then_some((at, end))
+            });
+            if let Some((at, end)) = token {
+                edits.push((at, end, published));
+            }
+        }
+    }
+    if edits.is_empty() {
+        return manifest;
+    }
+    edits.sort_unstable_by_key(|&(at, ..)| at);
+    edits.dedup_by_key(|&mut (at, ..)| at);
+    let mut out: Vec<u8> = Vec::with_capacity(manifest.len());
+    let mut copied = 0usize;
+    for (at, end, published) in &edits {
+        out.extend_from_slice(&manifest[copied..*at]);
+        let _ = write!(
+            out,
+            "{}",
+            bun_core::fmt::format_json_string_utf8(published, Default::default())
+        );
+        copied = *end;
+    }
+    out.extend_from_slice(&manifest[copied..]);
+    out
 }
 
 /// Fetches `name`'s manifest, resolves `version` (exact, range, or dist-tag), downloads that tarball and unpacks it in memory.

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -712,7 +712,7 @@ fn read_dir_tree(root: &[u8], as_published: bool) -> Result<Tree, crate::Error> 
     Ok(tree)
 }
 
-/// The lockfile `bun pm pack` reads in `dir`: the first one above it when that lists `dir` as a workspace, else `dir`'s own.
+/// The lockfile `bun pm pack` reads in `dir`: the nearest one above it that lists `dir` as a workspace, else `dir`'s own.
 fn lockfile_for<'a>(
     lockfile: &'a mut Lockfile,
     dir: &[u8],
@@ -747,7 +747,7 @@ fn lockfile_for<'a>(
         &mut dir_buf[..],
         &[b"."],
     ));
-    // A workspace is packed from its project's root, so a lockfile in the workspace's own folder does not count.
+    // A workspace is packed from its project's root, so only a lockfile above `dir` that lists it counts here.
     let mut root = dir;
     let mut is_workspace = false;
     while let Some(parent) = bun_paths::dirname(root)
@@ -755,20 +755,21 @@ fn lockfile_for<'a>(
         .filter(|parent| parent.len() < root.len())
     {
         root = parent;
-        let Some(loaded) = load(lockfile, root) else {
+        if load(lockfile, root) != Some(true) {
             continue;
-        };
+        }
         let string_buf = lockfile.buffers.string_bytes.as_slice();
-        is_workspace = loaded
-            && lockfile.packages.items_resolution().iter().any(|res| {
-                res.tag == resolution::Tag::Workspace
-                    && strings::without_trailing_slash(join_abs_string_buf::<platform::Auto>(
-                        root,
-                        &mut buf[..],
-                        &[res.workspace().slice(string_buf)],
-                    )) == dir
-            });
-        break;
+        is_workspace = lockfile.packages.items_resolution().iter().any(|res| {
+            res.tag == resolution::Tag::Workspace
+                && strings::without_trailing_slash(join_abs_string_buf::<platform::Auto>(
+                    root,
+                    &mut buf[..],
+                    &[res.workspace().slice(string_buf)],
+                )) == dir
+        });
+        if is_workspace {
+            break;
+        }
     }
     (is_workspace || load(lockfile, dir) == Some(true)).then_some(&*lockfile)
 }

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -712,7 +712,7 @@ fn read_dir_tree(root: &[u8], as_published: bool) -> Result<Tree, crate::Error> 
     Ok(tree)
 }
 
-/// The lockfile `bun pm pack` reads in `dir`: the nearest one at or above it, if `dir` is that project's root or a workspace in it.
+/// The lockfile `bun pm pack` reads in `dir`: the first one above it when that lists `dir` as a workspace, else `dir`'s own.
 fn lockfile_for<'a>(
     lockfile: &'a mut Lockfile,
     dir: &[u8],
@@ -726,6 +726,17 @@ fn lockfile_for<'a>(
     {
         return None;
     }
+    // `Some(true)`: loaded. `Some(false)`: there is one, and it does not load. `None`: there is none.
+    fn load(lockfile: &mut Lockfile, dir: &[u8]) -> Option<bool> {
+        let fd = bun_sys::open_dir_at(Fd::cwd(), dir).ok()?;
+        let loaded = match lockfile.load_from_dir::<false>(fd, None, &mut bun_ast::Log::init()) {
+            LoadResult::Ok(_) => Some(true),
+            LoadResult::NotFound => None,
+            LoadResult::Err(_) => Some(false),
+        };
+        fd.close();
+        loaded
+    }
     let (mut dir_buf, mut buf) = (
         bun_paths::path_buffer_pool::get(),
         bun_paths::path_buffer_pool::get(),
@@ -736,39 +747,30 @@ fn lockfile_for<'a>(
         &mut dir_buf[..],
         &[b"."],
     ));
+    // A workspace is packed from its project's root, so a lockfile in the workspace's own folder does not count.
     let mut root = dir;
-    loop {
-        let fd = bun_sys::open_dir_at(Fd::cwd(), root).ok()?;
-        let found = match lockfile.load_from_dir::<false>(fd, None, &mut bun_ast::Log::init()) {
-            LoadResult::Ok(_) => Some(true),
-            LoadResult::NotFound => None,
-            LoadResult::Err(_) => Some(false),
+    let mut is_workspace = false;
+    while let Some(parent) = bun_paths::dirname(root)
+        .map(strings::without_trailing_slash)
+        .filter(|parent| parent.len() < root.len())
+    {
+        root = parent;
+        let Some(loaded) = load(lockfile, root) else {
+            continue;
         };
-        fd.close();
-        match found {
-            Some(true) => break,
-            Some(false) => return None,
-            None => {
-                let parent = strings::without_trailing_slash(bun_paths::dirname(root)?);
-                if parent.len() >= root.len() {
-                    return None;
-                }
-                root = parent;
-            }
-        }
+        let string_buf = lockfile.buffers.string_bytes.as_slice();
+        is_workspace = loaded
+            && lockfile.packages.items_resolution().iter().any(|res| {
+                res.tag == resolution::Tag::Workspace
+                    && strings::without_trailing_slash(join_abs_string_buf::<platform::Auto>(
+                        root,
+                        &mut buf[..],
+                        &[res.workspace().slice(string_buf)],
+                    )) == dir
+            });
+        break;
     }
-    let lockfile = &*lockfile;
-    let string_buf = lockfile.buffers.string_bytes.as_slice();
-    let listed = root == dir
-        || lockfile.packages.items_resolution().iter().any(|res| {
-            res.tag == resolution::Tag::Workspace
-                && strings::without_trailing_slash(join_abs_string_buf::<platform::Auto>(
-                    root,
-                    &mut buf[..],
-                    &[res.workspace().slice(string_buf)],
-                )) == dir
-        });
-    listed.then_some(lockfile)
+    (is_workspace || load(lockfile, dir) == Some(true)).then_some(&*lockfile)
 }
 
 /// Whether `token`, a JSON string with its quotes, decodes to `value`. `"workspace:\u005e"` reads as `workspace:^`.

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -57,6 +57,21 @@ struct Tree {
     files: BTreeMap<Vec<u8>, Vec<u8>>,
     /// Permission bits per path (0o755…), when the source records them.
     modes: BTreeMap<Vec<u8>, u32>,
+    /// For a folder: the dependency versions in its package.json that use `workspace:` or `catalog:`.
+    protocol_versions: Vec<ProtocolVersion>,
+}
+
+/// A dependency version in a folder's package.json that `bun pm pack` replaces before it writes the tarball.
+struct ProtocolVersion {
+    /// `dependencies`, `devDependencies`, …
+    section: &'static [u8],
+    name: Vec<u8>,
+    /// The version as written, e.g. `workspace:^`.
+    spec: Vec<u8>,
+    /// Its string token, quotes included, in the package.json bytes.
+    token: core::ops::Range<usize>,
+    /// The version pack writes in its place. `None` when it does not resolve (pack refuses those).
+    published: Option<Vec<u8>>,
 }
 
 /// `original_cwd` is the folder the user ran the command from; inside a workspace the manager has since `chdir`ed
@@ -136,6 +151,8 @@ pub(crate) fn exec(
         Some(tree) => tree,
         None => materialize(pm, &left_spec)?,
     };
+    publish_versions(&mut left, &right.protocol_versions);
+    publish_versions(&mut right, &left.protocol_versions);
     // Show local paths the way they were typed, not as resolved against the invoking folder.
     for (tree, spec) in [(&mut left, &left_spec), (&mut right, &right_spec)] {
         if let Spec::Dir(p) | Spec::Tarball(p) = spec {
@@ -476,6 +493,7 @@ fn materialize(pm: &mut PackageManager, spec: &Spec) -> Result<Tree, crate::Erro
                 label: path.clone(),
                 files: BTreeMap::new(),
                 modes: BTreeMap::new(),
+                protocol_versions: Vec::new(),
             };
             read_tarball_into(&bytes, &mut tree)?;
             Ok(tree)
@@ -546,6 +564,7 @@ fn read_dir_tree(pm: &mut PackageManager, root: &[u8]) -> Result<Tree, crate::Er
         label: root.to_vec(),
         files: BTreeMap::new(),
         modes: BTreeMap::new(),
+        protocol_versions: Vec::new(),
     };
     let root_fd = match bun_sys::open_dir_at(Fd::cwd(), root) {
         Ok(fd) => fd,
@@ -616,10 +635,8 @@ fn read_dir_tree(pm: &mut PackageManager, root: &[u8]) -> Result<Tree, crate::Er
                         Err(err) => fail(err, rel),
                     }
                 }
-                tree.files.insert(
-                    b"package.json".to_vec(),
-                    with_published_versions(pkg, &json, lockfile),
-                );
+                tree.protocol_versions = protocol_versions(&pkg, &json, lockfile);
+                tree.files.insert(b"package.json".to_vec(), pkg);
                 root_fd.close();
                 return Ok(tree);
             }
@@ -701,9 +718,9 @@ fn read_dir_tree(pm: &mut PackageManager, root: &[u8]) -> Result<Tree, crate::Er
 }
 
 /// This project's lockfile, loaded into `lockfile`, when `manifest` (the package.json of `dir`) has `workspace:` or
-/// `catalog:` versions and `bun pm pack` run in `dir` would resolve them from it: `dir` is the package the command
-/// was run in, the project root, or a workspace the lockfile lists. Any other folder keeps its versions as written,
-/// so a workspace here that happens to share a name never stands in for one of its own.
+/// `catalog:` versions and `dir` is a folder whose `bun pm pack` reads that lockfile: the package the command was
+/// run in, the project root, or a workspace the lockfile lists. Any other folder keeps its versions as written, so
+/// a workspace here that happens to share a name never stands in for one of its own.
 fn project_lockfile<'a>(
     pm: &mut PackageManager,
     lockfile: &'a mut Lockfile,
@@ -746,21 +763,19 @@ fn project_lockfile<'a>(
     covered.then_some(lockfile)
 }
 
-/// `manifest` (a package.json, parsed as `json`) with each `workspace:` and `catalog:` dependency version replaced by
-/// the one `bun pm pack` writes into the tarball, so a workspace package compares equal to its published copy. The
-/// rest of the file stays as written, and so does a version that does not resolve (pack refuses those).
-fn with_published_versions(
-    manifest: Vec<u8>,
+/// The `workspace:` and `catalog:` dependency versions in `manifest` (a package.json, parsed as `json`), each with the
+/// version `bun pm pack` writes into the tarball in its place.
+fn protocol_versions(
+    manifest: &[u8],
     json: &bun_js_parser::Expr,
     lockfile: Option<&Lockfile>,
-) -> Vec<u8> {
-    // The string token of each version to replace (its start and end in `manifest`), and what replaces it.
-    let mut edits: Vec<(usize, usize, Vec<u8>)> = Vec::new();
+) -> Vec<ProtocolVersion> {
+    let mut versions: Vec<ProtocolVersion> = Vec::new();
     for section in bun_install_types::DependencyGroup::FOUR {
-        let Some(section) = json.get_object(section.prop) else {
+        let Some(dependencies) = json.get_object(section.prop) else {
             continue;
         };
-        let Some(dependencies) = section.data.e_object() else {
+        let Some(dependencies) = dependencies.data.e_object() else {
             continue;
         };
         for dependency in dependencies.properties.slice() {
@@ -773,39 +788,65 @@ fn with_published_versions(
             ) else {
                 continue;
             };
-            let Some(Ok(published)) =
-                crate::cli::pack_command::published_version(lockfile, name, spec)
+            let Some(published) = crate::cli::pack_command::published_version(lockfile, name, spec)
             else {
                 continue;
             };
-            // Only a token that reads exactly as the value the parser gave is replaced.
+            // Only a token that reads exactly as the value the parser gave can be replaced.
             let token = usize::try_from(version.loc.start).ok().and_then(|at| {
-                let end = bun_parsers::json::skip_string_token(&manifest, at)?;
-                (manifest[at + 1..end - 1] == *spec).then_some((at, end))
+                let end = bun_parsers::json::skip_string_token(manifest, at)?;
+                (manifest[at + 1..end - 1] == *spec).then_some(at..end)
             });
-            if let Some((at, end)) = token {
-                edits.push((at, end, published));
+            if let Some(token) = token {
+                versions.push(ProtocolVersion {
+                    section: section.prop,
+                    name: name.to_vec(),
+                    spec: spec.to_vec(),
+                    token,
+                    published: published.ok(),
+                });
             }
         }
     }
+    versions
+}
+
+/// Replaces the `workspace:` and `catalog:` versions in a folder's package.json with the ones `bun pm pack` publishes,
+/// so a workspace package compares equal to its published copy. The rest of the file stays as written. So does a
+/// version that `other`, the folder on the other side, spells the same way: the two already compare equal, and maybe
+/// only one of them has a lockfile that resolves it (two checkouts of one package).
+fn publish_versions(tree: &mut Tree, other: &[ProtocolVersion]) {
+    let Some(manifest) = tree.files.get_mut(b"package.json".as_slice()) else {
+        return;
+    };
+    let mut edits: Vec<(&core::ops::Range<usize>, &[u8])> = tree
+        .protocol_versions
+        .iter()
+        .filter(|v| {
+            !other
+                .iter()
+                .any(|o| o.section == v.section && o.name == v.name && o.spec == v.spec)
+        })
+        .filter_map(|v| Some((&v.token, v.published.as_deref()?)))
+        .collect();
     if edits.is_empty() {
-        return manifest;
+        return;
     }
-    edits.sort_unstable_by_key(|&(at, ..)| at);
-    edits.dedup_by_key(|&mut (at, ..)| at);
+    edits.sort_unstable_by_key(|(token, _)| token.start);
+    edits.dedup_by_key(|(token, _)| token.start);
     let mut out: Vec<u8> = Vec::with_capacity(manifest.len());
     let mut copied = 0usize;
-    for (at, end, published) in &edits {
-        out.extend_from_slice(&manifest[copied..*at]);
+    for (token, published) in edits {
+        out.extend_from_slice(&manifest[copied..token.start]);
         let _ = write!(
             out,
             "{}",
             bun_core::fmt::format_json_string_utf8(published, Default::default())
         );
-        copied = *end;
+        copied = token.end;
     }
     out.extend_from_slice(&manifest[copied..]);
-    out
+    *manifest = out;
 }
 
 /// Fetches `name`'s manifest, resolves `version` (exact, range, or dist-tag), downloads that tarball and unpacks it in memory.
@@ -946,6 +987,7 @@ fn fetch_registry_tree(
         label,
         files: BTreeMap::new(),
         modes: BTreeMap::new(),
+        protocol_versions: Vec::new(),
     };
     read_tarball_into(tarball.list.as_slice(), &mut tree)?;
     Ok(tree)

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -57,21 +57,6 @@ struct Tree {
     files: BTreeMap<Vec<u8>, Vec<u8>>,
     /// Permission bits per path (0o755…), when the source records them.
     modes: BTreeMap<Vec<u8>, u32>,
-    /// For a folder: the dependency versions in its package.json that use `workspace:` or `catalog:`.
-    protocol_versions: Vec<ProtocolVersion>,
-}
-
-/// A dependency version in a folder's package.json that `bun pm pack` replaces before it writes the tarball.
-struct ProtocolVersion {
-    /// `dependencies`, `devDependencies`, …
-    section: &'static [u8],
-    name: Vec<u8>,
-    /// The version as written, e.g. `workspace:^`.
-    spec: Vec<u8>,
-    /// Its string token, quotes included, in the package.json bytes.
-    token: core::ops::Range<usize>,
-    /// The version pack writes in its place. `None` when it does not resolve (pack refuses those).
-    published: Option<Vec<u8>>,
 }
 
 /// `original_cwd` is the folder the user ran the command from; inside a workspace the manager has since `chdir`ed
@@ -116,13 +101,15 @@ pub(crate) fn exec(
         .collect();
 
     let (mut left_spec, mut right_spec) = resolve_sides(pm, &args, original_cwd);
+    // Two folders compare as written: the patch between them has to apply to the files on disk.
+    let as_published = !matches!((&left_spec, &right_spec), (Spec::Dir(_), Spec::Dir(_)));
     // `bun pm diff ./pkg` / `./pkg 2.0.0`: a registry side without a name takes it from the local side's package.json.
     let mut left_early: Option<Tree> = None;
     if let (Spec::Dir(_) | Spec::Tarball(_), Spec::Registry { name, .. }) =
         (&left_spec, &mut right_spec)
     {
         if name.is_empty() {
-            let local = materialize(pm, &left_spec)?;
+            let local = materialize(pm, &left_spec, as_published)?;
             *name = package_name_in(&local).unwrap_or_else(|| {
                 Status::clear();
                 Output::err_generic(
@@ -134,7 +121,7 @@ pub(crate) fn exec(
             left_early = Some(local);
         }
     }
-    let mut right = materialize(pm, &right_spec)?;
+    let mut right = materialize(pm, &right_spec, as_published)?;
     if let Spec::Registry { name, .. } = &mut left_spec {
         if name.is_empty() {
             *name = package_name_in(&right).unwrap_or_else(|| {
@@ -149,10 +136,8 @@ pub(crate) fn exec(
     }
     let mut left = match left_early {
         Some(tree) => tree,
-        None => materialize(pm, &left_spec)?,
+        None => materialize(pm, &left_spec, as_published)?,
     };
-    publish_versions(&mut left, &right.protocol_versions);
-    publish_versions(&mut right, &left.protocol_versions);
     // Show local paths the way they were typed, not as resolved against the invoking folder.
     for (tree, spec) in [(&mut left, &left_spec), (&mut right, &right_spec)] {
         if let Spec::Dir(p) | Spec::Tarball(p) = spec {
@@ -471,7 +456,11 @@ impl Drop for Status {
     }
 }
 
-fn materialize(pm: &mut PackageManager, spec: &Spec) -> Result<Tree, crate::Error> {
+fn materialize(
+    pm: &mut PackageManager,
+    spec: &Spec,
+    as_published: bool,
+) -> Result<Tree, crate::Error> {
     let _status = match spec {
         Spec::Registry { name, version } => {
             Status::show("fetching", &[&name[..], b"@", &version[..]].concat())
@@ -493,12 +482,11 @@ fn materialize(pm: &mut PackageManager, spec: &Spec) -> Result<Tree, crate::Erro
                 label: path.clone(),
                 files: BTreeMap::new(),
                 modes: BTreeMap::new(),
-                protocol_versions: Vec::new(),
             };
             read_tarball_into(&bytes, &mut tree)?;
             Ok(tree)
         }
-        Spec::Dir(path) => read_dir_tree(pm, path),
+        Spec::Dir(path) => read_dir_tree(path, as_published),
     }
 }
 
@@ -559,12 +547,11 @@ fn read_tarball_into(bytes: &[u8], tree: &mut Tree) -> Result<(), crate::Error> 
     Ok(())
 }
 
-fn read_dir_tree(pm: &mut PackageManager, root: &[u8]) -> Result<Tree, crate::Error> {
+fn read_dir_tree(root: &[u8], as_published: bool) -> Result<Tree, crate::Error> {
     let mut tree = Tree {
         label: root.to_vec(),
         files: BTreeMap::new(),
         modes: BTreeMap::new(),
-        protocol_versions: Vec::new(),
     };
     let root_fd = match bun_sys::open_dir_at(Fd::cwd(), root) {
         Ok(fd) => fd,
@@ -590,7 +577,11 @@ fn read_dir_tree(pm: &mut PackageManager, root: &[u8]) -> Result<Tree, crate::Er
         if let Ok(pkg) = bun_sys::File::read_from(root_fd, b"package.json") {
             // Before the parse below: loading a lockfile resets the AST store that parse allocates from.
             let mut lockfile = Lockfile::default();
-            let lockfile = project_lockfile(pm, &mut lockfile, root, &pkg);
+            let lockfile = if as_published {
+                lockfile_for(&mut lockfile, root, &pkg)
+            } else {
+                None
+            };
             let bump = Bump::new();
             let src: &[u8] = bump.alloc_slice_copy(&pkg);
             if let Ok(json) = bun_parsers::json::parse_utf8(
@@ -635,7 +626,11 @@ fn read_dir_tree(pm: &mut PackageManager, root: &[u8]) -> Result<Tree, crate::Er
                         Err(err) => fail(err, rel),
                     }
                 }
-                tree.protocol_versions = protocol_versions(&pkg, &json, lockfile);
+                let pkg = if as_published {
+                    with_published_versions(pkg, &json, lockfile)
+                } else {
+                    pkg
+                };
                 tree.files.insert(b"package.json".to_vec(), pkg);
                 root_fd.close();
                 return Ok(tree);
@@ -717,9 +712,8 @@ fn read_dir_tree(pm: &mut PackageManager, root: &[u8]) -> Result<Tree, crate::Er
     Ok(tree)
 }
 
-/// This project's lockfile, loaded into `lockfile`, when `manifest` (the package.json of `dir`) needs it and it covers `dir`.
-fn project_lockfile<'a>(
-    pm: &mut PackageManager,
+/// The lockfile `bun pm pack` reads in `dir`: the nearest one at or above it, if `dir` is that project's root or a workspace in it.
+fn lockfile_for<'a>(
     lockfile: &'a mut Lockfile,
     dir: &[u8],
     manifest: &[u8],
@@ -728,46 +722,59 @@ fn project_lockfile<'a>(
     if !strings::contains(manifest, b"workspace:") && !strings::contains(manifest, b"catalog:") {
         return None;
     }
-    let loaded = matches!(
-        lockfile.load_from_cwd::<false>(Some(&mut *pm), &mut bun_ast::Log::init()),
-        LoadResult::Ok(_)
-    );
-    if !loaded {
-        return None;
-    }
-    let lockfile = &*lockfile;
-    // Every path compared goes through the same join, so `./packages/a/` and `packages/a` are one folder.
-    fn absolute<'b>(top_level_dir: &'b [u8], buf: &'b mut [u8], path: &[u8]) -> &'b [u8] {
-        strings::without_trailing_slash(join_abs_string_buf::<platform::Auto>(
-            top_level_dir,
-            buf,
-            &[path],
-        ))
-    }
-    let top_level_dir = bun_resolver::fs::FileSystem::instance().top_level_dir();
     let (mut dir_buf, mut buf) = (
         bun_paths::path_buffer_pool::get(),
         bun_paths::path_buffer_pool::get(),
     );
-    let dir = absolute(top_level_dir, &mut dir_buf[..], dir);
-    let mut is_dir = |path: &[u8]| absolute(top_level_dir, &mut buf[..], path) == dir;
+    // Every path compared goes through the same join, so `./packages/a/` and `packages/a` are one folder.
+    let dir = strings::without_trailing_slash(join_abs_string_buf::<platform::Auto>(
+        dir,
+        &mut dir_buf[..],
+        &[],
+    ));
+    let mut root = dir;
+    loop {
+        let fd = bun_sys::open_dir_at(Fd::cwd(), root).ok()?;
+        let found = match lockfile.load_from_dir::<false>(fd, None, &mut bun_ast::Log::init()) {
+            LoadResult::Ok(_) => Some(true),
+            LoadResult::NotFound => None,
+            LoadResult::Err(_) => Some(false),
+        };
+        fd.close();
+        match found {
+            Some(true) => break,
+            Some(false) => return None,
+            None => {
+                let parent = strings::without_trailing_slash(bun_paths::dirname(root)?);
+                if parent.len() >= root.len() {
+                    return None;
+                }
+                root = parent;
+            }
+        }
+    }
+    let lockfile = &*lockfile;
     let string_buf = lockfile.buffers.string_bytes.as_slice();
-    // `bun pm pack` reads this lockfile in the invoking package, the project root and each workspace it lists. Not elsewhere.
-    let covered = is_dir(b"")
-        || bun_paths::dirname(pm.original_package_json_path.as_bytes()).is_some_and(&mut is_dir)
+    let listed = root == dir
         || lockfile.packages.items_resolution().iter().any(|res| {
-            res.tag == resolution::Tag::Workspace && is_dir(res.workspace().slice(string_buf))
+            res.tag == resolution::Tag::Workspace
+                && strings::without_trailing_slash(join_abs_string_buf::<platform::Auto>(
+                    root,
+                    &mut buf[..],
+                    &[res.workspace().slice(string_buf)],
+                )) == dir
         });
-    covered.then_some(lockfile)
+    listed.then_some(lockfile)
 }
 
-/// The `workspace:` and `catalog:` versions in `manifest` (parsed as `json`), each with what `bun pm pack` publishes for it.
-fn protocol_versions(
-    manifest: &[u8],
+/// `manifest` (a package.json, parsed as `json`) with its `workspace:` and `catalog:` versions as `bun pm pack` publishes them.
+fn with_published_versions(
+    manifest: Vec<u8>,
     json: &bun_js_parser::Expr,
     lockfile: Option<&Lockfile>,
-) -> Vec<ProtocolVersion> {
-    let mut versions: Vec<ProtocolVersion> = Vec::new();
+) -> Vec<u8> {
+    // The string token of each version to replace (its start and end in `manifest`), and what replaces it.
+    let mut edits: Vec<(usize, usize, Vec<u8>)> = Vec::new();
     for section in bun_install_types::DependencyGroup::FOUR {
         let Some(dependencies) = json.get_object(section.prop) else {
             continue;
@@ -785,63 +792,40 @@ fn protocol_versions(
             ) else {
                 continue;
             };
-            let Some(published) = crate::cli::pack_command::published_version(lockfile, name, spec)
+            // A version that does not resolve stays as written: pack refuses to publish it.
+            let Some(Ok(published)) =
+                crate::cli::pack_command::published_version(lockfile, name, spec)
             else {
                 continue;
             };
-            // Only a token that reads exactly as the value the parser gave can be replaced.
+            // Only a token that reads exactly as the value the parser gave is replaced.
             let token = usize::try_from(version.loc.start).ok().and_then(|at| {
-                let end = bun_parsers::json::skip_string_token(manifest, at)?;
-                (manifest[at + 1..end - 1] == *spec).then_some(at..end)
+                let end = bun_parsers::json::skip_string_token(&manifest, at)?;
+                (manifest[at + 1..end - 1] == *spec).then_some((at, end))
             });
-            if let Some(token) = token {
-                versions.push(ProtocolVersion {
-                    section: section.prop,
-                    name: name.to_vec(),
-                    spec: spec.to_vec(),
-                    token,
-                    published: published.ok(),
-                });
+            if let Some((at, end)) = token {
+                edits.push((at, end, published));
             }
         }
     }
-    versions
-}
-
-/// Writes the published versions into `tree`'s package.json. `other` holds the versions of the folder on the other side.
-fn publish_versions(tree: &mut Tree, other: &[ProtocolVersion]) {
-    let Some(manifest) = tree.files.get_mut(b"package.json".as_slice()) else {
-        return;
-    };
-    let mut edits: Vec<(&core::ops::Range<usize>, &[u8])> = tree
-        .protocol_versions
-        .iter()
-        // A version both folders spell the same way already compares equal, and maybe only one folder's lockfile resolves it.
-        .filter(|v| {
-            !other
-                .iter()
-                .any(|o| o.section == v.section && o.name == v.name && o.spec == v.spec)
-        })
-        .filter_map(|v| Some((&v.token, v.published.as_deref()?)))
-        .collect();
     if edits.is_empty() {
-        return;
+        return manifest;
     }
-    edits.sort_unstable_by_key(|(token, _)| token.start);
-    edits.dedup_by_key(|(token, _)| token.start);
+    edits.sort_unstable_by_key(|&(at, ..)| at);
+    edits.dedup_by_key(|&mut (at, ..)| at);
     let mut out: Vec<u8> = Vec::with_capacity(manifest.len());
     let mut copied = 0usize;
-    for (token, published) in edits {
-        out.extend_from_slice(&manifest[copied..token.start]);
+    for (at, end, published) in &edits {
+        out.extend_from_slice(&manifest[copied..*at]);
         let _ = write!(
             out,
             "{}",
             bun_core::fmt::format_json_string_utf8(published, Default::default())
         );
-        copied = token.end;
+        copied = *end;
     }
     out.extend_from_slice(&manifest[copied..]);
-    *manifest = out;
+    out
 }
 
 /// Fetches `name`'s manifest, resolves `version` (exact, range, or dist-tag), downloads that tarball and unpacks it in memory.
@@ -982,7 +966,6 @@ fn fetch_registry_tree(
         label,
         files: BTreeMap::new(),
         modes: BTreeMap::new(),
-        protocol_versions: Vec::new(),
     };
     read_tarball_into(tarball.list.as_slice(), &mut tree)?;
     Ok(tree)

--- a/test/cli/install/bun-pm-diff.test.ts
+++ b/test/cli/install/bun-pm-diff.test.ts
@@ -337,6 +337,13 @@ diffme@1.0.0 → diffme@2.0.0
       stderr: "",
       exitCode: 0,
     });
+    // An absolute path is used as typed, so this one reaches the lockfile lookup with its `..` still in it.
+    const roundabout = `${String(dir)}/packages/b/../a`;
+    expect(await diff([tgz, roundabout], join(String(dir), "vendor", "a"))).toEqual({
+      stdout: `${tgz} → ${roundabout}\nNo differences (2 files)\n`,
+      stderr: "",
+      exitCode: 0,
+    });
 
     // A folder the nearest lockfile does not list keeps what it says: `workspace:2.x` is published as `2.x`
     // anywhere, and the others are not taken from a workspace that has the same name.

--- a/test/cli/install/bun-pm-diff.test.ts
+++ b/test/cli/install/bun-pm-diff.test.ts
@@ -344,6 +344,13 @@ diffme@1.0.0 → diffme@2.0.0
       ],
     });
     expect(vendored.exitCode).toBe(0);
+
+    // Two folders that spell a version the same way compare as written, even when only one of them resolves.
+    expect(await diff(["./vendor/a", "./packages/a"], String(dir))).toEqual({
+      stdout: "./vendor/a → ./packages/a\nNo differences (2 files)\n",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 
   test("patch output marks a side that ends without a newline", async () => {

--- a/test/cli/install/bun-pm-diff.test.ts
+++ b/test/cli/install/bun-pm-diff.test.ts
@@ -272,6 +272,7 @@ diffme@1.0.0 → diffme@2.0.0
 
   test("a workspace package's workspace: and catalog: versions are compared as `bun pm pack` publishes them", async () => {
     const manifest = (pkg: object) => JSON.stringify(pkg, null, 2) + "\n";
+    // One version is spelled with a JSON escape: pack resolves what the string decodes to.
     const a = manifest({
       name: "ws-a",
       version: "1.0.0",
@@ -279,7 +280,8 @@ diffme@1.0.0 → diffme@2.0.0
       devDependencies: { "ws-c": "workspace:2.x" },
       peerDependencies: { "ws-b": "workspace:*", diffme: "catalog:legacy" },
       optionalDependencies: { "ws-d": "workspace:~" },
-    });
+    }).replace('"workspace:~"', '"workspace:\\u007e"');
+    expect(a).toContain('"ws-d": "workspace:\\u007e"');
     using dir = tempDir("pm-diff-workspace", {
       "package.json": manifest({
         name: "ws-root",

--- a/test/cli/install/bun-pm-diff.test.ts
+++ b/test/cli/install/bun-pm-diff.test.ts
@@ -294,6 +294,8 @@ diffme@1.0.0 → diffme@2.0.0
       }),
       "packages/a/package.json": a,
       "packages/a/index.js": "module.exports = 1;\n",
+      // Pack reads the lockfile of the project root, so this one must not get in the way.
+      "packages/a/bun.lock": "{ not a lockfile",
       "packages/b/package.json": manifest({ name: "ws-b", version: "1.0.1" }),
       "packages/c/package.json": manifest({ name: "ws-c", version: "2.3.4" }),
       "packages/d/package.json": manifest({ name: "ws-d", version: "3.0.0" }),

--- a/test/cli/install/bun-pm-diff.test.ts
+++ b/test/cli/install/bun-pm-diff.test.ts
@@ -317,7 +317,7 @@ diffme@1.0.0 → diffme@2.0.0
     const member = join(String(dir), "packages", "a");
     const tgz = await pack(member, join(String(dir), "out"));
 
-    // What was just packed from this folder is this folder, from inside the package and from the workspace root.
+    // The dependency versions pack just wrote are the ones this folder shows, from inside the package and from the root.
     expect(await diff([tgz, "."], member)).toEqual({
       stdout: `${tgz} → .\nNo differences (2 files)\n`,
       stderr: "",
@@ -329,8 +329,15 @@ diffme@1.0.0 → diffme@2.0.0
       exitCode: 0,
     });
 
-    // A folder this project's lockfile does not list keeps what it says: `workspace:2.x` is published as `2.x`
-    // anywhere, and the others are not taken from a workspace here that has the same name.
+    // The lockfile is the folder's own, not the one of the project the command runs in.
+    expect(await diff([tgz, "../../packages/a"], join(String(dir), "vendor", "a"))).toEqual({
+      stdout: `${tgz} → ../../packages/a\nNo differences (2 files)\n`,
+      stderr: "",
+      exitCode: 0,
+    });
+
+    // A folder the nearest lockfile does not list keeps what it says: `workspace:2.x` is published as `2.x`
+    // anywhere, and the others are not taken from a workspace that has the same name.
     const vendored = await diff([tgz, "./vendor/a", "--json"], String(dir));
     expect(vendored.stderr).toBe("");
     expect(JSON.parse(vendored.stdout)).toMatchObject({
@@ -345,7 +352,7 @@ diffme@1.0.0 → diffme@2.0.0
     });
     expect(vendored.exitCode).toBe(0);
 
-    // Two folders that spell a version the same way compare as written, even when only one of them resolves.
+    // Two folders compare as written, so the patch between them applies to the files on disk.
     expect(await diff(["./vendor/a", "./packages/a"], String(dir))).toEqual({
       stdout: "./vendor/a → ./packages/a\nNo differences (2 files)\n",
       stderr: "",

--- a/test/cli/install/bun-pm-diff.test.ts
+++ b/test/cli/install/bun-pm-diff.test.ts
@@ -270,6 +270,82 @@ diffme@1.0.0 → diffme@2.0.0
     expect(exitCode).toBe(0);
   });
 
+  test("a workspace package's workspace: and catalog: versions are compared as `bun pm pack` publishes them", async () => {
+    const manifest = (pkg: object) => JSON.stringify(pkg, null, 2) + "\n";
+    const a = manifest({
+      name: "ws-a",
+      version: "1.0.0",
+      dependencies: { "ws-b": "workspace:^", diffme: "catalog:" },
+      devDependencies: { "ws-c": "workspace:2.x" },
+      peerDependencies: { "ws-b": "workspace:*", diffme: "catalog:legacy" },
+      optionalDependencies: { "ws-d": "workspace:~" },
+    });
+    using dir = tempDir("pm-diff-workspace", {
+      "package.json": manifest({
+        name: "ws-root",
+        private: true,
+        workspaces: {
+          packages: ["packages/*"],
+          catalog: { diffme: "^1.0.0" },
+          catalogs: { legacy: { diffme: "1.0.0" } },
+        },
+      }),
+      "packages/a/package.json": a,
+      "packages/a/index.js": "module.exports = 1;\n",
+      "packages/b/package.json": manifest({ name: "ws-b", version: "1.0.1" }),
+      "packages/c/package.json": manifest({ name: "ws-c", version: "2.3.4" }),
+      "packages/d/package.json": manifest({ name: "ws-d", version: "3.0.0" }),
+      // The same files outside the `workspaces` globs: `bun pm pack` has no lockfile to resolve these from.
+      "vendor/a/package.json": a,
+      "vendor/a/index.js": "module.exports = 1;\n",
+      "out/.keep": "",
+    });
+    await using install = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...bunEnv, NPM_CONFIG_REGISTRY: registry, BUN_CONFIG_REGISTRY: registry },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, installErr, installExit] = await Promise.all([
+      install.stdout.text(),
+      install.stderr.text(),
+      install.exited,
+    ]);
+    expect(installErr).not.toContain("error:");
+    expect(installExit).toBe(0);
+    const member = join(String(dir), "packages", "a");
+    const tgz = await pack(member, join(String(dir), "out"));
+
+    // What was just packed from this folder is this folder, from inside the package and from the workspace root.
+    expect(await diff([tgz, "."], member)).toEqual({
+      stdout: `${tgz} → .\nNo differences (2 files)\n`,
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(await diff([tgz, "./packages/a/"], String(dir))).toEqual({
+      stdout: `${tgz} → ./packages/a/\nNo differences (2 files)\n`,
+      stderr: "",
+      exitCode: 0,
+    });
+
+    // A folder this project's lockfile does not list keeps what it says: `workspace:2.x` is published as `2.x`
+    // anywhere, and the others are not taken from a workspace here that has the same name.
+    const vendored = await diff([tgz, "./vendor/a", "--json"], String(dir));
+    expect(vendored.stderr).toBe("");
+    expect(JSON.parse(vendored.stdout)).toMatchObject({
+      files: [{ path: "package.json", linesAdded: 5, linesRemoved: 5 }],
+      notes: [
+        "dependencies ws-b: ^1.0.1 → workspace:^",
+        "dependencies diffme: ^1.0.0 → catalog:",
+        "optionalDependencies ws-d: ~3.0.0 → workspace:~",
+        "peerDependencies ws-b: 1.0.1 → workspace:*",
+        "peerDependencies diffme: 1.0.0 → catalog:legacy",
+      ],
+    });
+    expect(vendored.exitCode).toBe(0);
+  });
+
   test("patch output marks a side that ends without a newline", async () => {
     using dir = tempDir("pm-diff-nonl", {
       "a/package.json": `{"name":"x","version":"1.0.0"}`,

--- a/test/cli/install/bun-pm-diff.test.ts
+++ b/test/cli/install/bun-pm-diff.test.ts
@@ -294,8 +294,10 @@ diffme@1.0.0 → diffme@2.0.0
       }),
       "packages/a/package.json": a,
       "packages/a/index.js": "module.exports = 1;\n",
-      // Pack reads the lockfile of the project root, so this one must not get in the way.
+      // Pack reads the lockfile of the project root, so these two must not get in the way: one in the
+      // workspace's own folder that does not load, one between it and the root that lists nothing.
       "packages/a/bun.lock": "{ not a lockfile",
+      "packages/bun.lock": manifest({ lockfileVersion: 1, workspaces: { "": { name: "stray" } }, packages: {} }),
       "packages/b/package.json": manifest({ name: "ws-b", version: "1.0.1" }),
       "packages/c/package.json": manifest({ name: "ws-c", version: "2.3.4" }),
       "packages/d/package.json": manifest({ name: "ws-d", version: "3.0.0" }),


### PR DESCRIPTION
### Problem
- `bun pm diff` reads a local folder as `bun pm pack` would publish it, but inserts its `package.json` as the raw bytes on disk (`src/runtime/cli/pm_diff_command.rs:616`). Pack first replaces `workspace:` and `catalog:` dependency versions (`edit_root_package_json` in `pack_command.rs`).
- So a workspace package never matches its published copy. `bun pm diff pkg.tgz .` right after `bun pm pack` reports a `package.json` change and `! dependencies pmdiff-b: ^1.0.1 → workspace:^`. The default `bun pm diff` does the same.

### Fix
- The resolution moves out of `edit_root_package_json` into `published_version(lockfile, name, spec)`. Pack and `bun pm diff` both call it. Pack keeps its three error messages.
- Against a tarball or a registry version, `bun pm diff` replaces only those version string tokens in the folder's manifest. A version that does not resolve stays as written. Two folders compare as written, so the patch between them applies to the files on disk.
- The lockfile is the nearest `bun.lock` above the folder that lists it as a workspace, else the folder's own. That is the lockfile pack reads in that folder. It loads only when the manifest contains `workspace:`, `catalog:` or a JSON escape.
- Verified: `test/cli/install/bun-pm-diff.test.ts` (the new case fails on 1.4.3, passes with the debug build). Also `bun-pack.test.ts`, `bun-publish.test.ts`, `catalogs.test.ts`. Self-reviewed: 3 concerns raised, 2 addressed, 1 listed under Notes as out of scope. The four bot review comments (JSON escapes, path normalization, lockfile precedence twice) are addressed.

### Background
- `workspace:^` publishes as `^<the sibling workspace's version>`. `catalog:` publishes as the range the root `package.json` defines. Registry consumers have neither, so pack rewrites both.
- `bun.lock` records both (`lockfile.workspace_versions`, `lockfile.catalogs`).
- A lockfile load resets the thread-local AST store, so `read_dir_tree` loads the lockfile before it parses `package.json`.

<details><summary>Notes</summary>

**Repro** (1.4.3 and main):

```sh
mkdir -p /tmp/pmdiff/packages/a /tmp/pmdiff/packages/b && cd /tmp/pmdiff
echo '{"name":"root","private":true,"workspaces":["packages/*"]}' > package.json
echo '{"name":"pmdiff-a","version":"1.0.0","dependencies":{"pmdiff-b":"workspace:^"}}' > packages/a/package.json
echo 'module.exports = 1' > packages/a/index.js
echo '{"name":"pmdiff-b","version":"1.0.1"}' > packages/b/package.json
bun install
cd packages/a && bun pm pack --quiet --destination ../../out
bun pm diff ../../out/pmdiff-a-1.0.0.tgz .
#   ! dependencies pmdiff-b: ^1.0.1 → workspace:^
```

**Scope: dependency versions only.** This PR makes the two commands share one resolver for dependency versions. It does not make pack-then-diff empty in every case. Three differences remain, and all three exist on 1.4.3:
- Pack re-prints `package.json` (guessed indentation, expanded objects, decoded escapes). A minified or hand-formatted manifest still shows as `formatting only` on a terminal, and as a hunk in piped or `--raw` output, against its own tarball. Two existing tests rely on a local manifest being compared as written: `a reformat-only release collapses to 'formatting only'` and `--json is one stable document`. So this PR changes only the version tokens. A manifest in the printer's own format (2-space `JSON.stringify`) prints `No differences`.
- Pack sets the executable bits on `bin` files in the tarball (`add_archive_entry`). The folder side keeps the mode on disk, so a `bin` file that is `0644` on disk shows `old mode 100755 / new mode 100644`.
- Pack adds the files of `bundledDependencies`. The folder side does not, so they show as removed.

**How a token is replaced.** The JSON parser records the offset of each value. `with_published_versions` takes the string token at that offset, decodes it, checks that it is the value the parser returned, and writes the JSON-quoted published version in its place. A version spelled with a JSON escape (`"workspace:\u005e"`) resolves too, as in pack (52c0511988). A token that does not decode to the value stays as written.

**Two folders.** The first commit converted every folder. With two folders of which only one resolved (a second checkout, a git worktree), identical folders showed `! dependencies ws-b: workspace:^ → ^1.0.1`, and 1.4.3 prints `No differences`. 9b4a2c5985 tried a rule per dependency (skip a version that both folders spell the same way). Review showed that it mixes published and written versions in one hunk, so `bun pm diff ./old/a ./packages/a > changes.patch` no longer reproduced the right folder. 00d19c1fe8 replaces it: two folders compare as written, exactly as in 1.4.3. An extracted tarball against the source folder therefore still shows `^1.0.1 → workspace:^`, as on 1.4.3. Use the tarball itself for that comparison.

**Which lockfile.** `lockfile_for` walks up from the folder's parent and takes the nearest `bun.lock` or `bun.lockb` that lists the folder as a workspace. It goes past a lockfile that does not load or does not list the folder. When no lockfile above lists the folder, it uses the folder's own lockfile (the folder is a project root). A stray or broken `bun.lock` inside a workspace folder, or between it and the root, therefore does not shadow the project's, as in pack (a7dcd02fac, 0ea16f59d7). The result does not depend on the folder the command runs in: `cd /tmp && bun pm diff pkg.tgz /abs/path/packages/a` prints `No differences`. A folder that the nearest lockfile does not list (a vendored copy, a new workspace before `bun install`) keeps `workspace:^` as written. `workspace:1.x` becomes `1.x` in any folder, because pack needs no lockfile for it. A symlink that points at a member from outside the project stays as written, because the walk starts from the path as given.

**Known limit: a stale `bun.lock`.** "A workspace it lists" trusts the lockfile, not the root `workspaces` globs. If the root `package.json` stops matching `packages/a` and `bun install` has not run since, `bun pm diff pkg.tgz ./packages/a` still resolves `workspace:^`, while `bun pm pack` in `packages/a` fails. One `bun install` clears that state.

**Cases checked by hand with the debug build (00d19c1fe8):** the member from inside (`.`), from the root (`./packages/a/`), from a sibling (`../a`), from `/tmp` with no project, from another project, the project root itself, a folder outside the `workspaces` globs, a symlinked path, a clone against the project, an extracted tarball against the source folder, two members with different spellings (`workspace:^ → workspace:~`). Checked on earlier commits and unchanged by the later ones: no lockfile, a corrupt lockfile (both stay as written, exit 0), a manifest with a BOM, a CRLF manifest, a key equal to its value (`"workspace:^": "workspace:^"`). On 52c0511988: a manifest with no literal `workspace:` text (all four spelled `work\u0073pace:`). On 8ab8d69fc2: absolute paths that are not normalized (`/proj/packages/b/../a`, `/proj//packages/./a/`, the root as `/proj/packages/../`).

**Pack behaviour is unchanged.** `published_version` holds the same rules in the same order: a bare `^`, `~` or `*` takes the workspace's version from `lockfile.workspace_versions`, any other `workspace:` range is published as written, `catalog:` reads `lockfile.catalogs`. The three error messages keep their text. `bun-pack.test.ts` (86), `catalogs.test.ts` (89) and `bun-publish.test.ts` (46) pass.

**Platforms.** The new test passed on Windows x64 with the first commit's code. The later commits ran on Linux x64 only on my side (`bun-pm-diff.test.ts`: 47 pass, 1 skip). CI is green on 0ea16f59d7 on all lanes, Windows included (build 114565).

**Related:** #38813 changes where pack reads these versions from (the `package.json` files, not `bun.lock`). `published_version` is then the one place to switch for both commands.

</details>
