### PR TITLE
bundler: keep a property read's `this` and getter for an unbound item of a require() / import() local

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1260,11 +1260,6 @@ impl Expr {
         })
     }
 
-    #[inline]
-    pub fn has_value_for_this_in_call(&self) -> bool {
-        matches!(self.data, Data::EDot(_) | Data::EIndex(_))
-    }
-
     /// The given "expr" argument should be the operand of a "!" prefix operator
     /// (i.e. the "x" in "!x"). This returns a simplified expression for the
     /// whole operator (i.e. the "!x") if it can be simplified, or false if not.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1182,30 +1182,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Is `expr` the import item that `maybe_rewrite_property_access` made of
-    /// `ns.a`, where `ns` is a local that holds an `import()` / `require()`
-    /// result? The linker binds it only to an export of a bundled ES module.
-    /// Otherwise it prints `ns.a`, a property read on an object: a getter can
-    /// run, and a call through it passes `ns` as `this`.
-    ///
-    /// Only valid before `to_ast`: `ImportScanner::scan` runs there and sets
-    /// the same bit on the items of `import * as ns`. Every caller runs in the
-    /// visit pass or at the end of `append_part`, both earlier.
+    /// Is `expr` an item read off a local that holds an `import()` / `require()` result (`ns.a`)?
     pub(crate) fn is_namespace_local_read(&self, expr: &Expr) -> bool {
-        matches!(
-            expr.data,
-            js_ast::ExprData::EImportIdentifier(id)
-                if self.symbols[id.ref_.inner_index() as usize]
-                    .namespace_alias
-                    .as_ref()
-                    .is_some_and(|alias| alias.was_originally_property_access)
-        )
+        let js_ast::ExprData::EImportIdentifier(id) = expr.data else {
+            return false;
+        };
+        self.symbols[id.ref_.inner_index() as usize]
+            .namespace_alias
+            .as_ref()
+            .is_some_and(|alias| {
+                self.dynamic_import_namespace_locals
+                    .contains_key(&alias.namespace_ref)
+            })
     }
 
-    /// Does a call through `expr` pass a `this`? If so, a wrapper that strips
-    /// it, such as `(0, expr)()`, has to stay.
+    /// Does `expr()` pass a `this`? A namespace-local item can: unbound, it prints `ns.a`.
     pub(crate) fn has_value_for_this_in_call(&self, expr: &Expr) -> bool {
-        expr.has_value_for_this_in_call() || self.is_namespace_local_read(expr)
+        matches!(
+            expr.data,
+            js_ast::ExprData::EDot(_) | js_ast::ExprData::EIndex(_)
+        ) || self.is_namespace_local_read(expr)
     }
 
     /// `const { a, b: c } = …` or `.then(({ a }) => …)`: the locals may become
@@ -6299,6 +6295,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     return true;
                 }
             }
