### PR TITLE
bundler: metafile names the input behind a split import() / require() as entryPoint

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1535,6 +1535,7 @@ interface BuildMetafile {
         path: string;
         kind: ImportKind;
         original?: string; // Original specifier before resolution
+        entryPoint?: string; // import() / require() split into another output file: the input that file was built from
         external?: boolean;
       }>;
       format?: "esm" | "cjs" | "json" | "css";

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4372,6 +4372,15 @@ declare module "bun" {
           kind: ImportKind;
           /** Original import specifier before resolution (if different from path) */
           original?: string;
+          /**
+           * With `splitting`, an `import()` (or, for `target: "bun"`, a
+           * `require()` of an ES module) of a bundled file loads another
+           * output file: `path` then points at that output instead of an
+           * input, and `external` is `true`. `entryPoint` is the input file
+           * that output was built from. It is a key of `inputs` and equals
+           * that output's `outputs[...].entryPoint`.
+           */
+          entryPoint?: string;
           /** Whether this import is external to the bundle */
           external?: boolean;
           /** Import attributes, for example `{ type: "json" }` */

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -237,6 +237,15 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
         }
     }
 
+    // A split `import()` / `require()` record names its target's chunk
+    // (`compute_cross_chunk_dependencies`); "entryPoint" adds the input.
+    let mut entry_of_chunk: StringHashMap<u32> = StringHashMap::default();
+    for chunk in chunks.iter() {
+        if chunk.entry_point.is_entry_point() && !chunk.unique_key.is_empty() {
+            entry_of_chunk.put(chunk.unique_key, chunk.entry_point.source_index())?;
+        }
+    }
+
     // Write inputs
     let mut source_index: u32 = 0;
     while (source_index as usize) < sources.len() {
@@ -340,6 +349,17 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
                         "{}",
                         bfmt::format_json_string_utf8(record.original_path, Default::default())
                     )?;
+                    j.push_owned(buf.into_boxed_slice());
+                }
+
+                if record.flags.contains(ImportRecordFlags::IMPORTS_CHUNK)
+                    && let Some(&entry_point) = entry_of_chunk.get(record.path.text)
+                    && let Some(entry_source) = sources.get(entry_point as usize)
+                    && !entry_source.path.pretty.is_empty()
+                {
+                    j.push_static(b",\n          \"entryPoint\": ");
+                    let mut buf: Vec<u8> = Vec::new();
+                    write_json_string(&mut buf, entry_source.path.pretty)?;
                     j.push_owned(buf.into_boxed_slice());
                 }
 

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -6,6 +6,7 @@ interface MetafileImport {
   path: string;
   kind: string;
   original?: string;
+  entryPoint?: string;
   external?: boolean;
   with?: { type: string };
 }
