### PR TITLE
transpiler cache: reject an entry with no sourcemap section

### DIFF
--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -510,6 +510,9 @@ impl Entry {
             }
 
             self.sourcemap = sourcemap;
+        } else {
+            // `put` never writes one. A hit would leave the module's stack traces unmapped.
+            return Err(crate::CrateError::InvalidSourceMap);
         }
 
         if self.metadata.esm_record_byte_length > 0 {
@@ -969,6 +972,10 @@ bun_ast::link_impl_TranspilerCacheImpl! {
         put(output_code_bytes, sourcemap, esm_record) => {
             let this = &mut *this;
             if this.input_hash.is_none() || IS_DISABLED.load(Ordering::Relaxed) {
+                return;
+            }
+            // Printed with source maps off. `Entry::load` rejects an entry with no sourcemap.
+            if sourcemap.is_empty() {
                 return;
             }
             debug_assert!(this.entry.is_none());

--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -183,8 +183,7 @@ impl SavedSourceMap {
         source: &bun_ast::Source,
         mut mappings: MutableString,
     ) -> bun_js_printer::Result<()> {
-        // Readers take a stored blob's header on trust. A transpiler cache hit
-        // for an entry with no sourcemap section passes an empty buffer here.
+        // A cache hit for an entry with no sourcemap section passes an empty buffer.
         if !InternalSourceMap::is_valid_blob(mappings.list.as_slice()) {
             return Ok(());
         }

--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -183,7 +183,7 @@ impl SavedSourceMap {
         source: &bun_ast::Source,
         mut mappings: MutableString,
     ) -> bun_js_printer::Result<()> {
-        // A cache hit for an entry with no sourcemap section passes an empty buffer.
+        // Readers take a stored blob's header on trust.
         if !InternalSourceMap::is_valid_blob(mappings.list.as_slice()) {
             return Ok(());
         }

--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -183,26 +183,35 @@ impl SavedSourceMap {
         source: &bun_ast::Source,
         mut mappings: MutableString,
     ) -> bun_js_printer::Result<()> {
+        // A table value tagged `InternalSourceMap` is the blob's data pointer,
+        // and consumers read the blob header through it with no length in hand
+        // (`ParsedSourceMap::from_internal`, on the first stack remap). So a
+        // buffer that is not a whole blob must never enter the table. An empty
+        // `MutableString` reaches here from a runtime transpiler cache hit for
+        // an entry with no sourcemap section: its data pointer is the empty
+        // `Box<[u8]>` sentinel, so that remap read address 0x11.
+        if !InternalSourceMap::is_valid_blob(mappings.list.as_slice()) {
+            return Ok(());
+        }
+
+        let incoming = InternalSourceMap {
+            data: mappings.list.as_ptr(),
+        };
         // --hot can re-read a file mid-rewrite (truncate + write) and transpile
         // a comment-only prefix into a 0-mapping map. Overwriting a real map
         // with that would make any still-unreported error from the previous
         // transpile remap against nothing and leak transpiled coords. A map
         // with no mappings can never answer a lookup, so dropping it is never
         // worse than installing it.
-        if mappings.list.len() >= SourceMap::internal_source_map::HEADER_SIZE {
-            let incoming = InternalSourceMap {
-                data: mappings.list.as_ptr(),
-            };
-            if incoming.mapping_count() == 0 {
-                self.lock();
-                let contains = self.map.contains_key(&hash(source.path.text));
-                self.unlock();
-                if contains {
-                    return Ok(());
-                }
-                // Note: reshaped for borrowck — the lock is
-                // released before returning since no further table access follows.
+        if incoming.mapping_count() == 0 {
+            self.lock();
+            let contains = self.map.contains_key(&hash(source.path.text));
+            self.unlock();
+            if contains {
+                return Ok(());
             }
+            // Note: reshaped for borrowck — the lock is
+            // released before returning since no further table access follows.
         }
 
         // Note: every caller MOVES an owned

--- a/src/jsc/SavedSourceMap.rs
+++ b/src/jsc/SavedSourceMap.rs
@@ -183,26 +183,21 @@ impl SavedSourceMap {
         source: &bun_ast::Source,
         mut mappings: MutableString,
     ) -> bun_js_printer::Result<()> {
-        // A table value tagged `InternalSourceMap` is the blob's data pointer,
-        // and consumers read the blob header through it with no length in hand
-        // (`ParsedSourceMap::from_internal`, on the first stack remap). So a
-        // buffer that is not a whole blob must never enter the table. An empty
-        // `MutableString` reaches here from a runtime transpiler cache hit for
-        // an entry with no sourcemap section: its data pointer is the empty
-        // `Box<[u8]>` sentinel, so that remap read address 0x11.
+        // Readers take a stored blob's header on trust. A transpiler cache hit
+        // for an entry with no sourcemap section passes an empty buffer here.
         if !InternalSourceMap::is_valid_blob(mappings.list.as_slice()) {
             return Ok(());
         }
 
-        let incoming = InternalSourceMap {
-            data: mappings.list.as_ptr(),
-        };
         // --hot can re-read a file mid-rewrite (truncate + write) and transpile
         // a comment-only prefix into a 0-mapping map. Overwriting a real map
         // with that would make any still-unreported error from the previous
         // transpile remap against nothing and leak transpiled coords. A map
         // with no mappings can never answer a lookup, so dropping it is never
         // worse than installing it.
+        let incoming = InternalSourceMap {
+            data: mappings.list.as_ptr(),
+        };
         if incoming.mapping_count() == 0 {
             self.lock();
             let contains = self.map.contains_key(&hash(source.path.text));
@@ -210,8 +205,6 @@ impl SavedSourceMap {
             if contains {
                 return Ok(());
             }
-            // Note: reshaped for borrowck — the lock is
-            // released before returning since no further table access follows.
         }
 
         // Note: every caller MOVES an owned

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -433,6 +433,9 @@ describe("transpiler cache", () => {
       expect(newCacheCount()).toBe(0);
     });
 
+    // Four runs that each miss the cache and write a new entry. One run takes
+    // about 1.4 s on a debug build with the sanitizers on, which is past the
+    // 5 s default for the whole test.
     test("--drop invalidates cache", () => {
       writeFileSync(
         join(temp_dir, "a.js"),
@@ -450,7 +453,7 @@ describe("transpiler cache", () => {
 
       expect(run(temp_dir, ["a.js"])).toBe("logged\nwritten");
       expect(newCacheCount()).toBe(0);
-    });
+    }, 30_000);
   });
 
   // Serving the entry point from the cache must not change how the modules it
@@ -690,4 +693,88 @@ console.log("OK");
   expect(third.stdout.toString()).toContain("OK");
   expect(third.signalCode).toBeUndefined();
   expect(third.exitCode).toBe(0);
+});
+
+// A cache hit registers the stored sourcemap section as the module's source
+// map, and stack remapping reads that section as an InternalSourceMap blob. A
+// section with no blob header in it must not be registered: the first error's
+// stack reads the header through a pointer to nothing.
+//
+// Metadata layout (src/jsc/RuntimeTranspilerCache.rs, Metadata::encode):
+//   0: cache_version u32, 4: module_type u8, 5: output_encoding u8, then
+//   twelve u64 fields; sourcemap_byte_length @ 62.
+describe("a cached entry with no sourcemap section", () => {
+  const SOURCEMAP_BYTE_LENGTH_AT = 62;
+
+  // A module large enough for the cache (>= 4 KiB) that throws and prints the
+  // first frame of the error's stack. Reading the stack is what remaps the
+  // captured frame through the cached sourcemap.
+  function writeThrowingModule() {
+    const line = `// ${Buffer.alloc(120, "x").toString()}\n`;
+    const filler = Buffer.alloc(120 * line.length, line).toString();
+    writeFileSync(
+      join(temp_dir, "boom.ts"),
+      `${filler}
+function boom(): number {
+  throw new Error("boom");
+}
+try {
+  boom();
+} catch (e) {
+  console.log((e as Error).stack!.split("\\n")[1].trim());
+}
+console.log("OK");
+`,
+    );
+  }
+
+  const run = (extra: Record<string, string> = {}) =>
+    Bun.spawnSync({ cmd: [bunExe(), "./boom.ts"], cwd: temp_dir, env: { ...env, ...extra } });
+
+  function storedSourceMapLength() {
+    const entries = readdirSync(cache_dir).filter(name => name.endsWith(".pile"));
+    expect(entries).toHaveLength(1);
+    return Number(readFileSync(join(cache_dir, entries[0])).readBigUInt64LE(SOURCEMAP_BYTE_LENGTH_AT));
+  }
+
+  test("written by a run with source maps off", () => {
+    writeThrowingModule();
+
+    // BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS turns source maps off for the run,
+    // so the printer produces no sourcemap and the entry this run writes has
+    // an empty sourcemap section.
+    const first = run({ BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS: "1" });
+    expect(first.stdout.toString()).toContain("OK");
+    expect(first.exitCode).toBe(0);
+    expect(storedSourceMapLength()).toBe(0);
+
+    // This run does remap stack traces, and it is served that entry.
+    const second = run();
+    expect(second.stdout.toString()).toContain("at boom");
+    expect(second.stdout.toString()).toContain("OK");
+    expect(second.signalCode).toBeUndefined();
+    expect(second.exitCode).toBe(0);
+  });
+
+  test("whose stored sourcemap length was zeroed", () => {
+    writeThrowingModule();
+
+    const first = run();
+    expect(first.stdout.toString()).toContain("OK");
+    expect(first.exitCode).toBe(0);
+    expect(storedSourceMapLength()).toBeGreaterThan(0);
+
+    // Point the metadata at no sourcemap bytes, leaving the rest of the entry
+    // (including the section that follows) untouched.
+    const entry = join(cache_dir, readdirSync(cache_dir).find(name => name.endsWith(".pile"))!);
+    const data = readFileSync(entry);
+    data.writeBigUInt64LE(0n, SOURCEMAP_BYTE_LENGTH_AT);
+    writeFileSync(entry, data);
+
+    const second = run();
+    expect(second.stdout.toString()).toContain("at boom");
+    expect(second.stdout.toString()).toContain("OK");
+    expect(second.signalCode).toBeUndefined();
+    expect(second.exitCode).toBe(0);
+  });
 });

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -748,11 +748,13 @@ console.log("OK");
     expect(first.exitCode).toBe(0);
     expect(storedSourceMapLength()).toBe(0);
 
-    // This run does remap stack traces, and it is served that entry.
+    // This run does remap stack traces, and it is served that entry. A run
+    // that missed the cache would have written the entry again, with a map.
     const second = run();
     expect(second.stdout.toString()).toContain("at boom");
     expect(second.stdout.toString()).toContain("OK");
     expect(second.signalCode).toBeUndefined();
+    expect(storedSourceMapLength()).toBe(0);
     expect(second.exitCode).toBe(0);
   });
 
@@ -771,10 +773,13 @@ console.log("OK");
     data.writeBigUInt64LE(0n, SOURCEMAP_BYTE_LENGTH_AT);
     writeFileSync(entry, data);
 
+    // The length is still zero afterwards, so this run was served the entry
+    // and did not write it again.
     const second = run();
     expect(second.stdout.toString()).toContain("at boom");
     expect(second.stdout.toString()).toContain("OK");
     expect(second.signalCode).toBeUndefined();
+    expect(storedSourceMapLength()).toBe(0);
     expect(second.exitCode).toBe(0);
   });
 });

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -433,9 +433,6 @@ describe("transpiler cache", () => {
       expect(newCacheCount()).toBe(0);
     });
 
-    // Four runs that each miss the cache and write a new entry. One run takes
-    // about 1.4 s on a debug build with the sanitizers on, which is past the
-    // 5 s default for the whole test.
     test("--drop invalidates cache", () => {
       writeFileSync(
         join(temp_dir, "a.js"),
@@ -453,7 +450,7 @@ describe("transpiler cache", () => {
 
       expect(run(temp_dir, ["a.js"])).toBe("logged\nwritten");
       expect(newCacheCount()).toBe(0);
-    }, 30_000);
+    });
   });
 
   // Serving the entry point from the cache must not change how the modules it
