### PR TITLE
node:net: send the FIN when end() on a socket runs around its TLS wrap

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -242,12 +242,15 @@ function failWrite(self, negErrno, callback) {
     }
   }
 }
-function endNT(socket, callback, err) {
+function endNT(self, socket, callback) {
   // Node's _final half-closes the writable side (sends FIN) and leaves the
   // readable side open; the Duplex's allowHalfOpen drives the eventual destroy.
   // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/net.js#L500
-  socket.shutdown();
-  callback(err);
+  // A TLS wrap that adopted the fd since _final ran retired `socket`: its
+  // shutdown() is a no-op now, and the raw half on _handle shares the fd.
+  const current = self._handle;
+  (current?.[kAdoptedTLSRaw] ? current : socket).shutdown();
+  callback();
 }
 function emitCloseNT(self, hasError) {
   self.emit("close", hasError);
@@ -2288,7 +2291,7 @@ Socket.prototype._final = function _final(callback) {
   if (!socket) return callback();
 
   // emit FIN allowHalfOpen only allow the readable side to close first
-  process.nextTick(endNT, socket, callback);
+  process.nextTick(endNT, this, socket, callback);
 };
 
 Object.defineProperty(Socket.prototype, "localAddress", {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -246,9 +246,8 @@ function endNT(self, socket, callback) {
   // Node's _final half-closes the writable side (sends FIN) and leaves the
   // readable side open; the Duplex's allowHalfOpen drives the eventual destroy.
   // https://github.com/nodejs/node/blob/614050b657e9757c1097aa85f92f2cb51149dc0d/lib/net.js#L500
-  // A TLS wrap that adopted the fd since _final ran retired `socket`: its
-  // shutdown() is a no-op now, and the raw half on _handle shares the fd.
   const current = self._handle;
+  // A TLS wrap that adopted the fd since _final ran detached `socket`: the raw half on _handle has the fd now.
   (current?.[kAdoptedTLSRaw] ? current : socket).shutdown();
   callback();
 }

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -110,6 +110,12 @@ test.each([
   },
 );
 
+// server.close() leaves live connections open, and a failed assertion must not leave one behind.
+function closeAll(server: net.Server, sockets: net.Socket[]) {
+  for (const socket of sockets) socket.destroy();
+  server.close();
+}
+
 // The wrap takes the fd of the wrapped socket over one tick after the constructor, the same tick
 // the wrapped socket's end() shuts the fd down in. Node v26.3.0 reports the same client events.
 test.each<[string, (raw: net.Socket, tlsSocket: tls.TLSSocket) => void]>([
@@ -125,10 +131,12 @@ test.each<[string, (raw: net.Socket, tlsSocket: tls.TLSSocket) => void]>([
 ])(
   "the wrapped socket's %s in the tick of new tls.TLSSocket(socket, { isServer: true }) sends the FIN",
   async (_, endWrapped) => {
+    const sockets: net.Socket[] = [];
     const server = net.createServer(raw => {
       raw.on("error", () => {});
       const tlsSocket = new tls.TLSSocket(raw, { isServer: true, ...certs });
       tlsSocket.on("error", () => {});
+      sockets.push(raw, tlsSocket);
       endWrapped(raw, tlsSocket);
     });
     await once(server.listen(0, "127.0.0.1"), "listening");
@@ -138,6 +146,7 @@ test.each<[string, (raw: net.Socket, tlsSocket: tls.TLSSocket) => void]>([
         host: "127.0.0.1",
         rejectUnauthorized: false,
       });
+      sockets.push(client);
       const events: string[] = [];
       const { promise, resolve } = Promise.withResolvers<string[]>();
       // Reached only when the FIN never arrives: the handshake completes and the connection stays open.
@@ -150,7 +159,7 @@ test.each<[string, (raw: net.Socket, tlsSocket: tls.TLSSocket) => void]>([
       client.on("close", () => resolve(events));
       expect(await promise).toEqual(["end", "error ECONNRESET"]);
     } finally {
-      server.close();
+      closeAll(server, sockets);
     }
   },
 );
@@ -160,28 +169,28 @@ test.each<[string, (raw: net.Socket, tlsSocket: tls.TLSSocket) => void]>([
 test.each(["connected", "connecting"])(
   "end() on a %s socket before tls.connect({ socket }) in the same tick sends the FIN",
   async state => {
+    const sockets: net.Socket[] = [];
     const { promise, resolve } = Promise.withResolvers<string>();
-    const server = tls.createServer(certs, socket => {
-      // Reached only when the FIN never arrives.
+    // Reached only when the FIN never arrives.
+    const server = tls.createServer(certs, () => resolve("secureConnection"));
+    server.on("connection", socket => {
       socket.on("error", () => {});
-      socket.destroy();
-      resolve("secureConnection");
+      sockets.push(socket);
     });
     server.on("tlsClientError", err => resolve(`tlsClientError ${(err as NodeJS.ErrnoException).code}`));
     await once(server.listen(0, "127.0.0.1"), "listening");
     try {
       const raw = net.connect({ port: (server.address() as net.AddressInfo).port, host: "127.0.0.1" });
       raw.on("error", () => {});
+      sockets.push(raw);
       if (state === "connected") await once(raw, "connect");
       raw.end();
       const tlsSocket = tls.connect({ socket: raw, rejectUnauthorized: false });
       tlsSocket.on("error", () => {});
-      const closed = new Promise(resolve => tlsSocket.on("close", resolve));
+      sockets.push(tlsSocket);
       expect(await promise).toBe("tlsClientError ECONNRESET");
-      tlsSocket.destroy();
-      await closed;
     } finally {
-      server.close();
+      closeAll(server, sockets);
     }
   },
 );
@@ -193,10 +202,12 @@ test.skipIf(isWindows)(
   async () => {
     using dir = tempDir("net-reconnect", {});
     const path = join(String(dir), "s.sock");
+    const sockets: net.Socket[] = [];
     const { promise, resolve } = Promise.withResolvers<string>();
     let connections = 0;
     const server = net.createServer({ allowHalfOpen: true }, socket => {
       const id = ++connections;
+      sockets.push(socket);
       socket.on("error", () => {});
       socket.on("end", () => {
         if (id === 2) resolve("the new connection received a FIN");
@@ -207,14 +218,14 @@ test.skipIf(isWindows)(
     try {
       const client = net.connect(path);
       client.on("error", () => {});
+      sockets.push(client);
       await once(client, "connect");
       client.end();
       client.destroy();
       client.connect(path, () => resolve("connect"));
       expect(await promise).toBe("connect");
-      client.destroy();
     } finally {
-      server.close();
+      closeAll(server, sockets);
     }
   },
 );

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "bun:test";
 import { once } from "events";
-import { tls as certs } from "harness";
+import { tls as certs, isWindows, tempDir } from "harness";
 import net from "net";
+import { join } from "path";
 import tls from "tls";
 
 test("should be able to upgrade a paused socket and also have backpressure on it #15438", async () => {
@@ -103,6 +104,115 @@ test.each([
       expect(raw.readableLength).toBe(0);
       tlsSocket.destroy();
       await closed;
+    } finally {
+      server.close();
+    }
+  },
+);
+
+// The wrap takes the fd of the wrapped socket over one tick after the constructor, the same tick
+// the wrapped socket's end() shuts the fd down in. Node v26.3.0 reports the same client events.
+test.each<[string, (raw: net.Socket, tlsSocket: tls.TLSSocket) => void]>([
+  ["end()", raw => raw.end()],
+  ["destroySoon()", raw => raw.destroySoon()],
+  [
+    "end() before the TLSSocket's end()",
+    (raw, tlsSocket) => {
+      raw.end();
+      tlsSocket.end();
+    },
+  ],
+])(
+  "the wrapped socket's %s in the tick of new tls.TLSSocket(socket, { isServer: true }) sends the FIN",
+  async (_, endWrapped) => {
+    const server = net.createServer(raw => {
+      raw.on("error", () => {});
+      const tlsSocket = new tls.TLSSocket(raw, { isServer: true, ...certs });
+      tlsSocket.on("error", () => {});
+      endWrapped(raw, tlsSocket);
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const client = tls.connect({
+        port: (server.address() as net.AddressInfo).port,
+        host: "127.0.0.1",
+        rejectUnauthorized: false,
+      });
+      const events: string[] = [];
+      const { promise, resolve } = Promise.withResolvers<string[]>();
+      // Reached only when the FIN never arrives: the handshake completes and the connection stays open.
+      client.on("secureConnect", () => {
+        events.push("secureConnect");
+        client.destroy();
+      });
+      client.on("end", () => events.push("end"));
+      client.on("error", err => events.push(`error ${(err as NodeJS.ErrnoException).code}`));
+      client.on("close", () => resolve(events));
+      expect(await promise).toEqual(["end", "error ECONNRESET"]);
+    } finally {
+      server.close();
+    }
+  },
+);
+
+// tls.connect({ socket }) takes the fd over at once, or in the 'connect' listener it adds after the
+// one end() added. Either way the takeover lands between end() and the shutdown that end() deferred.
+test.each(["connected", "connecting"])(
+  "end() on a %s socket before tls.connect({ socket }) in the same tick sends the FIN",
+  async state => {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const server = tls.createServer(certs, socket => {
+      // Reached only when the FIN never arrives.
+      socket.on("error", () => {});
+      socket.destroy();
+      resolve("secureConnection");
+    });
+    server.on("tlsClientError", err => resolve(`tlsClientError ${(err as NodeJS.ErrnoException).code}`));
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const raw = net.connect({ port: (server.address() as net.AddressInfo).port, host: "127.0.0.1" });
+      raw.on("error", () => {});
+      if (state === "connected") await once(raw, "connect");
+      raw.end();
+      const tlsSocket = tls.connect({ socket: raw, rejectUnauthorized: false });
+      tlsSocket.on("error", () => {});
+      const closed = new Promise(resolve => tlsSocket.on("close", resolve));
+      expect(await promise).toBe("tlsClientError ECONNRESET");
+      tlsSocket.destroy();
+      await closed;
+    } finally {
+      server.close();
+    }
+  },
+);
+
+// Only a TLS wrap moves the deferred shutdown to the handle that replaced the one end() saw.
+// connect(path) also installs a new handle at once, for a connection that end() did not close.
+test.skipIf(isWindows)(
+  "end(), destroy() and connect(path) in one tick do not half-close the new connection",
+  async () => {
+    using dir = tempDir("net-reconnect", {});
+    const path = join(String(dir), "s.sock");
+    const { promise, resolve } = Promise.withResolvers<string>();
+    let connections = 0;
+    const server = net.createServer({ allowHalfOpen: true }, socket => {
+      const id = ++connections;
+      socket.on("error", () => {});
+      socket.on("end", () => {
+        if (id === 2) resolve("the new connection received a FIN");
+      });
+      socket.resume();
+    });
+    await once(server.listen(path), "listening");
+    try {
+      const client = net.connect(path);
+      client.on("error", () => {});
+      await once(client, "connect");
+      client.end();
+      client.destroy();
+      client.connect(path, () => resolve("connect"));
+      expect(await promise).toBe("connect");
+      client.destroy();
     } finally {
       server.close();
     }


### PR DESCRIPTION
### Problem
- `new tls.TLSSocket(socket, { isServer: true })` then `socket.end()` in the same tick emits `'finish'` on `socket` and sends no FIN. The handshake completes and the connection stays open. Node v26.3.0 sends the FIN: the client reports `'end'` and `ECONNRESET`.
- `socket.end()` right before `tls.connect({ socket })` does the same.
- Cause: `Socket.prototype._final` (`src/js/node/net.ts:2283`) captures `this._handle` and defers `shutdown()` one tick. The TLS wrap adopts the fd in that window (`net.ts:2449`, `2058`, `2107`) and detaches the captured handle, so `shutdown()` does nothing.

### Fix
- `endNT` reads `self._handle` when it runs. If that is the raw half of an adopted TLS pair (`kAdoptedTLSRaw`), it shuts that handle down.
- Every other case keeps the captured handle, as before. A new test pins one: `end(); destroy(); connect(path)` in one tick.
- The FIN still follows what the adoption wrote. Node sends it first. See the notes.
- Verified: `test/js/node/tls/node-tls-upgrade.test.ts` (6 new tests, 5 fail on main, node v26.3.0 agrees). Also `test/js/node/{tls,net,http2}/`, `test/js/bun/net/`, vendored `test-{tls,net,https,http2}-*.js`.

### Background
- `_final` is the shutdown hook of a stream's writable side. `'finish'` follows its callback.
- A TLS wrap over a `net.Socket` adopts its fd into a native TLS socket (`upgradeTLS`). That returns two handles on one fd: a TLS half, and a raw half that writes without TLS and replaces `socket._handle`. The old TCP handle is detached: every call on it is a no-op.
- The server wrap adopts one tick after the constructor, so bytes already read reach the TLS engine. `tls.connect({ socket })` adopts at once, or in a `'connect'` listener.

<details><summary>Notes</summary>

No user reported this. It came from a comparison of bun with node v26.3.0 on TLS wrap shapes. `bun 1.4.3-canary.1` behaves like main.

Repro for the server shape (needs a self-signed `key.pem` and `cert.pem`):

```js
const net = require("net"), tls = require("tls"), fs = require("fs");
const key = fs.readFileSync("key.pem"), cert = fs.readFileSync("cert.pem"), ev = [];
const srv = net.createServer(raw => {
  const s = new tls.TLSSocket(raw, { isServer: true, key, cert });
  for (const e of ["secure", "end", "finish"]) s.on(e, () => ev.push("tls " + e));
  s.on("close", h => ev.push("tls close hadError=" + h));
  s.on("error", e => ev.push("tls error " + e.code));
  for (const e of ["end", "finish", "close"]) raw.on(e, () => ev.push("raw " + e));
  raw.end(); // same tick as the wrap
});
srv.listen(0, "127.0.0.1", () => {
  const c = tls.connect({ port: srv.address().port, host: "127.0.0.1", rejectUnauthorized: false });
  c.on("error", e => ev.push("C error " + e.code));
  c.resume();
  c.on("secureConnect", () => ev.push("C secureConnect"));
  c.on("end", () => ev.push("C end"));
  setTimeout(() => { console.log(ev.join(" | ")); process.exit(0); }, 900);
});
```

| runtime | output |
| --- | --- |
| node v26.3.0 | `raw finish \| C end \| C error ECONNRESET \| tls end \| tls finish \| raw close \| tls close hadError=false` |
| main (`4b5862fd88`) | `raw finish \| C secureConnect \| tls secure`, then nothing, the connection stays open |
| this branch | `raw finish \| C end \| C error ECONNRESET \| raw end \| raw close \| tls close hadError=false` |

The client side now matches node. The server side after the FIN (`raw end`, no `tls end` or `tls finish`) is what main already does for `raw.end()` one tick or more after the wrap. It is the same code path from that point on, and this change does not touch it.

The client shape, with a `tls.createServer` peer: `raw.end(); tls.connect({ socket: raw })`.

| runtime | peer reports |
| --- | --- |
| node v26.3.0 | `tlsClientError ECONNRESET` |
| main | `secureConnection`, the FIN never arrives |
| this branch | `tlsClientError ECONNRESET` |

How wide the window is. For the server shape and for a connected client socket it is one tick. For a client socket that is still connecting it lasts until the connect: `raw.end()`, and `tls.connect({ socket: raw })` any time before `'connect'`. `_final` parks on `'connect'` first, so its listener runs before the one the wrap adds.

Why the order of the two ticks gives this result. The `TLSSocket` constructor queues the adoption with `process.nextTick`. `socket.end()` with nothing buffered calls `_final` at once, which queues `endNT` behind it. The adoption runs first. `hasUnflushedWrites(connection)` is false, because an `end()` with no data leaves `writableLength === 0`. So `handle.upgradeTLS()` runs, sets the old handle to detached (`socket_body.rs`, `this.socket.set(DETACHED)`), and `connection._handle = raw`. Then `endNT` calls `shutdown()` on the detached handle.

The same change also fixes `socket.destroySoon()` and `socket.end(); tlsSocket.end()` in the wrap tick. Both left the connection open on main. Both are test cases now.

Why the check on `kAdoptedTLSRaw`. A first version shut down whatever `self._handle` was at the tick. `connect(path)` installs its new handle at once, so `end(); destroy(); connect(path)` in one tick sent the FIN of the old connection on the new one, and the connect callback never ran. Node, main and this branch all run the callback. The last new test covers that. A TCP `connect(port)` installs its handle later and was not affected.

What stays different from node:
- Node calls `shutdown()` inside `_final`, so its FIN always precedes what the TLS layer writes. Here the FIN follows what the adoption wrote. On the client shape the ClientHello goes out before the FIN. The client then reports `'secureConnect'` and `'end'`, where node reports `'end'` and `ECONNRESET`. The peer reports `tlsClientError ECONNRESET` in both.
- On the server shape the same applies only when the ClientHello is already in the wrapped socket's read buffer at the wrap, for example a STARTTLS client that pipelines it, or a server that reads the first bytes before it wraps. Then the handshake completes, `'secure'` fires, and both sides see `'end'` after it. Node resets the client without a handshake. On main that connection stays open.
- To send the FIN first, the adoption would have to take a fd whose write side is already shut down. That path is broken today, see the next paragraph.
- `shutdown()` on the raw half goes through the TLS shutdown path of the shared socket. During the handshake that is a plain FIN. After the handshake it also sends close_notify. Main already does that for `raw.end()` one tick after the wrap.

Not part of this change, seen on main while testing: `raw.end()` before `new tls.TLSSocket(raw, { isServer: true })` in the same tick adopts a fd whose write side is shut down. `us_socket_adopt` returns early for a shut-down socket and leaves `kind` as TCP, and `us_socket_adopt_tls` attaches the SSL anyway. A debug build then fails `debug_assert!(s_ref.kind() == SocketKind::BunSocketTls)` in `us_dispatch_ssl_raw_tap`. A release build reports `ECONNRESET` on the TLS socket and never closes the wrapped socket.

Related open PRs, none of which touches `endNT`: #42339 and #42367 fix `end()` on the TLS socket before its handle attaches. #42330 covers a client-side wrap without `isServer`. All three merge clean with this branch.

Self-review: the one concern that needed a code change was the `kAdoptedTLSRaw` check above. It also asked for the extra test cases and for the open description of what stays different from node.

Suites run with the debug build: all of `test/js/node/tls/`, `test/js/node/net/`, `test/js/node/http2/`, `test/js/bun/net/`. The 663 vendored `parallel/` and `sequential/` `test-{tls,net,https,http2}-*.js` scripts ran on the first version of the fix, and the 91 of them that wrap a socket ran again on the final one. Failures, none from this change:
- `node-tls-server.test.ts` "SNICallback runs even when the requested servername matches the bind hostname", and 8 `net.Socket read` tests in `node-net.test.ts`: `ECONNREFUSED 127.0.0.1`, `localhost` resolves to `::1` only in this container.
- `node-net.test.ts` "unref should exit" and "#13126", `socket.test.ts` "should not call drain before handshake": need public DNS.
- Timeouts on a loaded machine (load average above 200), the same on a debug build of main: `node-tls-root-certs-concurrent-init.test.ts`, `node-http2-streams-rehash.test.ts` "hashmap rehash", `node-net.test.ts` "should not leak when connect({path}) fails synchronously on a reused handle".
- Vendored `test-https-timeout.js` times out on the debug build, also with main's `src/`. It passes on the release binary. `test-tls-client-allow-partial-trust-chain.js` is a `node:test` file and passes under `bun test`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/tls/node-tls-upgrade.test.ts

<!-- robobun:evidence:end -->