### PR TITLE
node:module: accept any `this` in Module.prototype.require

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -294,6 +294,15 @@ declare function $evaluateCommonJSModule(
   sourceModule: JSCommonJSModule,
 ): JSCommonJSModule[];
 declare function $evictIsolationSourceProviderCache(key?: string): void;
+/** Loads `id` into `mod`. Returns -1 when the module is ESM and has to come from the ESM registry. */
+declare function $requireCommonJS(
+  id: string,
+  mod: JSCommonJSModule,
+  parentFilename: unknown,
+  userArgumentCount: number,
+  userOptions: unknown,
+): LoaderModule | -1;
+declare function $requireNativeModule(id: string): any;
 
 declare function $overridableRequire(this: JSCommonJSModule, id: string): any;
 

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -157,6 +157,7 @@ using namespace JSC;
     macro(relative) \
     macro(removeAbortAlgorithmFromSignal) \
     macro(require) \
+    macro(requireCommonJS) \
     macro(requireESM) \
     macro(requireMap) \
     macro(requireNativeModule) \

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -13,11 +13,7 @@ export function require(this: JSCommonJSModule, _: string) {
 }
 
 // overridableRequire can be overridden by setting `Module.prototype.require`
-//
-// It is also the value of `Module.prototype.require`, so user code can call it
-// with any `this`, including null. Like Node, `this` is only the parent of the
-// loaded module, so do not look up loader internals on it:
-// https://github.com/nodejs/node/blob/b7e6a5d37e7a14ef0f2cc95214b95d66c4081415/lib/internal/modules/cjs/loader.js#L1611-L1623
+// As in Node, `this` is only the parent and can be any value, even null: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/modules/cjs/loader.js#L1611
 $overriddenName = "require";
 $visibility = "Private";
 export function overridableRequire(this: JSCommonJSModule, originalId: string, options?: { paths?: string[] }) {

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -13,10 +13,17 @@ export function require(this: JSCommonJSModule, _: string) {
 }
 
 // overridableRequire can be overridden by setting `Module.prototype.require`
+//
+// It is also the value of `Module.prototype.require`, so user code can call it
+// with any `this`, including null. Like Node, `this` is only the parent of the
+// loaded module, so do not look up loader internals on it:
+// https://github.com/nodejs/node/blob/b7e6a5d37e7a14ef0f2cc95214b95d66c4081415/lib/internal/modules/cjs/loader.js#L1611-L1623
 $overriddenName = "require";
 $visibility = "Private";
 export function overridableRequire(this: JSCommonJSModule, originalId: string, options?: { paths?: string[] }) {
-  const id = $resolveSync(originalId, this.filename, false, false, options ? options.paths : undefined, this, options);
+  // Read once, before the module enters $requireMap: `filename` can be a user getter.
+  const parentFilename = this?.filename;
+  const id = $resolveSync(originalId, parentFilename, false, false, options ? options.paths : undefined, this, options);
   if (id.startsWith("node:")) {
     if (id !== originalId) {
       // A terrible special case where Node.js allows non-prefixed built-ins to
@@ -31,7 +38,7 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
       }
     }
 
-    return this.$requireNativeModule(id);
+    return $requireNativeModule(id);
   } else {
     const existing = $requireMap.$get(id);
     if (existing) {
@@ -68,7 +75,7 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
   }
 
   if (id === "bun:test") {
-    return Bun.jest(this.filename);
+    return Bun.jest(parentFilename);
   }
 
   // To handle import/export cycles, we need to create a module object and put
@@ -87,9 +94,10 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
   if (IS_BUN_DEVELOPMENT) {
     $assert(mod.id === id);
     try {
-      out = this.$require(
+      out = $requireCommonJS(
         id,
         mod,
+        parentFilename,
         // did they pass a { type } object?
         $argumentCount(),
         // the object containing a "type" attribute, if they passed one
@@ -101,7 +109,7 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
       throw E;
     }
   } else {
-    out = this.$require(id, mod, $argumentCount(), $argument(1));
+    out = $requireCommonJS(id, mod, parentFilename, $argumentCount(), $argument(1));
   }
 
   // -1 means we need to lookup the module from the ESM registry.

--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -67,8 +67,6 @@ declare interface Error {
 }
 
 interface JSCommonJSModule {
-  $require(id: string, mod: any, args_count: number, args: Array): any;
-  $requireNativeModule(id: string): any;
   children: JSCommonJSModule[];
   exports: any;
   id: string;

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -86,9 +86,6 @@
 namespace Bun {
 using namespace JSC;
 
-JSC_DECLARE_HOST_FUNCTION(jsFunctionRequireCommonJS);
-JSC_DECLARE_HOST_FUNCTION(jsFunctionRequireNativeModule);
-
 static bool canPerformFastEnumeration(Structure* s)
 {
     if (s->typeInfo().overridesGetOwnPropertySlot())
@@ -841,19 +838,6 @@ public:
         Base::finishCreation(vm);
         ASSERT(inherits(info()));
         Bun::reifyStaticPropertyTable(vm, info(), JSCommonJSModulePrototypeTableValues, *this);
-
-        this->putDirectNativeFunction(
-            vm,
-            globalObject,
-            clientData(vm)->builtinNames().requirePrivateName(),
-            2,
-            jsFunctionRequireCommonJS, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete);
-        this->putDirectNativeFunction(
-            vm,
-            globalObject,
-            clientData(vm)->builtinNames().requireNativeModulePrivateName(),
-            0,
-            jsFunctionRequireNativeModule, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete);
     }
 };
 
@@ -1300,23 +1284,22 @@ ALWAYS_INLINE EncodedJSValue finishRequireWithError(Zig::GlobalObject* globalObj
     if (throwScope.exception()) [[unlikely]] \
     return finishRequireWithError(globalObject, throwScope, specifierValue)
 
-// JSCommonJSModule.$require(resolvedId, newModule, userArgumentCount, userOptions)
+// $requireCommonJS(resolvedId, newModule, parentFilename, userArgumentCount, userOptions)
+//
+// The parent is the `this` of `Module.prototype.require`, which can be any value, so this
+// function takes the filename and not the parent.
 JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireCommonJS, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
 {
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    ASSERT(callframe->argumentCount() == 4);
-    // If overriddenRequire is called with invalid this, execution could potentially reach here.
-    JSCommonJSModule* referrerModule = dynamicDowncast<JSCommonJSModule>(callframe->thisValue());
-    if (!referrerModule)
-        return throwVMTypeError(globalObject, throwScope);
+    ASSERT(callframe->argumentCount() == 5);
     JSValue specifierValue = callframe->uncheckedArgument(0);
     // If Module._resolveFilename is overridden, this could cause this to be a non-string
     WTF::String specifier = specifierValue.toWTFString(globalObject);
     REQUIRE_CJS_RETURN_IF_EXCEPTION;
     // If this.filename is overridden, this could cause this to be a non-string
-    WTF::String referrer = referrerModule->filename().toWTFString(globalObject);
+    WTF::String referrer = callframe->uncheckedArgument(2).toWTFString(globalObject);
     REQUIRE_CJS_RETURN_IF_EXCEPTION;
 
     // This is always a new JSCommonJSModule object; cast cannot fail.
@@ -1329,10 +1312,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireCommonJS, (JSGlobalObject * lexicalGlo
     // We need to be able to wire in the "type" import attribute from bundled code..
     // So we do it via CommonJS require().
     // $argumentCount() always returns a Int32 JSValue
-    int32_t userArgumentCount = callframe->argument(2).asInt32();
+    int32_t userArgumentCount = callframe->argument(3).asInt32();
     // If they called require(id), skip the check for the type attribute
     if (userArgumentCount >= 2) [[unlikely]] {
-        JSValue options = callframe->uncheckedArgument(3);
+        JSValue options = callframe->uncheckedArgument(4);
         if (options.isObject()) {
             JSObject* obj = options.getObject();
             // This getter is expensive and rare.
@@ -1368,10 +1351,6 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireNativeModule, (JSGlobalObject * lexica
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-
-    JSCommonJSModule* thisObject = dynamicDowncast<JSCommonJSModule>(callframe->thisValue());
-    if (!thisObject)
-        return throwVMTypeError(globalObject, throwScope);
 
     JSValue specifierValue = callframe->argument(0);
     WTF::String specifier = specifierValue.toWTFString(globalObject);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1285,9 +1285,6 @@ ALWAYS_INLINE EncodedJSValue finishRequireWithError(Zig::GlobalObject* globalObj
     return finishRequireWithError(globalObject, throwScope, specifierValue)
 
 // $requireCommonJS(resolvedId, newModule, parentFilename, userArgumentCount, userOptions)
-//
-// The parent is the `this` of `Module.prototype.require`, which can be any value, so this
-// function takes the filename and not the parent.
 JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireCommonJS, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
 {
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -799,11 +799,10 @@ public:
     using Base = JSC::JSNonFinalObject;
     static JSCommonJSModulePrototype* create(
         JSC::VM& vm,
-        JSC::JSGlobalObject* globalObject,
         JSC::Structure* structure)
     {
         JSCommonJSModulePrototype* prototype = new (NotNull, Bun::allocatePlainObjectCell(vm, sizeof(JSCommonJSModulePrototype))) JSCommonJSModulePrototype(vm, structure);
-        prototype->finishCreation(vm, globalObject);
+        prototype->finishCreation(vm);
         return prototype;
     }
 
@@ -833,7 +832,7 @@ public:
         return &vm.plainObjectSpace();
     }
 
-    void finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+    void finishCreation(JSC::VM& vm)
     {
         Base::finishCreation(vm);
         ASSERT(inherits(info()));
@@ -855,7 +854,7 @@ JSC::Structure* JSCommonJSModule::createStructure(
 {
     auto& vm = JSC::getVM(globalObject);
 
-    auto* prototype = JSCommonJSModulePrototype::create(vm, globalObject, JSCommonJSModulePrototype::createStructure(vm, globalObject, globalObject->objectPrototype()));
+    auto* prototype = JSCommonJSModulePrototype::create(vm, JSCommonJSModulePrototype::createStructure(vm, globalObject, globalObject->objectPrototype()));
 
     // Do not set the number of inline properties on this structure
     // there may be an off-by-one error in the Structure which causes `require.id` to become the require

--- a/src/jsc/bindings/JSCommonJSModule.h
+++ b/src/jsc/bindings/JSCommonJSModule.h
@@ -27,6 +27,8 @@ static constexpr ASCIILiteral commonJSDefaultWrapperEnd = "})"_s;
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionCreateCommonJSModule);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionEvaluateCommonJSModule);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionRequireCommonJS);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionRequireNativeModule);
 JSC_DECLARE_HOST_FUNCTION(functionJSCommonJSModule_compile);
 
 void populateESMExports(

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2865,6 +2865,8 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
         { BuiltinName::k_esmRegistryDelete, 1, functionEsmRegistryDelete },
         { BuiltinName::k_esmRegistryEvaluatedKeys, 0, functionEsmRegistryEvaluatedKeys },
         { BuiltinName::k_esmLoadSync, 1, functionEsmLoadSync },
+        { BuiltinName::k_requireCommonJS, 5, Bun::jsFunctionRequireCommonJS },
+        { BuiltinName::k_requireNativeModule, 1, Bun::jsFunctionRequireNativeModule },
         { BuiltinName::k_makeErrorWithCode, 2, jsFunctionMakeErrorWithCode },
         { BuiltinName::k_toClass, 1, jsFunctionToClass },
         { BuiltinName::k_inherits, 1, jsFunctionInherits },

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -766,30 +766,40 @@ console.log("survived", require("./late.js"));`,
     using dir = tempDir("module-prototype-require-this", {
       "dep.cjs": `module.exports = { name: "dep" };`,
       "sub/dep.cjs": `module.exports = { name: "sub/dep" };`,
+      "sees-parent.cjs": `module.exports = module.parent === globalThis.expectedParent;`,
       "bad.cjs": `module.exports = ;`,
+      "throws.cjs": `throw new Error("boom");`,
       "main.cjs": `
         const Module = require("node:module");
         const path = require("node:path");
         const dep = path.join(__dirname, "dep.cjs");
+        const seesParent = path.join(__dirname, "sees-parent.cjs");
         const bad = path.join(__dirname, "bad.cjs");
+        const throws = path.join(__dirname, "throws.cjs");
         const anchor = path.join(__dirname, "sub", "anchor.cjs");
 
-        function load(parent, request) {
+        function attempt(fn) {
           try {
-            return Module.prototype.require.call(parent, request);
+            return fn();
           } catch (e) {
             return "threw " + e.name;
           }
         }
+        const load = (parent, request) => attempt(() => Module.prototype.require.call(parent, request));
 
         const plain = { id: __filename, filename: __filename };
         const result = {};
 
         result.plainObject = load(plain, dep);
         result.cached = require.cache[dep].exports;
+        result.loaded = require.cache[dep].loaded;
         result.parentIsThis = require.cache[dep].parent === plain;
         result.requireAgain = require(dep) === result.plainObject;
         delete require.cache[dep];
+
+        // The module also sees the parent while it runs.
+        globalThis.expectedParent = plain;
+        result.parentDuringLoad = load(plain, seesParent);
 
         result.inheritsFromModule = load(Object.create(module), dep);
         delete require.cache[dep];
@@ -804,6 +814,13 @@ console.log("survived", require("./late.js"));`,
         result.undefinedThis = load(undefined, dep);
         delete require.cache[dep];
 
+        // A call with no receiver. There is no parent filename, so a relative id resolves from the cwd.
+        const unbound = Module.prototype.require;
+        result.noReceiver = attempt(() => unbound(dep));
+        delete require.cache[dep];
+        result.noReceiverRelative = attempt(() => unbound("./dep.cjs"));
+        delete require.cache[dep];
+
         result.relativeToFilename = load({ id: anchor, filename: anchor }, "./dep.cjs");
         result.builtin = load({}, "path") === path;
         result.prefixedBuiltin = load({}, "node:path") === path;
@@ -816,6 +833,15 @@ console.log("survived", require("./late.js"));`,
           threw = true;
         }
         result.failedLoad = { threw, leftInCache: bad in require.cache };
+
+        // A module that throws while it runs: the caller gets that error, not one from the loader.
+        let thrown;
+        try {
+          Module.prototype.require.call(plain, throws);
+        } catch (e) {
+          thrown = e.name + ": " + e.message;
+        }
+        result.throwingLoad = { thrown, leftInCache: throws in require.cache };
 
         console.log(JSON.stringify(result));
       `,
@@ -832,17 +858,22 @@ console.log("survived", require("./late.js"));`,
     expect(JSON.parse(stdout)).toEqual({
       plainObject: { name: "dep" },
       cached: { name: "dep" },
+      loaded: true,
       parentIsThis: true,
       requireAgain: true,
+      parentDuringLoad: true,
       inheritsFromModule: { name: "dep" },
       number: { name: "dep" },
       nullThis: { name: "dep" },
       nullParent: null,
       undefinedThis: { name: "dep" },
+      noReceiver: { name: "dep" },
+      noReceiverRelative: { name: "dep" },
       relativeToFilename: { name: "sub/dep" },
       builtin: true,
       prefixedBuiltin: true,
       failedLoad: { threw: true, leftInCache: false },
+      throwingLoad: { thrown: "Error: boom", leftInCache: false },
     });
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -760,6 +760,93 @@ console.log("survived", require("./late.js"));`,
     expect(await proc.exited).toBe(0);
   });
 
+  // Node's Module.prototype.require is `Module._load(id, this, false)`: `this` is only the parent,
+  // so it does not have to be a module, or an object at all.
+  test("Module.prototype.require accepts a `this` that is not a module", async () => {
+    using dir = tempDir("module-prototype-require-this", {
+      "dep.cjs": `module.exports = { name: "dep" };`,
+      "sub/dep.cjs": `module.exports = { name: "sub/dep" };`,
+      "bad.cjs": `module.exports = ;`,
+      "main.cjs": `
+        const Module = require("node:module");
+        const path = require("node:path");
+        const dep = path.join(__dirname, "dep.cjs");
+        const bad = path.join(__dirname, "bad.cjs");
+        const anchor = path.join(__dirname, "sub", "anchor.cjs");
+
+        function load(parent, request) {
+          try {
+            return Module.prototype.require.call(parent, request);
+          } catch (e) {
+            return "threw " + e.name;
+          }
+        }
+
+        const plain = { id: __filename, filename: __filename };
+        const result = {};
+
+        result.plainObject = load(plain, dep);
+        result.cached = require.cache[dep].exports;
+        result.parentIsThis = require.cache[dep].parent === plain;
+        result.requireAgain = require(dep) === result.plainObject;
+        delete require.cache[dep];
+
+        result.inheritsFromModule = load(Object.create(module), dep);
+        delete require.cache[dep];
+
+        result.number = load(5, dep);
+        delete require.cache[dep];
+
+        result.nullThis = load(null, dep);
+        result.nullParent = require.cache[dep]?.parent;
+        delete require.cache[dep];
+
+        result.undefinedThis = load(undefined, dep);
+        delete require.cache[dep];
+
+        result.relativeToFilename = load({ id: anchor, filename: anchor }, "./dep.cjs");
+        result.builtin = load({}, "path") === path;
+        result.prefixedBuiltin = load({}, "node:path") === path;
+
+        // A load that fails must not leave its placeholder module in require.cache.
+        let threw = false;
+        try {
+          Module.prototype.require.call(plain, bad);
+        } catch {
+          threw = true;
+        }
+        result.failedLoad = { threw, leftInCache: bad in require.cache };
+
+        console.log(JSON.stringify(result));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      plainObject: { name: "dep" },
+      cached: { name: "dep" },
+      parentIsThis: true,
+      requireAgain: true,
+      inheritsFromModule: { name: "dep" },
+      number: { name: "dep" },
+      nullThis: { name: "dep" },
+      nullParent: null,
+      undefinedThis: { name: "dep" },
+      relativeToFilename: { name: "sub/dep" },
+      builtin: true,
+      prefixedBuiltin: true,
+      failedLoad: { threw: true, leftInCache: false },
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test.each([
     "/file/name/goes/here.js",
     "file/here.js",


### PR DESCRIPTION
### Problem
- `Module.prototype.require.call({ filename: __filename }, id)` throws `TypeError: undefined is not a function` and leaves a placeholder module in `require.cache`. A later `require(id)` returns `{}` and never runs the file. A debug build prints `[overridableRequire] ASSERTION FAILED: $requireMap.$get(id) === undefined`.
- Node v26.3.0 loads the module: `this` is only the parent for `Module._load(id, this, false)`, and can be any value, also `null`.
- Cause: `overridableRequire` (`src/js/builtins/CommonJS.ts:77`) puts the placeholder in the require map, then calls `this.$require(...)` (`:104`). `$require` and `$requireNativeModule` exist only on `JSCommonJSModulePrototype`.

### Fix
- The two native functions are now private globals, `$requireCommonJS` and `$requireNativeModule`. They do not use `this`.
- `overridableRequire` reads `this?.filename` once, before the placeholder enters the map, and passes the value down. No user getter can run between the insert and the load.
- Correct because the native loader used the parent only for its filename. `$createCommonJSModule` and `$evaluateCommonJSModule` already accept any parent.
- Verified: new test in `test/js/node/module/node-module-module.test.js` (1.4.3-canary.1 gets 17 of 18 fields wrong, Node prints the expected JSON). Also `test/js/node/module/` and Node's 48 `test-require-*`/`test-module-*`/`test-cjs-*` files. Self-reviewed: 6 concerns raised, 5 addressed, 1 rejected (see Notes).

### Background
- The require map is the `Map` behind `require.cache`. `overridableRequire` puts an empty placeholder in it before the load, so require cycles resolve. A failed load must remove it.
- `overridableRequire` is the builtin behind each `require()` and the value of `Module.prototype.require`, so user code can call it with any `this`.
- `this.$require` is a private-name property lookup on `this`. `$requireCommonJS(...)` is a lookup on the global object that user code cannot reach or replace.

<details><summary>Notes</summary>

**Repro** (two files in one directory, `bun main.cjs`):

```js
// x.js
module.exports = { real: true };
// main.cjs
const Module = require("module");
const path = require("path");
const id = path.join(__dirname, "x.js");
try {
  Module.prototype.require.call({ filename: __filename }, id);
  console.log("no error");
} catch (e) {
  console.log("caught:", e.name, e.message);
}
console.log("require(id) ->", require(id));
```

| | first call | `require(id)` |
|---|---|---|
| node v26.3.0 | `no error` | `{ real: true }` |
| bun 1.4.3-canary.1 | `caught: TypeError undefined is not a function` | `{}` |
| this PR | `no error` | `{ real: true }` |

**Node source.** [`Module.prototype.require`](https://github.com/nodejs/node/blob/b7e6a5d37e7a14ef0f2cc95214b95d66c4081415/lib/internal/modules/cjs/loader.js#L1611-L1623) passes `this` to `wrapModuleLoad(id, this, false)` and does not check it. With no parent, a relative id resolves from the current directory ([`_resolveLookupPaths`](https://github.com/nodejs/node/blob/b7e6a5d37e7a14ef0f2cc95214b95d66c4081415/lib/internal/modules/cjs/loader.js#L976-L984)). Bun does the same with an `undefined` filename.

**Reach.** There is no user report. One caller is known: dd-trace's [`bundler-register.js`](https://github.com/DataDog/dd-trace-js/blob/25e73f6b19dcae9f4fdff228a97545f92fb0a4db/packages/datadog-instrumentations/src/helpers/bundler-register.js#L30-L38) calls `Module.prototype.require.call(module, "http")` with the plain-object `module` of a webpack or esbuild bundle, inside a `try/catch`. On Bun that call throws, the error is swallowed, and the `http`/`https` hooks are not applied again. `new Module(id).require` is a different bug (#35583).

**`this` shapes.** All of these load in Node and with this PR. On 1.4.3-canary.1: `{}`, a function and a number throw `undefined is not a function` and leave the stale entry. `Object.create(module)` throws `Type error` from the early return in `jsFunctionRequireCommonJS` and leaves the stale entry. `null` and `undefined` throw at `this.filename`. A builtin id with any of these throws `undefined is not a function` (no stale entry, because builtins never enter the map).

**Self-review.** Addressed: (1) my first version read `filename` from the parent inside the native function. A getter that deletes the cache entry and throws on that read aborted debug builds with `ASSERTION FAILED: wasRemoved` in `finishRequireWithError`. The filename is now read once in JS before the insert, and the native function takes the value. (2) A `null` or `undefined` `this` now works. (3) This text states the reach. (4) The items under "Not changed" are listed. (5) Benchmark below. Rejected: a test row that pins "a relative id resolves from the current directory" for `Object.create(module)`. That result comes from the module prototype getters, which return `undefined` for a receiver that only inherits from a module. Node resolves from the inherited filename, so a test must not pin it.

**Not changed.**
- `Object.create(module)` needs its own `filename` to anchor a relative id (see above).
- A parent that is not a module but has a `children` array does not get the child pushed. Node pushes it (`updateChildren`).
- `module.parent = value` does not keep a value that is not a module (`setterParent`). This is not related to `require`.
- An object `filename` with a `toString` that deletes the cache entry and throws can still reach `ASSERT(wasRemoved)` on a debug build, on main too. #42311 removes that assert.

**Benchmark.** Release builds of main 471b5868b6 and of this branch, same build directory. CPU time (user + system) around the loop, minimum of 100 alternating runs. The host is shared and busy (load average 60 to 110), so medians move ±10% in both directions. The minimums agree.

| workload | main | this PR | delta |
|---|---|---|---|
| 3000 distinct files, first load | 153.4 ms | 152.8 ms | -0.4% |
| same, second run of 100 | 151.8 ms | 152.3 ms | +0.4% |
| `require("node:fs")` × 1M | 221.8 ms | 219.0 ms | -1.3% |
| `require("fs")` × 1M | 205.1 ms | 206.9 ms | +0.9% |
| cached `require("./m0.js")` × 1M | 839.0 ms | 811.5 ms | -3.3% |

The cached row returns from the require map before it reaches the changed calls, so its delta shows the noise of the host. The change removes one property lookup on `this` and adds nothing per call.

**Deleted with this change.** The two `putDirectNativeFunction` calls in `JSCommonJSModulePrototype::finishCreation`. The `globalObject` parameter of that function and of `create`, which nothing else used. The two `dynamicDowncast<JSCommonJSModule>(thisValue)` guards in the native functions. `$require` and `$requireNativeModule` in `interface JSCommonJSModule` (`src/js/private.d.ts`).

**Stack traces.** An error that passes through the native loader frame (a throw in a plugin `onLoad` or in a `Module._extensions` handler) showed that frame as `at anonymous (unknown)`. It now shows `at unknown`, the same as the `$esmLoadSync` frame for `require()` of an ES module. No test matches that text.

**Suites run on the fixed debug build.** `test/js/node/module/node-module-module.test.js`, `require-extensions.test.ts`, `module-resolve-filename-paths.test.js`, `test/js/bun/resolve/require.test.ts`, `require-esm-*.test.ts`, `esModule*.test`, `test/js/bun/plugin/plugins.test.ts`, `test/js/bun/test/mock/mock-module.test.ts`, `test/cli/run/run-cjs.test.ts`, `commonjs-*.test.ts`, `require-and-import-trailing.test.ts`, `esm-defineProperty.test.ts`. The repro scripts are clean under `BUN_JSC_validateExceptionChecks=1`. In `test/cli/run/require-cache.test.ts` the leak tests time out on my debug+ASAN build: one large-AST `require()` takes about 700 ms there against 14 to 20 ms on release, so 55 iterations do not fit in the 20 s limit with or without this change.

**Duplicate.** #42362 fixed the same bug with the same approach, and is closed in favor of this PR. On a 45-case script (receiver shapes, `filename` getters, ES module, JSON, cycles, `Module._extensions`, `Module._resolveFilename`) the two builds print the same output, and each PR's test passes on the other PR's build. The test cases that were only in #42362 are now in this test: the `loaded` flag of the cache entry, `module.parent` as the module sees it while it runs, a call with no receiver (an absolute id, and an id relative to the cwd), and a module that throws while it runs (the caller gets that error, `require.cache` has no entry).

**Nearby open PRs.** #42311 found this bug and left it out on purpose. #33026 restructures `overridableRequire` and keeps `this.$require`. Its native `Module._load` builds a throwaway module to stand in as `this`. With the filename passed as a value it does not need that. #35583 adds `require` to the module prototype for `new Module(id).require`. The one that lands second needs a small rebase.

</details>

