### PR TITLE
node:http2: tear down a client's pushed streams with the session

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4806,8 +4806,9 @@ class ServerHttp2Session extends Http2Session {
     process.nextTick(emitSessionCloseNT, this, asyncFrame);
   }
 }
-function emitTimeout(session: ClientHttp2Session) {
-  session.emit("timeout");
+function emitTimeout(stream: Http2Stream) {
+  // A pushed stream the user destroyed stays enumerable until the peer finishes it.
+  if (!stream.destroyed) stream.emit("timeout");
 }
 // Outbound-progress snapshot taken the last time the session's idle timer expired while writes
 // were still pending (see sessionTimerExpired / node's chunksSentSinceLastWrite).
@@ -4904,6 +4905,13 @@ function destroySelfOnEnd(this: Http2Stream) {
   this.destroy();
 }
 function streamCancel(stream: Http2Stream) {
+  if (stream[kPush]) {
+    // node end()s a pushed stream when it creates it, so its close(CANCEL) here only records the
+    // code. Ours is still writable: close() would emit 'aborted' and end() into a native write
+    // that rejects the id. Record the code; streamSocketClosed destroys the stream.
+    if (!stream.closed) stream.rstCode = NGHTTP2_CANCEL;
+    return;
+  }
   stream.close(NGHTTP2_CANCEL);
 }
 
@@ -4917,13 +4925,15 @@ function streamSocketClosed(stream: Http2Stream) {
     stream.destroy();
   }
 }
-// A stream whose session was close()d before the socket finished connecting never reached the
-// peer; node destroys it with ERR_HTTP2_GOAWAY_SESSION (no $ERR intrinsic exists for this code).
+// The GOAWAY's last-stream-id counts the streams this side initiated (RFC 9113 6.8). A pushed
+// stream is the peer's and keeps running (nghttp2 session_close_stream_on_goaway skips it).
 function rejectStreamAboveGoawayLastId(lastStreamId: number, stream: Http2Stream) {
-  if (typeof stream?.id === "number" && stream.id > lastStreamId) {
+  if (typeof stream?.id === "number" && stream.id > lastStreamId && !stream[kPush]) {
     streamRejectedByGoawaySession(stream);
   }
 }
+// A stream whose session was close()d before the socket finished connecting never reached the
+// peer; node destroys it with ERR_HTTP2_GOAWAY_SESSION (no $ERR intrinsic exists for this code).
 function streamRejectedByGoawaySession(stream: Http2Stream) {
   if (!stream.destroyed) {
     const err = new Error("New streams cannot be created after receiving a GOAWAY");

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3513,6 +3513,24 @@ impl H2FrameParser {
         JSValue::UNDEFINED
     }
 
+    /// Ids rooted in `sctx` with no `streams` entry: the streams a server pushed to this client.
+    /// PUSH_PROMISE reserves them in the engine and the JS `streamPush` handler roots them through
+    /// setStreamContext, but nothing creates a legacy `Stream`, so a fan-out over `streams` alone
+    /// misses them. A snapshot, like `StreamResumableIterator`: the JS a caller runs between ids
+    /// can close streams, so each id is looked up again.
+    fn sctx_only_stream_ids(&self) -> Vec<u32> {
+        if self.is_server.get() {
+            return Vec::new();
+        }
+        let streams = self.streams.get();
+        self.sctx
+            .get()
+            .keys()
+            .copied()
+            .filter(|id| !streams.contains_key(id))
+            .collect()
+    }
+
     /// Record outbound DATA the legacy encoder wrote so the engine's send windows track reality.
     /// Buffered in cells and applied in rewrite_read: inbound WINDOW_UPDATE handling always goes
     /// through rewrite_read first, so the windows are in sync before any overflow check runs.
@@ -4126,6 +4144,15 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
             }
         }
         let stream_ctx = self.rewrite_stream_ctx(stream_id);
+        if effective == 7 {
+            // Release the per-stream JS context root so it can be collected (also done by
+            // free_resources, but a stream may have no legacy entry). Before the dispatch: such
+            // a stream has no CLOSED state, so a present root is what makes an
+            // emitErrorToAllStreams that the JS below re-enters treat it as open.
+            self.sctx.with_mut(|m| {
+                m.remove(&stream_id);
+            });
+        }
         self.dispatch_with_extra(
             JSH2FrameParser::Gc::onStreamEnd,
             stream_ctx,
@@ -4140,11 +4167,6 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
                 // SAFETY: stream is *mut Stream from self.streams; valid while the map entry exists
                 unsafe { (*stream).free_resources::<false>(self) };
             }
-            // Release the per-stream JS context root so it can be collected (also done by
-            // free_resources, but a stream may have no legacy entry).
-            self.sctx.with_mut(|m| {
-                m.remove(&stream_id);
-            });
         }
     }
 
