### PR TITLE
bundler: a differential check of what chunk folding does

### DIFF
--- a/scripts/splitting-fuzz.ts
+++ b/scripts/splitting-fuzz.ts
@@ -1,0 +1,31 @@
+// bun scripts/splitting-fuzz.ts <bun> <graphs> [first seed]
+// Runs test/bundler/splitting-fuzz.ts over many seeds against <bun> and prints the seeds where chunk folding made a
+// bundle worse than the unfolded one (rerun a seed with `<graphs>` = 1 to look at it).
+import { resolve } from "node:path";
+import { checkGraph } from "../test/bundler/splitting-fuzz";
+
+const [bun, count = "100", first = "1"] = process.argv.slice(2);
+if (!bun) {
+  console.error("usage: bun scripts/splitting-fuzz.ts <bun> <graphs> [first seed]");
+  process.exit(1);
+}
+const target = Bun.which(bun) ?? resolve(bun);
+const tally = { ok: 0, skipped: 0, worse: 0, folded: 0 };
+const parallel = 8;
+const end = Number(first) + Number(count);
+for (let seed = Number(first); seed < end; seed += parallel) {
+  const batch = [];
+  for (let s = seed; s < Math.min(end, seed + parallel); s++) batch.push(checkGraph(target, s));
+  for (const result of await Promise.all(batch)) {
+    tally[result.status]++;
+    if (result.folded) tally.folded++;
+    if (result.status !== "ok")
+      console.log(`seed ${result.seed} ${result.status}:\n  ` + result.problems.slice(0, 6).join("\n  "));
+  }
+}
+console.log(JSON.stringify({ graphs: Number(count), firstSeed: Number(first), ...tally }));
+// Folding changes about one graph in sixteen.
+if (tally.folded === 0 && Number(count) >= 200 && tally.skipped < Number(count)) {
+  console.error("folding changed no bundle: does <bun> read foldChunksForTesting (--expose-internals gate)?");
+  process.exit(1);
+}

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1397,6 +1397,7 @@ pub struct LinkerOptions {
     /// below this also fold into a chunk more entry points load (0 = off).
     /// See `merge_small_chunks`.
     pub(crate) min_chunk_size: u64,
+    pub(crate) fold_chunks: bool,
     pub(crate) module_preload: bool,
     pub(crate) source_maps: SourceMapOption,
     pub(crate) target: Target,
@@ -1443,6 +1444,7 @@ impl Default for LinkerOptions {
             footer: b"",
             css_chunking: false,
             min_chunk_size: 0,
+            fold_chunks: true,
             module_preload: true,
             source_maps: SourceMapOption::None,
             target: Target::Browser,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -401,6 +401,47 @@ impl<'a> LinkerContext<'a> {
         Some(other)
     }
 
+    /// Calls `each` with every other file that loading `source_index` loads first:
+    /// what the import records of its live parts load
+    /// (`file_loaded_by_import`) and the files declaring the bindings those
+    /// parts use. A CSS or HTML file has no parts; every record counts.
+    pub(crate) fn for_each_file_loaded_by(&self, source_index: u32, mut each: impl FnMut(u32)) {
+        let records = &self.graph.ast.items_import_records()[source_index as usize];
+        if self.graph.ast.items_css()[source_index as usize].is_some()
+            || self.parse_graph().input_files.items_loader()[source_index as usize] == Loader::Html
+        {
+            for record in records.iter() {
+                if record.source_index.is_valid() && record.source_index.get() != source_index {
+                    each(record.source_index.get());
+                }
+            }
+            return;
+        }
+        let parts_live = &self.graph.parts_live[source_index as usize];
+        for (part_index, part) in self.graph.ast.items_parts()[source_index as usize]
+            .as_slice()
+            .iter()
+            .enumerate()
+        {
+            if !parts_live.is_set(part_index) {
+                continue;
+            }
+            for &record_index in part.import_record_indices.iter() {
+                if let Some(other) =
+                    self.file_loaded_by_import(&records[record_index as usize], source_index)
+                    && other != source_index
+                {
+                    each(other);
+                }
+            }
+            for dependency in part.dependencies.iter() {
+                if dependency.source_index.get() != source_index {
+                    each(dependency.source_index.get());
+                }
+            }
+        }
+    }
+
     /// `"sideEffects": false` (or the resolver's equivalent), unless
     /// `--ignore-dce-annotations` says not to trust it.
     pub(crate) fn file_has_no_side_effects(&self, source_index: u32) -> bool {
@@ -962,7 +1003,6 @@ impl<'a> LinkerContext<'a> {
         let entry_points: *const [crate::IndexInt] = self.graph.entry_points.items_source_index();
         let distances: *mut [u32] = self.graph.files.items_distance_from_entry_point_mut();
         let file_entry_bits: *mut [AutoBitSet] = self.graph.files.items_entry_bits_mut();
-        let loaders: *const [Loader] = self.parse_graph().input_files.items_loader();
 
         // SAFETY: see block comment above — disjoint SoA columns, stable slabs
         // (no reallocation during tree-shaking). All column derefs share that
@@ -978,7 +1018,6 @@ impl<'a> LinkerContext<'a> {
             parts_live,
             distances,
             file_entry_bits,
-            loaders,
         ) = unsafe {
             (
                 &*entry_points,
@@ -989,7 +1028,6 @@ impl<'a> LinkerContext<'a> {
                 &mut *parts_live,
                 &mut *distances,
                 &mut *file_entry_bits,
-                &*loaders,
             )
         };
         let entry_points_len = entry_points.len();
@@ -1040,11 +1078,7 @@ impl<'a> LinkerContext<'a> {
 
             let mut ctx = CodeSplitCtx {
                 distances,
-                parts,
-                import_records,
                 file_entry_bits,
-                css_reprs,
-                loaders,
                 queue: std::collections::VecDeque::new(),
             };
 
@@ -2818,20 +2852,16 @@ pub enum TreeShakeWork {
     },
 }
 
-pub(crate) struct CodeSplitCtx<'a, 'r> {
+pub(crate) struct CodeSplitCtx<'r> {
     pub(crate) distances: &'r mut [u32],
-    pub(crate) parts: &'r [bun_ast::PartList<'a>],
-    pub(crate) import_records: &'r [bun_ast::import_record::List<'a>],
     pub(crate) file_entry_bits: &'r mut [AutoBitSet],
-    pub(crate) css_reprs: &'r [crate::bundled_ast::CssCol],
-    pub(crate) loaders: &'r [Loader],
     pub(crate) queue: std::collections::VecDeque<(crate::IndexInt, u32)>,
 }
 
 impl<'a> LinkerContext<'a> {
     pub(crate) fn mark_file_reachable_for_code_splitting(
         &mut self,
-        ctx: &mut CodeSplitCtx<'a, '_>,
+        ctx: &mut CodeSplitCtx<'_>,
         source_index: crate::IndexInt,
         entry_points_count: usize,
         distance: u32,
@@ -2866,55 +2896,12 @@ impl<'a> LinkerContext<'a> {
                 ctx.distances[source_index as usize] = distance;
             }
             let out_dist = distance + 1;
-
-            let records = &ctx.import_records[source_index as usize];
-
-            // CSS and HTML files have no parts: follow every import record.
-            if ctx.css_reprs[source_index as usize].is_some()
-                || ctx.loaders[source_index as usize] == Loader::Html
-            {
-                for record in records.iter() {
-                    if record.source_index.is_valid()
-                        && !ctx.file_entry_bits[record.source_index.get() as usize]
-                            .is_set(entry_points_count)
-                    {
-                        ctx.queue.push_back((record.source_index.get(), out_dist));
-                    }
+            let (file_entry_bits, queue) = (&ctx.file_entry_bits, &mut ctx.queue);
+            self.for_each_file_loaded_by(source_index, |other| {
+                if !file_entry_bits[other as usize].is_set(entry_points_count) {
+                    queue.push_back((other, out_dist));
                 }
-                continue;
-            }
-
-            // A dead part prints nothing, so only live parts reach other files.
-            let parts_live = &self.graph.parts_live[source_index as usize];
-            for (part_index, part) in ctx.parts[source_index as usize]
-                .as_slice()
-                .iter()
-                .enumerate()
-            {
-                if !parts_live.is_set(part_index) {
-                    continue;
-                }
-
-                for &import_index in part.import_record_indices.iter() {
-                    let Some(other) =
-                        self.file_loaded_by_import(&records[import_index as usize], source_index)
-                    else {
-                        continue;
-                    };
-                    if !ctx.file_entry_bits[other as usize].is_set(entry_points_count) {
-                        ctx.queue.push_back((other, out_dist));
-                    }
-                }
-
-                for dependency in part.dependencies.iter() {
-                    let dep = dependency.source_index.get();
-                    if dep != source_index
-                        && !ctx.file_entry_bits[dep as usize].is_set(entry_points_count)
-                    {
-                        ctx.queue.push_back((dep, out_dist));
-                    }
-                }
-            }
+            });
         }
     }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3046,6 +3046,7 @@ pub mod bv2_impl {
                 this.transpiler.options.min_chunk_size.unwrap_or_else(|| {
                     crate::options::default_min_chunk_size(this.transpiler.options.target)
                 });
+            this.linker.options.fold_chunks = this.transpiler.options.fold_chunks;
             this.linker.options.module_preload = this.transpiler.options.module_preload;
             this.linker.options.source_maps = this.transpiler.options.source_map;
             this.linker.options.tree_shaking = this.transpiler.options.tree_shaking;

--- a/src/bundler/linker_context/README.md
+++ b/src/bundler/linker_context/README.md
@@ -741,6 +741,7 @@ The renamed symbols are then used during final code generation to produce output
 - Computes, per `import()` entry point, which other entry points are guaranteed to be loaded already whenever it loads
 - Reduces each chunk key (`File.entry_bits`) to its load-condition class by dropping such redundant dynamic entries
 - Rewrites the entry bits of files to those of the class's parent chunk (the chunk keyed by the reduced set, else the largest member) before `computeChunks()` groups files
+- Keeps a chunk out of the fold when it can be in the middle of being evaluated while an entry of its class loads (it, or a file that statically imports its way to it, `require()`s a split ES module): the entry's chunk reads the other members then
 - With `--min-chunk-size`, additionally folds small chunks with no top-level side effects into a chunk loaded by a superset of their entries when every dependency is already loaded wherever the target is, no static import cycle between chunks results, and every CommonJS/ESM wrapper the moved code initializes at the top level is already initialized by a chunk the target imports
 
 #### `computeCrossChunkDependencies.rs`

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -277,7 +277,7 @@ pub(crate) fn compute_chunks(
             }
         }
     }
-    if code_splitting {
+    if code_splitting && this.options.fold_chunks {
         let min_chunk_size = this.options.min_chunk_size;
         merge_small_chunks(this, temp, min_chunk_size)?;
     }

--- a/src/bundler/linker_context/mergeSmallChunks.rs
+++ b/src/bundler/linker_context/mergeSmallChunks.rs
@@ -167,6 +167,8 @@ struct Group {
     wants_inits: bool,
     /// Neither merged nor merged into.
     pinned: bool,
+    /// See `entries_loaded_mid_evaluation`.
+    loads_mid_evaluation: Option<AutoBitSet>,
     /// Every live part of every file is side-effect free.
     pure: bool,
     /// Groups holding files that this group's live parts statically import
@@ -190,6 +192,12 @@ struct Group {
 }
 
 impl Group {
+    fn loads_entry_of(&self, entries: &AutoBitSet) -> bool {
+        self.loads_mid_evaluation
+            .as_ref()
+            .is_some_and(|loads| loads.has_intersection(entries))
+    }
+
     fn new(
         target: Target,
         bits: &AutoBitSet,
@@ -207,6 +215,7 @@ impl Group {
             recheck: false,
             wants_inits: false,
             pinned,
+            loads_mid_evaluation: None,
             pure: true,
             deps: Vec::new(),
             importers: Vec::new(),
@@ -253,6 +262,16 @@ fn fold(groups: &mut [Group], from: usize, into: usize) {
     }
     merge_sorted(&mut target.needs_init, &source.needs_init);
     merge_sorted(&mut target.provides_init, &source.provides_init);
+    if let Some(loads) = source.loads_mid_evaluation.take() {
+        union_into(&mut target.loads_mid_evaluation, loads);
+    }
+}
+
+fn union_into(slot: &mut Option<AutoBitSet>, bits: AutoBitSet) {
+    match slot {
+        Some(all) => all.set_union(&bits),
+        None => *slot = Some(bits),
+    }
 }
 
 /// Follow `merged_into` links to the group that now owns the files.
@@ -587,6 +606,104 @@ fn immediate_dominators<'a>(
     idom
 }
 
+/// Per group, the `require()`d entries that can start loading while the group is being evaluated (`None`: none).
+fn entries_loaded_mid_evaluation(
+    this: &LinkerContext,
+    sync_calls: &ArrayHashMap<u32, AutoBitSet>,
+    required_sync: &AutoBitSet,
+    file_entry_bits: &[AutoBitSet],
+    group_of_file: &[usize],
+    groups_len: usize,
+    entries: usize,
+) -> crate::Result<Vec<Option<AutoBitSet>>> {
+    let mut loads: Vec<Option<AutoBitSet>> = Vec::new();
+    loads.resize_with(groups_len, || None);
+    if sync_calls.count() == 0 {
+        return Ok(loads);
+    }
+    // `leads_to[x]`: what loading `x` can go on to `require()`.
+    let mut leads_to: Vec<Option<AutoBitSet>> = Vec::new();
+    leads_to.resize_with(entries, || None);
+    for (&file, calls) in sync_calls.keys().iter().zip(sync_calls.values()) {
+        let mut reached_by = file_entry_bits[file as usize].iterator::<true, true>();
+        while let Some(x) = reached_by.next() {
+            if required_sync.is_set(x) {
+                union_into(&mut leads_to[x], calls.clone()?);
+            }
+        }
+    }
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for x in 0..entries {
+            let Some(mut further) = leads_to[x].take() else {
+                continue;
+            };
+            let before = further.count();
+            let mut via = further.clone()?;
+            via.unset(x);
+            let mut via = via.iterator::<true, true>();
+            while let Some(y) = via.next() {
+                if let Some(next) = &leads_to[y] {
+                    further.set_union(next);
+                }
+            }
+            changed |= further.count() != before;
+            leads_to[x] = Some(further);
+        }
+    }
+    // A file is being evaluated while what it imports is, so what a file can
+    // start loading, every file that statically imports its way to it can.
+    let mut file_loads: Vec<Option<AutoBitSet>> = Vec::new();
+    file_loads.resize_with(group_of_file.len(), || None);
+    for (&file, calls) in sync_calls.keys().iter().zip(sync_calls.values()) {
+        let mut all = calls.clone()?;
+        let mut direct = calls.iterator::<true, true>();
+        while let Some(x) = direct.next() {
+            if let Some(further) = &leads_to[x] {
+                all.set_union(further);
+            }
+        }
+        file_loads[file as usize] = Some(all);
+    }
+    let mut importers: Vec<Vec<u32>> = vec![Vec::new(); group_of_file.len()];
+    for source_index in this.graph.reachable_files.iter() {
+        let file = source_index.get();
+        if group_of_file[file as usize] != usize::MAX {
+            this.for_each_file_loaded_by(file, |other| importers[other as usize].push(file));
+        }
+    }
+    let mut changed: Vec<u32> = sync_calls.keys().to_vec();
+    while let Some(file) = changed.pop() {
+        let Some(theirs) = file_loads[file as usize].take() else {
+            continue;
+        };
+        for &importer in &importers[file as usize] {
+            match &mut file_loads[importer as usize] {
+                Some(mine) if theirs.subset_of(mine) => {}
+                Some(mine) => {
+                    mine.set_union(&theirs);
+                    changed.push(importer);
+                }
+                slot => {
+                    *slot = Some(theirs.clone()?);
+                    changed.push(importer);
+                }
+            }
+        }
+        file_loads[file as usize] = Some(theirs);
+    }
+    for (file, file_loads) in file_loads.into_iter().enumerate() {
+        let Some(file_loads) = file_loads else {
+            continue;
+        };
+        // Only `sync_calls` keys and the importers filtered above have a set.
+        debug_assert!(group_of_file[file] != usize::MAX);
+        union_into(&mut loads[group_of_file[file]], file_loads);
+    }
+    Ok(loads)
+}
+
 /// Folds code-splitting chunks into other chunks where that is unobservable,
 /// so fewer modules are loaded at runtime.
 ///
@@ -606,7 +723,12 @@ fn immediate_dominators<'a>(
 ///    `x`'s chunk imports what it needs from the `main` chunk. Different
 ///    entries may cover different importers: with `import("./cmd")` in both
 ///    `main` and a lazy `repl`, the `{main, repl, cmd}` chunk loads iff `main`
-///    or `repl` does.
+///    or `repl` does. A chunk that can be in the middle of being evaluated
+///    when an entry of its class is loaded stays out of this: with
+///    `--target=bun` a `require()` of a split ES module loads that entry's
+///    chunk from inside the file making the call, and the other members must
+///    then be chunks that have finished or not started, not files further down
+///    the caller's own chunk.
 /// 2. A chunk whose live parts have no top-level side effects may join a chunk
 ///    loaded by a superset of its entries, as long as everything it imports is
 ///    already loaded wherever that target is (or is side-effect free too); the
@@ -616,7 +738,8 @@ fn immediate_dominators<'a>(
 ///    `init_x()` (a static import of a wrapped module, e.g. `react`) does not
 ///    count as a side effect when a chunk the target statically imports makes
 ///    the same call first, and no fold may close a static import cycle
-///    between chunks.
+///    between chunks or join a chunk to one that can be evaluating when an
+///    entry the other is needed by loads.
 ///
 /// Runs before `compute_chunks` groups files by `entry_bits`; it rewrites
 /// `File.entry_bits` in place so everything downstream (chunk membership,
@@ -674,6 +797,8 @@ pub(crate) fn merge_small_chunks(
     // guaranteed to precede the target; folding shared code into the
     // importer's chunk could place it after the call site.
     let mut required_sync = AutoBitSet::init_empty(entry_points_len)?;
+    // ... and, per file making such calls, the entries it loads that way.
+    let mut sync_calls: ArrayHashMap<u32, AutoBitSet> = ArrayHashMap::new();
     for source_index in this.graph.reachable_files.iter() {
         let source_index = source_index.get();
         if !is_live_js(source_index) {
@@ -701,6 +826,14 @@ pub(crate) fn merge_small_chunks(
                     .contains(ImportRecordFlags::CROSS_CHUNK_REQUIRE)
                 {
                     required_sync.set(target_entry as usize);
+                    match sync_calls.entry(source_index) {
+                        MapEntry::Occupied(calls) => calls.into_mut().set(target_entry as usize),
+                        MapEntry::Vacant(calls) => {
+                            let mut called = AutoBitSet::init_empty(entry_points_len)?;
+                            called.set(target_entry as usize);
+                            calls.insert(called);
+                        }
+                    }
                 } else {
                     importer_bits[target_entry as usize]
                         .set_union(&file_entry_bits[source_index as usize]);
@@ -966,6 +1099,21 @@ pub(crate) fn merge_small_chunks(
         groups.put(key, group)?;
     }
 
+    for (group, loads) in entries_loaded_mid_evaluation(
+        this,
+        &sync_calls,
+        &required_sync,
+        file_entry_bits,
+        group_of_file,
+        groups.count(),
+        entry_points_len,
+    )?
+    .into_iter()
+    .enumerate()
+    {
+        groups.values_mut()[group].loads_mid_evaluation = loads;
+    }
+
     // Static dependencies between groups, along the edges that assigned
     // `File.entry_bits` (so a dependency's key is a superset of its
     // importer's) and symbol dependencies. Only rule 2 consults them.
@@ -976,22 +1124,10 @@ pub(crate) fn merge_small_chunks(
         if group_index == usize::MAX {
             continue;
         }
-        let parts_live = &this.graph.parts_live[source_index];
         let deps = &mut groups.values_mut()[group_index].deps;
-        for (part_index, part) in parts[source_index].as_slice().iter().enumerate() {
-            if !parts_live.is_set(part_index) {
-                continue;
-            }
-            for &record_index in part.import_record_indices.iter() {
-                let record = &import_records[source_index][record_index as usize];
-                if let Some(other) = this.file_loaded_by_import(record, source_index as u32) {
-                    deps.push(group_of_file[other as usize]);
-                }
-            }
-            for dependency in part.dependencies.iter() {
-                deps.push(group_of_file[dependency.source_index.get() as usize]);
-            }
-        }
+        this.for_each_file_loaded_by(source_index as u32, |other| {
+            deps.push(group_of_file[other as usize]);
+        });
     }
     // An entry point's chunk also imports every binding the entry re-exports
     // (`compute_cross_chunk_dependencies`).
@@ -1025,13 +1161,15 @@ pub(crate) fn merge_small_chunks(
     // parent loses bits its files had; it still runs before they do because
     // an entry that remains in the key precedes them and imports every chunk
     // with side effects carrying its bit (`compute_cross_chunk_dependencies`).
+    // A member that can be evaluating when an entry of the class loads stays
+    // out (rule 1 in the doc comment above).
     let mut folded_same = 0usize;
-    for (class_key, (_, members)) in classes.keys().iter().zip(classes.values()) {
+    for (class_key, (class, members)) in classes.keys().iter().zip(classes.values()) {
         let unpinned = || {
-            members
-                .iter()
-                .copied()
-                .filter(|&i| !groups.values()[i].pinned)
+            members.iter().copied().filter(|&i| {
+                let group = &groups.values()[i];
+                !group.pinned && !group.loads_entry_of(class)
+            })
         };
         let Some(target_index) = unpinned().max_by(|&a, &b| {
             (groups.keys()[a] == *class_key)
@@ -1047,6 +1185,13 @@ pub(crate) fn merge_small_chunks(
         for &member in members {
             let group = &groups.values()[member];
             if member == target_index || group.pinned || group.target != Some(target_platform) {
+                continue;
+            }
+            if group.loads_entry_of(class) {
+                debug_merge!(
+                    "can be evaluating when an entry of its class loads: {}",
+                    bstr::BStr::new(sources[group.first_source as usize].path.pretty)
+                );
                 continue;
             }
             fold(groups.values_mut(), member, target_index);
@@ -1274,6 +1419,8 @@ pub(crate) fn merge_small_chunks(
                     || t.pinned
                     || t.target != c.target
                     || !c.loaded.subset_of(&t.loaded)
+                    || t.loads_entry_of(&c.loaded)
+                    || c.loads_entry_of(&t.loaded)
                 {
                     continue;
                 }

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1321,6 +1321,10 @@ pub struct BundleOptions<'a> {
     /// 0 disables that; chunks with identical load conditions always fold.
     /// `None` picks `default_min_chunk_size(target)`.
     pub min_chunk_size: Option<u64>,
+    /// Code splitting: fold chunks together (`merge_small_chunks`). Only
+    /// tests turn it off (`foldChunksForTesting: false`), to compare a bundle
+    /// with and without folding.
+    pub fold_chunks: bool,
     /// `<link rel=modulepreload>` for split browser chunks (HTML + `import()`).
     pub module_preload: bool,
 
@@ -1530,6 +1534,7 @@ impl<'a> BundleOptions<'a> {
             repl_mode: self.repl_mode,
             css_chunking: self.css_chunking,
             min_chunk_size: self.min_chunk_size,
+            fold_chunks: self.fold_chunks,
             module_preload: self.module_preload,
             ignore_dce_annotations: self.ignore_dce_annotations,
             emit_dce_annotations: self.emit_dce_annotations,
@@ -1711,6 +1716,7 @@ impl<'a> BundleOptions<'a> {
             transform_options: std::sync::Arc::clone(&transform),
             css_chunking: false,
             min_chunk_size: None,
+            fold_chunks: true,
             module_preload: true,
             drop: transform.drop.clone().into_boxed_slice(),
             bundler_feature_flags,

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -30,12 +30,19 @@ pub struct ModuleLoader {
     pub interactive_eval_script: Option<Box<[u8]>>,
 }
 
-pub static IS_ALLOWED_TO_USE_INTERNAL_TESTING_APIS: core::sync::atomic::AtomicBool =
+static IS_ALLOWED_TO_USE_INTERNAL_TESTING_APIS: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
 
 #[inline]
-pub(crate) fn set_is_allowed_to_use_internal_testing_apis(v: bool) {
+pub fn set_is_allowed_to_use_internal_testing_apis(v: bool) {
     IS_ALLOWED_TO_USE_INTERNAL_TESTING_APIS.store(v, core::sync::atomic::Ordering::Relaxed);
+}
+
+/// Whether `bun:internal-for-testing` resolves: `--expose-internals` in release builds, always in debug builds.
+#[inline]
+pub fn is_allowed_to_use_internal_testing_apis() -> bool {
+    bun_core::env::IS_DEBUG
+        || IS_ALLOWED_TO_USE_INTERNAL_TESTING_APIS.load(core::sync::atomic::Ordering::Relaxed)
 }
 
 impl ModuleLoader {

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -146,6 +146,8 @@ pub mod js_bundler {
         pub(crate) css_chunking: bool,
         /// `minChunkSize`: see `BundleOptions::min_chunk_size`.
         pub(crate) min_chunk_size: Option<u64>,
+        /// `foldChunksForTesting`, read only where `bun:internal-for-testing` resolves: see `BundleOptions::fold_chunks`.
+        pub(crate) fold_chunks: bool,
         pub(crate) module_preload: bool,
         pub(crate) drop: StringSet,
         pub(crate) features: StringSet,
@@ -212,6 +214,7 @@ pub mod js_bundler {
                 metafile_markdown_path: OwnedString::default(),
                 css_chunking: false,
                 min_chunk_size: None,
+                fold_chunks: true,
                 module_preload: true,
                 drop: StringSet::default(),
                 features: StringSet::default(),
@@ -848,6 +851,12 @@ pub mod js_bundler {
             }
             if let Some(module_preload) = config.get_boolean_loose(global_this, "modulePreload")? {
                 this.module_preload = module_preload;
+            }
+            if bun_jsc::module_loader::is_allowed_to_use_internal_testing_apis()
+                && let Some(fold_chunks) =
+                    config.get_boolean_loose(global_this, "foldChunksForTesting")?
+            {
+                this.fold_chunks = fold_chunks;
             }
 
             if let Some(min_chunk_size) =

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1024,6 +1024,7 @@ impl CompletionStruct for JSBundleCompletionTask {
         transpiler.options.tree_shaking_override = config.tree_shaking;
         transpiler.options.css_chunking = config.css_chunking;
         transpiler.options.min_chunk_size = config.min_chunk_size;
+        transpiler.options.fold_chunks = config.fold_chunks;
         transpiler.options.module_preload = config.module_preload;
         let compile_to_standalone_html = 'brk: {
             if config.compile.is_none() || config.target != bun_ast::Target::Browser {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1226,8 +1226,7 @@ pub(crate) fn parse(cmd: CommandTag, ctx: Context<'_>) -> crate::Result<api::Tra
             // sets (VirtualMachine::configure_from_env): allows resolving
             // `bun:internal-for-testing` / `internal/test/binding` in release
             // builds. Debug builds always allow them.
-            bun_jsc::module_loader::IS_ALLOWED_TO_USE_INTERNAL_TESTING_APIS
-                .store(true, core::sync::atomic::Ordering::Relaxed);
+            bun_jsc::module_loader::set_is_allowed_to_use_internal_testing_apis(true);
             bun_resolve_builtins::set_expose_internals_enabled(true);
         }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3647,12 +3647,8 @@ fn get_hardcoded_module(
         | HardcodedModule::NodeInternalReplHistory
         | HardcodedModule::NodeInternalUtilInspect => {
             // Gated behind `--expose-internals` (release) / always-on (debug).
-            if !bun_core::env::IS_DEBUG {
-                let allowed = bun_jsc::module_loader::IS_ALLOWED_TO_USE_INTERNAL_TESTING_APIS
-                    .load(core::sync::atomic::Ordering::Relaxed);
-                if !allowed {
-                    return None;
-                }
+            if !bun_jsc::module_loader::is_allowed_to_use_internal_testing_apis() {
+                return None;
             }
             let name: &'static str = hardcoded.into();
             Some(js_synthetic_module(name.as_bytes()))
@@ -3662,12 +3658,8 @@ fn get_hardcoded_module(
             // same as `bun:internal-for-testing`. The tag key uses the
             // generated `internal:`-prefixed canonical specifier (see
             // `generated_resolved_source_tag.rs`).
-            if !bun_core::env::IS_DEBUG {
-                let allowed = bun_jsc::module_loader::IS_ALLOWED_TO_USE_INTERNAL_TESTING_APIS
-                    .load(core::sync::atomic::Ordering::Relaxed);
-                if !allowed {
-                    return None;
-                }
+            if !bun_jsc::module_loader::is_allowed_to_use_internal_testing_apis() {
+                return None;
             }
             Some(js_synthetic_module(b"internal:test/binding"))
         }

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -2537,10 +2537,31 @@ describe("bundler", () => {
   // way back to that file, whatever else it needs must be a chunk that can be evaluated on demand at that moment,
   // not code sitting further down the caller's own chunk. Each graph runs unbundled and bundled; the output must match.
   const requireCycleGraphs: Record<string, { files: Record<string, string>; todo?: string; folding?: true }> = {
+    "the caller imports itself": {
+      files: {
+        "main.ts": `
+          import { tools } from './registry.ts'
+          console.log(tools.map(t => t.name).join(","))
+          export const later = () => import('./other.ts')
+        `,
+        "registry.ts": `
+          import * as self from './registry.ts'
+          export function buildTool(name: string) { return { name } }
+          export const tools = [require('./tool.ts').Tool, { name: typeof self.buildTool }]
+        `,
+        "tool.ts": `
+          import { buildTool } from './registry.ts'
+          export const Tool = buildTool("tool")
+        `,
+        "other.ts": `
+          import { buildTool } from './registry.ts'
+          export const other = buildTool("other")
+        `,
+      },
+    },
     // base.ts is needed by tool.ts and imports registry.ts, which require()s tool.ts. `other` (loaded after main) is
     // redundant in registry.ts's key, and dropping it must not fold base.ts into registry.ts's chunk.
     "a file the target needs imports the caller": {
-      todo: "folding puts base.ts in registry.ts's chunk, after the call",
       folding: true,
       files: {
         "main.ts": `
@@ -2571,7 +2592,6 @@ describe("bundler", () => {
     // The same with a leaf that shares the caller's key and is imported ahead of the call: it is the caller's group
     // that has to stay out, not whichever group comes second.
     "the caller shares its chunk with a leaf": {
-      todo: "folding puts base.ts in registry.ts's chunk, after the call",
       folding: true,
       files: {
         "main.ts": `
@@ -2853,13 +2873,18 @@ describe("bundler", () => {
   // Random graphs, each run unbundled, bundled without folding and bundled with it (splitting-fuzz.ts). Folding may
   // not lose a value or an order of top-level effects that the unfolded bundle and the source agree on. Folding
   // changes the bundle of about one graph in sixteen; these are from those.
-  for (const [seed, todo] of [
-    [3, ""],
-    [47, ""],
-    [25, "f3 and f3:done run after f6 and f9 once folded"],
+  for (const [seed, folded, todo] of [
+    [47, true, ""],
+    [59, true, ""],
+    // A chunk that can be evaluating while an entry of its class loads stays out of the fold: 762 and 993 lost an
+    // order and a read to it, and 3 was folded without harm.
+    [3, false, ""],
+    [762, false, ""],
+    [993, false, ""],
+    [496, true, "f5 runs after f1 once folded"],
   ] as const) {
     test.todoIf(!!todo).concurrent(`splitting/FoldingNeverMakesABundleWorse: graph ${seed}`, async () => {
-      expect(await checkGraph(bunExe(), seed)).toEqual({ seed, status: "ok", folded: true, problems: [] });
+      expect(await checkGraph(bunExe(), seed)).toEqual({ seed, status: "ok", folded, problems: [] });
     });
   }
 

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -4,6 +4,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { SourceMapConsumer } from "source-map";
 import { itBundled, type BundlerTestBundleAPI } from "./expectBundled";
+import { checkGraph, run } from "./splitting-fuzz";
 
 const env = {
   ...bunEnv,
@@ -2531,6 +2532,336 @@ describe("bundler", () => {
     },
     run: { file: "/out/main.js", stdout: "tool:shared shared" },
   });
+
+  // A split require() evaluates its target in the middle of the file making the call. Where the target imports its
+  // way back to that file, whatever else it needs must be a chunk that can be evaluated on demand at that moment,
+  // not code sitting further down the caller's own chunk. Each graph runs unbundled and bundled; the output must match.
+  const requireCycleGraphs: Record<string, { files: Record<string, string>; todo?: string; folding?: true }> = {
+    // base.ts is needed by tool.ts and imports registry.ts, which require()s tool.ts. `other` (loaded after main) is
+    // redundant in registry.ts's key, and dropping it must not fold base.ts into registry.ts's chunk.
+    "a file the target needs imports the caller": {
+      todo: "folding puts base.ts in registry.ts's chunk, after the call",
+      folding: true,
+      files: {
+        "main.ts": `
+          import { tools } from './registry.ts'
+          import { base } from './base.ts'
+          export const later = () => import('./other.ts')
+          console.log(tools[0].name, base.kind)
+        `,
+        "registry.ts": `
+          export function buildTool(name: string) { return { name } }
+          export const tools = [require('./tool.ts').Tool]
+        `,
+        "tool.ts": `
+          import { base } from './base.ts'
+          import { buildTool } from './registry.ts'
+          export const Tool = buildTool("tool:" + base.kind)
+        `,
+        "base.ts": `
+          import { buildTool } from './registry.ts'
+          export const base = { kind: "base", make: () => buildTool("x") }
+        `,
+        "other.ts": `
+          import { buildTool } from './registry.ts'
+          export const other = buildTool("other")
+        `,
+      },
+    },
+    // The same with a leaf that shares the caller's key and is imported ahead of the call: it is the caller's group
+    // that has to stay out, not whichever group comes second.
+    "the caller shares its chunk with a leaf": {
+      todo: "folding puts base.ts in registry.ts's chunk, after the call",
+      folding: true,
+      files: {
+        "main.ts": `
+          import { tools } from './registry.ts'
+          import { base } from './base.ts'
+          export const a = () => import('./other.ts')
+          export const b = () => import('./foo.ts')
+          console.log(tools[0].name, base.kind)
+        `,
+        "registry.ts": `
+          import { leaf } from './leaf.ts'
+          import { x } from './x.ts'
+          export function buildTool(name: string) { return { name: name + leaf + x } }
+          export const tools = [require('./tool.ts').Tool]
+        `,
+        "leaf.ts": `export const leaf = "+leaf"`,
+        "x.ts": `export const x = "+x"`,
+        "tool.ts": `
+          import { base } from './base.ts'
+          import { buildTool } from './registry.ts'
+          export const Tool = buildTool("tool:" + base.kind)
+        `,
+        "base.ts": `
+          import { buildTool } from './registry.ts'
+          export const base = { kind: "base", make: () => buildTool("x") }
+        `,
+        "other.ts": `
+          import { buildTool } from './registry.ts'
+          export const other = buildTool("other")
+        `,
+        "foo.ts": `
+          import { x } from './x.ts'
+          export const foo = x
+        `,
+      },
+    },
+    // The call is in base.ts, one require() further along than the one that starts the chain.
+    "a chain of two calls": {
+      files: {
+        "main.ts": `
+          import { tools } from './registry.ts'
+          import { base } from './base.ts'
+          import { shared2 } from './shared2.ts'
+          const later = () => import('./other.ts')
+          console.log(tools[0].name, base.kind, base.extra, shared2.name, typeof later)
+        `,
+        "registry.ts": `
+          export function buildTool(name: string) { return { name } }
+          export const tools = [require('./tool.ts').Tool]
+        `,
+        "tool.ts": `
+          import { base } from './base.ts'
+          import { buildTool } from './registry.ts'
+          export const Tool = { get name() { return buildTool("tool:" + base.kind).name } }
+        `,
+        "base.ts": `
+          import { buildTool } from './registry.ts'
+          export const base = { kind: "base", make: () => buildTool("x"), extra: require('./tool2.ts').T2 }
+        `,
+        "tool2.ts": `
+          import { shared2 } from './shared2.ts'
+          export const T2 = "t2:" + shared2.name
+        `,
+        "shared2.ts": `export const shared2 = { name: "s2" }`,
+        "other.ts": `
+          import { buildTool } from './registry.ts'
+          export const other = buildTool("other")
+        `,
+      },
+    },
+    // One call inside a function nobody calls while loading, one at the top level of another file.
+    "a call in a function and a call at the top level": {
+      files: {
+        "main.ts": `
+          import "./a.ts"
+          import "./b.ts"
+          import "./g.ts"
+        `,
+        "a.ts": `
+          export const a = 1
+          export function later() { return require("./x.ts") }
+          console.log("a")
+        `,
+        "b.ts": `
+          export function bfn() { return 2 }
+          const x = require("./x.ts")
+          console.log("b got", x.v)
+        `,
+        "f.ts": `
+          import { a } from "./a.ts"
+          export const fval = a + 10
+          console.log("f")
+        `,
+        "g.ts": `
+          import { fval } from "./f.ts"
+          import { later } from "./a.ts"
+          globalThis.later = later
+          console.log("g", fval)
+        `,
+        "x.ts": `
+          import { fval } from "./f.ts"
+          import { bfn } from "./b.ts"
+          export const v = fval + 1
+          export const w = () => bfn()
+          console.log("x")
+        `,
+      },
+    },
+    "a class extends one from a file with a call in a function": {
+      files: {
+        "main.ts": `
+          import "./a.ts"
+          import { Z } from "./z.ts"
+          import "./f.ts"
+          console.log(new Z().tag())
+        `,
+        "a.ts": `
+          export class Base { tag() { return "base" } }
+          export const lazy = () => require("./x.ts")
+        `,
+        "x.ts": `
+          import { l2 } from "./f.ts"
+          export const x = typeof l2
+        `,
+        "f.ts": `export const l2 = () => require("./x2.ts")`,
+        "x2.ts": `
+          import { Z } from "./z.ts"
+          export const x2 = Z.name
+        `,
+        "z.ts": `
+          import { Base } from "./a.ts"
+          export class Z extends Base { tag() { return "z<" + super.tag() } }
+        `,
+      },
+    },
+    "the target requires a CommonJS file the entry point imports too": {
+      files: {
+        "main.ts": `
+          import { tools } from './registry.ts'
+          import cjs from './cjs.cjs'
+          console.log(tools[0].n, cjs.x)
+        `,
+        "registry.ts": `export const tools = [require('./tool.ts').Tool]`,
+        "tool.ts": `
+          const c = require('./cjs.cjs')
+          export const Tool = { n: c.x }
+        `,
+        "cjs.cjs": `exports.x = "cjs"`,
+      },
+    },
+    "the caller's own imports run before the target": {
+      todo: "the code registry.ts shares with tool.ts is hoisted ahead of registry.ts's import of setup.ts",
+      files: {
+        "main.ts": `
+          import { tools } from './registry.ts'
+          import { shared } from './shared.ts'
+          console.log(tools[0].name, shared.name)
+        `,
+        "registry.ts": `
+          import './setup.ts'
+          export const tools = [require('./tool.ts').Tool]
+        `,
+        "setup.ts": `globalThis.X = "set"`,
+        "shared.ts": `export const shared = { name: "shared:" + globalThis.X }`,
+        "tool.ts": `
+          import { shared } from './shared.ts'
+          export const Tool = { name: "tool:" + shared.name }
+        `,
+      },
+    },
+    "a file the target needs shares the caller's chunk and comes after it": {
+      todo: "files reached by the same entry points share a chunk, and nothing orders helper.ts ahead of registry.ts",
+      files: {
+        "main.ts": `
+          import { tools } from './registry.ts'
+          import { viaMain } from './via-main.ts'
+          console.log(tools.map(t => t.name).join(","), viaMain())
+        `,
+        "registry.ts": `
+          export function buildTool(name: string) { return { name } }
+          export const tools = [require('./tool.ts').Tool]
+        `,
+        "tool.ts": `
+          import { buildTool } from './registry.ts'
+          import { viaTool } from './via-tool.ts'
+          export const Tool = buildTool("tool+" + viaTool())
+        `,
+        "via-main.ts": `
+          import { helperName } from './mid.ts'
+          export function viaMain() { return helperName() }
+        `,
+        "via-tool.ts": `
+          import { helperName } from './mid.ts'
+          export function viaTool() { return helperName() }
+        `,
+        "mid.ts": `
+          import { helper } from './helper.ts'
+          export function helperName() { return helper.name }
+        `,
+        "helper.ts": `export const helper = { name: "helper" }`,
+      },
+    },
+  };
+  for (const [name, { files, todo, folding }] of Object.entries(requireCycleGraphs)) {
+    // `folding`: the graph goes wrong because of a fold, so the build without folding has to get it right.
+    for (const fold of folding ? [true, false] : [true]) {
+      test
+        .todoIf(!!todo && fold)
+        .concurrent(`splitting/SplitRequireCycle: ${name}${fold ? "" : " (without folding)"}`, async () => {
+          using dir = tempDir("splitting-require-cycle", files);
+          const cwd = String(dir);
+          const [unbundled, build] = await Promise.all([
+            run([bunExe(), "main.ts"], cwd, env),
+            Bun.build({
+              entrypoints: [join(String(dir), "main.ts")],
+              outdir: join(String(dir), "out"),
+              splitting: true,
+              target: "bun",
+              format: "esm",
+              // @ts-expect-error internal to Bun's tests
+              foldChunksForTesting: fold,
+            }),
+          ]);
+          expect(unbundled.stdout).not.toBe("");
+          expect(unbundled.exitCode).toBe(0);
+          expect(build.logs).toEqual([]);
+          expect(await run([bunExe(), join("out", "main.js")], cwd, env)).toEqual(unbundled);
+        });
+    }
+  }
+
+  // Without folding, the chunk that a fold would have removed is kept; the program prints the same.
+  for (const foldChunks of [undefined, false]) {
+    itBundled(`splitting/FoldChunksForTesting/${foldChunks === false ? "off" : "on"}`, {
+      backend: "api",
+      files: {
+        "/main.js": `import { shared } from "./shared.js"; console.log("main", shared); import("./lazy.js");`,
+        "/lazy.js": `import { shared } from "./shared.js"; console.log("lazy", shared);`,
+        "/shared.js": `export const shared = "shared";`,
+      },
+      entryPoints: ["/main.js"],
+      splitting: true,
+      foldChunks,
+      outdir: "/out",
+      run: { file: "/out/main.js", stdout: "main shared\nlazy shared" },
+      onAfterBundle(api) {
+        const chunks = readdirSync(api.outdir).filter(name => name.endsWith(".js"));
+        expect(chunks.length).toBe(foldChunks === false ? 3 : 2);
+      },
+    });
+  }
+
+  // `foldChunksForTesting` is read only where `bun:internal-for-testing` resolves (always, in a debug build).
+  test.skipIf(isDebug).concurrent("splitting/FoldChunksForTesting is ignored without --expose-internals", async () => {
+    using dir = tempDir("splitting-fold-chunks-gate", {
+      "main.js": `import { shared } from "./shared.js"; console.log("main", shared); import("./lazy.js");`,
+      "lazy.js": `import { shared } from "./shared.js"; console.log("lazy", shared);`,
+      "shared.js": `export const shared = "shared";`,
+      "build.js": `
+        const result = await Bun.build({
+          entrypoints: [import.meta.dir + "/main.js"],
+          splitting: true,
+          foldChunksForTesting: false,
+        });
+        console.log(result.outputs.length);
+      `,
+    });
+    const { BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: _, ...withoutInternals } = env;
+    const chunks = async (...flags: string[]) => {
+      const { stdout, ...rest } = await run([bunExe(), ...flags, "build.js"], String(dir), withoutInternals);
+      return { stdout: stdout.trim(), ...rest };
+    };
+    expect(await Promise.all([chunks(), chunks("--expose-internals")])).toEqual([
+      { stdout: "2", stderr: "", exitCode: 0 },
+      { stdout: "3", stderr: "", exitCode: 0 },
+    ]);
+  });
+
+  // Random graphs, each run unbundled, bundled without folding and bundled with it (splitting-fuzz.ts). Folding may
+  // not lose a value or an order of top-level effects that the unfolded bundle and the source agree on. Folding
+  // changes the bundle of about one graph in sixteen; these are from those.
+  for (const [seed, todo] of [
+    [3, ""],
+    [47, ""],
+    [25, "f3 and f3:done run after f6 and f9 once folded"],
+  ] as const) {
+    test.todoIf(!!todo).concurrent(`splitting/FoldingNeverMakesABundleWorse: graph ${seed}`, async () => {
+      expect(await checkGraph(bunExe(), seed)).toEqual({ seed, status: "ok", folded: true, problems: [] });
+    });
+  }
 
   // Browser-side files of a server build (an imported HTML page's scripts)
   // cannot call import.meta.require; their require() keeps the wrapper.

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -265,6 +265,8 @@ export interface BundlerTestInput {
   modulePreload?: boolean;
   /** `--min-chunk-size` / `minChunkSize`; requires `splitting` */
   minChunkSize?: number;
+  /** `false` skips chunk folding (`merge_small_chunks`). Internal to Bun's tests: api backend only. */
+  foldChunks?: boolean;
   serverComponents?: boolean;
   reactCompiler?: boolean;
   reactCompilerOutputMode?: "client" | "ssr";
@@ -544,6 +546,7 @@ function expectBundled(
     splitRequire,
     modulePreload,
     minChunkSize,
+    foldChunks,
     target,
     todo: notImplemented,
     treeShaking,
@@ -680,6 +683,9 @@ function expectBundled(
   }
   if (ESBUILD && minChunkSize !== undefined) {
     throw new UnsupportedOptionError("minChunkSize not possible in esbuild backend");
+  }
+  if (ESBUILD && foldChunks !== undefined) {
+    throw new UnsupportedOptionError("foldChunks not possible in esbuild backend");
   }
   if (ESBUILD && splitRequire !== undefined) {
     throw new UnsupportedOptionError("splitRequire not possible in esbuild backend");
@@ -829,6 +835,9 @@ function expectBundled(
       }
       if (reactCompilerOutputMode) {
         throw new Error("reactCompilerOutputMode not possible in backend=CLI (API-only option)");
+      }
+      if (foldChunks !== undefined) {
+        throw new Error("foldChunks not possible in backend=CLI (API-only option)");
       }
       const cmd = (
         !ESBUILD
@@ -1256,6 +1265,7 @@ function expectBundled(
           splitRequire,
           modulePreload,
           minChunkSize,
+          ...(foldChunks === undefined ? {} : { foldChunksForTesting: foldChunks }),
           target,
           reactCompiler,
           reactCompilerOutputMode,

--- a/test/bundler/splitting-fuzz.ts
+++ b/test/bundler/splitting-fuzz.ts
@@ -1,0 +1,275 @@
+// Differential check of what code splitting for `--target=bun` does when it folds chunks together
+// (`merge_small_chunks`). A random module graph is run unbundled, bundled with folding off (`foldChunksForTesting:
+// false`, an option only Bun's tests use) and bundled with folding on. Every module logs when its top level starts and
+// ends, and every value it reads at its top level ("!" when the binding is not initialized yet), so the three runs
+// always finish and can be compared line by line.
+//
+// Code splitting alone already moves shared modules ahead of the chunk that imports them, so a bundle's log can
+// differ from the unbundled one. Folding puts those modules back among their importers, so it may differ from the
+// unfolded bundle too. What it must never do is make things worse: a fold is wrong when the unfolded bundle agrees with
+// the unbundled program on some fact and the folded one does not. The facts compared are (1) each value read, and
+// (2) the relative order of the top-level effects.
+//
+// scripts/splitting-fuzz.ts runs many seeds against a given binary.
+import { spawn } from "bun";
+import { bunEnv, tempDir } from "harness";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function rng(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type Graph = { files: Record<string, string>; entries: string[] };
+
+function generateGraph(seed: number): Graph {
+  const rnd = rng(seed);
+  const int = (n: number) => Math.floor(rnd() * n);
+  const chance = (p: number) => rnd() < p;
+  const n = 5 + int(10);
+  const twoEntries = chance(0.25);
+
+  const staticImports: number[][] = [];
+  for (let i = 0; i < n; i++) {
+    const imports = new Set<number>();
+    const count = i === 0 ? 1 + int(3) : int(3);
+    for (let k = 0; k < count; k++) {
+      // mostly forward edges; a back edge now and then closes a cycle
+      const j = chance(0.15) ? int(n) : Math.min(n - 1, i + 1 + int(n - i));
+      if (j !== i && j !== 0) imports.add(j);
+    }
+    staticImports.push([...imports]);
+  }
+  // Modules that await at their top level, and everything that statically reaches one, cannot be require()d.
+  const awaits = new Set<number>();
+  for (let i = 1; i < n; i++) if (chance(0.08)) awaits.add(i);
+  const reachesAwait = new Set<number>(awaits);
+  for (let changed = true; changed; ) {
+    changed = false;
+    for (let i = 0; i < n; i++) {
+      if (!reachesAwait.has(i) && staticImports[i].some(j => reachesAwait.has(j))) {
+        reachesAwait.add(i);
+        changed = true;
+      }
+    }
+  }
+  const requirable = [...Array(n).keys()].filter(i => i !== 0 && !reachesAwait.has(i));
+  const pure = new Set<number>();
+  for (let i = 1; i < n; i++) if (!awaits.has(i) && chance(0.25)) pure.add(i);
+
+  // `load<i>_<j>()` in module i does require(module j)
+  const loaders: { file: number; target: number }[] = [];
+  for (let i = 0; i < n; i++) {
+    if (requirable.length && chance(0.45)) {
+      const target = requirable[int(requirable.length)];
+      if (target !== i) loaders.push({ file: i, target });
+    }
+  }
+
+  // several call sites for one target
+  for (const { target } of [...loaders]) {
+    if (chance(0.3)) {
+      const file = int(n);
+      if (file !== target && !loaders.some(l => l.file === file && l.target === target)) loaders.push({ file, target });
+    }
+  }
+
+  const files: Record<string, string> = {};
+  for (let i = 0; i < n; i++) {
+    let src = `import { note, read, attempt, later } from "./log.ts";\n`;
+    const uses: string[] = [];
+    let base: number | undefined;
+    for (const j of staticImports[i]) {
+      const names = [`get${j}`, `C${j}`];
+      for (const l of loaders) if (l.file === j) names.push(`load${l.file}_${l.target}`);
+      src += `import { ${names.join(", ")} } from "./f${j}.ts";\n`;
+      if (base === undefined && chance(0.4)) base = j;
+    }
+    if (staticImports[i].length && chance(0.2)) {
+      const j = staticImports[i][int(staticImports[i].length)];
+      src += chance(0.5)
+        ? `export { get${j} as via${i}_get${j} } from "./f${j}.ts";\n`
+        : `export * as ns${i}_${j} from "./f${j}.ts";\n`;
+    }
+    const isPure = pure.has(i);
+    if (!isPure) src += `note("f${i}");\n`;
+    if (awaits.has(i)) src += `await null;\n`;
+    src += `export const val${i} = "v${i}";\n`;
+    src += `export function get${i}() { return val${i}; }\n`;
+    src +=
+      base === undefined || isPure
+        ? `export class C${i} { tag() { return "c${i}"; } }\n`
+        : `export const C${i} = attempt("f${i}:class", () => class extends C${base} { tag() { return "c${i}<" + super.tag(); } });\n`;
+    for (const l of loaders) {
+      if (l.file === i)
+        src += `export function load${i}_${l.target}() { return require("./f${l.target}.ts").get${l.target}(); }\n`;
+    }
+    if (!isPure) {
+      for (const j of staticImports[i]) {
+        if (chance(0.5)) uses.push(`read("f${i}<f${j}", () => get${j}())`);
+        if (chance(0.2)) uses.push(`read("f${i}<C${j}", () => new C${j}().tag())`);
+        for (const l of loaders) {
+          if (l.file === j && chance(0.5))
+            uses.push(`read("f${i}<load${l.file}_${l.target}", () => load${l.file}_${l.target}())`);
+        }
+      }
+      for (const l of loaders) {
+        if (l.file === i && chance(0.35)) uses.push(`read("f${i}<load${i}_${l.target}", () => load${i}_${l.target}())`);
+      }
+      if (requirable.length && chance(0.25)) {
+        const t = requirable[int(requirable.length)];
+        if (t !== i) uses.push(`read("f${i}<require${t}", () => require("./f${t}.ts").get${t}())`);
+      }
+      for (const use of uses) src += use + ";\n";
+      if (chance(0.2)) {
+        const t = 1 + int(n - 1);
+        if (t !== i)
+          src += `later(() => import("./f${t}.ts").then(m => read("f${i}~import${t}", () => m.get${t}())));\n`;
+      }
+      src += `note("f${i}:done");\n`;
+    }
+    files[`f${i}.ts`] = src;
+  }
+  files["log.ts"] = `
+const lines: string[] = [];
+const thunks: (() => Promise<unknown>)[] = [];
+export function note(what: string) { lines.push(what); }
+export function read(what: string, get: () => unknown) {
+  let value: unknown;
+  try { value = get(); } catch { value = undefined; }
+  lines.push(what + "=" + (value === undefined ? "!" : String(value)));
+  return value;
+}
+export function attempt<T>(what: string, make: () => T): T | undefined {
+  try { return make(); } catch { lines.push(what + "=!"); return undefined; }
+}
+export function later(thunk: () => Promise<unknown>) { thunks.push(thunk); }
+export async function finish() {
+  for (let i = 0; i < thunks.length; i++) { note("later" + i); await thunks[i](); }
+  console.log(lines.join("\\n"));
+}
+`;
+  const entries = ["entry.ts"];
+  files["entry.ts"] = `import { finish } from "./log.ts";\nawait import("./f0.ts");\nawait finish();\n`;
+  if (twoEntries) {
+    const other = 1 + int(n - 1);
+    files["entry2.ts"] = `import { finish } from "./log.ts";\nawait import("./f${other}.ts");\nawait finish();\n`;
+    entries.push("entry2.ts");
+  }
+  return { files, entries };
+}
+
+type Env = Record<string, string | undefined>;
+
+// Evaluation order is what is compared; the async transpiler makes it vary from run to run.
+export const env: Env = { ...bunEnv, BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER: "1" };
+
+export async function run(cmd: string[], cwd: string, env: Env) {
+  await using proc = spawn({ cmd, cwd, stdout: "pipe", stderr: "pipe", env });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+/** The values a log says were read, and its top-level effects in order. */
+function facts(log: string) {
+  const reads = new Map<string, string>();
+  const effects: string[] = [];
+  for (const line of log.split("\n")) {
+    if (!line) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) effects.push(line);
+    else reads.set(line.slice(0, eq), line.slice(eq + 1));
+  }
+  return { reads, effects };
+}
+
+function worse(reference: string, unfolded: string, folded: string): string[] {
+  const [ref, off, on] = [facts(reference), facts(unfolded), facts(folded)];
+  const problems: string[] = [];
+  // A line like "f3:class=!" is only written when something failed, so a key one log lacks counts as "fine" there.
+  for (const what of new Set([...ref.reads.keys(), ...off.reads.keys(), ...on.reads.keys()])) {
+    const [value, offValue, onValue] = [ref, off, on].map(log => log.reads.get(what) ?? "fine");
+    if (offValue === value && onValue !== value) {
+      problems.push(`${what}: ${value} unbundled and unfolded, ${on.reads.get(what) ?? "missing"} folded`);
+    }
+  }
+  const position = (effects: string[]) => new Map(effects.map((effect, index) => [effect, index]));
+  const [offAt, onAt] = [position(off.effects), position(on.effects)];
+  for (let a = 0; a < ref.effects.length; a++) {
+    for (let b = a + 1; b < ref.effects.length; b++) {
+      const [x, y] = [ref.effects[a], ref.effects[b]];
+      const agrees = (at: Map<string, number>) => at.has(x) && at.has(y) && at.get(x)! < at.get(y)!;
+      if (agrees(offAt) && !agrees(onAt)) problems.push(`order of ${x} and ${y} kept unfolded, lost folded`);
+    }
+  }
+  return problems;
+}
+
+/**
+ * "skipped": the graph could not be judged (`problems` says why). "worse": folding lost something.
+ * `folded`: folding changed the bundle at all. When it did not there is nothing to compare, and the bundles are not run.
+ */
+export type GraphResult = { seed: number; status: "ok" | "skipped" | "worse"; folded: boolean; problems: string[] };
+
+function sameFiles(a: string, b: string) {
+  const [inA, inB] = [readdirSync(a).sort(), readdirSync(b).sort()];
+  return (
+    inA.length === inB.length &&
+    inA.every((name, i) => name === inB[i] && readFileSync(join(a, name)).equals(readFileSync(join(b, name))))
+  );
+}
+
+export async function checkGraph(bun: string, seed: number): Promise<GraphResult> {
+  const graph = generateGraph(seed);
+  using dir = tempDir("splitting-fuzz", {
+    ...graph.files,
+    "build.ts": `
+      for (const [outdir, fold] of [["off", false], ["on", true]]) {
+        const result = await Bun.build({
+          entrypoints: ${JSON.stringify(graph.entries)}.map(entry => import.meta.dir + "/" + entry),
+          outdir: import.meta.dir + "/" + outdir,
+          splitting: true,
+          target: "bun",
+          format: "esm",
+          foldChunksForTesting: fold,
+        });
+        if (!result.success) throw new Error(outdir + ": " + result.logs.join("\\n"));
+      }
+    `,
+  });
+  const cwd = String(dir);
+  const build = await run([bun, "build.ts"], cwd, env);
+  if (build.exitCode !== 0) {
+    return { seed, status: "skipped", folded: false, problems: ["the build failed: " + build.stderr.slice(0, 400)] };
+  }
+  if (sameFiles(join(cwd, "off"), join(cwd, "on"))) return { seed, status: "ok", folded: false, problems: [] };
+
+  const skipped: string[] = [];
+  const problems: string[] = [];
+  await Promise.all(
+    graph.entries.map(async entry => {
+      const js = entry.replace(/\.ts$/, ".js");
+      const [reference, unfolded, folded] = await Promise.all([
+        run([bun, entry], cwd, env),
+        run([bun, join("off", js)], cwd, env),
+        run([bun, join("on", js)], cwd, env),
+      ]);
+      if (reference.exitCode !== 0)
+        skipped.push(`${entry}: the unbundled run failed: ` + reference.stderr.slice(0, 400));
+      else if (unfolded.exitCode !== 0)
+        skipped.push(`${entry}: the unfolded bundle failed: ` + unfolded.stderr.slice(0, 400));
+      else if (folded.exitCode !== 0)
+        problems.push(`${entry}: only the folded bundle failed: ` + folded.stderr.slice(0, 400));
+      else problems.push(...worse(reference.stdout, unfolded.stdout, folded.stdout).map(p => `${entry}: ${p}`));
+    }),
+  );
+  const status = problems.length ? "worse" : skipped.length ? "skipped" : "ok";
+  return { seed, status, folded: true, problems: problems.length ? problems : skipped };
+}

--- a/test/bundler/splitting-fuzz.ts
+++ b/test/bundler/splitting-fuzz.ts
@@ -81,9 +81,14 @@ function generateGraph(seed: number): Graph {
     }
   }
 
+  // Draws for shapes added after seeds were pinned come from a stream of their own, so old seeds keep their graphs.
+  const later = rng(seed ^ 0x5bd1e995);
+
   const files: Record<string, string> = {};
   for (let i = 0; i < n; i++) {
     let src = `import { note, read, attempt, later } from "./log.ts";\n`;
+    const importsItself = later() < 0.1 && !pure.has(i);
+    if (importsItself) src += `import * as self${i} from "./f${i}.ts";\n`;
     const uses: string[] = [];
     let base: number | undefined;
     for (const j of staticImports[i]) {
@@ -112,6 +117,8 @@ function generateGraph(seed: number): Graph {
         src += `export function load${i}_${l.target}() { return require("./f${l.target}.ts").get${l.target}(); }\n`;
     }
     if (!isPure) {
+      // An import nothing uses is dropped from a .ts file.
+      if (importsItself) uses.push(`read("f${i}<self", () => typeof self${i}.get${i})`);
       for (const j of staticImports[i]) {
         if (chance(0.5)) uses.push(`read("f${i}<f${j}", () => get${j}())`);
         if (chance(0.2)) uses.push(`read("f${i}<C${j}", () => new C${j}().tag())`);


### PR DESCRIPTION
### What

`bun build --splitting` folds chunks that always load together (`merge_small_chunks`). Whether a fold is observable
depends on evaluation order in ways hand-written tests keep missing. This adds a way to ask mechanically, and the
tests it produced. It is test tooling: no public option, no behaviour change for users.

- **A switch for tests.** `BundleOptions::fold_chunks` (default `true`) skips `merge_small_chunks` when `false`.
  `Bun.build` reads it from the key `foldChunksForTesting` only where `bun:internal-for-testing` resolves
  (`--expose-internals` or the test runner's environment in a release build; always in a debug build). Without that
  gate the key is ignored like any unknown key. No CLI flag, no `.d.ts` entry, no docs. `itBundled` gets a
  `foldChunks` option (api backend only) that passes it.
  What ships in a release binary: one `bool` in `BundleOptions` / `LinkerOptions` / the `Bun.build` config struct,
  the `&& fold_chunks` test before `merge_small_chunks`, and the gated read. The three places that checked the
  `bun:internal-for-testing` gate (two in `jsc_hooks.rs`, this one) now call one
  `module_loader::is_allowed_to_use_internal_testing_apis()`; the static behind it became private.
- **`test/bundler/splitting-fuzz.ts`.** Generates a random module graph from a seed: static imports with cycles,
  re-exports, classes extending classes from other modules, side-effect-free modules, top-level await, `import()`,
  `require()` at the top level and inside hoisted functions that other files do or do not call while loading,
  several call sites per target, one or two entry points. Every module logs when its top level starts and ends and
  every value it reads there (`!` for a binding that is not initialized yet), so the unbundled program, the bundle
  without folding and the bundle with folding all run to completion and are compared fact by fact. Code splitting
  alone already moves shared modules ahead of their importers and folding moves them back, so the three logs
  legitimately differ. A fold is wrong when the unfolded bundle agrees with the source on a value, or on the order of
  two effects, and the folded bundle does not. A graph whose bundle folding leaves byte for byte the same is reported
  as such and not run.
- **`scripts/splitting-fuzz.ts <bun> <graphs> [first seed]`** runs a campaign and prints the seeds that got worse. It
  exits 1 when folding changed no bundle at all in 200+ graphs (a binary that does not read the key).

### What it finds on main's bundler

Seeds 1 to 5,000, release build of this branch (the bundler is main's): folding changes the bundle of 313 graphs, and
in 19 of those the folded bundle loses a value or an order of two side effects that both the source and the unfolded
bundle have; in at least 6 of the 19 the loss is a read of an uninitialized binding. The run takes under two minutes
on a busy 64-core machine.

### Tests added (`test/bundler/bundler_splitting.test.ts`)

- `splitting/FoldChunksForTesting/on|off`: 2 chunks vs 3, same output.
- `splitting/FoldChunksForTesting is ignored without --expose-internals` (skipped in debug builds, where the gate is
  always open): a child without the gate gets 2 chunks with `foldChunksForTesting: false`; with
  `--expose-internals` it gets 3.
- `splitting/FoldingNeverMakesABundleWorse: graph 3 / 47`: two seeds whose bundle folding does change; `graph 25` is
  one it gets wrong and is `todo` with the reason.
- `splitting/SplitRequireCycle: ...`: eight `require()` cycle shapes that run unbundled and bundled and must print
  the same. Four fail today and are `todo` with the reason. Two of those four are caused by a fold (rule 1 puts a file
  the `require()`d chunk needs into the caller's chunk, after the call); those two also run without folding, as
  real tests, and pass. The other two fail with and without folding (files reached by the same entry points share a
  chunk whatever order they need).

### How verified

- Release build, Linux x64, with the runner's environment: `bundler_splitting.test.ts` 118 pass / 5 todo / 0 fail;
  together with `esbuild/splitting`, `bundler_compile_splitting`, `bun-build-api`, `metafile`, `esbuild/metafile`:
  293 pass / 8 todo / 0 fail. `--todo` confirms none of the todo cases passes.
- On 1.4.1 the tests that need the switch fail (the key does not exist there).
- The gate by hand on the release binary: `Bun.build({ splitting: true, foldChunksForTesting: false })` writes 2
  chunks; 3 with `--expose-internals` or `BUN_OPTIONS=--expose-internals`. `bun build --help` has no such flag.
  `bun:internal-for-testing` still resolves with the flag and is still blocked without it.
- `cargo clippy -p bun_bundler -p bun_runtime -p bun_jsc --no-deps` clean; `cargo fmt --check` and `prettier` clean.
