### PR TITLE
install: let --concurrent-scripts override bunfig concurrentScripts

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1972,7 +1972,6 @@ pub fn init(
 
     let options = Options {
         global: cli.global,
-        max_concurrent_lifecycle_scripts: (cpu_count * 2) as usize,
         ..Default::default()
     };
 
@@ -2489,13 +2488,7 @@ fn init_with_runtime_once(
 
         wr!(cache_directory, None);
         wr!(cache_directory_path, ZBox::from_bytes(b""));
-        wr!(
-            options,
-            Options {
-                max_concurrent_lifecycle_scripts: (cpu_count * 2) as usize,
-                ..Default::default()
-            }
-        );
+        wr!(options, Options::default());
         wr!(
             active_lifecycle_scripts,
             crate::lifecycle_script_runner::List {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1972,9 +1972,7 @@ pub fn init(
 
     let options = Options {
         global: cli.global,
-        max_concurrent_lifecycle_scripts: cli
-            .concurrent_scripts
-            .unwrap_or((cpu_count * 2) as usize),
+        max_concurrent_lifecycle_scripts: (cpu_count * 2) as usize,
         ..Default::default()
     };
 
@@ -2494,9 +2492,7 @@ fn init_with_runtime_once(
         wr!(
             options,
             Options {
-                max_concurrent_lifecycle_scripts: cli
-                    .concurrent_scripts
-                    .unwrap_or((cpu_count * 2) as usize),
+                max_concurrent_lifecycle_scripts: (cpu_count * 2) as usize,
                 ..Default::default()
             }
         );

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -153,10 +153,7 @@ impl Default for Options {
             json_output: false,
             max_retry_count: 5,
             min_simultaneous_requests: 4,
-            // Placeholder only. Every constructor supplies the real default
-            // (`cpu_count * 2` for an install). `load()` then applies bunfig's
-            // `concurrentScripts`, then `--concurrent-scripts`.
-            max_concurrent_lifecycle_scripts: 0,
+            max_concurrent_lifecycle_scripts: usize::from(bun_core::get_thread_count()) * 2,
             publish_config: PublishConfig::default(),
             ca: Box::default(),
             ca_file_name: b"",

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -153,8 +153,9 @@ impl Default for Options {
             json_output: false,
             max_retry_count: 5,
             min_simultaneous_requests: 4,
-            // Placeholder only — every constructor supplies the real value
-            // (`cli.concurrent_scripts` or `cpu_count * 2`).
+            // Placeholder only. Every constructor supplies the real default
+            // (`cpu_count * 2` for an install). `load()` then applies bunfig's
+            // `concurrentScripts`, then `--concurrent-scripts`.
             max_concurrent_lifecycle_scripts: 0,
             publish_config: PublishConfig::default(),
             ca: Box::default(),
@@ -795,6 +796,11 @@ impl Options {
 
             if let Some(save_text_lockfile) = cli.save_text_lockfile {
                 self.save_text_lockfile = Some(save_text_lockfile);
+            }
+
+            // 0 is "not set", like `concurrentScripts = 0` in bunfig. A limit of 0 never starts a script.
+            if let Some(concurrent_scripts) = cli.concurrent_scripts.filter(|&n| n != 0) {
+                self.max_concurrent_lifecycle_scripts = concurrent_scripts;
             }
 
             if let Some(min_age_ms) = cli.minimum_release_age_ms {

--- a/test/cli/install/config-precedence.test.ts
+++ b/test/cli/install/config-precedence.test.ts
@@ -453,6 +453,33 @@ describe.concurrent("bun install config precedence", () => {
     expect(exitCode).toBe(0);
   });
 
+  test.each([
+    { flag: 2, outcome: "beats", concurrentScripts: 1, events: ["Starting", "Starting", "Finished", "Finished"] },
+    { flag: 1, outcome: "beats", concurrentScripts: 2, events: ["Starting", "Finished", "Starting", "Finished"] },
+    // 0 is not a limit. The flag and bunfig both read it as "not set".
+    { flag: 0, outcome: "yields to", concurrentScripts: 1, events: ["Starting", "Finished", "Starting", "Finished"] },
+  ])(
+    "--concurrent-scripts=$flag $outcome bunfig concurrentScripts = $concurrentScripts",
+    async ({ concurrentScripts, flag, events }) => {
+      const dep = (name: string) => JSON.stringify({ name, version: "1.0.0", scripts: { postinstall: "echo hi" } });
+      using dir = tempDir("config-precedence", {
+        // Only the hoisted linker applies the limit.
+        "project/bunfig.toml": bunfig({ linker: "hoisted", concurrentScripts }),
+        "project/package.json": packageJson({ a: "file:./a", b: "file:./b" }, { trustedDependencies: ["a", "b"] }),
+        "project/a/package.json": dep("a"),
+        "project/b/package.json": dep("b"),
+      });
+      const { stderr, exitCode } = await install(String(dir), ["--verbose", `--concurrent-scripts=${flag}`]);
+      expect(stderr).not.toContain("error:");
+      // --verbose logs each spawn and each exit of a package's scripts. The installer spawns as many
+      // packages as the limit allows before it waits for an exit: both with a limit of 2, one with 1.
+      expect(Array.from(stderr.matchAll(/\[Scripts\] (Starting|Finished) scripts for/g), match => match[1])).toEqual(
+        events,
+      );
+      expect(exitCode).toBe(0);
+    },
+  );
+
   test("~/.npmrc install-strategy applies when bunfig does not set a linker", async () => {
     using dir = tempDir("config-precedence", {
       "home/.npmrc": "install-strategy=linked\n",


### PR DESCRIPTION
### Problem

- `[install] concurrentScripts` in `bunfig.toml` wins over `--concurrent-scripts`. Every other install flag beats its bunfig key. With `concurrentScripts = 1` and `--concurrent-scripts=3`, three `sleep 1` postinstall scripts take 3.01 s, not 1 s.
- `PackageManager::init` (`src/install/PackageManager.rs:1975`, `:2497`) stored the flag value in `Options`. Then `Options::load` (`src/install/PackageManager/PackageManagerOptions.rs:569`) overwrote it with the bunfig value. Found by code reading (noted in #42379), not by a user.

### Fix

- `Options::load` applies the flag after the bunfig section, like `--linker`. `Options::default()` computes the default (2x CPU count). The constructors no longer set the field, and the `0` placeholder is gone.
- The new block reads `0` as "not set", as bunfig does. A limit of 0 never starts a script, and on main a bunfig value hides a flag `0`. #42379 drops the `0` in the parser. Either merge order is safe.
- Verified: `test/cli/install/config-precedence.test.ts` (three new cases, two fail on 1.4.3-canary.1). Also "reach max concurrent scripts" in `bun-install-lifecycle-scripts.test.ts`.
- Self-reviewed: 5 points raised (1 in code, the `0` case), all addressed.

### Background

- `max_concurrent_lifecycle_scripts` is the number of packages that can run lifecycle scripts at once. Only the hoisted linker and `bun pm trust` apply it (isolated: #42421), so the test sets `linker = "hoisted"`.
- With `--verbose`, the installer logs `Starting scripts for "x"` at each spawn and `Finished scripts for "x"` at each exit. It spawns all that the limit allows before it polls for an exit.
- The order of the lines shows the limit: two `Starting` lines first for 2, `Starting, Finished, Starting, Finished` for 1.

<details><summary>Notes</summary>

Repro without network (`file:` dependencies, release 1.4.3-canary.1+6a92015fc, Linux x64):

```sh
d=$(mktemp -d); cd "$d"
for i in 1 2 3; do mkdir dep$i; echo "{\"name\":\"dep$i\",\"version\":\"1.0.0\",\"scripts\":{\"postinstall\":\"sleep 1\"}}" > dep$i/package.json; done
echo '{"name":"app","version":"1.0.0","dependencies":{"dep1":"file:./dep1","dep2":"file:./dep2","dep3":"file:./dep3"},"trustedDependencies":["dep1","dep2","dep3"]}' > package.json
printf '[install]\nconcurrentScripts = 1\n' > bunfig.toml
bun install --linker=hoisted --concurrent-scripts=3   # 3.01s, expected about 1 s
rm -rf node_modules bun.lock
printf '[install]\nconcurrentScripts = 3\n' > bunfig.toml
bun install --linker=hoisted --concurrent-scripts=1   # 1.0s, expected about 3 s
```

Without `bunfig.toml` the flag works: `--concurrent-scripts=3` takes 1.0 s and `--concurrent-scripts=1` takes 3.0 s.

The test does not measure time. The limit fixes the order of the `--verbose` lines. `run_available_scripts` (`src/install/PackageInstaller.rs:784`) spawns every pending package that `can_run_scripts` allows in one loop, with no event loop tick between the spawns. `handle_exit` (`src/install/lifecycle_script_runner.rs:825`) prints `Finished` in the same call that decrements the alive count. I ran `bun install --verbose` 30 times for each of the two orders on the debug build, with and without `BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1` (120 runs). Every run gave the expected order. With `src/` at main, the debug build fails the two "beats" cases and passes the `0` case.

`get_thread_count()` caches its result, and both constructors already call it before they build `Options`. So the move of the default into `Options::default()` does not change the value or the time of the first call.

Values checked on the fixed debug build (hoisted linker, two packages):

| bunfig `concurrentScripts` | flag | limit in effect |
| --- | --- | --- |
| 1 | 2 | 2 |
| 2 | 1 | 1 |
| 1 | 0 | 1 (same as main) |
| 1 | `abc` | 1 (same as main) |
| not set | 0 | default (main spins, that is #42379) |
| 2 | not set | 2 |
| not set | 1 | 1 |

`bun pm trust --all --concurrent-scripts=0` with `concurrentScripts = 1` also runs the script and exits 0.

Related open PRs in the same two functions, with no overlap in lines: #36219 and #38744 (`PackageManager::init`), #42379 (`CommandLineArguments.rs`).

Not in this PR: `BUN_INSTALL_VERBOSE` has the same shape. `init` sets the verbose state from it, then `load` overwrites the state with the `--verbose` flag. The variable is not documented.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/config-precedence.test.ts
bun test v1.4.3 (6a92015fc)

test/cli/install/config-precedence.test.ts:
(pass) bun install config precedence > project bunfig registry beats project .npmrc registry [347.89ms]
(pass) bun install config precedence > project bunfig registry beats ~/.npmrc registry [362.85ms]
(pass) bun install config precedence > ~/.npmrc _authToken applies to the registry set in project bunfig [353.24ms]
(pass) bun install config precedence > project .npmrc registry beats ~/.npmrc registry [504.46ms]
(pass) bun install config precedence > project bunfig linker beats ~/.npmrc install-strategy [765.98ms]
(pass) bun install config precedence > bunfig scoped registry keeps credentials from ~/.npmrc [383.82ms]
(pass) bun install config precedence > project .npmrc scoped registry and token apply alongside a bunfig registry [519.13ms]
(pass) bun install config precedence > ~/.npmrc registry= plus its _authToken still authenticate the registry set in project bunfig [427.82ms]
(pass) bun install config precedence > proj
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/cli/install/config-precedence.test.ts:
(pass) bun install config precedence > project bunfig registry beats ~/.npmrc registry [180.60ms]
(pass) bun install config precedence > project bunfig linker beats ~/.npmrc install-strategy [187.61ms]
(pass) bun install config precedence > project bunfig registry beats project .npmrc registry [186.94ms]
(pass) bun install config precedence > project .npmrc registry beats ~/.npmrc registry [183.86ms]
(pass) bun install config precedence > project .npmrc scoped registry and token apply alongside a bunfig registry [177.58ms]
(pass) bun install config precedence > ~/.npmrc _authToken applies to the registry set in project bunfig [182.66ms]
(pass) bun install config precedence > ~/.npmrc registry= plus its _authToken still authenticate the registry set in project bunfig [183.80ms]
(pass) bun install config precedence > bunfig scoped registry keeps credentials from ~/.npmrc [186.81ms]
(pass) bun install config precedence > project .npmrc _authToken applies when bunfig spells the same registry with a trailing slash [181.91ms]
(pass) bun install config precedence > project .npmrc scoped _auth
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/config-precedence.test.ts
bun test v1.4.3 (6a92015fc)

test/cli/install/config-precedence.test.ts:
(pass) bun install config precedence > project bunfig linker beats ~/.npmrc install-strategy [372.16ms]
(pass) bun install config precedence > project bunfig registry beats project .npmrc registry [356.97ms]
(pass) bun install config precedence > project .npmrc registry beats ~/.npmrc registry [364.24ms]
(pass) bun install config precedence > ~/.npmrc _authToken applies to the registry set in project bunfig [360.95ms]
(pass) bun install config precedence > project bunfig registry beats ~/.npmrc registry [510.70ms]
(pass) bun install config precedence > project .npmrc scoped registry and token apply alongside a bunfig registry [346.11ms]
(pass) bun install config precedence > ~/.npmrc registry= plus its _authToken still authenticate the registry set in project bunfig [228.69ms]
(pass) bun install config precedence > project .npmrc _authToken applies when bunfig spells the same registry with a trailing slash [247.20ms]
(pass
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 965ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/135] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/135] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[3/135] cc obj/packages/bun-usockets/src/loop.c.o
[4/135] cc obj/packages/bun-usockets/src/bsd.c.o
[5/135] cc obj/packages/bun-usockets/src/fault_inject.c.o
[6/135] cc obj/packages/bun-usockets/src/socket.c.o
[7/135] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[8/135] cc obj/packages/bun-usockets/src/udp.c.o
[9/135] cc obj/packages/bun-usockets/src/node_quic_shim.c.o
[10/135] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[11/135] cc obj/packages/bun-usockets/src/context.c.o
[12/135] cc obj/packages/bun-usockets/src/quic.c.o
[13/135] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[14/135] gen cpp.rs (cppbind)
[14/135] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/install/PackageManager.rs                      | 13 +----------
 .../PackageManager/PackageManagerOptions.rs        |  9 +++++---
 test/cli/install/config-precedence.test.ts         | 27 ++++++++++++++++++++++
 3 files changed, 34 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/install/PackageManager.rs                            5      3     29
src/install/PackageManager/PackageManagerOptions.rs      4      5     28
test/cli/install/config-precedence.test.ts               6      4     28
```

</details>

<!-- robobun:evidence:end -->