### PR TITLE
bundler: keep a chunk out of a fold when it can be evaluating while an entry of its class loads

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -401,6 +401,47 @@ impl<'a> LinkerContext<'a> {
         Some(other)
     }
 
+    /// Calls `each` with every other file that loading `source_index` loads first:
+    /// what the import records of its live parts load
+    /// (`file_loaded_by_import`) and the files declaring the bindings those
+    /// parts use. A CSS or HTML file has no parts; every record counts.
+    pub(crate) fn for_each_file_loaded_by(&self, source_index: u32, mut each: impl FnMut(u32)) {
+        let records = &self.graph.ast.items_import_records()[source_index as usize];
+        if self.graph.ast.items_css()[source_index as usize].is_some()
+            || self.parse_graph().input_files.items_loader()[source_index as usize] == Loader::Html
+        {
+            for record in records.iter() {
+                if record.source_index.is_valid() && record.source_index.get() != source_index {
+                    each(record.source_index.get());
+                }
+            }
+            return;
+        }
+        let parts_live = &self.graph.parts_live[source_index as usize];
+        for (part_index, part) in self.graph.ast.items_parts()[source_index as usize]
+            .as_slice()
+            .iter()
+            .enumerate()
+        {
+            if !parts_live.is_set(part_index) {
+                continue;
+            }
+            for &record_index in part.import_record_indices.iter() {
+                if let Some(other) =
+                    self.file_loaded_by_import(&records[record_index as usize], source_index)
+                    && other != source_index
+                {
+                    each(other);
+                }
+            }
+            for dependency in part.dependencies.iter() {
+                if dependency.source_index.get() != source_index {
+                    each(dependency.source_index.get());
+                }
+            }
+        }
+    }
+
     /// `"sideEffects": false` (or the resolver's equivalent), unless
     /// `--ignore-dce-annotations` says not to trust it.
     pub(crate) fn file_has_no_side_effects(&self, source_index: u32) -> bool {
@@ -962,7 +1003,6 @@ impl<'a> LinkerContext<'a> {
         let entry_points: *const [crate::IndexInt] = self.graph.entry_points.items_source_index();
         let distances: *mut [u32] = self.graph.files.items_distance_from_entry_point_mut();
         let file_entry_bits: *mut [AutoBitSet] = self.graph.files.items_entry_bits_mut();
-        let loaders: *const [Loader] = self.parse_graph().input_files.items_loader();
 
         // SAFETY: see block comment above — disjoint SoA columns, stable slabs
         // (no reallocation during tree-shaking). All column derefs share that
@@ -978,7 +1018,6 @@ impl<'a> LinkerContext<'a> {
             parts_live,
             distances,
             file_entry_bits,
-            loaders,
         ) = unsafe {
             (
                 &*entry_points,
@@ -989,7 +1028,6 @@ impl<'a> LinkerContext<'a> {
                 &mut *parts_live,
                 &mut *distances,
                 &mut *file_entry_bits,
-                &*loaders,
             )
         };
         let entry_points_len = entry_points.len();
@@ -1040,11 +1078,7 @@ impl<'a> LinkerContext<'a> {
 
             let mut ctx = CodeSplitCtx {
                 distances,
-                parts,
-                import_records,
                 file_entry_bits,
-                css_reprs,
-                loaders,
                 queue: std::collections::VecDeque::new(),
             };
 
@@ -2818,20 +2852,16 @@ pub enum TreeShakeWork {
     },
 }
 
-pub(crate) struct CodeSplitCtx<'a, 'r> {
+pub(crate) struct CodeSplitCtx<'r> {
     pub(crate) distances: &'r mut [u32],
-    pub(crate) parts: &'r [bun_ast::PartList<'a>],
-    pub(crate) import_records: &'r [bun_ast::import_record::List<'a>],
     pub(crate) file_entry_bits: &'r mut [AutoBitSet],
-    pub(crate) css_reprs: &'r [crate::bundled_ast::CssCol],
-    pub(crate) loaders: &'r [Loader],
     pub(crate) queue: std::collections::VecDeque<(crate::IndexInt, u32)>,
 }
 
 impl<'a> LinkerContext<'a> {
     pub(crate) fn mark_file_reachable_for_code_splitting(
         &mut self,
-        ctx: &mut CodeSplitCtx<'a, '_>,
+        ctx: &mut CodeSplitCtx<'_>,
         source_index: crate::IndexInt,
         entry_points_count: usize,
         distance: u32,
@@ -2866,55 +2896,12 @@ impl<'a> LinkerContext<'a> {
                 ctx.distances[source_index as usize] = distance;
             }
             let out_dist = distance + 1;
-
-            let records = &ctx.import_records[source_index as usize];
-
-            // CSS and HTML files have no parts: follow every import record.
-            if ctx.css_reprs[source_index as usize].is_some()
-                || ctx.loaders[source_index as usize] == Loader::Html
-            {
-                for record in records.iter() {
-                    if record.source_index.is_valid()
-                        && !ctx.file_entry_bits[record.source_index.get() as usize]
-                            .is_set(entry_points_count)
-                    {
-                        ctx.queue.push_back((record.source_index.get(), out_dist));
-                    }
+            let (file_entry_bits, queue) = (&ctx.file_entry_bits, &mut ctx.queue);
+            self.for_each_file_loaded_by(source_index, |other| {
+                if !file_entry_bits[other as usize].is_set(entry_points_count) {
+                    queue.push_back((other, out_dist));
                 }
-                continue;
-            }
-
-            // A dead part prints nothing, so only live parts reach other files.
-            let parts_live = &self.graph.parts_live[source_index as usize];
-            for (part_index, part) in ctx.parts[source_index as usize]
-                .as_slice()
-                .iter()
-                .enumerate()
-            {
-                if !parts_live.is_set(part_index) {
-                    continue;
-                }
-
-                for &import_index in part.import_record_indices.iter() {
-                    let Some(other) =
-                        self.file_loaded_by_import(&records[import_index as usize], source_index)
-                    else {
-                        continue;
-                    };
-                    if !ctx.file_entry_bits[other as usize].is_set(entry_points_count) {
-                        ctx.queue.push_back((other, out_dist));
-                    }
-                }
-
-                for dependency in part.dependencies.iter() {
-                    let dep = dependency.source_index.get();
-                    if dep != source_index
-                        && !ctx.file_entry_bits[dep as usize].is_set(entry_points_count)
-                    {
-                        ctx.queue.push_back((dep, out_dist));
-                    }
-                }
-            }
+            });
         }
     }
 

--- a/src/bundler/linker_context/README.md
+++ b/src/bundler/linker_context/README.md
@@ -741,6 +741,7 @@ The renamed symbols are then used during final code generation to produce output
 - Computes, per `import()` entry point, which other entry points are guaranteed to be loaded already whenever it loads
 - Reduces each chunk key (`File.entry_bits`) to its load-condition class by dropping such redundant dynamic entries
 - Rewrites the entry bits of files to those of the class's parent chunk (the chunk keyed by the reduced set, else the largest member) before `computeChunks()` groups files
+- Keeps a chunk out of the fold when it can be in the middle of being evaluated while an entry of its class loads (it, or a file that statically imports its way to it, `require()`s a split ES module): the entry's chunk reads the other members then
 - With `--min-chunk-size`, additionally folds small chunks with no top-level side effects into a chunk loaded by a superset of their entries when every dependency is already loaded wherever the target is, no static import cycle between chunks results, and every CommonJS/ESM wrapper the moved code initializes at the top level is already initialized by a chunk the target imports
 
 #### `computeCrossChunkDependencies.rs`

--- a/src/bundler/linker_context/mergeSmallChunks.rs
+++ b/src/bundler/linker_context/mergeSmallChunks.rs
@@ -167,6 +167,8 @@ struct Group {
     wants_inits: bool,
     /// Neither merged nor merged into.
     pinned: bool,
+    /// See `entries_loaded_mid_evaluation`.
+    loads_mid_evaluation: Option<AutoBitSet>,
     /// Every live part of every file is side-effect free.
     pure: bool,
     /// Groups holding files that this group's live parts statically import
@@ -190,6 +192,12 @@ struct Group {
 }
 
 impl Group {
+    fn loads_entry_of(&self, entries: &AutoBitSet) -> bool {
+        self.loads_mid_evaluation
+            .as_ref()
+            .is_some_and(|loads| loads.has_intersection(entries))
+    }
+
     fn new(
         target: Target,
         bits: &AutoBitSet,
@@ -207,6 +215,7 @@ impl Group {
             recheck: false,
             wants_inits: false,
             pinned,
+            loads_mid_evaluation: None,
             pure: true,
             deps: Vec::new(),
             importers: Vec::new(),
@@ -253,6 +262,16 @@ fn fold(groups: &mut [Group], from: usize, into: usize) {
     }
     merge_sorted(&mut target.needs_init, &source.needs_init);
     merge_sorted(&mut target.provides_init, &source.provides_init);
+    if let Some(loads) = source.loads_mid_evaluation.take() {
+        union_into(&mut target.loads_mid_evaluation, loads);
+    }
+}
+
+fn union_into(slot: &mut Option<AutoBitSet>, bits: AutoBitSet) {
+    match slot {
+        Some(all) => all.set_union(&bits),
+        None => *slot = Some(bits),
+    }
 }
 
 /// Follow `merged_into` links to the group that now owns the files.
@@ -587,6 +606,104 @@ fn immediate_dominators<'a>(
     idom
 }
 
+/// Per group, the `require()`d entries that can start loading while the group is being evaluated (`None`: none).
+fn entries_loaded_mid_evaluation(
+    this: &LinkerContext,
+    sync_calls: &ArrayHashMap<u32, AutoBitSet>,
+    required_sync: &AutoBitSet,
+    file_entry_bits: &[AutoBitSet],
+    group_of_file: &[usize],
+    groups_len: usize,
+    entries: usize,
+) -> crate::Result<Vec<Option<AutoBitSet>>> {
+    let mut loads: Vec<Option<AutoBitSet>> = Vec::new();
+    loads.resize_with(groups_len, || None);
+    if sync_calls.count() == 0 {
+        return Ok(loads);
+    }
+    // `leads_to[x]`: what loading `x` can go on to `require()`.
+    let mut leads_to: Vec<Option<AutoBitSet>> = Vec::new();
+    leads_to.resize_with(entries, || None);
+    for (&file, calls) in sync_calls.keys().iter().zip(sync_calls.values()) {
+        let mut reached_by = file_entry_bits[file as usize].iterator::<true, true>();
+        while let Some(x) = reached_by.next() {
+            if required_sync.is_set(x) {
+                union_into(&mut leads_to[x], calls.clone()?);
+            }
+        }
+    }
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for x in 0..entries {
+            let Some(mut further) = leads_to[x].take() else {
+                continue;
+            };
+            let before = further.count();
+            let mut via = further.clone()?;
+            via.unset(x);
+            let mut via = via.iterator::<true, true>();
+            while let Some(y) = via.next() {
+                if let Some(next) = &leads_to[y] {
+                    further.set_union(next);
+                }
+            }
+            changed |= further.count() != before;
+            leads_to[x] = Some(further);
+        }
+    }
+    // A file is being evaluated while what it imports is, so what a file can
+    // start loading, every file that statically imports its way to it can.
+    let mut file_loads: Vec<Option<AutoBitSet>> = Vec::new();
+    file_loads.resize_with(group_of_file.len(), || None);
+    for (&file, calls) in sync_calls.keys().iter().zip(sync_calls.values()) {
+        let mut all = calls.clone()?;
+        let mut direct = calls.iterator::<true, true>();
+        while let Some(x) = direct.next() {
+            if let Some(further) = &leads_to[x] {
+                all.set_union(further);
+            }
+        }
+        file_loads[file as usize] = Some(all);
+    }
+    let mut importers: Vec<Vec<u32>> = vec![Vec::new(); group_of_file.len()];
+    for source_index in this.graph.reachable_files.iter() {
+        let file = source_index.get();
+        if group_of_file[file as usize] != usize::MAX {
+            this.for_each_file_loaded_by(file, |other| importers[other as usize].push(file));
+        }
+    }
+    let mut changed: Vec<u32> = sync_calls.keys().to_vec();
+    while let Some(file) = changed.pop() {
+        let Some(theirs) = file_loads[file as usize].take() else {
+            continue;
+        };
+        for &importer in &importers[file as usize] {
+            match &mut file_loads[importer as usize] {
+                Some(mine) if theirs.subset_of(mine) => {}
+                Some(mine) => {
+                    mine.set_union(&theirs);
+                    changed.push(importer);
+                }
+                slot => {
+                    *slot = Some(theirs.clone()?);
+                    changed.push(importer);
+                }
+            }
+        }
+        file_loads[file as usize] = Some(theirs);
+    }
+    for (file, file_loads) in file_loads.into_iter().enumerate() {
+        let Some(file_loads) = file_loads else {
+            continue;
+        };
+        // Only `sync_calls` keys and the importers filtered above have a set.
+        debug_assert!(group_of_file[file] != usize::MAX);
+        union_into(&mut loads[group_of_file[file]], file_loads);
+    }
+    Ok(loads)
+}
+
 /// Folds code-splitting chunks into other chunks where that is unobservable,
 /// so fewer modules are loaded at runtime.
 ///
@@ -606,7 +723,12 @@ fn immediate_dominators<'a>(
 ///    `x`'s chunk imports what it needs from the `main` chunk. Different
 ///    entries may cover different importers: with `import("./cmd")` in both
 ///    `main` and a lazy `repl`, the `{main, repl, cmd}` chunk loads iff `main`
-///    or `repl` does.
+///    or `repl` does. A chunk that can be in the middle of being evaluated
+///    when an entry of its class is loaded stays out of this: with
+///    `--target=bun` a `require()` of a split ES module loads that entry's
+///    chunk from inside the file making the call, and the other members must
+///    then be chunks that have finished or not started, not files further down
+///    the caller's own chunk.
 /// 2. A chunk whose live parts have no top-level side effects may join a chunk
 ///    loaded by a superset of its entries, as long as everything it imports is
 ///    already loaded wherever that target is (or is side-effect free too); the
@@ -616,7 +738,8 @@ fn immediate_dominators<'a>(
 ///    `init_x()` (a static import of a wrapped module, e.g. `react`) does not
 ///    count as a side effect when a chunk the target statically imports makes
 ///    the same call first, and no fold may close a static import cycle
-///    between chunks.
+///    between chunks or join a chunk to one that can be evaluating when an
+///    entry the other is needed by loads.
 ///
 /// Runs before `compute_chunks` groups files by `entry_bits`; it rewrites
 /// `File.entry_bits` in place so everything downstream (chunk membership,
@@ -674,6 +797,8 @@ pub(crate) fn merge_small_chunks(
     // guaranteed to precede the target; folding shared code into the
     // importer's chunk could place it after the call site.
     let mut required_sync = AutoBitSet::init_empty(entry_points_len)?;
+    // ... and, per file making such calls, the entries it loads that way.
+    let mut sync_calls: ArrayHashMap<u32, AutoBitSet> = ArrayHashMap::new();
     for source_index in this.graph.reachable_files.iter() {
         let source_index = source_index.get();
         if !is_live_js(source_index) {
@@ -701,6 +826,14 @@ pub(crate) fn merge_small_chunks(
                     .contains(ImportRecordFlags::CROSS_CHUNK_REQUIRE)
                 {
                     required_sync.set(target_entry as usize);
+                    match sync_calls.entry(source_index) {
+                        MapEntry::Occupied(calls) => calls.into_mut().set(target_entry as usize),
+                        MapEntry::Vacant(calls) => {
+                            let mut called = AutoBitSet::init_empty(entry_points_len)?;
+                            called.set(target_entry as usize);
+                            calls.insert(called);
+                        }
+                    }
                 } else {
                     importer_bits[target_entry as usize]
                         .set_union(&file_entry_bits[source_index as usize]);
@@ -966,6 +1099,21 @@ pub(crate) fn merge_small_chunks(
         groups.put(key, group)?;
     }
 
+    for (group, loads) in entries_loaded_mid_evaluation(
+        this,
+        &sync_calls,
+        &required_sync,
+        file_entry_bits,
+        group_of_file,
+        groups.count(),
+        entry_points_len,
+    )?
+    .into_iter()
+    .enumerate()
+    {
+        groups.values_mut()[group].loads_mid_evaluation = loads;
+    }
+
     // Static dependencies between groups, along the edges that assigned
     // `File.entry_bits` (so a dependency's key is a superset of its
     // importer's) and symbol dependencies. Only rule 2 consults them.
@@ -976,22 +1124,10 @@ pub(crate) fn merge_small_chunks(
         if group_index == usize::MAX {
             continue;
         }
-        let parts_live = &this.graph.parts_live[source_index];
         let deps = &mut groups.values_mut()[group_index].deps;
-        for (part_index, part) in parts[source_index].as_slice().iter().enumerate() {
-            if !parts_live.is_set(part_index) {
-                continue;
-            }
-            for &record_index in part.import_record_indices.iter() {
-                let record = &import_records[source_index][record_index as usize];
-                if let Some(other) = this.file_loaded_by_import(record, source_index as u32) {
-                    deps.push(group_of_file[other as usize]);
-                }
-            }
-            for dependency in part.dependencies.iter() {
-                deps.push(group_of_file[dependency.source_index.get() as usize]);
-            }
-        }
+        this.for_each_file_loaded_by(source_index as u32, |other| {
+            deps.push(group_of_file[other as usize]);
+        });
     }
     // An entry point's chunk also imports every binding the entry re-exports
     // (`compute_cross_chunk_dependencies`).
@@ -1025,13 +1161,15 @@ pub(crate) fn merge_small_chunks(
     // parent loses bits its files had; it still runs before they do because
     // an entry that remains in the key precedes them and imports every chunk
     // with side effects carrying its bit (`compute_cross_chunk_dependencies`).
+    // A member that can be evaluating when an entry of the class loads stays
+    // out (rule 1 in the doc comment above).
     let mut folded_same = 0usize;
-    for (class_key, (_, members)) in classes.keys().iter().zip(classes.values()) {
+    for (class_key, (class, members)) in classes.keys().iter().zip(classes.values()) {
         let unpinned = || {
-            members
-                .iter()
-                .copied()
-                .filter(|&i| !groups.values()[i].pinned)
+            members.iter().copied().filter(|&i| {
+                let group = &groups.values()[i];
+                !group.pinned && !group.loads_entry_of(class)
+            })
         };
         let Some(target_index) = unpinned().max_by(|&a, &b| {
             (groups.keys()[a] == *class_key)
@@ -1047,6 +1185,13 @@ pub(crate) fn merge_small_chunks(
         for &member in members {
             let group = &groups.values()[member];
             if member == target_index || group.pinned || group.target != Some(target_platform) {
+                continue;
+            }
+            if group.loads_entry_of(class) {
+                debug_merge!(
+                    "can be evaluating when an entry of its class loads: {}",
+                    bstr::BStr::new(sources[group.first_source as usize].path.pretty)
+                );
                 continue;
             }
             fold(groups.values_mut(), member, target_index);
@@ -1274,6 +1419,8 @@ pub(crate) fn merge_small_chunks(
                     || t.pinned
                     || t.target != c.target
                     || !c.loaded.subset_of(&t.loaded)
+                    || t.loads_entry_of(&c.loaded)
+                    || c.loads_entry_of(&t.loaded)
                 {
                     continue;
                 }

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -2537,10 +2537,31 @@ describe("bundler", () => {
   // way back to that file, whatever else it needs must be a chunk that can be evaluated on demand at that moment,
   // not code sitting further down the caller's own chunk. Each graph runs unbundled and bundled; the output must match.
   const requireCycleGraphs: Record<string, { files: Record<string, string>; todo?: string; folding?: true }> = {
+    "the caller imports itself": {
+      files: {
+        "main.ts": `
+          import { tools } from './registry.ts'
+          console.log(tools.map(t => t.name).join(","))
+          export const later = () => import('./other.ts')
+        `,
+        "registry.ts": `
+          import * as self from './registry.ts'
+          export function buildTool(name: string) { return { name } }
+          export const tools = [require('./tool.ts').Tool, { name: typeof self.buildTool }]
+        `,
+        "tool.ts": `
+          import { buildTool } from './registry.ts'
+          export const Tool = buildTool("tool")
+        `,
+        "other.ts": `
+          import { buildTool } from './registry.ts'
+          export const other = buildTool("other")
+        `,
+      },
+    },
     // base.ts is needed by tool.ts and imports registry.ts, which require()s tool.ts. `other` (loaded after main) is
     // redundant in registry.ts's key, and dropping it must not fold base.ts into registry.ts's chunk.
     "a file the target needs imports the caller": {
-      todo: "folding puts base.ts in registry.ts's chunk, after the call",
       folding: true,
       files: {
         "main.ts": `
@@ -2571,7 +2592,6 @@ describe("bundler", () => {
     // The same with a leaf that shares the caller's key and is imported ahead of the call: it is the caller's group
     // that has to stay out, not whichever group comes second.
     "the caller shares its chunk with a leaf": {
-      todo: "folding puts base.ts in registry.ts's chunk, after the call",
       folding: true,
       files: {
         "main.ts": `
@@ -2853,13 +2873,18 @@ describe("bundler", () => {
   // Random graphs, each run unbundled, bundled without folding and bundled with it (splitting-fuzz.ts). Folding may
   // not lose a value or an order of top-level effects that the unfolded bundle and the source agree on. Folding
   // changes the bundle of about one graph in sixteen; these are from those.
-  for (const [seed, todo] of [
-    [3, ""],
-    [47, ""],
-    [25, "f3 and f3:done run after f6 and f9 once folded"],
+  for (const [seed, folded, todo] of [
+    [47, true, ""],
+    [59, true, ""],
+    // A chunk that can be evaluating while an entry of its class loads stays out of the fold: 762 and 993 lost an
+    // order and a read to it, and 3 was folded without harm.
+    [3, false, ""],
+    [762, false, ""],
+    [993, false, ""],
+    [496, true, "f5 runs after f1 once folded"],
   ] as const) {
     test.todoIf(!!todo).concurrent(`splitting/FoldingNeverMakesABundleWorse: graph ${seed}`, async () => {
-      expect(await checkGraph(bunExe(), seed)).toEqual({ seed, status: "ok", folded: true, problems: [] });
+      expect(await checkGraph(bunExe(), seed)).toEqual({ seed, status: "ok", folded, problems: [] });
     });
   }
 

--- a/test/bundler/splitting-fuzz.ts
+++ b/test/bundler/splitting-fuzz.ts
@@ -81,9 +81,14 @@ function generateGraph(seed: number): Graph {
     }
   }
 
+  // Draws for shapes added after seeds were pinned come from a stream of their own, so old seeds keep their graphs.
+  const later = rng(seed ^ 0x5bd1e995);
+
   const files: Record<string, string> = {};
   for (let i = 0; i < n; i++) {
     let src = `import { note, read, attempt, later } from "./log.ts";\n`;
+    const importsItself = later() < 0.1 && !pure.has(i);
+    if (importsItself) src += `import * as self${i} from "./f${i}.ts";\n`;
     const uses: string[] = [];
     let base: number | undefined;
     for (const j of staticImports[i]) {
@@ -112,6 +117,8 @@ function generateGraph(seed: number): Graph {
         src += `export function load${i}_${l.target}() { return require("./f${l.target}.ts").get${l.target}(); }\n`;
     }
     if (!isPure) {
+      // An import nothing uses is dropped from a .ts file.
+      if (importsItself) uses.push(`read("f${i}<self", () => typeof self${i}.get${i})`);
       for (const j of staticImports[i]) {
         if (chance(0.5)) uses.push(`read("f${i}<f${j}", () => get${j}())`);
         if (chance(0.2)) uses.push(`read("f${i}<C${j}", () => new C${j}().tag())`);


### PR DESCRIPTION
One commit on top of #42442 (it un-todos two of that PR's cycle cases, extends its generator and pins seeds); review and land after it.

Stacked on the chunk-folding differential check (it turns two of that PR's `todo` cases into passing tests and
extends its generator). Review the second commit.

### The miscompile

With `--splitting --target=bun`, a `require()` of an ES module is a chunk boundary: the target's chunk is loaded
synchronously from the middle of the file making the call. Rule 1 of `merge_small_chunks` folds chunks whose keys
reduce to the same load-condition class. Minimal failing input (fails on 1.4.1 and on main):

```ts
// main.ts
import { tools } from './registry.ts'
import { base } from './base.ts'
export const later = () => import('./other.ts')   // makes registry.ts's key {main, tool, other}
console.log(tools[0].name, base.kind)
// registry.ts
export function buildTool(name: string) { return { name } }
export const tools = [require('./tool.ts').Tool]
// tool.ts
import { base } from './base.ts'                   // base.ts's key is {main, tool}
import { buildTool } from './registry.ts'
export const Tool = buildTool("tool:" + base.kind)
// base.ts
import { buildTool } from './registry.ts'
export const base = { kind: "base", make: () => buildTool("x") }
// other.ts
import { buildTool } from './registry.ts'
export const other = buildTool("other")
```

`bun main.ts` prints `tool:base base`. So does `bun build --splitting --target=bun` with folding off (5 files).
With folding (4 files) the bundle throws `TypeError: undefined is not an object (evaluating 'base.kind')`:
`other` is redundant in `registry.ts`'s key (it only loads after `main`), so both keys reduce to `{main, tool}`,
`base.ts` is folded into `registry.ts`'s chunk, and it lands after the `require()` that needs it.

### Why no order inside the chunk fixes it

Every member of a class holds files that each entry of the class needs. When a member `require()`s such an entry,
the entry's chunk reads the other members while the caller is still in the middle of its own evaluation. As chunks
of their own, the others are evaluated on demand at that moment (an ES module that has not started is run; one that
has finished is reused). Inside the caller's chunk they are just statements before or after the call. Putting
`base.ts` before `registry.ts` is right for this entry point and wrong for one that reaches the cycle through
`base.ts` first (`base.ts` imports `registry.ts`, whose `buildTool` it calls). With two ways into the cycle no single
order serves both. The module loader solves this per load, at run time; a static order cannot.

### The rule

A member of a class stays a chunk of its own when it can be in the middle of being evaluated while an entry of the
class loads: a file of it calls `require()` on the entry, or on an entry whose files go on to do so, or statically
imports its way to a file that does (a file is being evaluated while what it imports is). The other members fold as
before. They can only have finished or not started when the entry loads, and none of them imports its way to a member
that stayed out, so no two chunks end up importing each other. Rule 2 (`--min-chunk-size`) applies the same test to a
candidate and its target.

The traversal this needs (what loading a file loads first) was open-coded in the code-splitting reachability pass and
in rule 2's dependency list; all three now call `LinkerContext::for_each_file_loaded_by`.

### Where it takes effect

Only with `--splitting` (which requires `--format=esm`) and `--target=bun`, with or without `--compile`. The rule
reads `ImportRecordFlags::CROSS_CHUNK_REQUIRE`, which is only set on a `require()` of an ES module from a file that
targets Bun in a splitting build. Without such a record nothing is computed and no group is marked. Checked: 2,000
random graphs built with `--target=browser` and `--target=node` are byte for byte the same before and after (25 of
the 2,000 differ for `--target=bun`); the example above builds to the same 3 files for both.

### What it fixes, measured

`bun scripts/splitting-fuzz.ts`, 30,000 random graphs, same generator for both binaries. "Worse" = the folded bundle
loses a value, or the order of two top-level side effects, that both the source and the unfolded bundle have.

| | main | this branch |
|---|---|---|
| graphs whose bundle folding changes | 1,734 | 1,416 |
| worse than unfolded | 142 | 107 |
| ... a read comes out different | 23 | 2 (both: the source reads an uninitialized binding, the folded bundle has the value) |
| ... a read of an uninitialized binding | 21 | 0 |
| worse here and fine on main | | 0 |

What is left (107) are folds that move a module's side effects relative to another chunk's without breaking a read.

### What it does not do

That measure compares a build with itself unfolded. The other comparison is this branch's folded bundle against
main's folded bundle, each against the source, over 6,000 of the same graphs (74 bundles differ):

| versus the source | only main's bundle gets it right | only this branch's does |
|---|---|---|
| no read of an uninitialized binding | 6 graphs | 6 graphs |
| order of two side effects | 21 graphs | 8 graphs |

Not folding such a class makes the bundle equal to the unfolded one, and the unfolded layout has hazards of its own
(files with the same key share a chunk whatever order they need) that a fold sometimes happens to cure. So this
removes one class of wrong folds, and the crash above, and guarantees that a fold never introduces an uninitialized
read the unfolded bundle does not have. It does not make bundles agree with their source more often overall. The
hazards of the unfolded layout are the larger number and are a separate piece of work (see the comparison below).

### How this compares with esbuild

The same random graphs through esbuild 0.28.2 (`--bundle --splitting --format=esm --platform=node`, output run in
Node) and through Bun, every bundle's log compared with the unbundled source's. 3,000 graphs per table; the numbers
are graphs.

Graphs both bundlers express the same way (static imports with cycles, re-exports, classes extending classes from
other modules, `import()`, top-level await; no `require()`):

| | reads an uninitialized binding the source reads fine | two side effects in another order than the source |
|---|---|---|
| esbuild, split | 15 | 249 |
| Bun, split, unfolded | 15 | 237 |
| Bun, split, folded (main) | 12 | 220 |
| Bun, split, folded (this branch) | 12 | 220 |

The full generator (2,958 of the 3,000 graphs contain a `require()` of an ES module; esbuild does not split on
`require()`, it wraps the target lazily in the importing chunk):

| | uninitialized read the source does not have | side effects reordered | never finishes |
|---|---|---|---|
| esbuild, split | 12 | 154 | 2 (unsettled top-level await) |
| Bun, split, unfolded | 101 | 450 | 0 |
| Bun, split, folded (main) | 99 | 444 | 0 |
| Bun, split, folded (this branch) | 100 | 450 | 0 |

Code splitting alone has the same evaluation-order hazard in both bundlers, at the same rate. About 85% of Bun's
uninitialized reads, and about half of its reorders, exist only because a `require()` of an ES module is a chunk
boundary that is evaluated in the middle of the caller. That is what is left to fix, and it is in the unfolded layout,
not in folding.

### Cost

A chunk only stays out of a class that holds an entry it can start loading.

- A 1,900-module synthetic app (55 tools behind a registry, `--compile --bytecode --splitting --format=esm
  --target=bun`): 706 chunks before and after; startup 123.5M vs 123.3M instructions; RssAnon 12.6 vs 12.7 MB;
  bundling 578.6M vs 580.7M instructions (+0.4%).
- A large bundled CLI application (13,232 inputs, 1,681 chunks, 642 split `require()` edges): not rebuilt. A model of
  rule 1 over its metafile (the `entryPoint` field on split `require()` edges makes that possible) counts 125 folded
  classes and 375 folds today, of which 12 classes hold a member that calls an entry of its own class: 20 folds given
  up, so about +20 chunks of 1,681. Leaving those whole classes unfolded would be 128. Counting only the files that
  call `require()` themselves, and not their importers, is not enough, because every importer of the caller is being
  evaluated when the call runs.
- On random graphs, which are much denser in `require()` cycles than applications: all folds are given up in 318 of
  the 1,734 graphs folding used to change.
- A 12,000-file import chain with 650 split `require()` sites: +0.8% bundling instructions, same chunk count.

### Tests

- `splitting/SplitRequireCycle: a file the target needs imports the caller` and `... the caller shares its chunk
  with a leaf` were `todo` and now pass folded as well as unfolded. `... the caller imports itself` is new (a file
  that statically imports itself must not loop the propagation).
- `splitting/FoldingNeverMakesABundleWorse`: seeds 762 and 993 (main loses an order and a read there) and 3 (a
  harmless fold this gives up) now expect an unfolded, correct bundle; 47 and 59 stay folded; 496 is `todo` (a
  side-effect reorder of the remaining kind).
- Without the fix (release build of the parent commit) 5 of these fail: the two cycle graphs and seeds 3, 762, 993.
- The generator makes self-importing files now, drawn from a random stream of its own.

### How verified

- Release build, Linux x64: `bundler_splitting.test.ts` 124 pass / 3 todo / 0 fail; together with `esbuild/splitting`,
  `bundler_compile_splitting`, `bun-build-api`, `metafile`, `esbuild/metafile`, `bundler_dynamic_import_dce`,
  `bundler_compile_prelinked`, `bundler_cjs`, `bundler_cjs2esm`, `bundler_edgecase`, `bundler_regressions`,
  `html-import-manifest`, `standalone`, `bun-build-compile`: 1,009 pass / 17 todo / 0 fail.
- The example by hand, on 1.4.1, main and this branch, for `--target=bun|node|browser`.
- `cargo clippy -p bun_bundler --no-deps` and `cargo fmt --check` clean; `prettier` clean.