+            // Unless the linker binds it, this is a property read that can run a getter.
+            js_ast::ExprData::EImportIdentifier(_) if self.is_namespace_local_read(expr) => {
+                return false;
+            }
             js_ast::ExprData::ECommonjsExportIdentifier(_)
             | js_ast::ExprData::EImportIdentifier(_) => {
                 // References to an ES6 import item are always side-effect free in an
@@ -6317,10 +6317,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 //
                 // So we deliberately ignore this edge case and always treat import item
                 // references as being side-effect free.
-                //
-                // `ns.a` off a `require()` / `import()` local is not an ES6 import in
-                // the source. It stays a property read unless the linker binds it.
-                return !self.is_namespace_local_read(expr);
+                return true;
             }
             js_ast::ExprData::EIf(ex) => {
                 return self.expr_can_be_removed_if_unused_without_dce_check(&ex.test)

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1187,6 +1187,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// result? The linker binds it only to an export of a bundled ES module.
     /// Otherwise it prints `ns.a`, a property read on an object: a getter can
     /// run, and a call through it passes `ns` as `this`.
+    ///
+    /// Only valid before `to_ast`: `ImportScanner::scan` runs there and sets
+    /// the same bit on the items of `import * as ns`. Every caller runs in the
+    /// visit pass or at the end of `append_part`, both earlier.
     pub(crate) fn is_namespace_local_read(&self, expr: &Expr) -> bool {
         matches!(
             expr.data,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1182,6 +1182,28 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// Is `expr` the import item that `maybe_rewrite_property_access` made of
+    /// `ns.a`, where `ns` is a local that holds an `import()` / `require()`
+    /// result? The linker binds it only to an export of a bundled ES module.
+    /// Otherwise it prints `ns.a`, a property read on an object: a getter can
+    /// run, and a call through it passes `ns` as `this`.
+    pub(crate) fn is_namespace_local_read(&self, expr: &Expr) -> bool {
+        matches!(
+            expr.data,
+            js_ast::ExprData::EImportIdentifier(id)
+                if self.symbols[id.ref_.inner_index() as usize]
+                    .namespace_alias
+                    .as_ref()
+                    .is_some_and(|alias| alias.was_originally_property_access)
+        )
+    }
+
+    /// Does a call through `expr` pass a `this`? If so, a wrapper that strips
+    /// it, such as `(0, expr)()`, has to stay.
+    pub(crate) fn has_value_for_this_in_call(&self, expr: &Expr) -> bool {
+        expr.has_value_for_this_in_call() || self.is_namespace_local_read(expr)
+    }
+
     /// `const { a, b: c } = …` or `.then(({ a }) => …)`: the locals may become
     /// import items. One already read (before its declaration, or from a
     /// function above it) stays a local, since that read must not see the
@@ -3112,14 +3134,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 js_ast::ExprData::ECall(mut e) => {
                     // Don't substitute something into a call target that could change "this"
-                    match replacement.data {
-                        js_ast::ExprData::EDot(_) | js_ast::ExprData::EIndex(_) => {
-                            if matches!(e.target.data, js_ast::ExprData::EIdentifier(id) if id.ref_.eql(r#ref))
-                            {
-                                break 'outer;
-                            }
-                        }
-                        _ => {}
+                    if self.has_value_for_this_in_call(&replacement)
+                        && matches!(e.target.data, js_ast::ExprData::EIdentifier(id) if id.ref_.eql(r#ref))
+                    {
+                        break 'outer;
                     }
 
                     if let Some(done) = self.substitute_single_use_symbol_in_child(
@@ -6295,7 +6313,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 //
                 // So we deliberately ignore this edge case and always treat import item
                 // references as being side-effect free.
-                return true;
+                //
+                // `ns.a` off a `require()` / `import()` local is not an ES6 import in
+                // the source. It stays a property read unless the linker binds it.
+                return !self.is_namespace_local_read(expr);
             }
             js_ast::ExprData::EIf(ex) => {
                 return self.expr_can_be_removed_if_unused_without_dce_check(&ex.test)

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -239,7 +239,7 @@ impl BinaryExpressionVisitor {
                     } else {
                         // The left operand has no side effects, but we need to preserve
                         // the comma operator semantics when used as a call target
-                        if is_call_target && e_.right.has_value_for_this_in_call() {
+                        if is_call_target && p.has_value_for_this_in_call(&e_.right) {
                             // Keep the comma expression to strip "this" binding
                             e_.left = Expr {
                                 data: prefill::data::ZERO,
@@ -359,7 +359,7 @@ impl BinaryExpressionVisitor {
                         // "(null ?? fn)()" => "fn()"
                         // "(null ?? this.fn)" => "this.fn"
                         // "(null ?? this.fn)()" => "(0, this.fn)()"
-                        if is_call_target && e_.right.has_value_for_this_in_call() {
+                        if is_call_target && p.has_value_for_this_in_call(&e_.right) {
                             return Expr::join_with_comma(
                                 Expr {
                                     data: ExprData::ENumber(E::Number::new(0.0)),
@@ -381,7 +381,7 @@ impl BinaryExpressionVisitor {
                         // "(0 || fn)()" => "fn()"
                         // "(0 || this.fn)" => "this.fn"
                         // "(0 || this.fn)()" => "(0, this.fn)()"
-                        if is_call_target && e_.right.has_value_for_this_in_call() {
+                        if is_call_target && p.has_value_for_this_in_call(&e_.right) {
                             return Expr::join_with_comma(
                                 Expr {
                                     data: prefill::data::ZERO,
@@ -403,7 +403,7 @@ impl BinaryExpressionVisitor {
                         // "(1 && fn)()" => "fn()"
                         // "(1 && this.fn)" => "this.fn"
                         // "(1 && this.fn)()" => "(0, this.fn)()"
-                        if is_call_target && e_.right.has_value_for_this_in_call() {
+                        if is_call_target && p.has_value_for_this_in_call(&e_.right) {
                             return Expr::join_with_comma(
                                 Expr {
                                     data: prefill::data::ZERO,

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1109,7 +1109,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
                             if inlined.can_be_inlined_from_property_access() {
                                 // "[obj.m][0]()" => "(0, obj.m)()"
-                                *e = if is_call_target && inlined.has_value_for_this_in_call() {
+                                *e = if is_call_target && p.has_value_for_this_in_call(&inlined) {
                                     p.new_expr(E::Number::new(0.0), expr.loc)
                                         .join_with_comma(inlined)
                                 } else {
@@ -1536,7 +1536,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // "(1 ? fn : 2)()" => "fn()"
             // "(1 ? this.fn : 2)" => "this.fn"
             // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
-            if is_call_target && e_.yes.has_value_for_this_in_call() {
+            if is_call_target && p.has_value_for_this_in_call(&e_.yes) {
                 *e = p
                     .new_expr(E::Number::new(0.0), e_.test.loc)
                     .join_with_comma(e_.yes);
@@ -1563,7 +1563,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // "(1 ? fn : 2)()" => "fn()"
             // "(1 ? this.fn : 2)" => "this.fn"
             // "(1 ? this.fn : 2)()" => "(0, this.fn)()"
-            if is_call_target && e_.no.has_value_for_this_in_call() {
+            if is_call_target && p.has_value_for_this_in_call(&e_.no) {
                 *e = p
                     .new_expr(E::Number::new(0.0), e_.test.loc)
                     .join_with_comma(e_.no);

--- a/test/bundler/bundler_dynamic_import_dce.test.ts
+++ b/test/bundler/bundler_dynamic_import_dce.test.ts
@@ -4302,6 +4302,98 @@ describe("bundler", () => {
     run: { stdout: "0" },
   });
 
+  // ── An item the linker does not bind is still a property read ─────────
+  // `ns.a` off a `require()` / `import()` local prints as written when the
+  // importee is CommonJS or external, or when `ns` escapes. It then reads a
+  // property of an object: a call through it passes `ns` as `this`, and a
+  // getter can run.
+
+  const lazyExports = /* js */ `
+    let count = 0;
+    const log = [];
+    Object.defineProperty(exports, "boot", { enumerable: true, get() { return ++count; } });
+    Object.defineProperty(exports, "count", { enumerable: true, get() { return count; } });
+    Object.defineProperty(exports, "first", { enumerable: true, get() { log.push("first"); return 1; } });
+    Object.defineProperty(exports, "second", { enumerable: true, get() { log.push("second"); return 2; } });
+    exports.log = log;
+  `;
+
+  for (const minifySyntax of [false, true]) {
+    const suffix = minifySyntax ? "MinifySyntax" : "";
+
+    // TypeScript's CommonJS output calls an import as `(0, util_1.who)()`.
+    itBundled(`dynamic_import_dce/UnboundItemCallWithoutThis${suffix}`, {
+      files: {
+        "/entry.js": /* js */ `
+          const util_1 = require("./util.cjs");
+          console.log(util_1.who(), (0, util_1.who)(), (0, util_1.who)?.());
+          console.log((true ? util_1.who : 0)(), (1 && util_1.who)(), (0 || util_1.who)(), (null ?? util_1.who)());
+          function viaLocal() {
+            const who = util_1.who;
+            return who();
+          }
+          console.log(viaLocal());
+          const ns = await import("./util.cjs");
+          console.log(ns.who(), (0, ns.who)());
+          await import("./util.cjs").then(m => console.log(m.who(), (0, m.who)()));
+          const escaped = require("./esm.js");
+          globalThis.escaped = escaped;
+          console.log(escaped.who(), (0, escaped.who)());
+        `,
+        "/util.cjs": /* js */ `
+          "use strict";
+          exports.tag = "exports";
+          exports.who = function () { return this === undefined ? "undefined" : this.tag; };
+        `,
+        "/esm.js": /* js */ `
+          export const tag = "namespace";
+          export function who() { return this === undefined ? "undefined" : this.tag; }
+        `,
+      },
+      minifySyntax,
+      run: {
+        stdout: [
+          "exports undefined undefined",
+          "undefined undefined undefined undefined",
+          "undefined",
+          "exports undefined",
+          "exports undefined",
+          "namespace undefined",
+        ].join("\n"),
+      },
+    });
+
+    // An unused read stays, and a read does not move past another read.
+    itBundled(`dynamic_import_dce/UnboundItemReadRunsGetter${suffix}`, {
+      files: {
+        "/entry.js": /* js */ `
+          const ns = require("./lazy.cjs");
+          ns.boot;
+          void ns.boot;
+          const unused = ns.boot;
+          if (ns.boot) {}
+          console.log(ns.count);
+          function order() {
+            const first = ns.first;
+            return ns.second + first;
+          }
+          order();
+          console.log(ns.log.join());
+          const ext = require("ext");
+          ext.boot;
+          void ext.boot;
+          console.log(ext.count);
+        `,
+        "/lazy.cjs": lazyExports,
+      },
+      runtimeFiles: { "/node_modules/ext/index.js": lazyExports },
+      external: ["ext"],
+      target: "bun",
+      minifySyntax,
+      run: { stdout: "4\nfirst,second\n2" },
+    });
+  }
+
   // ── Cases that keep the namespace object ──────────────────────────────
 
   function itKeepsNamespace(

--- a/test/bundler/bundler_dynamic_import_dce.test.ts
+++ b/test/bundler/bundler_dynamic_import_dce.test.ts
@@ -4315,6 +4315,7 @@ describe("bundler", () => {
     Object.defineProperty(exports, "count", { enumerable: true, get() { return count; } });
     Object.defineProperty(exports, "first", { enumerable: true, get() { log.push("first"); return 1; } });
     Object.defineProperty(exports, "second", { enumerable: true, get() { log.push("second"); return 2; } });
+    Object.defineProperty(exports, "bump", { enumerable: true, get() { globalThis.bumpLocal(); return 100; } });
     exports.log = log;
   `;
 
@@ -4326,8 +4327,9 @@ describe("bundler", () => {
       files: {
         "/entry.js": /* js */ `
           const util_1 = require("./util.cjs");
-          console.log(util_1.who(), (0, util_1.who)(), (0, util_1.who)?.());
+          console.log(util_1.who(), (0, util_1.who)(), (0, util_1.who)?.(), (0, util_1["who"])());
           console.log((true ? util_1.who : 0)(), (1 && util_1.who)(), (0 || util_1.who)(), (null ?? util_1.who)());
+          console.log((false ? 0 : util_1.who)(), [util_1.who][0]());
           function viaLocal() {
             const who = util_1.who;
             return who();
@@ -4353,8 +4355,9 @@ describe("bundler", () => {
       minifySyntax,
       run: {
         stdout: [
-          "exports undefined undefined",
+          "exports undefined undefined undefined",
           "undefined undefined undefined undefined",
+          "undefined undefined",
           "undefined",
           "exports undefined",
           "exports undefined",
@@ -4363,7 +4366,7 @@ describe("bundler", () => {
       },
     });
 
-    // An unused read stays, and a read does not move past another read.
+    // An unused read stays, and nothing moves past a read.
     itBundled(`dynamic_import_dce/UnboundItemReadRunsGetter${suffix}`, {
       files: {
         "/entry.js": /* js */ `
@@ -4379,10 +4382,28 @@ describe("bundler", () => {
           }
           order();
           console.log(ns.log.join());
+          let local = 0;
+          globalThis.bumpLocal = () => { local++; };
+          function pastRead() {
+            local = 0;
+            const copy = local;
+            return ns.bump + copy;
+          }
+          console.log(pastRead());
           const ext = require("ext");
           ext.boot;
           void ext.boot;
           console.log(ext.count);
+          const awaited = await import("./lazy.cjs");
+          awaited.boot;
+          void awaited.boot;
+          console.log(ns.count);
+          await import("./lazy.cjs").then(m => {
+            m.boot;
+            void m.boot;
+            const unused = m.boot;
+          });
+          console.log(ns.count);
         `,
         "/lazy.cjs": lazyExports,
       },
@@ -4390,7 +4411,7 @@ describe("bundler", () => {
       external: ["ext"],
       target: "bun",
       minifySyntax,
-      run: { stdout: "4\nfirst,second\n2" },
+      run: { stdout: "4\nfirst,second\n100\n2\n6\n9" },
     });
   }
 


### PR DESCRIPTION
### Problem
- Since #41186 (1.4.1), a bundle can call a CommonJS export with the wrong `this`. 1.4.0 is correct. For `const x_1 = require("./x.cjs")`, `(0, x_1.fn)()` prints `x_1.fn()` with `--minify-syntax`. TypeScript emits that call for CommonJS. `(true ? x_1.fn : 0)()` loses its wrapper with no flags.
- Getters of a CommonJS or external module do not run, or run in another order. An unused `ns.a;` or `void ns.a` is removed. With `--minify-syntax`, `const v = ns.g; return ns.h + v` becomes `ns.h + ns.g`.
- Cause: `maybe_rewrite_property_access` (`src/js_parser/fold.rs:175`) makes `ns.f` an import item. `Expr::has_value_for_this_in_call` (`src/ast/expr.rs:1264`) and `expr_can_be_removed_if_unused` (`src/js_parser/p.rs`) then treat it as a bound ES import.

### Fix
- `P::is_namespace_local_read` finds such an item: the `namespace_alias` of its symbol names a namespace local (`dynamic_import_namespace_locals`).
- `P::has_value_for_this_in_call` replaces the `Expr` method and also accepts such an item. The 7 wrapper folds and the single-use substitution call it. `expr_can_be_removed_if_unused` returns false for such an item.
- Correct because the parser cannot know the binding, and a kept wrapper or read is always valid. Items of `import * as ns` do not change.
- Verified: `test/bundler/bundler_dynamic_import_dce.test.ts`, 4 new cases, all fail on 1.4.3-canary. Also 24 other bundler suites. Self-reviewed (Notes).

### Background
- A namespace local holds the result of `require()` or `import()`: `const ns = require(x)`, `.then(ns => ...)`.
- An import item is a symbol that the linker can bind to an export of a bundled ES module. A bound item prints the name of the export. An unbound item (CommonJS or external importee, escaped `ns`) prints as written: `ns.f`.
- `a.b()` passes `a` as `this`. `(0, a.b)()` passes `undefined`.

<details><summary>Notes</summary>

**Repro with a real package.** `cross-fetch@4.1.0` (`dist/browser-ponyfill.js`) ends with `exports = ctx.fetch; exports.fetch = ctx.fetch; module.exports = exports`, where `ctx.fetch` is the platform `fetch` when there is one. TypeScript (`module: commonjs`) compiles

```ts
import { fetch } from "cross-fetch";
await fetch(url);
```

to `const cross_fetch_1 = require("cross-fetch"); await (0, cross_fetch_1.fetch)(url);`. `bun build --minify --target=browser` on 1.4.2 and 1.4.3-canary.1 prints `cross_fetch_1.fetch(url)`. That calls the platform `fetch` with the function object as `this`. Browsers reject that receiver (`Illegal invocation`). Checked under node 26.3.0 with a `globalThis.fetch` that makes the same receiver check: 1.4.0 `ok 200` with and without `--minify`, 1.4.2 and 1.4.3-canary.1 `ok 200` without flags and `TypeError: ... Illegal invocation` with `--minify`, this branch `ok 200` for both.

**Released binaries** (each bundle is built with that binary and run under node 26.3.0. The two entries are the ones in the new tests, reduced):

| | node on the source | 1.4.0 | 1.4.2 | 1.4.2 `--minify-syntax` | this branch, both |
|---|---|---|---|---|---|
| `(c ? ns.f : 0)()`, `(1 && ns.f)()`, `(0 \|\| ns.f)()`, `(null ?? ns.f)()` | `undefined` x4 | same | `exports` x4 | `exports` x4 | `undefined` x4 |
| `(0, ns.f)()`, `(0, ns.f)?.()`, `const f = ns.f; f()` | `undefined` x3 | same | `undefined` x3 | `exports` x3 | `undefined` x3 |
| getter count after `ns.boot; void ns.boot; const unused = ns.boot; if (ns.boot) {}` | 4 | 4 | 1 | 0 | 4 |
| `const first = ns.first; return ns.second + first` | `first,second` | same | `first,second` | `second,first` | `first,second` |

For both repros in the report, this branch prints the same text as 1.4.0, with and without `--minify-syntax`.

**How the item is found.** `fold.rs` gives the item a `namespace_alias` whose `namespace_ref` is the local. `is_namespace_local_read` looks that ref up in `dynamic_import_namespace_locals`. An earlier revision tested `was_originally_property_access`, which the import scanner also sets for items of `import * as ns` (later, in `to_ast`). The map lookup does not depend on that order.

**Why the `Expr` method is gone.** `Expr::has_value_for_this_in_call` cannot see the symbol table, so it cannot see these items. With it removed, a new fold site has to call the parser method. #41159 adds a fold site and rewrites both ternary arms with the `Expr` method. After a rebase it does not compile until it calls `p.has_value_for_this_in_call`.

**esbuild** (0.18.6 from `test/node_modules`, `--bundle --minify-syntax`): for `const ns = require("./x.cjs")` it keeps `ns.boot;` and `(0, ns.who)()`. For `import * as ns` of the same file it drops the read and prints `ns.who()`.

**Cost, for an item that the linker does bind.** Under `--minify-syntax`, `(0, ns.f)()` prints `(0, f)()` and not `f()`. An unused read stays (`a;`), so its export stays too. Both are the 1.4.0 behaviour. The 16 bundles that `bundler_bytecode_portable.test.ts` snapshots (lodash, acorn, react-dom, svelte, undici, happy-dom, immutable, about 50 libraries in one file, with and without `--minify`) are byte-identical to 1.4.3-canary output, so no snapshot moves.

**Scope.** Only `const` / `let` locals and `.then` parameters are tracked, so `var x = require(...)` (Babel, ES5 TypeScript output) was never affected. `const x = __importDefault(require(...))` / `__importStar(...)` is not a direct `require()` initializer and is not tracked either. With `--format=esm`, `require()` of a package in `DEFAULT_UNWRAP_COMMONJS_PACKAGES` (`react`, `react-dom`, `react-is`, `scheduler`, `react-client`, `react-server`, `react-refresh`) outside `try` becomes an import statement. Its items are `import * as ns` items, so they behave as on 1.4.0 and this PR does not change them.

**Related.** #40829 (open, conflicts with main) ports esbuild's `target_was_originally_property_access`, so the printer adds `(0, ...)` for any call target that became a property access. It covers the `this` part without a check in each fold and without the `(0, f)()` cost for a bound item. It does not cover the getter part. So the `this` half of this PR is a stopgap for a regression that is in two releases. When #40829 is rebased, drop the `is_namespace_local_read` arm of `P::has_value_for_this_in_call`, and a bound item prints `f()` again. The guard arm in `expr_can_be_removed_if_unused` stays. This PR merges cleanly with main and with #42366, which fixes a different bug of the same items.

**Not changed.** `ns.f()` written as a direct call on a bound item still calls `f()` with `this === undefined` (the behaviour change that #41186 lists). These siblings are wrong on 1.4.0 too, so they are not part of this regression. #42452 tracks them:
- The tagged-template form ``(0, o.f)`x` `` folds for each plain `EDot`.
- `(0, ns.f)()` and `(1 && ns.f)()` for an item of `import * as ns`, or of a named import, of a CommonJS module lose the wrapper. `import { f } from "./x.cjs"; f()` prints `import_x.f()`.
- Inside a CommonJS module, `(0, exports.f)()` and `(1 && exports.f)()` lose the wrapper (`ECommonjsExportIdentifier`).
- `([] ? o.m : 0)()` folds to `o.m()` for each property access (the ternary path for a test that is known but not free of side effects).

#40829 covers the `this` part of all four in the printer.

**Self-review.** A review of the diff raised these points. Addressed: the test for the item no longer depends on the order of the import scanner (map lookup), a new fold site cannot call a check that misses these items (the `Expr` method is gone), each changed fold site has a test shape (`(false ? 0 : ns.f)()`, `[ns.f][0]()`, `ns["f"]`), the getter test covers `await import()`, `.then` and a plain local that must not move past a read, and the notes above name #40829, #41159, the unwrap list and the siblings. Not taken: a fix for the sibling shapes, because they are not part of the regression.

**Suites run on the debug build, all pass:** `bundler_dynamic_import_dce` (278), `bundler_minify`, `bundler_cjs2esm`, `bundler_cjs`, `bundler_promiseall_deadcode`, `bundler_barrel`, `bundler_splitting`, `bundler_edgecase`, `bundler_regressions`, `bundler_bun`, `bundler_jsx`, `bundler_feature_flag`, `bundler_drop`, `bundler_npm`, `bundler_browser`, `bundler_plugin`, `esbuild/dce`, `esbuild/importstar`, `esbuild/importstar_ts`, `esbuild/splitting`, `esbuild/extra`, `esbuild/default`, `esbuild/ts`, `transpiler/transpiler.test.js`. `bundler_bytecode_portable` times out on a debug build (5 s per test), so its inputs were compared by hand as described above.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_dynamic_import_dce.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [1673.47ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [634.36ms]
(pass) bundler > dynamic_import_dce/AwaitDot [713.44ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [605.92ms]
(pass) bundler > dynamic_import_dce/LetBinding [856.41ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [1352.48ms]
(pass) bundler > dynamic_import_dce/BailoutRest [969.80ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [671.08ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [629.22ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [915.03ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [1288.02ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [840.47ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [919.71ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [803.36ms]
(pass) bundler > dy
... (truncated)

release without fix: 4 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [38.71ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [19.21ms]
(pass) bundler > dynamic_import_dce/AwaitDot [44.35ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [30.93ms]
(pass) bundler > dynamic_import_dce/LetBinding [128.81ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [18.44ms]
(pass) bundler > dynamic_import_dce/BailoutRest [73.38ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [18.44ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [18.13ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [51.83ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [41.71ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [51.03ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [55.02ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [56.98ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllDestructure [22.23ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllThenDestructure [70.99ms]
(pass) bundler > dynamic_import_dce/SplittingPro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_dynamic_import_dce.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [1817.72ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [755.03ms]
(pass) bundler > dynamic_import_dce/AwaitDot [767.65ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [838.54ms]
(pass) bundler > dynamic_import_dce/LetBinding [734.44ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [691.34ms]
(pass) bundler > dynamic_import_dce/BailoutRest [934.09ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [1147.38ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [732.34ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [1711.04ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [2215.43ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [1168.11ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [1147.40ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [1509.40ms]
(pass) bundler 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     9216f8bbd8
  features     baseline

23 deps, 131 codegen, 1172 objects in 1996ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (4ff919377)

Checked 22 installs across 61 packages (no changes) [38.00ms]
[2/1244] fetch zlib
[zlib] up to date
[3/1244] gen ErrorCode+*.h
[4/1244] gen bindgenv2
[5/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1217] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (4ff919377)

Checked 1 install across 2 packages (no changes) [6.00ms]
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (4ff919377)

Checked 111 installs across 104 packages (no changes) [119.00ms]
[11/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 43ms

  react-refresh.js  4
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/expr.rs                                 |   5 --
 src/js_parser/p.rs                              |  38 ++++++--
 src/js_parser/visit/visit_binary.rs             |   8 +-
 src/js_parser/visit/visit_expr.rs               |   6 +-
 test/bundler/bundler_dynamic_import_dce.test.ts | 113 ++++++++++++++++++++++++
 5 files changed, 150 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/ast/expr.rs                                      1      1     21
src/js_parser/p.rs                                   9      4     21
src/js_parser/visit/visit_binary.rs                  2      0     21
src/js_parser/visit/visit_expr.rs                    4      0     21
test/bundler/bundler_dynamic_import_dce.test.ts      2      1     21
```

</details>

<!-- robobun:evidence:end -->