### PR TITLE
docs: list the accepted bunfig jsx values and the [hashN] range

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -960,7 +960,7 @@ The `naming` field customizes the names and locations of the generated files. It
 
 - `[name]` - The name of the entrypoint file, without the extension.
 - `[ext]` - The extension of the generated bundle.
-- `[hash]` - A hash of the bundle contents: 8 lowercase alphanumeric characters. If two outputs with different contents would print the same characters, both get enough extra characters to differ (as do the outputs that reference them). `[hashN]` sets the minimum to `N` characters, where `N` is 1 to 13. `[hash9]` through `[hash13]` set a wider minimum; `[hash13]` is the full 64-bit hash. An `N` above 13 prints 13 characters. An `N` below 8 makes it more likely that two outputs print the same characters.
+- `[hash]` - A hash of the bundle contents: 8 lowercase alphanumeric characters. If two outputs with different contents would print the same characters, both get enough extra characters to differ (as do the outputs that reference them). `[hashN]` sets the minimum to `N` characters, where `N` is 1 to 13. `[hash9]` through `[hash13]` set a wider minimum; `[hash13]` is the full 64-bit hash. An `N` above 13 prints 13 characters. An `N` below 8 makes it more likely that two outputs need the extra characters.
 - `[dir]` - The relative path from the project root to the parent directory of the source file.
 - `[target]` - The target the file is built for: `browser`, `bun`, or `node`.
 
@@ -1598,7 +1598,7 @@ Each artifact also contains the following properties:
 | Property    | Description                                                                                                                                                |
 | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `kind`      | What kind of build output this file is. A build generates bundled entrypoints, code-split "chunks", sourcemaps, bytecode, and copied assets (like images). |
-| `path`      | Absolute path to the file on disk                                                                                                                          |
+| `path`      | Absolute path to the file on disk when `outdir` is set. Without `outdir`, a relative path such as `./index.js`.                                            |
 | `loader`    | The loader used to interpret the file. See [loaders](/bundler/loaders) for how Bun maps file extensions to built-in loaders.                               |
 | `hash`      | The hash of the file contents. Always defined for assets.                                                                                                  |
 | `sourcemap` | The sourcemap file corresponding to this file, if generated. Only defined for entrypoints and chunks.                                                      |

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -960,8 +960,11 @@ The `naming` field customizes the names and locations of the generated files. It
 
 - `[name]` - The name of the entrypoint file, without the extension.
 - `[ext]` - The extension of the generated bundle.
-- `[hash]` - A hash of the bundle contents: 8 lowercase alphanumeric characters. If two outputs with different contents would print the same characters, both get enough extra characters to differ (as do the outputs that reference them). `[hash9]` through `[hash13]` set a wider minimum; `[hash13]` is the full 64-bit hash.
+- `[hash]` - A hash of the bundle contents: 8 lowercase alphanumeric characters. If two outputs with different contents would print the same characters, both get enough extra characters to differ (as do the outputs that reference them). `[hashN]` sets the minimum to `N` characters, where `N` is 1 to 13. `[hash9]` through `[hash13]` set a wider minimum; `[hash13]` is the full 64-bit hash. An `N` above 13 prints 13 characters. An `N` below 8 makes it more likely that two outputs print the same characters.
 - `[dir]` - The relative path from the project root to the parent directory of the source file.
+- `[target]` - The target the file is built for: `browser`, `bun`, or `node`.
+
+Bun does not report bracketed text that is not one of these tokens. The text stays in the file name as written: `[name]-[hash:8].[ext]` produces `index-[hash:8].js`. The same applies to `[hash0]`, to an `N` of three or more digits, to uppercase `[HASH]`, and to tokens of other bundlers such as `[contenthash]`.
 
 For example:
 
@@ -1634,7 +1637,7 @@ BuildArtifact (entry-point) {
   path: "./index.js",
   loader: "tsx",
   kind: "entry-point",
-  hash: "824a039620219640",
+  hash: "h1ye2bca",
   Blob (74756 bytes) {
     type: "text/javascript;charset=utf-8"
   },
@@ -1642,16 +1645,16 @@ BuildArtifact (entry-point) {
     path: "./index.js.map",
     loader: "file",
     kind: "sourcemap",
-    hash: "e7178cda3e72e301",
     Blob (24765 bytes) {
       type: "application/json;charset=utf-8"
-    },
-    sourcemap: null
+    }
   }
 }
 ```
 
 </CodeGroup>
+
+This is the output of a build without `outdir`. With `outdir`, `path` is absolute and the `Blob (…)` line reads `FileRef ("<path>")`.
 
 ## Bytecode
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -37,17 +37,27 @@ preload = ["./preload.ts"]
 Configure how Bun handles JSX. You can also set these fields in the `compilerOptions` of your `tsconfig.json`, but `bunfig.toml` supports them for non-TypeScript projects.
 
 ```toml title="bunfig.toml" icon="settings"
