### PR TITLE
Name WebAssembly frames in error.stack and the error printer

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5876,6 +5876,7 @@ impl VirtualMachine {
                     || frame.source_url.eq_ascii(b"native")
                     || frame.source_url.eq_ascii(b"unknown")
                     || frame.source_url.eq_ascii(b"[unknown]")
+                    || frame.source_url.eq_ascii(b"[wasm code]")
                     || frame.source_url.starts_with_ascii(b"[source:")
                 {
                     top_frame_is_builtin = true;
@@ -6886,7 +6887,7 @@ impl VirtualMachine {
                     );
                     (name_str, loc_str)
                 };
-                if !name_str.is_empty() {
+                if !name_str.is_empty() && !loc_str.is_empty() {
                     let _ = write!(
                         writer,
                         "%0A      at {} ({})",
@@ -6894,10 +6895,16 @@ impl VirtualMachine {
                         bun_core::fmt::github_action(loc_str.as_bytes()),
                     );
                 } else {
+                    // A WebAssembly frame has a name and no location.
+                    let only = if name_str.is_empty() {
+                        &loc_str
+                    } else {
+                        &name_str
+                    };
                     let _ = write!(
                         writer,
                         "%0A      at {}",
-                        bun_core::fmt::github_action(loc_str.as_bytes()),
+                        bun_core::fmt::github_action(only.as_bytes()),
                     );
                 }
             }

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -516,6 +516,10 @@ String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSC::
 
 String functionName(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, const JSC::StackFrame& frame, FinalizerSafety finalizerSafety, unsigned int* flags)
 {
+    // A wasm frame has no callee and no code block. Same name as JSCStackFrame::retrieveFunctionName.
+    if (frame.isWasmFrame())
+        return JSC::Wasm::makeString(frame.wasmFunctionIndexOrName());
+
     bool isConstructor = false;
     if (finalizerSafety == FinalizerSafety::MustNotTriggerGC) {
 

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -350,6 +350,8 @@ WTF::String formatStackTrace(
         if (sourceURLForFrame.isEmpty()) {
             if (flags & static_cast<unsigned int>(FunctionNameFlags::Builtin)) {
                 sourceURLForFrame = "native"_s;
+            } else if (frame.isWasmFrame()) {
+                sourceURLForFrame = Zig::sourceURL(vm, frame);
             } else {
                 sourceURLForFrame = "unknown"_s;
             }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -348,8 +348,14 @@ impl TestFailure {
                 continue;
             }
             body.extend_from_slice(b"      at ");
+            let pos = frame.position;
+            // A WebAssembly frame has a name, no source and no position.
+            let in_parens = !func.slice().is_empty() && (!file.is_empty() || pos.line.is_valid());
             if !func.slice().is_empty() {
-                let _ = write!(body, "{} (", frame.name_formatter(false));
+                let _ = write!(body, "{}", frame.name_formatter(false));
+            }
+            if in_parens {
+                body.extend_from_slice(b" (");
             }
             let file_start = body.len();
             body.extend_from_slice(file);
@@ -360,13 +366,12 @@ impl TestFailure {
                     }
                 }
             }
-            let pos = frame.position;
             if pos.line.is_valid() && pos.column.is_valid() {
                 let _ = write!(body, ":{}:{}", pos.line.one_based(), pos.column.one_based());
             } else if pos.line.is_valid() {
                 let _ = write!(body, ":{}", pos.line.one_based());
             }
-            if !func.slice().is_empty() {
+            if in_parens {
                 body.push(b')');
             }
             body.push(b'\n');

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -704,6 +704,31 @@ describe("bun test", () => {
       expect(annotation).toMatch(/^::error file=.*,line=\d+,col=\d+,title=error: boom::/);
       expect(annotation).toContain("%0A      at odd%0Aname (");
     });
+    test("should annotate a WebAssembly frame, which has a name and no location", () => {
+      const stderr = runTest({
+        input: `
+          import { test } from "bun:test";
+          // (module $kit (func $trapper (export "trapper") unreachable)), names from the "name" custom section
+          const bytes = new Uint8Array([
+            0, 0x61, 0x73, 0x6d, 1, 0, 0, 0, 1, 4, 1, 0x60, 0, 0, 3, 2, 1, 0,
+            7, 11, 1, 7, 0x74, 0x72, 0x61, 0x70, 0x70, 0x65, 0x72, 0, 0, 10, 5, 1, 3, 0, 0, 0x0b,
+            0, 23, 4, 0x6e, 0x61, 0x6d, 0x65, 0, 4, 3, 0x6b, 0x69, 0x74, 1, 10, 1, 0, 7, 0x74, 0x72, 0x61, 0x70, 0x70, 0x65, 0x72,
+          ]);
+          const { trapper } = new WebAssembly.Instance(new WebAssembly.Module(bytes)).exports;
+          test("trap", function trapTest() {
+            trapper();
+          });
+        `,
+        env: {
+          GITHUB_ACTIONS: "true",
+          // Debug builds show private frames: the "wasm-stub" entry thunk next to the WebAssembly frame.
+          BUN_JSC_showPrivateScriptsInStackTraces: "0",
+        },
+        expectExitCode: 1,
+      });
+      const annotation = stderr.split("\n").find(l => l.startsWith("::error"));
+      expect(annotation).toContain("%0A      at kit.wasm-function[trapper]%0A      at trapTest (");
+    });
     test("should annotate a test timeout", () => {
       const stderr = runTest({
         input: `

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -608,6 +608,42 @@ describe("junit reporter", () => {
     expect(longPathCase.failure[0]._).toContain(`at fromLongPath (${longPath}:1:`);
     expect(pathCase.failure[0]._).toContain("at fromPath (generated.js:1:");
   });
+
+  it("prints a WebAssembly frame, which has a name and no source, in <failure>", async () => {
+    await using tmpDir = tempDir("junit-wasm-frame", {
+      "package.json": "{}",
+      "wasm.test.js": `
+        import { test } from "bun:test";
+        // (module $kit (func $trapper (export "trapper") unreachable)), names from the "name" custom section
+        const bytes = new Uint8Array([
+          0, 0x61, 0x73, 0x6d, 1, 0, 0, 0, 1, 4, 1, 0x60, 0, 0, 3, 2, 1, 0,
+          7, 11, 1, 7, 0x74, 0x72, 0x61, 0x70, 0x70, 0x65, 0x72, 0, 0, 10, 5, 1, 3, 0, 0, 0x0b,
+          0, 23, 4, 0x6e, 0x61, 0x6d, 0x65, 0, 4, 3, 0x6b, 0x69, 0x74, 1, 10, 1, 0, 7, 0x74, 0x72, 0x61, 0x70, 0x70, 0x65, 0x72,
+        ]);
+        const { trapper } = new WebAssembly.Instance(new WebAssembly.Module(bytes)).exports;
+        test("trap", function trapTest() { trapper(); });
+      `,
+    });
+
+    const junitPath = join(tmpDir, "junit.xml");
+    await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
+      cwd: tmpDir,
+      // Debug builds show private frames: the "wasm-stub" entry thunk next to the WebAssembly frame.
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1", BUN_JSC_showPrivateScriptsInStackTraces: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const xmlContent = await file(junitPath).text();
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+    });
+    const [trapCase] = result.testsuites.testsuite[0].testcase;
+
+    expect(trapCase.failure[0]._).toContain("      at kit.wasm-function[trapper]\n      at trapTest (wasm.test.js:");
+    expect(exitCode).toBe(1);
+  });
 });
 
 function filterJunitXmlOutput(xmlContent) {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1223,3 +1223,100 @@ test.concurrent.each([[{}], [{ BUN_JSC_useSourceProviderCache: "0" }]])(
     expect(exitCode).toBe(0);
   },
 );
+
+test("a WebAssembly frame keeps its function name in error.stack, the error printer, console.trace and process.report", async () => {
+  using dir = tempDir("wasm-frame-names", {
+    "fixture.js": [
+      `// (module $kit`,
+      `//   (import "env" "js" (func $js))`,
+      `//   (func $viaImport (export "viaImport") call $js)`,
+      `//   (func $trapper (export "trapper") unreachable))`,
+      `// The "name" custom section carries the module name and the function names.`,
+      `const str = s => [s.length, ...Buffer.from(s)];`,
+      `const section = (id, content) => [id, content.length, ...content];`,
+      `const bytes = new Uint8Array([`,
+      `  0, 0x61, 0x73, 0x6d, 1, 0, 0, 0,`,
+      `  ...section(1, [1, 0x60, 0, 0]),`,
+      `  ...section(2, [1, ...str("env"), ...str("js"), 0, 0]),`,
+      `  ...section(3, [2, 0, 0]),`,
+      `  ...section(7, [2, ...str("viaImport"), 0, 1, ...str("trapper"), 0, 2]),`,
+      `  ...section(10, [2, 4, 0, 0x10, 0, 0x0b, 3, 0, 0, 0x0b]),`,
+      `  ...section(0, [`,
+      `    ...str("name"),`,
+      `    ...section(0, str("kit")),`,
+      `    ...section(1, [3, 0, ...str("js"), 1, ...str("viaImport"), 2, ...str("trapper")]),`,
+      `  ]),`,
+      `]);`,
+      `let inJs;`,
+      `const { viaImport, trapper } = new WebAssembly.Instance(new WebAssembly.Module(bytes), { env: { js: () => inJs() } }).exports;`,
+      `const out = {};`,
+      ``,
+      `try { trapper(); } catch (e) { out.stack = e.stack; }`,
+      `try { trapper(); } catch (e) { out.inspect = Bun.inspect(e); }`,
+      `// Once error.stack is read, the error printer parses the frames back out of that string.`,
+      `function readStackThenInspect() {`,
+      `  try { trapper(); } catch (e) { e.stack; return Bun.inspect(e); }`,
+      `}`,
+      `out.inspectAfterStackRead = readStackThenInspect();`,
+      ``,
+      `inJs = () => { out.newError = new Error("below wasm").stack; };`,
+      `viaImport();`,
+      `inJs = () => { const target = {}; Error.captureStackTrace(target); out.captureStackTrace = target.stack; };`,
+      `viaImport();`,
+      `inJs = () => { out.report = process.report.getReport().javascriptStack.stack.join("\\n"); };`,
+      `viaImport();`,
+      ``,
+      `Error.prepareStackTrace = (_error, callSites) => callSites[0];`,
+      `try { trapper(); } catch (e) { out.callSite = { functionName: e.stack.getFunctionName(), fileName: e.stack.getFileName() }; }`,
+      `Error.prepareStackTrace = undefined;`,
+      ``,
+      `console.log(JSON.stringify(out));`,
+      `inJs = () => console.trace("traced");`,
+      `viaImport();`,
+    ].join("\n"),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.js"],
+    cwd: String(dir),
+    // Debug builds show private frames: the "wasm-stub" entry and exit thunks around each WebAssembly frame.
+    env: { ...bunEnv, BUN_JSC_showPrivateScriptsInStackTraces: "0" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Every JavaScript frame is in fixture.js, so the frames that are left are the WebAssembly frames.
+  const wasmFrames = text =>
+    text
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => line.startsWith("at ") && !line.includes("fixture.js"));
+
+  const [json, ...traced] = stdout.split("\n");
+  expect(json, stderr).toStartWith("{");
+  const { callSite, inspectAfterStackRead, ...texts } = JSON.parse(json);
+  const frames = Object.fromEntries(Object.entries(texts).map(([name, text]) => [name, wasmFrames(text)]));
+
+  expect({
+    callSite,
+    ...frames,
+    // console.trace() prints the trace where it prints the message.
+    traced: wasmFrames(traced.join("\n") + stderr),
+  }).toEqual({
+    // error.stack has what CallSite.getFunctionName() and CallSite.getFileName() return for the same frame.
+    callSite: { functionName: "kit.wasm-function[trapper]", fileName: "[wasm code]" },
+    stack: ["at kit.wasm-function[trapper] ([wasm code])"],
+    inspect: ["at kit.wasm-function[trapper]"],
+    newError: ["at kit.wasm-function[viaImport] ([wasm code])"],
+    captureStackTrace: ["at kit.wasm-function[viaImport] ([wasm code])"],
+    report: ["at kit.wasm-function[viaImport] ([wasm code])"],
+    traced: ["at kit.wasm-function[viaImport]"],
+  });
+
+  // The frame survives the round trip through the error.stack string, and the source preview still comes from the
+  // JavaScript frame below it.
+  expect(wasmFrames(inspectAfterStackRead)[0]).toStartWith("at kit.wasm-function[trapper] ([wasm code]");
+  expect(inspectAfterStackRead).toContain("|   try { trapper(); } catch (e) { e.stack; return Bun.inspect(e); }");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- `error.stack` and `process.report` print a WebAssembly frame as `at unknown`. `console.error`, `Bun.inspect`, the uncaught report, `console.trace()`, the JUnit reporter and the GitHub Actions annotation drop the frame. bun 1.1.42 printed `at kit.wasm-function[trapper] (native)` and `at kit.wasm-function[trapper]`.
- The `JSC::StackFrame` overload of `Zig::functionName` (`src/jsc/bindings/ErrorStackTrace.cpp:517`) has no arm for a wasm frame, so the name is empty. #16212 (v1.1.43) replaced JSC's `StackFrame::functionName`, which has the arm, with this overload.

### Fix
- The overload returns `Wasm::makeString(frame.wasmFunctionIndexOrName())` for a wasm frame. `CallSite.getFunctionName()` already returns this string.
- `error.stack` prints `at kit.wasm-function[trapper] ([wasm code])`, where `[wasm code]` is the value of `CallSite.getFileName()`. The error printer prints `at kit.wasm-function[trapper]`, as 1.1.42 did. The source preview skips a `[wasm code]` frame.
- The JUnit `<failure>` body and the GitHub annotation print a frame that has a name and no location as `at name`, not `at name ()`.
- Verified: new tests in `capture-stack-trace.test.js`, `junit.test.js` and `bun-test.test.ts`, which fail on 1.4.3-canary. Also ran `inspect-error.test.js`, `23022-stack-trace-iterator.test.ts`, `test/js/bun/wasm`. Self-reviewed: 3 concerns raised, 3 addressed.

### Background
- A `JSC::StackFrame` is one entry of the trace that JSC captures for an error. A wasm frame holds only a `Wasm::IndexOrName`: the function name from the module's `name` custom section, or the function index.
- Two C++ readers use `Zig::functionName`. `formatStackTrace` builds the `error.stack` string. `populateStackTrace` fills the `ZigStackFrame` structs that the Rust error printer prints.
- `CallSite` objects (the `Error.prepareStackTrace` API) use a third reader, `JSCStackFrame`. It always had the wasm arm.

<details><summary>Notes</summary>

**Byte offset.** Node prints `wasm://wasm/kit-<hash>:wasm-function[0]:0x24`. JSC's `WasmFrameData` holds `functionIndexOrName` and `functionIndex` only, and `StackVisitor` has no bytecode offset for a wasm call site in any tier. The offset needs a WebKit change. This PR does not add it.

**Output, module `kit`, function `trapper` that traps (release build).**

| consumer | 1.1.42 | 1.4.3-canary | this PR |
| --- | --- | --- | --- |
| `error.stack`, `Error.captureStackTrace`, `process.report` | `at kit.wasm-function[trapper] (native)` | `at unknown` | `at kit.wasm-function[trapper] ([wasm code])` |
| `console.error`, `Bun.inspect`, uncaught, `console.trace` | `at kit.wasm-function[trapper]` | (frame dropped) | `at kit.wasm-function[trapper]` |
| printer after a read of `error.stack` | | `at unknown:1:1` | `at kit.wasm-function[trapper] ([wasm code]:1:1)` |
| JUnit `<failure>`, GitHub annotation | | (frame dropped) | `at kit.wasm-function[trapper]` |

A module with no `name` section prints the index: `at .wasm-function[1] ([wasm code])`.

**Format choice for a maintainer.** `error.stack` could print `(native)` as the location, as 1.1.42 did and as `CallSite.toString()` and the default `Error.prepareStackTrace` still do. That is a one-line change in `formatStackTrace` (`"native"_s` in place of `Zig::sourceURL(vm, frame)`), and the `[wasm code]` entry in the source preview list then goes away. This PR prints `[wasm code]` because `CallSite.getFileName()` returns it for the same frame, and because #35177 uses the same label in the printer.

**Not changed.**
- `CallSite.toString()` prints `kit.wasm-function[trapper] (native)` because `isNative()` is true for a wasm frame. The default `Error.prepareStackTrace` uses the same formatter.
- After a read of `error.stack`, the printer parses the frames back out of the string. The `:1:1` in that row is the position that the parser invents for a frame without one. #38328 removes it.
- When a wasm frame is the top frame, the GitHub annotation has no `file=`/`line=`. #41862 covers that.

**Related open PRs.** #35177 adds a `[wasm code]` label to the printer for a wasm frame with no URL. With it, the two printer assertions in the new `capture-stack-trace` test need the ` ([wasm code])` suffix. #41862 replaces the source preview URL list that this PR adds `[wasm code]` to.

**Debug builds** show private frames (`showPrivateScriptsInStackTraces`), which adds `wasm-stub` entry and exit thunks around each wasm frame. The tests set `BUN_JSC_showPrivateScriptsInStackTraces=0`.

**Self-review.** A pass over every caller of the overload and every reader of `ZigStackFrame.function_name` found three places that print a named frame with no location badly: the JUnit body (`at name ()`), the GitHub annotation (`at name ()`), and my first JUnit change, which dropped the parentheses of a builtin frame that has a position and no file (`at forEach (:1:11)`). All three are fixed and the first two have tests.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts

<!-- robobun:evidence:end -->
