### PR TITLE
js_printer: inline a cross-module enum member only where the parser counted a read

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -317,7 +317,9 @@ pub struct Dot {
     /// `target` is an `EImportIdentifier` and this read was counted in
     /// `Part::import_symbol_property_uses` instead of as a use of the import,
     /// so the linker may bind it straight to the export it names
-    /// (`LinkerGraph::import_member_bindings`).
+    /// (`LinkerGraph::import_member_bindings`). The printer replaces only such
+    /// a node, with that export or with an inlined enum member's value. A
+    /// write or `delete` target is never counted, so it prints as written.
     pub is_import_property_use: bool,
 }
 impl Default for Dot {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1003,15 +1003,24 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // A folded `"a" + "b"` is a rope whose `data` is only "a".
                         s.resolve_rope_if_needed(p.arena);
 
+                        let opts = IdentifierOpts::default()
+                            .with_is_call_target(is_call_target)
+                            .with_is_template_tag(is_template_tag)
+                            .with_is_delete_target(is_delete_target)
+                            .with_assign_target(in_.assign_target);
+
                         // "a['b' + '']" => "a.b"
                         // "enum A { B = 'b' }; a[A.B]" => "a.b"
                         if p.options.features.minify_syntax && s.is_identifier(p.arena) {
+                            let is_import_property_use = e_.optional_chain.is_none()
+                                && p.record_import_property_use(&e_.target, s.data.slice(), opts);
                             let dot = p.new_expr(
                                 E::Dot {
                                     name: s.data,
                                     name_loc: unwrapped.loc,
                                     target: e_.target,
                                     optional_chain: e_.optional_chain,
+                                    is_import_property_use,
                                     ..Default::default()
                                 },
                                 expr.loc,
@@ -1034,11 +1043,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // Reminder that this can only be done after
                         // `target` is visited.
                         if e_.optional_chain.is_none() {
-                            let opts = IdentifierOpts::default()
-                                .with_is_call_target(is_call_target)
-                                .with_is_template_tag(is_template_tag)
-                                .with_is_delete_target(is_delete_target)
-                                .with_assign_target(in_.assign_target);
                             if let Some(rewrite) = p.maybe_rewrite_property_access(
                                 expr.loc,
                                 e_.target,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3667,18 +3667,20 @@ pub(crate) mod __gated_printer {
                     if e.optional_chain.is_none() {
                         flags.insert(ExprFlag::HasNonOptionalChainParent);
 
-                        // Inline cross-module TypeScript enum references here
-                        if let Some(inlined) =
-                            self.try_to_get_imported_enum_value(e.target, &e.name)
-                        {
-                            self.print_inlined_enum(inlined, &e.name, level);
-                            return;
-                        }
-                        if e.is_import_property_use
-                            && let Some(binding) = self.import_member_binding(e.target, &e.name)
-                        {
-                            self.print_expr(binding, level, flags);
-                            return;
+                        // A write or `delete` of `X.name` is not marked, so it
+                        // keeps the property access.
+                        if e.is_import_property_use {
+                            // Inline cross-module TypeScript enum references here
+                            if let Some(inlined) =
+                                self.try_to_get_imported_enum_value(e.target, &e.name)
+                            {
+                                self.print_inlined_enum(inlined, &e.name, level);
+                                return;
+                            }
+                            if let Some(binding) = self.import_member_binding(e.target, &e.name) {
+                                self.print_expr(binding, level, flags);
+                                return;
+                            }
                         }
                     } else {
                         if flags.contains(ExprFlag::HasNonOptionalChainParent) {
@@ -3723,26 +3725,23 @@ pub(crate) mod __gated_printer {
                     if e.optional_chain.is_none() {
                         flags.insert(ExprFlag::HasNonOptionalChainParent);
 
-                        if let Some(str) = e.index.data.as_e_string() {
-                            let str = str.flattened(self.bump);
-                            if str.is_utf8() {
-                                if let Some(value) =
-                                    self.try_to_get_imported_enum_value(e.target, str.slice8())
-                                {
-                                    self.print_inlined_enum(value, str.slice8(), level);
-                                    return;
-                                }
-                            }
-                        }
                         if e.is_import_property_use
                             && let Some(str) = e.index.unwrap_inlined().data.as_e_string()
                             && let str = str.flattened(self.bump)
                             && str.is_utf8()
-                            && let Some(binding) =
-                                self.import_member_binding(e.target, str.slice8())
                         {
-                            self.print_expr(binding, level, flags);
-                            return;
+                            if let Some(value) =
+                                self.try_to_get_imported_enum_value(e.target, str.slice8())
+                            {
+                                self.print_inlined_enum(value, str.slice8(), level);
+                                return;
+                            }
+                            if let Some(binding) =
+                                self.import_member_binding(e.target, str.slice8())
+                            {
+                                self.print_expr(binding, level, flags);
+                                return;
+                            }
                         }
                     } else {
                         if flags.contains(ExprFlag::HasNonOptionalChainParent) {

--- a/test/bundler/bundler_dynamic_import_dce.test.ts
+++ b/test/bundler/bundler_dynamic_import_dce.test.ts
@@ -4117,6 +4117,66 @@ describe("bundler", () => {
     stdout: "1 2",
   });
 
+  // Only a read of an enum member prints as its value. A write or a `delete`
+  // keeps the property access: `1 = 10` is a SyntaxError.
+  itElides("EnumMemberWriteTargets", {
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const { E } = await import("./x.ts");
+          const { E: fromRequire } = require("./x.ts");
+          const ns = await import("./x.ts");
+          E.A = 10;
+          fromRequire.B++;
+          ns.E.C += 5;
+          [E.D] = [40];
+          ({ v: fromRequire.F } = { v: 50 });
+          for (ns.E.G of [60]);
+          for (E["H"] in { key: 0 });
+          delete fromRequire.I;
+          await import("./x.ts").then(({ E: fromThen }) => {
+            fromThen.J ||= 0;
+            fromThen.J &&= 90;
+          });
+          [E.K = 11, ...fromRequire.L] = [, 1, 2];
+          ({ v: [ns.E.M] } = { v: [13] });
+          // Not an identifier, so it stays an index when minified too.
+          fromRequire["n-o"] = 14;
+          delete E["p-q"];
+          const read = key => E[key];
+          console.log(...["A", "B", "C", "D", "F", "G", "H", "I", "J", "K", "L", "M", "n-o", "p-q"].map(read));
+        }
+        main();
+      `,
+      "/x.ts": `export enum E { A = 1, B, C, D, F, G, H, I, J, K, L, M, "n-o", "p-q" } export const d = "DROPPED";`,
+    },
+    stdout: "10 3 8 40 50 60 key undefined 90 11 [ 1, 2 ] 13 14 undefined",
+    output(out) {
+      expect(out).toContain("E.A = 10;");
+      expect(out).toContain("delete E.I;");
+      expect(out).toContain('E["n-o"] = 14;');
+    },
+  });
+
+  // The parser reads the key of `E[Key.first]` through the inlined `Key.first`
+  // and drops `E`, so the printer has to read it the same way. `F`'s key is
+  // not an identifier, so it stays an index when minified too.
+  itElides("EnumIndexedByInlinedEnum", {
+    files: {
+      "/entry.ts": /* ts */ `
+        enum Key { first = "A", second = "B", third = "c-d" }
+        async function main() {
+          const { E, F } = await import("./x.ts");
+          const { E: fromRequire } = require("./x.ts");
+          console.log(E[Key.first], fromRequire[Key.second], F[Key.third]);
+        }
+        main();
+      `,
+      "/x.ts": `export enum E { A = 1, B = "two" } export enum F { "c-d" = 3 } export const d = "DROPPED";`,
+    },
+    stdout: "1 two 3",
+  });
+
   // An importer of the file that destructured the name must not bind
   // through it: that would load the split chunk eagerly.
   itBundled("dynamic_import_dce/ReexportedDestructuredNameStaysLazy", {

--- a/test/bundler/esbuild/ts.test.ts
+++ b/test/bundler/esbuild/ts.test.ts
@@ -2174,6 +2174,107 @@ describe("bundler", () => {
     minifySyntax: false, // intentionally disabled. enum inlining always happens
     dce: true,
   });
+  // Only a read is inlined. A write or a `delete` keeps the property access:
+  // `1 = 10` is a SyntaxError.
+  itBundled("ts/EnumCrossModuleInliningWriteTargets", {
+    files: {
+      "/entry.js": /* js */ `
+        import { E } from './enums'
+        import * as ns from './enums'
+        console.log(E.A, ns.E['B']);
+        E.A = 10;
+        E.B++;
+        ns.E.C += 5;
+        [E.D] = [40];
+        ({ v: E.F } = { v: 50 });
+        for (ns.E.G of [60]);
+        for (E['H'] in { key: 0 });
+        delete E.I;
+        E.J ||= 0;
+        E.J &&= 90;
+        [E.K = 11, ...E.L] = [, 1, 2];
+        ({ v: [E.M] } = { v: [13] });
+        // "delete NaN" is a SyntaxError in strict mode.
+        delete E.N;
+        E['P'] = 70;
+        delete ns.E['Q'];
+        E['r-s']++;
+        const read = key => E[key];
+        console.log(...['A', 'B', 'C', 'D', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'r-s'].map(read));
+      `,
+      "/enums.ts": /* ts */ `
+        export enum E { A = 1, B, C, D, F, G, H, I, J, K, L, M, N = 0 / 0, P = 5, Q, 'r-s' }
+      `,
+    },
+    minifySyntax: false, // intentionally disabled. enum inlining always happens
+    run: { stdout: "1 2\n10 3 8 40 50 60 key undefined 90 11 [ 1, 2 ] 13 undefined 70 undefined 8" },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("console.log(1 /* A */, 2 /* B */);");
+      api.expectFile("/out.js").toContain("E.A = 10;");
+      api.expectFile("/out.js").toContain("delete E.I;");
+      api.expectFile("/out.js").toContain('E["P"] = 70;');
+    },
+  });
+  // The parser reads the key of "E[Key.first]" through the inlined "Key.first"
+  // and drops "E", so the printer has to read it the same way.
+  itBundled("ts/EnumCrossModuleInliningIndexedByInlinedEnum", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { E_DROP } from './enums'
+        enum Key { first = 'A', second = 'B' }
+        console.log(E_DROP[Key.first], E_DROP[Key.second])
+      `,
+      "/enums.ts": /* ts */ `
+        export enum E_DROP { A = 1, B = 'two' }
+      `,
+    },
+    minifySyntax: false, // intentionally disabled. enum inlining always happens
+    dce: true,
+    run: { stdout: "1 two" },
+  });
+  // With minifySyntax the parser turns "E[key]" into "E.A" once the key folds to
+  // a string, after it visited "E". That node is still a counted read.
+  itBundled("ts/EnumCrossModuleInliningFoldedIndexMinify", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { E_DROP } from './enums'
+        enum Key { first = 'A' }
+        function viaConst() {
+          const second = 'B'
+          return E_DROP[second]
+        }
+        console.log(E_DROP[Key.first], E_DROP['A' + ''], viaConst())
+      `,
+      "/enums.ts": /* ts */ `
+        export enum E_DROP { A = 1, B = 'two' }
+      `,
+    },
+    minifySyntax: true,
+    dce: true,
+    run: { stdout: "1 1 two" },
+  });
+  // "logger.ts" runs before "levels.ts" has created the enum object, so the
+  // read only works inlined.
+  itBundled("ts/EnumCrossModuleInliningFoldedIndexInCycle", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { LogLevel } from './levels'
+        import { level } from './logger'
+        console.log(level, Object.keys(LogLevel).length)
+      `,
+      "/levels.ts": /* ts */ `
+        import './logger'
+        export enum LogLevel { production = 'warn', development = 'debug' }
+      `,
+      "/logger.ts": /* ts */ `
+        import { LogLevel } from './levels'
+        export const level = LogLevel[process.env.NODE_ENV]
+      `,
+    },
+    minifySyntax: true,
+    define: { "process.env.NODE_ENV": '"production"' },
+    run: { stdout: "warn 2" },
+  });
   itBundled("ts/EnumCrossModuleInliningDefinitions", {
     files: {
       "/entry.ts": /* ts */ `


### PR DESCRIPTION
### Problem
- `E[Key.first]` (`E`: enum from another file, `Key`: string enum in this file) bundles to `E["A"]` after the linker removed `E`: `ReferenceError: E is not defined`. `tsc` accepts this input.
- `E.A = 5` bundles to `1 /* A */ = 5`: `SyntaxError: Left side of assignment is not a reference`. So do `E.B++`, `[E.B] = [7]`, `delete E.N`. This needs JS or `as any`. #41186 added the `require()` / `import()` forms.
- No user reported either. Both date to #12144 (v1.1.18). Cause: `print_expr` (`src/js_printer/lib.rs`) picks the `X.name` nodes to inline on its own. The parser picks first (`record_import_property_use`, `src/js_parser/p.rs`). It unwraps an inlined key and, since #41009, skips write and `delete` targets.

### Fix
- The printer inlines only a node the parser marked `is_import_property_use`, and it unwraps the key the same way. A write or `delete` target has no mark and prints as written. The parser counted it as a use of `E`, so the enum object stays.
- With `--minify-syntax` the parser folds `E[key]` into `E.A` after the visit (`visit_expr.rs`). That node now gets the mark, so the read stays inlined.
- Trade: React Compiler output is built after the visit and has no mark. It prints `Status.Busy`, not `1`. It kept the enum object before too.
- Verified: `test/bundler/esbuild/ts.test.ts` (4 new cases), `test/bundler/bundler_dynamic_import_dce.test.ts` (2 new cases). 1.4.3-canary.1 fails 5 of 6. Other suites: see Notes.

### Background
- Enum values from another file are inlined at print time from the linker's `ts_enums` table. `E.A` prints as `1 /* A */`.
- `record_import_property_use` counts a read of `X.name` as a use of the property, not of `X`. The linker drops `X` when every counted read is a known member.
- `is_import_property_use` (on `E::Dot` / `E::Index`) records that count. `import_member_binding` already needs it.

<details><summary>Notes</summary>

- A read after a write still prints the value, as it does for an enum in the same file.
- Self-reviewed. Changes made after it: this body, the `is_import_property_use` doc comment, the `--minify-syntax` mark (the review found the import-cycle case below), and `EIndex` targets plus non-identifier keys in the tests, so the minified variants fail before the fix too.
- The fourth new case in `ts.test.ts` (`EnumCrossModuleInliningFoldedIndexInCycle`) passes on 1.4.3-canary.1. It guards the `--minify-syntax` path: `LogLevel[process.env.NODE_ENV]` in a file that runs before the enum's file. With only the printer change that bundle threw `TypeError: undefined is not an object (evaluating 'e.production')`.
- The mark on the folded node uses `record_import_property_use` only. It does not run `maybe_rewrite_property_access` there, so `ns["a" + ""]` on an `import * as ns` prints as before.
- The other two printer flaws from the same report have open PRs. I applied their printer hunks on 158ff6cdef and ran the static, `require()`, `await import()` and `.then()` forms. #36133 fixes `-1 /* A */ ** 2` in all 10 forms. The `EImportIdentifier` arm in #36124 fixes `void 0 ** 2` in all 8 forms. This PR does not touch those lines.
- #36744 wraps `delete NaN` as `delete (0, NaN)`. It predates #41009. With this change `delete E.N` prints as written, so that wrap is not needed.
- esbuild 0.21.5 prints the same `1 /* A */ = 5`. For `E[Key.first]` it keeps `E` and prints `E["A" /* first */]`, which runs.
- The runtime transpiler output does not change (`record_import_property_use` returns false without `bundle`, and `ts_enums` is only set by the linker), so the transpiler cache version stays.
- Suites run with the fix (0 failures): `esbuild/ts`, `esbuild/importstar`, `esbuild/dce`, `esbuild/default`, `esbuild/splitting`, `esbuild/lower`, `bundler_dynamic_import_dce` (282), `bundler_minify`, `bundler_edgecase`, `bundler_regressions`, `bundler_cjs`, `bundler_cjs2esm`, `bundler_barrel`, `bundler_splitting`, `bundler_promiseall_deadcode`, `bundler_jsx`, `transpiler/react-compiler`, `transpiler/transpiler.test.js`.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 failed, 16 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_dynamic_import_dce.test.ts test/bundler/esbuild/ts.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [1032.38ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [515.19ms]
(pass) bundler > dynamic_import_dce/AwaitDot [445.09ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [444.50ms]
(pass) bundler > dynamic_import_dce/LetBinding [433.63ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [431.10ms]
(pass) bundler > dynamic_import_dce/BailoutRest [497.31ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [533.98ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [457.53ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [466.12ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [956.95ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [491.20ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [431.22ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure 
... (truncated)

release without fix: 11 failed, 16 skipped
bun test v1.4.3-canary.1 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [30.41ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [18.93ms]
(pass) bundler > dynamic_import_dce/AwaitDot [20.70ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [27.55ms]
(pass) bundler > dynamic_import_dce/LetBinding [19.32ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [21.84ms]
(pass) bundler > dynamic_import_dce/BailoutRest [22.27ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [19.84ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [26.41ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [21.45ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [71.49ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [20.35ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [52.79ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [41.41ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllDestructure [21.26ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllThenDestructure [23.75ms]
(pass) bundler > dynamic_import_dce/SplittingProm
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 16 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_dynamic_import_dce.test.ts test/bundler/esbuild/ts.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [1067.33ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [617.03ms]
(pass) bundler > dynamic_import_dce/AwaitDot [559.07ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [528.97ms]
(pass) bundler > dynamic_import_dce/LetBinding [515.53ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [523.99ms]
(pass) bundler > dynamic_import_dce/BailoutRest [675.38ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [553.55ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [481.31ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [575.34ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [954.29ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [703.11ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [529.74ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure 
... (truncated)

release with fix: 16 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e7b7769098
  features     baseline

23 deps, 131 codegen, 1172 objects in 872ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (4ff919377)

Checked 22 installs across 61 packages (no changes) [29.00ms]
[2/1244] gen bindgenv2
[3/1244] gen ErrorCode+*.h
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (4ff919377)

Checked 1 install across 2 packages (no changes) [11.00ms]
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (4ff919377)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[7/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 KB  (entry point)

[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConst
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/e.rs                                    |   4 +-
 src/js_parser/visit/visit_expr.rs               |  14 ++--
 src/js_printer/lib.rs                           |  53 ++++++-------
 test/bundler/bundler_dynamic_import_dce.test.ts |  60 ++++++++++++++
 test/bundler/esbuild/ts.test.ts                 | 101 ++++++++++++++++++++++++
 5 files changed, 199 insertions(+), 33 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/ast/e.rs                                         1      1     25
src/js_parser/visit/visit_expr.rs                    1      2     25
src/js_printer/lib.rs                                7      2     25
test/bundler/bundler_dynamic_import_dce.test.ts      3      2     17
test/bundler/esbuild/ts.test.ts                      3      5     19
```

</details>

<!-- robobun:evidence:end -->