### PR TITLE
fix(node:http): preserve listener in closeAllConnections

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -445,15 +445,15 @@ Server.prototype.unref = function () {
 
 Server.prototype.closeAllConnections = function () {
   http1Fallback?.closeAllHttp1Connections(this);
-  const server = this[serverSymbol];
-  if (!server) {
+  const connections = this[kTrackedConnections];
+  if (!connections) {
     return;
   }
-  this[serverSymbol] = undefined;
-  clearInterval(this[kConnectionsCheckingInterval]);
-  this.listening = false;
-
-  server.stop(true);
+  for (const socket of connections) {
+    if (socket.parser !== null) {
+      socket.destroy();
+    }
+  }
 };
 
 Server.prototype.getConnections = function (callback) {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -201,57 +201,58 @@ describe("node:http", () => {
       }
     });
 
-    it.each(["upgrade", "connect"] as const)("leaves handed-off %s sockets open", async kind => {
-      const server = createServer();
-      const { promise: handedOff, resolve: onHandedOff } =
-        Promise.withResolvers<import("node:net").Socket>();
-      const onHandoff = (_request: IncomingMessage, socket: import("node:net").Socket) => {
-        socket.write(
-          kind === "upgrade"
-            ? "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n"
-            : "HTTP/1.1 200 Connection Established\r\n\r\n",
-        );
-        onHandedOff(socket);
-      };
-      if (kind === "upgrade") {
-        server.on("upgrade", onHandoff);
-      } else {
-        server.on("connect", onHandoff);
-      }
-      server.listen(0, "127.0.0.1");
-      await once(server, "listening");
-      const address = server.address() as AddressInfo;
-      const client = connect(address.port, "127.0.0.1");
-      let serverSocket: import("node:net").Socket | undefined;
-
-      try {
-        await once(client, "connect");
-        client.write(
-          kind === "upgrade"
-            ? "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n"
-            : "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n",
-        );
-        serverSocket = await handedOff;
-        await once(client, "data");
-
-        server.closeAllConnections();
-        expect({ listening: server.listening, serverSocketDestroyed: serverSocket.destroyed }).toEqual({
-          listening: true,
-          serverSocketDestroyed: false,
-        });
-        serverSocket.write("still-open");
-        const [data] = await once(client, "data");
-        expect(data.toString()).toBe("still-open");
-      } finally {
-        client.destroy();
-        serverSocket?.destroy();
-        server.closeAllConnections();
-        if (server.listening) {
-          const closed = once(server, "close");
-          server.close();
-          await closed;
+    describe.each(["upgrade", "connect"] as const)("%s handoff", kind => {
+      it("stays open after closeAllConnections()", async () => {
+        const server = createServer();
+        const { promise: handedOff, resolve: onHandedOff } = Promise.withResolvers<import("node:net").Socket>();
+        const onHandoff = (_request: IncomingMessage, socket: import("node:net").Socket) => {
+          socket.write(
+            kind === "upgrade"
+              ? "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n"
+              : "HTTP/1.1 200 Connection Established\r\n\r\n",
+          );
+          onHandedOff(socket);
+        };
+        if (kind === "upgrade") {
+          server.on("upgrade", onHandoff);
+        } else {
+          server.on("connect", onHandoff);
         }
-      }
+        server.listen(0, "127.0.0.1");
+        await once(server, "listening");
+        const address = server.address() as AddressInfo;
+        const client = connect(address.port, "127.0.0.1");
+        let serverSocket: import("node:net").Socket | undefined;
+
+        try {
+          await once(client, "connect");
+          client.write(
+            kind === "upgrade"
+              ? "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n"
+              : "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n",
+          );
+          serverSocket = await handedOff;
+          await once(client, "data");
+
+          server.closeAllConnections();
+          expect({ listening: server.listening, serverSocketDestroyed: serverSocket.destroyed }).toEqual({
+            listening: true,
+            serverSocketDestroyed: false,
+          });
+          serverSocket.write("still-open");
+          const [data] = await once(client, "data");
+          expect(data.toString()).toBe("still-open");
+        } finally {
+          client.destroy();
+          serverSocket?.destroy();
+          server.closeAllConnections();
+          if (server.listening) {
+            const closed = once(server, "close");
+            server.close();
+            await closed;
+          }
+        }
+      });
     });
 
     it("emits a listen() error on the next tick, before the event loop polls", async () => {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -176,6 +176,84 @@ describe("node:http", () => {
       expect({ order, listeningAtOnce }).toEqual({ order: ["listening", "nextTick"], listeningAtOnce: true });
     });
 
+    it("keeps listening after closeAllConnections()", async () => {
+      const server = createServer((_, response) => response.end("ok"));
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address() as AddressInfo;
+
+      try {
+        server.closeAllConnections();
+        expect({ listening: server.listening, address: server.address() }).toEqual({
+          listening: true,
+          address,
+        });
+        const response = await fetch(`http://127.0.0.1:${address.port}/`);
+        expect(await response.text()).toBe("ok");
+        const closeError = await new Promise<Error | undefined>(resolve => server.close(resolve));
+        expect(closeError).toBeUndefined();
+      } finally {
+        server.closeAllConnections();
+        if (server.listening) {
+          server.close();
+          await once(server, "close");
+        }
+      }
+    });
+
+    it.each(["upgrade", "connect"] as const)("leaves handed-off %s sockets open", async kind => {
+      const server = createServer();
+      const { promise: handedOff, resolve: onHandedOff } =
+        Promise.withResolvers<import("node:net").Socket>();
+      const onHandoff = (_request: IncomingMessage, socket: import("node:net").Socket) => {
+        socket.write(
+          kind === "upgrade"
+            ? "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n"
+            : "HTTP/1.1 200 Connection Established\r\n\r\n",
+        );
+        onHandedOff(socket);
+      };
+      if (kind === "upgrade") {
+        server.on("upgrade", onHandoff);
+      } else {
+        server.on("connect", onHandoff);
+      }
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const address = server.address() as AddressInfo;
+      const client = connect(address.port, "127.0.0.1");
+      let serverSocket: import("node:net").Socket | undefined;
+
+      try {
+        await once(client, "connect");
+        client.write(
+          kind === "upgrade"
+            ? "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n"
+            : "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n",
+        );
+        serverSocket = await handedOff;
+        await once(client, "data");
+
+        server.closeAllConnections();
+        expect({ listening: server.listening, serverSocketDestroyed: serverSocket.destroyed }).toEqual({
+          listening: true,
+          serverSocketDestroyed: false,
+        });
+        serverSocket.write("still-open");
+        const [data] = await once(client, "data");
+        expect(data.toString()).toBe("still-open");
+      } finally {
+        client.destroy();
+        serverSocket?.destroy();
+        server.closeAllConnections();
+        if (server.listening) {
+          const closed = once(server, "close");
+          server.close();
+          await closed;
+        }
+      }
+    });
+
     it("emits a listen() error on the next tick, before the event loop polls", async () => {
       const occupant = createServer();
       occupant.listen(0);


### PR DESCRIPTION
## Problem

`http.Server.closeAllConnections()` currently clears Bun's native server handle and calls `stop(true)`. That closes the listening socket as well as active connections. Node keeps the listener open, so a later `server.close(callback)` succeeds and the server can accept new requests in between.

This surfaced across OpenClaw's Bun test matrix as `ERR_SERVER_NOT_RUNNING` during otherwise standard fixture cleanup:

```js
server.closeAllConnections();
server.close(callback);
```

## Fix

Iterate Bun's existing tracked HTTP sockets and destroy connections whose HTTP parser is still attached. Leave the native server handle and listener state intact. Parser-detached Upgrade and CONNECT sockets remain under userland ownership, matching Node's `ConnectionsList` behavior.

The fixing line is the `socket.parser !== null` guarded `socket.destroy()` loop in `Server.prototype.closeAllConnections`.

## Verification

- Shipping Bun 1.4.2 fails the three new cases with `listening: false` and `address: null`.
- The isolated branch's debug build passes the full `test/js/node/http/node-http.test.ts` file: 162 passed, 1 pre-existing skip.
- Standalone probes match Node 26 for ordinary HTTP, Upgrade, and CONNECT: the listener remains active, handed-off sockets remain usable, and a later `close()` succeeds.
- Bun's imported Node HTTP and HTTPS close-all fixtures pass under the release build.
- OpenClaw's affected LM Studio, Bedrock, and Discord transport reproductions pass 23/23 with the patched runtime.
- Lint, Prettier, and independent P0-P2 review are clean.

## AI assistance

AI-assisted: Codex helped reduce the OpenClaw failures, inspect Bun and Node behavior, draft the patch and regression cases, and review the final diff. I ran the builds, tests, and compatibility probes locally.