-jsx = "react"
+jsx = "react" # "react" | "react-jsx" | "react-jsxDEV"
 jsxFactory = "h"
 jsxFragment = "Fragment"
 jsxImportSource = "react"
 ```
 
-Refer to the tsconfig docs for more information on these fields.
+`jsx` accepts three values. The match is case-sensitive.
+
+| `jsx`            | Transform                                                     |
+| ---------------- | ------------------------------------------------------------- |
+| `"react"`        | Classic: `React.createElement`, or `jsxFactory` when set      |
+| `"react-jsx"`    | Automatic: `jsx` from `react/jsx-runtime`                     |
+| `"react-jsxDEV"` | Automatic, development: `jsxDEV` from `react/jsx-dev-runtime` |
+
+Any other value is a configuration error. That includes `"preserve"` and the lowercase `"react-jsxdev"` that `tsconfig.json` accepts. Bun prints `Invalid jsx runtime, only 'react', 'react-jsx', and 'react-jsxDEV' are supported`, and commands such as `bun <file>`, `bun test`, `bun install`, and `bun build` exit with code 1.
+
+Refer to the tsconfig docs for more information on these fields. `jsxFragment` is the `bunfig.toml` name for `jsxFragmentFactory`.
 
 - [`jsx`](https://www.typescriptlang.org/tsconfig#jsx)
 - [`jsxFactory`](https://www.typescriptlang.org/tsconfig#jsxFactory)
-- [`jsxFragment`](https://www.typescriptlang.org/tsconfig#jsxFragment)
+- [`jsxFragment`](https://www.typescriptlang.org/tsconfig#jsxFragmentFactory)
 - [`jsxImportSource`](https://www.typescriptlang.org/tsconfig#jsxImportSource)
 
 ### `smol`

--- a/docs/runtime/debugger.mdx
+++ b/docs/runtime/debugger.mdx
@@ -263,7 +263,7 @@ The `CallSite` object has the following methods:
 | -------------------------- | ----------------------------------------------------- |
 | `getThis`                  | `this` value of the function call                     |
 | `getTypeName`              | typeof `this`                                         |
-| `getFunction`              | function object                                       |
+| `getFunction`              | function object, or `undefined` in strict mode        |
 | `getFunctionName`          | function name as a string                             |
 | `getMethodName`            | method name as a string                               |
 | `getFileName`              | file name or URL                                      |
@@ -279,6 +279,8 @@ The `CallSite` object has the following methods:
 | `isPromiseAll`             | Not implemented yet.                                  |
 | `getPromiseIndex`          | Not implemented yet.                                  |
 | `toString`                 | returns a string representation of the call site      |
+
+As in V8, `getFunction` returns `undefined` for a frame that runs strict-mode code and for every caller below that frame. ES modules and class bodies are always strict.
 
 If the `Function` object has already been garbage collected, some of these methods return `undefined`.
 

--- a/docs/runtime/jsx.mdx
+++ b/docs/runtime/jsx.mdx
@@ -19,7 +19,7 @@ console.log(<Component message="Hello world!" />);
 
 ## Configuration
 
-Bun reads your `tsconfig.json` or `jsconfig.json` to determine how to perform the JSX transform internally. If you'd rather not use either, you can set the same options in [`bunfig.toml`](/runtime/bunfig).
+Bun reads your `tsconfig.json` or `jsconfig.json` to determine how to perform the JSX transform internally. If you'd rather not use either, you can set the same options in [`bunfig.toml`](/runtime/bunfig#jsx). Two spellings differ there: the `jsx` key accepts only `react`, `react-jsx`, and `react-jsxDEV` (capital `DEV`), and `jsxFragmentFactory` is named `jsxFragment`.
 
 Bun respects the following compiler options.
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3263,8 +3263,10 @@ declare module "bun" {
     /**
      * Output file name templates. Tokens: `[dir]`, `[name]`, `[ext]`,
      * `[target]`, and `[hash]` (8 characters of the content hash, more when
-     * two outputs would otherwise share a name) or `[hash9]`…`[hash13]` for a
-     * wider minimum.
+     * two outputs would otherwise share a name) or `[hashN]` for a minimum of
+     * `N` characters (`N` is 1 to 13; `[hash9]`…`[hash13]` are wider than
+     * `[hash]`). Other bracketed text, such as `[hash:8]` or `[contenthash]`,
+     * is not a token. It stays in the file name as written.
      *
      * @default { entry: "[dir]/[name].[ext]", chunk: "./chunk-[hash].[ext]", asset: "./[name]-[hash].[ext]" }
      */

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -3263,10 +3263,8 @@ declare module "bun" {
     /**
      * Output file name templates. Tokens: `[dir]`, `[name]`, `[ext]`,
      * `[target]`, and `[hash]` (8 characters of the content hash, more when
-     * two outputs would otherwise share a name) or `[hashN]` for a minimum of
-     * `N` characters (`N` is 1 to 13; `[hash9]`…`[hash13]` are wider than
-     * `[hash]`). Other bracketed text, such as `[hash:8]` or `[contenthash]`,
-     * is not a token. It stays in the file name as written.
+     * two outputs would otherwise share a name) or `[hash9]`…`[hash13]` for a
+     * wider minimum.
      *
      * @default { entry: "[dir]/[name].[ext]", chunk: "./chunk-[hash].[ext]", asset: "./[name]-[hash].[ext]" }
      */


### PR DESCRIPTION
### Problem
- `docs/runtime/jsx.mdx:22` says `bunfig.toml` takes "the same options" as `tsconfig.json`. The bunfig `jsx` key accepts only `react`, `react-jsx` and `react-jsxDEV`, case-sensitive (`src/bunfig/bunfig.rs:955`). TypeScript's `react-jsxdev` gives `Invalid jsx runtime, only 'react', 'react-jsx', and 'react-jsxDEV' are supported`, and `bun <file>`, `bun test`, `bun install` and `bun build` exit 1.
- `docs/bundler/index.mdx:963` documents `[hash9]` to `[hash13]`. The parser accepts `[hash1]` to `[hash99]` and prints at most 13 characters (`src/bundler/options.rs:2125`). Other bracketed text (`[hash:8]`, `[contenthash]`) lands in the file name with no message.
- The `BuildArtifact` sample and the `CallSite.getFunction` row are stale.

### Fix
- `bunfig.mdx` lists the three values and says that any other value fails the load. `jsx.mdx` names the two spellings that differ (`react-jsxDEV`, `jsxFragment`). The `jsxFragment` link points at `#jsxFragmentFactory`.
- The `[hash]` bullet gives the range and says what is not a token. The token list gains `[target]`.
- The sample shows the 8 character hash and a sourcemap artifact without `hash` and `sourcemap` lines. The `path` row covers a build without `outdir`. `getFunction` says `undefined` for a strict-mode frame and its callers.
- Verified: each statement was run on canary `6a92015fc`. Docs only.

