### PR TITLE
Remove dead code from the WebCore, node, and sqlite bindings, uWS/uSockets, SecretsLinux, and five Rust crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,7 +1094,6 @@ dependencies = [
  "bun_errno",
  "bun_simdutf_sys",
  "const_format",
- "libc",
  "strum",
  "thiserror",
 ]

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -505,10 +505,6 @@ struct us_listen_socket_t *us_listen_socket_next(struct us_listen_socket_t *ls) 
     return ls->next;
 }
 
-LIBUS_SOCKET_DESCRIPTOR us_listen_socket_get_fd(struct us_listen_socket_t *ls) {
-    return us_poll_fd(&ls->s.p);
-}
-
 int us_listen_socket_port(struct us_listen_socket_t *ls) {
     return us_socket_local_port(&ls->s);
 }

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -709,7 +709,6 @@ struct us_socket_t *us_socket_detach(us_socket_r s) nonnull_fn_decl;
 int us_socket_ipc_write_fd(us_socket_r s, const char *data, int length, int fd) nonnull_fn_decl;
 void us_socket_sendfile_needs_more(us_socket_r s) nonnull_fn_decl;
 void *us_listen_socket_ext(struct us_listen_socket_t *ls) nonnull_fn_decl;
-LIBUS_SOCKET_DESCRIPTOR us_listen_socket_get_fd(struct us_listen_socket_t *ls) nonnull_fn_decl;
 int us_listen_socket_port(struct us_listen_socket_t *ls) nonnull_fn_decl;
 struct us_socket_group_t *us_listen_socket_group(struct us_listen_socket_t *ls) nonnull_fn_decl;
 /* Walk a group's live listeners. The list is the source of truth — anything
@@ -720,10 +719,8 @@ struct us_listen_socket_t *us_listen_socket_next(struct us_listen_socket_t *ls) 
 LIBUS_SOCKET_DESCRIPTOR us_socket_get_fd(us_socket_r s) nonnull_fn_decl;
 
 /* Bun extras */
-struct us_socket_t *us_socket_pair(us_socket_group_r group, unsigned char kind, int socket_ext_size, LIBUS_SOCKET_DESCRIPTOR *fds) nonnull_fn_decl;
 struct us_socket_t *us_socket_from_fd(us_socket_group_r group, unsigned char kind, struct ssl_ctx_st *ssl_ctx, int socket_ext_size, LIBUS_SOCKET_DESCRIPTOR fd, int options, int ipc)
     __attribute__((nonnull(1)));  /* ssl_ctx nullable */
-struct us_socket_t *us_socket_open(struct us_socket_t *s, int is_client, char *ip, int ip_length);
 /* The bundled Mozilla root certificates, DER-encoded, in static memory. Returns the count. */
 size_t us_bundled_root_certs_der(const uint8_t *const **out_certs, const size_t **out_lens);
 unsigned int us_get_remote_address_info(char *buf, us_socket_r s, const char **dest, int *port, int *is_ipv6);

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -1136,8 +1136,6 @@ void us_quic_socket_remote_address(us_quic_socket_t *s, char *buf, int *len, int
     }
 }
 
-void us_quic_socket_close(us_quic_socket_t *s) { if (s->conn) lsquic_conn_close(s->conn); }
-
 /* ───── client ─────
  *
  * lsquic only installs its own SSL_CTX_set_custom_verify when ea_get_ssl_ctx

--- a/packages/bun-usockets/src/quic.h
+++ b/packages/bun-usockets/src/quic.h
@@ -165,7 +165,6 @@ const struct us_quic_header_t *us_quic_stream_header(us_quic_stream_t *s, unsign
 void *us_quic_socket_ext(us_quic_socket_t *s);
 us_quic_socket_context_t *us_quic_socket_context(us_quic_socket_t *s);
 void us_quic_socket_remote_address(us_quic_socket_t *s, char *buf, int *len, int *port, int *is_ipv6);
-void us_quic_socket_close(us_quic_socket_t *s);
 
 #ifdef __cplusplus
 }

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -394,18 +394,6 @@ struct us_socket_t *us_socket_detach(struct us_socket_t *s) {
     return s;
 }
 
-struct us_socket_t *us_socket_pair(struct us_socket_group_t *group, unsigned char kind, int socket_ext_size, LIBUS_SOCKET_DESCRIPTOR *fds) {
-#if defined(LIBUS_USE_LIBUV) || defined(WIN32)
-    return 0;
-#else
-    if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds) != 0) {
-        return 0;
-    }
-
-    return us_socket_from_fd(group, kind, NULL, socket_ext_size, fds[0], 0, 0);
-#endif
-}
-
 /* Re-arm writable for a backpressured write without resuming the read side of
  * a paused socket: us_poll_change sets absolute flags, so including READABLE
  * unconditionally would silently undo us_socket_pause mid-backpressure and
@@ -750,13 +738,6 @@ int us_connecting_socket_get_error(struct us_connecting_socket_t *c) {
 
 int us_connecting_socket_get_dns_error(struct us_connecting_socket_t *c) {
     return c->error_is_dns ? c->error : 0;
-}
-
-struct us_socket_t *us_socket_open(struct us_socket_t *s, int is_client, char *ip, int ip_length) {
-    if (s->ssl) {
-        return us_internal_ssl_on_open(s, is_client, ip, ip_length);
-    }
-    return us_dispatch_open(s, is_client, ip, ip_length);
 }
 
 unsigned int us_get_remote_address_info(char *buf, struct us_socket_t *s, const char **dest, int *port, int *is_ipv6)

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -737,12 +737,6 @@ public:
         return std::move(*this);
     }
 
-    /* Port, callback */
-    TemplatedApp &&listen(int port, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler) {
-        handler(httpContext ? trackListenSocket(httpContext->listen(sslCtxOrNull(), nullptr, port, 0)) : nullptr);
-        return std::move(*this);
-    }
-
     /* Port, options, callback */
     TemplatedApp &&listen(int port, int options, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler) {
         handler(httpContext ? trackListenSocket(httpContext->listen(sslCtxOrNull(), nullptr, port, options)) : nullptr);
@@ -776,11 +770,6 @@ public:
     /* Switch this app into node:http compat mode (see HttpContext::enableNodeHttpCompat). */
     void enableNodeHttpCompat() {
         httpContext->enableNodeHttpCompat();
-    }
-
-    TemplatedApp &&run() {
-        uWS::run();
-        return std::move(*this);
     }
 
     TemplatedApp &&setUsingCustomExpectHandler(bool value) {

--- a/packages/bun-uws/src/Loop.h
+++ b/packages/bun-uws/src/Loop.h
@@ -19,7 +19,7 @@
 #ifndef UWS_LOOP_H
 #define UWS_LOOP_H
 
-/* The loop is lazily created per-thread and run with run() */
+/* The loop is lazily created per-thread */
 
 #include "LoopData.h"
 #include <libusockets.h>
@@ -189,17 +189,7 @@ public:
         us_wakeup_loop((us_loop_t *) this);
     }
 
-    /* Actively block and run this loop */
-    void run() {
-        us_loop_run((us_loop_t *) this);
-    }
-
 };
-
-/* Can be called from any thread to run the thread local loop */
-inline void run() {
-    Loop::get()->run();
-}
 
 }
 

