### PR TITLE
node:net: read bytesWritten from the native socket handle

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -1275,15 +1275,6 @@ function onServerStream(Http2ServerRequest, Http2ServerResponse, stream, headers
   server.emit("request", request, response);
 }
 
-// The h2 frame writer flushes through the native socket directly, bypassing the JS
-// Writable accounting net.Socket's bytesWritten getter is built on — the native
-// counter is the ground truth once frames hit the wire.
-function socketBytesWritten(socket) {
-  const native = socket._handle?.bytesWritten || 0;
-  const js = socket.bytesWritten || 0;
-  return native > js ? native : js;
-}
-
 const proxyCompatSocketHandler = {
   has(stream, prop) {
     const ref = stream.session !== undefined ? stream.session[bunHTTP2Socket] : stream;
@@ -1316,10 +1307,6 @@ const proxyCompatSocketHandler = {
       case "pause":
       case "resume":
         throw $ERR_HTTP2_NO_SOCKET_MANIPULATION();
-      case "bytesWritten": {
-        const ref = stream.session !== undefined ? stream.session[bunHTTP2Socket] : stream;
-        return socketBytesWritten(ref);
-      }
       default: {
         const ref = stream.session !== undefined ? stream.session[bunHTTP2Socket] : stream;
         const value = ref[prop];
@@ -1380,13 +1367,6 @@ const proxySocketHandler = {
       case "setKeepAlive":
       case "setNoDelay":
         throw $ERR_HTTP2_NO_SOCKET_MANIPULATION();
-      case "bytesWritten": {
-        const socket = session[bunHTTP2Socket];
-        if (!socket) {
-          throw $ERR_HTTP2_SOCKET_UNBOUND();
-        }
-        return socketBytesWritten(socket);
-      }
       default: {
         const socket = session[bunHTTP2Socket];
         if (!socket) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1839,10 +1839,7 @@ Object.defineProperty(Socket.prototype, "bufferSize", {
   },
 });
 
-// Node reads the handle while one exists and falls back to the value saved in
-// _destroy: https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L1043-L1045
-// Writers that bypass the JS write path (the node:http2 frame writer) only
-// update the native counter.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L1043-L1045
 Object.defineProperty(Socket.prototype, "_bytesDispatched", {
   get: function () {
     const handle = this._handle;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -502,8 +502,6 @@ const SocketHandlers: SocketHandler = {
       } else {
         self._pendingData = null;
       }
-
-      self[kBytesWritten] = socket.bytesWritten;
     }
   },
   end(socket) {
@@ -582,7 +580,6 @@ const SocketHandlers: SocketHandler = {
     }
 
     if (!self[kupgraded]) {
-      self[kBytesWritten] = socket.bytesWritten;
       // this is not actually emitted on nodejs when socket used on the connection
       // this is already emmited on non-TLS socket and on TLS socket is emmited secureConnect after handshake
       self.emit("connect", self);
@@ -1328,15 +1325,12 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
       const res = socket.$write(writeChunk || "", self._pendingEncoding || "utf8");
       if (res < 0) {
         // The retried send failed for good (peer gone): $write returned -errno.
-        self[kBytesWritten] = socket.bytesWritten;
         failWrite(self, res, callback);
       } else if (res) {
-        self[kBytesWritten] = socket.bytesWritten;
         self._pendingData = self[kwriteCallback] = null;
         unrefAfterDrain(self, socket);
         callback(null);
       } else {
-        self[kBytesWritten] = socket.bytesWritten;
         self._pendingData = null;
       }
     }
@@ -1843,15 +1837,20 @@ Object.defineProperty(Socket.prototype, "bufferSize", {
   },
 });
 
+// Node reads the handle while one exists and falls back to the value saved in
+// _destroy: https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L1043-L1045
+// Writers that bypass the JS write path (the node:http2 frame writer) only
+// update the native counter.
 Object.defineProperty(Socket.prototype, "_bytesDispatched", {
   get: function () {
-    return this[kBytesWritten] || 0;
+    const handle = this._handle;
+    return (handle ? handle.bytesWritten : this[kBytesWritten]) || 0;
   },
 });
 
 Object.defineProperty(Socket.prototype, "bytesWritten", {
   get: function () {
-    let bytes = this[kBytesWritten] || 0;
+    let bytes = this._bytesDispatched;
     const data = this._pendingData;
     const writableBuffer = this.writableBuffer;
     if (!writableBuffer) return undefined;
@@ -1895,7 +1894,6 @@ Socket.prototype[kAttach] = function (port, socket) {
   }
 
   if (!this[kupgraded]) {
-    this[kBytesWritten] = socket.bytesWritten;
     // this is not actually emitted on nodejs when socket used on the connection
     // this is already emmited on non-TLS socket and on TLS socket is emmited secureConnect after handshake
     this.emit("connect", this);
@@ -2833,7 +2831,6 @@ Socket.prototype._write = function _write(chunk, encoding, callback) {
     return false;
   }
   const res = socket.$write(chunk, encoding);
-  this[kBytesWritten] = socket.bytesWritten;
   if (res < 0) {
     // The kernel rejected the send outright (peer reset): $write returned the
     // negative errno; deliver it like the EBADF/EPIPE branch above.

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -264,6 +264,8 @@ function closeAdoptedTLSRawNowNT(handle, self, isException) {
 }
 function detachSocket(self) {
   if (!self) self = this;
+  const handle = self._handle;
+  if (handle) self[kBytesWritten] = handle.bytesWritten;
   self._handle = null;
 }
 function destroyNT(self, err) {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6345,10 +6345,20 @@ describe("net.Socket bytesWritten through an http2 session", () => {
 
     const raw = net.connect(port, "127.0.0.1");
     const client = http2.connect(`http://127.0.0.1:${port}`, { createConnection: () => raw });
+    const failed = new Promise((_, reject) => {
+      raw.once("error", reject);
+      client.once("error", reject);
+    });
     try {
       const req = client.request({ ":path": "/" });
       req.resume();
-      await new Promise(resolve => req.once("end", resolve));
+      await Promise.race([
+        failed,
+        new Promise((resolve, reject) => {
+          req.once("end", resolve);
+          req.once("error", reject);
+        }),
+      ]);
 
       const proxy = client.socket.bytesWritten;
       expect(proxy).toBeGreaterThan(0);
@@ -6357,7 +6367,7 @@ describe("net.Socket bytesWritten through an http2 session", () => {
 
       const closed = new Promise(resolve => raw.once("close", resolve));
       client.close();
-      await closed;
+      await Promise.race([failed, closed]);
       // The count survives the destroy of the handle.
       expect(raw.bytesWritten).toBeGreaterThanOrEqual(proxy);
       expect(raw._bytesDispatched).toBe(raw.bytesWritten);

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -6329,3 +6329,41 @@ describe("frames issued from inside a user-supplied Duplex transport's _write", 
     },
   );
 });
+
+describe("net.Socket bytesWritten through an http2 session", () => {
+  // The h2 frame writer writes through the native socket handle, not through
+  // the JS write path. The raw socket that the user passes to createConnection
+  // must count those bytes too, like the session.socket proxy does.
+  it("counts the frames the session writes on the raw createConnection socket", async () => {
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end("hello world from h2");
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const port = server.address().port;
+
+    const raw = net.connect(port, "127.0.0.1");
+    const client = http2.connect(`http://127.0.0.1:${port}`, { createConnection: () => raw });
+    try {
+      const req = client.request({ ":path": "/" });
+      req.resume();
+      await new Promise(resolve => req.once("end", resolve));
+
+      const proxy = client.socket.bytesWritten;
+      expect(proxy).toBeGreaterThan(0);
+      expect(raw.bytesWritten).toBe(proxy);
+      expect(raw._bytesDispatched).toBe(proxy);
+
+      const closed = new Promise(resolve => raw.once("close", resolve));
+      client.close();
+      await closed;
+      // The count survives the destroy of the handle.
+      expect(raw.bytesWritten).toBeGreaterThanOrEqual(proxy);
+      expect(raw._bytesDispatched).toBe(raw.bytesWritten);
+    } finally {
+      client.destroy();
+      await new Promise(resolve => server.close(resolve));
+    }
+  });
+});

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -3130,3 +3130,33 @@ describe.concurrent("uncaughtException from socket listeners", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+describe("bytesWritten after the peer resets the connection", () => {
+  // A reset reaches the server socket through the native close handler, which
+  // drops the handle before destroy() runs. The count must survive that.
+  it("keeps the count on a server socket that the client reset", async () => {
+    const { promise: serverClosed, resolve, reject } = Promise.withResolvers<Socket>();
+    const server = createServer(c => {
+      c.on("error", () => {});
+      c.on("close", () => resolve(c));
+      c.write("hello", () => c.write("world"));
+    });
+    server.on("error", reject);
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const client = connect(server.address().port, "127.0.0.1");
+      client.on("error", reject);
+      let received = 0;
+      client.on("data", chunk => {
+        received += chunk.length;
+        if (received === 10) client.resetAndDestroy();
+      });
+      const c = await serverClosed;
+      expect(c._handle).toBeNull();
+      expect(c.bytesWritten).toBe(10);
+      expect(c._bytesDispatched).toBe(10);
+    } finally {
+      await new Promise(resolve => server.close(resolve));
+    }
+  });
+});


### PR DESCRIPTION
### Problem
- A `net.Socket` that a `node:http2` session writes through reports `bytesWritten === 0` and `_bytesDispatched === 0`. The native handle holds the correct count (67 for the script in #42465). Node reports 67 on the socket too.
- The cause is the `_bytesDispatched` getter in `src/js/node/net.ts:1846`. It reads only `kBytesWritten`, a copy that the JS write path refreshes after each write. The h2 frame writer writes through the native handle and never runs that path.

### Fix
- `_bytesDispatched` reads `this._handle.bytesWritten` while a handle exists and falls back to `kBytesWritten` when it does not. This is what node does (`lib/net.js` `_bytesDispatched`). `bytesWritten` builds on `_bytesDispatched`.
- The per-write copies into `kBytesWritten` are gone. Both paths that drop the handle save the final count first: `_destroy` for a local `destroy()`, and `detachSocket` for the native close handler (a peer reset). So the value survives the close. The sync-fd write path has no handle and still counts into `kBytesWritten` directly.
- The `bytesWritten` special cases in the two `node:http2` socket proxies are gone. The default case of each proxy forwards to the socket, which now returns the same value.
- Verified: `test/js/node/http2/node-http2.test.js` (new block, fails on stock bun with `Received: 0`) and `test/js/node/net/node-net.test.ts` (new block, guards the peer reset path). Also all of `node-http2.test.js`, `node-http.test.ts`, `node-tls-upgrade.test.ts`, and the node `test-*-byteswritten`, `test-net-bytes-*`, `test-net-connect-buffer*` files.

### Background
- `net.Socket._handle` is the native socket wrapper. Its `bytesWritten` getter counts bytes the native side wrote or queued.
- `kBytesWritten` is a symbol property on the JS socket. It now holds only the count saved at destroy time, or the count of a sync-fd socket that has no native handle.
- The read-side twin of this bug is #42302, fixed by #42313. That PR resets the read count when `connect()` reuses a handle. This PR does not change the written count on reconnect.

Fixes #42465

<details><summary>Notes</summary>

The node-net.test.ts suite has four `net.Socket read` tests, `unref should exit when no more work pending`, `should trigger error when aborted even if connection failed #13126`, and `should not leak when connect({path}) fails synchronously on a reused handle` failing in my container on main as well (ECONNREFUSED, the server binds `localhost` and the client dials 127.0.0.1). The diff does not change the result of any test in that file.

Review found that the first push lost the count on a peer reset: the native close handler runs `detachSocket`, which nulled `_handle` before `_destroy` could save the count. The second commit saves it in `detachSocket` and adds the net test for it.

Edge cases probed on the fixed build: a detached `new net.Socket()` reports 0, a connecting socket reports 0, a socket after `write("abcde")` reports 5, and the same socket after `destroy()` still reports 5 with `_handle === null`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->