### PR TITLE
Bun.gc(true) and gc() return what the collection freed to the OS before they return

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1462,6 +1462,16 @@ impl VirtualMachine {
         vm.heap_size()
     }
 
+    /// `Bun.gc(force)` and `gc()`. Whoever asks for a synchronous collection reads the footprint next: what the collection
+    /// freed goes back to the OS now, not whenever the allocator's purge delay has passed.
+    pub fn garbage_collect_from_js(&self, sync: bool) -> usize {
+        let size = self.garbage_collect(sync);
+        if sync {
+            bun_core::Global::mimalloc_cleanup(true);
+        }
+        size
+    }
+
     #[inline]
     pub fn auto_garbage_collect(&self) {
         if self.aggressive_garbage_collection != GCLevel::None {

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1032,7 +1032,7 @@ fn sleep_sync(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsResult
 
 // HOST_EXPORT(Bun__gc, c)
 pub fn gc(vm: &mut VirtualMachine, sync: bool) -> usize {
-    vm.garbage_collect(sync)
+    vm.garbage_collect_from_js(sync)
 }
 
 #[bun_jsc::host_fn]

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -404,7 +404,7 @@ pub fn bindgen_bunobject_dispatch_gc(
     // `garbage_collect(force)`: mimalloc cleanup, then sync `runGC(true)`
     // when `force`, else `collect_async()` + `heap_size()`.
     // SAFETY: bun_vm() never null for a Bun-owned global.
-    unsafe { *out = global.bun_vm().as_mut().garbage_collect(force) };
+    unsafe { *out = global.bun_vm().as_mut().garbage_collect_from_js(force) };
     true
 }
 

--- a/test/js/bun/gc/gc-controller-cadence.test.ts
+++ b/test/js/bun/gc/gc-controller-cadence.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux, tempDir } from "harness";
 
 // Bun's GarbageCollectionController used to sample `blockBytesAllocated +
 // extraMemorySize` on every event-loop tick and arm a 16 ms one-shot whenever
@@ -260,4 +260,31 @@ describe("idle release lets FTL code age out", () => {
     expect(after, stdout).toBeGreaterThan(before! / 2);
     expect(exitCode).toBe(0);
   });
+});
+
+// A leak test reads the footprint right after Bun.gc(true). The allocator hands freed pages back after a purge delay, on
+// its own thread, so what the collection had just freed was still resident then: 250 MB of dead typed arrays left RSS
+// where it was. MADV_FREE (macOS) and ASAN's allocator do not show in RSS either way.
+test.skipIf(!isLinux || isASAN)("Bun.gc(true) returns what it freed to the OS before it returns", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const rss = () => process.memoryUsage.rss() / 1048576;
+        let arrays = [];
+        for (let i = 0; i < 2000; i++) arrays.push(new Uint8Array(128 * 1024).fill(1));
+        const held = rss();
+        arrays = null;
+        Bun.gc(true);
+        console.log(JSON.stringify({ released: held - rss() }));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(JSON.parse(stdout).released).toBeGreaterThan(200);
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## What

`Bun.gc(true)` and the global `gc()` follow the synchronous collection with `mi_collect(true)`.
`VirtualMachine::garbage_collect()` keeps its `mi_collect(false)` before the collection; the two JS-visible entry points go
through a new `garbage_collect_from_js()` that adds the forced collect afterwards. The collections the runtime decides on
itself (the GC controller's, `--smol`'s) are unchanged.

Files: `src/jsc/VirtualMachine.rs`, `src/runtime/api/BunObject.rs`, `src/runtime/hw_exports.rs`,
`test/js/bun/gc/gc-controller-cadence.test.ts` (one test).

## Why

`garbage_collect()` ran `mi_collect(false)` *before* the collection, so nothing the collection freed was looked at by it, and
mimalloc hands free pages back to the OS after a purge delay, on its own thread. Whoever asks for a synchronous collection reads
the footprint next: every RSS-delta leak test does. It saw what was live plus whatever had been freed over the last purge delay.

```js
let a = [];
for (let i = 0; i < 2000; i++) a.push(new Uint8Array(128 * 1024).fill(1));
a = null;
Bun.gc(true); // RSS 280 MB before and after; 30 MB after with this change
```

Three collections in a row do not lower it; 300 ms of doing nothing does; `MIMALLOC_PURGE_DELAY=0` does. It is memory the
allocator has already been given back, not memory anything holds.

`test/cli/run/require-cache.test.ts` measures exactly that lag. Its fixtures re-evaluate a module a few hundred times, each
evaluation leaves a few MB of garbage, and RSS after the closing `Bun.gc(true)` depends on when the purge thread last ran.

| fixture run on its own (12-24 runs, RSS delta in MB, the test's limit is 64 or 100) | main | this branch |
|---|---|---|
| via require() with a lot of long export names | -7..16 | 1..24 |
| via require() with a lot of function calls | -5..7 | -1..2 |
| via await import() with a lot of function calls | 0..11 | 0..3 |
| via import() with a lot of long export names | -45..167, over the limit in 17 of 24 | -71..40, and 221 in 1 of 12 |

The last fixture imports through the transpiler's worker threads, whose heaps this thread's `mi_collect` does not reach; that
is what is left of its spread.

## Test

`Bun.gc(true) returns what it freed to the OS before it returns`: a child allocates 250 MB of typed arrays, drops them, calls
`Bun.gc(true)` and reports how far RSS fell; more than 200 MB expected (Linux, not ASAN: MADV_FREE and ASAN's allocator do
not show in RSS either way). Fails on main (released: -0.5 MB), passes here (250 MB).
`test/cli/run/require-cache.test.ts`: 16 of 16, three runs.
