### PR TITLE
test: run the 013880 fixture in a subprocess

### DIFF
--- a/test/regression/issue/013880.test.ts
+++ b/test/regression/issue/013880.test.ts
@@ -1,5 +1,22 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
 
-test("regression", () => {
-  expect(() => require("./013880-fixture.cjs")).not.toThrow();
+// The fixture sets Error.prepareStackTrace and never restores it, so it runs in
+// its own process. Without --isolate, `bun test` runs every file in one process,
+// and a require() here would leave the hook installed for every later file.
+test("reading .stack inside Error.prepareStackTrace does not call the hook again", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "013880-fixture.cjs")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  // "trigger" prints once: the hook runs for the outer error only. The error
+  // that the hook catches gets the default format when the hook reads its .stack.
+  expect(stdout).toMatch(/^trigger\n\[Function: abc\]\nError: 1\n(?: {4}at .+\n)+$/);
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem
- `test/regression/issue/013880.test.ts` breaks the test files that run after it in the same process. With `test/js/node/v8/capture-stack-trace.test.js`, 21 tests fail with `error: Received value must be a string: undefined`, because `err.stack` is `undefined`. Each file passes alone.
- `013880-fixture.cjs:10` sets `Error.prepareStackTrace` to a hook that returns `undefined` and never restores it. The test loads the fixture with `require()`, so the hook stays installed in the test process.

### Fix
- Run the fixture with `Bun.spawn`. The hook ends with the child process.
- The test asserts that the hook prints `trigger` one time and that the error it catches gets the default stack format.
- It still covers #13880. With the guard at `src/jsc/bindings/FormatStackTraceForJS.cpp:554` removed locally, it fails with `RangeError: Maximum call stack size exceeded`.
- Verified with `bun bd test`: `013880.test.ts` and three files that use `Error.prepareStackTrace`, in one process. Before: 24 fail. After: 52 pass.

### Background
- `Error.prepareStackTrace` is a V8 API. If it is a function, the runtime calls it to build `.stack` and uses its return value. It is a property of the global `Error`, so all code in the process shares it.
- `bun test a b` runs both files in one process with one global. `--isolate` gives each file a new global. `--parallel` implies `--isolate`.
- CI starts one process per file or uses `--parallel`, so only a local run of several files sees this.
- #13880 was a stack overflow: a `.stack` read inside the hook called the hook again. #14548 added the guard and this test.

<details><summary>Notes</summary>

Reproduction on the released build, no source change needed:

```
# together: 26 pass, 21 fail
USE_SYSTEM_BUN=1 bun test test/js/node/v8/capture-stack-trace.test.js test/regression/issue/013880.test.ts

# alone: 46 pass, 0 fail
USE_SYSTEM_BUN=1 bun test test/js/node/v8/capture-stack-trace.test.js

# with --isolate or --parallel=2: 47 pass, 0 fail
USE_SYSTEM_BUN=1 bun test --isolate test/js/node/v8/capture-stack-trace.test.js test/regression/issue/013880.test.ts
```

`bun test` ran `013880.test.ts` first in that pair. The `afterEach` in `capture-stack-trace.test.js` restores `Error.prepareStackTrace` to the value it saved at module load. That value is already the leaked hook, so the restore does not help.

`test/regression/issue/prepare-stack-trace-crash.test.ts` is a second file that the leak breaks. It calls `Error.prepareStackTrace(e)` directly and expects a string. After `013880.test.ts` in the same process, 3 of its 3 tests fail.

The three other files in the verification run are `test/js/node/v8/capture-stack-trace.test.js`, `test/regression/issue/prepare-stack-trace-crash.test.ts` and `test/regression/issue/fix-bindings-stack-trace.test.ts`.

The old test asserted only that `require()` of the fixture did not throw.

Why a subprocess and not a `try`/`finally` around the `require()`: the fixture is a script that changes a process-wide setting, which is the case where the repo's test guidelines ask for `Bun.spawn` with `bunExe()` and `bunEnv`. The subprocess also lets the test read stdout, so it can assert that the hook ran one time. The `require()` form could only assert that nothing was thrown.

The stdout check is `/^trigger\n\[Function: abc\]\nError: 1\n(?: {4}at .+\n)+$/`. It does not pin the frame names or positions, so a change to how `new Function` frames are named does not touch this test.

The other test files that assign `Error.prepareStackTrace` in the test process already restore it in `try`/`finally` or `afterEach`: `fix-bindings-stack-trace.test.ts`, `structured-clone.test.ts`, `vm.test.ts`, `util.test.js`, `capture-stack-trace.test.js`. `external-sourcemap-stack-leak.test.ts` and `error-prepare-stack-default-fixture.js` assign it in a child process.

The new test also passes under the ASAN lane's environment (`BUN_JSC_validateExceptionChecks=1`, `BUN_DESTRUCT_VM_ON_EXIT=1`, `detect_leaks=1` with `test/leaksan.supp`). The child inherits those through `bunEnv`.

This PR changes no file under `src/`.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/regression/issue/013880.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/regression/issue/013880.test.ts"
bun test v1.4.3 (6a92015fc)

test/regression/issue/013880.test.ts:
(pass) reading .stack inside Error.prepareStackTrace does not call the hook again [475.47ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [3.73s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/regression/issue/013880.test.ts | 21 +++++++++++++++++++--
 1 file changed, 19 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
test/regression/issue/013880.test.ts      2      3     23
```

</details>

<!-- robobun:evidence:end -->