### PR TITLE
js_parser: record the merged symbol for an export that is re-declared later

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1996,6 +1996,27 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 ),
             );
         } else if !self.is_deoptimized_common_js() {
+            // `export var x; var x;`: the linker and the renamer use the symbol that replaced the module scope's `x`.
+            let mut r#ref = r#ref;
+            let symbol = &self.symbols[r#ref.inner_index() as usize];
+            if symbol.has_link() {
+                let mut end = symbol.link.get();
+                loop {
+                    let next = self.symbols[end.inner_index() as usize].link.get();
+                    if !next.is_valid() {
+                        break;
+                    }
+                    end = next;
+                }
+                // The name of `export default (function f(f) {})` links to its parameter.
+                let name = symbol.original_name.slice();
+                let member = self
+                    .module_scope()
+                    .get_member_with_hash(name, js_ast::Scope::get_member_hash(name));
+                if member.is_some_and(|member| member.ref_.eql(end)) {
+                    r#ref = end;
+                }
+            }
             self.named_exports.put(
                 alias,
                 js_ast::NamedExport {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -703,6 +703,155 @@ describe("bundler", () => {
       `,
     },
   });
+  // A later `var x` merges with an earlier `export var x`: the parser links the
+  // exported symbol to the later one. The export has to name the merged symbol,
+  // or tree shaking drops every declaration of `x` and the importer throws
+  // "ReferenceError: x is not defined".
+  itBundled("edgecase/ExportVarRedeclaredLater", {
+    files: {
+      "/entry.js": /* js */ `
+        import { twice } from "./twice.ts";
+        import { thrice } from "./thrice.js";
+        import { first, second } from "./destructured.js";
+        import { nested } from "./nested.js";
+        console.log(twice, thrice, first, second, nested);
+      `,
+      "/twice.ts": /* ts */ `
+        export var twice: number = 1;
+        var twice: number = 2;
+      `,
+      "/thrice.js": /* js */ `
+        export var thrice = 1;
+        var thrice = 2;
+        var thrice = 3;
+      `,
+      // The destructuring statement is never removed, so before the fix this
+      // printed the stale "1 2" instead of throwing.
+      "/destructured.js": /* js */ `
+        export var [first, { second }] = [1, { second: 2 }];
+        var first = 10;
+        var second = 20;
+      `,
+      // Hoisting links the other way, from the nested symbol to the exported one.
+      "/nested.js": /* js */ `
+        export var nested = 1;
+        {
+          var nested = 2;
+        }
+      `,
+    },
+    run: {
+      stdout: "2 3 10 20 2",
+    },
+  });
+  itBundled("edgecase/ExportVarRedeclaredLaterOtherImportForms", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as ns from "./namespace.js";
+        import { reExported, starReExported } from "./barrel.js";
+        const { required } = require("./required.js");
+        const { dynamic } = await import("./dynamic.js");
+        console.log(JSON.stringify(ns), reExported, starReExported, required, dynamic);
+      `,
+      "/namespace.js": /* js */ `
+        export var viaNamespace = 1;
+        var viaNamespace = 2;
+      `,
+      "/barrel.js": /* js */ `
+        export { reExported } from "./re-exported.js";
+        export * from "./star-re-exported.js";
+      `,
+      "/re-exported.js": /* js */ `
+        export var reExported = 1;
+        var reExported = 2;
+      `,
+      "/star-re-exported.js": /* js */ `
+        export var starReExported = 1;
+        var starReExported = 2;
+      `,
+      "/required.js": /* js */ `
+        export var required = 1;
+        var required = 2;
+      `,
+      "/dynamic.js": /* js */ `
+        export var dynamic = 1;
+        var dynamic = 2;
+      `,
+    },
+    run: {
+      stdout: `{"viaNamespace":2} 2 2 2 2`,
+    },
+  });
+  itBundled("edgecase/ExportVarRedeclaredLaterEntryPoint", {
+    files: {
+      "/entry.js": /* js */ `
+        export var x = 1;
+        var x = 2;
+      `,
+    },
+    runtimeFiles: {
+      "/test.js": /* js */ `
+        import { x } from "./out.js";
+        console.log(x);
+      `,
+    },
+    run: {
+      file: "/test.js",
+      stdout: "2",
+    },
+  });
+  itBundled("edgecase/ExportVarRedeclaredLaterSplitting", {
+    files: {
+      "/a.js": /* js */ `
+        import { x } from "./shared.js";
+        console.log("a", x);
+      `,
+      "/b.js": /* js */ `
+        import { x } from "./shared.js";
+        console.log("b", x);
+      `,
+      "/shared.js": /* js */ `
+        export var x = 1;
+        var x = 2;
+      `,
+    },
+    entryPoints: ["/a.js", "/b.js"],
+    splitting: true,
+    outdir: "/out",
+    run: [
+      { file: "/out/a.js", stdout: "a 2" },
+      { file: "/out/b.js", stdout: "b 2" },
+    ],
+  });
+  // Without bundling, the minifier pins the name of each exported symbol. It
+  // pinned the replaced symbol, so the export was renamed. The name of the
+  // default export links to its parameter, which is not a module-scope merge:
+  // pinning that parameter would let a local take the same short name.
+  itBundled("edgecase/ExportVarRedeclaredLaterKeepsNameWhenMinified", {
+    files: {
+      "/entry.js": /* js */ `
+        export var x = 1;
+        var x = 2;
+        export default (function a(a) {
+          var longname = 5;
+          var othername = 7;
+          return a + longname * othername;
+        });
+      `,
+    },
+    bundling: false,
+    minifyIdentifiers: true,
+    runtimeFiles: {
+      "/test.js": /* js */ `
+        import f, { x } from "./out.js";
+        console.log(x, f(1));
+      `,
+    },
+    run: {
+      file: "/test.js",
+      stdout: "2 36",
+    },
+  });
   // https://github.com/oven-sh/bun/issues/30271
   //
   // When dead-code elimination prunes an if/else body, the scaffolding


### PR DESCRIPTION
### Problem
- `bun build` drops every declaration of `x` for `export var x = 1; var x = 2;`, so the importer throws `ReferenceError: x is not defined`. Unbundled, it prints `2`. `export var [a] = [1]; var a = 10;` prints a stale `1`.
- `declare_symbol` (`src/js_parser/p.rs:5217`) links the first `x` symbol to the second. `record_export` (`p.rs:1967`) stored the first in `named_exports`. `to_ast` (`p.rs:9288`) keys `top_level_symbols_to_parts` by the last, so the linker (`src/bundler/linker_context/scanImportsAndExports.rs:940`) finds no declaring parts.
- Without bundling, `--minify-identifiers` pins the dead first symbol (`src/js_printer/lib.rs:7837`) and renames the export to `r`.

### Fix
- `record_export` stores the end of the link chain when that symbol is the module scope's member for the name. Other links stay: the name of `export default (function f(f) {})` links to its parameter.
- Correct because `record_export` runs inside `to_ast`, after parsing and visiting, so chains are final. Only `declare_symbol` replaces a module-scope member, and it links the old symbol to the new one.
- Verified: five `edgecase/ExportVarRedeclaredLater*` cases in `test/bundler/bundler_edgecase.test.ts`, all fail on stock bun. Self-reviewed: 11 concerns raised, 9 addressed, 2 rejected as separate causes on main (Notes).
- This closes one producer of the key mismatch, not all. `var x = 1; if (c) { var x; use(x) }` still loses `var x = 1` on main, here and in esbuild (Notes).

### Background
- Each file has a flat symbol table. When two declarations merge (`var x; var x;`), the scope keeps the newest symbol and the older one gets `link = newer`. Readers must follow links.
- A module is split into parts, one per top-level statement. Tree shaking keeps a part only when a live part depends on it.
- `named_exports` maps an export name to its symbol, and `top_level_symbols_to_parts` maps a symbol to its declaring parts. The linker joins them for each import.

<details><summary>Notes</summary>

**Context**
- No user has reported this. `tsc` rejects the shape (TS2395: individual declarations in a merged declaration must be all exported or all local), and esbuild 0.18.6, 0.21.5, 0.25.1 and 0.28.2 produce the same broken bundle, so there is no upstream fix to mirror. This is low-priority correctness work. The renamed export under `--no-bundle --minify-identifiers` is specific to Bun.
- Found while working on #42242. That PR adds a path-compressing `follow_symbols` helper and does not change this behaviour. This change open-codes the loop, as the other parser sites on main do, and touches no line that #42242 touches. Whichever lands second can convert this loop too.
- `AstBuilder::record_export` (`src/bundler/AstBuilder.rs:579`) is left alone on purpose. Its symbols come only from `new_symbol`, so none of them has a link.

**Shapes**
- Broken before, now equal to the unbundled run: named import, three declarations, destructuring, `import * as ns` (also when the namespace object escapes), `export { x } from`, `export * from`, `export * as ns from`, `require()`, `import()`, `--splitting`, `--format=cjs`, `--minify`, and the file as the entry point (the output was `export { x }` with no declaration).
- Already correct, still correct: `var x = 1; export var x = 2;`, `export { x }; var x = 1; var x = 2;`, `export var x = 1; { var x = 2; }` (hoisting links the nested symbol to the outer one), and a module whose top-level code or functions also read `x`. A read inside a nested block that declares `x` again is sibling 1 below, and it is not fixed.
- `export function f() {} var f = 1;`, `export var f = 1; function f() {}` and `export default function f() {} var f = 2;` are not valid ES modules. Node and unbundled Bun reject them with a `SyntaxError`. Before, the bundle dropped both declarations and `typeof f` printed `undefined`. Now the bundle keeps both declarations and fails to load with the same `SyntaxError` as the source.

**Known siblings, not fixed here**

The invariant is that every ref used to look up `top_level_symbols_to_parts`, or read for a per-symbol fact, is the end of its link chain. This PR normalises one producer (`named_exports`). These others remain, each identical on main and on this branch:
1. `part.symbol_uses`. `var x = 1; if (c) { var x; console.log(x); }` bundles without `var x = 1` and prints `undefined`. `var i = 10; for (var i; i < 12; i++) console.log(i);` bundles without `var i = 10` and prints nothing. Hoisting links the block's `x` to the outer one, the read is recorded under the block's symbol, and `doStep5.rs:390` looks that ref up without a follow. esbuild 0.28.2 does the same. This is the remainder of #2814. The fix belongs in `to_ast` (re-key `symbol_uses`), as a follow-up after #42242.
2. `parse_entry.rs:1300`. `export var a = 1; var { a } = await import("./n.js");` imported from another file prints `undefined`. The destructured local is the end of the chain, so `has_link()` is false for it, and with a use count of zero it counts as never read.
3. `has_been_assigned_to` is read from one symbol of a chain without a follow in `binds_call_item` (`LinkerContext.rs:4352`) and at `parse_entry.rs:1322`. For an export the read now lands on the end of the chain, which is where `record_assignment` writes the flag. A duplicate `var` declaration is still not recorded as an assignment.
4. `export default (function foo(foo) {})` imported from another file throws `ReferenceError` in a bundle, because the export symbol is a nested-scope symbol. That needs a change in `default_name_for_expr` (`p.rs:4665`).

**Self-review: concerns raised**
1. Addressed. An unconditional follow regressed `--no-bundle --minify-identifiers` for `export default (function a(a) { var longname = 5; ... })`. `default_name_for_expr` reuses the function expression's own name as the export symbol, and that name links to the parameter `a` in the function-args scope. The pin then landed on the parameter, and a local got the same short name (`f(1)` gave 42, not 36). The follow now applies only when the end of the chain is the module scope's member for the name, the same check as `scan_imports.rs:344`. The `...KeepsNameWhenMinified` case guards it (it fails with the unconditional follow).
2. Addressed. The code comment said "keyed by" for a flag and was three lines. It is now two one-line comments.
3. Addressed. The namespace test now lets the namespace object escape (`JSON.stringify(ns)`), so the `__export` getter path (`doStep5.rs:638`) runs.
4. Addressed. One module in the first test is `.ts`, so both parser instantiations run. `nested.js` pins the reverse link direction.
5. Addressed. This description names esbuild, `AstBuilder` and #42242.
6. Not addressed, separate cause. A module that is wrapped in `__esm` (it is `require()`d, or `import()`ed without splitting) hoists `var p = 10` out of the wrapper with its value when the initializer can be moved (`generateCodeForFileInChunkJS.rs:764`), while an earlier `[p] = [1]` stays inside and runs later. `var p = [1][0]; var p = 10; export { p };` required from another file prints `1` on main and on this branch (unbundled: `10`). `export var [p] = [1]; var p = 10;` in a wrapped module now reaches that same bug (prints `1`), where it threw `ReferenceError` before.
7. Not addressed, separate cause. The dev server lowering (`lower_esm_exports_hmr.rs:79`) reads `use_count_estimate` of the replaced first symbol, so `export var x = 1; var x = 2;` exports `1` there. Unchanged by this PR.
8. Addressed. The description presented the mismatch as closed. It now lists sibling 1 in the Fix section and all known siblings above.
9. Addressed. Siblings 2 and 3 are listed.
10. Addressed. The "also reads `x`" line no longer implies that nested reads work.
11. Addressed. The demand line is the first Context bullet.
- The second review pass also proposed a `symbol_uses` re-key in `to_ast`, a chain-end `debug_assert!` in the linker lookup, and a generated shape matrix test. It asked to keep them out of this diff and stack them after #42242.
- `register_dynamic_import_items` (`p.rs:1131`) compares `named_exports` refs with `DynamicImportItem.local`. A `local` never has a link (`parse_entry.rs:1329`), so the comparison only changes when an exported `var` is re-declared by a destructured `import()` local. It then keeps that local a local, which is what its comment asks for.

**Suites run on the debug build, all pass**
- `test/bundler/bundler_edgecase.test.ts` (179 pass).
- `test/bundler/esbuild/{default,dce,importstar,importstar_ts,ts,splitting}.test.ts`.
- `test/bundler/bundler_{minify,splitting,cjs2esm,barrel,dynamic_import_dce,regressions}.test.ts`.
- `test/bundler/transpiler/transpiler.test.js`, `test/bake/dev/esm.test.ts`.
- Gate sequence run locally: with `src/` at `origin/main` the five cases fail on the debug build, with `src/` at HEAD the whole file passes.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 11 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [867.18ms]
(pass) bundler > edgecase/EmptyCommonJSModule [956.13ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [947.47ms]
(pass) bundler > edgecase/ImportStarFunction [692.65ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [886.02ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [337.23ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [875.26ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [479.08ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [641.90ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [486.13ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [337.14ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [1038.40ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [759.49ms]
(pass) bundler 
... (truncated)

release without fix: 5 failed, 11 skipped
bun test v1.4.3-canary.1 (4ff919377)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [154.39ms]
(pass) bundler > edgecase/EmptyCommonJSModule [19.86ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [19.13ms]
(pass) bundler > edgecase/ImportStarFunction [18.91ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [61.18ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [6.90ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [40.31ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [82.72ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [46.66ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [8.21ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [6.75ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [17.48ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [17.20ms]
(pass) bundler > edgecase/ValidLoaderSeenAsInvalid [8.09ms]
(pass) bundler > edgecase/InvalidLoaderSegfault [4.63ms]
(todo) bundler > edgecase/ScriptTagEscape
(pass) bundler > edgecase/JSONDef
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 11 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [841.92ms]
(pass) bundler > edgecase/EmptyCommonJSModule [598.99ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [714.33ms]
(pass) bundler > edgecase/ImportStarFunction [714.39ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [671.16ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [174.91ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [532.52ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [376.02ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [267.40ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [353.45ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [213.56ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [536.34ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [653.34ms]
(pass) bundler >
... (truncated)

release with fix: 11 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     af0d6163cc
  features     baseline

23 deps, 131 codegen, 1172 objects in 1076ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (4ff919377)

Checked 22 installs across 61 packages (no changes) [46.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] fetch tinycc
[tinycc] up to date
[4/1243] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (4ff919377)

Checked 1 install across 2 packages (no changes) [3.00ms]
[5/1243] gen bindgenv2
[6/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[7/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (4ff919377)

Checked 111 installs across 104 packages (no changes) [142.00ms]
[9/1216] fetch zlib
[zlib] up to date
[10/1216] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../../build/release/codegen/bun-error/bun-error.c
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                    |  21 +++++
 test/bundler/bundler_edgecase.test.ts | 149 ++++++++++++++++++++++++++++++++++
 2 files changed, 170 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js_parser/p.rs                         7      2     14
test/bundler/bundler_edgecase.test.ts      3      4     13
```

</details>

**self-review** · 11 surviving concerns

- should-fix: This is a real bug fix, but it patches 1 of at least 5 places where a non-root `Symbol.link` ref reaches a reader that does not follow it. On the PR's own build, `var x = 1; if (c) { var x; use(x) }` still has its live declaration removed by the same key mismatch against `top_level_symbols_to_par…
- should-fix: All four left-out miscompiles reproduce on the PR build and none has a tracker, which the house rule requires; one is not in the PR body, and this PR changes another from a loud ReferenceError to a silent stale value. File issues and link them from the body; `todo: true` fixtures are a good addit…
- should-fix: The `.eql(end)` half of the new guard in `record_export` is tested by none of the five fixtures. Replacing the guard with `member.is_some()` passes all five, and a sibling fixture with one added line (`var a = 100;`) kills that mutant.
- consider: Bug fix (bundler miscompile) with no external demand signal. The bug is real and deterministic, but the only observer is the author's sibling automated session. The triggering pattern occurs 0 times in a 72.8k-file corpus, tsc rejects it, no mainstream tool emits it, and esbuild has shipped the i…
- consider: Kind: bug fix (bundler miscompile). If this PR is closed, no user observes a difference. The shape has miscompiled since the bundler landed in April 2023, and the same bug is in esbuild 0.28.2, with no report on either tracker. It occurs 0 times in about 108k real files. Closing it also makes not…
- consider: Bug fix with no demand signal: no reporter on Bun's or esbuild's tracker (esbuild has had the same bug since 0.18.6 or earlier), and the triggering shape appears in 0 of about 84,500 JS/TS files on disk. When it does hit, it is a bundle-time miscompile (ReferenceError on load, or a silent stale v…
- consider: Kind: bug fix. This PR is not redundant under any of the three homes probed for the `part.symbol_uses` sibling. The sibling is the unfixed remainder of user-reported #2814, and the PR's Notes omit it.
- consider: Bug fix at the right layer, but it hand-fixes one of at least three parser producers that give the linker a linked ref as a `top_level_symbols_to_parts` key. Two sibling miscompiles still reproduce on this branch; the PR Notes list one and omit the other. A `debug_assert!` at the end of `to_ast` …
- consider: Kind: bug fix. Per-producer is the right shape: three linker-visible members in two fields, plus two parser-internal counter reads, but two reproducible same-family miscompiles are missing from the PR's exclusion list.
- consider: Kind: bug fix. The five fixtures are enough for this PR. I generated the proposed matrix and ran it: this PR's own family goes from 423 red cells to 0. The branch still has 344 red cells (all `__esm` hoist order) and 120 more once an importer that does not import `x` is added (the `symbol_uses` f…
- consider: Kind: bug fix (a miscompile with a confirmed repro; an automated session found it and there is no user report). The concern holds. There is a second root cause that `record_export` cannot reach. Three facts about a variable are stored on one symbol of a merged declaration and read from the other …

36 concerns were raised and did not survive verification.

<!-- robobun:evidence:end -->