### PR TITLE
node:net: honor the typeOfService option of net.Socket and net.connect

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1607,6 +1607,12 @@ function Socket(options?) {
   // Bun's native _handle.setKeepAlive takes milliseconds (it is the public
   // Bun.Socket), so store ms here. Node stores seconds because libuv does.
   this[kSetKeepAliveInitialDelay] = MathMax(0, ~~keepAliveInitialDelay);
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L478-L481
+  const typeOfService = opts.typeOfService;
+  if (typeOfService !== undefined) {
+    validateInt32(typeOfService, "options.typeOfService", 0, 255);
+  }
+  this[kSetTOS] = typeOfService;
 
   this[khandlers] = SocketHandlers2;
   this[kDestroyOnRead] = false;

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -753,12 +753,12 @@ function TLSSocket(socket?, options?) {
 
   this._rejectUnauthorized = !!options.rejectUnauthorized;
 
-  // Never forward readable / writable: node's TLSSocket builds its own net.Socket options. https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L590-L600
+  // Never forward readable / writable / typeOfService: node's TLSSocket builds its own net.Socket options. https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L590-L600
   NetSocket.$call(
     this,
-    options.readable === undefined && options.writable === undefined
+    options.readable === undefined && options.writable === undefined && options.typeOfService === undefined
       ? options
-      : { ...options, readable: undefined, writable: undefined },
+      : { ...options, readable: undefined, writable: undefined, typeOfService: undefined },
   );
 
   // Node's _init installs this as the first 'error' listener and removes it in

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -2123,6 +2123,76 @@ describe.concurrent("pauseOnConnect", () => {
   });
 });
 
