### PR TITLE
test: make script-leak.test.ts detect a retained vm.Script and pass on debug builds

### DIFF
--- a/test/js/node/vm/script-leak.test.ts
+++ b/test/js/node/vm/script-leak.test.ts
@@ -1,30 +1,50 @@
-const vm = require("vm");
-const { describe, it, expect } = require("bun:test");
-const { isASAN, rss } = require("harness");
+import { heapStats } from "bun:jsc";
+import { describe, expect, it } from "bun:test";
+import { isASAN, isDebug, rss } from "harness";
+import vm from "node:vm";
+
+// Each script carries ~50 KB of source. A full GC after every batch bounds the
+// garbage that can pile up, so a release build reads ~90 MB when nothing leaks
+// and ~430 MB when all 8000 scripts are retained. Without the batch GC, RSS is
+// the allocator's high-water mark over the whole loop in both cases.
+//
+// RSS cannot judge the other builds. A debug build compiles each script ~50x
+// slower, so its loop is short. ASAN's quarantine keeps up to 256 MB of freed
+// memory resident. The object count does not depend on RSS and covers them.
+const ITERATIONS = isDebug ? 100 : isASAN ? 1_000 : 8_000;
+const BATCH = isDebug ? 50 : 500;
+const RSS_LIMIT_MB = 256;
 
 describe("vm.Script", () => {
   it("shouldn't leak memory", () => {
+    Bun.gc(true);
+    const initialCount = heapStats().objectTypeCounts.Script ?? 0;
     const initialUsage = rss();
 
     {
-      const source = `/*\n${Buffer.alloc(10000, " * aaaaa\n").toString("utf8")}\n*/ Buffer.alloc(10, 'hello');`;
+      const source = `/*\n${Buffer.alloc(50_000, " * aaaaa\n").toString("utf8")}\n*/ Buffer.alloc(10, 'hello').toString();`;
 
+      let result;
       function go(i) {
         const script = new vm.Script(source + "//" + i);
-        script.runInThisContext();
+        result = script.runInThisContext();
       }
 
-      for (let i = 0; i < 10000; ++i) {
+      for (let i = 0; i < ITERATIONS; ++i) {
         go(i);
+        if ((i + 1) % BATCH === 0) Bun.gc(true);
       }
+
+      expect(result).toBe("hellohello");
     }
 
     Bun.gc(true);
 
     const finalUsage = rss();
+    const finalCount = heapStats().objectTypeCounts.Script ?? 0;
     const megabytes = Math.round(((finalUsage - initialUsage) / 1024 / 1024) * 100) / 100;
-    // ASAN's quarantine retains freed allocations (default 256 MB) so RSS
-    // deltas run far higher under bun-asan; widen the threshold there.
-    expect(megabytes).toBeLessThan(isASAN ? 700 : 200);
+
+    expect(finalCount).toBeLessThanOrEqual(initialCount + 10);
+    if (!isDebug && !isASAN) expect(megabytes).toBeLessThan(RSS_LIMIT_MB);
   });
 });


### PR DESCRIPTION
### Problem
- `bun bd test test/js/node/vm/script-leak.test.ts` always fails: `(fail) vm.Script > shouldn't leak memory [27888.03ms] ^ this test timed out after 5000ms`. A debug ASAN build needs 28 s for the 10,000 scripts.
- The RSS bound cannot detect a leak. Release RSS grows 119 to 124 MB with all 10,000 scripts retained and 85 to 121 MB with none. The bound is 200 MB. The loop forces no GC, so both cases read the allocator's high-water mark.

### Fix
- Run a full GC after every 500 scripts and use a 50 KB source. On release, 8,000 scripts read 86 to 92 MB with no leak and 425 to 431 MB when all are retained. The bound is 256 MB.
- Assert the `Script` object count from `heapStats()` on every build. Debug builds run 100 scripts and ASAN builds 1,000. RSS cannot judge them, so they skip that bound.
- Keep the default timeout: `REVIEW.md` says to shrink the workload.
- Verified: `bun bd test` on this file passes in 1.2 to 2.3 s, `USE_SYSTEM_BUN=1 bun test` in 1.1 to 1.5 s. A copy that retains every script fails on both.

### Background
- Each `vm.Script` is one `NodeVMScript` cell with the class name `Script`. `heapStats().objectTypeCounts` counts live cells per class name.
- ASAN keeps up to 256 MB of freed allocations resident (its quarantine), so RSS there hides a leak of this size.
- `bun bd` (debug, ASAN) uses the default 5 s timeout. CI passes 90 s, or 270 s on ASAN, and never timed out.

<details><summary>Notes</summary>

Found while working on an unrelated change: `bun bd test test/js/node/vm/` fails locally for everyone because of this file. The same report named the second test in `test/js/bun/resolve/load-same-js-file-a-lot.test.ts`. #36929 already covers that file, so this PR does not touch it. #41606 gives `sourcetextmodule-leak.test.ts` the same shape.

Where the debug time goes (`bun bd`, linux x64): about 2.2 ms fixed cost for each `new vm.Script` plus `runInThisContext`, and about 40 ms for each MB of source. At 10 KB a script, the fixed cost is most of the 28 s. That is why the debug loop has few scripts.

Old test, release bun 1.4.3, RSS delta through `bun test`:

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| nothing retained | 121 MB | 84.59 MB | 121 MB |
| all 10,000 scripts pushed to an array | 118.72 MB | 124 MB | 124 MB |

All six runs pass the 200 MB bound.

New test:

| build | scripts | nothing retained | every script retained |
| --- | --- | --- | --- |
| release | 8,000 | 86 to 92 MB, count 2 | 425 to 431 MB, count 8002. Fails `Expected: <= 12 Received: 8002`. With the count assertion removed it fails `Expected: < 256 Received: 425.52` |
| debug ASAN (`bun bd`) | 100 | 6 MB, count 2 | 11 MB, count 102. Fails `Expected: <= 12 Received: 102` |
| ASAN parameters (1,000 scripts) on the debug ASAN build | 1,000 | 46 MB, count 2 | 62 MB, count 1002 |

The count before the loop is 2: the `Script` prototype and constructor share the class name. The bound is that count plus 10.

Part of the 90 MB floor is on purpose. JSC's code cache keeps recent sources alive (`workingSetMaxBytes` is 16 MB and `workingSetMaxEntries` is 2000 in `CodeCache.h`), and a GC does not clear it.

The release ASAN lane cannot use RSS at this size. Everything the loop frees stays resident until the quarantine holds 256 MB, so the no-leak run and the leak run read close to each other. That lane still has the object count, ASAN itself on 1,000 create, run and collect cycles, and LeakSanitizer at exit (this file is not in `test/no-validate-leaksan.txt`).

The count assertion is inline and synchronous. Nothing releases a script asynchronously, so there is nothing to poll for. On a debug build the 1 s poll in `expectMaxObjectTypeCount` turned the leak failure into a 5 s timeout.

The file now uses `import` like `vm-script-fetcher-leak.test.ts` next to it (`test/CLAUDE.md` asks for module-scope imports).

CI cost: the file took about 0.3 s on release lanes and 1.9 s on the ASAN lane (`test/expected-durations.json`). It now takes about 1.1 s on a release build here.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/vm/script-leak.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/vm/script-leak.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/vm/script-leak.test.ts:
(pass) vm.Script > shouldn't leak memory [1208.33ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [4.00s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/vm/script-leak.test.ts | 38 ++++++++++++++++++++++++++++---------
 1 file changed, 29 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
test/js/node/vm/script-leak.test.ts      1      4     23
```

</details>

<!-- robobun:evidence:end -->