### PR TITLE
fuzzilli: keep auto-install in the REPRL child off the npm registry

### DIFF
--- a/src/runtime/cli/fuzzilli_command.rs
+++ b/src/runtime/cli/fuzzilli_command.rs
@@ -11,6 +11,14 @@ use bun_sys::{self as sys, Fd, FdExt, O};
 use super::run_command::RunCommand;
 use crate::Command;
 
+/// Nothing listens here, so an auto-install that a fuzz program starts fails at `connect()`.
+#[cfg(unix)]
+const DEAD_REGISTRY: &core::ffi::CStr = c"http://127.0.0.1:1/";
+
+/// In place of the user's cache. The path is fixed because a killed REPRL child cannot clean up.
+#[cfg(unix)]
+const SCRATCH_CACHE_DIR: &core::ffi::CStr = c"/tmp/bun-fuzzilli-install-cache";
+
 pub(crate) struct FuzzilliCommand;
 
 impl FuzzilliCommand {
@@ -88,36 +96,8 @@ impl FuzzilliCommand {
 
             bun_core::pretty_errorln!("<r><d>[FUZZILLI] Temp file written, booting JS runtime<r>");
 
-            // A fuzz program can call `require("a")`. With no node_modules above the wrapper, that
-            // auto-installs. The fuzzer must still reach that code, but it must not download or
-            // run packages. So the defaults are a registry that nothing listens on and a scratch
-            // cache in place of the user's. Child processes inherit both. A campaign that has a
-            // fixture registry sets BUN_CONFIG_REGISTRY itself. The cache path is fixed because
-            // Fuzzilli respawns this process constantly, and a killed one cannot clean up.
-            // The package manager ignores a registry that is empty or is not http(s) and goes on
-            // to the next source, so such a value does not count as set.
-            let has_registry = bun_core::getenv_z(zstr!("BUN_CONFIG_REGISTRY"))
-                .is_some_and(|url| url.starts_with(b"http://") || url.starts_with(b"https://"));
-            let has_cache_dir = bun_core::getenv_z(zstr!("BUN_INSTALL_CACHE_DIR"))
-                .is_some_and(|dir| !dir.is_empty());
-            // SAFETY: main thread during startup, before any concurrent reader of the environment
-            // exists. setenv copies the NUL-terminated strings.
-            let defaults_set = unsafe {
-                (has_registry
-                    || libc::setenv(
-                        c"BUN_CONFIG_REGISTRY".as_ptr(),
-                        c"http://127.0.0.1:1/".as_ptr(),
-                        1,
-                    ) == 0)
-                    && (has_cache_dir
-                        || libc::setenv(
-                            c"BUN_INSTALL_CACHE_DIR".as_ptr(),
-                            c"/tmp/bun-fuzzilli-install-cache".as_ptr(),
-                            1,
-                        ) == 0)
-            };
-            // Without them the child would use the live registry.
-            if !defaults_set {
+            // Auto-install stays reachable for the fuzzer, but no program may download a package.
+            if !Self::set_install_defaults() {
                 bun_core::pretty_errorln!(
                     "<r><red>error<r>: Could not set BUN_CONFIG_REGISTRY and BUN_INSTALL_CACHE_DIR in the environment: {}",
                     sys::last_error()
@@ -136,6 +116,28 @@ impl FuzzilliCommand {
             temp_dir_fd.close();
 
             result
+        }
+    }
+
+    /// Child processes inherit both variables. A campaign with a fixture registry sets its own.
+    #[cfg(unix)]
+    fn set_install_defaults() -> bool {
+        // The package manager skips a registry that is not http(s), so that value is not a choice.
+        let has_registry = bun_core::getenv_z(zstr!("BUN_CONFIG_REGISTRY"))
+            .is_some_and(|url| url.starts_with(b"http://") || url.starts_with(b"https://"));
+        let has_cache_dir =
+            bun_core::getenv_z(zstr!("BUN_INSTALL_CACHE_DIR")).is_some_and(|dir| !dir.is_empty());
+        // SAFETY: main thread during startup, before any concurrent reader of the environment
+        // exists. setenv copies the NUL-terminated strings.
+        unsafe {
+            (has_registry
+                || libc::setenv(c"BUN_CONFIG_REGISTRY".as_ptr(), DEAD_REGISTRY.as_ptr(), 1) == 0)
+                && (has_cache_dir
+                    || libc::setenv(
+                        c"BUN_INSTALL_CACHE_DIR".as_ptr(),
+                        SCRATCH_CACHE_DIR.as_ptr(),
+                        1,
+                    ) == 0)
         }
     }
 

--- a/src/runtime/cli/fuzzilli_command.rs
+++ b/src/runtime/cli/fuzzilli_command.rs
@@ -90,9 +90,10 @@ impl FuzzilliCommand {
 
             // A fuzz program can call `require("a")`. With no node_modules above the wrapper, that
             // auto-installs. The fuzzer must still reach that code, but it must not download or
-            // run packages. So the defaults are a registry that nothing listens on and a cache
-            // that starts empty. Child processes inherit both. A campaign that has a fixture
-            // registry sets BUN_CONFIG_REGISTRY itself.
+            // run packages. So the defaults are a registry that nothing listens on and a scratch
+            // cache in place of the user's. Child processes inherit both. A campaign that has a
+            // fixture registry sets BUN_CONFIG_REGISTRY itself. The cache path is fixed because
+            // Fuzzilli respawns this process constantly, and a killed one cannot clean up.
             // SAFETY: main thread during startup, before any concurrent reader of the environment
             // exists. setenv copies the NUL-terminated strings.
             unsafe {

--- a/src/runtime/cli/fuzzilli_command.rs
+++ b/src/runtime/cli/fuzzilli_command.rs
@@ -88,6 +88,26 @@ impl FuzzilliCommand {
 
             bun_core::pretty_errorln!("<r><d>[FUZZILLI] Temp file written, booting JS runtime<r>");
 
+            // A fuzz program can call `require("a")`. With no node_modules above the wrapper, that
+            // auto-installs. The fuzzer must still reach that code, but it must not download or
+            // run packages. So the defaults are a registry that nothing listens on and a cache
+            // that starts empty. Child processes inherit both. A campaign that has a fixture
+            // registry sets BUN_CONFIG_REGISTRY itself.
+            // SAFETY: main thread during startup, before any concurrent reader of the environment
+            // exists. setenv copies the NUL-terminated strings.
+            unsafe {
+                libc::setenv(
+                    c"BUN_CONFIG_REGISTRY".as_ptr(),
+                    c"http://127.0.0.1:1/".as_ptr(),
+                    0,
+                );
+                libc::setenv(
+                    c"BUN_INSTALL_CACHE_DIR".as_ptr(),
+                    c"/tmp/bun-fuzzilli-install-cache".as_ptr(),
+                    0,
+                );
+            }
+
             // Run the temp file
             let temp_path: &[u8] = b"/tmp/bun-fuzzilli-reprl.js";
             // The `Run.boot` entry point is hosted on `RunCommand` to avoid the

--- a/src/runtime/cli/fuzzilli_command.rs
+++ b/src/runtime/cli/fuzzilli_command.rs
@@ -96,17 +96,25 @@ impl FuzzilliCommand {
             // Fuzzilli respawns this process constantly, and a killed one cannot clean up.
             // SAFETY: main thread during startup, before any concurrent reader of the environment
             // exists. setenv copies the NUL-terminated strings.
-            unsafe {
+            let defaults_set = unsafe {
                 libc::setenv(
                     c"BUN_CONFIG_REGISTRY".as_ptr(),
                     c"http://127.0.0.1:1/".as_ptr(),
                     0,
+                ) == 0
+                    && libc::setenv(
+                        c"BUN_INSTALL_CACHE_DIR".as_ptr(),
+                        c"/tmp/bun-fuzzilli-install-cache".as_ptr(),
+                        0,
+                    ) == 0
+            };
+            // Without them the child would use the live registry.
+            if !defaults_set {
+                bun_core::pretty_errorln!(
+                    "<r><red>error<r>: Could not set BUN_CONFIG_REGISTRY and BUN_INSTALL_CACHE_DIR in the environment: {}",
+                    sys::last_error()
                 );
-                libc::setenv(
-                    c"BUN_INSTALL_CACHE_DIR".as_ptr(),
-                    c"/tmp/bun-fuzzilli-install-cache".as_ptr(),
-                    0,
-                );
+                Global::exit(1);
             }
 
             // Run the temp file

--- a/src/runtime/cli/fuzzilli_command.rs
+++ b/src/runtime/cli/fuzzilli_command.rs
@@ -94,19 +94,27 @@ impl FuzzilliCommand {
             // cache in place of the user's. Child processes inherit both. A campaign that has a
             // fixture registry sets BUN_CONFIG_REGISTRY itself. The cache path is fixed because
             // Fuzzilli respawns this process constantly, and a killed one cannot clean up.
+            // The package manager ignores a registry that is empty or is not http(s) and goes on
+            // to the next source, so such a value does not count as set.
+            let has_registry = bun_core::getenv_z(zstr!("BUN_CONFIG_REGISTRY"))
+                .is_some_and(|url| url.starts_with(b"http://") || url.starts_with(b"https://"));
+            let has_cache_dir = bun_core::getenv_z(zstr!("BUN_INSTALL_CACHE_DIR"))
+                .is_some_and(|dir| !dir.is_empty());
             // SAFETY: main thread during startup, before any concurrent reader of the environment
             // exists. setenv copies the NUL-terminated strings.
             let defaults_set = unsafe {
-                libc::setenv(
-                    c"BUN_CONFIG_REGISTRY".as_ptr(),
-                    c"http://127.0.0.1:1/".as_ptr(),
-                    0,
-                ) == 0
-                    && libc::setenv(
-                        c"BUN_INSTALL_CACHE_DIR".as_ptr(),
-                        c"/tmp/bun-fuzzilli-install-cache".as_ptr(),
-                        0,
-                    ) == 0
+                (has_registry
+                    || libc::setenv(
+                        c"BUN_CONFIG_REGISTRY".as_ptr(),
+                        c"http://127.0.0.1:1/".as_ptr(),
+                        1,
+                    ) == 0)
+                    && (has_cache_dir
+                        || libc::setenv(
+                            c"BUN_INSTALL_CACHE_DIR".as_ptr(),
+                            c"/tmp/bun-fuzzilli-install-cache".as_ptr(),
+                            1,
+                        ) == 0)
             };
             // Without them the child would use the live registry.
             if !defaults_set {

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
+import fs from "node:fs";
 import path from "node:path";
 
 // The fuzzilli REPRL wrapper (src/js/eval/fuzzilli-reprl.ts) executes
@@ -20,4 +21,93 @@ test("REPRL loop survives a payload that calls process.execve", async () => {
 
   expect(stdout).toContain("STATUS_WRITES=2 LIVE=true");
   expect(exitCode).toBe(0);
+});
+
+declare const fuzzilli: unknown;
+// `bun fuzzilli` is compiled in only with --fuzzilli=on (bun run build:debug:fuzzilli).
+// The same flag adds a fuzzilli() global.
+const isFuzzilliBuild = typeof fuzzilli === "function";
+
+// Runs the programs in one `bun fuzzilli` child. Fuzzilli sends "exec" and a u64
+// length on fd 100 and the source on fd 102. The child answers "HELO" and then
+// one u32 status per program on fd 101. Regular files stand in for the pipes.
+async function runReprl(programs: string[], env: Record<string, string | undefined>) {
+  const sources = programs.map(source => Buffer.from(source, "utf8"));
+  const control = [Buffer.from("HELO")];
+  for (const source of sources) {
+    const size = Buffer.alloc(8);
+    size.writeBigUInt64LE(BigInt(source.length));
+    control.push(Buffer.from("exec"), size);
+  }
+  using dir = tempDir("fuzzilli-reprl", {
+    "control.bin": Buffer.concat(control),
+    "programs.bin": Buffer.concat(sources),
+    "status.bin": "",
+  });
+  const file = (name: string) => path.join(String(dir), name);
+
+  const stdio: any[] = ["ignore", "pipe", "pipe"];
+  stdio[100] = Bun.file(file("control.bin"));
+  stdio[101] = Bun.file(file("status.bin"));
+  stdio[102] = Bun.file(file("programs.bin"));
+
+  await using proc = Bun.spawn({ cmd: [bunExe(), "fuzzilli"], env, cwd: String(dir), stdio });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const status = fs.readFileSync(file("status.bin"));
+  const statuses: number[] = [];
+  for (let offset = 4; offset + 4 <= status.length; offset += 4) {
+    statuses.push(status.readUInt32LE(offset));
+  }
+  return { handshake: status.subarray(0, 4).toString("latin1"), statuses, stdout, exitCode };
+}
+
+// Fuzzilli picks string literals at random, so a fuzz program can ask for any
+// package name. No node_modules is above the REPRL wrapper, and that is where
+// bun auto-installs. The fuzzer must still reach that code, but the child must
+// not download packages unless the campaign names a registry for it.
+test.skipIf(!isFuzzilliBuild)("bun fuzzilli auto-installs only from BUN_CONFIG_REGISTRY", async () => {
+  const requests: string[] = [];
+  await using registry = Bun.serve({
+    port: 0,
+    fetch(req) {
+      requests.push(new URL(req.url).pathname);
+      return new Response("{}", { status: 404, headers: { "content-type": "application/json" } });
+    },
+  });
+  using cache = tempDir("fuzzilli-reprl-cache", {});
+
+  const programs = [
+    `require("a");`,
+    `require.resolve("b");`,
+    `Bun.resolveSync("c", "/tmp");`,
+    `import("d").catch(e => console.log("import: " + e.message));`,
+    `console.log("cache: " + process.env.BUN_INSTALL_CACHE_DIR);`,
+  ];
+  // An uncaught exception is exit code 1, which REPRL encodes as 1 << 8.
+  const statuses = [0x100, 0x100, 0x100, 0, 0];
+
+  // npm's variable ranks below BUN_CONFIG_REGISTRY. The child defaults that one
+  // to an address that nothing listens on, so the registry here sees nothing.
+  const env = { ...bunEnv };
+  delete env.BUN_CONFIG_REGISTRY;
+  delete env.BUN_INSTALL_CACHE_DIR;
+  const byDefault = await runReprl(programs, { ...env, NPM_CONFIG_REGISTRY: registry.url.href });
+  expect(requests).toEqual([]);
+  expect(byDefault.stdout).toContain("uncaught:ResolveMessage: Cannot find module 'a'");
+  expect(byDefault.stdout).toContain("uncaught:ResolveMessage: Cannot find module 'b'");
+  expect(byDefault.stdout).toContain("uncaught:ResolveMessage: Cannot find package 'c'");
+  expect(byDefault.stdout).toContain("import: Cannot find package 'd'");
+  // Not the cache of the user that runs the fuzzer.
+  expect(byDefault.stdout).toMatch(/^cache: \/.+/m);
+  expect(byDefault).toMatchObject({ handshake: "HELO", statuses, exitCode: 0 });
+
+  // A campaign that sets the variable gets every request.
+  const withRegistry = await runReprl(programs, {
+    ...env,
+    BUN_CONFIG_REGISTRY: registry.url.href,
+    BUN_INSTALL_CACHE_DIR: String(cache),
+  });
+  expect(requests).toEqual(["/a", "/b", "/c", "/d"]);
+  expect(withRegistry).toMatchObject({ handshake: "HELO", statuses, exitCode: 0 });
 });

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -99,15 +99,16 @@ test.skipIf(!isFuzzilliBuild)("bun fuzzilli auto-installs only from BUN_CONFIG_R
   expect(byDefault.stdout).toContain("uncaught:ResolveMessage: Cannot find package 'c'");
   expect(byDefault.stdout).toContain("import: Cannot find package 'd'");
   // Not the cache of the user that runs the fuzzer.
-  expect(byDefault.stdout).toMatch(/^cache: \/.+/m);
+  expect(byDefault.stdout).toContain("cache: /tmp/bun-fuzzilli-install-cache\n");
   expect(byDefault).toMatchObject({ handshake: "HELO", statuses, exitCode: 0 });
 
-  // A campaign that sets the variable gets every request.
+  // A campaign that sets the variables keeps its values and gets every request.
   const withRegistry = await runReprl(programs, {
     ...env,
     BUN_CONFIG_REGISTRY: registry.url.href,
     BUN_INSTALL_CACHE_DIR: String(cache),
   });
   expect(requests).toEqual(["/a", "/b", "/c", "/d"]);
+  expect(withRegistry.stdout).toContain(`cache: ${cache}\n`);
   expect(withRegistry).toMatchObject({ handshake: "HELO", statuses, exitCode: 0 });
 });

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import fs from "node:fs";
 import path from "node:path";
@@ -73,17 +73,7 @@ async function runReprl(programs: string[], env: Record<string, string | undefin
 // package name. No node_modules is above the REPRL wrapper, and that is where
 // bun auto-installs. The fuzzer must still reach that code, but the child must
 // not download packages unless the campaign names a registry for it.
-test.skipIf(!isFuzzilliBuild)("bun fuzzilli auto-installs only from BUN_CONFIG_REGISTRY", async () => {
-  const requests: string[] = [];
-  await using registry = Bun.serve({
-    port: 0,
-    fetch(req) {
-      requests.push(new URL(req.url).pathname);
-      return new Response("{}", { status: 404, headers: { "content-type": "application/json" } });
-    },
-  });
-  using cache = tempDir("fuzzilli-reprl-cache", {});
-
+describe.skipIf(!isFuzzilliBuild)("bun fuzzilli auto-install", () => {
   const programs = [
     `require("a");`,
     `require.resolve("b");`,
@@ -94,28 +84,58 @@ test.skipIf(!isFuzzilliBuild)("bun fuzzilli auto-installs only from BUN_CONFIG_R
   // An uncaught exception is exit code 1, which REPRL encodes as 1 << 8.
   const statuses = [0x100, 0x100, 0x100, 0, 0];
 
-  // npm's variable ranks below BUN_CONFIG_REGISTRY. The child defaults that one
-  // to an address that nothing listens on, so the registry here sees nothing.
-  const env = { ...bunEnv };
-  delete env.BUN_CONFIG_REGISTRY;
-  delete env.BUN_INSTALL_CACHE_DIR;
-  const byDefault = await runReprl(programs, { ...env, NPM_CONFIG_REGISTRY: registry.url.href });
-  expect(requests).toEqual([]);
-  expect(byDefault.stdout).toContain("uncaught:ResolveMessage: Cannot find module 'a'");
-  expect(byDefault.stdout).toContain("uncaught:ResolveMessage: Cannot find module 'b'");
-  expect(byDefault.stdout).toContain("uncaught:ResolveMessage: Cannot find package 'c'");
-  expect(byDefault.stdout).toContain("import: Cannot find package 'd'");
-  // Not the cache of the user that runs the fuzzer.
-  expect(byDefault.stdout).toContain("cache: /tmp/bun-fuzzilli-install-cache\n");
-  expect(byDefault).toMatchObject({ handshake: "HELO", statuses, stderr: [], exitCode: 0 });
+  function startRegistry() {
+    const requests: string[] = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        requests.push(new URL(req.url).pathname);
+        return new Response("{}", { status: 404, headers: { "content-type": "application/json" } });
+      },
+    });
+    return { requests, server, url: server.url.href };
+  }
 
-  // A campaign that sets the variables keeps its values and gets every request.
-  const withRegistry = await runReprl(programs, {
-    ...env,
-    BUN_CONFIG_REGISTRY: registry.url.href,
-    BUN_INSTALL_CACHE_DIR: String(cache),
+  function childEnv(extra: Record<string, string>) {
+    const env = { ...bunEnv };
+    delete env.BUN_CONFIG_REGISTRY;
+    delete env.BUN_INSTALL_CACHE_DIR;
+    return { ...env, ...extra };
+  }
+
+  // The tests share /tmp/bun-fuzzilli-reprl.js, which every child writes again, so they run in turn.
+  test.each([
+    ["unset", {}],
+    // The package manager skips an empty value and a registry with no scheme.
+    ["values that the package manager ignores", { BUN_CONFIG_REGISTRY: "localhost:4873", BUN_INSTALL_CACHE_DIR: "" }],
+  ])("reaches no registry when the variables are %s", async (_, inherited) => {
+    const registry = startRegistry();
+    await using _server = registry.server;
+
+    // npm's variable ranks below BUN_CONFIG_REGISTRY. The child defaults that one
+    // to an address that nothing listens on, so the registry here sees nothing.
+    const result = await runReprl(programs, childEnv({ ...inherited, NPM_CONFIG_REGISTRY: registry.url }));
+    expect(registry.requests).toEqual([]);
+    expect(result.stdout).toContain("uncaught:ResolveMessage: Cannot find module 'a'");
+    expect(result.stdout).toContain("uncaught:ResolveMessage: Cannot find module 'b'");
+    expect(result.stdout).toContain("uncaught:ResolveMessage: Cannot find package 'c'");
+    expect(result.stdout).toContain("import: Cannot find package 'd'");
+    // Not the cache of the user that runs the fuzzer.
+    expect(result.stdout).toContain("cache: /tmp/bun-fuzzilli-install-cache\n");
+    expect(result).toMatchObject({ handshake: "HELO", statuses, stderr: [], exitCode: 0 });
   });
-  expect(requests).toEqual(["/a", "/b", "/c", "/d"]);
-  expect(withRegistry.stdout).toContain(`cache: ${cache}\n`);
-  expect(withRegistry).toMatchObject({ handshake: "HELO", statuses, stderr: [], exitCode: 0 });
+
+  test("reaches the registry that BUN_CONFIG_REGISTRY names", async () => {
+    const registry = startRegistry();
+    await using _server = registry.server;
+    using cache = tempDir("fuzzilli-reprl-cache", {});
+
+    const result = await runReprl(
+      programs,
+      childEnv({ BUN_CONFIG_REGISTRY: registry.url, BUN_INSTALL_CACHE_DIR: String(cache) }),
+    );
+    expect(registry.requests).toEqual(["/a", "/b", "/c", "/d"]);
+    expect(result.stdout).toContain(`cache: ${cache}\n`);
+    expect(result).toMatchObject({ handshake: "HELO", statuses, stderr: [], exitCode: 0 });
+  });
 });

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -52,14 +52,21 @@ async function runReprl(programs: string[], env: Record<string, string | undefin
   stdio[102] = Bun.file(file("programs.bin"));
 
   await using proc = Bun.spawn({ cmd: [bunExe(), "fuzzilli"], env, cwd: String(dir), stdio });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   const status = fs.readFileSync(file("status.bin"));
   const statuses: number[] = [];
   for (let offset = 4; offset + 4 <= status.length; offset += 4) {
     statuses.push(status.readUInt32LE(offset));
   }
-  return { handshake: status.subarray(0, 4).toString("latin1"), statuses, stdout, exitCode };
+  return {
+    handshake: status.subarray(0, 4).toString("latin1"),
+    statuses,
+    stdout,
+    // The fuzz build prints a [COV] and a [FUZZILLI] banner. Every other line is an error.
+    stderr: stderr.split("\n").filter(line => line && !line.includes("[COV]") && !line.includes("[FUZZILLI]")),
+    exitCode,
+  };
 }
 
 // Fuzzilli picks string literals at random, so a fuzz program can ask for any
@@ -100,7 +107,7 @@ test.skipIf(!isFuzzilliBuild)("bun fuzzilli auto-installs only from BUN_CONFIG_R
   expect(byDefault.stdout).toContain("import: Cannot find package 'd'");
   // Not the cache of the user that runs the fuzzer.
   expect(byDefault.stdout).toContain("cache: /tmp/bun-fuzzilli-install-cache\n");
-  expect(byDefault).toMatchObject({ handshake: "HELO", statuses, exitCode: 0 });
+  expect(byDefault).toMatchObject({ handshake: "HELO", statuses, stderr: [], exitCode: 0 });
 
   // A campaign that sets the variables keeps its values and gets every request.
   const withRegistry = await runReprl(programs, {
@@ -110,5 +117,5 @@ test.skipIf(!isFuzzilliBuild)("bun fuzzilli auto-installs only from BUN_CONFIG_R
   });
   expect(requests).toEqual(["/a", "/b", "/c", "/d"]);
   expect(withRegistry.stdout).toContain(`cache: ${cache}\n`);
-  expect(withRegistry).toMatchObject({ handshake: "HELO", statuses, exitCode: 0 });
+  expect(withRegistry).toMatchObject({ handshake: "HELO", statuses, stderr: [], exitCode: 0 });
 });

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -104,38 +104,34 @@ describe.skipIf(!isFuzzilliBuild)("bun fuzzilli auto-install", () => {
   }
 
   // The tests share /tmp/bun-fuzzilli-reprl.js, which every child writes again, so they run in turn.
-  test.each([
-    ["unset", {}],
-    // The package manager skips an empty value and a registry with no scheme.
-    ["values that the package manager ignores", { BUN_CONFIG_REGISTRY: "localhost:4873", BUN_INSTALL_CACHE_DIR: "" }],
-  ])("reaches no registry when the variables are %s", async (_, inherited) => {
-    const registry = startRegistry();
-    await using _server = registry.server;
+  // "ignored" is a value that the package manager skips: a registry with no scheme, an empty path.
+  describe.each([
+    ["unset", "unset"],
+    ["ignored", "ignored"],
+    ["set", "set"],
+    ["set", "unset"],
+    ["unset", "set"],
+  ])("BUN_CONFIG_REGISTRY %s, BUN_INSTALL_CACHE_DIR %s", (registry, cache) => {
+    test("only a registry that the campaign names gets requests", async () => {
+      const local = startRegistry();
+      await using _server = local.server;
+      using ownCache = tempDir("fuzzilli-reprl-cache", {});
 
-    // npm's variable ranks below BUN_CONFIG_REGISTRY. The child defaults that one
-    // to an address that nothing listens on, so the registry here sees nothing.
-    const result = await runReprl(programs, childEnv({ ...inherited, NPM_CONFIG_REGISTRY: registry.url }));
-    expect(registry.requests).toEqual([]);
-    expect(result.stdout).toContain("uncaught:ResolveMessage: Cannot find module 'a'");
-    expect(result.stdout).toContain("uncaught:ResolveMessage: Cannot find module 'b'");
-    expect(result.stdout).toContain("uncaught:ResolveMessage: Cannot find package 'c'");
-    expect(result.stdout).toContain("import: Cannot find package 'd'");
-    // Not the cache of the user that runs the fuzzer.
-    expect(result.stdout).toContain("cache: /tmp/bun-fuzzilli-install-cache\n");
-    expect(result).toMatchObject({ handshake: "HELO", statuses, stderr: [], exitCode: 0 });
-  });
+      // npm's variable ranks below BUN_CONFIG_REGISTRY. The child defaults that one to an
+      // address that nothing listens on, so the local registry sees nothing through npm's.
+      const inherited: Record<string, string> = { NPM_CONFIG_REGISTRY: local.url };
+      if (registry !== "unset") inherited.BUN_CONFIG_REGISTRY = registry === "set" ? local.url : "localhost:4873";
+      if (cache !== "unset") inherited.BUN_INSTALL_CACHE_DIR = cache === "set" ? String(ownCache) : "";
 
-  test("reaches the registry that BUN_CONFIG_REGISTRY names", async () => {
-    const registry = startRegistry();
-    await using _server = registry.server;
-    using cache = tempDir("fuzzilli-reprl-cache", {});
-
-    const result = await runReprl(
-      programs,
-      childEnv({ BUN_CONFIG_REGISTRY: registry.url, BUN_INSTALL_CACHE_DIR: String(cache) }),
-    );
-    expect(registry.requests).toEqual(["/a", "/b", "/c", "/d"]);
-    expect(result.stdout).toContain(`cache: ${cache}\n`);
-    expect(result).toMatchObject({ handshake: "HELO", statuses, stderr: [], exitCode: 0 });
+      const result = await runReprl(programs, childEnv(inherited));
+      expect(local.requests).toEqual(registry === "set" ? ["/a", "/b", "/c", "/d"] : []);
+      expect(result.stdout).toContain("uncaught:ResolveMessage: Cannot find module 'a'");
+      expect(result.stdout).toContain("uncaught:ResolveMessage: Cannot find module 'b'");
+      expect(result.stdout).toContain("uncaught:ResolveMessage: Cannot find package 'c'");
+      expect(result.stdout).toContain("import: Cannot find package 'd'");
+      // The default is not the cache of the user that runs the fuzzer.
+      expect(result.stdout).toContain(`cache: ${cache === "set" ? ownCache : "/tmp/bun-fuzzilli-install-cache"}\n`);
+      expect(result).toMatchObject({ handshake: "HELO", statuses, stderr: [], exitCode: 0 });
+    });
   });
 });


### PR DESCRIPTION
### Problem
- A fuzz program in `bun fuzzilli` can make bun download an npm package and run it in the fuzz process. `this.require("a")` installs `a@4.0.8` and `a_mock@2.0.5` into `~/.bun/install/cache` and runs `a/index.js`.
- `FuzzilliCommand::exec` (`src/runtime/cli/fuzzilli_command.rs:95`) boots `/tmp/bun-fuzzilli-reprl.js` the way `bun run` does. No `node_modules` directory is above `/tmp`, so auto-install is on.

### Fix
- Before the boot, default `BUN_CONFIG_REGISTRY` to `http://127.0.0.1:1/` and `BUN_INSTALL_CACHE_DIR` to `/tmp/bun-fuzzilli-install-cache`. A usable value from the campaign stays.
- Auto-install stays on, because Fuzzilli found #29255, #29485, #29483 and #41149 in that code. Each attempt now fails at `connect()`, in about 10 ms. A `bun` child that a program spawns inherits both variables.
- Verified: `test/js/bun/util/fuzzilli-reprl.test.ts` with `bun run build:debug:fuzzilli`. Without the fix, a local registry in `NPM_CONFIG_REGISTRY` receives `/a`, `/b`, `/c`, `/d`, and with the fix nothing. CI does not run the test: all other builds compile `bun fuzzilli` out, so it skips there.
- Self-reviewed: the review rejected my first diff, which disabled auto-install, and asked for this shape. Two of its points remain open (Notes).

### Background
- Fuzzilli is a JavaScript fuzzer. It starts `bun fuzzilli` as a child and sends programs over fds 100 to 102 (the REPRL protocol). One child evaluates many programs.
- `bun fuzzilli` exists only in a build with `--fuzzilli=on`. No CI lane uses that flag.
- Auto-install applies when no `node_modules` directory is above the importing file. Bun fetches an unresolved bare specifier from the registry into the global cache, then loads it.

<details><summary>Notes</summary>

**The alternative.** My first diff was one line: `ctx.debug.global_cache = GlobalCache::disable` before `RunCommand::boot`, the value that `--no-install` sets. It is airtight for the resolver in the process. It has two costs. The fuzzer can no longer reach runtime auto-install, which is on by default for users and is where the four fixes above came from. And it does not reach a `bun` child that a program spawns (`bun -e`, `bun x`, `bun add`). If the owners of the fuzz campaign prefer the hard switch, it goes in the same place and the test keeps its first half.

**Why the test uses `NPM_CONFIG_REGISTRY`.** `PackageManagerOptions.rs:620` reads `BUN_CONFIG_REGISTRY` first, then `NPM_CONFIG_REGISTRY`, then `npm_config_registry`, and the first one wins over `.npmrc` and `bunfig.toml`. So the default also outranks a registry that the machine of the fuzzer inherits from npm. Before the fix the lower variable is the only one set, and the local registry receives the requests.

**What counts as a value from the campaign.** A `BUN_CONFIG_REGISTRY` that starts with `http://` or `https://`, and a `BUN_INSTALL_CACHE_DIR` that is not empty. `PackageManagerOptions.rs:628` skips every other registry value and goes on to `NPM_CONFIG_REGISTRY` and then to npm. So `export BUN_CONFIG_REGISTRY=` does not turn the default off.

**If `setenv` fails.** The command prints the errno and exits with code 1 before the boot, like the other failures in `exec`. It does not start a child that would use the live registry.

**What the defaults do not cover.**
- A scoped registry still applies to `@scope/name`. For the process that is `[install.scopes]` in the `bunfig.toml` of the working directory. A `bun install` child also reads `.npmrc`. The environment variable sets only the default scope.
- A fixture registry fills the scratch cache. That is the choice of the campaign.
- The scratch cache path is fixed. Fuzzilli starts a new child after every 1000 programs and after every crash or timeout, and a killed child cannot remove a private directory. So another local user who creates the directory first can fill it. The wrapper at `/tmp/bun-fuzzilli-reprl.js` has the same property today. A campaign on a shared host sets `BUN_INSTALL_CACHE_DIR` itself.

**What needs no change.** An assignment to `process.env.BUN_CONFIG_REGISTRY` in a program does not change the registry of the process. I checked this: the package manager reads the environment that the process started with. A Worker VM builds its transpiler with `GlobalCache::disable` (`src/bundler/options.rs:1771`), and only `RunCommand::wire_transpiler_from_ctx` copies the CLI value. I confirmed that `require("pkg")` in a Worker sends no request.

**The three `NodeModuleModule.cpp(1169)` fuzzer reports** that led here are a real bug in `require.cache`. #41266 fixes it. They are not a reason for this change.

**The two open points of the review.** It wanted this change on top of #42027 and not on main, and it wanted a test that CI runs. Neither is possible from this branch. #42027 replaces the `/tmp` boot with `reprl::run` and rewrites this test file, so the two PRs conflict in both files. The same two `setenv` calls go before `VirtualMachine::init` there. That PR compiles the loop into debug and ASAN builds, so this test can then run in CI under its `describe.skipIf(!enabled)`.

**Binaries that are already built.** The same two variables in `processEnv` of `Sources/Fuzzilli/Profiles/BunProfile.swift` (oven-sh/fuzzilli) give them the same protection. That profile already sets `ASAN_OPTIONS` and `BUN_DEBUG_QUIET_LOGS` there.

**Probes, fuzzilli debug build, linux x64.** I ran the test file by hand on a `--fuzzilli=on` build with and without the change in `src/`. The new cases are one table of five rows: both variables unset, both set to ignored values, both set, and each one set alone. Without the change four rows fail, for example the first one at `expect(local.requests).toEqual([])` with `["/a", "/b", "/c", "/d"]`. The row with both set passes. With the change all rows pass. A build without that flag skips the test in both states.
- Before: programs `require("a")`, `require.resolve("b")`, `Bun.resolveSync("c", "/tmp")`, `import("d")` with a local 404 registry in the environment. The registry logs `/a`, `/b`, `/c`, `/d`.
- After, only `NPM_CONFIG_REGISTRY` set to the local registry: no request. `process.env` in the program shows both defaults. `require("a")` throws `Cannot find module 'a'` after 14 ms (first use, starts the package manager), `Bun.resolveSync` after 7 ms. A `bun -e` child of the program sends no request.
- After, `BUN_CONFIG_REGISTRY` set to the local registry: it logs `/a`, `/c`, `/d` and `/child-pkg` from the child.
- A stray `/tmp/node_modules` directory turns auto-install off for the wrapper. The second half of the test then fails, which is correct: the fuzzer does not reach auto-install on that machine.
- `cargo check -p bun_runtime` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, `cargo clippy -p bun_runtime`, and `bun bd test test/js/bun/util/fuzzilli-reprl.test.ts` (1 pass, 1 skip) are clean.

</details>
