### PR TITLE
docs(bundler): add a React Compiler section

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -480,6 +480,127 @@ bun build ./app.tsx --outdir ./out
 
 </CodeGroup>
 
+### reactCompiler
+
+<Warning>The React Compiler integration is experimental.</Warning>
+
+Runs the [React Compiler](https://react.dev/learn/react-compiler) over `.jsx` and `.tsx` files while bundling. The compiler memoizes the values, callbacks, and JSX inside each component and hook it compiles, so you don't write `useMemo`, `useCallback`, or `React.memo` by hand. It is built into Bun: you don't install Babel or `babel-plugin-react-compiler`.
+
+<Tabs>
+  <Tab title="JavaScript">
+    ```ts title="build.ts" icon="/icons/typescript.svg"
+    await Bun.build({
+      entrypoints: ['./index.tsx'],
+      outdir: './out',
+      reactCompiler: true,
+    })
+    ```
+  </Tab>
+  <Tab title="CLI">
+    ```bash terminal icon="terminal"
+    bun build ./index.tsx --outdir ./out --react-compiler
+    ```
+  </Tab>
+</Tabs>
+
+For example, take this component:
+
+```tsx Counter.tsx icon="/icons/typescript.svg"
+import { useState } from "react";
+
+export function Counter() {
+  const [count, setCount] = useState(0);
+  return <button onClick={() => setCount(count + 1)}>{count}</button>;
+}
+```
+
+The compiled function keeps the click handler and the element in a cache (`$`), and creates them again only when `count` changes. This is the output with `NODE_ENV=production`:
+
+{/* prettier-ignore */}
+```js out/index.js icon="/icons/javascript.svg"
+import { useState } from "react";
+import { jsx } from "react/jsx-runtime";
+import { c as _c } from "react/compiler-runtime";
+function Counter() {
+  let $ = _c(5);
+  let [count, setCount] = useState(0);
+  let t0;
+  if ($[0] !== count)
+    t0 = () => setCount(count + 1), $[0] = count, $[1] = t0;
+  else
+    t0 = $[1];
+  let t1;
+  if ($[2] !== count || $[3] !== t0)
+    t1 = /* @__PURE__ */ jsx("button", {
+      onClick: t0,
+      children: count
+    }), $[2] = count, $[3] = t0, $[4] = t1;
+  else
+    t1 = $[4];
+  return t1;
+}
+```
+
+The output imports `c` from `react/compiler-runtime`. That module is part of React 19. With React 17 or 18 the import does not resolve, and the build fails with `Could not resolve: "react/compiler-runtime"`.
+
+#### Which functions are compiled
+
+Bun uses the default `infer` mode of the compiler, the same as `babel-plugin-react-compiler`. It compiles a function that creates JSX or calls a hook, if the function is one of these:
+
+- A component: the name starts with a capital letter.
+- A hook: the name is `use` plus a capital letter or a digit, such as `useCart`.
+- The argument of `memo()`, `forwardRef()`, `React.memo()`, or `React.forwardRef()`.
+
+It also compiles each function whose body starts with the `"use memo"` directive.
+
+It skips:
+
+- A function whose body starts with the `"use no memo"` directive, and every function of a file that starts with `"use no memo"`.
+- A function that contains an `eslint-disable-next-line` comment for `react-hooks/rules-of-hooks` or `react-hooks/exhaustive-deps`. An `eslint-disable` comment for one of these rules skips every function after it in the file.
+- A function that it cannot compile, for example a function that calls a hook inside an `if`. Bun leaves that function as written, prints no message, and compiles the rest of the file.
+- A file that the `jsx` or `tsx` [loader](/bundler/loaders) does not handle. A hook in a `.ts` or `.js` file is not compiled.
+- A file under `node_modules`.
+
+#### reactCompilerOutputMode
+
+The compiler has two output modes. The default depends on [`target`](#target).
+
+| Mode       | Default for               | Output                                             |
+| ---------- | ------------------------- | -------------------------------------------------- |
+| `"client"` | `target: "browser"`       | Memoized components and hooks, as in the example   |
+| `"ssr"`    | `target: "bun"`, `"node"` | Components reduced to what one server render needs |
+
+`"ssr"` output has no memo cache and no `react/compiler-runtime` import. The compiler replaces `useState` and `useReducer` with their initial values, removes effects, and removes event handler props and `ref` props from built-in elements such as `<button>`. With `--target=bun`, the `Counter` component above becomes:
+
+{/* prettier-ignore */}
+```js out/index.js icon="/icons/javascript.svg"
+function Counter() {
+  let count = 0;
+  return /* @__PURE__ */ jsx("button", {
+    children: count
+  });
+}
+```
+
+Do not send `"ssr"` output to a browser. The components never update and never handle events. To bundle interactive components with `target: "bun"` or `target: "node"`, set the mode in the JavaScript API. The CLI has no flag for it: the mode follows `--target`.
+
+```ts title="build.ts" icon="/icons/typescript.svg"
+await Bun.build({
+  entrypoints: ["./index.tsx"],
+  outdir: "./out",
+  target: "bun",
+  reactCompiler: true,
+  reactCompilerOutputMode: "client",
+});
+```
+
+Browser code that a server build reaches through an [HTML import](/bundler/fullstack) is always compiled in `"client"` mode.
+
+#### Limits
+
+- `bun build --no-bundle` accepts `--react-compiler` and ignores it.
+- Only `bun build` and `Bun.build()` run the compiler. `bun run`, `bun test`, and the development server do not, and `bunfig.toml` has no key for it.
+
 ### splitting
 
 Whether to enable code splitting.

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -541,7 +541,7 @@ function Counter() {
 }
 ```
 
-The output imports `c` from `react/compiler-runtime`. That module is part of React 19. With React 17 or 18 the import does not resolve, and the build fails with `Could not resolve: "react/compiler-runtime"`.
+This is the `"client"` [output mode](#reactcompileroutputmode). It imports `c` from `react/compiler-runtime`. That module is part of React 19. With React 17 or 18 the import does not resolve, and the build fails with `Could not resolve: "react/compiler-runtime"`. The `"ssr"` output mode has no such import, so it does not need React 19.
 
 #### Which functions are compiled
 

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -514,10 +514,17 @@ export function Counter() {
 }
 ```
 
-The compiled function keeps the click handler and the element in a cache (`$`), and creates them again only when `count` changes. This is the output with `NODE_ENV=production`:
+Build it with React marked as external, so that the output holds only the component:
+
+```bash terminal icon="terminal"
+NODE_ENV=production bun build ./Counter.tsx --outdir ./out --react-compiler --external react --external 'react/*'
+```
+
+The compiled function keeps the click handler and the element in a cache (`$`), and creates them again only when `count` changes:
 
 {/* prettier-ignore */}
-```js out/index.js icon="/icons/javascript.svg"
+```js out/Counter.js icon="/icons/javascript.svg"
+// Counter.tsx
 import { useState } from "react";
 import { jsx } from "react/jsx-runtime";
 import { c as _c } from "react/compiler-runtime";
@@ -539,6 +546,9 @@ function Counter() {
     t1 = $[4];
   return t1;
 }
+export {
+  Counter
+};
 ```
 
 This is the `"client"` [output mode](#reactcompileroutputmode). It imports `c` from `react/compiler-runtime`. That module is part of React 19. With React 17 or 18 the import does not resolve, and the build fails with `Could not resolve: "react/compiler-runtime"`. The `"ssr"` output mode has no such import, so it does not need React 19.
@@ -570,10 +580,10 @@ The compiler has two output modes. The default depends on [`target`](#target).
 | `"client"` | `target: "browser"`       | Memoized components and hooks, as in the example   |
 | `"ssr"`    | `target: "bun"`, `"node"` | Components reduced to what one server render needs |
 
-`"ssr"` output has no memo cache and no `react/compiler-runtime` import. The compiler replaces `useState` and `useReducer` with their initial values, removes effects, and removes event handler props and `ref` props from built-in elements such as `<button>`. With `--target=bun`, the `Counter` component above becomes:
+`"ssr"` output has no memo cache and no `react/compiler-runtime` import. The compiler replaces `useState` and `useReducer` with their initial values, removes effects, and removes event handler props and `ref` props from built-in elements such as `<button>`. With `--target=bun` added to the command above, the `Counter` function in `out/Counter.js` becomes:
 
 {/* prettier-ignore */}
-```js out/index.js icon="/icons/javascript.svg"
+```js out/Counter.js icon="/icons/javascript.svg"
 function Counter() {
   let count = 0;
   return /* @__PURE__ */ jsx("button", {
@@ -586,9 +596,10 @@ Do not send `"ssr"` output to a browser. The components never update and never h
 
 ```ts title="build.ts" icon="/icons/typescript.svg"
 await Bun.build({
-  entrypoints: ["./index.tsx"],
+  entrypoints: ["./Counter.tsx"],
   outdir: "./out",
   target: "bun",
+  external: ["react", "react/*"],
   reactCompiler: true,
   reactCompilerOutputMode: "client",
 });

--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -1933,6 +1933,16 @@ interface BuildConfig {
     sideEffects?: boolean;
     development?: boolean;
   };
+  /**
+   * Run the React Compiler over `.jsx`/`.tsx` source files. Experimental.
+   * @default false
+   */
+  reactCompiler?: boolean;
+  /**
+   * Output mode for the React Compiler. Only applies when `reactCompiler` is `true`.
+   * @default "client" when target is "browser"; "ssr" when target is "bun" or "node"
+   */
+  reactCompilerOutputMode?: "client" | "ssr";
   naming?:
     | string
     | {


### PR DESCRIPTION
### Problem
- `bun build --react-compiler` and `Bun.build({ reactCompiler, reactCompilerOutputMode })` have two one-sentence descriptions (`docs/snippets/cli/build.mdx:181`, `packages/bun-types/bun.d.ts:3548`). No page says which functions are compiled, how to opt a function in or out, or which React version the output needs.
- `--target=bun` and `--target=node` select the `ssr` output mode. That output is not interactive: `useState(0)` becomes `let count = 0` and `onClick` is removed. The docs do not say so.

### Fix
- New `### reactCompiler` section in `docs/bundler/index.mdx`, after `### jsx`. It shows how to turn the compiler on, with an example that runs as written. The `## Reference` block lists the two options.
- It lists the `infer` rules, the `"use memo"` and `"use no memo"` directives, the eslint suppression comments, and the limits (`jsx`/`tsx` loader only, not `node_modules`, bundle mode only).
- It describes the two output modes, what `ssr` removes, and how to select `client` for a server target.
- Each statement describes main at a749e0a9b6. Each was checked in source and run on canary `6a92015fc`. The section marks the feature experimental.

### Background
- The React Compiler rewrites a component so that values, callbacks and JSX are cached between renders. Bun has a Rust port in `src/react_compiler/`. The parser calls it for each candidate function.
- Only the `jsx` and `tsx` loaders turn it on, and not under `node_modules` (`src/bundler/ParseTask.rs:2550`).
- The output mode comes from the target (`src/runtime/cli/build_command.rs:199`, `src/runtime/api/js_bundle_completion_task.rs:1055`). The browser graph of an HTML import is always `client` (`src/bundler/bundle_v2.rs:1733`).

<details><summary>Notes</summary>

Runs on `1.4.3-canary.1+6a92015fc` (Linux x64), `--external react --external 'react/*'`.

Selection, one file with eight functions:

```
function Named({ a }) { return <b>{a}</b> }                   compiled
function useThing(x) { const [s] = useState(x); ... }         compiled
function helper({ a }) { return <b>{a}</b> }                  not compiled
function optedIn({ a }) { "use memo"; ... }                   compiled
function OptedOut({ a }) { "use no memo"; ... }               not compiled
memo(({ a }) => <i>{a}</i>)                                   compiled
forwardRef((props, ref) => <i ref={ref}>{props.a}</i>)        compiled
function Suppressed() { // eslint-disable-next-line react-hooks/rules-of-hooks ... }   not compiled
```

Also: a file that starts with `"use no memo"` has no compiled function. A function with `"use memo"` and no JSX and no hook is compiled. `function Plain({ a }) { return a + 1 }` is not compiled. An anonymous `export default function` is not compiled. A hook in `useHook.ts` is not compiled. A component in `node_modules/pkg/index.jsx` is not compiled.

A component that calls `useState` inside an `if` is left as written. The build prints nothing and exits 0. The other component of that file is compiled.

With React 18.3.1 installed and `react` not external: `error: Could not resolve: "react/compiler-runtime"`. The same build with `--target=bun` (ssr output) succeeds and has no `react/compiler-runtime` import.

`Bun.build({ reactCompiler: true, target })`: `browser` gives client output, `bun` and `node` give ssr output. `target: "bun"` with `reactCompilerOutputMode: "client"` gives client output.

`--target=bun` on a component that uses `useState`, `useReducer`, `useEffect`, `useLayoutEffect`, `useRef`, `useMemo` and `useCallback`: the two state hooks become their initial values, both effects are gone, `useMemo` and `useCallback` are inlined, and `ref`, `onClick` and `onMouseEnter` are gone from `<div>` and `<span>`. Props of a component element are kept.

`bun build ./server.ts --target=bun --react-compiler`, where `server.ts` imports `index.html`: the browser chunk imports `react/compiler-runtime` and keeps `useState(0)`.

`bun build ./Counter.tsx --react-compiler --no-bundle` prints the transpiled file with no memo cache.

`src/bunfig/bunfig.rs` and `src/runtime/bake/` have no reference to the compiler.

The eslint rules are in `src/js_parser/lexer.rs:1911-1937`. The directive lists are in `src/react_compiler/program.rs:127-130`. The name rules are in `src/react_compiler/program.rs:612-623`.

Related open work:
- #40444 adds `--react-compiler-output-mode` and rewrites the two one-sentence descriptions. When it lands, the sentence "The CLI has no flag for it" has to change.
- #42033 makes `--no-bundle` act on `--react-compiler`. When it lands, the first bullet under Limits has to change.
- The section does not describe open compiler bugs. Those have their own PRs.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->