### PR TITLE
node:http2: cap the client originSet at maxOriginSetSize like node 26.4.0

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -432,6 +432,7 @@ declare function $ERR_HTTP2_STREAM_ERROR(code): Error;
 declare function $ERR_HTTP2_SESSION_ERROR(code): Error;
 declare function $ERR_HTTP2_PAYLOAD_FORBIDDEN(status): Error;
 declare function $ERR_HTTP2_INVALID_INFO_STATUS(code): RangeError;
+declare function $ERR_HTTP2_TOO_MANY_ORIGINS(maxOriginSetSize: number): Error;
 declare function $ERR_INVALID_URL(input, base?): TypeError;
 declare function $ERR_INVALID_CHAR(name, field?): TypeError;
 declare function $ERR_HTTP_INVALID_HEADER_VALUE(value: string, name: string): TypeError;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4967,8 +4967,7 @@ class ClientHttp2Session extends Http2Session {
   // RFC 9113 reserved (pushed) streams the peer may have open at once (node session option).
   #maxReservedRemoteStreams: number = 200;
   #reservedStreamsCount: number = 0;
-  // node's kMaxOriginSetSize (CVE-2026-48619): the peer's ORIGIN frames may not grow
-  // originSet past this, or the session is destroyed with ERR_HTTP2_TOO_MANY_ORIGINS.
+  // Cap on originSet entries from the peer's ORIGIN frames (node's maxOriginSetSize option).
   #maxOriginSetSize: number = 128;
   #strictFieldWhitespaceValidation: boolean = true;
   // Client-side SETTINGS_MAX_CONCURRENT_STREAMS accounting: requests whose HEADERS frame has been
@@ -5325,8 +5324,7 @@ class ClientHttp2Session extends Http2Session {
       // node.js emits value, origin, streamId
       self.emit("altsvc", value, origin, streamId);
     },
-    // The native parser dispatches one origin as a string and several as an array. It never
-    // dispatches an empty frame.
+    // The native parser never dispatches an empty ORIGIN frame.
     origin(self: ClientHttp2Session, origin: string | Array<string>) {
       if (!self) return;
       if (self.encrypted) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4967,6 +4967,9 @@ class ClientHttp2Session extends Http2Session {
   // RFC 9113 reserved (pushed) streams the peer may have open at once (node session option).
   #maxReservedRemoteStreams: number = 200;
   #reservedStreamsCount: number = 0;
+  // node's kMaxOriginSetSize (CVE-2026-48619): the peer's ORIGIN frames may not grow
+  // originSet past this, or the session is destroyed with ERR_HTTP2_TOO_MANY_ORIGINS.
+  #maxOriginSetSize: number = 128;
   #strictFieldWhitespaceValidation: boolean = true;
   // Client-side SETTINGS_MAX_CONCURRENT_STREAMS accounting: requests whose HEADERS frame has been
   // submitted and whose stream has not closed yet, plus the queue of requests waiting for a slot
@@ -5326,15 +5329,16 @@ class ClientHttp2Session extends Http2Session {
       if (!self) return;
       if (self.encrypted) {
         const originSet = initOriginSet(self);
-        if ($isArray(origin)) {
-          for (const item of origin) {
-            originSet.add(item);
+        const origins = $isArray(origin) ? origin : origin ? [origin] : [];
+        if (origins.length === 0) return;
+        for (let i = 0; i < origins.length; i++) {
+          if (originSet.size >= self.#maxOriginSetSize) {
+            self.destroy($ERR_HTTP2_TOO_MANY_ORIGINS(self.#maxOriginSetSize));
+            return;
           }
-          self.emit("origin", origin);
-        } else if (origin) {
-          originSet.add(origin);
-          self.emit("origin", [origin]);
+          originSet.add(origins[i]);
         }
+        self.emit("origin", origins);
       }
     },
     write(self: ClientHttp2Session, buffer: Buffer) {
@@ -5605,6 +5609,11 @@ class ClientHttp2Session extends Http2Session {
 
     assertIsObject(options, "options");
     options = { ...options };
+
+    if (options.maxOriginSetSize != null) {
+      validateNumber(options.maxOriginSetSize, "options.maxOriginSetSize", 0);
+      this.#maxOriginSetSize = options.maxOriginSetSize;
+    }
 
     assertIsArray(options.remoteCustomSettings, "options.remoteCustomSettings");
     if (options.remoteCustomSettings) {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -5325,12 +5325,13 @@ class ClientHttp2Session extends Http2Session {
       // node.js emits value, origin, streamId
       self.emit("altsvc", value, origin, streamId);
     },
-    origin(self: ClientHttp2Session, origin: string | Array<string> | undefined) {
+    // The native parser dispatches one origin as a string and several as an array. It never
+    // dispatches an empty frame.
+    origin(self: ClientHttp2Session, origin: string | Array<string>) {
       if (!self) return;
       if (self.encrypted) {
         const originSet = initOriginSet(self);
-        const origins = $isArray(origin) ? origin : origin ? [origin] : [];
-        if (origins.length === 0) return;
+        const origins = $isArray(origin) ? origin : [origin];
         for (let i = 0; i < origins.length; i++) {
           if (originSet.size >= self.#maxOriginSetSize) {
             self.destroy($ERR_HTTP2_TOO_MANY_ORIGINS(self.#maxOriginSetSize));

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1865,6 +1865,7 @@ static constexpr SimpleErrorMessage simpleErrorMessages[] = {
     { ErrorCode::ERR_HTTP2_SESSION_ERROR, 1, { "Session closed with error code "_s, ""_s, ""_s } },
     { ErrorCode::ERR_HTTP2_PAYLOAD_FORBIDDEN, 1, { "Responses with "_s, " status must not have a payload"_s, ""_s } },
     { ErrorCode::ERR_HTTP2_INVALID_INFO_STATUS, 1, { "Invalid informational status code: "_s, ""_s, ""_s } },
+    { ErrorCode::ERR_HTTP2_TOO_MANY_ORIGINS, 1, { "The server sent more ORIGIN frames than the allowed number of "_s, ""_s, ""_s } },
     { ErrorCode::ERR_HTTP_INVALID_HEADER_VALUE, 2, { "Invalid value \""_s, "\" for header \""_s, "\""_s } },
     { ErrorCode::ERR_HTTP_HEADERS_SENT, 1, { "Cannot "_s, " headers after they are sent to the client"_s, ""_s } },
     { ErrorCode::ERR_UNESCAPED_CHARACTERS, 1, { ""_s, " contains unescaped characters"_s, ""_s } },

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -119,6 +119,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_HTTP2_TRAILERS_NOT_READY", Error],
   ["ERR_HTTP2_TOO_MANY_CUSTOM_SETTINGS", Error],
   ["ERR_HTTP2_TOO_MANY_INVALID_FRAMES", Error],
+  ["ERR_HTTP2_TOO_MANY_ORIGINS", Error],
   ["ERR_HTTP2_UNSUPPORTED_PROTOCOL", Error],
   ["ERR_HTTP2_INVALID_SETTING_VALUE", TypeError, "TypeError", RangeError],
   ["ERR_ILLEGAL_CONSTRUCTOR", TypeError],

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6335,10 +6335,6 @@ describe("http2 client caps originSet at maxOriginSetSize (CVE-2026-48619)", () 
   let server;
   beforeAll(async () => {
     server = http2.createSecureServer(TLS_CERT);
-    server.on("stream", stream => {
-      stream.respond();
-      stream.end("ok");
-    });
     // Every session gets ORIGIN frames of 10 new origins each, until it closes.
     server.on("session", session => {
       let i = 0;
@@ -6358,8 +6354,9 @@ describe("http2 client caps originSet at maxOriginSetSize (CVE-2026-48619)", () 
   });
   const url = () => `https://localhost:${server.address().port}`;
 
-  // Connects, sends one request, and resolves with what the session saw once it closes.
-  // With `stopAbove`, the client destroys itself once originSet grows past that size.
+  // Connects and resolves with what the session saw once it closes. No request is opened,
+  // so a destroyed session has no stream left to error. With `stopAbove`, the client
+  // destroys itself once originSet grows past that size.
   function run(options, stopAbove) {
     const { promise, resolve } = Promise.withResolvers();
     const client = http2.connect(url(), { ...TLS_OPTIONS, ...options });
@@ -6376,7 +6373,6 @@ describe("http2 client caps originSet at maxOriginSetSize (CVE-2026-48619)", () 
       result.goaway = true;
     });
     client.on("close", () => resolve(result));
-    client.request().resume();
     return promise;
   }
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6329,3 +6329,96 @@ describe("frames issued from inside a user-supplied Duplex transport's _write", 
     },
   );
 });
+
+describe("http2 client caps originSet at maxOriginSetSize (CVE-2026-48619)", () => {
+  // node >= 26.4.0: test/parallel/test-http2-origin-set-max-size.mjs
+  let server;
+  beforeAll(async () => {
+    server = http2.createSecureServer(TLS_CERT);
+    server.on("stream", stream => {
+      stream.respond();
+      stream.end("ok");
+    });
+    // Every session gets ORIGIN frames of 10 new origins each, until it closes.
+    server.on("session", session => {
+      let i = 0;
+      const timer = setInterval(() => {
+        try {
+          session.origin(...Array.from({ length: 10 }, () => `https://o${i++}.example.com`));
+        } catch {
+          clearInterval(timer);
+        }
+      }, 1);
+      session.on("close", () => clearInterval(timer));
+    });
+    await new Promise(resolve => server.listen(0, resolve));
+  });
+  afterAll(() => {
+    server.close();
+  });
+  const url = () => `https://localhost:${server.address().port}`;
+
+  // Connects, sends one request, and resolves with what the session saw once it closes.
+  function run(options) {
+    const { promise, resolve } = Promise.withResolvers();
+    const client = http2.connect(url(), { ...TLS_OPTIONS, ...options });
+    const result = { originEvents: 0, maxSize: 0, error: null, goaway: false };
+    client.on("origin", () => {
+      result.originEvents++;
+      result.maxSize = Math.max(result.maxSize, client.originSet.length);
+      if (options.stopAbove !== undefined && client.originSet.length > options.stopAbove) client.destroy();
+    });
+    client.on("error", err => {
+      result.error = err;
+    });
+    client.on("goaway", () => {
+      result.goaway = true;
+    });
+    client.on("close", () => resolve(result));
+    client.request().resume();
+    return promise;
+  }
+
+  it("rejects a maxOriginSetSize that is not a number", () => {
+    for (const maxOriginSetSize of [Symbol(), "0", 1n, {}, [], true, false, /s/, () => {}]) {
+      expect(() => http2.connect(url(), { ...TLS_OPTIONS, maxOriginSetSize })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+    }
+    for (const maxOriginSetSize of [NaN, -1]) {
+      expect(() => http2.connect(url(), { ...TLS_OPTIONS, maxOriginSetSize })).toThrow(
+        expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+      );
+    }
+  });
+
+  it("defaults to 128 and destroys the session with ERR_HTTP2_TOO_MANY_ORIGINS", async () => {
+    const result = await run({});
+    // The set starts with the session's own origin. 12 frames of 10 fit, the 13th overflows.
+    expect(result.originEvents).toBe(12);
+    expect(result.maxSize).toBe(121);
+    expect(result.goaway).toBe(false);
+    expect(result.error?.code).toBe("ERR_HTTP2_TOO_MANY_ORIGINS");
+    expect(result.error?.message).toBe("The server sent more ORIGIN frames than the allowed number of 128");
+    expect(result.error).toBeInstanceOf(Error);
+  });
+
+  it("does not emit 'origin' for the frame that overflows a small maxOriginSetSize", async () => {
+    for (const maxOriginSetSize of [-0, 9, 1.5]) {
+      const result = await run({ maxOriginSetSize });
+      expect(result.originEvents).toBe(0);
+      expect(result.goaway).toBe(false);
+      expect(result.error?.code).toBe("ERR_HTTP2_TOO_MANY_ORIGINS");
+    }
+  });
+
+  it("accepts a maxOriginSetSize above the default", async () => {
+    for (const maxOriginSetSize of [512, Infinity]) {
+      const result = await run({ maxOriginSetSize, stopAbove: 128 });
+      expect(result.originEvents).toBe(13);
+      expect(result.maxSize).toBe(131);
+      expect(result.error).toBeNull();
+      expect(result.goaway).toBe(false);
+    }
+  });
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6359,14 +6359,15 @@ describe("http2 client caps originSet at maxOriginSetSize (CVE-2026-48619)", () 
   const url = () => `https://localhost:${server.address().port}`;
 
   // Connects, sends one request, and resolves with what the session saw once it closes.
-  function run(options) {
+  // With `stopAbove`, the client destroys itself once originSet grows past that size.
+  function run(options, stopAbove) {
     const { promise, resolve } = Promise.withResolvers();
     const client = http2.connect(url(), { ...TLS_OPTIONS, ...options });
     const result = { originEvents: 0, maxSize: 0, error: null, goaway: false };
     client.on("origin", () => {
       result.originEvents++;
       result.maxSize = Math.max(result.maxSize, client.originSet.length);
-      if (options.stopAbove !== undefined && client.originSet.length > options.stopAbove) client.destroy();
+      if (stopAbove !== undefined && client.originSet.length > stopAbove) client.destroy();
     });
     client.on("error", err => {
       result.error = err;
@@ -6414,7 +6415,7 @@ describe("http2 client caps originSet at maxOriginSetSize (CVE-2026-48619)", () 
 
   it("accepts a maxOriginSetSize above the default", async () => {
     for (const maxOriginSetSize of [512, Infinity]) {
-      const result = await run({ maxOriginSetSize, stopAbove: 128 });
+      const result = await run({ maxOriginSetSize }, 128);
       expect(result.originEvents).toBe(13);
       expect(result.maxSize).toBe(131);
       expect(result.error).toBeNull();

--- a/test/js/node/test/parallel/test-http2-origin-set-max-size.mjs
+++ b/test/js/node/test/parallel/test-http2-origin-set-max-size.mjs
@@ -1,0 +1,100 @@
+import {
+  expectsError,
+  hasCrypto,
+  mustCall,
+  mustNotCall,
+  mustSucceed,
+  skip,
+} from '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import assert from 'node:assert';
+
+if (!hasCrypto)
+  skip('missing crypto');
+
+const {
+  createSecureServer,
+  connect,
+} = await import('node:http2');
+
+const key = fixtures.readKey('agent8-key.pem', 'binary');
+const cert = fixtures.readKey('agent8-cert.pem', 'binary');
+const ca = fixtures.readKey('fake-startcom-root-cert.pem', 'binary');
+
+const server = createSecureServer({ key, cert });
+server.on('session', (session) => {
+  let i = 0;
+  const timer = setInterval(() => {
+    try {
+      session.origin(...Array.from({ length: 10 }, () => `https://o${i++}.example.com`));
+    } catch {
+      clearInterval(timer);
+    }
+  }, 10);
+
+  session.on('close', () => {
+    clearInterval(timer);
+  });
+});
+
+await new Promise((resolve) => server.listen(0, resolve));
+
+// Test fantasist values
+[Symbol(), '0', 1n, {}, [], true, false, /s/, () => {}].forEach((maxOriginSetSize) => {
+  assert.throws(
+    () => connect(`https://localhost:${server.address().port}`, { ca, maxOriginSetSize }),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+});
+[NaN, -1].forEach((maxOriginSetSize) => {
+  assert.throws(
+    () => connect(`https://localhost:${server.address().port}`, { ca, maxOriginSetSize }),
+    { code: 'ERR_OUT_OF_RANGE' },
+  );
+});
+
+await new Promise((resolve) => server.getConnections(mustSucceed((count) => {
+  assert.strictEqual(count, 0);
+  resolve();
+})));
+
+// Test default value
+await new Promise((resolve) => {
+  const client = connect(`https://localhost:${server.address().port}`, { ca });
+
+  client.on('origin', mustCall(12)); // Default value is 128, the first 12 frames should pass, the 13th one should error
+  client.on('error', expectsError({
+    code: 'ERR_HTTP2_TOO_MANY_ORIGINS',
+  }));
+  client.on('goaway', mustNotCall());
+  client.on('close', resolve);
+});
+
+// Test non-default values
+await Promise.all([-0, 9, 1.5].map((maxOriginSetSize) => new Promise((resolve) => {
+  const client = connect(`https://localhost:${server.address().port}`, { ca, maxOriginSetSize });
+
+  client.on('origin', mustNotCall()); // The server send 10 origins on the first frame, that's already too many.
+  client.on('error', expectsError({
+    code: 'ERR_HTTP2_TOO_MANY_ORIGINS',
+  }));
+  client.on('goaway', mustNotCall());
+  client.on('close', resolve);
+})));
+
+
+// Test values higher than the default value
+await Promise.all([512, Infinity].map((maxOriginSetSize) => new Promise((resolve) => {
+  const client = connect(`https://localhost:${server.address().port}`, { ca, maxOriginSetSize });
+
+  client.on('origin', mustCall(() => {
+    if (client.originSet.length > 128) {
+      client.destroy();
+    }
+  }, 13));
+  client.on('error', mustNotCall());
+  client.on('goaway', mustNotCall());
+  client.on('close', resolve);
+})));
+
+server.close();


### PR DESCRIPTION
Fixes #42407

### Problem
- A `node:http2` client adds every origin of every inbound ORIGIN frame to `session.originSet` with no limit. A TLS server can send new origins for the life of the session and grow client memory without bound. The issue's repro reaches 301 entries and never errors.
- The cause is the client `origin` handler in `src/js/node/http2.ts:5331`. It calls `originSet.add` for each entry and never checks the size. Node.js fixed the same bug in v26.4.0 (CVE-2026-48619, nodejs/node@87d847bc70).

### Fix
- `http2.connect()` accepts `maxOriginSetSize`. It is validated with `validateNumber(..., 0)` like node: a non-number throws `ERR_INVALID_ARG_TYPE`, `NaN` or a negative value throws `ERR_OUT_OF_RANGE`. The default is 128.
- The `origin` handler checks `originSet.size >= maxOriginSetSize` before each add. When the check fails it destroys the session with the new `ERR_HTTP2_TOO_MANY_ORIGINS` ("The server sent more ORIGIN frames than the allowed number of 128") and does not emit `'origin'` for that frame. This is node's `onOrigin` line for line.
- The handler also drops a dead empty-frame guard. The native parser (`h2_frame_parser.rs`) never dispatches an ORIGIN frame with zero entries.
- Verified: `test/js/node/http2/node-http2.test.js` (new describe block, 3 of 4 tests fail on stock bun) and node's own `test/js/node/test/parallel/test-http2-origin-set-max-size.mjs` (vendored, fails on stock bun). Also the full `node-http2.test.js` file and `test-http2-origin.js`.

### Background
- An ORIGIN frame (RFC 8336) lets a server list the origins it can serve on one connection. A client collects them in `session.originSet`. Bun only does this on a TLS session, like node.
- The set starts with the session's own origin, so with the default of 128 the first 12 frames of 10 origins fit and the 13th overflows. Node's test and the new bun test both assert those counts.
- Open PR #42391 rewrites the same handler to validate inbound ORIGIN frames. It does not add the cap. Whichever lands second needs a small rebase of this one function.

<details><summary>Notes</summary>

- Self-reviewed: 3 concerns raised, 2 addressed (the dead `origins.length === 0` guard, and vendoring node's test). The third asked for a tracking issue for the CVE. No prior CVE port in this repo used one, so I did not file it.
- `ERR_HTTP2_TOO_MANY_ORIGINS` is registered in `src/jsc/bindings/ErrorCode.ts` (plain `Error`) and its message template in `src/jsc/bindings/ErrorCode.cpp`.
- The vendored node test is the current `main` version of `test-http2-origin-set-max-size.mjs`. It differs from the version in the fix commit only in that it no longer opens a request on each session. It runs in about 5 s on the debug build.
- `node:http2` types come from `@types/node`, so `packages/bun-types` has no change.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (6a92015fc)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [1541.22ms]
(pass) node none > Client Basics > should be able to send a POST request [991.93ms]
(pass) node none > Client Basics > constants [21.79ms]
(pass) node none > Client Basics > getDefaultSettings [8.95ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [21.83ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [8.77ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [5.38ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [7.34ms]
(pass) node none > Client Basics > should be able to send data using end [987.85ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [956.90ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 6 skipped
bun test v1.4.3-canary.1 (8f0aab5ce)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.94ms]
(pass) node none > Client Basics > getDefaultSettings [0.30ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.34ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.21ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.05ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.09ms]
(pass) node none > Client Basics > is possible to abort request [1.82ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.88ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.78ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [0.88ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [58.42ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > should fail to con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (6a92015fc)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [1163.02ms]
(pass) node none > Client Basics > should be able to send a POST request [811.74ms]
(pass) node none > Client Basics > constants [22.92ms]
(pass) node none > Client Basics > getDefaultSettings [8.43ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [18.81ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [8.19ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [4.28ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [6.68ms]
(pass) node none > Client Basics > should be able to send data using end [805.63ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [762.87ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 720ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/79] gen ErrorCode+*.h
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (8244ms)
Bundle modules (77ms)
Postprocesss modules (554ms)
Bundle Functions (843ms)
Generate Code (42ms)

[9.77s] Bundled "src/js" for production
  2600 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 5m 12s
[4/8] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[5/8] link bun-profile
[7/8] strip bun
[7/8] bun-profile --revision
1.4.3-canary.1+6d5f4ea9f
[build] done
bun test v1.4.3-canary.1 (6d5f4ea9f)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.93ms]
(pass) node none > Client Basics > getDefaultSettings [0.18ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.31ms]
(pass) node none > C
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins.d.ts                               |   1 +
 src/js/node/http2.ts                               |  24 +++--
 src/jsc/bindings/ErrorCode.cpp                     |   1 +
 src/jsc/bindings/ErrorCode.ts                      |   1 +
 test/js/node/http2/node-http2.test.js              |  90 +++++++++++++++++++
 .../parallel/test-http2-origin-set-max-size.mjs    | 100 +++++++++++++++++++++
 6 files changed, 209 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/builtins.d.ts                                          1      1     17
src/js/node/http2.ts                                          4      7     17
src/jsc/bindings/ErrorCode.cpp                                1      1     17
src/jsc/bindings/ErrorCode.ts                                 1      2     17
test/js/node/http2/node-http2.test.js                         2      6     17
…s/node/test/parallel/test-http2-origin-set-max-size.mjs      0      0     19
```

</details>

**root cause** · written by the author bot

The `node:http2` client added every origin from every inbound ORIGIN frame to `session.originSet` with no upper bound, so a TLS server could grow the set indefinitely for the life of the session (CVE-2026-48619). The fix mirrors Node v26.4.0 by adding a `maxOriginSetSize` option to `http2.connect` (default 128, validated as a number greater than or equal to zero) and checking it in the client's origin handler before each add. When the set is already at the limit, the session is destroyed with `ERR_HTTP2_TOO_MANY_ORIGINS` and the `'origin'` event is not emitted for that frame.

<!-- robobun:evidence:end -->