### PR TITLE
react-compiler: do not compile a member update whose object or key has side effects

### DIFF
--- a/src/react_compiler/lowering/build_hir/expr.rs
+++ b/src/react_compiler/lowering/build_hir/expr.rs
@@ -9,10 +9,10 @@ use bun_ast::{self as ast, E, Expr, G, Loc, OpCode, Ref, StoreRef, symbol};
 
 use super::function::{lower_function_to_value, lower_object_method};
 use super::helpers::{
-    AssignmentStyle, MemberProperty, build_temporary_place, expression_type_name, lower_arguments,
-    lower_assignment, lower_expression_to_temporary, lower_identifier, lower_member_expression,
-    lower_object_property_key, lower_optional_call_expression, lower_optional_member_expression,
-    lower_value_to_temporary,
+    AssignmentStyle, MemberProperty, build_temporary_place, can_lower_member_update,
+    expression_type_name, lower_arguments, lower_assignment, lower_expression_to_temporary,
+    lower_identifier, lower_member_expression, lower_object_property_key,
+    lower_optional_call_expression, lower_optional_member_expression, lower_value_to_temporary,
 };
 use super::jsx::lower_jsx_call;
 use crate::lowering::FunctionNode;
@@ -856,6 +856,9 @@ fn lower_compound_assignment(
             lower_compound_assignment_identifier(builder, ident.ref_, bin, binary_op, loc)
         }
         Data::EDot(_) | Data::EIndex(_) => {
+            if !can_lower_member_update(builder, &bin.left)? {
+                return Ok(unsupported_node("AssignmentExpression", loc));
+            }
             let member_loc = convert_loc(bin.left.loc);
             let lowered = lower_member_expression(builder, &bin.left, None)?;
             let object = lowered.object;
@@ -1056,6 +1059,9 @@ fn lower_update(
                 UpdateOperator::Increment => BinaryOperator::Add,
                 UpdateOperator::Decrement => BinaryOperator::Subtract,
             };
+            if !can_lower_member_update(builder, &unary.value)? {
+                return Ok(unsupported_node("UpdateExpression", loc));
+            }
             let member_loc = convert_loc(unary.value.loc);
             let lowered = lower_member_expression(builder, &unary.value, None)?;
             let object = lowered.object;

--- a/src/react_compiler/lowering/build_hir/helpers.rs
+++ b/src/react_compiler/lowering/build_hir/helpers.rs
@@ -376,6 +376,87 @@ pub(super) fn lower_member_expression(
     }
 }
 
+/// Intentional deviation: upstream lowers `a[k] += v` and `a[k]++` to a load
+/// and a store that both read the object temporary and the key temporary, and
+/// codegen prints an unnamed temporary at every site that reads it. So
+/// `a[i++] += 1` comes out as `a[i++] = a[i++] + 1`, and in a callback
+/// `get().n++` calls `get` twice. facebook/react#36733 names the bug. For
+/// `??=`, `||=` and `&&=` it holds such an operand in a promoted `const`
+/// (`copy_to_promoted_temporary`). Until upstream does the same for these two
+/// lowerings, an object or key that cannot be evaluated twice is a `Todo`,
+/// which leaves the function uncompiled.
+///
+/// `target` is the `EDot` or `EIndex` that is updated. Returns false after it
+/// records the `Todo`.
+pub(super) fn can_lower_member_update(
+    builder: &mut HirBuilder,
+    target: &Expr,
+) -> Result<bool, CompilerError> {
+    let supported = match &target.data {
+        Data::EDot(d) => can_evaluate_twice(&d.target),
+        Data::EIndex(i) => can_evaluate_twice(&i.target) && can_evaluate_twice(&i.index),
+        _ => true,
+    };
+    if !supported {
+        builder.record_error(CompilerErrorDetail {
+            category: ErrorCategory::Todo,
+            reason: "(BuildHIR::lowerExpression) Handle a compound assignment or update of a member whose object or key has side effects".to_string(),
+            description: None,
+            loc: convert_loc(target.loc),
+            suggestions: None,
+        })?;
+    }
+    Ok(supported)
+}
+
+/// True when `expr` only reads: bindings, properties, literals, and operators
+/// over those. Evaluating it a second time gives the same value and nothing
+/// can observe that it ran twice. A property read counts as a read because the
+/// compiler already takes it to be free of side effects (dead code elimination
+/// drops an unused one). A call, `i++`, an assignment, `await`, or anything
+/// that allocates must run exactly once.
+fn can_evaluate_twice(expr: &Expr) -> bool {
+    match &expr.data {
+        Data::EIdentifier(_)
+        | Data::EImportIdentifier(_)
+        | Data::EPrivateIdentifier(_)
+        | Data::EThis(_)
+        | Data::EUndefined(_)
+        | Data::ENull(_)
+        | Data::EBoolean(_)
+        | Data::EBranchBoolean(_)
+        | Data::ENumber(_)
+        | Data::EBigInt(_)
+        | Data::EString(_) => true,
+        Data::EInlinedEnum(e) => can_evaluate_twice(&e.value),
+        Data::EDot(d) => can_evaluate_twice(&d.target),
+        Data::EIndex(i) => can_evaluate_twice(&i.target) && can_evaluate_twice(&i.index),
+        Data::EUnary(unary) => {
+            OpCode::unary_assign_target(unary.op) == ast::AssignTarget::None
+                && unary.op != OpCode::UnDelete
+                && can_evaluate_twice(&unary.value)
+        }
+        Data::EBinary(bin) => {
+            bin.op.binary_assign_target() == ast::AssignTarget::None
+                && can_evaluate_twice(&bin.left)
+                && can_evaluate_twice(&bin.right)
+        }
+        Data::EIf(cond) => {
+            can_evaluate_twice(&cond.test)
+                && can_evaluate_twice(&cond.yes)
+                && can_evaluate_twice(&cond.no)
+        }
+        Data::ETemplate(template) => {
+            template.tag.is_none()
+                && template
+                    .parts()
+                    .iter()
+                    .all(|part| can_evaluate_twice(&part.value))
+        }
+        _ => false,
+    }
+}
+
 // =============================================================================
 // lower_identifier_for_assignment
 // =============================================================================

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -2030,6 +2030,134 @@ describe("bundler", () => {
     },
     run: { stdout: '{"h":"div","props":{"title":"A"},"children":["hi"]}' },
   });
