### PR TITLE
node:http2: drop DATA and WINDOW_UPDATE on a closed stream like nghttp2

### DIFF
--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -591,10 +591,7 @@ impl Connection {
         }
         self.replenish_buf = buf;
         // Evict closed streams so the map (and this scan) stay bounded on long-lived connections.
-        // A late DATA/RST/WINDOW_UPDATE for an evicted id takes the unknown-stream path, which
-        // answers RST_STREAM(STREAM_CLOSED) - the 5.1 closed-state behavior. A late HEADERS for an
-        // evicted id re-opens a fresh entry (the parity check still applies); that matches how
-        // trailers-after-close are treated as a new block by the legacy parser as well.
+        // A late HEADERS for an evicted id re-opens a fresh entry (the parity check still applies).
         let mut evict = std::mem::take(&mut self.evict_buf);
         evict.clear();
         for (id, s) in self.streams.iter() {
@@ -851,6 +848,9 @@ impl Connection {
     ) -> bool {
         let increment =
             u32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]) & 0x7fff_ffff;
+        if hdr.stream_id != 0 && self.is_closed_stream(sink, hdr.stream_id) {
+            return false;
+        }
         // §6.9.1: a 0 increment is an error (connection error on stream 0).
         if increment == 0 {
             if hdr.stream_id == 0 {
@@ -1387,8 +1387,10 @@ impl Connection {
         let recv_limit = self
             .acked_local_initial_window
             .max(self.local_settings.initial_window_size) as i64;
-        let mut discard = false;
+        let closed = self.is_closed_stream(sink, hdr.stream_id);
+        let mut discard = closed;
         match self.streams.get_mut(&hdr.stream_id) {
+            _ if closed => {}
             None => {
                 self.send_rst_stream(sink, hdr.stream_id, ErrorCode::StreamClosed);
                 sink.on_stream_reset(hdr.stream_id, ErrorCode::StreamClosed.as_u32());
@@ -1466,6 +1468,19 @@ impl Connection {
         }
     }
 
+    fn has_existed(&self, sink: &impl Sink, stream_id: u32) -> bool {
+        stream_id <= self.last_stream_id || stream_id <= sink.highest_started_stream_id()
+    }
+
+    /// RFC 9113 §5.1 closed state: frames on such a stream are dropped, as nghttp2 does.
+    fn is_closed_stream(&self, sink: &impl Sink, stream_id: u32) -> bool {
+        match self.streams.get(&stream_id) {
+            Some(s) => s.state == State::Closed,
+            // A stream the embedder opened has no entry here until its first inbound frame.
+            None => !sink.is_local_stream(stream_id) && self.has_existed(sink, stream_id),
+        }
+    }
+
     fn handle_data(&mut self, sink: &impl Sink, hdr: &FrameHeader, payload: &[u8]) -> bool {
         let mut off = 0usize;
         let mut end = payload.len();
@@ -1524,11 +1539,14 @@ impl Connection {
             s.state = State::Open;
             self.streams.insert(hdr.stream_id, s);
         }
+        if self.is_closed_stream(sink, hdr.stream_id) {
+            return false;
+        }
         let recv_limit = self
             .acked_local_initial_window
             .max(self.local_settings.initial_window_size) as i64;
         let decision = match self.streams.get_mut(&hdr.stream_id) {
-            // §5.1: DATA for an unknown/closed stream is a STREAM_CLOSED error.
+            // §5.1: DATA for a stream nobody opened is a STREAM_CLOSED error.
             None => DataDecision::Rst(ErrorCode::StreamClosed),
             Some(s) => {
                 if !stream::can_receive_data(s.state) {
@@ -1647,10 +1665,7 @@ impl Connection {
         // closed, not idle — a late RST_STREAM on it MUST be tolerated. Anything at or
         // below the highest stream id either layer has started has existed; the embedder's
         // mark covers locally-initiated streams this engine never saw HEADERS for.
-        if on_idle
-            && (hdr.stream_id <= self.last_stream_id
-                || hdr.stream_id <= sink.highest_started_stream_id())
-        {
+        if on_idle && self.has_existed(sink, hdr.stream_id) {
             return false;
         }
         if on_idle {
@@ -1931,9 +1946,7 @@ impl Connection {
     /// The outbound half does not run through this engine yet, so without this hook a
     /// completed request's entry would linger as HalfClosedRemote forever — the map (and
     /// the per-batch replenish/evict scans) would grow by one entry per request. Removal
-    /// has the same observable behavior as scan-eviction of a Closed stream: late frames
-    /// for the id take the unknown-stream path (RST STREAM_CLOSED, the §5.1 closed-state
-    /// answer) and a late HEADERS re-opens a fresh entry.
+    /// has the same observable behavior as scan-eviction of a Closed stream.
     pub fn close_stream(&mut self, stream_id: u32) {
         self.streams.remove(&stream_id);
     }

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1928,3 +1928,118 @@ describe("stream release after a queued END_STREAM", () => {
     }
   });
 });
+
+// RFC 9113 §5.1: frames on a closed stream are discarded after minimal processing, which for DATA
+// means counting it toward the connection flow-control window. nghttp2 sends nothing back.
+describe("DATA and WINDOW_UPDATE on a closed stream", () => {
+  const PING = encodeFrame(FrameType.PING, 0, 0, Buffer.alloc(8, 1));
+  const isPingAck = (f: Frame) => f.type === FrameType.PING && (f.flags & 0x1) !== 0;
+  const isFatal = (f: Frame) => f.type === FrameType.RST_STREAM || f.type === FrameType.GOAWAY;
+  const windowUpdate = (id: number, increment: number) => {
+    const payload = Buffer.alloc(4);
+    payload.writeUInt32BE(increment, 0);
+    return encodeFrame(FrameType.WINDOW_UPDATE, 0, id, payload);
+  };
+  const ONE_BYTE = encodeFrame(FrameType.DATA, 0, 1, Buffer.from("x"));
+  // A zero increment and an overflow are stream errors on a stream that is still open.
+  const WINDOW_UPDATES = [windowUpdate(1, 0), windowUpdate(1, 0x7fffffff)];
+  const floods: [string, Buffer][] = [
+    ["DATA", Buffer.concat(Array(2000).fill(ONE_BYTE))],
+    ["WINDOW_UPDATE", Buffer.concat(Array.from({ length: 2000 }, (_, i) => WINDOW_UPDATES[i % 2]))],
+  ];
+
+  test.each(floods)("server: %s gets no RST_STREAM", async (_, flood) => {
+    const c = await RawH2.connect(port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendFrame(FrameType.HEADERS, 0x5, 1, requestHeaderBlock("GET"));
+      await c.waitFor(f => f.type === FrameType.DATA && f.streamId === 1 && (f.flags & 0x1) !== 0);
+      c.send(flood);
+      c.sendFrame(FrameType.HEADERS, 0x5, 3, requestHeaderBlock("GET"));
+      c.send(PING);
+      await c.waitFor(isPingAck);
+      expect(c.frames.filter(isFatal)).toEqual([]);
+      expect(c.frames.some(f => f.type === FrameType.HEADERS && f.streamId === 3)).toBe(true);
+    } finally {
+      c.destroy();
+    }
+  });
+
+  test("server: DATA still counts toward the connection window", async () => {
+    const c = await RawH2.connect(port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendFrame(FrameType.HEADERS, 0x5, 1, requestHeaderBlock("GET"));
+      await c.waitFor(f => f.type === FrameType.DATA && f.streamId === 1 && (f.flags & 0x1) !== 0);
+      // 49,152 bytes: inside the 65,535-byte connection window and past the half of it at which the
+      // server sends a WINDOW_UPDATE.
+      const large = encodeFrame(FrameType.DATA, 0, 1, Buffer.alloc(16_384));
+      c.send(Buffer.concat([large, large, large]));
+      const credit = await c.waitFor(f => f.type === FrameType.WINDOW_UPDATE && f.streamId === 0);
+      expect(credit.payload.readUInt32BE(0)).toBeGreaterThanOrEqual(32_767);
+      expect(c.frames.filter(isFatal)).toEqual([]);
+    } finally {
+      c.destroy();
+    }
+  });
+
+  test.each(floods)("client: %s gets no RST_STREAM, and the session keeps working", async (_, flood) => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    let sessionError: Error | undefined;
+    client.on("error", e => (sessionError = e));
+    // One request, answered by the raw server with 200 and a body that ends the stream.
+    const roundTrip = async (id: number) => {
+      const req = client.request({ ":path": "/" });
+      req.resume();
+      const closed = once(req, "close");
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === id);
+      raw.sendFrame(FrameType.HEADERS, 0x4, id, Buffer.from([0x88]));
+      raw.sendFrame(FrameType.DATA, 0x1, id, Buffer.from("ok"));
+      await closed;
+    };
+    try {
+      await raw.waitFor(f => f.type === FrameType.SETTINGS);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      await roundTrip(1);
+      raw.socket!.write(Buffer.concat([flood, PING]));
+      await raw.waitFor(isPingAck);
+      await roundTrip(3);
+      expect(raw.frames.filter(isFatal)).toEqual([]);
+      expect(sessionError).toBeUndefined();
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  // The engine has no entry for a request stream until the first frame arrives on it. That is
+  // not a closed stream: an upload larger than the window needs this WINDOW_UPDATE to finish.
+  test("client: WINDOW_UPDATE before any HEADERS or DATA on a request stream is applied", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      await raw.waitFor(f => f.type === FrameType.SETTINGS);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      const body = Buffer.alloc(100_000, "u");
+      const req = client.request({ ":method": "POST", ":path": "/" });
+      req.on("error", () => {});
+      req.end(body);
+      const uploaded = () =>
+        raw.frames.filter(f => f.type === FrameType.DATA && f.streamId === 1).reduce((n, f) => n + f.length, 0);
+      // The 65,535-byte stream and connection windows stop the upload here.
+      await raw.waitFor(() => uploaded() === 65_535);
+      raw.socket!.write(Buffer.concat([windowUpdate(0, 65_535), windowUpdate(1, 65_535)]));
+      await raw.waitFor(f => f.type === FrameType.DATA && f.streamId === 1 && (f.flags & 0x1) !== 0);
+      expect(uploaded()).toBe(body.length);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+});


### PR DESCRIPTION
### Problem
- DATA on a closed stream gets one `RST_STREAM(STREAM_CLOSED)` and one JS dispatch per frame (`Connection::handle_data` in `src/runtime/api/bun/h2/connection.rs`: `None => DataDecision::Rst(ErrorCode::StreamClosed)`). A zero-increment WINDOW_UPDATE gets `RST_STREAM(PROTOCOL_ERROR)` the same way. Node sends nothing.
- So a client that cancels a download sends one RST_STREAM per DATA frame still in flight. Against a node v26.3.0 server, with 1 MiB windows and 100-byte messages, one `req.close(NGHTTP2_CANCEL)` sent 4,635 RST_STREAM frames. Node counts them against its stream reset limit and ended the session. node as the client sends 1.

### Fix
- `is_closed_stream` is true for a `Closed` entry, and for an id that was used and has no entry in either layer. `handle_data`, `begin_streamed_data` and `handle_window_update` drop the frame for such a stream. DATA still counts toward the connection window (RFC 9113 §5.1).
- A stream the embedder opened has no engine entry until its first inbound frame. It is not closed, so a WINDOW_UPDATE that arrives before any HEADERS still applies.
- `handle_rst_stream` uses the same id test, now `has_existed`.
- Verified: `test/js/node/http2/h2-conformance.test.ts` (6 new tests, 5 fail on main), `test/js/node/http2/`, and the 261 `test-http2-*` node tests.

### Background
- `Connection` is the inbound h2 engine. `H2FrameParser` embeds it, still encodes outbound frames, and keeps its own stream map. `Sink::is_local_stream` asks that map.
- The engine evicts a closed stream after each read. An id at or below the highest id either side started is closed, not idle.
- node sets nghttp2's `no_closed_streams`. nghttp2 then finds no stream, skips the payload, and only updates the connection window.

<details><summary>Notes</summary>

**What node does (v26.3.0, nghttp2 1.69.0, `deps/nghttp2/lib/nghttp2_session.c`)**

| inbound | node | main | this PR |
|---|---|---|---|
| DATA on a closed stream ([L5235-L5245](https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L5235-L5245), [L6923-L6958](https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L6923-L6958)) | dropped, counts toward the connection window | RST_STREAM(STREAM_CLOSED) per frame | dropped, counts toward the connection window |
| WINDOW_UPDATE on a closed stream, zero increment ([L4764-L4767](https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L4764-L4767)) | dropped | RST_STREAM(PROTOCOL_ERROR) per frame | dropped |
| WINDOW_UPDATE on a closed stream, other increments | dropped | dropped | dropped |
| DATA on an id nobody opened | connection error PROTOCOL_ERROR | RST_STREAM(STREAM_CLOSED) per frame | unchanged |

node passes [`nghttp2_option_set_no_closed_streams(option, 1)`](https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L116), so `nghttp2_session_get_stream_raw` finds nothing for a closed id and `session_on_data_received_fail_fast` returns `NGHTTP2_ERR_IGN_PAYLOAD`.

**The cancel case.** A stock node v26.3.0 `http2.createServer()` writes 100-byte messages, one per event-loop turn, behind a TCP proxy that adds 150 ms each way and counts frames. The client sets `initialWindowSize` and `setLocalWindowSize` to 1 MiB, reads for 900 ms, calls `req.close(NGHTTP2_CANCEL)`, then sends one more request on the same session.

| client | RST_STREAM sent | DATA frames that arrived after the cancel | server | next request |
|---|---|---|---|---|
| bun 1.4.3 (6a92015fc) | 4,635 (1 CANCEL, 4,634 STREAM_CLOSED) | 4,634 | `sessionError` ERR_HTTP2_ERROR "Protocol error" | no response |
| this branch | 2 (both CANCEL) | 3,801 | no error | `pong` |
| node v26.3.0 | 1 | 4,593 | no error | `pong` |

The count per cancel is the number of DATA frames in flight. With the default 65,535-byte windows and 100-byte messages it was 330 per cancel, so a few cancels per second reach node's limit of 1,000 (refilled at 33 per second). With 16 KiB frames and the default window it is at most 4. The second CANCEL on this branch is a separate fault (the client resets the stream twice).

**Floods.** 20,000 one-byte DATA frames, or 20,000 `WINDOW_UPDATE(increment 0)` frames, on stream 1 after it was served: main writes 20,000 RST_STREAM frames back (260,120 and 260,143 bytes), node and this branch write none (120 bytes back in total). This PR does not stop the same reply for an id nobody opened. Node makes that a connection error, and #32987 covers it.

**WINDOW_UPDATE.** A compliant peer never sends a zero increment, and a late non-zero one was already dropped. The change there is closed-state parity with nghttp2. The new part that matters is the order: nghttp2 looks the stream up before it reads the increment.

**`has_existed` and #37985.** The id test is the one `handle_rst_stream` already had: at or below `last_stream_id` or the embedder's `highest_started_stream_id()`. It mixes both parities, so on a server an even id that was never used, below the highest odd id, counts as closed. #37985 adds `last_peer_stream_id`, a mark for peer-initiated ids only. When it lands, `has_existed` is the one place to switch.

**Scope.** `Bun.serve`'s HTTP/2 and `fetch`'s HTTP/2 client are separate code. They are not touched.

**History of this PR.** It first also carried nghttp2's glitch rate limit and the unexpected SETTINGS ACK check. A self-review said to split them out because they share no code with this fix. They are #42522 (glitch rate limit) and #42519 (unexpected SETTINGS ACK) now. The WINDOW_UPDATE row comes from the review comment below.

**Tests.** `DATA and WINDOW_UPDATE on a closed stream` in `h2-conformance.test.ts`, both roles, raw sockets on the other side. The server and client flood tests and the connection-window test fail on main. The last test sends WINDOW_UPDATE for a request stream before any HEADERS or DATA on it, so a 100,000-byte upload can finish. It passes on main and fails when `is_closed_stream` omits the `is_local_stream` check (the upload stalls at 65,535 bytes).
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [344.92ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [101.56ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [80.47ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [41.54ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [36.89ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [33.54ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [38.05ms]
(pass) PING (checklist §3.7) > a PING on a non-zero str
... (truncated)

release without fix: 5 FAILED
bun test v1.4.3-canary.1 (231685649)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [9.94ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [2.65ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [2.34ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [1.16ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [1.10ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [0.94ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [1.05ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [0.94ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [1.01ms]
(pass) WINDOW_UPDATE
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [375.31ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [154.84ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [78.18ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [41.85ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [35.37ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [32.45ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [37.45ms]
(pass) PING (checklist §3.7) > a PING on a non-zero str
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 666ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2/connection.rs      |  39 ++++++----
 test/js/node/http2/h2-conformance.test.ts | 115 ++++++++++++++++++++++++++++++
 2 files changed, 141 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/api/bun/h2/connection.rs           5     14     54
test/js/node/http2/h2-conformance.test.ts      0      0     54
```

</details>

<!-- robobun:evidence:end -->