### PR TITLE
react-compiler: treat a throw into a catch handler as reactive control flow

### DIFF
--- a/src/react_compiler/inference/infer_reactive_places.rs
+++ b/src/react_compiler/inference/infer_reactive_places.rs
@@ -247,7 +247,7 @@ pub(crate) fn infer_reactive_places(
                 reactive_map.is_reactive(op.identifier);
             }
 
-            // See `ReactiveThrows`.
+            // A block throws reactively if it reads a reactive value or only runs under a reactive test.
             let throws_reactively = throws_to_handler(&block.terminal)
                 && (block_has_reactive_input || has_reactive_control);
             if throws_reactively || reactive_throws.controls(*block_id) {
@@ -462,9 +462,7 @@ fn is_reactive_controlled_block(
         || reactive_throws.controls(block_id)
 }
 
-// =============================================================================
 // Reactive throws (not in upstream)
-// =============================================================================
 
 fn throws_to_handler(terminal: &Terminal) -> bool {
     matches!(
@@ -476,44 +474,20 @@ fn throws_to_handler(terminal: &Terminal) -> bool {
     )
 }
 
-/// Reactive control flow through `try` / `catch`. Upstream's
-/// ControlDominators.ts only looks at `if` / `branch` / `switch` terminals, so
-/// it memoizes a value that is assigned in a `catch` with no dependency.
-///
-/// A `MaybeThrow` terminal with a handler is a branch as well: control goes to
-/// the handler when an instruction of the block throws. It has no test operand
-/// to look up in the `ReactivityMap`, so the block itself is recorded. It
-/// throws reactively when one of its instructions has a reactive input, or
-/// when the block itself is reactive-controlled: then whether it runs at all,
-/// and so whether it throws, can change between renders.
-///
-/// In a `try` block every instruction ends its block with a `MaybeThrow`, so
-/// the frontier of a block is mostly just the block before it. One level of
-/// control dependence, which is all upstream reads, then loses what is further
-/// back: an earlier reactive throw, or a reactive `if` around the blocks. So
-/// control dependence on a reactive throw is transitive here. It passes
-/// through every block that only runs depending on one.
+/// `try` / `catch` control flow: a `MaybeThrow` with a handler is a branch that has no test operand.
 #[derive(Default)]
 struct ReactiveThrows {
-    /// For a block, the blocks on its post-dominator frontier. Only filled in
-    /// for a function that has a `MaybeThrow` with a handler.
+    /// Post-dominator frontier of each block, recorded only when the function has a handler.
     frontiers: IdMap<BlockId, Vec<BlockId>>,
-    /// The `MaybeThrow` blocks that throw reactively and the blocks that only
-    /// run depending on one of them, as far as the fixpoint got.
+    /// Blocks that throw reactively, plus every block that only runs depending on one of them.
     blocks: HashSet<BlockId>,
-    /// The handler bindings whose handler a reactive throw controls: the
-    /// caught value comes from the instruction that threw. The binding is
-    /// declared before the `try` statement but only bound in the `catch`
-    /// clause. Marking it reactive would make a scope around the statement
-    /// depend on it, out of scope. Reading it counts as a reactive input
-    /// instead, which makes the `catch` parameter reactive.
+    /// Reactive handler bindings. Only reads count: a binding is declared before its `try`, out of scope.
     caught_values: HashSet<IdentifierId>,
     has_changes: bool,
 }
 
 impl ReactiveThrows {
-    /// Whether a reactive throw decides, directly or through the branches in
-    /// between, if control reaches `block_id`.
+    /// Transitive, because in a `try` the frontier of a block is mostly just the block before it.
     fn controls(&self, block_id: BlockId) -> bool {
         self.frontiers
             .get(block_id)

--- a/src/react_compiler/inference/infer_reactive_places.rs
+++ b/src/react_compiler/inference/infer_reactive_places.rs
@@ -14,7 +14,7 @@
 //! 4. Mutation with reactive operands
 //! 5. Conditional assignment based on reactive control flow
 
-use crate::collections::{FxHashMap as HashMap, IdMap};
+use crate::collections::{FxHashMap as HashMap, FxHashSet as HashSet, IdMap};
 
 use crate::diagnostics::CompilerDiagnostic;
 use crate::hir::dominator::post_dominator_frontier;
@@ -62,6 +62,12 @@ pub(crate) fn infer_reactive_places(
     // per block) is a function of the CFG only, so compute it once here instead
     // of inside the fixpoint loop.
     let mut control_tests: IdMap<BlockId, Vec<IdentifierId>> = IdMap::new();
+    let mut reactive_throws = ReactiveThrows::default();
+    let has_handler = func
+        .body
+        .blocks
+        .values()
+        .any(|block| throws_to_handler(&block.terminal));
     for &block_id in &block_ids {
         let frontier = post_dominator_frontier(func, &post_dominators, block_id);
         let mut tests = Vec::new();
@@ -83,6 +89,11 @@ pub(crate) fn infer_reactive_places(
             }
         }
         control_tests.insert(block_id, tests);
+        if has_handler && !frontier.is_empty() {
+            reactive_throws
+                .frontiers
+                .insert(block_id, frontier.into_iter().collect());
+        }
     }
 
     // Track phi operand reactive flags during fixpoint.
@@ -95,8 +106,12 @@ pub(crate) fn infer_reactive_places(
     // Fixpoint iteration — compute reactive set
     loop {
         for block_id in &block_ids {
-            let has_reactive_control =
-                is_reactive_controlled_block(*block_id, &control_tests, &mut reactive_map);
+            let has_reactive_control = is_reactive_controlled_block(
+                *block_id,
+                &control_tests,
+                &reactive_throws,
+                &mut reactive_map,
+            );
 
             // Process phi nodes
             let block = func.body.blocks.get(block_id).unwrap();
@@ -120,7 +135,12 @@ pub(crate) fn infer_reactive_places(
                     reactive_map.mark_reactive(phi.place.identifier);
                 } else {
                     for (pred, _operand) in &phi.operands {
-                        if is_reactive_controlled_block(*pred, &control_tests, &mut reactive_map) {
+                        if is_reactive_controlled_block(
+                            *pred,
+                            &control_tests,
+                            &reactive_throws,
+                            &mut reactive_map,
+                        ) {
                             reactive_map.mark_reactive(phi.place.identifier);
                             break;
                         }
@@ -130,6 +150,7 @@ pub(crate) fn infer_reactive_places(
 
             // Process instructions
             let block = func.body.blocks.get(block_id).unwrap();
+            let mut block_has_reactive_input = false;
             for instr_id in &block.instructions {
                 let instr = &func.instructions[instr_id.0 as usize];
 
@@ -146,7 +167,8 @@ pub(crate) fn infer_reactive_places(
                         .map(|p| p.identifier)
                         .collect();
                 for &op_id in &operands {
-                    let reactive = reactive_map.is_reactive(op_id);
+                    let reactive =
+                        reactive_map.is_reactive(op_id) || reactive_throws.is_caught_value(op_id);
                     has_reactive_input = has_reactive_input || reactive;
                 }
 
@@ -172,6 +194,7 @@ pub(crate) fn infer_reactive_places(
                     }
                     _ => {}
                 }
+                block_has_reactive_input |= has_reactive_input;
 
                 if has_reactive_input {
                     // Mark lvalues reactive (unless stable)
@@ -223,9 +246,33 @@ pub(crate) fn infer_reactive_places(
             for op in visitors::each_terminal_operand(&block.terminal) {
                 reactive_map.is_reactive(op.identifier);
             }
+
+            // See `ReactiveThrows`.
+            let throws_reactively = throws_to_handler(&block.terminal)
+                && (block_has_reactive_input || has_reactive_control);
+            if throws_reactively || reactive_throws.controls(*block_id) {
+                reactive_throws.mark_reactive(*block_id);
+            }
+            if let Terminal::Try {
+                handler,
+                handler_binding: Some(binding),
+                ..
+            } = &block.terminal
+            {
+                if is_reactive_controlled_block(
+                    *handler,
+                    &control_tests,
+                    &reactive_throws,
+                    &mut reactive_map,
+                ) {
+                    reactive_throws.mark_caught_value(binding.identifier);
+                }
+            }
         }
 
-        if !reactive_map.snapshot() {
+        // Each snapshot resets its own change flag, so take both.
+        let has_changes = reactive_map.snapshot();
+        if !reactive_throws.snapshot() && !has_changes {
             break;
         }
     }
@@ -240,6 +287,7 @@ pub(crate) fn infer_reactive_places(
         &mut reactive_map,
         &mut stable_sidemap,
         &phi_operand_reactive,
+        &reactive_throws,
     );
 
     Ok(())
@@ -403,6 +451,7 @@ impl StableSidemap {
 fn is_reactive_controlled_block(
     block_id: BlockId,
     control_tests: &IdMap<BlockId, Vec<IdentifierId>>,
+    reactive_throws: &ReactiveThrows,
     reactive_map: &mut ReactivityMap,
 ) -> bool {
     control_tests
@@ -410,6 +459,87 @@ fn is_reactive_controlled_block(
         .unwrap()
         .iter()
         .any(|&id| reactive_map.is_reactive(id))
+        || reactive_throws.controls(block_id)
+}
+
+// =============================================================================
+// Reactive throws (not in upstream)
+// =============================================================================
+
+fn throws_to_handler(terminal: &Terminal) -> bool {
+    matches!(
+        terminal,
+        Terminal::MaybeThrow {
+            handler: Some(_),
+            ..
+        }
+    )
+}
+
+/// Reactive control flow through `try` / `catch`. Upstream's
+/// ControlDominators.ts only looks at `if` / `branch` / `switch` terminals, so
+/// it memoizes a value that is assigned in a `catch` with no dependency.
+///
+/// A `MaybeThrow` terminal with a handler is a branch as well: control goes to
+/// the handler when an instruction of the block throws. It has no test operand
+/// to look up in the `ReactivityMap`, so the block itself is recorded. It
+/// throws reactively when one of its instructions has a reactive input, or
+/// when the block itself is reactive-controlled: then whether it runs at all,
+/// and so whether it throws, can change between renders.
+///
+/// In a `try` block every instruction ends its block with a `MaybeThrow`, so
+/// the frontier of a block is mostly just the block before it. One level of
+/// control dependence, which is all upstream reads, then loses what is further
+/// back: an earlier reactive throw, or a reactive `if` around the blocks. So
+/// control dependence on a reactive throw is transitive here. It passes
+/// through every block that only runs depending on one.
+#[derive(Default)]
+struct ReactiveThrows {
+    /// For a block, the blocks on its post-dominator frontier. Only filled in
+    /// for a function that has a `MaybeThrow` with a handler.
+    frontiers: IdMap<BlockId, Vec<BlockId>>,
+    /// The `MaybeThrow` blocks that throw reactively and the blocks that only
+    /// run depending on one of them, as far as the fixpoint got.
+    blocks: HashSet<BlockId>,
+    /// The handler bindings whose handler a reactive throw controls: the
+    /// caught value comes from the instruction that threw. The binding is
+    /// declared before the `try` statement but only bound in the `catch`
+    /// clause. Marking it reactive would make a scope around the statement
+    /// depend on it, out of scope. Reading it counts as a reactive input
+    /// instead, which makes the `catch` parameter reactive.
+    caught_values: HashSet<IdentifierId>,
+    has_changes: bool,
+}
+
+impl ReactiveThrows {
+    /// Whether a reactive throw decides, directly or through the branches in
+    /// between, if control reaches `block_id`.
+    fn controls(&self, block_id: BlockId) -> bool {
+        self.frontiers
+            .get(block_id)
+            .is_some_and(|frontier| frontier.iter().any(|id| self.blocks.contains(id)))
+    }
+
+    fn mark_reactive(&mut self, block_id: BlockId) {
+        if self.blocks.insert(block_id) {
+            self.has_changes = true;
+        }
+    }
+
+    fn is_caught_value(&self, id: IdentifierId) -> bool {
+        self.caught_values.contains(&id)
+    }
+
+    fn mark_caught_value(&mut self, id: IdentifierId) {
+        if self.caught_values.insert(id) {
+            self.has_changes = true;
+        }
+    }
+
+    /// Reset change tracking, returns true if there were changes.
+    fn snapshot(&mut self) -> bool {
+        std::mem::take(&mut self.has_changes)
+    }
 }
 
 // =============================================================================
@@ -549,6 +679,7 @@ fn apply_reactive_flags_replay(
     reactive_map: &mut ReactivityMap,
     stable_sidemap: &mut StableSidemap,
     phi_operand_reactive: &HashMap<(BlockId, usize, usize), bool>,
+    reactive_throws: &ReactiveThrows,
 ) {
     let reactive_ids = build_reactive_id_set(reactive_map);
 
@@ -599,7 +730,7 @@ fn apply_reactive_flags_replay(
                     .collect();
             let mut has_reactive_input = false;
             for &op_id in &value_operand_ids {
-                if reactive_ids[op_id.0 as usize] {
+                if reactive_ids[op_id.0 as usize] || reactive_throws.is_caught_value(op_id) {
                     has_reactive_input = true;
                 }
             }

--- a/src/react_compiler/inference/infer_reactive_places.rs
+++ b/src/react_compiler/inference/infer_reactive_places.rs
@@ -92,7 +92,7 @@ pub(crate) fn infer_reactive_places(
         .values()
         .any(|block| throws_to_handler(&block.terminal));
     let mut reactive_throws = ReactiveThrows::new(if has_handler {
-        env.next_block_id().0 as usize
+        post_dominators.exit.0 as usize
     } else {
         0
     });

--- a/src/react_compiler/inference/infer_reactive_places.rs
+++ b/src/react_compiler/inference/infer_reactive_places.rs
@@ -17,12 +17,13 @@
 use crate::collections::{FxHashMap as HashMap, FxHashSet as HashSet, IdMap};
 
 use crate::diagnostics::CompilerDiagnostic;
-use crate::hir::dominator::post_dominator_frontier;
+use crate::hir::dominator::{PostDominator, post_dominator_frontier};
 use crate::hir::environment::Environment;
 use crate::hir::object_shape::HookKind;
 use crate::hir::visitors;
 use crate::hir::{
-    BlockId, Effect, FunctionId, HirFunction, IdentifierId, InstructionValue, Terminal, Type,
+    BasicBlock, BlockId, Effect, FunctionId, HirFunction, IdentifierId, InstructionValue, Terminal,
+    Type,
 };
 
 use crate::utils::DisjointSet;
@@ -62,12 +63,6 @@ pub(crate) fn infer_reactive_places(
     // per block) is a function of the CFG only, so compute it once here instead
     // of inside the fixpoint loop.
     let mut control_tests: IdMap<BlockId, Vec<IdentifierId>> = IdMap::new();
-    let mut reactive_throws = ReactiveThrows::default();
-    let has_handler = func
-        .body
-        .blocks
-        .values()
-        .any(|block| throws_to_handler(&block.terminal));
     for &block_id in &block_ids {
         let frontier = post_dominator_frontier(func, &post_dominators, block_id);
         let mut tests = Vec::new();
@@ -89,12 +84,18 @@ pub(crate) fn infer_reactive_places(
             }
         }
         control_tests.insert(block_id, tests);
-        if has_handler && !frontier.is_empty() {
-            reactive_throws
-                .frontiers
-                .insert(block_id, frontier.into_iter().collect());
-        }
     }
+
+    let has_handler = func
+        .body
+        .blocks
+        .values()
+        .any(|block| throws_to_handler(&block.terminal));
+    let mut reactive_throws = ReactiveThrows::new(if has_handler {
+        env.next_block_id().0 as usize
+    } else {
+        0
+    });
 
     // Track phi operand reactive flags during fixpoint.
     // In TS, isReactive() sets place.reactive as a side effect. But when a phi
@@ -251,7 +252,7 @@ pub(crate) fn infer_reactive_places(
             let throws_reactively = throws_to_handler(&block.terminal)
                 && (block_has_reactive_input || has_reactive_control);
             if throws_reactively || reactive_throws.controls(*block_id) {
-                reactive_throws.mark_reactive(*block_id);
+                reactive_throws.mark_dependents(block, &post_dominators);
             }
             if let Terminal::Try {
                 handler,
@@ -474,30 +475,84 @@ fn throws_to_handler(terminal: &Terminal) -> bool {
     )
 }
 
+/// The terminals with more than one successor.
+fn for_each_branch_target(terminal: &Terminal, mut f: impl FnMut(BlockId)) {
+    match terminal {
+        Terminal::MaybeThrow {
+            continuation,
+            handler: Some(handler),
+            ..
+        } => {
+            f(*continuation);
+            f(*handler);
+        }
+        Terminal::If {
+            consequent,
+            alternate,
+            ..
+        }
+        | Terminal::Branch {
+            consequent,
+            alternate,
+            ..
+        } => {
+            f(*consequent);
+            f(*alternate);
+        }
+        Terminal::Switch { cases, .. } => {
+            for case in cases {
+                f(case.block);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// `try` / `catch` control flow: a `MaybeThrow` with a handler is a branch that has no test operand.
-#[derive(Default)]
 struct ReactiveThrows {
-    /// Post-dominator frontier of each block, recorded only when the function has a handler.
-    frontiers: IdMap<BlockId, Vec<BlockId>>,
-    /// Blocks that throw reactively, plus every block that only runs depending on one of them.
-    blocks: HashSet<BlockId>,
+    /// By `BlockId`: a reactive throw decides whether the block runs. Empty without a handler.
+    controlled: Vec<bool>,
     /// Reactive handler bindings. Only reads count: a binding is declared before its `try`, out of scope.
     caught_values: HashSet<IdentifierId>,
     has_changes: bool,
 }
 
 impl ReactiveThrows {
-    /// Transitive, because in a `try` the frontier of a block is mostly just the block before it.
-    fn controls(&self, block_id: BlockId) -> bool {
-        self.frontiers
-            .get(block_id)
-            .is_some_and(|frontier| frontier.iter().any(|id| self.blocks.contains(id)))
+    fn new(block_count: usize) -> Self {
+        ReactiveThrows {
+            controlled: vec![false; block_count],
+            caught_values: HashSet::default(),
+            has_changes: false,
+        }
     }
 
-    fn mark_reactive(&mut self, block_id: BlockId) {
-        if self.blocks.insert(block_id) {
-            self.has_changes = true;
-        }
+    /// Transitive, because in a `try` the frontier of a block is mostly just the block before it.
+    fn controls(&self, block_id: BlockId) -> bool {
+        self.controlled
+            .get(block_id.0 as usize)
+            .copied()
+            .unwrap_or(false)
+    }
+
+    /// Marks the blocks control-dependent on `block`: each branch target, then up the post-dominator tree.
+    fn mark_dependents(&mut self, block: &BasicBlock, post_dominators: &PostDominator) {
+        let stop = post_dominators.get(block.id);
+        for_each_branch_target(&block.terminal, |target| {
+            let mut current = target;
+            while Some(current) != stop {
+                let Some(controlled) = self.controlled.get_mut(current.0 as usize) else {
+                    break;
+                };
+                if !*controlled {
+                    *controlled = true;
+                    self.has_changes = true;
+                }
+                let Some(next) = post_dominators.get(current) else {
+                    break;
+                };
+                current = next;
+            }
+        });
     }
 
     fn is_caught_value(&self, id: IdentifierId) -> bool {

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -821,6 +821,246 @@ describe("bundler", () => {
     },
   });
 
+  // Whether control enters a `catch` handler, and from which instruction,
+  // depends on the values the `try` block reads. When those are reactive, so is
+  // every value that depends on the path taken: a local assigned in the `try`
+  // block or in the handler, a `return` from either inside `useMemo`, and the
+  // caught value. Each component below renders several times against one memo
+  // cache, as React does for one component instance, and has to follow its
+  // props on every render.
+  itBundled("react-compiler/TryCatchIsReactiveControlFlow", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useMemo } from "react";
+
+        function parse(text) {
+          if (text.startsWith("!")) throw new Error("cannot parse " + text);
+          return text;
+        }
+        function alwaysThrows() {
+          throw new Error("always");
+        }
+        function neverThrows() {}
+
+        function AssignedInCatch(props) {
+          let status = "ok";
+          try {
+            parse(props.text);
+          } catch {
+            status = "failed";
+          }
+          return <div>{status}</div>;
+        }
+
+        function ReturnedFromUseMemo({ text }) {
+          const status = useMemo(() => {
+            try {
+              parse(text);
+              return "ok";
+            } catch {
+              return "failed";
+            }
+          }, [text]);
+          return <div>{status}</div>;
+        }
+
+        // The element built in the handler is memoized on the caught value.
+        function CaughtValue(props) {
+          let element;
+          try {
+            parse(props.text);
+            element = <b>ok</b>;
+          } catch (error) {
+            element = <i>{error.message}</i>;
+          }
+          return <div>{element}</div>;
+        }
+
+        // A reactive scope spans the whole try statement. The catch parameter
+        // is only bound inside the clause, so that scope cannot depend on it.
+        function ScopeAroundTry(props) {
+          let element = null;
+          try {
+            props.strict && parse(props.text);
+          } catch (error) {
+            element = <i>{error.message}</i>;
+          }
+          return <div>{element}</div>;
+        }
+
+        // The handler reads a local whose value depends on which call threw.
+        function ReadInCatch(props) {
+          let stage = "first";
+          let failedAt = "none";
+          try {
+            parse(props.first);
+            stage = "second";
+            parse(props.second);
+          } catch {
+            failedAt = stage;
+          }
+          return <div>{failedAt}</div>;
+        }
+
+        // No call that can enter the outer handler reads a reactive value, but
+        // alwaysThrows() only runs when the inner handler does.
+        function NestedTry(props) {
+          let status = "ok";
+          try {
+            try {
+              parse(props.text);
+            } catch {
+              alwaysThrows();
+            }
+            neverThrows();
+          } catch {
+            status = "failed";
+          }
+          return <div>{status}</div>;
+        }
+
+        // Each call in an arm can leave for the handler, so the end of the arm
+        // depends on the call before it, and only through that on the if.
+        function IfInTry(props) {
+          let side = "none";
+          try {
+            if (props.left) {
+              neverThrows();
+              side = "left";
+            } else {
+              neverThrows();
+              side = "right";
+            }
+          } catch {
+            return null;
+          }
+          return <div>{side}</div>;
+        }
+
+        // Both sides of the try statement split on a static test before they
+        // join again, so no path into the join starts at the throw itself.
+        function SplitOnBothSides({ text }) {
+          const status = useMemo(() => {
+            try {
+              parse(text);
+              if (globalThis.isMobile) return "ok on mobile";
+              return "ok";
+            } catch {
+              if (globalThis.isMobile) return "failed on mobile";
+              return "failed";
+            }
+          }, [text]);
+          return <div>{status}</div>;
+        }
+
+        // The try block reads nothing reactive, but how often it runs does
+        // depend on the props, and its handler leaves the loop body early.
+        function StaticTryInLoop(props) {
+          let failures = 0;
+          for (const item of props.items) {
+            try {
+              alwaysThrows();
+            } catch {
+              failures++;
+              continue;
+            }
+          }
+          return <div>{failures}</div>;
+        }
+
+        // This try block reads nothing reactive and always runs, so the local
+        // its handler assigns is not a dependency.
+        function NothingReactiveInTry(props) {
+          let staticStatus = "ok";
+          try {
+            parse(globalThis.staticText);
+          } catch {
+            staticStatus = "failed";
+          }
+          return <div title={props.title}>{staticStatus}</div>;
+        }
+
+        function text(node) {
+          if (Array.isArray(node)) return node.map(text).join("");
+          if (node !== null && typeof node === "object") return text(node.props.children);
+          return String(node);
+        }
+        function renders(Component, ...renderProps) {
+          const results = renderProps.map(props => {
+            globalThis.memoCacheOwner = Component;
+            return text(Component(props));
+          });
+          // A component the compiler skipped never asks for a cache.
+          const compiled = globalThis.memoCaches.has(Component) ? "memoized" : "not compiled";
+          console.log(Component.name + " (" + compiled + "): " + results.join(", "));
+        }
+
+        globalThis.staticText = "static";
+        const texts = [{ text: "!a" }, { text: "b" }, { text: "!c" }, { text: "d" }];
+        renders(AssignedInCatch, ...texts);
+        renders(ReturnedFromUseMemo, ...texts);
+        renders(CaughtValue, ...texts);
+        renders(
+          ScopeAroundTry,
+          { strict: true, text: "!a" },
+          { strict: false, text: "!a" },
+          { strict: true, text: "!c" },
+          { strict: true, text: "d" },
+        );
+        renders(
+          ReadInCatch,
+          { first: "a", second: "b" },
+          { first: "!a", second: "b" },
+          { first: "a", second: "!b" },
+          { first: "a", second: "b" },
+        );
+        renders(NestedTry, ...texts);
+        renders(IfInTry, { left: true }, { left: false }, { left: true }, { left: false });
+        renders(SplitOnBothSides, ...texts);
+        renders(StaticTryInLoop, { items: [] }, { items: [1, 2] }, { items: [1] }, { items: [] });
+        renders(NothingReactiveInTry, { title: "a" }, { title: "b" });
+      `,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+      "/node_modules/react/index.js": `exports.useMemo = callback => callback();`,
+      "/node_modules/react/jsx-runtime.js": `exports.jsx = exports.jsxs = (type, props) => ({ type, props });`,
+      "/node_modules/react/jsx-dev-runtime.js": `exports.jsxDEV = (type, props) => ({ type, props });`,
+      // One cache for each component function stands in for the cache React
+      // keeps for each component instance.
+      "/node_modules/react/compiler-runtime.js": /* js */ `
+        const caches = (globalThis.memoCaches = new Map());
+        exports.c = size => {
+          const owner = globalThis.memoCacheOwner;
+          let cache = caches.get(owner);
+          if (cache === undefined) {
+            cache = new Array(size).fill(Symbol.for("react.memo_cache_sentinel"));
+            caches.set(owner, cache);
+          }
+          return cache;
+        };
+      `,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    run: {
+      stdout: `
+        AssignedInCatch (memoized): failed, ok, failed, ok
+        ReturnedFromUseMemo (memoized): failed, ok, failed, ok
+        CaughtValue (memoized): cannot parse !a, ok, cannot parse !c, ok
+        ScopeAroundTry (memoized): cannot parse !a, null, cannot parse !c, null
+        ReadInCatch (memoized): none, first, second, none
+        NestedTry (memoized): failed, ok, failed, ok
+        IfInTry (memoized): left, right, left, right
+        SplitOnBothSides (memoized): failed, ok, failed, ok
+        StaticTryInLoop (memoized): 0, 2, 1, 0
+        NothingReactiveInTry (memoized): ok, ok
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).not.toContain("!== staticStatus");
+    },
+  });
+
   itBundled("react-compiler/NonComponentUntouched", {
     files: {
       "/entry.jsx": /* jsx */ `

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -888,6 +888,19 @@ describe("bundler", () => {
           return <div>{element}</div>;
         }
 
+        // The closure captures a handler local that came from the caught value.
+        // (One that captures the catch parameter itself is not compiled.)
+        function ClosureInCatch(props) {
+          let read = () => "none";
+          try {
+            parse(props.text);
+          } catch (error) {
+            const message = error.message;
+            read = () => message;
+          }
+          return <div>{read()}</div>;
+        }
+
         // The handler reads a local whose value depends on which call threw.
         function ReadInCatch(props) {
           let stage = "first";
@@ -1007,6 +1020,7 @@ describe("bundler", () => {
           { strict: true, text: "!c" },
           { strict: true, text: "d" },
         );
+        renders(ClosureInCatch, ...texts);
         renders(
           ReadInCatch,
           { first: "a", second: "b" },
@@ -1048,6 +1062,7 @@ describe("bundler", () => {
         ReturnedFromUseMemo (memoized): failed, ok, failed, ok
         CaughtValue (memoized): cannot parse !a, ok, cannot parse !c, ok
         ScopeAroundTry (memoized): cannot parse !a, null, cannot parse !c, null
+        ClosureInCatch (memoized): cannot parse !a, none, cannot parse !c, none
         ReadInCatch (memoized): none, first, second, none
         NestedTry (memoized): failed, ok, failed, ok
         IfInTry (memoized): left, right, left, right

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1057,7 +1057,11 @@ describe("bundler", () => {
       `,
     },
     onAfterBundle(api) {
-      expect(api.readFile("/out.js")).not.toContain("!== staticStatus");
+      const out = api.readFile("/out.js");
+      // The element still reads the local by its name, so a dependency on it
+      // would be spelled `!== staticStatus`.
+      expect(out).toContain("children: staticStatus");
+      expect(out).not.toContain("!== staticStatus");
     },
   });
 


### PR DESCRIPTION
### Problem

- With `bun build --react-compiler --target=browser`, a value that depends on whether a `try` block throws is memoized with no dependency. `try { JSON.parse(p.t) } catch { ok = "invalid" } return <div>{ok}</div>` compiles to `if ($[0] === __MEMO_CACHE_SENTINEL) t0 = jsxDEV("div", { children: ok })`. A second render returns the first element. A `try` in `useMemo`, JSX built from `e.message` in a handler, and a reactive `if` inside a `try` break the same way.
- Cause: the control check in `src/react_compiler/inference/infer_reactive_places.rs:70` reads only `if`, `branch` and `switch` tests. A `MaybeThrow` edge to a handler has no test operand.

### Fix

- A `MaybeThrow` block with a handler throws reactively when one of its instructions has a reactive input, or when the block is reactive-controlled. It then controls the blocks behind it like a reactive `if`, transitively.
- A read of the handler binding is a reactive input when a reactive throw controls the handler. The binding itself is not marked: it is declared before the statement, so a scope around the statement would depend on it out of scope.
- Verified: `test/bundler/transpiler/react-compiler.test.ts` (`TryCatchIsReactiveControlFlow`, 9 of 10 lines are stale on main), `react-compiler-fixtures.test.ts`, `bundler_jsx.test.ts`.

### Background

- A value is reactive when it can change between renders. Only such a value becomes a dependency of a memoized scope.
- A phi joins the values a variable has on different paths. It is reactive when an operand is, or when a predecessor block depends on a reactive test (read one level deep from the post-dominator frontier).
- In a `try` block each instruction ends its block with `MaybeThrow { continuation, handler }`, so the frontier of a block is mostly the block before it.
- `inference/` ports upstream `ControlDominators.ts`. Upstream has the same bug (babel-plugin-react-compiler 1.0.0). This is a deliberate difference, kept in one struct, `ReactiveThrows`.

<details><summary>Notes</summary>

**Differential check.** 134 components with `try` / `catch`, each rendered 3 to 5 times against one memo cache, compiled output compared with the uncompiled program. With this change 128 match. The 6 that do not are one known gap, below. Main (b99371011f) is stale on 70 of the 134. Shapes: loops, `break` / `continue` / `return` in the handler, value blocks, `switch`, three levels of nesting, a `try` in a `catch`, `useMemo`, `useCallback`, `useState`, effect dependency arrays, a mutated, stored, reassigned or returned catch parameter, scopes that span the statement.

**Real code.** 12,864 source files that contain `try`, from 22 open-source React codebases (PostHog, Grafana, Supabase, Bluesky, Dub, Metabase, lobe-chat and others), compiled with main and with this change. 1,910 have a compiled function. 11 outputs change. Each gains a dependency on the caught value (`e.message`) or on a local that the `try` or the handler decides (`isVerified`, `isArgumentsStreaming`, `eligibilityError`, `error`). Example: Grafana `HeatmapPanel` builds its `{ warning }` object from the caught exception in the handler. That object was memoized on the sentinel alone, so the first warning stayed. A scanner that resolves each memo guard dependency lexically finds 0 out-of-scope dependencies in all outputs.

**Memory.** A function with no `try` / `catch` allocates nothing new. One that has a handler gets one `AutoBitSet` with a bit for each block (inline up to 127 blocks, so usually no allocation), plus a set with one entry for each reactive catch binding. No frontier is stored: a block that throws reactively marks the blocks that are control-dependent on it by a walk up the post-dominator tree, which the pass already computes. The first version of this PR stored a copy of every frontier. The walk gives the same relation as `post_dominator_frontier` on 5,425 compiled functions, and the output is byte-identical to that first version on 1,739 fixture files and 1,145 local files compiled with `compilationMode: "all"`, so the numbers in these notes carry over.

**Upstream fixtures.** No output in `test/bundler/transpiler/react-compiler-fixtures/` changes (1,806 inputs), also not when the 42 fixtures that contain `try` are compiled with `@compilationMode:"all"`. Upstream has no fixture for this case.

**Why the handler binding is not marked reactive.** An earlier version of this change marked it. The binding temporary is declared before the `try` statement (`DeclareLocal Catch`), so a scope that spans the statement took it as a dependency and emitted `if ($[0] !== props.x || $[1] !== t0) { try {...} catch (t0) {...} }`, a `ReferenceError` on every render. `ScopeAroundTry` in the test covers this shape.

**Precision.** A `try` block that reads nothing reactive and always runs adds no dependency (`NothingReactiveInTry`). A `try` statement inside a reactive-controlled region (after a reactive early return, in a reactive loop) now always has a reactive handler, also when its body reads nothing reactive. That is needed for shapes like `for (const x of props.items) { try { f() } catch { n++; continue } }`, and it changes no output in the 12,864 files.

**Each rule is covered by a line of the test.** Old binding rule: `ScopeAroundTry` throws `ReferenceError: t0 is not defined`. No caught-value rule: `CaughtValue` and `ScopeAroundTry` are stale on the third render. No transitivity through blocks that do not throw: `IfInTry` and `SplitOnBothSides` are stale. No transitivity between throwing blocks: `NestedTry` is stale. No seed from a reactive-controlled block: `StaticTryInLoop` is stale.

**Known gap, not in this change.** An IIFE (or a `useMemo` call) that sits inside a `try` block and has a branch in its body. `InlineImmediatelyInvokedFunctionExpressions` inlines the body without `MaybeThrow` terminals, so the graph has no edge from those blocks to the handler. That is a different pass, and upstream has the same behaviour.

**Self-review.** 4 concerns raised, 3 addressed: the out-of-scope binding (fixed at the source, with a test), coverage of loops / `if` / `switch` / `&&` inside `try` with a named catch parameter (added), and control dependence read one level deep (made transitive instead of documented). Not taken: a lexical guard in `codegen.rs` that skips a function with an out-of-scope dependency. With the binding fixed nothing reaches it, so it would ship untested.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (09bb54630)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [590.40ms]
(pass) bundler > react-compiler/ComponentWithHooks [254.12ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [229.44ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [261.47ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [139.45ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [94.92ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [405.04ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [101.18ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [653.07ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [96.32ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [95.90ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [241.02ms]
(pass) bundler > react-c
... (truncated)

release without fix: 6 failed, 1 skipped
bun test v1.4.3-canary.1 (09bb54630)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [13.94ms]
(pass) bundler > react-compiler/ComponentWithHooks [6.27ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [5.96ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [5.91ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [6.48ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [4.29ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [10.36ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [6.65ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [13.13ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [5.91ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [5.46ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [8.79ms]
(pass) bundler > react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking [10.90ms]
(pass) bundler > react-compiler/RequireStringPreservesImportRecord [6.30ms]
(pass) bundler > react-compiler/BranchBooleanFeat
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (09bb54630)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [679.82ms]
(pass) bundler > react-compiler/ComponentWithHooks [411.52ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [299.26ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [305.35ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [152.25ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [130.68ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [408.60ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [149.12ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [728.08ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [145.21ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [132.04ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [265.90ms]
(pass) bundler > reac
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     73f3c59afd
  features     lto, baseline

23 deps, 131 codegen, 1176 objects in 701ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1254] mkdir stamps
[2/1254] mkdir codegen
[3/1254] mkdir pch
[4/1254] mkdir obj
[5/1254] install /workspace/bun
bun install v1.4.3-canary.1 (09bb54630)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[6/1254] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (09bb54630)

Checked 1 install across 2 packages (no changes) [2.00ms]
[7/1254] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (09bb54630)

Checked 111 installs across 104 packages (no changes) [7.00ms]
[8/1254] fetch picohttpparser
[picohttpparser] up to date
[9/1254] gen ErrorCode+*.h
[10/1254] gen node-fallbacks/react-refresh.js
Bundled 1 module in 10ms

  react-refresh.js  4.81 KB  (entry point)

[11/1254] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       34.9kb
  ../../build/release/codegen/bun-error/bun-
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../inference/infer_reactive_places.rs             | 181 +++++++++++++-
 test/bundler/transpiler/react-compiler.test.ts     | 259 +++++++++++++++++++++
 2 files changed, 431 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/react_compiler/inference/infer_reactive_places.rs      8     10     48
test/bundler/transpiler/react-compiler.test.ts             5      2     43
```

</details>

<!-- robobun:evidence:end -->

