### PR TITLE
react_compiler: fix panics on a dead try body and on a useMemo call nested in another

### DIFF
--- a/src/react_compiler/optimization/constant_propagation.rs
+++ b/src/react_compiler/optimization/constant_propagation.rs
@@ -25,7 +25,7 @@
 //! Analogous to TS `Optimization/ConstantPropagation.ts`.
 
 use crate::collections::IdMap;
-use crate::diagnostics::JsString;
+use crate::diagnostics::{CompilerDiagnostic, JsString};
 use crate::hir::cfg_utils::{
     get_reverse_postordered_blocks, mark_instruction_ids, mark_predecessors,
     remove_dead_do_while_statements, remove_unnecessary_try_catch, remove_unreachable_for_updates,
@@ -75,18 +75,21 @@ type Constants = IdMap<IdentifierId, Constant>;
 // Public entry point
 // =============================================================================
 
-pub(crate) fn constant_propagation(func: &mut HirFunction, env: &mut Environment) {
+pub(crate) fn constant_propagation(
+    func: &mut HirFunction,
+    env: &mut Environment,
+) -> Result<(), CompilerDiagnostic> {
     let mut constants: Constants = IdMap::new();
-    constant_propagation_impl(func, env, &mut constants);
+    constant_propagation_impl(func, env, &mut constants)
 }
 
 fn constant_propagation_impl(
     func: &mut HirFunction,
     env: &mut Environment,
     constants: &mut Constants,
-) {
+) -> Result<(), CompilerDiagnostic> {
     loop {
-        let have_terminals_changed = apply_constant_propagation(func, env, constants);
+        let have_terminals_changed = apply_constant_propagation(func, env, constants)?;
         if !have_terminals_changed {
             break;
         }
@@ -119,19 +122,20 @@ fn constant_propagation_impl(
          * Finally, merge together any blocks that are now guaranteed to execute
          * consecutively
          */
-        merge_consecutive_blocks(func, &mut env.functions);
+        merge_consecutive_blocks(func, &mut env.functions)?;
 
         // TODO: port assertConsistentIdentifiers(fn) and assertTerminalSuccessorsExist(fn)
         // from TS HIR validation. These are debug assertions that verify structural
         // invariants after the CFG cleanup helpers run.
     }
+    Ok(())
 }
 
 fn apply_constant_propagation(
     func: &mut HirFunction,
     env: &mut Environment,
     constants: &mut Constants,
-) -> bool {
+) -> Result<bool, CompilerDiagnostic> {
     let mut has_changes = false;
 
     let block_ids: Vec<_> = func.body.blocks.keys().copied().collect();
@@ -164,7 +168,7 @@ fn apply_constant_propagation(
                  */
                 continue;
             }
-            let result = evaluate_instruction(constants, func, env, *instr_id);
+            let result = evaluate_instruction(constants, func, env, *instr_id)?;
             if let Some(value) = result {
                 let lvalue_id = func.instructions[instr_id.0 as usize].lvalue.identifier;
                 constants.insert(lvalue_id, value);
@@ -227,7 +231,7 @@ fn apply_constant_propagation(
         }
     }
 
-    has_changes
+    Ok(has_changes)
 }
 
 // =============================================================================
@@ -281,9 +285,9 @@ fn evaluate_instruction(
     func: &mut HirFunction,
     env: &mut Environment,
     instr_id: crate::hir::InstructionId,
-) -> Option<Constant> {
+) -> Result<Option<Constant>, CompilerDiagnostic> {
     let instr = &func.instructions[instr_id.0 as usize];
-    match &instr.value {
+    let value = match &instr.value {
         InstructionValue::Primitive { value, loc } => Some(Constant::Primitive {
             value: value.clone(),
             loc: *loc,
@@ -406,10 +410,10 @@ fn evaluate_instruction(
                     },
                 );
                 // But return the value prior to the update (preserving its original loc)
-                return Some(Constant::Primitive {
+                return Ok(Some(Constant::Primitive {
                     value: PrimitiveValue::Number(n),
                     loc: prev_loc,
-                });
+                }));
             }
             None
         }
@@ -433,7 +437,7 @@ fn evaluate_instruction(
                 // Store and return the updated value
                 let lvalue_id = lvalue.identifier;
                 constants.insert(lvalue_id, result.clone());
-                return Some(result);
+                return Ok(Some(result));
             }
             None
         }
@@ -459,7 +463,7 @@ fn evaluate_instruction(
                         value: PrimitiveValue::Boolean(negated),
                         loc,
                     };
-                    return Some(result);
+                    return Ok(Some(result));
                 }
                 None
             }
@@ -480,7 +484,7 @@ fn evaluate_instruction(
                         value: PrimitiveValue::Number(FloatValue::new(negated)),
                         loc,
                     };
-                    return Some(result);
+                    return Ok(Some(result));
                 }
                 None
             }
