### PR TITLE
js_printer: print a valid expression for an unused require() operand

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2801,6 +2801,7 @@ pub(crate) mod __gated_printer {
                 }
 
                 // Internal "require()" or "import()"
+                let start = self.writer.written();
                 let has_side_effects = meta.wrapper_ref.is_valid()
                     || meta.exports_ref.is_valid()
                     || meta.was_unwrapped_require
@@ -2876,6 +2877,12 @@ pub(crate) mod __gated_printer {
                     if !meta.exports_ref.is_empty() {
                         self.print_symbol(meta.exports_ref);
                     }
+                }
+
+                // An unused "require()" with no wrapper to call is still an expression
+                if flags.contains(ExprFlag::ExprResultIsUnused) && self.writer.written() == start {
+                    self.print_space_before_identifier();
+                    self.print(b"0");
                 }
 
                 if wrap_comma_operator {
@@ -3751,9 +3758,8 @@ pub(crate) mod __gated_printer {
                         }
                         flags.remove(ExprFlag::HasNonOptionalChainParent);
                     }
+                    flags &= ExprFlag::HasNonOptionalChainParent | ExprFlag::ForbidCall;
 
-                    // The index target is not directly followed by `of`.
-                    flags.remove(ExprFlag::IsFollowedByOf);
                     self.print_expr(e.target, Level::Postfix, flags);
 
                     let is_optional_chain_start =
@@ -3788,6 +3794,8 @@ pub(crate) mod __gated_printer {
                         self.print(b"(");
                         flags.remove(ExprFlag::ForbidIn);
                     }
+                    // The other flags describe this expression, not its operands.
+                    flags &= ExprFlag::ForbidIn;
                     self.print_expr(e.test, Level::Conditional, flags);
                     self.print_space();
                     self.print(b"?");

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2101,6 +2101,108 @@ describe("bundler", () => {
       stdout: "123",
     },
   });
