### PR TITLE
semver: reject a major, minor or patch number above u64::MAX

### DIFF
--- a/docs/runtime/semver.mdx
+++ b/docs/runtime/semver.mdx
@@ -36,7 +36,7 @@ semver.satisfies("1.0.0", "1.0.0 - 1.0.1"); // true
 
 `satisfies` returns `false` if `version` is invalid, or if either argument contains a non-ASCII character. Bun ignores the parts of `range` that it cannot parse. A `range` with no parseable part behaves like `*`.
 
-A major, minor, or patch number above 2^64 - 1 makes a version invalid. No version satisfies a `range` that has such a number.
+A major, minor, or patch number above 2^64 - 1 makes a version invalid. No version satisfies a `range` that has such a number before any wildcard. A number after a wildcard, as in `1.x.5`, has no effect on a `range`.
 
 ## `Bun.semver.order(versionA: string, versionB: string): 0 | 1 | -1`
 

--- a/docs/runtime/semver.mdx
+++ b/docs/runtime/semver.mdx
@@ -36,6 +36,8 @@ semver.satisfies("1.0.0", "1.0.0 - 1.0.1"); // true
 
 `satisfies` returns `false` if `version` is invalid, or if either argument contains a non-ASCII character. Bun ignores the parts of `range` that it cannot parse. A `range` with no parseable part behaves like `*`.
 
+A major, minor, or patch number above 2^64 - 1 makes a version invalid. No version satisfies a `range` that has such a number.
+
 ## `Bun.semver.order(versionA: string, versionB: string): 0 | 1 | -1`
 
 Returns `0` if `versionA` and `versionB` are equal, `1` if `versionA` is greater than `versionB`, and `-1` if `versionA` is less than `versionB`.

--- a/src/semver/SemverQuery.rs
+++ b/src/semver/SemverQuery.rs
@@ -472,6 +472,25 @@ impl Group {
         }
     }
 