@@ -509,10 +513,10 @@ fn evaluate_instruction(
                         value: prim.clone(),
                         loc,
                     };
-                    return Some(Constant::Primitive {
+                    return Ok(Some(Constant::Primitive {
                         value: prim.clone(),
                         loc,
-                    });
+                    }));
                 }
             }
             None
@@ -542,7 +546,7 @@ fn evaluate_instruction(
                                 value: PrimitiveValue::Number(FloatValue::new(len)),
                                 loc,
                             };
-                        return Some(result);
+                        return Ok(Some(result));
                     }
                 }
             }
@@ -559,7 +563,7 @@ fn evaluate_instruction(
                 for q in quasis {
                     match q.cooked {
                         Some(cooked) => result.extend_from_slice(cooked.slice()),
-                        None => return None,
+                        None => return Ok(None),
                     }
                 }
                 let loc = *loc;
@@ -568,15 +572,15 @@ fn evaluate_instruction(
                     value: value.clone(),
                     loc,
                 };
-                return Some(Constant::Primitive { value, loc });
+                return Ok(Some(Constant::Primitive { value, loc }));
             }
 
             if subexprs.len() != quasis.len() - 1 {
-                return None;
+                return Ok(None);
             }
 
             if quasis.iter().any(|q| q.cooked.is_none()) {
-                return None;
+                return Ok(None);
             }
 
             let mut quasi_index = 0usize;
@@ -587,7 +591,7 @@ fn evaluate_instruction(
                 let sub_expr_value = read(constants, sub_expr);
                 let sub_prim = match sub_expr_value {
                     Some(Constant::Primitive { ref value, .. }) => value,
-                    _ => return None,
+                    _ => return Ok(None),
                 };
 
                 match sub_prim {
@@ -600,10 +604,10 @@ fn evaluate_instruction(
                     }
                     PrimitiveValue::String(s) => match s.as_bytes() {
                         Some(b) => result.extend_from_slice(b),
-                        None => return None,
+                        None => return Ok(None),
                     },
                     // TS rejects undefined subexpression values
-                    PrimitiveValue::Undefined => return None,
+                    PrimitiveValue::Undefined => return Ok(None),
                 };
 
                 result.extend_from_slice(quasis[quasi_index].cooked.unwrap().slice());
@@ -637,12 +641,12 @@ fn evaluate_instruction(
         }
         InstructionValue::FunctionExpression { lowered_func, .. } => {
             let func_id = lowered_func.func;
-            process_inner_function(func_id, env, constants);
+            process_inner_function(func_id, env, constants)?;
             None
         }
         InstructionValue::ObjectMethod { lowered_func, .. } => {
             let func_id = lowered_func.func;
-            process_inner_function(func_id, env, constants);
+            process_inner_function(func_id, env, constants)?;
             None
         }
         InstructionValue::StartMemoize { deps, .. } => {
@@ -709,20 +713,26 @@ fn evaluate_instruction(
         | InstructionValue::Debugger { .. }
         | InstructionValue::FinishMemoize { .. }
         | InstructionValue::UnsupportedNode { .. } => None,
-    }
+    };
+    Ok(value)
 }
 
 // =============================================================================
 // Inner function processing
 // =============================================================================
 
