### PR TITLE
yaml: line up a collection nested in a sequence item at every indent width

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1525,8 +1525,6 @@ declare module "bun" {
      *              Without this parameter, outputs flow-style (single-line) YAML.
      *              With this parameter, outputs block-style (multi-line) YAML.
      *              The number is clamped between 0 and 10, and the first 10 characters of the string are used.
-     *              A collection inside a sequence item starts on the `- ` line. Its other entries line up with
-     *              the first one, 2 spaces after the dash, whatever `space` is.
      * @returns A string containing the YAML document.
      *
      * @example

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1525,6 +1525,8 @@ declare module "bun" {
      *              Without this parameter, outputs flow-style (single-line) YAML.
      *              With this parameter, outputs block-style (multi-line) YAML.
      *              The number is clamped between 0 and 10, and the first 10 characters of the string are used.
+     *              A collection inside a sequence item starts on the `- ` line. Its other entries line up with
+     *              the first one, 2 spaces after the dash, whatever `space` is.
      * @returns A string containing the YAML document.
      *
      * @example

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -53,7 +53,8 @@ fn stringify(global: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValu
 struct Stringifier {
     stack_check: StackCheck,
     builder: wtf::StringBuilder,
-    indent: usize,
+    /// One entry per open block collection, outermost first.
+    indent: Vec<IndentStep>,
 
     known_collections: HashMap<JSValue, AnchorAlias>,
     array_item_counter: usize,
@@ -67,6 +68,19 @@ enum Space {
     Number(u32),
     Str(bun_core::String),
 }
+
+/// How far a block collection indents the lines inside one of its entries.
+#[derive(Clone, Copy)]
+enum IndentStep {
+    /// One unit of the `space` argument.
+    MappingValue,
+    /// `SEQUENCE_ITEM_INDENT`, whatever `space` is. A collection that starts on the dash
+    /// line has its first entry there, and the rest must line up with it.
+    SequenceItem,
+}
+
+/// As wide as the `- ` that starts a sequence item.
+const SEQUENCE_ITEM_INDENT: &[u8] = b"  ";
 
 impl Space {
     fn init(global: &JSGlobalObject, space_value: JSValue) -> JsResult<Space> {
@@ -193,7 +207,7 @@ impl Stringifier {
         Ok(Stringifier {
             stack_check: StackCheck::init(),
             builder: wtf::StringBuilder::init(),
-            indent: 0,
+            indent: Vec::new(),
             known_collections: HashMap::default(),
             array_item_counter: 0,
             prop_names,
@@ -478,9 +492,9 @@ impl Stringifier {
 
                         // don't need to print a newline here for any value
 
-                        self.indent += 1;
+                        self.indent.push(IndentStep::SequenceItem);
                         self.stringify(global, item)?;
-                        self.indent -= 1;
+                        self.indent.pop();
                     }
                 }
             }
@@ -542,7 +556,7 @@ impl Stringifier {
                     self.append_string(&prop_name);
                     self.builder.append_latin1(b": ");
 
-                    self.indent += 1;
+                    self.indent.push(IndentStep::MappingValue);
 
                     let prop_value = value.unwrap_boxed_primitive(global)?;
                     if prop_value_needs_newline(prop_value) {
@@ -550,7 +564,7 @@ impl Stringifier {
                     }
 
                     self.stringify_unwrapped(global, prop_value)?;
-                    self.indent -= 1;
+                    self.indent.pop();
                 }
                 if first {
                     self.builder.append_latin1(b"{}");
@@ -561,17 +575,25 @@ impl Stringifier {
         Ok(())
     }
 
-    fn newline(&mut self) {
-        let indent_count = self.indent;
+    /// Length of the indentation `newline()` writes when one `space` unit is `unit_len` long.
+    fn indent_len(&self, unit_len: usize) -> usize {
+        self.indent
+            .iter()
+            .map(|step| match step {
+                IndentStep::MappingValue => unit_len,
+                IndentStep::SequenceItem => SEQUENCE_ITEM_INDENT.len(),
+            })
+            .sum()
+    }
 
+    fn newline(&mut self) {
         match &self.space {
             Space::Minified => {}
             Space::Number(space_num) => {
-                let space_num = *space_num as usize;
+                let columns = self.indent_len(*space_num as usize);
                 self.builder.append_lchar(b'\n');
-                self.builder
-                    .ensure_unused_capacity(indent_count * space_num);
-                for _ in 0..indent_count * space_num {
+                self.builder.ensure_unused_capacity(columns);
+                for _ in 0..columns {
                     self.builder.append_lchar(b' ');
                 }
             }
@@ -581,9 +603,14 @@ impl Stringifier {
                 let clamped = space_str.trunc(10);
 
                 self.builder
-                    .ensure_unused_capacity(indent_count * clamped.length());
-                for _ in 0..indent_count {
-                    self.builder.append_string(&clamped);
+                    .ensure_unused_capacity(self.indent_len(clamped.length()));
+                for step in &self.indent {
+                    match step {
+                        IndentStep::MappingValue => self.builder.append_string(&clamped),
+                        IndentStep::SequenceItem => {
+                            self.builder.append_latin1(SEQUENCE_ITEM_INDENT)
+                        }
+                    }
                 }
             }
         }

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -74,12 +74,11 @@ enum Space {
 enum IndentStep {
     /// One unit of the `space` argument.
     MappingValue,
-    /// `SEQUENCE_ITEM_INDENT`, whatever `space` is. A collection that starts on the dash
-    /// line has its first entry there, and the rest must line up with it.
+    /// `SEQUENCE_ITEM_INDENT`, whatever `space` is.
     SequenceItem,
 }
 
-/// As wide as the `- ` that starts a sequence item.
+/// As wide as `- `: a collection that starts on the dash line keeps its entries aligned.
 const SEQUENCE_ITEM_INDENT: &[u8] = b"  ";
 
 impl Space {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2853,6 +2853,109 @@ config:
       expect(YAML.stringify(obj, null, 2)).toBe(expected);
     });
 
+    // `- ` is two columns wide whatever `space` is. A collection that starts on the dash line has its
+    // first entry two columns after the dash, so its later entries go there too. Only a mapping value
+    // is indented by `space`.
+    describe("collections nested in a sequence item, at every indent width", () => {
+      // These tests are about indentation, so each line is compared without its trailing whitespace.
+      const lines = (value: unknown, space: number | string) =>
+        YAML.stringify(value, null, space)
+          .split("\n")
+          .map(line => line.trimEnd());
+
+      test("a nested sequence lines up with its first item", () => {
+        for (const space of [1, 2, 3, 4, 8]) {
+          expect(lines([[1, 2], 3], space)).toEqual(["- - 1", "  - 2", "- 3"]);
+          expect(lines([[[1, 2], 3], 4], space)).toEqual(["- - - 1", "    - 2", "  - 3", "- 4"]);
+        }
+        expect(lines({ k: [[1, 2], 3] }, 4)).toEqual(["k:", "    - - 1", "      - 2", "    - 3"]);
+      });
+
+      test("a nested mapping lines up with its first key", () => {
+        for (const space of [1, 2, 3, 4, 8]) {
+          expect(lines([{ a: 1, b: 2 }], space)).toEqual(["- a: 1", "  b: 2"]);
+        }
+        expect(lines({ k: [{ a: 1, b: 2 }] }, 1)).toEqual(["k:", " - a: 1", "   b: 2"]);
+        expect(lines({ k: [{ a: 1, b: 2 }] }, 3)).toEqual(["k:", "   - a: 1", "     b: 2"]);
+        expect(lines({ k: [{ a: 1, b: 2 }] }, 4)).toEqual(["k:", "    - a: 1", "      b: 2"]);
+        expect(lines({ k: [{ a: 1, b: 2 }] }, "    ")).toEqual(["k:", "    - a: 1", "      b: 2"]);
+      });
+
+      test("a mapping value inside the item is indented by `space` from its key", () => {
+        expect(lines([{ a: [1, 2], b: { c: 1, d: 2 } }], 4)).toEqual([
+          "- a:",
+          "      - 1",
+          "      - 2",
+          "  b:",
+          "      c: 1",
+          "      d: 2",
+        ]);
+        expect(lines([{ a: [1, 2], b: { c: 1, d: 2 } }], 1)).toEqual([
+          "- a:",
+          "   - 1",
+          "   - 2",
+          "  b:",
+          "   c: 1",
+          "   d: 2",
+        ]);
+      });
+
+      test("an anchored collection starts on the line after the dash, two columns in", () => {
+        const shared = { a: 1, b: [1, 2] };
+        expect(lines([shared, shared], 4)).toEqual([
+          "- &item0",
+          "  a: 1",
+          "  b:",
+          "      - 1",
+          "      - 2",
+          "- *item0",
+        ]);
+      });
+
+      test("the dash indent is spaces even when `space` is another string", () => {
+        expect(lines([[1, 2], { a: 1, b: 2 }], "\t")).toEqual(["- - 1", "  - 2", "- a: 1", "  b: 2"]);
+      });
+
+      const shared = { x: 1, y: [1, 2] };
+      const values: unknown[] = [
+        [[1, 2], 3],
+        [{ a: 1, b: 2 }],
+        { k: [{ a: 1, b: 2 }] },
+        { k: { j: [[1, 2], [3]] } },
+        [[[[1, 2], { a: 1, b: 2 }], 3], 4],
+        [{ a: [1, 2], b: { c: [{ d: 1, e: 2 }], f: [[]] } }, {}],
+        [shared, { again: shared }, [shared, 1]],
+        {
+          apiVersion: "apps/v1",
+          kind: "Deployment",
+          spec: {
+            template: {
+              spec: {
+                containers: [
+                  {
+                    name: "web",
+                    image: "nginx:1.27",
+                    ports: [{ containerPort: 80, protocol: "TCP" }],
+                    env: [
+                      { name: "A", value: "1" },
+                      { name: "B", value: "2" },
+                    ],
+                  },
+                  { name: "sidecar", args: ["--port", "9000"] },
+                ],
+              },
+            },
+          },
+        },
+      ];
+
+      test.each([1, 2, 3, 4, 5, 8, 10, " ", "   ", "    "])("round-trips with space %j", space => {
+        for (const value of values) {
+          expect(YAML.parse(YAML.stringify(value, null, space))).toEqual(value);
+        }
+      });
+    });
+
     test("stringifies objects with special keys", () => {
       expect(YAML.stringify({ "special-key": "value" }, null, 2)).toBe("special-key: value");
       expect(YAML.stringify({ "123": "numeric" }, null, 2)).toBe('"123": numeric');

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2853,9 +2853,8 @@ config:
       expect(YAML.stringify(obj, null, 2)).toBe(expected);
     });
 
-    // `- ` is two columns wide whatever `space` is. A collection that starts on the dash line has its
-    // first entry two columns after the dash, so its later entries go there too. Only a mapping value
-    // is indented by `space`.
+    // `- ` is two columns wide whatever `space` is, so the entries of a collection that starts on the
+    // dash line are two columns after the dash. Only a mapping value is indented by `space`.
     describe("collections nested in a sequence item, at every indent width", () => {
       // These tests are about indentation, so each line is compared without its trailing whitespace.
       const lines = (value: unknown, space: number | string) =>


### PR DESCRIPTION
### Problem

- `Bun.YAML.stringify(value, null, space)` writes wrong YAML for every `space` other than 2 when a sequence item holds a collection. At 4, `[[1, 2], 3]` gives `- - 1\n    - 2\n- 3`, which parses as `[["1 - 2"], 3]`. `[{ a: 1, b: 2 }]` gives `- a: 1\n    b: 2`: `YAML Parse error: Unexpected token`.
- Cause: `src/runtime/api/YAMLObject.rs:481`. A sequence item added one indent level, and `newline()` wrote `level * space` columns. The `- ` before the first entry is always 2 columns wide.

### Fix

- The stringifier keeps one `IndentStep` for each open block collection. A mapping value adds one `space` unit. A sequence item adds 2 columns. `newline()` writes the sum.
- Output at `space` 2 does not change. At other widths the indentation is the same as the `yaml` npm package: `k:\n    - a: 1\n      b: 2` at 4.
- Not changed: a `space` string that is not all spaces (`"\t"`) still gives invalid YAML when a mapping nests.
- Verified: `test/js/bun/yaml/yaml.test.ts`, new block "collections nested in a sequence item, at every indent width". 14 of the 15 new tests fail on 1.4.3 (`space` 2 is the control). All of `test/js/bun/yaml/` passes.

### Background

- In block style YAML, indentation gives the structure, and only spaces can indent.
- A collection can start on the `- ` line of a sequence item: `- a: 1`. Its other entries must start at the column of the first entry, which is the dash column plus 2.
- A line that is indented more than that continues the scalar before it. That is why `- - 1\n    - 2` reads as the string `1 - 2`, with no error.

<details><summary>Notes</summary>

**Reproduction** (from the report, 15 of 18 lines print MISMATCH on 1.4.3, 1 of 18 with this change):

```js
const cases = [[[1, 2], 3], [{ a: 1, b: 2 }], { k: [{ a: 1, b: 2 }] }];
for (const indent of [2, 1, 3, 4, 8, "\t"])
  for (const v of cases) {
    const y = Bun.YAML.stringify(v, null, indent);
    let back, err = "";
    try { back = Bun.YAML.parse(y); } catch (e) { err = e.message; }
    console.log(JSON.stringify(indent), JSON.stringify(y), err || JSON.stringify(back), !err && Bun.deepEquals(back, v) ? "ok" : "MISMATCH");
  }
```

The line that still mismatches is `{ k: [{ a: 1, b: 2 }] }` with `"\t"`: `k: \n\t- a: 1\n\t  b: 2`, `Tab characters cannot be used as indentation`. That is the mapping indent, which uses the string as it is. The two other `"\t"` cases have no mapping indent and now round-trip.

**Which layout.** Three layouts are valid YAML for a collection in a sequence item when `space` is not 2:

| | `[{ a: 1, b: 2 }]` at 4 | who |
|---|---|---|
| entries 2 columns after the dash | `- a: 1\n  b: 2` | `yaml` 2.9.1, Prettier 3.6.2 (`--tab-width 4`) |
| pad after the dash to the indent width | `-   a: 1\n    b: 2` | js-yaml 5.4.1 (indent 2 or more), PyYAML 6.0.2 |
| collection on the next line | `-\n a: 1\n b: 2` | js-yaml 5.4.1 at indent 1 |

This PR uses the first one. It keeps the output at `space` 2 as it is, and it works for `space` 1 without a second form. I compared the output with `yaml` 2.9.1 for `[[1,2],3]`, `[{a:1,b:2}]`, `{k:[{a:1,b:2}]}`, `{k:{j:[[1,2],[3]]}}`, `[[[1,2],3],4]` and `[{a:[1,2],b:{c:1,d:2}}]` at 1, 2, 3, 4 and 8. The indentation is the same in all 30 (Bun still writes a space after `k:` and no final newline).

**Output that changes but was valid before.** A mapping value that is inside a sequence item was indented by 2 `space` units from the dash. It is now indented by 2 columns plus 1 `space` unit. Example at 4: `[{ a: { b: 1 } }]` was `- a: \n        b: 1` and is now `- a: \n      b: 1`. Both parse to the same value.

**Round-trip probe.** 20,887 small shapes (exhaustive to depth 3 over scalars, strings that need quotes, empty collections) plus 3,000 seeded random values with shared references, plus a cyclic value, at `space` 1, 2, 3, 4, 5, 7, 8, 10 and space strings of 1, 2, 3, 4 and 10 spaces: 310,544 round trips. 1.4.3 fails 182,557 of them. This branch fails 0.

**Related.** #41116 names this bug in its notes as out of scope and limits block scalars to `space` 2 or more because of it.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [2.77ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.37ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.10ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [1.84ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.20ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.14ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [3.10ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [2.93ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [3.36ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [2.98ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [2.57ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [3.78ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [2.97ms]
(pass) Bun
... (truncated)

release without fix: 18 skipped
bun test v1.4.3-canary.1 (d621a0105)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [0.07ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [0.03ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [0.02ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [0.06ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from DataView [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Blob [0.04ms]
(pass) Bun.YAML > parse > i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [2.69ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.46ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.12ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [1.86ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.20ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.31ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [3.00ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [2.93ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [3.68ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [3.03ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [2.94ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [2.91ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [3.33ms]
(pass) Bun
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1260ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/ins
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/YAMLObject.rs |  56 ++++++++++++++++-------
 test/js/bun/yaml/yaml.test.ts | 102 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 143 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/runtime/api/YAMLObject.rs      5      7     15
test/js/bun/yaml/yaml.test.ts      1      2     15
```

</details>

<!-- robobun:evidence:end -->