--- a/scripts/azure.mjs
+++ b/scripts/azure.mjs
@@ -464,7 +464,7 @@ export const azure = {
    * @returns {Promise<import("./machine.mjs").Machine>}
    */
   async createMachine(options) {
-    const { os, arch, tags, sshKeys } = options;
+    const { os, arch, tags } = options;
     const vmName = `bun-${os}-${arch}-${Date.now()}`;
     const publicIpName = `${vmName}-ip`;
     const nicName = `${vmName}-nic`;

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -639,7 +639,7 @@ const aws = {
  * @returns {string}
  */
 export function getUserData(cloudInit) {
-  const { os, userData } = cloudInit;
+  const { os } = cloudInit;
 
   // For Windows, use PowerShell script
   if (os === "windows") {
@@ -656,7 +656,6 @@ export function getUserData(cloudInit) {
  */
 function getCloudInit(cloudInit) {
   const username = cloudInit["username"] || "root";
-  const password = cloudInit["password"] || crypto.randomUUID();
   const authorizedKeys = cloudInit["sshKeys"]?.map(({ publicKey }) => publicKey) || [];
 
   let sftpPath = "/usr/lib/openssh/sftp-server";
@@ -678,13 +677,6 @@ function getCloudInit(cloudInit) {
       break;
     default:
       throw new Error(`Unsupported os: ${cloudInit["os"]}`);
-  }
-
-  let users;
-  if (username === "root") {
-    users = [`root:${password}`];
-  } else {
-    users = [`root:${password}`, `${username}:${password}`];
   }
 
   // https://cloudinit.readthedocs.io/en/stable/

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1000,7 +1000,7 @@ async function runTests() {
             .replaceAll("\\", "/"),
         );
 
-      const { ok, error, stdout, crashes } = await startGroup(`${range} ${label}`, () =>
+      const { ok, stdout, crashes } = await startGroup(`${range} ${label}`, () =>
         spawnBun(execPath, {
           args: [
             "test",
@@ -2853,7 +2853,7 @@ function formatTestToMarkdown(result, concise, retries, unlisted = false) {
       if (!error) {
         continue;
       }
-      const { file, line } = error;
+      const { line } = error;
       if (line) {
         errorLine = line;
         break;
@@ -3111,7 +3111,7 @@ function generateJUnitReport(outfile, results) {
   const testSuites = new Map();
 
   for (const result of results) {
-    const { testPath, ok, status, error, tests, stdoutPreview, stdout, duration = 0 } = result;
+    const { testPath, status, error, tests, stdoutPreview, stdout, duration = 0 } = result;
 
     if (!testSuites.has(testPath)) {
       testSuites.set(testPath, {

--- a/scripts/tart.mjs
+++ b/scripts/tart.mjs
@@ -260,11 +260,6 @@ export const tart = {
       await spawnScp({ ...connectOptions, source, destination });
     };
 
-    const rdp = async () => {
-      const connectOptions = await connect();
-      await spawnRdp({ ...connectOptions });
-    };
-
     const close = async () => {
       await this.deleteVm(name);
     };

--- a/scripts/tart.mjs
+++ b/scripts/tart.mjs
@@ -260,6 +260,11 @@ export const tart = {
       await spawnScp({ ...connectOptions, source, destination });
     };
 
+    const rdp = async () => {
+      const connectOptions = await connect();
+      await spawnRdp({ ...connectOptions });
+    };
+
     const close = async () => {
       await this.deleteVm(name);
     };

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -608,9 +608,6 @@ bun_dispatch::link_interface! {
     pub ErrnoNames[Sys] {
         fn name(errno: i32) -> Option<&'static str>;
         fn max_dense() -> u32;
-        // Raw Win32 `GetLastError()` code → `SystemErrno` tag name.
-        // Always `None` on non-Windows.
-        fn win32_name(code: u32) -> Option<&'static str>;
     }
 }
 

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2739,7 +2739,18 @@ impl<'a> Transpiler<'a> {
         }
         self.options.transform_only = true;
 
-        self.process_resolve_queue(self.options.import_path_format)?;
+        // Only the main-thread transpiler reaches here; worker option clones
+        // carry `output_dir_handle: None` and would route output to stdout.
+        let outstream = match self
+            .options
+            .output_dir_handle
+            .as_ref()
+            .map(bun_sys::Dir::fd)
+        {
+            None => TransformOutstream::Stdout,
+            Some(output_dir) => TransformOutstream::Dir(output_dir),
+        };
+        self.process_resolve_queue(self.options.import_path_format, outstream)?;
 
         if bun_core::FeatureFlags::TRACING
             && self.options.log().level.at_least(bun_ast::Level::Info)
@@ -2767,6 +2778,7 @@ impl<'a> Transpiler<'a> {
     fn process_resolve_queue(
         &mut self,
         import_path_format: options::ImportPathFormat,
+        outstream: TransformOutstream,
     ) -> crate::Result<()> {
         while let Some(item) = self.resolve_queue.pop_front() {
             bun_ast::Expr::data_store_reset();
@@ -2774,30 +2786,34 @@ impl<'a> Transpiler<'a> {
             bun_ast::store_ast_alloc_heap::reset();
 
             let errors_before = self.log().errors;
-            let output_file =
-                match self.build_with_resolve_result_eager(&item, import_path_format, None) {
-                    Ok(Some(f)) => f,
-                    Ok(None) => continue,
-                    Err(err) => {
-                        // Print errors (unlike parse errors) add nothing to the
-                        // log, and an unlogged failure exits 0 with no output.
-                        if self.log().errors == errors_before {
-                            let path: &[u8] = item.path_const().map(|p| p.text).unwrap_or(b"");
-                            let message: &str = match err {
-                                crate::Error::JsPrinter(js_printer::Error::StackOverflow) => {
-                                    "Maximum call stack size exceeded while generating code for"
-                                }
-                                _ => "Failed to generate code for",
-                            };
-                            self.log_mut().add_error_fmt(
-                                None,
-                                bun_ast::Loc::EMPTY,
-                                format_args!("{} \"{}\"", message, bstr::BStr::new(path)),
-                            );
-                        }
-                        continue;
+            let output_file = match self.build_with_resolve_result_eager(
+                &item,
+                import_path_format,
+                outstream,
+                None,
+            ) {
+                Ok(Some(f)) => f,
+                Ok(None) => continue,
+                Err(err) => {
+                    // Print errors (unlike parse errors) add nothing to the
+                    // log, and an unlogged failure exits 0 with no output.
+                    if self.log().errors == errors_before {
+                        let path: &[u8] = item.path_const().map(|p| p.text).unwrap_or(b"");
+                        let message: &str = match err {
+                            crate::Error::JsPrinter(js_printer::Error::StackOverflow) => {
+                                "Maximum call stack size exceeded while generating code for"
+                            }
+                            _ => "Failed to generate code for",
+                        };
+                        self.log_mut().add_error_fmt(
+                            None,
+                            bun_ast::Loc::EMPTY,
+                            format_args!("{} \"{}\"", message, bstr::BStr::new(path)),
+                        );
                     }
-                };
+                    continue;
+                }
+            };
             self.output_files.push(output_file);
         }
         Ok(())
@@ -2859,6 +2875,7 @@ impl<'a> Transpiler<'a> {
         &mut self,
         resolve_result: &resolver::Result,
         import_path_format: options::ImportPathFormat,
+        _outstream: TransformOutstream,
         client_entry_point_: Option<&mut EntryPoints::ClientEntryPoint>,
     ) -> crate::Result<Option<options::OutputFile>> {
         if resolve_result.flags.is_external() {
@@ -3236,4 +3253,13 @@ impl<'a> Transpiler<'a> {
             },
         ))
     }
+}
+
+/// Outstream selector for `process_resolve_queue` /
+/// `build_with_resolve_result_eager` — a runtime enum since the only
+/// behavioural difference is unused (`_ = outstream`).
+#[derive(Clone, Copy)]
+enum TransformOutstream {
+    Stdout,
+    Dir(#[expect(dead_code)] bun_sys::Fd),
 }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -2739,18 +2739,7 @@ impl<'a> Transpiler<'a> {
         }
         self.options.transform_only = true;
 
-        // Only the main-thread transpiler reaches here; worker option clones
-        // carry `output_dir_handle: None` and would route output to stdout.
-        let outstream = match self
-            .options
-            .output_dir_handle
-            .as_ref()
-            .map(bun_sys::Dir::fd)
-        {
-            None => TransformOutstream::Stdout,
-            Some(output_dir) => TransformOutstream::Dir(output_dir),
-        };
-        self.process_resolve_queue(self.options.import_path_format, outstream)?;
+        self.process_resolve_queue(self.options.import_path_format)?;
 
         if bun_core::FeatureFlags::TRACING
             && self.options.log().level.at_least(bun_ast::Level::Info)
@@ -2778,7 +2767,6 @@ impl<'a> Transpiler<'a> {
     fn process_resolve_queue(
         &mut self,
         import_path_format: options::ImportPathFormat,
-        outstream: TransformOutstream,
     ) -> crate::Result<()> {
         while let Some(item) = self.resolve_queue.pop_front() {
             bun_ast::Expr::data_store_reset();
@@ -2786,34 +2774,30 @@ impl<'a> Transpiler<'a> {
             bun_ast::store_ast_alloc_heap::reset();
 
             let errors_before = self.log().errors;
-            let output_file = match self.build_with_resolve_result_eager(
-                &item,
-                import_path_format,
-                outstream,
-                None,
-            ) {
-                Ok(Some(f)) => f,
-                Ok(None) => continue,
-                Err(err) => {
-                    // Print errors (unlike parse errors) add nothing to the
-                    // log, and an unlogged failure exits 0 with no output.
-                    if self.log().errors == errors_before {
-                        let path: &[u8] = item.path_const().map(|p| p.text).unwrap_or(b"");
-                        let message: &str = match err {
-                            crate::Error::JsPrinter(js_printer::Error::StackOverflow) => {
-                                "Maximum call stack size exceeded while generating code for"
-                            }
-                            _ => "Failed to generate code for",
-                        };
-                        self.log_mut().add_error_fmt(
-                            None,
-                            bun_ast::Loc::EMPTY,
-                            format_args!("{} \"{}\"", message, bstr::BStr::new(path)),
-                        );
+            let output_file =
+                match self.build_with_resolve_result_eager(&item, import_path_format, None) {
+                    Ok(Some(f)) => f,
+                    Ok(None) => continue,
+                    Err(err) => {
+                        // Print errors (unlike parse errors) add nothing to the
+                        // log, and an unlogged failure exits 0 with no output.
+                        if self.log().errors == errors_before {
+                            let path: &[u8] = item.path_const().map(|p| p.text).unwrap_or(b"");
+                            let message: &str = match err {
+                                crate::Error::JsPrinter(js_printer::Error::StackOverflow) => {
+                                    "Maximum call stack size exceeded while generating code for"
+                                }
+                                _ => "Failed to generate code for",
+                            };
+                            self.log_mut().add_error_fmt(
+                                None,
+                                bun_ast::Loc::EMPTY,
+                                format_args!("{} \"{}\"", message, bstr::BStr::new(path)),
+                            );
+                        }
+                        continue;
                     }
-                    continue;
-                }
-            };
+                };
             self.output_files.push(output_file);
         }
         Ok(())
@@ -2875,7 +2859,6 @@ impl<'a> Transpiler<'a> {
         &mut self,
         resolve_result: &resolver::Result,
         import_path_format: options::ImportPathFormat,
-        _outstream: TransformOutstream,
         client_entry_point_: Option<&mut EntryPoints::ClientEntryPoint>,
     ) -> crate::Result<Option<options::OutputFile>> {
         if resolve_result.flags.is_external() {
@@ -3253,13 +3236,4 @@ impl<'a> Transpiler<'a> {
             },
         ))
     }
-}
-
-/// Outstream selector for `process_resolve_queue` /
-/// `build_with_resolve_result_eager` — a runtime enum since the only
-/// behavioural difference is unused (`_ = outstream`).
-#[derive(Clone, Copy)]
-enum TransformOutstream {
-    Stdout,
-    Dir(#[expect(dead_code)] bun_sys::Fd),
 }

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -367,33 +367,12 @@ const fn system_errno_max_dense() -> u32 {
     SystemErrno::MAX as u32
 }
 
-/// Raw Win32 `GetLastError()` code → `SystemErrno` tag name, via the
-/// `Win32Error` mapping table. Restores `error.code` fidelity (ENOENT,
-/// EACCES, ...) for `?`-propagated `std::io::Error`s on Windows. Exists on all
-/// platforms because the `ErrnoNames` link-interface is platform-independent;
-/// always `None` off Windows.
-#[inline]
-fn win32_errno_name(code: u32) -> Option<&'static str> {
-    #[cfg(windows)]
-    {
-        let code = u16::try_from(code).ok()?;
-        SystemErrno::init_win32_error(windows_errno::Win32Error::from_raw(code))
-            .map(<&'static str>::from)
-    }
-    #[cfg(not(windows))]
-    {
-        let _ = code;
-        None
-    }
-}
-
 // Wire the above into bun_core's `ErrnoNames` hook. `()` owner — pure
 // stateless functions; the handle is the const `ErrnoNames::SYS`.
 bun_core::link_impl_ErrnoNames! {
     Sys for extern () => |_this| {
         name(errno) => system_errno_name(errno),
         max_dense() => system_errno_max_dense(),
-        win32_name(code) => win32_errno_name(code),
     }
 }
 
@@ -510,27 +489,6 @@ mod errno_name_tests {
             assert_eq!((-524isize as usize).get_errno(), E::EUNKNOWN);
             assert_eq!((-2isize as usize).get_errno(), E::ENOENT);
             assert_eq!(7usize.get_errno(), E::SUCCESS);
-        }
-    }
-
-    /// `win32_errno_name` translation contract: known `GetLastError()` codes
-    /// map to POSIX names on Windows, unmapped/out-of-range codes are `None`,
-    /// and the helper is a constant `None` off Windows.
-    #[test]
-    fn win32_errno_names() {
-        #[cfg(windows)]
-        {
-            // ERROR_FILE_NOT_FOUND / ERROR_ACCESS_DENIED.
-            assert_eq!(win32_errno_name(2), Some("ENOENT"));
-            assert_eq!(win32_errno_name(5), Some("EPERM"));
-            // Unmapped Win32 code and the `u16::try_from` overflow fallback.
-            assert_eq!(win32_errno_name(0), None);
-            assert_eq!(win32_errno_name(u32::MAX), None);
-        }
-        #[cfg(not(windows))]
-        {
-            assert_eq!(win32_errno_name(2), None);
-            assert_eq!(win32_errno_name(u32::MAX), None);
         }
     }
 

--- a/src/event_loop/lib.rs
+++ b/src/event_loop/lib.rs
@@ -47,16 +47,12 @@ pub use bun_io::PipeReadScratch;
 bun_dispatch::link_interface! {
     pub JsEventLoop[Jsc] {
         fn iteration_number() -> u64;
-        fn file_polls() -> *mut bun_io::file_poll::Store;
-        fn put_file_poll(poll: *mut bun_io::FilePoll, was_ever_registered: bool);
         fn uws_loop() -> *mut bun_uws::Loop;
         fn tick();
         fn auto_tick();
         fn auto_tick_active();
         fn global_object() -> *mut ();
         fn bun_vm() -> *mut ();
-        fn stdout() -> *mut ();
-        fn stderr() -> *mut ();
         fn enter();
         fn exit();
         fn enqueue_task(task: Task);

--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -315,7 +315,6 @@ type ClassWithIntrinsics<T> = { [K in keyof T as T[K] extends Function ? `$${K}`
 declare interface Map<K, V> extends ClassWithIntrinsics<Map<K, V>> {}
 declare interface CallableFunction extends ClassWithIntrinsics<CallableFunction> {}
 declare interface Promise<T> extends ClassWithIntrinsics<Promise<T>> {}
-declare interface ArrayBufferConstructor extends ClassWithIntrinsics<ArrayBufferConstructor> {}
 declare interface PromiseConstructor extends ClassWithIntrinsics<PromiseConstructor> {}
 
 declare interface UnderlyingSource {
@@ -552,7 +551,6 @@ interface Map<K, V> {
 
 interface ObjectConstructor {
   $defineProperty: typeof Object.defineProperty;
-  $defineProperties: typeof Object.defineProperties;
 }
 
 /** gets a property on an object */

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -230,7 +230,6 @@ export function requireESMFromHijackedExtension(this: JSCommonJSModule, id: stri
 
 $visibility = "Private";
 export function createRequireCache() {
-  var moduleMap = new Map();
   var inner = {
     [Symbol.for("nodejs.util.inspect.custom")]() {
       return { ...proxy };
@@ -270,7 +269,6 @@ export function createRequireCache() {
     },
 
     deleteProperty(_target, key: string) {
-      moduleMap.$delete(key);
       $requireMap.$delete(key);
       $esmRegistryDelete(key);
       $evictIsolationSourceProviderCache(key);

--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -555,7 +555,6 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
         process.emitWarning(`Label '${label}' already exists for console.time()`);
         return;
       }
-      // trace(kTraceBegin, kTraceConsoleCategory, `time::${label}`, 0);
       this._times.set(label, process.hrtime());
     },
 
@@ -563,7 +562,6 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
       // Coerces everything other than Symbol to a string
       label = `${label}`;
       const found = timeLogImpl(this, "timeEnd", label);
-      // trace(kTraceEnd, kTraceConsoleCategory, `time::${label}`, 0);
       if (found) {
         this._times.delete(label);
       }
@@ -573,7 +571,6 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
       // Coerces everything other than Symbol to a string
       label = `${label}`;
       timeLogImpl(this, "timeLog", label, data);
-      // trace(kTraceInstant, kTraceConsoleCategory, `time::${label}`, 0);
     },
 
     trace: function trace(...args) {
@@ -612,7 +609,6 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
       if (count === undefined) count = 1;
       else count++;
       counts.set(label, count);
-      // trace(kTraceCount, kTraceConsoleCategory, `count::${label}`, 0, count);
       this.log(`${label}: ${count}`);
     },
 
@@ -623,7 +619,6 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
         process.emitWarning(`Count for '${label}' does not exist`);
         return;
       }
-      // trace(kTraceCount, kTraceConsoleCategory, `count::${label}`, 0, 0);
       counts.delete(`${label}`);
     },
 

--- a/src/js/builtins/Ipc.ts
+++ b/src/js/builtins/Ipc.ts
@@ -51,7 +51,6 @@ export function serialize(message, handle, options) {
 export function parseHandle(target, serialized, fd) {
   const emit = $newRustFunction("ipc.rs", "emitHandleIPCMessage", 3);
   const net = require("node:net");
-  // const dgram = require("node:dgram");
   switch (serialized.type) {
     case "net.Server": {
       const server = new net.Server();

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -348,8 +348,6 @@ export function initializeNextTickQueue(
 ) {
   var queue;
   var tickInitHooks;
-  var process;
-  var nextTickQueue = nextTickQueue;
   var drainMicrotasks = drainMicrotasksFn;
   var reportUncaughtException = reportUncaughtExceptionFn;
 

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -1078,9 +1078,6 @@ var lazyDefaultSQL: Bun.SQL;
 
 function resetDefaultSQL(sql) {
   lazyDefaultSQL = sql;
-  // this will throw "attempt to assign to readonly property"
-  // Object.assign(defaultSQLObject, lazyDefaultSQL);
-  // exportsObject.default = exportsObject.sql = lazyDefaultSQL;
 }
 
 function ensureDefaultSQL() {

--- a/src/js/internal/fifo.ts
+++ b/src/js/internal/fifo.ts
@@ -8,7 +8,6 @@ class Dequeue<T> {
   constructor() {
     this._head = 0;
     this._tail = 0;
-    // this._capacity = 0;
     this._capacityMask = 0x3;
     this._list = $newArrayWithSize(4);
   }

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -60,6 +60,8 @@ export const enum NodeHTTPResponseAbortEvent {
   timeout = 2,
 }
 export const enum NodeHTTPIncomingRequestType {
+  FetchRequest,
+  FetchResponse,
   NodeHTTPResponse,
 }
 export const enum NodeHTTPBodyReadState {

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -60,8 +60,6 @@ export const enum NodeHTTPResponseAbortEvent {
   timeout = 2,
 }
 export const enum NodeHTTPIncomingRequestType {
-  FetchRequest,
-  FetchResponse,
   NodeHTTPResponse,
 }
 export const enum NodeHTTPBodyReadState {

--- a/src/js/internal/stream.promises.ts
+++ b/src/js/internal/stream.promises.ts
@@ -6,8 +6,6 @@ const { isIterable, isNodeStream, isWebStream } = require("internal/streams/util
 const { pipelineImpl: pl } = require("internal/streams/pipeline");
 const { finished } = require("internal/streams/end-of-stream");
 
-// require("internal/stream");
-
 function pipeline(...streams) {
   return new Promise((resolve, reject) => {
     let signal;

--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -111,7 +111,6 @@ function ensureConstructed(this: NativeReadable, cb: null | (() => void)) {
 // maxToRead can be the highWaterMark (by default) or the remaining amount of the stream to read
 // This is so the consumer of the stream can terminate the stream early if they know
 // how many bytes they want to read (ie. when reading only part of a file)
-// ObjectDefinePrivateProperty(NativeReadable.prototype, "_getRemainingChunk", );
 function getRemainingChunk(stream: NativeReadable, maxToRead?: number) {
   maxToRead ??= stream[kHighWaterMark] as number;
   var chunk = stream[kRemainingChunk];

--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -5,7 +5,6 @@ function isPemObject(obj: unknown): obj is { pem: unknown } {
 }
 
 function isPemArray(obj: unknown): obj is [{ pem: unknown }] {
-  // if (obj instanceof Object && "pem" in obj) return isValidTLSArray(obj.pem);
   return $isArray(obj) && obj.every(isPemObject);
 }
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -510,6 +510,8 @@ Server.prototype[EventEmitter.captureRejectionSymbol] = function (err, event, ..
       break;
     }
     default:
+      // net.Server.prototype[EventEmitter.captureRejectionSymbol].apply(this, arguments);
+      //   .apply(this, arguments);
       const { 1: res } = args;
       res?.socket?.destroy();
       break;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -510,8 +510,6 @@ Server.prototype[EventEmitter.captureRejectionSymbol] = function (err, event, ..
       break;
     }
     default:
-      // net.Server.prototype[EventEmitter.captureRejectionSymbol].apply(this, arguments);
-      //   .apply(this, arguments);
       const { 1: res } = args;
       res?.socket?.destroy();
       break;

--- a/src/js/node/assert.ts
+++ b/src/js/node/assert.ts
@@ -432,7 +432,6 @@ Assert.prototype.notStrictEqual = function notStrictEqual(actual, expected, mess
  * @returns {void}
  */
 Assert.prototype.partialDeepStrictEqual = function partialDeepStrictEqual(actual, expected, message) {
-  // emitExperimentalWarning("assert.partialDeepStrictEqual");
   if (arguments.length < 2) {
     throw $ERR_MISSING_ARGS("actual", "expected");
   }

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -49,10 +49,6 @@ const kFromNode = Symbol("kFromNode");
 // Pass DEBUG_CHILD_PROCESS=1 to enable debug output
 if ($debug) {
   $debug("child_process: debug mode on");
-  globalThis.__lastId = null;
-  globalThis.__getId = () => {
-    return globalThis.__lastId !== null ? globalThis.__lastId++ : 0;
-  };
 }
 
 // Sections:
@@ -1021,10 +1017,6 @@ function normalizeSpawnArguments(file, args, options) {
 
   const env = options.env || process.env;
   const bunEnv = {};
-
-  // // process.env.NODE_V8_COVERAGE always propagates, making it possible to
-  // // collect coverage for programs that spawn with white-listed environment.
-  // copyProcessEnvToEnv(env, "NODE_V8_COVERAGE", options.env);
 
   let envKeys: string[] = [];
   for (const key in env) {

--- a/src/js/node/cluster.ts
+++ b/src/js/node/cluster.ts
@@ -4,9 +4,6 @@ const { isPrimary } = require("internal/cluster/isPrimary");
 const cluster = isPrimary ? require("internal/cluster/primary") : require("internal/cluster/child");
 export default cluster;
 
-//
-//
-
 function initializeClusterIPC() {
   if (process.argv[1] && process.env.NODE_UNIQUE_ID) {
     cluster._setupWorker();

--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -427,7 +427,6 @@ function Socket(type, listener) {
   const handle = newHandle(type, lookup);
   handle[kOwnerSymbol] = this;
 
-  // this[async_id_symbol] = handle.getAsyncId();
   this.type = type;
 
   if (typeof listener === "function") this.on("message", listener);
@@ -1503,7 +1502,6 @@ function stopReceiving(socket) {
 
   if (!state.receiving) return;
 
-  // state.handle.recvStop();
   state.receiving = false;
 }
 

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6562,6 +6562,8 @@ Http2Server.prototype[EventEmitter.captureRejectionSymbol] = function (err, even
       break;
     }
     default:
+      // args.unshift(err, event);
+      // ReflectApply(net.Server.prototype[EventEmitter.captureRejectionSymbol], this, args);
       break;
   }
 };

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6562,8 +6562,6 @@ Http2Server.prototype[EventEmitter.captureRejectionSymbol] = function (err, even
       break;
     }
     default:
-      // args.unshift(err, event);
-      // ReflectApply(net.Server.prototype[EventEmitter.captureRejectionSymbol], this, args);
       break;
   }
 };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -2226,7 +2226,6 @@ Socket.prototype._destroy = function _destroy(err, callback) {
     $debug("close handle");
     const isException = err ? true : false;
     // `bytesRead` and `kBytesWritten` should be accessible after `.destroy()`
-    // this[kBytesRead] = this._handle.bytesRead;
     this[kBytesWritten] = this._handle.bytesWritten;
 
     const currentHandle = this._handle;
@@ -3080,7 +3079,7 @@ function lookupAndConnectMultiple(self, lookup, host, options, dnsopts, port, lo
 }
 
 function internalConnect(self, options, path);
-function internalConnect(self, options, address, port, addressType, localAddress, localPort, _flags?) {
+function internalConnect(self, options, address, port, addressType, localAddress, localPort) {
   $assert(self.connecting);
 
   let err;
@@ -3222,7 +3221,7 @@ function internalConnectMultiple(context, canceled?) {
     self[kReinitializeHandle](newDetachedSocket(typeof self[bunTlsSymbol] === "function"));
   }
 
-  const { localPort, port, _flags } = context;
+  const { localPort, port } = context;
   const { address, family: addressType } = context.addresses[current];
   let localAddress;
   let err;
@@ -3299,7 +3298,6 @@ function internalConnectMultiple(context, canceled?) {
   $debug("connect/multiple: attempting to connect to %s:%d (addressType: %d)", address, port, addressType);
   self.emit("connectionAttempt", address, port, addressType);
 
-  // const req = new TCPConnectWrap();
   const req = {};
   req.oncomplete = afterConnectMultiple.bind(undefined, context, current);
   req.address = address;
@@ -4278,7 +4276,6 @@ function createServer(options, connectionListener) {
 }
 
 function normalizeArgs(args: unknown[]): [options: Record<PropertyKey, any>, cb: Function | null] {
-  // while (args.length && args[args.length - 1] == null) args.pop();
   let arr;
 
   if (args.length === 0) {

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -70,7 +70,6 @@ class BodyReadable extends ReadableFromWeb {
   }
 
   get bodyUsed() {
-    // return this.#response.bodyUsed;
     return this.#bodyUsed;
   }
 
@@ -188,7 +187,6 @@ async function request(
   if (typeof url === "object" && url !== null && query) if (query) url.search = new URLSearchParams(query).toString();
 
   method = method && typeof method === "string" ? method.toUpperCase() : null;
-  // idempotent = idempotent === undefined ? method === "GET" || method === "HEAD" : idempotent;
 
   if (inputBody && (method === "GET" || method === "HEAD")) {
     throw new Error("Body not allowed for GET or HEAD requests");

--- a/src/jsc/bindings/BakeAdditionsToGlobalObject.h
+++ b/src/jsc/bindings/BakeAdditionsToGlobalObject.h
@@ -2,7 +2,6 @@
 #include "root.h"
 #include "headers-handwritten.h"
 #include "BunBuiltinNames.h"
-#include "headers-handwritten.h"
 
 namespace Bun {
 using namespace JSC;

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -175,7 +175,6 @@ public:
     JSC::IsoHeapCellType m_heapCellTypeForNapiHandleScopeImpl;
     JSC::IsoHeapCellType m_heapCellTypeForBakeGlobalObject;
     JSC::IsoHeapCellType m_heapCellTypeForNativePromiseContext;
-    // JSC::IsoHeapCellType m_heapCellTypeForGeneratedClass;
 
 private:
     Lock m_lock;

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -637,7 +637,6 @@ static JSValue constructJSONLObject(VM& vm, JSObject* bunObject)
 static JSValue constructBunPeekObject(VM& vm, JSObject* bunObject)
 {
     JSGlobalObject* globalObject = bunObject->globalObject();
-    JSC::Identifier identifier = JSC::Identifier::fromString(vm, "peek"_s);
     JSFunction* peekFunction = JSFunction::create(vm, globalObject, peekPeekCodeGenerator(vm), globalObject->globalScope());
     JSFunction* peekStatus = JSFunction::create(vm, globalObject, peekPeekStatusCodeGenerator(vm), globalObject->globalScope());
     peekFunction->putDirect(vm, PropertyName(JSC::Identifier::fromString(vm, "status"_s)), peekStatus, JSC::PropertyAttribute::ReadOnly | JSC::PropertyAttribute::DontDelete | 0);
@@ -646,7 +645,6 @@ static JSValue constructBunPeekObject(VM& vm, JSObject* bunObject)
 }
 
 extern "C" uint64_t Bun__readOriginTimer(void*);
-extern "C" double Bun__readOriginTimerStart(void*);
 
 JSC_DEFINE_HOST_FUNCTION(functionBunSleep,
     (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -671,10 +671,6 @@ extern "C" JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(JSMock__jsModuleMock, __attr
                             moduleNamespaceObject->overrideExportValue(globalObject, vm.propertyNames->defaultKeyword, exportsValue);
                             RETURN_IF_EXCEPTION(scope, {});
                         }
-
-                        // TODO: do we need to handle intermediate loading state here?
-                        // entry->putDirect(vm, Identifier::fromString(vm, String("evaluated"_s)), jsBoolean(true), 0);
-                        // entry->putDirect(vm, Identifier::fromString(vm, String("state"_s)), jsNumber(JSC::JSModuleLoader::Status::Ready), 0);
                     }
                 }
             }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -146,7 +146,6 @@ extern "C" BunString Bun__Node__getRedirectWarnings();
 extern "C" size_t Bun__Node__getDisabledWarnings(const uint8_t** bufs, size_t* lens, size_t cap);
 extern "C" bool Bun__getEnvValue(JSC::JSGlobalObject* globalObject, const EncodedSlice* name, EncodedSlice* value);
 extern "C" bool Bun__Node__ProcessThrowDeprecation;
-extern "C" bool Bun__Node__ProcessPendingDeprecation;
 extern "C" void Bun__writeProfilesBeforeSelfKill();
 extern "C" int32_t bun_stdio_tty[3];
 
@@ -843,7 +842,6 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionUmask, (JSGlobalObject * globalObject, 
 }
 
 extern "C" uint64_t Bun__readOriginTimer(void*);
-extern "C" double Bun__readOriginTimerStart(void*);
 extern "C" void Bun__VirtualMachine__exitDuringUncaughtException(void*);
 
 // https://github.com/nodejs/node/blob/1936160c31afc9780e4365de033789f39b7cbc0c/src/api/hooks.cc#L49

--- a/src/jsc/bindings/CallSite.h
+++ b/src/jsc/bindings/CallSite.h
@@ -26,7 +26,6 @@ public:
         IsEval = 2,
         IsConstructor = 4,
         IsNative = 8,
-        IsWasm = 16,
         IsFunction = 32,
         IsAsync = 64,
     };

--- a/src/jsc/bindings/ConsoleObject.cpp
+++ b/src/jsc/bindings/ConsoleObject.cpp
@@ -12,7 +12,6 @@
 
 #include <JavaScriptCore/JSGlobalObjectInspectorController.h>
 #include <JavaScriptCore/JSGlobalObjectDebuggable.h>
-#include <JavaScriptCore/ConsoleClient.h>
 
 #include "GCDefferalContext.h"
 #include <JavaScriptCore/InspectorScriptProfilerAgent.h>

--- a/src/jsc/bindings/DOMFormData.h
+++ b/src/jsc/bindings/DOMFormData.h
@@ -41,8 +41,6 @@ namespace WebCore {
 class ScriptExecutionContext;
 
 template<typename> class ExceptionOr;
-class HTMLElement;
-class HTMLFormElement;
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(DOMFormData);
 
 class DOMFormData : public RefCounted<DOMFormData>, public ContextDestructionObserver {

--- a/src/jsc/bindings/InspectorLifecycleAgent.cpp
+++ b/src/jsc/bindings/InspectorLifecycleAgent.cpp
@@ -114,13 +114,11 @@ void InspectorLifecycleAgent::reportError(ZigException& exception)
 
 Protocol::ErrorStringOr<void> InspectorLifecycleAgent::preventExit()
 {
-    m_preventingExit = true;
     return {};
 }
 
 Protocol::ErrorStringOr<void> InspectorLifecycleAgent::stopPreventingExit()
 {
-    m_preventingExit = false;
     return {};
 }
 

--- a/src/jsc/bindings/InspectorLifecycleAgent.h
+++ b/src/jsc/bindings/InspectorLifecycleAgent.h
@@ -44,7 +44,6 @@ private:
     std::unique_ptr<LifecycleReporterFrontendDispatcher> m_frontendDispatcher;
     Ref<LifecycleReporterBackendDispatcher> m_backendDispatcher;
     bool m_enabled { false };
-    bool m_preventingExit { false };
 };
 
 } // namespace Inspector

--- a/src/jsc/bindings/InternalModuleRegistry.cpp
+++ b/src/jsc/bindings/InternalModuleRegistry.cpp
@@ -130,7 +130,6 @@ JSC::JSValue generateInternalModule(JSC::JSGlobalObject* globalObject, JSC::VM& 
         globalObject->debugger()->sourceParsed(globalObject, source.provider(), -1, ""_s);
     }
 
-    JSC::MarkedArgumentBuffer argList;
     JSValue result = JSC::profiledCall(
         globalObject,
         ProfilingReason::Other,

--- a/src/jsc/bindings/JSBakeResponse.cpp
+++ b/src/jsc/bindings/JSBakeResponse.cpp
@@ -114,7 +114,6 @@ JSBakeResponse* JSBakeResponse::create(JSC::VM& vm, Zig::GlobalObject* globalObj
 
     // _store = { _validated: 0 }
     JSObject* storeObject = JSC::constructEmptyObject(globalObject);
-    auto validatedIdent = JSC::Identifier::fromString(vm, "validated"_s);
     storeObject->putDirect(vm, builtinNames.validatedPublicName(), jsNumber(0), 0);
     ptr->putDirect(vm, builtinNames._storePublicName(), storeObject, 0);
 
@@ -172,7 +171,6 @@ public:
     }
 
     DECLARE_INFO;
-    // DECLARE_EXPORT_INFO;
 
     // Must be defined for each specialization class.
     static JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES construct(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -42,7 +42,6 @@
 #include <JavaScriptCore/InternalFunction.h>
 #include <JavaScriptCore/LazyClassStructure.h>
 #include <JavaScriptCore/LazyClassStructureInlines.h>
-#include <JavaScriptCore/FunctionPrototype.h>
 
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -31,8 +31,6 @@
 #include "napi_external.h"
 #include "WebCoreJSBuiltins.h"
 
-#include <JavaScriptCore/JSPromise.h>
-
 #if OS(WINDOWS)
 #include <windows.h>
 #else

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -65,13 +65,11 @@
 #include "ModuleLoader.h"
 #include <JavaScriptCore/JSMap.h>
 
-#include <JavaScriptCore/JSMapInlines.h>
 #include <JavaScriptCore/GetterSetter.h>
 #include "ZigSourceProvider.h"
 #include <JavaScriptCore/FunctionPrototype.h>
 #include "JSCommonJSModule.h"
 #include <JavaScriptCore/JSModuleNamespaceObject.h>
-#include <JavaScriptCore/JSSourceCode.h>
 #include <JavaScriptCore/LazyPropertyInlines.h>
 #include <JavaScriptCore/HeapAnalyzer.h>
 #include "PathInlines.h"
@@ -774,7 +772,6 @@ JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * glo
     String dirnameString = dirnameValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
 
-    WTF::NakedPtr<JSC::Exception> exception;
     evaluateCommonJSModuleOnce(
         vm,
         uncheckedDowncast<Zig::GlobalObject>(globalObject),
@@ -1465,8 +1462,6 @@ void JSCommonJSModule::evaluateWithPotentiallyOverriddenCompile(
         auto trimStart = sourceString.find('\n');
         WTF::String sourceStringWithoutWrapper;
         if (trimStart != WTF::notFound) {
-            auto wrapperStart = globalObject->m_moduleWrapperStart;
-            auto wrapperEnd = globalObject->m_moduleWrapperEnd;
             sourceStringWithoutWrapper = sourceString.substring(trimStart, sourceString.length() - trimStart - 4);
         } else {
             sourceStringWithoutWrapper = sourceString;

--- a/src/jsc/bindings/JSDOMExceptionHandling.cpp
+++ b/src/jsc/bindings/JSDOMExceptionHandling.cpp
@@ -54,15 +54,10 @@ void reportException(JSGlobalObject* lexicalGlobalObject, JSC::Exception* except
 
     ErrorHandlingScope errorScope(lexicalGlobalObject->vm());
 
-    // auto callStack = Inspector::createScriptCallStackFromException(lexicalGlobalObject, exception);
     (void)scope.tryClearException();
     vm.clearLastException();
 
     auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject);
-    // if (auto* window = dynamicDowncast<JSDOMWindow>( globalObject)) {
-    //     if (!window->wrapped().isCurrentlyDisplayedInFrame())
-    //         return;
-    // }
 
     int lineNumber = 0;
     int columnNumber = 0;

--- a/src/jsc/bindings/JSDOMGlobalObject.h
+++ b/src/jsc/bindings/JSDOMGlobalObject.h
@@ -21,8 +21,6 @@ Zig::GlobalObject* toJSDOMGlobalObject(ScriptExecutionContext& ctx, DOMWrapperWo
 template<class JSClass>
 JSClass* toJSDOMGlobalObject(JSC::VM& vm, JSC::JSValue value)
 {
-    // static_assert(std::is_base_of_v<JSDOMGlobalObject, JSClass>);
-
     if (auto* object = value.getObject()) {
         if (object->type() == JSC::GlobalProxyType)
             return dynamicDowncast<JSClass>(uncheckedDowncast<JSC::JSGlobalProxy>(object)->target());

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -22,11 +22,9 @@
 #include "wtf/Compiler.h"
 #include "wtf/Forward.h"
 #include <JavaScriptCore/JSCInlines.h>
-#include <JavaScriptCore/SubspaceInlines.h>
 #include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/PropertyDescriptor.h>
-#include "BunProcess.h"
 #include "ScriptExecutionContext.h"
 #include "SharedEnvStore.h"
 #include "wtf/NeverDestroyed.h"
@@ -343,7 +341,6 @@ bool JSEnvironmentVariableMap::deleteProperty(JSCell* cell, JSGlobalObject* glob
     RELEASE_AND_RETURN(scope, Base::deleteProperty(cell, globalObject, propertyName, slot));
 }
 
-extern "C" int Bun__getTLSRejectUnauthorizedValue();
 extern "C" void Bun__setTLSRejectUnauthorizedValue(int value);
 extern "C" int Bun__getVerboseFetchValue();
 extern "C" void Bun__setVerboseFetchValue(int value);

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -13,7 +13,6 @@
 #include "BunClientData.h"
 #include <JavaScriptCore/LazyProperty.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
-#include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/JSPromiseConstructor.h>
 #include <JavaScriptCore/LazyPropertyInlines.h>
 #include <JavaScriptCore/VMTrapsInlines.h>

--- a/src/jsc/bindings/JSWrappingFunction.cpp
+++ b/src/jsc/bindings/JSWrappingFunction.cpp
@@ -28,12 +28,10 @@ JS_EXPORT_PRIVATE JSWrappingFunction* JSWrappingFunction::create(
     ASSERT(wrappedFn != nullptr);
 
     auto nameStr = symbolName->tag == BunStringTag::Empty ? WTF::emptyString() : symbolName->toWTFString();
-    auto name = Identifier::fromString(vm, nameStr);
     // Pass callHostFunctionAsConstructor so `new` on the wrapper throws a
     // TypeError instead of jumping to a null native constructor.
     NativeExecutable* executable = vm.getHostFunction(functionPointer, ImplementationVisibility::Public, callHostFunctionAsConstructor, 0, nameStr);
 
-    // Structure* structure = globalObject->FFIFunctionStructure();
     Structure* structure = JSWrappingFunction::createStructure(vm, globalObject, globalObject->objectPrototype());
     JSWrappingFunction* function = new (NotNull, allocateCell<JSWrappingFunction>(vm)) JSWrappingFunction(vm, executable, globalObject, structure, wrappedFn);
     ASSERT(function->structure()->globalObject());

--- a/src/jsc/bindings/JSX509CertificatePrototype.cpp
+++ b/src/jsc/bindings/JSX509CertificatePrototype.cpp
@@ -308,10 +308,6 @@ JSC_DEFINE_HOST_FUNCTION(jsX509CertificateProtoFuncCheckIP, (JSGlobalObject * gl
     RETURN_IF_EXCEPTION(scope, {});
     WTF::CString ip = view->utf8();
 
-    // ignore flags
-    // uint32_t flags = getFlags(vm, globalObject, scope, callFrame->argument(1));
-    // RETURN_IF_EXCEPTION(scope, {});
-
     auto check = thisObject->checkIP(globalObject, ip.data());
     RETURN_IF_EXCEPTION(scope, {});
     if (!check) return JSValue::encode(jsUndefined());

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -327,7 +327,6 @@ static OnLoadResult handleOnLoadResult(Zig::GlobalObject* globalObject, JSC::JSV
         OnLoadResult result = {};
         result.type = OnLoadResultTypePromise;
         result.value.promise = objectValue;
-        result.wasMock = wasModuleMock;
         return result;
     }
 

--- a/src/jsc/bindings/ModuleLoader.h
+++ b/src/jsc/bindings/ModuleLoader.h
@@ -45,7 +45,6 @@ union OnLoadResultValue {
 struct OnLoadResult {
     OnLoadResultValue value;
     OnLoadResultType type;
-    bool wasMock;
 };
 
 extern "C" bool isBunTest;

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -7,7 +7,6 @@
 
 #include <JavaScriptCore/AggregateError.h>
 #include <JavaScriptCore/ObjectConstructor.h>
-#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/JSFunction.h>
 #include "JSFetchHeaders.h"
 #include "HTTPLatin1String.h"
@@ -17,7 +16,6 @@
 #include "ZigGeneratedClasses.h"
 #include "ScriptExecutionContext.h"
 #include "AsyncContextFrame.h"
-#include "ZigGeneratedClasses.h"
 #include <JavaScriptCore/LazyPropertyInlines.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
 #include "JSSocketAddressDTO.h"

--- a/src/jsc/bindings/NodeVM.h
+++ b/src/jsc/bindings/NodeVM.h
@@ -51,7 +51,6 @@ public:
     String filename;
     OrdinalNumber lineOffset = OrdinalNumber::fromZeroBasedInt(0);
     OrdinalNumber columnOffset = OrdinalNumber::fromZeroBasedInt(0);
-    bool failed = false;
     bool filenameProvided = false;
 
     BaseVMOptions() = default;

--- a/src/jsc/bindings/NodeVMScript.h
+++ b/src/jsc/bindings/NodeVMScript.h
@@ -77,7 +77,6 @@ public:
     WTF::Vector<uint8_t>& cachedData() { return m_options.cachedData; }
     JSC::ProgramExecutable* cachedExecutable() const { return m_cachedExecutable.get(); }
     bool cachedDataProduced() const { return m_cachedDataProduced; }
-    void cachedDataProduced(bool value) { m_cachedDataProduced = value; }
     TriState cachedDataRejected() const { return m_cachedDataRejected; }
     void cachedDataRejected(TriState value) { m_cachedDataRejected = value; }
 

--- a/src/jsc/bindings/SecretsLinux.cpp
+++ b/src/jsc/bindings/SecretsLinux.cpp
@@ -14,12 +14,7 @@ using namespace WTF;
 
 // Minimal GLib type definitions to avoid linking against GLib
 typedef struct _GError GError;
-typedef struct _GHashTable GHashTable;
-typedef struct _GList GList;
 typedef struct _SecretSchema SecretSchema;
-typedef struct _SecretService SecretService;
-typedef struct _SecretValue SecretValue;
-typedef struct _SecretItem SecretItem;
 
 typedef int gboolean;
 typedef char gchar;
@@ -70,20 +65,6 @@ struct _GError {
     gchar* message;
 };
 
-struct _GList {
-    gpointer data;
-    GList* next;
-    GList* prev;
-};
-
-// Secret search flags
-typedef enum {
-    SECRET_SEARCH_NONE = 0,
-    SECRET_SEARCH_ALL = 1 << 1,
-    SECRET_SEARCH_UNLOCK = 1 << 2,
-    SECRET_SEARCH_LOAD_SECRETS = 1 << 3
-} SecretSearchFlags;
-
 class LibsecretFramework {
 public:
     void* secret_handle;
@@ -92,15 +73,6 @@ public:
 
     // GLib function pointers
     void (*g_error_free)(GError* error);
-    void (*g_free)(gpointer mem);
-    GHashTable* (*g_hash_table_new)(void* hash_func, void* key_equal_func);
-    void (*g_hash_table_destroy)(GHashTable* hash_table);
-    gpointer (*g_hash_table_lookup)(GHashTable* hash_table, gpointer key);
-    void (*g_hash_table_insert)(GHashTable* hash_table, gpointer key, gpointer value);
-    void (*g_list_free)(GList* list);
-    void (*g_list_free_full)(GList* list, void (*free_func)(gpointer));
-    guint (*g_str_hash)(gpointer v);
-    gboolean (*g_str_equal)(gpointer v1, gpointer v2);
 
     // libsecret function pointers
     gboolean (*secret_password_store_sync)(const SecretSchema* schema,
@@ -122,21 +94,6 @@ public:
         ...);
 
     void (*secret_password_free)(gchar* password);
-
-    GList* (*secret_service_search_sync)(SecretService* service,
-        const SecretSchema* schema,
-        GHashTable* attributes,
-        SecretSearchFlags flags,
-        void* cancellable,
-        GError** error);
-
-    SecretValue* (*secret_item_get_secret)(SecretItem* self);
-    const gchar* (*secret_value_get_text)(SecretValue* value);
-    void (*secret_value_unref)(gpointer value);
-    GHashTable* (*secret_item_get_attributes)(SecretItem* self);
-    gboolean (*secret_item_load_secret_sync)(SecretItem* self,
-        void* cancellable,
-        GError** error);
 
     LibsecretFramework()
         : secret_handle(nullptr)
@@ -196,15 +153,6 @@ private:
     {
         // Load GLib functions
         g_error_free = (void (*)(GError*))dlsym(glib_handle, "g_error_free");
-        g_free = (void (*)(gpointer))dlsym(glib_handle, "g_free");
-        g_hash_table_new = (GHashTable * (*)(void*, void*)) dlsym(glib_handle, "g_hash_table_new");
-        g_hash_table_destroy = (void (*)(GHashTable*))dlsym(glib_handle, "g_hash_table_destroy");
-        g_hash_table_lookup = (gpointer (*)(GHashTable*, gpointer))dlsym(glib_handle, "g_hash_table_lookup");
-        g_hash_table_insert = (void (*)(GHashTable*, gpointer, gpointer))dlsym(glib_handle, "g_hash_table_insert");
-        g_list_free = (void (*)(GList*))dlsym(glib_handle, "g_list_free");
-        g_list_free_full = (void (*)(GList*, void (*)(gpointer)))dlsym(glib_handle, "g_list_free_full");
-        g_str_hash = (guint (*)(gpointer))dlsym(glib_handle, "g_str_hash");
-        g_str_equal = (gboolean (*)(gpointer, gpointer))dlsym(glib_handle, "g_str_equal");
 
         // Load libsecret functions
         secret_password_store_sync = (gboolean (*)(const SecretSchema*, const gchar*, const gchar*, const gchar*, void*, GError**, ...))
@@ -214,15 +162,8 @@ private:
         secret_password_clear_sync = (gboolean (*)(const SecretSchema*, void*, GError**, ...))
             dlsym(secret_handle, "secret_password_clear_sync");
         secret_password_free = (void (*)(gchar*))dlsym(secret_handle, "secret_password_free");
-        secret_service_search_sync = (GList * (*)(SecretService*, const SecretSchema*, GHashTable*, SecretSearchFlags, void*, GError**))
-            dlsym(secret_handle, "secret_service_search_sync");
-        secret_item_get_secret = (SecretValue * (*)(SecretItem*)) dlsym(secret_handle, "secret_item_get_secret");
-        secret_value_get_text = (const gchar* (*)(SecretValue*))dlsym(secret_handle, "secret_value_get_text");
-        secret_value_unref = (void (*)(gpointer))dlsym(secret_handle, "secret_value_unref");
-        secret_item_get_attributes = (GHashTable * (*)(SecretItem*)) dlsym(secret_handle, "secret_item_get_attributes");
-        secret_item_load_secret_sync = (gboolean (*)(SecretItem*, void*, GError**))dlsym(secret_handle, "secret_item_load_secret_sync");
 
-        return g_error_free && g_free && g_hash_table_new && g_hash_table_destroy && g_hash_table_lookup && g_hash_table_insert && g_list_free && secret_password_store_sync && secret_password_lookup_sync && secret_password_clear_sync && secret_password_free;
+        return g_error_free && secret_password_store_sync && secret_password_lookup_sync && secret_password_clear_sync && secret_password_free;
     }
 };
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -48,7 +48,6 @@
 #include "JavaScriptCore/JSIteratorPrototype.h"
 #include "JavaScriptCore/JSObject.h"
 #include "JavaScriptCore/JSObjectInlines.h"
-#include "JavaScriptCore/JSPromise.h"
 #include "JavaScriptCore/JSSourceCode.h"
 #include "JavaScriptCore/JSString.h"
 #include "JavaScriptCore/JSWeakMap.h"
@@ -94,7 +93,6 @@
 #include "JSBuffer.h"
 #include "streams/JSByteLengthQueuingStrategy.h"
 #include "JSCloseEvent.h"
-#include "JSCommonJSExtensions.h"
 #include "streams/JSCountQueuingStrategy.h"
 #include "JSCustomEvent.h"
 #include "JSDOMConvertBase.h"
@@ -201,7 +199,6 @@
 #include "JSAsymmetricKeyObjectPrototype.h"
 #include "JSPublicKeyObject.h"
 #include "JSPrivateKeyObject.h"
-#include "webcore/JSMIMEParams.h"
 #include "JSNodePerformanceHooksHistogram.h"
 #include "JSS3File.h"
 #include "S3Error.h"
@@ -247,9 +244,7 @@ using JSModuleRecord = JSC::JSModuleRecord;
 using Identifier = JSC::Identifier;
 using SourceOrigin = JSC::SourceOrigin;
 using JSObject = JSC::JSObject;
-using JSNonFinalObject = JSC::JSNonFinalObject;
 namespace JSCastingHelpers = JSC::JSCastingHelpers;
-// #include <iostream>
 
 Structure* createMemoryFootprintStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject);
 
@@ -304,9 +299,7 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
             JSC::Options::useJIT() = true;
             JSC::Options::useBBQJIT() = true;
             JSC::Options::useConcurrentJIT() = true;
-            // JSC::Options::useSigillCrashAnalyzer() = true;
             JSC::Options::useSourceProviderCache() = true;
-            // JSC::Options::useUnlinkedCodeBlockJettisoning() = false;
             // JSModuleLoader is now a JSCell (not a JSObject) so exposing it as
             // the global `Loader` would let user code dereference a non-object
             // and trip JSValue::synthesizePrototype's isSymbol() debug assert.
@@ -546,7 +539,6 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__create(void* console_client, 
     }
 
     globalObject->setConsole(console_client);
-    globalObject->isThreadLocalDefaultGlobalObject = true;
     Bun__setDefaultGlobalObject(globalObject);
     JSC::gcProtect(globalObject);
 
@@ -675,7 +667,6 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__createForTestIsolation(Zig::G
     }
 
     globalObject->setConsole(console_client);
-    globalObject->isThreadLocalDefaultGlobalObject = true;
     Bun__setDefaultGlobalObject(globalObject);
     JSC::gcProtect(globalObject);
 
@@ -706,7 +697,6 @@ extern "C" JSC::JSGlobalObject* Zig__GlobalObject__createForTestIsolation(Zig::G
         oldGlobal->clearModuleRegistry();
         scope.assertNoExceptionExceptTermination();
     }
-    oldGlobal->isThreadLocalDefaultGlobalObject = false;
     JSC::gcUnprotect(oldGlobal);
 
     return globalObject;
@@ -900,9 +890,6 @@ String GlobalObject::defaultAgentClusterID()
 
 String GlobalObject::agentClusterID() const
 {
-    // TODO: workers
-    // if (is<SharedWorkerGlobalScope>(scriptExecutionContext()))
-    //     return makeString(WProcess::identifier().toUInt64(), "-sharedworker");
     return defaultAgentClusterID();
 }
 
@@ -1043,7 +1030,6 @@ GlobalObject::GlobalObject(JSC::VM& vm, JSC::Structure* structure, const JSC::Gl
     , m_scriptExecutionContext(new WebCore::ScriptExecutionContext(&vm, this))
     , globalEventScope(adoptRef(*new Bun::GlobalEventScope(m_scriptExecutionContext)))
 {
-    // m_scriptExecutionContext = globalEventScope.m_context;
     mockModule = Bun::JSMockModule::create(this);
     globalEventScope->m_context = m_scriptExecutionContext;
 }
@@ -1057,7 +1043,6 @@ GlobalObject::GlobalObject(JSC::VM& vm, JSC::Structure* structure, WebCore::Scri
     , m_scriptExecutionContext(new WebCore::ScriptExecutionContext(&vm, this, contextId))
     , globalEventScope(adoptRef(*new Bun::GlobalEventScope(m_scriptExecutionContext)))
 {
-    // m_scriptExecutionContext = globalEventScope.m_context;
     mockModule = Bun::JSMockModule::create(this);
     globalEventScope->m_context = m_scriptExecutionContext;
 }
@@ -1569,7 +1554,6 @@ extern "C" JSC::EncodedJSValue Bun__makeTypedArrayWithBytesNoCopy(JSC::JSGlobalO
 #define JSC_TYPED_ARRAY_FACTORY(type) \
     case Type##type:                  \
         RELEASE_AND_RETURN(scope, JSValue::encode(JS##type##Array::create(globalObject, globalObject->typedArrayStructure(Type##type, isResizableOrGrowableShared), WTF::move(buffer), offset, length)));
-#undef JSC_TYPED_ARRAY_CHECK
         FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(JSC_TYPED_ARRAY_FACTORY)
     case NotTypedArray:
     case TypeDataView:

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -62,7 +62,6 @@ struct node_module;
 #include "BunPlugin.h"
 #include "JSMockFunction.h"
 #include "InternalModuleRegistry.h"
-#include "headers-handwritten.h"
 #include "BunMarkdownTagStrings.h"
 #include "BunGlobalScope.h"
 #include <js_native_api.h>
@@ -74,15 +73,6 @@ struct node_module;
 
 namespace Bun {
 class JSCommonJSExtensions;
-class InternalModuleRegistry;
-class JSMockModule;
-class JSMockFunction;
-}
-
-namespace WebCore {
-class GlobalEventScope;
-class SubtleCrypto;
-class EventTarget;
 }
 
 extern "C" void Bun__reportError(JSC::JSGlobalObject*, JSC::EncodedJSValue);
@@ -140,11 +130,6 @@ public:
 
     DOMGuardedObjectSet& guardedObjects() WTF_REQUIRES_LOCK(m_gcLock) { return m_guardedObjects; }
 
-    const DOMGuardedObjectSet& guardedObjects() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS
-    {
-        ASSERT(!Thread::mayBeGCThread());
-        return m_guardedObjects;
-    }
     DOMGuardedObjectSet& guardedObjects(NoLockingNecessaryTag) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     {
         ASSERT(!vm().heap.mutatorShouldBeFenced());
@@ -339,7 +324,6 @@ public:
         return Bun__ZigGlobalObject__uvLoop(m_bunVM);
     }
 #endif
-    bool isThreadLocalDefaultGlobalObject = false;
 
     JSObject* subtleCrypto() { return m_subtleCryptoObject.getInitializedOnMainThread(this); }
 
@@ -497,7 +481,6 @@ public:
                                                                                                              \
     V(public, WriteBarrier<Bun::JSNextTickQueue>, m_nextTickQueue)                                           \
                                                                                                              \
-    /* WriteBarrier<Unknown> m_JSBunDebuggerValue; */                                                        \
     V(private, ThenablesArray, m_thenables)                                                                  \
     V(private, NativeModuleDefaultsArray, m_nativeModuleDefaults)                                            \
                                                                                                              \

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -217,15 +217,7 @@ using namespace WebCore;
 typedef uint8_t ExpectFlags;
 
 // Note: keep this in sync with Flags in src/runtime/test_runner/expect.rs
-// clang disable unused warning
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-variable"
-
-static constexpr int FLAG_PROMISE_RESOLVES = (1 << 0);
-static constexpr int FLAG_PROMISE_REJECTS = (1 << 1);
 static constexpr int FLAG_NOT = (1 << 2);
-
-#pragma clang diagnostic pop
 
 extern "C" bool ExpectCustomAsymmetricMatcher__execute(void* self, JSC::EncodedJSValue thisValue, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue leftValue);
 
@@ -3225,8 +3217,6 @@ bool Bun__deepEqualsNodeStrictSkipProto(JSC::EncodedJSValue JSValue0, JSC::Encod
     return deepEqualsWrapperImpl<true, false, true, true>(JSValue0, JSValue1, globalObject);
 }
 
-#undef IMPL_DEEP_EQUALS_WRAPPER
-
 bool JSC__JSValue__jestDeepMatch(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* globalObject, bool replacePropsWithAsymmetricMatchers)
 {
     JSValue obj = JSValue::decode(JSValue0);
@@ -4084,7 +4074,6 @@ JSC::EncodedJSValue JSC__JSGlobalObject__generateHeapSnapshot(JSC::JSGlobalObjec
     auto& vm = JSC::getVM(globalObject);
 
     JSC::JSLockHolder lock(vm);
-    // JSC::DeferTermination deferScope(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     Bun__Feature__heap_snapshot += 1;

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -561,20 +561,6 @@ extern "C" ssize_t sys_pwritev2(int fd, const struct iovec* iov, int iovcnt,
     make_pos_h_l(&pos_h, &pos_l, offset);
     return syscall(__NR_pwritev2, fd, iov, iovcnt, pos_l, pos_h, flags);
 }
-#else
-extern "C" ssize_t preadv2(int fd, const struct iovec* iov, int iovcnt,
-    off_t offset, unsigned int flags)
-{
-    errno = ENOSYS;
-    return -1;
-}
-extern "C" ssize_t pwritev2(int fd, const struct iovec* iov, int iovcnt,
-    off_t offset, unsigned int flags)
-{
-    errno = ENOSYS;
-    return -1;
-}
-
 #endif
 
 extern "C" void Bun__onExit();

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -22,14 +22,6 @@ typedef struct EncodedSlice {
     size_t len;
 } EncodedSlice;
 
-#ifndef __cplusplus
-typedef uint8_t BunStringTag;
-typedef union BunStringImpl {
-    EncodedSlice encoded;
-    void* wtf;
-} BunStringImpl;
-
-#else
 namespace WTF {
 class StringImpl;
 class String;
@@ -66,7 +58,6 @@ enum class UWSResponseKind : int32_t {
     H2 = 2,
     H3 = 3,
 };
-#endif
 
 typedef struct BunString {
     BunStringTag tag;
@@ -202,7 +193,6 @@ inline constexpr BunPluginTarget BunPluginTargetNode = 2;
 inline constexpr BunPluginTarget BunPluginTargetMax = BunPluginTargetNode;
 
 typedef uint8_t ZigStackFrameCode;
-inline constexpr ZigStackFrameCode ZigStackFrameCodeNone = 0;
 inline constexpr ZigStackFrameCode ZigStackFrameCodeEval = 1;
 inline constexpr ZigStackFrameCode ZigStackFrameCodeModule = 2;
 inline constexpr ZigStackFrameCode ZigStackFrameCodeFunction = 3;
@@ -284,9 +274,6 @@ inline constexpr JSErrorCode JSErrorCodeSyntaxError = 4;
 inline constexpr JSErrorCode JSErrorCodeTypeError = 5;
 inline constexpr JSErrorCode JSErrorCodeURIError = 6;
 inline constexpr JSErrorCode JSErrorCodeAggregateError = 7;
-inline constexpr JSErrorCode JSErrorCodeOutOfMemoryError = 8;
-inline constexpr JSErrorCode JSErrorCodeStackOverflow = 253;
-inline constexpr JSErrorCode JSErrorCodeUserErrorCode = 254;
 
 // Must be kept in sync with Loader in src/options_types/schema.rs
 typedef uint8_t BunLoaderType;
@@ -295,12 +282,8 @@ inline constexpr BunLoaderType BunLoaderTypeJSX = 1;
 inline constexpr BunLoaderType BunLoaderTypeJS = 2;
 inline constexpr BunLoaderType BunLoaderTypeTS = 3;
 inline constexpr BunLoaderType BunLoaderTypeTSX = 4;
-inline constexpr BunLoaderType BunLoaderTypeCSS = 5;
-inline constexpr BunLoaderType BunLoaderTypeFILE = 6;
 inline constexpr BunLoaderType BunLoaderTypeJSON = 7;
-inline constexpr BunLoaderType BunLoaderTypeJSONC = 8;
 inline constexpr BunLoaderType BunLoaderTypeTOML = 9;
-inline constexpr BunLoaderType BunLoaderTypeWASM = 10;
 inline constexpr BunLoaderType BunLoaderTypeNAPI = 11;
 inline constexpr BunLoaderType BunLoaderTypeYAML = 19;
 inline constexpr BunLoaderType BunLoaderTypeMD = 21;
@@ -331,11 +314,6 @@ typedef void WebSocketHTTPClient;
 typedef void WebSocketHTTPSClient;
 typedef void WebSocketClient;
 typedef void WebSocketClientTLS;
-
-#ifndef __cplusplus
-typedef struct Bun__ArrayBuffer Bun__ArrayBuffer;
-typedef struct JSC::JSUint8Array JSC::JSUint8Array;
-#endif
 
 #ifdef __cplusplus
 

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -51,7 +51,6 @@
 #include <JavaScriptCore/IteratorOperations.h>
 #include <JavaScriptCore/JSArray.h>
 #include <JavaScriptCore/JSPromise.h>
-#include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/JSArrayBuffer.h>
@@ -67,12 +66,10 @@
 
 #include "../modules/ObjectModule.h"
 
-#include <JavaScriptCore/JSSourceCode.h>
 #include "napi_external.h"
 #include "wtf/Assertions.h"
 #include "wtf/Compiler.h"
 #include "wtf/NakedPtr.h"
-#include <JavaScriptCore/JSArrayBuffer.h>
 #include <JavaScriptCore/FunctionPrototype.h>
 #include "JSCommonJSModule.h"
 #include "wtf/text/ASCIIFastPath.h"

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -532,13 +532,6 @@ public:
 
         BoundFinalizer() = default;
 
-        BoundFinalizer(const Bun::NapiFinalizer& finalizer, void* data)
-            : callback(finalizer.callback())
-            , hint(finalizer.hint())
-            , data(data)
-        {
-        }
-
         BoundFinalizer(napi_finalize callback, void* hint, void* data)
             : callback(callback)
             , hint(hint)

--- a/src/jsc/bindings/napi_finalizer.h
+++ b/src/jsc/bindings/napi_finalizer.h
@@ -21,7 +21,6 @@ public:
     void clear();
 
     inline napi_finalize callback() const { return m_callback; }
-    inline void* hint() const { return m_hint; }
 
 private:
     napi_finalize m_callback = nullptr;

--- a/src/jsc/bindings/ncrypto.h
+++ b/src/jsc/bindings/ncrypto.h
@@ -116,8 +116,6 @@ public:
 
     inline auto begin() const noexcept { return errors_.begin(); }
     inline auto end() const noexcept { return errors_.end(); }
-    inline auto rbegin() const noexcept { return errors_.rbegin(); }
-    inline auto rend() const noexcept { return errors_.rend(); }
 
     std::optional<WTF::String> pop_back();
 
@@ -267,9 +265,6 @@ private:
 
 class Cipher final {
 public:
-    static constexpr size_t MAX_KEY_LENGTH = EVP_MAX_KEY_LENGTH;
-    static constexpr size_t MAX_IV_LENGTH = EVP_MAX_IV_LENGTH;
-
     Cipher() = default;
     Cipher(const EVP_CIPHER* cipher)
         : cipher_(cipher)

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -17,8 +17,6 @@ extern "C" void Bun__NodeHTTPResponse_setClosed(void* zigResponse);
 extern "C" void Bun__NodeHTTPResponse_markTunneled(void* zigResponse);
 extern "C" void Bun__NodeHTTPResponse_onClose(void* zigResponse, JSC::EncodedJSValue jsValue);
 extern "C" void us_socket_free_stream_buffer(us_socket_stream_buffer_t* streamBuffer);
-extern "C" uint64_t uws_res_get_remote_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
-extern "C" uint64_t uws_res_get_local_address_info(void* res, const char** dest, int* port, bool* is_ipv6);
 extern "C" EncodedJSValue us_socket_buffered_js_write(void* socket, bool is_ssl, bool ended, us_socket_stream_buffer_t* streamBuffer, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue data, JSC::EncodedJSValue encoding);
 extern "C" int us_socket_is_ssl_handshake_finished(struct us_socket_t* s);
 extern "C" int us_socket_ssl_handshake_callback_has_fired(struct us_socket_t* s);

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
@@ -29,12 +29,6 @@ struct us_socket_stream_buffer_t {
 struct us_socket_t;
 }
 
-namespace uWS {
-template<bool SSL, bool IsNodeHttp>
-struct HttpResponseData;
-struct WebSocketData;
-}
-
 namespace WebCore {
 class JSNodeHTTPResponse;
 }
@@ -114,10 +108,6 @@ public:
      * until the request body has been fully parsed (Upgrade requests with a
      * body deliver it through the request first, like Node 26). */
     void upgradeToTunnelMode(bool afterBody = false);
-
-    /* Trailer fields received after the current request's chunked body, as a
-     * flat [name, value, ...] JS array preserving wire casing; jsUndefined()
-     * when there are none. Clears the captured section. */
 
     /* Set the trailer fields (pre-rendered "name: value\r\n" lines) to write
      * between the terminating 0 chunk and the final CRLF of the current

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.h
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocketPrototype.h
@@ -26,13 +26,6 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        auto* structure = Bun::createClassStructure(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
-        structure->setMayBePrototype(true);
-        return structure;
-    }
-
 private:
     JSNodeHTTPServerSocketPrototype(JSC::VM& vm, JSC::Structure* structure)
         : Base(vm, structure)

--- a/src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.h
+++ b/src/jsc/bindings/node/crypto/CryptoGenRsaKeyPair.h
@@ -9,7 +9,6 @@ namespace Bun {
 enum class RsaKeyVariant {
     RSA_SSA_PKCS1_v1_5,
     RSA_PSS,
-    RSA_OAEP,
 };
 
 struct RsaKeyPairJobCtx : KeyPairJobCtx {

--- a/src/jsc/bindings/node/crypto/CryptoUtil.h
+++ b/src/jsc/bindings/node/crypto/CryptoUtil.h
@@ -14,7 +14,6 @@ using namespace JSC;
 enum class DSASigEnc {
     DER,
     P1363,
-    Invalid,
 };
 
 // ML-DSA / ML-KEM parameter sets, as provided by BoringSSL's EVP_PKEY
@@ -45,7 +44,6 @@ namespace StringBytes {
 EncodedJSValue encode(JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, std::span<const uint8_t> bytes, BufferEncodingType encoding);
 };
 
-// void CheckThrow(JSC::JSGlobalObject* globalObject, SignBase::Error error);
 JSC::JSValue unsignedBigIntToBuffer(JSC::JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, JSValue bigIntValue, ASCIILiteral name);
 WebCore::BufferEncodingType getEncodingDefaultBuffer(JSGlobalObject* globalObject, ThrowScope& scope, JSValue encodingValue);
 std::optional<ncrypto::EVPKeyPointer> keyFromString(JSGlobalObject* lexicalGlobalObject, JSC::ThrowScope& scope, const WTF::StringView& keyView, JSValue passphraseValue);
@@ -95,18 +93,7 @@ public:
         return reinterpret_cast<const T*>(data_);
     }
 
-    template<typename T = void>
-    operator ncrypto::Buffer<const T>() const
-    {
-        return ncrypto::Buffer<const T> {
-            .data = data<T>(),
-            .len = size(),
-        };
-    }
-
     inline size_t size() const { return size_; }
-
-    inline bool empty() const { return size_ == 0; }
 
     inline operator bool() const { return data_ != nullptr; }
 

--- a/src/jsc/bindings/node/crypto/JSDiffieHellman.h
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellman.h
@@ -30,7 +30,6 @@ public:
     }
 
     ncrypto::DHPointer& getImpl() { return m_dh; }
-    const ncrypto::DHPointer& getImpl() const { return m_dh; }
     int verifyError() const { return m_verifyError; }
 
     template<typename, JSC::SubspaceAccess mode>

--- a/src/jsc/bindings/node/crypto/JSDiffieHellmanGroup.h
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellmanGroup.h
@@ -29,7 +29,6 @@ public:
     }
 
     ncrypto::DHPointer& getImpl() { return m_dh; }
-    const ncrypto::DHPointer& getImpl() const { return m_dh; }
     int verifyError() const { return m_verifyError; }
 
     static void destroy(JSC::JSCell* cell) { static_cast<JSDiffieHellmanGroup*>(cell)->~JSDiffieHellmanGroup(); }

--- a/src/jsc/bindings/node/crypto/JSKeyObject.h
+++ b/src/jsc/bindings/node/crypto/JSKeyObject.h
@@ -31,7 +31,6 @@ public:
     }
 
     KeyObject& handle() { return m_handle; }
-    const KeyObject& handle() const { return m_handle; }
 
     void finishCreation(JSC::VM&, JSC::JSGlobalObject*);
     static void destroy(JSC::JSCell* cell) { static_cast<JSKeyObject*>(cell)->~JSKeyObject(); }

--- a/src/jsc/bindings/node/crypto/JSSign.h
+++ b/src/jsc/bindings/node/crypto/JSSign.h
@@ -10,8 +10,6 @@
 
 namespace Bun {
 
-// JSC_DECLARE_HOST_FUNCTION(jsSignOneShot);
-
 class JSSign;
 class JSSignPrototype;
 class JSSignConstructor;

--- a/src/jsc/bindings/node/crypto/KeyObject.h
+++ b/src/jsc/bindings/node/crypto/KeyObject.h
@@ -32,7 +32,6 @@ public:
 
     enum class KeyEncodingContext {
         Input,
-        Export,
         Generate,
     };
 
@@ -104,7 +103,6 @@ public:
     void getRsaKeyDetails(JSC::JSGlobalObject*, JSC::ThrowScope&, JSC::JSObject* result);
     void getDsaKeyDetails(JSC::JSGlobalObject*, JSC::ThrowScope&, JSC::JSObject* result);
     void getEcKeyDetails(JSC::JSGlobalObject*, JSC::ThrowScope&, JSC::JSObject* result);
-    // void getDhKeyDetails(JSC::JSGlobalObject* , JSC::ThrowScope& , JSC::JSObject* result);
 
     JSC::JSValue asymmetricKeyType(JSC::JSGlobalObject*);
     JSC::JSObject* asymmetricKeyDetails(JSC::JSGlobalObject*, JSC::ThrowScope&);

--- a/src/jsc/bindings/node/http/NodeHTTPParser.h
+++ b/src/jsc/bindings/node/http/NodeHTTPParser.h
@@ -97,7 +97,6 @@ struct StringPtr {
     size_t m_size;
 };
 
-#define HTTP_BOTH 0
 #define HTTP_REQUEST 1
 #define HTTP_RESPONSE 2
 
@@ -189,9 +188,6 @@ public:
     bool m_haveFlushed = false;
 
     inline bool isInitialized() const { return m_parserData.settings != nullptr; }
-
-    // We don't use m_gotException. Instead, we use RETURN_IF_EXCEPTION
-    // bool m_gotException;
 
     size_t m_currentBufferLen;
     const char* m_currentBufferData;

--- a/src/jsc/bindings/root.h
+++ b/src/jsc/bindings/root.h
@@ -3,11 +3,6 @@
 #ifndef BUN__ROOT__H
 #define BUN__ROOT__H
 
-// pick an arbitrary #define to test
-#ifdef ENABLE_3D_TRANSFORMS
-#error "root.h must be included before any other WebCore or JavaScriptCore headers"
-#endif
-
 #if defined(WIN32) || defined(_WIN32)
 #define BUN_EXPORT __declspec(dllexport)
 #else

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -64,13 +64,6 @@ static constexpr int32_t kOwnedByDatabaseFlag = 1 << 3;
 // i.e. it shouldn't have any impact on startup time
 #if LAZY_LOAD_SQLITE
 #include "lazy_sqlite3.h"
-
-#else
-static inline int lazyLoadSQLite()
-{
-    return 0;
-}
-
 #endif
 /* ******************************************************************************** */
 
@@ -334,9 +327,6 @@ JSC_DECLARE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionIterate);
 JSC_DECLARE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRows);
 JSC_DECLARE_HOST_FUNCTION(jsSQLStatementExecuteStatementFunctionRawRows);
 
-JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetColumnNames);
-JSC_DECLARE_CUSTOM_GETTER(jsSqlStatementGetColumnCount);
-
 JSC_DECLARE_HOST_FUNCTION(jsSQLStatementSerialize);
 JSC_DECLARE_HOST_FUNCTION(jsSQLStatementDeserialize);
 
@@ -391,7 +381,6 @@ static JSValue createSQLiteError(JSC::JSGlobalObject* globalObject, sqlite3* db)
 
 class SQLiteBindingsMap {
 public:
-    SQLiteBindingsMap() = default;
     SQLiteBindingsMap(uint16_t count = 0, bool trimLeadingPrefix = false)
     {
         this->trimLeadingPrefix = trimLeadingPrefix;

--- a/src/jsc/bindings/sqlite/NodeSqlite.cpp
+++ b/src/jsc/bindings/sqlite/NodeSqlite.cpp
@@ -37,7 +37,6 @@
 #include "sqlite3_local.h"
 static_assert(BUN_SQLITE_BUNDLED_VERSION_NUMBER == SQLITE_VERSION_NUMBER,
     "update BUN_SQLITE_BUNDLED_VERSION to match sqlite3_local.h");
-static inline int lazyLoadSQLite() { return 0; }
 static constexpr bool lazy_sqlite3_has_session = true;
 #define LAZY_SQLITE_HAS_LOAD_EXTENSION() true
 #endif
@@ -817,8 +816,6 @@ static JSValue rowToObjectCached(JSGlobalObject* globalObject, ThrowScope& scope
 
 static JSValue rowToArray(JSGlobalObject* globalObject, ThrowScope& scope, sqlite3_stmt* stmt, int numCols, bool useBigInts)
 {
-    auto& vm = getVM(globalObject);
-    (void)vm;
     JSArray* row = constructEmptyArray(globalObject, nullptr, numCols);
     RETURN_IF_EXCEPTION(scope, {});
     for (int i = 0; i < numCols; ++i) {
@@ -1250,8 +1247,6 @@ JSC_DEFINE_HOST_FUNCTION(jsDatabaseSyncClose, (JSGlobalObject * globalObject, Ca
 
 JSC_DEFINE_HOST_FUNCTION(jsDatabaseSyncDispose, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
-    auto& vm = JSC::getVM(globalObject);
-    (void)vm;
     JSDatabaseSync* self = dynamicDowncast<JSDatabaseSync>(callFrame->thisValue());
     if (self && self->isOpen()) {
         self->closeInternal();

--- a/src/jsc/bindings/sqlite/lazy_sqlite3.h
+++ b/src/jsc/bindings/sqlite/lazy_sqlite3.h
@@ -18,14 +18,11 @@ struct sqlite3_session;
 struct sqlite3_changeset_iter;
 }
 
-typedef int (*lazy_sqlite3_bind_blob_type)(sqlite3_stmt*, int, const void*, int n, void (*)(void*));
 typedef int (*lazy_sqlite3_bind_blob64_type)(sqlite3_stmt*, int, const void*, sqlite3_uint64, void (*)(void*));
 typedef int (*lazy_sqlite3_bind_double_type)(sqlite3_stmt*, int, double);
 typedef int (*lazy_sqlite3_bind_int_type)(sqlite3_stmt*, int, int);
 typedef int (*lazy_sqlite3_bind_int64_type)(sqlite3_stmt*, int, sqlite3_int64);
 typedef int (*lazy_sqlite3_bind_null_type)(sqlite3_stmt*, int);
-typedef int (*lazy_sqlite3_bind_text_type)(sqlite3_stmt*, int, const char*, int, void (*)(void*));
-typedef int (*lazy_sqlite3_bind_text16_type)(sqlite3_stmt*, int, const void*, int, void (*)(void*));
 typedef int (*lazy_sqlite3_bind_text64_type)(sqlite3_stmt*, int, const char*, sqlite3_uint64, void (*)(void*), unsigned char encoding);
 typedef int (*lazy_sqlite3_bind_parameter_count_type)(sqlite3_stmt*);
 typedef int (*lazy_sqlite3_bind_parameter_index_type)(sqlite3_stmt*, const char* zName);
@@ -49,7 +46,6 @@ typedef const char* (*lazy_sqlite3_column_database_name_type)(sqlite3_stmt*, int
 typedef const char* (*lazy_sqlite3_column_table_name_type)(sqlite3_stmt*, int);
 typedef const char* (*lazy_sqlite3_column_origin_name_type)(sqlite3_stmt*, int);
 typedef const char* (*lazy_sqlite3_errmsg_type)(sqlite3*);
-typedef int (*lazy_sqlite3_errcode_type)(sqlite3*);
 typedef int (*lazy_sqlite3_extended_errcode_type)(sqlite3*);
 typedef int (*lazy_sqlite3_error_offset_type)(sqlite3*);
 typedef const char* (*lazy_sqlite3_errstr_type)(int);
@@ -123,7 +119,6 @@ typedef int (*lazy_sqlite3changeset_apply_type)(sqlite3*, int nChangeset, void* 
 // every TU that includes this header (JSSQLStatement.cpp + NodeSqlite.cpp),
 // so bun:sqlite's Database.setCustomSQLite() also affects node:sqlite and
 // exactly one dlopen happens per process.
-inline lazy_sqlite3_bind_blob_type lazy_sqlite3_bind_blob;
 inline lazy_sqlite3_bind_blob64_type lazy_sqlite3_bind_blob64;
 inline lazy_sqlite3_bind_double_type lazy_sqlite3_bind_double;
 inline lazy_sqlite3_bind_int_type lazy_sqlite3_bind_int;
@@ -131,8 +126,6 @@ inline lazy_sqlite3_bind_int64_type lazy_sqlite3_bind_int64;
 inline lazy_sqlite3_bind_null_type lazy_sqlite3_bind_null;
 inline lazy_sqlite3_bind_parameter_count_type lazy_sqlite3_bind_parameter_count;
 inline lazy_sqlite3_bind_parameter_index_type lazy_sqlite3_bind_parameter_index;
-inline lazy_sqlite3_bind_text_type lazy_sqlite3_bind_text;
-inline lazy_sqlite3_bind_text16_type lazy_sqlite3_bind_text16;
 inline lazy_sqlite3_bind_text64_type lazy_sqlite3_bind_text64;
 inline lazy_sqlite3_changes_type lazy_sqlite3_changes;
 inline lazy_sqlite3_changes64_type lazy_sqlite3_changes64;
@@ -155,7 +148,6 @@ inline lazy_sqlite3_column_database_name_type lazy_sqlite3_column_database_name;
 inline lazy_sqlite3_column_table_name_type lazy_sqlite3_column_table_name;
 inline lazy_sqlite3_column_origin_name_type lazy_sqlite3_column_origin_name;
 inline lazy_sqlite3_errmsg_type lazy_sqlite3_errmsg;
-inline lazy_sqlite3_errcode_type lazy_sqlite3_errcode;
 inline lazy_sqlite3_errstr_type lazy_sqlite3_errstr;
 inline lazy_sqlite3_expanded_sql_type lazy_sqlite3_expanded_sql;
 inline lazy_sqlite3_sql_type lazy_sqlite3_sql;
@@ -219,7 +211,6 @@ inline lazy_sqlite3session_changeset_type lazy_sqlite3session_changeset;
 inline lazy_sqlite3session_patchset_type lazy_sqlite3session_patchset;
 inline lazy_sqlite3changeset_apply_type lazy_sqlite3changeset_apply;
 
-#define sqlite3_bind_blob lazy_sqlite3_bind_blob
 #define sqlite3_bind_blob64 lazy_sqlite3_bind_blob64
 #define sqlite3_bind_double lazy_sqlite3_bind_double
 #define sqlite3_bind_int lazy_sqlite3_bind_int
@@ -227,8 +218,6 @@ inline lazy_sqlite3changeset_apply_type lazy_sqlite3changeset_apply;
 #define sqlite3_bind_null lazy_sqlite3_bind_null
 #define sqlite3_bind_parameter_count lazy_sqlite3_bind_parameter_count
 #define sqlite3_bind_parameter_index lazy_sqlite3_bind_parameter_index
-#define sqlite3_bind_text lazy_sqlite3_bind_text
-#define sqlite3_bind_text16 lazy_sqlite3_bind_text16
 #define sqlite3_bind_text64 lazy_sqlite3_bind_text64
 #define sqlite3_changes lazy_sqlite3_changes
 #define sqlite3_changes64 lazy_sqlite3_changes64
@@ -250,7 +239,6 @@ inline lazy_sqlite3changeset_apply_type lazy_sqlite3changeset_apply;
 #define sqlite3_column_table_name lazy_sqlite3_column_table_name
 #define sqlite3_column_origin_name lazy_sqlite3_column_origin_name
 #define sqlite3_errmsg lazy_sqlite3_errmsg
-#define sqlite3_errcode lazy_sqlite3_errcode
 #define sqlite3_errstr lazy_sqlite3_errstr
 #define sqlite3_expanded_sql lazy_sqlite3_expanded_sql
 #define sqlite3_sql lazy_sqlite3_sql
@@ -356,7 +344,6 @@ inline int lazyLoadSQLite()
     }
     lazy_sqlite3_open_v2 = (lazy_sqlite3_open_v2_type)dlsym(sqlite3_handle, "sqlite3_open_v2");
     if (!lazy_sqlite3_open_v2) return -1;
-    lazy_sqlite3_bind_blob = (lazy_sqlite3_bind_blob_type)dlsym(sqlite3_handle, "sqlite3_bind_blob");
     lazy_sqlite3_bind_blob64 = (lazy_sqlite3_bind_blob64_type)dlsym(sqlite3_handle, "sqlite3_bind_blob64");
     lazy_sqlite3_bind_double = (lazy_sqlite3_bind_double_type)dlsym(sqlite3_handle, "sqlite3_bind_double");
     lazy_sqlite3_bind_int = (lazy_sqlite3_bind_int_type)dlsym(sqlite3_handle, "sqlite3_bind_int");
@@ -364,8 +351,6 @@ inline int lazyLoadSQLite()
     lazy_sqlite3_bind_null = (lazy_sqlite3_bind_null_type)dlsym(sqlite3_handle, "sqlite3_bind_null");
     lazy_sqlite3_bind_parameter_count = (lazy_sqlite3_bind_parameter_count_type)dlsym(sqlite3_handle, "sqlite3_bind_parameter_count");
     lazy_sqlite3_bind_parameter_index = (lazy_sqlite3_bind_parameter_index_type)dlsym(sqlite3_handle, "sqlite3_bind_parameter_index");
-    lazy_sqlite3_bind_text = (lazy_sqlite3_bind_text_type)dlsym(sqlite3_handle, "sqlite3_bind_text");
-    lazy_sqlite3_bind_text16 = (lazy_sqlite3_bind_text16_type)dlsym(sqlite3_handle, "sqlite3_bind_text16");
     lazy_sqlite3_bind_text64 = (lazy_sqlite3_bind_text64_type)dlsym(sqlite3_handle, "sqlite3_bind_text64");
     lazy_sqlite3_changes = (lazy_sqlite3_changes_type)dlsym(sqlite3_handle, "sqlite3_changes");
     lazy_sqlite3_changes64 = (lazy_sqlite3_changes64_type)dlsym(sqlite3_handle, "sqlite3_changes64");
@@ -388,7 +373,6 @@ inline int lazyLoadSQLite()
     lazy_sqlite3_column_table_name = (lazy_sqlite3_column_table_name_type)dlsym(sqlite3_handle, "sqlite3_column_table_name");
     lazy_sqlite3_column_origin_name = (lazy_sqlite3_column_origin_name_type)dlsym(sqlite3_handle, "sqlite3_column_origin_name");
     lazy_sqlite3_errmsg = (lazy_sqlite3_errmsg_type)dlsym(sqlite3_handle, "sqlite3_errmsg");
-    lazy_sqlite3_errcode = (lazy_sqlite3_errcode_type)dlsym(sqlite3_handle, "sqlite3_errcode");
     lazy_sqlite3_errstr = (lazy_sqlite3_errstr_type)dlsym(sqlite3_handle, "sqlite3_errstr");
     lazy_sqlite3_expanded_sql = (lazy_sqlite3_expanded_sql_type)dlsym(sqlite3_handle, "sqlite3_expanded_sql");
     lazy_sqlite3_sql = (lazy_sqlite3_sql_type)dlsym(sqlite3_handle, "sqlite3_sql");

--- a/src/jsc/bindings/uv-posix-polyfills.c
+++ b/src/jsc/bindings/uv-posix-polyfills.c
@@ -29,8 +29,6 @@ uint64_t uv__hrtime(uv_clocktype_t type);
 #include "uv-posix-polyfills-darwin.c"
 #elif defined(__FreeBSD__)
 #include "uv-posix-polyfills-posix.c"
-#elif defined(__CYGWIN__) || defined(__MSYS__) || defined(__HAIKU__) || defined(__QNX__) || defined(__GNU__)
-#include "uv-posix-polyfills-posix.c"
 #endif
 
 uv_pid_t uv_os_getpid()

--- a/src/jsc/bindings/v8/V8Array.cpp
+++ b/src/jsc/bindings/v8/V8Array.cpp
@@ -16,7 +16,6 @@ ASSERT_V8_TYPE_LAYOUT_MATCHES(v8::Array)
 
 using JSC::ArrayAllocationProfile;
 using JSC::JSArray;
-using JSC::JSGlobalObject;
 using JSC::JSValue;
 using JSC::MarkedArgumentBuffer;
 

--- a/src/jsc/bindings/v8/V8FunctionTemplate.cpp
+++ b/src/jsc/bindings/v8/V8FunctionTemplate.cpp
@@ -16,7 +16,6 @@ ASSERT_V8_ENUM_MATCHES(SideEffectType, kHasSideEffect)
 ASSERT_V8_ENUM_MATCHES(SideEffectType, kHasNoSideEffect)
 ASSERT_V8_ENUM_MATCHES(SideEffectType, kHasSideEffectToReceiver)
 
-using JSC::JSCell;
 using JSC::JSValue;
 using JSC::Structure;
 

--- a/src/jsc/bindings/v8/V8FunctionTemplate.h
+++ b/src/jsc/bindings/v8/V8FunctionTemplate.h
@@ -72,11 +72,6 @@ private:
     {
         return Data::localToObjectPointer<shim::FunctionTemplate>();
     }
-
-    const shim::FunctionTemplate* localToObjectPointer() const
-    {
-        return Data::localToObjectPointer<shim::FunctionTemplate>();
-    }
 };
 
 } // namespace v8

--- a/src/jsc/bindings/v8/V8Object.cpp
+++ b/src/jsc/bindings/v8/V8Object.cpp
@@ -14,7 +14,6 @@ ASSERT_V8_ENUM_MATCHES(PropertyAttribute, DontDelete)
 
 using JSC::Identifier;
 using JSC::JSFinalObject;
-using JSC::JSGlobalObject;
 using JSC::JSObject;
 using JSC::JSValue;
 using JSC::PutPropertySlot;

--- a/src/jsc/bindings/v8/node.cpp
+++ b/src/jsc/bindings/v8/node.cpp
@@ -14,7 +14,6 @@ static_assert(REPORTED_NODEJS_ABI_VERSION == NODE_MODULE_VERSION,
 
 using v8::Context;
 using v8::HandleScope;
-using v8::Isolate;
 using v8::Local;
 using v8::MaybeLocal;
 using v8::Object;

--- a/src/jsc/bindings/v8/shim/Handle.cpp
+++ b/src/jsc/bindings/v8/shim/Handle.cpp
@@ -32,12 +32,6 @@ Handle::Handle(const Handle& that)
     *this = that;
 }
 
-Handle::Handle(const ObjectLayout* that)
-    : m_toV8Object(&this->m_object)
-{
-    m_object = *that;
-}
-
 Handle& Handle::operator=(const Handle& that)
 {
     m_object = that.m_object;

--- a/src/jsc/bindings/v8/shim/Handle.h
+++ b/src/jsc/bindings/v8/shim/Handle.h
@@ -63,8 +63,6 @@ struct Handle {
 
     Handle(const Handle& that);
 
-    Handle(const ObjectLayout* that);
-
     Handle()
         : m_toV8Object(0)
         , m_object()

--- a/src/jsc/bindings/v8/shim/Oddball.h
+++ b/src/jsc/bindings/v8/shim/Oddball.h
@@ -11,7 +11,6 @@ struct Oddball {
     enum class Kind : int {
         kUndefined = 4,
         kNull = 3,
-        kInvalid = 255,
         kTrue = 99,
         kFalse = 98,
     };

--- a/src/jsc/bindings/v8/v8_api_internal.cpp
+++ b/src/jsc/bindings/v8/v8_api_internal.cpp
@@ -44,7 +44,6 @@ void DisposeGlobal(uintptr_t* location)
 {
     if (location) weakHandleParameters().remove(location);
     // TODO free up a slot in the handle scope
-    (void)location;
 }
 
 void MakeWeak(uintptr_t* location, void* data, WeakCallbackInfo<void>::Callback weak_callback, WeakCallbackType type)

--- a/src/jsc/bindings/v8/v8_api_internal.h
+++ b/src/jsc/bindings/v8/v8_api_internal.h
@@ -11,7 +11,6 @@ class Local;
 class Value;
 class Data;
 
-static constexpr int kInternalFieldsInWeakCallback = 2;
 static constexpr int kEmbedderFieldsInWeakCallback = 2;
 
 template<typename T>

--- a/src/jsc/bindings/webcore/JSAbortController.cpp
+++ b/src/jsc/bindings/webcore/JSAbortController.cpp
@@ -287,38 +287,8 @@ void JSAbortController::finishCreation(VM& vm)
     ASSERT(inherits(info()));
 }
 
-#if ENABLE(BINDING_INTEGRITY)
-#if PLATFORM(WIN)
-#pragma warning(disable : 4483)
-extern "C" {
-extern void (*const __identifier("??_7AbortController@WebCore@@6B@")[])();
-}
-#else
-extern "C" {
-extern void* _ZTVN7WebCore15AbortControllerE[];
-}
-#endif
-#endif
-
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<AbortController>&& impl)
 {
-
-    if constexpr (std::is_polymorphic_v<AbortController>) {
-#if ENABLE(BINDING_INTEGRITY)
-        // const void* actualVTablePointer = getVTablePointer(impl.ptr());
-#if PLATFORM(WIN)
-        void* expectedVTablePointer = __identifier("??_7AbortController@WebCore@@6B@");
-#else
-        // void* expectedVTablePointer = &_ZTVN7WebCore15AbortControllerE[2];
-#endif
-
-        // If you hit this assertion you either have a use after free bug, or
-        // AbortController has subclasses. If AbortController has subclasses that get passed
-        // to toJS() we currently require AbortController you to opt out of binding hardening
-        // by adding the SkipVTableValidation attribute to the interface IDL definition
-        // RELEASE_ASSERT(actualVTablePointer == expectedVTablePointer);
-#endif
-    }
     return createWrapper<AbortController>(globalObject, WTF::move(impl));
 }
 

--- a/src/jsc/bindings/webcore/JSCloseEvent.cpp
+++ b/src/jsc/bindings/webcore/JSCloseEvent.cpp
@@ -324,38 +324,8 @@ void JSCloseEvent::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-#if ENABLE(BINDING_INTEGRITY)
-#if PLATFORM(WIN)
-#pragma warning(disable : 4483)
-extern "C" {
-extern void (*const __identifier("??_7CloseEvent@WebCore@@6B@")[])();
-}
-#else
-extern "C" {
-extern void* _ZTVN7WebCore10CloseEventE[];
-}
-#endif
-#endif
-
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<CloseEvent>&& impl)
 {
-
-    if constexpr (std::is_polymorphic_v<CloseEvent>) {
-#if ENABLE(BINDING_INTEGRITY)
-        // const void* actualVTablePointer = getVTablePointer(impl.ptr());
-#if PLATFORM(WIN)
-        void* expectedVTablePointer = __identifier("??_7CloseEvent@WebCore@@6B@");
-#else
-        // void* expectedVTablePointer = &_ZTVN7WebCore10CloseEventE[2];
-#endif
-
-        // If you hit this assertion you either have a use after free bug, or
-        // CloseEvent has subclasses. If CloseEvent has subclasses that get passed
-        // to toJS() we currently require CloseEvent you to opt out of binding hardening
-        // by adding the SkipVTableValidation attribute to the interface IDL definition
-        // RELEASE_ASSERT(actualVTablePointer == expectedVTablePointer);
-#endif
-    }
     return createWrapper<CloseEvent>(globalObject, WTF::move(impl));
 }
 

--- a/src/jsc/bindings/webcore/JSCustomEvent.cpp
+++ b/src/jsc/bindings/webcore/JSCustomEvent.cpp
@@ -329,19 +329,6 @@ void JSCustomEvent::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-#if ENABLE(BINDING_INTEGRITY)
-#if PLATFORM(WIN)
-#pragma warning(disable : 4483)
-extern "C" {
-extern void (*const __identifier("??_7CustomEvent@WebCore@@6B@")[])();
-}
-#else
-extern "C" {
-extern void* _ZTVN7WebCore11CustomEventE[];
-}
-#endif
-#endif
-
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<CustomEvent>&& impl)
 {
     return createWrapper<CustomEvent>(globalObject, WTF::move(impl));

--- a/src/jsc/bindings/webcore/JSPerformanceObserver.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceObserver.cpp
@@ -366,38 +366,8 @@ void JSPerformanceObserverOwner::finalize(JSC::Handle<JSC::Unknown> handle, void
     uncacheWrapper(world, &jsPerformanceObserver->wrapped(), jsPerformanceObserver);
 }
 
-#if ENABLE(BINDING_INTEGRITY)
-#if PLATFORM(WIN)
-#pragma warning(disable : 4483)
-extern "C" {
-extern void (*const __identifier("??_7PerformanceObserver@WebCore@@6B@")[])();
-}
-#else
-extern "C" {
-extern void* _ZTVN7WebCore19PerformanceObserverE[];
-}
-#endif
-#endif
-
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<PerformanceObserver>&& impl)
 {
-
-    if constexpr (std::is_polymorphic_v<PerformanceObserver>) {
-#if ENABLE(BINDING_INTEGRITY)
-        // const void* actualVTablePointer = getVTablePointer(impl.ptr());
-#if PLATFORM(WIN)
-        void* expectedVTablePointer = __identifier("??_7PerformanceObserver@WebCore@@6B@");
-#else
-        // void* expectedVTablePointer = &_ZTVN7WebCore19PerformanceObserverE[2];
-#endif
-
-        // If you hit this assertion you either have a use after free bug, or
-        // PerformanceObserver has subclasses. If PerformanceObserver has subclasses that get passed
-        // to toJS() we currently require PerformanceObserver you to opt out of binding hardening
-        // by adding the SkipVTableValidation attribute to the interface IDL definition
-        // RELEASE_ASSERT(actualVTablePointer == expectedVTablePointer);
-#endif
-    }
     return createWrapper<PerformanceObserver>(globalObject, WTF::move(impl));
 }
 

--- a/src/jsc/bindings/webcore/JSPerformanceServerTiming.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceServerTiming.cpp
@@ -259,19 +259,6 @@ void JSPerformanceServerTimingOwner::finalize(JSC::Handle<JSC::Unknown> handle, 
     uncacheWrapper(world, jsPerformanceServerTiming->protectedWrapped().ptr(), jsPerformanceServerTiming);
 }
 
-#if ENABLE(BINDING_INTEGRITY)
-#if PLATFORM(WIN)
-#pragma warning(disable : 4483)
-extern "C" {
-extern void (*const __identifier("??_7PerformanceServerTiming@WebCore@@6B@")[])();
-}
-#else
-extern "C" {
-extern void* _ZTVN7WebCore23PerformanceServerTimingE[];
-}
-#endif
-#endif
-
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<PerformanceServerTiming>&& impl)
 {
     return createWrapper<PerformanceServerTiming>(globalObject, WTF::move(impl));

--- a/src/jsc/bindings/webcore/JSPerformanceTiming.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceTiming.cpp
@@ -582,38 +582,8 @@ void JSPerformanceTimingOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* 
     uncacheWrapper(world, &jsPerformanceTiming->wrapped(), jsPerformanceTiming);
 }
 
-#if ENABLE(BINDING_INTEGRITY)
-#if PLATFORM(WIN)
-#pragma warning(disable : 4483)
-extern "C" {
-extern void (*const __identifier("??_7PerformanceTiming@WebCore@@6B@")[])();
-}
-#else
-extern "C" {
-extern void* _ZTVN7WebCore17PerformanceTimingE[];
-}
-#endif
-#endif
-
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<PerformanceTiming>&& impl)
 {
-
-    if constexpr (std::is_polymorphic_v<PerformanceTiming>) {
-#if ENABLE(BINDING_INTEGRITY)
-        // const void* actualVTablePointer = getVTablePointer(impl.ptr());
-#if PLATFORM(WIN)
-        void* expectedVTablePointer = __identifier("??_7PerformanceTiming@WebCore@@6B@");
-#else
-        // void* expectedVTablePointer = &_ZTVN7WebCore17PerformanceTimingE[2];
-#endif
-
-        // If you hit this assertion you either have a use after free bug, or
-        // PerformanceTiming has subclasses. If PerformanceTiming has subclasses that get passed
-        // to toJS() we currently require PerformanceTiming you to opt out of binding hardening
-        // by adding the SkipVTableValidation attribute to the interface IDL definition
-        // RELEASE_ASSERT(actualVTablePointer == expectedVTablePointer);
-#endif
-    }
     return createWrapper<PerformanceTiming>(globalObject, WTF::move(impl));
 }
 

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -1033,38 +1033,8 @@ void JSWebSocketOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
     uncacheWrapper(world, &jsWebSocket->wrapped(), jsWebSocket);
 }
 
-#if ENABLE(BINDING_INTEGRITY)
-#if PLATFORM(WIN)
-#pragma warning(disable : 4483)
-extern "C" {
-extern void (*const __identifier("??_7WebSocket@WebCore@@6B@")[])();
-}
-#else
-extern "C" {
-extern void* _ZTVN7WebCore9WebSocketE[];
-}
-#endif
-#endif
-
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<WebSocket>&& impl)
 {
-
-    if constexpr (std::is_polymorphic_v<WebSocket>) {
-#if ENABLE(BINDING_INTEGRITY)
-        // const void* actualVTablePointer = getVTablePointer(impl.ptr());
-#if PLATFORM(WIN)
-        void* expectedVTablePointer = __identifier("??_7WebSocket@WebCore@@6B@");
-#else
-        // void* expectedVTablePointer = &_ZTVN7WebCore9WebSocketE[2];
-#endif
-
-        // If you hit this assertion you either have a use after free bug, or
-        // WebSocket has subclasses. If WebSocket has subclasses that get passed
-        // to toJS() we currently require WebSocket you to opt out of binding hardening
-        // by adding the SkipVTableValidation attribute to the interface IDL definition
-        // RELEASE_ASSERT(actualVTablePointer == expectedVTablePointer);
-#endif
-    }
     return createWrapper<WebSocket>(globalObject, WTF::move(impl));
 }
 

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -988,38 +988,8 @@ void JSWorkerOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
     uncacheWrapper(world, &jsWorker->wrapped(), jsWorker);
 }
 
-#if ENABLE(BINDING_INTEGRITY)
-#if PLATFORM(WIN)
-#pragma warning(disable : 4483)
-extern "C" {
-extern void (*const __identifier("??_7Worker@WebCore@@6B@")[])();
-}
-#else
-extern "C" {
-extern void* _ZTVN7WebCore6WorkerE[];
-}
-#endif
-#endif
-
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<Worker>&& impl)
 {
-
-    if constexpr (std::is_polymorphic_v<Worker>) {
-#if ENABLE(BINDING_INTEGRITY)
-        // const void* actualVTablePointer = getVTablePointer(impl.ptr());
-#if PLATFORM(WIN)
-        void* expectedVTablePointer = __identifier("??_7Worker@WebCore@@6B@");
-#else
-        // void* expectedVTablePointer = &_ZTVN7WebCore6WorkerE[2];
-#endif
-
-        // If you hit this assertion you either have a use after free bug, or
-        // Worker has subclasses. If Worker has subclasses that get passed
-        // to toJS() we currently require Worker you to opt out of binding hardening
-        // by adding the SkipVTableValidation attribute to the interface IDL definition
-        // RELEASE_ASSERT(actualVTablePointer == expectedVTablePointer);
-#endif
-    }
     return createWrapper<Worker>(globalObject, WTF::move(impl));
 }
 

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmMLKEM.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmMLKEM.h
@@ -31,8 +31,6 @@
 
 namespace WebCore {
 
-class CryptoKeyAKP;
-
 // One implementation backs ML-KEM-768/1024; the registered subclasses below
 // only pin the name and identifier, mirroring Node's ml_kem.js. ML-KEM-512
 // is not registered because the vendored BoringSSL has no EVP support for it.

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmParameters.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmParameters.h
@@ -53,7 +53,6 @@ public:
         Pbkdf2Params,
         RsaHashedKeyGenParams,
         RsaHashedImportParams,
-        RsaKeyGenParams,
         RsaOaepParams,
         RsaPssParams,
         X25519Params,

--- a/src/jsc/bindings/webcrypto/CryptoAlgorithmRsaKeyGenParams.h
+++ b/src/jsc/bindings/webcrypto/CryptoAlgorithmRsaKeyGenParams.h
@@ -38,8 +38,6 @@ public:
     size_t modulusLength;
     RefPtr<Uint8Array> publicExponent;
 
-    Class parametersClass() const override { return Class::RsaKeyGenParams; }
-
     const Vector<uint8_t>& publicExponentVector() const
     {
         if (!m_publicExponentVector.isEmpty() || !publicExponent->byteLength())
@@ -54,7 +52,5 @@ private:
 };
 
 } // namespace WebCore
-
-SPECIALIZE_TYPE_TRAITS_CRYPTO_ALGORITHM_PARAMETERS(RsaKeyGenParams)
 
 #endif // ENABLE(WEB_CRYPTO)

--- a/src/jsc/bindings/webcrypto/CryptoKeyOKPOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyOKPOpenSSL.cpp
@@ -29,7 +29,6 @@
 #if ENABLE(WEB_CRYPTO)
 
 #include "JsonWebKey.h"
-// #include "Logging.h"
 #include <wtf/text/Base64.h>
 #include <openssl/curve25519.h>
 #include "CommonCryptoDERUtilities.h"

--- a/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
+++ b/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
@@ -166,8 +166,6 @@ void JSCryptoKey::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
-
-    // static_assert(!std::is_base_of<ActiveDOMObject, CryptoKey>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
 }
 
 JSObject* JSCryptoKey::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)

--- a/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
@@ -211,8 +211,6 @@ void JSSubtleCrypto::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
-
-    // static_assert(!std::is_base_of<ActiveDOMObject, SubtleCrypto>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
 }
 
 JSObject* JSSubtleCrypto::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)

--- a/src/jsc/bindings/webcrypto/SubtleCrypto.h
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.h
@@ -42,7 +42,6 @@
 namespace JSC {
 class ArrayBufferView;
 class ArrayBuffer;
-class CallFrame;
 }
 
 namespace WebCore {

--- a/src/jsc/bindings/workaround-missing-symbols.cpp
+++ b/src/jsc/bindings/workaround-missing-symbols.cpp
@@ -43,12 +43,6 @@ extern "C" int kill(int pid, int sig)
 
 #endif
 
-#if !defined(WIN32)
-#ifndef UNLIKELY
-#define UNLIKELY(x) __builtin_expect(!!(x), 0)
-#endif
-#endif
-
 #if defined(__FreeBSD__) && !ASSERT_ENABLED
 // WTF references this counter from text/StringCommon.h under STRING_STATS;
 // Debug WebKit defines it (StringView.cpp); Release doesn't, but Bun's
@@ -82,7 +76,6 @@ std::atomic<int> wtfStringCopyCount;
 #include <sys/random.h>
 #include <sys/syscall.h>
 #include <unistd.h>
-#include <dlfcn.h>
 
 #ifndef _STAT_VER
 #if defined(__aarch64__)

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -20,7 +20,6 @@ static_assert(WTF::maxECMAScriptTime == 8.64e15, "bun_jsc::wtf::MAX_ECMASCRIPT_T
 #if !OS(WINDOWS)
 #include <stdatomic.h>
 
-#include <cassert>
 #include <signal.h>
 #include <termios.h>
 static int orig_termios_fd = -1;
@@ -66,37 +65,7 @@ static void uv__tty_make_raw(struct termios* tio)
 {
     ASSERT(tio != NULL);
 
-#if defined __sun || defined __MVS__
-    /*
-     * This implementation of cfmakeraw for Solaris and derivatives is taken from
-     * http://www.perkin.org.uk/posts/solaris-portability-cfmakeraw.html.
-     */
-    tio->c_iflag &= ~(IMAXBEL | IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
-    tio->c_oflag &= ~OPOST;
-    tio->c_lflag &= ~(ECHO | ECHONL | ICANON | ISIG | IEXTEN);
-    tio->c_cflag &= ~(CSIZE | PARENB);
-    tio->c_cflag |= CS8;
-
-    /*
-     * By default, most software expects a pending read to block until at
-     * least one byte becomes available.  As per termio(7I), this requires
-     * setting the MIN and TIME parameters appropriately.
-     *
-     * As a somewhat unfortunate artifact of history, the MIN and TIME slots
-     * in the control character array overlap with the EOF and EOL slots used
-     * for canonical mode processing.  Because the EOF character needs to be
-     * the ASCII EOT value (aka Control-D), it has the byte value 4.  When
-     * switching to raw mode, this is interpreted as a MIN value of 4; i.e.,
-     * reads will block until at least four bytes have been input.
-     *
-     * Other platforms with a distinct MIN slot like Linux and FreeBSD appear
-     * to default to a MIN value of 1, so we'll force that value here:
-     */
-    tio->c_cc[VMIN] = 1;
-    tio->c_cc[VTIME] = 0;
-#else
     cfmakeraw(tio);
-#endif /* #ifdef __sun */
 }
 
 #endif

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1454,42 +1454,12 @@ fn el_ref<'a>(owner: *mut ()) -> &'a mut EventLoop {
 bun_event_loop::link_impl_JsEventLoop! {
     Jsc for EventLoop => |this| {
         iteration_number() => (&*(*this).usockets_loop()).iteration_number(),
-        // Return raw to avoid asserting uniqueness — multiple handles may name the
-        // same VM.
-        file_polls() => core::ptr::from_mut(
-            (*this)
-                .vm_ref()
-                .as_mut()
-                .rare_data()
-                .file_polls
-                .get_or_insert_with(|| Box::new(Async::file_poll::Store::init()))
-                .as_mut(),
-        ),
-        put_file_poll(poll, was_ever_registered) => {
-            // `Store::put` only needs the VM as an opaque `EventLoopCtx`; reach it
-            // via the JS-ctx hook so we don't form a competing `&mut VirtualMachine`
-            // while holding the store.
-            let store = core::ptr::from_mut(
-                (*this)
-                    .vm_ref()
-                    .as_mut()
-                    .rare_data()
-                    .file_polls
-                    .get_or_insert_with(|| Box::new(Async::file_poll::Store::init()))
-                    .as_mut(),
-            );
-            let ctx = Async::posix_event_loop::get_vm_ctx(Async::AllocatorType::Js);
-            // `poll` is a live hive-slot pointer (vtable contract) — non-null.
-            (*store).put(core::ptr::NonNull::new_unchecked(poll), ctx, was_ever_registered);
-        },
         uws_loop() => (*this).usockets_loop(),
         tick() => (*this).tick(),
         auto_tick() => (*this).auto_tick(),
         auto_tick_active() => (*this).auto_tick_active(),
         global_object() => (*this).global.map_or(core::ptr::null_mut(), |p| p.as_ptr().cast()),
         bun_vm() => (*this).virtual_machine.map_or(core::ptr::null_mut(), |p| p.as_ptr().cast()),
-        stdout() => (*this).vm_ref().as_mut().rare_data().stdout().cast(),
-        stderr() => (*this).vm_ref().as_mut().rare_data().stderr().cast(),
         enter() => (*this).enter(),
         exit() => (*this).exit(),
         enqueue_task(task) => (*this).enqueue_task(task),

--- a/src/paths/Cargo.toml
+++ b/src/paths/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 strum.workspace = true
 bstr.workspace = true
 const_format.workspace = true
-libc.workspace = true
 bun_alloc.workspace = true
 bun_core.workspace = true
 bun_errno.workspace = true

--- a/src/runtime/bake/BakeGlobalObject.cpp
+++ b/src/runtime/bake/BakeGlobalObject.cpp
@@ -271,7 +271,6 @@ extern "C" GlobalObject* BakeCreateProdGlobal(void* console)
     JSC::gcProtect(global);
 
     global->setConsole(console);
-    global->isThreadLocalDefaultGlobalObject = true;
 
     vm.heap.disableStopIfNecessaryTimer();
 

--- a/src/runtime/bake/DevServerSourceProvider.cpp
+++ b/src/runtime/bake/DevServerSourceProvider.cpp
@@ -2,9 +2,6 @@
 #include "BunBuiltinNames.h"
 #include "BunString.h"
 
-// Implemented on the Rust side to handle registration.
-extern "C" void Bun__addDevServerSourceProvider(void* bun_vm, Bake::DevServerSourceProvider* opaque_source_provider, const BunString* specifier);
-
 // Exported for the Rust side to access DevServerSourceProvider.
 extern "C" BunString DevServerSourceProvider__getSourceSlice(Bake::DevServerSourceProvider* provider)
 {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -161,9 +161,7 @@ pub use bun_windows_sys::FS_INFORMATION_CLASS;
 pub use bun_windows_sys::IO_STATUS_BLOCK;
 pub use bun_windows_sys::OBJECT_ATTRIBUTES;
 pub use bun_windows_sys::STANDARD_RIGHTS_READ;
-pub use bun_windows_sys::advapi32;
 pub use bun_windows_sys::kernel32::SetConsoleCtrlHandler;
-pub use bun_windows_sys::user32;
 pub use bun_windows_sys::{CONSOLE_SCREEN_BUFFER_INFO, SMALL_RECT};
 pub use bun_windows_sys::{CTRL_BREAK_EVENT, CTRL_C_EVENT, CTRL_CLOSE_EVENT};
 pub use bun_windows_sys::{DELETE, GENERIC_READ, GENERIC_WRITE, SYNCHRONIZE};
@@ -571,8 +569,7 @@ pub use bun_windows_sys::externs::{
 // live in bun_windows_sys::externs; Zeroable impls for these nominal types
 // live in bun_core/lib.rs (orphan-rule home). Do NOT re-declare here.
 pub use bun_windows_sys::externs::{
-    IO_COUNTERS, JOBOBJECT_ASSOCIATE_COMPLETION_PORT, JOBOBJECT_BASIC_LIMIT_INFORMATION,
-    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectAssociateCompletionPortInformation,
+    IO_COUNTERS, JOBOBJECT_BASIC_LIMIT_INFORMATION, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
     JobObjectExtendedLimitInformation,
 };
 
@@ -1232,8 +1229,6 @@ pub fn detect_runtime_version() -> &'static str {
 pub use bun_windows_sys::externs::InitializeProcThreadAttributeList;
 
 pub use bun_windows_sys::externs::UpdateProcThreadAttribute;
-
-pub use bun_windows_sys::externs::IsProcessInJob;
 
 pub(crate) const EXTENDED_STARTUPINFO_PRESENT: DWORD = 0x80000;
 pub(crate) const PROC_THREAD_ATTRIBUTE_JOB_LIST: DWORD = 0x2000D;

--- a/src/uws_sys/_libusockets.h
+++ b/src/uws_sys/_libusockets.h
@@ -75,7 +75,6 @@ struct uws_app_s;
 struct uws_req_s;
 struct uws_res_s;
 struct uws_websocket_s;
-struct uws_header_iterator_s;
 typedef struct uws_app_s uws_app_t;
 typedef struct uws_req_s uws_req_t;
 typedef struct uws_res_s uws_res_t;

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -344,20 +344,6 @@ extern "C"
     }
   }
 
-  void uws_app_run(int ssl, uws_app_t *app)
-  {
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      uwsApp->run();
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-      uwsApp->run();
-    }
-  }
-
   void uws_app_close(int ssl, uws_app_t *app)
   {
     if (ssl)
@@ -409,31 +395,6 @@ extern "C"
       uwsApp->setOnClientError([handler, user_data](int is_ssl, struct us_socket_t *rawSocket, uint8_t errorCode, char *rawPacket, int rawPacketLength) {
         handler(user_data, is_ssl, rawSocket, errorCode, rawPacket, rawPacketLength);
       });
-    }
-  }
-
-  void uws_app_listen(int ssl, uws_app_t *app, int port,
-                      uws_listen_handler handler, void *user_data)
-  {
-    uws_app_listen_config_t config;
-    config.port = port;
-    config.host = nullptr;
-    config.options = 0;
-
-    if (ssl)
-    {
-      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-      uwsApp->listen(port, [handler,
-                            user_data](struct us_listen_socket_t *listen_socket)
-                     { handler((struct us_listen_socket_t *)listen_socket, user_data); });
-    }
-    else
-    {
-      uWS::App *uwsApp = (uWS::App *)app;
-
-      uwsApp->listen(port, [handler,
-                            user_data](struct us_listen_socket_t *listen_socket)
-                     { handler((struct us_listen_socket_t *)listen_socket, user_data); });
     }
   }
 

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -738,7 +738,6 @@ pub mod ntdll {
             Length: ULONG,
             FsInformationClass: FS_INFORMATION_CLASS,
         ) -> NTSTATUS;
-        pub fn NtClose(Handle: HANDLE) -> NTSTATUS;
 
         // ── futex (`WaitOnAddress`) — used by `bun_threading::Futex` ──
         // Linked from ntdll instead of `API-MS-Win-Core-Synch-l1-2-0.dll`
@@ -793,12 +792,6 @@ pub mod ntdll {
     }
     pub use super::RtlNtStatusToDosError;
 }
-pub use ntdll::NtClose;
-
-/// `user32` namespace (subset placeholder; fill in as needed).
-pub mod user32 {}
-/// `advapi32` namespace (subset placeholder; fill in as needed).
-pub mod advapi32 {}
 
 // `bun.windows.libuv` is exposed from the higher-tier `bun_sys::windows`
 // module, NOT here — `bun_windows_sys` is the leaf Win32 externs crate and
@@ -960,8 +953,8 @@ pub mod kernel32 {
     }
     // Re-export externs declared at the crate root so `kernel32::Foo` resolves.
     pub use super::{
-        CreateFileW, GetCurrentDirectoryW, GetFileAttributesW, GetSystemDirectoryW, GetSystemInfo,
-        SYSTEM_INFO, SetCurrentDirectoryW, SetFilePointerEx,
+        CreateFileW, GetCurrentDirectoryW, GetFileAttributesW, GetSystemDirectoryW,
+        SetCurrentDirectoryW, SetFilePointerEx,
     };
     pub use super::{
         GetConsoleCP, GetConsoleMode, GetConsoleOutputCP, SetConsoleCP, SetConsoleMode,
@@ -1358,26 +1351,6 @@ unsafe extern "system" {
     ) -> BOOL;
 }
 
-/// `SYSTEM_INFO` (`sysinfoapi.h`).
-#[repr(C)]
-pub struct SYSTEM_INFO {
-    pub wProcessorArchitecture: WORD,
-    pub wReserved: WORD,
-    pub dwPageSize: DWORD,
-    pub lpMinimumApplicationAddress: *mut c_void,
-    pub lpMaximumApplicationAddress: *mut c_void,
-    pub dwActiveProcessorMask: usize,
-    pub dwNumberOfProcessors: DWORD,
-    pub dwProcessorType: DWORD,
-    pub dwAllocationGranularity: DWORD,
-    pub wProcessorLevel: WORD,
-    pub wProcessorRevision: WORD,
-}
-#[cfg_attr(windows, link(name = "kernel32"))]
-unsafe extern "system" {
-    pub fn GetSystemInfo(lpSystemInfo: *mut SYSTEM_INFO);
-}
-
 pub const TOKEN_QUERY: DWORD = 0x0008;
 /// `TOKEN_INFORMATION_CLASS::TokenIsAppContainer`
 pub const TOKEN_IS_APP_CONTAINER: c_int = 29;
@@ -1455,8 +1428,6 @@ unsafe extern "C" {
 // bun_core re-export / impl-Zeroable against these types directly; do NOT
 // re-declare them downstream.
 
-/// `JOBOBJECTINFOCLASS::JobObjectAssociateCompletionPortInformation` (`winnt.h`).
-pub const JobObjectAssociateCompletionPortInformation: DWORD = 7;
 /// `JOBOBJECTINFOCLASS::JobObjectExtendedLimitInformation` (`winnt.h`).
 pub const JobObjectExtendedLimitInformation: DWORD = 9;
 
@@ -1480,14 +1451,6 @@ pub struct PROCESS_BASIC_INFORMATION {
 }
 /// `PROCESSINFOCLASS::ProcessBasicInformation` (`winternl.h`).
 pub const ProcessBasicInformation: ULONG = 0;
-
-/// `JOBOBJECT_ASSOCIATE_COMPLETION_PORT` (`winnt.h`).
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct JOBOBJECT_ASSOCIATE_COMPLETION_PORT {
-    pub CompletionKey: LPVOID, // PVOID
-    pub CompletionPort: HANDLE,
-}
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -1780,8 +1743,6 @@ unsafe extern "system" {
         lpPreviousValue: *mut c_void, // [out, optional]
         lpReturnSize: *mut usize,     // [in, optional]
     ) -> BOOL;
-
-    pub fn IsProcessInJob(process: HANDLE, job: HANDLE, result: *mut BOOL) -> BOOL;
 
     pub fn CreatePseudoConsole(
         size: COORD,


### PR DESCRIPTION
### Problem
- About 845 lines are unreachable. Examples: the `_ZTVN7WebCore15AbortControllerE` vtable declarations behind `ENABLE(BINDING_INTEGRITY)` (the only use is inside a comment), `uws_app_listen` and `uws_app_run` (the Rust importers left in #42078), and 15 `dlsym` results in `SecretsLinux.cpp` that no code calls.
- rustc, clang, and hawk do not flag these items. They are `pub` link-interface methods, `extern "C"` definitions, inline members, write-only fields, or code inside comments.

### Fix
- Delete each item and its knock-on declarations. One edit changes a runtime condition: the `load()` check in `SecretsLinux.cpp` now tests the 5 pointers that the file calls, not 11. No CI lane runs it (the `Bun.secrets` tests are `todoIf(isCI && !isWindows)`). The other edits that are not whole-line deletions only drop a name from a list (Notes).
- Correct because each symbol has zero references in `src/`, generated code, `packages/`, `scripts/`, and `test/` on every platform. A relink of `bun-debug` with `--gc-sections --print-gc-sections` also discards every native function removed here.
- No item is already removed by one of the 27 open dead-code PRs (checked file by file against their diffs).
- Verified: `bun bd`, `bun run rust:check-all` (12 of 12 targets), `test/internal/source-lints`, and the suites in Notes. Self-reviewed: 5 concerns raised, 5 addressed.

### Background
- `ENABLE(BINDING_INTEGRITY)` is a WebKit bindings-generator check that compares a wrapped object's vtable pointer with the expected one. Here the check body is commented out, so the `extern` vtable declarations have no user. #40525 removes the same block from 5 other files.
- `bun_dispatch::link_interface!` lets a low-tier crate call a high-tier crate. Each method becomes a `#[no_mangle]` export plus a `pub fn` dispatcher, which rustc's `dead_code` lint cannot see.
- `libuwsockets.cpp` is the C API that Rust uses to drive uWS. A function there is dead when no `.rs` file imports it.

<details><summary>Notes</summary>

#### WebCore bindings (206 lines)
- `JSAbortController.cpp`, `JSCloseEvent.cpp`, `JSPerformanceObserver.cpp`, `JSPerformanceTiming.cpp`, `JSWebSocket.cpp`, `JSWorker.cpp`: the `#if ENABLE(BINDING_INTEGRITY)` vtable `extern` block, and the `if constexpr (std::is_polymorphic_v<T>)` block in `toJSNewlyCreated` whose body is comments only.
- `JSCustomEvent.cpp`, `JSPerformanceServerTiming.cpp`: the vtable `extern` block.

#### uWS and uSockets
- `uws_app_listen`, `uws_app_run` (`src/uws_sys/libuwsockets.cpp`) and the members only they called: `TemplatedApp::listen(int, handler)`, `TemplatedApp::run()`, `Loop::run()`, free `uWS::run()` (`packages/bun-uws/src/App.h`, `Loop.h`).
- `us_socket_pair`, `us_socket_open` (`socket.c`), `us_listen_socket_get_fd` (`context.c`), `us_quic_socket_close` (`quic.c`), and their prototypes. The Rust declarations left in #42078.
- `struct uws_header_iterator_s;` (`_libusockets.h`). A redundant `extern "C"` declaration in `DevServerSourceProvider.cpp` (the header declares it).

#### Top-level `src/jsc/bindings`
- `SecretsLinux.cpp`: pointers `g_free`, `g_hash_table_new`, `g_hash_table_destroy`, `g_hash_table_lookup`, `g_hash_table_insert`, `g_list_free`, `g_list_free_full`, `g_str_hash`, `g_str_equal`, `secret_service_search_sync`, `secret_item_get_secret`, `secret_value_get_text`, `secret_value_unref`, `secret_item_get_attributes`, `secret_item_load_secret_sync`, their `dlsym` lines, and the types only they used (`GHashTable`, `GList`, `_GList`, `SecretService`, `SecretValue`, `SecretItem`, `SecretSearchFlags`).
- `wtf-bindings.cpp`: the `__sun` / `__MVS__` `cfmakeraw` fallback. No Bun target defines these macros.
- `c-bindings.cpp`: the non-Linux `preadv2` / `pwritev2` ENOSYS stubs. Rust calls `sys_preadv2` / `sys_pwritev2` only under `cfg(linux | android)`.
- `ZigGlobalObject.h`, `ZigGlobalObject.cpp`, `BakeGlobalObject.cpp`: write-only `isThreadLocalDefaultGlobalObject`, the const `guardedObjects()` overload, the commented member `m_JSBunDebuggerValue`, duplicate forward declarations, `using JSNonFinalObject`, `#undef JSC_TYPED_ARRAY_CHECK`, commented-out lines.
- `headers-handwritten.h`: the `#ifndef __cplusplus` branches (the header includes C++ headers before them, no `.c` file includes it) and the constants `ZigStackFrameCodeNone`, `JSErrorCodeOutOfMemoryError`, `JSErrorCodeStackOverflow`, `JSErrorCodeUserErrorCode`, `BunLoaderTypeCSS`, `BunLoaderTypeFILE`, `BunLoaderTypeJSONC`, `BunLoaderTypeWASM`.
- `bindings.cpp`: `FLAG_PROMISE_RESOLVES`, `FLAG_PROMISE_REJECTS` and the `-Wunused-variable` pragma that existed for them, `#undef IMPL_DEEP_EQUALS_WRAPPER`.
- `napi.h`: the `BoundFinalizer(const NapiFinalizer&, void*)` constructor. `napi_finalizer.h`: `hint()`.
- `InspectorLifecycleAgent`: write-only `m_preventingExit`. `ModuleLoader.h`: write-only `OnLoadResult::wasMock`.
- `workaround-missing-symbols.cpp`: the `#define UNLIKELY` block. `root.h`: the `ENABLE_3D_TRANSFORMS` `#error` guard (no WebKit build defines the flag). `ncrypto.h`: `CryptoErrorList::rbegin` / `rend`, `Cipher::MAX_KEY_LENGTH` / `MAX_IV_LENGTH`. `uv-posix-polyfills.c`: the unreachable `__CYGWIN__` branch. `NodeVM.h`: `BaseVMOptions::failed`. `NodeVMScript.h`: the `cachedDataProduced(bool)` setter. `CallSite.h`: `Flags::IsWasm`. `DOMFormData.h`: forward declarations of `HTMLElement`, `HTMLFormElement`.
- Unused locals: `identifier` (`BunObject.cpp`), `validatedIdent` (`JSBakeResponse.cpp`), `wrapperStart`, `wrapperEnd`, `exception` (`JSCommonJSModule.cpp`), `name` (`JSWrappingFunction.cpp`), `argList` (`InternalModuleRegistry.cpp`).
- 20 duplicate `#include` lines in the same preprocessor scope. Duplicate or unused `extern "C"` declarations: `Bun__readOriginTimerStart` (2), `Bun__getTLSRejectUnauthorizedValue`, `Bun__Node__ProcessPendingDeprecation`.
- Commented-out code older than one year in `JSDOMExceptionHandling.cpp`, `JSX509CertificatePrototype.cpp`, `BunPlugin.cpp`, `BunClientData.h`, `JSWrappingFunction.cpp`, `JSBakeResponse.cpp`, `JSDOMGlobalObject.h`.

#### node, webcrypto, sqlite, v8
- `CryptoUtil.h`: `ByteSource::operator ncrypto::Buffer<const T>()`, `ByteSource::empty()`, `DSASigEnc::Invalid`.
- `JSNodeHTTPServerSocketPrototype::createStructure`. Unused `uWS` forward declarations, an orphaned doc comment, and two unused `extern "C"` prototypes in `JSNodeHTTPServerSocket.{h,cpp}`.
- `RsaKeyVariant::RSA_OAEP`, `KeyObject::KeyEncodingContext::Export`, the const overloads `JSDiffieHellman::getImpl`, `JSDiffieHellmanGroup::getImpl`, `JSKeyObject::handle`, `HTTP_BOTH`, and commented-out declarations in `JSSign.h`, `KeyObject.h`, `CryptoUtil.h`, `NodeHTTPParser.h`.
- webcrypto: `CryptoAlgorithmParameters::Class::RsaKeyGenParams` with its `parametersClass()` override and type-trait specialization (the class is only a base class), forward declarations `CryptoKeyAKP` and `JSC::CallFrame`, three commented-out lines.
- sqlite: four lazily loaded entry points that nothing calls (`sqlite3_bind_blob`, `sqlite3_bind_text`, `sqlite3_bind_text16`, `sqlite3_errcode`) in `lazy_sqlite3.h`. The `lazyLoadSQLite()` stubs in the `#else` arm (every caller is inside `#if LAZY_LOAD_SQLITE`). Duplicate `JSC_DECLARE_CUSTOM_GETTER` lines. The unusable `SQLiteBindingsMap() = default`. Dead `vm` locals in `NodeSqlite.cpp`.
- v8 shim: `shim::Handle::Handle(const ObjectLayout*)`, the private const `FunctionTemplate::localToObjectPointer()`, `kInternalFieldsInWeakCallback`, `Oddball::Kind::kInvalid`, four unused `using` declarations.

#### Rust
- `JsEventLoop::{file_polls, put_file_poll, stdout, stderr}`: declarations in `src/event_loop/lib.rs`, impl arms in `src/jsc/event_loop.rs`.
- `ErrnoNames::win32_name`, `win32_errno_name`, and its unit test (`src/bun_core/lib.rs`, `src/errno/lib.rs`). The callers left in #33909.
- `bun_windows_sys::externs`: `NtClose`, `IsProcessInJob`, `GetSystemInfo` with `SYSTEM_INFO`, `JobObjectAssociateCompletionPortInformation` with `JOBOBJECT_ASSOCIATE_COMPLETION_PORT`, the empty `user32` and `advapi32` modules, and their re-exports in `src/sys/windows/mod.rs`. Every caller uses a local `safe fn` declaration.
- The `libc` dependency of `bun_paths`.

#### Built-in JS and scripts
- `src/js/builtins`: the never-filled `moduleMap` in `CommonJS.ts`, two no-op `var` redeclarations of parameters in `ProcessObjectInternals.ts`, `$defineProperties` and `ArrayBufferConstructor` in `builtins.d.ts`.
- `src/js/node`: `globalThis.__lastId` / `__getId` in `child_process.ts` (debug only, never called), the never-passed `_flags` parameter of `internalConnect` in `net.ts`.
- Commented-out code older than one year in `ConsoleObject.ts`, `Ipc.ts`, `sql.ts`, `undici.js`, `fifo.ts`, `tls.ts`, `stream.promises.ts`, `native-readable.ts`, `net.ts`, `dgram.ts`, `assert.ts`, `child_process.ts`, `cluster.ts`.
- `scripts/`: write-only `users` / `password` in `machine.mjs`, five unused destructured names in `machine.mjs`, `azure.mjs`, `runner.node.mjs`.

#### Edits that are not whole-line deletions
- `SecretsLinux.cpp`: the `load()` return chain loses the 6 pointers that were removed.
- `packages/bun-uws/src/Loop.h`: the file comment no longer names the removed `run()`.
- Lists that lose a name: destructuring in `scripts/*.mjs` and `net.ts`, the `internalConnect` parameter list, and `pub use` lists in `bun_windows_sys` and `src/sys/windows/mod.rs`.

#### Found but not in this diff
- `NodeHTTPIncomingRequestType.FetchRequest` / `.FetchResponse` in `src/js/internal/http.ts`: unused, but their removal renumbers `NodeHTTPResponse` from 2 to 0, and `util.inspect(req)` shows that value.
- The commented-out captureRejection lines in `_http_server.ts` and `http2.ts`: #41738 turns them into live code.
- The `rdp` closure in `scripts/tart.mjs`: #29315 already removes it.
- `TransformOutstream` in `src/bundler/transpiler.rs`: the value is threaded through two private functions and never read (the payload carries `#[expect(dead_code)]`). Its removal leaves `BundleOptions::output_dir_handle` write-only while that field still owns the output directory fd, so both belong in one separate change.
- `call: true` on the 7 `noConstructor` matcher classes in `jest.classes.ts`: #40915 already changes it. Two commented-out blocks in `bindings.cpp`: #40232 already removes them.
- `NullableInnerParameterType` aliases in `IDLTypes.h`: dead after #41445 lands.
- `lsquic_sys` `Settings::scid_len` / `delay_onclose` and their C shims: no caller, left because node:quic is in active work.
- Write-only `#[no_mangle] static Bun__Node__CAStore` in `Arguments.rs`: no reader in C++.
- `ErrnoNames::max_dense`: no caller, but its removal leaves `SystemErrno::MAX` test-only on Windows.
- `AsyncContextFrame.exchange` in `src/js/internal/async_context_frame.ts`: no caller, mirrors Node's internal API.
- About 35 `Zig::*_getter` functions from `WEBCORE_GENERATED_CONSTRUCTOR_GETTER` that lld discards. The macro needs a split.
- `ncrypto` branches on `OPENSSL_VERSION_MAJOR` / `OPENSSL_FIPS` that BoringSSL never defines (about 129 lines, not fully verified).

#### How the candidates were found
- A rust-analyzer SCIP index of the workspace, then every zero-reference `pub` item demoted to `pub(crate)` and judged by rustc's `dead_code` lint on linux, windows, macOS, freebsd, and android targets. Result: nothing outside the open PRs, hawk keeps the `pub` surface clean.
- The `--print-gc-sections` relink (921k discarded sections), filtered to strong symbols in Bun's own objects and the Rust staticlib, then checked name by name against the open PR diffs.
- `nm` of the prebuilt `libWTF.a` / `libJavaScriptCore.a` import tables to keep symbols that only WebKit references (`WTFTimer__*`, `Bun__errorInstance__finalize`, `Bun__reportUnhandledError`).
- Per-area reads of the C++ bindings, `src/js`, and `scripts/` with the TypeScript checker (`noUnusedLocals`) and `rg`.

#### Tests run with the debug build
`test/js/bun/test/expect.test.js` (416 pass), `test/js/web/abort/abort.test.ts`, `test/js/web/workers/worker.test.ts`, `test/js/web/workers/message-event.test.ts`, `test/js/bun/sqlite/sqlite.test.js`, `test/js/node/sqlite/node-sqlite.test.ts`, `test/js/node/crypto/node-crypto.test.js`, `test/js/node/crypto/ecdh.test.ts`, `test/js/bun/http/serve-listen.test.ts`, `test/js/node/http/node-http.test.ts`, `test/js/node/net/node-net-server.test.ts`, `test/js/node/process/process-nexttick.test.js`, `test/js/node/child_process/child_process.test.ts`, `test/js/node/cluster.test.ts`, `test/js/node/vm/vm.test.ts`, `test/js/bun/plugin/plugins.test.ts`, `test/js/first_party/undici/undici.test.ts`, `test/js/bun/test/mock-fn.test.js`, `test/js/web/console/console-log.test.ts`, `test/bundler/cli.test.ts`, `cargo test -p bun_errno`. Failures seen are the same with the released binary or are 5 s timeouts on a loaded host that pass with a longer timeout: external-network WebSocket tests, IPv6 multicast in `node-dgram`, `Bun.secrets` (no libsecret in the container), "spawn in the default shell", `sqlite #13082`.

</details>

