### PR TITLE
node:http2: close the transport after a fatal send from an event loop task

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1002,8 +1002,7 @@ impl Drop for Keepalive<'_> {
     }
 }
 
-/// A [`Keepalive`] for a frame that is entered holding a ref of its own (a queued task's): it
-/// counts that ref instead of taking another.
+/// A [`Keepalive`] that counts a ref the frame already owns (a queued task's).
 struct OwnedKeepalive(RefPtr<H2FrameParser>);
 
 impl OwnedKeepalive {
@@ -2969,8 +2968,8 @@ impl H2FrameParser {
     /// Windows CI agents). -1 (socket closed/shut down/not writable yet) is NOT
     /// latched: those are routine during setup and teardown and the close path that
     /// produced them owns the lifecycle. Latch the fatal and let the deferred tick
-    /// queue the transport's close - the failing write can be deep inside frame
-    /// emission, so the close must not run under the caller's stack.
+    /// close the transport - the failing write can be deep inside frame emission, so
+    /// the close must not run under the caller's stack.
     /// Errno classification lives in `us_socket_write_check_error` (socket.c):
     /// would-block/transient errnos re-arm writable and are never reported
     /// here, known peer-gone errnos are reported immediately, and every other
@@ -2993,15 +2992,7 @@ impl H2FrameParser {
         }
     }
 
-    /// Queues `FatalWriteCloseTask`. The close has to run from the top of the event loop, and
-    /// the deferred task queue is not that: it runs whenever the outermost JS call returns, and
-    /// that call can be a dispatch `on_native_read` made. A close made there detached the
-    /// socket under its own read. The rest of the read wrote through the detached transport,
-    /// and the session reported that write's error (`ERR_SOCKET_CLOSED` on a server, `EBADF`
-    /// on a client). The close also runs JS close handlers, and JS that runs inside the queue
-    /// gets no checkpoint of its own (`EventLoop::exit()` skips it there): with the socket as
-    /// the last handle, the process exited before their `process.nextTick` follow-up ran.
-    /// `FileSink::run_pending_later` leaves the queue the same way.
+    /// The close must not run inside the deferred task queue: it can run under `on_native_read`.
     fn queue_transport_close_after_fatal_write(&self) {
         if self.fatal_write_close_queued.replace(true) {
             return;
@@ -3012,8 +3003,7 @@ impl H2FrameParser {
             task,
             FatalWriteCloseTask::run,
         ));
-        // A queued task makes the next poll non-blocking on POSIX only. From a `setImmediate`
-        // callback the poll comes before the next `tick()`, and libuv would sleep in it.
+        // A queued task does not shorten the libuv poll.
         #[cfg(windows)]
         event_loop.wakeup();
     }
@@ -3365,8 +3355,7 @@ extern "C" fn on_auto_flush_trampoline(ctx: *mut c_void) -> bool {
     unsafe { (*(ctx.cast_const().cast::<H2FrameParser>())).on_auto_flush() }
 }
 
-/// The event loop task `queue_transport_close_after_fatal_write` queues. Its ref keeps the
-/// parser alive in the queue, and `ManagedTask` drops it if the loop releases the task unrun.
+/// Keeps the parser alive in the task queue. `ManagedTask` drops it if the task never runs.
 struct FatalWriteCloseTask(RefPtr<H2FrameParser>);
 
 impl FatalWriteCloseTask {
@@ -3374,8 +3363,7 @@ impl FatalWriteCloseTask {
         // SAFETY: the box `queue_transport_close_after_fatal_write` leaked; `ManagedTask`
         // hands it over once.
         let Self(queued_ref) = *unsafe { bun_core::heap::take(this) };
-        // The close re-enters JS, so the ref this frame holds has to be a counted one:
-        // `finalize` can release it if `process.exit()` strands the frame.
+        // Counted, so `finalize` can release it if `process.exit()` strands this frame.
         let keepalive = OwnedKeepalive::adopt(queued_ref);
         let parser: &H2FrameParser = &keepalive.0;
         parser.fatal_write_close_queued.set(false);

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1002,6 +1002,30 @@ impl Drop for Keepalive<'_> {
     }
 }
 
+/// A [`Keepalive`] for a frame that is entered holding a ref of its own (a queued task's): it
+/// counts that ref instead of taking another.
+struct OwnedKeepalive(RefPtr<H2FrameParser>);
+
+impl OwnedKeepalive {
+    fn adopt(parser: RefPtr<H2FrameParser>) -> Self {
+        parser
+            .native_keepalives
+            .set(parser.native_keepalives.get() + 1);
+        Self(parser)
+    }
+}
+
+impl Drop for OwnedKeepalive {
+    fn drop(&mut self) {
+        let parser = &self.0;
+        debug_assert!(parser.native_keepalives.get() > 0);
+        // The field's own drop releases the ref after this, and can free the parser.
+        parser
+            .native_keepalives
+            .set(parser.native_keepalives.get() - 1);
+    }
+}
+
 /// A `&mut Stream` that only exists inside an armed dispatch scope (`enter_stream_dispatch`):
 /// while it is live, rewrite_read defers stream frees, so user JS that re-enters `read()`
 /// (option getters, header-value `toString`) cannot free the stream out from under the borrow.
@@ -1135,11 +1159,13 @@ pub struct H2FrameParser {
     /// True while flush() has bytes out in an onWrite dispatch to a JS-backed socket.
     js_socket_flushing: Cell<bool>,
     /// A native write returned a terminal result (socket closed, shut down, or the kernel
-    /// rejected the send). Latched once; the deferred tick closes the transport.
+    /// rejected the send). Latched once; the deferred tick queues the transport's close.
     transport_write_fatal: Cell<bool>,
     /// An outbound header block the HPACK encoder could not emit. Latched once; the deferred
     /// tick reports it, because it is detected inside a user submit call.
     pending_header_compression_error: Cell<bool>,
+    /// A `FatalWriteCloseTask` is in the event loop's task queue.
+    fatal_write_close_queued: Cell<bool>,
     /// Frames written by the legacy outbound encoder (perf_hooks http2 session stats).
     frames_sent_legacy: Cell<u64>,
     /// Engine counters mirrored at the end of each rewrite_read batch, so reading them
@@ -2943,8 +2969,8 @@ impl H2FrameParser {
     /// Windows CI agents). -1 (socket closed/shut down/not writable yet) is NOT
     /// latched: those are routine during setup and teardown and the close path that
     /// produced them owns the lifecycle. Latch the fatal and let the deferred tick
-    /// close the transport - the failing write can be deep inside frame emission, so
-    /// the close must not run under the caller's stack.
+    /// queue the transport's close - the failing write can be deep inside frame
+    /// emission, so the close must not run under the caller's stack.
     /// Errno classification lives in `us_socket_write_check_error` (socket.c):
     /// would-block/transient errnos re-arm writable and are never reported
     /// here, known peer-gone errnos are reported immediately, and every other
@@ -2967,7 +2993,32 @@ impl H2FrameParser {
         }
     }
 
-    /// Runs from the deferred tick (never under a write): closes the native socket so the
+    /// Queues `FatalWriteCloseTask`. The close has to run from the top of the event loop, and
+    /// the deferred task queue is not that: it runs whenever the outermost JS call returns, and
+    /// that call can be a dispatch `on_native_read` made. A close made there detached the
+    /// socket under its own read. The rest of the read wrote through the detached transport,
+    /// and the session reported that write's error (`ERR_SOCKET_CLOSED` on a server, `EBADF`
+    /// on a client). The close also runs JS close handlers, and JS that runs inside the queue
+    /// gets no checkpoint of its own (`EventLoop::exit()` skips it there): with the socket as
+    /// the last handle, the process exited before their `process.nextTick` follow-up ran.
+    /// `FileSink::run_pending_later` leaves the queue the same way.
+    fn queue_transport_close_after_fatal_write(&self) {
+        if self.fatal_write_close_queued.replace(true) {
+            return;
+        }
+        let task = bun_core::heap::into_raw(Box::new(FatalWriteCloseTask(self.ref_guard())));
+        let event_loop = self.global_this.bun_vm().event_loop_mut();
+        event_loop.enqueue_task(bun_jsc::ManagedTask::ManagedTask::new_owned(
+            task,
+            FatalWriteCloseTask::run,
+        ));
+        // A queued task makes the next poll non-blocking on POSIX only. From a `setImmediate`
+        // callback the poll comes before the next `tick()`, and libuv would sleep in it.
+        #[cfg(windows)]
+        event_loop.wakeup();
+    }
+
+    /// Runs from `FatalWriteCloseTask` (never under a write): closes the native socket so the
     /// normal socket-close teardown runs (native callback detach, JS 'close', session
     /// destroy) - the same path a peer disconnect takes. Closes WITHOUT detaching: a
     /// close_and_detach here severed the JS wrapper before on_close could dispatch, so
@@ -3001,17 +3052,14 @@ impl H2FrameParser {
         if self.transport_write_fatal.get() {
             // Returning `false` makes DeferredTaskQueue::run remove the entry
             // itself, so only the registration's flag and ref are released here
-            // - never a re-entrant map mutation from inside run(). The flag is
-            // cleared before the close so the teardown paths the close re-enters
-            // (detach -> unregister_auto_flush) see an unregistered flusher and
-            // early-return instead of removing a map entry run() still owns.
+            // - never a re-entrant map mutation from inside run().
             self.auto_flusher.get().registered.set(false);
             self.deref();
             // An empty write buffer here means a later write in the same flush()
             // cycle already drained the bytes the failing send left behind (racy
             // one-off errnos, e.g. macOS EPROTOTYPE) - the transport recovered.
             if self.has_backpressure() {
-                self.close_transport_after_fatal_write();
+                self.queue_transport_close_after_fatal_write();
             } else {
                 self.transport_write_fatal.set(false);
             }
@@ -3315,6 +3363,32 @@ extern "C" fn on_auto_flush_trampoline(ctx: *mut c_void) -> bool {
     // `register_auto_flush`; `DeferredTaskQueue::run` feeds it back unchanged
     // on the JS thread. `on_auto_flush` takes `&self`.
     unsafe { (*(ctx.cast_const().cast::<H2FrameParser>())).on_auto_flush() }
+}
+
+/// The event loop task `queue_transport_close_after_fatal_write` queues. Its ref keeps the
+/// parser alive in the queue, and `ManagedTask` drops it if the loop releases the task unrun.
+struct FatalWriteCloseTask(RefPtr<H2FrameParser>);
+
+impl FatalWriteCloseTask {
+    fn run(this: *mut Self) -> JsResult<()> {
+        // SAFETY: the box `queue_transport_close_after_fatal_write` leaked; `ManagedTask`
+        // hands it over once.
+        let Self(queued_ref) = *unsafe { bun_core::heap::take(this) };
+        // The close re-enters JS, so the ref this frame holds has to be a counted one:
+        // `finalize` can release it if `process.exit()` strands the frame.
+        let keepalive = OwnedKeepalive::adopt(queued_ref);
+        let parser: &H2FrameParser = &keepalive.0;
+        parser.fatal_write_close_queued.set(false);
+        // JS ran since the deferred tick queued this task: decide again, the way that tick does.
+        if parser.transport_write_fatal.get() {
+            if parser.has_backpressure() {
+                parser.close_transport_after_fatal_write();
+            } else {
+                parser.transport_write_fatal.set(false);
+            }
+        }
+        Ok(())
+    }
 }
 
 // (`JsValueArrayPush` / `VmReportExtraMemory` shims removed —
@@ -7631,6 +7705,7 @@ impl H2FrameParser {
             js_socket_flushing: Cell::new(false),
             transport_write_fatal: Cell::new(false),
             pending_header_compression_error: Cell::new(false),
+            fatal_write_close_queued: Cell::new(false),
             frames_sent_legacy: Cell::new(0),
             engine_frames_received: Cell::new(0),
             engine_frames_sent: Cell::new(0),

--- a/test/js/node/http2/node-http2-syscall-fault.test.ts
+++ b/test/js/node/http2/node-http2-syscall-fault.test.ts
@@ -250,7 +250,7 @@ describe("node:http2 closes its transport after a send() the kernel rejects", ()
   //
   // Each fixture starts no timer, because a timer wakes the loop and hides the first bug. It
   // reports what it saw when the process exits on its own.
-  const bothClosed = { streamClosed: true, sessionClosed: true };
+  const bothClosed = JSON.stringify({ streamClosed: true, sessionClosed: true });
 
   // No injection, so these run on every build and platform. One process holds both ends of the
   // connection. The peer resets and the client writes in the same turn, so the kernel has the
@@ -306,9 +306,11 @@ describe("node:http2 closes its transport after a send() the kernel rejects", ()
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual({ ...bothClosed, unexpectedErrors: [] });
-      expect(exitCode).toBe(0);
+      expect({ seen: stdout.trim(), stderr, exitCode }).toEqual({
+        seen: JSON.stringify({ streamClosed: true, sessionClosed: true, unexpectedErrors: [] }),
+        stderr: "",
+        exitCode: 0,
+      });
     });
   });
 
@@ -349,9 +351,7 @@ describe("node:http2 closes its transport after a send() the kernel rejects", ()
           stderr: "pipe",
         });
         const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect(stderr).toBe("");
-        expect(JSON.parse(stdout)).toEqual(bothClosed);
-        expect(exitCode).toBe(0);
+        expect({ seen: stdout.trim(), stderr, exitCode }).toEqual({ seen: bothClosed, stderr: "", exitCode: 0 });
       } finally {
         for (const socket of accepted) socket.destroy();
         peer.close();
@@ -401,6 +401,8 @@ describe("node:http2 closes its transport after a send() the kernel rejects", ()
       let stdout = "";
       let client: net.Socket | undefined;
       let sentBody = false;
+      // Drained while the loop below reacts to stdout: a full stderr pipe would block the child.
+      const stderrText = proc.stderr.text();
       try {
         for await (const chunk of proc.stdout) {
           stdout += Buffer.from(chunk).toString();
@@ -422,11 +424,9 @@ describe("node:http2 closes its transport after a send() the kernel rejects", ()
             client!.write(frame(0, 0, 1, Buffer.from("body")));
           }
         }
-        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-        expect(stderr).toBe("");
-        const lines = stdout.trim().split("\n");
-        expect(JSON.parse(lines[lines.length - 1])).toEqual(bothClosed);
-        expect(exitCode).toBe(0);
+        const [stderr, exitCode] = await Promise.all([stderrText, proc.exited]);
+        const seen = stdout.trim().split("\n").at(-1);
+        expect({ seen, stderr, exitCode }).toEqual({ seen: bothClosed, stderr: "", exitCode: 0 });
       } finally {
         client?.destroy();
       }

--- a/test/js/node/http2/node-http2-syscall-fault.test.ts
+++ b/test/js/node/http2/node-http2-syscall-fault.test.ts
@@ -3,11 +3,15 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tls as certs, isASAN, isWindows } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
+import net from "node:net";
 import path from "node:path";
 
 const skip = !fault.available() || isWindows;
 
-afterEach(() => fault.clear());
+// fault.clear() throws on a build without the hooks, and the real-reset cases below run there too.
+afterEach(() => {
+  if (fault.available()) fault.clear();
+});
 
 // http2 sessions go through the same uSockets bsd_recv/bsd_send chokepoints.
 // Faults are process-global, so client and server (both in this process)
@@ -234,6 +238,200 @@ describe.skipIf(skip)("node:http2 under injected syscall faults", () => {
       expect(exitCode).toBe(0);
     },
   );
+});
+
+describe("node:http2 closes its transport after a send() the kernel rejects", () => {
+  // That close runs the socket's JS close handlers, and they finish the teardown from
+  // process.nextTick. It ran inside the deferred task queue. No microtask checkpoint follows that
+  // queue, and the closed socket was the last handle: the process exited 0 with no 'close' on the
+  // stream or on the session. That queue also runs under a read callback, when the JS the read
+  // dispatched returns. The rest of the read then wrote through the detached transport, and the
+  // session reported that write's error.
+  //
+  // Each fixture starts no timer, because a timer wakes the loop and hides the first bug. It
+  // reports what it saw when the process exits on its own.
+  const bothClosed = { streamClosed: true, sessionClosed: true };
+
+  // No injection, so these run on every build and platform. One process holds both ends of the
+  // connection. The peer resets and the client writes in the same turn, so the kernel has the
+  // RST and the loop has not polled it. Node reports a clean close when a write sees the reset
+  // and ECONNRESET when a read does: any other error is an artifact.
+  describe.concurrent("a real reset that a client's send() sees first", () => {
+    const fixture = (whenSettingsArrive: string) => `
+      const http2 = require("node:http2");
+      const seen = { streamClosed: false, sessionClosed: false, unexpectedErrors: [] };
+      const onError = err => {
+        if (err.code !== "ECONNRESET") seen.unexpectedErrors.push(err.code);
+      };
+      let peer;
+      const listener = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        socket: {
+          open(socket) {
+            peer = socket;
+            // One connection only: from here the two sockets are the only handles.
+            listener.stop();
+            socket.write(Buffer.from([0, 0, 0, 4, 0, 0, 0, 0, 0])); // empty SETTINGS
+          },
+          data() {},
+          error() {},
+        },
+      });
+      const session = http2.connect("http://127.0.0.1:" + listener.port);
+      session.on("error", onError);
+      session.on("close", () => (seen.sessionClosed = true));
+      function resetThenRequest() {
+        peer.terminate(); // closes with an RST
+        const req = session.request({ ":path": "/" });
+        req.on("error", onError);
+        req.on("close", () => (seen.streamClosed = true));
+        req.resume();
+        req.end();
+      }
+      session.on("remoteSettings", ${whenSettingsArrive});
+      process.on("exit", () => console.log(JSON.stringify(seen)));
+    `;
+
+    test.each([
+      // Nothing is left on the stack to run a checkpoint after the close: no event at all.
+      ["from setImmediate", "() => setImmediate(resetThenRequest)"],
+      // 'remoteSettings' is emitted from the read that parsed the frame: EBADF (EPIPE on Windows).
+      ["inside a read callback", "resetThenRequest"],
+    ])("request made %s", async (_, when) => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture(when)],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({ ...bothClosed, unexpectedErrors: [] });
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  // The fault rules are process-global, so the faulted side runs in a subprocess and its raw
+  // peer lives here.
+  describe.skipIf(skip)("an injected errno", () => {
+    test("client: the failing send is the request's HEADERS inside the connect flush", async () => {
+      const fixture = `
+        const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+        const http2 = require("node:http2");
+        const seen = { streamClosed: false, sessionClosed: false };
+        // The connect flush sends the preface, then the queued request's HEADERS: fail the second send.
+        fault.set({ syscall: "send", action: "errno", errno: "ECONNRESET", after: 1, repeat: -1 });
+        const session = http2.connect("http://127.0.0.1:" + process.env.H2_PEER_PORT);
+        session.on("error", () => {});
+        session.on("close", () => (seen.sessionClosed = true));
+        const req = session.request({ ":path": "/" });
+        req.on("error", () => {});
+        req.on("close", () => (seen.streamClosed = true));
+        req.resume();
+        req.end();
+        process.on("exit", () => console.log(JSON.stringify(seen)));
+      `;
+      const accepted: net.Socket[] = [];
+      const peer = net.createServer(socket => {
+        accepted.push(socket);
+        socket.on("error", () => {});
+        // An empty SETTINGS: the client owes an ACK, so a send follows the preface in any case.
+        socket.write(Buffer.from([0, 0, 0, 4, 0, 0, 0, 0, 0]));
+      });
+      peer.listen(0, "127.0.0.1");
+      await once(peer, "listening");
+      try {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", fixture],
+          env: { ...bunEnv, H2_PEER_PORT: String((peer.address() as net.AddressInfo).port) },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout)).toEqual(bothClosed);
+        expect(exitCode).toBe(0);
+      } finally {
+        for (const socket of accepted) socket.destroy();
+        peer.close();
+      }
+    });
+
+    test("server: the failing send is a response, after the listener closed", async () => {
+      // A server that shuts down while a request is in flight. The stream has no 'error' listener:
+      // a client that vanishes is routine for a server, and it has to close quietly. The response
+      // is written from a read callback, and the deferred task queue ran under it: the rest of the
+      // read wrote through the detached transport and the stream got that write's ERR_SOCKET_CLOSED.
+      const fixture = `
+        const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+        const fs = require("node:fs");
+        const http2 = require("node:http2");
+        const seen = { streamClosed: false, sessionClosed: false };
+        const server = http2.createServer();
+        server.on("session", session => session.on("close", () => (seen.sessionClosed = true)));
+        server.on("stream", stream => {
+          stream.on("close", () => (seen.streamClosed = true));
+          // With the listener closed, the accepted socket is the last handle.
+          server.close();
+          // The response stays open, so only the transport can close the stream.
+          stream.once("data", () => {
+            fault.set({ syscall: "send", action: "errno", errno: "ECONNRESET", repeat: -1 });
+            stream.respond({ ":status": 200 });
+            stream.write("x");
+          });
+          fs.writeSync(1, "stream\\n");
+        });
+        process.on("exit", () => fs.writeSync(1, JSON.stringify(seen) + "\\n"));
+        server.listen(0, "127.0.0.1", () => fs.writeSync(1, "port=" + server.address().port + "\\n"));
+      `;
+      await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+      // A raw client: preface, SETTINGS, and the headers of one POST. Its body follows once the
+      // server has the stream, so the response is written in a later turn than server.close().
+      const frame = (type: number, flags: number, streamId: number, payload = Buffer.alloc(0)) => {
+        const header = Buffer.alloc(9);
+        header.writeUIntBE(payload.length, 0, 3);
+        header[3] = type;
+        header[4] = flags;
+        header.writeUInt32BE(streamId, 5);
+        return Buffer.concat([header, payload]);
+      };
+      // :method POST, :scheme http and :path / from the static table, then a literal :authority.
+      const requestBlock = Buffer.concat([Buffer.from([0x83, 0x86, 0x84, 0x01, 0x09]), Buffer.from("localhost")]);
+      let stdout = "";
+      let client: net.Socket | undefined;
+      let sentBody = false;
+      try {
+        for await (const chunk of proc.stdout) {
+          stdout += Buffer.from(chunk).toString();
+          const port = /port=(\d+)/.exec(stdout);
+          if (port && !client) {
+            client = net.connect(Number(port[1]), "127.0.0.1", () => {
+              client!.write(
+                Buffer.concat([
+                  Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "latin1"),
+                  frame(4, 0, 0),
+                  frame(1, 0x4, 1, requestBlock),
+                ]),
+              );
+            });
+            client.on("error", () => {});
+          }
+          if (!sentBody && stdout.includes("stream\n")) {
+            sentBody = true;
+            client!.write(frame(0, 0, 1, Buffer.from("body")));
+          }
+        }
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        const lines = stdout.trim().split("\n");
+        expect(JSON.parse(lines[lines.length - 1])).toEqual(bothClosed);
+        expect(exitCode).toBe(0);
+      } finally {
+        client?.destroy();
+      }
+    });
+  });
 });
 
 describe.skipIf(skip)("node:http2 seeded short-I/O fuzz", () => {


### PR DESCRIPTION
### Problem
- When the kernel rejects a `send()` after a peer reset, a plaintext `node:http2` session closes its transport inside the deferred task queue (`src/runtime/api/bun/h2_frame_parser.rs:3014`). Regression in 1.4.0 (#32488).
- That queue also runs under `on_native_read`. The rest of the read then writes through the detached transport: a client reports `EBADF`, and a server stream with no `'error'` listener ends the process with `ERR_SOCKET_CLOSED`.
- Its JS close handlers finish from `process.nextTick`, and no checkpoint follows the deferred tasks (`src/jsc/event_loop.rs:419-432`). With the socket as the last handle, the process exits 0 with no `'close'` event.

### Fix
- The deferred tick queues an event loop task (`FatalWriteCloseTask`) that closes the socket, as `FileSink::run_pending_later` does.
- Correct because a task runs from the top of the loop and a checkpoint follows it, like a close that the poll reports. The reported outcome stays the same.
- Verified: `test/js/node/http2/node-http2-syscall-fault.test.ts`, four new cases: two with a real reset (fail on 1.4.3 and main), two with fault injection (fail on main's `src/`). Also `test/js/node/http2/`, node's 261 `test-http2-*` files, grpc-js.
- Self-reviewed: 7 concerns raised, 6 addressed (Notes).

### Background
- `H2FrameParser` is the native HTTP/2 engine behind an `Http2Session`.
- The deferred task queue holds auto-flush callbacks. It runs at the end of each microtask checkpoint, and `EventLoop::exit()` skips its checkpoint while it runs.
- `transport_write_fatal` is the latch a rejected `send()` sets. TLS writes report no errno, so only h2c sessions set it.
- #42353 adds a checkpoint after the deferred tasks. That delivers the lost events, but the close still runs under the read (see Notes).

<details><summary>Notes</summary>

**Scope.** Plaintext HTTP/2 only (`http2.connect("http://...")`, `http2.createServer()`, gRPC over insecure channels). `us_socket_write_check_error` returns early for TLS sockets (`packages/bun-usockets/src/socket.c`), so a TLS session never sets the latch. No user reported this. It was found during the work on #42182.

**What main does, measured** (main @6a92015f, linux-x64 debug, and 1.4.3-canary release. The two client cases below behave the same on the Windows x64 canary).

Client, peer resets at the preface (peer under node, client under bun, no timer in the client), 3/3:

```
main:         exit=0 session.connect || session.destroyed=false stream.destroyed=false
this branch:  exit=0 session.connect | stream.end | stream.close(rstCode=8) | session.close
node v26.3.0: exit=0 session.connect | stream.error:ECONNRESET | stream.close(rstCode=2) | session.error:ECONNRESET | session.close
```

Client, one process holds both ends, the peer resets and the client calls `request()` in the same turn:

```
request() from setImmediate or a timer
  main:        (no event)
  this branch: stream.end | stream.close(rstCode=8) | session.close
request() inside 'remoteSettings' (a read callback)
  main:        session.error:EBADF | session.close | stream.error:EBADF | stream.close(rstCode=2)   (EPIPE on Windows)
  this branch: stream.end | stream.close(rstCode=8) | session.close
```

Server, the listener is closed while a request is in flight, then the response write fails:

```
write made from setImmediate (injected ECONNRESET on send)
  main:        exit=0, no 'close' on the stream or the session
  this branch: exit=0, stream 'close' and session 'close'
write made from the stream's 'data' handler (real reset, or injected)
  main:        exit=1, uncaught ERR_SOCKET_CLOSED on the stream, no stream 'close'
  this branch: exit=0, session.close | stream.close(rstCode=8)
```

The clean close (`rstCode` 8, no `'error'`) is what main already reports when something else wakes the loop, and it is what Node's `socketOnClose` does to open streams (`NGHTTP2_CANCEL`). #42182 changes the client result to `ECONNRESET`. This PR does not change which result is reported, only that it is delivered.

**Why the read callback case breaks on main.** `rewrite_read` dispatches a frame event to JS. The handler writes, the send fails, and the latch registers the auto flusher. When the handler returns, the outermost `exit()` runs the checkpoint and then the deferred tasks, so the fatal branch closes the socket while `on_native_read` for that same socket is still on the stack. The close detaches the native socket. `rewrite_read` then ends with `self.flush()`, which finds no native socket and goes through the JS `write` handler. `net.Socket._write` fails that write, the session takes it as a transport error and destroys its streams with it.

**Relation to #42353, and the order.** #42353 (`node:http2: submit a request's frames after request() returns`) drains pending microtasks again after `deferred_tasks.run()`. With it, the `process.nextTick` follow-up of a close made inside the queue runs, so the lost-events half of this bug goes away for every deferred task. Its `on_auto_flush` still calls `close_transport_after_fatal_write()` directly, so the close still runs under `on_native_read`, and the `EBADF` and `ERR_SOCKET_CLOSED` results stay. The two changes compose. #42353 deletes the `has_backpressure()` block that this PR edits, so the second one to land has a small conflict there: keep `queue_transport_close_after_fatal_write()` in the place of the direct close. If this PR lands first, all four new cases fail before it and pass after it. If #42353 lands first, the two cases that lose every event pass without this change, and the two read callback cases still need it.

**Other open PRs.** #42182 (close client sessions with the send errno) edits `close_transport_after_fatal_write` and adds a line to the recovered-send branch. The task's own recovered-send branch then needs the same line. #37782 edits the condition of the fatal branch. #42197 adds `BunSocket::Closed`. None of these touches the line this PR changes.

**Ordering.** The task runs in the next `tick()`. When the deferred tick ran from an I/O callback or a timer, that is before the next poll. When it ran from a `setImmediate` callback, one non-blocking poll comes first, so the read side can report the reset before the task runs. The task then finds the socket closed or detached and does nothing. On Linux the failed `send()` has consumed the socket error, so that read is a clean EOF.

**State between the deferred tick and the task.** The latch stays set, so later fatal results do nothing. Other paths can register the auto flusher again (`cork()`), and the fatal branch then runs again: `fatal_write_close_queued` makes that a no-op. The task decides again when it runs, the way the deferred tick does: it closes if bytes are still buffered, and clears the latch if a later write drained them. A teardown releases the queued task through `ManagedTask::release`, which drops the boxed ref. In `run`, the queue's ref becomes a counted keepalive (`OwnedKeepalive`) before the close re-enters JS, so `finalize` can release it if `process.exit()` strands the frame (`release_refs_stranded_by_exit`). Checked with `BUN_DESTRUCT_VM_ON_EXIT=1` and LeakSanitizer: `process.exit()` from inside the close dispatch reports no leak.

**The tests.** All four cases are in one `describe` in `node-http2-syscall-fault.test.ts`. Every fixture reports at `process.on("exit")` and starts no timer. The asserts are Node-neutral: `'close'` on the stream and on the session, exit code 0, empty stderr, and no error other than `ECONNRESET`. The two real-reset cases need no fault injection, so they run on release lanes and on Windows (the file's `afterEach` now calls `fault.clear()` only when the hooks exist). One process holds both ends, the peer resets and the client calls `request()` in the same turn, once from `setImmediate` (main: no event) and once inside `'remoteSettings'` (main: `EBADF`). Checked on Windows x64: the canary fails both, this branch passes both, 3/3 runs. The two injected cases use `socketFaultInjection` (debug and ASAN builds, not Windows). The client case fails the second send of the connect flush, which is the reported scenario. The server case closes its listener with a request in flight and then writes the response from the stream's `'data'` handler (main: exit 1, uncaught `ERR_SOCKET_CLOSED`).

**Windows.** A queued task makes the next poll non-blocking on POSIX only (`get_timeout` drops `has_pending_immediate` on Windows, and `uv_run(UV_RUN_ONCE)` takes no timeout). `auto_tick` wakes libuv for immediates, not for tasks. So `queue_transport_close_after_fatal_write` calls `wakeup()` on Windows, for the case where it runs from a `setImmediate` callback and the poll comes before the next `tick()`.

**Not changed.** A send that fails inside the deferred tick itself (the usual corked path) latches and registers the auto flusher again, so the fatal branch runs at the next checkpoint, as before. From a `setImmediate` callback that checkpoint comes after the next poll. A dead socket has an event pending, so that poll returns at once. With an injected errno it waits for the next unrelated wake (measured: 0.3 to 0.8 s, bounded by the 4 s socket sweep).

**Self-review.** Changes made after it: the doc comment of `queue_transport_close_after_fatal_write` leads with the stack reason, the task decides again when it runs, the loop is woken on Windows, the server test no longer waits for an unrelated wake, `OwnedKeepalive` replaces an `unsafe` block, and this text states the h2c scope and the relation to #42353. Left out: the `pending_header_compression_error` branch of `on_auto_flush` also dispatches JS from inside the queue. It is a separate path with its own latch, so this PR leaves it alone.

Suites run on linux-x64 (debug): `test/js/node/http2/` (all files), `test/js/node/test/parallel/test-http2-*` and `sequential/test-http2-*` (261 files pass), `test/js/third_party/grpc-js` (321 pass, the same 7 failures as main: 5 need DNS, 2 time out on debug builds), `test/js/third_party/undici-h2`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/http2/node-http2-syscall-fault.test.ts

<!-- robobun:evidence:end -->