### PR TITLE
Bun.plugin: transpile a copy of typed array onLoad contents

### DIFF
--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -306,8 +306,9 @@ OnLoadResult handleOnLoadResultNotPromise(Zig::GlobalObject* globalObject, JSC::
             }
         } else if (JSC::JSArrayBufferView* view = dynamicDowncast<JSC::JSArrayBufferView>(contentsValue)) {
             // The lexer, the AST and the printer read the source until the transpile ends.
-            // Another thread can write a SharedArrayBuffer in that time, and a macro runs
-            // JS that can write, resize or detach any buffer. So they read a copy.
+            // Another thread can write a SharedArrayBuffer in that time. A macro runs JS in
+            // that time, and JS can overwrite, detach or move the storage of an unshared,
+            // fixed-length view too. So every view is copied, not only a shared or resizable one.
             if (!result.sourceTextCopy.tryAppend(view->span())) [[unlikely]] {
                 throwOutOfMemoryError(globalObject, scope);
                 result.value.error = scope.exception();

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -305,7 +305,16 @@ OnLoadResult handleOnLoadResultNotPromise(Zig::GlobalObject* globalObject, JSC::
                 result.value.sourceText.value = contentsValue;
             }
         } else if (JSC::JSArrayBufferView* view = dynamicDowncast<JSC::JSArrayBufferView>(contentsValue)) {
-            result.value.sourceText.string = EncodedSlice { reinterpret_cast<const unsigned char*>(view->vector()), view->byteLength() };
+            // The lexer, the AST and the printer read the source until the transpile ends.
+            // Another thread can write a SharedArrayBuffer in that time, and a macro runs
+            // JS that can write, resize or detach any buffer. So they read a copy.
+            if (!result.sourceTextCopy.tryAppend(view->span())) [[unlikely]] {
+                throwOutOfMemoryError(globalObject, scope);
+                result.value.error = scope.exception();
+                (void)scope.tryClearException();
+                return result;
+            }
+            result.value.sourceText.string = EncodedSlice { result.sourceTextCopy.span().data(), result.sourceTextCopy.size() };
             result.value.sourceText.value = contentsValue;
         }
     }

--- a/src/jsc/bindings/ModuleLoader.h
+++ b/src/jsc/bindings/ModuleLoader.h
@@ -46,6 +46,8 @@ struct OnLoadResult {
     OnLoadResultValue value;
     OnLoadResultType type;
     bool wasMock;
+    // The bytes `value.sourceText.string` points to when `contents` was a typed array.
+    WTF::Vector<uint8_t> sourceTextCopy;
 };
 
 extern "C" bool isBunTest;

--- a/src/jsc/bindings/ModuleLoader.h
+++ b/src/jsc/bindings/ModuleLoader.h
@@ -47,6 +47,7 @@ struct OnLoadResult {
     OnLoadResultType type;
     bool wasMock;
     // The bytes `value.sourceText.string` points to when `contents` was a typed array.
+    // No inline capacity: the struct is returned by value, and the pointer has to survive the move.
     WTF::Vector<uint8_t> sourceTextCopy;
 };
 