+
+  // The compiler lowers `a[k] += v` and `a[k]++` to a load and a store that
+  // both read the object and the key, and codegen prints an unnamed temporary
+  // at every site that reads it: `a[i++] += 10` came out as
+  // `a[i++] = a[i++] + 10`. An object or key that does more than read (`i++`,
+  // a call) now leaves the function uncompiled. One that only reads is still
+  // printed at both sites. `client` mode is target=browser, `ssr` mode is
+  // target=bun. `minifySyntax` joins the statements with commas first.
+  for (const target of ["browser", "bun"] as const) {
+    for (const minifySyntax of [false, true]) {
+      itBundled(`react-compiler/MemberUpdateEvaluatesObjectAndKeyOnce-${target}-syntax=${minifySyntax}`, {
+        files: {
+          "/entry.jsx": /* jsx */ `
+            const log = [];
+            let n = 0;
+            const next = () => (log.push("next"), n++);
+            const key = k => (log.push("key:" + k), k);
+            const store = { b: { n: 1 } };
+            const get = k => (log.push("get:" + k), store[k]);
+            const wrap = (...xs) => xs;
+            const Stub = () => null;
+
+            function Body({ arr, start }) {
+              let i = start;
+              const a = [...arr];
+              let b = [...arr];
+              const box = { list: [...arr] };
+              a[i++] += 10;
+              a[next()]++;
+              --a[next()];
+              b[i++] *= 2;
+              box.list[next()] -= 1;
+              a[(log.push("seq"), 3)] **= 2;
+              get("b")[key("n")] *= 2;
+              get("b").n += 5;
+              get("b").n++;
+              return <div>{[a.join(), b.join(), box.list.join(), i, store.b.n].join("|")}</div>;
+            }
+
+            function Handler({ arr }) {
+              const onEvent = () => {
+                const a = [...arr];
+                let b = [...arr];
+                a[next()] += 10;
+                a[next()]++;
+                b[next()] -= 1;
+                get("b")[key("n")] *= 2;
+                get("b").n += 5;
+                --get("b").n;
+                const doubled = (a[key(0)] *= 2);
+                const bump = x => (a[key(x)] += 100);
+                const pre = () => {
+                  return ++a[key(2)];
+                };
+                return [a.join(), b.join(), store.b.n, doubled, bump(1), pre()].join("|");
+              };
+              return <Stub run={onEvent} />;
+            }
+
+            function InCallArgument({ arr }) {
+              const a = [...arr];
+              const r = wrap((a[next()] += 1), next());
+              return <div>{[a.join(), r.join()].join("|")}</div>;
+            }
+
+            function InLoopUpdate({ arr }) {
+              const a = [...arr];
+              for (let j = 0; j < 2; a[next()] += j++) {}
+              return <div>{a.join()}</div>;
+            }
+
+            function Reads({ arr, k }) {
+              const a = [...arr];
+              const o = { v: { w: 2 } };
+              a[k] += 1;
+              a[k + 1]++;
+              a[\`\${k}\`] -= 4;
+              o.v.w *= 7;
+              const r = wrap((a[k] += 1), --o.v.w);
+              return <div>{[a.join(), o.v.w, r.join()].join("|")}</div>;
+            }
+
+            const run = (name, fn) => {
+              n = 0;
+              store.b.n = 1;
+              const value = fn();
+              console.log(name + ": " + value + " [" + log.splice(0).join(" ") + "]");
+            };
+            const arr = [1, 2, 3, 4];
+            run("Body", () => Body({ arr, start: 0 }).props.children);
+            run("Handler", () => Handler({ arr }).props.run());
+            run("InCallArgument", () => InCallArgument({ arr }).props.children);
+            run("InLoopUpdate", () => InLoopUpdate({ arr }).props.children);
+            run("Reads", () => Reads({ arr, k: 0 }).props.children);
+          `,
+          ...jsxCallShapeRuntime,
+        },
+        reactCompiler: true,
+        backend: "cli",
+        target,
+        minifySyntax,
+        // What the source prints when nothing compiles it.
+        run: {
+          stdout: `
+            Body: 12,1,3,16|1,4,3,4|1,2,2,4|2|8 [next next next seq get:b key:n get:b get:b]
+            Handler: 22,3,3,4|1,2,2,4|6|22|103|4 [next next next get:b key:n get:b get:b key:0 key:1 key:2]
+            InCallArgument: 2,2,3,4|2,1 [next next]
+            InLoopUpdate: 1,3,3,4 [next next]
+            Reads: -1,3,3,4|13|-1,13 []
+          `,
+        },
+        onAfterBundle(api) {
+          const out = api.readFile("/out.js");
+          // Not compiled: the parameter is still the destructuring pattern.
+          expect(out).toContain("function Body({ arr, start })");
+          expect(out).toContain("function Handler({ arr })");
+          expect(out).toContain("function InCallArgument({ arr })");
+          expect(out).toContain("function InLoopUpdate({ arr })");
+          // Compiled: the props object became the parameter `t0`, and the
+          // reads are printed at both sites, as upstream prints them.
+          expect(out).toContain("function Reads(t0)");
+          expect(out).toContain("a[k] = a[k] + 1");
+          expect(out).toContain("a[k + 1] = a[k + 1] + 1");
+          expect(out).toContain("o.v.w = o.v.w * 7");
+        },
+      });
+    }
+  }
 });
 
 // Three passes kept one copy of their work per basic block or per nesting


