### PR TITLE
docs: use https for Discord link in windows build guide

### DIFF
--- a/docs/project/building-windows.mdx
+++ b/docs/project/building-windows.mdx
@@ -3,7 +3,7 @@ title: Building Windows
 description: Building Bun on Windows
 ---
 
-Use [PowerShell 7 (`pwsh.exe`)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.4) instead of the default `powershell.exe`. If you run into problems, ask in the [#contributing channel on our Discord](http://bun.com/discord).
+Use [PowerShell 7 (`pwsh.exe`)](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.4) instead of the default `powershell.exe`. If you run into problems, ask in the [#contributing channel on our Discord](https://bun.com/discord).
 
 ## Prerequisites
 


### PR DESCRIPTION
The Discord invite link used plain `http://`. Switch to `https://`, matching the other Discord links in docs (feedback, installation guides).