### PR TITLE
react-compiler: restore a local assigned inside a reactive scope on every cache hit

### DIFF
--- a/.claude/skills/sync-react-compiler.md
+++ b/.claude/skills/sync-react-compiler.md
@@ -44,7 +44,9 @@ the porting reference for the AST-boundary files.
 2. **Apply whole-crate diffs mechanically.** For each hunk under the
    whole-crate section, apply it to the corresponding `src/react_compiler/<dir>/`
    file. The only systematic edit is import paths (`react_compiler_hir::` →
-   `crate::hir::`, etc.); everything else lands verbatim.
+   `crate::hir::`, etc.); everything else lands verbatim. A few sites fix
+   miscompiles that upstream still has. `DESIGN.md` lists them under
+   "Behaviour that differs from upstream". Keep them when a hunk touches one.
 
 3. **Re-port AST-boundary diffs by hand.** For each hunk under the
    AST-boundary section, re-port it into the named Bun file using the

--- a/src/react_compiler/DESIGN.md
+++ b/src/react_compiler/DESIGN.md
@@ -66,6 +66,17 @@ Keep the diff between upstream and the port as small as the type substitution
 allows — the `/sync-react-compiler` skill re-ports upstream changes hunk by
 hunk, so gratuitous restructuring makes that harder.
 
+### Behaviour that differs from upstream
+
+A few sites in the whole-crate ports fix a miscompile that upstream still has.
+Each one has a comment that starts with "Upstream". Keep them on a sync, and
+drop one only when upstream fixes the same case.
+
+| Where                                                                | What Bun does                                                                                                                                                      | Test (`test/bundler/transpiler/react-compiler.test.ts`)   |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| `inference/propagate_scope_dependencies_hir.rs` `visit_reassignment` | A reassignment is an output of every enclosing reactive scope that starts after the declaration, not only of the innermost one. Each restores it on its cache hit. | `react-compiler/LocalAssignedInsideScopeSurvivesCacheHit` |
+| `inference/propagate_scope_dependencies_hir.rs` `handle_instruction` | `x++` and `--x` register `x` as a reassignment of the scope, as `x = x + 1` does.                                                                                  | same                                                      |
+
 ### Type mapping (input: lowering)
 
 | upstream `react_compiler_ast`                                            | `bun_ast`                                                                      |

