### PR TITLE
node:module: end the Module._stat path at the first null byte

### DIFF
--- a/src/jsc/NodeModuleModule.rs
+++ b/src/jsc/NodeModuleModule.rs
@@ -101,6 +101,9 @@ fn find_path_inner(
 }
 
 pub fn stat(path: &[u8]) -> i32 {
+    // Node passes the path to `uv_fs_stat` as a C string, which ends at the first NUL:
+    // https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L1100-L1118
+    let path = bun_core::slice_to_nul(path);
     // PERF: `exists_at_type`
     // takes a `&ZStr`, so we copy into a NUL-terminated heap buffer here.
     let zpath = bun_core::ZBox::from_bytes(path);

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -556,6 +556,33 @@ console.log("survived", require("./late.js"));`,
     expect(exitCode).toBe(0);
   }, 20_000);
 
+  test("Module._stat ends the path at the first null byte", async () => {
+    using dir = tempDir("module-stat-null-byte", { "file.js": "", "directory": { "x": "" } });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { _stat } = require("node:module");
+         const path = require("node:path");
+         const file = path.join(process.cwd(), "file.js");
+         const directory = path.join(process.cwd(), "directory");
+         console.log(JSON.stringify({
+           file: _stat(file + "\\0ignored"),
+           directory: _stat(directory + "\\0ignored"),
+           missing: _stat(path.join(process.cwd(), "missing\\0file.js")) < 0,
+         }));`,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    // node v26.3.0 prints the same line. It passes the path to uv_fs_stat as a C string.
+    expect(stdout).toBe('{"file":0,"directory":1,"missing":true}\n');
+    expect(exitCode).toBe(0);
+  });
+
   test("Module.wrap", () => {
     var mod = { exports: {} };
     expect(eval(wrap("exports.foo = 1; return 42"))(mod.exports, mod)).toBe(42);


### PR DESCRIPTION
### Problem
- `require("node:module")._stat("a\0b")` panics an assert build on Linux: `panic: ZStr::as_cstr: interior NUL would truncate the C view` (`src/bun_core/util.rs:181`, from `fstatat` at `src/sys/linux_syscall.rs:201`).
- The cause is `stat` (`src/jsc/NodeModuleModule.rs:103`). It copies the whole JS string into a `ZBox` and stats it. Nothing handles a null byte inside the string.

### Fix
- `stat` cuts the path at the first null byte (`bun_core::slice_to_nul`) before it builds the `ZBox`.
- Node does the same. [`InternalModuleStat`](https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L1100-L1118) passes the path to `uv_fs_stat` as a `char*`. Node v26.3.0 returns `0` for `file + "\0x"` and `1` for `dir + "\0x"`, on Linux and on Windows.
- Release builds on Linux and macOS do not change, because the kernel already stops at the null byte. Windows returned `-1` and now returns Node's answer.
- Verified: `test/js/node/module/node-module-module.test.js` ("Module._stat ends the path at the first null byte"). The unfixed debug build panics, and the Windows canary prints `-1`. Also ran the whole file, `test/js/node/test/parallel/test-module-stat.js`, and the new test on a Windows x64 debug build.

### Background
- `Module._stat(path)` is node's stat for the CommonJS loader. It returns 0 for a file, 1 for a directory, and a negative number otherwise. It never throws.
- `ZStr` and `ZBox` are Bun's NUL-terminated byte strings. The code that builds one must keep null bytes out of it.
- `ZStr::as_cstr` converts to a Rust `CStr`, which forbids an interior null byte. A `debug_assert` checks that. Only the Linux syscall layer takes a `CStr`. macOS and Windows do not reach the assert.

<details><summary>Notes</summary>

Linux, in a directory that holds `file.js` and `directory/` (the script of the new test):

```
node v26.3.0:             {"file":0,"directory":1,"missing":true}
bun 1.4.3 release:        {"file":0,"directory":1,"missing":true}
bun debug, before:        panic: ZStr::as_cstr: interior NUL would truncate the C view
bun debug, this branch:   {"file":0,"directory":1,"missing":true}
```

The panic stack before the change: `ZStr::as_cstr <- linux_syscall::fstatat <- bun_sys::fstatat <- exists_at_type <- node_module_module::stat (NodeModuleModule.rs:107) <- bindgen_NodeModuleModule_dispatch_stat1 (hw_exports.rs:367)`.

Windows Server 2019 x64:

```js
const M = require("module");
console.log(JSON.stringify({
  empty: M._stat(""), cwd: M._stat(process.cwd()), nulFirst: M._stat("\0" + process.cwd()),
  dirNul: M._stat(process.cwd() + "\0x"), exeNul: M._stat(process.execPath + "\0x"), exe: M._stat(process.execPath),
}));
```

```
node v26.3.0:                  {"empty":-4058,"cwd":1,"nulFirst":1,"dirNul":1,"exeNul":0,"exe":0}
bun 1.4.3-canary.1+3d40e50c1:  {"empty":1,"cwd":1,"nulFirst":-1,"dirNul":-1,"exeNul":-1,"exe":0}
this branch (debug build):     {"empty":1,"cwd":1,"nulFirst":1,"dirNul":1,"exeNul":0,"exe":0}
```

- `empty: 1` on Windows is the empty-path behaviour that #38052 fixes. This change does not touch it.
- The test does not assert a path that starts with a null byte. Node on POSIX stats the empty path and returns `-2`. Node on Windows returns `1`, because `path.toNamespacedPath` resolves the string against the cwd before the C string is cut. Bun stats the empty path: negative on POSIX, and on Windows `1` today and `ENOENT` after #38052.
- The alternative is to return a negative number for every path with a null byte. Node does not validate in this function, so that would be stricter than Node on every platform and would change the release answer on Linux and macOS.
- `Module._stat` is the only place in `src/jsc/` that builds a `ZBox` from a JS string.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->