### PR TITLE
css: recognize :target-current, :target-before and :target-after

### DIFF
--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -949,6 +949,12 @@ pub enum PseudoClass {
     Target,
     /// The [:target-within](https://drafts.csswg.org/selectors-4/#the-target-within-pseudo) pseudo class.
     TargetWithin,
+    /// The [:target-current](https://drafts.csswg.org/css-overflow-5/#selectordef-target-current) pseudo class.
+    TargetCurrent,
+    /// The [:target-before](https://drafts.csswg.org/css-overflow-5/#selectordef-target-before) pseudo class.
+    TargetBefore,
+    /// The [:target-after](https://drafts.csswg.org/css-overflow-5/#selectordef-target-after) pseudo class.
+    TargetAfter,
     /// The [:visited](https://drafts.csswg.org/selectors-4/#visited-pseudo) pseudo class.
     Visited,
 
@@ -1482,6 +1488,10 @@ fn lookup_non_ts_pseudo_class(name: &[u8]) -> Option<PseudoClass> {
         b"local-link" => P::LocalLink,
         b"target" => P::Target,
         b"target-within" => P::TargetWithin,
+        // https://drafts.csswg.org/css-overflow-5/#active-before-after-scroll-markers
+        b"target-current" => P::TargetCurrent,
+        b"target-before" => P::TargetBefore,
+        b"target-after" => P::TargetAfter,
         b"visited" => P::Visited,
         // https://drafts.csswg.org/selectors-4/#input-pseudos
         b"enabled" => P::Enabled,

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -1081,6 +1081,11 @@ pub(crate) mod serialize {
             PseudoClass::LocalLink => dest.write_str(b":local-link")?,
             PseudoClass::Target => dest.write_str(b":target")?,
             PseudoClass::TargetWithin => dest.write_str(b":target-within")?,
+
+            // https://drafts.csswg.org/css-overflow-5/#active-before-after-scroll-markers
+            PseudoClass::TargetCurrent => dest.write_str(b":target-current")?,
+            PseudoClass::TargetBefore => dest.write_str(b":target-before")?,
+            PseudoClass::TargetAfter => dest.write_str(b":target-after")?,
             PseudoClass::Visited => dest.write_str(b":visited")?,
 
             // https://drafts.csswg.org/selectors-4/#input-pseudos

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -161,6 +161,30 @@ describe("css tests", () => {
         opera: 67 << 16,
       },
     );
+
+    // https://github.com/oven-sh/bun/issues/42480
+    // :target-current, :target-before and :target-after are the css-overflow-5
+    // scroll marker pseudo-classes. They must be in the pseudo-class table so
+    // that the name is printed in one canonical spelling and two rules that
+    // differ only in the case of the name merge. :target-within is the
+    // in-file control for what a known name does.
+    minify_test(
+      indoc`.a:TARGET-CURRENT { color: red }
+      .b:TARGET-WITHIN { color: red }
+      .c:Target-Before { color: red }
+      .d:target-AFTER { color: red }
+      .e:target-current { color: red }`,
+      ".a:target-current{color:red}.b:target-within{color:red}.c:target-before{color:red}.d:target-after{color:red}.e:target-current{color:red}",
+    );
+    minify_test(
+      indoc`.x:target-current { color: red }
+      .x:TARGET-CURRENT { color: red }
+      .y:target-before { color: red }
+      .y:TARGET-BEFORE { color: red }
+      .z:target-after { color: red }
+      .z:TARGET-AFTER { color: red }`,
+      ".x:target-current{color:red}.y:target-before{color:red}.z:target-after{color:red}",
+    );
   });
 
   describe("calc edge case", () => {


### PR DESCRIPTION
Fixes #42480. Adopts the change from #41139 by @oddharsh (credited as co-author in the commit). That PR is a fork PR whose CI never ran.

### Problem
- `bun build --minify` emits `.a:TARGET-CURRENT{color:red}` verbatim, and it keeps `.x:target-current{color:red}.x:TARGET-CURRENT{color:red}` as two rules. The same input with `:target-within` is lowercased and merged into one rule.
- The cause: `lookup_non_ts_pseudo_class` (`src/css/selectors/parser.rs:1440`) has no entries for `target-current`, `target-before` and `target-after`. Each parses as `PseudoClass::Custom`, which keeps its bytes and never compares equal to another spelling.

### Fix
- Add the three `PseudoClass` variants, the three table entries next to `target-within`, and the three serialization arms in `src/css/selectors/selector.rs`.
- This is the same shape as #41122 (`::details-content` and friends). `is_compatible` returns false for them, as it does for `TargetWithin`, so only the casing and the rule merge change.
- lightningcss 1.33.0 carries the three names behind `ParserFlags::SCROLL_NAVIGATION_CONTROLS`, which is off by default. Nothing on the `bun build` or `Bun.build` path can set a parser flag, so this PR enables the entries unconditionally. That is a deliberate divergence from the upstream default.
- Verified: `test/js/bun/css/css.test.ts` (two new `minify_test` cases under "pseudo-class edge case", both fail on released bun). Also `test/bundler/css/` and `test/js/bun/css/`.

### Background
- The CSS parser in `src/css/` is a port of lightningcss. Pseudo-class names are ASCII case-insensitive, so the table lookup lowercases the name and the serializer prints a fixed spelling.
- A name that is not in the table becomes `PseudoClass::Custom` with the original bytes. The rule merger compares selectors structurally, so two `Custom` values with different bytes stay separate rules.
- `:target-current`, `:target-before` and `:target-after` come from css-overflow-5. They match the active scroll marker and the markers before and after it.

<details><summary>Notes</summary>

- Repro with the debug build after the fix: `.x:target-current{color:red}.x:TARGET-CURRENT{color:red}.c:TARGET-BEFORE{color:red}.d:TARGET-AFTER{color:red}` minifies to `.x:target-current{color:red}.c:target-before{color:red}.d:target-after{color:red}`.
- `test/js/bun/css/css.test.ts`: 1183 pass, 67 skip, 0 fail with the debug build.
- `test/bundler/css/`: 174 pass, 0 fail.
- `test/js/bun/css/`: the fuzz tests in `css-fuzz.test.ts` and one large-stylesheet timing test hit their 10s and 5s timeouts under the ASAN debug build in a capped container. They do not touch pseudo-class parsing. All other tests in the directory pass.
- #38572 (open) changes the bare pseudo-class fallback so that unknown names warn. With these entries in the table the three names stay silent when that lands.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.11ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.03ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.04ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: wh
... (truncated)

release without fix: 2 failed, 67 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.11ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.03ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.03ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/css.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.68ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.10ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.04ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: wh
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 772ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_collections v0.0.0 (/workspace/bun/src/collections)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Comp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/selectors/parser.rs   | 10 ++++++++++
 src/css/selectors/selector.rs |  5 +++++
 test/js/bun/css/css.test.ts   | 24 ++++++++++++++++++++++++
 3 files changed, 39 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/css/selectors/parser.rs        0      0      8
src/css/selectors/selector.rs      0      0      9
test/js/bun/css/css.test.ts        1      2      7
```

</details>

**root cause** · written by the author bot

Bun's CSS selector parser had no entries for the css-overflow-5 pseudo-classes `:target-current`, `:target-before` and `:target-after` in its pseudo-class lookup table, so each parsed as `PseudoClass::Custom` and was emitted with whatever casing it arrived in, and two spellings of the same selector never compared equal for rule merging. The fix adds three unit variants to the `PseudoClass` enum, three case-insensitive table entries mapping the names to those variants, and three serializer arms that print the canonical lowercase form, mirroring the existing `TargetWithin` handling. With the …

<!-- robobun:evidence:end -->