### PR TITLE
bundler: keep a destructured require() local a copy unless the export has its value from the start

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4354,21 +4354,15 @@ impl<'a> LinkerContext<'a> {
         let Some(export) = self.graph.symbols.get_const(result.r#ref) else {
             return true;
         };
-        // A direct `eval` in the exporting file can assign it too. An import
-        // that matching cannot follow is a binding of an external module,
-        // which changes out of sight.
+        // Assigned by code, by a direct `eval`, or by an external module.
         if export.has_been_assigned_to()
             || export.must_not_be_renamed()
             || export.kind == bun_ast::symbol::Kind::Import
         {
             return false;
         }
-        // The importee's own initializer changes the export too. A `require()`
-        // can run while the importee initializes (an import cycle, or a
-        // callback no import graph shows), and the pattern then copies the
-        // value from before the initializer. Only a function declaration and a
-        // namespace object (printed outside the wrapper) have their value from
-        // the start. An `import()` settles after the initializer.
+        // A `require()` can run while the importee initializes. Only a function
+        // declaration and a namespace object have their value before that.
         let record = &self.graph.ast.items_import_records()[source_index as usize].as_slice()
             [named_import.import_record_index as usize];
         record.kind != ImportKind::Require

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -4326,7 +4326,13 @@ impl<'a> LinkerContext<'a> {
     }
 
     /// Whether the export an item of such a record matched can stand in for it.
-    fn binds_call_item(&self, import_ref: Ref, result: &MatchImport) -> bool {
+    fn binds_call_item(
+        &self,
+        source_index: crate::IndexInt,
+        import_ref: Ref,
+        named_import: &NamedImport,
+        result: &MatchImport,
+    ) -> bool {
         // A lifted CommonJS export changes through `exports.x = …`, which the
         // parser does not record as an assignment.
         if !matches!(result.kind, MatchImportKind::Normal)
@@ -4342,15 +4348,32 @@ impl<'a> LinkerContext<'a> {
             .symbols
             .get_const(import_ref)
             .is_some_and(|symbol| symbol.namespace_alias.is_none());
-        !is_pattern_local
-            || !self
-                .graph
-                .symbols
-                .get_const(result.r#ref)
-                .is_some_and(|symbol| {
-                    // A direct `eval` in the exporting file can assign it too.
-                    symbol.has_been_assigned_to() || symbol.must_not_be_renamed()
-                })
+        if !is_pattern_local {
+            return true;
+        }
+        let Some(export) = self.graph.symbols.get_const(result.r#ref) else {
+            return true;
+        };
+        // A direct `eval` in the exporting file can assign it too. An import
+        // that matching cannot follow is a binding of an external module,
+        // which changes out of sight.
+        if export.has_been_assigned_to()
+            || export.must_not_be_renamed()
+            || export.kind == bun_ast::symbol::Kind::Import
+        {
+            return false;
+        }
+        // The importee's own initializer changes the export too. A `require()`
+        // can run while the importee initializes (an import cycle, or a
+        // callback no import graph shows), and the pattern then copies the
+        // value from before the initializer. Only a function declaration and a
+        // namespace object (printed outside the wrapper) have their value from
+        // the start. An `import()` settles after the initializer.
+        let record = &self.graph.ast.items_import_records()[source_index as usize].as_slice()
+            [named_import.import_record_index as usize];
+        record.kind != ImportKind::Require
+            || export.kind.is_function()
+            || self.is_esm_namespace_ref(result.source_index, result.r#ref)
     }
 
     /// Must `X.name()` keep `X` as `this`, where `X.name` is export `ref_`?
@@ -4579,7 +4602,9 @@ impl<'a> LinkerContext<'a> {
                 &mut re_exports,
             );
 
-            if is_call_item && !self.binds_call_item(import_ref, &result) {
+            if is_call_item
+                && !self.binds_call_item(source_index, import_ref, named_import, &result)
+            {
                 continue;
             }
 

--- a/test/bundler/bundler_dynamic_import_dce.test.ts
+++ b/test/bundler/bundler_dynamic_import_dce.test.ts
@@ -3665,6 +3665,7 @@ describe("bundler", () => {
   // A throwing importee rejects the `import()` (caught by the surrounding
   // `try`), and every later `import()` / `require()` throws the same error.
   itElides("InitThrows", {
+    keepsNamespace: true,
     files: {
       "/entry.js": /* js */ `
         async function load() {
@@ -3820,6 +3821,171 @@ describe("bundler", () => {
     stdout: "x init a\nx a a",
   });
 
+  // In an import cycle, `require()` can return an importee that is still
+  // initializing. None of these declarations is an assignment to the parser.
+  // The first `take()` runs before them and the second one after them.
+  itElides("RequireCycleSnapshotOfDeclarations", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": `import "./b.js";`,
+      "/a.js": /* js */ `
+        const reads = [];
+        export function take() {
+          const { init, redeclared, forOf, forIn, later, renamed, fn } = require("./b.js");
+          const ns = require("./b.js");
+          const { init: fromLocal } = ns;
+          reads.push(() => [init, redeclared, forOf, forIn, later, renamed, fn(), fromLocal].map(String).join());
+        }
+        export function read() {
+          return reads.map(r => r()).join("\\n");
+        }
+      `,
+      "/b.js": /* js */ `
+        import { take, read } from "./a.js";
+        export var redeclared = String(1), forOf = String(1), forIn = String(1), later;
+        export { hoisted as renamed };
+        export function fn() { return "fn"; }
+        take();
+        export var init = String("late");
+        var redeclared = String(2);
+        for (var forOf of ["of"]) {}
+        for (var forIn in { in: 1 }) {}
+        var later = String("late");
+        var hoisted = String("late");
+        take();
+        console.log(read());
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "undefined,1,1,1,undefined,undefined,fn,undefined\nlate,2,of,in,late,late,fn,late",
+  });
+
+  // A function declaration has its value before the importee initializes, so
+  // it is bound in a cycle too.
+  itElides("RequireCycleFunctionDeclaration", {
+    files: {
+      "/entry.js": `import "./b.js";`,
+      "/a.js": /* js */ `
+        export function early() {
+          const { fn, gen } = require("./b.js");
+          return fn() + typeof gen;
+        }
+      `,
+      "/b.js": /* js */ `
+        import { early } from "./a.js";
+        console.log(early());
+        export function fn() { return "fn "; }
+        export function* gen() {}
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "fn function",
+  });
+
+  // The importee is in a cycle without the importer. It has initialized when
+  // `require()` returns, so the copy reads the initialized value.
+  itElides("RequireOfAnotherCycle", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        import { read } from "./a.js";
+        console.log(read());
+      `,
+      "/a.js": /* js */ `
+        export function read() {
+          const { v } = require("./b.js");
+          return v;
+        }
+      `,
+      "/b.js": /* js */ `
+        import { w } from "./c.js";
+        export var v = String("V") + w();
+        export const d = "DROPPED";
+      `,
+      "/c.js": /* js */ `
+        import "./b.js";
+        export function w() { return "W"; }
+      `,
+    },
+    stdout: "VW",
+  });
+
+  // `b.js` imports `a.js`, whose top-level `require()` then returns `b.js`
+  // before its body has run.
+  itElides("RequireCycleAtTopLevel", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": `import "./b.js";`,
+      "/a.js": /* js */ `
+        const { v } = require("./b.js");
+        export function read() {
+          return v;
+        }
+      `,
+      "/b.js": /* js */ `
+        import { read } from "./a.js";
+        export var v = String("V");
+        console.log(read());
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "undefined",
+  });
+
+  // The cycle goes through a dependency of the importee. `d.js` runs before
+  // `c.js`, which holds the export that `b.js` re-exports.
+  itElides("RequireCycleThroughReExport", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        import "./b.js";
+        import { read } from "./a.js";
+        console.log(read());
+      `,
+      "/a.js": /* js */ `
+        let get;
+        export function take() {
+          const { v } = require("./b.js");
+          get = () => v;
+        }
+        export function read() {
+          return get();
+        }
+      `,
+      "/b.js": /* js */ `
+        import "./d.js";
+        export { v } from "./c.js";
+        export const d = "DROPPED";
+      `,
+      "/c.js": `export var v = String("C");`,
+      "/d.js": /* js */ `
+        import { take } from "./a.js";
+        take();
+      `,
+    },
+    stdout: "undefined",
+  });
+
+  // A file that requires itself is a cycle of one file.
+  itElides("RequireOfItself", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": `import "./a.js";`,
+      "/a.js": /* js */ `
+        let get;
+        function take() {
+          const { v } = require("./a.js");
+          get = () => v;
+        }
+        take();
+        export var v = String("V");
+        console.log(get());
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "undefined",
+  });
+
   // A default value reads the name off the real object.
   itElides("ThenAndPromiseAll", {
     keepsNamespace: true,
@@ -3903,6 +4069,7 @@ describe("bundler", () => {
   // A wrapped importer turns its top-level declarations into assignments;
   // the pattern's source is still the object literal.
   itElides("WrappedImporter", {
+    keepsNamespace: true,
     files: {
       "/entry.js": /* js */ `
         async function main() {
@@ -3918,6 +4085,27 @@ describe("bundler", () => {
         export function show() { console.log(b, one, two, ns.a); }
       `,
       "/x.js": `console.log("x init"); export const a = "a", b = "b"; export const d = "DROPPED";`,
+    },
+    stdout: "x init\nb a b a",
+  });
+
+  // The same with a function export, which a `require()` pattern still binds.
+  itElides("WrappedImporterBoundFunction", {
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const { show } = await import("./inner.js");
+          show();
+        }
+        main();
+      `,
+      "/inner.js": /* js */ `
+        const { b } = require("./x.js");
+        const ns = require("./x.js");
+        const one = ns.a, two = ns.b();
+        export function show() { console.log(b(), one, two, ns.a); }
+      `,
+      "/x.js": `console.log("x init"); export const a = "a"; export function b() { return "b"; } export const d = "DROPPED";`,
     },
     stdout: "x init\nb a b a",
   });
@@ -4147,14 +4335,177 @@ describe("bundler", () => {
   });
 
   // A wrapped importer hoists its top-level names out of the closure. A bound
-  // name is the export's own binding (here a class), so it is not redeclared.
-  itElides("WrappedImporterBoundClass", {
+  // name is the export's own binding (here a function), so it is not redeclared.
+  itElides("WrappedImporterDoesNotRedeclareBoundName", {
+    files: {
+      "/entry.js": `const { y } = require("./b.js"); console.log(y());`,
+      "/b.js": `const { z } = require("./a.js"); export function y() { return z.v; }`,
+      "/a.js": `export function z() {} z.v = "zv"; export const d = "DROPPED";`,
+    },
+    stdout: "zv",
+  });
+
+  // A class has no value before its declaration runs, so a `require()`
+  // pattern local of it is a copy. The wrapped importer hoists that local.
+  itElides("WrappedImporterClassIsCopy", {
+    keepsNamespace: true,
     files: {
       "/entry.js": `const { y } = require("./b.js"); console.log(y);`,
       "/b.js": `const { z } = require("./a.js"); export const y = z.v;`,
       "/a.js": `export class z { static v = "zv" } export const d = "DROPPED";`,
     },
     stdout: "zv",
+  });
+
+  // A `require()` can run while the importee initializes, so a pattern local
+  // of an export that is not a function declaration stays a copy. Here the
+  // importee reaches the pattern through a callback, not through an import.
+  itElides("RequireDuringInitThroughCallbackIsCopy", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        import { register } from "./registry.js";
+        import { early, late } from "./a.js";
+        register(early);
+        require("./b.js");
+        console.log(late());
+      `,
+      "/registry.js": /* js */ `
+        let callback;
+        export function register(fn) { callback = fn; }
+        export function fire() { callback(); }
+      `,
+      "/a.js": /* js */ `
+        let get;
+        export function early() { const { v } = require("./b.js"); get = () => v; }
+        export function late() { return get(); }
+      `,
+      "/b.js": /* js */ `
+        import { fire } from "./registry.js";
+        fire();
+        export var v = String("V");
+      `,
+    },
+    stdout: "undefined",
+  });
+
+  // The same through an import cycle: the importee imports the importer.
+  itElides("RequireDuringInitThroughCycleIsCopy", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": `import "./b.js";`,
+      "/a.js": /* js */ `
+        let get;
+        export function early() { const { v } = require("./b.js"); get = () => v; }
+        export function late() { return get(); }
+      `,
+      "/b.js": /* js */ `
+        import { early, late } from "./a.js";
+        early();
+        export let v = String("V");
+        console.log(late());
+      `,
+    },
+    stdout: "undefined",
+  });
+
+  // Each declaration form that has no value before its line runs.
+  itElides("RequireDuringInitCopiesEachForm", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        import { register } from "./registry.js";
+        import { early, late } from "./a.js";
+        register(early);
+        require("./b.js");
+        console.log(late());
+      `,
+      "/registry.js": /* js */ `
+        let callback;
+        export function register(fn) { callback = fn; }
+        export function fire() { callback(); }
+      `,
+      "/a.js": /* js */ `
+        let get;
+        export function early() {
+          const { a, b, c, d, f } = require("./b.js");
+          get = () => [a, b, c, d, typeof f].join();
+        }
+        export function late() { return get(); }
+      `,
+      "/b.js": /* js */ `
+        import { fire } from "./registry.js";
+        fire();
+        export var a = String("a");
+        export let b = String("b");
+        export const c = String("c");
+        export class d { static x = String("d") }
+        export function f() {}
+      `,
+    },
+    stdout: ",,,,function",
+  });
+
+  // A function declaration has its value from the start, so its local is
+  // still bound and the call still needs no namespace object.
+  itElides("RequireDuringInitBindsFunction", {
+    files: {
+      "/entry.js": /* js */ `
+        import { register } from "./registry.js";
+        import { early, late } from "./a.js";
+        register(early);
+        require("./b.js");
+        console.log(late());
+      `,
+      "/registry.js": /* js */ `
+        let callback;
+        export function register(fn) { callback = fn; }
+        export function fire() { callback(); }
+      `,
+      "/a.js": /* js */ `
+        let get;
+        export function early() { const { f } = require("./b.js"); get = () => f(); }
+        export function late() { return get(); }
+      `,
+      "/b.js": /* js */ `
+        import { fire } from "./registry.js";
+        fire();
+        export function f() { return "F"; }
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "F",
+  });
+
+  // An `import()` settles after the importee initialized, so its local is
+  // still bound, with the callback shape too.
+  itElides("ImportDuringInitThroughCallbackStaysBound", {
+    files: {
+      "/entry.js": /* js */ `
+        import { register } from "./registry.js";
+        import { early, late } from "./a.js";
+        register(early);
+        require("./b.js");
+        late().then(v => console.log(v));
+      `,
+      "/registry.js": /* js */ `
+        let callback;
+        export function register(fn) { callback = fn; }
+        export function fire() { callback(); }
+      `,
+      "/a.js": /* js */ `
+        let got;
+        export function early() { got = import("./b.js").then(({ v }) => v); }
+        export function late() { return got; }
+      `,
+      "/b.js": /* js */ `
+        import { fire } from "./registry.js";
+        fire();
+        export var v = String("V");
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "V",
   });
 
   // No single export to bind to: the name reads `undefined`, with no warning.
@@ -4301,6 +4652,33 @@ describe("bundler", () => {
     },
     run: { stdout: "0" },
   });
+
+  // A re-export of an external module's binding changes where the bundler
+  // cannot see, so a destructured copy of it stays a snapshot.
+  for (const format of ["esm", "cjs"] as const) {
+    itBundled(`dynamic_import_dce/ExternalReExportDestructureIsSnapshot_${format}`, {
+      files: {
+        "/entry.js": /* js */ `
+          async function main() {
+            const { counter, inc } = await import("./b.js");
+            inc();
+            const { counter: second } = require("./b.js");
+            inc();
+            console.log(counter, second);
+          }
+          main();
+        `,
+        "/b.js": `export { counter, inc } from "ext";`,
+      },
+      runtimeFiles: {
+        "/node_modules/ext/index.js": `export let counter = 0; export function inc() { counter++; }`,
+        "/node_modules/ext/package.json": `{ "name": "ext", "type": "module", "main": "index.js" }`,
+      },
+      external: ["ext"],
+      format,
+      run: { stdout: "0 1" },
+    });
+  }
 
   // ── Cases that keep the namespace object ──────────────────────────────
 

--- a/test/bundler/bundler_dynamic_import_dce.test.ts
+++ b/test/bundler/bundler_dynamic_import_dce.test.ts
@@ -4384,6 +4384,7 @@ describe("bundler", () => {
         import { fire } from "./registry.js";
         fire();
         export var v = String("V");
+        export const d = "DROPPED";
       `,
     },
     stdout: "undefined",
@@ -4403,6 +4404,7 @@ describe("bundler", () => {
         import { early, late } from "./a.js";
         early();
         export let v = String("V");
+        export const d = "DROPPED";
         console.log(late());
       `,
     },
@@ -4441,6 +4443,7 @@ describe("bundler", () => {
         export const c = String("c");
         export class d { static x = String("d") }
         export function f() {}
+        export const dropped = "DROPPED";
       `,
     },
     stdout: ",,,,function",


### PR DESCRIPTION
### Problem

- `const { v } = require("./b.js")` copies `v` when the pattern runs. Since #41186 (1.4.1) the bundler binds the local to the export when nothing assigns the export, so each later read is live. A `require()` can run while `b.js` still initializes. Then the copy is `undefined`, but the bundle reads `"V"`. 1.4.0 prints `undefined`.
- Cause: `binds_call_item` (`src/bundler/LinkerContext.rs:4329`) refuses only an export that `has_been_assigned_to()`. The initializer of `export var v = f()` is not an assignment, and it runs after the pattern when the importee reaches the pattern while it initializes.
- #42447 finds the import cycles that make this happen. An importee can also reach the pattern through a callback (#42449). No import graph shows that path. This PR replaces #42447.

### Fix

- A `require()` pattern local is bound only to an export that has its value before the importee initializes: a function declaration, or a namespace object. The bundle prints both outside the `__esm` wrapper. A re-export of an external module's binding is never bound (from #42447).
- Any other export reads through the namespace object when the pattern runs, as in 1.4.0: `const { v } = (init_b(), __toCommonJS(exports_b))`. That object lists only the names the pattern reads, so unused exports are still dropped.
- This retires part of #41186 on purpose: the elision for a `require()` pattern of a `var`, `let`, `const` or `class` export. `import()` locals stay bound. Its promise settles after the importee initialized.
- Verified: `test/bundler/bundler_dynamic_import_dce.test.ts` (328 tests, 54 new, 37 of them fail on 1.4.3). Also 12 other bundler suites (list in Notes).

### Background

- A wrapped ES module is `var init_b = __esm(() => { ... })`. The first `init_b()` runs the body. A nested call during that run returns at once. Function declarations and the namespace object `exports_b` are printed before the wrapper.
- The namespace object has a getter for each export. A pattern that reads it copies the current value.
- To bind a local, the linker merges its symbol with the export's symbol. The pattern prints as `init_b();` and each read prints the export. That is a live read.

<details><summary>Notes</summary>

Repro from the issue. `bun run entry.js`, 1.4.0 and this branch print `undefined`. 1.4.1, 1.4.2, 1.4.3 and main print `V`.

```js
// entry.js
import { register } from "./registry.js";
import { early, late } from "./a.js";
register(early);
require("./b.js");
console.log(late());
// registry.js
let callback;
export function register(fn) { callback = fn; }
export function fire() { callback(); }
// a.js
let get;
export function early() { const { v } = require("./b.js"); get = () => v; }
export function late() { return get(); }
// b.js
import { fire } from "./registry.js";
fire();
export var v = String("V");
```

Relation to #42447. That PR keeps the binding for a `require()` outside an import cycle and finds cycles with a search over the import records. This rule does not need the search: it treats every `require()` the same, because a callback can make any `require()` run during the initializer. The cycle tests of #42447 are ported here. `RequireOfAnotherCycle` now keeps the namespace object. Its `Kind::Import` guard for an external re-export is ported too, with its test: without the guard, `ExternalReExportDestructureIsSnapshot_esm` prints `2 1` on this branch.

Cost, measured minified with `--target=bun`. A file with one `require()` pattern of a `const` export: 268 bytes on 1.4.3, 851 bytes here (1.4.0 prints the same shape). The difference is the `__export`, `__toCommonJS` and `__defProp` helpers, once per bundle. A second such pattern adds 22 bytes. Each run of a pattern reads a getter instead of a variable. Tree shaking of the importee is not affected: the object lists only the names the pattern reads. `import()` patterns, which #41186 was written for, are unchanged.

Follow-up, not in this PR. The other direction from #42449 keeps the binding and prints a copy where the pattern runs (`init_b(); const v2 = v;`). That needs a symbol state the linker records without a merge, and printer changes for the pattern, the local statement, and the hoisting of top-level locals out of a wrapper. It restores the elision for `require()` if that matters.

Test changes. `ElideInitThrows`, `ElideWrappedImporter` and the class case of `ElideWrappedImporterBoundClass` (now `ElideWrappedImporterClassIsCopy`) keep their `const` and `class` exports and now expect the namespace object. `ElideWrappedImporterBoundFunction` and `ElideWrappedImporterDoesNotRedeclareBoundName` are the same shapes with a function export, which is still bound. `ElideRequireDuringInit*` are the callback shapes from the issue. `ElideImportDuringInitThroughCallbackStaysBound` guards `import()`.

Other suites that pass: `esbuild/default`, `esbuild/dce`, `esbuild/importstar`, `esbuild/importstar_ts`, `bundler_edgecase`, `bundler_cjs`, `bundler_cjs2esm`, `bundler_regressions`, `bundler_barrel`, `bundler_splitting`, `bundler_minify`, `bundler_promiseall_deadcode`, and `test/regression/issue/cyclic-imports-async-bundler.test.js`.

Self-reviewed: 3 changes asked for, 3 made. They are the external re-export guard with its test, the ported cycle tests, and the original forms of the three adjusted tests kept next to the function variants.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 37 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_dynamic_import_dce.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [1148.86ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [530.45ms]
(pass) bundler > dynamic_import_dce/AwaitDot [600.55ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [555.72ms]
(pass) bundler > dynamic_import_dce/LetBinding [579.90ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [581.74ms]
(pass) bundler > dynamic_import_dce/BailoutRest [668.62ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [854.17ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [650.63ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [622.19ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [918.75ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [617.29ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [543.06ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [582.49ms]
(pass) bundler > dyna
... (truncated)

release without fix: 37 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [34.56ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [19.14ms]
(pass) bundler > dynamic_import_dce/AwaitDot [25.20ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [19.40ms]
(pass) bundler > dynamic_import_dce/LetBinding [13.13ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [21.14ms]
(pass) bundler > dynamic_import_dce/BailoutRest [61.83ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [22.37ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [22.90ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [21.37ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [38.20ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [30.68ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [27.77ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [25.14ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllDestructure [27.85ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllThenDestructure [23.31ms]
(pass) bundler > dynamic_import_dce/SplittingProm
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_dynamic_import_dce.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [1382.02ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [914.33ms]
(pass) bundler > dynamic_import_dce/AwaitDot [575.03ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [575.13ms]
(pass) bundler > dynamic_import_dce/LetBinding [570.68ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [627.64ms]
(pass) bundler > dynamic_import_dce/BailoutRest [647.56ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [621.54ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [696.97ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [613.14ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [1114.32ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [733.44ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [658.49ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [678.30ms]
(pass) bundler > dyn
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 834ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/139] gen JS modules (bundle-modules)
Preprocess modules (10951ms)
Bundle modules (65ms)
Postprocesss modules (1007ms)
Bundle Functions (771ms)
Generate Code (55ms)

[12.86s] Bundled "src/js" for production
  2600 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/139] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_output_tags v0.0.0 (/workspace/bun/src/bun_output_tags)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_dispatch v0.0.0 (/workspace/bun/src/dispatch)
[1m[92m   Compiling[0m bun_opaque v0.0.0 (/workspace/bun/src/opaque)
[1m[92m   Compiling[0m bun_wyhash v0.0.0 (/workspace/bun/src/wyhash)
[1m[92m   Compiling[0m bun_highway v0.0.0 (/workspace/bun/src/highway)
[1m[92m   Compiling[0m bun_simdutf_sys v0.0.0 (/workspace/bun/src/simdutf_sys)
[1m[92m   Compiling[0m bun_core_macros v0.0.0 (/workspace/bun/src/bun_core_macros)
[1m[92m   Compiling[0m bun_mimalloc_sys v0.0.0 (/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/LinkerContext.rs                    |  41 ++-
 test/bundler/bundler_dynamic_import_dce.test.ts | 385 +++++++++++++++++++++++-
 2 files changed, 413 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/bundler/LinkerContext.rs                         4      8     17
test/bundler/bundler_dynamic_import_dce.test.ts      2     11     17
```

</details>

**root cause** · written by the author bot

`binds_call_item` in `src/bundler/LinkerContext.rs` bound the local of a destructured `require()` pattern to the export whenever nothing assigned that export, but a `require()` can run while the importee is still initializing (for example through a callback, which no import path reveals), so the bound local read the later initialized value instead of the `undefined` that a plain copy would hold. The fix restricts that binding to exports that already have their value before initialization completes, namely function declarations and ESM namespace references, and treats every other `require()`…

<!-- robobun:evidence:end -->