### PR TITLE
bundler: widen [hash] names by output path, to a fixpoint

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2595,10 +2595,12 @@ impl<'a> LinkerContext<'a> {
     /// each other still differ).
     ///
     /// The width is the template's (`[hash]` = 8, `[hashN]` = N) unless two
-    /// chunks with different hashes would print the same characters; those
-    /// widen until they differ, and every chunk that reaches a widened chunk
-    /// (its output embeds that chunk's path or id) has the widths folded into
-    /// its own hash so that its name changes with its bytes.
+    /// chunks with different hashes would print the same characters or the
+    /// same output path; those widen until they differ, and every chunk that
+    /// reaches a widened chunk (its output embeds that chunk's path or id) has
+    /// the widths folded into its own hash so that its name changes with its
+    /// bytes. A widened chunk goes into that hash by its own hash, not by its
+    /// index, so a widening adds no dependence on the order of the chunks.
     pub(crate) fn final_chunk_hashes(
         &self,
         chunks: &[Chunk],
@@ -2709,27 +2711,125 @@ impl<'a> LinkerContext<'a> {
         let mut names: Vec<ContentHash> = (0..n)
             .map(|i| ContentHash::new(closure[i], min_len[i]))
             .collect();
-        for _ in 0..ContentHash::MAX_LEN {
-            if !ContentHash::widen_to_distinguish(&mut names) {
+
+        // Every round but the last widens a name and no name passes `MAX_LEN`,
+        // so this ends. A round gives the chunks it re-hashes new characters
+        // at their old widths, so under a short `[hashN]` it can take many.
+        loop {
+            // The printed hashes have to differ (they are the chunk ids), and so do the paths.
+            let mut any_widened = false;
+            loop {
+                let ids = ContentHash::widen_to_distinguish(&mut names);
+                let paths = self.widen_shared_paths(chunks, &mut names);
+                if !ids && !paths {
+                    break;
+                }
+                any_widened = true;
+            }
+            if !any_widened {
                 break;
             }
+            // A chunk digests each widened chunk it reaches by that chunk's
+            // hash, and sums them, so that the order of the chunks does not
+            // change the result.
+            let widened: Vec<(usize, u64)> = (0..n)
+                .filter(|&j| names[j].len() != min_len[j])
+                .map(|j| {
+                    let mut hash = ContentHasher::default();
+                    hash.write(&closure[j].to_ne_bytes());
+                    hash.write_ints(&[names[j].len() as u32]);
+                    (j, hash.digest())
+                })
+                .collect();
             for i in 0..n {
-                let mut hash = ContentHasher::default();
-                let mut any = false;
-                let mut iter = reach[i].iterator::<true, true>();
-                while let Some(j) = iter.next() {
-                    if j != i && names[j].len() != min_len[j] {
-                        hash.write_ints(&[j as u32, names[j].len() as u32]);
-                        any = true;
+                let mut widths: Option<u64> = None;
+                for &(j, digest) in &widened {
+                    if j != i && reach[i].is_set(j) {
+                        widths = Some(widths.unwrap_or(0).wrapping_add(digest));
                     }
                 }
-                if any {
+                if let Some(widths) = widths {
+                    let mut hash = ContentHasher::default();
+                    hash.write(&widths.to_ne_bytes());
                     hash.write(&closure[i].to_ne_bytes());
                     names[i] = ContentHash::new(hash.digest(), names[i].len());
                 }
             }
         }
         Ok(names)
+    }
+
+    /// Where `chunk` goes under the output directory when `hash` is its final hash.
+    pub(crate) fn chunk_rel_path(
+        &self,
+        chunk: &Chunk,
+        hash: bun_core::fmt::ContentHash,
+    ) -> Vec<u8> {
+        let mut rel_path: Vec<u8> = Vec::new();
+        // The byte-writer, not `Display`/`write!`: that goes via
+        // `from_utf8_lossy`, which would replace non-UTF-8 dir bytes with
+        // U+FFFD and corrupt the output path.
+        // Disk output sanitizes leading `..`; `--compile` keeps it so
+        // runtime bunfs references to out-of-root entrypoints resolve.
+        chunk
+            .template
+            .print_with_hash(
+                &mut rel_path,
+                Some(hash),
+                !self.options.compile_mode.is_executable(),
+            )
+            .expect("write to Vec<u8>");
+        bun_paths::resolve_path::platform_to_posix_in_place::<u8>(&mut rel_path);
+
+        // A `./[dir]/…` template with `[dir] == "."` yields `././x.js`,
+        // which importers of the chunk would copy verbatim.
+        while let Some(i) = strings::index_of(&rel_path, b"/./") {
+            rel_path.drain(i..i + 2);
+        }
+        rel_path
+    }
+
+    /// Two chunks under different naming templates can print one output path
+    /// from different hashes: a literal next to `[hash]` reads as a character
+    /// of a wider hash. Gives each chunk of such a group one more character,
+    /// unless their full hashes print one path too. Returns whether any name
+    /// changed.
+    fn widen_shared_paths(
+        &self,
+        chunks: &[Chunk],
+        names: &mut [bun_core::fmt::ContentHash],
+    ) -> bool {
+        use bun_core::fmt::ContentHash;
+        let paths: Vec<Vec<u8>> = (chunks.iter().zip(names.iter()))
+            .map(|(chunk, &name)| self.chunk_rel_path(chunk, name))
+            .collect();
+        let mut order: Vec<usize> = (0..chunks.len()).collect();
+        order.sort_unstable_by(|&a, &b| paths[a].cmp(&paths[b]));
+        let mut widened = false;
+        for group in order.chunk_by(|&a, &b| paths[a] == paths[b]) {
+            if group.len() < 2 {
+                continue;
+            }
+            let full = |i: usize| {
+                let hash = ContentHash::new(names[i].value, ContentHash::MAX_LEN);
+                self.chunk_rel_path(&chunks[i], hash)
+            };
+            let first = full(group[0]);
+            if group[1..].iter().all(|&i| full(i) == first) {
+                continue;
+            }
+            for &i in group {
+                if names[i].len() < ContentHash::MAX_LEN
+                    && chunks[i]
+                        .template
+                        .needs(crate::options::PlaceholderField::Hash)
+                {
+                    names[i] = ContentHash::new(names[i].value, names[i].len() + 1);
+                    widened = true;
+                }
+            }
+        }
+        widened
     }
 
     // Sort cross-chunk exports by chunk name for determinism

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -399,27 +399,8 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
         // paths of each chunk.
         let hashes = c.final_chunk_hashes(chunks)?;
         for index in 0..chunks.len() {
-            let chunk = &mut chunks[index];
-            chunk.template.placeholder.hash = Some(hashes[index]);
-
-            let mut rel_path: Vec<u8> = Vec::new();
-            // Use the byte-writer (`PathTemplate::print`) directly —
-            // routing through `Display`/`write!` goes via `from_utf8_lossy`,
-            // which would replace non-UTF-8 dir bytes with U+FFFD and corrupt
-            // the output path.
-            // Disk output sanitizes leading `..`; `--compile` keeps it so
-            // runtime bunfs references to out-of-root entrypoints resolve.
-            chunk
-                .template
-                .print(&mut rel_path, !c.options.compile_mode.is_executable())
-                .expect("write to Vec<u8>");
-            path::resolve_path::platform_to_posix_in_place::<u8>(&mut rel_path);
-
-            // A `./[dir]/…` template with `[dir] == "."` yields `././x.js`,
-            // which importers of the chunk would copy verbatim.
-            while let Some(i) = strings::index_of(&rel_path, b"/./") {
-                rel_path.drain(i..i + 2);
-            }
+            chunks[index].template.placeholder.hash = Some(hashes[index]);
+            let rel_path = c.chunk_rel_path(&chunks[index], hashes[index]);
 
             let claimed = path_names_map.get_or_put(&rel_path)?;
             if claimed.found_existing {

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -2453,13 +2453,23 @@ impl PathTemplate {
         writer: &mut W,
         sanitize_parent_dirs: bool,
     ) -> bun_io::Result<()> {
+        self.print_with_hash(writer, self.placeholder.hash, sanitize_parent_dirs)
+    }
+
+    /// [`print`](Self::print) with `hash` in place of the template's own.
+    pub(crate) fn print_with_hash<W: bun_io::Write>(
+        &self,
+        writer: &mut W,
+        hash: Option<bun_core::fmt::ContentHash>,
+        sanitize_parent_dirs: bool,
+    ) -> bun_io::Result<()> {
         path_template_print(
             writer,
             &self.data,
             &self.placeholder.dir,
             &self.placeholder.name,
             &self.placeholder.ext,
-            self.placeholder.hash,
+            hash,
             &self.placeholder.target,
             sanitize_parent_dirs,
         )

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -866,6 +866,139 @@ test.concurrent("bun build widens [hash] names that would otherwise collide", as
   expect(exitCode).toBe(0);
 });
 
+describe.concurrent("bun build widens [hash] names", () => {
+  // Runs in `dir` so that the paths the output names hash are the relative ones.
+  async function build(dir: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--splitting", "--target=bun", ...args],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, , exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    return { stderr, exitCode };
+  }
+
+  test("when a literal of another naming template prints the same path", async () => {
+    // `c` plus any one hash character is the name of an entry point, so the
+    // lazy chunk cannot stay at `c[hash1]`.
+    const alphabet = [..."0123456789abcdefghjkmnpqrstvwxyz"];
+    const files: Record<string, string> = { "lazy.js": `export default "lazy";\n` };
+    for (const ch of alphabet) files[`c${ch}.js`] = `export default () => import("./lazy.js");\n`;
+    using dir = tempDir("bundle-hash-widen-literal", files);
+
+    const { stderr, exitCode } = await build(
+      String(dir),
+      ...alphabet.map(ch => `./c${ch}.js`),
+      "--outdir=dist",
+      "--entry-naming=[name].[ext]",
+      "--chunk-naming=c[hash1].[ext]",
+    );
+    expect(stderr).toBe("");
+    const names = fs.readdirSync(path.join(String(dir), "dist"));
+    const chunks = names.filter(name => !(name in files));
+    expect({ count: names.length, chunks }).toEqual({
+      count: alphabet.length + 1,
+      chunks: [expect.stringMatching(/^c[0-9a-z]{2}\.js$/)],
+    });
+    expect(fs.readFileSync(path.join(String(dir), "dist", "c0.js"), "utf8")).toContain(`import("./${chunks[0]}")`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("when two naming templates print the same path from different hashes", async () => {
+    // With these inputs, the entry `s/e4.js` widens to `c8` and the chunk of
+    // `s/l0.js` prints `8` after the literal `c`: both asked for `./c8.js`.
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 8; i++) {
+      files[`s/l${i}.js`] = `export default "L${i}-17";`;
+      files[`s/e${i}.js`] = `import("./l${i}.js").then(m=>console.log("e${i}",m.default,17));`;
+    }
+    using dir = tempDir("bundle-hash-widen-templates", files);
+
+    const { stderr, exitCode } = await build(
+      String(dir),
+      ...Array.from({ length: 8 }, (_, i) => `./s/e${i}.js`),
+      "--outdir=dist",
+      "--entry-naming=[hash1].[ext]",
+      "--chunk-naming=c[hash1].[ext]",
+    );
+    expect(stderr).toBe("");
+    expect(fs.readdirSync(path.join(String(dir), "dist")).length).toBe(16);
+    expect(exitCode).toBe(0);
+  });
+
+  test("until the chunks of a connected graph all differ", async () => {
+    // Each chunk reaches every other one, so each widening re-hashes all of
+    // them at their old widths, and under `[hash1]` some of those collide again.
+    const n = 170;
+    const files: Record<string, string> = {};
+    for (let i = 0; i < n; i++) {
+      files[`g/m${i}.js`] = `export const id=${i};\nexport const next=()=>import("./m${(i + 1) % n}.js");\n`;
+    }
+    using dir = tempDir("bundle-hash-widen-ring", files);
+
+    const { stderr, exitCode } = await build(
+      String(dir),
+      "./g/m0.js",
+      "--outdir=dist",
+      "--entry-naming=[name].[ext]",
+      "--chunk-naming=C[hash1].[ext]",
+    );
+    expect(stderr).toBe("");
+    const dist = path.join(String(dir), "dist");
+    const names = new Set(fs.readdirSync(dist));
+    expect(names.size).toBe(n);
+    // Follow the ring from the entry point: every import() names an output.
+    const seen = new Set<string>();
+    for (let name = "m0.js"; !seen.has(name); ) {
+      seen.add(name);
+      name = fs.readFileSync(path.join(dist, name), "utf8").match(/import\("\.\/([^"]+)"\)/)![1];
+      expect(names.has(name)).toBe(true);
+    }
+    expect(seen.size).toBe(n);
+    expect(exitCode).toBe(0);
+  });
+
+  test("by the hash of each widened chunk, not by its index", async () => {
+    // The chunk index follows the order of the entry points. In this graph no
+    // chunk reaches two chunks whose relative order follows it, so `[hash]`
+    // gives the same names for any order, and a widening has to keep that.
+    const n = 40;
+    const files: Record<string, string> = { "src/shared.js": `export function tag(x){return "<"+x+">"}\n` };
+    for (let i = 1; i <= n; i++) {
+      files[`src/lazy/l${i}.js`] = `export default ${i};\n`;
+      files[`src/e${i}.js`] =
+        `import {tag} from './shared.js'; import('./lazy/l${i}.js').then(m=>console.log(tag('e${i}'), m.default));\n`;
+    }
+    using dir = tempDir("bundle-hash-widen-order", files);
+    const entries = Array.from({ length: n }, (_, i) => `./src/e${i + 1}.js`);
+
+    const outputs = async (outdir: string, entries: string[]) => {
+      const { stderr, exitCode } = await build(
+        String(dir),
+        ...entries,
+        `--outdir=${outdir}`,
+        // 81 outputs cannot all differ in one character of a 32-character alphabet.
+        "--entry-naming=E[hash1].[ext]",
+        "--chunk-naming=C[hash1].[ext]",
+      );
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      const names = fs.readdirSync(path.join(String(dir), outdir)).sort();
+      return Object.fromEntries(
+        names.map(name => [name, fs.readFileSync(path.join(String(dir), outdir, name), "utf8")]),
+      );
+    };
+    const [forward, reversed] = await Promise.all([
+      outputs("forward", entries),
+      outputs("reversed", entries.toReversed()),
+    ]);
+    expect(Object.keys(forward).length).toBe(2 * n + 1);
+    expect(reversed).toEqual(forward);
+  });
+});
+
 describe("CLI argument error messages", () => {
   test("--format with an unrecognized value echoes the value back", async () => {
     using dir = tempDir("build-format-err", { "in.js": "console.log(1)" });


### PR DESCRIPTION
### Problem

- `final_chunk_hashes` (`src/bundler/LinkerContext.rs`, from #41317) compares printed hash strings only. With `[hash1].[ext]` entries and `c[hash1].[ext]` chunks, an entry widened to `c8` and a chunk `8` both get `./c8.js`: `error: Multiple files share the same output path`.
- The widen and re-hash loop stops after 13 rounds. Each round re-hashes chunks at their old widths, so they collide again. A ring of 170 `import()` chunks under `C[hash1].[ext]` fails the same way.
- The re-hash writes the index of each widened chunk, which follows entry order. 40 entries under `[hash1]`: 72 of 81 names differ between two orders.

### Fix

- `widen_shared_paths` renders each output path. Chunks that share a path get one more character each, unless their full hashes print one path too.
- The loop runs until no name widens. Widths only grow, up to 13, so it ends.
- The re-hash sums `digest(hash, width)` over the widened chunks that a chunk reaches, so a widening adds no dependence on the chunk index. With no widening, output is byte-identical to before.
- Verified: `test/bundler/cli.test.ts` (4 new tests, all fail on canary). Also `bun-build-api`, `bundler_splitting`, `bundler_edgecase`.

### Background

- `[hash]` prints 8 characters of a 64-bit hash, `[hashN]` prints N ≤ 13. Since #41317, chunks whose different hashes print alike get more.
- A chunk embeds the paths of the chunks it imports. When one widens, each chunk that reaches it folds the width into its own hash, so its name changes with its bytes.
- A chunk id is the printed hash alone. A split `require()` embeds it, so hash strings must differ even where paths differ.

<details><summary>Notes</summary>

Scope. This is hardening of #41317 before it ships. A fuzz run against #41317 found the three cases. There is no user report. Each case needs a widening. At `[hash]` and `[hash9]` to `[hash13]` a widening is rare (about N²/2⁴¹ per build), so in practice the cases need `[hash1]` to `[hash4]`. The first case also needs a template literal from the hash alphabet (`0-9a-hjkmnp-tv-z`) next to the hash. The default templates use `-` and `.`, which are outside it. #41317 says of the duplicate-path error that it "can now only fire for genuinely identical content", and that "the check repeats to a fixpoint". This change makes both true.

Not in scope:
- Entry order. `closure[i]` digests the reached chunks in chunk order (from #40518), so names can depend on the entry order with or without a widening. This change only stops a widening from adding to that.
- File-loader assets. The loop in `bundle_v2.rs` still compares hash strings among assets only. Asset paths that collide are #36009.

Recipes, canary `1.4.3-canary.1+6a92015fc` (same result as main `471b5868b`) against this branch:

| recipe | before | after |
| --- | --- | --- |
| 8 entries + 8 `import()` chunks, `[hash1].[ext]` / `c[hash1].[ext]` | rc 1, `./c8.js` claimed by `s/l0.js` and `s/e4.js`, with a false `these inputs produce identical content` note | 16 files, all 8 entries run |
| ring of 170, `C[hash1].[ext]` | rc 1, `./C2t.js` claimed by `g/m10.js` and `g/m93.js` | 170 files, a walk of `next()` visits 170 modules |
| 40 entries forward and reversed, `E[hash1]` / `C[hash1]` | 72 names in only one of the two trees (0 under `[hash]`) | 0, the trees are byte-identical |
| 20 entries, then add a 21st | 15 of 41 outputs renamed | 1 of 41 |
| ring of 6000, `C[hash4].[ext]` | rc 1 | 6000 files |

Cross-template stress: N entries, each with one `import()` chunk, templates `[hash1].[ext]`/`c[hash1].[ext]`, `e[hash1].[ext]`/`[hash1].[ext]`, `[hash1]0.[ext]`/`[hash2].[ext]`, N = 50, 100, 200, 400. This branch builds all 12. Canary fails 9 of 12. An option matrix on the 40-entry recipe (4 template pairs, target bun, browser with minify, sourcemap linked, sourcemap external with minify) has no dangling reference.

Cost. A build with no widening pays one extra render and sort of the chunk paths. A round costs one bitset test per (chunk, widened chunk) pair. A model of the loop in release mode (random 64-bit hashes, the same `widen_to_distinguish`): 0 rounds at the default width up to 20000 chunks. Ring of 170 under `[hash1]`: 8 to 24 rounds (the old cap of 13 fails 41% of seeds). Ring of 3000 under `[hash4]`: 15 rounds, 0.05 s. Ring of 6000 under `[hash4]`: 156 rounds, 3.6 s. Ring of 6000 under `[hash3]`: 275 rounds, 15.8 s. The last two failed before.

A hashed chunk that collides with a name that has no `[hash]` now widens (entry naming `[name].[ext]`, entries `c0.js` to `cz.js`, chunk naming `c[hash1].[ext]`). Before, that build failed. The first new test uses this case because it collides by construction: every `c` plus one character is taken.

The test for two hashed templates uses the exact inputs of the report. Whether those two names meet depends on the printed bytes. The tests run the CLI in the temp directory so that the hashes see relative paths. In the graph of the order test, no chunk reaches two chunks whose relative order follows the entry points, so `[hash]` gives the same names for any order.

Suites run with the debug build: `bun-build-api`, `bundler_naming`, `bundler_splitting`, `bundler_edgecase`, `esbuild/splitting`, `esbuild/css`, `bundler_loader`, `bundler_html`, `bundler_html_server`, `html-import-manifest`, `metafile`, `bundler_compile_splitting`.

Self-reviewed: 3 concerns raised, 3 addressed. The title and a doc sentence said that names do not depend on the entry order (narrowed to the widening step, see "Not in scope"). The re-hash kept four vectors of state across rounds (now computed again each round, same names). The scope and the asset exclusion were not stated (added above).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->