@@ -696,19 +693,23 @@ console.log("OK");
 });
 
 // A cache hit registers the stored sourcemap section as the module's source
-// map, and stack remapping reads that section as an InternalSourceMap blob. A
-// section with no blob header in it must not be registered: the first error's
-// stack reads the header through a pointer to nothing.
+// map, and stack remapping reads that section as an InternalSourceMap blob
+// through a bare pointer. An entry with no sourcemap section has nothing to
+// read: it must be a miss, so the module is transpiled again and its stack
+// traces still remap.
 //
 // Metadata layout (src/jsc/RuntimeTranspilerCache.rs, Metadata::encode):
 //   0: cache_version u32, 4: module_type u8, 5: output_encoding u8, then
 //   twelve u64 fields; sourcemap_byte_length @ 62.
 describe("a cached entry with no sourcemap section", () => {
   const SOURCEMAP_BYTE_LENGTH_AT = 62;
+  // 120 filler lines, one blank line, the function header, then the throw.
+  const THROW_LINE = 123;
 
   // A module large enough for the cache (>= 4 KiB) that throws and prints the
   // first frame of the error's stack. Reading the stack is what remaps the
-  // captured frame through the cached sourcemap.
+  // captured frame through the module's sourcemap. The transpiled output has
+  // no filler comments, so a frame that is not remapped reports line 2.
   function writeThrowingModule() {
     const line = `// ${Buffer.alloc(120, "x").toString()}\n`;
     const filler = Buffer.alloc(120 * line.length, line).toString();
@@ -731,55 +732,58 @@ console.log("OK");
   const run = (extra: Record<string, string> = {}) =>
     Bun.spawnSync({ cmd: [bunExe(), "./boom.ts"], cwd: temp_dir, env: { ...env, ...extra } });
 
+  const cacheEntries = () =>
+    existsSync(cache_dir) ? readdirSync(cache_dir).filter(name => name.endsWith(".pile")) : [];
+
   function storedSourceMapLength() {
-    const entries = readdirSync(cache_dir).filter(name => name.endsWith(".pile"));
+    const entries = cacheEntries();
     expect(entries).toHaveLength(1);
     return Number(readFileSync(join(cache_dir, entries[0])).readBigUInt64LE(SOURCEMAP_BYTE_LENGTH_AT));
   }
 
-  test("written by a run with source maps off", () => {
+  function expectRemappedFrame(result: ReturnType<typeof run>) {
+    expect(result.stdout.toString()).toContain(`boom.ts:${THROW_LINE}:`);
+    expect(result.stdout.toString()).toContain("OK");
+    expect(result.signalCode).toBeUndefined();
+  }
+
+  test("is not written by a run with source maps off", () => {
     writeThrowingModule();
 
     // BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS turns source maps off for the run,
-    // so the printer produces no sourcemap and the entry this run writes has
-    // an empty sourcemap section.
+    // so the printer has no sourcemap to store next to the output.
     const first = run({ BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS: "1" });
     expect(first.stdout.toString()).toContain("OK");
+    expect(cacheEntries()).toEqual([]);
     expect(first.exitCode).toBe(0);
-    expect(storedSourceMapLength()).toBe(0);
 
-    // This run does remap stack traces, and it is served that entry. A run
-    // that missed the cache would have written the entry again, with a map.
+    // A run with source maps on finds no entry, transpiles the module itself
+    // and writes an entry that has a sourcemap.
     const second = run();
-    expect(second.stdout.toString()).toContain("at boom");
-    expect(second.stdout.toString()).toContain("OK");
-    expect(second.signalCode).toBeUndefined();
-    expect(storedSourceMapLength()).toBe(0);
+    expectRemappedFrame(second);
+    expect(storedSourceMapLength()).toBeGreaterThan(0);
     expect(second.exitCode).toBe(0);
   });
 
-  test("whose stored sourcemap length was zeroed", () => {
+  test("is rejected and written again with a sourcemap", () => {
     writeThrowingModule();
 
     const first = run();
-    expect(first.stdout.toString()).toContain("OK");
-    expect(first.exitCode).toBe(0);
+    expectRemappedFrame(first);
     expect(storedSourceMapLength()).toBeGreaterThan(0);
+    expect(first.exitCode).toBe(0);
 
-    // Point the metadata at no sourcemap bytes, leaving the rest of the entry
-    // (including the section that follows) untouched.
-    const entry = join(cache_dir, readdirSync(cache_dir).find(name => name.endsWith(".pile"))!);
+    // Point the metadata at no sourcemap bytes and leave the rest of the entry
+    // untouched. The loader sees what a build that stored entries with source
+    // maps off left behind.
+    const entry = join(cache_dir, cacheEntries()[0]);
     const data = readFileSync(entry);
     data.writeBigUInt64LE(0n, SOURCEMAP_BYTE_LENGTH_AT);
     writeFileSync(entry, data);
 
-    // The length is still zero afterwards, so this run was served the entry
-    // and did not write it again.
     const second = run();
-    expect(second.stdout.toString()).toContain("at boom");
-    expect(second.stdout.toString()).toContain("OK");
-    expect(second.signalCode).toBeUndefined();
-    expect(storedSourceMapLength()).toBe(0);
+    expectRemappedFrame(second);
+    expect(storedSourceMapLength()).toBeGreaterThan(0);
     expect(second.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem

- A transpiler cache hit for an entry with no sourcemap section kills the process on the first thrown error: `panic(main thread): Segmentation fault at address 0x11`. The entry stays, so every later run dies too. Found by fuzzing, no user report.
- No tampering needed: a run with `BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS=1` writes such an entry and the next run dies. Nothing outside bun's source uses that flag.
- `Entry::load` (`src/jsc/RuntimeTranspilerCache.rs:500`) accepts a zero-length section and leaves `sourcemap` an empty `Box<[u8]>`. `SavedSourceMap::put_mappings` (`src/jsc/SavedSourceMap.rs:192`) stores its dangling data pointer (0x1) as the module's map. The first remap reads the header at 0x1+16.

### Fix

- `Entry::load` returns `InvalidSourceMap` for a zero-length section. Its caller already unlinks the entry on a load error, so the run transpiles again and writes an entry with a map (the #41457 layer).
- `put()` writes no entry when the printer made no sourcemap, so no entry this build writes has an empty section.
- `put_mappings` drops a buffer that fails `InternalSourceMap::is_valid_blob`. The check is O(1) and adds no hashing (#40948).
- Verified: two new cases in `test/cli/run/transpiler-cache.test.ts`, which fail on stock bun and with only the `put_mappings` check. Also ran `test/js/bun/sourcemap/` and `inspect-error.test.js`.

### Background

- The transpiler cache (`.pile`) stores a module's transpiled output and source map, so a hit can still remap stack traces.
- `InternalSourceMap` is bun's in-process map format: one blob with a 32-byte header. Readers hold a bare pointer to it, with no length.
- With source maps on, the printer always emits that header (33 bytes for a comment-only file). Only a flag run or a damaged entry has an empty section.

<details><summary>Notes</summary>

Three crash signatures come from the one stored pointer. All three reproduce on 1.4.3-canary.1 (release, Linux x64) and are gone with this branch:

- first thrown error: `Segmentation fault at address 0x11`, `get_with_content` <- `resolve_mapping` <- `resolve_source_mapping` <- `remap_stack_frame_positions` <- `Bun::formatStackTrace`
- the same module loaded twice (`delete require.cache[p]`, `--hot`): `panic(main thread): Segmentation fault at address 0x1`. `put_value` releases the old value, and `free_owned` reads `total_len` through it
- a Worker that imported the module is terminated: `panic: Segmentation fault at address 0x1`, same `free_owned`, from the table's `Drop`

Repro, with a TS module over the 4 KiB cache floor that throws and reads `error.stack`:

```console
$ export BUN_RUNTIME_TRANSPILER_CACHE_PATH=$PWD/c
$ BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS=1 bun boom.ts   # writes an entry with an empty sourcemap section
Error: boom |     at boom (/tmp/t2/boom.ts:2:14)
OK
$ bun boom.ts
panic(main thread): Segmentation fault at address 0x11
```

Reproduced 2/2 on main release-asan, canary release and 1.4.2, so it is not a regression. Sentry, last 90 days: one event has `get_with_content` in its stack at fault address 0x11 (BUN-50M8, 2026-09-12, canary d316760e8). That event is the fuzz run itself.

Why three changes and not only the `put_mappings` check. The first push of this PR had only that check. It stopped the crash, but a hit on such an entry then reported transpiled positions (`boom.ts:2:14`, the true frame is `123:13`) for as long as the entry lived. That is a false cache hit. `put_mappings` can only drop the buffer. The caller of `Entry::load` is the layer that can recover, because it evicts the entry and the run transpiles again. The `put_mappings` check stays because the function is safe code that stored a pointer readers trust. It replaces the old `len >= HEADER_SIZE` test, which guarded only the zero-mapping shortcut and then stored a shorter buffer anyway.

Behavior under `BUN_FEATURE_FLAG_DISABLE_SOURCE_MAPS`: a flag run still reads the cache, and it no longer writes it. An entry an older build wrote with the flag on is evicted on first load. I checked this with an entry that stock bun wrote: this branch rejected it and wrote it again with a 93-byte map.

No `EXPECTED_VERSION` or `features_hash` change. The entry format is the same, and a valid entry loads exactly as before.

The other inputs that reach the same state, all handled by the load check: the `(offset, length)` pairs of the sourcemap and esm record sections swapped (the esm record length is 0 for a module without one), and a `sourcemap_byte_length` zeroed in place.

Not done: verifying the section against `metadata.sourcemap_hash`. #39717 added that and #40948 reverted it, because it hashes the sourcemap on every cache hit.

#40383 rewrites the lock calls inside the same `put_mappings` block. The overlap is about eight lines.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/transpiler-cache.test.ts

<!-- robobun:evidence:end -->