+  // "/a.js" and "/b.js" have no wrapper to call, so a require() of one whose
+  // result is unused has nothing to print. It still has to be an expression.
+  itBundled("edgecase/EsmWrapperEliminationUnusedRequire", {
+    files: {
+      "/entry.js": /* js */ `
+        export function f(flag, key) {
+          const log = [];
+          flag ? require("./a.js") : require("./b.js");
+          require("./a.js") ? log.push("test") : log.push("unreachable");
+          require("./a.js")[key];
+          require("./a.js"), log.push("left");
+          log.push("right"), require("./b.js");
+          flag ? log.push("yes") : (log.push("no"), require("./b.js"));
+          for (require("./a.js"); ; ) break;
+          require("./b.js");
+          const { name } = require("./b.js");
+          log.push(name);
+          return log.join(" ");
+        }
+        console.log(f(true, "name"));
+        console.log(f(false, "name"));
+      `,
+      "/a.js": `export const name = "a";`,
+      "/b.js": `export const name = "b";`,
+    },
+    target: "bun",
+    run: { stdout: "test left right yes b\ntest left right no b" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out.slice(out.indexOf("// entry.js"))).toMatchInlineSnapshot(`
+        "// entry.js
+        function f(flag, key) {
+          const log = [];
+          flag ? __toCommonJS(exports_a) : __toCommonJS(exports_b);
+          __toCommonJS(exports_a) ? log.push("test") : log.push("unreachable");
+          __toCommonJS(exports_a)[key];
+          0, log.push("left");
+          log.push("right"), 0;
+          flag ? log.push("yes") : (log.push("no"), __toCommonJS(exports_b));
+          for (0;; )
+            break;
+          0;
+          0;
+          log.push(name2);
+          return log.join(" ");
+        }
+        console.log(f(true, "name"));
+        console.log(f(false, "name"));
+        export {
+          f
+        };
+        "
+      `);
+    },
+  });
+  // --minify-syntax joins adjacent expression statements with commas, and
+  // --minify-whitespace drops the ";" of a last statement.
+  itBundled("edgecase/EsmWrapperEliminationUnusedRequireMinify", {
+    files: {
+      "/entry.js": /* js */ `
+        export function f() {
+          const log = [];
+          log.push(1);
+          require("./a.js");
+          log.push(2);
+          return log.join(" ");
+        }
+        function g(flag) {
+          return require("./b.js"), String(flag);
+        }
+        function h(flag) {
+          if (flag) require("./a.js");
+        }
+        console.log(f(), g(true), h(true));
+      `,
+      "/a.js": `export const name = "a";`,
+      "/b.js": `export const name = "b";`,
+    },
+    target: "bun",
+    minifySyntax: true,
+    minifyWhitespace: true,
+    run: { stdout: "1 2 true undefined" },
+  });
+  // "/w.js" has a wrapper, and init_w() returns undefined. The test of a
+  // conditional and the target of an index read the value of the require().
+  itBundled("edgecase/RequireOfEsmAsConditionalTestOrIndexTarget", {
+    files: {
+      "/entry.js": /* js */ `
+        export function f(key) {
+          const log = [];
+          require("./w.js") ? log.push("truthy") : log.push("falsy");
+          require("./w.js")[key];
+          log.push(globalThis.ranW);
+          return log.join(" ");
+        }
+        console.log(f("name"));
+      `,
+      "/w.js": `globalThis.ranW = "w ran"; export const name = "w";`,
+    },
+    target: "bun",
+    run: { stdout: "truthy w ran" },
+  });
   itBundled("edgecase/TsEnumTreeShakingUseAndInlineClass", {
     files: {
       "/entry.ts": `


### PR DESCRIPTION
### Problem
- `bun build` prints wrong or unparsable code when a `require()` of a bundled ES module is an operand of an expression statement. `require("./a") ? x() : y();` prints `init_a() ? x() : y();` and always calls `y()`. `c ? require("./a") : require("./b");` prints `c ? __toCommonJS(exports_a) : ;` (`SyntaxError: Unexpected token ';'`).
- Cause 1: the `EIf` and `EIndex` arms (`src/js_printer/lib.rs:3785`, `:3721`) pass the flags of the parent, with `ExprResultIsUnused`, to their operands.
- Cause 2: with that flag, `print_require_or_import_expr` (`lib.rs:2765`) prints nothing for a module with no `init_*` wrapper. `--minify` then prints `log(1),,log(2)` and `if(c)}`.

### Fix
- `EIf` passes only `ForbidIn` to its test and no branch. `EIndex` passes only `HasNonOptionalChainParent | ForbidCall` to its target, like `EDot`. esbuild has the same masks.
- An unused `require()` that printed nothing now prints `0`: `log(1),0,log(2)`, `if(c)0`. A bare `require("./a");` prints `0;`, not `;`.
- Correct because each position now holds an expression and nothing reads the `0`.
- Verified: three new tests in `test/bundler/bundler_edgecase.test.ts` fail on 1.4.3. Self-reviewed: 10 concerns raised, 9 addressed, 1 rejected (Notes).

### Background
- The printer passes `ExprFlag`s from a parent expression to a child. `ExprResultIsUnused` means nothing reads the value of the child. An expression statement sets it. The comma operator forwards it.
- The bundler wraps a `require()`d ES module in `var init_x = __esm(...)`. `require()` prints `(init_x(), __toCommonJS(exports_x))`, or only `init_x()` when unused. `init_x()` returns `undefined`.
- When every top-level statement can be hoisted, Bun emits no wrapper (`needs_wrapper_ref`, `src/js_parser/p.rs:9519`, #12729). esbuild always emits one.

<details><summary>Notes</summary>

**History.** No user report exists. #42376 found the first form and left it for a separate change. So did #41638, for the mask. The wrong branch (`init_a() ? x() : y()`) is in 1.0.0. The unparsable forms start in v1.1.21, the first release with #12729. 1.1.20 prints `flag ? (init_st(), __toCommonJS(exports_st)) : init_ot();`.

**Before and after**, `bun build --target=bun`. `./a` and `./b` have no wrapper, `./w` has one:

| source | 1.4.3 | this PR |
| --- | --- | --- |
| `flag ? require("./a") : require("./b");` | `flag ? __toCommonJS(exports_a) : ;` | `flag ? __toCommonJS(exports_a) : __toCommonJS(exports_b);` |
| `require("./a") ? x() : y();` | ` ? x() : y();` | `__toCommonJS(exports_a) ? x() : y();` |
| `require("./a")[k];` | `[k];` | `__toCommonJS(exports_a)[k];` |
| `require("./a"), x();` | `, x();` | `0, x();` |
| `x(), require("./b");` | `x(), ;` | `x(), 0;` |
| `require("./a");` | `;` | `0;` |
| `for (require("./a");;)` | `for (;; )` | `for (0;; )` |
| `require("./w") ? x() : y();` | `init_w() ? x() : y();` (calls `y`) | `(init_w(), __toCommonJS(exports_w)) ? x() : y();` |
| `require("./w")[k];` | `init_w()[k];` (TypeError) | `(init_w(), __toCommonJS(exports_w))[k];` |

With `--minify`: `function f(c){if(c)}` is now `if(c)0`, `while(c)}` is now `while(c)0`, `if(c);else}` is now `if(c)0;else 0`, `return,String(c)` is now `return 0,String(c)`, and `log(1),,log(2)` is now `log(1),0,log(2)`.

**Why `0` also for a whole statement.** A first version kept `;` for a statement that is only the `require()`. That is not valid under `--minify-whitespace`: the printer drops the `;` before `}`, so `if (c) require("./a")` as the last statement prints `if(c)}`. One rule for every position is smaller and has no such case.

**The filler applies only when the result is unused.** A used `require()` that has nothing to print stays a loud syntax error and does not become a silent `0`. That case exists: #33881 (for #16941) fixes `var R = ;` for a CommonJS module with no wrapper.

**The masks also remove redundant parentheses** in plain transpiler output. All forms are valid before and after:

| source | before | after |
| --- | --- | --- |
| `new (a() ? c : d)()` | `new ((a()) ? c : d)` | `new (a() ? c : d)` |
| `(a?.b ? c : d).e` | `((a?.b) ? c : d).e` | `(a?.b ? c : d).e` |
| `(a?.b ? c : d)[e]` | `((a?.b) ? c : d)[e]` | `(a?.b ? c : d)[e]` |

The no branch of a conditional still gets `ForbidIn` in every context (`a ? b : (c in d)`). esbuild passes it only inside a `for` initializer. This PR does not change that.

**Rejected review concern.** `return require("./a")` with `--minify-whitespace` prints `return__toCommonJS(exports_a)`. The cause is different: the arm prints a used result with no `print_space_before_identifier()`. #30669 reports it and #30673 has the fix in three hunks. One of those hunks here would not close that PR, so this PR leaves it there.

**Related.** #27176 fixed the `import()` form of cause 2 in the same function (`Promise.resolve().then(() => )`).

**With `--react-compiler` and without #42376**, the compiler folds `const m = flag ? require("./a") : require("./b")` to the first module and leaves the statement from the first table row. Today that is a syntax error. With this PR alone it parses, and `m` is module `a` on both paths until #42376 lands.

**Question for a maintainer.** The other fix for cause 2 is to always create the wrapper, as esbuild does (the gate at `src/js_parser/p.rs:9297`). Then `require()` always prints `init_x()` and no filler is needed. The cost is an empty `__esm` wrapper for each such module, which #12729 removed on purpose. This PR does not do that.

**Suites run with the debug build, all pass:** `bundler_edgecase`, `bundler_dynamic_import_dce`, `bundler_cjs2esm`, `bundler_cjs`, `bundler_minify`, `bundler_bun`, `bundler_browser`, `bundler_splitting`, `bundler_promiseall_deadcode`, `bundler_loader`, `bundler_plugin`, `bundler_naming`, `bundler_defer`, `bundler_allow_unresolved`, `metafile`, `esbuild/{default,dce,importstar,importstar_ts,splitting,extra,packagejson,ts,loader}`, `transpiler/{transpiler,react-compiler,runtime-transpiler,function-tostring-require}`, `test/regression/issue/24709.test.ts`.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 11 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [1015.75ms]
(pass) bundler > edgecase/EmptyCommonJSModule [1053.97ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [756.73ms]
(pass) bundler > edgecase/ImportStarFunction [865.84ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [769.18ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [309.14ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [910.28ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [962.68ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [1007.44ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [598.92ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [510.41ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [1253.92ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [676.24ms]
(pass) bundl
... (truncated)

release without fix: 3 failed, 11 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [21.43ms]
(pass) bundler > edgecase/EmptyCommonJSModule [18.66ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [19.49ms]
(pass) bundler > edgecase/ImportStarFunction [17.25ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [18.25ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [6.38ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [17.86ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [20.88ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [8.94ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [8.78ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [7.78ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [17.86ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [17.39ms]
(pass) bundler > edgecase/ValidLoaderSeenAsInvalid [6.43ms]
(pass) bundler > edgecase/InvalidLoaderSegfault [4.19ms]
(todo) bundler > edgecase/ScriptTagEscape
(pass) bundler > edgecase/JSONDefau
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 11 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_edgecase.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/bundler_edgecase.test.ts:
(pass) bundler > edgecase/EmptyFile [919.40ms]
(pass) bundler > edgecase/EmptyCommonJSModule [642.46ms]
(pass) bundler > edgecase/NestedRedirectToABuiltin [741.55ms]
(pass) bundler > edgecase/ImportStarFunction [730.41ms]
(pass) bundler > edgecase/ImportStarSyntaxErrorBug [707.04ms]
(todo) bundler > edgecase/BunPluginTreeShakeImport
(pass) bundler > edgecase/TemplateStringIssue622 [179.87ms]
(pass) bundler > edgecase/ImportNamedFromExportStarCJS [750.12ms]
(pass) bundler > edgecase/NodeEnvDefaultUnset [343.53ms]
(pass) bundler > edgecase/NodeEnvDefaultDevelopment [335.99ms]
(pass) bundler > edgecase/NodeEnvDefaultProduction [332.09ms]
(todo) bundler > edgecase/NodeEnvOptionalChaining
(pass) bundler > edgecase/StarExternal [206.08ms]
(pass) bundler > edgecase/ImportNamespaceAndDefault [614.74ms]
(todo) bundler > edgecase/ExternalES6ConvertedToCommonJSSimplified
(pass) bundler > edgecase/ImportTrailingSlash [593.73ms]
(pass) bundler >
... (truncated)

release with fix: 11 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1265ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/138] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/138] gen cpp.rs (cppbind)
[3/138] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[4/138] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[5/138] gen JS modules (bundle-modules)
Preprocess modules (14107ms)
Bundle modules (72ms)
Postprocesss modules (173ms)
Bundle Functions (674ms)
Generate Code (47ms)

[15.08s] Bundled "src/js" for production
  2599 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[5/137] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/work
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_printer/lib.rs                 |  12 +++-
 test/bundler/bundler_edgecase.test.ts | 102 ++++++++++++++++++++++++++++++++++
 2 files changed, 112 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/js_printer/lib.rs                     14     16     27
test/bundler/bundler_edgecase.test.ts      4      8     27
```

</details>

<!-- robobun:evidence:end -->