### PR TITLE
react-compiler: keep a state hook in ssr output while its setter is reachable

### DIFF
--- a/src/react_compiler/DESIGN.md
+++ b/src/react_compiler/DESIGN.md
@@ -66,6 +66,14 @@ Keep the diff between upstream and the port as small as the type substitution
 allows — the `/sync-react-compiler` skill re-ports upstream changes hunk by
 hunk, so gratuitous restructuring makes that harder.
 
+### Intentional differences from upstream
+
+A re-sync must keep these. Each one has a test that fails without it.
+
+| File                               | Difference                                                                                                                                                                                                                                                                                                                                                                                           |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `optimization/optimize_for_ssr.rs` | Upstream inlines every `useState`/`useReducer` and replaces every function that calls a setter with `undefined`. The output then reads setters that have no declaration and calls `undefined`. The port inlines a hook only when dead code elimination keeps no read of the other destructured items, and never replaces a function. Test: `react-compiler/SsrKeepsStateHookWhileSetterIsReachable`. |
+
 ### Type mapping (input: lowering)
 
 | upstream `react_compiler_ast`                                            | `bun_ast`                                                                      |

--- a/src/react_compiler/hir/mod.rs
+++ b/src/react_compiler/hir/mod.rs
@@ -1820,11 +1820,6 @@ pub fn is_plain_object_type(ty: &Type) -> bool {
     matches!(ty, Type::Object { shape_id: Some(id) } if *id == object_shape::BUILT_IN_OBJECT_ID)
 }
 