+// https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L478-L481
+describe.concurrent("typeOfService option", () => {
+  it("is validated by the Socket constructor", () => {
+    const codeFor = (typeOfService: unknown) => {
+      try {
+        new Socket({ typeOfService } as import("node:net").SocketConstructorOpts);
+        return "accepted";
+      } catch (e) {
+        return (e as NodeJS.ErrnoException).code;
+      }
+    };
+    expect({
+      0: codeFor(0),
+      255: codeFor(255),
+      undefined: codeFor(undefined),
+      256: codeFor(256),
+      "-1": codeFor(-1),
+      1.5: codeFor(1.5),
+      NaN: codeFor(NaN),
+      string: codeFor("16"),
+      null: codeFor(null),
+    }).toEqual({
+      0: "accepted",
+      255: "accepted",
+      undefined: "accepted",
+      256: "ERR_OUT_OF_RANGE",
+      "-1": "ERR_OUT_OF_RANGE",
+      1.5: "ERR_OUT_OF_RANGE",
+      NaN: "ERR_OUT_OF_RANGE",
+      string: "ERR_INVALID_ARG_TYPE",
+      null: "ERR_INVALID_ARG_TYPE",
+    });
+  });
+
+  it("is what getTypeOfService() returns before the socket connects", () => {
+    expect({
+      withOption: new Socket({ typeOfService: 0x10 }).getTypeOfService(),
+      withoutOption: new Socket().getTypeOfService(),
+    }).toEqual({ withOption: 0x10, withoutOption: 0 });
+  });
+
+  // node's TLSSocket builds its own net.Socket options, and typeOfService is not one of them:
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L590-L600
+  it("is neither validated nor kept by a TLSSocket", () => {
+    const tosOf = (typeOfService: number) =>
+      new TLSSocket(undefined, { typeOfService } as import("node:tls").TLSSocketOptions).getTypeOfService();
+    expect({ invalid: tosOf(999), valid: tosOf(0x10) }).toEqual({ invalid: 0, valid: 0 });
+  });
+
+  // Windows often ignores IP_TOS; node's test-net-socket-tos.js does not check the kernel-side value there either.
+  it.skipIf(isWindows)("is applied to the connection", async () => {
+    const server = createServer(socket => socket.on("error", () => {}).resume());
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      const port = (server.address() as import("node:net").AddressInfo).port;
+      const viaConnect = connect({ port, host: "127.0.0.1", typeOfService: 0x10 });
+      const viaSocket = new Socket({ typeOfService: 0x10 }).connect(port, "127.0.0.1");
+      const plain = connect(port, "127.0.0.1");
+      await Promise.all([once(viaConnect, "connect"), once(viaSocket, "connect"), once(plain, "connect")]);
+      // The kernel may rewrite the two ECN bits; the upper six (DSCP) are what was asked for.
+      const dscp = (socket: Socket) => socket.getTypeOfService() & 0xfc;
+      const got = { viaConnect: dscp(viaConnect), viaSocket: dscp(viaSocket), plain: dscp(plain) };
+      for (const socket of [viaConnect, viaSocket, plain]) socket.destroy();
+      expect(got).toEqual({ viaConnect: 0x10, viaSocket: 0x10, plain: 0 });
+    } finally {
+      server.close();
+    }
+  });
+});
+
 describe("net.Server accepted-socket buffering", () => {
   it("delivers bytes buffered before a 'readable' listener attaches, past peer FIN", async () => {
     // read(0) instead of resume(): bytes that arrive before the connection


### PR DESCRIPTION
### Problem
- `net.connect({ typeOfService })` and `new net.Socket({ typeOfService })` accept the option and drop it. `getTypeOfService()` returns `0` where Node v26.3.0 returns the value, the connection keeps TOS 0, and invalid values (`999`, `"16"`) do not throw.
- The `Socket` constructor in `src/js/node/net.ts` never reads `options.typeOfService`, so `kSetTOS` stays unset. Node validates and stores it at [`lib/net.js#L478-L481`](https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L478-L481). `setTypeOfService()`, `getTypeOfService()` and the connect path that applies `kSetTOS` already exist.

### Fix
- The constructor validates the own `typeOfService` option with `validateInt32(value, "options.typeOfService", 0, 255)` and stores it in `kSetTOS`, as Node does. The existing connect path applies it to the handle.
- `TLSSocket` forwards its whole options object to the `net.Socket` constructor. Node's `TLSSocket` passes a fixed list without `typeOfService`: `tls.connect({ typeOfService: 999 })` does not throw there, and a valid value is not applied. `src/js/node/tls.ts` now strips the option, next to `readable` / `writable`.
- Verified: `test/js/node/net/node-net.test.ts` (`typeOfService option`, 4 tests). 3 fail on bun 1.4.3, all pass with this change. Also ran `test/js/node/tls/node-tls-connect.test.ts` and `test-net-socket-tos.js`.

### Background
- Type of Service is the `IP_TOS` byte of an IPv4 packet (`IPV6_TCLASS` for IPv6). An application sets it to mark traffic priority. The kernel can rewrite the low two bits (ECN).
- Node added `socket.setTypeOfService()`, `socket.getTypeOfService()` and the `typeOfService` constructor option in v25.6.0 (nodejs/node#61503).
- `kSetTOS` is the slot on a `net.Socket` that holds a value set before a connection exists. `afterConnect` and the native `open` handler call `_handle.setTypeOfService()` with it once the socket is connected.

<details><summary>Notes</summary>

Repro:

```js
const net = require("net");
const server = net.createServer(s => s.resume()).listen(0, "127.0.0.1", () => {
  const c = net.connect({ port: server.address().port, host: "127.0.0.1", typeOfService: 0x10 }, () => {
    console.log(c.getTypeOfService());
    c.destroy();
    server.close();
  });
});
```

| | output |
| --- | --- |
| node v26.3.0 | `16` |
| bun 1.4.3 | `0` |
| this branch | `16` |

Validation, `new net.Socket({ typeOfService: v })`, identical between node v26.3.0 and this branch (name, code and message):

```
999  | RangeError | ERR_OUT_OF_RANGE     | The value of "options.typeOfService" is out of range. It must be >= 0 && <= 255. Received 999
-1   | RangeError | ERR_OUT_OF_RANGE     | The value of "options.typeOfService" is out of range. It must be >= 0 && <= 255. Received -1
1.5  | RangeError | ERR_OUT_OF_RANGE     | The value of "options.typeOfService" is out of range. It must be an integer. Received 1.5
NaN  | RangeError | ERR_OUT_OF_RANGE     | The value of "options.typeOfService" is out of range. It must be an integer. Received NaN
'16' | TypeError  | ERR_INVALID_ARG_TYPE | The "options.typeOfService" property must be of type number. Received type string ('16')
null | TypeError  | ERR_INVALID_ARG_TYPE | The "options.typeOfService" property must be of type number. Received null
```

bun 1.4.3 accepts all of them.

- The option is read from the own properties of the options object (`opts`, the rest of the destructure), the same set Node sees after its `options = { ...options }` copy.
- TLS, node v26.3.0: `tls.connect({ typeOfService: 999 })` is accepted, `tls.connect({ typeOfService: 16 })` then `getTypeOfService()` gives `0`. Without the `tls.ts` change this branch threw `ERR_OUT_OF_RANGE` for the first and returned `16` for the second.
- The test that reads the kernel value skips Windows. Windows often ignores `IP_TOS`, and Node's own `test-net-socket-tos.js` does not assert the kernel value there. The validation test and the cached-value test run on every platform.
- The upstream `test-net-socket-tos.js` in the tree is identical to v26.3.0 and does not cover the constructor option, so the new tests are in `node-net.test.ts`. The same assertions pass under node v26.3.0 as a plain script.
- Also ran these upstream tests with the debug build: `test-net-socket-constructor`, `test-net-connect-options-port`, `test-net-keepalive`, `test-net-options-lookup`, `test-net-connect-options-allowhalfopen`, `test-tls-connect-simple`, `test-tls-socket-constructor-alpn-options-parsing`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->