### PR TITLE
jsx: make the key-after-spread warning follow the @jsxRuntime pragma

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -173,7 +173,6 @@ pub(crate) struct ParserSnapshot<'a> {
     log_warnings: u32,
     allow_in: bool,
     allow_private_identifiers: bool,
-    has_classic_runtime_warned: bool,
     has_non_local_export_declare_inside_namespace: bool,
     should_fold_typescript_constant_expressions: bool,
     fn_or_arrow_data_parse: FnOrArrowDataParse,
@@ -8296,7 +8295,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             log_warnings: log.warnings,
             allow_in: self.allow_in,
             allow_private_identifiers: self.allow_private_identifiers,
-            has_classic_runtime_warned: self.has_classic_runtime_warned,
             has_non_local_export_declare_inside_namespace: self
                 .has_non_local_export_declare_inside_namespace,
             should_fold_typescript_constant_expressions: self
@@ -8330,7 +8328,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         self.allow_in = snapshot.allow_in;
         self.allow_private_identifiers = snapshot.allow_private_identifiers;
-        self.has_classic_runtime_warned = snapshot.has_classic_runtime_warned;
         self.has_non_local_export_declare_inside_namespace =
             snapshot.has_non_local_export_declare_inside_namespace;
         self.should_fold_typescript_constant_expressions =

--- a/src/js_parser/parse/parse_jsx.rs
+++ b/src/js_parser/parse/parse_jsx.rs
@@ -1,7 +1,7 @@
 #![warn(unused_must_use)]
 use crate::lexer::T;
 use crate::p::P;
-use crate::parser::{JSXTag, options};
+use crate::parser::JSXTag;
 use bun_ast::expr::Data as ExprData;
 use bun_ast::flags;
 use bun_ast::op::Level;
@@ -41,7 +41,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             start_tag = Some(t);
             can_be_inlined = p.options.features.jsx_optimization_inline;
 
-            let mut spread_loc: bun_ast::Loc = bun_ast::Loc::EMPTY;
             let mut props: Vec<G::Property> = Vec::new();
             let mut first_spread_prop_i: i32 = -1;
             let mut i: i32 = 0;
@@ -114,7 +113,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 if first_spread_prop_i == -1 {
                                     first_spread_prop_i = i;
                                 }
-                                spread_loc = p.lexer.loc();
                                 let value = p.parse_expr(Level::Comma)?;
                                 props.push(G::Property {
                                     value: Some(value),
@@ -220,17 +218,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 flags.insert(flags::JSXElement::IsKeyAfterSpread);
             }
             properties = G::PropertyList::move_from_list(props);
-            if is_key_after_spread
-                && p.options.jsx.runtime == options::JSXRuntime::Automatic
-                && !p.has_classic_runtime_warned
-            {
-                p.log().add_warning(
-                    Some(p.source),
-                    spread_loc,
-                    b"\"key\" prop after a {...spread} is deprecated in JSX. Falling back to classic runtime.",
-                );
-                p.has_classic_runtime_warned = true;
-            }
         }
 
         // People sometimes try to use the output of "JSON.stringify()" as a JSX

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -367,6 +367,35 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     break 'tagger p.jsx_import(JSXImport::Fragment, expr.loc);
                 };
 
