### PR TITLE
bundler: keep a destructured require() local a copy inside an import cycle

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1714,6 +1714,97 @@ pub(crate) struct ImportMemberResolution {
 pub(crate) type ImportMemberResolutions =
     bun_collections::HashMap<(crate::IndexInt, bun_ast::StoreStr), Option<ImportMemberResolution>>;
 
+/// The import cycle each file is in: its strongly connected component in the
+/// graph of import records of every kind. Step 4 finds them for the first item
+/// that asks.
+#[derive(Default)]
+pub(crate) struct ImportCycles {
+    cycle_of_file: Option<Vec<u32>>,
+}
+
+impl ImportCycles {
+    /// `importer` imports `importee`. Does `importee` import it back, directly
+    /// or through other files?
+    fn is_cycle(
+        &mut self,
+        import_records: &[bun_ast::import_record::List<'_>],
+        importer: crate::IndexInt,
+        importee: crate::IndexInt,
+    ) -> bool {
+        let cycle_of_file = self
+            .cycle_of_file
+            .get_or_insert_with(|| Self::find(import_records));
+        cycle_of_file[importer as usize] == cycle_of_file[importee as usize]
+    }
+
+    /// Tarjan's algorithm, with the recursion kept in `path`.
+    fn find(import_records: &[bun_ast::import_record::List<'_>]) -> Vec<u32> {
+        const UNSET: u32 = u32::MAX;
+        let file_count = import_records.len();
+        let mut visit_order = vec![UNSET; file_count];
+        // The first visited file each file reaches, among those still in `open`.
+        let mut earliest = vec![UNSET; file_count];
+        let mut cycle_of_file = vec![UNSET; file_count];
+        // The visited files whose cycle is not complete yet.
+        let mut open: Vec<usize> = Vec::new();
+        // The files from the root to the current one, each with its next record.
+        let mut path: Vec<(usize, usize)> = Vec::new();
+        let mut visited: u32 = 0;
+        let mut cycle_count: u32 = 0;
+
+        for root in 0..file_count {
+            if visit_order[root] != UNSET {
+                continue;
+            }
+            let mut entering = Some(root);
+            loop {
+                if let Some(file) = entering.take() {
+                    visit_order[file] = visited;
+                    earliest[file] = visited;
+                    visited += 1;
+                    open.push(file);
+                    path.push((file, 0));
+                }
+                let Some(top) = path.last_mut() else {
+                    break;
+                };
+                let file = top.0;
+                if let Some(record) = import_records[file].as_slice().get(top.1) {
+                    top.1 += 1;
+                    // An invalid index is out of range too.
+                    let target = record.source_index.get() as usize;
+                    if target >= file_count {
+                        continue;
+                    }
+                    if visit_order[target] == UNSET {
+                        entering = Some(target);
+                    } else if cycle_of_file[target] == UNSET {
+                        earliest[file] = earliest[file].min(visit_order[target]);
+                    }
+                    continue;
+                }
+
+                path.pop();
+                if let Some(&(parent, _)) = path.last() {
+                    earliest[parent] = earliest[parent].min(earliest[file]);
+                }
+                // `file` is the first visited file of its cycle. The files
+                // above it in `open` are the other ones.
+                if earliest[file] == visit_order[file] {
+                    while let Some(member) = open.pop() {
+                        cycle_of_file[member] = cycle_count;
+                        if member == file {
+                            break;
+                        }
+                    }
+                    cycle_count += 1;
+                }
+            }
+        }
+        cycle_of_file
+    }
+}
+
 // Clone: bitwise OK — `alias` borrows from the AST arena (non-owning); all
 // other fields are POD.
 #[derive(Clone, Default)]
@@ -4326,7 +4417,14 @@ impl<'a> LinkerContext<'a> {
     }
 
     /// Whether the export an item of such a record matched can stand in for it.
-    fn binds_call_item(&self, import_ref: Ref, result: &MatchImport) -> bool {
+    fn binds_call_item(
+        &self,
+        source_index: crate::IndexInt,
+        import_ref: Ref,
+        named_import: &NamedImport,
+        result: &MatchImport,
+        import_cycles: &mut ImportCycles,
+    ) -> bool {
         // A lifted CommonJS export changes through `exports.x = …`, which the
         // parser does not record as an assignment.
         if !matches!(result.kind, MatchImportKind::Normal)
@@ -4342,15 +4440,31 @@ impl<'a> LinkerContext<'a> {
             .symbols
             .get_const(import_ref)
             .is_some_and(|symbol| symbol.namespace_alias.is_none());
-        !is_pattern_local
-            || !self
-                .graph
-                .symbols
-                .get_const(result.r#ref)
-                .is_some_and(|symbol| {
-                    // A direct `eval` in the exporting file can assign it too.
-                    symbol.has_been_assigned_to() || symbol.must_not_be_renamed()
-                })
+        if !is_pattern_local {
+            return true;
+        }
+        let Some(export) = self.graph.symbols.get_const(result.r#ref) else {
+            return true;
+        };
+        // A direct `eval` in the exporting file can assign it too. An import
+        // that matching cannot follow is a binding of an external module,
+        // which changes out of sight.
+        if export.has_been_assigned_to()
+            || export.must_not_be_renamed()
+            || export.kind == bun_ast::symbol::Kind::Import
+        {
+            return false;
+        }
+        // Its own declaration changes it too, while the importee initializes.
+        // `import()` settles after that, but a `require()` in an import cycle
+        // can return in the middle of it. Only a function declaration has its
+        // value from the start.
+        let import_records = self.graph.ast.items_import_records();
+        let record = &import_records[source_index as usize].as_slice()
+            [named_import.import_record_index as usize];
+        record.kind != ImportKind::Require
+            || export.kind.is_function()
+            || !import_cycles.is_cycle(import_records, source_index, record.source_index.get())
     }
 
     /// Must `X.name()` keep `X` as `this`, where `X.name` is export `ref_`?
@@ -4520,6 +4634,7 @@ impl<'a> LinkerContext<'a> {
         imports_to_bind: &mut crate::RefImportData,
         source_index: crate::IndexInt,
         member_resolutions: &mut ImportMemberResolutions,
+        import_cycles: &mut ImportCycles,
     ) {
         // Note: `ArrayHashMap` has no in-place key sort and `NamedImport` is
         // non-Clone (owns a `Vec`), so we sort an index vector over the live
@@ -4579,7 +4694,15 @@ impl<'a> LinkerContext<'a> {
                 &mut re_exports,
             );
 
-            if is_call_item && !self.binds_call_item(import_ref, &result) {
+            if is_call_item
+                && !self.binds_call_item(
+                    source_index,
+                    import_ref,
+                    named_import,
+                    &result,
+                    import_cycles,
+                )
+            {
                 continue;
             }
 

--- a/src/bundler/linker_context/scanImportsAndExports.rs
+++ b/src/bundler/linker_context/scanImportsAndExports.rs
@@ -540,6 +540,7 @@ pub(crate) fn scan_imports_and_exports(
             let _trace = perf::trace("Bundler.MatchImportsWithExports");
             let mut member_resolutions =
                 crate::linker_context_mod::ImportMemberResolutions::default();
+            let mut import_cycles = crate::linker_context_mod::ImportCycles::default();
             for source_index_ in &reachable {
                 let source_index = source_index_.get() as usize;
 
@@ -558,6 +559,7 @@ pub(crate) fn scan_imports_and_exports(
                         &mut col!(imports_to_bind_list)[source_index],
                         source_index_.get(),
                         &mut member_resolutions,
+                        &mut import_cycles,
                     );
 
                     if this.log().errors > 0 {

--- a/test/bundler/bundler_dynamic_import_dce.test.ts
+++ b/test/bundler/bundler_dynamic_import_dce.test.ts
@@ -3820,6 +3820,196 @@ describe("bundler", () => {
     stdout: "x init a\nx a a",
   });
 
+  // In an import cycle, `require()` can return an importee that is still
+  // initializing. A pattern copies what an export holds at that time.
+  itElides("RequireCycleSnapshot", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": `import "./b.js";`,
+      "/a.js": /* js */ `
+        let get;
+        export function early() {
+          const { v } = require("./b.js");
+          get = () => v;
+        }
+        export function late() {
+          return get();
+        }
+      `,
+      "/b.js": /* js */ `
+        import { early, late } from "./a.js";
+        early();
+        export var v = String("V");
+        console.log(late());
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "undefined",
+  });
+
+  // None of these declarations is an assignment to the parser. The first
+  // `take()` runs before them and the second one after them.
+  itElides("RequireCycleSnapshotOfDeclarations", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": `import "./b.js";`,
+      "/a.js": /* js */ `
+        const reads = [];
+        export function take() {
+          const { init, redeclared, forOf, forIn, later, renamed, fn } = require("./b.js");
+          const ns = require("./b.js");
+          const { init: fromLocal } = ns;
+          reads.push(() => [init, redeclared, forOf, forIn, later, renamed, fn(), fromLocal].map(String).join());
+        }
+        export function read() {
+          return reads.map(r => r()).join("\\n");
+        }
+      `,
+      "/b.js": /* js */ `
+        import { take, read } from "./a.js";
+        export var redeclared = String(1), forOf = String(1), forIn = String(1), later;
+        export { hoisted as renamed };
+        export function fn() { return "fn"; }
+        take();
+        export var init = String("late");
+        var redeclared = String(2);
+        for (var forOf of ["of"]) {}
+        for (var forIn in { in: 1 }) {}
+        var later = String("late");
+        var hoisted = String("late");
+        take();
+        console.log(read());
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "undefined,1,1,1,undefined,undefined,fn,undefined\nlate,2,of,in,late,late,fn,late",
+  });
+
+  // A function declaration has its value before the importee initializes, so
+  // it is bound in a cycle too.
+  itElides("RequireCycleFunctionDeclaration", {
+    files: {
+      "/entry.js": `import "./b.js";`,
+      "/a.js": /* js */ `
+        export function early() {
+          const { fn, gen } = require("./b.js");
+          return fn() + typeof gen;
+        }
+      `,
+      "/b.js": /* js */ `
+        import { early } from "./a.js";
+        console.log(early());
+        export function fn() { return "fn "; }
+        export function* gen() {}
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "fn function",
+  });
+
+  // The importee is in a cycle without the importer: it has initialized when
+  // `require()` returns.
+  itElides("RequireOfAnotherCycle", {
+    files: {
+      "/entry.js": /* js */ `
+        import { read } from "./a.js";
+        console.log(read());
+      `,
+      "/a.js": /* js */ `
+        export function read() {
+          const { v } = require("./b.js");
+          return v;
+        }
+      `,
+      "/b.js": /* js */ `
+        import { w } from "./c.js";
+        export var v = String("V") + w();
+        export const d = "DROPPED";
+      `,
+      "/c.js": /* js */ `
+        import "./b.js";
+        export function w() { return "W"; }
+      `,
+    },
+    stdout: "VW",
+  });
+
+  // `b.js` imports `a.js`, whose top-level `require()` then returns `b.js`
+  // before its body has run.
+  itElides("RequireCycleAtTopLevel", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": `import "./b.js";`,
+      "/a.js": /* js */ `
+        const { v } = require("./b.js");
+        export function read() {
+          return v;
+        }
+      `,
+      "/b.js": /* js */ `
+        import { read } from "./a.js";
+        export var v = String("V");
+        console.log(read());
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "undefined",
+  });
+
+  // The cycle goes through a dependency of the importee. `d.js` runs before
+  // `c.js`, which holds the export that `b.js` re-exports.
+  itElides("RequireCycleThroughReExport", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        import "./b.js";
+        import { read } from "./a.js";
+        console.log(read());
+      `,
+      "/a.js": /* js */ `
+        let get;
+        export function take() {
+          const { v } = require("./b.js");
+          get = () => v;
+        }
+        export function read() {
+          return get();
+        }
+      `,
+      "/b.js": /* js */ `
+        import "./d.js";
+        export { v } from "./c.js";
+        export const d = "DROPPED";
+      `,
+      "/c.js": `export var v = String("C");`,
+      "/d.js": /* js */ `
+        import { take } from "./a.js";
+        take();
+      `,
+    },
+    stdout: "undefined",
+  });
+
+  // A file that requires itself is a cycle of one file.
+  itElides("RequireOfItself", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": `import "./a.js";`,
+      "/a.js": /* js */ `
+        let get;
+        function take() {
+          const { v } = require("./a.js");
+          get = () => v;
+        }
+        take();
+        export var v = String("V");
+        console.log(get());
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "undefined",
+  });
+
   // A default value reads the name off the real object.
   itElides("ThenAndPromiseAll", {
     keepsNamespace: true,
@@ -4301,6 +4491,33 @@ describe("bundler", () => {
     },
     run: { stdout: "0" },
   });
+
+  // A re-export of an external module's binding changes where the bundler
+  // cannot see, so a destructured copy of it stays a snapshot.
+  for (const format of ["esm", "cjs"] as const) {
+    itBundled(`dynamic_import_dce/ExternalReExportDestructureIsSnapshot_${format}`, {
+      files: {
+        "/entry.js": /* js */ `
+          async function main() {
+            const { counter, inc } = await import("./b.js");
+            inc();
+            const { counter: second } = require("./b.js");
+            inc();
+            console.log(counter, second);
+          }
+          main();
+        `,
+        "/b.js": `export { counter, inc } from "ext";`,
+      },
+      runtimeFiles: {
+        "/node_modules/ext/index.js": `export let counter = 0; export function inc() { counter++; }`,
+        "/node_modules/ext/package.json": `{ "name": "ext", "type": "module", "main": "index.js" }`,
+      },
+      external: ["ext"],
+      format,
+      run: { stdout: "0 1" },
+    });
+  }
 
   // ── Cases that keep the namespace object ──────────────────────────────
 


### PR DESCRIPTION
### Problem

- `const { v } = require("./b.js")` copies `v`. Since #41186 (1.4.1) the bundler binds the local to the export when nothing assigns the export, so later reads are live. In an import cycle, `require()` can return while `b.js` still initializes. The copy is `undefined`, but the bundle reads `"V"`. 1.4.0 is correct.
- Cause: `binds_call_item` (`src/bundler/LinkerContext.rs:4329`) refuses only an export that `has_been_assigned_to()`. An initializer (`export var v = f()`) is not an assignment.
- It also binds a re-export of an external module's binding, which that module can change.

### Fix

- A `require()` pattern local stays unbound when the importee imports the importer back, directly or through other files. The pattern reads the namespace object, as in 1.4.0.
- `ImportCycles` finds the cycles (strongly connected components of the import records, Tarjan) once per link, on first use.
- Still bound: function declarations, `import()`, `require()` outside a cycle. A rule with no cycle search fails `ElideWrappedImporterBoundClass`.
- An export that is an import which matching cannot follow (`Kind::Import`) is not bound to a pattern local.
- Verified: `test/bundler/bundler_dynamic_import_dce.test.ts`, 30 new tests, 21 fail on main.

### Background

- A wrapped ES module is `var init_b = __esm(() => { ... })`. The first `init_b()` runs the body. A nested call during that run returns at once.
- The namespace object `exports_b` has a getter for each export. A pattern that reads it copies the current value.
- To bind a local, the linker merges its symbol with the export's symbol. The pattern prints as `init_b();` and each read prints the export.

<details><summary>Notes</summary>

Why the three cases stay bound. A function declaration has its value before the importee initializes. The promise of an `import()` settles after the importee initialized. A `require()` outside a cycle returns after the importee initialized. The 9 new tests that pass on main guard these cases. Other forms that the parser does not record as an assignment: a second `var v = 2`, and a `for (var v of list)` head. For the external re-export, `0 1` became `2 2` in ESM output.

No user reported this. Another session found it by a read of the code, and a differential run confirmed it. Node.js does not have the shape: its `require()` of an ES module in a cycle throws `ERR_REQUIRE_CYCLE_MODULE`.

Repro (1.4.1, 1.4.2 and main print `V`. 1.4.0, esbuild and `bun run entry.js` print `undefined`):

```js
// entry.js
import "./b.js";
// a.js
let get;
export function early() { const { v } = require("./b.js"); get = () => v; }
export function late() { return get(); }
// b.js
import { early, late } from "./a.js";
early();
export var v = String("V");
console.log(late());
```

`bun build ./entry.js --target=bun --outdir out && bun out/entry.js`. The same occurs with `--format=cjs`. With this change the module code of the bundle is the same as in the 1.4.0 bundle. Only the `__esm` helper differs, from #41186.

What the bundle matches. It matches the 1.4.0 bundle and esbuild. It matches unbundled code for `var`. For `let`, `const` and `class` unbundled code throws a `ReferenceError` (temporal dead zone), and a bundle has none: it read the initialized value before this change, and it reads `undefined` now, as in 1.4.0. A bundle also hoists a literal initializer (`export var v = "V"`) out of the wrapper, in 1.4.0 too.

Why `import()` needs no check: the bundle prints `await Promise.resolve().then(() => init_b())`. The microtask cannot run while `init_b` is on the stack. For an importee with top-level await, `init_b()` returns the promise of the whole run. `require()` of such a module is a build error.

Why the importer and the direct importee are the pair to compare: the importer has a record for the importee, so the two are in one cycle exactly when the importee reaches the importer. If the export comes from a third file through `export { v } from "./c.js"`, a path from that file to the importer also puts the importee in the cycle, because the importee has a record for that file.

Cost. A `require()` pattern inside an import cycle that reads a variable, a class or a constant prints as in 1.4.0 again. That includes a lazy `require()` that a function uses to break a cycle. A minimal example goes from 163 to 758 bytes minified (1.4.0: 748). Most of that is the `__export` and `__toCommonJS` helpers, one time for each bundle. Each call of such a function pays for the pattern again: about 70 ns, where the bound form took 2 ns and 1.4.0 took 50 ns. On a random graph of 10000 files with 10 records each, the cycle search takes 1.6 ms.

Limit. The check sees import cycles only. Suppose the importee calls a callback while it initializes, the callback reached it through a third module, and the callback runs the `require()`. Then the local is still bound and reads live. #42449 tracks that case, with a repro. The two ways to close it both cost more than this change: never bind a `require()` pattern, or print a copy of the export at the pattern.

Checks beyond the test file:

- 36 hand-made shapes, run unbundled, as an ESM bundle and as a CJS bundle: each declaration form, re-exports, `export *`, a cycle through a dependency of the importee, a cycle made of `require()` calls only, a file that requires itself, a namespace local (`const ns = require(); const { a } = ns`), and `import()` in a cycle. All 36 bundles from this branch print what the 1.4.0 bundles print.
- 400 random projects: 3 to 7 modules, random static imports, and functions that destructure a `require()` (pattern, namespace local, renamed key) and run during initialization. The oracle is the bundle that bun 1.4.0 makes, because 1.4.0 never binds a pattern local. All 800 bundles from this branch print what the oracle prints. With the bundler of main, 266 of the first 300 differ.
- The Tarjan walk, in a standalone program, against brute-force reachability on 20000 random graphs, and on a chain of 300000 files (the walk does not use native recursion).
- Three mutations of the new condition, each caught by a test: the rule applied to `import()` too (`ElideCycle` fails), no exception for function declarations (`ElideRequireCycleFunctionDeclaration` fails), each `require()` taken as a cycle (`ElideRequireOfAnotherCycle` and `ElideWrappedImporterBoundClass` fail).

Other suites that pass on this branch: `esbuild/default`, `esbuild/dce`, `esbuild/importstar`, `esbuild/importstar_ts`, `bundler_edgecase`, `bundler_cjs`, `bundler_cjs2esm`, `bundler_regressions`, `bundler_barrel`, `bundler_splitting`, `bundler_minify`, `bundler_promiseall_deadcode`, and `test/regression/issue/cyclic-imports-async-bundler.test.js`.

Self-reviewed: 4 changes asked for, 4 made. They are the external re-export case, three more fixtures (a top-level `require()`, a cycle through a re-export, a file that requires itself), the tracking issue, and the corrections to this text.

Found on the way, not changed here: `export var a = 1; var a = 2;` with `import { a } from "./b.js"` gives `ReferenceError: a is not defined` in the bundle. Tree shaking drops both declarations. 1.4.0 does the same.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 21 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_dynamic_import_dce.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [1043.05ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [418.88ms]
(pass) bundler > dynamic_import_dce/AwaitDot [639.43ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [551.29ms]
(pass) bundler > dynamic_import_dce/LetBinding [454.30ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [454.41ms]
(pass) bundler > dynamic_import_dce/BailoutRest [568.03ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [439.39ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [504.53ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [562.37ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [882.55ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [409.14ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [564.71ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [473.04ms]
(pass) bundler > dyna
... (truncated)

release without fix: 21 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [28.63ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [17.02ms]
(pass) bundler > dynamic_import_dce/AwaitDot [16.30ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [14.22ms]
(pass) bundler > dynamic_import_dce/LetBinding [17.73ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [15.36ms]
(pass) bundler > dynamic_import_dce/BailoutRest [16.33ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [15.51ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [15.83ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [17.21ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [29.87ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [17.39ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [17.63ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [18.38ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllDestructure [18.02ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllThenDestructure [17.08ms]
(pass) bundler > dynamic_import_dce/SplittingProm
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_dynamic_import_dce.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [967.57ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [401.76ms]
(pass) bundler > dynamic_import_dce/AwaitDot [399.58ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [460.54ms]
(pass) bundler > dynamic_import_dce/LetBinding [449.75ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [520.68ms]
(pass) bundler > dynamic_import_dce/BailoutRest [510.27ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [523.09ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [711.21ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [485.70ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [919.70ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [477.29ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [561.19ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [506.89ms]
(pass) bundler > dynam
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c78e503d53
  features     baseline

23 deps, 131 codegen, 1172 objects in 1248ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] fetch zlib
[zlib] up to date
[2/1244] fetch tinycc
[tinycc] up to date
[3/1243] install /workspace/bun
bun install v1.4.3-canary.1 (4ff919377)

Checked 22 installs across 61 packages (no changes) [51.00ms]
[4/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1216] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (4ff919377)

Checked 1 install across 2 packages (no changes) [3.00ms]
[6/1216] gen bindgenv2
[7/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[8/1216] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[9/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (4ff91937
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs                       | 145 ++++++++++++--
 .../linker_context/scanImportsAndExports.rs        |   2 +
 test/bundler/bundler_dynamic_import_dce.test.ts    | 217 +++++++++++++++++++++
 3 files changed, 353 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/bundler/LinkerContext.rs                             6      7     16
src/bundler/linker_context/scanImportsAndExports.rs      1      1     16
test/bundler/bundler_dynamic_import_dce.test.ts          3      4     16
```

</details>

<!-- robobun:evidence:end -->