### PR TITLE
node:net: keep delivering when an onread callback calls pause() then read()

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1319,6 +1319,9 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     socket.data.req = undefined;
     if (self[kupgraded]) {
       self.connecting = false;
+      // A socket over a wrapped handle starts its reads in the constructor in node. The
+      // constructor's read(0) is skipped while the wrapped socket still connects, so start them here.
+      if (!self.isPaused()) self.read(0);
       SocketHandlers2.drain!(socket);
     }
   },

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -191,7 +191,10 @@ const kOnreadTail = Symbol("kOnreadTail");
 const kOnreadDraining = Symbol("kOnreadDraining");
 const kOnreadBuffer = Symbol("kOnreadBuffer");
 const kOnreadPendingEnd = Symbol("kOnreadPendingEnd");
-const kOnreadReadRequested = Symbol("kOnreadReadRequested");
+// Node's `handle.reading` (lib/net.js#L817-L845): pause() clears it, read()/resume() set it.
+// The onread delivery loop stops on this, not on isPaused(), so a pause() followed by a
+// read() inside the callback keeps delivering.
+const kOnreadReading = Symbol("kOnreadReading");
 const kOnreadEmptyTail = Buffer.alloc(0);
 const kwriteCallback = Symbol("writeCallback");
 const kSocketClass = Symbol("kSocketClass");
