### PR TITLE
require.cache: listing or probing keys no longer creates a namespace object per ES module

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -229,6 +229,7 @@ declare function $format(): TODO;
 declare function $esmNamespaceForCjs(key: string): any | undefined;
 declare function $esmRegistryDelete(key: string): boolean;
 declare function $esmRegistryEvaluatedKeys(): string[];
+declare function $esmRegistryHasEvaluated(key: string): boolean;
 declare function $esmLoadSync(key: string): any;
 declare function $get(): TODO;
 declare function $handleEvent(): TODO;

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -79,6 +79,7 @@ using namespace JSC;
     macro(esmNamespaceForCjs) \
     macro(esmRegistryDelete) \
     macro(esmRegistryEvaluatedKeys) \
+    macro(esmRegistryHasEvaluated) \
     macro(evaluateCommonJSModule) \
     macro(evictIsolationSourceProviderCache) \
     macro(expires) \

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -244,6 +244,7 @@ export function createRequireCache() {
   // $requireMap.
   const isBuiltinKey = (key: string | symbol) =>
     typeof key === "string" && (key.startsWith("node:") || key.startsWith("bun:"));
+  const hasKey = (key: string) => $requireMap.$has(key) || (!isBuiltinKey(key) && $esmRegistryHasEvaluated(key));
   var proxy = new Proxy(inner, {
     get(_target, key: string) {
       const entry = $requireMap.$get(key);
@@ -266,7 +267,7 @@ export function createRequireCache() {
     },
 
     has(_target, key: string) {
-      return $requireMap.$has(key) || (!isBuiltinKey(key) && $esmNamespaceForCjs(key) !== undefined);
+      return hasKey(key);
     },
 
     deleteProperty(_target, key: string) {
@@ -280,7 +281,7 @@ export function createRequireCache() {
     ownKeys(_target) {
       var array = [...$requireMap.$keys()];
       for (const key of $esmRegistryEvaluatedKeys()) {
-        if (!isBuiltinKey(key) && !array.includes(key)) {
+        if (!isBuiltinKey(key) && !$requireMap.$has(key)) {
           $arrayPush(array, key);
         }
       }
@@ -293,7 +294,7 @@ export function createRequireCache() {
     },
 
     getOwnPropertyDescriptor(_target, key: string) {
-      if ($requireMap.$has(key) || (!isBuiltinKey(key) && $esmNamespaceForCjs(key) !== undefined)) {
+      if (hasKey(key)) {
         return {
           configurable: true,
           enumerable: true,

--- a/src/jsc/bindings/BunModuleRegistry.h
+++ b/src/jsc/bindings/BunModuleRegistry.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "root.h"
+#include <JavaScriptCore/Identifier.h>
+#include <JavaScriptCore/JSModuleLoader.h>
+#include <JavaScriptCore/ModuleRegistryEntry.h>
+
+namespace Bun {
+
+// The registry has one entry per (specifier, import attribute type); `registryEntry` picks the one that stands for a specifier.
+template<typename Each>
+void forEachModuleRegistrySpecifier(JSC::JSModuleLoader* loader, const Each& each)
+{
+    auto& vm = loader->vm();
+    for (auto& [key, entry] : loader->moduleMap()) {
+        if (!key.first || !entry)
+            continue;
+        if (key.second != JSC::ScriptFetchParameters::Type::JavaScript && loader->registryEntry(JSC::Identifier::fromUid(vm, key.first)) != entry.get())
+            continue;
+        each(key.first, entry.get());
+    }
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/InspectorLifecycleAgent.cpp
+++ b/src/jsc/bindings/InspectorLifecycleAgent.cpp
@@ -1,4 +1,5 @@
 #include "InspectorLifecycleAgent.h"
+#include "BunModuleRegistry.h"
 #include "ZigGlobalObject.h"
 #include <JavaScriptCore/InspectorFrontendRouter.h>
 #include <JavaScriptCore/InspectorBackendDispatcher.h>
@@ -144,10 +145,9 @@ Protocol::ErrorStringOr<ModuleGraph> InspectorLifecycleAgent::getModuleGraph()
     Ref<JSON::ArrayOf<String>> esm = JSON::ArrayOf<String>::create();
     {
         Vector<String> keys;
-        for (auto& [key, entry] : global->moduleLoader()->moduleMap()) {
-            if (key.first)
-                keys.append(String { key.first });
-        }
+        Bun::forEachModuleRegistrySpecifier(global->moduleLoader(), [&](UniquedStringImpl* specifier, JSC::ModuleRegistryEntry*) {
+            keys.append(String { specifier });
+        });
         // ModuleMap is hash-ordered; sort so the inspector output is stable.
         std::sort(keys.begin(), keys.end(), WTF::codePointCompareLessThan);
         for (auto& k : keys)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1,6 +1,7 @@
 #include "root.h"
 
 #include "ZigGlobalObject.h"
+#include "BunModuleRegistry.h"
 #include "BuiltinModuleKeys.h"
 #include "IsolatedModuleCache.h"
 #include "MessagePort.h"
@@ -760,21 +761,38 @@ static bool isModuleLoadSettled(JSC::ModuleRegistryEntry* entry)
     return record->moduleEnvironmentMayBeNull() != nullptr;
 }
 
+// A key that is not an atom already names no module, and does not become one.
+static JSC::AbstractModuleRecord* evaluatedModuleRecord(JSC::JSGlobalObject* globalObject, JSValue keyValue)
+{
+    if (!keyValue.isString())
+        return nullptr;
+    auto atom = asString(keyValue)->toExistingAtomString(globalObject);
+    if (!atom.data)
+        return nullptr;
+    auto* entry = globalObject->moduleLoader()->registryEntry(JSC::Identifier::fromUid(globalObject->vm(), atom.data));
+    return entry && isModuleEvaluated(entry->record()) ? entry->record() : nullptr;
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionEsmNamespaceForCjs, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue keyValue = callFrame->argument(0);
-    if (!keyValue.isString())
-        return JSValue::encode(jsUndefined());
-    auto key = JSC::Identifier::fromString(vm, asString(keyValue)->value(globalObject));
+    auto* record = evaluatedModuleRecord(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, {});
-    auto* entry = globalObject->moduleLoader()->registryEntry(key);
-    if (!entry || !isModuleEvaluated(entry->record()))
+    if (!record)
         return JSValue::encode(jsUndefined());
-    auto* ns = entry->record()->getModuleNamespace(globalObject, false);
+    auto* ns = record->getModuleNamespace(globalObject, false);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(ns);
+}
+
+JSC_DEFINE_HOST_FUNCTION(functionEsmRegistryHasEvaluated, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* record = evaluatedModuleRecord(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(jsBoolean(!!record));
 }
 
 JSC_DEFINE_HOST_FUNCTION(functionEsmRegistryDelete, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
@@ -800,11 +818,10 @@ JSC_DEFINE_HOST_FUNCTION(functionEsmRegistryEvaluatedKeys, (JSC::JSGlobalObject 
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSC::MarkedArgumentBuffer keys;
-    for (auto& [key, entry] : globalObject->moduleLoader()->moduleMap()) {
-        if (!key.first || !entry || !isModuleEvaluated(entry->record()))
-            continue;
-        keys.append(jsString(vm, String { key.first }));
-    }
+    Bun::forEachModuleRegistrySpecifier(globalObject->moduleLoader(), [&](UniquedStringImpl* specifier, JSC::ModuleRegistryEntry* entry) {
+        if (isModuleEvaluated(entry->record()))
+            keys.append(jsString(vm, String { specifier }));
+    });
     if (keys.hasOverflowed()) [[unlikely]] {
         throwOutOfMemoryError(globalObject, scope);
         return {};
@@ -2892,6 +2909,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
         { BuiltinName::k_esmNamespaceForCjs, 1, functionEsmNamespaceForCjs },
         { BuiltinName::k_esmRegistryDelete, 1, functionEsmRegistryDelete },
         { BuiltinName::k_esmRegistryEvaluatedKeys, 0, functionEsmRegistryEvaluatedKeys },
+        { BuiltinName::k_esmRegistryHasEvaluated, 1, functionEsmRegistryHasEvaluated },
         { BuiltinName::k_esmLoadSync, 1, functionEsmLoadSync },
         { BuiltinName::k_makeErrorWithCode, 2, jsFunctionMakeErrorWithCode },
         { BuiltinName::k_toClass, 1, jsFunctionToClass },

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -597,6 +597,50 @@ describe("bundler", () => {
       });
     }
 
+    // A chunk that is only linked statically has no module namespace object.
+    itBundled("compile/splitting/NamespaceObjectsOnlyForImportedChunks", {
+      compile: true,
+      splitting: true,
+      bytecode: true,
+      format: "esm",
+      files: {
+        "/entry.ts": /* js */ `
+          import { heapStats } from "bun:jsc";
+          import { shared } from "./shared.ts";
+          const count = (type: string) => heapStats().objectTypeCounts[type] ?? 0;
+          const before = { namespaces: count("ModuleNamespaceObject"), records: count("ModuleRecord") };
+          const { one } = await import("./one.ts");
+          const { two } = require("./two.ts") as typeof import("./two.ts");
+          const bundled = Object.keys(require.cache).filter(key => key.includes("$bunfs") || key.includes("~BUN"));
+          console.log(shared(), one(), two());
+          // The chunks share code, so more of them were loaded than were asked for by name.
+          console.log("chunks other than the two asked for:", bundled.length > 2, count("ModuleRecord") - before.records > 2);
+          console.log("namespace objects added:", count("ModuleNamespaceObject") - before.namespaces);
+          const wrapped = bundled.map(key => typeof require.cache[key]?.exports);
+          console.log("after reading", wrapped.length > 2, "chunks out of require.cache:", count("ModuleNamespaceObject") - before.namespaces === wrapped.length);
+        `,
+        "/shared.ts": /* js */ `
+          export function shared() { return "shared"; }
+        `,
+        "/common.ts": /* js */ `
+          export function common() { return "common"; }
+        `,
+        "/one.ts": /* js */ `
+          import { shared } from "./shared.ts";
+          import { common } from "./common.ts";
+          export function one() { return "one+" + shared() + "+" + common(); }
+        `,
+        "/two.ts": /* js */ `
+          import { common } from "./common.ts";
+          export function two() { return "two+" + common(); }
+        `,
+      },
+      run: {
+        stdout:
+          "shared one+shared+common two+common\nchunks other than the two asked for: true true\nnamespace objects added: 2\nafter reading true chunks out of require.cache: true",
+      },
+    });
+
     // The executable embeds its entry point at `/$bunfs/root/<outfile>`. A chunk that loads the entry point with
     // `import()` or `require()` must name that path, and must get the module that already ran, not a second copy.
     // The "api" backend of `itBundled` sets `naming.entry` to the name of the outfile, and that also names the chunk of

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -50,6 +50,101 @@ describe.concurrent("require.cache", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("listing require.cache does not create a namespace object for each ES module", async () => {
+    using dir = tempDir("require-cache-esm-namespaces", {
+      "a.mjs": `export const a = 1;`,
+      "b.mjs": `import { a } from "./a.mjs"; export const b = a + 1;`,
+      "index.mjs": `
+        import { heapStats } from "bun:jsc";
+        import { b } from "./b.mjs";
+        import { join } from "node:path";
+        const namespaces = () => heapStats().objectTypeCounts.ModuleNamespaceObject ?? 0;
+        const aPath = join(import.meta.dir, "a.mjs");
+        const before = namespaces();
+        const keys = Object.keys(require.cache)
+          .filter(key => key.startsWith(import.meta.dir))
+          .map(key => key.slice(import.meta.dir.length + 1))
+          .sort();
+        const has = aPath in require.cache;
+        const descriptor = Object.getOwnPropertyDescriptor(require.cache, aPath);
+        const createdByListing = namespaces() - before;
+        const { a } = require.cache[aPath].exports;
+        const createdByGet = namespaces() - before - createdByListing;
+        // The key is now in both tables; it is still listed once.
+        const listedAfterGet = Object.keys(require.cache).filter(key => key === aPath).length;
+        console.log(JSON.stringify({ b, keys, has, descriptor, createdByListing, a, createdByGet, listedAfterGet }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({
+        b: 2,
+        keys: ["a.mjs", "b.mjs"],
+        has: true,
+        descriptor: { writable: false, enumerable: true, configurable: true },
+        createdByListing: 0,
+        a: 1,
+        createdByGet: 1,
+        listedAfterGet: 1,
+      }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("a specifier imported under two import attribute types is one key of require.cache", async () => {
+    using dir = tempDir("require-cache-esm-attribute-types", {
+      "a.mjs": `export const a = 1;`,
+      "data.json": `{"x":1}`,
+      // Never imported as JavaScript.
+      "only.json": `{"y":2}`,
+      "index.mjs": `
+        import { join } from "node:path";
+        import { a } from "./a.mjs";
+        import text from "./a.mjs" with { type: "text" };
+        import data from "./data.json";
+        import sameData from "./data.json" with { type: "json" };
+        import only from "./only.json" with { type: "json" };
+        import onlyText from "./only.json" with { type: "text" };
+        const keys = Object.keys(require.cache)
+          .filter(key => key.startsWith(import.meta.dir))
+          .map(key => key.slice(import.meta.dir.length + 1))
+          .sort();
+        // Every key that is listed is there when asked for by name.
+        const present = keys.map(key => join(import.meta.dir, key)).every(key => key in require.cache && require.cache[key]);
+        console.log(JSON.stringify({ a, text: text.length > 0, x: data.x + sameData.x, y: only.y, onlyText, keys, present }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({
+        a: 1,
+        text: true,
+        x: 2,
+        y: 2,
+        onlyText: `{"y":2}`,
+        keys: ["a.mjs", "data.json", "only.json"],
+        present: true,
+      }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   describe.skipIf(isBroken && isIntelMacOS)("files transpiled and loaded don't leak the output source code", () => {
     test("via require() with a lot of long export names", async () => {
       let text = "";


### PR DESCRIPTION
### What

`key in require.cache`, `Object.keys(require.cache)` (also `for..in`, `Reflect.ownKeys`, `Object.hasOwn`) and
`Object.getOwnPropertyDescriptor(require.cache, key)` asked the ES module registry for the module's *namespace
object* to find out whether the module had finished evaluating. Every evaluated ES module therefore got a
`JSModuleNamespaceObject` the first time anything enumerated or probed the cache. The record keeps its namespace, so
they are never collected. A module that is only ever linked statically does not need one.

- The `has` and `getOwnPropertyDescriptor` traps call a new private builtin, `$esmRegistryHasEvaluated(key)`, which
  looks at the record's status and creates nothing. Only reading `require.cache[key]` still creates the namespace,
  because that is the value it returns.
- Both lookups go through `JSString::toExistingAtomString`, so probing a key no module has does not add it to the
  atom table (it used `Identifier::fromString`).
- `ownKeys` tested each registry key against the array it was building (`array.includes`). It asks `$requireMap`
  instead.
- The registry holds one entry per (specifier, import attribute type), so with `includes` gone
  `$esmRegistryEvaluatedKeys` has to return each specifier once (a duplicate makes the Proxy throw). It walks the
  registry with `forEachModuleRegistrySpecifier` (new, `BunModuleRegistry.h`), which keeps the entry
  `JSModuleLoader::registryEntry(specifier)` returns: the entry `has` and `get` already look at, so the three traps
  agree. The inspector's `LifecycleReporter.getModuleGraph` listed a file imported under two attribute types twice in
  `esm`; it uses the same walk.

Nothing else about `require.cache` changes: a script that exercises `in`, `Object.keys`, `for..in`,
`Reflect.ownKeys`, `getOwnPropertyDescriptor`, `hasOwn`, get, `delete`, spread, rope/symbol/number keys, built-in
keys and modules that are still evaluating prints the same on 1.4.1 and on this branch apart from the namespace
object counts.

### Numbers

An entry point that statically imports 700 small ES modules, then does one `Object.keys(require.cache)`, or 700
`path in require.cache` probes. `heapStats()` from `bun:jsc` (it collects before it counts), release builds:

| | namespace objects before | after | heap size delta |
|---|---|---|---|
| 1.4.1, `Object.keys` | 1 | 701 | +116 KB |
| 1.4.1, `in` x 700 | 1 | 701 | +119 KB |
| this branch, `Object.keys` | 1 | 1 | +17 KB |
| this branch, `in` x 700 | 1 | 1 | +26 KB |

In a large bundled CLI application built with `--compile --splitting`, one `Object.keys(require.cache)` from a
diagnostic preload left 869 of the 895 loaded modules with a namespace object.

One `Object.keys(require.cache)` call (after the first) with 2,000 / 4,000 ES modules loaded: 38 ms / 69 ms on 1.4.1,
2.6 ms / 3.2 ms on this branch. Measured on a busy machine: read it as an order of magnitude.

### How verified

- `test/cli/run/require-cache.test.ts`
  - "listing require.cache does not create a namespace object for each ES module": counts `ModuleNamespaceObject`
    around `Object.keys`, `in` and `getOwnPropertyDescriptor` (0 created) and around `require.cache[key]` (1 created:
    the positive control). Fails on 1.4.1 (`createdByListing: 2, createdByGet: 0`).
  - "a specifier imported under two import attribute types is one key of require.cache": a file imported plainly and
    as text, plainly and as json, and only as json + text; each is one key, and every listed key is `in` the cache
    and readable. This one passes on 1.4.1 (the `includes` it replaces deduplicated); it pins the replacement.
    With the `continue` in `forEachModuleRegistrySpecifier` removed it fails with
    `TypeError: Proxy handler's 'ownKeys' trap result must not contain any duplicate names`.
- `test/bundler/bundler_compile_splitting.test.ts`: `compile/splitting/NamespaceObjectsOnlyForImportedChunks`, a
  `--compile --splitting --bytecode` executable that loads more chunks than it asks for by name has exactly the two
  namespace objects its `import()` and `require()` returned after listing `require.cache`, and one per chunk once
  each is read out of `require.cache`. Fails on 1.4.1 (4 instead of 2).
- Release build, Linux x64: `test/cli/run/require-cache.test.ts` 18/18,
  `test/bundler/bundler_compile_splitting.test.ts` 29/29, `test/js/node/module` + `test/js/bun/resolve` 502 pass /
  2 fail (both `resolve.test.ts` cases that re-run the binary through `runuser`, which cannot execute a binary
  under a root-only directory; unrelated), `test/js/bun/test/mock` + `test/js/bun/plugin` 160/160,
  `test/cli/inspect/bun-inspector-protocol.test.ts` passes (it is timing-flaky under load on 1.4.1 too).
- `clang-format` and `prettier` clean on the touched files. No Rust changed.