@@ -456,6 +457,66 @@ describe("bundler metafile", () => {
     const outputs = (result.metafile as Metafile).outputs as Record<string, MetafileOutput>;
     const outputPaths = Object.keys(outputs);
     expect(outputPaths).toContain(dynamicImport!.path);
+  });
+
+  describe.each(["browser", "bun"] as const)("target %s", target => {
+    test.each([
+      { kind: "dynamic-import", call: `import("./lazy.js").then(m => console.log(m.value))` },
+      ...(target === "bun"
+        ? [{ kind: "require-call", call: `export const load = () => require("./lazy.js").value` }]
+        : []),
+    ])("metafile names the input a split $kind loads as entryPoint", async ({ kind, call }) => {
+      using dir = tempDir("metafile-split-import-test", {
+        "entry.js": `import { shared } from "./shared.js"; console.log(shared); ${call};`,
+        "lazy.js": `import { shared } from "./shared.js"; export const value = shared + 1;`,
+        "shared.js": `export const shared = 123;`,
+      });
+
+      const result = await Bun.build({
+        entrypoints: [`${dir}/entry.js`],
+        metafile: true,
+        splitting: true,
+        target,
+      });
+
+      expect(result.success).toBe(true);
+      const { inputs, outputs } = result.metafile as Metafile;
+      const [lazyInput] = Object.keys(inputs).filter(path => path.endsWith("lazy.js"));
+      const [entryInput] = Object.keys(inputs).filter(path => path.endsWith("entry.js"));
+      const [lazyOutput] = Object.keys(outputs).filter(path => outputs[path].entryPoint === lazyInput);
+      expect(lazyInput).toBeString();
+      expect(lazyOutput).toMatch(/^\.\/chunk-[a-z0-9]+\.js$/);
+      expect(inputs[entryInput].imports.filter(imp => imp.kind === kind)).toEqual([
+        { path: lazyOutput, kind, original: "./lazy.js", entryPoint: lazyInput, external: true },
+      ]);
+      // A static import has no chunk of its own to name.
+      expect(inputs[entryInput].imports.filter(imp => imp.kind === "import-statement")).toEqual([
+        {
+          path: Object.keys(inputs).find(path => path.endsWith("shared.js"))!,
+          kind: "import-statement",
+          original: "./shared.js",
+        },
+      ]);
+    });
+  });
+
+  test("metafile names the same input as entryPoint when two entry points import() it", async () => {
+    using dir = tempDir("metafile-split-import-two-entries", {
+      "a.js": `import("./lazy.js").then(m => console.log("a", m.value));`,
+      "b.js": `import("./lazy.js").then(m => console.log("b", m.value));`,
+      "lazy.js": `export const value = 1;`,
+    });
+    const result = await Bun.build({
+      entrypoints: [`${dir}/a.js`, `${dir}/b.js`],
+      metafile: true,
+      splitting: true,
+    });
+    expect(result.success).toBe(true);
+    const { inputs } = result.metafile as Metafile;
+    const input = (name: string) => Object.keys(inputs).find(path => path.endsWith(name))!;
+    const split = (name: string) =>
+      inputs[input(name)].imports.filter(imp => imp.kind === "dynamic-import").map(imp => imp.entryPoint);
+    expect({ a: split("a.js"), b: split("b.js") }).toEqual({ a: [input("lazy.js")], b: [input("lazy.js")] });
   });
 
   test("metafile includes cssBundle for CSS outputs", async () => {


### PR DESCRIPTION
### What

With `--splitting`, an `import()` of a bundled file (or, for `--target=bun`, a `require()` of an ES module) is a
chunk boundary. The metafile reports that edge in `inputs[file].imports` with the *output chunk* as `path` and
`"external": true`:

```json
{ "path": "./chunk-abc123.js", "kind": "dynamic-import", "original": "./lazy.js", "external": true }
```

To get back to the input file a tool had to join through `outputs["./chunk-abc123.js"].entryPoint`. Tools that walk
`inputs` to build a module graph (which file lazily loads which) need the input path on the edge itself. The join is
also not always possible: when outputs are nested (entry points in different directories, or
`naming.chunk: "chunks/[name]-[hash].[ext]"`), `path` on these records is relative to the first chunk
(`"../../chunks/lazy-tf6qf5xp.js"`) and is not a key of `outputs` (`"./chunks/lazy-tf6qf5xp.js"`). That is the
behaviour of the current release too and is left alone here.

The edge now also carries `"entryPoint": "<input path>"`, which is a key of `inputs`:

```json
{ "path": "./chunk-abc123.js", "kind": "dynamic-import", "original": "./lazy.js", "entryPoint": "lazy.js", "external": true }
```

This is additive. `path`, `kind`, `original` and `external` are unchanged, and the field is only written for records
that were rewritten to point at a chunk (`ImportRecordFlags::IMPORTS_CHUNK`). The name matches
`outputs[chunk].entryPoint`, which holds the same value.

### How

`compute_cross_chunk_dependencies` rewrites such a record's `path.text` to the target chunk's unique key and clears
its `source_index`. `MetafileBuilder::generate` builds one map from unique key to the entry point's source index
over the chunks (once per build, only when a metafile is requested) and looks the record up in it. No field is
added to `ImportRecord`.

- `packages/bun-types/bun.d.ts`: `entryPoint?: string` on `BuildMetafile["inputs"][string]["imports"][number]`.
- `docs/bundler/index.mdx`: the field in the metafile shape.

A real external (`import("node:fs")`) has no `entryPoint`. An `import()` of a file that is itself a user entry point
has one (it names that entry point). `--metafile-md` does not use the field yet: it still treats these edges as
external imports, as it does today.

### How verified

- `test/bundler/metafile.test.ts`
  - "metafile names the input a split dynamic-import / require-call loads as entryPoint", for `target: "browser"`
    and `target: "bun"`: the whole edge is compared (`path` is still the chunk in `outputs`, `external: true`,
    `entryPoint` is the key of `inputs`), and a static import in the same file has no `entryPoint`.
  - "metafile names the same input as entryPoint when two entry points import() it".
  - The existing "metafile tracks dynamic-import imports" test (chunk path in `path`) is untouched and passes.
  - All four new tests fail on 1.4.1 and pass on this branch.
- Release build, Linux x64: `test/bundler/metafile.test.ts` 49/49; `esbuild/metafile`, `esbuild/splitting`,
  `bundler_splitting`, `bun-build-api`, `bundler_dynamic_import_dce`, `html-import-manifest`, `cli` together 578 pass
  / 1 fail (`bytecode: repeated builds don't retain the generated code` hits the 5 s default timeout on a loaded
  machine; passes in 7 s with a longer timeout; unrelated). No snapshot file changes.
- `bun build --splitting --target=bun --metafile=meta.json` by hand: `import()`, `require()`, `import()` of a JSON
  file and of another entry point carry `entryPoint`, each a key of `inputs` and equal to
  `outputs[path].entryPoint`; `import("node:fs")` does not.
- `cargo clippy -p bun_bundler --no-deps` clean; `prettier` clean on the touched files.