-fn process_inner_function(func_id: FunctionId, env: &mut Environment, constants: &mut Constants) {
+fn process_inner_function(
+    func_id: FunctionId,
+    env: &mut Environment,
+    constants: &mut Constants,
+) -> Result<(), CompilerDiagnostic> {
     let mut inner = std::mem::replace(
         &mut env.functions[func_id.0 as usize],
         placeholder_function(),
     );
-    constant_propagation_impl(&mut inner, env, constants);
+    constant_propagation_impl(&mut inner, env, constants)?;
     env.functions[func_id.0 as usize] = inner;
+    Ok(())
 }
 
 // =============================================================================

--- a/src/react_compiler/optimization/inline_iifes.rs
+++ b/src/react_compiler/optimization/inline_iifes.rs
@@ -43,6 +43,7 @@
 use std::collections::HashSet;
 
 use crate::collections::IdMap;
+use crate::diagnostics::CompilerDiagnostic;
 use crate::hir::cfg_utils::{
     create_temporary_place, get_reverse_postordered_blocks, mark_instruction_ids, mark_predecessors,
 };
@@ -61,7 +62,7 @@ use crate::optimization::merge_consecutive_blocks::merge_consecutive_blocks;
 pub(crate) fn inline_immediately_invoked_function_expressions(
     func: &mut HirFunction,
     env: &mut Environment,
-) {
+) -> Result<(), CompilerDiagnostic> {
     // Track all function expressions that are assigned to a temporary
     let mut functions: IdMap<IdentifierId, FunctionId> = IdMap::new();
     // Functions that are inlined (by identifier id of the callee)
@@ -305,8 +306,10 @@ pub(crate) fn inline_immediately_invoked_function_expressions(
         func.body.blocks = get_reverse_postordered_blocks(&func.body, &func.instructions);
         mark_instruction_ids(&mut func.body, &mut func.instructions);
         mark_predecessors(&mut func.body);
-        merge_consecutive_blocks(func, &mut env.functions);
+        merge_consecutive_blocks(func, &mut env.functions)?;
     }
+
+    Ok(())
 }
 
 /// Returns true for "block" and "catch" block kinds which correspond to statements

--- a/src/react_compiler/optimization/merge_consecutive_blocks.rs
+++ b/src/react_compiler/optimization/merge_consecutive_blocks.rs
@@ -16,6 +16,7 @@
 use std::collections::HashSet;
 
 use crate::collections::IdMap;
+use crate::diagnostics::{CompilerDiagnostic, ErrorCategory};
 use crate::hir::cfg_utils::mark_predecessors;
 use crate::hir::visitors;
 use crate::hir::{
@@ -26,7 +27,10 @@ use crate::hir_vec;
 use crate::ssa::enter_ssa::placeholder_function;
 
 /// Merge consecutive blocks in the function's CFG, including inner functions.
-pub(crate) fn merge_consecutive_blocks(func: &mut HirFunction, functions: &mut [HirFunction]) {
+pub(crate) fn merge_consecutive_blocks(
+    func: &mut HirFunction,
+    functions: &mut [HirFunction],
+) -> Result<(), CompilerDiagnostic> {
     // Collect inner function IDs for recursive processing
     let inner_func_ids: Vec<usize> = func
         .body
@@ -50,7 +54,7 @@ pub(crate) fn merge_consecutive_blocks(func: &mut HirFunction, functions: &mut [
         // Use std::mem::replace to temporarily take the inner function out,
         // process it, then put it back (standard borrow checker workaround)
         let mut inner_func = std::mem::replace(&mut functions[func_id], placeholder_function());
-        merge_consecutive_blocks(&mut inner_func, functions);
+        merge_consecutive_blocks(&mut inner_func, functions)?;
         functions[func_id] = inner_func;
     }
 
@@ -99,20 +103,17 @@ pub(crate) fn merge_consecutive_blocks(func: &mut HirFunction, functions: &mut [
         let eval_order = func.body.blocks[&pred_id].terminal.evaluation_order();
 
         // Collect phi data from the block being merged
-        let phis: Vec<_> = block
+        let phis = block
             .phis
             .iter()
             .map(|phi| {
-                assert_eq!(
-                    phi.operands.len(),
-                    1,
-                    "Found a block with a single predecessor but where a phi has multiple ({}) operands",
-                    phi.operands.len()
-                );
-                let operand = phi.operands.values().next().unwrap().clone();
-                (phi.place.identifier, operand)
+                let mut operands = phi.operands.values();
+                match (operands.next(), operands.next()) {
+                    (Some(operand), None) => Ok((phi.place.identifier, operand.clone())),
+                    _ => Err(multiple_phi_operands(phi.operands.len())),
+                }
             })
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
         let block_instr_ids = block.instructions.clone();
         let block_terminal = block.terminal.clone();
 
@@ -184,6 +185,20 @@ pub(crate) fn merge_consecutive_blocks(func: &mut HirFunction, functions: &mut [
             merged.get(block_id)
         });
     }
+
+    Ok(())
+}
+
+#[cold]
+#[inline(never)]
+fn multiple_phi_operands(count: usize) -> CompilerDiagnostic {
+    CompilerDiagnostic::new(
+        ErrorCategory::Invariant,
+        format!(
+            "Found a block with a single predecessor but where a phi has multiple ({count}) operands"
+        ),
+        None,
+    )
 }
 
 /// Tracks which blocks have been merged and into which target.

--- a/src/react_compiler/optimization/prune_maybe_throws.rs
+++ b/src/react_compiler/optimization/prune_maybe_throws.rs
@@ -34,7 +34,7 @@ pub(crate) fn prune_maybe_throws(
         remove_dead_do_while_statements(&mut func.body);
         remove_unnecessary_try_catch(&mut func.body);
         mark_instruction_ids(&mut func.body, &mut func.instructions);
-        merge_consecutive_blocks(func, functions);
+        merge_consecutive_blocks(func, functions)?;
 
         // Rewrite phi operands to reference the updated predecessor blocks
         for block in func.body.blocks.values_mut() {

--- a/src/react_compiler/pipeline.rs
+++ b/src/react_compiler/pipeline.rs
@@ -358,7 +358,7 @@ fn run_hir_passes(
     timed!(
         "InlineImmediatelyInvokedFunctionExpressions",
         crate::optimization::inline_immediately_invoked_function_expressions(hir, env)
-    );
+    )?;
 
     timed!(
         "MergeConsecutiveBlocks",
@@ -366,7 +366,7 @@ fn run_hir_passes(
             hir,
             &mut env.functions,
         )
-    );
+    )?;
 
     timed!("EnterSSA", crate::ssa::enter_ssa(hir, env)).map_err(ssa_diag_to_error)?;
 
@@ -378,7 +378,7 @@ fn run_hir_passes(
     timed!(
         "ConstantPropagation",
         crate::optimization::constant_propagation(hir, env)
-    );
+    )?;
 
     timed!("InferTypes", crate::typeinference::infer_types(hir, env))?;
 

--- a/src/react_compiler/validation/validate_exhaustive_dependencies.rs
+++ b/src/react_compiler/validation/validate_exhaustive_dependencies.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use crate::collections::IdMap;
 use crate::diagnostics::{
     CompilerDiagnostic, CompilerDiagnosticDetail, CompilerSuggestion, CompilerSuggestionOperation,
-    ErrorCategory, SourceLocation,
+    ErrorCategory, SourceLocation, cold_invariant,
 };
 use crate::hir::environment::Environment;
 use crate::hir::environment_config::ExhaustiveEffectDepsMode;
@@ -778,16 +778,21 @@ fn collect_dependencies(
                 InstructionValue::FinishMemoize {
                     manual_memo_id,
                     decl,
+                    loc,
                     ..
                 } => {
                     if let Some(cb) = callbacks.as_mut() {
                         // onFinishMemoize — mirrors TS behavior
                         let sm = cb.start_memo.take();
                         if let Some(sm) = sm {
-                            assert_eq!(
-                                sm.manual_memo_id, *manual_memo_id,
-                                "Found FinishMemoize without corresponding StartMemoize"
-                            );
+                            if sm.manual_memo_id != *manual_memo_id {
+                                return Err(cold_invariant(
+                                    "Found FinishMemoize without corresponding StartMemoize",
+                                    None,
+                                    *loc,
+                                )
+                                .into());
+                            }
 
                             if cb.validate_memo {
                                 // Visit the decl to add it as a dependency candidate

--- a/src/react_compiler/validation/validate_no_set_state_in_render.rs
+++ b/src/react_compiler/validation/validate_no_set_state_in_render.rs
@@ -9,7 +9,9 @@
 
 use std::collections::HashSet;
 
-use crate::diagnostics::{CompilerDiagnostic, CompilerDiagnosticDetail, ErrorCategory};
+use crate::diagnostics::{
+    CompilerDiagnostic, CompilerDiagnosticDetail, ErrorCategory, cold_invariant,
+};
 use crate::hir::dominator::compute_unconditional_blocks;
 use crate::hir::environment::Environment;
 use crate::hir::{
@@ -92,18 +94,34 @@ fn validate_impl(
                         }
                     }
                 }
-                InstructionValue::StartMemoize { manual_memo_id, .. } => {
-                    assert!(
-                        active_manual_memo_id.is_none(),
-                        "Unexpected nested StartMemoize instructions"
-                    );
+                InstructionValue::StartMemoize {
+                    manual_memo_id,
+                    loc,
+                    ..
+                } => {
+                    if active_manual_memo_id.is_some() {
+                        return Err(cold_invariant(
+                            "Unexpected nested StartMemoize instructions",
+                            None,
+                            *loc,
+                        )
+                        .into());
+                    }
                     active_manual_memo_id = Some(*manual_memo_id);
                 }
-                InstructionValue::FinishMemoize { manual_memo_id, .. } => {
-                    assert!(
-                        active_manual_memo_id == Some(*manual_memo_id),
-                        "Expected FinishMemoize to align with previous StartMemoize instruction"
-                    );
+                InstructionValue::FinishMemoize {
+                    manual_memo_id,
+                    loc,
+                    ..
+                } => {
+                    if active_manual_memo_id != Some(*manual_memo_id) {
+                        return Err(cold_invariant(
+                            "Expected FinishMemoize to align with previous StartMemoize instruction",
+                            None,
+                            *loc,
+                        )
+                        .into());
+                    }
                     active_manual_memo_id = None;
                 }
                 InstructionValue::CallExpression { callee, .. } => {

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -843,6 +843,191 @@ describe("bundler", () => {
     },
   });
 
+  // Stub react packages for the two tests below. A compiled function calls `c`
+  // once per render, so the second number of each pair is 1 for a compiled
+  // function and 0 for a function the compiler left as written.
+  const countingReact = {
+    "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+    "/node_modules/react/index.js": /* js */ `
+      exports.useMemo = fn => fn();
+      exports.useCallback = fn => fn;
+    `,
+    "/node_modules/react/jsx-runtime.js": `exports.jsx = exports.jsxs = (type, props) => ({ type, props });`,
+    "/node_modules/react/jsx-dev-runtime.js": `exports.jsxDEV = (type, props) => ({ type, props });`,
+    "/node_modules/react/compiler-runtime.js": /* js */ `
+      let count = 0;
+      exports.c = size => {
+        count++;
+        return new Array(size).fill(Symbol.for("react.memo_cache_sentinel"));
+      };
+      exports.calls = () => count;
+    `,
+  };
+  const renderWithCallCount = /* js */ `
+    function render(fn, props) {
+      const before = calls();
+      const result = fn(props);
+      return [result.props, calls() - before];
+    }
+  `;
+
+  // Dead code elimination removes a load whose value is unused. When that
+  // empties a try body, PruneMaybeThrows drops the edge to the catch block, and
+  // the phi that joins a local the catch block assigns keeps an operand for a
+  // block that is gone. Babel raises `Invariant: Found a block with a single
+  // predecessor but where a phi has multiple (2) operands` and skips that one
+  // function. `window` is not defined here, so a function left as written
+  // takes its catch path. The last two functions are the controls.
+  itBundled("react-compiler/DeadTryBodyWithCatchAssignmentSkipsOnlyThatFunction", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useMemo } from "react";
+        import { calls } from "react/compiler-runtime";
+
+        function DeadLoad() {
+          let supported = true;
+          try {
+            window.localStorage;
+          } catch {
+            supported = false;
+          }
+          return <span>{supported ? "on" : "off"}</span>;
+        }
+        function DeadLoadWithCatchBinding() {
+          let message = "none";
+          try {
+            const { localStorage } = window;
+          } catch (e) {
+            message = e.name;
+          }
+          return <span>{message}</span>;
+        }
+        function DeadLoadInUseMemo() {
+          const supported = useMemo(() => {
+            let ok = true;
+            try {
+              typeof window.localStorage;
+            } catch {
+              ok = false;
+            }
+            return ok;
+          }, []);
+          return <span>{supported ? "on" : "off"}</span>;
+        }
+        function DeadOnlyInProduction(props) {
+          let ok = true;
+          try {
+            if (process.env.NODE_ENV !== "production") {
+              validate(props);
+            }
+            const label = props.label;
+          } catch {
+            ok = false;
+          }
+          return <span>{ok ? "on" : "off"}</span>;
+        }
+        function CallInTryBody() {
+          let supported = true;
+          try {
+            window.localStorage.getItem("key");
+          } catch {
+            supported = false;
+          }
+          return <span>{supported ? "on" : "off"}</span>;
+        }
+        function Plain({ name }) {
+          return <div>Hello {name}</div>;
+        }
+
+        ${renderWithCallCount}
+        console.log(JSON.stringify({
+          DeadLoad: render(DeadLoad),
+          DeadLoadWithCatchBinding: render(DeadLoadWithCatchBinding),
+          DeadLoadInUseMemo: render(DeadLoadInUseMemo),
+          DeadOnlyInProduction: render(DeadOnlyInProduction, { label: "x" }),
+          CallInTryBody: render(CallInTryBody),
+          Plain: render(Plain, { name: "bun" }),
+        }));
+      `,
+      ...countingReact,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    define: { "process.env.NODE_ENV": '"production"' },
+    run: {
+      stdout: JSON.stringify({
+        DeadLoad: [{ children: "off" }, 0],
+        DeadLoadWithCatchBinding: [{ children: "ReferenceError" }, 0],
+        DeadLoadInUseMemo: [{ children: "off" }, 0],
+        DeadOnlyInProduction: [{ children: "on" }, 0],
+        CallInTryBody: [{ children: "off" }, 1],
+        Plain: [{ children: ["Hello ", "bun"] }, 1],
+      }),
+    },
+  });
+
+  // DropManualMemoization puts a StartMemoize marker after the load of
+  // `useMemo` / `useCallback` and a FinishMemoize marker after the call. A
+  // manual memo call in the arguments of another one nests the two pairs, and
+  // ValidateNoSetStateInRender has the invariant `Unexpected nested StartMemoize
+  // instructions`. Babel leaves each of these functions as written: 1.0.0
+  // raises that invariant for the third-argument form and rejects a call in a
+  // dependency list one pass earlier. The last function is the control.
+  itBundled("react-compiler/NestedManualMemoCallSkipsOnlyThatFunction", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useCallback, useMemo } from "react";
+        import * as React from "react";
+        import { calls } from "react/compiler-runtime";
+
+        function MemoInDependencyList({ a, b }) {
+          const x = useMemo(() => a + b, [a, useMemo(() => b * 2, [b])]);
+          return <div>{x}</div>;
+        }
+        function MemoInCallbackDependencyList(props) {
+          const f = useCallback(() => props.a, [useMemo(() => props.a, [props.a])]);
+          return <div>{f()}</div>;
+        }
+        function NamespaceMemoInDependencyList({ a, b }) {
+          const x = React.useMemo(() => a + b, [a, React.useMemo(() => b * 2, [b])]);
+          return <div>{x}</div>;
+        }
+        function MemoAsThirdArgument({ a, b }) {
+          const x = useMemo(() => a, [a], useMemo(() => b, [b]));
+          return <div>{x}</div>;
+        }
+        function SequentialMemos({ a, b }) {
+          const twice = useMemo(() => b * 2, [b]);
+          const x = useMemo(() => a + twice, [a, twice]);
+          return <div>{x}</div>;
+        }
+
+        ${renderWithCallCount}
+        console.log(JSON.stringify({
+          MemoInDependencyList: render(MemoInDependencyList, { a: 1, b: 2 }),
+          MemoInCallbackDependencyList: render(MemoInCallbackDependencyList, { a: 5 }),
+          NamespaceMemoInDependencyList: render(NamespaceMemoInDependencyList, { a: 1, b: 2 }),
+          MemoAsThirdArgument: render(MemoAsThirdArgument, { a: 1, b: 2 }),
+          SequentialMemos: render(SequentialMemos, { a: 1, b: 2 }),
+        }));
+      `,
+      ...countingReact,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    run: {
+      stdout: JSON.stringify({
+        MemoInDependencyList: [{ children: 3 }, 0],
+        MemoInCallbackDependencyList: [{ children: 5 }, 0],
+        NamespaceMemoInDependencyList: [{ children: 3 }, 0],
+        MemoAsThirdArgument: [{ children: 1 }, 0],
+        SequentialMemos: [{ children: 5 }, 1],
+      }),
+    },
+  });
+
   // A compiled component that needs zero memo slots must not import the
   // runtime. The import is registered from codegen next to the `_c(N)` call,
   // so a body with nothing to memoize leaves `react/compiler-runtime` out.


### PR DESCRIPTION
### Problem
- `bun build --react-compiler` aborts on `try { window.localStorage; } catch { ok = false; }` when `ok` is read later: ``panic: assertion `left == right` failed: Found a block with a single predecessor but where a phi has multiple (2) operands`` (`src/react_compiler/optimization/merge_consecutive_blocks.rs:106`). Dead code elimination empties the try body, `prune_maybe_throws` drops the edge to the catch block, and the phi for `ok` keeps the operand of the removed block.
- `useMemo(() => a + b, [a, useMemo(() => b * 2, [b])])` aborts with `panic: Unexpected nested StartMemoize instructions` (`src/react_compiler/validation/validate_no_set_state_in_render.rs:96`). `drop_manual_memoization` nests the marker pairs of the two calls.
- Both are upstream invariants. Babel catches them and leaves that function uncompiled. The port has `assert!`, and Bun builds with `panic = "abort"`.

### Fix
- `merge_consecutive_blocks` returns the invariant as an error. Its four callers propagate it with `?`.
- The three asserts on StartMemoize / FinishMemoize pairing (`validate_no_set_state_in_render`, `validate_exhaustive_dependencies`) become `cold_invariant` errors.
- Correct because `program.rs` leaves a function that returns an error uncompiled, as babel-plugin-react-compiler 1.0.0 does for the same inputs. Compiled output does not change.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (two new tests, SIGABRT on 1.4.3 canary). Also `react-compiler-fixtures.test.ts`.

### Background
- The compiler lowers a component to a control flow graph in SSA form. A phi joins the values a local has on each incoming edge of a block.
- `prune_maybe_throws` removes the edge from a try body to its catch block when nothing left in the body can throw.
- StartMemoize and FinishMemoize mark the range of a source `useMemo` / `useCallback` call for later validations.
- `compile_fn` returns `Result`. `program.rs` skips that one function for each `Err`.

<details><summary>Notes</summary>

**Provenance.** Found by fuzzing. There is no user report and no issue to close. Same family as #42375 (merged) and #42378 (open): an upstream `CompilerError.invariant` that the port has as a panic.

**Repro** (any directory, 1.4.3 canary 6a92015fc; main b99371011f still has both asserts):

```jsx
// a.jsx
export function Banner() {
  let supported = true;
  try {
    window.localStorage;
  } catch {
    supported = false;
  }
  return <span>{supported ? "on" : "off"}</span>;
}
```

```jsx
// c.jsx
import { useMemo } from "react";
export function Sum({ a, b }) {
  const x = useMemo(() => a + b, [a, useMemo(() => b * 2, [b])]);
  return <div>{x}</div>;
}
```

```
$ bun build --react-compiler a.jsx --external react --external 'react/*'
panic: assertion `left == right` failed: Found a block with a single predecessor but where a phi has multiple (2) operands
Crashed while visiting a.jsx
$ bun build --react-compiler c.jsx --external react --external 'react/*'
panic: Unexpected nested StartMemoize instructions
Crashed while visiting c.jsx
```

Every `--target` aborts, and `Bun.build({ reactCompiler: true })` aborts the calling process. With this change both builds exit 0, `BUN_DEBUG_react_compiler=1` on a debug build logs `compile_fn err: ... Invariant ...` for that function, and the function is printed as written. A `Bun.build` with `a.jsx`, `c.jsx` and a third entry point returns `success: true` with the third file memoized.

**First site.** Frames: `merge_consecutive_blocks` (`merge_consecutive_blocks.rs:106`), `prune_maybe_throws` (the second run, after SSA and DeadCodeElimination), `run_hir_passes`, `compile_fn` (`pipeline.rs:172`). The try body must be fully dead after dead code elimination (property, global and index loads, destructuring, `typeof`, literals, unused declarations; a call or a value that is read later keeps it alive), and the catch block must assign a local that is read after the try. `const unused = 1` in the try body is enough (#42432 lists that form as not fixed there). The same body in the callback of a `useMemo` aborts too, because the callback is inlined. A variant builds in development and aborts only with `--production` or `--define process.env.NODE_ENV='"production"'`: `try { if (process.env.NODE_ENV !== "production") { validate(props); } const label = props.label; } catch { ok = false; }`.

The cause is upstream's. `PruneMaybeThrows.ts` calls `mergeConsecutiveBlocks` before it rewrites phi operands, and it has no step that drops the operand of a predecessor that became unreachable. `ConstantPropagation.ts` has that step. facebook/react main (019019be) still has this order in TS and in `compiler/crates/react_compiler_optimization`, and both still have the invariant (`assert_eq!` in the Rust crate).

**Alternative not taken for the first site.** Drop the phi operands of removed predecessors in `prune_maybe_throws` before the merge, as `constant_propagation` does. The function then compiles, which upstream does not do today. The compiled output also has no try/catch any more, because dead code elimination removed the load. `try { window.localStorage } catch { supported = false }` would always render `on`, also where the load throws. `pipeline.rs` says the pass sequence stays identical with upstream, so this PR only changes how the invariant is reported.

**Why `constant_propagation.rs` and `inline_iifes.rs` change.** They call `merge_consecutive_blocks`. Neither can reach the invariant today: `inline_iifes` and the standalone pipeline pass run before SSA, so no block has a phi, and `constant_propagation` removes the operands of unreachable predecessors right before it merges. They return `Result` so that the helper has no caller that has to panic or drop the error. `evaluate_instruction` recurses into nested functions, so its return type changes from `Option<Constant>` to `Result<Option<Constant>, _>`. The edits there are mechanical (`return Some(x)` to `return Ok(Some(x))`).

**Second site.** Frames: `validate_impl` (`validate_no_set_state_in_render.rs:96`), `validate_no_set_state_in_render` (`:26`), `run_hir_passes` (`pipeline.rs:467`). `drop_manual_memoization` puts StartMemoize after the load of `useMemo` / `useCallback` and FinishMemoize after the call, so a manual memo call anywhere in the arguments of another one nests the pairs. For a call in the dependency list, the port also records `Expected the dependency list to be an array of simple expressions`, as upstream main does (`env.recordError`), and continues. This validation runs before the pipeline checks the recorded errors. `useMemo(() => a, [a], useMemo(() => b, [b]))` nests the pairs with no recorded error. A `useMemo` in the callback of another `useMemo` does not nest them, because the pass does not visit nested functions.

**Comparison with babel-plugin-react-compiler 1.0.0.** I ran it on the 11 functions of the two new tests. It leaves the same 8 as written and compiles the same 3. Its errors: `Found a block with a single predecessor but where a phi has multiple (2) operands` for the four try forms, `Unexpected nested StartMemoize instructions` for the third-argument form, and `Expected the dependency list to be an array of simple expressions` for the three dependency-list forms (1.0.0 throws from DropManualMemoization, one pass earlier than main).

**The two FinishMemoize checks.** No known input reaches `Expected FinishMemoize to align with previous StartMemoize instruction` (`validate_no_set_state_in_render.rs:103`) or `Found FinishMemoize without corresponding StartMemoize` (`validate_exhaustive_dependencies.rs:787`). A nested input always fails the StartMemoize check first, and `validate_exhaustive_dependencies` tolerates nesting. They are the same pairing invariant, so they change with it. To exercise the new paths I forced each comparison to fail in a local build (selected by an environment variable, not committed). Each time `bun build` exited 0, the debug log showed the invariant for the function with the `useMemo` calls, and the other function in the file still compiled. `validate_preserved_manual_memoization.rs` already returns early on both conditions.

**Not changed here.** The other `assert!` / `.expect()` / `unreachable!` sites in `src/react_compiler` stay as they are. No known input reaches them, and most need `Result` plumbing through a pass that returns `()`. In `validation/` these are `validate_exhaustive_dependencies.rs:187` and `:326` and `validate_locals_not_reassigned_after_render.rs:262`. #42378 lists the ones in `reactive_scopes/` and `inference/`. A stack overflow or an allocation failure still ends the process.

**What the tests check.** Each test bundles one file with `--target=browser` through the CLI and runs the output against a fake `react/compiler-runtime` whose `c` counts its calls. A compiled function calls `c` once per render, so the count is 1 for a compiled function and 0 for a skipped one. The try test also defines `process.env.NODE_ENV` as `"production"` for the production-only form. `window` is not defined when the output runs, so a function that is left as written takes its catch path (`off`, `ReferenceError`). Each of the 8 skipped functions aborts 1.4.3 canary on its own. The controls (a call in the try body, a plain component, two sequential `useMemo` calls) make 1 call each, so the skip is per function and not per file.

**Sweep.** Built all 1806 source files under `test/bundler/transpiler/react-compiler-fixtures/` with `--target=browser` and `--target=bun` on 1.4.3 canary. None aborts with either message, so no upstream fixture has these shapes.

**Suites run with the debug build:** `test/bundler/transpiler/react-compiler.test.ts` (60 pass), `test/bundler/transpiler/react-compiler-fixtures.test.ts` (3293 pass, 320 skip). `cargo clippy -p bun_react_compiler` and `cargo fmt --check` are clean. `cargo check -p bun_react_compiler --release` passes.

Self-reviewed: the review raised no code concern. It asked for the provenance line and the "Not changed here" paragraph above.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [756.88ms]
(pass) bundler > react-compiler/ComponentWithHooks [296.42ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [242.88ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [273.37ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [136.87ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [109.58ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [335.54ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [105.36ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [667.91ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [117.72ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [102.23ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [416.81ms]
(pass) bundler > reac
... (truncated)

release without fix: 19 failed, 1 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [21.56ms]
(pass) bundler > react-compiler/ComponentWithHooks [8.98ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [9.04ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [17.23ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [9.27ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [5.62ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [13.75ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [5.15ms]
1031 |       ]);
1032 |       const stdout = Buffer.from(stdoutBytes);
1033 |       const stderr = Buffer.from(stderrBytes);
1034 |       const success = exitCode === 0;
1035 |       if (buildProc.signalCode) {
1036 |         throw new Error(
                         ^
error: [react-compiler/SsrObjectMethodShorthand] 'bun build' subprocess killed by SIGABRT
cmd: /workspace/bun/build/release/bun build /tmp/bun-build-tests/bun-BPbkFv/react-compiler/SsrObjectMethodShorthand/entry.jsx --outfile=/tmp/bun-build-tests/bun
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [987.51ms]
(pass) bundler > react-compiler/ComponentWithHooks [387.22ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [305.29ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [262.03ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [171.58ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [143.95ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [457.10ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [138.57ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [965.24ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [139.29ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [157.04ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [392.76ms]
(pass) bundler > reac
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 783ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/works
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../optimization/constant_propagation.rs           |  72 ++++----
 src/react_compiler/optimization/inline_iifes.rs    |   7 +-
 .../optimization/merge_consecutive_blocks.rs       |  39 +++--
 .../optimization/prune_maybe_throws.rs             |   2 +-
 src/react_compiler/pipeline.rs                     |   6 +-
 .../validation/validate_exhaustive_dependencies.rs |  15 +-
 .../validation/validate_no_set_state_in_render.rs  |  40 +++--
 test/bundler/transpiler/react-compiler.test.ts     | 185 +++++++++++++++++++++
 8 files changed, 301 insertions(+), 65 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/react_compiler/optimization/constant_propagation.rs       2      0     13
src/react_compiler/optimization/inline_iifes.rs               1      0     13
…react_compiler/optimization/merge_consecutive_blocks.rs      1      4     13
src/react_compiler/optimization/prune_maybe_throws.rs         1      1     13
src/react_compiler/pipeline.rs                                2      0     13
…compiler/validation/validate_exhaustive_dependencies.rs      1      0     13
…_compiler/validation/validate_no_set_state_in_render.rs      1      0     13
test/bundler/transpiler/react-compiler.test.ts                3      3     13
```

</details>

<!-- robobun:evidence:end -->