--- a/test/js/bun/plugin/plugin-shared-contents-fixture.ts
+++ b/test/js/bun/plugin/plugin-shared-contents-fixture.ts
@@ -1,0 +1,81 @@
+// Fixture for plugins.test.ts.
+//
+//   bun plugin-shared-contents-fixture.ts <imports>
+//
+// An onLoad callback returns a Uint8Array over a SharedArrayBuffer as
+// `contents` while a worker flips the `_` separators of the numeric literals in
+// it to digits and back. The lexer counts the separators of a literal,
+// allocates `length - count` bytes, then copies every byte that is not a `_`.
+// A transpiler that reads the shared bytes in place aborts the process when a
+// separator turns into a digit between the two passes. One that reads a private
+// copy sees one value per byte, and every value of a byte gives a valid module.
+// Prints "ok" after <imports> imports that ran while the worker wrote.
+import { plugin } from "bun";
+import { isMainThread, Worker, workerData } from "node:worker_threads";
+
+const literals = 64;
+const literal = "  1_000_000_000_000_000,\n";
+const base = new TextEncoder().encode(
+  "export default [\n" + Buffer.alloc(literals * literal.length, literal).toString() + "];\n",
+);
+
+if (isMainThread) {
+  const bytes = new SharedArrayBuffer(base.length);
+  // The number of passes the worker has made over the bytes it flips.
+  const passes = new Int32Array(new SharedArrayBuffer(4));
+  const worker = new Worker(new URL(import.meta.url), { workerData: { bytes, passes } });
+  worker.unref();
+
+  const contents = new Uint8Array(bytes);
+  contents.set(base);
+
+  if (Atomics.wait(passes, 0, 0, 30_000) === "timed-out") {
+    throw new Error("the worker did not start");
+  }
+
+  plugin({
+    name: "shared contents",
+    setup(build) {
+      build.onResolve({ filter: /.*/, namespace: "shared" }, ({ path }) => ({ path, namespace: "shared" }));
+      build.onLoad({ filter: /.*/, namespace: "shared" }, () => ({ contents, loader: "ts" }));
+    },
+  });
+
+  // Count an import only when the worker made a pass while it ran. A debug
+  // build is slow enough that every import counts. A release build can finish
+  // many imports before the worker's thread gets a core of its own, so the
+  // total is capped: a starved worker ends the run, it does not hang it.
+  const imports = Number(process.argv[2]);
+  let seen = Atomics.load(passes, 0);
+  for (let overlapped = 0, total = 0; overlapped < imports && total < imports * 20; total++) {
+    const { default: values } = await import("shared:" + total);
+    if (values.length !== literals || !values.every(value => value >= 1e15)) {
+      throw new Error("import " + total + " gave " + JSON.stringify(values));
+    }
+
+    const now = Atomics.load(passes, 0);
+    if (now !== seen) {
+      seen = now;
+      overlapped++;
+    }
+  }
+
+  console.log("ok");
+  process.exit(0);
+} else {
+  const { bytes, passes } = workerData as { bytes: SharedArrayBuffer; passes: Int32Array };
+  const contents = new Uint8Array(bytes);
+
+  const separators: number[] = [];
+  for (let i = 0; i < base.length; i++) {
+    if (base[i] === 0x5f) separators.push(i);
+  }
+
+  // `Atomics.store` so that the compiler keeps every store and the other
+  // thread sees each one.
+  for (;;) {
+    for (const at of separators) Atomics.store(contents, at, 0x30);
+    for (const at of separators) Atomics.store(contents, at, 0x5f);
+    if (Atomics.add(passes, 0, 1) === 0) Atomics.notify(passes, 0);
+  }
+}

--- a/test/js/bun/plugin/plugin-shared-contents-fixture.ts
+++ b/test/js/bun/plugin/plugin-shared-contents-fixture.ts
@@ -1,23 +1,30 @@
 // Fixture for plugins.test.ts.
 //
-//   bun plugin-shared-contents-fixture.ts <imports>
-//
 // An onLoad callback returns a Uint8Array over a SharedArrayBuffer as
 // `contents` while a worker flips the `_` separators of the numeric literals in
-// it to digits and back. The lexer counts the separators of a literal,
-// allocates `length - count` bytes, then copies every byte that is not a `_`.
-// A transpiler that reads the shared bytes in place aborts the process when a
-// separator turns into a digit between the two passes. One that reads a private
+// it to `0` and back. The lexer counts the separators of a literal, allocates
+// `length - count` bytes, then copies every byte that is not a `_`. A
+// transpiler that reads the shared bytes in place aborts the process when a
+// separator turns into a digit between the two passes, and gives the literal a
+// wrong value when a digit turns into a separator. One that reads a private
 // copy sees one value per byte, and every value of a byte gives a valid module.
-// Prints "ok" after <imports> imports that ran while the worker wrote.
+// Prints "ok" after `imports` imports that ran while the worker wrote.
 import { plugin } from "bun";
 import { isMainThread, Worker, workerData } from "node:worker_threads";
+
+const underscore = 0x5f;
+const zero = 0x30;
 
 const literals = 64;
 const literal = "  1_000_000_000_000_000,\n";
 const base = new TextEncoder().encode(
   "export default [\n" + Buffer.alloc(literals * literal.length, literal).toString() + "];\n",
 );
