### PR TITLE
docs: drop stray space on blank line in hot guide

### DIFF
--- a/docs/guides/http/hot.mdx
+++ b/docs/guides/http/hot.mdx
@@ -17,7 +17,7 @@ Bun detects when you are running an HTTP server with `Bun.serve()`. It reloads y
 <Note>
 Hot reloading doesn't reload the page in your browser.
 </Note>
- 
+
 ```ts index.ts icon="/icons/typescript.svg"
 Bun.serve({
   port: 3000,


### PR DESCRIPTION
Blank line after the `</Note>` block carried a single stray space. Trivial whitespace cleanup, no rendered change.