### PR TITLE
react-compiler: register the locals of a compiled function in its own scope

### DIFF
--- a/src/js_parser/react_compiler_host.rs
+++ b/src/js_parser/react_compiler_host.rs
@@ -178,7 +178,9 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> P<'a, TS, SCAN_ONLY> {
             for (key, member) in args.members.iter() {
                 let kind = self.symbols[member.ref_.inner_index() as usize].kind;
                 if kind == js_ast::symbol::Kind::Arguments || Some(member.ref_) == name {
-                    // SAFETY: `key` is the key of a member of a live scope.
+                    // SAFETY: `put` stores `key` by reference, so it has to
+                    // outlive `args`. It is already the key of a member of
+                    // `args`, stored under the same contract.
                     unsafe { kept.put(key, *member) };
                 }
             }

--- a/src/js_parser/react_compiler_host.rs
+++ b/src/js_parser/react_compiler_host.rs
@@ -159,14 +159,7 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
 }
 
 impl<'a, const TS: bool, const SCAN_ONLY: bool> P<'a, TS, SCAN_ONLY> {
-    /// Call when the React Compiler replaced the parameters and the body of the
-    /// function whose FunctionBody scope is `current_scope`. The new ones declare
-    /// only symbols from `Host::new_local`, which are in this scope's `generated`.
-    /// Of the symbols that the parser declared for the old ones, the output still
-    /// prints `arguments` and `name`: a function expression declares its own name
-    /// in its FunctionArgs scope. Nothing prints the others. If they stay, the
-    /// renamer numbers each new local around the old symbol of the same name
-    /// (`count` prints as `count2`).
+    /// Drops the replaced body's symbols, or the renamer prints a new local `count` as `count2`.
     pub(crate) fn drop_symbols_of_replaced_function(&mut self, name: Option<js_ast::Ref>) {
         let mut body = self.current_scope;
         debug_assert!(body.kind == js_ast::scope::Kind::FunctionBody);
@@ -174,6 +167,7 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> P<'a, TS, SCAN_ONLY> {
         body.children.clear();
         if let Some(mut args) = body.parent {
             debug_assert!(args.kind == js_ast::scope::Kind::FunctionArgs);
+            // Still printed: `arguments`, and `name` when a function expression declares it here.
             let mut kept = js_ast::scope::Members::EMPTY;
             for (key, member) in args.members.iter() {
                 let kind = self.symbols[member.ref_.inner_index() as usize].kind;

--- a/src/js_parser/react_compiler_host.rs
+++ b/src/js_parser/react_compiler_host.rs
@@ -108,6 +108,15 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
         ref_
     }
 
+    fn new_local(&mut self, name: &[u8]) -> js_ast::Ref {
+        let p = &mut *self.p;
+        let name = p.arena.alloc_slice_copy(name);
+        let ref_ = p.new_symbol(js_ast::symbol::Kind::Other, name);
+        // current_scope is the FunctionBody of the function being compiled.
+        VecExt::append(&mut p.current_scope_mut().generated, ref_);
+        ref_
+    }
+
     fn new_import_item(&mut self, name: &[u8]) -> js_ast::Ref {
         let p = &mut *self.p;
         let name = p.arena.alloc_slice_copy(name);
@@ -150,6 +159,34 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
 }
 
 impl<'a, const TS: bool, const SCAN_ONLY: bool> P<'a, TS, SCAN_ONLY> {
+    /// Call when the React Compiler replaced the parameters and the body of the
+    /// function whose FunctionBody scope is `current_scope`. The new ones declare
+    /// only symbols from `Host::new_local`, which are in this scope's `generated`.
+    /// Of the symbols that the parser declared for the old ones, the output still
+    /// prints `arguments` and `name`: a function expression declares its own name
+    /// in its FunctionArgs scope. Nothing prints the others. If they stay, the
+    /// renamer numbers each new local around the old symbol of the same name
+    /// (`count` prints as `count2`).
+    pub(crate) fn drop_symbols_of_replaced_function(&mut self, name: Option<js_ast::Ref>) {
+        let mut body = self.current_scope;
+        debug_assert!(body.kind == js_ast::scope::Kind::FunctionBody);
+        body.members = js_ast::scope::Members::EMPTY;
+        body.children.clear();
+        if let Some(mut args) = body.parent {
+            debug_assert!(args.kind == js_ast::scope::Kind::FunctionArgs);
+            let mut kept = js_ast::scope::Members::EMPTY;
+            for (key, member) in args.members.iter() {
+                let kind = self.symbols[member.ref_.inner_index() as usize].kind;
+                if kind == js_ast::symbol::Kind::Arguments || Some(member.ref_) == name {
+                    // SAFETY: `key` is the key of a member of a live scope.
+                    unsafe { kept.put(key, *member) };
+                }
+            }
+            args.members = kept;
+            args.children.retain(|child| *child == body);
+        }
+    }
+
     /// Sets `react_compiler_may_replace_body` for the visit of the pending candidate. Returns the old value.
     pub(crate) fn enter_react_compiler_candidate(
         &mut self,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1778,6 +1778,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .binding
                 .filter(|r| *r != js_ast::Ref::NONE)
                 .map(|r| p.load_name_from_ref(r));
+            // `Host::new_local` appends the locals of the compiled function here.
+            let generated_len = p.current_scope().generated.len();
             let compiled = {
                 let host = &mut crate::react_compiler_host::ReactCompilerHost::new(p);
                 bun_react_compiler::maybe_compile_pending(
@@ -1793,6 +1795,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 stmts.clear();
                 stmts.extend(new_body);
                 p.react_compiler_result = Some(result);
+                p.drop_symbols_of_replaced_function(pending.binding);
+            } else {
+                p.current_scope_mut().generated.truncate(generated_len);
             }
         }
 

--- a/src/react_compiler/DESIGN.md
+++ b/src/react_compiler/DESIGN.md
@@ -120,6 +120,14 @@ New symbols (`$`, `t0`, `c`, `_c`) are minted via the `Host` trait
 implemented by the parser's `P`; the import of `react/compiler-runtime` is
 registered via `Host::add_import_record`.
 
+Every local of a compiled function is a new symbol, also one the source
+declared. `Host::new_local` registers it in the body scope of that function
+(`Scope::generated`), and once the body is replaced the parser drops the
+symbols it declared for the old one (all but `arguments` and the own name of a
+function expression). The bundler's renamer then numbers the new symbols like
+the locals of any other function. `Host::new_generated` is for a name declared
+at module level, such as an outlined `_temp`.
+
 ### Bail-out semantics
 
 Any `bun_ast` node the port cannot lower (bundler-only synthetics: `ESpecial`,

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -368,8 +368,7 @@ pub(crate) fn codegen_function(
         let identifiers = rename_variables(&mut reactive_fn_mut, cx.env);
         let mut outlined_cx = Context::new(cx.env, cx.cg, identifiers);
         let mut codegen = codegen_reactive_function(&mut outlined_cx, &reactive_fn_mut)?;
-        // The declaration is hoisted to module level. The same name gives the
-        // `Ref` that the `LoadGlobal` at the use site printed.
+        // Module level. `name_to_ref` gives the `Ref` the use site's `LoadGlobal` printed.
         codegen.id = reactive_fn_mut.id.as_ref().map(|name| LocRef {
             loc: convert_loc(reactive_fn_mut.loc),
             ref_: cx.cg.ref_for_name(store_str(name.as_bytes())),

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -125,6 +125,7 @@ impl<'h> Codegen<'h> {
         }
     }
 
+    /// The symbol for a name declared at module level ([`Host::new_generated`]).
     fn ref_for_name(&mut self, name: StoreStr) -> Ref {
         if let Some(&r) = self.name_to_ref.get(&name) {
             self.host.record_usage(r);
@@ -135,12 +136,23 @@ impl<'h> Codegen<'h> {
         r
     }
 
+    /// The symbol for a name the compiled function declares ([`Host::new_local`]).
+    fn ref_for_local(&mut self, name: StoreStr) -> Ref {
+        if let Some(&r) = self.name_to_ref.get(&name) {
+            self.host.record_usage(r);
+            return r;
+        }
+        let r = self.host.new_local(name.slice());
+        self.name_to_ref.insert(name, r);
+        r
+    }
+
     fn well_known(&mut self, w: WellKnown, name: &[u8]) -> Ref {
         if let Some(r) = self.well_known[w as usize] {
             self.host.record_usage(r);
             return r;
         }
-        let r = self.host.new_generated(name);
+        let r = self.host.new_local(name);
         self.well_known[w as usize] = Some(r);
         r
     }
@@ -201,7 +213,7 @@ impl<'h> Codegen<'h> {
         let mut cursor = std::io::Cursor::new(&mut buf[..]);
         write!(cursor, "bb{}", id.0).unwrap();
         let len = cursor.position() as usize;
-        let r = self.host.new_generated(&buf[..len]);
+        let r = self.host.new_local(&buf[..len]);
         self.label_to_ref.insert(id, r);
         r
     }
@@ -355,7 +367,13 @@ pub(crate) fn codegen_function(
 
         let identifiers = rename_variables(&mut reactive_fn_mut, cx.env);
         let mut outlined_cx = Context::new(cx.env, cx.cg, identifiers);
-        let codegen = codegen_reactive_function(&mut outlined_cx, &reactive_fn_mut)?;
+        let mut codegen = codegen_reactive_function(&mut outlined_cx, &reactive_fn_mut)?;
+        // The declaration is hoisted to module level. The same name gives the
+        // `Ref` that the `LoadGlobal` at the use site printed.
+        codegen.id = reactive_fn_mut.id.as_ref().map(|name| LocRef {
+            loc: convert_loc(reactive_fn_mut.loc),
+            ref_: cx.cg.ref_for_name(store_str(name.as_bytes())),
+        });
         outlined.push(OutlinedFunction {
             func: codegen,
             #[cfg(any(debug_assertions, bun_asan, feature = "fixtures"))]
@@ -448,7 +466,7 @@ impl<'a, 'h> Context<'a, 'h> {
             return Err(unnamed_identifier_err(id.0));
         };
         let (IdentifierName::Named(s) | IdentifierName::Promoted(s)) = name;
-        let r = self.cg.ref_for_name(*s);
+        let r = self.cg.ref_for_local(*s);
         self.cg.id_to_ref.insert(id, r);
         Ok(r)
     }
@@ -502,16 +520,8 @@ fn codegen_reactive_function(
     let (memo_blocks, memo_values, pruned_memo_blocks, pruned_memo_values) =
         count_memo_blocks(func, cx.env);
 
-    let id = func.id.as_ref().map(|name| {
-        let r = cx.cg.ref_for_name(store_str(name.as_bytes()));
-        LocRef {
-            loc: convert_loc(func.loc),
-            ref_: r,
-        }
-    });
-
     Ok(CodegenFunction {
-        id,
+        id: None,
         #[cfg(any(debug_assertions, bun_asan, feature = "fixtures"))]
         name_hint: func.name_hint.clone(),
         params,
@@ -2338,7 +2348,7 @@ fn codegen_function_expression(
                 fn_flags |= flags::Function::HasRestArg;
             }
             let fn_name = name.as_ref().map(|n| {
-                let r = cx.cg.ref_for_name(*n);
+                let r = cx.cg.ref_for_local(*n);
                 LocRef { loc, ref_: r }
             });
             Expr::init(

--- a/src/react_compiler/pipeline.rs
+++ b/src/react_compiler/pipeline.rs
@@ -317,13 +317,15 @@ pub(crate) fn compile_outlined_fn(
     let (reactive_fn, unique_identifiers) = run_hir_passes(&mut hir, &mut env, context)?;
 
     let mut cg = Codegen::new(host, arena);
-    let codegen_result =
+    let mut codegen_result =
         codegen::codegen_function(&reactive_fn, &mut env, &mut cg, context, unique_identifiers)?;
 
     if env.has_errors() {
         return Err(env.take_errors());
     }
 
+    // The `Ref` that the use site in the component printed.
+    codegen_result.id = codegen_fn.id;
     Ok(codegen_result)
 }
 

--- a/src/react_compiler/program.rs
+++ b/src/react_compiler/program.rs
@@ -97,15 +97,10 @@ pub trait Host {
     /// resolved from the current scope the way the visit pass resolves it.
     fn jsx_classic_factory(&mut self, loc: Loc) -> Expr;
 
-    /// A new symbol declared at module level: the name of an outlined
-    /// function, or of a binding the compiler imports.
+    /// A new symbol for a module-level name, such as an outlined function.
     fn new_generated(&mut self, name: &[u8]) -> Ref;
 
-    /// A new symbol declared by the function being compiled (or by a function
-    /// outlined from it): a local, a parameter, a label, or the name of a
-    /// nested function expression. The host registers it with that function's
-    /// scope, so the renamer keeps it apart from each top-level name the
-    /// function reads.
+    /// A new symbol for a name that the compiled function (or one outlined from it) declares.
     fn new_local(&mut self, name: &[u8]) -> Ref;
 
     fn new_import_item(&mut self, name: &[u8]) -> Ref {

--- a/src/react_compiler/program.rs
+++ b/src/react_compiler/program.rs
@@ -97,7 +97,16 @@ pub trait Host {
     /// resolved from the current scope the way the visit pass resolves it.
     fn jsx_classic_factory(&mut self, loc: Loc) -> Expr;
 
+    /// A new symbol declared at module level: the name of an outlined
+    /// function, or of a binding the compiler imports.
     fn new_generated(&mut self, name: &[u8]) -> Ref;
+
+    /// A new symbol declared by the function being compiled (or by a function
+    /// outlined from it): a local, a parameter, a label, or the name of a
+    /// nested function expression. The host registers it with that function's
+    /// scope, so the renamer keeps it apart from each top-level name the
+    /// function reads.
+    fn new_local(&mut self, name: &[u8]) -> Ref;
 
     fn new_import_item(&mut self, name: &[u8]) -> Ref {
         self.new_generated(name)

--- a/test/bundler/transpiler/react-compiler-fixtures.test.ts
+++ b/test/bundler/transpiler/react-compiler-fixtures.test.ts
@@ -448,6 +448,13 @@ describe("react-compiler upstream fixtures", () => {
 
       const want = slotCounts(expected.code ?? "");
       const got = slotCounts(output);
+      // A component that `@enableJsxOutlining` outlines has memo slots of its
+      // own. Bun declares an outlined function ahead of the module's other
+      // statements, upstream after the function it came from.
+      if (pragmas.has("enableJsxOutlining")) {
+        want.sort((a, b) => a - b);
+        got.sort((a, b) => a - b);
+      }
 
       const wantRuntime = (expected.code ?? "").includes("react/compiler-runtime");
       const gotRuntime = output.includes("react/compiler-runtime");

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1882,6 +1882,193 @@ describe("bundler", () => {
     }
   }
 
+  // The bundler prints an import under the name of the export it links to:
+  // `defaultTheme` below prints as `theme`. A compiled function gets new
+  // symbols for its parameters, its locals and its temporaries (`t0`, `$`).
+  // The renamer has to number them like the symbols of any other function, or
+  // a local with the name of that export shadows it:
+  // `let theme = custom ?? theme`.
+  for (const target of ["bun", "browser"] as const) {
+    for (const minifyIdentifiers of [false, true]) {
+      itBundled(`react-compiler/LocalNamedLikeAnExportItReads-${target}-identifiers=${minifyIdentifiers}`, {
+        files: {
+          "/entry.ts": /* ts */ `
+            import * as forms from "./forms";
+            const lines: string[] = [];
+            const check = (flag?: boolean) => {
+              if (flag) throw "thrown";
+            };
+            for (const [name, form] of Object.entries(forms)) {
+              try {
+                lines.push(name + "=" + form({ custom: "mine", flag: true, list: [{ x: 1 }, { x: 2 }], check }));
+                lines.push(name + "=" + form({ list: [{ x: 3 }], check }));
+              } catch (e) {
+                lines.push(name + " threw " + e);
+              }
+            }
+            console.log(lines.join("\\n"));
+          `,
+          "/forms.tsx": /* tsx */ `
+            import { useEffect, useState, memo, forwardRef } from "react";
+            import * as values from "./values";
+            import {
+              Wrapped as BaseWrapped,
+              theme as defaultTheme,
+              custom as defaultCustom,
+              item as defaultItem,
+              s as format,
+              e as suffix,
+              t0 as first,
+              t1 as second,
+              $ as dollar,
+            } from "./values";
+
+            export function Local({ custom }) {
+              useEffect(() => {});
+              const theme = custom ?? defaultTheme;
+              return theme;
+            }
+            export function useLocal({ custom }) {
+              useEffect(() => {});
+              let theme = defaultTheme;
+              if (custom) theme = custom + "/" + defaultTheme;
+              return theme;
+            }
+            export const MemoLocal = memo(({ custom }) => {
+              useEffect(() => {});
+              const theme = custom ?? defaultTheme;
+              return theme;
+            });
+            export function Parameter({ custom }) {
+              useEffect(() => {});
+              return (custom ?? "none") + " " + defaultCustom;
+            }
+            export function NamespaceMember({ flag }) {
+              useEffect(() => {});
+              const theme = flag ? values.theme : "none";
+              return theme;
+            }
+            // The compiler hoists a callback that captures nothing to module
+            // level. Its parameter is a new symbol too.
+            export function OutlinedParameter({ list }) {
+              useEffect(() => {});
+              return list.map(item => item.x + defaultItem.y).join(",") + ";" + list.map(s => format(s.x)).join(",");
+            }
+            export function NestedParameter({ list, custom }) {
+              useEffect(() => {});
+              return list.map(item => item.x + defaultItem.y + (custom ?? "")).join(",");
+            }
+            export function CatchBinding({ flag, check }) {
+              useEffect(() => {});
+              try {
+                check(flag);
+              } catch (e) {
+                return e + suffix;
+              }
+              return "none" + suffix;
+            }
+            // The props object is \`t0\`, the memo cache is \`$\`, and the value
+            // of a memo block is \`t1\`.
+            export function Temporaries({ custom }) {
+              const [count] = useState(1);
+              const all = [String(custom), count, first, second, dollar];
+              return all.join(" ");
+            }
+            // A function expression declares its own name in its own scope.
+            // The compiled function keeps that name, so it is still numbered.
+            export const OwnNameForwardRef = forwardRef(function Wrapped({ custom }, ref) {
+              useEffect(() => {});
+              return "<" + BaseWrapped({ custom, by: "forwardRef" }) + ">";
+            });
+            export const OwnNameMemo = memo(function Wrapped({ custom }) {
+              useEffect(() => {});
+              return "<" + BaseWrapped({ custom, by: "memo" }) + ">";
+            });
+            export const OwnNamePlain = function Wrapped({ custom }) {
+              useEffect(() => {});
+              return "<" + BaseWrapped({ custom, by: "plain" }) + ">";
+            };
+          `,
+          "/values.ts": /* ts */ `
+            export const theme = "dark";
+            export const custom = "CUSTOM";
+            export const item = { y: 10 };
+            export function s(value: number) {
+              return "<" + value + ">";
+            }
+            export const e = "!";
+            export const t0 = "T0";
+            export const t1 = "T1";
+            export const $ = "DOLLAR";
+            export function Wrapped({ custom, by }: { custom?: string; by: string }) {
+              return by + ":" + custom;
+            }
+          `,
+          "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+          "/node_modules/react/index.js": /* js */ `
+            export function useEffect() {}
+            export function useState(value) {
+              return [value, () => {}];
+            }
+            export function memo(component) {
+              return component;
+            }
+            export function forwardRef(component) {
+              return component;
+            }
+          `,
+          "/node_modules/react/compiler-runtime.js": /* js */ `
+            export function c(size) {
+              return new Array(size).fill(Symbol.for("react.memo_cache_sentinel"));
+            }
+          `,
+        },
+        reactCompiler: true,
+        backend: "cli",
+        target,
+        minifyIdentifiers,
+        run: {
+          stdout: `
+            CatchBinding=thrown!
+            CatchBinding=none!
+            Local=mine
+            Local=dark
+            MemoLocal=mine
+            MemoLocal=dark
+            NamespaceMember=dark
+            NamespaceMember=none
+            NestedParameter=11mine,12mine
+            NestedParameter=13
+            OutlinedParameter=11,12;<1>,<2>
+            OutlinedParameter=13;<3>
+            OwnNameForwardRef=<forwardRef:mine>
+            OwnNameForwardRef=<forwardRef:undefined>
+            OwnNameMemo=<memo:mine>
+            OwnNameMemo=<memo:undefined>
+            OwnNamePlain=<plain:mine>
+            OwnNamePlain=<plain:undefined>
+            Parameter=mine CUSTOM
+            Parameter=none CUSTOM
+            Temporaries=mine 1 T0 T1 DOLLAR
+            Temporaries=undefined 1 T0 T1 DOLLAR
+            useLocal=mine/dark
+            useLocal=dark
+          `,
+        },
+        onAfterBundle(api) {
+          if (minifyIdentifiers) return;
+          const out = api.readFile("/out.js");
+          // Every function above compiled: the compiler outlines the empty
+          // effect callback (client) or drops the effect (ssr).
+          expect(out).not.toMatch(/\(\(\) => \{\s*\}\)/);
+          // A local that shares its name with nothing the function reads
+          // keeps it.
+          expect(out).toMatch(/function Local\(t0\) \{\s*let \{ custom \} = t0;/);
+        },
+      });
+    }
+  }
+
   // The compiler lowers the call the visit pass made of each JSX element into
   // HIR and builds a new call from that. Both steps have to use the call shape
   // of the file's JSX runtime. The classic runtime, and `key` after a spread in


### PR DESCRIPTION
### Problem

- With `bun build --react-compiler` and unminified names, a local of a compiled function can shadow the export it reads. `const theme = custom ?? defaultTheme` prints `let theme = custom ?? theme`: `ReferenceError: Cannot access 'theme' before initialization.` Parameters, `catch` bindings and the temporaries `t0`, `$` break too, often with a wrong value and no error.
- The compiler makes a new symbol for each local. The parser's host put them all in the module scope (`src/js_parser/react_compiler_host.rs:83`), where the linker's renamer does not name them.

### Fix

- `Host::new_local` registers such a symbol in the body scope of the compiled function. `Host::new_generated` stays for module-level names.
- After a compile, the parser drops the members and child scopes of the replaced body, except `arguments` and the own name of a function expression. The rest is dead, and each new local would be numbered around the dead symbol of its name (`count2`).
- Correct because the renamer now treats these symbols like any other local. 1488 of 1499 fixture outputs are identical.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (4 new tests, 2 fail on 1.4.3-canary). Also `react-compiler-fixtures.test.ts`, `bundler_jsx.test.ts`.

### Background

- The React Compiler runs per function, after the parser visited the body. It builds a new body from its own IR.
- The linker's number renamer names top-level symbols from each part's declared symbols, then the symbols of nested scopes (`members` and `generated`). `--minify-identifiers` uses another renamer, which hid this.
- The bundler prints an import under the name of its export (`defaultTheme` prints as `theme`). The linker picks that name, after the compiler's own rename pass.

<details><summary>Notes</summary>

**Repro.** `theme.js`: `export const theme = "dark";`. `app.jsx`:

```jsx
import { useEffect } from "react";
import { theme as defaultTheme } from "./theme";
export function App({ custom }) {
  useEffect(() => {});
  const theme = custom ?? defaultTheme;
  return theme;
}
console.log(App({ custom: "light" }), App({}));
```

`bun build --react-compiler --target=bun app.jsx --outfile=c.js && bun c.js` prints `light dark` with this change. Before, it throws the ReferenceError above. Without `--react-compiler` the bundler prints `theme2` for the local, and this change gives the same name. 1.4.0 to 1.4.3-canary and main have the bug.

**The new tests.** `LocalNamedLikeAnExportItReads-{bun,browser}-identifiers={false,true}` run 12 forms: a local, a hook, a `memo` arrow, a destructured parameter, a namespace member, the parameter of an outlined callback, the parameter of a nested callback, a `catch` binding, the temporaries, and three function expressions that have the name of the export they call (`forwardRef(function Wrapped…)`, `memo(function Wrapped…)`, `const X = function Wrapped…`). On 1.4.3-canary 8 forms print a wrong value or throw in the two builds that keep the names. The two `identifiers=true` builds pass before and after. They guard the nested slots that the locals now get.

**Which names the codegen treats as module level.** A `LoadGlobal` or `StoreGlobal` that carries no `Ref` (the name of an outlined function), the id of an outlined function, and the import names for hook guards and instrumentation. Everything else is a local: named and promoted identifiers, the memo cache `$`, labels (`bb0`), the own name of a nested function expression. `codegen_reactive_function` no longer resolves the function id. The only consumer is the outlined declaration, so the loop over outlined functions resolves it.

**What stays in the scopes of a compiled function.** The parser declares the own name of a function expression in its FunctionArgs scope, next to the parameters and `arguments`. The compiled function keeps that name, so the helper keeps that member. Without it, `forwardRef(function Button(props) { return BaseButton(props) })` over `import { Button as BaseButton }` prints `function Button(props) { return Button(props) }` and never returns. The `generated` lists stay too (a React Refresh `_s` lives there).

**Locals of an outlined function.** They go in the scope of the component they came from, because `current_scope` is that body when the codegen runs. The declaration is printed at module level. That is safe: every use that the outlined function makes is recorded in the scope of the component, so the renamer keeps its locals apart from each top-level symbol that it reads.

**JSX outlining (debug and ASAN builds only, `@enableJsxOutlining`).** The outlined component is compiled a second time from its generated AST. Before, that second pass failed: its locals were in the `generated` list of the module scope, and `resolve_identifier` classifies such a symbol as a global. The component was dropped from the output, and its use site referenced a name that nothing declared. The 9 `jsx-outlining-*` fixtures passed through the "Bun compiled a strict subset" branch. Now the second pass succeeds, and the slot counts equal the upstream values (`5`, `8`, `9`, `11`). Bun declares an outlined function ahead of the other statements of the module, upstream after the function it came from. So the fixtures test compares the slot counts of those fixtures as sorted lists. `compile_outlined_fn` also keeps the `Ref` that the use site printed.

**A/B of all upstream fixtures** (1499 outputs, the same `Bun.build` call as the fixtures test, base `b99371011f`):

- Names not minified: 11 outputs differ. 9 are the `jsx-outlining-*` fixtures above. `repro-no-declarations-in-reactive-scope-with-early-return` reads an unbound global `item`, and the renamer now numbers the callback parameter `item` around it (`item2`), as it does in a function that is not compiled. `context-variable-as-jsx-element-tag` has `function Component() { let Component = ... }`. The parser records a use of the binding of a compiled function inside its scope, so the local prints as `Component2`. Both are correct.
- `minify: { identifiers: true }`: 519 outputs differ, all parse. The locals now get nested slots (shared between functions) where they took top-level slots before.

**End to end.** A multi-file app (12 components, React 18.3.1 with a `compiler-runtime` polyfill, locals named like 26 exports that they read, two function expressions named like the component they wrap) rendered with `react-dom/server`. 8 build variants (`bun` and `browser` targets, each with no flag, `--minify-identifiers`, `--minify`, `--minify-syntax`). With this change all 8 render the same markup as the build without the compiler. On the base commit the 4 variants that do not minify identifiers crash (`let list = items ?? items`).

Also checked against the build without the compiler: `--splitting` with two entry points, `--format=cjs`, `--format=iife`, a component module that is loaded with `require()` (ESM wrapper), and a CommonJS component module.

**Not in this PR.**

- All outlined functions of a file go in one part. If tree shaking drops a component and keeps another one of the same file, the outlined functions of the dropped one are still printed, with locals that no scope names. Nothing calls them. Main does the same.
- A debug-only check that the number renamer named every renamable symbol it prints would catch this class. Other suites (`exports` and `module` of a CommonJS wrapper, decorator temporaries) trip such a check today, so it needs its own change.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 320 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler-fixtures.test.ts test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler-fixtures.test.ts:
(pass) react-compiler upstream fixtures > fixture corpus is present [2.47ms]
(pass) react-compiler upstream fixtures > alias-capture-in-method-receiver > minify.syntax [10.12ms]
(pass) react-compiler upstream fixtures > alias-capture-in-method-receiver-and-mutate > minify.syntax [0.79ms]
(pass) react-compiler upstream fixtures > alias-computed-load > minify.syntax [0.50ms]
(pass) react-compiler upstream fixtures > alias-nested-member-path > minify.syntax [0.46ms]
(pass) react-compiler upstream fixtures > alias-capture-in-method-receiver > compile [43.83ms]
(pass) react-compiler upstream fixtures > alias-nested-member-path-mutate > minify.syntax [0.48ms]
(pass) react-compiler upstream fixtures > alias-capture-in-method-receiver-and-mutate > compile [18.00ms]
(pass) react-compiler upstream fixtures > alias-while > minify.syntax [0.48ms]
(pass) react-com
... (truncated)

release without fix: 1147 skipped
bun test v1.4.3-canary.1 (37bc842c2)

test/bundler/transpiler/react-compiler-fixtures.test.ts:
(pass) react-compiler upstream fixtures > fixture corpus is present [0.16ms]
(pass) react-compiler upstream fixtures > alias-capture-in-method-receiver > minify.syntax [0.35ms]
(pass) react-compiler upstream fixtures > alias-capture-in-method-receiver-and-mutate > minify.syntax [0.01ms]
(pass) react-compiler upstream fixtures > alias-computed-load > minify.syntax
(pass) react-compiler upstream fixtures > alias-nested-member-path > minify.syntax
(pass) react-compiler upstream fixtures > alias-nested-member-path-mutate > minify.syntax
(pass) react-compiler upstream fixtures > alias-while > minify.syntax
(pass) react-compiler upstream fixtures > aliased_usememo > minify.syntax [0.02ms]
(pass) react-compiler upstream fixtures > alias-while > compile [0.90ms]
(pass) react-compiler upstream fixtures > alias-capture-in-method-receiver > compile [2.03ms]
(pass) react-compiler upstream fixtures > alias-capture-in-method-receiver-and-mutate > compile [1.07ms]
(pass) react-compiler upstream fixtures > alias-nested-member-path-mutate > compile [0.99ms]
(pass) react-compiler upstream f
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 320 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler-fixtures.test.ts test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler-fixtures.test.ts:
(pass) react-compiler upstream fixtures > fixture corpus is present [3.27ms]
(pass) react-compiler upstream fixtures > alias-capture-in-method-receiver > minify.syntax [10.87ms]
(pass) react-compiler upstream fixtures > alias-capture-in-method-receiver-and-mutate > minify.syntax [0.91ms]
(pass) react-compiler upstream fixtures > alias-computed-load > minify.syntax [0.52ms]
(pass) react-compiler upstream fixtures > alias-nested-member-path > minify.syntax [2.79ms]
(pass) react-compiler upstream fixtures > alias-capture-in-method-receiver > compile [51.67ms]
(pass) react-compiler upstream fixtures > alias-nested-member-path-mutate > minify.syntax [0.58ms]
(pass) react-compiler upstream fixtures > alias-capture-in-method-receiver-and-mutate > compile [22.67ms]
(pass) react-compiler upstream fixtures > alias-while > minify.syntax [0.47ms]
(pass) react-com
... (truncated)

release with fix: 1147 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 917ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/react_compiler_host.rs               |  33 ++++
 src/js_parser/visit/mod.rs                         |   5 +
 src/react_compiler/DESIGN.md                       |   8 +
 src/react_compiler/codegen.rs                      |  37 ++--
 src/react_compiler/pipeline.rs                     |   4 +-
 src/react_compiler/program.rs                      |   4 +
 .../transpiler/react-compiler-fixtures.test.ts     |   7 +
 test/bundler/transpiler/react-compiler.test.ts     | 187 +++++++++++++++++++++
 8 files changed, 270 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/js_parser/react_compiler_host.rs                         4      5     39
src/js_parser/visit/mod.rs                                   3      3     38
src/react_compiler/DESIGN.md                                 2      2     39
src/react_compiler/codegen.rs                                6      4     39
src/react_compiler/pipeline.rs                               2      1     39
src/react_compiler/program.rs                                3      2     39
test/bundler/transpiler/react-compiler-fixtures.test.ts      1      1     14
test/bundler/transpiler/react-compiler.test.ts               4      1     26
```

</details>

<!-- robobun:evidence:end -->