+    /// A group that no version satisfies.
+    fn null_set(input: &[u8]) -> Group {
+        Group {
+            head: List {
+                head: Query {
+                    range: Range {
+                        left: Comparator::null_set(),
+                        ..Default::default()
+                    },
+                    next: None,
+                },
+                tail: None,
+                next: None,
+            },
+            input: std::ptr::from_ref::<[u8]>(input),
+            ..Default::default()
+        }
+    }
+
     pub fn is_exact(&self) -> bool {
         self.head.next.is_none()
             && self.head.head.next.is_none()
@@ -945,6 +964,10 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
 
         if !skip_round {
             let parse_result = Version::parse(sliced.sub(&input[i..]));
+            // node-semver rejects the whole range for a number it cannot hold.
+            if parse_result.overflow {
+                return Ok(Group::null_set(input));
+            }
             let version = parse_result.version.min();
             if version.tag.has_build() {
                 list.flags.set(Flags::BUILD);
@@ -997,6 +1020,9 @@ pub fn parse(input: &[u8], sliced: SlicedString) -> Result<Group, AllocError> {
 
             if hyphenate {
                 let second_parsed = Version::parse(sliced.sub(&input[i..]));
+                if second_parsed.overflow {
+                    return Ok(Group::null_set(input));
+                }
                 let mut second_version = second_parsed.version.min();
                 if second_version.tag.has_build() {
                     list.flags.set(Flags::BUILD);

--- a/src/semver/SemverRange.rs
+++ b/src/semver/SemverRange.rs
@@ -1,8 +1,9 @@
 use core::cmp::Ordering;
 use core::fmt;
 
-use crate::Version;
 use crate::query::token::Wildcard;
+use crate::version::Tag;
+use crate::{SlicedString, Version};
 
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
@@ -183,6 +184,21 @@ pub struct Comparator {
 }
 
 impl Comparator {
+    /// `<0.0.0-0`, the comparator node-semver uses for the empty set. `0.0.0-0`
+    /// is the lowest version, so no version satisfies it.
+    pub(crate) fn null_set() -> Comparator {
+        Comparator {
+            op: Op::Lt,
+            version: Version {
+                tag: Tag {
+                    pre: SlicedString::init(b"0", b"0").external(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        }
+    }
+
     /// `< {major+1}.0.0`, or `<= u64::MAX.u64::MAX.u64::MAX` when `major+1`
     /// would overflow so the desugared range stays non-empty at the ceiling.
     pub(crate) fn lt_next_major(major: u64) -> Comparator {

--- a/src/semver/SemverRange.rs
+++ b/src/semver/SemverRange.rs
@@ -184,8 +184,7 @@ pub struct Comparator {
 }
 
 impl Comparator {
-    /// `<0.0.0-0`, the comparator node-semver uses for the empty set. `0.0.0-0`
-    /// is the lowest version, so no version satisfies it.
+    /// `<0.0.0-0`: no version satisfies it. node-semver uses it for the empty set.
     pub(crate) fn null_set() -> Comparator {
         Comparator {
             op: Op::Lt,

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -528,23 +528,24 @@ impl<T: VersionInt> VersionType<T> {
 
                     last_char_i = i;
 
-                    match part_i {
-                        0 => {
-                            result.version.major =
-                                Self::parse_version_number(&input[part_start_i..last_char_i]);
-                            part_i = 1;
+                    if part_i < 3 {
+                        let number = Self::parse_version_number(&input[part_start_i..last_char_i]);
+                        if number.is_none() {
+                            result.valid = false;
+                            // A number after a wildcard has no effect on a range, so
+                            // the range parser still needs the rest of this token read.
+                            if result.wildcard == Wildcard::None {
+                                result.overflow = true;
+                                is_done = true;
+                                break;
+                            }
                         }
-                        1 => {
-                            result.version.minor =
-                                Self::parse_version_number(&input[part_start_i..last_char_i]);
-                            part_i = 2;
+                        match part_i {
+                            0 => result.version.major = number,
+                            1 => result.version.minor = number,
+                            _ => result.version.patch = number,
                         }
-                        2 => {
-                            result.version.patch =
-                                Self::parse_version_number(&input[part_start_i..last_char_i]);
-                            part_i = 3;
-                        }
-                        _ => {}
+                        part_i += 1;
                     }
 
                     if i < input.len()
@@ -652,11 +653,12 @@ impl<T: VersionInt> VersionType<T> {
         result
     }
 
+    /// `None` when the number is above `T::MAX`.
     fn parse_version_number(input: &[u8]) -> Option<T> {
         // Callers slice `input` from the first digit to the first non-digit,
         // so every byte is already `b'0'..=b'9'` and the slice is non-empty.
         debug_assert!(!input.is_empty() && input.iter().all(u8::is_ascii_digit));
-        Some(T::parse_ascii(input).unwrap_or(T::ZERO))
+        T::parse_ascii(input)
     }
 }
 
@@ -1191,6 +1193,10 @@ pub struct TagResult {
 pub struct ParseResult<T: VersionInt> {
     pub wildcard: Wildcard,
     pub valid: bool,
+    /// A major, minor or patch number before any wildcard is above `T::MAX`. The
+    /// range parser ignores `valid`, so it reads this to tell that number apart
+    /// from text it can skip.
+    pub(crate) overflow: bool,
     pub version: Partial<T>,
     pub(crate) len: u32,
 }
@@ -1200,6 +1206,7 @@ impl<T: VersionInt> Default for ParseResult<T> {
         Self {
             wildcard: Wildcard::None,
             valid: true,
+            overflow: false,
             version: Partial::default(),
             len: 0,
         }

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -532,8 +532,7 @@ impl<T: VersionInt> VersionType<T> {
                         let number = Self::parse_version_number(&input[part_start_i..last_char_i]);
                         if number.is_none() {
                             result.valid = false;
-                            // A number after a wildcard has no effect on a range, so
-                            // the range parser still needs the rest of this token read.
+                            // A range ignores a number after a wildcard, so keep reading the token.
                             if result.wildcard == Wildcard::None {
                                 result.overflow = true;
                                 is_done = true;
@@ -1193,9 +1192,7 @@ pub struct TagResult {
 pub struct ParseResult<T: VersionInt> {
     pub wildcard: Wildcard,
     pub valid: bool,
-    /// A major, minor or patch number before any wildcard is above `T::MAX`. The
-    /// range parser ignores `valid`, so it reads this to tell that number apart
-    /// from text it can skip.
+    /// A number before any wildcard is above `T::MAX`. The range parser reads this, not `valid`.
     pub(crate) overflow: bool,
     pub version: Partial<T>,
     pub(crate) len: u32,

--- a/test/bun.lock
+++ b/test/bun.lock
@@ -79,6 +79,7 @@
         "reflect-metadata": "0.2.2",
         "rollup": "4.4.1",
         "sass": "1.79.4",
+        "semver": "7.7.4",
         "sharp": "0.34.5",
         "sinon": "6.0.0",
         "socket.io": "4.7.1",

--- a/test/cli/install/bun-pm-version.test.ts
+++ b/test/cli/install/bun-pm-version.test.ts
@@ -274,6 +274,66 @@ describe.concurrent("bun pm version", () => {
       expect(code5).toBe(0);
     });
 
+    it("rejects a version number above u64::MAX like npm", async () => {
+      // The parser used to read such a number as 0, so `patch` on "1.0.18446744073709551616" printed v1.0.1.
+      const u64Max = "18446744073709551615";
+      const aboveU64Max = "18446744073709551616";
+
+      const bump = async (version: string, arg: string) => {
+        await using testDir = tempDir(`version-${i++}`, {
+          "package.json": JSON.stringify({ name: "test", version }, null, 2),
+        });
+        const { output, error, code } = await runCommand(
+          [bunExe(), "pm", "version", arg, "--no-git-tag-version"],
+          testDir,
+          false,
+        );
+        const after = (await Bun.file(join(String(testDir), "package.json")).json()).version;
+        return { output, error, code, after };
+      };
+
+      const results = await Promise.all([
+        bump(`1.0.${aboveU64Max}`, "patch"),
+        bump(`1.0.${aboveU64Max}`, "minor"),
+        bump("1.0.99999999999999999999", "patch"),
+        bump("1.0.0", `1.0.${aboveU64Max}`),
+        // u64::MAX itself still fits.
+        bump(`1.0.${u64Max}`, "minor"),
+        bump("1.0.0", `1.0.${u64Max}`),
+      ]);
+
+      expect(results).toEqual([
+        {
+          output: "",
+          error: `error: Current version "1.0.${aboveU64Max}" is not a valid semver\n`,
+          code: 1,
+          after: `1.0.${aboveU64Max}`,
+        },
+        {
+          output: "",
+          error: `error: Current version "1.0.${aboveU64Max}" is not a valid semver\n`,
+          code: 1,
+          after: `1.0.${aboveU64Max}`,
+        },
+        {
+          output: "",
+          error: `error: Current version "1.0.99999999999999999999" is not a valid semver\n`,
+          code: 1,
+          after: "1.0.99999999999999999999",
+        },
+        {
+          output: "",
+          error:
+            `error: Invalid version argument: "1.0.${aboveU64Max}"\n` +
+            "note: Valid options: patch, minor, major, prepatch, preminor, premajor, prerelease, from-git, or a specific semver version\n",
+          code: 1,
+          after: "1.0.0",
+        },
+        { output: "v1.1.0\n", error: "", code: 0, after: "1.1.0" },
+        { output: `v1.0.${u64Max}\n`, error: "", code: 0, after: `1.0.${u64Max}` },
+      ]);
+    });
+
     it("handles missing package.json like npm", async () => {
       await using testDir = tempDir(`version-${i++}`, {
         "README.md": "# Test project",

--- a/test/cli/install/semver.test.ts
+++ b/test/cli/install/semver.test.ts
@@ -14,7 +14,8 @@
 // ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 // IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
+import nodeSemver from "semver";
 import { unsortedPrereleases } from "./semver-fixture.js";
 const { satisfies, order } = Bun.semver;
 
@@ -38,6 +39,22 @@ function testSatisfies(right: any, left: any, expected: boolean) {
   expect(satisfies(leftBuffer, rightBuffer)).toBe(expected);
   expect(satisfies(leftBuffer, right)).toBe(expected);
   expect(satisfies(left, rightBuffer)).toBe(expected);
+}
+
+const u64Max = "18446744073709551615";
+// u64::MAX + 1, then 20 and 30 digits: the answer must not depend on the length.
+const numbersAboveU64Max = ["18446744073709551616", Buffer.alloc(20, "9").toString(), Buffer.alloc(30, "9").toString()];
+
+function versionsWith(big: string) {
+  return [
+    `${big}.0.0`,
+    `1.${big}.0`,
+    `1.0.${big}`,
+    `v1.0.${big}`,
+    `1.0.${big}-beta.1`,
+    `1.0.${big}+build`,
+    `${big}.${big}.${big}`,
+  ];
 }
 
 describe("Bun.semver.order()", () => {
@@ -178,6 +195,24 @@ describe("Bun.semver.order()", () => {
       expect(order(right, left)).toBe(0);
     }
   });
+
+  test("a major, minor or patch number above u64::MAX is an invalid version", () => {
+    // These used to read the number as 0, so "1.0.18446744073709551616" compared equal to "1.0.0".
+    // node-semver throws "Invalid patch version" (its limit is Number.MAX_SAFE_INTEGER).
+    for (const big of numbersAboveU64Max) {
+      for (const version of versionsWith(big)) {
+        expect(() => order(version, "1.0.0")).toThrow(`Invalid SemVer: ${version}\n`);
+        expect(() => order("1.0.0", version)).toThrow(`Invalid SemVer: ${version}\n`);
+      }
+      // order() accepts a wildcard, but not such a number after it.
+      expect(() => order(`1.x.${big}`, "1.0.0")).toThrow(`Invalid SemVer: 1.x.${big}\n`);
+    }
+
+    // u64::MAX itself still fits.
+    expect(order(`1.0.${u64Max}`, "1.0.0")).toBe(1);
+    expect(order(`1.${u64Max}.0`, `1.0.${u64Max}`)).toBe(1);
+    expect(order(`${u64Max}.${u64Max}.${u64Max}`, `${u64Max}.${u64Max}.${u64Max}`)).toBe(0);
+  });
 });
 
 describe("Bun.semver.satisfies()", () => {
@@ -242,8 +277,8 @@ describe("Bun.semver.satisfies()", () => {
   });
 
   test("long version components are not treated as wildcards", () => {
-    // A component >20 bytes must parse to its numeric value (or clamp on overflow),
-    // not fall through to a wildcard. node-semver loose mode agrees with all of these.
+    // A component >20 bytes must parse to its numeric value (or make the range match nothing on
+    // overflow), not fall through to a wildcard. node-semver loose mode agrees with all of these.
     const twenty = Buffer.alloc(20, "9").toString();
     const twentyOne = Buffer.alloc(21, "9").toString();
     for (const big of [twenty, twentyOne]) {
@@ -310,6 +345,129 @@ describe("Bun.semver.satisfies()", () => {
     testSatisfies(`~${M1}`, `${M1}.0.0`, true);
     testSatisfies(M1, `${M1}.0.0`, true);
     testSatisfies(`^${M1}`, `${M}.0.0`, false);
+  });
+
+  test("a version with a number above u64::MAX satisfies nothing", () => {
+    // These used to read the number as 0, so "1.0.18446744073709551616" satisfied "1.0.0".
+    // node-semver returns false: the version is invalid.
+    const ranges = ["*", "", "x", ">=0.0.0", `<=${u64Max}.${u64Max}.${u64Max}`, "1.0.0", "^1.0.0", "1.x", ">=1.0.0-0"];
+    for (const big of numbersAboveU64Max) {
+      for (const version of versionsWith(big)) {
+        for (const range of ranges) {
+          testSatisfies(range, version, false);
+        }
+        testSatisfies(version, version, false);
+      }
+    }
+  });
+
+  test("a range with a number above u64::MAX is satisfied by nothing", () => {
+    // These used to read the number as 0, so "^99999999999999999999" was "^0" and "0.5.0" satisfied it.
+    // node-semver throws "Invalid major version" for the whole range, also when the
+    // number is in one "||" alternative only, so satisfies() is false for every version.
+    const rangesWith = (big: string) => [
+      // exact
+      `${big}.0.0`,
+      `=${big}.0.0`,
+      `v${big}.0.0`,
+      `1.${big}.0`,
+      `1.0.${big}`,
+      `1.0.${big}-beta.1`,
+      // primitive comparators
+      `>=${big}.0.0`,
+      `>${big}.0.0`,
+      `<${big}.0.0`,
+      `<=${big}.0.0`,
+      `<=1.0.${big}`,
+      `<1.${big}.0`,
+      `>= ${big}.0.0`,
+      // caret and tilde
+      `^${big}`,
+      `^${big}.2.3`,
+      `^0.${big}`,
+      `^0.0.${big}`,
+      `~${big}`,
+      `~1.${big}`,
+      `~1.0.${big}`,
+      `~>1.${big}`,
+      // partial versions and x-ranges
+      `${big}`,
+      `${big}.x`,
+      `${big}.*.*`,
+      `1.${big}`,
+      `1.${big}.x`,
+      `>=${big}.x`,
+      `<1.${big}.x`,
+      // hyphen ranges, the number on each side
+      `1.0.0 - ${big}.0.0`,
+      `1.0.0 - ${big}`,
+      `1.0.0 - 1.${big}.x`,
+      `${big}.0.0 - 2.0.0`,
+      `0.0.0 - 1.0.${big}`,
+      // the number is in one comparator of an intersection
+      `>=0.0.0 <${big}.0.0`,
+      `<${big}.0.0 >=0.0.0`,
+      `>=1.0.0 <=1.0.${big}`,
+      // the number is in one alternative of a union
+      `1.0.0 || ${big}.0.0`,
+      `${big}.0.0 || 1.0.0`,
+      `* || <${big}.0.0`,
+      `<${big}.0.0 || *`,
+      `^1.0.0 || ^${big}`,
+    ];
+    const versions = [
+      "0.0.0",
+      "0.5.0",
+      "1.0.0",
+      "1.0.5",
+      "2.0.0",
+      `${u64Max}.${u64Max}.${u64Max}`,
+      "0.0.0-0",
+      "1.0.0-beta.1",
+    ];
+    for (const big of numbersAboveU64Max) {
+      for (const range of rangesWith(big)) {
+        for (const version of versions) {
+          testSatisfies(range, version, false);
+        }
+      }
+    }
+
+    // A number after a wildcard has no effect on a range, as in node-semver: "1.x.<big>" is "1.x".
+    for (const big of numbersAboveU64Max) {
+      testSatisfies(`1.x.${big}`, "1.5.0", true);
+      testSatisfies(`1.x.${big}`, "2.0.0", false);
+      testSatisfies(`^1.x.${big}`, "1.5.0", true);
+      testSatisfies(`~1.*.${big}`, "1.5.0", true);
+      testSatisfies(`>=1.x.${big}`, "2.0.0", true);
+      testSatisfies(`>=1.x.${big}`, "0.9.0", false);
+      testSatisfies(`*.${big}`, "1.0.0", true);
+      testSatisfies(`x.${big}.${big}`, "1.0.0", true);
+      testSatisfies(`1.0.0 - 1.x.${big}`, "1.5.0", true);
+      testSatisfies(`1.0.0 - 1.x.${big}`, "2.0.0", false);
+      testSatisfies(`1.x.${big} - 3.0.0`, "2.5.0", true);
+      testSatisfies(`1.x.${big} - 3.0.0`, "3.5.0", false);
+      testSatisfies(`1.*.${big} || 3.0.0`, "3.0.0", true);
+      testSatisfies(`1.*.${big} || 3.0.0`, "2.5.0", false);
+      // The text after that number still belongs to the same comparator: "-2" is a
+      // prerelease here, not the start of the hyphen range "1.x.<big> - 2".
+      testSatisfies(`1.x.${big}-2`, "1.5.0", true);
+      testSatisfies(`1.x.${big}-2`, "2.0.0", false);
+      testSatisfies(`1.x.${big}-2`, "2.5.0", false);
+      testSatisfies(`1.x.${big}-0`, "1.5.0", true);
+      testSatisfies(`^1.x.${big}-2`, "2.5.0", false);
+      testSatisfies(`>=1.x.${big}-2`, "2.5.0", true);
+      testSatisfies(`>=1.x.${big}-2`, "0.9.0", false);
+      testSatisfies(`1.x.${big}+2`, "1.5.0", true);
+      testSatisfies(`1.x.${big}+2`, "2.5.0", false);
+    }
+
+    // u64::MAX itself still fits: the same shapes keep their meaning.
+    testSatisfies(`<${u64Max}.0.0`, "1.0.0", true);
+    testSatisfies(`<=1.0.${u64Max}`, "1.0.5", true);
+    testSatisfies(`1.0.0 - ${u64Max}.0.0`, "2.0.0", true);
+    testSatisfies(`1.0.0 || ${u64Max}.0.0`, "1.0.0", true);
+    testSatisfies(`1.0.0 || ${u64Max}.0.0`, `${u64Max}.0.0`, true);
   });
 
   test("ranges", () => {
@@ -809,6 +967,136 @@ describe("Bun.semver.satisfies()", () => {
   test("pre-release snapshot", () => {
     expect(unsortedPrereleases.sort(Bun.semver.order)).toMatchSnapshot();
   });
+});
+
+test("a number above u64::MAX gives the same answers as node-semver (seeded differential)", () => {
+  // Replay a failure with BUN_SEMVER_FUZZ_SEED=<seed>. Soak with BUN_SEMVER_FUZZ_ITERS=<n>.
+  const seed = Number(process.env.BUN_SEMVER_FUZZ_SEED ?? 0x73656d76) >>> 0;
+  const iterations = Number(process.env.BUN_SEMVER_FUZZ_ITERS ?? 100);
+  let state = seed;
+  const next = () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+  const pick = <T>(list: readonly T[]): T => list[Math.floor(next() * list.length)];
+
+  const small = ["0", "1", "2", "10"];
+  const wildcard = ["x", "X", "*"];
+  const suffix = ["", "", "", "-2", "-0", "-beta.1", "+2"];
+  const comparing = [">=", ">", "<", "<=", "^", "~"];
+  const operator = ["", "", "=", "v", "~>", ...comparing];
+
+  // One to three parts, exactly one of them above u64::MAX. Every shape here gives the same
+  // answer in Bun and node-semver when the number is small. That leaves out two shapes where
+  // they differ for any number: a wildcard as the first part (">x.1"), and a comparator with
+  // no operator inside an intersection (">=1.0.0 2.x").
+  const partial = (wildcards: boolean) => {
+    // The number after a wildcard has no effect, and the text after it stays in the same comparator.
+    if (wildcards && next() < 0.3) {
+      return `${pick(small)}.${pick(wildcard)}.${pick(numbersAboveU64Max)}${pick(suffix)}`;
+    }
+    const length = 1 + Math.floor(next() * 3);
+    const bigAt = Math.floor(next() * length);
+    const parts: string[] = [];
+    for (let i = 0; i < length; i++) {
+      if (i === bigAt) parts.push(pick(numbersAboveU64Max));
+      else if (wildcards && i > 0 && next() < 0.3) parts.push(pick(wildcard));
+      else parts.push(pick(small));
+    }
+    return parts.join(".") + (length === 3 ? pick(suffix) : "");
+  };
+  const plain = () => `${pick(small)}.${pick(small)}.${pick(small)}`;
+  const range = () => {
+    switch (Math.floor(next() * 8)) {
+      case 0:
+        return `${pick(operator)}${partial(true)} || ${pick(operator)}${plain()}`;
+      case 1:
+        return `${pick(operator)}${plain()} || ${pick(operator)}${partial(true)}`;
+      case 2:
+        return `>=${plain()} ${pick(comparing)}${partial(true)}`;
+      case 3:
+        return `${pick(comparing)}${partial(true)} <${plain()}`;
+      case 4:
+        return `${plain()} - ${partial(true)}`;
+      case 5:
+        return `${partial(true)} - ${plain()}`;
+      default:
+        return pick(operator) + partial(true);
+    }
+  };
+
+  const versions = ["0.0.0", "0.1.0", "1.0.0", "1.2.10", "2.0.0", "10.10.10"];
+  const attempt = (fn: () => number) => {
+    try {
+      return fn();
+    } catch {
+      return "throws";
+    }
+  };
+  const disagreements: object[] = [];
+  for (let i = 0; i < iterations; i++) {
+    const r = range();
+    for (const v of versions) {
+      const bun = satisfies(v, r);
+      const node = nodeSemver.satisfies(v, r);
+      if (bun !== node) disagreements.push({ satisfies: [v, r], bun, node });
+    }
+
+    const version = partial(false);
+    const bun = attempt(() => order(version, "1.0.0"));
+    const node = attempt(() => nodeSemver.compare(version, "1.0.0"));
+    if (bun !== node) disagreements.push({ order: [version, "1.0.0"], bun, node });
+    if (satisfies(version, "*") !== nodeSemver.satisfies(version, "*")) {
+      disagreements.push({ satisfies: [version, "*"], bun: satisfies(version, "*") });
+    }
+  }
+  expect({ seed, disagreements }).toEqual({ seed, disagreements: [] });
+});
+
+test("bun install does not resolve a dependency range that has a number above u64::MAX", async () => {
+  // "^99999999999999999999" used to be read as "^0", so this installed foo@0.5.0.
+  const requested: string[] = [];
+  await using registry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const { pathname } = new URL(req.url);
+      requested.push(pathname);
+      if (pathname !== "/foo") return new Response("not found", { status: 404 });
+      return Response.json({
+        name: "foo",
+        "dist-tags": { latest: "1.0.0" },
+        versions: Object.fromEntries(
+          ["0.5.0", "1.0.0"].map(version => [
+            version,
+            { name: "foo", version, dist: { tarball: new URL(`/foo-${version}.tgz`, req.url).href } },
+          ]),
+        ),
+      });
+    },
+  });
+  using dir = tempDir("semver-number-above-u64-max", {
+    "package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { foo: "^99999999999999999999" },
+    }),
+    "bunfig.toml": `[install]\ncache = false\nregistry = "${registry.url}"\n`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain(
+    'error: No version matching "^99999999999999999999" found for specifier "foo" (but package exists)',
+  );
+  expect(requested).toEqual(["/foo"]);
+  expect(exitCode).toBe(1);
 });
 
 test("a version range with >=256 || comparators does not abort", async () => {

--- a/test/package.json
+++ b/test/package.json
@@ -81,6 +81,7 @@
     "reflect-metadata": "0.2.2",
     "rollup": "4.4.1",
     "sass": "1.79.4",
+    "semver": "7.7.4",
     "sharp": "0.34.5",
     "sinon": "6.0.0",
     "socket.io": "4.7.1",


### PR DESCRIPTION
### Problem
- A major, minor or patch number above `u64::MAX` parses as 0 and the version stays valid. `bun pm version patch` on `1.0.18446744073709551616` prints `v1.0.1`, and `Bun.semver.order` says it equals `1.0.0`. A code audit found this. No user report exists.
- A range has the same fault: `"foo": "^99999999999999999999"` is read as `^0`, so `bun install` installs `foo@0.5.0`. npm and node-semver reject these.
- The cause is `parse_version_number` (`src/semver/Version.rs:655`): `T::parse_ascii(input).unwrap_or(T::ZERO)`.

### Fix
- `Version::parse` sets `valid = false` for such a number and stops. Every caller that reads `valid` now rejects it.
- The range parser never reads `valid`, so `ParseResult` carries `overflow`. On overflow the whole range becomes `<0.0.0-0`, the empty set of node-semver, which also rejects the whole range. A number after a wildcard (`1.x.<big>`) has no effect on a range, so the parser reads past it.
- Verified: 6 new tests in `test/cli/install/semver.test.ts` and `bun-pm-version.test.ts` fail on 1.4.3-canary and pass here. One is a seeded differential against `semver@7.7.4`, a new pinned test dependency.
- Self-reviewed: 3 concerns raised, 2 addressed. Not addressed: the `+ 1` overflow in `bun pm version`, which a separate change covers.

### Background
- `Version::parse` returns a `ParseResult`: the numbers as `Option`s, a `wildcard` that names the first missing part, and a `valid` flag. A range uses it for each comparator.
- `SemverQuery::parse` cannot fail. It skips text it does not understand, so a range has no invalid state. A range that nothing satisfies is the closest equivalent.
- #22889 (`u32` to `u64`) and #34521 both kept this fallback to 0. This PR removes it.

<details><summary>Notes</summary>

**History.** An overflow that was accepted in silence caused real reports when the numbers were `u32`: a wrong-version install (#21793) and a crash (#16041). #22889 answered by widening to `u64`, which moved the limit and kept the fallback. #34521 removed a 20-byte length limit from `parse_version_number` and kept `unwrap_or(T::ZERO)` to limit its scope. Its tests expect `false` only, and they still pass.

**Reach.** registry.npmjs.org validates a version at publish time (node-semver allows at most 2^53 - 1), so a version above `u64::MAX` comes only from a hand-written `package.json`, a `Bun.semver` argument, a registry that does not validate, or a hand-edited lockfile. A range is different: the dependency map of a published manifest is stored as text (`npm.rs:2691`), and `Package.rs:740` hands each entry to `dependency.rs:1164`, which calls the range parser.

**Callers.** All 19 call sites of `Version::parse` / `parse_utf8` were read. These check `valid` and need no change: `pm_version_command.rs` (both sites), `SemverObject.rs` `order`, `npm.rs` (manifest version keys), `bun.lock.rs`, `Package.rs`, `resolution.rs`, `yarn.rs`, `pnpm.rs`, `migration.rs`, `PackageManagerResolution.rs`, `update_interactive_command.rs`, `pm_view_command.rs`, `why_command.rs`, `pm_diff_command.rs`, `compile_target.rs`, `analytics`. Two sites ignore `valid` for every kind of invalid input and use `.version.min()`: the dist-tag map (`npm.rs:3020`) and `npm_lock.rs:532`. For those the result is unchanged (the unread number still counts as 0).

**`Bun.semver.satisfies(version, range)`.** The binding checks the `wildcard` of the version, not `valid`. The parser stops at the number without counting it, so `wildcard` names that part and `satisfies` returns `false`. `SemverObject.rs` is not touched, so there is no overlap with #32998.

**Manifest version keys.** A registry manifest key such as `1.0.99999999999999999999` was stored as `1.0.0` and could shadow the real `1.0.0`. It now takes the path every invalid key takes today (`npm.rs:2127`): release builds log `Failed to parse dependency` and skip the key, debug builds hit the existing `debug_assert!(parsed_version.valid)`.

**After a wildcard.** The parser keeps reading after such a number when a wildcard comes first. If it stopped there, the range parser would read the rest of the token again: `1.x.<big>-2` would become the hyphen range `1.x.<big> - 2` and admit `2.0.0`. The self-review found this on an earlier revision. The table test has rows for it.

**Strict and loose mode.** Every fixed test row agrees with node-semver in strict mode. In loose mode node-semver formats a 30-digit hyphen bound as `1e+30` and drops it, so three row shapes differ there. That is an accident of number formatting in JavaScript. The seeded differential uses strict mode. Its generator leaves out two shapes where Bun and node-semver differ for any number: a wildcard as the first part (`>x.1`) and a comparator with no operator inside an intersection (#32993). It passes on 16 more seeds at 600 iterations each.

**Differential run.** 6000 generated version and range pairs through release 1.4.3-canary, this build and node-semver. Every changed `satisfies` result has a number above `u64::MAX` and is now `false`. Every changed `order` result has one and now throws. On rows with such a number, this build agrees with node-semver loose mode on 1561 of 1565 (release: 1061). Three of the four left are the `1e+30` case. The fourth has the number after a wildcard and is unchanged from release.

**Not changed, possible follow-ups.** The `+ 1` in `bun pm version` at `u64::MAX` and its `u32` prerelease counter (`pm_version_command.rs:616`) are a separate change. Numeric prerelease identifiers above `u64::MAX` (#33625). `satisfies` for other invalid versions such as `1.2.3.4` (#32998). `--target` drops an invalid version token in silence (`compile_target.rs:288`, #37389). Other ranges that node-semver rejects and Bun accepts could use `Group::null_set` later.

**Suites run.** `test/cli/install/`: semver, bun-pm-version, overrides, nested-overrides, catalogs, bun-add-catalog, bun-pm-why, bun-update, bun-add, bun-install, migrate-bun-lockb-v2, `migration/*`. `test/regression/issue/08040` and `26657`. `test/internal/source-lints`. The failures seen need the network (`git clone`, bitbucket, gitlab) and fail the same way on the release binary.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/bun-pm-version.test.ts test/cli/install/semver.test.ts
bun test v1.4.3 (6a92015fc)

test/cli/install/bun-pm-version.test.ts:
(pass) bun pm version > help and version previews > should show help when no arguments provided [258.26ms]
(pass) bun pm version > basic version incrementing > should set specific version [205.38ms]
(pass) bun pm version > basic version incrementing > handles empty package.json [688.25ms]
(pass) bun pm version > basic version incrementing > should increment versions correctly [760.21ms]
300 |         // u64::MAX itself still fits.
301 |         bump(`1.0.${u64Max}`, "minor"),
302 |         bump("1.0.0", `1.0.${u64Max}`),
303 |       ]);
304 | 
305 |       expect(results).toEqual([
                            ^
error: expect(received).toEqual(expected)

  [
    {
-     "after": "1.0.18446744073709551616",
-     "code": 1,
-     "error": 
- "error: Current version "1.0.18446744073709551616" is not a valid semver
+     "after": "1.0.1",
+     "code": 0,
+     "error": "",
+     "output": 
+ "v1.0.1
 
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (d85bd1383)

test/cli/install/bun-pm-version.test.ts:
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint: 	git branch -m <name>
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint: 	git branch -m <name>
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/bun-pm-version.test.ts test/cli/install/semver.test.ts
bun test v1.4.3 (6a92015fc)

test/cli/install/bun-pm-version.test.ts:
(pass) bun pm version > help and version previews > should show help when no arguments provided [369.41ms]
(pass) bun pm version > basic version incrementing > should set specific version [402.23ms]
(pass) bun pm version > basic version incrementing > handles empty package.json [675.56ms]
(pass) bun pm version > error handling > handles missing package.json like npm [229.24ms]
(pass) bun pm version > error handling > handles empty string package.json like npm [311.85ms]
(pass) bun pm version > error handling > rejects a version number above u64::MAX like npm [915.73ms]
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1338ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/138] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/138] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[3/138] gen cpp.rs (cppbind)
[4/138] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[5/138] gen JS modules (bundle-modules)
Preprocess modules (14590ms)
Bundle modules (91ms)
Postprocesss modules (209ms)
Bundle Functions (760ms)
Generate Code (55ms)

[15.71s] Bundled "src/js" for production
  2600 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[5/137] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_semver v0.0.0 (/workspace/bun/src/semver)
[1m[92m   Compiling[0m bun_uws_sys v0.0.0 (/work
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/semver.mdx                 |   2 +
 src/semver/SemverQuery.rs               |  26 +++
 src/semver/SemverRange.rs               |  17 +-
 src/semver/Version.rs                   |  36 ++--
 test/bun.lock                           |   1 +
 test/cli/install/bun-pm-version.test.ts |  60 +++++++
 test/cli/install/semver.test.ts         | 294 +++++++++++++++++++++++++++++++-
 test/package.json                       |   1 +
 8 files changed, 417 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
docs/runtime/semver.mdx                      2      3     26
src/semver/SemverQuery.rs                    2      3     26
src/semver/SemverRange.rs                    1      2     26
src/semver/Version.rs                        4      6     27
test/bun.lock                                0      0     29
test/cli/install/bun-pm-version.test.ts      1      1     10
test/cli/install/semver.test.ts              4     13     23
test/package.json                            1      1     28
```

</details>

<!-- robobun:evidence:end -->