### PR TITLE
worker_threads: do not abort when markAsUntransferable/markAsUncloneable gets a WebAssembly GC reference

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -4338,6 +4338,10 @@ size_t SerializedScriptValue::computeMemoryCost() const
 
 static void markObjectWithPrivateName(VM& vm, JSObject& object, const Identifier& privateName)
 {
+    // A WebAssembly GC struct/array has a Structure that never transitions, so putDirect would
+    // abort. It is already neither cloneable nor transferable. Node leaves it unmarked too.
+    if (object.type() == WebAssemblyGCObjectType)
+        return;
     if (object.getDirect(vm, privateName))
         return;
     object.putDirect(vm, privateName, jsBoolean(true), PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | 0);

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -138,6 +138,70 @@ test("markAsUncloneable and markAsUntransferable markers are private, unforgeabl
   expectDataCloneError(() => structuredClone(unmarkAttempt));
 });
 
+// A WebAssembly GC struct/array reference is an object that cannot take a property. Node returns
+// undefined and leaves it unmarked. It runs in a subprocess because the bug aborted the process.
+test("markAsUntransferable and markAsUncloneable leave WebAssembly GC references unmarked", async () => {
+  const fixture = `
+    // (module
+    //   (type $s (struct (field (mut i32))))
+    //   (type $a (array (mut i32)))
+    //   (func (export "struct") (result (ref null $s)) struct.new_default $s)
+    //   (func (export "array") (result (ref null $a)) i32.const 3 array.new_default $a))
+    const bytes = new Uint8Array([
+      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+      // types: struct, array, () -> (ref null 0), () -> (ref null 1)
+      0x01, 0x12, 0x04, 0x5f, 0x01, 0x7f, 0x01, 0x5e, 0x7f, 0x01, 0x60, 0x00, 0x01, 0x63, 0x00, 0x60, 0x00, 0x01, 0x63, 0x01,
+      // functions
+      0x03, 0x03, 0x02, 0x02, 0x03,
+      // exports: "struct" -> func 0, "array" -> func 1
+      0x07, 0x12, 0x02, 0x06, 0x73, 0x74, 0x72, 0x75, 0x63, 0x74, 0x00, 0x00, 0x05, 0x61, 0x72, 0x72, 0x61, 0x79, 0x00, 0x01,
+      // code: struct.new_default 0 / i32.const 3, array.new_default 1
+      0x0a, 0x0f, 0x02, 0x05, 0x00, 0xfb, 0x01, 0x00, 0x0b, 0x07, 0x00, 0x41, 0x03, 0xfb, 0x07, 0x01, 0x0b,
+    ]);
+    const { struct, array } = new WebAssembly.Instance(new WebAssembly.Module(bytes)).exports;
+    const wt = require("node:worker_threads");
+    const errorName = fn => {
+      try {
+        fn();
+        return "no error";
+      } catch (e) {
+        return e.name;
+      }
+    };
+    const result = {};
+    for (const [kind, ref] of [["struct", struct()], ["array", array()]]) {
+      const { port1 } = new wt.MessageChannel();
+      result[kind] = {
+        markAsUntransferable: String(wt.markAsUntransferable(ref)),
+        markAsUncloneable: String(wt.markAsUncloneable(ref)),
+        isMarkedAsUntransferable: wt.isMarkedAsUntransferable(ref),
+        clone: errorName(() => structuredClone(ref)),
+        transfer: errorName(() => port1.postMessage(1, [ref])),
+      };
+      port1.close();
+    }
+    console.log(JSON.stringify(result));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const unmarked = {
+    markAsUntransferable: "undefined",
+    markAsUncloneable: "undefined",
+    isMarkedAsUntransferable: false,
+    clone: "DataCloneError",
+    transfer: "DataCloneError",
+  };
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ struct: unmarked, array: unmarked });
+  expect(exitCode).toBe(0);
+});
+
 test("all worker_threads worker instance properties are present", async () => {
   const worker = new Worker(new URL("./worker.js", import.meta.url));
   expect(worker).toHaveProperty("threadId");


### PR DESCRIPTION
### Problem
- `worker_threads.markAsUntransferable(ref)` and `markAsUncloneable(ref)` abort the process when `ref` is a WebAssembly GC struct or array. Release: `panic(main thread): abort() called`, exit code 134. Debug: `ASSERTION FAILED: WebAssemblyGCStructure should not do transition` in `JSC::Structure::create`, `StructureInlines.h(66)`.
- The cause is `markObjectWithPrivateName` (`src/jsc/bindings/webcore/SerializedScriptValue.cpp:4339`). It stores the mark, a private-name property, with `putDirect()` on any object. That adds a property through a Structure transition. A WebAssembly GC Structure refuses every transition.

### Fix
- `markObjectWithPrivateName` returns early when `object.type() == WebAssemblyGCObjectType`. JSC uses the same check in `JSObject::definePrivateField`.
- Correct because the reference is already neither cloneable nor transferable. `structuredClone(ref)` and `postMessage(x, [ref])` throw `DataCloneError` with or without a mark. Node.js v26.3.0 also returns `undefined` and leaves `isMarkedAsUntransferable(ref)` at `false`.
- The check is on the type, not on extensibility. Frozen objects must still take the mark, as in Node.js.
- Verified: new test in `test/js/node/worker_threads/worker_threads.test.ts`. It fails without the fix on release and debug builds. Also ran the rest of that file, the Node.js `mark-as-*` tests and the structured clone tests.

### Background
- A WebAssembly GC reference is the JS view of a wasm `struct` or `array` (Kotlin/Wasm and dart2wasm return them). In JSC it is a non-extensible `JSObject` with a null prototype and no property storage.
- A Structure describes the property layout of an object. To add a property, JSC moves the object to a new Structure (a transition). `WebAssemblyGCStructure` has a fixed layout and asserts that it never transitions.
- `putDirect()` skips the object's own `put` and `defineOwnProperty` hooks. For these references the hooks throw `TypeError`.

<details><summary>Notes</summary>

Repro (`bun b.js`, or `bun b.js uncloneable`):

```js
// (type $s (struct (field (mut i32))))  (func (export "mk") (result (ref null $s)) struct.new_default $s)
const bytes = new Uint8Array([0,0x61,0x73,0x6d,1,0,0,0, 1,10,2, 0x5f,1,0x7f,1, 0x60,0,1,0x63,0, 3,2,1,1, 7,6,1,2,0x6d,0x6b,0,0, 10,7,1,5,0,0xfb,1,0,0x0b]);
const obj = new WebAssembly.Instance(new WebAssembly.Module(bytes)).exports.mk();
const wt = require("worker_threads");
wt[process.argv[2] === "uncloneable" ? "markAsUncloneable" : "markAsUntransferable"](obj);
console.log("survived");
```

- Before: bun 1.4.3-canary.1 aborts with exit code 134 for both functions. Node.js v26.3.0 prints `survived`. After: bun prints `survived`.
- `isMarkedAsUntransferable(ref)` and the serializer read the mark with `getDirect()`. That read is safe on these references (it finds no property), so only the write needed a guard. The test asserts both.
- The check lives in `markObjectWithPrivateName` because that function owns the `putDirect()`. Both host functions in `webcore/Worker.cpp` and the two N-API callers go through it. #40015 edits `jsFunctionMarkAsUntransferable` in `Worker.cpp`. This PR does not touch that file.
- `JSObject::setPrivateBrand` and `JSObject::butterfly()` in JSC use the same `type() == WebAssemblyGCObjectType` check.
- The same abort is reachable through two other entry points, and open PRs cover them: `spyOn` (#34976) and `Error.captureStackTrace` (#33412, a null `globalObject()` there).
- Other object kinds, compared with Node.js v26.3.0: frozen, sealed and non-extensible plain objects and a frozen `ArrayBuffer` take the mark in both runtimes. For a `Proxy`, Node.js throws `TypeError` and bun marks the proxy cell. This PR does not change that.
- Suites run with the debug build: `test/js/node/worker_threads/worker_threads.test.ts`, `test/js/node/test/parallel/test-worker-message-transfer-port-mark-as-untransferable.js`, `test/js/node/test/parallel/test-worker-message-mark-as-uncloneable.js`, `test/js/web/workers/structured-clone.test.ts`, `test/js/web/workers/worker-postmessage-transfer.test.ts`.
- One unrelated test in the file (`terminate(): nothing of the worker's runs after the request`) failed once in the full run on a loaded machine and passed 3 of 3 alone. It does not call the changed function.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1660.62ms]
(pass) all worker_threads module properties are present [59.94ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [37.91ms]
195 |     markAsUncloneable: "undefined",
196 |     isMarkedAsUntransferable: false,
197 |     clone: "DataCloneError",
198 |     transfer: "DataCloneError",
199 |   };
200 |   expect(stderr).toBe("");
                       ^
error: expect(received).toBe(expected)

- ""
+ "ASSERTION FAILED: WebAssemblyGCStructure should not do transition
+ assertionFailureDueToUnreachableCode
+ vendor/WebKit/Source/JavaScriptCore/runtime/StructureInlines.h(66) : static Structure *JSC::Structure::create(VM &, Structure *, DeferredStructureTransitionWatchpointFire *)
+ no stacktrace available"

- Expected  - 1
+ Received  + 4

      at <anonymous> (/workspace/bun/test/js/node/worker_threads/worker_threads.test.ts
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [30.09ms]
(pass) all worker_threads module properties are present [0.49ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [0.55ms]
195 |     markAsUncloneable: "undefined",
196 |     isMarkedAsUntransferable: false,
197 |     clone: "DataCloneError",
198 |     transfer: "DataCloneError",
199 |   };
200 |   expect(stderr).toBe("");
                       ^
error: expect(received).toBe(expected)

- ""
+ "============================================================
+ Bun Canary v1.4.3-canary.1 (6a92015fc) Linux x64
+ Linux Kernel v7.0.0 | glibc v2.41
+ CPU: sse42 popcnt avx avx2 avx512
+ Args: "/workspace/bun/build/release/bun" "-e" "\n    // (module\n    //   (type $s (struct (field (mut i32))))\n    //   (type $a (array (mut i32)))\n    //   (func (export \"struct\") (result (ref null $s)) struct."...
+ Features: bunfig jsc tsconfig 
+ Builtins: "bun:main" "node:worker_threads" 
+ 
+ Elapsed: 14ms | User: 10ms | Sys: 5ms
+ RSS: 35.89 MB | Peak: 49.73 MB | Commit: 38.80 MB | Faults: 0 | Machine: 34.3
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/worker_threads/worker_threads.test.ts:
(pass) support eval in worker [1671.82ms]
(pass) all worker_threads module properties are present [47.37ms]
(pass) markAsUncloneable and markAsUntransferable markers are private, unforgeable, and permanent [31.99ms]
(pass) markAsUntransferable and markAsUncloneable leave WebAssembly GC references unmarked [1030.36ms]
(pass) all worker_threads worker instance properties are present [272.40ms]
(pass) threadId module and worker property is consistent [341.82ms]
(pass) receiveMessageOnPort works across threads [1684.38ms]
(pass) receiveMessageOnPort works as FIFO [24.87ms]
(pass) you can override globalThis.postMessage [1707.13ms]
(pass) support require in eval [1279.59ms]
cwd /workspace/bun
realpath test/js/node/worker_threads/fixture-argv.js
(pass) support require in eval for a file [1681.29ms]
(pass) support require in eval for a file that doesnt exist [1601.38ms]
(pass) support worker eval that throws [1637
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     d28187e9e5
  features     baseline

23 deps, 131 codegen, 1172 objects in 902ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (6a92015fc)

Checked 22 installs across 61 packages (no changes) [16.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (6a92015fc)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (6a92015fc)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[5/1244] gen bindgenv2
[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1216] fetch zlib
[zlib] up to date
[9/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 9ms

  react-refresh.js  4.81 KB  (entry point)

[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] fetch picohttpparser
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/SerializedScriptValue.cpp |  4 ++
 test/js/node/worker_threads/worker_threads.test.ts | 64 ++++++++++++++++++++++
 2 files changed, 68 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/webcore/SerializedScriptValue.cpp      2      1     10
test/js/node/worker_threads/worker_threads.test.ts      3      2     10
```

</details>

**root cause** · written by the author bot

`markObjectWithPrivateName` in `src/jsc/bindings/webcore/SerializedScriptValue.cpp` wrote its private marker with `putDirect` on any object passed to `worker_threads.markAsUntransferable` or `markAsUncloneable`, which bypasses the object's own `put` and `defineOwnProperty` checks. A WebAssembly GC struct or array reference has a Structure that refuses every transition, so that write aborted the process instead of throwing or being ignored. The fix returns early when `object.type() == Web `AssemblyGCObjectType`, so both functions now return undefined and leave the reference unmarked, matchin…

<!-- robobun:evidence:end -->