### PR TITLE
install: apply --concurrent-scripts to the isolated linker

### DIFF
--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -25,7 +25,7 @@ use super::{directories, enqueue};
 use crate::dependency::Behavior;
 use crate::isolated_install::installer as store_installer;
 use crate::isolated_install::store::{EntryColumns as _, NodeColumns as _};
-use crate::lifecycle_script_runner::InstallCtx;
+use crate::lifecycle_script_runner::{InstallCtx, LifecycleScriptSubprocess};
 use crate::network_task::{Authorization, ForTarballError};
 use crate::package_manifest_map::Value as ManifestEntry;
 use bun_core::fmt::PathSep;
@@ -377,41 +377,11 @@ fn run_tasks_erased(
                 store_installer::Result::Blocked => {
                     installer.on_task_blocked(task.entry_id);
                 }
-                &store_installer::Result::RunScripts(list) => {
-                    let entry_id = task.entry_id;
-                    let node_id = installer.store.entries.items_node_id()[entry_id.get() as usize];
-                    let dep_id = installer.store.nodes.items_dep_id()[node_id.get() as usize];
-                    let dep = &installer.lockfile().buffers.dependencies[dep_id as usize];
-                    let optional = dep.behavior.contains(Behavior::OPTIONAL);
-                    // SAFETY: `list` is the per-entry scripts slot owned by
-                    // `store.entries.items_scripts()[entry_id]`; this Task is
-                    // its sole consumer (see Installer.rs Yield::RunScripts).
-                    let list_val = unsafe { (*list).clone() };
-                    // reshaped for borrowck — `Command::Context<'a>`
-                    // is `&'a mut ContextData`; reborrow instead of moving the
-                    // field out of `*installer`.
-                    let command_ctx: Command::Context<'_> = &mut *installer.command_ctx;
-                    // `installer.manager == manager` (same allocation,
-                    // see fn-signature note); call via the body shadow which is a
-                    // reborrow of `manager_ptr` — no extra unsafe alias needed.
-                    let spawn_res = manager.spawn_package_lifecycle_scripts(
-                        command_ctx,
-                        list_val,
-                        optional,
-                        false,
-                        Some(InstallCtx {
-                            entry_id,
-                            installer: installer_ptr,
-                        }),
-                    );
-                    if let Err(err) = spawn_res {
-                        // .monotonic is okay for the same reason as `.done`: we popped this
-                        // task from the `UnboundedQueue`, and the task is no longer running.
-                        installer.store.entries.items_step()[entry_id.get() as usize]
-                            .store(store_installer::Step::Done as u32, Ordering::Relaxed);
-                        installer
-                            .on_task_fail(entry_id, &store_installer::TaskError::RunScripts(err));
-                    }
+                store_installer::Result::RunScripts(_) => {
+                    // Queued, not spawned: the drain below enforces
+                    // `--concurrent-scripts` and keeps the spawn order FIFO
+                    // across ticks.
+                    installer.pending_lifecycle_scripts.push_back(task.entry_id);
                 }
                 store_installer::Result::Done => {
                     if Environment::CI_ASSERT {
@@ -425,6 +395,55 @@ fn run_tasks_erased(
                     installer
                         .on_task_complete(task.entry_id, store_installer::CompleteState::Success);
                 }
+            }
+        }
+
+        // `--concurrent-scripts=0` still reaches here as 0. With a limit of 0
+        // nothing would ever spawn and the install would never finish.
+        let max_concurrent_scripts = manager.options.max_concurrent_lifecycle_scripts.max(1);
+        // A script exit runs `handle_exit` inside the event loop tick that
+        // precedes this call, so the count is current here.
+        // .monotonic is okay because scripts are spawned and reaped on this thread.
+        while LifecycleScriptSubprocess::alive_count().load(Ordering::Relaxed)
+            < max_concurrent_scripts
+        {
+            let Some(entry_id) = installer.pending_lifecycle_scripts.pop_front() else {
+                break;
+            };
+            let node_id = installer.store.entries.items_node_id()[entry_id.get() as usize];
+            let dep_id = installer.store.nodes.items_dep_id()[node_id.get() as usize];
+            let dep = &installer.lockfile().buffers.dependencies[dep_id as usize];
+            let optional = dep.behavior.contains(Behavior::OPTIONAL);
+            let list = installer.store.entries.items_scripts()[entry_id.get() as usize]
+                .get()
+                .expect("a queued RunScripts entry has a scripts list");
+            // SAFETY: `list` is the per-entry scripts slot owned by
+            // `store.entries.items_scripts()[entry_id]`; this Task is
+            // its sole consumer (see Installer.rs Yield::RunScripts).
+            let list_val = unsafe { (*list).clone() };
+            // reshaped for borrowck — `Command::Context<'a>`
+            // is `&'a mut ContextData`; reborrow instead of moving the
+            // field out of `*installer`.
+            let command_ctx: Command::Context<'_> = &mut *installer.command_ctx;
+            // `installer.manager == manager` (same allocation,
+            // see fn-signature note); call via the body shadow which is a
+            // reborrow of `manager_ptr` — no extra unsafe alias needed.
+            let spawn_res = manager.spawn_package_lifecycle_scripts(
+                command_ctx,
+                list_val,
+                optional,
+                false,
+                Some(InstallCtx {
+                    entry_id,
+                    installer: installer_ptr,
+                }),
+            );
+            if let Err(err) = spawn_res {
+                // .monotonic is okay for the same reason as `.done`: we popped this
+                // task from the `UnboundedQueue`, and the task is no longer running.
+                installer.store.entries.items_step()[entry_id.get() as usize]
+                    .store(store_installer::Step::Done as u32, Ordering::Relaxed);
+                installer.on_task_fail(entry_id, &store_installer::TaskError::RunScripts(err));
             }
         }
     }

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2065,6 +2065,7 @@ pub(crate) fn install_isolated_packages(
             global_store_tmp_suffix: fast_random(),
             summary: Default::default(),
             task_queue: Default::default(),
+            pending_lifecycle_scripts: Default::default(),
         };
         // No long-lived `&mut PackageManager` reborrow here — `installer.start_task()`,
         // `on_task_complete()`, and `on_task_fail()` below all reach the manager through

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -1,4 +1,5 @@
 use core::sync::atomic::{AtomicU8, Ordering};
+use std::collections::VecDeque;
 use std::io::Write as _;
 
 use bun_ast::Log;
@@ -117,6 +118,13 @@ pub struct Installer<'a> {
     /// Main-thread only: `waiters_head[dep]` starts the intrusive list of blocked entries waiting on `dep`, linked through `next_waiter`.
     pub(crate) waiters_head: Box<[StoreEntryId]>,
     pub(crate) next_waiter: Box<[StoreEntryId]>,
+
+    /// Main-thread only: entries that yielded `Result::RunScripts` and wait
+    /// for `LifecycleScriptSubprocess::alive_count()` to drop below
+    /// `options.max_concurrent_lifecycle_scripts`. `run_tasks` spawns them in
+    /// order as running scripts exit. The scripts list is re-read from
+    /// `store.entries.items_scripts()[entry_id]` at spawn time.
+    pub(crate) pending_lifecycle_scripts: VecDeque<StoreEntryId>,
 }
 
 impl<'a> Installer<'a> {

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -473,8 +473,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
         unsafe {
             if !(*this).has_incremented_alive_count {
                 (*this).has_incremented_alive_count = true;
-                // .monotonic is okay because because this value is only used by hoisted installs, which
-                // only use this type on the main thread.
+                // .monotonic is okay because this value is only read and written on the main thread.
                 let _ = ALIVE_COUNT.fetch_add(1, Ordering::Relaxed);
             }
         }
@@ -493,7 +492,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             unsafe {
                 if (*this).has_incremented_alive_count {
                     (*this).has_incremented_alive_count = false;
-                    // .monotonic is okay because because this value is only used by hoisted installs.
+                    // .monotonic is okay because this value is only read and written on the main thread.
                     let _ = ALIVE_COUNT.fetch_sub(1, Ordering::Relaxed);
                 }
                 Self::ensure_not_in_heap(this);
@@ -833,8 +832,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
 
         if self.has_incremented_alive_count {
             self.has_incremented_alive_count = false;
-            // .monotonic is okay because because this value is only used by hoisted installs, which
-            // only use this type on the main thread.
+            // .monotonic is okay because this value is only read and written on the main thread.
             let _ = ALIVE_COUNT.fetch_sub(1, Ordering::Relaxed);
         }
 

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2,7 +2,7 @@ import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { existsSync, lstatSync, readFileSync, readlinkSync, statSync } from "fs";
 import { mkdir, readlink, rm, symlink } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, readdirSorted, runBunInstall, tempDir } from "harness";
+import { VerdaccioRegistry, bunEnv, bunExe, isWindows, readdirSorted, runBunInstall, tempDir } from "harness";
 import { createRequire } from "module";
 import { basename, dirname, join } from "path";
 import { pathToFileURL } from "url";
@@ -2107,6 +2107,110 @@ test("runs lifecycle scripts correctly", async () => {
   expect(lifecyclePreinstallDir).toEqual(["lifecycle-preinstall"]);
   expect(lifecyclePostinstallDir).toEqual(["lifecycle-postinstall"]);
   expect(allLifecycleScriptsDir).toEqual(["all-lifecycle-scripts"]);
+});
+
+test("--concurrent-scripts limits how many lifecycle scripts run at once", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+  const logFile = join(packageDir, "scripts.log");
+  const deps = ["dep-a", "dep-b", "dep-c"];
+
+  // Each script appends a start line, sleeps, then appends an end line. With a
+  // limit of 1 no script may start before the previous one ends. POSIX uses
+  // `sh` builtins so the scripts stay cheap under a debug build. Windows runs
+  // scripts with bun's shell, which has no `sleep`, so it runs a bun script.
+  await Promise.all([
+    ...deps.map(name =>
+      Promise.all([
+        write(
+          join(packageDir, name, "package.json"),
+          JSON.stringify({
+            name,
+            version: "1.0.0",
+            scripts: {
+              postinstall: isWindows
+                ? `${bunExe()} postinstall.js`
+                : `echo "start ${name}" >> "$SCRIPT_LOG" && sleep 0.5 && echo "end ${name}" >> "$SCRIPT_LOG"`,
+            },
+          }),
+        ),
+        write(
+          join(packageDir, name, "postinstall.js"),
+          `
+            const { appendFileSync } = require("fs");
+            appendFileSync(process.env.SCRIPT_LOG, "start ${name}\\n");
+            Bun.sleepSync(500);
+            appendFileSync(process.env.SCRIPT_LOG, "end ${name}\\n");
+          `,
+        ),
+      ]),
+    ),
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-concurrent-scripts",
+        dependencies: Object.fromEntries(deps.map(name => [name, `file:./${name}`])),
+        trustedDependencies: deps,
+      }),
+    ),
+  ]);
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install", "--concurrent-scripts=1"],
+    cwd: packageDir,
+    env: { ...bunEnv, SCRIPT_LOG: logFile },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error:");
+  expect(stdout).toContain("3 packages installed");
+  expect(exitCode).toBe(0);
+
+  const lines = (await file(logFile).text()).trim().split("\n");
+  const order = lines.filter(line => line.startsWith("start ")).map(line => line.slice("start ".length));
+  expect(order.toSorted()).toEqual(deps);
+  expect(lines).toEqual(order.flatMap(name => [`start ${name}`, `end ${name}`]));
+});
+
+test("--concurrent-scripts=0 still runs every lifecycle script", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+  const logFile = join(packageDir, "scripts.log");
+  const deps = ["dep-a", "dep-b", "dep-c"];
+
+  await Promise.all([
+    ...deps.map(name =>
+      write(
+        join(packageDir, name, "package.json"),
+        JSON.stringify({
+          name,
+          version: "1.0.0",
+          scripts: { postinstall: `echo "${name}" >> "$SCRIPT_LOG"` },
+        }),
+      ),
+    ),
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-concurrent-scripts-zero",
+        dependencies: Object.fromEntries(deps.map(name => [name, `file:./${name}`])),
+        trustedDependencies: deps,
+      }),
+    ),
+  ]);
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install", "--concurrent-scripts=0"],
+    cwd: packageDir,
+    env: { ...bunEnv, SCRIPT_LOG: logFile },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("error:");
+  expect(stdout).toContain("3 packages installed");
+  expect(exitCode).toBe(0);
+
+  expect((await file(logFile).text()).trim().split("\n").toSorted()).toEqual(deps);
 });
 
 // Self-contained HTTP server that serves package manifests & tarballs


