### PR TITLE
h3blast: define the BoringSSL embedder hooks so it links again

### DIFF
--- a/packages/h3blast/Makefile
+++ b/packages/h3blast/Makefile
@@ -21,10 +21,6 @@ LIBDEPS   := build/libdeps.a
 BIN := h3blast
 SRCS := src/h3blast.c src/boringssl_hooks.c
 
-# Bun's debug profile compiles its deps with ASan, so the runtime has to be
-# linked in too. Expanded in the recipe, once $(LIBDEPS) exists.
-ASAN = $(if $(shell nm -u $(LIBDEPS) | grep -m1 __asan_init),-fsanitize=address)
-
 all: $(BIN)
 
 $(LIBDEPS):
@@ -36,10 +32,18 @@ $(LIBDEPS):
 	@mkdir -p build
 	@echo "  AR    $@"
 	@find $(DEP_DIRS) -name '*.o' | xargs ar rcs $@
+	@if nm -u $@ | grep -q __asan_init; then \
+		rm -f $@; \
+		echo "error: the dep objects under $(OBJ) are ASan-instrumented"; \
+		echo "       (the default for Bun's debug profile). h3blast is a load"; \
+		echo "       generator: run 'bun run build:release' in the repo root,"; \
+		echo "       then 'make'"; \
+		exit 1; \
+	fi
 
 $(BIN): $(SRCS) $(LIBDEPS)
 	@echo "  CC    $@"
-	@$(CC) $(CFLAGS) $(ASAN) -o $@ $(SRCS) $(LIBDEPS) $(LDFLAGS)
+	@$(CC) $(CFLAGS) -o $@ $(SRCS) $(LIBDEPS) $(LDFLAGS)
 
 clean:
 	rm -f $(BIN) $(LIBDEPS)

--- a/packages/h3blast/Makefile
+++ b/packages/h3blast/Makefile
@@ -19,6 +19,11 @@ DEP_DIRS  := $(addprefix $(OBJ)/,$(DEPS))
 LIBDEPS   := build/libdeps.a
 
 BIN := h3blast
+SRCS := src/h3blast.c src/boringssl_hooks.c
+
+# Bun's debug profile compiles its deps with ASan, so the runtime has to be
+# linked in too. Expanded in the recipe, once $(LIBDEPS) exists.
+ASAN = $(if $(shell nm -u $(LIBDEPS) | grep -m1 __asan_init),-fsanitize=address)
 
 all: $(BIN)
 
@@ -32,9 +37,9 @@ $(LIBDEPS):
 	@echo "  AR    $@"
 	@find $(DEP_DIRS) -name '*.o' | xargs ar rcs $@
 
-$(BIN): src/h3blast.c $(LIBDEPS)
+$(BIN): $(SRCS) $(LIBDEPS)
 	@echo "  CC    $@"
-	@$(CC) $(CFLAGS) -o $@ $< $(LIBDEPS) $(LDFLAGS)
+	@$(CC) $(CFLAGS) $(ASAN) -o $@ $(SRCS) $(LIBDEPS) $(LDFLAGS)
 
 clean:
 	rm -f $(BIN) $(LIBDEPS)

--- a/packages/h3blast/Makefile
+++ b/packages/h3blast/Makefile
@@ -23,7 +23,9 @@ SRCS := src/h3blast.c src/boringssl_hooks.c
 
 all: $(BIN)
 
-$(LIBDEPS):
+# Archived again on every run: PROFILE picks the objects and a Bun rebuild
+# replaces them, and neither shows in this file's age.
+$(LIBDEPS): FORCE
 	@if [ ! -d "$(OBJ)/lsquic" ]; then \
 		echo "error: no dep objects found under $(OBJ)"; \
 		echo "       run 'bun run build:$(PROFILE)' in the repo root first"; \
@@ -31,6 +33,7 @@ $(LIBDEPS):
 	fi
 	@mkdir -p build
 	@echo "  AR    $@"
+	@rm -f $@
 	@find $(DEP_DIRS) -name '*.o' | xargs ar rcs $@
 	@if nm -u $@ | grep -q __asan_init; then \
 		rm -f $@; \
@@ -48,4 +51,6 @@ $(BIN): $(SRCS) $(LIBDEPS)
 clean:
 	rm -f $(BIN) $(LIBDEPS)
 
-.PHONY: all clean
+FORCE:
+
+.PHONY: all clean FORCE

--- a/packages/h3blast/README.md
+++ b/packages/h3blast/README.md
@@ -46,9 +46,9 @@ cd packages/h3blast
 make                   # → ./h3blast
 ```
 
-`PROFILE=debug make` links against the debug objects instead. Bun's debug
-profile builds them with ASan, so the Makefile links the ASan runtime too. Expect
-lower numbers than from a release h3blast.
+`PROFILE=debug make` links against the debug objects instead. `make` refuses
+objects that are ASan-instrumented, which is the default for Bun's debug profile
+on Linux. An instrumented load generator does not give useful numbers.
 
 Bun compiles BoringSSL to call embedder hooks (allocator, PEM base64) that the
 `bun` binary defines. `src/boringssl_hooks.c` defines libc-backed ones for

--- a/packages/h3blast/README.md
+++ b/packages/h3blast/README.md
@@ -46,7 +46,14 @@ cd packages/h3blast
 make                   # → ./h3blast
 ```
 