-/// Returns true if the type is a startTransition function (BuiltInStartTransition).
-pub fn is_start_transition_type(ty: &Type) -> bool {
-    matches!(ty, Type::Function { shape_id: Some(id), .. } if *id == object_shape::BUILT_IN_START_TRANSITION_ID)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/react_compiler/optimization/dead_code_elimination.rs
+++ b/src/react_compiler/optimization/dead_code_elimination.rs
@@ -67,7 +67,7 @@ pub(crate) fn dead_code_elimination(func: &mut HirFunction, env: &Environment) {
 }
 
 /// State for tracking referenced identifiers during mark phase.
-struct State {
+pub(super) struct State {
     /// SSA-specific usages (by IdentifierId)
     identifiers: HashSet<IdentifierId>,
     /// Named variable usages (any version)
@@ -102,7 +102,7 @@ fn reference(
 
 /// Check if any version of the given identifier is used somewhere.
 /// Checks both the specific SSA id and (for named identifiers) any usage of that name.
-fn is_id_or_name_used(
+pub(super) fn is_id_or_name_used(
     state: &State,
     identifiers: &[crate::hir::Identifier],
     identifier_id: IdentifierId,
@@ -151,7 +151,7 @@ fn reference_reassigned_variables(
 }
 
 /// Phase 1: Find all referenced identifiers via fixed-point iteration.
-fn find_referenced_identifiers(func: &HirFunction, env: &Environment) -> State {
+pub(super) fn find_referenced_identifiers(func: &HirFunction, env: &Environment) -> State {
     let has_loop = has_back_edge(func);
     // Collect block ids in reverse order (postorder - successors before predecessors)
     let reversed_block_ids: Vec<BlockId> = func.body.blocks.keys().rev().copied().collect();

--- a/src/react_compiler/optimization/optimize_for_ssr.rs
+++ b/src/react_compiler/optimization/optimize_for_ssr.rs
@@ -5,30 +5,30 @@
 
 //! Optimizes the code for running in an SSR environment.
 //!
-//! Assumes that setState will not be called during render during initial mount,
-//! which allows inlining useState/useReducer.
+//! Assumes a single render: effects and the event handlers of builtin JSX tags never run.
 //!
 //! Optimizations:
-//! - Inline useState/useReducer
+//! - Inline useState/useReducer when nothing that is kept reads the setter or dispatch function
 //! - Remove effects (useEffect, useLayoutEffect, useInsertionEffect)
-//! - Remove event handlers (functions that call setState or startTransition)
 //! - Remove known event handler props and ref props from builtin JSX tags
 //! - Inline useEffectEvent to its argument
 //!
 //! Ported from TypeScript `src/Optimization/OptimizeForSSR.ts`.
+//! Unlike upstream, a function that calls setState is never replaced with `undefined`.
 
 use std::collections::HashMap;
 
+use super::dead_code_elimination::{find_referenced_identifiers, is_id_or_name_used};
 use crate::hir::environment::Environment;
 use crate::hir::object_shape::HookKind;
 use crate::hir::visitors::{each_instruction_value_operand, each_terminal_operand};
 use crate::hir::{
     ArrayPatternElement, HirFunction, IdentifierId, InstructionValue, PlaceOrSpread,
-    PrimitiveValue, hir_vec, is_set_state_type, is_start_transition_type,
+    PrimitiveValue, hir_vec,
 };
 
 /// Optimizes a function for SSR by inlining state hooks, removing effects,
-/// removing event handlers, and stripping known event handler / ref JSX props.
+/// and stripping known event handler / ref JSX props.
 ///
 /// Corresponds to TS `optimizeForSSR(fn: HIRFunction): void`.
 pub(crate) fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
@@ -157,30 +157,15 @@ pub(crate) fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
         }
     }
 
-    // Phase 2: Apply transformations
+    // Phase 2: Remove what a server render never runs
     //
-    // - Replace FunctionExpression with Primitive(undefined) if it calls setState/startTransition
     // - Remove known event handler props and ref props from builtin JSX tags
-    // - Replace Destructure of inlined state with StoreLocal
     // - Replace useEffectEvent(fn) with LoadLocal(fn)
     // - Replace useEffect/useLayoutEffect/useInsertionEffect with Primitive(undefined)
-    // - Replace useState/useReducer with their inlined replacement
     for (_block_id, block) in &func.body.blocks {
         for &instr_id in &block.instructions {
             let instr = &mut func.instructions[instr_id.0 as usize];
             match &instr.value {
-                InstructionValue::FunctionExpression {
-                    lowered_func, loc, ..
-                } => {
-                    let inner_func = &env.functions[lowered_func.func.0 as usize];
-                    if has_known_non_render_call(inner_func, env) {
-                        let loc = *loc;
-                        instr.value = InstructionValue::Primitive {
-                            value: PrimitiveValue::Undefined,
-                            loc,
-                        };
-                    }
-                }
                 InstructionValue::JsxExpression { tag, .. } => {
                     if let crate::hir::JsxTag::Builtin(builtin) = tag {
                         // Only optimize non-custom-element builtin tags
@@ -195,30 +180,6 @@ pub(crate) fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                         !is_known_event_handler(&tag_name, name) && *name != b"ref"
                                     }
                                 });
-                            }
-                        }
-                    }
-                }
-                InstructionValue::Destructure { value, lvalue, loc } => {
-                    let value_id = env.identifiers[value.identifier.0 as usize].id;
-                    if inlined_state.contains_key(&value_id) {
-                        // Invariant: destructuring pattern must be ArrayPattern with at least one Identifier item
-                        if let crate::hir::Pattern::Array(arr) = &lvalue.pattern {
-                            if !arr.items.is_empty() {
-                                if let ArrayPatternElement::Place(first_place) = &arr.items[0] {
-                                    let loc = *loc;
-                                    let kind = lvalue.kind;
-                                    let store = InstructionValue::StoreLocal {
-                                        lvalue: crate::hir::LValue {
-                                            place: first_place.clone(),
-                                            kind,
-                                        },
-                                        value: value.clone(),
-                                        type_annotation: None,
-                                        loc,
-                                    };
-                                    instr.value = store;
-                                }
                             }
                         }
                     }
@@ -260,6 +221,85 @@ pub(crate) fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                 loc,
                             };
                         }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if inlined_state.is_empty() {
+        return;
+    }
+
+    // Phase 3: Inlining drops the setter's declaration, so keep a hook if DCE keeps a read of it
+    let referenced = find_referenced_identifiers(func, env);
+    // DCE prunes a hook call with an unread result, but not the `init(arg)` call that would replace it
+    inlined_state.retain(|id, _| is_id_or_name_used(&referenced, &env.identifiers, *id));
+    for (_block_id, block) in &func.body.blocks {
+        for &instr_id in &block.instructions {
+            let instr = &func.instructions[instr_id.0 as usize];
+            if let InstructionValue::Destructure { value, lvalue, .. } = &instr.value {
+                let value_id = env.identifiers[value.identifier.0 as usize].id;
+                if !inlined_state.contains_key(&value_id) {
+                    continue;
+                }
+                let crate::hir::Pattern::Array(arr) = &lvalue.pattern else {
+                    continue;
+                };
+                let is_rest_used = arr.items.iter().skip(1).any(|item| match item {
+                    ArrayPatternElement::Place(place) => {
+                        is_id_or_name_used(&referenced, &env.identifiers, place.identifier)
+                    }
+                    ArrayPatternElement::Spread(spread) => {
+                        is_id_or_name_used(&referenced, &env.identifiers, spread.place.identifier)
+                    }
+                    ArrayPatternElement::Hole => false,
+                });
+                if is_rest_used {
+                    inlined_state.remove(&value_id);
+                }
+            }
+        }
+    }
+
+    // Phase 4: Inline the hooks that are left
+    for (_block_id, block) in &func.body.blocks {
+        for &instr_id in &block.instructions {
+            let instr = &mut func.instructions[instr_id.0 as usize];
+            match &instr.value {
+                InstructionValue::Destructure { value, lvalue, loc } => {
+                    let value_id = env.identifiers[value.identifier.0 as usize].id;
+                    if inlined_state.contains_key(&value_id) {
+                        // Invariant: destructuring pattern must be ArrayPattern with at least one Identifier item
+                        if let crate::hir::Pattern::Array(arr) = &lvalue.pattern {
+                            if !arr.items.is_empty() {
+                                if let ArrayPatternElement::Place(first_place) = &arr.items[0] {
+                                    let loc = *loc;
+                                    let kind = lvalue.kind;
+                                    let store = InstructionValue::StoreLocal {
+                                        lvalue: crate::hir::LValue {
+                                            place: first_place.clone(),
+                                            kind,
+                                        },
+                                        value: value.clone(),
+                                        type_annotation: None,
+                                        loc,
+                                    };
+                                    instr.value = store;
+                                }
+                            }
+                        }
+                    }
+                }
+                InstructionValue::MethodCall { property, .. }
+                | InstructionValue::CallExpression {
+                    callee: property, ..
+                } => {
+                    let callee_id = property.identifier;
+                    let hook_kind = get_hook_kind(env, callee_id);
+                    match hook_kind {
                         Some(HookKind::UseReducer | HookKind::UseState) => {
                             let lvalue_id = env.identifiers[instr.lvalue.identifier.0 as usize].id;
                             if let Some(replacement) = inlined_state.get(&lvalue_id) {
@@ -305,27 +345,6 @@ enum InlinedStateReplacement {
         arg: crate::hir::Place,
         loc: Option<crate::hir::SourceLocation>,
     },
-}
-
-/// Returns true if the function body contains a call to setState or startTransition.
-/// This identifies functions that are event handlers and can be replaced with undefined
-/// during SSR.
-///
-/// Corresponds to TS `hasKnownNonRenderCall(fn: HIRFunction): boolean`.
-fn has_known_non_render_call(func: &HirFunction, env: &Environment) -> bool {
-    for (_block_id, block) in &func.body.blocks {
-        for &instr_id in &block.instructions {
-            let instr = &func.instructions[instr_id.0 as usize];
-            if let InstructionValue::CallExpression { callee, .. } = &instr.value {
-                let callee_type =
-                    &env.types[env.identifiers[callee.identifier.0 as usize].type_.0 as usize];
-                if is_set_state_type(callee_type) || is_start_transition_type(callee_type) {
-                    return true;
-                }
-            }
-        }
-    }
-    false
 }
 
 /// Returns true if the prop name matches the known event handler pattern `on[A-Z]`.

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -348,6 +348,257 @@ describe("bundler", () => {
     },
   });
 
+  // https://github.com/oven-sh/bun/issues/40442
+  // The ssr pass turns `const [state, setState] = useState(init)` into
+  // `const state = init`, which drops the declaration of `setState`. That is
+  // only correct when nothing the render can reach reads the setter, and a
+  // handler that calls a setter has to stay a function for whoever receives it.
+  // Each function below is compiled in ssr mode and called once, then the test
+  // calls the handlers it got back. The fake hooks log their calls, so an
+  // empty log means the compiler inlined the hook.
+  itBundled("react-compiler/SsrKeepsStateHookWhileSetterIsReachable", {
+    files: {
+      "/entry.js": /* js */ `
+        import { log } from "react";
+        import * as forms from "./forms";
+
+        const show = value => JSON.stringify(value, (key, v) => (typeof v === "function" ? "fn" : v));
+        function run(name, fn) {
+          log.length = 0;
+          let result;
+          try {
+            result = show(fn());
+          } catch (e) {
+            result = "threw " + e;
+          }
+          console.log(name + ": " + result + " " + JSON.stringify(log));
+        }
+
+        run("CallsHandlerInRender", () => forms.CallsHandlerInRender({ n: 3 }));
+        run("useToggle", () => {
+          const [on, toggle] = forms.useToggle();
+          toggle();
+          return on;
+        });
+        run("useMemoizedToggle", () => {
+          const toggle = forms.useMemoizedToggle();
+          toggle();
+          return toggle;
+        });
+        run("HandlerAboveHook", () => forms.HandlerAboveHook());
+        run("ArrowAboveHook", () => forms.ArrowAboveHook());
+        run("SetterAsProp", () => {
+          const el = forms.SetterAsProp();
+          el.props.setV(5);
+          return el;
+        });
+        run("useCounter", () => {
+          const [v, setV] = forms.useCounter();
+          setV(2);
+          return v;
+        });
+        run("SetterCalledInRender", () => forms.SetterCalledInRender({ n: 2 }));
+        run("HandlerToComponent", () => {
+          const el = forms.HandlerToComponent();
+          el.props.onPick();
+          return el;
+        });
+        run("DispatchInObject", () => {
+          const el = forms.DispatchInObject();
+          el.props.api.add();
+          return el;
+        });
+        run("HandlerInNestedClosure", () => {
+          const el = forms.HandlerInNestedClosure({ items: ["a", "b"] });
+          for (const item of el.props.children) item.props.onPick();
+          return el;
+        });
+        run("TransitionHandlerToComponent", () => {
+          const el = forms.TransitionHandlerToComponent();
+          el.props.onGo();
+          return el;
+        });
+        run("ReducerInitializerReadsSetter", () => forms.ReducerInitializerReadsSetter({ init: set => typeof set }));
+        run("UnreadReducerInitializerReadsSetter", () =>
+          forms.UnreadReducerInitializerReadsSetter({ init: set => typeof set }),
+        );
+        run("HostHandlerOnly", () => forms.HostHandlerOnly());
+        run("HostReducerOnly", () => forms.HostReducerOnly());
+      `,
+      "/forms.jsx": /* jsx */ `
+        import { useState, useReducer, useEffect, useRef, useMemo, useTransition } from "react";
+
+        function Child() {
+          return null;
+        }
+        function reducer(state) {
+          return state;
+        }
+
+        export function CallsHandlerInRender({ n }) {
+          const [seen, setSeen] = useState(0);
+          const sync = () => {
+            if (seen < n) setSeen(n);
+          };
+          sync();
+          return <b>{seen}</b>;
+        }
+        export function useToggle() {
+          const [on, setOn] = useState(false);
+          const toggle = () => setOn(!on);
+          return [on, toggle];
+        }
+        export function useMemoizedToggle() {
+          const [on, setOn] = useState(false);
+          return useMemo(() => () => setOn(!on), [on]);
+        }
+        export function HandlerAboveHook() {
+          function inc() {
+            setCount(c => c + 1);
+          }
+          const [count, setCount] = useState(0);
+          return <button onClick={inc}>{count}</button>;
+        }
+        export function ArrowAboveHook() {
+          const inc = () => setCount(c => c + 1);
+          const [count, setCount] = useState(0);
+          return <button onClick={inc}>{count}</button>;
+        }
+        export function SetterAsProp() {
+          const [v, setV] = useState(0);
+          return <Child v={v} setV={setV} />;
+        }
+        export function useCounter() {
+          const [v, setV] = useState(0);
+          return [v, setV];
+        }
+        export function SetterCalledInRender({ n }) {
+          const [v, setV] = useState(0);
+          if (v < n) setV(n);
+          return <b>{v}</b>;
+        }
+        export function HandlerToComponent() {
+          const [v, setV] = useState(0);
+          return <Child onPick={() => setV(1)}>{v}</Child>;
+        }
+        export function DispatchInObject() {
+          const [state, dispatch] = useReducer((s, a) => s + a, 1);
+          return <Child api={{ add: () => dispatch(1) }}>{state}</Child>;
+        }
+        export function HandlerInNestedClosure({ items }) {
+          const [picked, setPicked] = useState(null);
+          return (
+            <ul>
+              {items.map(item => (
+                <Child key={item} onPick={() => setPicked(item)} picked={item === picked} />
+              ))}
+            </ul>
+          );
+        }
+        export function TransitionHandlerToComponent() {
+          const [pending, startTransition] = useTransition();
+          const go = () => startTransition(() => {});
+          return <Child onGo={go}>{pending}</Child>;
+        }
+
+        // useReducer(reducer, arg, init) is inlined to init(arg), which reads the
+        // setter, so the useState call has to stay. When nothing reads the reducer
+        // state either, both hooks go and nothing is left to call init.
+        export function ReducerInitializerReadsSetter({ init }) {
+          const [draft, setDraft] = useState("");
+          const [state, dispatch] = useReducer(reducer, setDraft, init);
+          return <input onChange={() => dispatch(draft)} value={state} />;
+        }
+        export function UnreadReducerInitializerReadsSetter({ init }) {
+          const [draft, setDraft] = useState("");
+          const [state, dispatch] = useReducer(reducer, setDraft, init);
+          return <input onChange={() => dispatch(state)} value={draft} />;
+        }
+
+        // Only a host element's event handler, an effect and a host element's
+        // ref read these setters, and the ssr pass removes all three.
+        export function HostHandlerOnly() {
+          const [count, setCount] = useState(0);
+          const ref = useRef(null);
+          useEffect(() => {
+            setCount(1);
+          }, []);
+          return (
+            <button ref={ref} onClick={() => setCount(count + 1)}>
+              {count}
+            </button>
+          );
+        }
+        export function HostReducerOnly() {
+          const [state, dispatch] = useReducer((s, a) => s + a, 1);
+          const add = () => dispatch(1);
+          return <button onClick={add}>{state}</button>;
+        }
+      `,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+      "/node_modules/react/index.js": /* js */ `
+        export const log = [];
+        function set(value) {
+          log.push("set " + (typeof value === "function" ? "fn" : value));
+        }
+        export function useState(initial) {
+          log.push("useState");
+          return [initial, set];
+        }
+        export function useReducer(reducer, initial, init) {
+          log.push("useReducer");
+          return [init ? init(initial) : initial, set];
+        }
+        export function useTransition() {
+          log.push("useTransition");
+          return [false, callback => (log.push("startTransition"), callback())];
+        }
+        export function useRef(current) {
+          log.push("useRef");
+          return { current };
+        }
+        export function useEffect() {
+          log.push("useEffect");
+        }
+        export function useMemo(create) {
+          log.push("useMemo");
+          return create();
+        }
+      `,
+      "/node_modules/react/jsx-runtime.js": /* js */ `
+        export const jsx = (type, props) => ({ type: typeof type === "function" ? type.name : type, props });
+        export const jsxs = jsx;
+      `,
+      "/node_modules/react/jsx-dev-runtime.js": /* js */ `
+        export const jsxDEV = (type, props) => ({ type: typeof type === "function" ? type.name : type, props });
+      `,
+    },
+    reactCompiler: true,
+    reactCompilerOutputMode: "ssr",
+    target: "bun",
+    backend: "api",
+    run: {
+      stdout: `
+        CallsHandlerInRender: {"type":"b","props":{"children":0}} ["useState","set 3"]
+        useToggle: false ["useState","set true"]
+        useMemoizedToggle: "fn" ["useState","set true"]
+        HandlerAboveHook: {"type":"button","props":{"children":0}} ["useState"]
+        ArrowAboveHook: {"type":"button","props":{"children":0}} ["useState"]
+        SetterAsProp: {"type":"Child","props":{"v":0,"setV":"fn"}} ["useState","set 5"]
+        useCounter: 0 ["useState","set 2"]
+        SetterCalledInRender: {"type":"b","props":{"children":0}} ["useState","set 2"]
+        HandlerToComponent: {"type":"Child","props":{"onPick":"fn","children":0}} ["useState","set 1"]
+        DispatchInObject: {"type":"Child","props":{"api":{"add":"fn"},"children":1}} ["useReducer","set 1"]
+        HandlerInNestedClosure: {"type":"ul","props":{"children":[{"type":"Child","props":{"onPick":"fn","picked":false}},{"type":"Child","props":{"onPick":"fn","picked":false}}]}} ["useState","set a","set b"]
+        TransitionHandlerToComponent: {"type":"Child","props":{"onGo":"fn","children":false}} ["useTransition","startTransition"]
+        ReducerInitializerReadsSetter: {"type":"input","props":{"value":"function"}} ["useState"]
+        UnreadReducerInitializerReadsSetter: {"type":"input","props":{"value":""}} []
+        HostHandlerOnly: {"type":"button","props":{"children":0}} []
+        HostReducerOnly: {"type":"button","props":{"children":1}} []
+      `,
+    },
+  });
+
   itBundled("react-compiler/BundledReactPreservesImportRefs", {
     files: {
       "/entry.tsx": /* tsx */ `


### PR DESCRIPTION
### Problem

- `bun build --react-compiler --target=bun` emits code that throws at render: `TypeError: sync is not a function` (render calls a closure that calls a setter), `ReferenceError: setV is not defined` (a setter goes to a prop), `ReferenceError: t0 is not defined` (a handler is above the `useState` line).
- The cause is `optimize_for_ssr` (`src/react_compiler/optimization/optimize_for_ssr.rs`). `has_known_non_render_call` replaced every closure that calls a setter with `undefined` and ignored its uses. The `Destructure` of an inlined hook kept only its first item, so the other items lost their declaration.

### Fix

- The pass removes effects and host element handler props first. Then it inlines a `useState` or `useReducer` call only if the mark phase of dead code elimination finds a read of its result and no read of another pattern item.
- It never replaces a closure with `undefined`. Dead code elimination removes an unread closure, so `<button onClick={...}>` compiles as before.
- Correct because a declaration goes only when dead code elimination removes every read of it. Before, `<Chip onDelete={...} />` lost the icon that `Chip` renders when it has a handler.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (new `SsrKeepsStateHookWhileSetterIsReachable`, fails on 1.4.3). Also `react-compiler-fixtures.test.ts`.

### Background

- The build target selects the output mode: `browser` is client, `bun` and `node` are ssr. Only ssr runs this pass. Upstream has it behind an experimental option.
- `Destructure [a, b] = t` declares `a` and `b`. Dead code elimination runs next.
- A context variable is a local that a closure captures before its declaration. Its destructure writes a temporary, then `StoreContext setCount = t0`, which dead code elimination never removes.

<details><summary>Notes</summary>

Related: #40442 reports that the ssr mode removes `useState` calls and handlers for `--target=bun`. This PR does not close it. Its `Counter` example compiles to the same output as before (only a host element handler reads the setter), and a custom renderer still needs client mode. #40444 adds a CLI flag for the output mode and does not touch the pass. Whether a server target selects ssr mode by default is a separate decision. The explicit `reactCompilerOutputMode: "ssr"` runs the same pass, so the pass has to be sound under either default.

**Difference from upstream.** `OptimizeForSSR.ts` on facebook/react main still has `hasKnownNonRenderCall` and the first-item-only destructure rewrite. Upstream's fixture `ssr/ssr-infer-event-handlers-from-setState.js` expects `<CustomInput onChange={onChange} />` with `const onChange = undefined`. This branch keeps that closure and the `useState` call. The file header and a new table in `src/react_compiler/DESIGN.md` record the difference for the next re-sync.

**Why the result of the hook has to be read.** Dead code elimination prunes a `useState` or `useReducer` call in ssr mode when nothing reads its result. It does not prune the `init(arg)` call that replaces `useReducer(reducer, arg, init)`. With `useReducer(reducer, setDraft, init)` and no read of the reducer state, the mark phase saw no read of `setDraft`, the pass inlined the `useState`, and the output was `init(setDraft)` with no `setDraft`. The pass now leaves such a call to dead code elimination. With that, every operand of a replacement was already read before the rewrite, so the rewrite cannot make a removed declaration live again.

**Render check with `react-dom/server` 18.3.1** (`renderToStaticMarkup`, bundle built with `--react-compiler --target=bun`):

| component | source | 1.4.3 | this branch |
| --- | --- | --- | --- |
| closure called in render, `if (seen < n) setSeen(n)` | `<b>3</b>` | `TypeError: sync is not a function` | `<b>3</b>` |
| `useToggle()` returns `[on, toggle]` | `false:function` | `false:undefined` | `false:function` |
| handler declared above `useState` | `<button>0</button>` | `ReferenceError: t0 is not defined` | `<button>0</button>` |
| `<Chip onDelete={...}>`, `Chip` renders `<i>x</i>` if it has a handler | `<span>one<i>x</i></span>` | `<span>one</span>` | `<span>one<i>x</i></span>` |

**The new test** bundles 16 components and hooks with `reactCompilerOutputMode: "ssr"`, calls each one once with fake hooks that log their calls, and then calls the handlers it got back. 14 of the 16 throw on 1.4.3. The last two (`HostHandlerOnly`, `HostReducerOnly`) have an empty hook log before and after: the pass still inlines them.

**Fixture sweep.** Built each of the 1807 files under `test/bundler/transpiler/react-compiler-fixtures/` with `bun build --react-compiler --target=bun --external '*'`, and the 171 `.ts` files a second time as `.tsx` (the compiler does not run on `.ts` files). No build aborts. Against the same base, 14 outputs change. Each change is a closure or a state hook that is now kept, for example `preserve-use-memo-unused-state.js`: `function useFoo() {}` before, `return () => { setState(_temp); }` after. A TypeScript check of every output for names that are unbound in the ssr output and bound in the plain output: 3 files before (`setX`, `setY`, `setValue`), 0 after.

**What is no longer inlined.** The hook call stays when a closure that reads the setter is still reachable: a handler passed to a component, a setter passed or returned, a closure inside a nested function (`items.map(i => <li onClick={() => setSel(i)} />)`, the pass does not strip props inside nested functions), and a `useCallback` handler (the `FinishMemoize` marker keeps the closure through dead code elimination). Each of these keeps the semantics of the source.

**Not changed.** The pass still strips every `on[A-Z]` prop and `ref` from host elements, and dead code elimination in ssr mode still prunes an unread `useState(fn)` or `useReducer` call together with its initializer. Both are upstream behavior.

**Suites run with the debug build:** `react-compiler.test.ts` (59 pass), `react-compiler-fixtures.test.ts` (3293 pass, 320 skip). `cargo clippy -p bun_react_compiler` is clean.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [652.27ms]
(pass) bundler > react-compiler/ComponentWithHooks [233.81ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [234.02ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [328.11ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [143.39ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [122.66ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [397.66ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [144.05ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [650.55ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [134.50ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [139.81ms]
runtime failed file: /tmp/bun-build-tests/bun-uUrcKs/react-compiler/SsrKeepsStateHookWhileSetter
... (truncated)

release without fix: 18 failed, 1 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [18.97ms]
(pass) bundler > react-compiler/ComponentWithHooks [9.31ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [9.04ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [8.79ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [6.16ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [3.88ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [11.01ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [4.93ms]
1031 |       ]);
1032 |       const stdout = Buffer.from(stdoutBytes);
1033 |       const stderr = Buffer.from(stderrBytes);
1034 |       const success = exitCode === 0;
1035 |       if (buildProc.signalCode) {
1036 |         throw new Error(
                         ^
error: [react-compiler/SsrObjectMethodShorthand] 'bun build' subprocess killed by SIGABRT
cmd: /workspace/bun/build/release/bun build /tmp/bun-build-tests/bun-ujSw2V/react-compiler/SsrObjectMethodShorthand/entry.jsx --outfile=/tmp/bun-build-tests/bun-
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [1091.01ms]
(pass) bundler > react-compiler/ComponentWithHooks [330.32ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [295.61ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [449.48ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [211.02ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [136.39ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [381.31ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [153.96ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [821.80ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [144.65ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [124.93ms]
(pass) bundler > react-compiler/SsrKeepsStateHookWhileSetterIsReachable [974.74ms]
(pass) bundl
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f3827fbd93
  features     baseline

23 deps, 131 codegen, 1172 objects in 901ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.3-canary.1 (6a92015fc)

Checked 22 installs across 61 packages (no changes) [28.00ms]
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (6a92015fc)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1244] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[6/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (6a92015fc)

Checked 111 installs across 104 packages (no changes) [16.00ms]
[7/1244] fetch tinycc
[tinycc] up to date
[8/1243] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] fetch zlib
[zlib] up to date
[11/1216] gen .bind.ts → Ge
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/react_compiler/DESIGN.md                       |   8 +
 src/react_compiler/hir/mod.rs                      |   5 -
 .../optimization/dead_code_elimination.rs          |   6 +-
 .../optimization/optimize_for_ssr.rs               | 153 +++++++------
 test/bundler/transpiler/react-compiler.test.ts     | 251 +++++++++++++++++++++
 5 files changed, 348 insertions(+), 75 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/react_compiler/DESIGN.md                                  1      1     15
src/react_compiler/hir/mod.rs                                 0      0     15
src/react_compiler/optimization/dead_code_elimination.rs      1      0     15
src/react_compiler/optimization/optimize_for_ssr.rs           3      1     15
test/bundler/transpiler/react-compiler.test.ts                2      2     15
```

</details>

<!-- robobun:evidence:end -->