### PR TITLE
error: stop CallSite.getFunction() from handing out JSC internal functions

### DIFF
--- a/src/jsc/bindings/CallSite.cpp
+++ b/src/jsc/bindings/CallSite.cpp
@@ -79,6 +79,14 @@ void CallSite::finishCreation(VM& vm, JSCStackFrame& stackFrame, bool encountere
     } else {
         m_function.set(vm, this, callee);
     }
+    // isToplevel() judges a frame by its callee. m_function cannot tell it what
+    // the callee was: a frame that hides its callee stores undefined there.
+    if (!isStrictFrame) {
+        auto* function = calleeFunction(callee);
+        if (function && !function->isHostFunction()) {
+            m_flags |= static_cast<unsigned int>(Flags::IsSloppyFunctionCall);
+        }
+    }
 
     m_functionName.set(vm, this, stackFrame.functionName());
     m_sourceURL.set(vm, this, stackFrame.sourceURL());

--- a/src/jsc/bindings/CallSite.cpp
+++ b/src/jsc/bindings/CallSite.cpp
@@ -20,6 +20,29 @@ namespace Zig {
 
 const JSC::ClassInfo CallSite::s_info = { "CallSite"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(CallSite) };
 
+static JSC::JSFunction* calleeFunction(JSC::JSCell* callee)
+{
+    return callee ? dynamicDowncast<JSC::JSFunction>(callee) : nullptr;
+}
+
+/* getFunction() hands the frame's callee to JS. Hand out only a function that
+ * user code could have called itself. JSC has callees that it could not:
+ *   - a host function or a builtin, which are JSC's own implementation
+ *   - the body function JSC compiles for an async function or a generator
+ *   - no JSFunction at all, for a wasm frame or an eval/program frame
+ * The body function is the dangerous one. It takes JSC's own arguments (the
+ * generator object, a state, a value, a resume mode and a frame), so a call
+ * from JS writes generator internal fields into whatever the caller passed. */
+static bool isUserFunction(JSC::JSCell* callee)
+{
+    auto* function = calleeFunction(callee);
+    if (!function || function->isHostFunction() || function->isBuiltinFunction()) {
+        return false;
+    }
+
+    return !JSC::isGeneratorOrAsyncFunctionBodyParseMode(function->jsExecutable()->parseMode());
+}
+
 void CallSite::finishCreation(VM& vm, JSCStackFrame& stackFrame, bool encounteredStrictFrame)
 {
     Base::finishCreation(vm);
@@ -32,6 +55,7 @@ void CallSite::finishCreation(VM& vm, JSCStackFrame& stackFrame, bool encountere
      * Thus, if we've already encountered a strict frame, we'll treat our frame as strict too. */
 
     bool isStrictFrame = encounteredStrictFrame;
+    JSC::JSCell* callee = stackFrame.callee();
     JSC::CodeBlock* codeBlock = stackFrame.codeBlock();
     if (!isStrictFrame) {
         if (codeBlock) {
@@ -42,10 +66,18 @@ void CallSite::finishCreation(VM& vm, JSCStackFrame& stackFrame, bool encountere
     // JSC::StackFrame has no receiver, so getThis() is always undefined.
     m_thisValue.set(vm, this, JSC::jsUndefined());
     if (isStrictFrame) {
-        m_function.set(vm, this, JSC::jsUndefined());
         m_flags |= static_cast<unsigned int>(Flags::IsStrict);
+    }
+    /* A strict frame hides its function from every caller below it, through the
+     * Flags::IsStrict cascade in createCallSitesFromFrames. A frame whose
+     * callee is not a user function hides only its own: it does not set that
+     * flag. JSC shows host frames that V8 leaves out of the stack, such as
+     * Reflect.construct under a transpiled `super()` call, so cascading from
+     * those would hide callers that V8 reports. */
+    if (isStrictFrame || !isUserFunction(callee)) {
+        m_function.set(vm, this, JSC::jsUndefined());
     } else {
-        m_function.set(vm, this, stackFrame.callee());
+        m_function.set(vm, this, callee);
     }
 
     m_functionName.set(vm, this, stackFrame.functionName());

--- a/src/jsc/bindings/CallSite.cpp
+++ b/src/jsc/bindings/CallSite.cpp
@@ -25,14 +25,6 @@ static JSC::JSFunction* calleeFunction(JSC::JSCell* callee)
     return callee ? dynamicDowncast<JSC::JSFunction>(callee) : nullptr;
 }
 
-/* getFunction() hands the frame's callee to JS. Hand out only a function that
- * user code could have called itself. JSC has callees that it could not:
- *   - a host function or a builtin, which are JSC's own implementation
- *   - the body function JSC compiles for an async function or a generator
- *   - no JSFunction at all, for a wasm frame or an eval/program frame
- * The body function is the dangerous one. It takes JSC's own arguments (the
- * generator object, a state, a value, a resume mode and a frame), so a call
- * from JS writes generator internal fields into whatever the caller passed. */
 static bool isUserFunction(JSC::JSCell* callee)
 {
     auto* function = calleeFunction(callee);
@@ -40,6 +32,7 @@ static bool isUserFunction(JSC::JSCell* callee)
         return false;
     }
 
+    // A generator or async body function takes JSC-internal arguments: a call from JS corrupts memory.
     return !JSC::isGeneratorOrAsyncFunctionBodyParseMode(function->jsExecutable()->parseMode());
 }
 
@@ -68,19 +61,13 @@ void CallSite::finishCreation(VM& vm, JSCStackFrame& stackFrame, bool encountere
     if (isStrictFrame) {
         m_flags |= static_cast<unsigned int>(Flags::IsStrict);
     }
-    /* A strict frame hides its function from every caller below it, through the
-     * Flags::IsStrict cascade in createCallSitesFromFrames. A frame whose
-     * callee is not a user function hides only its own: it does not set that
-     * flag. JSC shows host frames that V8 leaves out of the stack, such as
-     * Reflect.construct under a transpiled `super()` call, so cascading from
-     * those would hide callers that V8 reports. */
+    // Hiding a callee must not set IsStrict: that cascades to the callers, and JSC shows host frames that V8 omits.
     if (isStrictFrame || !isUserFunction(callee)) {
         m_function.set(vm, this, JSC::jsUndefined());
     } else {
         m_function.set(vm, this, callee);
     }
-    // isToplevel() judges a frame by its callee. m_function cannot tell it what
-    // the callee was: a frame that hides its callee stores undefined there.
+    // isToplevel() needs the real callee: m_function is undefined when the callee is hidden.
     if (!isStrictFrame) {
         auto* function = calleeFunction(callee);
         if (function && !function->isHostFunction()) {

--- a/src/jsc/bindings/CallSite.h
+++ b/src/jsc/bindings/CallSite.h
@@ -29,8 +29,6 @@ public:
         IsWasm = 16,
         IsFunction = 32,
         IsAsync = 64,
-        // A sloppy frame whose callee is a function written in JS, whether or
-        // not getFunction() hands that function out.
         IsSloppyFunctionCall = 128,
     };
 

--- a/src/jsc/bindings/CallSite.h
+++ b/src/jsc/bindings/CallSite.h
@@ -29,6 +29,9 @@ public:
         IsWasm = 16,
         IsFunction = 32,
         IsAsync = 64,
+        // A sloppy frame whose callee is a function written in JS, whether or
+        // not getFunction() hands that function out.
+        IsSloppyFunctionCall = 128,
     };
 
 private:
@@ -79,6 +82,7 @@ public:
     bool isStrict() const { return m_flags & static_cast<unsigned int>(Flags::IsStrict); }
     bool isNative() const { return m_flags & static_cast<unsigned int>(Flags::IsNative); }
     bool isAsync() const { return m_flags & static_cast<unsigned int>(Flags::IsAsync); }
+    bool isSloppyFunctionCall() const { return m_flags & static_cast<unsigned int>(Flags::IsSloppyFunctionCall); }
 
     void setLineNumber(OrdinalNumber lineNumber) { m_lineNumber = lineNumber; }
     void setColumnNumber(OrdinalNumber columnNumber) { m_columnNumber = columnNumber; }

--- a/src/jsc/bindings/CallSitePrototype.cpp
+++ b/src/jsc/bindings/CallSitePrototype.cpp
@@ -14,7 +14,6 @@
 #include <JavaScriptCore/Operations.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
-#include <JavaScriptCore/JSBoundFunction.h>
 using namespace JSC;
 
 namespace Zig {
@@ -169,24 +168,8 @@ JSC_DEFINE_HOST_FUNCTION(callSiteProtoFuncIsToplevel, (JSGlobalObject * globalOb
 {
     ENTER_PROTO_FUNC();
 
-    if (JSValue functionValue = callSite->function()) {
-        if (JSObject* fn = functionValue.getObject()) {
-            if (JSFunction* function = dynamicDowncast<JSFunction>(fn)) {
-                if (function->inherits<JSC::JSBoundFunction>()) {
-                    return JSC::JSValue::encode(JSC::jsBoolean(false));
-                }
-
-                if (function->isHostFunction()) {
-                    return JSC::JSValue::encode(JSC::jsBoolean(true));
-                }
-
-                if (auto* executable = function->jsExecutable()) {
-                    return JSValue::encode(jsBoolean(executable->isProgramExecutable() || executable->isModuleProgramExecutable()));
-                }
-            } else if (dynamicDowncast<InternalFunction>(functionValue)) {
-                return JSC::JSValue::encode(JSC::jsBoolean(true));
-            }
-        }
+    if (callSite->isSloppyFunctionCall()) {
+        return JSC::JSValue::encode(JSC::jsBoolean(false));
     }
 
     JSC::JSValue thisValue = callSite->thisValue();

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -551,20 +551,12 @@ test("CallFrame.p.isNative", () => {
   Error.prepareStackTrace = prevPrepareStackTrace;
 });
 
-// getFunction() hands out the frame's callee. A JSC frame can carry a callee
-// that user code could never call itself: a host function, a builtin, the body
-// function JSC compiles for an async function or a generator, or no function at
-// all for a wasm or program frame. A body function takes JSC's own arguments, so
-// a call from JS crashes the interpreter. Each such frame now reports undefined.
-//
-// The frames below one of them keep their own function. A frame only hides its
-// caller's function when it is really strict, which is the Flags::IsStrict
-// cascade. The `...Caller=self` rows pin that half.
-//
-// isToplevel() used to read the same stored function. The `...IsToplevel=false`
-// rows pin that its answer does not change for a frame that now hides it.
-//
-// The fixture is CommonJS because a strict frame already returns undefined.
+// getFunction() must report undefined for a callee that user code could never
+// have called: a host function, a builtin, an async or generator body function,
+// a wasm frame, a program frame. A call to a body function crashed the process.
+// `...Caller=self` rows: a frame below one of those keeps its own function.
+// `...IsToplevel=false` rows: hiding a callee does not change isToplevel().
+// The fixture is CommonJS because a strict frame already reports undefined.
 test.concurrent("CallFrame.p.getFunction hides internal callees from sloppy code", async () => {
   using dir = tempDir("callsite-internal-callee", {
     "internal-callee-fixture.cjs": `

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -561,6 +561,9 @@ test("CallFrame.p.isNative", () => {
 // caller's function when it is really strict, which is the Flags::IsStrict
 // cascade. The `...Caller=self` rows pin that half.
 //
+// isToplevel() used to read the same stored function. The `...IsToplevel=false`
+// rows pin that its answer does not change for a frame that now hides it.
+//
 // The fixture is CommonJS because a strict frame already returns undefined.
 test.concurrent("CallFrame.p.getFunction hides internal callees from sloppy code", async () => {
   using dir = tempDir("callsite-internal-callee", {
@@ -590,6 +593,7 @@ test.concurrent("CallFrame.p.getFunction hides internal callees from sloppy code
           const host = named(sites, "map");
           out.push("hostFound=" + !!host);
           out.push("host=" + show(host && host.getFunction()));
+          out.push("hostIsToplevel=" + (host && host.isToplevel()));
           const caller = named(sites, "hostCaller");
           out.push("hostCaller=" + (caller && caller.getFunction() === hostCaller ? "self" : show(caller && caller.getFunction())));
         });
@@ -626,18 +630,23 @@ test.concurrent("CallFrame.p.getFunction hides internal callees from sloppy code
         return (async function af() {
           const sites = new Error().stack;
           out.push("asyncPrefix=" + show(sites[0].getFunction()));
+          out.push("asyncPrefixIsToplevel=" + sites[0].isToplevel());
           const caller = named(sites, "asyncPrefixCaller");
           out.push("asyncPrefixCaller=" + (caller && caller.getFunction() === asyncPrefixCaller ? "self" : show(caller && caller.getFunction())));
           await 1;
 
-          const asyncBody = new Error().stack[0].getFunction();
+          const asyncBodySite = new Error().stack[0];
+          const asyncBody = asyncBodySite.getFunction();
           out.push("asyncBody=" + show(asyncBody));
+          out.push("asyncBodyIsToplevel=" + asyncBodySite.isToplevel());
           if (typeof asyncBody === "function") asyncBody();
 
           function* gen() {
             yield 1;
-            const generatorBody = new Error().stack[0].getFunction();
+            const generatorBodySite = new Error().stack[0];
+            const generatorBody = generatorBodySite.getFunction();
             out.push("generatorBody=" + show(generatorBody));
+            out.push("generatorBodyIsToplevel=" + generatorBodySite.isToplevel());
             if (typeof generatorBody === "function") generatorBody();
           }
           const it = gen();
@@ -666,15 +675,19 @@ test.concurrent("CallFrame.p.getFunction hides internal callees from sloppy code
     "native=undefined",
     "hostFound=true",
     "host=undefined",
+    "hostIsToplevel=false",
     "hostCaller=self",
     "evalProgram=undefined",
     "wasmFrames=true",
     "wasm=undefined",
     "wasmCaller=self",
     "asyncPrefix=undefined",
+    "asyncPrefixIsToplevel=false",
     "asyncPrefixCaller=self",
     "asyncBody=undefined",
+    "asyncBodyIsToplevel=false",
     "generatorBody=undefined",
+    "generatorBodyIsToplevel=false",
   ]);
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -551,6 +551,265 @@ test("CallFrame.p.isNative", () => {
   Error.prepareStackTrace = prevPrepareStackTrace;
 });
 
+// getFunction() hands out the frame's callee. A JSC frame can carry a callee
+// that user code could never call itself: a host function, a builtin, the body
+// function JSC compiles for an async function or a generator, or no function at
+// all for a wasm or program frame. A body function takes JSC's own arguments, so
+// a call from JS crashes the interpreter. Each such frame now reports undefined.
+//
+// The frames below one of them keep their own function. A frame only hides its
+// caller's function when it is really strict, which is the Flags::IsStrict
+// cascade. The `...Caller=self` rows pin that half.
+//
+// The fixture is CommonJS because a strict frame already returns undefined.
+test.concurrent("CallFrame.p.getFunction hides internal callees from sloppy code", async () => {
+  using dir = tempDir("callsite-internal-callee", {
+    "internal-callee-fixture.cjs": `
+      const { nativeFrameForTesting } = require("bun:internal-for-testing");
+      Error.prepareStackTrace = (e, sites) => sites;
+
+      const out = [];
+      const show = v => (typeof v === "function" ? "function/" + v.length : typeof v === "object" && v !== null ? "object" : String(v));
+      const named = (sites, name) => sites.find(s => s.getFunctionName() === name);
+
+      function sloppy() {
+        out.push("sloppy=" + (new Error().stack[0].getFunction() === sloppy ? "self" : "?"));
+      }
+      sloppy();
+
+      nativeFrameForTesting(function underNativeFrame() {
+        const sites = new Error().stack;
+        out.push("nativeIsNative=" + sites[1].isNative());
+        out.push("native=" + show(sites[1].getFunction()));
+        return 0;
+      });
+
+      function hostCaller() {
+        [0].map(function underHostFunction() {
+          const sites = new Error().stack;
+          const host = named(sites, "map");
+          out.push("hostFound=" + !!host);
+          out.push("host=" + show(host && host.getFunction()));
+          const caller = named(sites, "hostCaller");
+          out.push("hostCaller=" + (caller && caller.getFunction() === hostCaller ? "self" : show(caller && caller.getFunction())));
+        });
+      }
+      hostCaller();
+
+      // A program frame's callee is a JSCallee, not a function at all. Stock bun
+      // handed the JSCallee object itself to getFunction().
+      out.push("evalProgram=" + show(eval("new Error().stack")[0].getFunction()));
+
+      // A wasm frame has no JSFunction callee either, and merely reading
+      // getFunction() on one crashed stock bun.
+      const wasmBytes = new Uint8Array([0,0x61,0x73,0x6d,1,0,0,0, 1,4,1,0x60,0,0, 2,7,1,1,0x65,1,0x66,0,0, 3,2,1,0, 7,7,1,3,0x72,0x75,0x6e,0,1, 10,6,1,4,0,0x10,0,0x0b]);
+      function wasmCaller() {
+        const instance = new WebAssembly.Instance(new WebAssembly.Module(wasmBytes), {
+          e: {
+            f() {
+              const sites = new Error().stack;
+              const wasmFrames = sites.filter(s => s.getFileName() === "[wasm code]");
+              out.push("wasmFrames=" + (wasmFrames.length > 0));
+              out.push("wasm=" + [...new Set(wasmFrames.map(s => show(s.getFunction())))].join(","));
+              const caller = named(sites, "wasmCaller");
+              out.push("wasmCaller=" + (caller && caller.getFunction() === wasmCaller ? "self" : show(caller && caller.getFunction())));
+            },
+          },
+        });
+        instance.exports.run();
+      }
+      wasmCaller();
+
+      function asyncPrefixCaller() {
+        // Read the stack before the first await: JSC runs even the synchronous
+        // prefix of an async function in the body function.
+        return (async function af() {
+          const sites = new Error().stack;
+          out.push("asyncPrefix=" + show(sites[0].getFunction()));
+          const caller = named(sites, "asyncPrefixCaller");
+          out.push("asyncPrefixCaller=" + (caller && caller.getFunction() === asyncPrefixCaller ? "self" : show(caller && caller.getFunction())));
+          await 1;
+
+          const asyncBody = new Error().stack[0].getFunction();
+          out.push("asyncBody=" + show(asyncBody));
+          if (typeof asyncBody === "function") asyncBody();
+
+          function* gen() {
+            yield 1;
+            const generatorBody = new Error().stack[0].getFunction();
+            out.push("generatorBody=" + show(generatorBody));
+            if (typeof generatorBody === "function") generatorBody();
+          }
+          const it = gen();
+          it.next();
+          it.next();
+
+          console.log(out.join("\\n"));
+        })();
+      }
+      asyncPrefixCaller();
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "internal-callee-fixture.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim().split("\n")).toEqual([
+    "sloppy=self",
+    "nativeIsNative=true",
+    "native=undefined",
+    "hostFound=true",
+    "host=undefined",
+    "hostCaller=self",
+    "evalProgram=undefined",
+    "wasmFrames=true",
+    "wasm=undefined",
+    "wasmCaller=self",
+    "asyncPrefix=undefined",
+    "asyncPrefixCaller=self",
+    "asyncBody=undefined",
+    "generatorBody=undefined",
+  ]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+// Bun installs native promise reactions so that a pending user promise can
+// resume native work. Each reaction reads its trailing argument as a native
+// context, so each of the three below crashed the process when user code got
+// hold of it and called it. Every fixture keeps the nameless native function
+// that getFunction() reports and then calls it.
+const grabNativeReaction = `
+  let leaked;
+  let namelessNativeSites = 0;
+  function grabNativeReaction() {
+    const previous = Error.prepareStackTrace;
+    Error.prepareStackTrace = (e, sites) => sites;
+    for (const site of new Error().stack) {
+      if (site.isNative() && !site.getFunctionName()) namelessNativeSites++;
+      let fn;
+      try {
+        fn = site.getFunction();
+      } catch {}
+      if (typeof fn === "function" && site.isNative() && !fn.name) leaked = fn;
+    }
+    Error.prepareStackTrace = previous;
+  }
+  function reportAndCallLeaked() {
+    // The reaction frame has to be on the stack, or "leaked=undefined" would
+    // hold for a reason that has nothing to do with getFunction().
+    console.log("reactionFrameSeen=" + (namelessNativeSites > 0));
+    console.log("leaked=" + typeof leaked);
+    if (typeof leaked === "function") leaked({}, undefined);
+    console.log("survived");
+  }
+`;
+
+async function runNativeReactionFixture(prefix, files) {
+  using dir = tempDir(prefix, files);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.cjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim().split("\n")).toEqual(["reactionFrameSeen=true", "leaked=undefined", "survived"]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+}
+
+test.concurrent("CallFrame.p.getFunction does not expose the HTMLRewriter reaction", async () => {
+  await runNativeReactionFixture("callsite-rewriter-reaction", {
+    "fixture.cjs": `
+      ${grabNativeReaction}
+
+      new HTMLRewriter()
+        .on("p", {
+          element() {
+            grabNativeReaction();
+            // The rewriter suspends only while this promise is pending. The
+            // suspension installs the reaction whose frame the handler for the
+            // second <p> can see.
+            return new Promise(resolve => setTimeout(resolve, 1));
+          },
+        })
+        .transform(new Response("<p>a</p><p>b</p>"))
+        .text()
+        .then(reportAndCallLeaked);
+    `,
+  });
+});
+
+test.concurrent("CallFrame.p.getFunction does not expose the serve reject reaction", async () => {
+  await runNativeReactionFixture("callsite-serve-reaction", {
+    "fixture.cjs": `
+      ${grabNativeReaction}
+
+      // error() runs under the reaction that rejected the fetch() promise.
+      const server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch: () => new Promise((resolve, reject) => setTimeout(() => reject(new Error("x")), 1)),
+        error() {
+          grabNativeReaction();
+          return new Response("e");
+        },
+      });
+
+      fetch(server.url)
+        .then(response => response.text())
+        .then(async () => {
+          await server.stop(true);
+          reportAndCallLeaked();
+        });
+    `,
+  });
+});
+
+test.concurrent("CallFrame.p.getFunction does not expose the module loader reaction", async () => {
+  await runNativeReactionFixture("callsite-module-loader-reaction", {
+    "mod.xyzzy": "",
+    "fixture.cjs": `
+      ${grabNativeReaction}
+
+      // The reaction reads the plugin result object, so this getter runs under
+      // its frame.
+      Bun.plugin({
+        name: "x",
+        setup(build) {
+          build.onLoad({ filter: /\\.xyzzy$/ }, () =>
+            new Promise(resolve =>
+              setTimeout(
+                () =>
+                  resolve({
+                    get contents() {
+                      grabNativeReaction();
+                      return "export default 1";
+                    },
+                    loader: "js",
+                  }),
+                1,
+              ),
+            ),
+          );
+        },
+      });
+
+      import(require("path").join(__dirname, "mod.xyzzy")).then(reportAndCallLeaked);
+    `,
+  });
+});
+
 test("return non-strings from Error.prepareStackTrace", () => {
   // This behavior is allowed by V8 and used by the node-depd npm package.
   let prevPrepareStackTrace = Error.prepareStackTrace;


### PR DESCRIPTION
### Problem

- `CallSite.getFunction()` (the `Error.prepareStackTrace` API) returned the frame's callee unchecked. JSC has callees user code could never have called: a host function, a builtin, an async or generator body function, or no function at all (wasm and program frames).
- Five shapes crash 1.4.2, canary and main. After one `await`, calling what `getFunction()` returns gives `panic(main thread): Segmentation fault at address 0x32`. A wasm frame faults at `0x5` on the read.
- Cause: `CallSite::finishCreation` (`src/jsc/bindings/CallSite.cpp:34`) only checks the strictness of the frame's code block. `JSCStackFrame` leaves that null for host and hidden builtin frames.

### Fix

- `getFunction()` reports `undefined` unless the callee is a function user code could have called. A user function gets itself, including the CommonJS wrapper.
- Caller frames keep their function: hiding a callee does not set `Flags::IsStrict`. `isToplevel()` reads a new flag computed from the real callee, so its answers do not change.
- Deleted: the function-inspecting block in `callSiteProtoFuncIsToplevel`, and its `JSBoundFunction.h` include.
- Verified: four new blocks in `test/js/node/v8/capture-stack-trace.test.js`, all failing on 1.4.2 and with `src/` reverted. 627 pass across the stack-trace suites.

### Background

- JSC compiles an async function or a generator into a wrapper (what the user named) and a body that takes five internal arguments. The synchronous prefix runs in the body too, so the wrapper is never a frame's callee.
- `createCallSitesFromFrames` (`FormatStackTraceForJS.cpp:844`) copies `isStrict()` down the frame list. JSC shows host frames V8 omits (`Reflect.construct` under a transpiled `super()`), so a cascade from a hidden callee would blank callers node reports.
- JSC frames carry no receiver, so `isToplevel()` judges by the callee.

<details><summary>Notes</summary>

#### The five crashes

A fuzz ledger reported the async body and three native promise reactions. A review of the first draft of this patch found the wasm frame. Each crashes release 1.4.2 (exit 139), and each exits cleanly with this change.

| shape | 1.4.2 | with this change |
| --- | --- | --- |
| async function body after `await` | SEGV `0x32` | `undefined` |
| generator body after `next()` | SEGV `0x32` | `undefined` |
| wasm frame, on read alone | SEGV `0x5` | `undefined` |
| HTMLRewriter suspension reaction | SEGV `0x12` | `undefined` |
| `Bun.serve` `error()` reaction, and the `Bun.plugin` onLoad reaction | SEGV `0x12` / `0x1A` | `undefined` |

The first fixture, as CommonJS so that the top frame is sloppy:

```js
async function f() {
  await 1;
  Error.prepareStackTrace = (e, sites) => sites;
  return new Error().stack[0].getFunction();
}
f().then(g => {
  console.log(g === f, g.length);
  g();
});
```

1.4.2 prints `false 5` and then segfaults. `0x32` is an encoded `undefined` (`0xa`) plus `0x28`, the offset of a generator internal field. Under ASAN the frames are `llint_op_put_internal_field <- llint_op_call_ignore_result <- llint_call_javascript <- JSC::MicrotaskCall::tryCallWithArguments`, so the body function wrote a generator field into a plain `undefined`.

The wasm crash has three more entry shapes. Each is the same null callee, each segfaults 1.4.2 at `0x5`, and each exits cleanly with this change, also under ASAN: the wasm frame as the first call site of a trap (`WebAssembly.RuntimeError`, which is what an error reporter walks), a wasm stack overflow whose `RangeError` carries only wasm frames, and a wasm frame that JSPI resumed. The test covers the import-callback shape.

The reaction crashes all reach the same place. A handler from `Zig::GlobalObject::thenable()` runs user JS synchronously: a later HTMLRewriter element handler, `Bun.serve`'s `error()`, or a getter on a plugin's onLoad result. That user JS keeps the nameless native function `getFunction()` reported, and calls it. The handler then reads its trailing argument as a native context. 12 of the 54 `PromiseFunctions` handlers decode a raw pointer from a JS number, so the class is worse than a bad cast. The host-function arm closes all of them, because `getFunction()` is the only way user code could name one.

#### How old each route is

The unchecked hand-out itself is old. Release 1.3.14 has the same logic in `CallSite.cpp`, `thenable()` is already `ImplementationVisibility::Public` there, and `Bun__NativePromiseContext__take` already uses `uncheckedDowncast` (#28613). The fuzz ledger reports that the wasm shape crashes 1.3.14 too.

The HTMLRewriter route is new in 1.4.0, and the ledger measured it: 1.3.14 is clean, 1.4.0 to 1.4.2 crash at `0x12`. The cause is #36733, not an engine upgrade. Before it, the rewriter handled an async handler with `vm.wait_for_promise()`, which spins the event loop in place, so no native reaction existed. #36733 suspends the rewrite and resumes it through `Bun__HTMLRewriter__onHandlerResolve`, which put a reaction frame on the stack for the first time.

The `Bun.serve` `error()` route and the `Bun.plugin` onLoad route use machinery that predates 1.3.14 (the onLoad reaction is from 2022), so they are probably older than that window. I read that from history and did not run it: I have no 1.3.14 binary here.

#### What node returns

Measured on node v26.3.0 with the same fixtures.

| frame | node | 1.4.2 | with this change |
| --- | --- | --- | --- |
| sloppy user function | itself | itself | itself |
| CommonJS module wrapper | itself | itself | itself |
| `Array.prototype.map` | undefined | the `map` function | undefined |
| program frame under `eval` | undefined | a non-function `JSCallee` object | undefined |
| async or generator body | the wrapper | the body (length 5) | undefined |
| wasm frame | a `Number` | crash | undefined |
| any caller below the above | see 2. below | itself | itself |

Two divergences remain, both deliberate:

1. Node returns the wrapper for an async or generator frame. JSC keeps no back pointer from a body function to its wrapper, so the wrapper cannot be recovered. `getFunctionName()` still reports the user's name. JSC applies the same policy in `callerGetter` (`FunctionPrototype.cpp`).
2. Node blanks the caller frames below a builtin frame, because V8 compiles its builtins strict. Bun does not, and this change does not start. I measured that trigger: it moves a 22-shape host and builtin probe from 4/22 to 22/22 against node. It also blanks callers that node reports wherever JSC shows a host frame V8 hides, and `Reflect.construct` under Babel's `_callSuper` is one of those. It is a separable hunk. Say so if you want it.

#### isToplevel()

`m_function` has two readers, `getFunction()` and `isToplevel()`. The first push of this PR narrowed what `m_function` holds and did not account for the second reader. A review comment about dead branches in `callSiteProtoFuncIsToplevel` made me measure it: on a 16-row probe, `isToplevel()` flipped from `false` to `true` on 5 rows, the `Array.prototype.map` frame and every async or generator frame.

`isToplevel()` now reads `Flags::IsSloppyFunctionCall`, which `finishCreation` computes from the real callee: the frame is sloppy and its callee is a `JSFunction` that is not a host function. All 16 rows match 1.4.2 again, and four new `...IsToplevel=false` test rows pin it. Those rows fail on the first push of this PR.

The replaced block had a `JSBoundFunction` arm, a host-function arm, a `jsExecutable()` arm and an `InternalFunction` arm. With `m_function` narrowed, only the `jsExecutable()` arm could still run. The `JSBoundFunction` arm never could: a bound-function thunk is `ImplementationVisibility::Private` and never gets a `CallSite`, which I checked on both the `prepareStackTrace` and the `captureStackTrace` path.

#### Dropped from the first draft

The first draft cascaded from every hidden callee and carried three hardening hunks. A review plus my own measurements cut all four:

- The cascade blanked `getFunction()` for a plain sloppy caller that both node and 1.4.2 return.
- `ImplementationVisibility::Private` on the `thenable()` handlers hides a useless `at unknown` frame. With `BUN_JSC_showPrivateScriptsInStackTraces=0` it also flips `typeof err.stack` from `"string"` to `"undefined"` for three `Bun.plugin` onLoad validation errors, whose only frame was the reaction. It needs the empty-frame-vector case to produce a header-only stack first, the way `FormatStackTraceForJS.cpp:234` already does for the `captureStackTrace` path. Worth doing, but not here.
- A `dynamicDowncast` in `Bun__NativePromiseContext__take`. #40203 is open and already touches that function.
- Two `dynamicDowncast` guards in the module loader onLoad reactions. With this change nothing can reach them, and an unreachable, untested guard is not worth the lines.

#### Suites run, on the debug ASAN build

`capture-stack-trace.test.js` 50/50. The stack-trace set is 627 pass, 0 fail: `test/js/node/v8`, `vm.test.ts`, `vm-sourceUrl.test.ts`, `util.test.js`, `test/js/bun/sourcemap`, `reportError.test.ts`, `console-log.test.ts`, `23022-stack-trace-iterator`, `circular-error-stack`, `circular-error-stack-edge-cases`, `fix-bindings-stack-trace`, `prepare-stack-trace-crash`. `stack.test.ts` and `013880.test.ts` pass on their own. `node:test` `test-error-prepare-stack-trace.js`, `test-util-getcallsites-preparestacktrace.js` and `test-shadow-realm-prepare-stack-trace.js` exit 0. Earlier drafts, whose reach was wider, also cleared the html-rewriter (207), plugin and resolve (506), streams (549), serve (295) and `node:http` (372) suites.

Two failures in that area are not from this change, and each now has its own session. `test/regression/issue/013880.test.ts` leaks a global `Error.prepareStackTrace` into the shared test process and breaks 21 tests in `capture-stack-trace.test.js`. It reproduces on release 1.4.2: that file alone passes, and the two files together fail 21. `test/js/node/vm/script-leak.test.ts` sets an `isASAN` RSS threshold but no `isASAN` timeout, so it needs 25s against a 5s default on any `bun bd` build.

#### Flake check

The four new blocks passed 5 runs in a row, and 3 more with 24 CPU burners running, to stand in for a slow ASAN lane. Each reaction fixture needs a genuinely pending promise to make the native reaction exist. An already-resolved promise and a `queueMicrotask`-resolved promise both fail to install the suspension, which I checked, so the fixtures use `setTimeout(resolve, 1)` inside the fixture process. The test itself only awaits the process exit. Each reaction fixture also asserts `reactionFrameSeen=true`, so `leaked=undefined` cannot pass because the frame stopped appearing.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.3 (6a92015fc)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [24.55ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [40.55ms]
(pass) capture stack trace [12.79ms]
(pass) capture stack trace with message [14.33ms]
(pass) capture stack trace with constructor [11.08ms]
(pass) capture stack trace limit [43.64ms]
(pass) prepare stack trace [22.91ms]
(pass) capture stack trace second argument [35.13ms]
(pass) capture stack trace edge cases [23.74ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [39.79ms]
(pass) prepare stack trace call sites [24.06ms]
(pass) sanity check [26.96ms]
(pass) CallFrame isEval works as expected [16.18ms]
(pass) CallFrame isTopLevel returns false for Function constructor [17.42ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [17.16ms]
(pass) CallFrame.p.isConstructor [6.29ms]
(pass) CallFrame.p.isNative [7.07ms]
726 |     stderr: "pipe",
727 |   });
728 | 
729 |   const [stdout, st
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (8a7f62b47)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [0.14ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.09ms]
(pass) capture stack trace [0.09ms]
(pass) capture stack trace with message [0.06ms]
(pass) capture stack trace with constructor [0.06ms]
(pass) capture stack trace limit [0.19ms]
(pass) prepare stack trace [0.11ms]
(pass) capture stack trace second argument [0.17ms]
(pass) capture stack trace edge cases [0.10ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [0.22ms]
(pass) prepare stack trace call sites [0.14ms]
(pass) sanity check [0.11ms]
(pass) CallFrame isEval works as expected [0.09ms]
(pass) CallFrame isTopLevel returns false for Function constructor [0.09ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [0.10ms]
(pass) CallFrame.p.isConstructor [0.03ms]
(pass) CallFrame.p.isNative [0.03ms]
(pass) CallFrame.p.getFunction does not expose the module loader reaction [9.47ms]
(pass) CallFrame.p.getFunction does not expose the HTMLRewriter reaction [11.12ms]
(pass) CallFrame.p.getFunction does not expose the serve reject reaction [11.29ms]
(pass
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.3 (6a92015fc)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [22.42ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [33.22ms]
(pass) capture stack trace [9.60ms]
(pass) capture stack trace with message [10.80ms]
(pass) capture stack trace with constructor [8.87ms]
(pass) capture stack trace limit [32.05ms]
(pass) prepare stack trace [17.69ms]
(pass) capture stack trace second argument [24.93ms]
(pass) capture stack trace edge cases [18.24ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [30.12ms]
(pass) prepare stack trace call sites [19.79ms]
(pass) sanity check [21.41ms]
(pass) CallFrame isEval works as expected [11.96ms]
(pass) CallFrame isTopLevel returns false for Function constructor [12.53ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [13.89ms]
(pass) CallFrame.p.isConstructor [5.20ms]
(pass) CallFrame.p.isNative [5.26ms]
(pass) CallFrame.p.getFunction does not expose the serve reject reaction
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 710ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[2/9] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[3/9] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[4/9] gen cpp.rs (cppbind)
[4/9] cargo bun_runtime → libbun_runtime.a
^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
^[[1m^[[92m   Compiling^[[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/CallSite.cpp               |  31 +++-
 src/jsc/bindings/CallSite.h                 |   2 +
 src/jsc/bindings/CallSitePrototype.cpp      |  21 +--
 test/js/node/v8/capture-stack-trace.test.js | 264 ++++++++++++++++++++++++++++
 4 files changed, 297 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/CallSite.cpp                    5     11     34
src/jsc/bindings/CallSite.h                      2      3     33
src/jsc/bindings/CallSitePrototype.cpp           2      2     33
test/js/node/v8/capture-stack-trace.test.js      6     10     33
```

</details>

**root cause** · written by the author bot

`CallSite` treated a frame as non-strict whenever it lacked a CodeBlock with a strict executable, so native frames, builtin JS frames, and the internal async/generator body functions that JSC runs after the first suspension all had their callee stored and handed back through `getFunction()`; calling one of those internal callees with caller-chosen arguments let plain JavaScript write generator internal fields into arbitrary objects, which segfaulted the interpreter. The fix narrows the callee exposure in one place: the function is only stored when it is a `JSFunction` whose `FunctionExecuta…

<!-- robobun:evidence:end -->

