### PR TITLE
node:net: call the onread callback with the socket as `this`

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1708,7 +1708,8 @@ function Socket(options?) {
     } else {
       this[kOnreadBuffer] = onreadBuffer;
     }
-    // onStreamRead calls the user callback bare - a throw is an uncaught
+    // onStreamRead calls the user callback as a method of the socket and
+    // outside any try/catch: `this` is the socket, and a throw is an uncaught
     // exception, not a socket 'error'. Node bounds each kernel read to the
     // onread buffer's size, so each slice is a separate onStreamRead call and
     // a swallowed uncaughtException loses no bytes; bun slices one larger
@@ -1722,7 +1723,7 @@ function Socket(options?) {
         if (dest === true) {
           let ret;
           try {
-            ret = onreadCallback(total - offset, true);
+            ret = onreadCallback.$call(self, total - offset, true);
             if (onreadBufferIsFn) {
               const next = onreadBuffer();
               if (isUint8Array(next)) self[kOnreadBuffer] = next;
@@ -1753,7 +1754,7 @@ function Socket(options?) {
         offset += n;
         let ret;
         try {
-          ret = onreadCallback(n, dest);
+          ret = onreadCallback.$call(self, n, dest);
           if (onreadBufferIsFn) {
             const next = onreadBuffer();
             if (isUint8Array(next)) self[kOnreadBuffer] = next;

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -30,7 +30,7 @@ import {
   Stream,
 } from "node:net";
 import { join } from "node:path";
-import { TLSSocket } from "node:tls";
+import { createServer as createTLSServer, connect as tlsConnect, TLSSocket } from "node:tls";
 
 const socket_domain = tmpdirSync();
 
@@ -2533,6 +2533,98 @@ describe("net.Socket onread buffer factory", () => {
         ["aaaa", true],
         ["bbbb", true],
       ]);
+    } finally {
+      client?.destroy();
+      server.close();
+    }
+  });
+});
+
+describe("net.Socket onread callback receiver", () => {
+  // Node calls the callback as a method of the stream, so `this` is the
+  // net.Socket or the TLSSocket: `stream[kBufferCb](nread, userBuf)`.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/stream_base_commons.js#L179
+  it.each([
+    ["net.connect with a static buffer", false, () => Buffer.alloc(4)],
+    ["net.connect with a buffer factory", false, () => () => Buffer.alloc(4)],
+    ["net.connect with a factory that never yields a Uint8Array", false, () => () => null as any],
+    ["tls.connect with a static buffer", true, () => Buffer.alloc(4)],
+  ] as const)("`this` is the socket: %s", async (_label, secure, makeBuffer) => {
+    const receiverIsSocket: boolean[] = [];
+    let received = 0;
+    const done = Promise.withResolvers<void>();
+    const onConnection = (c: Socket) => {
+      c.on("error", () => {});
+      c.end("abcdefgh");
+    };
+    const server = secure ? createTLSServer(tlsCert, onConnection) : createServer(onConnection);
+    let client: Socket | undefined;
+    try {
+      const listening = Promise.withResolvers<void>();
+      server.once("error", listening.reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", listening.reject);
+        listening.resolve();
+      });
+      await listening.promise;
+      const options = {
+        port: (server.address() as import("node:net").AddressInfo).port,
+        host: "127.0.0.1",
+        onread: {
+          buffer: makeBuffer(),
+          callback(this: unknown, n: number) {
+            receiverIsSocket.push(this === client);
+            received += n;
+            if (received === 8) done.resolve();
+            return true;
+          },
+        },
+      };
+      client = secure ? tlsConnect({ ...options, rejectUnauthorized: false }) : createConnection(options);
+      client.on("error", done.reject);
+      await done.promise;
+      expect(client).toBeInstanceOf(secure ? TLSSocket : Socket);
+      // At least one call, and every call had the socket as its receiver.
+      expect([...new Set(receiverIsSocket)]).toEqual([true]);
+    } finally {
+      client?.destroy();
+      server.close();
+    }
+  });
+
+  it("the callback can pause() and resume() the socket through `this`", async () => {
+    // 8 bytes through a 4-byte buffer: the second slice waits for resume().
+    const received: string[] = [];
+    const done = Promise.withResolvers<void>();
+    const server = createServer(c => c.end("abcdefgh"));
+    let client: Socket | undefined;
+    try {
+      const listening = Promise.withResolvers<void>();
+      server.once("error", listening.reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", listening.reject);
+        listening.resolve();
+      });
+      await listening.promise;
+      client = createConnection({
+        port: (server.address() as import("node:net").AddressInfo).port,
+        host: "127.0.0.1",
+        onread: {
+          buffer: Buffer.alloc(4),
+          callback(this: Socket, n: number, buf: Buffer) {
+            received.push(buf.toString("latin1", 0, n));
+            if (received.length === 1) {
+              this.pause();
+              setImmediate(() => this.resume());
+            } else if (received.join("").length === 8) {
+              done.resolve();
+            }
+          },
+        },
+      });
+      client.on("error", done.reject);
+      await done.promise;
+      expect(received).toEqual(["abcd", "efgh"]);
     } finally {
       client?.destroy();
       server.close();

--- a/test/js/node/test/parallel/test-net-onread-static-buffer.js
+++ b/test/js/node/test/parallel/test-net-onread-static-buffer.js
@@ -1,0 +1,186 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+
+const message = Buffer.from('hello world');
+
+// Test typical usage
+net.createServer(common.mustCall(function(socket) {
+  this.close();
+  socket.end(message);
+})).listen(0, common.mustCall(function() {
+  let received = 0;
+  const buffers = [];
+  const sockBuf = Buffer.alloc(8);
+  net.connect({
+    port: this.address().port,
+    onread: {
+      buffer: sockBuf,
+      callback: common.mustCallAtLeast(function(nread, buf) {
+        assert.strictEqual(buf, sockBuf);
+        received += nread;
+        buffers.push(Buffer.from(buf.slice(0, nread)));
+      })
+    }
+  }).on('data', common.mustNotCall()).on('end', common.mustCall(() => {
+    assert.strictEqual(received, message.length);
+    assert.deepStrictEqual(Buffer.concat(buffers), message);
+  }));
+}));
+
+// Test Uint8Array support
+net.createServer(common.mustCall(function(socket) {
+  this.close();
+  socket.end(message);
+})).listen(0, common.mustCall(function() {
+  let received = 0;
+  let incoming = new Uint8Array(0);
+  const sockBuf = new Uint8Array(8);
+  net.connect({
+    port: this.address().port,
+    onread: {
+      buffer: sockBuf,
+      callback: common.mustCallAtLeast(function(nread, buf) {
+        assert.strictEqual(buf, sockBuf);
+        received += nread;
+        const newIncoming = new Uint8Array(incoming.length + nread);
+        newIncoming.set(incoming);
+        newIncoming.set(buf.slice(0, nread), incoming.length);
+        incoming = newIncoming;
+      })
+    }
+  }).on('data', common.mustNotCall()).on('end', common.mustCall(() => {
+    assert.strictEqual(received, message.length);
+    assert.deepStrictEqual(incoming, new Uint8Array(message));
+  }));
+}));
+
+// Test Buffer callback usage
+net.createServer(common.mustCall(function(socket) {
+  this.close();
+  socket.end(message);
+})).listen(0, common.mustCall(function() {
+  let received = 0;
+  const incoming = [];
+  const bufPool = [ Buffer.alloc(2), Buffer.alloc(2), Buffer.alloc(2) ];
+  let bufPoolIdx = -1;
+  let bufPoolUsage = 0;
+  net.connect({
+    port: this.address().port,
+    onread: {
+      buffer: () => {
+        ++bufPoolUsage;
+        bufPoolIdx = (bufPoolIdx + 1) % bufPool.length;
+        return bufPool[bufPoolIdx];
+      },
+      callback: common.mustCallAtLeast(function(nread, buf) {
+        assert.strictEqual(buf, bufPool[bufPoolIdx]);
+        received += nread;
+        incoming.push(Buffer.from(buf.slice(0, nread)));
+      })
+    }
+  }).on('data', common.mustNotCall()).on('end', common.mustCall(() => {
+    assert.strictEqual(received, message.length);
+    assert.deepStrictEqual(Buffer.concat(incoming), message);
+    assert.strictEqual(bufPoolUsage, 7);
+  }));
+}));
+
+// Test Uint8Array callback support
+net.createServer(common.mustCall(function(socket) {
+  this.close();
+  socket.end(message);
+})).listen(0, common.mustCall(function() {
+  let received = 0;
+  let incoming = new Uint8Array(0);
+  const bufPool = [ new Uint8Array(2), new Uint8Array(2), new Uint8Array(2) ];
+  let bufPoolIdx = -1;
+  let bufPoolUsage = 0;
+  net.connect({
+    port: this.address().port,
+    onread: {
+      buffer: () => {
+        ++bufPoolUsage;
+        bufPoolIdx = (bufPoolIdx + 1) % bufPool.length;
+        return bufPool[bufPoolIdx];
+      },
+      callback: common.mustCallAtLeast(function(nread, buf) {
+        assert.strictEqual(buf, bufPool[bufPoolIdx]);
+        received += nread;
+        const newIncoming = new Uint8Array(incoming.length + nread);
+        newIncoming.set(incoming);
+        newIncoming.set(buf.slice(0, nread), incoming.length);
+        incoming = newIncoming;
+      })
+    }
+  }).on('data', common.mustNotCall()).on('end', common.mustCall(() => {
+    assert.strictEqual(received, message.length);
+    assert.deepStrictEqual(incoming, new Uint8Array(message));
+    assert.strictEqual(bufPoolUsage, 7);
+  }));
+}));
+
+// Test explicit socket pause
+net.createServer(common.mustCall(function(socket) {
+  this.close();
+  socket.end(message);
+})).listen(0, common.mustCall(function() {
+  let received = 0;
+  const buffers = [];
+  const sockBuf = Buffer.alloc(8);
+  let paused = false;
+  net.connect({
+    port: this.address().port,
+    onread: {
+      buffer: sockBuf,
+      callback: common.mustCallAtLeast(function(nread, buf) {
+        assert.strictEqual(paused, false);
+        assert.strictEqual(buf, sockBuf);
+        received += nread;
+        buffers.push(Buffer.from(buf.slice(0, nread)));
+        paused = true;
+        this.pause();
+        setTimeout(() => {
+          paused = false;
+          this.resume();
+        }, 100);
+      })
+    }
+  }).on('data', common.mustNotCall()).on('end', common.mustCall(() => {
+    assert.strictEqual(received, message.length);
+    assert.deepStrictEqual(Buffer.concat(buffers), message);
+  }));
+}));
+
+// Test implicit socket pause
+net.createServer(common.mustCall(function(socket) {
+  this.close();
+  socket.end(message);
+})).listen(0, common.mustCall(function() {
+  let received = 0;
+  const buffers = [];
+  const sockBuf = Buffer.alloc(8);
+  let paused = false;
+  net.connect({
+    port: this.address().port,
+    onread: {
+      buffer: sockBuf,
+      callback: common.mustCallAtLeast(function(nread, buf) {
+        assert.strictEqual(paused, false);
+        assert.strictEqual(buf, sockBuf);
+        received += nread;
+        buffers.push(Buffer.from(buf.slice(0, nread)));
+        paused = true;
+        setTimeout(() => {
+          paused = false;
+          this.resume();
+        }, 100);
+        return false;
+      })
+    }
+  }).on('data', common.mustNotCall()).on('end', common.mustCall(() => {
+    assert.strictEqual(received, message.length);
+    assert.deepStrictEqual(Buffer.concat(buffers), message);
+  }));
+}));


### PR DESCRIPTION
### Problem

- An `onread` callback given to `net.connect()` or `tls.connect()` runs with `this === undefined`. A callback that uses `this` throws `TypeError: undefined is not an object (evaluating 'this.pause')`.
- Node calls the callback as a method of the socket: `stream[kBufferCb](nread, userBuf)` in [`onStreamRead`](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/stream_base_commons.js#L179). So `this` is the `net.Socket` or the `TLSSocket`.
- The cause is the `deliver` closure in the `Socket` constructor (`src/js/node/net.ts:1726` and `:1757`). It calls `onreadCallback(...)` as a plain function.

### Fix

- Both call sites now use `onreadCallback.$call(self, ...)`. `self` is the socket that the constructor builds. `TLSSocket` reaches the same constructor through `NetSocket.$call(this, options)`, so `self` is the `TLSSocket` there.
- The same two lines and the same upstream test are in c3bd460ed3 of the draft #35391, next to many unrelated changes. This PR lands them alone.
- Verified: `test/js/node/net/node-net.test.ts`, new block `net.Socket onread callback receiver` (5 tests, all fail without the fix). Node's `test-net-onread-static-buffer.js` (v26.3.0) is added unchanged. It fails without the fix.
- Self-reviewed: 5 concerns raised, 5 addressed. The Notes list what this PR leaves out.

### Background

- `onread` is a `net.connect()` option. The socket copies incoming bytes into a buffer that the caller owns and calls `onread.callback(nread, buf)`. It does not emit `'data'`.
- `deliver` is the only function that calls the callback. The native `data` handler calls it. The `resume()` path calls it again for bytes that a paused callback left behind.
- `.$call` is the builtin-JS form of `Function.prototype.call`. User code cannot patch it.

<details><summary>Notes</summary>

#### Node against bun

```js
const net = require("net");
const srv = net.createServer(c => c.end("hello")).listen(0, "127.0.0.1", () => {
  const s = net.connect({
    port: srv.address().port,
    host: "127.0.0.1",
    onread: {
      buffer: Buffer.alloc(16),
      callback(n, buf) {
        console.log("this is socket:", this === s);
        srv.close();
        s.destroy();
      },
    },
  });
});
```

```
$ node --version && node repro.js
v26.3.0
this is socket: true
$ bun --revision && bun repro.js
1.4.3-canary.1+4ff919377
this is socket: false
$ bun bd repro.js        # this branch
this is socket: true
```

`test/js/node/test/parallel/test-net-onread-static-buffer.js` on the released bun:

```
TypeError: undefined is not an object (evaluating 'this.pause')
      at <anonymous> (test-net-onread-static-buffer.js:143:9)
      at deliver (node:net:884:35)
      at data (node:net:912:29)
```

#### Fail-before

- `USE_SYSTEM_BUN=1 bun test test/js/node/net/node-net.test.ts -t "onread callback receiver"`: 0 pass, 5 fail.
- Debug build with `src/` at `main`: 0 pass, 5 fail. With the fix: 5 pass.
- `test-net-onread-static-buffer.js` on the debug build: 10 of 10 runs fail without the fix, 10 of 10 pass with it. Its "explicit socket pause" and "implicit socket pause" sections call `this.pause()` and `this.resume()` in the callback.

#### Not changed on purpose

- The buffer factory (`onread.buffer` as a function) stays a plain call. Node also calls it with no receiver: `bufGen()` in [`onStreamRead`](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/stream_base_commons.js#L182) and in [`initSocketHandle`](https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L336).
- Node's `test-tls-onread-static-buffer.js` is not added. It uses arrow functions and a `client` variable, so it does not observe the receiver. It already passes on `main`. My test has a `tls.connect` row that does observe it.

#### Not addressed here

Two other user callbacks in `net.ts` get a receiver that differs from node. Both need more than a receiver argument, so they are left out:

- `SNICallback` (`src/js/node/net.ts:874`, `cb.$call(server, ...)`). Node calls `owner._SNICallback(...)`, so `this` is the server-side `TLSSocket` ([wrap.js#L215](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L215)). Bun calls it from the native SNI dispatch, which passes the `tls.Server` and the connection handle.
- `checkServerIdentity` (`src/js/node/net.ts:365`, plain call). Node calls `options.checkServerIdentity(...)`, so `this` is node's copy of the connect options ([wrap.js#L1671](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1671)). Bun's internal options object has a different shape.

Bugs that the review found in the same area. This PR does not change them:

- #42419: `tls.connect({ socket, onread })` uses `onread`. Node passes `onread: null` when it wraps a socket.
- #42418: `pause()` then `read()` inside the callback stops the delivery.
- #33256 (open PR): `destroy()` emits a spurious `'end'`.

#### Overlap with open PRs

- #42313 (approved) moves the loop of `deliver` into a new `deliverSlices` function and edits the same `node:tls` import line in `node-net.test.ts`. The import line here is identical to the one there.
- #42305 touches the same closure on other lines.
- `git merge-tree` of this branch with the head of each PR gives no conflict. The merged `deliverSlices` has both `.$call(self, ...)` lines.

#### Other suites

- Run on the debug build with the fix, all pass: `test/js/node/tls/node-tls-upgrade.test.ts`, `test/js/node/net/socket-reconnect-live.test.ts`, `test/js/node/net/handle-leak.test.ts`, and the `onread` test in `test/js/node/tls/node-tls-connect.test.ts`.
- The full `node-net.test.ts` run has 107 passes and 11 failures in my container. The released bun fails 10 of the 11 there too. `localhost` resolves to `::1` first: 8 `net.Socket read` tests get `ECONNREFUSED 127.0.0.1`, and all 8 pass when `localhost` resolves to `127.0.0.1`. There is no outbound DNS: `unref should exit...` and `#13126` get `EAI_AGAIN www.example.com`. The last one is a leak test that does not use `onread`. It exceeds its 60 s limit under the debug build.
- The new upstream test ran only on Linux x64 so far. It has two 100 ms timers and two exact `bufPoolUsage === 7` checks, so the Windows and macOS lanes are the first run there.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->