### PR TITLE
docs: fix WebSocket casing in websockets heading

### DIFF
--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -299,7 +299,7 @@ Bun.serve({
 
 ---
 
-## Connect to a `Websocket` server
+## Connect to a `WebSocket` server
 
 Bun implements the `WebSocket` class. To create a WebSocket client that connects to a `ws://` or `wss://` server, create an instance of `WebSocket`, as you would in the browser.
 


### PR DESCRIPTION
Heading used `` `Websocket` `` while the rest of the file (41 hits, including the very next sentence) uses `` `WebSocket` ``.