@@ -4185,6 +4207,10 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
             }
         }
         let stream_ctx = self.rewrite_stream_ctx(stream_id);
+        // Unrooted before the dispatch, for the same reason as in on_stream_end.
+        self.sctx.with_mut(|m| {
+            m.remove(&stream_id);
+        });
         if code == crate::api::h2::wire::ErrorCode::Cancel.as_u32() {
             // A peer CANCEL is an abort, not an error (node emits 'aborted' and closes with
             // rstCode 8 without an 'error' event).
@@ -4201,15 +4227,12 @@ impl crate::api::h2::connection::Sink for H2FrameParser {
                 JSValue::js_number(code as f64),
             );
         }
-        // The reset closes the stream; free the legacy slot (queueing the engine eviction)
-        // and release its JS context root, mirroring the on_stream_end full-close path.
+        // The reset closes the stream; free the legacy slot (queueing the engine eviction),
+        // mirroring the on_stream_end full-close path.
         if let Some(stream) = self.streams.get().get(&stream_id).copied() {
             // SAFETY: stream is *mut Stream from self.streams; valid while the map entry exists
             unsafe { (*stream).free_resources::<false>(self) };
         }
-        self.sctx.with_mut(|m| {
-            m.remove(&stream_id);
-        });
     }
 }
 
@@ -6501,20 +6524,26 @@ impl H2FrameParser {
         } else {
             JSValue::UNDEFINED
         };
-        let mut _count: u32 = 0;
-        let mut it = StreamResumableIterator::init(this);
-        while let Some(stream) = it.next() {
-            // SAFETY: stream is *mut Stream from self.streams; valid while the map entry exists
-            let Some(value) = (unsafe { (*stream).js_context.get() }) else {
-                continue;
-            };
+        let visit = |value: JSValue| {
             this.handlers.get().vm.event_loop_mut().run_callback(
                 callback,
                 global_object,
                 this_value,
                 &[value],
             );
-            _count += 1;
+        };
+        let mut it = StreamResumableIterator::init(this);
+        while let Some(stream) = it.next() {
+            // SAFETY: stream is *mut Stream from self.streams; valid while the map entry exists
+            let Some(value) = (unsafe { (*stream).js_context.get() }) else {
+                continue;
+            };
+            visit(value);
+        }
+        for id in this.sctx_only_stream_ids() {
+            if let Some(value) = this.sctx.get().get(&id).and_then(|s| s.get()) {
+                visit(value);
+            }
         }
         Ok(JSValue::UNDEFINED)
     }
@@ -6591,6 +6620,18 @@ impl H2FrameParser {
                 stream.free_resources::<false>(this);
                 this.dispatch_with_extra(JSH2FrameParser::Gc::onStreamError, identifier, error_arg);
             }
+        }
+        for id in this.sctx_only_stream_ids() {
+            // No `Stream` to mark CLOSED here: a present root is what says the peer has not
+            // closed this one (on_stream_end / on_stream_reset drop it before they dispatch).
+            let Some(identifier) = this
+                .sctx
+                .with_mut(|m| m.remove(&id))
+                .and_then(|root| root.get())
+            else {
+                continue;
+            };
+            this.dispatch_with_extra(JSH2FrameParser::Gc::onStreamError, identifier, error_arg);
         }
         Ok(JSValue::UNDEFINED)
     }

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -798,6 +798,148 @@ describe("push stream states (checklist §5.1, RFC 9113 §6.4/§8.4)", () => {
       raw.close();
     }
   });
