### PR TITLE
node:http: range-check server.keepAliveTimeout and server.maxHeaderSize assigned after construction

### DIFF
--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -613,6 +613,10 @@ struct HttpResponseData;
          * (method, " HTTP/1.1\r\n", ": ", "\r\n"). Raw bounds get that framing as slack so
          * we don't reject requests Node accepts. Finite: ≤UWS_HTTP_MAX_HEADERS_COUNT*4 + 64. */
         static constexpr size_t MAX_HEADER_FRAMING_SLACK = UWS_HTTP_MAX_HEADERS_COUNT * 4 + 64;
+        /* The raw bound for a non-zero maxHeaderSize. Saturates: node:http passes UINT64_MAX for "no limit". */
+        static constexpr uint64_t maxRawHeaderSize(uint64_t maxHeaderSize) {
+            return maxHeaderSize > UINT64_MAX - MAX_HEADER_FRAMING_SLACK ? UINT64_MAX : maxHeaderSize + MAX_HEADER_FRAMING_SLACK;
+        }
 
         /* Maximum chunk-extension bytes per chunk, matching Node/llhttp's
          * kMaxChunkExtensionsSize (16 KiB). Enforced for every server
@@ -1158,7 +1162,7 @@ struct HttpResponseData;
             consumedTotal += consumed;
 
             /* Even if we could parse it, check for length here as well */
-            const uint64_t maxBufferedHeaderSize = maxHeaderSize ? (maxHeaderSize + MAX_HEADER_FRAMING_SLACK) : MAX_FALLBACK_SIZE;
+            const uint64_t maxBufferedHeaderSize = maxHeaderSize ? maxRawHeaderSize(maxHeaderSize) : MAX_FALLBACK_SIZE;
             if (consumed > maxBufferedHeaderSize) {
                 return HttpParserResult::error(HTTP_ERROR_431_REQUEST_HEADER_FIELDS_TOO_LARGE, HTTP_PARSER_ERROR_REQUEST_HEADER_FIELDS_TOO_LARGE);
             }
