### PR TITLE
bun pm version: read the prerelease number as a u64, reject a version npm calls invalid

### DIFF
--- a/src/runtime/cli/pm_version_command.rs
+++ b/src/runtime/cli/pm_version_command.rs
@@ -321,8 +321,7 @@ impl PmVersionCommand {
         Ok(())
     }
 
-    /// node-semver's limit for major, minor and patch. It also keeps `+ 1` from wrapping.
-    /// https://github.com/npm/node-semver/blob/v7.7.2/classes/semver.js#L50-L60
+    /// node-semver's limit: https://github.com/npm/node-semver/blob/v7.7.2/classes/semver.js#L50-L60
     fn is_valid_version(result: &Semver::version::ParseResult<u64>) -> bool {
         const MAX_SAFE_INTEGER: u64 = (1 << 53) - 1;
         let version = result.version.min();

--- a/src/runtime/cli/pm_version_command.rs
+++ b/src/runtime/cli/pm_version_command.rs
@@ -321,8 +321,7 @@ impl PmVersionCommand {
         Ok(())
     }
 
-    /// `npm version` refuses a major, minor or patch above Number.MAX_SAFE_INTEGER. Below that
-    /// limit, `+ 1` cannot wrap.
+    /// node-semver's limit for major, minor and patch. It also keeps `+ 1` from wrapping.
     /// https://github.com/npm/node-semver/blob/v7.7.2/classes/semver.js#L50-L60
     fn is_valid_version(result: &Semver::version::ParseResult<u64>) -> bool {
         const MAX_SAFE_INTEGER: u64 = (1 << 53) - 1;
@@ -539,8 +538,7 @@ impl PmVersionCommand {
         Self::increment_version(current_str, &current, version_type, &prerelease_id)
     }
 
-    /// The number after the prerelease identifier `identifier`. `None` when it is not a number
-    /// or `+ 1` does not fit. A u64 like `Tag::order_pre`: a u32 read 20250101123456 as a string.
+    /// `None` for a name, and for a number with no successor in the u64 `Tag::order_pre` compares in.
     fn next_prerelease_number(identifier: &[u8]) -> Option<u64> {
         bun_core::fmt::parse_decimal::<u64>(identifier)?.checked_add(1)
     }

--- a/src/runtime/cli/pm_version_command.rs
+++ b/src/runtime/cli/pm_version_command.rs
@@ -321,13 +321,22 @@ impl PmVersionCommand {
         Ok(())
     }
 
+    /// `npm version` refuses a major, minor or patch above Number.MAX_SAFE_INTEGER. Below that
+    /// limit, `+ 1` cannot wrap.
+    /// https://github.com/npm/node-semver/blob/v7.7.2/classes/semver.js#L50-L60
+    fn is_valid_version(result: &Semver::version::ParseResult<u64>) -> bool {
+        const MAX_SAFE_INTEGER: u64 = (1 << 53) - 1;
+        let version = result.version.min();
+        result.valid && version.major.max(version.minor).max(version.patch) <= MAX_SAFE_INTEGER
+    }
+
     fn parse_version_argument(arg: &[u8]) -> (VersionType, Option<&[u8]>) {
         if let Some(vtype) = VersionType::from_string(arg) {
             return (vtype, None);
         }
 
         let version = Semver::Version::parse(Semver::SlicedString::init(arg, arg));
-        if version.valid {
+        if Self::is_valid_version(&version) {
             return (VersionType::Specific, Some(arg));
         }
 
@@ -498,12 +507,7 @@ impl PmVersionCommand {
         }
 
         let current = Semver::Version::parse(Semver::SlicedString::init(current_str, current_str));
-        // `npm version` calls such a version invalid too. Below the limit, `+ 1` cannot wrap.
-        // https://github.com/npm/node-semver/blob/v7.7.2/classes/semver.js#L50-L60
-        const MAX_SAFE_INTEGER: u64 = (1 << 53) - 1;
-        let version = current.version.min();
-        if !current.valid || version.major.max(version.minor).max(version.patch) > MAX_SAFE_INTEGER
-        {
+        if !Self::is_valid_version(&current) {
             Output::err_generic(
                 "Current version \"{}\" is not a valid semver",
                 (BStr::new(current_str),),

--- a/src/runtime/cli/pm_version_command.rs
+++ b/src/runtime/cli/pm_version_command.rs
@@ -498,7 +498,12 @@ impl PmVersionCommand {
         }
 
         let current = Semver::Version::parse(Semver::SlicedString::init(current_str, current_str));
-        if !current.valid {
+        // `npm version` calls such a version invalid too. Below the limit, `+ 1` cannot wrap.
+        // https://github.com/npm/node-semver/blob/v7.7.2/classes/semver.js#L50-L60
+        const MAX_SAFE_INTEGER: u64 = (1 << 53) - 1;
+        let version = current.version.min();
+        if !current.valid || version.major.max(version.minor).max(version.patch) > MAX_SAFE_INTEGER
+        {
             Output::err_generic(
                 "Current version \"{}\" is not a valid semver",
                 (BStr::new(current_str),),
@@ -518,7 +523,7 @@ impl PmVersionCommand {
                     break 'blk current_prerelease[..dot_index as usize].to_vec();
                 }
 
-                break 'blk if bun_core::fmt::parse_decimal::<u32>(current_prerelease).is_some() {
+                break 'blk if Self::next_prerelease_number(current_prerelease).is_some() {
                     Vec::new()
                 } else {
                     current_prerelease.to_vec()
@@ -528,6 +533,12 @@ impl PmVersionCommand {
         // `defer allocator.free(prerelease_id)` — handled by Drop.
 
         Self::increment_version(current_str, &current, version_type, &prerelease_id)
+    }
+
+    /// The number after the prerelease identifier `identifier`. `None` when it is not a number
+    /// or `+ 1` does not fit. A u64 like `Tag::order_pre`: a u32 read 20250101123456 as a string.
+    fn next_prerelease_number(identifier: &[u8]) -> Option<u64> {
+        bun_core::fmt::parse_decimal::<u64>(identifier)?.checked_add(1)
     }
 
     fn increment_version(
@@ -613,18 +624,17 @@ impl PmVersionCommand {
 
                     if let Some(dot_index) = strings::last_index_of_char(current_prerelease, b'.') {
                         let number_str = &current_prerelease[(dot_index as usize) + 1..];
-                        let next_num = bun_core::fmt::parse_decimal::<u32>(number_str).unwrap_or(0);
+                        let next_num = Self::next_prerelease_number(number_str).unwrap_or(1);
                         return Ok(fmt_bytes(format_args!(
                             "{}.{}.{}-{}.{}",
                             new_version.major,
                             new_version.minor,
                             new_version.patch,
                             BStr::new(identifier),
-                            next_num + 1
+                            next_num
                         )));
                     } else {
-                        let num = bun_core::fmt::parse_decimal::<u32>(current_prerelease);
-                        if let Some(n) = num {
+                        if let Some(next_num) = Self::next_prerelease_number(current_prerelease) {
                             if !preid.is_empty() {
                                 return Ok(fmt_bytes(format_args!(
                                     "{}.{}.{}-{}.{}",
@@ -632,7 +642,7 @@ impl PmVersionCommand {
                                     new_version.minor,
                                     new_version.patch,
                                     BStr::new(preid),
-                                    n + 1
+                                    next_num
                                 )));
                             } else {
                                 return Ok(fmt_bytes(format_args!(
@@ -640,7 +650,7 @@ impl PmVersionCommand {
                                     new_version.major,
                                     new_version.minor,
                                     new_version.patch,
-                                    n + 1
+                                    next_num
                                 )));
                             }
                         } else {

--- a/test/cli/install/bun-pm-version.test.ts
+++ b/test/cli/install/bun-pm-version.test.ts
@@ -274,6 +274,34 @@ describe.concurrent("bun pm version", () => {
       expect(code5).toBe(0);
     });
 
+    // `npm version` rejects these too (node-semver: "Invalid patch version"). The number used to wrap:
+    // the first three wrote 1.0.0, 1.0.0 and 0.0.0, and the `+ 1` aborted a debug build.
+    it.each([
+      ["1.0.18446744073709551615", "patch"],
+      ["1.18446744073709551615.0", "minor"],
+      ["18446744073709551615.0.0", "major"],
+      ["1.0.18446744073709551615", "prerelease"],
+      ["1.0.9007199254740992", "patch"],
+    ])("rejects %s as the version to increment with %s", async (version, increment) => {
+      await using testDir = tempDir(`version-${i++}`, {
+        "package.json": JSON.stringify({ name: "test", version }, null, 2),
+      });
+
+      const { output, error, code } = await runCommand(
+        [bunExe(), "pm", "version", increment, "--no-git-tag-version"],
+        testDir,
+        false,
+      );
+      const packageJson = await Bun.file(join(String(testDir), "package.json")).json();
+
+      expect({ output, error, code, version: packageJson.version }).toEqual({
+        output: "",
+        error: `error: Current version "${version}" is not a valid semver\n`,
+        code: 1,
+        version,
+      });
+    });
+
     it("handles missing package.json like npm", async () => {
       await using testDir = tempDir(`version-${i++}`, {
         "README.md": "# Test project",
@@ -577,6 +605,37 @@ describe.concurrent("bun pm version", () => {
 
       expect(code6).toBe(0);
       expect(output6.trim()).toBe("v1.0.0-4");
+    });
+
+    // The prerelease number used to be read as a u32: 4294967295 wrapped to 0 and a build timestamp
+    // (above 2^32 - 1) counted as 0, so both wrote a version lower than the current one.
+    it.each([
+      ["1.0.0-beta.4294967295", [], "1.0.0-beta.4294967296"],
+      ["1.0.0-4294967295", [], "1.0.0-4294967296"],
+      ["1.0.0-4294967295", ["--preid", "rc"], "1.0.0-rc.4294967296"],
+      ["1.0.0-canary.20250101123456", [], "1.0.0-canary.20250101123457"],
+      ["1.0.0-20250101123456", [], "1.0.0-20250101123457"],
+      ["1.0.0-beta.18446744073709551614", [], "1.0.0-beta.18446744073709551615"],
+      // No larger number fits, so this one counts as a name and gets a new field.
+      ["1.0.0-18446744073709551615", [], "1.0.0-18446744073709551615.1"],
+      ["1.0.9007199254740991-0", [], "1.0.9007199254740991-1"],
+    ])("increments the prerelease number of %s", async (version, flags, expected) => {
+      await using testDir = tempDir(`version-${i++}`, {
+        "package.json": JSON.stringify({ name: "test", version }, null, 2),
+      });
+
+      const { output, error, code } = await runCommand(
+        [bunExe(), "pm", "version", "prerelease", ...flags, "--no-git-tag-version"],
+        testDir,
+      );
+      const packageJson = await Bun.file(join(String(testDir), "package.json")).json();
+
+      expect({ output, error, code, version: packageJson.version }).toEqual({
+        output: `v${expected}\n`,
+        error: "",
+        code: 0,
+        version: expected,
+      });
     });
 
     it("should preserve prerelease identifiers correctly", async () => {

--- a/test/cli/install/bun-pm-version.test.ts
+++ b/test/cli/install/bun-pm-version.test.ts
@@ -205,6 +205,20 @@ describe.concurrent("bun pm version", () => {
       expect(packageJson.version).toBe("2.0.0");
     });
 
+    // `npm version patch` writes the same version, although both tools then refuse to increment it again.
+    it("increments a number equal to Number.MAX_SAFE_INTEGER", async () => {
+      await using testDir = tempDir(`version-${i++}`, {
+        "package.json": JSON.stringify({ name: "test", version: "1.0.9007199254740991" }, null, 2),
+      });
+
+      const { output, error, code } = await runCommand(
+        [bunExe(), "pm", "version", "patch", "--no-git-tag-version"],
+        testDir,
+      );
+
+      expect({ output, error, code }).toEqual({ output: "v1.0.9007199254740992\n", error: "", code: 0 });
+    });
+
     it("should set specific version", async () => {
       const testDir = setupTest();
 
@@ -299,6 +313,25 @@ describe.concurrent("bun pm version", () => {
         error: `error: Current version "${version}" is not a valid semver\n`,
         code: 1,
         version,
+      });
+    });
+
+    // The same limit applies to a version given as the argument. `npm version` prints "Invalid version".
+    it("rejects a specific version with a number above Number.MAX_SAFE_INTEGER", async () => {
+      const testDir = setupTest();
+
+      const { output, error, code } = await runCommand(
+        [bunExe(), "pm", "version", "1.0.9007199254740992", "--no-git-tag-version"],
+        testDir,
+        false,
+      );
+      const packageJson = await Bun.file(join(testDir, "package.json")).json();
+
+      expect({ output, error: error.split("\n")[0], code, version: packageJson.version }).toEqual({
+        output: "",
+        error: 'error: Invalid version argument: "1.0.9007199254740992"',
+        code: 1,
+        version: "1.0.0",
       });
     });
 


### PR DESCRIPTION
### Problem

- `bun pm version prerelease` parses the prerelease number as a `u32` (`pm_version_command.rs:521`, `:616`, `:626`). `1.0.0-beta.4294967295` becomes `1.0.0-beta.0`. A number above 2^32 - 1 fails the parse and counts as 0, so `1.0.0-canary.20250101123456` becomes `1.0.0-canary.1`. Both results are lower than the current version.
- `patch`, `minor`, `major` and the `pre*` forms add 1 unchecked (`:541-672`). `1.0.18446744073709551615` with `patch` writes `1.0.0`. A debug build aborts with `panic: attempt to add with overflow`.

### Fix

- One helper, `next_prerelease_number`, parses a `u64` and adds 1 with `checked_add`. A `u64` is the width `Tag::order_pre` compares numeric identifiers in.
- A number with no successor counts as a name. The failed `u32` parse already did that: `1.0.0-18446744073709551615` becomes `1.0.0-18446744073709551615.1`.
- A version with a component above `Number.MAX_SAFE_INTEGER` takes the existing "is not a valid semver" exit, and the existing "Invalid version argument" exit when it is the argument. `npm version` rejects both (node-semver: "Invalid patch version"). Below that limit `+ 1` cannot wrap.
- Verified: `test/cli/install/bun-pm-version.test.ts`. 12 of the 15 new cases fail on 1.4.3-canary. The other three pin the limits.

### Background

- A semver prerelease is a dot-separated list after `-`. Numeric identifiers compare as numbers and sort below names.
- `bun pm version` reads `version` from package.json, computes the next one and writes it back. With no argument it prints a preview of each increment.
- node-semver, which `npm version` uses, refuses a major, minor or patch above 2^53 - 1.

<details><summary>Notes</summary>

**Origin.** An integer cast audit of main found the two wraps. No user reported them. The timestamp case was found while I reproduced the first one.

**Before and after (release 1.4.3-canary, then this branch)**

| version | command | before | after | npm (semver 7.8.1) |
| --- | --- | --- | --- | --- |
| `1.0.0-beta.4294967295` | `prerelease` | `1.0.0-beta.0` | `1.0.0-beta.4294967296` | same |
| `1.0.0-4294967295` | `prerelease` | `1.0.0-0` | `1.0.0-4294967296` | same |
| `1.0.0-canary.20250101123456` | `prerelease` | `1.0.0-canary.1` | `1.0.0-canary.20250101123457` | same |
| `1.0.0-20250101123456` | `prerelease` | `1.0.0-20250101123456.1` | `1.0.0-20250101123457` | same |
| `1.0.18446744073709551615` | `patch` | `1.0.0` | error, exit 1 | `Invalid version` |
| `18446744073709551615.0.0` | `major` | `0.0.0` | error, exit 1 | `Invalid version` |

The `--preid rc` row in the test (`1.0.0-4294967295` to `1.0.0-rc.4294967296`) follows bun's existing rule that a new preid keeps the counter (the existing test expects `1.0.3-1` to `1.0.3-abcd.2`). npm restarts at `rc.0`.

**Not changed**

- A number above `u64::MAX` parses as 0 in the shared semver parser (`src/semver/Version.rs:659`), so `1.0.99999999999999999999` still bumps to `1.0.1`. `bun install` shares that parser. It is tracked separately.
- When the last identifier of a dotted prerelease is not a number (`1.0.0-beta.rc`), `prerelease` writes `1.0.0-beta.1`. npm appends a field. `1.0.0-beta.18446744073709551615` takes that path.
- A component equal to `Number.MAX_SAFE_INTEGER` is accepted, and `patch` then writes `1.0.9007199254740992`. `npm version patch` (npm 11, semver 7.8.1) writes the same version.

**The help screen.** `bun pm version` with no argument computes the previews with the same function. For a version above the limit it now prints the same "is not a valid semver" error that it prints for any other invalid version.

**Overlap.** #37596 restructures the same match arms and has no overflow rule. The PR that lands second needs a small rebase.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/bun-pm-version.test.ts
bun test v1.4.3 (6a92015fc)

test/cli/install/bun-pm-version.test.ts:
(pass) bun pm version > help and version previews > should show help when no arguments provided [259.13ms]
(pass) bun pm version > basic version incrementing > increments a number equal to Number.MAX_SAFE_INTEGER [218.05ms]
(pass) bun pm version > basic version incrementing > should set specific version [225.92ms]
(pass) bun pm version > basic version incrementing > handles empty package.json [261.43ms]
(pass) bun pm version > basic version incrementing > should increment versions correctly [528.42ms]
(pass) bun pm version > help and version previews > shows help with version previews [1014.43ms]
(pass) bun pm version > error handling > handles various error conditions [986.39ms]
306 |         testDir,
307 |         false,
308 |       );
309 |       const packageJson = await Bun.file(join(String(testDir), "package.json")).json();
310 | 
311 |       expect({ output, error, code, version: packageJson.version }).toEqual({
         
... (truncated)

release without fix: 12 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/cli/install/bun-pm-version.test.ts:
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint: 	git branch -m <name>
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint: 	git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint: 	git branch -m <name>
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/cli/install/bun-pm-version.test.ts
bun test v1.4.3 (6a92015fc)

test/cli/install/bun-pm-version.test.ts:
(pass) bun pm version > help and version previews > should show help when no arguments provided [286.03ms]
(pass) bun pm version > basic version incrementing > increments a number equal to Number.MAX_SAFE_INTEGER [199.91ms]
(pass) bun pm version > basic version incrementing > handles empty package.json [191.28ms]
(pass) bun pm version > basic version incrementing > should set specific version [334.47ms]
(pass) bun pm version > error handling > rejects 1.0.18446744073709551615 as the version to increment with patch [205.97ms]
(pass) bun pm version > basic version incrementing > should increment versions correctly [548.30ms]
(pass) bun pm version > error handling > rejects 1.18446744073709551615.0 as the version to increment with minor [354.82ms]
(pass) bun pm version > error handling > rejects 18446744073709551615.0.0 as the version to increment with major [219.89ms]
(pass) bun pm version > error handling > rejects a specific ver
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1140ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/126] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/126] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/126] gen cpp.rs (cppbind)
[4/126] gen JS modules (bundle-modules)
Preprocess modules (16356ms)
Bundle modules (92ms)
Postprocesss modules (232ms)
Bundle Functions (1263ms)
Generate Code (45ms)

[18.00s] Bundled "src/js" for production
  2600 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[4/125] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_perf v0.0.0 (/workspace/bun/src/perf)
[1m[92m   Compiling[0m bun_threading v0.0.0 (/workspace/bun/src/threading)
[1m[92m   Compiling[0m bun_which v0.0.0 (/workspace/bun/src/which)
[1m[92m   Compiling[0m bun_spawn_sys v0.0.0 (/workspace/bun/src/sp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/pm_version_command.rs   | 29 +++++++----
 test/cli/install/bun-pm-version.test.ts | 92 +++++++++++++++++++++++++++++++++
 2 files changed, 112 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/cli/pm_version_command.rs        5      3     17
test/cli/install/bun-pm-version.test.ts      1      3     15
```

</details>

<!-- robobun:evidence:end -->