### PR TITLE
Bun.JSONL: a chunk cut inside a \u escape, an exponent or the BOM is incomplete, not an error

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -4,7 +4,7 @@
  * From https://github.com/oven-sh/WebKit releases.
  */
 // Preview of oven-sh/WebKit#638 (on top of cf1b36ec, the previous pin here): Bun.JSONL reports
-// a chunk that ends inside a \uXXXX escape or a number's exponent as incomplete, not as an error.
+// a chunk that ends inside a \u escape or a number's exponent as incomplete, not as an error.
 // Swap in the merged sha once that PR lands.
 export const WEBKIT_VERSION = "autobuild-preview-pr-638-2a5a22bc";
 

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,10 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "cf1b36ec8703d8e87436094d21d478d358c7d886";
+// Preview of oven-sh/WebKit#638 (on top of cf1b36ec, the previous pin here): Bun.JSONL reports
+// a chunk that ends inside a \uXXXX escape or a number's exponent as incomplete, not as an error.
+// Swap in the merged sha once that PR lands.
+export const WEBKIT_VERSION = "autobuild-preview-pr-638-2a5a22bc";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -434,6 +434,21 @@ static JSValue constructDNSObject(VM& vm, JSObject* bunObject)
 JSC_DECLARE_HOST_FUNCTION(jsFunctionJSONLParse);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionJSONLParseChunk);
 