+                let runtime = if p.options.jsx.runtime == options::JSX::Runtime::Automatic {
+                    options::JSX::Runtime::Automatic
+                } else {
+                    options::JSX::Runtime::Classic
+                };
+                let is_key_after_spread = e_.flags.contains(Flags::JSXElement::IsKeyAfterSpread);
+
+                // Not in the parse pass: a `@jsxRuntime` pragma, anywhere in the file,
+                // reaches `options.jsx.runtime` only in `prepare_for_visit_pass`.
+                if is_key_after_spread
+                    && runtime == options::JSX::Runtime::Automatic
+                    && !p.has_classic_runtime_warned
+                {
+                    p.has_classic_runtime_warned = true;
+                    let spread_loc = e_
+                        .properties
+                        .slice()
+                        .iter()
+                        .rev()
+                        .find(|property| property.kind == G::PropertyKind::Spread)
+                        .and_then(|property| property.value)
+                        .map_or(expr.loc, |value| value.loc);
+                    p.log().add_warning(
+                        Some(p.source),
+                        spread_loc,
+                        b"\"key\" prop after a {...spread} is deprecated in JSX. Falling back to classic runtime.",
+                    );
+                }
+
                 for property in e_.properties.slice_mut() {
                     if property.kind != G::PropertyKind::Spread {
                         p.visit_expr(property.key.as_mut().expect("infallible: prop has key"));
@@ -381,12 +410,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
 
-                let runtime = if p.options.jsx.runtime == options::JSX::Runtime::Automatic {
-                    options::JSX::Runtime::Automatic
-                } else {
-                    options::JSX::Runtime::Classic
-                };
-                let is_key_after_spread = e_.flags.contains(Flags::JSXElement::IsKeyAfterSpread);
                 let children_count = e_.children.len_u32();
 
                 // TODO: maybe we should split these into two different AST Nodes

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -385,6 +385,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         .properties
                         .slice()
                         .iter()
+                        .take(e_.key_prop_index as u32 as usize)
                         .rev()
                         .find(|property| property.kind == G::PropertyKind::Spread)
                         .and_then(|property| property.value)

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -374,8 +374,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 };
                 let is_key_after_spread = e_.flags.contains(Flags::JSXElement::IsKeyAfterSpread);
 
-                // Not in the parse pass: a `@jsxRuntime` pragma, anywhere in the file,
-                // reaches `options.jsx.runtime` only in `prepare_for_visit_pass`.
                 if is_key_after_spread
                     && runtime == options::JSX::Runtime::Automatic
                     && !p.has_classic_runtime_warned

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { join } from "node:path";
 import { BundlerTestInput, itBundled } from "./expectBundled";
 
 const helpers = {
@@ -424,6 +425,18 @@ describe("bundler", () => {
       jsx: { runtime: "classic" },
       bundleWarnings: { "/index.jsx": [warning] },
       run: { stdout: `["react","div",{"a":1,"key":"k"},[]]` },
+    });
+
+    test("the warning points at the spread before the key", async () => {
+      const source = `export const el = <div {...first} key="k" {...last} />;`;
+      using dir = tempDir("jsx-key-after-spread-location", { "index.jsx": source });
+      const build = await Bun.build({
+        entrypoints: [join(String(dir), "index.jsx")],
+        external: ["react", "react/*"],
+      });
+      expect(build.logs.map(({ message, position }) => ({ message, offset: position?.offset }))).toEqual([
+        { message: warning, offset: source.indexOf("first") },
+      ]);
     });
   });
   itBundledDevAndProd("jsx/PragmaMultiple", {

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -361,6 +361,71 @@ describe("bundler", () => {
       `,
     },
   });
+  // `<div {...props} key="k" />` makes the automatic runtime fall back to
+  // createElement, with a warning. The runtime that decides this is the one in
+  // effect after the @jsxRuntime pragma is applied, and a pragma applies to the
+  // whole file from any position in it.
+  describe("keyAfterSpreadWarning", () => {
+    const keyAfterSpread = /* js */ `
+      import { print } from 'bun-test-helpers'
+      const props = { a: 1 }
+      print(<div {...props} key="k" />)
+    `;
+    const warning = '"key" prop after a {...spread} is deprecated in JSX. Falling back to classic runtime.';
+
+    itBundled("jsx/KeyAfterSpreadClassicPragmaNoWarning", {
+      files: {
+        "/index.jsx": `
+          /** @jsxRuntime classic */
+          import * as React from 'custom-classic'
+          ${keyAfterSpread}
+        `,
+        ...helpers,
+      },
+      target: "bun",
+      bundleWarnings: {},
+      run: { stdout: `["custom-classic","div",{"a":1,"key":"k"},[]]` },
+    });
+    itBundled("jsx/KeyAfterSpreadClassicPragmaAfterJsxNoWarning", {
+      files: {
+        "/index.jsx": `
+          import * as React from 'custom-classic'
+          ${keyAfterSpread}
+          /** @jsxRuntime classic */
+        `,
+        ...helpers,
+      },
+      target: "bun",
+      bundleWarnings: {},
+      run: { stdout: `["custom-classic","div",{"a":1,"key":"k"},[]]` },
+    });
+    itBundled("jsx/KeyAfterSpreadAutomaticPragmaWarns", {
+      files: {
+        "/index.jsx": `
+          /** @jsxRuntime automatic */
+          ${keyAfterSpread}
+        `,
+        ...helpers,
+      },
+      target: "bun",
+      jsx: { runtime: "classic" },
+      bundleWarnings: { "/index.jsx": [warning] },
+      run: { stdout: `["react","div",{"a":1,"key":"k"},[]]` },
+    });
+    itBundled("jsx/KeyAfterSpreadAutomaticPragmaAfterJsxWarns", {
+      files: {
+        "/index.jsx": `
+          ${keyAfterSpread}
+          /** @jsxRuntime automatic */
+        `,
+        ...helpers,
+      },
+      target: "bun",
+      jsx: { runtime: "classic" },
+      bundleWarnings: { "/index.jsx": [warning] },
+      run: { stdout: `["react","div",{"a":1,"key":"k"},[]]` },
+    });
+  });
   itBundledDevAndProd("jsx/PragmaMultiple", {
     todo: true,
     files: {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2549,6 +2549,30 @@ console.log(<div {...obj} key="after" />);`),
     );
   });
 