### Background
- `bunfig.toml` and `tsconfig.json` have separate JSX option parsers. The tsconfig parser lowercases the value and ignores an unknown one. The bunfig parser does neither.
- A naming template such as `[name]-[hash].[ext]` sets the output file names. `[hashN]` sets the minimum hash width.
- `Error.prepareStackTrace` receives `CallSite` objects. V8 hides the function of a strict-mode frame, and so does Bun.

<details><summary>Notes</summary>

Runs on `1.4.3-canary.1+6a92015fc` (Linux x64).

bunfig `jsx` values, `bun build --no-bundle x.jsx`:

```
react         React.createElement(Box, ...)
react-jsx     jsx from "react/jsx-runtime"
react-jsxDEV  jsxDEV from "react/jsx-dev-runtime"
react-jsxdev  error: Invalid jsx runtime, only 'react', 'react-jsx', and 'react-jsxDEV' are supported
preserve      same error
classic       same error
automatic     same error
```

With `jsx = "react-jsxdev"` in `bunfig.toml`: `bun y.js`, `bun install`, `bun pm ls`, `bun test`, `bun build y.js` exit 1. `bun run y.js` prints the error and still runs the file.

`--entry-naming "[name]-<token>.[ext]"` on `a.js`:

```
[hash]         a-2v3v3rry.js
[hash1]        a-4.js
[hash5]        a-k7n5j.js
[hash08]       a-5f15h8dm.js
[hash13]       a-bx5g0d15kwqb5.js
[hash14]       a-vbxqg107s5kh6.js      (13 characters)
[hash99]       a-t765mc2p85v44.js      (13 characters)
[hash0]        a-[hash0].js
[hash100]      a-[hash100].js
[hash:8]       a-[hash:8].js
[contenthash]  a-[contenthash].js
[HASH]         a-[HASH].js
[target]       browser/a.js, bun/a.js, node/a.js
```

`BuildArtifact` sample: `console.log(build.outputs[0])` with `sourcemap: "external"`. Without `outdir` the output has `path: "./index.js"` and a `Blob (N bytes)` line. With `outdir` it has an absolute `path` and a `FileRef ("<path>")` line. Chunks follow the same rule (`./chunk-zjmt193s.js` without `outdir`). In both, `hash` has 8 characters, and the sourcemap artifact has no `hash` line and no `sourcemap` line (`src/runtime/api/JSBundler.rs:2139`, `:2164`).

`CallSite.getFunction()` in a `.cjs` file: a sloppy function gives the function. A class method gives `undefined`, and so does each sloppy caller below it. Node.js v26.3.0 gives the same answers. `src/jsc/bindings/CallSite.cpp:34-49` has the rule.

Related open work:
- #41643 makes the bunfig `jsx` match case-insensitive. When it lands, the clause about the lowercase `react-jsxdev` in `bunfig.mdx` has to change with it.
- The sentence "both get enough extra characters to differ" in the `[hash]` bullet is from #41317 and is not changed here.
- The `naming` JSDoc in `packages/bun-types/bun.d.ts` still says "`[hash9]`…`[hash13]` for a wider minimum". That statement is correct, only shorter than the docs page, so this PR leaves it.
- `getFunction` can also return internal functions for builtin and native frames. That needs a runtime guard first. The docs do not describe it.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->