### PR TITLE
bun:jsc: loadedModules()

### DIFF
--- a/docs/runtime/utils.mdx
+++ b/docs/runtime/utils.mdx
@@ -1007,3 +1007,34 @@ const array = Array(1024).fill({ a: 1 });
 estimateShallowMemoryUsageOf(array);
 // => 16
 ```
+
+---
+
+## `loadedModules` in `bun:jsc`
+
+The `loadedModules` function lists the modules the ES module loader and the CommonJS loader hold, as `{ id, state }`.
+
+- `id` is the resolved specifier: an absolute path for a file, or a name like `node:fs` for a built-in module.
+- `state` says how far loading has come: `"fetching"`, `"unlinked"`, `"linking"`, `"linked"`, `"evaluating"`, `"evaluating-async"`, `"evaluated"` or `"errored"`.
+
+```js
+import { loadedModules } from "bun:jsc";
+
+const evaluated = loadedModules().filter(m => m.state === "evaluated");
+console.log(evaluated.length, "modules evaluated so far");
+```
+
+Unlike `Object.keys(require.cache)`, the list includes modules that have not finished loading and built-in modules that an ES module imported. Most built-in modules loaded with `require()` come from an internal table and are not listed.
+
+To see what an executable built with `bun build --compile` loads, preload a script that calls `loadedModules()` when the process exits:
+
+```js loaded.js icon="/icons/javascript.svg"
+process.on("exit", () => {
+  const { loadedModules } = require("bun:jsc");
+  for (const { id, state } of loadedModules()) console.log(state, id);
+});
+```
+
+```sh
+BUN_OPTIONS="--preload=./loaded.js" ./my-app
+```

--- a/packages/bun-types/jsc.d.ts
+++ b/packages/bun-types/jsc.d.ts
@@ -192,6 +192,31 @@ declare module "bun:jsc" {
   function isRope(input: string): boolean;
 
   /**
+   * Returns the modules the ES module loader and the CommonJS loader of the
+   * current global know about, one entry per resolved specifier, in no
+   * particular order.
+   *
+   * Unlike enumerating `require.cache`, this includes modules that have not
+   * finished loading and the built-in modules an ES module imported, and it
+   * creates nothing per module other than the returned entries. Most built-in
+   * modules loaded with `require()` come from an internal table that neither
+   * loader tracks, and are not listed; neither is the internal module that
+   * imports the entry point.
+   *
+   * In a `bun build --compile` executable the ids of bundled chunks are their
+   * paths in the embedded filesystem.
+   *
+   * @example
+   * ```ts
+   * import { loadedModules } from "bun:jsc";
+   *
+   * const evaluated = loadedModules().filter(m => m.state === "evaluated");
+   * console.log(evaluated.length, "modules evaluated so far");
+   * ```
+   */
+  function loadedModules(): LoadedModule[];
+
+  /**
    * Returns the URL of the source file containing the code that called this
    * function, such as `"file:///home/me/app/index.ts"`. Code created with
    * `eval` or `new Function` reports the file that created it.
@@ -372,6 +397,38 @@ declare module "bun:jsc" {
    * @returns The normalized time zone string
    */
   function setTimeZone(timeZone: string): string;
+
+  /**
+   * One module known to the module loaders, returned by {@link loadedModules}.
+   */
+  interface LoadedModule {
+    /**
+     * The resolved specifier the loaders key the module by: an absolute path
+     * for a file, or a name like `node:fs` for a built-in module. For a file
+     * this is the module's key in `require.cache`.
+     */
+    id: string;
+    /**
+     * How far loading has come. ES modules go through `"fetching"` (the source
+     * is being loaded), `"unlinked"`, `"linking"`, `"linked"`, `"evaluating"`
+     * or `"evaluating-async"`, and `"evaluated"`; `"errored"` means loading,
+     * linking or evaluating the module threw.
+     *
+     * `"evaluating-async"` means the module, or a module it imports, has a
+     * top-level `await`. The module stays in this state, including while its
+     * own body runs, until that has finished.
+     *
+     * JSON, text and built-in modules are `"evaluated"` as soon as they are
+     * loaded, which can be before the module that imports them is linked.
+     *
+     * A CommonJS module is `"unlinked"` until its body starts running and
+     * `"evaluated"` from then on, including while it is still running (as seen
+     * from a module it `require()`s, or from itself). One that threw is
+     * `"errored"` if an `import` loaded it; `require()` forgets a module that
+     * threw, so it is not listed.
+     */
+    state: "fetching" | "unlinked" | "linking" | "linked" | "evaluating" | "evaluating-async" | "evaluated" | "errored";
+  }
 
   /**
    * Statistics about the JavaScript heap, returned by {@link heapStats}.

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -169,6 +169,7 @@ using namespace JSC;
     macro(size) \
     macro(specifier) \
     macro(start) \
+    macro(state) \
     macro(status) \
     macro(statusCode) \
     macro(statusMessage) \

--- a/src/jsc/bindings/BunModuleRegistry.h
+++ b/src/jsc/bindings/BunModuleRegistry.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "root.h"
+#include <JavaScriptCore/Identifier.h>
+#include <JavaScriptCore/JSModuleLoader.h>
+#include <JavaScriptCore/ModuleRegistryEntry.h>
+
+namespace Bun {
+
+// The registry has one entry per (specifier, import attribute type); `registryEntry` picks the one that stands for a specifier.
+template<typename Each>
+void forEachModuleRegistrySpecifier(JSC::JSModuleLoader* loader, const Each& each)
+{
+    auto& vm = loader->vm();
+    for (auto& [key, entry] : loader->moduleMap()) {
+        if (!key.first || !entry)
+            continue;
+        if (key.second != JSC::ScriptFetchParameters::Type::JavaScript && loader->registryEntry(JSC::Identifier::fromUid(vm, key.first)) != entry.get())
+            continue;
+        each(key.first, entry.get());
+    }
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2297,6 +2297,15 @@ void GlobalObject::finishCreation(VM& vm)
         { OBJECT_OFFSETOF(GlobalObject, m_commonJSModuleObjectStructure), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
              init.set(Bun::createCommonJSModuleStructure(static_cast<Zig::GlobalObject*>(init.owner)));
          } },
+        { OBJECT_OFFSETOF(GlobalObject, m_loadedModuleStructure), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
+             PropertyOffset offset;
+             auto* structure = init.owner->structureCache().emptyObjectStructureForPrototype(init.owner, init.owner->objectPrototype(), 2);
+             structure = Structure::addPropertyTransition(init.vm, structure, init.vm.propertyNames->id, 0, offset);
+             ASSERT(offset == 0);
+             structure = Structure::addPropertyTransition(init.vm, structure, WebCore::builtinNames(init.vm).statePublicName(), 0, offset);
+             ASSERT(offset == 1);
+             init.set(structure);
+         } },
         { OBJECT_OFFSETOF(GlobalObject, m_JSSocketAddressDTOStructure), [](const LazyProperty<JSGlobalObject, Structure>::Initializer& init) {
              init.set(Bun::JSSocketAddressDTO::createStructure(init.vm, init.owner));
          } },

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -286,6 +286,8 @@ public:
     JSObject* lazyTestModuleObject() const { return m_lazyTestModuleObject.getInitializedOnMainThread(this); }
     Structure* CommonJSModuleObjectStructure() const { return m_commonJSModuleObjectStructure.getInitializedOnMainThread(this); }
     Structure* JSSocketAddressDTOStructure() const { return m_JSSocketAddressDTOStructure.getInitializedOnMainThread(this); }
+    // { id, state }: an element of what `loadedModules()` from "bun:jsc" returns.
+    Structure* loadedModuleStructure() const { return m_loadedModuleStructure.getInitializedOnMainThread(this); }
     Structure* JSReactElementStructure() const { return m_JSReactElementStructure.getInitializedOnMainThread(this); }
     Structure* JSMarkdownListItemMetaStructure() const { return m_JSMarkdownListItemMetaStructure.getInitializedOnMainThread(this); }
     Structure* JSMarkdownListMetaStructure() const { return m_JSMarkdownListMetaStructure.getInitializedOnMainThread(this); }
@@ -629,6 +631,7 @@ public:
     V(public, LazyPropertyOfGlobalObject<Structure>, m_cachedNodeVMGlobalObjectStructure)                    \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_commonJSModuleObjectStructure)                       \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSSocketAddressDTOStructure)                         \
+    V(private, LazyPropertyOfGlobalObject<Structure>, m_loadedModuleStructure)                               \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSReactElementStructure)                             \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSMarkdownListItemMetaStructure)                     \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSMarkdownListMetaStructure)                         \

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -24,7 +24,12 @@
 #include <JavaScriptCore/JIT.h>
 #include <JavaScriptCore/JSBasePrivate.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/JSMapIterator.h>
+#include <JavaScriptCore/JSModuleLoader.h>
+#include <JavaScriptCore/JSModuleRecord.h>
 #include <JavaScriptCore/JSONObject.h>
+#include <JavaScriptCore/ModuleRegistryEntry.h>
+#include <JavaScriptCore/SyntheticModuleRecord.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/JavaScript.h>
 #include <JavaScriptCore/ObjectConstructor.h>
@@ -48,6 +53,8 @@
 #include "ZigSourceProvider.h"
 #include "StrongRootBlock.h"
 #include "BunClientData.h"
+#include "JSCommonJSModule.h"
+#include "BunModuleRegistry.h"
 #include "mimalloc.h"
 extern "C" char* mi_stats_get_json(size_t, char*);
 extern "C" char* mi_heap_dump_json(bool include_blocks, bool hash_addresses);
@@ -967,6 +974,133 @@ JSC_DEFINE_HOST_FUNCTION(functionEstimateDirectMemoryUsageOf, (JSGlobalObject * 
     return JSValue::encode(jsNumber(0));
 }
 
+namespace Bun::LoadedModules {
+
+// The module that imports the entry point (`MAIN_FILE_NAME` in VirtualMachine.rs).
+static constexpr ASCIILiteral mainWrapperSpecifier = "bun:main"_s;
+
+enum class State : uint8_t {
+    Fetching,
+    Unlinked,
+    Linking,
+    Linked,
+    Evaluating,
+    EvaluatingAsync,
+    Evaluated,
+    Errored,
+};
+static constexpr std::array stateNames { "fetching"_s, "unlinked"_s, "linking"_s, "linked"_s, "evaluating"_s, "evaluating-async"_s, "evaluated"_s, "errored"_s };
+static_assert(stateNames.size() == static_cast<size_t>(State::Errored) + 1);
+
+static State stateOf(JSC::ModuleRegistryEntry* entry)
+{
+    using EntryStatus = JSC::ModuleRegistryEntry::Status;
+    switch (entry->status()) {
+    case EntryStatus::FetchFailed:
+    case EntryStatus::InstantiationFailed:
+    case EntryStatus::EvaluationFailed:
+        return State::Errored;
+    default:
+        break;
+    }
+    auto* record = entry->record();
+    if (!record)
+        return State::Fetching;
+    auto* cyclic = dynamicDowncast<JSC::CyclicModuleRecord>(record);
+    // A SyntheticModuleRecord is complete when it is created: it has its exports and nothing to link or run.
+    if (!cyclic)
+        return State::Evaluated;
+    if (cyclic->evaluationError())
+        return State::Errored;
+    using RecordStatus = JSC::CyclicModuleRecord::Status;
+    switch (cyclic->status()) {
+    case RecordStatus::New:
+    case RecordStatus::Unlinked:
+        return State::Unlinked;
+    case RecordStatus::Linking:
+        return State::Linking;
+    case RecordStatus::Linked:
+        return State::Linked;
+    case RecordStatus::Evaluating:
+        return State::Evaluating;
+    case RecordStatus::EvaluatingAsync:
+        return State::EvaluatingAsync;
+    case RecordStatus::Evaluated:
+        return State::Evaluated;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+// `hasEvaluated` is set when the body of a CommonJS module starts; nothing records that it finished.
+static State stateOf(Bun::JSCommonJSModule* module)
+{
+    return module->hasEvaluated ? State::Evaluated : State::Unlinked;
+}
+
+// A CommonJS module an ES module imports has no record until the import has been fetched, and the one Bun makes then
+// says nothing about the body having run.
+static bool isRecordOfCommonJSModule(JSC::ModuleRegistryEntry* entry, Bun::JSCommonJSModule* module)
+{
+    return module && (!entry->record() || dynamicDowncast<JSC::SyntheticModuleRecord>(entry->record()));
+}
+
+} // namespace Bun::LoadedModules
+
+JSC_DEFINE_HOST_FUNCTION(functionLoadedModules, (JSGlobalObject * lexicalGlobalObject, CallFrame*))
+{
+    using namespace Bun::LoadedModules;
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* structure = globalObject->loadedModuleStructure();
+    MarkedArgumentBuffer stateStrings;
+    for (auto name : stateNames)
+        stateStrings.append(jsNontrivialString(vm, String(name)));
+    MarkedArgumentBuffer modules;
+    auto append = [&](JSValue id, State state) {
+        auto* object = JSFinalObject::create(vm, structure);
+        object->putDirectOffset(vm, 0, id);
+        object->putDirectOffset(vm, 1, stateStrings.at(static_cast<unsigned>(state)));
+        modules.append(object);
+    };
+
+    auto* loader = globalObject->moduleLoader();
+    auto* requireMap = globalObject->requireMap();
+    // Nothing below runs JS or adds to either table. An id in both is listed once, from the registry.
+    Bun::forEachModuleRegistrySpecifier(loader, [&](UniquedStringImpl* specifier, JSC::ModuleRegistryEntry* entry) {
+        if (scope.exception() || WTF::equal(specifier, mainWrapperSpecifier))
+            return;
+        auto* id = jsString(vm, String { specifier });
+        auto* module = dynamicDowncast<Bun::JSCommonJSModule>(requireMap->get(globalObject, id));
+        if (scope.exception()) [[unlikely]]
+            return;
+        append(id, isRecordOfCommonJSModule(entry, module) ? stateOf(module) : stateOf(entry));
+    });
+    RETURN_IF_EXCEPTION(scope, {});
+
+    auto* iterator = JSMapIterator::create(vm, globalObject->mapIteratorStructure(), requireMap, IterationKind::Entries);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSValue key, value;
+    while (iterator->nextKeyValue(globalObject, key, value)) {
+        auto* module = dynamicDowncast<Bun::JSCommonJSModule>(value);
+        if (!module || !key.isString())
+            continue;
+        auto atom = asString(key)->toExistingAtomString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        if (atom.data && loader->registryEntry(Identifier::fromUid(vm, atom.data)))
+            continue;
+        append(key, stateOf(module));
+    }
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (stateStrings.hasOverflowed() || modules.hasOverflowed()) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return {};
+    }
+    RELEASE_AND_RETURN(scope, JSValue::encode(constructArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), modules)));
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionPercentAvailableMemoryInUse, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     return JSValue::encode(jsNull());
@@ -975,7 +1109,7 @@ JSC_DEFINE_HOST_FUNCTION(functionPercentAvailableMemoryInUse, (JSGlobalObject * 
 namespace Zig {
 DEFINE_NATIVE_MODULE(BunJSC)
 {
-    INIT_NATIVE_MODULE(BunJSC, 36);
+    INIT_NATIVE_MODULE(BunJSC, 37);
 
     putNativeFn(Identifier::fromString(vm, "callerSourceOrigin"_s), functionCallerSourceOrigin);
     putNativeFn(Identifier::fromString(vm, "jscDescribe"_s), functionDescribe);
@@ -991,6 +1125,7 @@ DEFINE_NATIVE_MODULE(BunJSC)
     putNativeFn(Identifier::fromString(vm, "samplingProfilerStackTraces"_s), functionSamplingProfilerStackTraces);
     putNativeFn(Identifier::fromString(vm, "noInline"_s), functionNeverInlineFunction);
     putNativeFn(Identifier::fromString(vm, "isRope"_s), functionIsRope);
+    putNativeFn(Identifier::fromString(vm, "loadedModules"_s), functionLoadedModules);
     putNativeFn(Identifier::fromString(vm, "memoryUsage"_s), functionCreateMemoryFootprint);
     putNativeFn(Identifier::fromString(vm, "noFTL"_s), functionNoFTL);
     putNativeFn(Identifier::fromString(vm, "noOSRExitFuzzing"_s), functionNoOSRExitFuzzing);

--- a/test/bundler/compile-argv.test.ts
+++ b/test/bundler/compile-argv.test.ts
@@ -396,6 +396,41 @@ describe("bundler", () => {
     },
   });
 
+  // A script injected with BUN_OPTIONS=--preload runs before the entry point
+  // of an existing executable and can inspect what it loaded.
+  for (const split of [false, true]) {
+    itBundled(`compile/BunOptionsEnvPreload${split ? "+splitting+bytecode" : ""}`, {
+      compile: true,
+      backend: "cli",
+      ...(split ? { splitting: true, bytecode: true, format: "esm" as const } : {}),
+      files: {
+        "/entry.ts": /* js */ `
+          console.log("entry sees", globalThis.preloaded);
+          const { lazy } = await import("./lazy.ts");
+          console.log(lazy());
+        `,
+        "/lazy.ts": /* js */ `
+          export function lazy() { return "lazy loaded"; }
+        `,
+      },
+      runtimeFiles: {
+        "/preload.js": /* js */ `
+          globalThis.preloaded = "what the preload set";
+          console.log("preload runs first");
+          process.on("exit", () => {
+            const bundled = require("bun:jsc").loadedModules().filter(m => m.id.includes("$bunfs") || m.id.includes("~BUN"));
+            console.log("bundled modules evaluated:", bundled.filter(m => m.state === "evaluated").length, "of", bundled.length);
+          });
+        `,
+      },
+      run: {
+        env: { BUN_OPTIONS: "--preload=./preload.js" },
+        setCwd: true,
+        stdout: `preload runs first\nentry sees what the preload set\nlazy loaded\nbundled modules evaluated: ${split ? "2 of 2" : "1 of 1"}`,
+      },
+    });
+  }
+
   // `bun -e` / `bun -p` start JSC in one-shot mode (no concurrent JIT, one GC
   // marker). That is decided by scanning argv, and a compiled executable's argv
   // belongs to the program, so `./app -p 8080` must keep the full configuration.

--- a/test/integration/bun-types/fixture/jsc.ts
+++ b/test/integration/bun-types/fixture/jsc.ts
@@ -8,6 +8,7 @@ import {
   gcAndSweep,
   heapSize,
   heapStats,
+  loadedModules,
   memoryUsage,
   noFTL,
   noOSRExitFuzzing,
@@ -18,6 +19,7 @@ import {
   serialize,
   startSamplingProfiler,
   totalCompileTime,
+  type LoadedModule,
   type SamplingProfile,
   type SamplingProfileStackFrame,
   type SamplingProfileStackTraces,
@@ -37,6 +39,12 @@ expectType(gcAndSweep()).is<number>();
 expectType(fullGC()).is<number>();
 expectType(edenGC()).is<number>();
 expectType(heapSize()).is<number>();
+
+const evaluated = loadedModules().filter(module => module.state === "evaluated");
+expectType(evaluated).is<LoadedModule[]>();
+for (const module of evaluated) {
+  expectType(module.id).is<string>();
+}
 
 const stats = heapStats();
 expectType(stats.heapSize).is<number>();

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -24,7 +24,7 @@ import {
   totalCompileTime,
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBuildKite, isWindows } from "harness";
+import { bunEnv, bunExe, isBuildKite, isWindows, tempDir } from "harness";
 
 describe("bun:jsc", () => {
   function count() {
@@ -254,6 +254,173 @@ describe("bun:jsc", () => {
     expect(stdout).toBe("ok\n");
     expect(exitCode).toBe(0);
   });
+});
+
+it("loadedModules lists every module the ES module and CommonJS loaders hold, once, with how far it has loaded", async () => {
+  using dir = tempDir("bun-jsc-loaded-modules", {
+    "a.mjs": `export const a = 1;`,
+    "b.mjs": `import { a } from "./a.mjs"; export const b = a + 1;`,
+    "c.cjs": `module.exports = { c: 3 };`,
+    "replaced.cjs": `module.exports = { r: 4 };`,
+    "data.json": `{"x":1}`,
+    "required.json": `{"y":2}`,
+    "note.txt": `hello`,
+    "throws.mjs": `throw new Error("boom");`,
+    "never-imported.mjs": `export {};`,
+    // What a CommonJS module sees of itself and of the module that require()d it, both still running.
+    "outer.cjs": `exports.inner = require("./inner.cjs").seen;`,
+    "inner.cjs": `
+      const { loadedModules } = require("bun:jsc");
+      exports.seen = loadedModules()
+        .filter(m => m.id === __filename || m.id === require("node:path").join(__dirname, "outer.cjs"))
+        .map(m => require("node:path").basename(m.id) + " " + m.state)
+        .sort();
+    `,
+    // A CommonJS entry point is imported by an internal ES module, and runs before that import has a record.
+    "entry.cjs": `
+      const { loadedModules } = require("bun:jsc");
+      console.log(JSON.stringify(loadedModules().filter(m => m.id === __filename || m.id === "bun:main").map(m => m.state)));
+    `,
+    "index.mjs": `
+      import { loadedModules, heapStats } from "bun:jsc";
+      import { join } from "node:path";
+      import { b } from "./b.mjs";
+      import source from "./a.mjs" with { type: "text" };
+      import data from "./data.json";
+      import sameData from "./data.json" with { type: "json" };
+      import note from "./note.txt";
+      const { c } = require("./c.cjs");
+      const { y } = require("./required.json");
+      const { r } = await import("./replaced.cjs");
+      const { inner } = require("./outer.cjs");
+      try { await import("./throws.mjs"); } catch {}
+      // A user-written require.cache entry does not hide the module the loader holds.
+      require.cache[join(import.meta.dir, "replaced.cjs")] = { exports: 1 };
+      const namespaces = () => heapStats().objectTypeCounts.ModuleNamespaceObject ?? 0;
+      const before = namespaces();
+      const modules = loadedModules();
+      const createdByListing = namespaces() - before;
+      const local = list => list
+        .filter(m => m.id.startsWith(import.meta.dir))
+        .map(m => m.id.slice(import.meta.dir.length + 1) + " " + m.state)
+        .sort();
+      // Reading require.cache makes a namespace object and a module object for the ES module; it is listed once still.
+      require.cache[join(import.meta.dir, "a.mjs")];
+      const createdByRequireCache = namespaces() - before;
+      console.log(JSON.stringify({
+        used: [b, source.length > 0, data.x + sameData.x, note, c, y, r],
+        inner,
+        createdByListing,
+        createdByRequireCache,
+        local: local(modules),
+        builtin: modules.filter(m => m.id === "bun:jsc" || m.id === "bun:main"),
+        afterRequireCache: local(loadedModules()).filter(line => line.startsWith("a.mjs")),
+      }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({
+      used: [2, true, 2, "hello", 3, 2, 4],
+      inner: ["inner.cjs evaluated", "outer.cjs evaluated"],
+      createdByListing: 0,
+      createdByRequireCache: 1,
+      local: [
+        "a.mjs evaluated",
+        "b.mjs evaluated",
+        "c.cjs evaluated",
+        "data.json evaluated",
+        "index.mjs evaluating-async",
+        "inner.cjs evaluated",
+        "note.txt evaluated",
+        "outer.cjs evaluated",
+        "replaced.cjs evaluated",
+        "required.json evaluated",
+        "throws.mjs errored",
+      ],
+      builtin: [{ id: "bun:jsc", state: "evaluated" }],
+      afterRequireCache: ["a.mjs evaluated"],
+    }),
+    stderr: "",
+    exitCode: 0,
+  });
+
+  await using entry = Bun.spawn({
+    cmd: [bunExe(), "entry.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(await Promise.all([entry.stdout.text(), entry.stderr.text(), entry.exited])).toEqual([
+    `["evaluated"]\n`,
+    "",
+    0,
+  ]);
+});
+
+it("loadedModules lists the loaders of the realm the function belongs to", async () => {
+  using dir = tempDir("bun-jsc-loaded-modules-realm", {
+    "in-realm.mjs": `
+      import { loadedModules } from "bun:jsc";
+      export const listed = loadedModules().map(m => m.id.split(/[\\\\/]/).pop() + " " + m.state).sort().join(",");
+    `,
+    "index.mjs": `
+      import { loadedModules } from "bun:jsc";
+      const realm = new ShadowRealm();
+      const inRealm = await realm.importValue(import.meta.dir + "/in-realm.mjs", "listed");
+      const main = loadedModules().filter(m => m.id.startsWith(import.meta.dir)).map(m => m.id.slice(import.meta.dir.length + 1)).sort();
+      console.log(JSON.stringify({ inRealm, main }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({ inRealm: "bun:jsc evaluated,in-realm.mjs evaluating", main: ["index.mjs"] }),
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// Unfixed, the state strings were only in a hash table the collector does not scan: entries came back with another
+// module's id as their state.
+it("loadedModules keeps its state strings alive while it allocates", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        import { loadedModules } from "bun:jsc";
+        import "node:fs";
+        import "node:path";
+        import "node:os";
+        const states = ["fetching", "unlinked", "linking", "linked", "evaluating", "evaluating-async", "evaluated", "errored"];
+        const bad = [];
+        for (let i = 0; i < 50; i++) {
+          for (const m of loadedModules()) if (!states.includes(m.state)) bad.push(m.id + " " + m.state);
+        }
+        console.log(JSON.stringify(bad));
+      `,
+    ],
+    env: { ...bunEnv, BUN_JSC_slowPathAllocsBetweenGCs: "3" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "[]", stderr: "", exitCode: 0 });
 });
 
 it("deserialize rejects an object reference index outside the deserialized object pool", async () => {


### PR DESCRIPTION
### What

`loadedModules()` from `bun:jsc` returns `{ id, state }` for every module the ES module loader and the CommonJS
loader hold, one entry per resolved specifier.

- `id`: the resolved specifier. An absolute path for a file (the module's key in `require.cache`), a name like
  `node:fs` for a built-in, the embedded-filesystem path for a chunk of a `bun build --compile` executable.
- `state`: `"fetching" | "unlinked" | "linking" | "linked" | "evaluating" | "evaluating-async" | "evaluated" |
  "errored"`.

```ts
import { loadedModules } from "bun:jsc";
const evaluated = loadedModules().filter(m => m.state === "evaluated");
```

### Why

The only way to ask a running program what it has loaded is `Object.keys(require.cache)`. That lists only modules
that finished evaluating, hides built-ins, and says nothing about modules that are in flight, waiting on a top-level
`await`, or failed. Working out why a large bundled CLI application evaluates the chunks it does at startup needed
exactly that, from outside the program: `BUN_OPTIONS=--preload=./probe.js ./app` with a probe that calls
`loadedModules()` on exit works on an existing `--compile` executable without rebuilding it. The PR pins that
`BUN_OPTIONS=--preload` reaches a compiled executable (plain and `--bytecode --splitting --format=esm`), which had no
test.

`bun:jsc` is the debugging / introspection module (`heapStats`, `memoryUsage`, `isRope`, `callerSourceOrigin`), which
is where this belongs rather than on `Bun` or `process`.

### Semantics worth reviewing

- Both tables are walked without creating anything but the result: no namespace objects, no atoms for lookups, no
  per-module scan of either table. The elements share one `Structure` kept lazily on the global object; the eight
  state strings are made once per call and kept in a `MarkedArgumentBuffer` while the elements are allocated.
- The registry keeps one entry per (specifier, import attribute type). A specifier is listed once, for the entry
  `JSModuleLoader::registryEntry(specifier)` returns (`forEachModuleRegistrySpecifier` in the new
  `BunModuleRegistry.h`; the `require.cache` PR adds the same header, byte for byte, so whichever lands second
  rebases to no change in that file).
- An id in both tables is listed once, from the registry. If its record is the synthetic one Bun makes for a CommonJS
  module an ES module imported, the state comes from the CommonJS module object, because that record is "linked"
  before the body has run.
- A CommonJS module is `"unlinked"` until its body starts and `"evaluated"` from then on, including while it is
  still running: `hasEvaluated` is set when the body starts and nothing records that it finished. The JSDoc says so
  and a test pins it from inside a `require()` chain. One that threw is `"errored"` when an `import` loaded it;
  `require()` drops a module that threw from its map, so it is not listed.
- `"evaluating-async"` is `CyclicModuleRecord::Status::EvaluatingAsync`: the module or one it imports has a top-level
  `await`, and it stays in that state while its own body runs. JSON, text and built-in (synthetic) records are
  `"evaluated"` as soon as they exist. Both are in the JSDoc.
- It lists the loaders of the realm the function belongs to (a `ShadowRealm` that imports `bun:jsc` sees only its own
  modules; a test pins that).
- The internal module that imports the entry point (`bun:main`) is left out. Built-ins `require()`d through the
  internal module table are in neither loader and are not listed; the JSDoc says so.
- A user-written `require.cache[path] = {...}` does not hide the module the loader still holds.

### Surface

- `packages/bun-types/jsc.d.ts`: `loadedModules(): LoadedModule[]`, `interface LoadedModule` with a literal union for
  `state`; fixture in `test/integration/bun-types/fixture/jsc.ts`.
- `docs/runtime/utils.mdx`: a short section next to the other `bun:jsc` entries (the full reference for `bun:jsc` is
  generated from the `.d.ts`).

### How verified

- `test/js/bun/jsc/bun-jsc.test.ts`: one fixture that imports ESM, CJS, JSON (imported and required), text, the same
  file under two attribute types, a module that throws, a CJS chain that inspects itself while running, a
  user-overwritten `require.cache` entry, and a CommonJS entry point; asserts the exact `{id, state}` list, that the
  listing created 0 namespace objects and that reading `require.cache[key]` afterwards created 1 (positive control
  for the counter).
  - "loadedModules keeps its state strings alive while it allocates": runs under
    `BUN_JSC_slowPathAllocsBetweenGCs=3` and checks every `state` is one of the eight values. An earlier version of
    this change cached the state strings in a hash table the collector does not scan; against that build this test
    reports entries whose `state` is another module's id (and the same script aborts in the marker with `=1`).
  - "loadedModules lists the loaders of the realm the function belongs to" (ShadowRealm).
- `test/bundler/compile-argv.test.ts`: `compile/BunOptionsEnvPreload` and `...+splitting+bytecode`.
- Release build, Linux x64: `test/js/bun/jsc/bun-jsc.test.ts` 41/41, `test/bundler/compile-argv.test.ts` 14/14. On
  1.4.1 the new tests fail (the function does not exist there). 300 calls over a mixed graph come back clean under
  `BUN_JSC_slowPathAllocsBetweenGCs=1/2/3/5` and `BUN_JSC_collectContinuously=1`.
- The docs snippets were run as written (the example, and `BUN_OPTIONS="--preload=./loaded.js"` against a
  `--compile --splitting` executable).
- `clang-format` and `prettier` clean. No Rust changed. The types fixture adds no errors to
  `test/integration/bun-types/bun-types.test.ts`.