--- a/src/react_compiler/inference/propagate_scope_dependencies_hir.rs
+++ b/src/react_compiler/inference/propagate_scope_dependencies_hir.rs
@@ -1807,6 +1807,18 @@ impl<'a> DependencyCollectionContext<'a> {
     }
 
     fn check_valid_dependency(&self, dep: &ReactiveScopeDependency, env: &Environment) -> bool {
+        match self.current_scope() {
+            Some(current_scope) => self.check_valid_dependency_of(dep, current_scope, env),
+            None => false,
+        }
+    }
+
+    fn check_valid_dependency_of(
+        &self,
+        dep: &ReactiveScopeDependency,
+        scope_id: ScopeId,
+        env: &Environment,
+    ) -> bool {
         // Ref value is not a valid dep
         let ty = &env.types[env.identifiers[dep.identifier.0 as usize].type_.0 as usize];
         if crate::hir::is_ref_value_type(ty) {
@@ -1823,11 +1835,9 @@ impl<'a> DependencyCollectionContext<'a> {
             .get(dep.identifier)
             .or_else(|| self.declarations.get(ident.declaration_id));
 
-        if let Some(current_scope) = self.current_scope() {
-            if let Some(decl) = current_declaration {
-                let scope_range_start = env.scopes[current_scope.0 as usize].range.start;
-                return decl.id < scope_range_start;
-            }
+        if let Some(decl) = current_declaration {
+            let scope_range_start = env.scopes[scope_id.0 as usize].range.start;
+            return decl.id < scope_range_start;
         }
         false
     }
@@ -1914,25 +1924,25 @@ impl<'a> DependencyCollectionContext<'a> {
         }
     }
 
+    /// Upstream records the reassignment on the innermost scope only. A cache
+    /// hit on an enclosing scope skips the inner scope too, so every enclosing
+    /// scope that starts after the declaration has to restore the variable.
     fn visit_reassignment(&mut self, place: &Place, env: &mut Environment) {
-        if let Some(current_scope) = self.current_scope() {
-            let scope = &env.scopes[current_scope.0 as usize];
-            let already = scope.reassignments.iter().any(|id| {
-                env.identifiers[id.0 as usize].declaration_id
-                    == env.identifiers[place.identifier.0 as usize].declaration_id
-            });
-            if !already
-                && self.check_valid_dependency(
-                    &ReactiveScopeDependency {
-                        identifier: place.identifier,
-                        reactive: place.reactive,
-                        path: hir_vec![],
-                        loc: place.loc,
-                    },
-                    env,
-                )
-            {
-                env.scopes[current_scope.0 as usize]
+        let dep = ReactiveScopeDependency {
+            identifier: place.identifier,
+            reactive: place.reactive,
+            path: hir_vec![],
+            loc: place.loc,
+        };
+        let decl_id = env.identifiers[place.identifier.0 as usize].declaration_id;
+        for &scope_id in &self.scope_stack {
+            let scope = &env.scopes[scope_id.0 as usize];
+            let already = scope
+                .reassignments
+                .iter()
+                .any(|id| env.identifiers[id.0 as usize].declaration_id == decl_id);
+            if !already && self.check_valid_dependency_of(&dep, scope_id, env) {
+                env.scopes[scope_id.0 as usize]
                     .reassignments
                     .push(place.identifier);
             }
@@ -2128,6 +2138,26 @@ fn handle_instruction(
             // Visit all operands (lvalue.place AND value)
             ctx.visit_operand(&lvalue.place, env);
             ctx.visit_operand(val, env);
+        }
+        // Upstream visits only `value` here. `x++` assigns `x` like `x = x + 1`
+        // does, so the scope has to restore `x` when its cache hits.
+        InstructionValue::PrefixUpdate {
+            lvalue, value: val, ..
+        }
+        | InstructionValue::PostfixUpdate {
+            lvalue, value: val, ..
+        } => {
+            ctx.visit_operand(val, env);
+            ctx.visit_reassignment(lvalue, env);
+            let scope_stack_copy = ctx.scope_stack.clone();
+            ctx.declare(
+                lvalue.identifier,
+                Decl {
+                    id,
+                    scope_stack: scope_stack_copy,
+                },
+                env,
+            );
         }
         _ => {
             // Visit all value operands

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1631,6 +1631,220 @@ describe("bundler", () => {
     },
   });
 
+  // `stubReact` with one memo cache per component, kept across calls the way
+  // React keeps it across renders. The test sets `globalThis.renderingComponent`
+  // before it calls a component.
+  const stubReactWithPersistentMemoCache = {
+    ...stubReact,
+    "/node_modules/react/compiler-runtime.js": /* js */ `
+      const caches = new Map();
+      exports.c = size => {
+        const key = globalThis.renderingComponent;
+        if (!caches.has(key)) caches.set(key, new Array(size).fill(Symbol.for("react.memo_cache_sentinel")));
+        return caches.get(key);
+      };
+    `,
+  };
+
+  // A `let` that is declared before a reactive scope and assigned inside it is
+  // an output of the scope: the scope stores it after the computation and
+  // restores it when its cache hits. Two cases were missed. A scope can sit
+  // inside another one, and a cache hit on the outer scope skips the inner
+  // scope too, so the outer scope has to store and restore the variable as
+  // well. And `x++` assigns `x` the way `x = x + 1` does. Each component below
+  // is rendered twice with the same props (the second render hits the cache)
+  // and then once with `a` changed.
+  itBundled("react-compiler/LocalAssignedInsideScopeSurvivesCacheHit", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        // The scope of inner is inside the scope of outer. Both are kept.
+        function TwoArrays(p) {
+          let v = "init";
+          const outer = [];
+          const inner = [];
+          v = "v" + p.a;
+          inner.push(p.b);
+          outer.push(p.c);
+          return <div v={v} outer={outer} inner={inner} />;
+        }
+        function ThreeArrays(p) {
+          let v = "init";
+          const outer = [];
+          const middle = [];
+          const inner = [];
+          v = "v" + p.a;
+          inner.push(p.a);
+          middle.push(p.b);
+          outer.push(p.c);
+          return <div v={v} outer={outer} middle={middle} inner={inner} />;
+        }
+        // Both scopes depend on p.a only, so the inner one is merged into the
+        // outer one.
+        function SameDependencies(p) {
+          let v = "init";
+          const outer = [];
+          const inner = [];
+          v = "v" + p.a;
+          inner.push(p.a);
+          outer.push(p.a);
+          return <div v={v} outer={outer} inner={inner} />;
+        }
+        function Destructuring(p) {
+          let v = "init", u = "init";
+          const outer = [];
+          const inner = [];
+          [v, u] = [p.a, p.b];
+          inner.push(p.b);
+          outer.push(p.c);
+          return <div v={[v, u]} outer={outer} inner={inner} />;
+        }
+        // The scope of w runs from its declaration to the end of the for-of. The
+        // do-while counter j has a scope of its own inside it, which is later
+        // pruned because nothing it computes needs memoization.
+        function DoWhileInsideScopeOfSibling(p) {
+          let v = "init";
+          let w = "w";
+          let j = 0;
+          do { j++; v = "v" + p.a; } while (j < p.n);
+          for (const it of p.items) { w = {}; }
+          return <div v={v} w={w} />;
+        }
+        // The scope of the object spread is inside loops, so it is flattened.
+        function SpreadInsideLoopsInsideScopeOfSibling(p) {
+          let v = "init";
+          let w = "w";
+          for (const k in p.obj) {
+            for (let i = 0; i < p.n; i++) {
+              switch (p.a) {
+                case 1: v = { ...p.obj }; break;
+                default: break;
+              }
+            }
+          }
+          for (const it of p.items) { w = {}; }
+          return <div v={v} w={w} />;
+        }
+        // One scope is enough for an update expression.
+        function PostfixUpdate(p) {
+          let v = 0;
+          const rows = [];
+          if (p.a === 1) v++;
+          rows.push(p.c);
+          return <div v={v} rows={rows} />;
+        }
+        function PrefixUpdateInNestedScope(p) {
+          let v = 0;
+          const outer = [];
+          const inner = [];
+          if (p.a === 1) --v;
+          inner.push(p.b);
+          outer.push(p.c);
+          return <div v={v} outer={outer} inner={inner} />;
+        }
+
+        const first = { a: 1, b: 2, c: 3, n: 1, items: [1], obj: { q: 1 } };
+        const second = { ...first, a: 2 };
+        const components = {
+          TwoArrays,
+          ThreeArrays,
+          SameDependencies,
+          Destructuring,
+          DoWhileInsideScopeOfSibling,
+          SpreadInsideLoopsInsideScopeOfSibling,
+          PostfixUpdate,
+          PrefixUpdateInNestedScope,
+        };
+        for (const [name, Component] of Object.entries(components)) {
+          globalThis.renderingComponent = name;
+          const renders = [first, first, second].map(props => JSON.stringify(Component(props).p.v));
+          console.log(name, ...renders);
+        }
+      `,
+      ...stubReactWithPersistentMemoCache,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    run: {
+      stdout: `
+        TwoArrays "v1" "v1" "v2"
+        ThreeArrays "v1" "v1" "v2"
+        SameDependencies "v1" "v1" "v2"
+        Destructuring [1,2] [1,2] [2,2]
+        DoWhileInsideScopeOfSibling "v1" "v1" "v2"
+        SpreadInsideLoopsInsideScopeOfSibling {"q":1} {"q":1} "init"
+        PostfixUpdate 1 1 0
+        PrefixUpdateInNestedScope -1 -1 0
+      `,
+    },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // Every component compiled: each one allocates a memo cache.
+      expect(out.match(/\blet \$ = [\w$]+\(\d+\);/g)).toHaveLength(8);
+    },
+  });
+
+  // Not fixed yet (facebook/react#37224, upstream has it too). The local is
+  // assigned on only some paths through the scope. On the other paths it keeps
+  // the value it had on entry, and that value is not a dependency of the scope.
+  // When only that value changes, the cache hits and restores the value of an
+  // older render: the second render of each component prints the first
+  // render's value. Before the outer scope restored the variable, the two
+  // nested shapes got the second render right and the fourth one wrong.
+  itBundled("react-compiler/LocalAssignedOnSomePathsKeepsItsValueOnEntry", {
+    todo: true,
+    files: {
+      "/entry.jsx": /* jsx */ `
+        function OneScope(p) {
+          let v = p.v;
+          const list = [];
+          if (p.off) v = "off";
+          list.push(p.b);
+          return <div v={v} list={list} />;
+        }
+        function NestedScopes(p) {
+          let v = p.v;
+          const outer = [];
+          const inner = [];
+          if (p.off) v = "off";
+          inner.push(p.b);
+          outer.push(p.c);
+          return <div v={v} outer={outer} inner={inner} />;
+        }
+        function LoopInsideScopeOfSibling(p) {
+          let v = p.v;
+          let w = "w";
+          for (const it of p.items) { if (p.off) v = "off"; }
+          for (const it of p.items) { w = {}; }
+          return <div v={v} w={w} />;
+        }
+
+        const items = [1];
+        const renders = [
+          { v: "a", off: false, b: 2, c: 3, items },
+          { v: "b", off: false, b: 2, c: 3, items },
+          { v: "b", off: true, b: 2, c: 3, items },
+          { v: "b", off: true, b: 2, c: 3, items },
+        ];
+        for (const [name, Component] of Object.entries({ OneScope, NestedScopes, LoopInsideScopeOfSibling })) {
+          globalThis.renderingComponent = name;
+          console.log(name, ...renders.map(props => JSON.stringify(Component(props).p.v)));
+        }
+      `,
+      ...stubReactWithPersistentMemoCache,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    run: {
+      stdout: `
+        OneScope "a" "b" "off" "off"
+        NestedScopes "a" "b" "off" "off"
+        LoopInsideScopeOfSibling "a" "b" "off" "off"
+      `,
+    },
+  });
+
   // Outside the compiler, the bundler binds a local that holds a `require()` /
   // `import()` export to the export itself: `const { a } = require("./m")`
   // declares nothing, and `ns.a` off `const ns = require("./m")` is an import


### PR DESCRIPTION
### Problem

- With `bun build --react-compiler` (client mode), a `let` assigned inside a reactive scope that is nested in another one reads `undefined` on the next render with unchanged props. The source of fuzz ledger entry 47853 prints `c1 undefined`.
- `visit_reassignment` (`src/react_compiler/inference/propagate_scope_dependencies_hir.rs`) records the variable on the innermost scope only. A cache hit on the outer scope skips the inner one too and does not restore the variable.
- `x++` and `--x` are not recorded at all: `let n = 0; const rows = []; if (p.h) n++; rows.push(p.c)` renders `1`, then `0`.

### Fix

- `visit_reassignment` records the variable on every scope on the stack that starts after the declaration.
- `handle_instruction` sends the target of `PrefixUpdate` / `PostfixUpdate` through `visit_reassignment`, like a `StoreLocal` reassignment.
- Correct because each such scope skips the assignment on a cache hit. Codegen already stores and restores every `scope.reassignments` entry.
- Verified: `react-compiler/LocalAssignedInsideScopeSurvivesCacheHit` in `test/bundler/transpiler/react-compiler.test.ts` (8 shapes, all wrong on main). Also `react-compiler-fixtures.test.ts` (no slot count changes) and `bundler_jsx.test.ts`.

### Background

- The compiler splits a component into reactive scopes. Each prints as `if (deps changed) { body; $[i] = out } else { out = $[i] }`. `$` is the memo cache React keeps between renders.
- A scope's outputs are its `declarations` and `reassignments` (variables declared before it that it assigns). Scopes can nest.
- `src/react_compiler/inference/` is a line for line port of upstream, which has both bugs. `DESIGN.md` now lists the two sites as deliberate differences.
- Part 1 of 2. The notes describe a related upstream bug that stays open.

<details><summary>Notes</summary>

**This is part 1.** One related upstream bug stays open and this change moves where it shows (facebook/react#37224, open fix facebook/react#37273). A local that is assigned on only some paths through a scope keeps its value on entry on the other paths, and that value is not a dependency of the scope. With one scope, main and upstream already restore a stale value when only that value changes (`let v = p.v; const x = []; if (p.off) v = "off"; x.push(p.b)` rendered with `v: "a"`, then `v: "b"` prints `"a" "a"`). With nested scopes, main gets that render right by accident (the outer scope never restores the variable) and gets the same-props render after the assignment wrong. After this change nested scopes behave like the single scope: the same-props render is right, the changed-value render is stale. `react-compiler/LocalAssignedOnSomePathsKeepsItsValueOnEntry` pins the three shapes as a `todo` with the correct output. Unconditional assignments and all update expressions are not affected (an update always reads the variable, so the value on entry is a dependency). The follow-up is to make the value on entry a dependency when a phi in the scope merges it (the upstream PR's approach, with its dependency stored before the computation). A review build of that on top of this change passed all fixtures with no slot count change. It should land before the next release.

Other facts:

- The reported source: `function App(p) { let v = "init"; let w = "w"; let j = 0; do { j++; v = "c" + p.a; } while (j < p.n); for (const it of p.items) { w = {}; } return <div data-v={v} data-w={w} />; }`. The second corpus shape (`v2 = { ...p.obj }` inside `for…in` > `for` > `switch`) has the same cause: the inner scope is the object spread, flattened because it is in a loop. It is one of the 8 test shapes.
- Upstream: `babel-plugin-react-compiler@1.0.0` miscompiles `let v = "init"; const x = []; const y = []; v = "c" + p.a; y.push(p.b); x.push(p.c);` the same way. Bun hits the nested case more because the port includes facebook/react#36732 (after 1.0.0). For the reported source, `w = {}` in the for-of is a loop-carried reassignment, so that change unions `w`'s phi with `let w = "w"`. The scope of `w` then runs from its declaration to the end of the for-of and contains the do-while. The counter `j` gets a scope inside it. `v = "c" + p.a` is recorded on the `j` scope only, `PruneNonEscapingScopes` removes that scope, and the reassignment is gone. 1.0.0 with that hunk applied prints the same wrong code as Bun.
- The inner scope can disappear three ways, each covered by a shape: pruned as non-escaping, flattened inside a loop, merged into the outer scope by `MergeReactiveScopesThatInvalidateTogether` (same dependencies).
- The other scope outputs were already nesting-aware: `declarations` walks the scope stack of the declaration, dependencies propagate to the parent in `exit_scope`, the early return value goes to the outermost scope.
- Differential fuzz (compiled against uncompiled, each component rendered 12 to 18 times over prop sets that include same-props renders): 3,000 generated control-flow components, 25 wrong on main, 9 wrong with this change, all 9 also wrong on main (the ones reduced so far are a different upstream bug: a memoized array or object that a later render mutates through a loop phi). A second fuzz aimed at the trade above (reactive initializers, one prop changed per render) has more fixed than newly wrong in every run (37/6, 27/4, 17/9).
- `ssr` output mode has no memo cache and is not affected.
- Branch `robobun/789e3863/react-compiler-reassigned-let-scope` (no PR yet) has another implementation of these two fixes together with the value-on-entry dependency.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [720.05ms]
(pass) bundler > react-compiler/ComponentWithHooks [321.19ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [411.03ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [419.22ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [170.69ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [155.20ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [366.91ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [136.20ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [657.54ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [117.14ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [109.68ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [376.58ms]
(pass) bundler > reac
... (truncated)

release without fix: 18 failed, 2 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [18.21ms]
(pass) bundler > react-compiler/ComponentWithHooks [9.94ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [7.88ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [7.56ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [7.33ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [4.39ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [11.18ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [4.16ms]
1031 |       ]);
1032 |       const stdout = Buffer.from(stdoutBytes);
1033 |       const stderr = Buffer.from(stderrBytes);
1034 |       const success = exitCode === 0;
1035 |       if (buildProc.signalCode) {
1036 |         throw new Error(
                         ^
error: [react-compiler/SsrObjectMethodShorthand] 'bun build' subprocess killed by SIGABRT
cmd: /workspace/bun/build/release/bun build /tmp/bun-build-tests/bun-87PIuT/react-compiler/SsrObjectMethodShorthand/entry.jsx --outfile=/tmp/bun-build-tests/bun-
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [1004.23ms]
(pass) bundler > react-compiler/ComponentWithHooks [400.98ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [308.80ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [331.15ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [226.69ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [349.34ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [478.69ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [179.34ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [970.85ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [155.44ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [131.90ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [481.07ms]
(pass) bundler > rea
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 958ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/wo
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.claude/skills/sync-react-compiler.md              |   4 +-
 src/react_compiler/DESIGN.md                       |  11 ++
 .../inference/propagate_scope_dependencies_hir.rs  |  76 +++++---
 test/bundler/transpiler/react-compiler.test.ts     | 214 +++++++++++++++++++++
 4 files changed, 281 insertions(+), 24 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
.claude/skills/sync-react-compiler.md                         1      1     26
src/react_compiler/DESIGN.md                                  2      1     26
…_compiler/inference/propagate_scope_dependencies_hir.rs      2      4     26
test/bundler/transpiler/react-compiler.test.ts                5      4     26
```

</details>

<!-- robobun:evidence:end -->