### PR TITLE
Bun.Transpiler: do not throw on a parser warning

### DIFF
--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -839,7 +839,7 @@ impl TransformTask {
     fn then(&mut self, promise: &mut JSPromise, global: &JSGlobalObject) -> JsResult<()> {
         // The job drops this `TransformTask` (running its `Drop`: transpiler
         // deref etc.) right after `then` returns.
-        if self.log.has_any() || self.err.is_some() {
+        if self.log.has_errors() || self.err.is_some() {
             let error_value: JsResult<JSValue> = 'brk: {
                 if let Some(err) = &self.err {
                     if !self.log.has_any() {
@@ -1317,7 +1317,7 @@ impl JSTranspiler {
             return Err(global.throw(format_args!("Failed to parse")));
         };
 
-        if (log_ref.warnings + log_ref.errors) > 0 {
+        if log_ref.has_errors() {
             return Err(global.throw_value(log_ref.to_js(global, format_args!("Parse error"))?));
         }
 
@@ -1501,7 +1501,7 @@ impl JSTranspiler {
             return Err(global.throw(format_args!("Failed to parse code")));
         };
 
-        if (log_ref.warnings + log_ref.errors) > 0 {
+        if log_ref.has_errors() {
             return Err(global.throw_value(log_ref.to_js(global, format_args!("Parse error"))?));
         }
 
@@ -1711,7 +1711,7 @@ impl JSTranspiler {
                 return Err(global.throw_error(err, "Failed to scan imports"));
             }
 
-            if (log.warnings + log.errors) > 0 {
+            if log.has_errors() {
                 return Err(
                     global.throw_value(log.to_js(global, format_args!("Failed to scan imports"))?)
                 );

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2485,9 +2485,13 @@ export default <>hi</>
       ]);
     });
 
-    it("a parse error next to a warning still throws", () => {
+    it("a parse error next to a warning still throws", async () => {
       const t = new Bun.Transpiler({ loader: "js" });
       const src = warnSrc + "bad??!?!?!";
+      const expectedErrors = [
+        ["warn", 'Treating "-->" as the start of a legacy HTML single-line comment'],
+        ["error", "Unexpected ?"],
+      ];
       for (const fn of ["transformSync", "scan", "scanImports"]) {
         let thrown;
         try {
@@ -2496,11 +2500,18 @@ export default <>hi</>
           thrown = e;
         }
         expect(thrown).toBeInstanceOf(AggregateError);
-        expect(thrown.errors.map(m => [m.level, m.message])).toEqual([
-          ["warn", 'Treating "-->" as the start of a legacy HTML single-line comment'],
-          ["error", "Unexpected ?"],
-        ]);
+        expect(thrown.errors.map(m => [m.level, m.message])).toEqual(expectedErrors);
       }
+
+      let rejected;
+      await t.transform(src).then(
+        () => {},
+        e => {
+          rejected = e;
+        },
+      );
+      expect(rejected).toBeInstanceOf(AggregateError);
+      expect(rejected.errors.map(m => [m.level, m.message])).toEqual(expectedErrors);
     });
   });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2450,6 +2450,60 @@ export default <>hi</>
     ).toThrow();
   });
 
+  describe("a parser warning does not throw", () => {
+    // `-->` at the start of a line is a legacy HTML comment. The parser logs a
+    // warning for it and keeps going.
+    const warnSrc = "x = 1\n--> legacy html comment\ny = 2\n";
+    const warnJsx = 'import { a } from "a";\nexport default <div {...obj} key="k" />;\n';
+
+    it("transformSync", () => {
+      const t = new Bun.Transpiler({ loader: "js" });
+      expect(t.transformSync(warnSrc)).toBe("x = 1;\ny = 2;\n");
+    });
+
+    it("transform", async () => {
+      const t = new Bun.Transpiler({ loader: "js" });
+      expect(await t.transform(warnSrc)).toBe("x = 1;\ny = 2;\n");
+    });
+
+    it("scan", () => {
+      const t = new Bun.Transpiler({ loader: "jsx" });
+      expect(t.scan(warnJsx)).toEqual({
+        imports: [{ kind: "import-statement", path: "a" }],
+        exports: ["default"],
+      });
+    });
+
+    it("scanImports", () => {
+      const t = new Bun.Transpiler({ loader: "jsx" });
+      // The key-after-spread warning makes the JSX fall back to the classic
+      // runtime, so the scan also lists the runtime requires.
+      expect(t.scanImports(warnJsx)).toEqual([
+        { kind: "import-statement", path: "a" },
+        { kind: "require-call", path: "react/jsx-dev-runtime" },
+        { kind: "require-call", path: "react" },
+      ]);
+    });
+
+    it("a parse error next to a warning still throws", () => {
+      const t = new Bun.Transpiler({ loader: "js" });
+      const src = warnSrc + "bad??!?!?!";
+      for (const fn of ["transformSync", "scan", "scanImports"]) {
+        let thrown;
+        try {
+          t[fn](src);
+        } catch (e) {
+          thrown = e;
+        }
+        expect(thrown).toBeInstanceOf(AggregateError);
+        expect(thrown.errors.map(m => [m.level, m.message])).toEqual([
+          ["warn", 'Treating "-->" as the start of a legacy HTML single-line comment'],
+          ["error", "Unexpected ?"],
+        ]);
+      }
+    });
+  });
+
   it("define with an empty-string key is ignored without leaving uninitialized slots", async () => {
     // `JSPropertyIterator` skips empty-name properties, but `names`/`values` were being
     // indexed by the property position instead of a dense counter, leaving garbage in the
@@ -3794,15 +3848,31 @@ class Foo {
     expectParseError("class Foo { static { continue } }", 'Cannot use "continue" here');
     expectParseError("x: { class Foo { static { break x } } }", 'There is no containing label named "x"');
     expectParseError("x: { class Foo { static { continue x } } }", 'There is no containing label named "x"');
+  });
 
-    expectParseError("class Foo { get #x() { this.#x = 1 } }", 'Writing to getter-only property "#x" will throw');
-    expectParseError("class Foo { get #x() { this.#x += 1 } }", 'Writing to getter-only property "#x" will throw');
-    expectParseError("class Foo { set #x(x) { this.#x } }", 'Reading from setter-only property "#x" will throw');
-    expectParseError("class Foo { set #x(x) { this.#x += 1 } }", 'Reading from setter-only property "#x" will throw');
+  it("private accessor and method misuse is a warning", async () => {
+    const cases = [
+      ["class Foo { get #x() { this.#x = 1 } }", 'Writing to getter-only property "#x" will throw'],
+      ["class Foo { get #x() { this.#x += 1 } }", 'Writing to getter-only property "#x" will throw'],
+      ["class Foo { set #x(x) { this.#x } }", 'Reading from setter-only property "#x" will throw'],
+      ["class Foo { set #x(x) { this.#x += 1 } }", 'Reading from setter-only property "#x" will throw'],
+      ["class Foo { #x() { this.#x = 1 } }", 'Writing to read-only method "#x" will throw'],
+      ["class Foo { #x() { this.#x += 1 } }", 'Writing to read-only method "#x" will throw'],
+    ];
 
-    // Writing to method warnings
-    expectParseError("class Foo { #x() { this.#x = 1 } }", 'Writing to read-only method "#x" will throw');
-    expectParseError("class Foo { #x() { this.#x += 1 } }", 'Writing to read-only method "#x" will throw');
+    // The transpiler keeps going after a warning, so the code is still printed.
+    for (const [code] of cases) {
+      expect(transpiler.transformSync(code)).toContain("class Foo");
+    }
+
+    using dir = tempDir("private-warnings", {
+      "in.js": cases.map(([code]) => `{ ${code} }`).join("\n") + "\n",
+    });
+    const result = await Bun.build({ entrypoints: [join(String(dir), "in.js")], write: false });
+    expect(result.success).toBe(true);
+    expect(result.logs.map(log => [log.level, log.position.line, log.message])).toEqual(
+      cases.map(([, message], i) => ["warn", i + 1, message]),
+    );
   });
 
   it("class bodies keep `this` and the class name as written", () => {


### PR DESCRIPTION
### Problem
- `Bun.Transpiler` throws, or rejects, when the parser logs a warning. The thrown value is a `BuildMessage` with `level: "warn"`, for example `Treating "-->" as the start of a legacy HTML single-line comment`. The caller gets no output for a source that `bun build` transpiles with exit 0.
- The cause is the check at each entry point in `src/runtime/api/JSTranspiler.rs`: `scan` (line 1320), `transform_sync` (line 1504), `scan_imports` (line 1714) test `warnings + errors > 0`, and the async `transform` tests `log.has_any()` (line 842).
- `logLevel: "error"` hides the warning for `transform` and `transformSync` only. `scan` and `scanImports` ignore it (#42426), so no workaround exists for them.

### Fix
- The four sites now test `log.has_errors()`. A warning-only parse returns the normal result. An error still throws the log as before.
- Warnings are dropped. This matches the runtime module loader, which gates on `errors > 0` only (`src/runtime/jsc_hooks.rs:2755`). A channel that returns warnings would be a new API and is out of scope.
- paperclover proposed this same `errors > 0` change in the review of #7464 (https://github.com/oven-sh/bun/pull/7464#discussion_r1416667804). The `logLevel` option landed instead because that diff missed the async site.
- Verified: `test/bundler/transpiler/transpiler.test.js`. The new block "a parser warning does not throw" fails on main (4 of 5 cases) and passes with the fix. The "class static blocks" test asserted six private accessor warnings through the throw. Those cases move to a new test that checks the warnings through `Bun.build` logs. Also ran all of `test/bundler/transpiler/`.

### Background
- The parser writes diagnostics to a `Log` (`src/ast/lib.rs`). Each message has a kind. `warnings` and `errors` count them by kind. `has_any()` is `warnings + errors > 0`, `has_errors()` is `errors > 0`.
- `Log::to_js` turns the log into one `BuildMessage`, or an `AggregateError` of them when it holds more than one message. With a warning next to an error the thrown value is still that `AggregateError`.
- The constructor checks for tsconfig and `define` errors (lines 966, 985, 1021) keep the old condition. They report config problems, not parser diagnostics.

Fixes #42427
Related: #7328, #42426, #42430

<details><summary>Notes</summary>

- Inputs that hit this on main: a `-->` legacy HTML comment at the start of a line, `<div {...obj} key="k" />`, `<div key />`, and the private accessor warnings such as `Writing to getter-only property "#x" will throw`.
- The `scanImports` case in the new test uses the JSX key-after-spread warning. That warning makes the file fall back to the classic runtime, so the result also lists `react/jsx-dev-runtime` and `react` as `require-call` imports.
- `test/bundler/transpiler/jsx-production.test.ts` timed out in my container when run with the whole directory (32 concurrent spawns, 3.3 s each, 5 s limit). It uses `bun run`, not `Bun.Transpiler`, and passes when run alone.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [10.10ms]
(pass) Bun.Transpiler > normalizes \r\n [12.37ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [8.30ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [9.84ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [3.22ms]
(pass) Bun.Transpiler > property access inlining > works [2.75ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.65ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [89.04ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [32.54ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [484.70ms]
(pass) Bun.Transpiler > property access inlining > bails out on optiona
... (truncated)

release without fix: 22 skipped
bun test v1.4.3-canary.1 (a53ef51a4)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.16ms]
(pass) Bun.Transpiler > normalizes \r\n [0.23ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.10ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.16ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.04ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [1.13ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.40ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [10.16ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.54ms]
(pass) Bun.Transpiler > property access inlining > template literal around an inlined string enum member > member as the first part of the
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [8.51ms]
(pass) Bun.Transpiler > normalizes \r\n [10.50ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [7.44ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [13.91ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [5.40ms]
(pass) Bun.Transpiler > property access inlining > works [3.62ms]
(pass) Bun.Transpiler > property access inlining > works nested [4.09ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [85.96ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [27.25ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [461.60ms]
(pass) Bun.Transpiler > property access inlining > bails out on optiona
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 916ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/125] gen cpp.rs (cppbind)
[3/125] gen JS modules (bundle-modules)
Preprocess modules (13389ms)
Bundle modules (96ms)
Postprocesss modules (198ms)
Bundle Functions (705ms)
Generate Code (52ms)

[14.45s] Bundled "src/js" for production
  2600 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[3/124] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 5m 16s
[120/124] cxx obj/src/jsc/bindings/webcrypto/CryptoAlgorithmRSASSA_PKCS1_v1_5.cpp.o
[121/124] link bun-profile
[123/124] strip bun
[123/124] bun-profile --revision
1.4.3-canary.1+242d4e0e2
[build] done
bun test v1.4.3-canary.1 (242d4e0e2)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/JSTranspiler.rs            |  8 +--
 test/bundler/transpiler/transpiler.test.js | 95 +++++++++++++++++++++++++++---
 2 files changed, 92 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/runtime/api/JSTranspiler.rs                 2      4     22
test/bundler/transpiler/transpiler.test.js      3      8     22
```

</details>

**root cause** · written by the author bot

The four `Bun.Transpiler` entry points (`transform`, `transformSync`, `scan`, `scanImports`) in `src/runtime/api/JSTranspiler.rs` threw the parser log whenever it contained any message, so a mere warning such as the legacy HTML comment notice or the JSX key-after-spread deprecation caused valid source to fail with a `BuildMessage` of level `warn` and no output. The fix changes each of those guards from a "warnings plus errors" or `has_any()` check to `has_errors()`, matching the runtime module loader, so warnings no longer abort the call while genuine errors still surface as an `AggregateEr…

<!-- robobun:evidence:end -->