### PR TITLE
react-compiler: keep require("x") and require.resolve("x") calls in a compiled function

### DIFF
--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -380,6 +380,12 @@ struct Context<'a, 'h> {
     declarations: HashSet<DeclarationId>,
     temp: Temporaries,
     object_methods: IdMap<IdentifierId, (InstructionValue, Option<DiagSourceLocation>)>,
+    /// The node (`NonLocalBinding::require_call_node`) that each callee
+    /// temporary of a `require("x")` or `require.resolve("x")` call loads. The
+    /// call is matched by that temporary. Its printed callee is not enough:
+    /// the call's result prints as the same node, so `require("x")()` would
+    /// read as `require("x")`.
+    require_call_nodes: IdMap<IdentifierId, Expr>,
     unique_identifiers: HashSet<String>,
     synthesized_names: HashMap<&'static str, String>,
 }
@@ -397,6 +403,7 @@ impl<'a, 'h> Context<'a, 'h> {
             declarations: HashSet::new(),
             temp: IdMap::new(),
             object_methods: IdMap::new(),
+            require_call_nodes: IdMap::new(),
             unique_identifiers,
             synthesized_names: HashMap::new(),
         }
@@ -1419,6 +1426,11 @@ fn codegen_instruction_nullable(
                     .insert(lvalue.identifier, (value.clone(), *loc));
                 return Ok(None);
             }
+            InstructionValue::LoadGlobal { binding, .. } => {
+                if let (Some(node), Some(lvalue)) = (binding.require_call_node(), &instr.lvalue) {
+                    cx.require_call_nodes.insert(lvalue.identifier, node);
+                }
+            }
             _ => {}
         }
     }