### PR DESCRIPTION
### Problem
- With `--react-compiler`, a compound assignment or `++` / `--` on a member evaluates the object and the key twice. `a[i++] += 10` becomes `a[i++] = a[i++] + 10`. In a callback `get().n += 5` becomes `get().n = get().n + 5`.
- The cause is `lower_compound_assignment` and `lower_update` (`src/react_compiler/lowering/build_hir/expr.rs`). Their load and store both read the object and key temporaries, and codegen prints an unnamed temporary at every site that reads it.
- Upstream prints the same text. facebook/react#36733 names the bug.

### Fix
- `can_lower_member_update` (`helpers.rs`) runs at the top of both member arms. If the object or the key does more than read, it records a `Todo`, which leaves the function uncompiled.
- An object or key that only reads (bindings, properties, literals, operators over those) is still printed at both sites, as upstream prints it. No upstream fixture changes.
- The guard has an `Intentional deviation:` comment with the upstream link, so a sync can replace it.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (four new cases, stock bun fails all four). Also `react-compiler-fixtures.test.ts` (3293 pass) and `bundler_jsx.test.ts`.

### Background
- The compiler lowers a function to HIR, where every intermediate value is a temporary. Codegen does not declare an unnamed temporary. It prints the temporary's expression where the temporary is read.
- A `Todo` is how the compiler says it cannot handle a construct. Bun then keeps the original function. The lowering has about 48 such sites.
- A nested function gets no pass that promotes temporaries to variables, so in a callback the object is doubled too, not only the key.

<details><summary>Notes</summary>