-`PROFILE=debug make` links against the debug objects instead.
+`PROFILE=debug make` links against the debug objects instead. Bun's debug
+profile builds them with ASan, so the Makefile links the ASan runtime too. Expect
+lower numbers than from a release h3blast.
+
+Bun compiles BoringSSL to call embedder hooks (allocator, PEM base64) that the
+`bun` binary defines. `src/boringssl_hooks.c` defines libc-backed ones for
+h3blast. If the link fails with an undefined `OPENSSL_*` symbol after a
+BoringSSL change, define the new hook there.
 
 ## Usage
 

--- a/packages/h3blast/src/boringssl_hooks.c
+++ b/packages/h3blast/src/boringssl_hooks.c
@@ -1,0 +1,69 @@
+// The embedder hooks Bun's BoringSSL objects call.
+//
+// scripts/build/deps/boringssl.ts compiles BoringSSL with
+// BORINGSSL_REQUIRE_MEMORY_HOOKS and BORINGSSL_PEM_FAST_PUBLIC_BASE64, which
+// turn the functions below into undefined symbols the embedder has to supply.
+// The bun binary gets them from src/boringssl/lib.rs (mimalloc) and
+// src/simdutf_sys/bun-simdutf.cpp (simdutf). h3blast links the same objects
+// without either, so it supplies libc-backed ones.
+
+#define _GNU_SOURCE
+#define BORINGSSL_PEM_FAST_PUBLIC_BASE64
+#include <malloc.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <openssl/base64.h>
+#include <openssl/mem.h>
+#include <openssl/pem.h>
+
+// crypto/mem.cc: back OPENSSL_malloc/OPENSSL_free. The free hook has to zero
+// the block itself and is never passed NULL.
+void *OPENSSL_memory_alloc(size_t size) { return malloc(size); }
+
+size_t OPENSSL_memory_get_size(void *ptr) { return malloc_usable_size(ptr); }
+
+void OPENSSL_memory_free(void *ptr) {
+    explicit_bzero(ptr, malloc_usable_size(ptr));
+    free(ptr);
+}
+
+// crypto/internal.h: back the allocations BoringSSL keeps off OPENSSL_malloc
+// (TLS record buffers, the error queue, thread-local tables). Not zeroed.
+void *OPENSSL_system_malloc(size_t size) { return malloc(size); }
+
+void *OPENSSL_system_realloc(void *ptr, size_t size) { return realloc(ptr, size); }
+
+void OPENSSL_system_free(void *ptr) { free(ptr); }
+
+// <openssl/pem.h>: base64 for PEM blocks that carry public data. Same shape as
+// the reference hooks in BoringSSL's crypto/pem/pem_test.cc.
+int OPENSSL_pem_public_base64_decode(uint8_t *out, size_t *out_len, size_t max_out,
+                                     const uint8_t *in, size_t in_len) {
+    uint8_t *stripped = malloc(in_len ? in_len : 1);
+    if (stripped == NULL) return 0;
+    size_t n = 0;
+    for (size_t i = 0; i < in_len; i++) {
+        if (!OPENSSL_isspace(in[i])) stripped[n++] = in[i];
+    }
+    int ok = EVP_DecodeBase64(out, out_len, max_out, stripped, n);
+    free(stripped);
+    return ok;
+}
+
+size_t OPENSSL_pem_public_base64_encode(char *out, size_t max_out, const uint8_t *in,
+                                        size_t in_len) {
+    size_t written = 0;
+    while (in_len > 0) {
+        // 48 input bytes fill one 64-character line.
+        size_t n = in_len > 48 ? 48 : in_len;
+        // EVP_EncodeBlock also writes a NUL, which the newline then replaces.
+        if (written + (n + 2) / 3 * 4 + 1 > max_out) return 0;
+        written += EVP_EncodeBlock((uint8_t *)out + written, in, n);
+        out[written++] = '\n';
+        in += n;
+        in_len -= n;
+    }
+    return written;
+}