+  // The key-after-spread warning is for the automatic runtime only. With the
+  // default log level a warning makes these calls throw.
+  it("JSX key after spread does not warn when a @jsxRuntime pragma selects classic", () => {
+    const transpiler = new Bun.Transpiler({ loader: "jsx" });
+    const jsx = `export const el = <div {...obj} key="after" />;`;
+    const output = `export const el = React.createElement("div", {\n  ...obj,\n  key: "after"\n});\n`;
+
+    for (const input of [`/** @jsxRuntime classic */\n${jsx}`, `${jsx}\n/** @jsxRuntime classic */`]) {
+      expect(transpiler.transformSync(input)).toBe(output);
+      expect(transpiler.scan(input)).toEqual({ exports: ["el"], imports: [] });
+    }
+  });
+
+  // scanImports runs the parse pass only. It does not transform the JSX, so it
+  // has no fallback to warn about, with any runtime.
+  it("scanImports does not throw on a JSX key after spread", () => {
+    const transpiler = new Bun.Transpiler({ loader: "jsx" });
+    const jsx = `import { obj } from "./obj";\nexport const el = <div {...obj} key="after" />;`;
+
+    for (const input of [jsx, `/** @jsxRuntime classic */\n${jsx}`]) {
+      expect(transpiler.scanImports(input)).toContainEqual({ kind: "import-statement", path: "./obj" });
+    }
+  });
+
   // Non-bundle transpile without `minify.identifiers` uses NoOpRenamer
   // (prints symbol.original_name verbatim), so the `generatedSymbolName`
   // hash suffix on the automatic JSX runtime import is the sole collision

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2549,28 +2549,31 @@ console.log(<div {...obj} key="after" />);`),
     );
   });
 
-  // The key-after-spread warning is for the automatic runtime only. With the
-  // default log level a warning makes these calls throw.
-  it("JSX key after spread does not warn when a @jsxRuntime pragma selects classic", () => {
-    const transpiler = new Bun.Transpiler({ loader: "jsx" });
+  describe("JSX key after spread", () => {
     const jsx = `export const el = <div {...obj} key="after" />;`;
-    const output = `export const el = React.createElement("div", {\n  ...obj,\n  key: "after"\n});\n`;
 
-    for (const input of [`/** @jsxRuntime classic */\n${jsx}`, `${jsx}\n/** @jsxRuntime classic */`]) {
-      expect(transpiler.transformSync(input)).toBe(output);
+    // The warning is for the automatic runtime only. With the default log
+    // level a warning makes these calls throw.
+    it.each([
+      ["before the JSX", `/** @jsxRuntime classic */\n${jsx}`],
+      ["after the JSX", `${jsx}\n/** @jsxRuntime classic */`],
+    ])("does not warn with a @jsxRuntime classic pragma %s", (_, input) => {
+      const transpiler = new Bun.Transpiler({ loader: "jsx" });
+      expect(transpiler.transformSync(input)).toBe(
+        `export const el = React.createElement("div", {\n  ...obj,\n  key: "after"\n});\n`,
+      );
       expect(transpiler.scan(input)).toEqual({ exports: ["el"], imports: [] });
-    }
-  });
+    });
 
-  // scanImports runs the parse pass only. It does not transform the JSX, so it
-  // has no fallback to warn about, with any runtime.
-  it("scanImports does not throw on a JSX key after spread", () => {
-    const transpiler = new Bun.Transpiler({ loader: "jsx" });
-    const jsx = `import { obj } from "./obj";\nexport const el = <div {...obj} key="after" />;`;
-
-    for (const input of [jsx, `/** @jsxRuntime classic */\n${jsx}`]) {
+    // scanImports runs the parse pass only. It does not transform the JSX, so it
+    // has no fallback to warn about, with any runtime.
+    it.each([
+      ["the automatic runtime", `import { obj } from "./obj";\n${jsx}`],
+      ["a @jsxRuntime classic pragma", `/** @jsxRuntime classic */\nimport { obj } from "./obj";\n${jsx}`],
+    ])("scanImports does not throw with %s", (_, input) => {
+      const transpiler = new Bun.Transpiler({ loader: "jsx" });
       expect(transpiler.scanImports(input)).toContainEqual({ kind: "import-statement", path: "./obj" });
-    }
+    });
   });
 
   // Non-bundle transpile without `minify.identifiers` uses NoOpRenamer


### PR DESCRIPTION
### Problem
- A file with `/** @jsxRuntime classic */` gets `warn: "key" prop after a {...spread} is deprecated in JSX. Falling back to classic runtime.` for `<p {...p} key={k} />`. It is already classic, so nothing falls back. The reverse is silent: `--jsx-runtime=classic` plus `/** @jsxRuntime automatic */` falls back to `createElement` with no warning.
- `bun build`, `Bun.build` logs and `Bun.Transpiler` show it. `Bun.Transpiler` throws on a warning (#42427). Found by inspection, no user report.
- Cause: the parse pass warned from `options.jsx.runtime` (`src/js_parser/parse/parse_jsx.rs:223`). The pragma reaches that option later, in `prepare_for_visit_pass` (`src/js_parser/p.rs:3371`).

### Fix
- The visit pass emits the warning (`e_jsx_element` in `src/js_parser/visit/visit_expr.rs`), where the fallback happens. The runtime is final there.
- The text, the once-per-file limit, the location (last spread prop) and the emitted code do not change.
- `Bun.Transpiler`: `transformSync` and `scan` now throw the warning for a classic config plus `@jsxRuntime automatic`. `scanImports` only parses, and no longer throws it.
- Verified: `test/bundler/bundler_jsx.test.ts` (4 new) and `test/bundler/transpiler/transpiler.test.js` (2 new). All 6 fail on bun 1.4.3. Also `react-compiler.test.ts`, `cli.test.ts`, `bun-build-api.test.ts`.

### Background
- Automatic runtime: `jsx(type, props, key)`. Classic runtime: `React.createElement(type, props, ...children)`, with `key` inside `props`.
- With a spread before `key`, `jsx()` cannot tell which `key` wins. Bun, Babel, TypeScript and esbuild compile that element with `createElement`. Bun also warns.
- A `@jsxRuntime` comment sets the runtime for one file. The lexer records it from any comment.
- The parse pass builds the AST. The visit pass lowers JSX to calls.

<details><summary>Notes</summary>

**`bun build`, 1.4.3 and this PR**

| configured runtime | `@jsxRuntime` pragma | 1.4.3 | this PR |
| --- | --- | --- | --- |
| automatic | none | warns | warns |
| automatic | `classic`, before or after the JSX | warns | no warning |
| classic | none | no warning | no warning |
| classic | `automatic`, before or after the JSX | falls back, no warning | warns |

```jsx
// w.jsx
/** @jsxRuntime classic */
import React from "react";
export const x = (p, k) => <p {...p} key={k}>x</p>;
```

```
$ bun build --external react w.jsx
... React.createElement("p", { ...p, key: k }, "x") ...
warn: "key" prop after a {...spread} is deprecated in JSX. Falling back to classic runtime.
   at w.jsx:3:35
