### PR TITLE
docs: drop trailing space in css :is() comment

### DIFF
--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -479,7 +479,7 @@ The `:is()` pseudo-class function (formerly `:matches()`) takes a selector list 
 
 ```css title="styles.css" icon="file-code"
 /* Instead of writing these separately */
-/* 
+/*
 .article h1,
 .article h2,
 .article h3 {


### PR DESCRIPTION
Stray trailing space after `/*` on the opening line of the `:is()` CSS example block.

Trivial whitespace cleanup, no rendered change.