### PR TITLE
bundler: keep import() / require() locals that must not read the export

### DIFF
--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -116,6 +116,11 @@ bitflags::bitflags! {
         /// Renaming can also break any identifier used inside a "with" statement.
         const MUST_NOT_BE_RENAMED = 1 << 2;
 
+        /// Another symbol's `link` points here: a redeclaration, or a `var` or
+        /// function that `hoist_symbols` merged out of a nested scope. The uses
+        /// counted on that symbol are missing from this `use_count_estimate`.
+        const IS_LINK_TARGET = 1 << 3;
+
         const REMOVE_OVERWRITTEN_FUNCTION_DECLARATION = 1 << 4;
 
         /// The file assigns this variable after its declaration (or a mapped
@@ -151,6 +156,7 @@ macro_rules! symbol_flag_accessors {
 symbol_flag_accessors! {
     must_start_with_capital_letter_for_jsx, set_must_start_with_capital_letter_for_jsx => MUST_START_WITH_CAPITAL_LETTER_FOR_JSX;
     must_not_be_renamed, set_must_not_be_renamed => MUST_NOT_BE_RENAMED;
+    is_link_target, set_is_link_target => IS_LINK_TARGET;
     remove_overwritten_function_declaration, set_remove_overwritten_function_declaration => REMOVE_OVERWRITTEN_FUNCTION_DECLARATION;
     has_been_assigned_to, set_has_been_assigned_to => HAS_BEEN_ASSIGNED_TO;
     called_as_method, set_called_as_method => CALLED_AS_METHOD;
@@ -234,6 +240,14 @@ impl Symbol {
     #[inline]
     pub fn has_link(&self) -> bool {
         self.link.get().is_valid()
+    }
+
+    /// In the parser: every use of the variable resolves to this symbol, so
+    /// `use_count_estimate` counts them all. No declaration merge links it in
+    /// either direction, and no direct `eval` or `with` can name it.
+    #[inline]
+    pub fn use_count_is_exact(&self) -> bool {
+        !self.has_link() && !self.is_link_target() && !self.must_not_be_renamed()
     }
 
     /// An import item the linker merged into the export it names. A local

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -339,8 +339,14 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// counts (one local bound to two records).
     pub(crate) dynamic_import_escaped_records: HashMap<u32, ()>,
     /// Import records with a use the printer can't rewrite to a direct read
-    /// of an export, so the linker must keep the namespace object.
+    /// of an export, so the linker must keep the namespace object. The local
+    /// may hold another namespace or none (a conditional initializer, a read
+    /// that runs before the declaration), so no read off it is an import item.
     pub(crate) dynamic_import_needs_object: HashMap<u32, ()>,
+    /// Tracked `const` / `let` locals that a read can reach before their
+    /// declaration runs (`can_read_local_before_init`), with the scope that
+    /// declares each. A local that has such a read stays a local.
+    pub(crate) dynamic_import_early_read_watch: Vec<(js_ast::StoreRef<js_ast::Scope>, Ref)>,
     /// Namespace locals that hold a copy, not the namespace (`{...rest}`), or
     /// that no source reads by name (`require_namespace_ref`).
     pub(crate) dynamic_import_copied_locals: HashMap<Ref, ()>,
@@ -1207,6 +1213,113 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 && self.symbols[id.r#ref.inner_index() as usize].use_count_estimate == 0
             {
                 self.dynamic_import_destructured_locals.insert(id.r#ref, ());
+            }
+        }
+    }
+
+    /// Whether code below a `const` / `let` declared at `loc` in the current
+    /// scope can run before the declaration. A read of the local there
+    /// throws, so it must not see an export. A later `case` of a `switch`
+    /// shares the scope of the case that declares. A function declared below
+    /// `loc` in this scope can run first when the code above `loc` already
+    /// refers to one. A declaration that prints as `var` has no such read.
+    pub(crate) fn can_read_local_before_init(
+        &self,
+        kind: js_ast::s::Kind,
+        loc: bun_ast::Loc,
+    ) -> bool {
+        if self.select_local_kind(kind) == js_ast::s::Kind::KVar {
+            return false;
+        }
+        self.fn_or_arrow_data_visit.switch_scope == Some(self.current_scope)
+            || self.current_scope().members.values().any(|member| {
+                let symbol = &self.symbols[member.ref_.inner_index() as usize];
+                member.loc.start > loc.start
+                    && symbol.kind.is_function()
+                    && (symbol.use_count_estimate > 0 || !symbol.use_count_is_exact())
+            })
+    }
+
+    /// Watches the tracked locals that `binding` declares in the current
+    /// scope: a read of one in a function declared below it, or in a later
+    /// `case`, keeps it a local (`keep_locals_read_since`).
+    pub(crate) fn watch_early_reads(&mut self, binding: js_ast::Binding) {
+        match binding.data {
+            bun_ast::binding::Data::BIdentifier(id) => {
+                if self.dynamic_import_namespace_locals.contains_key(&id.r#ref) {
+                    self.dynamic_import_early_read_watch
+                        .push((self.current_scope, id.r#ref));
+                }
+            }
+            bun_ast::binding::Data::BObject(object) => {
+                for property in object.properties() {
+                    if let bun_ast::binding::Data::BIdentifier(id) = property.value.data
+                        && self
+                            .dynamic_import_destructured_locals
+                            .contains_key(&id.r#ref)
+                    {
+                        self.dynamic_import_early_read_watch
+                            .push((self.current_scope, id.r#ref));
+                    }
+                }
+            }
+            // `const [{ a }, ns] = await Promise.all([…])`
+            bun_ast::binding::Data::BArray(array) => {
+                for item in array.items() {
+                    self.watch_early_reads(item.binding);
+                }
+            }
+            bun_ast::binding::Data::BMissing(_) => {}
+        }
+    }
+
+    /// How many reads of `local` the linker could bind to an export: the uses
+    /// of a local that a pattern binds, the `ns.a` items of a namespace local.
+    fn bindable_reads(&self, local: Ref) -> u32 {
+        if !self.dynamic_import_namespace_locals.contains_key(&local) {
+            return self.symbols[local.inner_index() as usize].use_count_estimate;
+        }
+        self.import_items_for_namespace
+            .get(&local)
+            .map_or(0, |items| {
+                items
+                    .values()
+                    .iter()
+                    .filter(|item| item.ref_.is_valid())
+                    .fold(0u32, |reads, item| {
+                        reads.saturating_add(
+                            self.symbols[item.ref_.inner_index() as usize].use_count_estimate,
+                        )
+                    })
+            })
+    }
+
+    /// The watched locals of the current scope, each with its bindable reads
+    /// so far. Take it before a function declared in this scope or a `case`.
+    pub(crate) fn watched_reads_in_scope(&self) -> Vec<(Ref, u32)> {
+        self.dynamic_import_early_read_watch
+            .iter()
+            .filter(|(scope, _)| *scope == self.current_scope)
+            .map(|&(_, local)| (local, self.bindable_reads(local)))
+            .collect()
+    }
+
+    /// The function or `case` visited since `before` can run before the
+    /// declaration of these locals. One it reads stays a local.
+    pub(crate) fn keep_locals_read_since(&mut self, before: Vec<(Ref, u32)>) {
+        for (local, reads) in before {
+            if self.bindable_reads(local) <= reads {
+                continue;
+            }
+            match self.dynamic_import_namespace_locals.get(&local) {
+                Some(records) => {
+                    for &record in records {
+                        self.dynamic_import_needs_object.insert(record, ());
+                    }
+                }
+                None => {
+                    self.dynamic_import_destructured_locals.remove(&local);
+                }
             }
         }
     }
@@ -3679,6 +3792,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             {
                                 // Silently merge this symbol into the existing symbol
                                 self.symbols[symbol_idx].link.set(member_in_scope.ref_);
+                                self.symbols[existing_idx].set_is_link_target(true);
                                 // `StringHashMap` get_or_put already stores the key on insert and
                                 // cannot hand out `&mut K` (see StringHashMapGetOrPut docs), so
                                 // no key write is needed here.
@@ -3750,6 +3864,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             // If this is a catch identifier, silently merge the existing symbol
                             // into this symbol but continue hoisting past this catch scope
                             self.symbols[existing_idx].link.set(value.ref_);
+                            self.symbols[symbol_idx].set_is_link_target(true);
                             // SAFETY: `name` is a symbol's `original_name`.
                             *unsafe { _scope.get_or_put_member_with_hash(name, hash.unwrap()) }
                                 .value_ptr = value;
@@ -5195,6 +5310,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 MR::ReplaceWithNew => {
                     self.symbols[symbol_idx].link.set(ref_);
+                    self.symbols[ref_.inner_index() as usize].set_is_link_target(true);
 
                     let existing_kind = self.symbols[symbol_idx].kind;
                     // If these are both functions, remove the overwritten declaration
@@ -9798,6 +9914,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             dynamic_import_namespace_locals: Default::default(),
             dynamic_import_escaped_records: Default::default(),
             dynamic_import_needs_object: Default::default(),
+            dynamic_import_early_read_watch: Vec::new(),
             dynamic_import_copied_locals: Default::default(),
             dynamic_import_destructured_locals: Default::default(),
             namespace_tracked_uses: Default::default(),
@@ -10321,6 +10438,23 @@ pub(crate) fn null_value_expr() -> js_ast::ExprData {
 /// the export the linker would bind.
 pub(crate) fn is_require_marker(record: &ImportRecord, name: &[u8]) -> bool {
     record.kind == bun_ast::ImportKind::Require && (name == b"default" || name == b"__esModule")
+}
+
+/// Whether a default value in the pattern, at any depth, can read a name. A
+/// primitive literal can't.
+pub(crate) fn binding_default_can_read_names(binding: js_ast::Binding) -> bool {
+    let reads =
+        |default_value: Option<Expr>| default_value.is_some_and(|v| !v.is_primitive_literal());
+    match binding.data {
+        bun_ast::binding::Data::BArray(array) => array
+            .items()
+            .iter()
+            .any(|item| reads(item.default_value) || binding_default_can_read_names(item.binding)),
+        bun_ast::binding::Data::BObject(object) => object.properties().iter().any(|property| {
+            reads(property.default_value) || binding_default_can_read_names(property.value)
+        }),
+        bun_ast::binding::Data::BIdentifier(_) | bun_ast::binding::Data::BMissing(_) => false,
+    }
 }
 
 /// The property walk of `try_track_dynamic_import_destructure`, which does not

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1254,12 +1254,11 @@ impl<'a> Parser<'a> {
                 };
                 let escaped = {
                     let symbol = &p.symbols[ns_ref.inner_index() as usize];
-                    // `must_not_be_renamed` / `contains_direct_eval` cover
+                    // An inexact use count and `contains_direct_eval` cover
                     // direct `eval()` (or `with`) in scope, which can read the
-                    // namespace by name without a tracked property access. A
-                    // linked symbol was merged with another declaration (a
-                    // hoisted `var`, a parameter), so its own use count says
-                    // nothing.
+                    // namespace by name without a tracked property access, and
+                    // a symbol merged with another declaration (a hoisted
+                    // `var`, a parameter), at either end of the link.
                     let tracked = p.namespace_tracked_uses.get(&ns_ref).copied().unwrap_or(0);
                     // A source-visible local escapes when it has uses nobody
                     // accounted for; the synthetic per-`import()` ref (never
@@ -1268,8 +1267,7 @@ impl<'a> Parser<'a> {
                         symbol.use_count_estimate > tracked || tracked == u32::MAX
                     } else {
                         tracked == 0
-                    }) || symbol.must_not_be_renamed()
-                        || symbol.has_link()
+                    }) || !symbol.use_count_is_exact()
                         || scope.is_some_and(|s| s.contains_direct_eval)
                         || p.dynamic_import_escaped_records
                             .contains_key(&import_record_id)
@@ -1297,10 +1295,7 @@ impl<'a> Parser<'a> {
                     // declaration or a direct `eval` can read it by name.
                     if local.is_valid() {
                         let symbol = &p.symbols[local.inner_index() as usize];
-                        if symbol.use_count_estimate == 0
-                            && !symbol.has_link()
-                            && !symbol.must_not_be_renamed()
-                        {
+                        if symbol.use_count_estimate == 0 && symbol.use_count_is_exact() {
                             continue;
                         }
                     }
@@ -1314,20 +1309,20 @@ impl<'a> Parser<'a> {
                     // A read off `ns` (an item already), or a local a pattern
                     // binds. Assigning to either, or reaching the local through
                     // a hoisting merge or a direct `eval`, keeps the read as
-                    // written.
+                    // written. So does a record that needs the object: `ns` may
+                    // hold another namespace or none, and the read must see that.
                     let is_item = local.is_valid()
                         && !is_require_marker
                         && (p.is_import_item.contains_key(&local)
                             || p.dynamic_import_destructured_locals.contains_key(&local))
                         && !p.symbols[ns_ref.inner_index() as usize].has_been_assigned_to()
-                        && p.dynamic_import_namespace_locals
-                            .get(&ns_ref)
-                            .is_none_or(|records| records.len() == 1)
+                        && !p
+                            .dynamic_import_needs_object
+                            .contains_key(&import_record_id)
                         && {
                             let symbol = &p.symbols[local.inner_index() as usize];
                             !symbol.has_been_assigned_to()
-                                && !symbol.has_link()
-                                && !symbol.must_not_be_renamed()
+                                && symbol.use_count_is_exact()
                                 && !p.named_imports.contains(&local)
                         };
                     if is_item {

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1286,7 +1286,8 @@ impl Default for FnOrArrowDataParse {
 #[derive(Clone, Copy, Default)]
 pub struct FnOrArrowDataVisit {
     pub(crate) is_inside_loop: bool,
-    pub(crate) is_inside_switch: bool,
+    /// Inside a `switch`: the scope that the cases of the innermost one share.
+    pub(crate) switch_scope: Option<js_ast::StoreRef<js_ast::Scope>>,
     pub(crate) is_outside_fn_or_arrow: bool,
 
     /// This is used to silence unresolvable imports due to "require" calls inside

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -407,6 +407,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
 
+                let tracked_before = self.imports_to_convert_from_dynamic_import.len();
+
                 // `const|let|var <binding> = await import("str")` — record which
                 // exports of the importee are observed so the linker can drop
                 // the rest from its namespace. The statement is left as written.
@@ -446,7 +448,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             {
                                 self.note_tracked_namespace_use(namespace_ref);
                                 // Another `var` declaration is the same variable.
-                                if kind != LocalKind::KVar && !is_export {
+                                // A `{...rest}` copy lacks the names bound beside it.
+                                if kind != LocalKind::KVar
+                                    && !is_export
+                                    && !self
+                                        .dynamic_import_copied_locals
+                                        .contains_key(&namespace_ref)
+                                {
                                     self.note_destructured_locals(obj.properties());
                                 }
                             }
@@ -567,6 +575,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
                         _ => {}
                     }
+                }
+
+                // One of the blocks above tracked this declarator. A read of
+                // its locals that runs before it throws, so that read must
+                // not see an export.
+                if self.imports_to_convert_from_dynamic_import.len() != tracked_before
+                    && self.can_read_local_before_init(kind, decl.binding.loc)
+                {
+                    self.watch_early_reads(decl.binding);
                 }
 
                 if IS_POSSIBLY_DECL_TO_REMOVE {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1982,6 +1982,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let js_ast::binding::Data::BArray(pattern) = first.binding.data else {
                         break 'promise_all_then;
                     };
+                    // A default value of the parameter is not visited yet. It can
+                    // read a name that the pattern binds after it, and that throws.
+                    if crate::p::binding_default_can_read_names(first.binding) {
+                        break 'promise_all_then;
+                    }
                     p.track_promise_all_destructure(items, &pattern);
                 }
             }
@@ -2038,7 +2043,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             .is_some()
                             {
                                 p.note_tracked_namespace_use(im.namespace_ref);
-                                p.note_destructured_locals(obj.properties());
+                                // A default value of the parameter is not visited yet. It
+                                // can read a name that the pattern binds after it, and
+                                // that throws.
+                                if !crate::p::binding_default_can_read_names(first_param.binding) {
+                                    p.note_destructured_locals(obj.properties());
+                                }
                             }
                         }
                         js_ast::binding::Data::BIdentifier(id) => {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -909,7 +909,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
         let open_parens_loc = data.func.open_parens_loc;
         let this_expr_count_before = p.this_expr_count;
+        let watched_reads = p.watched_reads_in_scope();
         data.func = p.visit_func(core::mem::take(&mut data.func), open_parens_loc, false);
+        p.keep_locals_read_since(watched_reads);
         p.react_compiler_candidate_name = None;
 
         let name_ref = data.func.name.expect("infallible: name checked").ref_;
@@ -1288,7 +1290,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 data.label = None;
             }
         } else if !p.fn_or_arrow_data_visit.is_inside_loop
-            && !p.fn_or_arrow_data_visit.is_inside_switch
+            && p.fn_or_arrow_data_visit.switch_scope.is_none()
         {
             let r = js_lexer::range_of_identifier(p.source, stmt.loc);
             p.log()
@@ -2139,10 +2141,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         {
             p.push_scope_for_visit_pass(js_ast::scope::Kind::Block, data.body_loc)
                 .expect("unreachable");
-            let old_is_inside_switch = p.fn_or_arrow_data_visit.is_inside_switch;
-            p.fn_or_arrow_data_visit.is_inside_switch = true;
+            let old_switch_scope = p.fn_or_arrow_data_visit.switch_scope;
+            p.fn_or_arrow_data_visit.switch_scope = Some(p.current_scope);
             let cases = data.cases.slice_mut();
             for i in 0..cases.len() {
+                // The `switch` can jump here past what an earlier case declares.
+                let watched_reads = p.watched_reads_in_scope();
                 if let Some(val) = cases[i].value.as_mut() {
                     p.visit_expr(val);
                     // TODO: error messages
@@ -2153,8 +2157,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.visit_stmts(&mut _stmts, StmtsKind::SwitchStmt)
                     .expect("unreachable");
                 cases[i].body = list_to_stmts(_stmts);
+                p.keep_locals_read_since(watched_reads);
             }
-            p.fn_or_arrow_data_visit.is_inside_switch = old_is_inside_switch;
+            p.fn_or_arrow_data_visit.switch_scope = old_switch_scope;
 
             for i in 0..cases.len() {
                 if p.should_lower_using_declarations(cases[i].body.slice()) {

--- a/test/bundler/bundler_dynamic_import_dce.test.ts
+++ b/test/bundler/bundler_dynamic_import_dce.test.ts
@@ -4302,6 +4302,356 @@ describe("bundler", () => {
     run: { stdout: "0" },
   });
 
+  // ── Locals that stay locals ───────────────────────────────────────────
+
+  // A `var` in a nested scope that names a `.then` parameter is that
+  // parameter: the two share a value, and a read can go through either one.
+  itElides("ThenParamRedeclaredInNestedScope", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        const retry = globalThis.retry === true;
+        async function main() {
+          await import("./m.js").then(({ a }) => {
+            if (retry) {
+              var a = "fallback";
+            }
+            console.log(a);
+          });
+          await import("./m.js").then(ns => {
+            for (var ns of [{ a: "last" }]) {}
+            console.log(ns.a);
+          });
+          await import("./m.js").then(({ a }) => {
+            {
+              var a;
+              console.log("inner", a);
+            }
+          });
+          await import("./m.js").then(ns => {
+            {
+              var ns;
+              console.log(Object.keys(ns).join());
+            }
+          });
+          await Promise.all([import("./m.js"), import("./m.js")]).then(([{ a }, ns]) => {
+            if (!retry) {
+              var ns = { b: "local" };
+            }
+            console.log(a, ns.b);
+          });
+        }
+        main();
+      `,
+      "/m.js": `export const a = "A"; export const b = "B";`,
+    },
+    stdout: "A\nlast\ninner A\na,b\nA local",
+  });
+
+  // Every statement that holds a nested `var` merges it the same way. None
+  // of these assigns, so each read sees the value the pattern bound.
+  const nestedVarStatements = [
+    `{ var a; }`,
+    `if (no) { var a = 1; }`,
+    `for (var a; no; ) {}`,
+    `for (var a in {}) {}`,
+    `for (var a of []) {}`,
+    `try {} catch { var a = 1; }`,
+    `switch (0) { case 1: var a = 1; }`,
+    `skip: { if (!no) break skip; var a = 1; }`,
+    `while (no) { var a = 1; }`,
+    `do { if (no) { var a = 1; } } while (no);`,
+    `{ var { a } = { a }; }`,
+  ];
+  itElides("ThenParamRedeclaredByEachStatement", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        const no = globalThis.no === true;
+        async function main() {
+          ${nestedVarStatements
+            .map(statement => `await import("./m.js").then(({ a }) => { ${statement} console.log(a); });`)
+            .join("\n")}
+        }
+        main();
+      `,
+      "/m.js": `export const a = "A";`,
+    },
+    stdout: nestedVarStatements.map(() => "A").join("\n"),
+  });
+
+  // A `{...rest}` copy does not have the names that the pattern beside it
+  // took, so a pattern off the copy reads the copy.
+  itElides("RestCopyDestructured", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        async function main() {
+          const { a, ...rest } = require("./m.js");
+          const { a: x, b } = rest;
+          console.log(a, x, b);
+          const { a: a2, ...rest2 } = await import("./m.js");
+          const { b: b2, ...rest3 } = rest2;
+          const { a: y, b: z, c } = rest3;
+          console.log(a2, b2, y, z, c);
+          await import("./m.js").then(({ a, ...rest }) => {
+            const { a: x, b } = rest;
+            console.log(a, x, b);
+          });
+          const ns = await import("./m.js");
+          const { a: a3, ...rest4 } = ns;
+          const { a: w, b: b3 } = rest4;
+          console.log(a3, w, b3);
+        }
+        main();
+      `,
+      "/m.js": `export const a = "A", b = "B", c = "C"; export const d = "DROPPED";`,
+    },
+    stdout: "A undefined B\nA B undefined undefined C\nA undefined B\nA undefined B",
+  });
+
+  // `ns` may be null. The pattern then throws, and the importee did not load.
+  itElides("ConditionalLocalDestructured", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        function g(c) {
+          const ns = c ? require("./a.js") : null;
+          try {
+            const { x, late } = ns;
+            return "got " + x + " " + late;
+          } catch (e) {
+            return "threw " + e.constructor.name;
+          }
+        }
+        async function h(c) {
+          let ns = !c ? undefined : await import("./a.js");
+          try {
+            const { x } = ns;
+            return "got " + x;
+          } catch (e) {
+            return "threw " + e.constructor.name;
+          }
+        }
+        async function main() {
+          console.log(g(false));
+          console.log(g(true));
+          console.log(await h(false));
+          console.log(await h(true));
+        }
+        main();
+      `,
+      "/a.js": /* js */ `
+        console.log("a init");
+        export const x = "ax";
+        export const late = [1, 2].join("-");
+        export const d = "DROPPED";
+      `,
+    },
+    stdout: "threw TypeError\na init\ngot ax 1-2\nthrew TypeError\ngot ax",
+  });
+
+  // A function declared below the `const` runs before it when the code above
+  // calls it. The read in it throws.
+  itElides("ReadBeforeDeclaration", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        function early(get) {
+          try {
+            console.log("early:", get());
+          } catch (e) {
+            console.log("early threw", e.name, /before initialization/.test(e.message));
+          }
+        }
+        function destructured() {
+          early(get);
+          const { a } = require("./m.js");
+          console.log("late:", get());
+          function get() { return a; }
+        }
+        function namespace() {
+          early(get);
+          const ns = require("./m.js");
+          console.log("late:", get());
+          function get() { return ns.a; }
+        }
+        async function awaited() {
+          early(() => get().next().value);
+          let { a } = await import("./m.js");
+          console.log("late:", get().next().value);
+          function* get() { yield typeof a; }
+        }
+        async function awaitedNamespace() {
+          early(get);
+          const ns = await import("./m.js");
+          console.log("late:", get());
+          function get() { return ns.a; }
+        }
+        async function all() {
+          early(get);
+          const [ns] = await Promise.all([import("./m.js")]);
+          console.log("late:", get());
+          function get() { return ns.a; }
+        }
+        // The call goes through a var that is merged into the function.
+        function merged() {
+          {
+            var get;
+            early(get);
+          }
+          const { a } = require("./m.js");
+          console.log("late:", get());
+          function get() { return a; }
+        }
+        // The function that runs early reaches the read through another one.
+        function indirect() {
+          early(first);
+          const { a } = require("./m.js");
+          console.log("late:", first());
+          function first() { return second(); }
+          function second() { return a; }
+        }
+        async function main() {
+          destructured();
+          namespace();
+          await awaited();
+          await awaitedNamespace();
+          await all();
+          merged();
+          indirect();
+        }
+        main();
+      `,
+      "/m.js": `console.log("m init"); export const a = String("A"); export const d = "DROPPED";`,
+    },
+    stdout: [
+      "early threw ReferenceError true\nm init\nlate: A",
+      "early threw ReferenceError true\nlate: A",
+      "early threw ReferenceError true\nlate: string",
+      "early threw ReferenceError true\nlate: A",
+      "early threw ReferenceError true\nlate: A",
+      "early threw ReferenceError true\nlate: A",
+      "early threw ReferenceError true\nlate: A",
+    ].join("\n"),
+  });
+
+  // A later `case` shares the scope of the one that declares, and runs
+  // without it. The importee did not load. (Each local has two uses in its
+  // own case, so the minifier does not move its initializer into a use.)
+  itElides("ReadInLaterSwitchCase", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        function pick(k) {
+          switch (k) {
+            case 0:
+              const { a } = require("./m.js");
+              return a + a.length;
+            case 1:
+              return a;
+          }
+        }
+        function pickNamespace(k) {
+          switch (k) {
+            case 0:
+              const ns = require("./m.js");
+              return ns.a + ns.a.length;
+            default:
+              return ns.a;
+          }
+        }
+        function pickInTest(k) {
+          switch (k) {
+            case 0:
+              const { a } = require("./m.js");
+              return a + a.length;
+            case a:
+              return "matched";
+          }
+        }
+        for (const f of [pick, pickNamespace, pickInTest]) {
+          try {
+            console.log(f(1));
+          } catch (e) {
+            console.log("threw", e.name, /before initialization/.test(e.message));
+          }
+          console.log(f(0));
+        }
+      `,
+      "/m.js": `console.log("m init"); export const a = "A"; export const d = "DROPPED";`,
+    },
+    stdout: "threw ReferenceError true\nm init\nA1\nthrew ReferenceError true\nA1\nthrew ReferenceError true\nA1",
+  });
+
+  // A default value of a `.then` parameter can read a name that the pattern
+  // binds after it. That read throws.
+  itElides("ThenParamDefaultReadsLaterName", {
+    keepsNamespace: true,
+    files: {
+      "/entry.js": /* js */ `
+        const report = e => console.log("threw", e.name, /before initialization/.test(e.message));
+        async function main() {
+          await import("./m.js").then(({ b = a, a }) => console.log(a, b)).catch(report);
+          await import("./m.js").then(({ b: { x } = a, a }) => console.log(a, x)).catch(report);
+          await import("./m.js").then(({ c: { x = a }, a }) => console.log(a, x)).catch(report);
+          await Promise.all([undefined, import("./m.js")]).then(([x = ns.a, ns]) => console.log(x, ns.a)).catch(report);
+          await Promise.all([{}, import("./m.js")]).then(([{ x = ns.a }, ns]) => console.log(x, ns.a)).catch(report);
+          await import("./m.js").then(({ a, b = a }) => console.log(a, b)).catch(report);
+        }
+        main();
+      `,
+      "/m.js": `export const a = "A"; export const c = {};`,
+    },
+    stdout: [
+      "threw ReferenceError true",
+      "threw ReferenceError true",
+      "threw ReferenceError true",
+      "threw ReferenceError true",
+      "threw ReferenceError true",
+      "A A",
+    ].join("\n"),
+  });
+
+  // Only a read that can run early keeps its local. A function declared below
+  // the `const` that nothing above refers to runs after it. One that the code
+  // above refers to, or a later `case`, matters only if it reads the local.
+  // A top-level `const` prints as `var`, so no read of it throws.
+  itElides("LocalWithoutEarlyRead", {
+    files: {
+      "/entry.js": /* js */ `
+        keep(top);
+        const { b } = require("./x.js");
+        function top() { return b; }
+        function keep(f) { globalThis.kept = f; }
+        async function unreferenced() {
+          const { a } = await import("./x.js");
+          const ns = require("./x.js");
+          function get() { return a + ns.b; }
+          console.log(get(), kept());
+        }
+        async function unrelated(k) {
+          log("start");
+          const { a } = await import("./x.js");
+          const ns = require("./x.js");
+          console.log(a, ns.b);
+          function log(s) { console.log(s); }
+          switch (k) {
+            case 0:
+              const { b } = require("./x.js");
+              const other = require("./x.js");
+              return b + other.a + other.a.length;
+            default:
+              return "none";
+          }
+        }
+        unreferenced().then(() => unrelated(0)).then(console.log);
+      `,
+      "/x.js": `export const a = "a", b = "b"; export const d = "DROPPED";`,
+    },
+    stdout: "ab b\nstart\na b\nba1",
+  });
+
   // ── Cases that keep the namespace object ──────────────────────────────
 
   function itKeepsNamespace(


### PR DESCRIPTION
### Problem
- Since #41186, `bun build` binds a local from `import()` / `require()` to the export in four shapes that need the local (1.4.0 is correct). Example: `const { a, ...rest } = require("./m"); const { a: x } = rest;` gives `x` the value of `a`.
- Shapes: a nested `var` that names a `.then` parameter, a pattern off a `{...rest}` copy or off `c ? require(x) : null`, a read that runs before the declaration.
- `is_item` (`src/js_parser/parse/parse_entry.rs:1318`) and `note_destructured_locals` (`src/js_parser/p.rs:1191`) check only the local's own symbol and reads above the declaration.

### Fix
- The parser flags a symbol that another symbol links to (`IS_LINK_TARGET`). `parse_entry` then checks both ends of a link.
- A pattern off a `{...rest}` copy makes no import items. `is_item` rejects a record in `dynamic_import_needs_object` (a conditional local).
- If code below a `const` / `let` can run first (a function declared below it that earlier code refers to, a later `case`), a read there keeps the local. Top-level declarations print as `var` and are exempt.
- Verified: `test/bundler/bundler_dynamic_import_dce.test.ts` (8 new cases, 28 of 32 variants fail on 1.4.3), 13 more suites. Self-reviewed: 3 changes asked, 3 made.

### Background
- An import item is a symbol that the linker binds to another module's export. The printer prints the export and drops the local from its pattern.
- A nested `var` that names a parameter is the same variable. `hoist_symbols` links its symbol to the parameter's, which gets no link itself.
- `dynamic_import_needs_object` holds the import records whose local can hold no namespace.

<details><summary>Notes</summary>

No user reported these. A comparison of bundled output with unbundled runs found them. 1.4.1 and 1.4.2 have them. "1.4.3" below is 1.4.3-canary.1+4ff919377.

**Repro.** `bun build ./entry.js --target=bun --outdir out && bun out/entry.js`, compared with `bun run entry.js`. It also reproduces with `--minify`, `--format=cjs`, `--target=node` and `--target=browser`.

| shape | unbundled | 1.4.3 bundle |
|---|---|---|
| `import("./m.js").then(({ a }) => { if (retry) { var a = "fallback"; } console.log(a); })` | `A` | `undefined` |
| `import("./m.js").then(ns => { for (var ns of [{ a: "last" }]) {} console.log(ns.a); })` | `last` | `A` |
| `const { a, ...rest } = require("./m.js"); const { a: x, b } = rest; console.log(a, x, b);` | `A undefined B` | `A A B` |
| `const ns = c ? require("./a.js") : null; try { const { x } = ns; … } catch …` with `c` false | `threw TypeError` | `got ax`, from a module that did not load |
| `get()` above `const { a } = require("./m.js")`, with `function get() { return a; }` below it | `ReferenceError` | `undefined` |
| `switch (k) { case 0: const { a } = require("./m.js"); return a; case 1: return a; }` with `k = 1` | `ReferenceError` | `A`, and `m.js` never runs |

**Variant matrix.** 72 variants of the four shapes: each statement that can hold a nested `var`, the `await import()` / `require()` / `.then` / `Promise.all` sources, `let`, a generator, `typeof`, nested and reversed ternaries, a rest of a rest, a `case` test, a function declared in a `case`. Each one was built with `--target=bun`, `--minify`, `--format=cjs`, `--target=node`, `--target=browser` and `--minify-syntax`, and compared with the unbundled run. On 1.4.3, 211 of the first 383 builds differ. On this branch none of 423 differ (5 differ only in how `console.log` prints a namespace object).

**The read-before-declaration rule.** `note_destructured_locals` already keeps a local that has a read above its declaration, "since that read must not see the export". Code below the declaration can also run first. There are two ways:
- A function declaration below it in the same scope, which the scope creates at entry. It can only run early if some code above the declaration refers to a function declared below it. `can_read_local_before_init` checks that: a member of the current scope that is a function, is declared after the local, and has a use (or an inexact use count, for `{ var get; get(); }` merged into `function get`).
- A later `case` of the same `switch`, or its test. All cases share one scope, and the `switch` can jump past the declaration. A declaration inside `case 0: { … }` is not affected.

When one of the two holds, `watch_early_reads` records the locals that the declaration binds. `s_function` and `s_switch` take `watched_reads_in_scope()` before each function declared in that scope and before each `case`, and call `keep_locals_read_since()` after it. A destructured local with a new use leaves `dynamic_import_destructured_locals`. A namespace local with a new `ns.a` item read gets its records into `dynamic_import_needs_object`, so its items print `ns.a`, the same as for `c ? require(x) : null`. The rule does not follow calls: once some function declared below is referred to early, a read in any function declared below counts.

**What the rule costs.** It changes output only when code that can run early reads the local. These layouts keep the #41186 output (zod 4, `const { z } = await import("zod")`, bytes unminified / minified):

| layout | main | this branch |
|---|---|---|
| no helper | 140,354 / 69,339 | same |
| `log("start")` above, `function log` below, `log` does not read `z` | 140,420 / 69,380 | same |
| the same with `const zod = await import("zod")` and `zod.z` | 140,420 / 69,386 | same |
| `const { z }` in an unbraced `case`, `default:` does not read `z` | 140,457 / 69,399 | same |
| `process.on("exit", report)` above, `function report` below reads `z` | 140,448 / 69,397 | 757,285 / 461,122 |

The last row is the cost. There `report` can run before the `await` finishes. That read throws in the source, and main reads the export of a module that is still loading. A top-level declaration is exempt, because `select_local_kind` prints it as `var`: 1.4.0 already returned `undefined` for an early read there, also with a CommonJS importee that never binds. So `module.exports = fn` above a top-level `require()` keeps the #41186 output. The scan reads the members of one scope, only for a declarator that `import()` / `require()` tracking matched.

**Not covered: `--minify-syntax` in a `switch` case.** With `--minify-syntax` (also `bun run`), `case 0: const ns = require("./m.js"); return ns.a; case 1: return ns.a;` still loses the declaration. Single-use substitution runs when one `case` body ends, before the other cases are visited, and moves the initializer into `return`. `case 1` then reads a free `ns`. That is older than #41186 and is tracked in #18477, with #30936 and #40791 open for it. `ReadInLaterSwitchCase` gives each local two uses in its own `case`, so the substitution does not apply, and it checks for `before initialization` in the message.

**`IS_LINK_TARGET`.** #41158 (open) adds a flag with the same meaning on another bit. This one has the same name and is set at the same three places (`hoist_symbols` twice, `declare_symbol` on `ReplaceWithNew`), so that PR can reuse it. Only the first place changes what this PR's tests see. The other two keep the name true.

**`is_item` and `records.len() == 1`.** `register_dynamic_import_namespace_local_multi` puts every record of a local with more than one record into `dynamic_import_needs_object`. The new check covers that case, so it replaces the old one.

**`switch_scope` replaces `is_inside_switch`.** Both would be set and restored together, so the `break` check now reads `switch_scope.is_none()`.

**`.then` parameter defaults.** `.then(({ b = a, a }) => …)` reads `a` before the pattern binds it. The tracking runs before the parameter is visited, so `a` had no use yet and was bound. Now a default value that is not a primitive literal stops the pattern's names from being items (`binding_default_can_read_names`). `Promise.all([…]).then(([x = ns.a, ns]) => …)` is not tracked at all.

**Self-review.** Asked before merge: do not claim the `switch` shape closed under `--minify-syntax` and make the test say why it throws (done, above). State the cost on correct code (an earlier version of this branch kept every local of a declaration once any function below it was referred to early. That cost zod 140 KB to 757 KB in the `log("start")` layout. The watch replaced it, and the table above is the cost now). Name the flag for its invariant and fold the three `has_link()` checks (done). Follow-ups done here: the `.then` default value, the merged `var get`. Not done: one shared predicate for every "can this namespace local bind" check, and a checked-in matrix with a Node oracle.

**Each clause is needed.** I removed each of the 23 conditions that the fix adds, one at a time, rebuilt, and ran the new tests. Each removal makes at least one new test fail.

**No change on real packages.** I bundled rollup, express, fastify, hono, axios, mongodb, pg, lodash, acorn, react-dom, svelte, undici, happy-dom, immutable and the corpus of `bundler_bytecode_portable.test.ts` with main and with this branch (46 outputs, 39 MB, minified and not). The outputs are byte-identical.

**Not changed.** A sloppy-mode `{ function a() {} }` that names a parameter is merged into the parameter, as in esbuild. The flag makes such a parameter stay a local too.

**Suites run with the debug build:** `bundler_dynamic_import_dce` (306 pass), `bundler_promiseall_deadcode`, `bundler_minify`, `bundler_cjs2esm`, `bundler_edgecase`, `bundler_barrel`, `bundler_splitting`, `esbuild/dce`, `esbuild/importstar`, `esbuild/splitting`, `esbuild/default`, `transpiler/transpiler`, `transpiler/react-compiler`, `regression/issue/cyclic-imports-async-bundler`. `bundler_bytecode_portable` times out on my machine in a debug build (its `bun build --bytecode` steps take longer than the test allows). Its bundler inputs are part of the byte-identical comparison above.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 28 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_dynamic_import_dce.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [1460.71ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [653.99ms]
(pass) bundler > dynamic_import_dce/AwaitDot [828.32ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [667.28ms]
(pass) bundler > dynamic_import_dce/LetBinding [656.12ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [706.23ms]
(pass) bundler > dynamic_import_dce/BailoutRest [757.13ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [1050.46ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [1056.61ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [771.77ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [1450.98ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [649.43ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [654.54ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [890.77ms]
(pass) bundler > d
... (truncated)

release without fix: 28 FAILED
bun test v1.4.3-canary.1 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [170.73ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [38.83ms]
(pass) bundler > dynamic_import_dce/AwaitDot [27.97ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [43.29ms]
(pass) bundler > dynamic_import_dce/LetBinding [24.80ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [24.29ms]
(pass) bundler > dynamic_import_dce/BailoutRest [26.16ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [41.73ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [18.82ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [24.03ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [35.37ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [97.31ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [21.13ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [21.16ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllDestructure [23.71ms]
(pass) bundler > dynamic_import_dce/SplittingPromiseAllThenDestructure [21.87ms]
(pass) bundler > dynamic_import_dce/SplittingPro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_dynamic_import_dce.test.ts
bun test v1.4.3 (4ff919377)

test/bundler/bundler_dynamic_import_dce.test.ts:
(pass) bundler > dynamic_import_dce/AwaitDestructure [1713.31ms]
(pass) bundler > dynamic_import_dce/AwaitDestructureAlias [830.07ms]
(pass) bundler > dynamic_import_dce/AwaitDot [765.57ms]
(pass) bundler > dynamic_import_dce/AwaitIndex [514.92ms]
(pass) bundler > dynamic_import_dce/LetBinding [619.80ms]
(pass) bundler > dynamic_import_dce/TwoSitesUnion [595.37ms]
(pass) bundler > dynamic_import_dce/BailoutRest [814.22ms]
(pass) bundler > dynamic_import_dce/BailoutDefault [651.17ms]
(pass) bundler > dynamic_import_dce/BailoutComputed [757.54ms]
(pass) bundler > dynamic_import_dce/SplittingNarrowedExports [684.32ms]
(pass) bundler > dynamic_import_dce/SplittingTwoImportersUnion [1199.03ms]
(pass) bundler > dynamic_import_dce/SplittingEscapeKeepsAll [611.99ms]
(pass) bundler > dynamic_import_dce/SplittingAwaitDot [742.69ms]
(pass) bundler > dynamic_import_dce/SplittingThenDestructure [746.07ms]
(pass) bundler > dyn
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     48362b59da
  features     baseline

23 deps, 131 codegen, 1172 objects in 1161ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (4ff919377)

Checked 22 installs across 61 packages (no changes) [75.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (4ff919377)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (4ff919377)

Checked 111 installs across 104 packages (no changes) [11.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] fetch tinycc
[tinycc] up to date
[6/1243] gen bindgenv2
[7/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 69ms

  react-refresh.js  4.81 KB  (entry point)

[8/1243] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 80ms
[9/1243] fetch libjpeg-turbo
[libjpeg-turbo]
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/symbol.rs                               |  14 +
 src/js_parser/p.rs                              | 136 ++++++++-
 src/js_parser/parse/parse_entry.rs              |  29 +-
 src/js_parser/parser.rs                         |   3 +-
 src/js_parser/visit/mod.rs                      |  19 +-
 src/js_parser/visit/visit_expr.rs               |  12 +-
 src/js_parser/visit/visit_stmt.rs               |  13 +-
 test/bundler/bundler_dynamic_import_dce.test.ts | 350 ++++++++++++++++++++++++
 8 files changed, 551 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/ast/symbol.rs                                    2      3     26
src/js_parser/p.rs                                   9      9     26
src/js_parser/parse/parse_entry.rs                   3      5     26
src/js_parser/parser.rs                              1      2     26
src/js_parser/visit/mod.rs                           5     10     26
src/js_parser/visit/visit_expr.rs                    3      1     26
src/js_parser/visit/visit_stmt.rs                    4      7     26
test/bundler/bundler_dynamic_import_dce.test.ts      4      4     26
```

</details>

<!-- robobun:evidence:end -->