--- a/packages/h3blast/src/h3blast.c
+++ b/packages/h3blast/src/h3blast.c
@@ -1178,10 +1178,6 @@ static int parse_args(int argc, char **argv, struct config *cfg) {
 
 // ───────────────────────── main ─────────────────────────
 
-// A `PROFILE=debug` build links ASan. h3blast exits with its workers' state
-// still allocated; LeakSanitizer would report that and fail the run.
-const char *__asan_default_options(void) { return "detect_leaks=0"; }
-
 int main(int argc, char **argv) {
     g_isatty = isatty(STDERR_FILENO) && isatty(STDOUT_FILENO);
     if (g_isatty && !getenv("NO_COLOR")) enable_color();

--- a/packages/h3blast/src/h3blast.c
+++ b/packages/h3blast/src/h3blast.c
@@ -1178,6 +1178,10 @@ static int parse_args(int argc, char **argv, struct config *cfg) {
 
 // ───────────────────────── main ─────────────────────────
 
+// A `PROFILE=debug` build links ASan. h3blast exits with its workers' state
+// still allocated; LeakSanitizer would report that and fail the run.
+const char *__asan_default_options(void) { return "detect_leaks=0"; }
+
 int main(int argc, char **argv) {
     g_isatty = isatty(STDERR_FILENO) && isatty(STDOUT_FILENO);
     if (g_isatty && !getenv("NO_COLOR")) enable_color();

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -48,6 +48,11 @@ export const boringssl: Dependency = {
       includes: ["include"],
       defines: {
         BORINGSSL_IMPLEMENTATION: true,
+        // The two defines below make BoringSSL call functions its embedder
+        // defines. packages/h3blast links these objects too, with its own
+        // definitions in packages/h3blast/src/boringssl_hooks.c: a new hook
+        // needs one there as well.
+        //
         // The fork (oven-sh/boringssl#11) binds OPENSSL_memory_* as plain externs
         // on every object format, not just as ELF weak symbols, and routes the
         // sites upstream keeps on libc malloc (TLS record buffers, error queue,

--- a/test/internal/h3blast-link.test.ts
+++ b/test/internal/h3blast-link.test.ts
@@ -2,15 +2,16 @@
 // BoringSSL itself: it links the objects a local Bun build leaves in
 // build/<profile>/obj/vendor. Bun compiles those objects for its own binary
 // (scripts/build/deps/boringssl.ts), so BoringSSL expects the embedder to
-// define its allocator and PEM base64 hooks, and the debug profile is
-// ASan-instrumented. h3blast has to keep up with both or its final link fails:
+// define its allocator and PEM base64 hooks. h3blast has to keep up or its
+// final link fails:
 //   undefined reference to `OPENSSL_memory_alloc'
+// Bun's debug profile also builds them with ASan. `make` refuses those.
 //
 // Test-only CI lanes run a prebuilt binary and have no build tree; skip there.
 import { Glob, which } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, isLinux, tempDir, tls } from "harness";
-import { cpSync, existsSync, statSync } from "node:fs";
+import { cpSync, existsSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 const repoRoot = join(import.meta.dir, "..", "..");
@@ -20,6 +21,13 @@ const make = which("make");
 const canBuild = isLinux && make !== null && which("cc") !== null;
 // DEPS in the Makefile.
 const deps = ["lsquic", "lsqpack", "lshpack", "boringssl", "hdrhistogram", "zlib"];
+// A C compile and an archive of ~550 objects, not a wait on a condition.
+const buildTimeout = 60_000;
+
+// crypto/mem.cc is where BoringSSL calls the allocator hooks. One build compiles
+// every object the same way, so this one tells how all of them were compiled.
+const probeObject = (profile: string) =>
+  join(repoRoot, "build", profile, "obj", "vendor", "boringssl", "crypto", "mem.cc.o");
 
 // Why h3blast cannot be linked against this profile's objects, or null if it can.
 // Objects are per profile. vendor/<dep> is shared: the headers h3blast.c compiles
@@ -29,49 +37,63 @@ const deps = ["lsquic", "lsqpack", "lshpack", "boringssl", "hdrhistogram", "zlib
 //   - A dep bump plus a debug-only rebuild leaves build/release with the old
 //     source's objects under the new headers. A patch has already added a field
 //     in the middle of struct lsquic_engine_settings.
-// Both are the state of the machine, not a broken h3blast, so they skip.
+//   - An LTO build (CI, or --lto=on) leaves LLVM bitcode in the .o files. ld
+//     rejects the archive: "error adding symbols: file format not recognized".
+// All are the state of the machine, not a broken h3blast, so they skip.
 function unusable(profile: string): string | null {
   const buildDir = join(repoRoot, "build", profile);
-  // The final link needs every object, so this says the set was complete once.
-  const exe = profile === "debug" ? "bun-debug" : "bun-profile";
-  if (!existsSync(join(buildDir, exe))) return `no build/${profile}/${exe}`;
+  // ninja links this last, after every object is up to date. Its age stands for
+  // theirs: obj/ also keeps objects of sources a dep has dropped, which never
+  // get rebuilt and would look stale forever.
+  const exeName = profile === "debug" ? "bun-debug" : "bun-profile";
+  const exe = statSync(join(buildDir, exeName), { throwIfNoEntry: false });
+  if (!exe) return `no build/${profile}/${exeName}`;
   for (const dep of deps) {
     const ref = statSync(join(repoRoot, "vendor", dep, ".ref"), { throwIfNoEntry: false });
     if (!ref) return `no vendor/${dep}/.ref`;
+    if (exe.mtimeMs < ref.mtimeMs) return `build/${profile}/${exeName} is older than vendor/${dep}/.ref`;
     const objDir = join(buildDir, "obj", "vendor", dep);
-    const objects = existsSync(objDir) ? [...new Glob("**/*.o").scanSync({ cwd: objDir, absolute: true })] : [];
-    if (objects.length === 0) return `no ${dep} objects in build/${profile}`;
-    if (objects.some(o => statSync(o).mtimeMs < ref.mtimeMs)) {
-      return `build/${profile} has ${dep} objects older than vendor/${dep}/.ref`;
+    if (!existsSync(objDir) || new Glob("**/*.o").scanSync({ cwd: objDir }).next().done) {
+      return `no ${dep} objects in build/${profile}`;
     }
   }
+  if (!existsSync(probeObject(profile))) return `no boringssl/crypto/mem.cc.o in build/${profile}`;
+  if (!readFileSync(probeObject(profile)).subarray(0, 4).equals(Buffer.from("\x7fELF", "latin1"))) {
+    return `build/${profile} objects are not ELF (LTO)`;
+  }
   return null;
+}
+
+// Copies the package so that nothing lands in the source tree and a binary left
+// over from a manual `make` cannot satisfy the build. Then runs `make` in the copy.
+async function runMake(dir: string, profile: string) {
+  cpSync(join(pkg, "Makefile"), join(dir, "Makefile"));
+  cpSync(join(pkg, "src"), join(dir, "src"), { recursive: true });
+  await using proc = Bun.spawn({
+    cmd: [make!, `ROOT=${repoRoot}`, `PROFILE=${profile}`],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
 }
 
 describe.concurrent("h3blast", () => {
   for (const profile of ["release", "debug"]) {
     const why = canBuild ? unusable(profile) : "needs Linux, make and cc";
+    // Every instrumented object references the ASan runtime's init function.
+    const asan = why === null && readFileSync(probeObject(profile)).includes("__asan_init");
+    const skipped = (reason: string | null) => (reason === null ? "" : ` (skipped: ${reason})`);
 
-    test.skipIf(why !== null)(
-      `links against build/${profile} and completes requests${why === null ? "" : ` (skipped: ${why})`}`,
+    test.skipIf(why !== null || asan)(
+      `links against build/${profile} and completes requests${skipped(why ?? (asan ? "ASan-instrumented objects" : null))}`,
       async () => {
-        // Build a copy so nothing lands in the source tree and a binary left
-        // over from a manual `make` cannot satisfy the build.
         using dir = tempDir("h3blast-link", {});
-        cpSync(join(pkg, "Makefile"), join(String(dir), "Makefile"));
-        cpSync(join(pkg, "src"), join(String(dir), "src"), { recursive: true });
-
         {
-          await using proc = Bun.spawn({
-            cmd: [make!, `ROOT=${repoRoot}`, `PROFILE=${profile}`],
-            cwd: String(dir),
-            env: bunEnv,
-            stdout: "pipe",
-            stderr: "pipe",
-          });
-          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-          // ld prints one line per reference, thousands of them when the ASan
-          // runtime is missing. Name each missing symbol once instead.
+          const { stdout, stderr, exitCode } = await runMake(String(dir), profile);
+          // ld prints one line per reference. Name each missing symbol once instead.
           // GNU ld: "undefined reference to `sym'", lld: "undefined symbol: sym".
           const missing = new Set(
             Array.from(stderr.matchAll(/undefined (?:reference to `|symbol: )([^'\s]+)/g), m => m[1]),
@@ -94,12 +116,12 @@ describe.concurrent("h3blast", () => {
             join(String(dir), "h3blast"),
             "--json",
             ...["--threads", "1", "--connections", "1", "--streams", "4"],
-            ...["--requests", String(requests)],
+            // --requests clears the time limit, so --duration comes after it. A
+            // run that stalls then ends with its counters printed.
+            ...["--requests", String(requests), "--duration", "10"],
             `https://127.0.0.1:${server.port}/`,
           ],
-          // An ASan-linked h3blast sets its own defaults (__asan_default_options
-          // in h3blast.c). It must not inherit the CI runner's detect_leaks=1.
-          env: { ...bunEnv, ASAN_OPTIONS: undefined },
+          env: bunEnv,
           stdout: "pipe",
           stderr: "pipe",
         });
@@ -107,16 +129,34 @@ describe.concurrent("h3blast", () => {
 
         expect(stderr).toBe("");
         const [result] = JSON.parse(stdout);
-        expect(result).toMatchObject({
+        // h3blast samples its counters at 10 Hz, so it can overshoot the target.
+        expect({ ...result, enough: result.requests >= requests }).toMatchObject({
+          enough: true,
           errors: 0,
           status: { "2xx": result.requests, "3xx": 0, "4xx": 0, "5xx": 0, other: 0 },
         });
-        // h3blast samples its counters at 10 Hz, so it can overshoot the target.
-        expect(result.requests).toBeGreaterThanOrEqual(requests);
         expect(exitCode).toBe(0);
       },
-      // A C compile and a link of ~550 objects, not a wait on a condition.
-      60_000,
+      buildTimeout,
+    );
+
+    test.skipIf(why !== null || !asan)(
+      `refuses build/${profile}, whose objects are ASan-instrumented${skipped(why ?? (asan ? null : "objects are not ASan-instrumented"))}`,
+      async () => {
+        using dir = tempDir("h3blast-link", {});
+        const { stdout, stderr, exitCode } = await runMake(String(dir), profile);
+        // The archive must not stay behind: LIBDEPS is not keyed by profile, so a
+        // later plain `make` would link it and fail on every __asan_* symbol.
+        const archive = existsSync(join(String(dir), "build", "libdeps.a"));
+        expect({ stdout, stderr: stderr.slice(-4096), exitCode, archive }).toMatchObject({
+          stdout: expect.stringContaining(
+            `error: the dep objects under ${repoRoot}/build/${profile}/obj/vendor are ASan-instrumented`,
+          ),
+          exitCode: 2,
+          archive: false,
+        });
+      },
+      buildTimeout,
     );
   }
 });

--- a/test/internal/h3blast-link.test.ts
+++ b/test/internal/h3blast-link.test.ts
@@ -11,7 +11,7 @@
 import { Glob, which } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, isLinux, tempDir, tls } from "harness";
-import { cpSync, existsSync, readFileSync, statSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const repoRoot = join(import.meta.dir, "..", "..");
@@ -64,11 +64,16 @@ function unusable(profile: string): string | null {
   return null;
 }
 
-// Copies the package so that nothing lands in the source tree and a binary left
-// over from a manual `make` cannot satisfy the build. Then runs `make` in the copy.
+// Runs `make` in a copy of the package, so that nothing lands in the source tree.
 async function runMake(dir: string, profile: string) {
   cpSync(join(pkg, "Makefile"), join(dir, "Makefile"));
   cpSync(join(pkg, "src"), join(dir, "src"), { recursive: true });
+  // What a build against another profile leaves behind: an archive (here an
+  // empty one) and a binary, both newer than the sources. The archive path is
+  // the same for every profile, so `make` must not take them as up to date.
+  mkdirSync(join(dir, "build"));
+  writeFileSync(join(dir, "build", "libdeps.a"), "!<arch>\n");
+  writeFileSync(join(dir, "h3blast"), "");
   await using proc = Bun.spawn({
     cmd: [make!, `ROOT=${repoRoot}`, `PROFILE=${profile}`],
     cwd: dir,

--- a/test/internal/h3blast-link.test.ts
+++ b/test/internal/h3blast-link.test.ts
@@ -7,10 +7,10 @@
 //   undefined reference to `OPENSSL_memory_alloc'
 //
 // Test-only CI lanes run a prebuilt binary and have no build tree; skip there.
-import { which } from "bun";
+import { Glob, which } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, isLinux, tempDir, tls } from "harness";
-import { cpSync, existsSync } from "node:fs";
+import { cpSync, existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 const repoRoot = join(import.meta.dir, "..", "..");
@@ -18,13 +18,42 @@ const pkg = join(repoRoot, "packages", "h3blast");
 const make = which("make");
 // h3blast is Linux-only (epoll, timerfd, sendmmsg).
 const canBuild = isLinux && make !== null && which("cc") !== null;
+// DEPS in the Makefile.
+const deps = ["lsquic", "lsqpack", "lshpack", "boringssl", "hdrhistogram", "zlib"];
+
+// Why h3blast cannot be linked against this profile's objects, or null if it can.
+// Objects are per profile. vendor/<dep> is shared: the headers h3blast.c compiles
+// against, and the .ref stamp a fetch rewrites only when the source changes.
+//   - Configure creates all of obj/ before anything compiles, so after an
+//     interrupted build the directories exist and the link misses lsquic_*, SSL_*.
+//   - A dep bump plus a debug-only rebuild leaves build/release with the old
+//     source's objects under the new headers. A patch has already added a field
+//     in the middle of struct lsquic_engine_settings.
+// Both are the state of the machine, not a broken h3blast, so they skip.
+function unusable(profile: string): string | null {
+  const buildDir = join(repoRoot, "build", profile);
+  // The final link needs every object, so this says the set was complete once.
+  const exe = profile === "debug" ? "bun-debug" : "bun-profile";
+  if (!existsSync(join(buildDir, exe))) return `no build/${profile}/${exe}`;
+  for (const dep of deps) {
+    const ref = statSync(join(repoRoot, "vendor", dep, ".ref"), { throwIfNoEntry: false });
+    if (!ref) return `no vendor/${dep}/.ref`;
+    const objDir = join(buildDir, "obj", "vendor", dep);
+    const objects = existsSync(objDir) ? [...new Glob("**/*.o").scanSync({ cwd: objDir, absolute: true })] : [];
+    if (objects.length === 0) return `no ${dep} objects in build/${profile}`;
+    if (objects.some(o => statSync(o).mtimeMs < ref.mtimeMs)) {
+      return `build/${profile} has ${dep} objects older than vendor/${dep}/.ref`;
+    }
+  }
+  return null;
+}
 
 describe.concurrent("h3blast", () => {
   for (const profile of ["release", "debug"]) {
-    const hasObjects = existsSync(join(repoRoot, "build", profile, "obj", "vendor", "lsquic"));
+    const why = canBuild ? unusable(profile) : "needs Linux, make and cc";
 
-    test.skipIf(!canBuild || !hasObjects)(
-      `links against build/${profile} and completes requests`,
+    test.skipIf(why !== null)(
+      `links against build/${profile} and completes requests${why === null ? "" : ` (skipped: ${why})`}`,
       async () => {
         // Build a copy so nothing lands in the source tree and a binary left
         // over from a manual `make` cannot satisfy the build.

--- a/test/internal/h3blast-link.test.ts
+++ b/test/internal/h3blast-link.test.ts
@@ -24,8 +24,8 @@ const deps = ["lsquic", "lsqpack", "lshpack", "boringssl", "hdrhistogram", "zlib
 // A C compile and an archive of ~550 objects, not a wait on a condition.
 const buildTimeout = 60_000;
 
-// crypto/mem.cc is where BoringSSL calls the allocator hooks. One build compiles
-// every object the same way, so this one tells how all of them were compiled.
+// crypto/mem.cc is where BoringSSL calls the allocator hooks. A build that ran
+// to the end compiled every object the same way, so this one tells how.
 const probeObject = (profile: string) =>
   join(repoRoot, "build", profile, "obj", "vendor", "boringssl", "crypto", "mem.cc.o");
 
@@ -39,12 +39,15 @@ const probeObject = (profile: string) =>
 //     in the middle of struct lsquic_engine_settings.
 //   - An LTO build (CI, or --lto=on) leaves LLVM bitcode in the .o files. ld
 //     rejects the archive: "error adding symbols: file format not recognized".
+//   - A rebuild with other flags (build:debug, then build:debug:noasan) that
+//     stops midway leaves objects of both kinds.
 // All are the state of the machine, not a broken h3blast, so they skip.
 function unusable(profile: string): string | null {
   const buildDir = join(repoRoot, "build", profile);
-  // ninja links this last, after every object is up to date. Its age stands for
-  // theirs: obj/ also keeps objects of sources a dep has dropped, which never
-  // get rebuilt and would look stale forever.
+  // ninja links this last, after every object is up to date. So the last build
+  // ran to the end if no object is newer, and it saw the current sources if no
+  // .ref is newer. An object can be much older: obj/ keeps the objects of
+  // sources a dep has dropped, and those never get rebuilt.
   const exeName = profile === "debug" ? "bun-debug" : "bun-profile";
   const exe = statSync(join(buildDir, exeName), { throwIfNoEntry: false });
   if (!exe) return `no build/${profile}/${exeName}`;
@@ -53,8 +56,10 @@ function unusable(profile: string): string | null {
     if (!ref) return `no vendor/${dep}/.ref`;
     if (exe.mtimeMs < ref.mtimeMs) return `build/${profile}/${exeName} is older than vendor/${dep}/.ref`;
     const objDir = join(buildDir, "obj", "vendor", dep);
-    if (!existsSync(objDir) || new Glob("**/*.o").scanSync({ cwd: objDir }).next().done) {
-      return `no ${dep} objects in build/${profile}`;
+    const objects = existsSync(objDir) ? [...new Glob("**/*.o").scanSync({ cwd: objDir, absolute: true })] : [];
+    if (objects.length === 0) return `no ${dep} objects in build/${profile}`;
+    if (objects.some(o => statSync(o).mtimeMs > exe.mtimeMs)) {
+      return `build/${profile} has ${dep} objects newer than ${exeName}: the last build did not finish`;
     }
   }
   if (!existsSync(probeObject(profile))) return `no boringssl/crypto/mem.cc.o in build/${profile}`;

--- a/test/internal/h3blast-link.test.ts
+++ b/test/internal/h3blast-link.test.ts
@@ -1,0 +1,93 @@
+// packages/h3blast is a standalone C program. It does not compile lsquic and
+// BoringSSL itself: it links the objects a local Bun build leaves in
+// build/<profile>/obj/vendor. Bun compiles those objects for its own binary
+// (scripts/build/deps/boringssl.ts), so BoringSSL expects the embedder to
+// define its allocator and PEM base64 hooks, and the debug profile is
+// ASan-instrumented. h3blast has to keep up with both or its final link fails:
+//   undefined reference to `OPENSSL_memory_alloc'
+//
+// Test-only CI lanes run a prebuilt binary and have no build tree; skip there.
+import { which } from "bun";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isLinux, tempDir, tls } from "harness";
+import { cpSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+const pkg = join(repoRoot, "packages", "h3blast");
+const make = which("make");
+// h3blast is Linux-only (epoll, timerfd, sendmmsg).
+const canBuild = isLinux && make !== null && which("cc") !== null;
+
+describe.concurrent("h3blast", () => {
+  for (const profile of ["release", "debug"]) {
+    const hasObjects = existsSync(join(repoRoot, "build", profile, "obj", "vendor", "lsquic"));
+
+    test.skipIf(!canBuild || !hasObjects)(
+      `links against build/${profile} and completes requests`,
+      async () => {
+        // Build a copy so nothing lands in the source tree and a binary left
+        // over from a manual `make` cannot satisfy the build.
+        using dir = tempDir("h3blast-link", {});
+        cpSync(join(pkg, "Makefile"), join(String(dir), "Makefile"));
+        cpSync(join(pkg, "src"), join(String(dir), "src"), { recursive: true });
+
+        {
+          await using proc = Bun.spawn({
+            cmd: [make!, `ROOT=${repoRoot}`, `PROFILE=${profile}`],
+            cwd: String(dir),
+            env: bunEnv,
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          // ld prints one line per reference, thousands of them when the ASan
+          // runtime is missing. Name each missing symbol once instead.
+          // GNU ld: "undefined reference to `sym'", lld: "undefined symbol: sym".
+          const missing = new Set(
+            Array.from(stderr.matchAll(/undefined (?:reference to `|symbol: )([^'\s]+)/g), m => m[1]),
+          );
+          expect([...missing].sort()).toEqual([]);
+          expect({ stdout, stderr: stderr.slice(-4096), exitCode }).toMatchObject({ exitCode: 0 });
+        }
+
+        await using server = Bun.serve({
+          port: 0,
+          tls,
+          http3: true,
+          http1: false,
+          fetch: () => new Response("Hello, World!"),
+        });
+
+        const requests = 32;
+        await using proc = Bun.spawn({
+          cmd: [
+            join(String(dir), "h3blast"),
+            "--json",
+            ...["--threads", "1", "--connections", "1", "--streams", "4"],
+            ...["--requests", String(requests)],
+            `https://127.0.0.1:${server.port}/`,
+          ],
+          // An ASan-linked h3blast sets its own defaults (__asan_default_options
+          // in h3blast.c). It must not inherit the CI runner's detect_leaks=1.
+          env: { ...bunEnv, ASAN_OPTIONS: undefined },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        expect(stderr).toBe("");
+        const [result] = JSON.parse(stdout);
+        expect(result).toMatchObject({
+          errors: 0,
+          status: { "2xx": result.requests, "3xx": 0, "4xx": 0, "5xx": 0, other: 0 },
+        });
+        // h3blast samples its counters at 10 Hz, so it can overshoot the target.
+        expect(result.requests).toBeGreaterThanOrEqual(requests);
+        expect(exitCode).toBe(0);
+      },
+      // A C compile and a link of ~550 objects, not a wait on a condition.
+      60_000,
+    );
+  }
+});


### PR DESCRIPTION
### Problem

- `make` in `packages/h3blast` fails at the final link after `bun run build:release`: ``undefined reference to `OPENSSL_memory_alloc'`` and 7 more (`OPENSSL_memory_free`, `OPENSSL_memory_get_size`, `OPENSSL_system_malloc`, `OPENSSL_system_realloc`, `OPENSSL_system_free`, `OPENSSL_pem_public_base64_encode`, `OPENSSL_pem_public_base64_decode`).
- h3blast links the vendor objects from `build/<profile>/obj/vendor`. `scripts/build/deps/boringssl.ts` compiles BoringSSL with `BORINGSSL_REQUIRE_MEMORY_HOOKS` and `BORINGSSL_PEM_FAST_PUBLIC_BASE64`, so the objects call functions that only the `bun` binary defines (`src/boringssl/lib.rs:109`, `src/simdutf_sys/bun-simdutf.cpp:127`). The hooks came with #34847, #39472 and #40862, after the Makefile.

### Fix

- Add `packages/h3blast/src/boringssl_hooks.c` with libc-backed definitions of the 8 hooks, and compile it into `h3blast`. The PEM hooks are the reference ones from `crypto/pem/pem_test.cc`.
- `PROFILE=debug make` never linked on Linux: the debug profile builds its deps with ASan. The Makefile now refuses such objects and says what to build. It archives the objects again on every `make`, because `build/libdeps.a` is one path for every profile.
- Verified: `test/internal/h3blast-link.test.ts` builds h3blast against a release tree and completes 32 requests against `Bun.serve({ http3: true })`. Against an ASan tree it checks the refusal. Both fail without the fix. It skips on lanes with no build tree.
- Self-reviewed: 16 concerns raised, 9 addressed. Not taken: a CI lint for the hook set, and three build-integration changes (Notes). No CI lane links h3blast, so the next new hook breaks `make` again. The README and a comment in `boringssl.ts` say where to add it.

### Background

- h3blast is the in-repo HTTP/3 load generator for `Bun.serve({ http3: true })`, a standalone C program outside the `bun` build.
- An embedder hook is a function a library declares and calls but does not define. The program that links the library defines it.
- ASan-instrumented objects call `__asan_*` functions from a runtime library. The link gets it only with `-fsanitize=address`.

<details><summary>Notes</summary>

- Reproduced on main at 4b5862fd88 (linux x64): 38x `OPENSSL_system_free`, 27x `OPENSSL_system_malloc`, 12x `OPENSSL_memory_alloc`, 7x `OPENSSL_memory_free`, 2x `OPENSSL_memory_get_size`, 1x each of the other three.
- In the debug profile `BORINGSSL_REQUIRE_MEMORY_HOOKS` is off (ASan). There `OPENSSL_memory_*` are weak references and `OPENSSL_system_*` are inline, so only the two PEM hooks and the `__asan_*` symbols are undefined.
- h3blast never reads PEM. The linker map shows `pem_lib.cc.o` is pulled in to satisfy `PEM_ASN1_read` for `ssl_x509.cc.o`, so the PEM hooks only have to exist. They are still real implementations, so a later `--cacert` option does not fail silently.
- PEM hooks checked against JS base64 (`Buffer.toString("base64")` wrapped at 64 columns) for input lengths 1, 2, 3, 47, 48, 49, 95, 96, 97, 1000, 4096 and 100000: encode output is identical, and decode of it returns the input. A trace build shows the hooks run for `CERTIFICATE` and not for `PRIVATE KEY`.
- The allocator hooks follow the contract in `crypto/mem.cc`: the free hook zeroes the block and never gets NULL. Bun's BoringSSL fork uses the hooks to allocate from mimalloc and to decode public PEM with simdutf.
- `explicit_bzero` and not `memset`: a compiler can drop a `memset` that is followed by `free`.
- Manual run: release h3blast, `-t 2 -c 4 -m 32 -d 3` against `test-server.js` on the release bun: 162,159 req/s, 0 errors. Linked with gcc 14.2 and with clang 21.
- `asanDefault = debug && ((darwin && arm64) || linux)` was already in `scripts/build/config.ts` at b424bb7147, the commit that added h3blast. With the Makefile from main, `PROFILE=debug make` prints 52,907 undefined references and leaves `build/libdeps.a`. That path is not keyed by profile, so the plain `make` that follows links the stale archive and fails with 51,968 undefined `__asan_*`.
- An earlier revision of this PR linked the ASan runtime when `libdeps.a` referenced `__asan_init`. With the same stale archive, plain `make` then produced an instrumented h3blast without a word. An ASan h3blast ran at about half the request rate of the release one. Hence the refusal.
- `$(LIBDEPS)` had no prerequisites. After a release build, `PROFILE=debug make` printed `Nothing to be done for 'all'`, so the ASan check did not run, and objects replaced by a Bun rebuild were ignored until `make clean`. The rule now depends on a phony target and starts from an empty archive. Every `make` takes about 3 s. The test plants a stale archive and binary before it runs `make`.
- Test skip gate: a profile is used only when its `bun-profile`/`bun-debug` exists, is not older than any `vendor/<dep>/.ref` and not older than any dep object, every dep has objects, and `boringssl/crypto/mem.cc.o` is ELF. ninja links the executable last, so a newer object means the last build did not finish (for example `build:debug`, then an interrupted `build:debug:noasan`, which leaves objects of both kinds). Reasons: `scripts/build/configure.ts` creates every object directory before ninja compiles anything. `vendor/<dep>` is shared by all profiles while objects are per profile, and `patches/lsquic/node-quic-accessors.patch` already added a field in the middle of `struct lsquic_engine_settings`. `obj/` keeps objects of sources a dep dropped, so per-object ages are not usable. An LTO tree holds LLVM bitcode that `ld` rejects (`file format not recognized`). A skip names its reason in the test title.
- Deleting `boringssl_hooks.c` from `SRCS`, the refusal, or the `FORCE` prerequisite from the Makefile each fails the test.
- Self-review, not taken in this PR. (1) A CI source lint that compares the `extern "C"` `OPENSSL_*` definitions in `src/` with `boringssl_hooks.c`: it was written and works, but it is a new CI policy for a dev tool and no maintainer asked for it, so it is left for a separate PR. (2) An exact-set hook check with `nm` in `scripts/build`. (3) Passing the deps' ABI `-D` flags to h3blast from `compile_commands.json`. No drift exists today. (4) An opt-in `h3blast` ninja target. (5) The README still asks for a full `bun run build:release`. A deps-only `--target` build is enough to link h3blast and is much faster, but the test gate keys on `bun-profile`.
- `CC ?= clang` in the Makefile has no effect in GNU make (`CC` has a built-in default, `cc`). This PR does not change that.

</details>