- Found by fuzzing, not by a user report. The four new test cases are client and ssr mode, each with and without `minifySyntax`. Reproduction: `function App({ arr, start }) { let i = start; const a = [...arr]; a[i++] += 10; return <div>{a.join()}:{i}</div>; }` printed `["12,2,3",":",2]` with `--react-compiler` and `["11,2,3",":",1]` without. It now prints the same both ways.
- Self-reviewed. The first version of this change kept such functions compiled: it held the object and key in a promoted `const` when the update was the whole expression of a statement (the same promote + `StoreLocal Const` sequence as `copy_to_promoted_temporary` in facebook/react#36733). The review measured the shape in real code: 0 of 178 member updates in about 24,000 component and hook functions (ant-design, material-ui, mattermost, cal.com, tldraw, drei and ten more) have an object or key that does more than read. So the bail gives the same correctness, drops nothing that was measured, and keeps the lowering close to upstream. The `const` path can come back with upstream's fix through a sync.
- Rejected from the review: folding the postfix result bug into this change (`const id = ref.current++` in a callback returns the new value, facebook/react#35205, upstream fixture `bug-ref-prefix-postfix-operator`). It has a different cause (the old value is printed after the store) and it does occur in real code, so a bail there costs real memoization and needs its own decision. It is tracked separately.
- Rejected from the review: a "local divergences" index in `DESIGN.md`. The in-code `Intentional deviation:` marker is the existing convention (`lowering/find_context_identifiers.rs`), and the other entries proposed for the index belong to changes that have not merged.
- Shapes checked against the plain build, in the component body and in a callback, client and ssr mode: `a[i++] += 10`, `a[next()]++`, `--a[next()]`, `b[i++] *= 2`, `box.list[next()] -= 1`, `a[(log("seq"), 3)] **= 2`, `get("b")[key("n")] *= 2`, `get("b").n += 5`, `get("b").n++`, `return ++a[key(2)]`, `x => (a[key(x)] += 100)`, `const v = (a[key(0)] *= 2)`, `wrap(a[next()] += 1)`, a `for` update clause, `a[await f()] += 1`, `a[o?.k()] *= 3`. Also as the body of `for`, `if` / `else`, `switch` cases, `try` / `catch`, a labeled block and `do` / `while`.
- The skip is silent in a release build. Not changed: the desugar of member `++` / `--` to `x = x + 1`, which differs from `++` for a string or a BigInt.
- For whoever ports upstream's fix: `copy_to_promoted_temporary` in facebook/react#36733 declares the `const` at any position. Inside a larger expression that moves the key ahead of earlier operands of the same statement (`f(i, o[i++] ||= 1)` reads `i` after the increment).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [733.24ms]
(pass) bundler > react-compiler/ComponentWithHooks [284.93ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [328.73ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [278.07ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [131.41ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [98.47ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [319.89ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [101.41ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [780.83ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [106.80ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [103.34ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [306.81ms]
(pass) bundler > react
... (truncated)

release without fix: 20 failed, 1 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [17.31ms]
(pass) bundler > react-compiler/ComponentWithHooks [8.50ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [29.10ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [9.02ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [9.57ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [5.18ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [12.20ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [5.65ms]
1031 |       ]);
1032 |       const stdout = Buffer.from(stdoutBytes);
1033 |       const stderr = Buffer.from(stderrBytes);
1034 |       const success = exitCode === 0;
1035 |       if (buildProc.signalCode) {
1036 |         throw new Error(
                         ^
error: [react-compiler/SsrObjectMethodShorthand] 'bun build' subprocess killed by SIGABRT
cmd: /workspace/bun/build/release/bun build /tmp/bun-build-tests/bun-6mtnKw/react-compiler/SsrObjectMethodShorthand/entry.jsx --outfile=/tmp/bun-build-tests/bun
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [636.30ms]
(pass) bundler > react-compiler/ComponentWithHooks [378.52ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [318.94ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [330.77ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [156.03ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [99.89ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [422.91ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [100.41ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [815.32ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [100.31ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [122.06ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [397.15ms]
(pass) bundler > react
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     ee712eb99c
  features     baseline

23 deps, 131 codegen, 1172 objects in 791ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (6a92015fc)

Checked 22 installs across 61 packages (no changes) [23.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (6a92015fc)

Checked 1 install across 2 packages (no changes) [9.00ms]
[4/1244] fetch tinycc
[tinycc] up to date
[5/1243] gen bindgenv2
[6/1243] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[7/1243] gen .bind.ts → GeneratedBindings.cpp
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1216] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspac
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/react_compiler/lowering/build_hir/expr.rs    |  14 ++-
 src/react_compiler/lowering/build_hir/helpers.rs |  81 ++++++++++++++
 test/bundler/transpiler/react-compiler.test.ts   | 128 +++++++++++++++++++++++
 3 files changed, 219 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/react_compiler/lowering/build_hir/expr.rs         2      0     17
src/react_compiler/lowering/build_hir/helpers.rs      4      3     17
test/bundler/transpiler/react-compiler.test.ts        2      2     17
```

</details>

<!-- robobun:evidence:end -->