### PR TITLE
crypto: apply a UTCTime timezone offset in X509Certificate validFrom/validTo

### DIFF
--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -953,11 +953,9 @@ BIOPointer X509View::getInfoAccess() const
     return bio;
 }
 
-// BoringSSL's X509 parser accepts a UTCTime with a "+hhmm" / "-hhmm" offset, but
-// its ASN1_TIME_print prints "Bad time value" for one. OpenSSL's, which Node
-// uses, applies the offset and prints the GMT time.
 static void printValidityTime(BIO* bio, const ASN1_TIME* time)
 {
+    // ASN1_TIME_print refuses a UTCTime "+hhmm" offset that the X509 parser accepts. OpenSSL prints it.
     int64_t seconds;
     if (!ASN1_TIME_to_posix(time, &seconds) && ASN1_TIME_to_posix_nonstandard(time, &seconds)) {
         if (DeleteFnPtr<ASN1_TIME, ASN1_TIME_free> utc { ASN1_TIME_set_posix(nullptr, seconds) }) {

--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -953,13 +953,28 @@ BIOPointer X509View::getInfoAccess() const
     return bio;
 }
 
+// BoringSSL's X509 parser accepts a UTCTime with a "+hhmm" / "-hhmm" offset, but
+// its ASN1_TIME_print prints "Bad time value" for one. OpenSSL's, which Node
+// uses, applies the offset and prints the GMT time.
+static void printValidityTime(BIO* bio, const ASN1_TIME* time)
+{
+    int64_t seconds;
+    if (!ASN1_TIME_to_posix(time, &seconds) && ASN1_TIME_to_posix_nonstandard(time, &seconds)) {
+        if (DeleteFnPtr<ASN1_TIME, ASN1_TIME_free> utc { ASN1_TIME_set_posix(nullptr, seconds) }) {
+            ASN1_TIME_print(bio, utc.get());
+            return;
+        }
+    }
+    ASN1_TIME_print(bio, time);
+}
+
 BIOPointer X509View::getValidFrom() const
 {
     ClearErrorOnReturn clearErrorOnReturn;
     if (cert_ == nullptr) return {};
     BIOPointer bio(BIO_new(BIO_s_mem()));
     if (!bio) return {};
-    ASN1_TIME_print(bio.get(), X509_get_notBefore(cert_));
+    printValidityTime(bio.get(), X509_get_notBefore(cert_));
     return bio;
 }
 
@@ -969,7 +984,7 @@ BIOPointer X509View::getValidTo() const
     if (cert_ == nullptr) return {};
     BIOPointer bio(BIO_new(BIO_s_mem()));
     if (!bio) return {};
-    ASN1_TIME_print(bio.get(), X509_get_notAfter(cert_));
+    printValidityTime(bio.get(), X509_get_notAfter(cert_));
     return bio;
 }
 

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { X509Certificate, createPrivateKey, createPublicKey, generateKeyPairSync } from "node:crypto";
+import { once } from "node:events";
 import { readFileSync } from "node:fs";
+import type { AddressInfo } from "node:net";
 import path from "node:path";
-import { rootCertificates } from "node:tls";
+import { connect, createServer, rootCertificates } from "node:tls";
 
 // Self-signed, valid until 2126. Subject CN=wildcard-san.example.com,
 // subjectAltName: DNS:*.wildcard.example.com, DNS:exact.example.com
@@ -182,6 +184,94 @@ vKS1+tUUY19gsw==
     expect(legacy.subject).toEqual({});
     expect(legacy.issuer).toEqual({});
     expect(cert.checkIssued(cert)).toBe(true);
+  });
+});
+
+// RFC 5280 forbids a timezone offset in a validity time, but BoringSSL's X509 parser and OpenSSL
+// both accept "YYMMDDHHMMSS+hhmm" / "-hhmm" in a UTCTime. BoringSSL's ASN1_TIME_print refuses that
+// form, so these strings were "Bad time value". Node prints the GMT time.
+describe("X509Certificate validity as a UTCTime with a timezone offset", () => {
+  // Self-signed EC P-256 certificate, CN=localhost. openssl does not write the offset form, so the
+  // TBSCertificate of an `openssl req -x509` certificate was rebuilt with this validity and signed
+  // again with `key`.
+  const notBefore = "200101000000-0530";
+  const notAfter = "301231235959+0100";
+  const cert = `-----BEGIN CERTIFICATE-----
+MIIBmzCCAUGgAwIBAgIUVlCjg2eA4PDTy99vuqiPfVXfhQ4wCgYIKoZIzj0EAwIw
+FDESMBAGA1UEAwwJbG9jYWxob3N0MCYXETIwMDEwMTAwMDAwMC0wNTMwFxEzMDEy
+MzEyMzU5NTkrMDEwMDAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwWTATBgcqhkjOPQIB
+BggqhkjOPQMBBwNCAASzoiClaPOi2ZSUk0jCrlwc2214IIsIlD1FqaxxRK5gJNU2
+mVAgAhdVErLTpbPYEOeN05B4h/AIGMIMn7TfFo4Qo2kwZzAdBgNVHQ4EFgQU08p9
+IYJGwyx5RAyF/oU1rT7FyU8wHwYDVR0jBBgwFoAU08p9IYJGwyx5RAyF/oU1rT7F
+yU8wDwYDVR0TAQH/BAUwAwEB/zAUBgNVHREEDTALgglsb2NhbGhvc3QwCgYIKoZI
+zj0EAwIDSAAwRQIgZKUnc1MqfDu+NVUZUJwpg79J92P133xIvE5EvI2KhbsCIQC0
+o5xAJFDUJCztalZEnJNOiwJTratQU3amSwINZggSFA==
+-----END CERTIFICATE-----`;
+  const key = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgtW4/jIJlViNFnoXq
+T0MUuFw1SKC16xeV6bTAuVXo8AqhRANCAASzoiClaPOi2ZSUk0jCrlwc2214IIsI
+lD1FqaxxRK5gJNU2mVAgAhdVErLTpbPYEOeN05B4h/AIGMIMn7TfFo4Q
+-----END PRIVATE KEY-----`;
+
+  // Every accessor of the validity, so that the strings and the Dates cannot disagree.
+  // toJSON() is the ISO string, or null for an Invalid Date.
+  const validity = (x509: X509Certificate) => {
+    const legacy = x509.toLegacyObject();
+    return {
+      validFrom: x509.validFrom,
+      validTo: x509.validTo,
+      valid_from: legacy.valid_from,
+      valid_to: legacy.valid_to,
+      validFromDate: x509.validFromDate.toJSON(),
+      validToDate: x509.validToDate.toJSON(),
+    };
+  };
+
+  test("validFrom / validTo, toLegacyObject() and the Date getters apply the offset", () => {
+    expect(validity(new X509Certificate(cert))).toEqual({
+      validFrom: "Jan  1 05:30:00 2020 GMT",
+      validTo: "Dec 31 22:59:59 2030 GMT",
+      valid_from: "Jan  1 05:30:00 2020 GMT",
+      valid_to: "Dec 31 22:59:59 2030 GMT",
+      validFromDate: "2020-01-01T05:30:00.000Z",
+      validToDate: "2030-12-31T22:59:59.000Z",
+    });
+  });
+
+  // A UTCTime holds the years 1950-2049. The offset moves these two times out of that range.
+  // Writing over the DER breaks the signature, which X509Certificate does not check.
+  test("the offset can move the time out of the UTCTime year range", () => {
+    const der = Buffer.from(new X509Certificate(cert).raw);
+    der.write("491231235959-0100", der.indexOf(notBefore), "latin1");
+    der.write("500101000000+0100", der.indexOf(notAfter), "latin1");
+    expect(validity(new X509Certificate(der))).toEqual({
+      validFrom: "Jan  1 00:59:59 2050 GMT",
+      validTo: "Dec 31 23:00:00 1949 GMT",
+      valid_from: "Jan  1 00:59:59 2050 GMT",
+      valid_to: "Dec 31 23:00:00 1949 GMT",
+      validFromDate: "2050-01-01T00:59:59.000Z",
+      validToDate: "1949-12-31T23:00:00.000Z",
+    });
+  });
+
+  test("tls getPeerCertificate() applies the offset", async () => {
+    const server = createServer({ cert, key }, socket => socket.end());
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      const { port } = server.address() as AddressInfo;
+      // The certificate is self-signed, and the verifier refuses the offset form.
+      const socket = connect({ host: "127.0.0.1", port, rejectUnauthorized: false });
+      await once(socket, "secureConnect");
+      const peer = socket.getPeerCertificate();
+      socket.destroy();
+      expect({ valid_from: peer.valid_from, valid_to: peer.valid_to }).toEqual({
+        valid_from: "Jan  1 05:30:00 2020 GMT",
+        valid_to: "Dec 31 22:59:59 2030 GMT",
+      });
+    } finally {
+      server.close();
+    }
   });
 });
 

--- a/test/js/node/crypto/x509.test.ts
+++ b/test/js/node/crypto/x509.test.ts
@@ -271,6 +271,7 @@ lD1FqaxxRK5gJNU2mVAgAhdVErLTpbPYEOeN05B4h/AIGMIMn7TfFo4Q
       });
     } finally {
       server.close();
+      await once(server, "close");
     }
   });
 });


### PR DESCRIPTION
### Problem
- For a certificate validity written as a UTCTime with a `+hhmm` / `-hhmm` offset, `validFrom` / `validTo`, `toLegacyObject()` and `tls` `getPeerCertificate()` return the text `Bad time value`. `validFromDate` / `validToDate` parse that text, so they are `Invalid Date`. Node v26.3.0 prints `Jan  1 05:30:00 2020 GMT`.
- The cause is `X509View::getValidFrom` / `getValidTo` (`src/jsc/bindings/ncrypto.cpp:956`). BoringSSL's `ASN1_TIME_print` refuses the offset form (`a_strex.cc:403`). Its X509 parser accepts it on purpose (`x_x509.cc:127`).
- Found by a read of the code. No user report.

### Fix
- If the strict `ASN1_TIME_to_posix` refuses a time that `ASN1_TIME_to_posix_nonstandard` accepts, the new helper `printValidityTime` builds a canonical `ASN1_TIME` from the POSIX value and prints that.
- Every other time goes to `ASN1_TIME_print` as before, with the same text.
- One difference from Node stays: OpenSSL refuses an offset hour above 12. BoringSSL accepts up to 23, and bun prints the adjusted time.
- Verified: `test/js/node/crypto/x509.test.ts` (3 new tests, all fail on bun 1.4.3). Also `test-crypto-x509.js` and `node-tls-cert.test.ts`. Self-reviewed: 7 concerns raised, 4 addressed, 3 rejected (Notes).

### Background
- A validity time is an `ASN1_TIME`: a UTCTime (`YYMMDDHHMMSSZ`, years 1950-2049) or a GeneralizedTime (`YYYYMMDDHHMMSSZ`).
- RFC 5280 requires the `Z`. Old `openssl` releases also wrote `+hhmm`. BoringSSL and OpenSSL still parse it, and their verifiers refuse it.
- `ASN1_TIME_set_posix` writes a POSIX time as a UTCTime, or as a GeneralizedTime when the year is not in 1950-2049.
- #42363 rewrites the Date getters for another cause (years below 100). The two PRs share no lines and merge in either order.

<details><summary>Notes</summary>

**Repro.** `X509Certificate` does not check the signature, so no key is needed:

```js
const { X509Certificate } = require("crypto");
const pem = `-----BEGIN CERTIFICATE-----
MIIBQTCB56ADAgECAgIQADAKBggqhkjOPQQDAjAUMRIwEAYDVQQDDAlsb2NhbGhv
c3QwJhcRMjAwMTAxMDAwMDAwLTA1MzAXETMwMTIzMTIzNTk1OSswMTAwMBQxEjAQ
BgNVBAMMCWxvY2FsaG9zdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABCQtkbkX
lrlz8CF1nNtiTQfycJJuLhomjtXEYUIeoBe5Ey35Qc26erwJ2SAd7pCET4dbMq6l
bhD7gboCwgF8bKKjITAfMB0GA1UdDgQWBBQ2GFUzbYzp/L+G0vfsoSV+Q0tANTAK
BggqhkjOPQQDAgNJADBGAiEA4Cwz/5GZ8HUxKb07DECoS1oODXoh+tqpGo5XgPLV
hfECIQCUgmYbXMJXdEHCLfPhbDY9d8a8u6CLY5sPf59XYnMSFg==
-----END CERTIFICATE-----`;
const c = new X509Certificate(pem);
console.log(JSON.stringify(c.validFrom), JSON.stringify(c.validTo));
```

| | output |
| --- | --- |
| bun 1.4.3 | `"Bad time value" "Bad time value"` |
| this branch | `"Jan  1 05:30:00 2020 GMT" "Dec 31 22:59:59 2030 GMT"` |
| node v26.3.0 | `"Jan  1 05:30:00 2020 GMT" "Dec 31 22:59:59 2030 GMT"` |

**Forms compared with Node v26.3.0 (OpenSSL 3.5.6).** Each row is a notBefore / notAfter pair written over the test certificate. bun 1.4.3 prints `Bad time value` for every row.

| notBefore / notAfter | this branch | node v26.3.0 |
| --- | --- | --- |
| `200101000000-0530` / `301231235959+0100` | `Jan  1 05:30:00 2020 GMT` / `Dec 31 22:59:59 2030 GMT` | same |
| `491231235959-0100` / `500101000000+0100` | `Jan  1 00:59:59 2050 GMT` / `Dec 31 23:00:00 1949 GMT` | same |
| `200101000000+0000` / `200101000000-0000` | `Jan  1 00:00:00 2020 GMT` / `Jan  1 00:00:00 2020 GMT` | same |
| `200229233000-0100` / `210228233000-0100` | `Mar  1 00:30:00 2020 GMT` / `Mar  1 00:30:00 2021 GMT` | same |
| `200101000000+1200` / `200101000000-1200` | `Dec 31 12:00:00 2019 GMT` / `Jan  1 12:00:00 2020 GMT` | same |
| `200101000000+1300` / `200101000000-2359` | `Dec 31 11:00:00 2019 GMT` / `Jan  1 23:59:00 2020 GMT` | `Bad time value` / `Bad time value` |

**The offset hour 13 to 23.** The two parsers disagree on the last row. OpenSSL's `ossl_asn1_time_to_tm` caps the offset hour at 12. BoringSSL's `CBS_parse_utc_time` caps it at 23. On that form bun now prints the instant that `ASN1_TIME_to_posix_nonstandard` gives. The Date getters return the same instant, on this branch and with #42363. Node's Date getters read an uninitialized value for both forms. They return a different date on each run, for example `1960-07-13T01:43:48.000Z`. Real UTC offsets go up to `+1400`.

**The Date getters.** On main, `validFromDate` / `validToDate` parse the `validFrom` / `validTo` text (`JSX509CertificatePrototype.cpp:711-755`). This PR does not change that code, but its output changes for the offset form: `Invalid Date` becomes the instant that Node returns. The new tests assert the two Dates next to the strings. #42363 computes the Dates from the `ASN1_TIME` and gives the same values, so the assertions hold in either merge order.

| build | `validFrom` | `validFromDate` |
| --- | --- | --- |
| main / bun 1.4.3 | `Bad time value` | `Invalid Date` |
| #42363 alone | `Bad time value` | `2020-01-01T05:30:00.000Z` |
| this PR alone | `Jan  1 05:30:00 2020 GMT` | `2020-01-01T05:30:00.000Z` |
| both | `Jan  1 05:30:00 2020 GMT` | `2020-01-01T05:30:00.000Z` |
| node v26.3.0 | `Jan  1 05:30:00 2020 GMT` | `2020-01-01T05:30:00.000Z` |

**The TLS test.** It covers one case: a client connects with `rejectUnauthorized: false` to a server that presents the self-signed test certificate, then reads `getPeerCertificate()`. bun and Node v26.3.0 both report `authorizationError` `ERROR_IN_CERT_NOT_AFTER_FIELD` for it. `getPeerCertificate()` goes through `Bun__X509__toJSLegacyEncoding` (`JSX509Certificate.cpp:896-908`), which calls the same `computeValidFrom` / `computeValidTo`. This PR does not change verification.

**Why `ASN1_TIME_set_posix`.** The offset can move a UTCTime out of the years 1950-2049 (second row). `ASN1_TIME_set_posix` then writes a GeneralizedTime, and `ASN1_TIME_print` prints the four-digit year. The helper reuses BoringSSL's printer, so it holds no copy of the format string or the month table. OpenSSL 3.5.6 prints with the same format (`"%s %2d %02d:%02d:%02d %d GMT"`), and always with the ` GMT` suffix after it applies the offset.

**Only a UTCTime reaches the new branch.** For a GeneralizedTime, `ASN1_TIME_to_posix` and `ASN1_TIME_to_posix_nonstandard` run the same parser with `allow_timezone_offset=0` (`a_gentm.cc:30`). BoringSSL's X509 parser refuses an offset on a GeneralizedTime, so such a certificate does not construct.

**Failure paths.** `notBefore` / `notAfter` are members of BoringSSL's X509 object, so `X509_get_notBefore` / `X509_get_notAfter` do not return null. If `ASN1_TIME_set_posix` fails (out of memory), the helper prints the original time, which gives `Bad time value` as before. `ClearErrorOnReturn` in the callers clears the error queue.

**The test certificate.** Self-signed EC P-256, CN=localhost. `openssl` does not write the offset form. The TBSCertificate of an `openssl req -x509` certificate was rebuilt with the new validity and signed again with the same key. The signature verifies, so a TLS server can present it.

**Suites run on the debug build.** `test/js/node/crypto/x509.test.ts` (36 pass). The Node tests `test-crypto-x509.js`, `test-tls-peer-certificate.js`, `test-tls-peer-certificate-encoding.js`, `test-tls-peer-certificate-multi-keys.js`, `test-tls-getcertificate-x509.js` and `test-tls-translate-peer-certificate.js`. Also `test/js/node/tls/node-tls-cert.test.ts`, `test/regression/issue/21274.test.ts`, the two local peer certificate tests of `node-tls-connect.test.ts`, and the certificate tests of `node-tls-server.test.ts`.

**Self-review.** Addressed:
- The body said that the Date getters do not change. Their output does change on main. The body now says so, and the tests assert the Dates.
- The TLS claim is now limited to the case that the test covers.
- The body now says that there is no user report.
- The offset hour 13 to 23 difference is now stated for the strings and for the Dates.

Rejected:
- Fold this change into #42363. That PR has another cause and is already in review. On main this change fixes all six accessors without it, and the two diffs share no lines. After both merge, the helper can take its POSIX value from #42363's `asn1TimeToPosix` in a small follow-up.
- Track the error code that chain verification gives for a trust anchor with this form. That is verification, not printing. This diff does not touch it.
- `util.inspect(cert)` prints `X509Certificate {}`. That is not related to this diff.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/crypto/x509.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/crypto/x509.test.ts:
(pass) X509Certificate.checkHost() > "sub.wildcard.example.com" returns the subjectAltName entry that matched [2.54ms]
(pass) X509Certificate.checkHost() > "SUB.WILDCARD.EXAMPLE.COM" returns the subjectAltName entry that matched [0.63ms]
(pass) X509Certificate.checkHost() > "exact.example.com" returns the subjectAltName entry that matched [0.29ms]
(pass) X509Certificate.checkHost() > "EXACT.EXAMPLE.COM" returns the subjectAltName entry that matched [0.24ms]
(pass) X509Certificate.checkHost() > "a.b.wildcard.example.com" does not match [1.96ms]
(pass) X509Certificate.checkHost() > "wildcard.example.com" does not match [0.40ms]
(pass) X509Certificate.checkHost() > "wildcard-san.example.com" does not match [0.24ms]
(pass) X509Certificate.checkHost() > "nomatch.example.org" does not match [0.21ms]
(pass) X509Certificate.checkHost() > wildcards: false only disables the wildcard entry [3.74ms]
(pass) X509Certificate.checkHost() > "agent1" falls b
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/js/node/crypto/x509.test.ts:
(pass) X509Certificate.checkHost() > "sub.wildcard.example.com" returns the subjectAltName entry that matched [0.06ms]
(pass) X509Certificate.checkHost() > "SUB.WILDCARD.EXAMPLE.COM" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "exact.example.com" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "EXACT.EXAMPLE.COM" returns the subjectAltName entry that matched
(pass) X509Certificate.checkHost() > "a.b.wildcard.example.com" does not match [0.03ms]
(pass) X509Certificate.checkHost() > "wildcard.example.com" does not match
(pass) X509Certificate.checkHost() > "wildcard-san.example.com" does not match
(pass) X509Certificate.checkHost() > "nomatch.example.org" does not match
(pass) X509Certificate.checkHost() > wildcards: false only disables the wildcard entry [0.04ms]
(pass) X509Certificate.checkHost() > "agent1" falls back to the subject CN and returns it [0.01ms]
(pass) X509Certificate.checkHost() > "AGENT1" falls back to the subject CN and returns it
(pass) X509Certificate.checkHost() > "AgEnT1" falls back to the subject CN a
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/crypto/x509.test.ts"
bun test v1.4.3 (4ff919377)

test/js/node/crypto/x509.test.ts:
(pass) X509Certificate.checkHost() > "sub.wildcard.example.com" returns the subjectAltName entry that matched [2.38ms]
(pass) X509Certificate.checkHost() > "SUB.WILDCARD.EXAMPLE.COM" returns the subjectAltName entry that matched [0.48ms]
(pass) X509Certificate.checkHost() > "exact.example.com" returns the subjectAltName entry that matched [0.28ms]
(pass) X509Certificate.checkHost() > "EXACT.EXAMPLE.COM" returns the subjectAltName entry that matched [0.24ms]
(pass) X509Certificate.checkHost() > "a.b.wildcard.example.com" does not match [1.83ms]
(pass) X509Certificate.checkHost() > "wildcard.example.com" does not match [0.38ms]
(pass) X509Certificate.checkHost() > "wildcard-san.example.com" does not match [0.25ms]
(pass) X509Certificate.checkHost() > "nomatch.example.org" does not match [0.21ms]
(pass) X509Certificate.checkHost() > wildcards: false only disables the wildcard entry [3.85ms]
(pass) X509Certificate.checkHost() > "agent1" falls b
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 707ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] gen cpp.rs (cppbind)
[1/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ncrypto.cpp     | 17 +++++++-
 test/js/node/crypto/x509.test.ts | 93 +++++++++++++++++++++++++++++++++++++++-
 2 files changed, 107 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/jsc/bindings/ncrypto.cpp          4      2     21
test/js/node/crypto/x509.test.ts      4      8     21
```

</details>

<!-- robobun:evidence:end -->