### PR TITLE
fix(node:fs): preserve child rm permission errors

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9522,30 +9522,6 @@ pub(crate) fn zig_delete_tree(
                             treat_as_dir = true;
                             continue 'handle_entry;
                         }
-                        #[cfg(target_os = "macos")]
-                        Err(e @ E::EACCES) => {
-                            // Same ancestor-rmdir retry as the directory sites:
-                            // node reports the containing directory's ENOTEMPTY on
-                            // macOS when a file child cannot be unlinked. EPERM is
-                            // NOT converted -- on macOS it can mean "target is a
-                            // directory" and must keep flowing to the caller.
-                            let ancestor = &stack[top_idx];
-                            let ancestor_name: &[u8] = if ancestor.name_is_borrowed {
-                                sub_path
-                            } else {
-                                &ancestor.name
-                            };
-                            if matches!(
-                                dt_delete_dir(
-                                    sys::Dir::borrow(&ancestor.parent_dir),
-                                    ancestor_name
-                                ),
-                                Err(E::ENOTEMPTY | E::EEXIST)
-                            ) {
-                                return Err(dt_err(E::ENOTEMPTY));
-                            }
-                            return Err(dt_err(e));
-                        }
                         // "EPERM because it's a directory" is OS-dependent
                         // (Linux returns EISDIR; macOS returns EPERM). We only
                         // get errno, so forward EPERM as PermissionDenied —

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -9,6 +9,7 @@ import {
   isGlibc,
   isIntelMacOS,
   isLinux,
+  isMacOS,
   isPosix,
   isWindows,
   tempDir,
@@ -3520,6 +3521,37 @@ describe("fs.exists", () => {
 });
 
 describe("rm", () => {
+  it.skipIf(!isMacOS || process.getuid?.() === 0)(
+    "preserves a child permission error during recursive removal",
+    async () => {
+      using dir = tempDir("fs-rm-child-eacces", {
+        "sync/locked/file.txt": "sync",
+        "async/locked/file.txt": "async",
+      });
+      const syncRoot = join(String(dir), "sync");
+      const syncLocked = join(syncRoot, "locked");
+      const asyncRoot = join(String(dir), "async");
+      const asyncLocked = join(asyncRoot, "locked");
+      fs.chmodSync(syncLocked, 0o500);
+      fs.chmodSync(asyncLocked, 0o500);
+      try {
+        let syncError: unknown;
+        try {
+          rmSync(syncRoot, { recursive: true, force: true });
+        } catch (error) {
+          syncError = error;
+        }
+        expect(syncError).toMatchObject({ code: "EACCES" });
+        await expect(promises.rm(asyncRoot, { recursive: true, force: true })).rejects.toMatchObject({
+          code: "EACCES",
+        });
+      } finally {
+        fs.chmodSync(syncLocked, 0o700);
+        fs.chmodSync(asyncLocked, 0o700);
+      }
+    },
+  );
+
   it("removes a file", () => {
     const path = `${tmpdir()}/${Date.now()}.rm.txt`;
     writeFileSync(path, "File written successfully", "utf8");


### PR DESCRIPTION
## Problem

On macOS, recursive `fs.rm()` and `fs.rmSync()` replace a child-file `EACCES` from `unlink` with `ENOTEMPTY` from the containing directory. Current Node 24 and Node 26 preserve the original `EACCES` for a readable and searchable directory that is not writable.

The mismatch comes from a macOS-only `zig_delete_tree` branch that retries removal of the ancestor after child-file deletion is denied. That branch reports the ancestor's error instead of the operation that actually failed.

## Fix

Let child-file `EACCES` flow through the existing recursive-rm error mapper. The separate directory-child handling remains unchanged, including the existing macOS `ENOTEMPTY` behavior covered by the vendored Node test.

The regression covers both sync and promise APIs with a real non-root permission failure.

## Verification

- Shipping Bun 1.4.2: the new test fails because both APIs report `ENOTEMPTY`.
- Patched debug Bun: focused regression passes.
- Patched debug Bun: `test/js/node/fs/fs.test.ts` passes 564 tests with 16 platform skips.
- `bun run rust:check-all`: 12 targets passed.
- Downstream OpenClaw worker fault-injection matrix: 15/15 under the patched custom release; 15/15 under Node.

## AI assistance

This change was developed with Codex assistance and manually reviewed and verified.