@@ -607,11 +610,19 @@ const SocketHandlers: SocketHandler = {
 
 // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/stream_base_commons.js#L191-L198; a stopped handle does not hold the loop, a pending write still does.
 function readStop(self, handle) {
+  self[kOnreadReading] = false;
   handle?.pause?.();
   // A socket over a generic duplex has no fd and never held the loop.
   if (self[kupgraded] && !(self[kupgraded] instanceof Socket)) return;
   self[kPausedUnref] = true;
   if (!self[kwriteCallback]) handle?.unref?.();
+}
+
+// https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L830-L845
+function readStart(self, handle) {
+  self[kOnreadReading] = true;
+  handle?.resume?.();
+  restorePausedHold(self, handle);
 }
 
 // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L494-L498
@@ -1734,7 +1745,7 @@ function Socket(options?) {
             reportError(e);
           }
           if (self.destroyed) return;
-          if (ret === false || self.isPaused()) {
+          if (ret === false || !self[kOnreadReading]) {
             self[kOnreadTail] = kOnreadEmptyTail;
             readStop(self, self._handle);
           }
@@ -1764,7 +1775,7 @@ function Socket(options?) {
           reportError(e);
         }
         if (self.destroyed) return;
-        if (ret === false || self.isPaused()) {
+        if (ret === false || !self[kOnreadReading]) {
           const rest = buffer.subarray(offset);
           self[kOnreadTail] = rest.length !== 0 ? rest : kOnreadEmptyTail;
           readStop(self, self._handle);
@@ -2328,9 +2339,12 @@ function hasUnflushedWrites(connection) {
   return connection.writableLength > 0 || connection[kwriteCallback] != null;
 }
 
-function drainOnreadTail(self, fromRead?) {
+// The queued tail goes to the callback before the handle reads again. The caller
+// asked for reads, so mark the handle reading now: a pause() before the drain
+// tick clears it again and the tick then delivers nothing.
+function drainOnreadTail(self) {
   if (self[kOnreadTail] === undefined) return false;
-  if (fromRead) self[kOnreadReadRequested] = true;
+  self[kOnreadReading] = true;
   if (!self[kOnreadDraining]) {
     self[kOnreadDraining] = true;
     process.nextTick(drainOnreadTailNT, self);
@@ -2340,20 +2354,17 @@ function drainOnreadTail(self, fromRead?) {
 
 function drainOnreadTailNT(socket) {
   socket[kOnreadDraining] = false;
-  const fromRead = socket[kOnreadReadRequested];
-  socket[kOnreadReadRequested] = false;
   const tail = socket[kOnreadTail];
   if (tail === undefined || socket.destroyed) return;
-  if (!fromRead && socket.isPaused()) return;
+  if (!socket[kOnreadReading]) return;
   socket[kOnreadTail] = undefined;
   socket[kOnreadDeliver](tail);
   if (socket[kOnreadTail] !== undefined || socket.destroyed) return;
   if (socket[kOnreadPendingEnd]) {
     socket[kOnreadPendingEnd] = false;
     finishSocketEnd(socket);
-  } else if (fromRead || !socket.isPaused()) {
-    socket._handle?.resume?.();
-    restorePausedHold(socket, socket._handle);
+  } else if (socket[kOnreadReading]) {
+    readStart(socket, socket._handle);
   }
 }
 
@@ -2366,7 +2377,8 @@ Socket.prototype.resume = function resume() {
   // An onread socket is the exception: https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L830-L845
   if (this.readableEnded && this[kOnreadBuffer] === undefined) return ret;
   if (!this.connecting && !drainOnreadTail(this)) {
-    this._handle?.resume?.();
+    readStart(this, this._handle);
+    return ret;
   }
   // Even while still connecting, so pause-then-resume stays symmetric.
   restorePausedHold(this, this._handle);
@@ -2468,9 +2480,8 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
 
 Socket.prototype.read = function read(size) {
   // See resume(): an ended readable side never restarts the handle.
-  if ((!this.readableEnded || this[kOnreadBuffer] !== undefined) && !this.connecting && !drainOnreadTail(this, true)) {
-    this._handle?.resume?.();
-    restorePausedHold(this, this._handle);
+  if ((!this.readableEnded || this[kOnreadBuffer] !== undefined) && !this.connecting && !drainOnreadTail(this)) {
+    readStart(this, this._handle);
   }
   return Duplex.prototype.read.$call(this, size);
 };
@@ -2479,9 +2490,8 @@ Socket.prototype._read = function _read(size) {
   const socket = this._handle;
   if (this.connecting || !socket) {
     this.once("connect", () => this._read(size));
-  } else if (!drainOnreadTail(this, true)) {
-    socket?.resume?.();
-    restorePausedHold(this, socket);
+  } else if (!drainOnreadTail(this)) {
+    readStart(this, socket);
   }
 };
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -191,9 +191,7 @@ const kOnreadTail = Symbol("kOnreadTail");
 const kOnreadDraining = Symbol("kOnreadDraining");
 const kOnreadBuffer = Symbol("kOnreadBuffer");
 const kOnreadPendingEnd = Symbol("kOnreadPendingEnd");
-// Node's `handle.reading` (lib/net.js#L817-L845): pause() clears it, read()/resume() set it.
-// The onread delivery loop stops on this, not on isPaused(), so a pause() followed by a
-// read() inside the callback keeps delivering.
+// Node's handle.reading: https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L817-L845
 const kOnreadReading = Symbol("kOnreadReading");
 const kOnreadEmptyTail = Buffer.alloc(0);
 const kwriteCallback = Symbol("writeCallback");
@@ -1319,8 +1317,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     socket.data.req = undefined;
     if (self[kupgraded]) {
       self.connecting = false;
-      // A socket over a wrapped handle starts its reads in the constructor in node. The
-      // constructor's read(0) is skipped while the wrapped socket still connects, so start them here.
+      // The constructor's read(0) is skipped while the wrapped socket connects.
       if (!self.isPaused()) self.read(0);
       SocketHandlers2.drain!(socket);
     }
@@ -2342,9 +2339,7 @@ function hasUnflushedWrites(connection) {
   return connection.writableLength > 0 || connection[kwriteCallback] != null;
 }
 
-// The queued tail goes to the callback before the handle reads again. The caller
-// asked for reads, so mark the handle reading now: a pause() before the drain
-// tick clears it again and the tick then delivers nothing.
+// The tail is delivered on the next tick. A pause() before then clears kOnreadReading and the tick delivers nothing.
 function drainOnreadTail(self) {
   if (self[kOnreadTail] === undefined) return false;
   self[kOnreadReading] = true;

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -2663,7 +2663,15 @@ it("onread: read() then pause() inside the callback stops the delivery", async (
         },
       },
     });
-    client.on("error", done.reject);
+    client.on("error", e => {
+      firstDelivery.reject(e);
+      done.reject(e);
+    });
+    client.on("close", () => {
+      const e = new Error(`closed before all data was delivered: ${received.join("|")}`);
+      firstDelivery.reject(e);
+      done.reject(e);
+    });
     await firstDelivery.promise;
     await new Promise<void>(resolve => serverSockets[0].end("wxyz", () => resolve()));
     for (let i = 0; i < 4; i++) await new Promise(resolve => setImmediate(resolve));

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -2587,6 +2587,96 @@ it("onread: read() after a redundant pause() still redelivers the declined tail"
   }
 });
 
+it("onread: pause() then read() inside the callback keeps delivering", async () => {
+  // https://github.com/oven-sh/bun/issues/42418 - node's read() restarts the
+  // handle (tryReadStart) right after pause() stopped it, so the rest of the
+  // chunk still reaches the callback without a later resume().
+  const received: string[] = [];
+  const done = Promise.withResolvers<void>();
+  const server = createServer(c => {
+    c.on("error", () => {});
+    c.end("abcdefgh");
+  });
+  let client: Socket | undefined;
+  try {
+    const listening = Promise.withResolvers<void>();
+    server.once("error", listening.reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", listening.reject);
+      listening.resolve();
+    });
+    await listening.promise;
+    client = createConnection({
+      port: (server.address() as import("node:net").AddressInfo).port,
+      host: "127.0.0.1",
+      onread: {
+        buffer: Buffer.alloc(4),
+        callback(n: number, buf: Buffer) {
+          received.push(buf.toString("latin1", 0, n));
+          client!.pause();
+          client!.read();
+          if (received.length === 2) done.resolve();
+        },
+      },
+    });
+    client.on("error", done.reject);
+    client.on("close", () => done.reject(new Error(`closed before all data was delivered: ${received.join("|")}`)));
+    await done.promise;
+    expect(received).toEqual(["abcd", "efgh"]);
+  } finally {
+    client?.destroy();
+    server.close();
+  }
+});
+
+it("onread: read() then pause() inside the callback stops the delivery", async () => {
+  // The opposite order: pause() is the last word, so the handle stays stopped
+  // until resume() (node's level-triggered handle.reading).
+  const serverSockets: Socket[] = [];
+  const server = createServer(c => {
+    serverSockets.push(c);
+    c.on("error", () => {});
+    c.write("abcdefgh");
+  });
+  const received: string[] = [];
+  const firstDelivery = Promise.withResolvers<void>();
+  const done = Promise.withResolvers<void>();
+  let client: Socket | undefined;
+  try {
+    const listening = Promise.withResolvers<void>();
+    server.once("error", listening.reject);
+    server.listen(0, "127.0.0.1", () => listening.resolve());
+    await listening.promise;
+    client = createConnection({
+      port: (server.address() as import("node:net").AddressInfo).port,
+      host: "127.0.0.1",
+      onread: {
+        buffer: Buffer.alloc(4),
+        callback(n: number, buf: Buffer) {
+          received.push(buf.toString("latin1", 0, n));
+          if (received.length === 1) {
+            client!.read();
+            client!.pause();
+            firstDelivery.resolve();
+          }
+          if (received.length === 3) done.resolve();
+        },
+      },
+    });
+    client.on("error", done.reject);
+    await firstDelivery.promise;
+    await new Promise<void>(resolve => serverSockets[0].end("wxyz", () => resolve()));
+    for (let i = 0; i < 4; i++) await new Promise(resolve => setImmediate(resolve));
+    expect(received).toEqual(["abcd"]);
+    client.resume();
+    await done.promise;
+    expect(received).toEqual(["abcd", "efgh", "wxyz"]);
+  } finally {
+    client?.destroy();
+    server.close();
+  }
+});
+
 it("onread: a peer FIN does not redeliver the declined tail before resume()", async () => {
   // The EOF path's read(0) must not restart a flow the callback paused: Node's
   // readStop leaves both the tail and the FIN unread until resume().

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -109,6 +109,42 @@ test.each([
   },
 );
 
+test("tls.connect({ socket, onread }) over a still connecting net.Socket reads until the peer ends", async () => {
+  // The wrapped socket has not connected yet, so the constructor does not start
+  // the reads. The open of the TLS handle has to start them instead, or the
+  // onread callback stops after its first buffer and the FIN never arrives.
+  const server = tls.createServer(certs, socket => {
+    socket.on("error", () => {});
+    socket.end("abcdefgh");
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  try {
+    const raw = net.connect({ port: (server.address() as net.AddressInfo).port, host: "127.0.0.1" });
+    raw.on("error", () => {});
+    let bytes = 0;
+    const tlsSocket = tls.connect({
+      socket: raw,
+      ca: certs.cert,
+      servername: "localhost",
+      onread: {
+        buffer: Buffer.alloc(4),
+        callback(n: number) {
+          bytes += n;
+        },
+      },
+    });
+    tlsSocket.on("data", data => (bytes += data.length));
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    tlsSocket.on("error", reject);
+    tlsSocket.on("close", () => reject(new Error(`closed before end after ${bytes} bytes`)));
+    tlsSocket.on("end", resolve);
+    await promise;
+    expect(bytes).toBe(8);
+  } finally {
+    server.close();
+  }
+});
+
 // Both peers keep their plaintext 'data' listener across the upgrade.
 test("a STARTTLS exchange hands no TLS bytes to the 'data' listeners of the wrapped sockets (#32239)", async () => {
   const saw: string[] = [];


### PR DESCRIPTION
### Problem
- An `onread` callback that calls `socket.pause()` and then `socket.read()` gets no more calls. The rest of the chunk stays in `kOnreadTail` until a later `resume()`. Node delivers it: the script in #42418 prints `[ 'abcd', 'efgh' ]` in node and `[ "abcd", "no call for 1 s" ]` in bun.
- The cause is the stop condition in the `deliver` closure of the `Socket` constructor (`src/js/node/net.ts`): `ret === false || self.isPaused()`. `Readable.prototype.read()` does not clear the paused flag of the stream, so `isPaused()` is still `true` after `pause(); read()`.

### Fix
- Add `kOnreadReading`, the equivalent of node's `handle.reading`. `readStop()` clears it. The new `readStart()` helper (the `handle.resume()` plus `restorePausedHold()` pair that `read()`, `_read()`, `resume()` and the tail drain all had inline) and `drainOnreadTail()` set it. `deliver` and `drainOnreadTailNT` stop on that flag. This replaces the `fromRead` and `kOnreadReadRequested` plumbing, which only covered a `read()` that ran after the tail existed.
- This is node's model: `pause()` stops the handle, `read()` and `resume()` start it, and `onStreamRead` stops it only on a `false` return ([net.js#L817-L845](https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L817-L845), [stream_base_commons.js#L191-L198](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/stream_base_commons.js#L191-L198)).
- A TLS socket over a wrapped `net.Socket` that is still connecting never called `read(0)`, so its flag stayed unset. The TLS handle open now calls `read(0)` unless the socket is paused, like node's constructor for a socket built over a handle.
- Verified: `test/js/node/net/node-net.test.ts` (two new `onread` tests, the first fails on the released bun) and `test/js/node/tls/node-tls-upgrade.test.ts` (one new test). Also ran the other `net`, `tls` and `http` suites and node's `test-net-*` and `test-tls-*` tests that wrap a socket.

### Background
- An `onread` socket hands each read to a user callback with a user buffer instead of `push()`. Node bounds each kernel read to that buffer. Bun reads bigger native chunks and slices them in `deliver`, so a stop in the middle of a chunk stores the rest in `kOnreadTail` for a later `drainOnreadTailNT` tick.
- `readStop()` pauses the native handle and drops its hold on the event loop. `restorePausedHold()` gives the hold back when reads start again.
- Self-reviewed: the review found one regression in the first version (the wrapped TLS socket case above), which the second commit fixes. #42305 removes `kOnreadReadRequested` in `dropOnreadTail()`. Whichever PR lands second drops that line.

<details><summary>Notes</summary>

- Behaviour matrix checked against node v26.3.0 on a plain TCP client: `pause(); read()`, `read(); pause()`, `pause(); resume()`, `false` then `read()`, FIN together with data, `pause(); read()` on the last slice with a FIN, `resume(); pause()` inside the callback, a late FIN then `resume()`. All match.
- Unchanged divergences that this PR does not touch: a TLS client paused while connecting still delivers one slice before it stops (node starts no reads at all until `resume()`), and `read(); pause()` inside a TLS callback stops at once where node's TLSWrap still emits the bytes it already decrypted.
- `pause()` on a socket that is not reading still calls `readStop()`, as before. `readStop()` is idempotent.
- Pre-existing failures in this sandbox, identical on the released bun and on the base tree: the `net.Socket read` group (ECONNREFUSED on a `localhost` listener), `unref should exit` (DNS), the `connect({path})` leak test (times out under ASAN), `SNICallback runs even when...`, and three `node-http-connect` and `node-http-proxy-url` tests that time out under ASAN.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->