@@ -1879,6 +1891,9 @@ fn codegen_base_instruction_value(
             }
         }
         InstructionValue::CallExpression { callee, args, .. } => {
+            if let Some(node) = cx.require_call_nodes.get(callee.identifier) {
+                return Ok(*node);
+            }
             let callee_expr = codegen_place_to_expression(cx, callee)?;
             let arguments = codegen_arguments(cx, args)?;
             if let ExprData::EImport(orig) = callee_expr.data {

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -380,11 +380,7 @@ struct Context<'a, 'h> {
     declarations: HashSet<DeclarationId>,
     temp: Temporaries,
     object_methods: IdMap<IdentifierId, (InstructionValue, Option<DiagSourceLocation>)>,
-    /// The node (`NonLocalBinding::require_call_node`) that each callee
-    /// temporary of a `require("x")` or `require.resolve("x")` call loads. The
-    /// call is matched by that temporary. Its printed callee is not enough:
-    /// the call's result prints as the same node, so `require("x")()` would
-    /// read as `require("x")`.
+    /// By callee temporary, as `require("x")()` prints the same callee as `require("x")`.
     require_call_nodes: IdMap<IdentifierId, Expr>,
     unique_identifiers: HashSet<String>,
     synthesized_names: HashMap<&'static str, String>,

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -1447,10 +1447,6 @@ pub enum NonLocalKind {
     /// constant. The original `Expr` is carried whole so codegen emits it
     /// unchanged and the bundler keeps any `import_record_index` / `Ref` /
     /// variant tag it holds.
-    ///
-    /// `import()`, `require("x")` and `require.resolve("x")` are calls, not
-    /// constants. Lowering emits a `CallExpression` whose callee loads the node,
-    /// and codegen emits the node for that call.
     BunOpaque(bun_ast::Expr),
 }
 
@@ -1522,8 +1518,7 @@ impl NonLocalBinding {
         }
     }
 
-    /// The `require("x")` or `require.resolve("x")` node this binding is the
-    /// callee of, or `None` for every other binding.
+    /// The node, when this binding is the callee of a `require("x")` or `require.resolve("x")` call.
     pub fn require_call_node(&self) -> Option<bun_ast::Expr> {
         use bun_ast::expr::Tag;
         match self.kind {

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -1447,6 +1447,10 @@ pub enum NonLocalKind {
     /// constant. The original `Expr` is carried whole so codegen emits it
     /// unchanged and the bundler keeps any `import_record_index` / `Ref` /
     /// variant tag it holds.
+    ///
+    /// `import()`, `require("x")` and `require.resolve("x")` are calls, not
+    /// constants. Lowering emits a `CallExpression` whose callee loads the node,
+    /// and codegen emits the node for that call.
     BunOpaque(bun_ast::Expr),
 }
 
@@ -1515,6 +1519,23 @@ impl NonLocalBinding {
             Some(self.ref_)
         } else {
             None
+        }
+    }
+
+    /// The `require("x")` or `require.resolve("x")` node this binding is the
+    /// callee of, or `None` for every other binding.
+    pub fn require_call_node(&self) -> Option<bun_ast::Expr> {
+        use bun_ast::expr::Tag;
+        match self.kind {
+            NonLocalKind::BunOpaque(e)
+                if matches!(
+                    e.data.tag(),
+                    Tag::ERequireString | Tag::ERequireResolveString
+                ) =>
+            {
+                Some(e)
+            }
+            _ => None,
         }
     }
 }

--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -315,10 +315,28 @@ pub(crate) fn lower_expression(
             value: PrimitiveValue::Boolean(lit.value),
             loc,
         }),
+        // `require("x")` evaluates a module and `require.resolve("x")` can throw.
+        // Like `import()` above, both lower as a call whose callee loads the
+        // node, so no pass drops, moves or merges them as it does a constant.
+        Data::ERequireString(_) | Data::ERequireResolveString(_) => {
+            let callee = lower_value_to_temporary(
+                builder,
+                InstructionValue::LoadGlobal {
+                    binding: NonLocalBinding {
+                        ref_: Ref::NONE,
+                        kind: NonLocalKind::BunOpaque(*expr),
+                    },
+                    loc,
+                },
+            )?;
+            Ok(InstructionValue::CallExpression {
+                callee,
+                args: AstAlloc::vec(),
+                loc,
+            })
+        }
         Data::ERequireCallTarget
         | Data::ERequireResolveCallTarget
-        | Data::ERequireString(_)
-        | Data::ERequireResolveString(_)
         | Data::EImportMetaMain(_)
         | Data::ERequireMain => Ok(InstructionValue::LoadGlobal {
             binding: NonLocalBinding {

--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -315,9 +315,7 @@ pub(crate) fn lower_expression(
             value: PrimitiveValue::Boolean(lit.value),
             loc,
         }),
-        // `require("x")` evaluates a module and `require.resolve("x")` can throw.
-        // Like `import()` above, both lower as a call whose callee loads the
-        // node, so no pass drops, moves or merges them as it does a constant.
+        // Calls, like `import()` above: `require("x")` runs a module, `require.resolve("x")` can throw.
         Data::ERequireString(_) | Data::ERequireResolveString(_) => {
             let callee = lower_value_to_temporary(
                 builder,

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -464,6 +464,177 @@ describe("bundler", () => {
     },
   });
 
+  // `require("x")` evaluates a module and `require.resolve("x")` can throw, so
+  // a compiled function has to keep each one a call: where the source has it,
+  // once, in source order. Lowered as a constant, dead code elimination dropped
+  // an unused one, constant propagation moved a used one to its reads, and a
+  // local assigned a different module on each path read the first module.
+  for (const target of ["bun", "browser"] as const) {
+    itBundled(`react-compiler/RequireIsACall-${target}`, {
+      files: {
+        "/entry.ts": /* ts */ `
+          import * as forms from "./forms";
+          const lines: string[] = [];
+          for (const [name, form] of Object.entries(forms)) {
+            globalThis.evaluated = [];
+            let result;
+            try {
+              result = form({ yes: true, no: false });
+              if (typeof result === "function") result = result();
+            } catch (e) {
+              result = "threw " + e;
+            }
+            lines.push(name + "=" + result + " evaluated=" + globalThis.evaluated.join(","));
+          }
+          console.log(lines.join("\\n"));
+        `,
+        "/forms.tsx": /* tsx */ `
+          import { useEffect } from "react";
+
+          export function Statement() {
+            useEffect(() => {});
+            require("./side/statement");
+            return "ok";
+          }
+          export function useHandler() {
+            useEffect(() => {});
+            return () => {
+              require("./side/handler");
+              return "ok";
+            };
+          }
+          export function InEffect() {
+            useEffect(() => {
+              require("./side/effect");
+            });
+            return "ok";
+          }
+          export function Conditional({ yes, no }) {
+            useEffect(() => {});
+            if (yes) require("./side/conditional-yes");
+            if (no) require("./side/conditional-no");
+            return "ok";
+          }
+          export function Void() {
+            useEffect(() => {});
+            void require("./side/void");
+            return "ok";
+          }
+          export function Sequence() {
+            useEffect(() => {});
+            const one = (require("./side/sequence"), 1);
+            return String(one);
+          }
+          export function UnusedLocal() {
+            useEffect(() => {});
+            const unused = require("./side/unused-local");
+            return "ok";
+          }
+          export function Ternary({ no }) {
+            useEffect(() => {});
+            const mod = no ? require("./side/ternary-a") : require("./side/ternary-b");
+            return mod.name;
+          }
+          export function IfElse({ no }) {
+            useEffect(() => {});
+            let mod;
+            if (no) {
+              mod = require("./side/if-a");
+            } else {
+              mod = require("./side/if-b");
+            }
+            return mod.name;
+          }
+          export function Order() {
+            useEffect(() => {});
+            const first = require("./side/order-1");
+            const { name } = require("./side/order-2");
+            return first.name + "," + name;
+          }
+          export function Reassigned() {
+            useEffect(() => {});
+            let mod = require("./side/reassigned-1");
+            try {
+              mod = require("./side/reassigned-2");
+            } catch {}
+            return mod.name;
+          }
+          export function ResolveMissing() {
+            useEffect(() => {});
+            try {
+              require.resolve("./side/not-there");
+              return "found";
+            } catch {
+              return "missing";
+            }
+          }
+          export function CallsTheExport({ yes }) {
+            useEffect(() => {});
+            return require("./side/function")(yes);
+          }
+        `,
+        ...Object.fromEntries(
+          [
+            "statement",
+            "handler",
+            "effect",
+            "conditional-yes",
+            "conditional-no",
+            "void",
+            "sequence",
+            "unused-local",
+            "ternary-a",
+            "ternary-b",
+            "if-a",
+            "if-b",
+            "order-1",
+            "reassigned-1",
+            "reassigned-2",
+          ].map(name => [`/side/${name}.js`, `globalThis.evaluated.push("${name}"); exports.name = "${name}";`]),
+        ),
+        "/side/order-2.js": `globalThis.evaluated.push("order-2"); export const name = "order-2";`,
+        "/side/function.js": `globalThis.evaluated.push("function"); module.exports = arg => "called with " + arg;`,
+        "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+        "/node_modules/react/index.js": /* js */ `
+          export function useEffect(effect) {
+            effect();
+          }
+        `,
+        "/node_modules/react/compiler-runtime.js": /* js */ `
+          export function c(size) {
+            return new Array(size).fill(Symbol.for("react.memo_cache_sentinel"));
+          }
+        `,
+      },
+      reactCompiler: true,
+      backend: "cli",
+      target,
+      run: {
+        // The ssr output mode (target "bun") removes effects, as they do not
+        // run on the server.
+        stdout: `
+          CallsTheExport=called with true evaluated=function
+          Conditional=ok evaluated=conditional-yes
+          IfElse=if-b evaluated=if-b
+          InEffect=ok evaluated=${target === "browser" ? "effect" : ""}
+          Order=order-1,order-2 evaluated=order-1,order-2
+          Reassigned=reassigned-2 evaluated=reassigned-1,reassigned-2
+          ResolveMissing=missing evaluated=
+          Sequence=1 evaluated=sequence
+          Statement=ok evaluated=statement
+          Ternary=ternary-b evaluated=ternary-b
+          UnusedLocal=ok evaluated=unused-local
+          Void=ok evaluated=void
+          useHandler=ok evaluated=handler
+        `,
+      },
+      onAfterBundle(api) {
+        // Every function above compiled: no call takes an inline arrow any more.
+        expect(api.readFile("/out.js")).not.toMatch(/useEffect\(\(\) =>/);
+      },
+    });
+  }
+
   itBundled("react-compiler/BranchBooleanFeatureFlagPreservesDCE", {
     files: {
       "/entry.jsx": /* jsx */ `


### PR DESCRIPTION
### Problem

- With `bun build --react-compiler`, an unused `require("./side")` in a compiled component or hook is deleted, so `./side` never runs. The plain bundler keeps `init_side()`.
- A used `require()` moves to each read of its local, so `const a = require("a"); const { b } = require("b")` evaluates `b` first. An unused `require.resolve("x")` is deleted too.
- Cause: `lower_expression` (`src/react_compiler/lowering/build_hir/expr.rs:318`) lowered `E::RequireString` to a pure `LoadGlobal { BunOpaque }` constant. Dead code elimination prunes an unused one. Constant propagation forwards a used one to every read.

### Fix

- Lower `E::RequireString` and `E::RequireResolveString` as a `CallExpression` whose callee loads the node, the shape `import()` already has. No pass prunes, forwards or merges a call. Upstream sees this source as a call too.
- Codegen finds such a call by its callee temporary (`Context::require_call_nodes`). The printed callee is not enough: `require("./fn")(arg)` would read as `require("./fn")`.
- Cost: in client mode a used `require()` result takes one memo slot, like any call result.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (2 new tests, 13 forms each, 12 fail on main). Also `react-compiler-fixtures.test.ts`, `bundler_dynamic_import_dce.test.ts`, `bundler_jsx.test.ts`.

### Background

- The React Compiler runs per function, after the parser. By then `require("x")` is one `E::RequireString` node that holds its import record index.
- A `LoadGlobal` instruction reads a global. The compiler treats it as a constant with no side effects.
- `BunOpaque` is a `LoadGlobal` that carries a whole Bun AST node. Codegen prints it back unchanged, so the bundler keeps its import record.
- #42376 fixes how constant propagation compares two such constants. Both PRs are needed, see Notes.

<details><summary>Notes</summary>

**Forms in the new tests.** Each form requires its own module, which records that it ran. "main" is a debug build of 4b5862fd88. The expected column is also what the plain bundler prints.

| form | expected | main |
| --- | --- | --- |
| `require("./s");` | `s` runs | does not run |
| the same inside a returned arrow | runs when called | does not run |
| the same inside a `useEffect` callback (client mode) | runs | does not run |
| `if (yes) require("./s")` | runs | does not run |
| `void require("./s")` | runs | does not run |
| `const one = (require("./s"), 1)` | runs | does not run |
| `const unused = require("./s")` | runs | does not run |
| `no ? require("./a") : require("./b")` | reads `b`, runs `b` | reads `a`, runs `b` then `a` |
| `if (no) m = require("./a"); else m = require("./b")` | reads `b` | reads `a` |
| `const first = require("./1"); const { name } = require("./2"); first.name + name` | runs `1`, `2` | runs `2`, `1` |
| `let m = require("./1"); try { m = require("./2") } catch {}` | runs `1`, `2` | runs `2` only |
| `try { require.resolve("./not-there"); return "found" } catch { return "missing" }` | `missing` | `found` |
| `require("./function")(yes)` (control for the codegen change) | calls the export | calls the export |

The ssr output mode (`--target=bun`) removes effects by design, so the `useEffect` form expects nothing there.

**Relation to #42376.** That PR makes `evaluate_phi` compare two `BunOpaque` constants by the node they carry, not by `name()`. It fixes the wrong-module rows above and also `import.meta.main` against `!import.meta.main` and import items, which this PR does not touch. It does not fix a dropped or a moved `require()` (its body lists the dropped one as not fixed). After this PR a `require("x")` / `require.resolve("x")` result is not a constant, so those two arms of `loads_same_value` can no longer be reached. Whichever PR lands second can delete them, and the duplicated ternary and if/else test forms. A trial merge of the two branches is clean in both orders.

**What the output looks like.** In ssr mode the compiled body mirrors the source (`init_side();`, `let mod = no ? require_a() : require_b();`). In client mode the result of `require()` is memoized like the result of any call to an unknown global: `if ($[0] === sentinel) { t0 = require_other(); $[0] = t0 } else t0 = $[0]`. Before, a used `require()` was printed inline at each read with no slot. The module system caches a module after its first evaluation, so the memo block does not change when a module runs.

**Differential.** 52 more shapes print the same lines with and without `--react-compiler`, for `--target=bun` and `--target=browser`: property reads in JSX, destructure with defaults, `new (require(x))()`, `??` / `||`, `typeof`, optional chains, template literals, spreads, asset-like requires in JSX attributes, `useMemo` / lazy `useState` initializers, loops, `switch`, early return, nested ternary, `for..in` / `for..of` / `for` init, IIFEs, labeled blocks, `try` / `catch` around a module that throws, `require(require(x))`, `require(require.resolve(x))`, `require(x)()`, `require(x)?.()`, `import()`. 35 of them were also run with `--format=cjs`, `--target=node`, `--minify`, `--minify-syntax` and `--splitting`. No shape that compiled before stops compiling. Four shapes that mutate a required module (`m.extra = 1`, `delete m.name`, `require(x).count++`, `require(x).value = 5`) are left uncompiled by 1.4.3-canary.1 (6a92015fc), and compile now.

**Why `require.resolve("x")` too.** It can throw (module not found), the plain bundler does not treat it as removable (`expr_can_be_removed_if_unused`), and upstream sees a method call on `require`.

**The codegen lookup.** The first version of this change matched the call by its printed callee, as the `import()` path does (`if let ExprData::EImport(orig) = callee_expr.data`). `require("./fn")(kind)` then printed as `require("./fn")`: the inner call prints as the bare node, which is also what the outer call's callee prints as. `Context::object_methods` is the existing pattern for an instruction that a later instruction consumes by identity, so `require_call_nodes` follows it. The `import()` path is unchanged.

**Unrelated bugs found on the way, not fixed here** (each reproduces without `require`):

1. `try { const unused = 1 } catch { found = "missing" }` in a compiled function panics in `merge_consecutive_blocks.rs:106` (`Found a block with a single predecessor but where a phi has multiple (2) operands`).
2. `const o = { get() { return 1 } }` in a compiled function panicked with `--target=bun` in `align_object_method_scopes.rs:52`. #42375 fixed it.
3. Without the compiler, `--target=node` prints `!import.meta.main` as `!require.main == module`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [1208.74ms]
(pass) bundler > react-compiler/ComponentWithHooks [513.09ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [511.03ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [508.73ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [402.06ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [380.54ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [709.99ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [269.00ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [1030.35ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [274.11ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [387.67ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [664.18ms]
(pass) bundler > re
... (truncated)

release without fix: 18 failed, 1 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [28.20ms]
(pass) bundler > react-compiler/ComponentWithHooks [13.50ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [10.06ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [14.05ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [16.48ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [12.22ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [89.38ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [9.94ms]
1031 |       ]);
1032 |       const stdout = Buffer.from(stdoutBytes);
1033 |       const stderr = Buffer.from(stderrBytes);
1034 |       const success = exitCode === 0;
1035 |       if (buildProc.signalCode) {
1036 |         throw new Error(
                         ^
error: [react-compiler/SsrObjectMethodShorthand] 'bun build' subprocess killed by SIGABRT
cmd: /workspace/bun/build/release/bun build /tmp/bun-build-tests/bun-q0TUYQ/react-compiler/SsrObjectMethodShorthand/entry.jsx --outfile=/tmp/bun-build-tests
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [1690.22ms]
(pass) bundler > react-compiler/ComponentWithHooks [494.28ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [499.07ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [586.56ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [310.00ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [281.44ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [560.13ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [377.70ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [1120.59ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [318.22ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [223.63ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [394.04ms]
(pass) bundler > re
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1120ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/124] gen cpp.rs (cppbind)
[2/124] gen JS modules (bundle-modules)
Preprocess modules (11235ms)
Bundle modules (147ms)
Postprocesss modules (165ms)
Bundle Functions (540ms)
Generate Code (53ms)

[12.15s] Bundled "src/js" for production
  2600 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Comp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/react_compiler/codegen.rs                  |  11 ++
 src/react_compiler/hir/mod.rs                  |  16 +++
 src/react_compiler/lowering/build_hir/expr.rs  |  20 ++-
 test/bundler/transpiler/react-compiler.test.ts | 171 +++++++++++++++++++++++++
 4 files changed, 216 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/react_compiler/codegen.rs                       6      6     18
src/react_compiler/hir/mod.rs                       3      2     18
src/react_compiler/lowering/build_hir/expr.rs       4      2     18
test/bundler/transpiler/react-compiler.test.ts      5      4     18
```

</details>

<!-- robobun:evidence:end -->