### PR TITLE
Bounds-check the InternalSourceMap window reader

### DIFF
--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -249,9 +249,10 @@ impl InternalSourceMap {
 
 /// Sanity-check the blob's outer header (total_len, sync_count, stream_offset)
 /// against its actual length so a *truncated* embedded section in a `--compile`
-/// binary degrades to "no sourcemap". This does not walk per-window
-/// `SyncEntry.byte_offset`/section lengths; the blob is self-produced at build
-/// time, and a tampered executable already implies arbitrary execution.
+/// binary or a damaged transpiler cache entry degrades to "no sourcemap". This
+/// is O(1): it does not walk per-window `SyncEntry.byte_offset`/section
+/// lengths. `WindowReader` bounds-checks those against the stream as it reads
+/// them, and a window that does not fit yields no mapping.
 pub fn is_valid_blob(blob: &[u8]) -> bool {
     if blob.len() < HEADER_SIZE {
         return false;
@@ -293,8 +294,17 @@ impl State {
         self.generated_line < line || (self.generated_line == line && self.generated_column <= col)
     }
 
-    fn to_mapping(self) -> Mapping {
-        Mapping {
+    /// `None` for a negative coordinate. `Builder` never stores one, so it
+    /// means the blob is damaged, and `Ordinal::from_zero_based` asserts on it.
+    fn to_mapping(self) -> Option<Mapping> {
+        if self.generated_line < 0
+            || self.generated_column < 0
+            || self.original_line < 0
+            || self.original_column < 0
+        {
+            return None;
+        }
+        Some(Mapping {
             generated: LineColumnOffset {
                 lines: Ordinal::from_zero_based(self.generated_line),
                 columns: Ordinal::from_zero_based(self.generated_column),
@@ -305,7 +315,7 @@ impl State {
             },
             source_index: self.source_index,
             name_index: -1,
-        }
+        })
     }
 }
 
@@ -344,21 +354,22 @@ fn write_varint(buf: *mut u8, signed: i32) -> usize {
     }
 }
 
-fn read_varint(bytes: &[u8], pos: &mut usize) -> i32 {
+/// `None` when the varint runs past the end of `bytes`.
+fn read_varint(bytes: &[u8], pos: &mut usize) -> Option<i32> {
     let mut i = *pos;
-    let first = bytes[i];
+    let first = *bytes.get(i)?;
     i += 1;
     if first < 0x80 {
         *pos = i;
-        return zigzag_decode(first as u32);
+        return Some(zigzag_decode(first as u32));
     }
     let mut result: u32 = (first & 0x7f) as u32;
     let mut shift: u32 = 7;
     loop {
-        if i >= bytes.len() || shift > 28 {
+        if shift > 28 {
             break;
         }
-        let byte = bytes[i];
+        let byte = *bytes.get(i)?;
         i += 1;
         result |= ((byte & 0x7f) as u32) << shift;
         if byte & 0x80 == 0 {
@@ -367,13 +378,20 @@ fn read_varint(bytes: &[u8], pos: &mut usize) -> i32 {
         shift += 7;
     }
     *pos = i;
-    zigzag_decode(result)
+    Some(zigzag_decode(result))
 }
 
+/// Reads the 8-byte mask that starts at `pos`. Bit `i` of the result is bit
+/// `i & 7` of byte `i >> 3`, the order `Builder::flush_window` sets them in.
 #[inline]
-fn test_bit(base: *const u8, idx: usize) -> bool {
-    // SAFETY: caller guarantees base[idx >> 3] is within the window header / mask region.
-    unsafe { (*base.add(idx >> 3) >> (idx & 7)) & 1 != 0 }
+fn read_mask(bytes: &[u8], pos: usize) -> Option<u64> {
+    Some(u64::from_le_bytes(*bytes.get(pos..)?.first_chunk()?))
+}
+
+/// `idx` is a delta index, so it is below `SYNC_INTERVAL - 1`.
+#[inline]
+fn test_bit(mask: u64, idx: u8) -> bool {
+    (mask >> idx) & 1 != 0
 }
 
 const FLAG_HAS_GEN_LINE_EXCEPTIONS: u8 = 1 << 2;
@@ -396,20 +414,26 @@ mod win_hdr {
 
 /// Parses a window header and steps through its deltas in order. Exception
 /// streams are consumed in order, so a reader is forward-only.
-// Invariant: `bytes`/`base`/`src_idx_mask` point into the blob and are only
-// valid while the blob is live. They are raw pointers (not lifetimes) because
-// readers are stored in lifetime-less caches (`FindCacheSlot`, `Cursor`) that
-// follow `InternalSourceMap`'s Copy-view design.
+///
+/// The bytes can come from disk (a transpiler cache entry, a `--compile`
+/// section), where `is_valid_blob` has only checked the outer header. So every
+/// read of the stream is bounds-checked: `parse` and `next` return `None` when
+/// a window or one of its lanes runs past the end of the stream.
+// Invariant: `bytes` points into the blob and is only valid while the blob is
+// live. It is a raw pointer (not a lifetime) because readers are stored in the
+// lifetime-less `Cursor`, which follows `InternalSourceMap`'s Copy-view design.
 #[derive(Copy, Clone)]
 struct WindowReader {
     bytes: *const [u8],
-    base: *const u8,
     gen_col_pos: usize,
     orig_line_exc_pos: usize,
     orig_col_exc_pos: usize,
     gen_line_exc_pos: usize,
-    src_idx_mask: *const u8,
     src_idx_exc_pos: usize,
+    gen_line_mask: u64,
+    orig_line_eq_mask: u64,
+    orig_col_eq_mask: u64,
+    src_idx_eq_mask: u64,
     count: u8,
     flags: u8,
     gen_line_exc_next_idx: u8,
@@ -417,15 +441,18 @@ struct WindowReader {
 }
 
 impl WindowReader {
+    /// An empty window: `done()` holds and nothing reads `bytes`.
     const DANGLING: WindowReader = WindowReader {
         bytes: ptr::slice_from_raw_parts(ptr::null(), 0),
-        base: ptr::null(),
         gen_col_pos: 0,
         orig_line_exc_pos: 0,
         orig_col_exc_pos: 0,
         gen_line_exc_pos: 0,
-        src_idx_mask: ptr::null(),
         src_idx_exc_pos: 0,
+        gen_line_mask: 0,
+        orig_line_eq_mask: 0,
+        orig_col_eq_mask: 0,
+        src_idx_eq_mask: 0,
         count: 0,
         flags: 0,
         gen_line_exc_next_idx: 0,
@@ -443,58 +470,64 @@ impl WindowReader {
         unsafe { &*self.bytes }
     }
 
-    fn parse(&mut self, bytes: &[u8], start: usize) {
-        // SAFETY: `start` is a valid window header offset within `bytes` (came
-        // from a SyncEntry.byte_offset produced by Builder).
-        let b = unsafe { bytes.as_ptr().add(start) };
-        self.bytes = std::ptr::from_ref::<[u8]>(bytes);
-        self.base = b;
-        // Clamp `count` so a corrupted header byte cannot drive `next()` past
-        // `FindCacheSlot.decoded[SYNC_INTERVAL]`. Well-formed blobs never
-        // exceed K; this is defense-in-depth for the standalone-graph path.
-        // SAFETY: window header is 32 bytes within the stream; COUNT_OFF/FLAGS_OFF
-        // are fixed offsets within that 32-byte header at `b`.
-        self.count = unsafe { *b.add(win_hdr::COUNT_OFF) }.min(SYNC_INTERVAL as u8);
-        // SAFETY: same — FLAGS_OFF is within the 32-byte header at `b`.
-        let flags = unsafe { *b.add(win_hdr::FLAGS_OFF) };
-        self.flags = flags;
-        self.delta_idx = 0;
+    /// Positions the reader on the window whose header starts at `start`.
+    /// Returns `None`, with the reader left empty, when the header or one of the
+    /// flagged sections does not fit inside `bytes`.
+    fn parse(&mut self, bytes: &[u8], start: usize) -> Option<()> {
+        *self = WindowReader::DANGLING;
+        let header: &[u8; win_hdr::GEN_COL_LANE_OFF] = bytes.get(start..)?.first_chunk()?;
+        let len_at = |off: usize| u16::from_ne_bytes([header[off], header[off + 1]]) as usize;
 
-        // SAFETY: u16 LE fields at fixed header offsets within the 32-byte header.
-        let gen_col_len: usize =
-            unsafe { u16::from_ne_bytes(*b.add(win_hdr::GEN_COL_LEN_OFF).cast::<[u8; 2]>()) }
-                as usize;
-        // SAFETY: ORIG_LINE_LEN_OFF is a fixed offset within the 32-byte header at `b`.
-        let orig_line_len: usize =
-            unsafe { u16::from_ne_bytes(*b.add(win_hdr::ORIG_LINE_LEN_OFF).cast::<[u8; 2]>()) }
-                as usize;
-        // SAFETY: ORIG_COL_LEN_OFF is a fixed offset within the 32-byte header at `b`.
-        let orig_col_len: usize =
-            unsafe { u16::from_ne_bytes(*b.add(win_hdr::ORIG_COL_LEN_OFF).cast::<[u8; 2]>()) }
-                as usize;
+        let flags = header[win_hdr::FLAGS_OFF];
+        let gen_col_pos = start + win_hdr::GEN_COL_LANE_OFF;
+        let orig_line_exc_pos = gen_col_pos + len_at(win_hdr::GEN_COL_LEN_OFF);
+        let orig_col_exc_pos = orig_line_exc_pos + len_at(win_hdr::ORIG_LINE_LEN_OFF);
+        let mut pos = orig_col_exc_pos + len_at(win_hdr::ORIG_COL_LEN_OFF);
 
-        self.gen_col_pos = start + win_hdr::GEN_COL_LANE_OFF;
-        self.orig_line_exc_pos = self.gen_col_pos + gen_col_len;
-        self.orig_col_exc_pos = self.orig_line_exc_pos + orig_line_len;
-        let mut pos = self.orig_col_exc_pos + orig_col_len;
-        self.gen_line_exc_next_idx = 0xFF;
-        if flags != 0 {
-            if flags & FLAG_HAS_GEN_LINE_EXCEPTIONS != 0 && pos < bytes.len() {
-                self.gen_line_exc_pos = pos;
-                self.gen_line_exc_next_idx = bytes[pos];
-                while pos < bytes.len() && bytes[pos] != 0xFF {
-                    pos += 1;
-                    let _ = read_varint(bytes, &mut pos);
+        let mut gen_line_exc_pos = 0;
+        let mut gen_line_exc_next_idx = 0xFF;
+        if flags & FLAG_HAS_GEN_LINE_EXCEPTIONS != 0 {
+            gen_line_exc_pos = pos;
+            gen_line_exc_next_idx = *bytes.get(pos)?;
+            // One pair per delta at most, so a damaged window cannot turn the
+            // search for the terminator into a scan of the whole stream.
+            let mut pairs = 0;
+            while *bytes.get(pos)? != 0xFF {
+                if pairs == SYNC_INTERVAL - 1 {
+                    return None;
                 }
+                pairs += 1;
                 pos += 1;
+                read_varint(bytes, &mut pos)?;
             }
-            if flags & FLAG_HAS_SRC_IDX != 0 {
-                // SAFETY: pos is within bytes (mask region is 8 bytes).
-                self.src_idx_mask = unsafe { bytes.as_ptr().add(pos) };
-                pos += 8;
-                self.src_idx_exc_pos = pos;
-            }
+            pos += 1;
         }
+        let mut src_idx_eq_mask = 0;
+        let mut src_idx_exc_pos = 0;
+        if flags & FLAG_HAS_SRC_IDX != 0 {
+            src_idx_eq_mask = read_mask(bytes, pos)?;
+            src_idx_exc_pos = pos + 8;
+        }
+
+        *self = WindowReader {
+            bytes: std::ptr::from_ref::<[u8]>(bytes),
+            gen_col_pos,
+            orig_line_exc_pos,
+            orig_col_exc_pos,
+            gen_line_exc_pos,
+            src_idx_exc_pos,
+            gen_line_mask: read_mask(header, win_hdr::GEN_LINE_MASK_OFF)?,
+            orig_line_eq_mask: read_mask(header, win_hdr::ORIG_LINE_EQ_MASK_OFF)?,
+            orig_col_eq_mask: read_mask(header, win_hdr::ORIG_COL_EQ_MASK_OFF)?,
+            src_idx_eq_mask,
+            // Well-formed windows never exceed `SYNC_INTERVAL`. The clamp keeps
+            // every delta index below 64, the width of the masks.
+            count: header[win_hdr::COUNT_OFF].min(SYNC_INTERVAL as u8),
+            flags,
+            gen_line_exc_next_idx,
+            delta_idx: 0,
+        };
+        Some(())
     }
 
     #[inline]
@@ -502,53 +535,49 @@ impl WindowReader {
         self.delta_idx + 1 >= self.count
     }
 
-    fn next(&mut self, state: &mut State) {
+    /// Applies the next delta to `state`. Returns `None` when a lane runs past
+    /// the end of the stream. The window then reads as `done()`.
+    fn next(&mut self, state: &mut State) -> Option<()> {
+        let applied = self.apply_next(state);
+        if applied.is_none() {
+            self.count = 0;
+        }
+        applied
+    }
+
+    fn apply_next(&mut self, state: &mut State) -> Option<()> {
         let delta_idx = self.delta_idx;
         self.delta_idx = delta_idx + 1;
-        let b = self.base;
         let bytes = self.bytes();
 
-        let mut d_gen_line: i32 = if test_bit(
-            // SAFETY: header masks are at fixed offsets within the 32-byte header at `b`.
-            unsafe { b.add(win_hdr::GEN_LINE_MASK_OFF) },
-            delta_idx as usize,
-        ) {
-            1
-        } else {
-            0
-        };
-        let d_gen_col = read_varint(bytes, &mut self.gen_col_pos);
-        let mut d_orig_line: i32 = if test_bit(
-            // SAFETY: header masks are at fixed offsets within the 32-byte header at `b`.
-            unsafe { b.add(win_hdr::ORIG_LINE_EQ_MASK_OFF) },
-            delta_idx as usize,
-        ) {
+        let mut d_gen_line: i32 = test_bit(self.gen_line_mask, delta_idx) as i32;
+        let d_gen_col = read_varint(bytes, &mut self.gen_col_pos)?;
+        let mut d_orig_line: i32 = if test_bit(self.orig_line_eq_mask, delta_idx) {
             d_gen_line
         } else {
-            read_varint(bytes, &mut self.orig_line_exc_pos)
+            read_varint(bytes, &mut self.orig_line_exc_pos)?
         };
-        let d_orig_col: i32 = if test_bit(
-            // SAFETY: header masks are at fixed offsets within the 32-byte header at `b`.
-            unsafe { b.add(win_hdr::ORIG_COL_EQ_MASK_OFF) },
-            delta_idx as usize,
-        ) {
+        let d_orig_col: i32 = if test_bit(self.orig_col_eq_mask, delta_idx) {
             d_gen_col
         } else {
-            read_varint(bytes, &mut self.orig_col_exc_pos)
+            read_varint(bytes, &mut self.orig_col_exc_pos)?
         };
 
         if self.flags != 0 {
-            self.next_rare(delta_idx, &mut d_gen_line, &mut d_orig_line, state);
+            self.next_rare(delta_idx, &mut d_gen_line, &mut d_orig_line, state)?;
         }
 
+        // Wrapping: a damaged delta must not trip the overflow check. A
+        // coordinate that ends up negative is dropped by `State::to_mapping`.
         if d_gen_line != 0 {
-            state.generated_line += d_gen_line;
+            state.generated_line = state.generated_line.wrapping_add(d_gen_line);
             state.generated_column = d_gen_col;
         } else {
-            state.generated_column += d_gen_col;
+            state.generated_column = state.generated_column.wrapping_add(d_gen_col);
         }
-        state.original_line += d_orig_line;
-        state.original_column += d_orig_col;
+        state.original_line = state.original_line.wrapping_add(d_orig_line);
+        state.original_column = state.original_column.wrapping_add(d_orig_col);
+        Some(())
     }
 
     #[cold]
@@ -558,24 +587,22 @@ impl WindowReader {
         d_gen_line: &mut i32,
         d_orig_line: &mut i32,
         state: &mut State,
-    ) {
+    ) -> Option<()> {
         let bytes = self.bytes();
         if self.gen_line_exc_next_idx == delta_idx {
             let mut p = self.gen_line_exc_pos + 1;
-            *d_gen_line = read_varint(bytes, &mut p);
-            if test_bit(
-                // SAFETY: header mask at fixed offset within `base`.
-                unsafe { self.base.add(win_hdr::ORIG_LINE_EQ_MASK_OFF) },
-                delta_idx as usize,
-            ) {
+            *d_gen_line = read_varint(bytes, &mut p)?;
+            if test_bit(self.orig_line_eq_mask, delta_idx) {
                 *d_orig_line = *d_gen_line;
             }
             self.gen_line_exc_pos = p;
-            self.gen_line_exc_next_idx = bytes[p];
+            self.gen_line_exc_next_idx = *bytes.get(p)?;
         }
-        if self.flags & FLAG_HAS_SRC_IDX != 0 && !test_bit(self.src_idx_mask, delta_idx as usize) {
-            state.source_index += read_varint(bytes, &mut self.src_idx_exc_pos);
+        if self.flags & FLAG_HAS_SRC_IDX != 0 && !test_bit(self.src_idx_eq_mask, delta_idx) {
+            let d_src_idx = read_varint(bytes, &mut self.src_idx_exc_pos)?;
+            state.source_index = state.source_index.wrapping_add(d_src_idx);
         }
+        Some(())
     }
 }
 
@@ -601,10 +628,16 @@ impl InternalSourceMap {
         Some(u32::try_from(lo - 1).expect("int cast"))
     }
 
-    fn seed_window(self, sync_idx: u32, state: &mut State, reader: &mut WindowReader) {
+    /// `None` when the window does not fit inside the stream (a damaged blob).
+    fn seed_window(
+        self,
+        sync_idx: u32,
+        state: &mut State,
+        reader: &mut WindowReader,
+    ) -> Option<()> {
         let se = self.sync_entry(sync_idx as usize);
         *state = se.to_state();
-        reader.parse(self.stream(), se.byte_offset as usize);
+        reader.parse(self.stream(), se.byte_offset as usize)
     }
 
     /// Matches the semantics of `Mapping.List.find`: returns the last mapping with
@@ -617,12 +650,12 @@ impl InternalSourceMap {
 
         let mut state = State::default();
         let mut reader = WindowReader::DANGLING;
-        self.seed_window(sync_idx, &mut state, &mut reader);
+        self.seed_window(sync_idx, &mut state, &mut reader)?;
 
         let mut best = state;
         while !reader.done() {
             let mut nxt = state;
-            reader.next(&mut nxt);
+            reader.next(&mut nxt)?;
             if !nxt.less_or_equal(target_line, target_col) {
                 break;
             }
@@ -633,7 +666,7 @@ impl InternalSourceMap {
         if best.generated_line != target_line {
             return None;
         }
-        Some(best.to_mapping())
+        best.to_mapping()
     }
 }
 
@@ -694,7 +727,7 @@ impl Cursor {
         if self.state.generated_line != target_line {
             return None;
         }
-        Some(self.state.to_mapping())
+        self.state.to_mapping()
     }
 
     fn advance_one(&mut self) -> Option<State> {
@@ -706,11 +739,11 @@ impl Cursor {
             self.sync_idx += 1;
             let mut seed = State::default();
             self.map
-                .seed_window(self.sync_idx, &mut seed, &mut self.reader);
+                .seed_window(self.sync_idx, &mut seed, &mut self.reader)?;
             return Some(seed);
         }
         let mut nxt = self.peek.unwrap_or(self.state);
-        self.reader.next(&mut nxt);
+        self.reader.next(&mut nxt)?;
         Some(nxt)
     }
 
@@ -720,10 +753,12 @@ impl Cursor {
             return false;
         };
         self.sync_idx = idx;
-        self.map.seed_window(idx, &mut self.state, &mut self.reader);
         self.peek = None;
-        self.has_state = true;
-        true
+        self.has_state = self
+            .map
+            .seed_window(idx, &mut self.state, &mut self.reader)
+            .is_some();
+        self.has_state
     }
 }
 
@@ -733,7 +768,8 @@ impl InternalSourceMap {
     }
 
     /// Re-encode the full mapping stream as a standard VLQ "mappings" string. Only
-    /// the inspector's inline-sourcemap path needs this.
+    /// the inspector's inline-sourcemap path needs this. Stops at the first
+    /// window that does not fit inside the stream (a damaged blob).
     pub fn append_vlq_to(self, out: &mut MutableString) {
         let n_sync = self.sync_count();
         // A 4-field VLQ segment averages ~5 bytes plus a separator. Cap by the
@@ -749,10 +785,14 @@ impl InternalSourceMap {
         while idx < n_sync {
             let mut state = State::default();
             let mut reader = WindowReader::DANGLING;
-            self.seed_window(idx, &mut state, &mut reader);
+            if self.seed_window(idx, &mut state, &mut reader).is_none() {
+                return;
+            }
             emit_vlq(&state, &mut prev, &mut generated_line, out);
             while !reader.done() {
-                reader.next(&mut state);
+                if reader.next(&mut state).is_none() {
+                    return;
+                }
                 emit_vlq(&state, &mut prev, &mut generated_line, out);
             }
             idx += 1;

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -68,7 +68,7 @@
 //!     [28..32]  stream_offset:     u32   -- byte offset from blob start to stream
 //!     [32..  ]  SyncEntry[sync_count]    -- 24 bytes each
 //!     [stream_offset..total_len-stream_tail_pad]  Window[sync_count]
-//!     [total_len-stream_tail_pad..total_len]      zero bytes (read-past pad)
+//!     [total_len-stream_tail_pad..total_len]      zero bytes (see `STREAM_TAIL_PAD`)
 //! ```
 //!
 //! SyncEntry: absolute state of this window's first mapping plus stream offset
@@ -108,10 +108,9 @@ pub(crate) const SYNC_INTERVAL: usize = 64;
 
 pub const HEADER_SIZE: usize = 32;
 
-/// `read_varint`'s 1-byte fast path reads `bytes[pos]` unconditionally; the
-/// exception cursors in `WindowReader` advance to one byte past their last
-/// varint, so a 1-byte tail pad keeps that read in-bounds for a window at the
-/// very end of the stream.
+/// One zero byte that `Builder::finalize` writes after the last window and
+/// `is_valid_blob` requires. It is part of the blob layout, so it stays. The
+/// reader does not rely on it: every read of the stream is bounds-checked.
 const STREAM_TAIL_PAD: usize = 1;
 
 /// The blob is stored in the SavedSourceMap table as a tagged pointer to its

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -380,10 +380,10 @@ fn read_varint(bytes: &[u8], pos: &mut usize) -> Option<i32> {
     Some(zigzag_decode(result))
 }
 
-/// Reads the 8-byte mask that starts at `pos`. Bit `i` of the result is bit
-/// `i & 7` of byte `i >> 3`, the order `Builder::flush_window` sets them in.
+/// Reads the 8 bytes that start at `pos`. For a mask, bit `i` of the result is
+/// bit `i & 7` of byte `i >> 3`, the order `Builder::flush_window` sets them in.
 #[inline]
-fn read_mask(bytes: &[u8], pos: usize) -> Option<u64> {
+fn read_u64_le(bytes: &[u8], pos: usize) -> Option<u64> {
     Some(u64::from_le_bytes(*bytes.get(pos..)?.first_chunk()?))
 }
 
@@ -470,24 +470,42 @@ impl WindowReader {
     }
 
     /// Positions the reader on the window whose header starts at `start`.
-    /// Returns `None`, with the reader left empty, when the header or one of the
-    /// flagged sections does not fit inside `bytes`.
+    /// Returns `None`, with the reader left `done()`, when the header or one of
+    /// the flagged sections does not fit inside `bytes`.
     fn parse(&mut self, bytes: &[u8], start: usize) -> Option<()> {
-        *self = WindowReader::DANGLING;
+        // Empty until the whole window is accepted.
+        self.count = 0;
+        self.delta_idx = 0;
         let header: &[u8; win_hdr::GEN_COL_LANE_OFF] = bytes.get(start..)?.first_chunk()?;
-        let len_at = |off: usize| u16::from_ne_bytes([header[off], header[off + 1]]) as usize;
+        // One load covers count, flags and the three u16 LE section lengths.
+        let fixed = read_u64_le(header, 0)?;
+        let len_at = |off: usize| ((fixed >> (8 * off)) & 0xffff) as usize;
+        let flags = (fixed >> (8 * win_hdr::FLAGS_OFF)) as u8;
 
-        let flags = header[win_hdr::FLAGS_OFF];
-        let gen_col_pos = start + win_hdr::GEN_COL_LANE_OFF;
-        let orig_line_exc_pos = gen_col_pos + len_at(win_hdr::GEN_COL_LEN_OFF);
-        let orig_col_exc_pos = orig_line_exc_pos + len_at(win_hdr::ORIG_LINE_LEN_OFF);
-        let mut pos = orig_col_exc_pos + len_at(win_hdr::ORIG_COL_LEN_OFF);
+        self.bytes = std::ptr::from_ref::<[u8]>(bytes);
+        self.gen_col_pos = start + win_hdr::GEN_COL_LANE_OFF;
+        self.orig_line_exc_pos = self.gen_col_pos + len_at(win_hdr::GEN_COL_LEN_OFF);
+        self.orig_col_exc_pos = self.orig_line_exc_pos + len_at(win_hdr::ORIG_LINE_LEN_OFF);
+        self.gen_line_mask = read_u64_le(header, win_hdr::GEN_LINE_MASK_OFF)?;
+        self.orig_line_eq_mask = read_u64_le(header, win_hdr::ORIG_LINE_EQ_MASK_OFF)?;
+        self.orig_col_eq_mask = read_u64_le(header, win_hdr::ORIG_COL_EQ_MASK_OFF)?;
+        self.flags = flags;
+        self.gen_line_exc_next_idx = 0xFF;
+        if flags != 0 {
+            let pos = self.orig_col_exc_pos + len_at(win_hdr::ORIG_COL_LEN_OFF);
+            self.parse_flagged_sections(bytes, pos)?;
+        }
+        // Well-formed windows never exceed `SYNC_INTERVAL`. The clamp keeps
+        // every delta index below 64, the width of the masks.
+        self.count = ((fixed >> (8 * win_hdr::COUNT_OFF)) as u8).min(SYNC_INTERVAL as u8);
+        Some(())
+    }
 
-        let mut gen_line_exc_pos = 0;
-        let mut gen_line_exc_next_idx = 0xFF;
-        if flags & FLAG_HAS_GEN_LINE_EXCEPTIONS != 0 {
-            gen_line_exc_pos = pos;
-            gen_line_exc_next_idx = *bytes.get(pos)?;
+    #[cold]
+    fn parse_flagged_sections(&mut self, bytes: &[u8], mut pos: usize) -> Option<()> {
+        if self.flags & FLAG_HAS_GEN_LINE_EXCEPTIONS != 0 {
+            self.gen_line_exc_pos = pos;
+            self.gen_line_exc_next_idx = *bytes.get(pos)?;
             // One pair per delta at most, so a damaged window cannot turn the
             // search for the terminator into a scan of the whole stream.
             let mut pairs = 0;
@@ -501,31 +519,10 @@ impl WindowReader {
             }
             pos += 1;
         }
-        let mut src_idx_eq_mask = 0;
-        let mut src_idx_exc_pos = 0;
-        if flags & FLAG_HAS_SRC_IDX != 0 {
-            src_idx_eq_mask = read_mask(bytes, pos)?;
-            src_idx_exc_pos = pos + 8;
+        if self.flags & FLAG_HAS_SRC_IDX != 0 {
+            self.src_idx_eq_mask = read_u64_le(bytes, pos)?;
+            self.src_idx_exc_pos = pos + 8;
         }
-
-        *self = WindowReader {
-            bytes: std::ptr::from_ref::<[u8]>(bytes),
-            gen_col_pos,
-            orig_line_exc_pos,
-            orig_col_exc_pos,
-            gen_line_exc_pos,
-            src_idx_exc_pos,
-            gen_line_mask: read_mask(header, win_hdr::GEN_LINE_MASK_OFF)?,
-            orig_line_eq_mask: read_mask(header, win_hdr::ORIG_LINE_EQ_MASK_OFF)?,
-            orig_col_eq_mask: read_mask(header, win_hdr::ORIG_COL_EQ_MASK_OFF)?,
-            src_idx_eq_mask,
-            // Well-formed windows never exceed `SYNC_INTERVAL`. The clamp keeps
-            // every delta index below 64, the width of the masks.
-            count: header[win_hdr::COUNT_OFF].min(SYNC_INTERVAL as u8),
-            flags,
-            gen_line_exc_next_idx,
-            delta_idx: 0,
-        };
         Some(())
     }
 

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -108,9 +108,7 @@ pub(crate) const SYNC_INTERVAL: usize = 64;
 
 pub const HEADER_SIZE: usize = 32;
 
-/// One zero byte that `Builder::finalize` writes after the last window and
-/// `is_valid_blob` requires. It is part of the blob layout, so it stays. The
-/// reader does not rely on it: every read of the stream is bounds-checked.
+/// Trailing zero byte of the blob layout. The bounds-checked reader does not need it.
 const STREAM_TAIL_PAD: usize = 1;
 
 /// The blob is stored in the SavedSourceMap table as a tagged pointer to its
@@ -248,10 +246,7 @@ impl InternalSourceMap {
 
 /// Sanity-check the blob's outer header (total_len, sync_count, stream_offset)
 /// against its actual length so a *truncated* embedded section in a `--compile`
-/// binary or a damaged transpiler cache entry degrades to "no sourcemap". This
-/// is O(1): it does not walk per-window `SyncEntry.byte_offset`/section
-/// lengths. `WindowReader` bounds-checks those against the stream as it reads
-/// them, and a window that does not fit yields no mapping.
+/// binary degrades to "no sourcemap". `WindowReader` bounds-checks the rest.
 pub fn is_valid_blob(blob: &[u8]) -> bool {
     if blob.len() < HEADER_SIZE {
         return false;
@@ -293,8 +288,7 @@ impl State {
         self.generated_line < line || (self.generated_line == line && self.generated_column <= col)
     }
 
-    /// `None` for a negative coordinate. `Builder` never stores one, so it
-    /// means the blob is damaged, and `Ordinal::from_zero_based` asserts on it.
+    /// `None` for a negative coordinate: only a damaged blob has one.
     fn to_mapping(self) -> Option<Mapping> {
         if self.generated_line < 0
             || self.generated_column < 0
@@ -380,8 +374,7 @@ fn read_varint(bytes: &[u8], pos: &mut usize) -> Option<i32> {
     Some(zigzag_decode(result))
 }
 
-/// Reads the 8 bytes that start at `pos`. For a mask, bit `i` of the result is
-/// bit `i & 7` of byte `i >> 3`, the order `Builder::flush_window` sets them in.
+/// Mask bit `i` of the result is bit `i & 7` of byte `pos + (i >> 3)`.
 #[inline]
 fn read_u64_le(bytes: &[u8], pos: usize) -> Option<u64> {
     Some(u64::from_le_bytes(*bytes.get(pos..)?.first_chunk()?))
@@ -413,14 +406,7 @@ mod win_hdr {
 
 /// Parses a window header and steps through its deltas in order. Exception
 /// streams are consumed in order, so a reader is forward-only.
-///
-/// The bytes can come from disk (a transpiler cache entry, a `--compile`
-/// section), where `is_valid_blob` has only checked the outer header. So every
-/// read of the stream is bounds-checked: `parse` and `next` return `None` when
-/// a window or one of its lanes runs past the end of the stream.
-// Invariant: `bytes` points into the blob and is only valid while the blob is
-// live. It is a raw pointer (not a lifetime) because readers are stored in the
-// lifetime-less `Cursor`, which follows `InternalSourceMap`'s Copy-view design.
+// `bytes` is a raw pointer into the blob because `Cursor` stores readers without a lifetime.
 #[derive(Copy, Clone)]
 struct WindowReader {
     bytes: *const [u8],
@@ -469,9 +455,7 @@ impl WindowReader {
         unsafe { &*self.bytes }
     }
 
-    /// Positions the reader on the window whose header starts at `start`.
-    /// Returns `None`, with the reader left `done()`, when the header or one of
-    /// the flagged sections does not fit inside `bytes`.
+    /// `None`, with the reader left `done()`, when the window at `start` does not fit in `bytes`.
     fn parse(&mut self, bytes: &[u8], start: usize) -> Option<()> {
         // Empty until the whole window is accepted.
         self.count = 0;
@@ -495,8 +479,7 @@ impl WindowReader {
             let pos = self.orig_col_exc_pos + len_at(win_hdr::ORIG_COL_LEN_OFF);
             self.parse_flagged_sections(bytes, pos)?;
         }
-        // Well-formed windows never exceed `SYNC_INTERVAL`. The clamp keeps
-        // every delta index below 64, the width of the masks.
+        // Clamped so every delta index stays below 64, the width of the masks.
         self.count = ((fixed >> (8 * win_hdr::COUNT_OFF)) as u8).min(SYNC_INTERVAL as u8);
         Some(())
     }
@@ -506,8 +489,7 @@ impl WindowReader {
         if self.flags & FLAG_HAS_GEN_LINE_EXCEPTIONS != 0 {
             self.gen_line_exc_pos = pos;
             self.gen_line_exc_next_idx = *bytes.get(pos)?;
-            // One pair per delta at most, so a damaged window cannot turn the
-            // search for the terminator into a scan of the whole stream.
+            // A window holds at most one pair per delta.
             let mut pairs = 0;
             while *bytes.get(pos)? != 0xFF {
                 if pairs == SYNC_INTERVAL - 1 {
@@ -531,8 +513,7 @@ impl WindowReader {
         self.delta_idx + 1 >= self.count
     }
 
-    /// Applies the next delta to `state`. Returns `None` when a lane runs past
-    /// the end of the stream. The window then reads as `done()`.
+    /// `None`, with the window left `done()`, when a lane runs past the end of the stream.
     fn next(&mut self, state: &mut State) -> Option<()> {
         let applied = self.apply_next(state);
         if applied.is_none() {
@@ -563,8 +544,7 @@ impl WindowReader {
             self.next_rare(delta_idx, &mut d_gen_line, &mut d_orig_line, state)?;
         }
 
-        // Wrapping: a damaged delta must not trip the overflow check. A
-        // coordinate that ends up negative is dropped by `State::to_mapping`.
+        // Wrapping: a damaged delta must not trip the overflow check.
         if d_gen_line != 0 {
             state.generated_line = state.generated_line.wrapping_add(d_gen_line);
             state.generated_column = d_gen_col;
@@ -624,7 +604,7 @@ impl InternalSourceMap {
         Some(u32::try_from(lo - 1).expect("int cast"))
     }
 
-    /// `None` when the window does not fit inside the stream (a damaged blob).
+    /// `None` when the window does not fit inside the stream.
     fn seed_window(
         self,
         sync_idx: u32,
@@ -764,8 +744,7 @@ impl InternalSourceMap {
     }
 
     /// Re-encode the full mapping stream as a standard VLQ "mappings" string. Only
-    /// the inspector's inline-sourcemap path needs this. Stops at the first
-    /// window that does not fit inside the stream (a damaged blob).
+    /// the inspector's inline-sourcemap path needs this.
     pub fn append_vlq_to(self, out: &mut MutableString) {
         let n_sync = self.sync_count();
         // A 4-field VLQ segment averages ~5 bytes plus a separator. Cap by the

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -288,27 +288,20 @@ impl State {
         self.generated_line < line || (self.generated_line == line && self.generated_column <= col)
     }
 
-    /// `None` for a negative coordinate: only a damaged blob has one.
-    fn to_mapping(self) -> Option<Mapping> {
-        if self.generated_line < 0
-            || self.generated_column < 0
-            || self.original_line < 0
-            || self.original_column < 0
-        {
-            return None;
-        }
-        Some(Mapping {
+    fn to_mapping(self) -> Mapping {
+        // Not `from_zero_based`: a damaged blob can decode to a negative coordinate.
+        Mapping {
             generated: LineColumnOffset {
-                lines: Ordinal::from_zero_based(self.generated_line),
-                columns: Ordinal::from_zero_based(self.generated_column),
+                lines: Ordinal(self.generated_line),
+                columns: Ordinal(self.generated_column),
             },
             original: LineColumnOffset {
-                lines: Ordinal::from_zero_based(self.original_line),
-                columns: Ordinal::from_zero_based(self.original_column),
+                lines: Ordinal(self.original_line),
+                columns: Ordinal(self.original_column),
             },
             source_index: self.source_index,
             name_index: -1,
-        })
+        }
     }
 }
 
@@ -513,13 +506,11 @@ impl WindowReader {
         self.delta_idx + 1 >= self.count
     }
 
-    /// `None`, with the window left `done()`, when a lane runs past the end of the stream.
-    fn next(&mut self, state: &mut State) -> Option<()> {
-        let applied = self.apply_next(state);
-        if applied.is_none() {
+    /// A lane that runs past the end of the stream leaves `state` as it is and `count` 0.
+    fn next(&mut self, state: &mut State) {
+        if self.apply_next(state).is_none() {
             self.count = 0;
         }
-        applied
     }
 
     fn apply_next(&mut self, state: &mut State) -> Option<()> {
@@ -631,7 +622,7 @@ impl InternalSourceMap {
         let mut best = state;
         while !reader.done() {
             let mut nxt = state;
-            reader.next(&mut nxt)?;
+            reader.next(&mut nxt);
             if !nxt.less_or_equal(target_line, target_col) {
                 break;
             }
@@ -639,10 +630,11 @@ impl InternalSourceMap {
             state = nxt;
         }
 
-        if best.generated_line != target_line {
+        // `count` 0: the header said so or a lane overran. The window is damaged.
+        if reader.count == 0 || best.generated_line != target_line {
             return None;
         }
-        best.to_mapping()
+        Some(best.to_mapping())
     }
 }
 
@@ -703,7 +695,7 @@ impl Cursor {
         if self.state.generated_line != target_line {
             return None;
         }
-        self.state.to_mapping()
+        Some(self.state.to_mapping())
     }
 
     fn advance_one(&mut self) -> Option<State> {
@@ -719,7 +711,8 @@ impl Cursor {
             return Some(seed);
         }
         let mut nxt = self.peek.unwrap_or(self.state);
-        self.reader.next(&mut nxt)?;
+        // On a lane overrun `nxt` stays a copy of the current state and the next call leaves the window.
+        self.reader.next(&mut nxt);
         Some(nxt)
     }
 
@@ -765,7 +758,8 @@ impl InternalSourceMap {
             }
             emit_vlq(&state, &mut prev, &mut generated_line, out);
             while !reader.done() {
-                if reader.next(&mut state).is_none() {
+                reader.next(&mut state);
+                if reader.count == 0 {
                     return;
                 }
                 emit_vlq(&state, &mut prev, &mut generated_line, out);

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -692,12 +692,12 @@ console.log("OK");
   expect(third.exitCode).toBe(0);
 });
 
-test("remaps a stack through a cached sourcemap whose body is damaged without a crash", () => {
+describe("a cached sourcemap whose body is damaged", () => {
   // The header check in the test above is O(1) on purpose: a cache hit does
   // not walk the sourcemap. So a section with a valid outer header and a
-  // damaged body still reaches SavedSourceMap, and stack remapping reads the
-  // damaged SyncEntry array and window stream. The reader has to bounds-check
-  // what it takes from them. A window that does not fit yields no mapping.
+  // damaged body still reaches SavedSourceMap, and the reader has to
+  // bounds-check what it takes from the SyncEntry array and the window stream.
+  // A window that does not fit yields no mapping.
   //
   // InternalSourceMap section (src/sourcemap/InternalSourceMap.rs):
   //   28: stream_offset u32, 32..stream_offset: SyncEntry[sync_count],
@@ -715,13 +715,37 @@ test("remaps a stack through a cached sourcemap whose body is damaged without a 
     "window stream filled with 0x80": s => void s.fill(0x80, s.readUInt32LE(28)),
   };
 
-  // Large enough for the cache (>= 4 KiB). The throw sits behind the filler, so
-  // the frames to remap are not in the first lines of the transpiled output.
+  // Large enough for the cache (>= 4 KiB), with the code behind the filler so
+  // the positions to remap are not in the first lines of the transpiled output.
   const line = `// ${Buffer.alloc(120, "x").toString()}\n`;
   const filler = Buffer.alloc(120 * line.length, line).toString();
-  writeFileSync(
-    join(temp_dir, "boom.ts"),
-    `${filler}
+
+  // Writes each damaged copy of the one cache entry in turn and hands it to
+  // `check`, which runs bun again. A rejected entry is unlinked and written
+  // again, so `servedFromDamagedEntry` proves the run was a cache hit.
+  function forEachDamagedEntry(check: (name: string, servedFromDamagedEntry: () => boolean) => void) {
+    const entries = readdirSync(cache_dir).filter(name => name.endsWith(".pile"));
+    expect(entries).toHaveLength(1);
+    const entry = join(cache_dir, entries[0]);
+    const pristine = readFileSync(entry);
+    const smOff = Number(pristine.readBigUInt64LE(SOURCEMAP_BYTE_OFFSET_AT));
+    const smLen = Number(pristine.readBigUInt64LE(SOURCEMAP_BYTE_LENGTH_AT));
+    expect(smLen).toBeGreaterThan(32);
+    expect(smOff + smLen).toBeLessThanOrEqual(pristine.length);
+
+    for (const [name, apply] of Object.entries(damage)) {
+      const data = Buffer.from(pristine);
+      apply(data.subarray(smOff, smOff + smLen));
+      expect(data.equals(pristine)).toBeFalse();
+      writeFileSync(entry, data);
+      check(name, () => readFileSync(entry).equals(data));
+    }
+  }
+
+  test("stack remapping does not crash", () => {
+    writeFileSync(
+      join(temp_dir, "boom.ts"),
+      `${filler}
 function boom(): number { throw new Error("boom"); }
 function mid(n: number): number { return n > 0 ? mid(n - 1) : boom(); }
 try {
@@ -731,39 +755,59 @@ try {
 }
 console.log("OK");
 `,
-  );
+    );
+    const run = () => Bun.spawnSync({ cmd: [bunExe(), "./boom.ts"], cwd: temp_dir, env, stderr: "inherit" });
 
-  const run = () => Bun.spawnSync({ cmd: [bunExe(), "./boom.ts"], cwd: temp_dir, env, stderr: "inherit" });
+    // The first run writes the cache entry.
+    const first = run();
+    expect(first.stdout.toString()).toBe("OK\n");
+    expect(first.exitCode).toBe(0);
 
-  // The first run writes the cache entry.
-  const first = run();
-  expect(first.stdout.toString()).toBe("OK\n");
-  expect(first.exitCode).toBe(0);
+    forEachDamagedEntry((name, servedFromDamagedEntry) => {
+      const result = run();
+      expect({
+        name,
+        stdout: result.stdout.toString(),
+        signalCode: result.signalCode,
+        exitCode: result.exitCode,
+        servedFromDamagedEntry: servedFromDamagedEntry(),
+      }).toEqual({ name, stdout: "OK\n", signalCode: undefined, exitCode: 0, servedFromDamagedEntry: true });
+    });
+  });
 
-  const entries = readdirSync(cache_dir).filter(name => name.endsWith(".pile"));
-  expect(entries).toHaveLength(1);
-  const entry = join(cache_dir, entries[0]);
-  const pristine = readFileSync(entry);
-  const smOff = Number(pristine.readBigUInt64LE(SOURCEMAP_BYTE_OFFSET_AT));
-  const smLen = Number(pristine.readBigUInt64LE(SOURCEMAP_BYTE_LENGTH_AT));
-  expect(smLen).toBeGreaterThan(32);
-  expect(smOff + smLen).toBeLessThanOrEqual(pristine.length);
+  // The coverage report walks every mapping of the module through a Cursor,
+  // the second reader of the same windows.
+  test("bun test --coverage does not crash", () => {
+    writeFileSync(
+      join(temp_dir, "lib.ts"),
+      `${filler}
+export function add(a: number, b: number): number { return a + b; }
+export function unused(a: number): number { if (a > 1) { return a * 2; } return a; }
+`,
+    );
+    // Below the minimum cache size, so lib.ts is the only entry.
+    writeFileSync(
+      join(temp_dir, "lib.test.ts"),
+      `import { expect, test } from "bun:test";
+import { add } from "./lib.ts";
+test("add", () => { expect(add(1, 2)).toBe(3); });
+`,
+    );
+    const run = () => Bun.spawnSync({ cmd: [bunExe(), "test", "--coverage", "./lib.test.ts"], cwd: temp_dir, env });
+    const passed = (result: ReturnType<typeof run>) => /\b1 pass\b/.test(result.stderr.toString());
 
-  for (const [name, apply] of Object.entries(damage)) {
-    const data = Buffer.from(pristine);
-    apply(data.subarray(smOff, smOff + smLen));
-    expect(data.equals(pristine)).toBeFalse();
-    writeFileSync(entry, data);
+    const first = run();
+    expect({ passed: passed(first), exitCode: first.exitCode }).toEqual({ passed: true, exitCode: 0 });
 
-    const result = run();
-    expect({
-      name,
-      stdout: result.stdout.toString(),
-      signalCode: result.signalCode,
-      exitCode: result.exitCode,
-      // A rejected entry is unlinked and written again. The damaged bytes are
-      // still there, so the run was a cache hit that remapped through them.
-      servedFromDamagedEntry: readFileSync(entry).equals(data),
-    }).toEqual({ name, stdout: "OK\n", signalCode: undefined, exitCode: 0, servedFromDamagedEntry: true });
-  }
+    forEachDamagedEntry((name, servedFromDamagedEntry) => {
+      const result = run();
+      expect({
+        name,
+        passed: passed(result),
+        signalCode: result.signalCode,
+        exitCode: result.exitCode,
+        servedFromDamagedEntry: servedFromDamagedEntry(),
+      }).toEqual({ name, passed: true, signalCode: undefined, exitCode: 0, servedFromDamagedEntry: true });
+    });
+  });
 });

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -761,6 +761,9 @@ console.log("OK");
       stdout: result.stdout.toString(),
       signalCode: result.signalCode,
       exitCode: result.exitCode,
-    }).toEqual({ name, stdout: "OK\n", signalCode: undefined, exitCode: 0 });
+      // A rejected entry is unlinked and written again. The damaged bytes are
+      // still there, so the run was a cache hit that remapped through them.
+      servedFromDamagedEntry: readFileSync(entry).equals(data),
+    }).toEqual({ name, stdout: "OK\n", signalCode: undefined, exitCode: 0, servedFromDamagedEntry: true });
   }
 });

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -691,3 +691,76 @@ console.log("OK");
   expect(third.signalCode).toBeUndefined();
   expect(third.exitCode).toBe(0);
 });
+
+test("remaps a stack through a cached sourcemap whose body is damaged without a crash", () => {
+  // The header check in the test above is O(1) on purpose: a cache hit does
+  // not walk the sourcemap. So a section with a valid outer header and a
+  // damaged body still reaches SavedSourceMap, and stack remapping reads the
+  // damaged SyncEntry array and window stream. The reader has to bounds-check
+  // what it takes from them. A window that does not fit yields no mapping.
+  //
+  // InternalSourceMap section (src/sourcemap/InternalSourceMap.rs):
+  //   28: stream_offset u32, 32..stream_offset: SyncEntry[sync_count],
+  //   stream_offset..total_len: window stream (32-byte header, then varints).
+  const SOURCEMAP_BYTE_OFFSET_AT = 54;
+  const SOURCEMAP_BYTE_LENGTH_AT = 62;
+  const damage: Record<string, (section: Buffer) => void> = {
+    // The stream shrinks to its 1-byte tail pad, so no window header fits.
+    "stream_offset points at the last byte": s => void s.writeUInt32LE(s.length - 1, 28),
+    // Every SyncEntry.byte_offset becomes 0xffffffff.
+    "SyncEntry array filled with 0xff": s => void s.fill(0xff, 32, s.readUInt32LE(28)),
+    // The window section lengths become 0xffff and every flag bit is set.
+    "window stream filled with 0xff": s => void s.fill(0xff, s.readUInt32LE(28)),
+    // The section lengths become 0x8080 and no varint ends.
+    "window stream filled with 0x80": s => void s.fill(0x80, s.readUInt32LE(28)),
+  };
+
+  // Large enough for the cache (>= 4 KiB). The throw sits behind the filler, so
+  // the frames to remap are not in the first lines of the transpiled output.
+  const line = `// ${Buffer.alloc(120, "x").toString()}\n`;
+  const filler = Buffer.alloc(120 * line.length, line).toString();
+  writeFileSync(
+    join(temp_dir, "boom.ts"),
+    `${filler}
+function boom(): number { throw new Error("boom"); }
+function mid(n: number): number { return n > 0 ? mid(n - 1) : boom(); }
+try {
+  mid(3);
+} catch (e) {
+  void (e as Error).stack;
+}
+console.log("OK");
+`,
+  );
+
+  const run = () => Bun.spawnSync({ cmd: [bunExe(), "./boom.ts"], cwd: temp_dir, env, stderr: "inherit" });
+
+  // The first run writes the cache entry.
+  const first = run();
+  expect(first.stdout.toString()).toBe("OK\n");
+  expect(first.exitCode).toBe(0);
+
+  const entries = readdirSync(cache_dir).filter(name => name.endsWith(".pile"));
+  expect(entries).toHaveLength(1);
+  const entry = join(cache_dir, entries[0]);
+  const pristine = readFileSync(entry);
+  const smOff = Number(pristine.readBigUInt64LE(SOURCEMAP_BYTE_OFFSET_AT));
+  const smLen = Number(pristine.readBigUInt64LE(SOURCEMAP_BYTE_LENGTH_AT));
+  expect(smLen).toBeGreaterThan(32);
+  expect(smOff + smLen).toBeLessThanOrEqual(pristine.length);
+
+  for (const [name, apply] of Object.entries(damage)) {
+    const data = Buffer.from(pristine);
+    apply(data.subarray(smOff, smOff + smLen));
+    expect(data.equals(pristine)).toBeFalse();
+    writeFileSync(entry, data);
+
+    const result = run();
+    expect({
+      name,
+      stdout: result.stdout.toString(),
+      signalCode: result.signalCode,
+      exitCode: result.exitCode,
+    }).toEqual({ name, stdout: "OK\n", signalCode: undefined, exitCode: 0 });
+  }
+});

--- a/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
@@ -293,6 +293,107 @@ describe("InternalSourceMap.toVLQ", () => {
   });
 });
 
+describe("InternalSourceMap with a damaged body", () => {
+  // A blob read back from disk (a transpiler cache entry, a --compile section)
+  // is only checked against its outer header: total_len, sync_count,
+  // stream_offset. The SyncEntry array and the window stream behind it are read
+  // as they are when a position is looked up, so find() and toVLQ() have to
+  // bounds-check every offset and length they take from those bytes.
+  //
+  // 72 mappings, 8 per line: window 0 holds 64 of them, window 1 the rest. The
+  // 3-line gap and the second source give window 0 both optional sections
+  // (gen-line exceptions, src-idx). Window 1 has neither.
+  function buildTwoWindowVLQ(): string {
+    let out = "";
+    let prev = { col: 0, src: 0, origLine: 0, origCol: 0 };
+    for (let line = 0; line < 9; line++) {
+      for (let k = 0; k < 8; k++) {
+        const cur = { col: k * 5, src: line < 4 ? 0 : 1, origLine: line * 2, origCol: k * 7 + (k & 1) };
+        if (k > 0) out += ",";
+        out +=
+          encodeVLQ(cur.col - prev.col) +
+          encodeVLQ(cur.src - prev.src) +
+          encodeVLQ(cur.origLine - prev.origLine) +
+          encodeVLQ(cur.origCol - prev.origCol);
+        prev = cur;
+      }
+      out += line === 2 ? ";;;" : ";";
+      prev.col = 0;
+    }
+    return out;
+  }
+
+  // Run in a child process so a crash is recorded as a failure here instead of
+  // taking down the test runner.
+  test.concurrent("find() and toVLQ() stay inside the blob", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { internalSourceMap } = require("bun:internal-for-testing");
+         const pristine = internalSourceMap.fromVLQ(process.env.VLQ);
+         const total = pristine.length;
+         const header = new DataView(pristine.buffer);
+         const streamOffset = header.getUint32(28, true);
+         console.log("windows " + header.getUint32(24, true));
+         // A column past every mapping walks the reader to the end of the line.
+         function probe(blob) {
+           let found = 0;
+           for (let line = 0; line < 12; line++) {
+             if (internalSourceMap.find(blob, line, 0x7fffffff) !== null) found++;
+           }
+           return found;
+         }
+         console.log("pristine " + probe(pristine));
+
+         // Whole-section damage. No window fits any more, so every lookup
+         // answers "no mapping". toVLQ() stops at the first window it cannot
+         // read: before it for the first three, after its seed for the last.
+         const fills = {
+           stream_offset_last: b => new DataView(b.buffer).setUint32(28, total - 1, true),
+           sync_ff: b => b.fill(0xff, 32, streamOffset),
+           stream_ff: b => b.fill(0xff, streamOffset),
+           stream_80: b => b.fill(0x80, streamOffset),
+         };
+         for (const [name, damage] of Object.entries(fills)) {
+           const blob = pristine.slice();
+           damage(blob);
+           console.log(name + " " + probe(blob) + " " + JSON.stringify(internalSourceMap.toVLQ(blob)));
+         }
+
+         // Single-byte damage at every body offset. What a lookup returns is
+         // unspecified (the byte can still decode). It has to return.
+         let blobs = 0;
+         for (let at = 32; at < total; at++) {
+           for (const value of [0x00, 0x80, 0xff]) {
+             if (pristine[at] === value) continue;
+             const blob = pristine.slice();
+             blob[at] = value;
+             probe(blob);
+             blobs++;
+           }
+         }
+         console.log("swept " + (blobs > 500));`,
+      ],
+      env: { ...bunEnv, VLQ: buildTwoWindowVLQ() },
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout.split("\n")).toEqual([
+      "windows 2",
+      "pristine 9",
+      'stream_offset_last 0 ""',
+      'sync_ff 0 ""',
+      'stream_ff 0 ""',
+      'stream_80 0 "AAAA"',
+      "swept true",
+      "",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("InternalSourceMap round-trip", () => {
   test("large blank-line run and many mappings re-encode byte-identically", () => {
     // append_vlq_to() reserves mapping_count * 6 bytes upfront and writes


### PR DESCRIPTION
### Problem
- Hardening from fuzzing, with no user report. A transpiler cache entry whose sourcemap section has a valid outer header and a damaged body crashes stack remapping: `heap-buffer-overflow READ of size 1` in `WindowReader::parse` (`src/sourcemap/InternalSourceMap.rs:459`), a SIGSEGV, or `panic: index out of bounds` in `read_varint`.
- `is_valid_blob` (#41457) checks only the outer header. `WindowReader` trusts every offset and length in the body. It reads through raw pointers and `bytes[i]`. #29358 accepted that for `--compile` blobs, but a cache directory is user-writable.

### Fix
- `parse` and `read_varint` return `None` when a read runs past the stream, and a lane overrun ends the window. `find` answers "no mapping", `Cursor` moves to the next window, `append_vlq_to` stops.
- `parse` copies the masks out of the header. 12 of the reader's 13 `unsafe` blocks are gone.
- No perf cost. A cache hit runs no changed code. On release builds a typical lookup is 20% to 40% faster, the worst case (a window's first mapping) is equal within 1%, and `bench/sourcemap/` is equal (Notes).
- Verified: `test/cli/run/transpiler-cache.test.ts` and `test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts` fail on main and pass here.

### Background
- `InternalSourceMap` is Bun's in-process sourcemap blob: a 32-byte header, a `SyncEntry` array, then a stream of windows of up to 64 mappings.
- A `SyncEntry` holds a window's first mapping and its byte offset. `find` binary-searches the array, then `WindowReader` decodes that window's varint deltas.
- The blob comes from the printer in process, or from disk: a cache hit or a `--compile` section.

<details><summary>Notes</summary>

Repro (any bun). It writes a `.ts` file of about 15 KB that throws, runs it once to fill the cache, damages the cached sourcemap body, and runs it again:

```sh
mkdir t && cd t && export BUN_RUNTIME_TRANSPILER_CACHE_PATH=$PWD/c
bun -e 'const l="// "+"x".repeat(120)+"\n";require("fs").writeFileSync("boom.ts",l.repeat(120)+`
function boom(): number { throw new Error("boom"); }
function mid(n: number): number { return n > 0 ? mid(n - 1) : boom(); }
try { mid(3); } catch (e) { console.log((e as Error).stack!.split("\\n").slice(0,3).join(" | ")); }
export const v: number = 1; console.log("OK");`)'
bun boom.ts
# M = stream_offset_last | sync_ff | stream_ff | stream_80
M=sync_ff bun -e 'const fs=require("fs"),f="c/"+fs.readdirSync("c").find(n=>n.endsWith(".pile")),b=fs.readFileSync(f);
const o=Number(b.readBigUInt64LE(54)),n=Number(b.readBigUInt64LE(62)),so=b.readUInt32LE(o+28),m=process.env.M;
if(m=="stream_offset_last")b.writeUInt32LE(n-1,o+28); if(m=="sync_ff")b.fill(0xff,o+32,o+so); if(m=="stream_ff")b.fill(0xff,o+so,o+n); if(m=="stream_80")b.fill(0x80,o+so,o+n);
fs.writeFileSync(f,b)'
bun boom.ts
```

Results before this change, release 1.4.3-canary.1 (6a92015fc): `sync_ff` exits 139 (SIGSEGV), `stream_ff` and `stream_80` exit 134 (`panic: index out of bounds`), `stream_offset_last` exits 0 after a silent read past the section. On the ASAN debug build of main, `stream_offset_last` aborts with `AddressSanitizer: heap-buffer-overflow ... InternalSourceMap.rs:459:30 in WindowReader::parse`. `bun test --coverage` reaches the same reader through `Cursor` and crashes the same way.

After this change all four exit 0 and print `OK`. The frames of the damaged file are not remapped (they show positions in the transpiled output), which is what a file with no sourcemap shows.

Performance. Two release builds (`bun scripts/build.ts --profile=release`) of the same tree, one with main's `InternalSourceMap.rs`, one with this branch (15f6ffbe26, the reader as of 6a2db02f66). Each number is the minimum over 5 to 8 alternating runs pinned to one CPU.

| bench | main | this branch |
| --- | --- | --- |
| `find()` through `bun:internal-for-testing`, 150k lines x 6 mappings, first mapping of a window | 441.0 ns/call | 443.8 ns/call |
| same, 32nd mapping of a window | 886 ns/call | 618 ns/call |
| same, 63rd mapping of a window | 1342 ns/call | 796 ns/call |
| same, 200k random positions | 1376 ns/call | 1104 ns/call |
| `bench/sourcemap/internal-sourcemap-bench.ts`, 300k x `new Error().stack` | 1.48 us/op | 1.42 us/op |
| `bench/sourcemap/append-vlq-bench.ts`, 200k mappings | 6.10 ms/op | 5.96 ms/op |
| `bench/sourcemap/append-vlq-bench.ts`, 5M-line gap | 1.81 ms/op | 1.82 ms/op |
| load of a cached 150k-line module (cache hit, measured on 0aa5ac65b7) | 160.9 ms | 158.3 ms |

The first row is the only case that is not faster. It is the lookup that stops after one delta (1 position in 64), so `parse`, which now copies three masks, is most of its cost. Its 8 runs per build overlap (main 441 to 465, branch 444 to 505), so the 0.6% is inside the spread. About 400 ns of each call is the JS call and the result object. An earlier revision of this text said 451 to 443 for that row. That did not reproduce.

A Rust harness links `bun_sourcemap` alone, with the inlining pinned to what the release binary has (`find`, `move_to`, `append_vlq_to` and `next` out of line, `seed_window` and `parse` inlined). Minimum of 7 runs: first mapping 31.1 to 31.1 ns, 32nd mapping 220 to 185 ns, `Cursor` sweep 15.3 to 15.3 ns/mapping (within 0.8% on three map shapes), `append_vlq_to` 22.0 to 21.7 ns/mapping. With free inlining the first-mapping case moved by +3 ns in one layout and -1 ns in another, so that row depends on layout. The `Cursor` number is a sequential sweep. It is not a claim about `--coverage` run time.

Why it is not slower. `read_varint` had a bounds check on every byte already. The check now returns `None` where it panicked. `next` returns nothing, as on main: a lane overrun sets `count` to 0 inside it, `find` tests `count` once after its loop, and `Cursor` needs no test. `parse` adds two compares. It reads count, flags and the three lengths with one 8-byte load where main did five loads, then copies the three masks. `next` tests a mask bit in the reader, where main loaded the header pointer and then a byte of the stream for each of the three tests. If exact parity on the first-mapping row matters more than the per-delta gain, `next` can read the mask bits from the stream again. That ties main everywhere and gives the gain up.

What this change does not do:

- It does not evict the damaged entry. The reader has no path back to the `.pile` file. The file name is the hash of the source text, so eviction at lookup time has to read and hash the source again. The entry is replaced when the source changes.
- It does not detect damage that still decodes inside the stream. A changed delta gives a wrong position. Only a hash of the section catches that. #39717 added one and #40948 reverted it, because its cost on every cache hit grows with the sourcemap.
- It does not validate `SyncEntry.byte_offset` values when the entry is loaded. That is the other possible fix. It is a walk of `sync_count` entries on every cache hit, the same kind of cost that #40948 removed.
- `append_vlq_to` stops at the first window it cannot read, but a damaged `generated_line` that decodes in bounds still sets the length of the `;` run it writes. No release build passes it a blob from disk: the inspector path re-encodes the printer's own chunk, and the source dump in `RuntimeTranspilerStore.rs` returns early unless debug assertions are on.

Details of the reader change:

- `parse` sets `count` to 0 first and stores the real count last, so a failed `parse` leaves `done()` true. `next` sets `count` to 0 when a lane read fails and leaves the state it was given unchanged. `find` returns `None` when `count` is 0 after its loop. `Cursor::advance_one` sees a copy of its current state, which changes nothing, and moves to the next window on its next call.
- `to_mapping` builds the ordinals without `Ordinal::from_zero_based`. State arithmetic wraps, so a damaged delta can give a negative coordinate. It goes to the caller like any other wrong value, and the debug assertion in `from_zero_based` cannot fire. Every consumer range-checks the value or prints it.
- The reader had 13 `unsafe` blocks. One is left, the `bytes()` accessor that turns the stored stream pointer back into a slice.
- The two flagged sections are parsed in a `#[cold]` function. Most windows have no flags.
- The search for the `0xFF` terminator of the gen-line exception section stops after 63 pairs, the most a window of 64 mappings can hold. A damaged window cannot turn it into a scan of the whole stream.
- The masks use `u64::from_le_bytes`. Bit `i` is bit `i & 7` of byte `i >> 3`, the order `Builder::flush_window` writes them in. `count` stays clamped to 64, so every delta index is below 63 and the shift is in range.
- The format does not change. The 1-byte tail pad stays.

Related: #42412 (an entry with no sourcemap section) appends tests at the end of the same `transpiler-cache.test.ts`. The one that merges second gets a conflict there and nowhere else.

Tests:

- `transpiler-cache.test.ts`, two tests: a module that throws and reads `.stack` (`find`), and `bun test --coverage` over a cached module (`Cursor`). Each does one warm run, then applies the four mutations above to a copy of the pristine entry. Each run has to succeed, exit 0 with no signal, and leave the damaged entry on disk unchanged, which proves the run was a cache hit. On the unfixed release build both die with SIGSEGV at the second mutation.
- `internal-sourcemap-roundtrip.test.ts`: a child process builds a two-window map through `bun:internal-for-testing`. Window 0 has both optional sections. It applies the same four mutations (every lookup returns `null`, `toVLQ` returns at most the first seed) and then every single-byte `0x00`/`0x80`/`0xff` mutation of the body, 12 lookups each.

Suites run on the debug ASAN build: `test/js/bun/sourcemap/` (42 pass), `test/cli/run/transpiler-cache.test.ts` (21 pass), `test/cli/test/coverage.test.ts` (14 pass), `test/bundler/compile-sourcemap-internal.test.ts`. `cargo clippy -p bun_sourcemap` is clean.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/transpiler-cache.test.ts

<!-- robobun:evidence:end -->