```

`bun run` does not print parser warnings, so it never showed this one.

**Not changed by this PR**

- `Bun.Transpiler` throws when the log holds a warning: #42427.
- `scan()` and `scanImports()` ignore `logLevel`: #42426.
- `codegen_jsx_expression` in `src/react_compiler/codegen.rs` (#42389) finds "key after a spread" again in its own IR and emits `createElement` with no warning. It also matches shapes that the parser flag does not cover (the `{key}` shorthand, a collapsed `{...{ ...x, key: k }}`). It never warned and it reads the final runtime, so it is not the same defect. Excluded on purpose.
- #35557 changes the JSX records that `scanImports` reports. The new `scanImports` test asserts only the import that the file itself has, so the two PRs can merge in any order.
- #20435 (`jsx: preserve`) edits the same condition in `e_jsx_element`. The PR that lands second needs a rebase. In both, the warning belongs to the `runtime == Automatic && is_key_after_spread` case.

**Why the parse pass cannot read `lexer.jsx_pragma`**

The lexer records pragmas from every comment, and the last one wins. A pragma after the JSX sets the runtime of the whole file, and the parse pass has not seen it when it parses the element. On 1.4.3, a file that ends with `/** @jsxRuntime classic */` compiles to `React.createElement` and still warns. The two `...PragmaAfterJsx...` tests cover this.

**Location of the warning**

- The value of the last spread prop of the element, as before. The visit pass reads it before it visits the props, because a visit can replace an expression.
- `{...(a)}` now points at `a` and not at `(`, one column to the right. A parenthesized expression keeps the location of its inner expression.
- When an element with key after spread sits inside a prop of another such element, the one warning per file now names the outer element. It named the inner one before.

**`scanImports`**

`scanImports` runs the parse pass only (`_scan_imports`). `prepare_for_visit_pass` does not run there, so no pragma applies, and nothing transforms the JSX. The report in #7328 met this warning as a throw from `scanImports`.

**`has_classic_runtime_warned`**

The parse pass no longer writes this field. `ParserSnapshot` undoes parse-pass writes after a speculative parse, so the field leaves the snapshot. The visit pass does not backtrack.

**Suites run with the debug build**

`bundler_jsx.test.ts`, `transpiler.test.js`, `react-compiler.test.ts`, `jsx-production.test.ts`, `jsx-tsconfig-react-jsx.test.ts`, `jsx-deep-nesting-stack-overflow.test.ts`, `jsx-namespaced-attributes.test.ts`, `jsx-symbol-collision.test.ts`, `cli.test.ts -t "warnings dont return exit code 1"`, `bun-build-api.test.ts -t "warnings do not fail a build"`, `esbuild/default.test.ts -t JSX`, `esbuild/loader.test.ts -t JSX`. `cargo clippy -p bun_js_parser` is clean.

Self-reviewed: the review asked for a rebase over #42389, a `scanImports` assertion, the `bundleWarnings: {}` idiom in the tests, and the "Not changed" list above. All are done.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 failed, 27 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_jsx.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (6a92015fc)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1415.73ms]
(pass) bundler > jsx/AutomaticProd [1076.81ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [1082.59ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [903.21ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [964.35ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [930.81ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [389.21ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [342.50ms]
(pass) bundler > jsx/ImportSourceDev [882.30ms]
(todo) bundler > jsx/ImportSourceProd
(pass) bundler > jsx/ClassicDev [875.92ms]
(pass) bundler > jsx/ClassicProd [781.78ms]
(pass) bundler > jsx/ClassicPragmaDev [751.65ms]
(pass) bundler > jsx/ClassicPragmaProd [743.51ms]
1188 |               warningsLeft.splice(i, 1);
1189 |             }
1190
... (truncated)

release without fix: 27 skipped
bun test v1.4.3-canary.1 (155c8780c)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [25.31ms]
(pass) bundler > jsx/AutomaticProd [14.16ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [19.93ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [14.03ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [19.29ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [15.64ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [6.91ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [6.51ms]
(pass) bundler > jsx/ImportSourceDev [13.59ms]
(todo) bundler > jsx/ImportSourceProd
(pass) bundler > jsx/ClassicDev [13.49ms]
(pass) bundler > jsx/ClassicProd [14.74ms]
(pass) bundler > jsx/ClassicPragmaDev [19.23ms]
(pass) bundler > jsx/ClassicPragmaProd [19.63ms]
(pass) bundler > keyAfterSpreadWarning > jsx/KeyAfterSpreadClassicPragmaNoWarning [16.85ms]
(pass) bundler > keyAfterSpreadWarning > jsx/KeyAfterSpreadClassicPragmaAfterJsxNoWarning [15.96ms]
(pass) bundler > keyAfterSpreadWarning > jsx/KeyAfterSpreadAutomaticPragmaWarns [18.83ms]
(pass) b
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 27 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_jsx.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (6a92015fc)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1415.13ms]
(pass) bundler > jsx/AutomaticProd [920.00ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [834.95ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [952.68ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [906.47ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [983.92ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [327.86ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [417.33ms]
(pass) bundler > jsx/ImportSourceDev [735.09ms]
(todo) bundler > jsx/ImportSourceProd
(pass) bundler > jsx/ClassicDev [773.46ms]
(pass) bundler > jsx/ClassicProd [704.94ms]
(pass) bundler > jsx/ClassicPragmaDev [737.39ms]
(pass) bundler > jsx/ClassicPragmaProd [849.57ms]
(pass) bundler > keyAfterSpreadWarning > jsx/KeyAfterSpreadClassicPragmaNoW
... (truncated)

release with fix: 27 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 957ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/124] gen cpp.rs (cppbind)
[2/124] gen JS modules (bundle-modules)
Preprocess modules (10614ms)
Bundle modules (101ms)
Postprocesss modules (190ms)
Bundle Functions (634ms)
Generate Code (47ms)

[11.60s] Bundled "src/js" for production
  2600 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                         |  3 --
 src/js_parser/parse/parse_jsx.rs           | 15 +-----
 src/js_parser/visit/visit_expr.rs          | 34 ++++++++++---
 test/bundler/bundler_jsx.test.ts           | 78 ++++++++++++++++++++++++++++++
 test/bundler/transpiler/transpiler.test.js | 27 +++++++++++
 5 files changed, 134 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/p.rs                              1      0     32
src/js_parser/parse/parse_jsx.rs                1      1     32
src/js_parser/visit/visit_expr.rs               4      4     32
test/bundler/bundler_jsx.test.ts                2      1     25
test/bundler/transpiler/transpiler.test.js      1      1     18
```

</details>

<!-- robobun:evidence:end -->