### PR TITLE
Honor logLevel in Bun.Transpiler scan() and scanImports()

### DIFF
--- a/src/bundler/cache.rs
+++ b/src/bundler/cache.rs
@@ -126,6 +126,7 @@ impl JavaScript {
         }
 
         let mut temp_log = bun_ast::Log::init();
+        temp_log.level = log.level;
         // scopeguard cannot capture &mut temp_log while it's used below;
         // explicit `append_to_maybe_recycled` calls at each exit.
 

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -1287,6 +1287,7 @@ impl JSTranspiler {
 
         let arena = Arena::new();
         let mut log = bun_ast::Log::init();
+        log.level = self.config.get().log.level;
         // SAFETY: `arena` outlives every use through `self.transpiler` in this fn body;
         // `_restore` (declared after `arena`/`log`, so dropped first) restores
         // `prev_arena` and `&self.config.log` before either local drops.
@@ -1641,6 +1642,7 @@ impl JSTranspiler {
 
         let arena = Arena::new();
         let mut log = bun_ast::Log::init();
+        log.level = self.config.get().log.level;
         // SAFETY: `arena` outlives every use through `self.transpiler` in this fn body;
         // `_restore` (declared after `arena`/`log`, so dropped first) restores
         // `prev_arena` and `&self.config.log` before either local drops.

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2437,6 +2437,15 @@ export default <>hi</>
     expect(() => bun.transformSync("bad??!?!?!")).toThrow("Unexpected ?");
   });
 
+  it('logLevel: "error" drops warnings in scan and scanImports', () => {
+    const bun = new Bun.Transpiler({ loader: "js", logLevel: "error" });
+    const src = 'import "./a";\nx = 1\n--> legacy html comment\ny = 2\n';
+
+    expect(bun.transformSync(src)).toContain("x = 1");
+    expect(bun.scan(src)).toEqual({ exports: [], imports: [{ kind: "import-statement", path: "./a" }] });
+    expect(bun.scanImports(src)).toEqual([{ kind: "import-statement", path: "./a" }]);
+  });
+
   it("invalid logLevel throws", () => {
     expect(
       () =>


### PR DESCRIPTION
### Problem
- `new Bun.Transpiler({ logLevel: "error" })` stops `transformSync()` from throwing on a parser warning. `scan()` and `scanImports()` still throw `BuildMessage: Treating "-->" as the start of a legacy HTML single-line comment`.
- `scan` and `scan_imports` in `src/runtime/api/JSTranspiler.rs` create a `Log` with the default level. The warning is counted, and the method throws the log because `warnings + errors > 0`. `bun_bundler::cache::JavaScript::scan` (`src/bundler/cache.rs:128`) also makes a temp log without the level, so `scanImports` needs that fix too.

### Fix
- Copy `config.log.level` into the per-call log in `scan` and `scan_imports`, as `transform_sync` and `TransformTask::create` already do.
- Copy `log.level` into the temp log in `cache::JavaScript::scan`, as `cache::JavaScript::parse` already does.
- With the level set to `error`, `Log::add_warning` drops the warning before it is counted, so the call returns the scan result.
- Verified: `test/bundler/transpiler/transpiler.test.js` (new test, fails on stock bun). The full file passes.

### Background
- `Log` (`bun_ast`) collects parser messages. `level` filters messages below it at add time. Counts (`warnings`, `errors`) only include messages that pass the filter.
- The bundler cache scan pass parses into a temp log and appends it to the caller's log at exit. The temp log needs the same level or the filter does not apply.

Fixes #42426

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [6.95ms]
(pass) Bun.Transpiler > normalizes \r\n [11.98ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [6.33ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [14.82ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [4.70ms]
(pass) Bun.Transpiler > property access inlining > works [5.19ms]
(pass) Bun.Transpiler > property access inlining > works nested [5.15ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [91.00ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [39.68ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [452.75ms]
(pass) Bun.Transpiler > property access inlining > bails out on optiona
... (truncated)

release without fix: 1 failed, 22 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.16ms]
(pass) Bun.Transpiler > normalizes \r\n [0.28ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.12ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.18ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.06ms]
(pass) Bun.Transpiler > property access inlining > works [0.06ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.04ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [1.21ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.39ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [8.29ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.72ms]
(pass) Bun.Transpiler > property access inlining > template literal around an inlined string enum member > member as the first part of the 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [10.01ms]
(pass) Bun.Transpiler > normalizes \r\n [11.89ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [8.04ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [14.68ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [4.92ms]
(pass) Bun.Transpiler > property access inlining > works [5.94ms]
(pass) Bun.Transpiler > property access inlining > works nested [5.56ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [94.37ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [42.30ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [329.28ms]
(pass) Bun.Transpiler > property access inlining > bails out on option
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 755ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/122] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/122] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/cache.rs                       | 1 +
 src/runtime/api/JSTranspiler.rs            | 2 ++
 test/bundler/transpiler/transpiler.test.js | 9 +++++++++
 3 files changed, 12 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/bundler/cache.rs                            1      1      5
src/runtime/api/JSTranspiler.rs                 2      0      5
test/bundler/transpiler/transpiler.test.js      1      1      5
```

</details>

**root cause** · written by the author bot

`scan()` and `scanImports()` in `src/runtime/api/JSTranspiler.rs`, along with the bundler cache's `JavaScript::scan` in `src/bundler/cache.rs`, each created a fresh per-call `Log` and left it at the default level instead of copying the transpiler's configured `log.level`, so parser warnings were counted and then thrown as a `BuildMessage` even when `logLevel: "error"` was set. The fix copies the configured level into each of those temporary logs, matching the existing pattern in `transform_sync` and `TransformTask::create`, so `add_warning` returns early at the error level and the scan meth…

<!-- robobun:evidence:end -->