### PR TITLE
node:module: set module.loaded when require() finishes loading a file

### DIFF
--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -138,6 +138,8 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
     }
 
     mod.exports = moduleExports ?? namespace;
+    // In a require cycle `$requireESM` answers while the module still evaluates.
+    if ($esmNamespaceForCjs(id) === undefined) return mod.exports;
   } else {
     const c = $evaluateCommonJSModule(mod, this);
     if (c && c.indexOf(mod) === -1) {

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -137,13 +137,15 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
       }
     }
 
-    return (mod.exports = moduleExports ?? namespace);
+    mod.exports = moduleExports ?? namespace;
+  } else {
+    const c = $evaluateCommonJSModule(mod, this);
+    if (c && c.indexOf(mod) === -1) {
+      c.push(mod);
+    }
   }
 
-  const c = $evaluateCommonJSModule(mod, this);
-  if (c && c.indexOf(mod) === -1) {
-    c.push(mod);
-  }
+  mod.loaded = true;
   return mod.exports;
 }
 

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -926,6 +926,139 @@ console.log("survived", require("./late.js"));`,
     expect(require("./esm_to_cjs_interop.mjs")).toEqual(Symbol.for("meow"));
   });
 
+  test("module.loaded is true after require() loads a file", async () => {
+    // Reads its own require.cache entry while its body runs.
+    const esm = `
+      import { createRequire } from "node:module";
+      const require = createRequire(import.meta.url);
+      export const loadedWhileEvaluating = require.cache[require.resolve(import.meta.filename)].loaded;
+    `;
+    using dir = tempDir("require-loaded", {
+      "cjs.cjs": "module.exports = 1;",
+      "esm.mjs": esm,
+      "esm.ts": "export const x: number = 3;",
+      // No module syntax. Bun loads this file the same way as an ES module.
+      "empty.js": "",
+      "throws.mjs": "throw new Error('boom');",
+      // Module._extensions[".js"] loads these. Their package.json makes them ES modules.
+      "pkg/package.json": JSON.stringify({ type: "module" }),
+      "pkg/esm.js": esm,
+      "pkg/direct.js": "export const z = 5;",
+      "assigned.js": "module.exports = 'from the file body';",
+      "imports-assigned.mjs": "export { default } from './assigned.js';",
+      "compiles.xyz": "",
+      "throws.abc": "",
+      "main.cjs": `
+        const Module = require("node:module");
+        const entry = file => require.cache[require.resolve("./" + file)];
+
+        require("./cjs.cjs");
+        const { loadedWhileEvaluating } = require("./esm.mjs");
+        require("./esm.ts");
+        require("./empty.js");
+        const plain = {
+          "cjs.cjs": entry("cjs.cjs").loaded,
+          "esm.mjs": entry("esm.mjs").loaded,
+          "esm.ts": entry("esm.ts").loaded,
+          "empty.js": entry("empty.js").loaded,
+          loadedWhileEvaluating,
+        };
+
+        let threw = false;
+        try {
+          require("./throws.mjs");
+        } catch {
+          threw = true;
+        }
+        const throwing = { threw, cached: entry("throws.mjs") !== undefined };
+
+        // A wrapper of the default handler. require() sets loaded after the wrapper returns.
+        const original = Module._extensions[".js"];
+        const inWrapper = [];
+        Module._extensions[".js"] = function (module, filename) {
+          const before = module.loaded;
+          original(module, filename);
+          inWrapper.push({ before, afterOriginal: module.loaded });
+        };
+        const wrapped = {
+          loadedWhileEvaluating: require("./pkg/esm.js").loadedWhileEvaluating,
+          inWrapper,
+          "pkg/esm.js": entry("pkg/esm.js").loaded,
+        };
+        Module._extensions[".js"] = original;
+
+        // The default handler alone does not set loaded.
+        const directModule = new Module(require.resolve("./pkg/direct.js"));
+        directModule.filename = directModule.id;
+        original(directModule, directModule.filename);
+        const direct = { loaded: directModule.loaded, exports: Object.keys(directModule.exports) };
+
+        // Handlers that do not call the default handler.
+        Module._extensions[".js"] = function (module) {
+          module.exports = { loadedInHandler: module.loaded };
+        };
+        const assigned = require("./assigned.js");
+        Module._extensions[".js"] = original;
+        require.extensions[".xyz"] = function (module, filename) {
+          module._compile("module.exports = 2;", filename);
+        };
+        require.extensions[".abc"] = function () {
+          throw new Error("boom");
+        };
+        require("./compiles.xyz");
+        let handlerThrew = false;
+        try {
+          require("./throws.abc");
+        } catch {
+          handlerThrew = true;
+        }
+        const custom = {
+          assigned,
+          "assigned.js": entry("assigned.js").loaded,
+          "compiles.xyz": entry("compiles.xyz").loaded,
+          handlerThrew,
+          "throws.abc cached": entry("throws.abc") !== undefined,
+        };
+
+        // An ES module imports the file that the handler loaded. It gets the handler's exports.
+        import("./imports-assigned.mjs")
+          .then(
+            ns => ns.default,
+            error => "import failed: " + error.message,
+          )
+          .then(imported => console.log(JSON.stringify({ plain, throwing, wrapped, direct, custom, imported })));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // Node v26.3.0 prints the same values.
+    expect(JSON.parse(stdout)).toEqual({
+      plain: { "cjs.cjs": true, "esm.mjs": true, "esm.ts": true, "empty.js": true, loadedWhileEvaluating: false },
+      throwing: { threw: true, cached: false },
+      wrapped: {
+        loadedWhileEvaluating: false,
+        inWrapper: [{ before: false, afterOriginal: false }],
+        "pkg/esm.js": true,
+      },
+      direct: { loaded: false, exports: ["z"] },
+      custom: {
+        assigned: { loadedInHandler: false },
+        "assigned.js": true,
+        "compiles.xyz": true,
+        handlerThrew: true,
+        "throws.abc cached": false,
+      },
+      imported: { loadedInHandler: false },
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test("Module.runMain", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1059,6 +1059,43 @@ console.log("survived", require("./late.js"));`,
     expect(exitCode).toBe(0);
   });
 
+  test("module.loaded stays false when require() returns an ES module that still evaluates", async () => {
+    // import() evaluates esm.mjs. Its body requires cjs.cjs, and cjs.cjs requires esm.mjs back.
+    // Node throws ERR_REQUIRE_CYCLE_MODULE here. Bun returns the live namespace.
+    using dir = tempDir("require-loaded-cycle", {
+      "main.mjs": `
+        await import("./esm.mjs");
+        console.log(JSON.stringify(globalThis.seenFromCjs));
+      `,
+      "esm.mjs": `
+        import { createRequire } from "node:module";
+        createRequire(import.meta.url)("./cjs.cjs");
+        export const value = 1;
+      `,
+      "cjs.cjs": `
+        const namespace = require("./esm.mjs");
+        let value;
+        try {
+          value = namespace.value;
+        } catch (error) {
+          value = error.name;
+        }
+        globalThis.seenFromCjs = { value, loaded: require.cache[require.resolve("./esm.mjs")].loaded };
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // The ReferenceError shows that the body of esm.mjs has not reached its export yet.
+    expect(JSON.parse(stdout)).toEqual({ value: "ReferenceError", loaded: false });
+    expect(exitCode).toBe(0);
+  });
+
   test("Module.runMain", async () => {
     await using proc = Bun.spawn({
       cmd: [


### PR DESCRIPTION
Replaces #35984 (closed in favor of this PR).

### Problem
- After `require()` loads a file, `require.cache[id].loaded` can stay `false`. Node v26.3.0 reports `true`. Affected: an ES module, a file with no module syntax (an empty `.js`), and a file whose `Module._extensions` handler assigns `module.exports` without `module._compile`.
- `overridableRequire` (`src/js/builtins/CommonJS.ts:76`) creates the module object with `hasEvaluated = false`. This C++ field backs the `loaded` accessor (`getterLoaded`, `src/jsc/bindings/JSCommonJSModule.cpp:625`). Only CommonJS evaluation and some native loaders set it.
- Second symptom: after such a handler loads `x.js`, `import "./x.js"` fails with `Failed to evaluate module`.

### Fix
- `overridableRequire` sets `mod.loaded = true` once, at its end, for every file. Node does the same at the end of `Module.prototype.load`.
- While a file loads, its entry still reports `false`, also inside a wrapper of `Module._extensions[".js"]` after the original handler returns. A load that throws still removes the entry.
- In a require cycle, `$requireESM` can answer while the ES module body still runs. Then the write is skipped and `loaded` stays `false`, as on main.
- Verified: two new tests in `test/js/node/module/node-module-module.test.js`. The first fails on bun 1.4.3 and on main, and Node v26.3.0 prints the same JSON. Also ran `test/js/node/module/` and `require-esm-*`.

### Background
- A `require.cache` entry is a `JSCommonJSModule` object. `require()` of an ES module also creates one, with the module namespace object as `exports`.
- The native `$require` returns `-1` when bun does not classify the file as CommonJS. `overridableRequire` then loads it through `$requireESM`.
- In Node, `module.loaded` is `false` while the file loads and `true` after. Node's ESM loader and jiti read it before they use a `require.cache` entry.

<details><summary>Notes</summary>

Repro (same script on bun and node):

```js
// a.js: module.exports = 1;   b.mjs: export default 2;   c.ts: export const x: number = 3;
const path = require("path");
require("./a.js"); require("./b.mjs"); require("./c.ts");
for (const f of ["a.js", "b.mjs", "c.ts"]) console.log(f, require.cache[path.join(__dirname, f)].loaded);
```

bun 1.4.3 and main: `true`, `false`, `false`. Node v26.3.0 and this branch: `true`, `true`, `true`.

Provenance: another session found this while it read the loader code. No user reported it. The flag and the `loaded` getter date from the loader rewrite in #3379 (June 2023). The one reader I found outside Node is jiti 2.7.0. It uses a `require.cache` entry only when `entry.loaded` is true. With `loaded: false` it evaluates the file a second time on its own path (not its native path, which is the default on bun).

Cause of the second symptom: the synthetic CommonJS source that backs the import (`commonJSModuleSyntheticSourceCode`, `src/jsc/bindings/JSCommonJSModule.cpp`) sees `hasEvaluated == false` and evaluates a module object that has no source.

Relation to #35984: that PR sets the same flag after a custom handler returns, in `evaluateCommonJSCustomExtension`. The write at the end of `overridableRequire` covers that case too, because `require()` is the only caller of that function. The test file of #35984 passes on this branch without its source change. #35984 is now closed in favor of this PR. Its three test cases (a handler that assigns `module.exports`, a handler that calls `module._compile`, a handler that throws) have the same rows in the first new test here: `assigned.js`, `compiles.xyz`, `throws.abc`.

An earlier version of this branch set the flag in the `out === -1` branch and in `requireESMFromHijackedExtension`. A self-review found that the second write made bun report `true` in two places where Node and bun 1.4.3 report `false`: inside a wrapper after the original handler returns, and after a direct call of the default handler on a `new Module()`. The test pins both places to `false`.

The flag is also the evaluate-once guard (`JSCommonJSModule::load`, `JSCommonJSModule::evaluate`). For the module objects that this PR changes, the guard does nothing new: they have no CommonJS source (`load` returns early when `sourceCode` is null). One trade-off remains, and #35984 has the same one. A handler that returns without a load, and calls the default handler on that module only after `require()` has returned, now gets a no-op from the default handler. Node runs the file body. I found no code that does this. `module._compile` is not affected.

Require cycles:
- `main.cjs` requires `a.mjs`, `a.mjs` imports `b.cjs`, `b.cjs` requires `a.mjs`. The inner `require()` finds the entry that the outer `require()` made. It reads `loaded: false` during the evaluation and `true` after. Node reports the same two values (its inner `require()` throws `ERR_REQUIRE_CYCLE_MODULE`).
- `import()` evaluates `esm.mjs`, its body requires `cjs.cjs`, and `cjs.cjs` requires `esm.mjs` back. The body of `esm.mjs` is on the stack, and its exports are still in TDZ. Bun returns the live namespace (`$esmLoadSync` answers from the registry for a record that is still `Evaluating`). Node throws `ERR_REQUIRE_CYCLE_MODULE` and makes no `require.cache` entry, so there is no Node value to match. The first push of this PR reported `loaded: true` at that point. A review comment found it. Now `overridableRequire` sets `loaded` only when the registry reports the module as evaluated (`$esmNamespaceForCjs(id) !== undefined`, the same check that the `require.cache` proxy uses). The second new test pins `false` here. It fails on the first push (008daea619).
- That module object keeps `loaded: false` after the evaluation ends. This is the behavior of main today. A fix for it needs a lazy read of the registry in the `loaded` getter, which is not in this PR.
- `functionEsmLoadSync` can also return for a record whose body finished and whose status still waits for an outer cycle root. The gate reads such a record as not evaluated, so that entry also keeps `false`, as on main. I could not reach this state. In six cycle fixtures, the registry reports the required module as evaluated when `require()` returns, and `loaded` is `true`. One of them has the shape of `test/js/bun/resolve/require-esm-evaluating-cycle.test.ts` (the body of `a.mjs` requires `b.mjs`, and `b.mjs` imports `a.mjs`). A gate that tells this state from a body on the stack needs a new native query for the status before the call, so it is not in this PR.
- `a.mjs` statically imports `b.cjs`, and `b.cjs` requires `a.mjs` back. Bun runs `b.cjs` before `a.mjs` starts to evaluate, so the inner `require()` runs `a.mjs` to completion (`namespace.value` is `1`, not TDZ). The registry reports it as evaluated and `loaded` is `true`. Virtual modules from `Bun.plugin` and `mock.module` also end at `true`.

Overlap with other open PRs:
- #42371 adds lines to the end of the `out === -1` branch to register the module in `this.children`. After this PR the same intent is to remove the `else`, so both branches share the `$evaluateCommonJSModule` call. The merge is mechanical.
- #42362 changes how `overridableRequire` calls `$require`. No overlap in lines.
- #33804 makes `loaded` an own property of the module object. `mod.loaded = true` works the same with it.

Suites run on the debug build with the fix: all eight test files in `test/js/node/module/`, the four `test/js/bun/resolve/require-esm-*.test.ts` files, `import-query.test.ts`, `builtin-esm-lazy-exports.test.ts`, `test/js/bun/plugin/plugins.test.ts`, `test/js/bun/test/mock/mock-module.test.ts`, `test/cli/test/isolation.test.ts`, `test/cli/run/run-cjs.test.ts`, `test/regression/issue/require-extensions-override.test.ts`, `22929-module-extensions-asi.test.ts`, `09739.test.ts`, `30493.test.ts`, and Node's `test-module-children.js`, `test-module-circular-dependency-warning.js`, `test-module-loading-error.js`, `test-module-loading-deprecated.js`, `test-require-cache.js`, `test-require-extensions-main.js`, `test-require-extension-over-directory.js`, `test-module-circular-symlinks.js`.

`test/cli/run/require-cache.test.ts` has leak tests that exceed their time limits on the local debug ASAN build. A debug build of main without this change fails them the same way (`require-cache-bug-leak-fixture.js`: 172 MB without the fix, 168 MB with it, both over the 120 MB limit for a binary that is not named `bun-asan`). Those fixtures load CommonJS files only.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->