+// How the UTF-8 byte order mark (EF BB BF) matches the start of the input. Partial: the input
+// ends inside the mark, so it is incomplete and not malformed.
+enum class UTF8BOMMatch : uint8_t { None,
+    Partial,
+    Full };
+
+static UTF8BOMMatch matchUTF8BOM(const uint8_t* data, size_t length)
+{
+    static constexpr uint8_t bom[] = { 0xEF, 0xBB, 0xBF };
+    size_t compared = std::min(length, sizeof(bom));
+    if (!compared || memcmp(data, bom, compared))
+        return UTF8BOMMatch::None;
+    return compared == sizeof(bom) ? UTF8BOMMatch::Full : UTF8BOMMatch::Partial;
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsFunctionJSONLParse, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -458,12 +473,15 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionJSONLParse, (JSGlobalObject * globalObject, C
         size_t length = view->byteLength();
 
         // Skip UTF-8 BOM if present
-        if (length >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF) {
+        auto bom = matchUTF8BOM(data, length);
+        if (bom == UTF8BOMMatch::Full) {
             data += 3;
             length -= 3;
         }
 
-        if (length <= String::MaxLength && simdutf::validate_ascii(reinterpret_cast<const char*>(data), length)) {
+        if (bom == UTF8BOMMatch::Partial) {
+            result = { 0, JSC::StreamingJSONParseResult::Status::NeedMoreData };
+        } else if (length <= String::MaxLength && simdutf::validate_ascii(reinterpret_cast<const char*>(data), length)) {
             auto chars = std::span { reinterpret_cast<const char8_t*>(data), length };
             result = JSC::streamingJSONParse(globalObject, StringView(chars), values);
         } else {
@@ -554,13 +572,17 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionJSONLParseChunk, (JSGlobalObject * globalObje
 
         // Skip UTF-8 BOM if present at the start of the slice
         size_t bomOffset = 0;
-        if (start == 0 && sliceLen >= 3 && sliceData[0] == 0xEF && sliceData[1] == 0xBB && sliceData[2] == 0xBF) {
+        auto bom = start == 0 ? matchUTF8BOM(sliceData, sliceLen) : UTF8BOMMatch::None;
+        if (bom == UTF8BOMMatch::Full) {
             sliceData += 3;
             sliceLen -= 3;
             bomOffset = 3;
         }
 
-        if (sliceLen <= String::MaxLength && simdutf::validate_ascii(reinterpret_cast<const char*>(sliceData), sliceLen)) {
+        if (bom == UTF8BOMMatch::Partial) {
+            // The chunk ends inside the BOM. Nothing is consumed until the rest of it arrives.
+            result = { 0, JSC::StreamingJSONParseResult::Status::NeedMoreData };
+        } else if (sliceLen <= String::MaxLength && simdutf::validate_ascii(reinterpret_cast<const char*>(sliceData), sliceLen)) {
             auto chars = std::span { reinterpret_cast<const char8_t*>(sliceData), sliceLen };
             result = JSC::streamingJSONParse(globalObject, StringView(chars), values);
             // For ASCII, byte offset = character offset

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -434,8 +434,6 @@ static JSValue constructDNSObject(VM& vm, JSObject* bunObject)
 JSC_DECLARE_HOST_FUNCTION(jsFunctionJSONLParse);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionJSONLParseChunk);
 
-// How the UTF-8 byte order mark (EF BB BF) matches the start of the input. Partial: the input
-// ends inside the mark, so it is incomplete and not malformed.
 enum class UTF8BOMMatch : uint8_t { None,
     Partial,
     Full };

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -443,7 +443,7 @@ describe("Bun.JSONL", () => {
         expect(result.error).toBeNull();
       });
 
-      // A read boundary can fall anywhere in a line, also inside a \uXXXX escape or the exponent of a number.
+      // A read boundary can fall anywhere in a line, also inside a \u escape or the exponent of a number.
       describe("a line cut at any position is incomplete, not an error", () => {
         const lines = [
           '{"name":"caf\\u00e9"}', // what Python's json.dumps emits for "café"

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -334,16 +334,17 @@ describe("Bun.JSONL", () => {
         expect(Bun.JSONL.parse(JSON.stringify({ s: bigStr }) + "\n")).toStrictEqual([{ s: bigStr }]);
       });
 
+      // A debug build with ASAN needs a little more than the default 5 seconds to scan 4 GB.
       test("4 GB Uint8Array of null bytes", () => {
         const buf = new Uint8Array(4 * 1024 * 1024 * 1024);
         expect(() => Bun.JSONL.parse(buf)).toThrow();
-      });
+      }, 30_000);
 
       test("4 GB Uint8Array with first byte 0xFF (non-ASCII path)", () => {
         const buf = new Uint8Array(4 * 1024 * 1024 * 1024);
         buf[0] = 255;
         expect(() => Bun.JSONL.parse(buf)).toThrow();
-      });
+      }, 30_000);
     });
   });
 

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -504,6 +504,33 @@ describe("Bun.JSONL", () => {
           }
         });
 
+        test("a Uint8Array that ends inside the UTF-8 byte order mark", () => {
+          const bytes = new Uint8Array([0xef, 0xbb, 0xbf, ...encoder.encode('{"a":1}\n{"b":2}\n')]);
+          const incomplete = { values: [], read: 0, done: false, error: null };
+          expect(Bun.JSONL.parseChunk(bytes.subarray(0, 1))).toEqual(incomplete);
+          expect(Bun.JSONL.parseChunk(bytes.subarray(0, 2))).toEqual(incomplete);
+          expect(Bun.JSONL.parseChunk(bytes, 0, 2)).toEqual(incomplete);
+          expect(Bun.JSONL.parseChunk(bytes.subarray(0, 3))).toEqual({ values: [], read: 3, done: true, error: null });
+          expect(Bun.JSONL.parse(bytes.subarray(0, 2))).toEqual([]);
+
+          // The streaming loop from the docs, one byte at a time.
+          const received: unknown[] = [];
+          const errors: string[] = [];
+          let buffer: Uint8Array = new Uint8Array(0);
+          for (let offset = 0; offset < bytes.length; offset++) {
+            buffer = Buffer.concat([buffer, bytes.subarray(offset, offset + 1)]);
+            const { values, read, error } = Bun.JSONL.parseChunk(buffer);
+            if (error) errors.push(`offset ${offset}: ${error.message}`);
+            received.push(...values);
+            buffer = buffer.subarray(read);
+          }
+          expect({ errors, received }).toEqual({ errors: [], received: [{ a: 1 }, { b: 2 }] });
+
+          // EF 41 is not a prefix of the mark, and the mark is only skipped at the start of the buffer.
+          expect(Bun.JSONL.parseChunk(new Uint8Array([0xef, 0x41])).error).toBeInstanceOf(SyntaxError);
+          expect(Bun.JSONL.parseChunk(bytes, 1, 2).error).toBeInstanceOf(SyntaxError);
+        });
+
         test("an escape or an exponent with its bad character in the input is still an error", () => {
           const malformed = [
             '"\\uz',

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -283,6 +283,12 @@ describe("Bun.JSONL", () => {
       test("returns complete values ignoring incomplete trailing array", () => {
         expect(Bun.JSONL.parse('{"a":1}\n[1,2,')).toStrictEqual([{ a: 1 }]);
       });
+
+      test("returns empty array for input that ends inside a \\u escape or an exponent", () => {
+        expect(Bun.JSONL.parse('{"name":"caf\\u00')).toStrictEqual([]);
+        expect(Bun.JSONL.parse("[1e-")).toStrictEqual([]);
+        expect(Bun.JSONL.parse("1e-")).toStrictEqual([]);
+      });
     });
 
     describe("whitespace and formatting", () => {
@@ -434,6 +440,92 @@ describe("Bun.JSONL", () => {
         expect(result.read).toBe(complete.join("\n").length);
         expect(result.done).toBe(false);
         expect(result.error).toBeNull();
+      });
+
+      // A read boundary can fall anywhere in a line, also inside a \uXXXX escape or the exponent of a number.
+      describe("a line cut at any position is incomplete, not an error", () => {
+        const lines = [
+          '{"name":"caf\\u00e9"}', // what Python's json.dumps emits for "café"
+          '{"\\u006bey":"\\ud83d\\ude00 \\u2028"}',
+          '"caf\\u00e9"',
+          "[1e-7,2E+5,-3.5e10,0.25E-3,6e2]",
+          '{"n":1e-7,"m":[2.5e+3],"t":true,"f":false,"z":null}',
+          '{"jp":"日本","e":"\\u00e9","n":[1e-7,2E+5]}', // not ASCII, so the 16-bit parser
+        ];
+        const encoder = new TextEncoder();
+        const decoder = new TextDecoder();
+        const inputKinds = [
+          ["string", (s: string): string | Uint8Array => s],
+          ["Uint8Array", (s: string): string | Uint8Array => encoder.encode(s)],
+        ] as const;
+
+        test.each(inputKinds)("every prefix of a line (%s)", (_, toInput) => {
+          const first = '{"first":1}';
+          const failures: string[] = [];
+          for (const line of lines) {
+            const input = toInput(`${first}\n${line}`);
+            for (let cut = first.length + 2; cut < input.length; cut++) {
+              const chunk = typeof input === "string" ? input.slice(0, cut) : input.subarray(0, cut);
+              const { values, read, done, error } = Bun.JSONL.parseChunk(chunk);
+              if (error !== null || done || read !== first.length || values.length !== 1) {
+                const shown = typeof chunk === "string" ? chunk : decoder.decode(chunk);
+                failures.push(`${JSON.stringify(shown)}: error=${error?.message} done=${done} read=${read}`);
+              }
+            }
+          }
+          expect(failures).toEqual([]);
+        });
+
+        test.each(inputKinds)("the streaming loop from the docs with any chunk size (%s)", (_, toInput) => {
+          const input = toInput(lines.join("\n") + "\n");
+          const expected = lines.map(line => JSON.parse(line));
+          for (const size of [1, 2, 3, 5, 7]) {
+            const received: unknown[] = [];
+            const errors: string[] = [];
+            let buffer: string | Uint8Array = typeof input === "string" ? "" : new Uint8Array(0);
+            for (let offset = 0; offset < input.length; offset += size) {
+              buffer =
+                typeof input === "string"
+                  ? (buffer as string) + input.slice(offset, offset + size)
+                  : Buffer.concat([buffer as Uint8Array, input.subarray(offset, offset + size)]);
+              const { values, read, error } = Bun.JSONL.parseChunk(buffer);
+              if (error) errors.push(`size ${size}, offset ${offset}: ${error.message}`);
+              received.push(...values);
+              buffer = typeof buffer === "string" ? buffer.slice(read) : buffer.subarray(read);
+            }
+            expect({ errors, received }).toEqual({ errors: [], received: expected });
+          }
+        });
+
+        test("a top-level number cut inside its exponent produces no value", () => {
+          for (const chunk of ["1e", "1e-", "1E+", "-2.5e", "-2.5E-"]) {
+            expect(Bun.JSONL.parseChunk(chunk)).toEqual({ values: [], read: 0, done: false, error: null });
+          }
+        });
+
+        test("an escape or an exponent with its bad character in the input is still an error", () => {
+          const malformed = [
+            '"\\uz',
+            '"\\u0z',
+            '"\\u00zz',
+            '"\\u00"',
+            '"\\u00\n',
+            '{"a":"\\u12"}\n',
+            '{"\\u00":1}\n',
+            "[1e-]",
+            "[1e+,",
+            "[1ex",
+            '{"a":1e}\n',
+            "[1.5e-\n",
+            "1e-\n",
+            "1e+x",
+          ];
+          for (const chunk of malformed) {
+            const { error, ...rest } = Bun.JSONL.parseChunk(chunk);
+            expect(error).toBeInstanceOf(SyntaxError);
+            expect({ chunk, ...rest }).toEqual({ chunk, values: [], read: 0, done: false });
+          }
+        });
       });
     });
 

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -1109,22 +1109,21 @@ describe("Bun.JSONL", () => {
         expect((result[0] as { s: string }).s).toBe("A".repeat(10000));
       });
 
-      // 50000 calls take about 4 seconds in a debug build with ASAN, and more on a busy machine.
       test("repeated parseChunk doesn't leak", () => {
         const input = '{"a":1}\n{"b":2}\n{"c":3}\n';
-        for (let i = 0; i < 50000; i++) {
+        for (let i = 0; i < 20000; i++) {
           Bun.JSONL.parseChunk(input);
         }
         expect(true).toBe(true);
-      }, 30_000);
+      });
 
       test("repeated parse with typed array doesn't leak", () => {
         const buf = new TextEncoder().encode('{"a":1}\n{"b":2}\n');
-        for (let i = 0; i < 50000; i++) {
+        for (let i = 0; i < 20000; i++) {
           Bun.JSONL.parse(buf);
         }
         expect(true).toBe(true);
-      }, 30_000);
+      });
     });
 
     describe("garbage input", () => {

--- a/test/js/bun/jsonl/jsonl-parse.test.ts
+++ b/test/js/bun/jsonl/jsonl-parse.test.ts
@@ -1109,13 +1109,14 @@ describe("Bun.JSONL", () => {
         expect((result[0] as { s: string }).s).toBe("A".repeat(10000));
       });
 
+      // 50000 calls take about 4 seconds in a debug build with ASAN, and more on a busy machine.
       test("repeated parseChunk doesn't leak", () => {
         const input = '{"a":1}\n{"b":2}\n{"c":3}\n';
         for (let i = 0; i < 50000; i++) {
           Bun.JSONL.parseChunk(input);
         }
         expect(true).toBe(true);
-      });
+      }, 30_000);
 
       test("repeated parse with typed array doesn't leak", () => {
         const buf = new TextEncoder().encode('{"a":1}\n{"b":2}\n');
@@ -1123,7 +1124,7 @@ describe("Bun.JSONL", () => {
           Bun.JSONL.parse(buf);
         }
         expect(true).toBe(true);
-      });
+      }, 30_000);
     });
 
     describe("garbage input", () => {


### PR DESCRIPTION
### Problem
- `Bun.JSONL.parseChunk` returns `SyntaxError: Failed to parse JSONL` for a chunk that ends inside a `\uXXXX` escape, after the `e-` / `e+` of a number, or inside the UTF-8 BOM. Every other cut position returns `error: null`, so the documented loop fails at random read boundaries.
- A top-level `1e-` also returns `values: [1]`.
- Escape and exponent: `LiteralParser::tryStreamingParse` (WebKit fork) reports an incomplete value only when the lexer stopped at the end of the input, and two lexer paths stop earlier. BOM: `BunObject.cpp:557` skips it only when all 3 bytes are there.

### Fix
- oven-sh/WebKit#638 makes both lexer paths stop at the end of the input for a cut token. This PR pins `WEBKIT_VERSION` to its preview build.
- `matchUTF8BOM` in `BunObject.cpp` tells a full BOM from a proper prefix. For a prefix, `parseChunk` returns `read: 0, done: false, error: null` and `parse` returns `[]`.
- Input whose bad character is present (`"\u0z`, `[1e-]`, `EF 41`) is still an error. The `JSON.parse` message for `[1e-]` changes from `Expected ']'` to `Exponent symbols should be followed by ...`.
- Verified: 8 new tests in `test/js/bun/jsonl/jsonl-parse.test.ts` fail on `1.4.3-canary.1` and pass on this branch.

### Background
- `parseChunk(buffer)` returns `{ values, read, done, error }`. The caller keeps `buffer.subarray(read)` and appends the next chunk. `error: null` with `done: false` means incomplete.
- The BOM is the bytes `EF BB BF` at the start of some UTF-8 files. `Bun.JSONL` skips it in `Uint8Array` input.
- `WEBKIT_VERSION` points at `autobuild-preview-pr-638-2a5a22bc`. Swap in the merged sha once oven-sh/WebKit#638 lands, before this PR merges.

<details><summary>Notes</summary>

**Test results.** Debug build of this branch: 277 of 277 tests in the file pass. A debug build of `main` with the pinned WebKit fails the 8 new tests. With only `src/` reverted to `main` (the preview WebKit stays), the BOM test fails and the other 276 pass.

**Four existing slow tests.** In a debug build with ASAN, `bun bd test` on this file exited 1 on `main` too, because of the default 5 second timeout. The two 4 GB tests get a 30 second timeout: a 4 GB scan takes 5.1 to 7.4 seconds there (under 1 second in a release build), and the size is the point of those tests. The two "doesn't leak" loops ran 50000 times, about 4 seconds and more on a busy machine. That count is arbitrary, so they now run 20000 times (about 1.5 seconds) and keep the default timeout.

**Reproduction** (same output on 1.4.2 `744846f844`, `1.4.3-canary.1`, and `main` at the pinned WebKit):

```js
const line = '{"name":"caf\\u00e9"}\n'; // what Python json.dumps emits for "café"
const bytes = new TextEncoder().encode(line);
for (let cut = 1; cut < bytes.length; cut++) {
  const r = Bun.JSONL.parseChunk(bytes.subarray(0, cut));
  if (r.error) console.log(JSON.stringify(line.slice(0, cut)), r.error.message);
}
console.log(Bun.JSONL.parseChunk("[1e-").error?.message); // Failed to parse JSONL
console.log(Bun.JSONL.parseChunk("1e-")); // values: [1], read: 1, error: SyntaxError
console.log(Bun.JSONL.parseChunk(new Uint8Array([0xef, 0xbb])).error?.message); // Failed to parse JSONL
```

**The new tests.**
- Every prefix of six lines (escapes in keys and values, a surrogate pair, `e-`, `E+`, fractions, keywords, one line that is not ASCII so that the 16-bit parser runs) after one complete line, as a string and as a `Uint8Array`. Each must return the first value, `read` at its end, `done: false`, `error: null`. The byte cuts also fall inside multi-byte UTF-8 sequences.
- The streaming loop from the docs over the same lines with chunk sizes 1, 2, 3, 5 and 7, for both input kinds. It must return every value and no error.
- `1e`, `1e-`, `1E+`, `-2.5e`, `-2.5E-` at the top level return no value.
- 14 malformed inputs stay errors with no value: `"\uz`, `"\u0z`, `"\u00zz`, `"\u00"`, `[1e-]`, `[1ex`, `1e-\n` and others.
- `Bun.JSONL.parse` returns `[]` for input that ends inside an escape or an exponent, as it does for `{`. It used to throw.
- BOM: `EF`, `EF BB` and `parseChunk(bytes, 0, 2)` are incomplete with `read: 0`. `EF BB BF` alone is `read: 3, done: true`. The loop from the docs, fed one byte at a time with a BOM in front of two lines, returns both values and no error. `EF 41`, and `BB` at `start = 1`, are still errors.

**Other verification, in oven-sh/WebKit#638.** A new JSTests stress test, the 72 other `*json*` stress tests on a `jsc` with and without the change, and a differential run over 152606 generated chunks: the pinned build says `error` for 34501 cuts of valid lines, the changed one for none, and the only results that differ on mutated input end in a partial `\u` escape or a partial exponent.

**Not changed here.** A top-level number that ends exactly at the end of a chunk is still returned as complete: `12` then `3\n` gives `12` and `3`. Nothing tells the parser that more input can follow, so that needs an API decision (for example, `parseChunk` could hold back a trailing top-level number until it sees the newline).

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 3 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/jsonl/jsonl-parse.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/jsonl/jsonl-parse.test.ts:
(pass) Bun.JSONL > has Symbol.toStringTag [2.80ms]
(pass) Bun.JSONL > parse > complete input > objects separated by newlines [2.56ms]
(pass) Bun.JSONL > parse > complete input > single value with trailing newline [1.93ms]
(pass) Bun.JSONL > parse > complete input > single value without trailing newline [1.85ms]
(pass) Bun.JSONL > parse > complete input > mixed JSON types [2.20ms]
(pass) Bun.JSONL > parse > complete input > empty string [1.30ms]
(pass) Bun.JSONL > parse > complete input > deeply nested objects [3.24ms]
(pass) Bun.JSONL > parse > complete input > unicode strings [2.58ms]
(pass) Bun.JSONL > parse > complete input > strings containing escaped newlines [1.90ms]
(pass) Bun.JSONL > parse > complete input > numbers: integers, floats, negative, exponents [1.71ms]
(pass) Bun.JSONL > parse > complete input > empty objects and arrays [1.86ms]
(pass) Bun.JSONL > parse > complete input > large number of lines [102.00ms]
(pass) Bu
... (truncated)

release without fix: 8 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/bun/jsonl/jsonl-parse.test.ts:
(pass) Bun.JSONL > has Symbol.toStringTag [0.05ms]
(pass) Bun.JSONL > parse > complete input > objects separated by newlines [0.09ms]
(pass) Bun.JSONL > parse > complete input > single value with trailing newline [0.03ms]
(pass) Bun.JSONL > parse > complete input > single value without trailing newline [0.02ms]
(pass) Bun.JSONL > parse > complete input > mixed JSON types [0.03ms]
(pass) Bun.JSONL > parse > complete input > empty string [0.02ms]
(pass) Bun.JSONL > parse > complete input > deeply nested objects [0.03ms]
(pass) Bun.JSONL > parse > complete input > unicode strings [0.05ms]
(pass) Bun.JSONL > parse > complete input > strings containing escaped newlines [0.03ms]
(pass) Bun.JSONL > parse > complete input > numbers: integers, floats, negative, exponents [0.02ms]
(pass) Bun.JSONL > parse > complete input > empty objects and arrays [0.02ms]
(pass) Bun.JSONL > parse > complete input > large number of lines [2.04ms]
(pass) Bun.JSONL > parse > error handling > throws on invalid JSON with no valid values before it [0.08ms]
(pass) Bun.JSONL > parse > error handling > throws on bare word w
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/jsonl/jsonl-parse.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/jsonl/jsonl-parse.test.ts:
(pass) Bun.JSONL > has Symbol.toStringTag [2.85ms]
(pass) Bun.JSONL > parse > complete input > objects separated by newlines [2.64ms]
(pass) Bun.JSONL > parse > complete input > single value with trailing newline [1.88ms]
(pass) Bun.JSONL > parse > complete input > single value without trailing newline [1.90ms]
(pass) Bun.JSONL > parse > complete input > mixed JSON types [2.35ms]
(pass) Bun.JSONL > parse > complete input > empty string [1.29ms]
(pass) Bun.JSONL > parse > complete input > deeply nested objects [2.97ms]
(pass) Bun.JSONL > parse > complete input > unicode strings [2.52ms]
(pass) Bun.JSONL > parse > complete input > strings containing escaped newlines [1.90ms]
(pass) Bun.JSONL > parse > complete input > numbers: integers, floats, negative, exponents [1.73ms]
(pass) Bun.JSONL > parse > complete input > empty objects and arrays [1.88ms]
(pass) Bun.JSONL > parse > complete input > large number of lines [127.11ms]
(pass) Bu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 674ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/112] gen BunObject.lut.h
Generating /workspace/bun/build/release/codegen/BunObject.lut.h from /workspace/bun/src/jsc/bindings/BunObject.cpp
[2/112] gen cpp.rs (cppbind)
[2/112] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_collections v0.0.0 (/workspace/bun/src/collections)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts          |   5 +-
 src/jsc/bindings/BunObject.cpp        |  28 ++++++--
 test/js/bun/jsonl/jsonl-parse.test.ts | 128 ++++++++++++++++++++++++++++++++--
 3 files changed, 152 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 2 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
scripts/build/deps/webkit.ts               2      1     45
src/jsc/bindings/BunObject.cpp             3      4     45
test/js/bun/jsonl/jsonl-parse.test.ts      8      6     45
```

</details>

<!-- robobun:evidence:end -->