@@ -1419,7 +1423,7 @@ public:
     HttpParserResult consumePostPadded(uint64_t maxHeaderSize, bool& isConnectRequest, bool requireHostHeader, bool useStrictMethodValidation, bool useInsecureHTTPParser, bool useLenientTransferEncoding, std::string *nodeHttpRequestTrailers, uint64_t *chunkedExtensionsByteCount, char *data, unsigned int length, void *user, MoveOnlyFunction<void *(void *, HttpRequest *)> &&requestHandler, MoveOnlyFunction<void *(void *, std::string_view, bool)> &&dataHandler) {
         /* The fallback buffer may not exceed the configured per-request header
          * limit (per-server maxHeaderSize can raise it above the default). */
-        const size_t maxFallbackSize = maxHeaderSize ? (size_t) (maxHeaderSize + MAX_HEADER_FRAMING_SLACK) : MAX_FALLBACK_SIZE;
+        const size_t maxFallbackSize = maxHeaderSize ? (size_t) maxRawHeaderSize(maxHeaderSize) : MAX_FALLBACK_SIZE;
         /* This resets BloomFilter by construction, but later we also reset it again.
         * Optimize this to skip resetting twice (req could be made global) */
         HttpRequest req;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2153,6 +2153,8 @@ const AUTO_HEADER_KEEP_ALIVE_TIMEOUT = 1 << 3;
 // line, so it is rendered natively with the other auto headers rather than being
 // pushed into the flat array (which goes out first).
 const AUTO_HEADER_TRANSFER_ENCODING_CHUNKED = 1 << 4;
+// The largest Keep-Alive timeout, in seconds, handed to the native writeHead (it takes a uint32).
+const kMaxNativeKeepAliveSecs = 0x7fffffff;
 // Out-parameters of renderNativeHeaders, read by its callers in the same
 // tick (no JS can run in between).
 let renderedAutoHeaders = 0;
@@ -2284,16 +2286,25 @@ function renderNativeHeaders(res) {
       ) {
         const keepAliveTimeout = res._keepAliveTimeout;
         const maxRequestsPerSocket = res._maxRequestsPerSocket;
-        if (keepAliveTimeout && !hasKeepAlive && ~~maxRequestsPerSocket > 0) {
-          // Rare path (maxRequestsPerSocket set): render both lines in JS.
-          flat.push("Connection", "keep-alive");
-          flat.push("Keep-Alive", `timeout=${MathFloor(keepAliveTimeout / 1000)}, max=${maxRequestsPerSocket}`);
+        if (keepAliveTimeout && !hasKeepAlive) {
+          const timeoutSecs = MathFloor(keepAliveTimeout / 1000);
+          const hasMax = ~~maxRequestsPerSocket > 0;
+          if (!hasMax && timeoutSecs >= 0 && timeoutSecs <= kMaxNativeKeepAliveSecs) {
+            autoHeaders |= AUTO_HEADER_CONN_KEEP_ALIVE | AUTO_HEADER_KEEP_ALIVE_TIMEOUT;
+            keepAliveSecs = timeoutSecs;
+          } else {
+            // Rare path (maxRequestsPerSocket set, or a server.keepAliveTimeout assigned after
+            // construction that is negative or too large for it): render both lines in JS. Node
+            // prints the number as is, so -5000 is "timeout=-5" there too.
+            // https://github.com/nodejs/node/blob/v26.3.0/lib/_http_outgoing.js#L513-L518
+            flat.push("Connection", "keep-alive");
+            flat.push(
+              "Keep-Alive",
+              hasMax ? `timeout=${timeoutSecs}, max=${maxRequestsPerSocket}` : `timeout=${timeoutSecs}`,
+            );
+          }
         } else {
           autoHeaders |= AUTO_HEADER_CONN_KEEP_ALIVE;
-          if (keepAliveTimeout && !hasKeepAlive) {
-            autoHeaders |= AUTO_HEADER_KEEP_ALIVE_TIMEOUT;
-            keepAliveSecs = MathFloor(keepAliveTimeout / 1000);
-          }
         }
       } else {
         // Like Node's shouldSendKeepAlive/_last handling: a user-cleared

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2293,10 +2293,7 @@ function renderNativeHeaders(res) {
             autoHeaders |= AUTO_HEADER_CONN_KEEP_ALIVE | AUTO_HEADER_KEEP_ALIVE_TIMEOUT;
             keepAliveSecs = timeoutSecs;
           } else {
-            // Rare path (maxRequestsPerSocket set, or a server.keepAliveTimeout assigned after
-            // construction that is negative or too large for it): render both lines in JS. Node
-            // prints the number as is, so -5000 is "timeout=-5" there too.
-            // https://github.com/nodejs/node/blob/v26.3.0/lib/_http_outgoing.js#L513-L518
+            // Rare path (maxRequestsPerSocket set, or seconds the native side cannot take): render both lines in JS, as Node prints them.
             flat.push("Connection", "keep-alive");
             flat.push(
               "Keep-Alive",

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -754,10 +754,7 @@ extern "C" EncodedJSValue NodeHTTPServer__onRequest_https(
         nodeHttpResponsePtr);
 }
 
-// server.maxHeaderSize is a plain property and only the constructor option is validated, so any
-// number reaches this. Node casts the double to uint64_t, which is undefined for NaN, a negative
-// and 2^64 or more. Here the first two select the default limit (0) and the last one no limit.
-// https://github.com/nodejs/node/blob/v26.3.0/src/node_http_parser.cc#L688-L692
+// Node's static_cast<uint64_t>(double) is undefined for these: NaN or below 1 selects the default limit (0), 2^64 or more selects none.
 static uint64_t maxHTTPHeaderSizeFromNumber(double value)
 {
     if (!(value >= 1)) return 0;

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -754,6 +754,17 @@ extern "C" EncodedJSValue NodeHTTPServer__onRequest_https(
         nodeHttpResponsePtr);
 }
 
+// server.maxHeaderSize is a plain property and only the constructor option is validated, so any
+// number reaches this. Node casts the double to uint64_t, which is undefined for NaN, a negative
+// and 2^64 or more. Here the first two select the default limit (0) and the last one no limit.
+// https://github.com/nodejs/node/blob/v26.3.0/src/node_http_parser.cc#L688-L692
+static uint64_t maxHTTPHeaderSizeFromNumber(double value)
+{
+    if (!(value >= 1)) return 0;
+    if (value >= 18446744073709551616.0) return UINT64_MAX;
+    return static_cast<uint64_t>(value);
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsHTTPSetCustomOptions, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -777,7 +788,7 @@ JSC_DEFINE_HOST_FUNCTION(jsHTTPSetCustomOptions, (JSGlobalObject * globalObject,
     Server__setAppFlags(globalObject, JSValue::encode(serverValue), requireHostHeader.toBoolean(globalObject), useStrictMethodValidation.toBoolean(globalObject), static_cast<uint8_t>(lenientBits & 0x3), httpAllowHalfOpen.toBoolean(globalObject));
     RETURN_IF_EXCEPTION(scope, {});
 
-    Server__setMaxHTTPHeaderSize(globalObject, JSValue::encode(serverValue), maxHeaderSizeNumber);
+    Server__setMaxHTTPHeaderSize(globalObject, JSValue::encode(serverValue), maxHTTPHeaderSizeFromNumber(maxHeaderSizeNumber));
     RETURN_IF_EXCEPTION(scope, {});
 
     Server__setOnClientError(globalObject, JSValue::encode(serverValue), JSValue::encode(callback));

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -887,7 +887,7 @@ impl NodeHTTPResponse {
             .get(4)
             .copied()
             .filter(|v| v.is_number())
-            .map_or(0, |v| v.to_int32() as u32);
+            .map_or(0, |v| v.to_u32());
         self.write_head_impl(
             global_object,
             arguments,
@@ -1083,7 +1083,7 @@ impl NodeHTTPResponse {
             .get(7)
             .copied()
             .filter(|v| v.is_number())
-            .map_or(0, |v| v.to_int32() as u32);
+            .map_or(0, |v| v.to_u32());
         // write_or_end::<true> reads (chunk, encoding, _, strictContentLength).
         let end_args = [
             arguments.get(3).copied().unwrap_or(JSValue::UNDEFINED),

--- a/test/js/node/http/node-http-maxHeaderSize.test.ts
+++ b/test/js/node/http/node-http-maxHeaderSize.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
 import { bunRun } from "harness";
+import { once } from "node:events";
 import http from "node:http";
+import net from "node:net";
 import path from "path";
 
 test("maxHeaderSize", async () => {
@@ -66,6 +68,59 @@ test("maxHeaderSize", async () => {
   }
 
   http.maxHeaderSize = originalMaxHeaderSize;
+});
+
+test("server.maxHeaderSize assigned after construction is not narrowed to a smaller limit", async () => {
+  // server.maxHeaderSize is a plain property and only the constructor option is validated.
+  // Node casts the number to uint64_t. On x64, -1 became 2^64 - 1 here too, and the parser
+  // added its framing slack to it: the limit wrapped to 863 bytes, and to 63 bytes for -800.
+  // On arm64 the same happened to Infinity.
+  async function statusFor(maxHeaderSize: number, headerValueLength: number) {
+    const server = http.createServer((req, res) => res.end("ok"));
+    server.maxHeaderSize = maxHeaderSize;
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as net.AddressInfo;
+      return await new Promise<string>((resolve, reject) => {
+        const socket = net.connect(port, "127.0.0.1");
+        let data = "";
+        socket.on("data", chunk => {
+          data += chunk;
+          const end = data.indexOf("\r\n");
+          if (end === -1) return;
+          socket.destroy();
+          resolve(data.slice(0, end));
+        });
+        socket.on("close", () => reject(new Error(`closed before the status line: ${JSON.stringify(data)}`)));
+        socket.on("error", reject);
+        socket.write(`GET / HTTP/1.1\r\nHost: x\r\nX-Pad: ${Buffer.alloc(headerValueLength, "a")}\r\n\r\n`);
+      });
+    } finally {
+      server.closeAllConnections();
+      server.close();
+    }
+  }
+
+  expect({
+    "-1, 2000 bytes": await statusFor(-1, 2000),
+    "-800, 100 bytes": await statusFor(-800, 100),
+    "Infinity, 20000 bytes": await statusFor(Infinity, 20000),
+    // Node's result for these two depends on the CPU, because the cast is undefined for them:
+    // no limit on x64, the default limit on arm64. Bun uses the default limit.
+    "-1, 20000 bytes": await statusFor(-1, 20000),
+    "NaN, 20000 bytes": await statusFor(NaN, 20000),
+    "4000, 2000 bytes": await statusFor(4000, 2000),
+    "4000, 5000 bytes": await statusFor(4000, 5000),
+  }).toEqual({
+    "-1, 2000 bytes": "HTTP/1.1 200 OK",
+    "-800, 100 bytes": "HTTP/1.1 200 OK",
+    "Infinity, 20000 bytes": "HTTP/1.1 200 OK",
+    "-1, 20000 bytes": "HTTP/1.1 431 Request Header Fields Too Large",
+    "NaN, 20000 bytes": "HTTP/1.1 431 Request Header Fields Too Large",
+    "4000, 2000 bytes": "HTTP/1.1 200 OK",
+    "4000, 5000 bytes": "HTTP/1.1 431 Request Header Fields Too Large",
+  });
 });
 
 test.concurrent("--max-http-header-size=1024", async () => {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3927,6 +3927,60 @@ it("the over-limit 503 advertises Connection: close, not keep-alive", async () =
   }
 });
 
+it.each([
+  ["res.end(body)", res => res.end("ok")],
+  ["res.write(body) then res.end()", res => (res.write("ok"), res.end())],
+])("Keep-Alive prints a server.keepAliveTimeout assigned after construction as is: %s", async (_, respond) => {
+  // server.keepAliveTimeout is a plain property in Node, so only the constructor option is
+  // validated. _storeHeader prints Math.floor(keepAliveTimeout / 1000) without a range check
+  // (Node v26.3.0 answers with exactly these lines). The first four do not fit the integer the
+  // native header writer takes: -5 used to go out as 4294967291 and 2^31 as 2147483647.
+  const expected = [
+    [-5000, "Keep-Alive: timeout=-5"],
+    [-0.5, "Keep-Alive: timeout=-1"],
+    [2 ** 31 * 1000, "Keep-Alive: timeout=2147483648"],
+    [Infinity, "Keep-Alive: timeout=Infinity"],
+    [(2 ** 31 - 1) * 1000, "Keep-Alive: timeout=2147483647"],
+    [5999, "Keep-Alive: timeout=5"],
+  ];
+  const actual: [number, string | undefined][] = [];
+  for (const [keepAliveTimeout] of expected) {
+    const server = createServer((req, res) => {
+      // The response took its copy when the request arrived. The idle timer reads the server's
+      // value once the response is done, and must not be armed with the numbers above.
+      server.keepAliveTimeout = 1000;
+      respond(res);
+    });
+    server.keepAliveTimeout = keepAliveTimeout as number;
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const { port } = server.address() as AddressInfo;
+      const head = await new Promise<string>((resolve, reject) => {
+        const socket = connect(port, "127.0.0.1");
+        let data = "";
+        socket.on("data", chunk => {
+          data += chunk;
+          const end = data.indexOf("\r\n\r\n");
+          if (end === -1) return;
+          socket.destroy();
+          resolve(data.slice(0, end));
+        });
+        socket.on("close", () =>
+          reject(new Error(`closed before the end of the response head: ${JSON.stringify(data)}`)),
+        );
+        socket.on("error", reject);
+        socket.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+      });
+      actual.push([keepAliveTimeout as number, head.split("\r\n").find(line => line.startsWith("Keep-Alive:"))]);
+    } finally {
+      server.closeAllConnections();
+      server.close();
+    }
+  }
+  expect(actual).toEqual(expected);
+});
+
 it("a non-200 CONNECT through a proxy that holds the connection open is destroyed client-side", async () => {
   // cleanupAndPropagate deliberately defers destroy to req.onSocket for
   // status-code tunnel failures; oncreate must forward the socket so


### PR DESCRIPTION
### Problem

- `server.keepAliveTimeout` and `server.maxHeaderSize` are plain properties. Only the constructor option is validated, so any number reaches native code.
- `server.keepAliveTimeout = -5000` answers `Keep-Alive: timeout=4294967291` (`to_int32() as u32`, `NodeHTTPResponse.rs:885`, `:1081`). Above 2^31 - 1 seconds it answers `timeout=2147483647`. Node prints `timeout=-5` and `timeout=2147483648`.
- `server.maxHeaderSize = -1` passes a `double` to a `uint64_t` (`NodeHTTP.cpp:780`). On x64 it becomes 2^64 - 1. `HttpParser.h:1161` adds 864 bytes of slack, the sum wraps to 863, and the server answers 431 to a request head above that. On arm64 `Infinity` does the same.

### Fix

- `renderNativeHeaders` prints `Connection` and `Keep-Alive` in JS when the seconds are negative or above 2^31 - 1. The lines match Node for each value. The native reader uses `to_u32()`.
- `maxHTTPHeaderSizeFromNumber` makes the conversion defined. NaN or a value below 1 selects the default limit. 2^64 or more selects no limit. The parser adds its slack with saturation.
- Verified: `node-http.test.ts` (the Keep-Alive test also passes under Node v26.3.0) and `node-http-maxHeaderSize.test.ts`. Both fail on 1.4.3-canary.

### Background

- bun's node:http writes `Connection`, `Keep-Alive` and `Date` from native code. JS passes flag bits and the Keep-Alive seconds. A JS path for the same two lines already exists for `maxRequestsPerSocket`.
- In the uWS parser a `maxHeaderSize` of 0 means the default. The parser allows `MAX_HEADER_FRAMING_SLACK` extra bytes, because llhttp does not count framing bytes.
- Node casts `maxHeaderSize` with `static_cast<uint64_t>(double)`. That cast is undefined for NaN, a negative and 2^64 or more, so Node's result for those depends on the CPU.

<details><summary>Notes</summary>

**Origin.** An integer cast audit of main found the Keep-Alive wrap and listed `maxHeaderSize = -1` as the same shape. No user reported them.

**Keep-Alive, response to `GET /` (release 1.4.3-canary, this branch, Node v26.3.0)**

| `server.keepAliveTimeout` | before | after | Node |
| --- | --- | --- | --- |
| `-5000` | `timeout=4294967291` | `timeout=-5` | `timeout=-5` |
| `-0.5` | `timeout=4294967295` | `timeout=-1` | `timeout=-1` |
| `2 ** 31 * 1000` | `timeout=2147483647` | `timeout=2147483648` | `timeout=2147483648` |
| `Infinity` | `timeout=2147483647` | `timeout=Infinity` | `timeout=Infinity` |
| `(2 ** 31 - 1) * 1000` | `timeout=2147483647` | same | same |

With `maxRequestsPerSocket` set, bun already printed the Node lines, because that path renders in JS. Source: [`_http_outgoing.js#L513-L518`](https://github.com/nodejs/node/blob/v26.3.0/lib/_http_outgoing.js#L513-L518).

The JS bound is 2^31 - 1 and not 2^32 - 1, because `keepAliveHeaderBlob` in `NodeHTTP.cpp` uses `~0u` as its "nothing cached" marker.

The test handler sets `server.keepAliveTimeout = 1000` before it responds. The response took its copy when the request arrived. The idle timer reads the server's value after the response, and the test must not arm it with 2^31 seconds.

**maxHeaderSize, status for a request with one padded header (x64)**

| `server.maxHeaderSize` | head | before | after | Node v26.3.0 x64 |
| --- | --- | --- | --- | --- |
| `-1` | 2000 bytes | 431 | 200 | 200 |
| `-800` | 100 bytes | 431 | 200 | 200 |
| `Infinity` | 20000 bytes | 200 | 200 | 200 |
| `-1` | 20000 bytes | 431 | 431 | 200 |
| `NaN` | 20000 bytes | 200 | 431 | 431 |

Row 4 is a deliberate choice. Node on x64 turns a negative into a limit no request reaches. Node on arm64 turns it into 0, which is the default limit. Bun now uses the default limit on both: a negative limit does not switch the limit off. Row 5 now matches Node, which reads `server.maxHeaderSize || 0`. Source: [`node_http_parser.cc#L688-L692`](https://github.com/nodejs/node/blob/v26.3.0/src/node_http_parser.cc#L688-L692).

**Suites run with the debug build.** `test/js/node/http/node-http.test.ts`, `test/js/node/http/node-http-maxHeaderSize.test.ts`, and from `test/js/node/test/parallel`: every `test-http-keep-alive*.js`, `test-http-keepalive-*.js`, `test-http-server-keep*.js`, `test-http-max-*.js` and `test-http-header-overflow.js`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http-maxHeaderSize.test.ts test/js/node/http/node-http.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/http/node-http-maxHeaderSize.test.ts:
(pass) maxHeaderSize [131.12ms]
110 |     // no limit on x64, the default limit on arm64. Bun uses the default limit.
111 |     "-1, 20000 bytes": await statusFor(-1, 20000),
112 |     "NaN, 20000 bytes": await statusFor(NaN, 20000),
113 |     "4000, 2000 bytes": await statusFor(4000, 2000),
114 |     "4000, 5000 bytes": await statusFor(4000, 5000),
115 |   }).toEqual({
           ^
error: expect(received).toEqual(expected)

  {
-   "-1, 2000 bytes": "HTTP/1.1 200 OK",
+   "-1, 2000 bytes": "HTTP/1.1 431 Request Header Fields Too Large",
    "-1, 20000 bytes": "HTTP/1.1 431 Request Header Fields Too Large",
-   "-800, 100 bytes": "HTTP/1.1 200 OK",
+   "-800, 100 bytes": "HTTP/1.1 431 Request Header Fields Too Large",
    "4000, 2000 bytes": "HTTP/1.1 200 OK",
    "4000, 5000 bytes": "HTTP/1.1 431 Request Header Fields Too Large",
    "Infinity, 20000 bytes": "HTTP/1.1 200 
... (truncated)

release without fix: 3 failed, 1 skipped
bun test v1.4.3-canary.1 (e1211fc0f)

test/js/node/http/node-http-maxHeaderSize.test.ts:
(pass) maxHeaderSize [11.62ms]
110 |     // no limit on x64, the default limit on arm64. Bun uses the default limit.
111 |     "-1, 20000 bytes": await statusFor(-1, 20000),
112 |     "NaN, 20000 bytes": await statusFor(NaN, 20000),
113 |     "4000, 2000 bytes": await statusFor(4000, 2000),
114 |     "4000, 5000 bytes": await statusFor(4000, 5000),
115 |   }).toEqual({
           ^
error: expect(received).toEqual(expected)

  {
-   "-1, 2000 bytes": "HTTP/1.1 200 OK",
+   "-1, 2000 bytes": "HTTP/1.1 431 Request Header Fields Too Large",
    "-1, 20000 bytes": "HTTP/1.1 431 Request Header Fields Too Large",
-   "-800, 100 bytes": "HTTP/1.1 200 OK",
+   "-800, 100 bytes": "HTTP/1.1 431 Request Header Fields Too Large",
    "4000, 2000 bytes": "HTTP/1.1 200 OK",
    "4000, 5000 bytes": "HTTP/1.1 431 Request Header Fields Too Large",
    "Infinity, 20000 bytes": "HTTP/1.1 200 OK",
-   "NaN, 20000 bytes": "HTTP/1.1 431 Request Header Fields Too Large",
+   "NaN, 20000 bytes": "HTTP/1.1 200 OK",
  }

- Expected  - 3
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/node/ht
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http-maxHeaderSize.test.ts test/js/node/http/node-http.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/http/node-http-maxHeaderSize.test.ts:
(pass) maxHeaderSize [115.62ms]
(pass) server.maxHeaderSize assigned after construction is not narrowed to a smaller limit [1507.77ms]
(pass) --max-http-header-size=NaN [149.70ms]
(pass) --max-http-header-size=16*1024 [1785.34ms]
(pass) --max-http-header-size=1024 [2009.13ms]

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [139.87ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [72.84ms]
(pass) node:http > createServer > request & response body streaming (large) [163.69ms]
(pass) node:http > createServer > request & response body streaming (small) [97.67ms]
(pass) node:http > createServer > listen should return server [22.66ms]
(pass) node:http > createServer > listen callback should be bound to server [25.18ms]
(pass) node:http > createServer > emits 'listening' on the next tick, before the event loop polls [31.02ms]
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 959ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/126] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/126] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/126] gen cpp.rs (cppbind)
[4/126] gen JS modules (bundle-modules)
Preprocess modules (12654ms)
Bundle modules (76ms)
Postprocesss modules (177ms)
Bundle Functions (524ms)
Generate Code (49ms)

[13.49s] Bundled "src/js" for production
  2600 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[4/126] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-uws/src/HttpParser.h                 |  8 +++-
 src/js/node/_http_server.ts                       | 24 ++++++----
 src/jsc/bindings/NodeHTTP.cpp                     | 10 ++++-
 src/runtime/server/NodeHTTPResponse.rs            |  4 +-
 test/js/node/http/node-http-maxHeaderSize.test.ts | 55 +++++++++++++++++++++++
 test/js/node/http/node-http.test.ts               | 54 ++++++++++++++++++++++
 6 files changed, 142 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
packages/bun-uws/src/HttpParser.h                      0      0     20
src/js/node/_http_server.ts                            4      2     20
src/jsc/bindings/NodeHTTP.cpp                          3      0     20
src/runtime/server/NodeHTTPResponse.rs                 2      0     20
test/js/node/http/node-http-maxHeaderSize.test.ts      0      0      7
test/js/node/http/node-http.test.ts                    0      0     17
```

</details>

<!-- robobun:evidence:end -->