### PR DESCRIPTION
### Problem
- `--concurrent-scripts` and `[install] concurrentScripts` limit the hoisted linker only. With `--linker=isolated`, `bun install` starts every lifecycle script as soon as its package is ready. Three `sleep 1` postinstalls finish in about 1 s instead of 3 s with `--concurrent-scripts=1`.
- The hoisted installer compares `LifecycleScriptSubprocess::alive_count()` with `options.max_concurrent_lifecycle_scripts` before each spawn (`src/install/PackageInstaller.rs:920`). The isolated path in `run_tasks` called `spawn_package_lifecycle_scripts` at once for each `Result::RunScripts` (`src/install/PackageManager/runTasks.rs:380`).
- Found by reading the code while working on #42379, not from a user report. Fixes #42421.

### Fix
- `run_tasks` pushes each `RunScripts` entry id onto a `VecDeque` on the store `Installer`. After the task batch it pops entries in FIFO order while `alive_count() < max_concurrent_lifecycle_scripts` and spawns them.
- No new wake-up is needed. A script exit runs `handle_exit` inside an event loop tick and decrements `alive_count`. `Wait::is_done` calls `run_tasks` after every tick, so the next queued entry starts on the tick after an exit.
- A limit of 0 counts as 1 in this drain. The CLI still keeps `--concurrent-scripts=0` as 0 (#42379 changes that). Without the clamp an isolated install with 0 would never spawn and never finish.
- Verified: two new tests in `test/cli/install/isolated-install.test.ts`. The limit test fails on release 1.4.3 (all three scripts overlap) and passes with this change. Also ran the rest of that file and the `reach max concurrent scripts` and `stress test` cases in `bun-install-lifecycle-scripts.test.ts`.

### Background
- A lifecycle script is a `preinstall`, `install`, `postinstall`, or `prepare` command from a dependency's package.json. Bun runs them for trusted dependencies.
- The isolated linker installs each package into `node_modules/.bun/<store entry>` with a thread pool task per entry. When an entry reaches a script step, the task yields `RunScripts` to the main thread and waits. The main thread spawns the scripts, and the exit handler completes the entry or restarts the task.
- `ALIVE_COUNT` in `src/install/lifecycle_script_runner.rs` counts running script subprocesses. Its comments said the value is only used by hoisted installs. This change updates them.

<details><summary>Notes</summary>

- Repro without a registry:
  ```sh
  d=$(mktemp -d); cd "$d"
  for i in 1 2 3; do mkdir dep$i; echo "{\"name\":\"dep$i\",\"version\":\"1.0.0\",\"scripts\":{\"postinstall\":\"sleep 1\"}}" > dep$i/package.json; done
  echo '{"name":"app","version":"1.0.0","dependencies":{"dep1":"file:./dep1","dep2":"file:./dep2","dep3":"file:./dep3"},"trustedDependencies":["dep1","dep2","dep3"]}' > package.json
  bun install --linker=isolated --concurrent-scripts=1   # 1.0 s before, 3.4 s after
  ```
- The limit test records `start`/`end` lines from each script into one log file and asserts they never interleave. On POSIX the scripts are `sh` builtins (`echo`, `sleep 0.5`) so the test takes about 2 s under a debug build. On Windows the scripts run through bun's shell, which has no `sleep`, so they run a small bun script instead.
- A preinstall goes through the same queue. After it exits, the exit handler restarts the pool task, which later yields `RunScripts` again for the remaining scripts.
- Smoke test: 60 `file:` packages with both `preinstall` and `postinstall`, with limits 1, 3, and the default. All 120 scripts ran and the install exited 0 each time.
- In `test/cli/install/isolated-install.test.ts`, the `store entry names of URL dependencies` cases sit at the 5 s local timeout under a debug build on this machine with and without this change. CI uses a longer per-test timeout.
- Self-reviewed: 3 concerns raised, 3 addressed (the `--concurrent-scripts=0` stall, the raw scripts pointer carried across ticks, and the origin of the report).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->