### PR TITLE
types: accept the Bun.color output formats the runtime supports

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5247,11 +5247,20 @@ declare module "bun" {
       | "ansi-16"
       | "ansi-16m"
       /**
+       * Aliases of `ansi-16m`
+       */
+      | "ansi-24bit"
+      | "ansi-truecolor"
+      /**
        * 256 color ANSI color string, for use in terminals which don't support true color
        *
        * Tries to match closest 24-bit color to 256 color palette
        */
       | "ansi-256"
+      /**
+       * Alias of `ansi-256`
+       */
+      | "ansi256"
       /**
        * Picks the format that produces the shortest output
        */
@@ -5303,11 +5312,23 @@ declare module "bun" {
    */
   function color(input: ColorInput, outputFormat: "[rgba]"): [number, number, number, number] | null;
   /**
+   * Convert any color input to rgba
+   * @param input Any color input
+   * @param outputFormat `[r,g,b,a]` is an alias of `[rgba]`
+   */
+  function color(input: ColorInput, outputFormat: "[r,g,b,a]"): [number, number, number, number] | null;
+  /**
    * Convert any color input to rgb
    * @param input Any color input
    * @param outputFormat Specify `{rgb}` to output as an object with `r`, `g`, and `b` properties
    */
   function color(input: ColorInput, outputFormat: "{rgb}"): { r: number; g: number; b: number } | null;
+  /**
+   * Convert any color input to rgb
+   * @param input Any color input
+   * @param outputFormat `{r,g,b}` is an alias of `{rgb}`
+   */
+  function color(input: ColorInput, outputFormat: "{r,g,b}"): { r: number; g: number; b: number } | null;
   /**
    * Convert any color input to rgba
    * @param input Any color input

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -501,6 +501,52 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  describe("Bun.color", () => {
+    test("accepts the output formats the runtime supports", async () => {
+      const checkDir = join(TEMP_DIR, "bun-color-format-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.include = ["bun-color-formats.ts"];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+        "bun-color-formats.ts": `Bun.color("red", "ansi-24bit") satisfies string | null;
+           Bun.color("red", "ansi-truecolor") satisfies string | null;
+           Bun.color("red", "ansi256") satisfies string | null;
+           Bun.color("red", "[r,g,b,a]") satisfies [number, number, number, number] | null;
+           Bun.color("red", "{r,g,b}") satisfies { r: number; g: number; b: number } | null;
+           // @ts-expect-error - not a format the runtime accepts
+           Bun.color("red", "ansi-128");`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+
+    // tsc cannot read the runtime's format table, so this ties the alias
+    // literals added to the .d.ts back to the running binary.
+    test("the alias formats match the runtime", () => {
+      for (const format of ["ansi-24bit", "ansi-truecolor", "ansi256"] as const) {
+        expect(typeof Bun.color("red", format)).toBe("string");
+      }
+      expect(Bun.color("red", "[r,g,b,a]")).toEqual(Bun.color("red", "[rgba]"));
+      expect(Bun.color("red", "{r,g,b}")).toEqual(Bun.color("red", "{rgb}"));
+      expect(Bun.color("red", "ansi-24bit")).toBe(Bun.color("red", "ansi-16m"));
+      expect(Bun.color("red", "ansi256")).toBe(Bun.color("red", "ansi-256"));
+    });
+  });
+
   // Runs on debug builds too, same as the Bun.mmap block above.
   describe("Event and EventTarget", () => {
     async function checkEventFixture(name: string, lib: string[], source: string) {


### PR DESCRIPTION
### What does this PR do?

`Bun.color()` accepts five output formats at runtime that the `.d.ts` overloads don't declare:

```js
Bun.color("red", "ansi-24bit");     // "\x1b[38;2;255;0;0m"  (alias of ansi-16m)
Bun.color("red", "ansi-truecolor"); // "\x1b[38;2;255;0;0m"  (alias of ansi-16m)
Bun.color("red", "ansi256");        // "\x1b[38;5;196m"      (alias of ansi-256)
Bun.color("red", "[r,g,b,a]");      // [255, 0, 0, 255]      (alias of [rgba])
Bun.color("red", "{r,g,b}");        // { r: 255, g: 0, b: 0 } (alias of {rgb})
```

The runtime's own invalid-format error advertises all of them:

```
format must be one of '[r,g,b,a]', '[rgb]', '[rgba]', '{r,g,b}', '{rgb}', '{rgba}',
'ansi_256', 'ansi-256', 'ansi_16', 'ansi-16', 'ansi_16m', 'ansi-16m', 'ansi-24bit',
'ansi-truecolor', 'ansi', 'ansi256', 'css', 'hex', 'HEX', 'hsl', 'lab', 'number',
'rgb' or 'rgba'
```

So a user who copies a format out of the error message gets a TypeScript error. #14657 fixed that error message to list the accepted formats but only touched `color_js.zig`, leaving the types behind.

This adds the five missing literals to the existing overloads. The `ansi_*` underscore spellings are also accepted by the runtime but are left out deliberately — the docs, the existing union, and the examples all use the hyphenated spellings, so typing only those keeps one canonical form.

### How did you verify your code works?

- Confirmed each format against the runtime on 1.4.2, including that the aliases produce byte-identical output to the formats they alias.
- Added a `Bun.color` block to `test/integration/bun-types/bun-types.test.ts`, modeled on the existing `TextDecoder` block from #40119:
  - a `tsc` check that all five formats type-check (plus a `@ts-expect-error` for a format the runtime rejects), and
  - a runtime check tying the literals back to the running binary (`ansi-24bit === ansi-16m`, `ansi256 === ansi-256`, `[r,g,b,a] === [rgba]`, `{r,g,b} === {rgb}`), so the union can't drift from the runtime again without the test failing.
- Both pass; reverting just the `.d.ts` fails the tsc case with five `TS2769: No overload matches this call` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