+// Each separator that reads as `0` makes the literal ten times larger.
+const values = new Set([1e15, 1e16, 1e17, 1e18, 1e19, 1e20]);
+
+// An unfixed build fails within 10 imports.
+const imports = 50;
 
 if (isMainThread) {
   const bytes = new SharedArrayBuffer(base.length);
@@ -45,12 +52,11 @@ if (isMainThread) {
   // build is slow enough that every import counts. A release build can finish
   // many imports before the worker's thread gets a core of its own, so the
   // total is capped: a starved worker ends the run, it does not hang it.
-  const imports = Number(process.argv[2]);
   let seen = Atomics.load(passes, 0);
   for (let overlapped = 0, total = 0; overlapped < imports && total < imports * 20; total++) {
-    const { default: values } = await import("shared:" + total);
-    if (values.length !== literals || !values.every(value => value >= 1e15)) {
-      throw new Error("import " + total + " gave " + JSON.stringify(values));
+    const { default: exported } = await import("shared:" + total);
+    if (exported.length !== literals || !exported.every(value => values.has(value))) {
+      throw new Error("import " + total + " gave " + JSON.stringify(exported));
     }
 
     const now = Atomics.load(passes, 0);
@@ -68,14 +74,14 @@ if (isMainThread) {
 
   const separators: number[] = [];
   for (let i = 0; i < base.length; i++) {
-    if (base[i] === 0x5f) separators.push(i);
+    if (base[i] === underscore) separators.push(i);
   }
 
   // `Atomics.store` so that the compiler keeps every store and the other
   // thread sees each one.
   for (;;) {
-    for (const at of separators) Atomics.store(contents, at, 0x30);
-    for (const at of separators) Atomics.store(contents, at, 0x5f);
+    for (const at of separators) Atomics.store(contents, at, zero);
+    for (const at of separators) Atomics.store(contents, at, underscore);
     if (Atomics.add(passes, 0, 1) === 0) Atomics.notify(passes, 0);
   }
 }

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1049,14 +1049,9 @@ describe.concurrent("Bun.plugin.clearAll()", () => {
 // The transpiler reads the source text until it has printed the module. The
 // bytes of a typed array can change in that time, so it reads a copy of them.
 describe.concurrent("onLoad contents in a typed array", () => {
-  // A worker flips the `_` separators of the numeric literals to digits and
-  // back. The lexer counts the separators of a literal, sizes a buffer for the
-  // digits, then reads the literal again to fill it. When it read the shared
-  // bytes in place, the two reads did not agree: within 10 imports a literal had
-  // the wrong value or the process aborted.
   it("transpiles a SharedArrayBuffer that a worker writes", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), resolve(import.meta.dir, "plugin-shared-contents-fixture.ts"), "100"],
+      cmd: [bunExe(), resolve(import.meta.dir, "plugin-shared-contents-fixture.ts")],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -1072,7 +1067,7 @@ describe.concurrent("onLoad contents in a typed array", () => {
 
   // A macro runs JS in the middle of the transpile. The printer reads the names
   // and the strings of the module back from the source after that.
-  it("transpiles the bytes onLoad returned when a macro overwrites and detaches them", async () => {
+  it("transpiles the bytes it was given when a macro overwrites and detaches them", async () => {
     using dir = tempDir("plugin-contents-macro", {
       "macro.ts": `
         export function clobber() {
@@ -1085,24 +1080,35 @@ describe.concurrent("onLoad contents in a typed array", () => {
         import { plugin } from "bun";
         import { join } from "node:path";
 
-        const source =
+        const source = new TextEncoder().encode(
           "import { clobber } from " + JSON.stringify(join(import.meta.dir, "macro.ts")) + ' with { type: "macro" };\\n' +
           "export const fromTheMacro = clobber();\\n" +
-          "export const afterTheMacro = 'after the macro';\\n";
-        const bytes = new TextEncoder().encode(source);
-        globalThis.contents = new Uint8Array(new ArrayBuffer(bytes.length));
-        globalThis.contents.set(bytes);
+          "export const afterTheMacro = 'after the macro';\\n",
+        );
+
+        // A view on an ArrayBuffer of its own, so that transfer() detaches exactly these bytes.
+        function contents() {
+          globalThis.contents = new Uint8Array(new ArrayBuffer(source.length));
+          globalThis.contents.set(source);
+          return globalThis.contents;
+        }
 
         plugin({
           name: "typed array contents",
           setup(build) {
             build.onResolve({ filter: /.*/, namespace: "bytes" }, ({ path }) => ({ path, namespace: "bytes" }));
-            build.onLoad({ filter: /.*/, namespace: "bytes" }, () => ({ contents: globalThis.contents, loader: "ts" }));
+            build.onLoad({ filter: /plain/, namespace: "bytes" }, () => ({ contents: contents(), loader: "ts" }));
+            build.onLoad({ filter: /promise/, namespace: "bytes" }, async () => ({ contents: contents(), loader: "ts" }));
+            build.module("bytes-module", () => ({ contents: contents(), loader: "ts" }));
           },
         });
 
-        const { fromTheMacro, afterTheMacro } = await import("bytes:module");
-        console.log(JSON.stringify({ fromTheMacro, afterTheMacro, byteLength: globalThis.contents.byteLength }));
+        const results = {};
+        for (const specifier of ["bytes:plain", "bytes:promise", "bytes-module"]) {
+          const { fromTheMacro, afterTheMacro } = await import(specifier);
+          results[specifier] = { fromTheMacro, afterTheMacro, byteLength: globalThis.contents.byteLength };
+        }
+        console.log(JSON.stringify(results));
       `,
     });
 
@@ -1115,9 +1121,10 @@ describe.concurrent("onLoad contents in a typed array", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+    const transpiled = { fromTheMacro: "clobbered", afterTheMacro: "after the macro", byteLength: 0 };
     // A debug build logs each macro call to stdout first.
     expect({ result: stdout.trim().split("\n").at(-1), stderr: stderr.trim(), exitCode }).toEqual({
-      result: JSON.stringify({ fromTheMacro: "clobbered", afterTheMacro: "after the macro", byteLength: 0 }),
+      result: JSON.stringify({ "bytes:plain": transpiled, "bytes:promise": transpiled, "bytes-module": transpiled }),
       stderr: "",
       exitCode: 0,
     });

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1046,6 +1046,84 @@ describe.concurrent("Bun.plugin.clearAll()", () => {
   });
 });
 
+// The transpiler reads the source text until it has printed the module. The
+// bytes of a typed array can change in that time, so it reads a copy of them.
+describe.concurrent("onLoad contents in a typed array", () => {
+  // A worker flips the `_` separators of the numeric literals to digits and
+  // back. The lexer counts the separators of a literal, sizes a buffer for the
+  // digits, then reads the literal again to fill it. When it read the shared
+  // bytes in place, the two reads did not agree: within 10 imports a literal had
+  // the wrong value or the process aborted.
+  it("transpiles a SharedArrayBuffer that a worker writes", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), resolve(import.meta.dir, "plugin-shared-contents-fixture.ts"), "100"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode }).toEqual({
+      stdout: "ok",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // A macro runs JS in the middle of the transpile. The printer reads the names
+  // and the strings of the module back from the source after that.
+  it("transpiles the bytes onLoad returned when a macro overwrites and detaches them", async () => {
+    using dir = tempDir("plugin-contents-macro", {
+      "macro.ts": `
+        export function clobber() {
+          globalThis.contents.fill(0x20);
+          globalThis.contents.buffer.transfer();
+          return "clobbered";
+        }
+      `,
+      "index.ts": `
+        import { plugin } from "bun";
+        import { join } from "node:path";
+
+        const source =
+          "import { clobber } from " + JSON.stringify(join(import.meta.dir, "macro.ts")) + ' with { type: "macro" };\\n' +
+          "export const fromTheMacro = clobber();\\n" +
+          "export const afterTheMacro = 'after the macro';\\n";
+        const bytes = new TextEncoder().encode(source);
+        globalThis.contents = new Uint8Array(new ArrayBuffer(bytes.length));
+        globalThis.contents.set(bytes);
+
+        plugin({
+          name: "typed array contents",
+          setup(build) {
+            build.onResolve({ filter: /.*/, namespace: "bytes" }, ({ path }) => ({ path, namespace: "bytes" }));
+            build.onLoad({ filter: /.*/, namespace: "bytes" }, () => ({ contents: globalThis.contents, loader: "ts" }));
+          },
+        });
+
+        const { fromTheMacro, afterTheMacro } = await import("bytes:module");
+        console.log(JSON.stringify({ fromTheMacro, afterTheMacro, byteLength: globalThis.contents.byteLength }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // A debug build logs each macro call to stdout first.
+    expect({ result: stdout.trim().split("\n").at(-1), stderr: stderr.trim(), exitCode }).toEqual({
+      result: JSON.stringify({ fromTheMacro: "clobbered", afterTheMacro: "after the macro", byteLength: 0 }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
 it("object loader: an error thrown by a getter on the exports object rejects the require()", () => {
   const boom = new Error("boom");
   plugin({


### PR DESCRIPTION
### Problem
- `Bun.plugin`: when `onLoad` or `build.module` returns `contents` as a typed array, the transpiler gets a pointer into that array (`src/jsc/bindings/ModuleLoader.cpp:308`). It reads them until the transpile ends.
- A worker that writes a `SharedArrayBuffer` behind `contents` aborts the process: `panic: index out of bounds: the len is 16 but the index is 16`. The lexer counts the `_` separators of a numeric literal, allocates `length - count` bytes, then reads the literal again (`src/js_parser/lexer.rs:3280`). Canary 1.4.3 fails 18 of 18 runs.
- A macro runs JS during the transpile. If it overwrites or detaches an unshared `contents` buffer, the printer emits garbage: `SyntaxError: Unexpected token '='`.

### Fix
- `handleOnLoadResultNotPromise` copies the bytes into a `WTF::Vector` that the `OnLoadResult` owns. The copy lives until `handleVirtualModuleResult` returns, after the transpile. An allocation failure rejects the import with an `OutOfMemoryError`.
- The copy is unconditional for typed arrays. A shared-or-resizable check does not cover a macro that writes or detaches a fixed-length buffer. A string is immutable and stays borrowed.
- Verified: two new tests in `test/js/bun/plugin/plugins.test.ts`. Both fail on the unfixed debug build and on canary. Also `test/js/bun/plugin/` and `mock-module.test.ts`.
- Self-reviewed: 9 concerns raised, 7 addressed. Notes list the 2 not taken.

### Background
- `OnLoadResult` carries the parsed `{ contents, loader }` result to `Bun__transpileVirtualModule`. It runs the parser and the printer on `contents` in place of a file.
- The AST keeps slices of the source for identifier names and string literals. The printer reads them after the macros ran.
- `Bun.build` plugins already copy `contents` (`JSBundlerPlugin__onLoadAsync`).

<details><summary>Notes</summary>

**Repro for the abort** (the fixture in this PR is a tighter version of it). Run `bun plugin-sab.ts`:

```ts
import { isMainThread, Worker, workerData } from "node:worker_threads";
import { plugin } from "bun";

const base = new TextEncoder().encode("export const a = 1_000_000_000_000_000;\n");
if (isMainThread) {
  const bytes = new SharedArrayBuffer(base.length);
  const ready = new SharedArrayBuffer(4);
  new Worker(new URL(import.meta.url), { workerData: { bytes, ready } }).unref();
  const input = new Uint8Array(bytes);
  input.set(base);
  Atomics.wait(new Int32Array(ready), 0, 0, 10_000);
  plugin({
    name: "sab",
    setup(build) {
      build.onResolve({ filter: /.*/, namespace: "sab" }, ({ path }) => ({ path, namespace: "sab" }));
      build.onLoad({ filter: /.*/, namespace: "sab" }, () => ({ contents: input, loader: "ts" }));
    },
  });
  for (let i = 0; i < 2000; i++) await import("sab:m" + i);
  console.log("ok");
  process.exit(0);
} else {
  const { bytes, ready } = workerData;
  const input = new Uint8Array(bytes);
  const at = [];
  for (let i = 0; i < base.length; i++) if (base[i] === 0x5f) at.push(i);
  Atomics.store(new Int32Array(ready), 0, 1);
  Atomics.notify(new Int32Array(ready), 0);
  for (;;) {
    for (const i of at) Atomics.store(input, i, 0x30);
    for (const i of at) Atomics.store(input, i, 0x5f);
  }
}
```

**What the unfixed builds do with the new tests.**
- SharedArrayBuffer test, canary 1.4.3 (4ff919377), 18 runs on several cores: 15 abort with the panic above. 3 stop because a literal has a wrong value (`1`, `570000000000000000000`). In those a digit turned into a `_` between the two reads, or the lexer parsed a `_` as a digit. All 18 fail within 10 imports.
- SharedArrayBuffer test, unfixed debug build, 3 runs: the panic on import 0, 1 and 3. The debug crash handler needs about 5 s to print the trace, so a local `bun bd test` reports this one as a timeout.
- Macro test, both unfixed builds, for sync `onLoad`, async `onLoad` and `build.module`: `SyntaxError: Unexpected token '='. Expected a parameter pattern or a ')' in parameter list.` The printer wrote spaces where the names were.

**Why the copy does not depend on `isShared()` or `isResizableOrGrowableShared()`.** Those checks are correct for a native call that does not run JS. This call runs JS: the visit pass calls macros (`src/js_parser/visit/visit_expr.rs`, `src/js_parser_jsc/Macro.rs`) on the same thread and the same global object, and the printer runs after them. JS can do these things to an unshared, fixed-length view:
- write it (`fill`)
- detach it (`transfer()`, `structuredClone` with a transfer list, `postMessage` with a transfer list)
- move its storage: a read of `.buffer` on a small typed array moves the bytes out of the GC cell, and the old block goes away at the next collection

The macro test in this PR uses a plain `new ArrayBuffer(n)`. It fails with a shared-or-resizable check.

**Why the test counts overlapped imports.** A release build finishes an import in about 50 µs. On a busy machine the worker's thread may not run during many of them. The fixture counts an import only when the worker completed a pass while it ran, and caps the total so that a starved worker cannot hang the run.

**Cost.** One `malloc` and one `memcpy` of the module source for each plugin-loaded module whose `contents` is a typed array. The lexer, the visitor and the printer then walk the same bytes, and the printed output is copied once more. String `contents` take the same path as before.

**Behavior that does not change.** I compared the fixed debug build with canary on these `contents` values, through sync `onLoad`, async `onLoad`, `build.module` and `require()`: empty view, detached view, `Buffer.subarray`, `DataView`, `Uint16Array`, a view on a `SharedArrayBuffer`, a view on a resizable buffer, an out-of-bounds length-tracking view, a 4 MB module, a string. The results are the same. The fixture and the macro probe also pass with `BUN_JSC_validateExceptionChecks=1`.

**Self-review, the 2 concerns not taken.**
- A view of 2 GiB or more now fails with `OutOfMemoryError` (the `WTF::Vector` limit). Before, it failed with "File is too large to parse (2 GiB maximum)". Neither build can load such a module.
- The worker test can pass on a broken build if the worker never gets CPU time. It can not fail on a fixed build. The macro test covers the same line with no timing.

**Related work.**
- #42310 copies shared or resizable input in `Bun.Transpiler`, `Bun.markdown`, `Bun.YAML.parse` and `Bun.TOML.parse`. It names this `onLoad` case as a follow-up. `transformSync` also runs macros, so a fixed-length buffer has the same macro hazard there.
- #41574 adds `Bun::stableBytes` (copy when shared) for the UTF-8 decoders. It takes the same `Vector<uint8_t>&` storage, so this site can call it later with `shared = true`.
- Bytes above 0x7F in a typed array are still read as Latin-1. #35729 fixes that.
- A bare `ArrayBuffer` or `SharedArrayBuffer` is still rejected. #33798 accepts them. It adds a second branch next to this one that borrows `impl()->data()`. That branch needs the same copy.
- #40404 rewrites the same line (`Zig::utf8Slice(view->span())`), also as a borrow.

</details>