+
+  /** Answers the client's first request with SETTINGS and PUSH_PROMISE(1 -> 2), then `extra`. */
+  async function promiseStream2(raw: RawH2Server, extra: Buffer[] = []) {
+    await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+    const promised = Buffer.alloc(4);
+    promised.writeUInt32BE(2, 0);
+    // [:method GET, :scheme http, :path /, :authority localhost], no dynamic table.
+    const block = Buffer.concat([Buffer.from([0x82, 0x86, 0x84, 0x01]), hpackLiteral("localhost")]);
+    raw.socket!.write(
+      Buffer.concat([
+        encodeFrame(FrameType.SETTINGS, 0, 0),
+        encodeFrame(FrameType.SETTINGS, 0x1, 0),
+        encodeFrame(FrameType.PUSH_PROMISE, 0x4 /* END_HEADERS */, 1, Buffer.concat([promised, block])),
+        ...extra,
+      ]),
+    );
+  }
+
+  function goawayFrame(lastStreamId: number, code: number): Buffer {
+    const payload = Buffer.alloc(8);
+    payload.writeUInt32BE(lastStreamId, 0);
+    payload.writeUInt32BE(code, 4);
+    return encodeFrame(FrameType.GOAWAY, 0, 0, payload);
+  }
+
+  /** Connects a client whose first request gets a pushed stream, and records that stream's events. */
+  function connectAndObservePush(raw: RawH2Server) {
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    const sessionClosed = Promise.withResolvers<void>();
+    const announced = Promise.withResolvers<http2.ClientHttp2Stream>();
+    client.on("close", () => {
+      sessionClosed.resolve();
+      // A no-op once the push was announced. Before that, the test cannot go on.
+      announced.reject(new Error("the session closed before the push was announced"));
+    });
+    const req = client.request({ ":path": "/" });
+    req.on("error", () => {});
+    req.resume();
+    const seen = { error: null as string | null, aborted: false, body: "" };
+    const pushedClosed = Promise.withResolvers<void>();
+    client.on("stream", pushed => {
+      pushed.on("error", (e: NodeJS.ErrnoException) => (seen.error = e.code ?? e.message));
+      pushed.on("aborted", () => (seen.aborted = true));
+      pushed.on("data", (d: Buffer) => (seen.body += d.toString()));
+      pushed.on("close", () => pushedClosed.resolve());
+      announced.resolve(pushed);
+    });
+    return {
+      client,
+      seen,
+      announced: announced.promise,
+      pushedClosed: pushedClosed.promise,
+      sessionClosed: sessionClosed.promise,
+    };
+  }
+
+  // The pushed stream is open (reserved) when the session goes away. node destroys it with the
+  // rest of the session's streams: 'close' always, plus the session error when there is one.
+  const teardowns: Array<{
+    how: string;
+    teardown: (client: http2.ClientHttp2Session, raw: RawH2Server) => unknown;
+    // Left empty where bun and node do not agree yet on the code a plain destroy() reports.
+    expected: { error?: string | null; rstCode?: number };
+  }> = [
+    { how: "session.destroy()", teardown: client => client.destroy(), expected: {} },
+    {
+      how: "session.destroy(err)",
+      teardown: client => client.destroy(new Error("boom")),
+      expected: { error: "boom", rstCode: ErrorCode.INTERNAL_ERROR },
+    },
+    {
+      how: "a GOAWAY that carries an error code",
+      teardown: (_, raw) => raw.socket!.write(goawayFrame(1, ErrorCode.ENHANCE_YOUR_CALM)),
+      expected: { error: "ERR_HTTP2_SESSION_ERROR", rstCode: ErrorCode.ENHANCE_YOUR_CALM },
+    },
+    {
+      how: "the peer closing the connection",
+      teardown: (_, raw) => raw.socket!.end(),
+      expected: { error: null, rstCode: ErrorCode.CANCEL },
+    },
+  ];
+  test.each(teardowns)("$how destroys a pushed stream that is still open", async ({ teardown, expected }) => {
+    const raw = await RawH2Server.listen();
+    const { client, seen, announced, pushedClosed, sessionClosed } = connectAndObservePush(raw);
+    try {
+      await promiseStream2(raw);
+      const pushed = await announced;
+      teardown(client, raw);
+      await sessionClosed;
+      // By the time the session reports 'close', the pushed stream is destroyed.
+      expect(pushed.destroyed).toBe(true);
+      await pushedClosed;
+      expect({ error: seen.error, aborted: seen.aborted, rstCode: pushed.rstCode }).toMatchObject({
+        aborted: false,
+        ...expected,
+      });
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  test("a session destroyed while a pushed stream handles the peer's reset does not report that stream twice", async () => {
+    const raw = await RawH2Server.listen();
+    const { client, seen, announced, pushedClosed } = connectAndObservePush(raw);
+    try {
+      await promiseStream2(raw);
+      const pushed = await announced;
+      // RST_STREAM(CANCEL) is already closing the stream when this listener runs. The teardown it
+      // starts must leave the stream to that reset: no 'error' on top of it.
+      pushed.on("aborted", () => client.destroy());
+      const code = Buffer.alloc(4);
+      code.writeUInt32BE(ErrorCode.CANCEL, 0);
+      raw.socket!.write(encodeFrame(FrameType.RST_STREAM, 0, 2, code));
+      await pushedClosed;
+      expect({ error: seen.error, rstCode: pushed.rstCode }).toEqual({ error: null, rstCode: ErrorCode.CANCEL });
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  test("a graceful GOAWAY leaves a pushed stream above its last-stream-id running", async () => {
+    const raw = await RawH2Server.listen();
+    const { client, seen, announced, pushedClosed } = connectAndObservePush(raw);
+    try {
+      // GOAWAY(last-stream-id 0) refuses the request on stream 1. Stream 2 is the server's own:
+      // the last-stream-id does not cover it (RFC 9113 6.8), so its response still arrives.
+      await promiseStream2(raw, [
+        encodeFrame(FrameType.HEADERS, 0x4 /* END_HEADERS */, 2, Buffer.from([0x88])), // :status 200
+        goawayFrame(0, ErrorCode.NO_ERROR),
+        encodeFrame(FrameType.DATA, 0x1 /* END_STREAM */, 2, Buffer.from("pushed body")),
+      ]);
+      await announced;
+      await pushedClosed;
+      expect(seen).toEqual({ error: null, aborted: false, body: "pushed body" });
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
 });
 
 describe("inbound flow control after local end-stream (RFC 9113 §6.9)", () => {


### PR DESCRIPTION
### Problem
- On an `http2.connect()` client, a pushed stream that is still open when the session goes away gets no `'error'` and no `'close'`, and `pushed.destroyed` stays `false`. Node v26.3.0 destroys it.
- A client's pushed stream is rooted only in the parser's `sctx` map. `emit_error_to_all_streams` (`src/runtime/api/bun/h2_frame_parser.rs:6562`) and `for_each_stream` (`:6489`) walk only the `streams` table, which has no entry for it.

### Fix
- Both functions also visit ids in `sctx` that have no `streams` entry. Only the client `streamPush` handler roots a context by id, so such an id is always a pushed stream.
- `on_stream_end` and `on_stream_reset` drop that root before they dispatch, so a `destroy()` from inside the dispatch does not report the stream twice. Two `forEachStream` callbacks skip a pushed stream: the GOAWAY last-stream-id sweep (it covers only client-opened streams, as in nghttp2), and `close()` on socket close (broken for a pushed stream, #33000).
- Verified: `test/js/node/http2/h2-conformance.test.ts` (6 new tests, 4 fail without the fix). Also `test/js/node/http2/` and 256 upstream `test-http2-*.js` files.
- Self-reviewed: 12 concerns raised, 9 addressed. Rejected: a fix of `close()` on pushed streams (#33000 owns it), a guard in the shared `emitStreamErrorNT` (grpc-js relies on it), and one test layout nit.

### Background
- Server push: the server reserves an even stream id with PUSH_PROMISE and answers on it. The client reports it with the session `'stream'` event.
- `H2FrameParser` has two layers. The rewritten engine parses inbound frames. The older `streams` table serves outbound calls and the teardown loops.
- `sctx` maps a stream id to a strong reference to its JS stream object.

<details><summary>Notes</summary>

**Teardown paths and what the pushed stream reports.** Raw server: SETTINGS, then PUSH_PROMISE(1 -> 2) after the request HEADERS. Before this change bun reported nothing on the pushed stream in any row.

| teardown | node v26.3.0 | bun with this change |
|---|---|---|
| `session.destroy()` | `close`, rstCode 0 | `error ERR_HTTP2_STREAM_CANCEL`, `close`, rstCode 8 |
| `session.destroy(err)` | `error` (same `err`), `close`, rstCode 2 | the same |
| `session.destroy(2)` | `error ERR_HTTP2_SESSION_ERROR`, `close`, rstCode 2 | the same |
| connection error (GOAWAY with an even last-stream-id) | `error ERR_HTTP2_ERROR`, `close`, rstCode 2 | the same |
| GOAWAY(last 1, ENHANCE_YOUR_CALM) | `error ERR_HTTP2_SESSION_ERROR`, `close`, rstCode 11 | the same |
| peer closes the socket | `end`, `close`, rstCode 8, no `aborted` | the same |
| peer resets the socket | `error ECONNRESET`, `close`, rstCode 2 | the same |
| GOAWAY(last 0 or 1, NO_ERROR) | the pushed stream keeps running and completes | the same (unchanged) |

The pushed stream now gets exactly what the request stream on the same session gets. Two differences from node remain, and they are the same for every stream, not only pushed ones: a plain `destroy()` reports `ERR_HTTP2_STREAM_CANCEL` with rstCode 8, and the session events fire before the stream events. #33802 changes both. It switches `destroy()` to `forEachStream(destroyStreamForSessionDestroy)`, which reaches pushed streams only with this change.

**Behavior that changes besides the fix.**
- `forEachStream(emitTimeout)`: a pushed stream now gets `'timeout'` on a session timeout, like a request stream does in bun. In bun `stream.setTimeout()` delegates to the session timer, so this is how a stream timeout is delivered. Node emits `'timeout'` on the session only.
- `emitTimeout` no longer emits on a destroyed stream.
- With no `'error'` listener on the pushed stream, `destroy(err)` and an error GOAWAY now raise an uncaught exception, where the stream was silently leaked before. Node does the same.

**Fan-out sites left alone on purpose.** `emit_abort_to_all_streams` has one caller, the server `#onClose`, and a server never has an id that is only in `sctx` (`handle_received_stream_id` inserts the table entry first, and `free_resources` drops the `sctx` root before the table entry goes away). `detach()` clears `sctx` wholesale.

**Known and not changed here.** `pushed.close(code)`, `pushed.end()` and `pushed.state` fail with `Invalid stream id` on a client, because the pushed id is not in the `streams` table. #33000 registers promised ids there. If it lands, `sctx_only_stream_ids()` returns nothing and the two new loops are inert, the `streamCancel` branch can go, and the GOAWAY guard stays necessary. A pushed stream that the user destroys keeps its `sctx` root until the peer finishes the stream (that root is what returns the session's open-stream count when the peer does). So a session teardown still dispatches to it: `emitStreamErrorNT` can rewrite its `rstCode` after `'close'` when it still has an `'error'` listener. I did not guard that write, because the same path delivers grpc-js status codes to destroyed streams.

**Tests.** The four `test.each` rows fail on the unfixed build at `expect(pushed.destroyed).toBe(true)`: when the session reports `'close'`, the pushed stream must already be destroyed (node destroys streams synchronously inside `destroy()`). Two tests pass on the unfixed build by design, because they pin guards this change needs:
- "a graceful GOAWAY leaves a pushed stream above its last-stream-id running" fails without the `!stream[kPush]` guard (`error: ERR_HTTP2_GOAWAY_SESSION`, empty body).
- "a session destroyed while a pushed stream handles the peer's reset ..." fails when `on_stream_reset` drops the root after the dispatch (`error: ERR_HTTP2_STREAM_CANCEL`).
- The socket-close row fails without the `streamCancel` branch (`aborted: true`, `error: Invalid stream id`).

I checked each of those three by removing the guard and running the test.

**Self-review, rejected items.** (1) Fix `close()` on pushed streams at the owner (end the writable side at creation): that needs the native changes of #33000 to avoid a double RST_STREAM and to return the open-stream count, so it stays there. (2) Guard the `rstCode` write in `emitStreamErrorNT` for destroyed streams: shared path, see above. (3) Move the test setup inside the `try`: the neighbouring test has the same layout.

**Suites run on the debug (ASAN) build.** `test/js/node/http2/` (582 pass), all 256 `test/js/node/test/parallel/test-http2-*.js`, the four `test/js/node/test/sequential/test-http2-*.js` that exist for http2 limits and timeouts, three grpc-js files (`test-idle-timer`, `test-end-to-end`, `test-deadline`), and the new tests 15 times in a row and once with `BUN_JSC_validateExceptionChecks=1`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [664.41ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [221.27ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [149.06ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [73.58ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [67.52ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [59.15ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [65.25ms]
(pass) PING (checklist §3.7) > a PING on a non-zero st
... (truncated)

release without fix: 4 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [10.38ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [2.92ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [2.36ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [1.22ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [0.98ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [0.98ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [1.06ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [0.87ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [0.95ms]
(pass) WINDOW_UPDAT
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [412.45ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [122.00ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [84.57ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [44.76ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [37.64ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [56.65ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [120.17ms]
(pass) PING (checklist §3.7) > a PING on a non-zero st
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 881ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (13774ms)
Bundle modules (65ms)
Postprocesss modules (201ms)
Bundle Functions (665ms)
Generate Code (52ms)

[14.77s] Bundled "src/js" for production
  2600 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 6m 13s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.3-canary.1+2d8df7449
[build] done
bun test v1.4.3-canary.1 (2d8df7449)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [10.56ms]
(pass) connection preface & SETTINGS handshake (checklist §1) >
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                      |  20 +++--
 src/runtime/api/bun/h2_frame_parser.rs    |  77 ++++++++++++----
 test/js/node/http2/h2-conformance.test.ts | 142 ++++++++++++++++++++++++++++++
 3 files changed, 216 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/http2.ts                           8      5     18
src/runtime/api/bun/h2_frame_parser.rs        11     13     18
test/js/node/http2/h2-conformance.test.ts      3      4     18
```

</details>

<!-- robobun:evidence:end -->