### PR TITLE
node:http2: send nothing from goaway() when opaqueData does not fit a GOAWAY frame

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -90,6 +90,10 @@ pub mod JSH2FrameParser {
 // ──────────────────────────────────────────────────────────────────────────
 
 const MAX_PAYLOAD_SIZE_WITHOUT_FRAME: usize = 16384 - FrameHeader::BYTE_SIZE - 1;
+/// nghttp2 caps a GOAWAY payload (last stream id + error code + opaque data) at
+/// NGHTTP2_MAX_PAYLOADLEN whatever MAX_FRAME_SIZE the peer advertises:
+/// https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L7227-L7229
+const MAX_GOAWAY_OPAQUE_DATA_SIZE: usize = 16384 - 8;
 
 /// `Copy` view of [`NativeSocket`] for call sites to snapshot across
 /// re-entrant writes. BACKREF — the socket strictly outlives the attachment:
@@ -399,6 +403,7 @@ impl FrameHeader {
     #[inline]
     fn write(&self, writer: &mut impl WireWriter, frames_sent: &Cell<u64>) -> bool {
         frames_sent.set(frames_sent.get() + 1);
+        debug_assert!(self.length <= MAX_FRAME_SIZE, "the length field is 24 bits");
         let mut buf = [0u8; Self::BYTE_SIZE];
         buf[0] = ((self.length >> 16) & 0xFF) as u8;
         buf[1] = ((self.length >> 8) & 0xFF) as u8;
@@ -4716,8 +4721,14 @@ impl H2FrameParser {
             if callframe.arguments_count() >= 3 {
                 if !opaque_data_arg.is_empty_or_undefined_or_null() {
                     if let Some(array_buffer) = opaque_data_arg.as_array_buffer(global_object) {
+                        let opaque_data = array_buffer.byte_slice();
+                        // node sends nothing: nghttp2 refuses the frame and node ignores the result.
+                        // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L2979-L2980
+                        if opaque_data.len() > MAX_GOAWAY_OPAQUE_DATA_SIZE {
+                            return Ok(JSValue::UNDEFINED);
+                        }
                         // Own the bytes: write() re-enters JS on JS-backed sockets and can detach this.
-                        let copied = array_buffer.byte_slice().to_vec();
+                        let copied = opaque_data.to_vec();
                         this.send_go_away(
                             0,
                             ErrorCode(error_code as u32),

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -90,9 +90,7 @@ pub mod JSH2FrameParser {
 // ──────────────────────────────────────────────────────────────────────────
 
 const MAX_PAYLOAD_SIZE_WITHOUT_FRAME: usize = 16384 - FrameHeader::BYTE_SIZE - 1;
-/// nghttp2 caps a GOAWAY payload (last stream id + error code + opaque data) at
-/// NGHTTP2_MAX_PAYLOADLEN whatever MAX_FRAME_SIZE the peer advertises:
-/// https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L7227-L7229
+/// nghttp2's limit: https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L7227-L7229
 const MAX_GOAWAY_OPAQUE_DATA_SIZE: usize = 16384 - 8;
 
 /// `Copy` view of [`NativeSocket`] for call sites to snapshot across
@@ -4722,8 +4720,7 @@ impl H2FrameParser {
                 if !opaque_data_arg.is_empty_or_undefined_or_null() {
                     if let Some(array_buffer) = opaque_data_arg.as_array_buffer(global_object) {
                         let opaque_data = array_buffer.byte_slice();
-                        // node sends nothing: nghttp2 refuses the frame and node ignores the result.
-                        // https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L2979-L2980
+                        // node sends nothing: https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L2979-L2980
                         if opaque_data.len() > MAX_GOAWAY_OPAQUE_DATA_SIZE {
                             return Ok(JSValue::UNDEFINED);
                         }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1968,6 +1968,105 @@ it("http2 session.goaway() sends custom data", async done => {
   });
 });
 
+// nghttp2 refuses a GOAWAY whose payload (8 fixed bytes + opaqueData) exceeds 16384 bytes, whatever
+// MAX_FRAME_SIZE the peer advertises, and node ignores the failure: the call returns normally and
+// sends nothing. node v26.3.0 puts exactly these frames on the wire from either side. They are read
+// off a raw socket because the last call used to wrap the 24-bit length field to 0, and an HTTP/2
+// peer reads the 16 MiB that follow as new frames.
+it.each(["client", "server"])(
+  "http2 %s session.goaway() sends nothing when opaqueData does not fit a 16384-byte GOAWAY payload",
+  async sender => {
+    const SETTINGS = 4;
+    const GOAWAY = 7;
+    const WINDOW_UPDATE = 8;
+    const kMaxOpaqueData = 16384 - 8;
+    const marker = Buffer.from("end");
+    const emptySettings = Buffer.from([0, 0, 0, SETTINGS, 0, 0, 0, 0, 0]);
+    const { promise: markerOrClose, resolve, reject } = Promise.withResolvers();
+
+    // [type, payload length] of each frame up to the marker GOAWAY. Payloads are skipped, not buffered.
+    const frames = [];
+    let sawMarker = false;
+    function frameScanner(skip) {
+      const header = Buffer.alloc(9);
+      let have = 0;
+      return chunk => {
+        for (let i = 0; i < chunk.length && !sawMarker && frames.length < 16; ) {
+          if (skip > 0) {
+            const n = Math.min(skip, chunk.length - i);
+            skip -= n;
+            i += n;
+            continue;
+          }
+          const n = Math.min(header.length - have, chunk.length - i);
+          chunk.copy(header, have, i, i + n);
+          have += n;
+          i += n;
+          if (have === header.length) {
+            have = 0;
+            skip = header.readUIntBE(0, 3);
+            frames.push([header[3], skip]);
+            sawMarker = header[3] === GOAWAY && skip === 8 + marker.length;
+          }
+        }
+        if (sawMarker) resolve();
+      };
+    }
+
+    // Runs once the peer's SETTINGS is read, so that close() leaves no unread bytes and no RST behind.
+    let returned;
+    function sendGoaways(session) {
+      returned = [kMaxOpaqueData, kMaxOpaqueData + 1, 2 ** 24 - 8].map(size =>
+        session.goaway(http2.constants.NGHTTP2_NO_ERROR, 0, Buffer.alloc(size, 0x41)),
+      );
+      session.goaway(http2.constants.NGHTTP2_NO_ERROR, 0, marker);
+      session.close();
+    }
+
+    let server, client;
+    try {
+      if (sender === "client") {
+        server = net.createServer(socket => {
+          socket.on("data", frameScanner(24)); // skips the client connection preface
+          socket.on("error", reject);
+          socket.on("close", resolve);
+          socket.write(emptySettings);
+        });
+        await new Promise(listening => server.listen(0, "127.0.0.1", listening));
+        client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+        client.on("error", reject);
+        client.once("remoteSettings", () => sendGoaways(client));
+      } else {
+        server = http2.createServer();
+        server.on("sessionError", reject);
+        server.on("session", session => session.once("remoteSettings", () => sendGoaways(session)));
+        await new Promise(listening => server.listen(0, "127.0.0.1", listening));
+        client = net.connect(server.address().port, "127.0.0.1", () => {
+          client.write(Buffer.concat([Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"), emptySettings]));
+        });
+        client.on("data", frameScanner(0));
+        client.on("error", reject);
+        client.on("close", resolve);
+      }
+      await markerOrClose;
+      expect({
+        returned,
+        // When SETTINGS, its ACK and WINDOW_UPDATE go out depends on timing, not on goaway().
+        frames: frames.filter(([type]) => type !== SETTINGS && type !== WINDOW_UPDATE),
+      }).toEqual({
+        returned: [undefined, undefined, undefined],
+        frames: [
+          [GOAWAY, 8 + kMaxOpaqueData],
+          [GOAWAY, 8 + marker.length],
+        ],
+      });
+    } finally {
+      client?.destroy();
+      server?.close();
+    }
+  },
+);
+
 it("http2 session.goaway() opaqueData survives re-entrant buffer detach over a JS Duplex", async () => {
   // The cork-flush path re-enters JS (onWrite → Duplex _write) when the transport is a JS
   // stream. If that JS detaches the opaqueData ArrayBuffer mid-write, the GOAWAY payload must
@@ -1975,7 +2074,8 @@ it("http2 session.goaway() opaqueData survives re-entrant buffer detach over a J
   const fixture = `
     const http2 = require("node:http2");
     const { Duplex } = require("node:stream");
-    const N = 64 * 1024;
+    // The most opaque data a GOAWAY carries. With its 17 header bytes it still overflows the 16 KiB cork.
+    const N = 16384 - 8;
     const GOAWAY_WIRE_SIZE = 9 + 8 + N;
     let opaque = new Uint8Array(N).fill(0x41);
     const spray = [], received = [];
@@ -2025,7 +2125,7 @@ it("http2 session.goaway() opaqueData survives re-entrant buffer detach over a J
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   const result = JSON.parse(stdout.trim());
-  expect(result).toEqual({ fired: true, declared: 64 * 1024, ok: 64 * 1024 });
+  expect(result).toEqual({ fired: true, declared: 16384 - 8, ok: 16384 - 8 });
   expect(exitCode).toBe(0);
 }, 15_000);
 


### PR DESCRIPTION
### Problem

- `session.goaway(code, lastStreamID, opaqueData)` writes `opaqueData` behind a GOAWAY header whatever its size. Above 16376 bytes the frame exceeds the default `MAX_FRAME_SIZE`.
- At `2**24 - 8` bytes `u32::try_from(8 + len)` fits, then `FrameHeader::write` keeps 24 bits (`h2_frame_parser.rs:403`). The length goes out as 0 and the peer reads the 16 MiB behind it as new frames.
- Node v26.3.0 sends nothing for these calls and does not throw.

### Fix

- The native `goaway()` returns before it writes when `opaqueData.length + 8 > 16384`. Client and server sessions share that function.
- This is nghttp2's rule. `nghttp2_session_add_goaway` returns `NGHTTP2_ERR_INVALID_ARGUMENT` above `NGHTTP2_MAX_PAYLOADLEN`, whatever `MAX_FRAME_SIZE` the peer advertises. `Http2Session::Goaway` in node ignores the result. 16384 is also the smallest legal `MAX_FRAME_SIZE`, so the frame always fits the peer.
- `FrameHeader::write` asserts the 24-bit bound in debug builds.
- Verified: `test/js/node/http2/node-http2.test.js`. The new test covers both session kinds. It fails on 1.4.3-canary and passes unchanged under Node v26.3.0. Also ran the other files in `test/js/node/http2/`.

### Background

- GOAWAY tells the peer to stop opening streams. Its payload is the last stream id, an error code and optional opaque debug data.
- Every HTTP/2 frame header stores the payload length in 24 bits. A peer rejects a frame larger than the `MAX_FRAME_SIZE` it advertised (default 16384).
- Node's http2 sits on nghttp2. Bun has its own frame writer in `h2_frame_parser.rs`.

<details><summary>Notes</summary>

**Origin.** An integer cast audit of main found the length wrap. No user reported it.

**Frames on the wire.** A raw TCP peer records `[type, payload length]` of what a session sends after three `goaway(0, 0, Buffer.alloc(n))` calls (n = 16376, 16377, `2**24 - 8`) and a 3-byte marker GOAWAY.

| runtime | GOAWAY frames |
| --- | --- |
| Node v26.3.0 | `[7, 16384]`, `[7, 11]` |
| bun 1.4.3-canary | `[7, 16384]`, `[7, 16385]`, `[7, 0]`, then `[0, 0]`, `[65, 4276545]`, ... (the opaque bytes read as frames) |
| this branch | `[7, 16384]`, `[7, 11]` |

The limit does not move when the peer advertises `MAX_FRAME_SIZE = 2**20`: Node still sends nothing for 16377 bytes.

Sources: [`nghttp2_session.c#L7227-L7229`](https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L7227-L7229), [`node_http2.cc#L2979-L2980`](https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L2979-L2980).

**Why no throw.** Node returns `undefined` and sends nothing. A throw here would be stricter than Node, and code that runs on Node would fail on bun.

**Other writers.** All other callers of `send_go_away` pass short static strings. ALTSVC and ORIGIN already have a 16384-byte rule. DATA and HEADERS are split by the peer's frame size.

**Existing test changed.** "opaqueData survives re-entrant buffer detach over a JS Duplex" (#36905) sent 64 KiB of opaque data. It now sends 16376 bytes, the most a GOAWAY carries. The frame is 16393 bytes, so it still overflows the 16 KiB cork buffer, and the fixture still reports `fired: true`.

**Overlap.** #37558 changes the error code conversion two lines above this check (`to_int32` to `to_u32`). #37554 shares the JS argument validation between client and server sessions and has no size rule. The PR that lands second needs a small rebase. nghttp2 also refuses a `lastStreamID` of the sender's own parity. That rule is not in this PR.

</details>
