### PR TITLE
bundler: resolve imports that end in a ?query

### DIFF
--- a/src/bundler/Graph.rs
+++ b/src/bundler/Graph.rs
@@ -103,6 +103,8 @@ pub struct HtmlImports {
 
 pub struct InputFile {
     pub(crate) source: bun_ast::Source,
+    /// The `?query` of the import that made this module. `PathToSourceIndexMap` has it in the key.
+    pub ignored_suffix: &'static [u8],
     pub(crate) secondary_path: AstVec<u8>,
     pub(crate) loader: options::Loader,
     pub side_effects: SideEffects,
@@ -118,6 +120,7 @@ impl Default for InputFile {
     fn default() -> Self {
         Self {
             source: bun_ast::Source::default(),
+            ignored_suffix: b"",
             secondary_path: AstAlloc::vec(),
             loader: options::Loader::default(),
             side_effects: SideEffects::default(),
@@ -135,6 +138,7 @@ impl Default for InputFile {
 bun_collections::multi_array_columns! {
     pub trait InputFileColumns for InputFile {
         source: bun_ast::Source,
+        ignored_suffix: &'static [u8],
         secondary_path: AstVec<u8>,
         loader: options::Loader,
         side_effects: SideEffects,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1881,6 +1881,9 @@ impl<'a> LinkerContext<'a> {
         if let crate::chunk::Content::Javascript(js) = &chunk.content {
             // SAFETY: parse_graph backref; exclusive access via &mut *.
             let sources = unsafe { (*self.parse_graph).input_files.items_source_mut() };
+            // SAFETY: same backref; a different column from `sources`.
+            let ignored_suffixes =
+                unsafe { (*self.parse_graph).input_files.items_ignored_suffix() };
             for part_range in js.parts_in_chunk_in_order.iter() {
                 let source: &mut Source = &mut sources[part_range.source_index.get() as usize];
 
@@ -1913,6 +1916,11 @@ impl<'a> LinkerContext<'a> {
 
                 // Then include the file path
                 hasher.write(file_path);
+                // `write` hashes the length too: no write for no suffix keeps the hashes as they were.
+                let ignored_suffix = ignored_suffixes[part_range.source_index.get() as usize];
+                if !ignored_suffix.is_empty() {
+                    hasher.write(ignored_suffix);
+                }
 
                 // Then include the part range
                 hasher.write_ints(&[part_range.part_index_begin, part_range.part_index_end]);

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -89,6 +89,8 @@ pub struct ParseTask {
     // lifetime-erased `'static` — paths borrow from `DirnameStore`
     // (process-lifetime BSS string pool); see `bun_resolver::fs::Path<'a>`.
     pub(crate) path: Fs::Path<'static>,
+    /// See `InputFile::ignored_suffix`.
+    pub(crate) ignored_suffix: &'static [u8],
     pub(crate) secondary_path_for_commonjs_interop: Option<Fs::Path<'static>>,
     pub(crate) contents_or_fd: ContentsOrFd,
     pub(crate) external_free_function: ExternalFreeFunction,
@@ -276,6 +278,7 @@ impl ParseTask {
             package_name,
             known_target,
             // defaults:
+            ignored_suffix: b"",
             secondary_path_for_commonjs_interop: None,
             external_free_function: ExternalFreeFunction::NONE,
             loader: None,
@@ -305,6 +308,7 @@ impl Default for ParseTask {
         ParseTask {
             ctx: None,
             path: Fs::Path::init(b""),
+            ignored_suffix: b"",
             secondary_path_for_commonjs_interop: None,
             contents_or_fd: ContentsOrFd::Contents(b""),
             external_free_function: ExternalFreeFunction::NONE,
@@ -590,6 +594,7 @@ pub mod parse_worker {
             loader: Some(Loader::Js),
             known_target: target,
             // defaults:
+            ignored_suffix: b"",
             secondary_path_for_commonjs_interop: None,
             external_free_function: ExternalFreeFunction::NONE,
             task: ThreadPoolLib::Task {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2669,8 +2669,10 @@ pub mod bv2_impl {
                 if let Some(secondary) = &resolve_result.path_pair.secondary {
                     if !secondary.is_disabled && !strings::eql_long(secondary.text, path.text, true)
                     {
+                        // `scan_for_secondary_paths` looks this up in `PathToSourceIndexMap`.
+                        let secondary_key = ignored_suffix.append_to(self.arena(), secondary.text);
                         self.graph.input_files.items_secondary_path_mut()[idx as usize] =
-                            bun_alloc::AstAlloc::vec_from_slice(secondary.text);
+                            bun_alloc::AstAlloc::vec_from_slice(secondary_key);
                         // Ensure the determinism pass runs.
                         self.graph.has_any_secondary_paths = true;
                     }
@@ -6921,7 +6923,10 @@ pub mod bv2_impl {
                         && !core::ptr::eq(secondary, path)
                         && !strings::eql_long(secondary.text, path.text, true)
                     {
-                        resolve_task.secondary_path_for_commonjs_interop = Some(*secondary);
+                        // `scan_for_secondary_paths` looks `text` up in `PathToSourceIndexMap`.
+                        let mut secondary = *secondary;
+                        secondary.text = ignored_suffix.append_to(self.arena(), secondary.text);
+                        resolve_task.secondary_path_for_commonjs_interop = Some(secondary);
                     }
                 }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6204,8 +6204,7 @@ pub mod bv2_impl {
         }
 
         /// `path_text` with the suffix back on it. For the path of the resolved file, this is
-        /// the key of the module in `PathToSourceIndexMap` and `ResolveQueue`. An import
-        /// record finds its module through `path.text`, so the record gets the key there.
+        /// the key of the module in `PathToSourceIndexMap` and `ResolveQueue`.
         fn append_to(self, arena: &ThreadLocalArena, path_text: &'static [u8]) -> &'static [u8] {
             if self.0.is_empty() {
                 return path_text;
@@ -6215,6 +6214,14 @@ pub mod bv2_impl {
             key[path_text.len()..].copy_from_slice(self.0);
             // SAFETY: the arena outlives the bundle pass.
             unsafe { interned_slice(key) }
+        }
+
+        /// An import record finds its module in `PathToSourceIndexMap` through `path.text`.
+        /// `module_key` is that text when the import has a suffix.
+        fn set_module_key(self, record: &mut ImportRecord, module_key: &'static [u8]) {
+            if !self.0.is_empty() {
+                record.path.text = module_key;
+            }
         }
     }
 
@@ -6500,7 +6507,7 @@ pub mod bv2_impl {
                             // SAFETY: arena-allocated `ParseTask` stored in the queue; arena outlives the pass.
                             import_record.path =
                                 path_as_static(&unsafe { &**resolve_entry.value_ptr }.path);
-                            import_record.path.text = module_key;
+                            ignored_suffix.set_module_key(import_record, module_key);
                             continue 'outer;
                         }
 
@@ -6515,7 +6522,7 @@ pub mod bv2_impl {
                             )
                         };
                         import_record.path = path_as_static(&path_primary);
-                        import_record.path.text = module_key;
+                        ignored_suffix.set_module_key(import_record, module_key);
                         bun_core::scoped_log!(
                             Bundle,
                             "created ParseTask from FileMap: {}",
@@ -6889,7 +6896,7 @@ pub mod bv2_impl {
                     // SAFETY: arena-allocated `ParseTask` stored in the queue; arena outlives the pass.
                     import_record.path =
                         path_as_static(&unsafe { &**resolve_entry.value_ptr }.path);
-                    import_record.path.text = module_key;
+                    ignored_suffix.set_module_key(import_record, module_key);
                     continue;
                 }
 
@@ -6898,7 +6905,7 @@ pub mod bv2_impl {
                     .expect("oom");
 
                 import_record.path = path_as_static(path);
-                import_record.path.text = module_key;
+                ignored_suffix.set_module_key(import_record, module_key);
                 // key already interned by get_or_put — no key_ptr on StringHashMapGetOrPut
                 bun_core::scoped_log!(Bundle, "created ParseTask: {}", bstr::BStr::new(&path.text));
                 // Arena-owned.

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2351,15 +2351,18 @@ pub mod bv2_impl {
             let source_dir =
                 Fs::PathName::init(&import_record.source_file).dir_with_trailing_slash();
 
-            // Check the FileMap first for in-memory files
-            if let Some(file_map) = self.file_map {
-                if let Some(_file_map_result) = file_map.resolve(
-                    self.arena(),
-                    &import_record.source_file,
-                    &import_record.specifier,
-                ) {
-                    let file_map_result = _file_map_result;
+            let mut had_busted_dir_cache = false;
+            let mut ignored_suffix = IgnoredSuffix::default();
+            let resolve_result: _resolver::Result = loop {
+                let specifier = ignored_suffix.strip_from(&import_record.specifier);
+
+                // Check the FileMap first for in-memory files
+                if let Some(file_map_result) = self.file_map.and_then(|file_map| {
+                    file_map.resolve(self.arena(), &import_record.source_file, specifier)
+                }) {
                     let mut path_primary = file_map_result.path_pair.primary;
+                    let module_key = ignored_suffix
+                        .append_to(self.arena(), file_map_result.path_pair.primary.text);
                     // reshaped for borrowck — `get_or_put` borrows `*self` mutably via
                     // `self.graph`; capture the slot as `*mut u32` so subsequent `self.*` calls
                     // type-check. SAFETY: `path_to_source_index_map(target)` is not mutated again
@@ -2367,7 +2370,7 @@ pub mod bv2_impl {
                     let (found_existing, value_ptr): (bool, *mut u32) = {
                         let entry = self
                             .path_to_source_index_map(target)
-                            .get_or_put(path_primary.text)
+                            .get_or_put(module_key)
                             .expect("oom");
                         (
                             entry.found_existing,
@@ -2381,7 +2384,7 @@ pub mod bv2_impl {
                                     [import_record.importer_source_index as usize]
                                     .as_mut_slice()
                                     [import_record.import_record_index as usize];
-                            if let Some(out_loader) = record.loader {
+                            if let Some(out_loader) = record.loader.or(ignored_suffix.loader()) {
                                 break 'brk out_loader;
                             }
                             // SAFETY: see `transpiler` note above.
@@ -2423,18 +2426,26 @@ pub mod bv2_impl {
                     }
                     return;
                 }
-            }
 
-            let mut had_busted_dir_cache = false;
-            let resolve_result: _resolver::Result = loop {
                 // SAFETY: see `transpiler` note above.
                 match unsafe { &mut *transpiler }.resolver.resolve(
                     source_dir,
-                    &import_record.specifier,
+                    specifier,
                     import_record.kind,
                 ) {
                     Ok(r) => break r,
                     Err(err) => {
+                        // Not for the dev server: its graph has one module for each file path.
+                        if err == _resolver::Error::ModuleNotFound
+                            && ignored_suffix.is_empty()
+                            && self.dev_server.is_none()
+                        {
+                            if let Some(suffix) = IgnoredSuffix::of(&import_record.specifier) {
+                                ignored_suffix = suffix;
+                                continue;
+                            }
+                        }
+
                         // Only perform directory busting when hot-reloading is enabled
                         if err == _resolver::Error::ModuleNotFound {
                             if let Some(dev) = &self.dev_server {
@@ -2608,9 +2619,10 @@ pub mod bv2_impl {
             path.assert_pretty_is_valid();
             path.assert_file_path_is_absolute();
 
+            let module_key = ignored_suffix.append_to(self.arena(), path.text);
             // borrowck: get-then-put (instead of a single get-or-put) so the map
             // borrow doesn't span `enqueue_parse_task` (which needs `&mut self`).
-            if let Some(existing) = self.path_to_source_index_map(target).get(path.text) {
+            if let Some(existing) = self.path_to_source_index_map(target).get(module_key) {
                 out_source_index = Some(Index::init(existing));
             } else {
                 path = self
@@ -2627,7 +2639,7 @@ pub mod bv2_impl {
                     let record: &ImportRecord = &self.graph.ast.items_import_records()
                         [import_record.importer_source_index as usize]
                         .as_slice()[import_record.import_record_index as usize];
-                    if let Some(out_loader) = record.loader {
+                    if let Some(out_loader) = record.loader.or(ignored_suffix.loader()) {
                         break 'brk out_loader;
                     }
                     // SAFETY: see `transpiler` note above.
@@ -2650,7 +2662,7 @@ pub mod bv2_impl {
                     )
                     .expect("oom");
                 self.path_to_source_index_map(target)
-                    .put(path.text, idx)
+                    .put(module_key, idx)
                     .expect("oom");
                 out_source_index = Some(Index::init(idx));
 
@@ -2670,7 +2682,7 @@ pub mod bv2_impl {
                 if self.transpiler.options.server_components && !loader.is_javascript_like() {
                     // reshaped for borrowck — cannot hold two `&mut` into
                     // `self.graph` simultaneously, so re-derive the map per insert.
-                    let key_text: Box<[u8]> = path.text.to_vec().into_boxed_slice();
+                    let key_text: Box<[u8]> = module_key.to_vec().into_boxed_slice();
                     let main_target = self.transpiler.options.target;
                     let separate_ssr = self
                         .framework
@@ -6162,6 +6174,48 @@ pub mod bv2_impl {
         }
     }
 
+    /// The `?query` or `#hash` at the end of an import specifier that does not resolve as
+    /// written (`import text from "./a.txt?raw"`). The bundler resolves the specifier again
+    /// without it, like esbuild. Imports of one file with different suffixes are different
+    /// modules, like in the runtime. Empty for every other import.
+    #[derive(Clone, Copy, Default)]
+    struct IgnoredSuffix<'s>(&'s [u8]);
+
+    impl<'s> IgnoredSuffix<'s> {
+        fn of(specifier: &'s [u8]) -> Option<Self> {
+            let start = strings::index_of_any(specifier, b"?#")?;
+            (start > 0).then(|| Self(&specifier[start..]))
+        }
+
+        fn is_empty(self) -> bool {
+            self.0.is_empty()
+        }
+
+        /// `specifier` is the specifier that `self` is the end of.
+        fn strip_from(self, specifier: &[u8]) -> &[u8] {
+            &specifier[..specifier.len() - self.0.len()]
+        }
+
+        /// The runtime loads a `?raw` import as text (`get_loader_and_virtual_source`).
+        fn loader(self) -> Option<Loader> {
+            (self.0 == b"?raw").then_some(Loader::Text)
+        }
+
+        /// `path_text` with the suffix back on it. For the path of the resolved file, this is
+        /// the key of the module in `PathToSourceIndexMap` and `ResolveQueue`. An import
+        /// record finds its module through `path.text`, so the record gets the key there.
+        fn append_to(self, arena: &ThreadLocalArena, path_text: &'static [u8]) -> &'static [u8] {
+            if self.0.is_empty() {
+                return path_text;
+            }
+            let key = arena.alloc_slice_fill_default::<u8>(path_text.len() + self.0.len());
+            key[..path_text.len()].copy_from_slice(path_text);
+            key[path_text.len()..].copy_from_slice(self.0);
+            // SAFETY: the arena outlives the bundle pass.
+            unsafe { interned_slice(key) }
+        }
+    }
+
     pub(crate) struct ResolveImportRecordCtx<'a> {
         pub(crate) import_records: &'a mut [ImportRecord],
         pub(crate) source: &'a bun_ast::Source,
@@ -6413,34 +6467,39 @@ pub mod bv2_impl {
                 // SAFETY: see note above — raw `*mut Transpiler` lives for `'a`.
                 let transpiler: &mut Transpiler<'a> = unsafe { &mut *transpiler_ptr };
 
-                // Check the FileMap first for in-memory files
-                if let Some(file_map) = self.file_map {
-                    if let Some(_file_map_result) =
-                        file_map.resolve(self.arena(), source.path.text, import_record.path.text)
-                    {
-                        let mut file_map_result = _file_map_result;
+                let mut had_busted_dir_cache = false;
+                let mut ignored_suffix = IgnoredSuffix::default();
+                let resolve_result: _resolver::Result = 'inner: loop {
+                    let specifier = ignored_suffix.strip_from(import_record.path.text);
+
+                    // Check the FileMap first for in-memory files
+                    if let Some(mut file_map_result) = self.file_map.and_then(|file_map| {
+                        file_map.resolve(self.arena(), source.path.text, specifier)
+                    }) {
                         let mut path_primary = file_map_result.path_pair.primary;
-                        let import_record_loader = import_record.loader.unwrap_or_else(|| {
-                            Fs::Path::init(path_primary.text)
-                                .loader(&transpiler.options.loaders)
-                                .unwrap_or(Loader::File)
-                        });
+                        let module_key = ignored_suffix.append_to(self.arena(), path_primary.text);
+                        let import_record_loader = import_record
+                            .loader
+                            .or(ignored_suffix.loader())
+                            .unwrap_or_else(|| {
+                                Fs::Path::init(path_primary.text)
+                                    .loader(&transpiler.options.loaders)
+                                    .unwrap_or(Loader::File)
+                            });
                         import_record.loader = Some(import_record_loader);
 
-                        if let Some(id) =
-                            self.path_to_source_index_map(target).get(path_primary.text)
-                        {
+                        if let Some(id) = self.path_to_source_index_map(target).get(module_key) {
                             import_record.source_index = Index::init(id);
-                            continue;
+                            continue 'outer;
                         }
 
-                        let resolve_entry =
-                            resolve_queue.get_or_put(path_primary.text).expect("oom");
+                        let resolve_entry = resolve_queue.get_or_put(module_key).expect("oom");
                         if resolve_entry.found_existing {
                             // SAFETY: arena-allocated `ParseTask` stored in the queue; arena outlives the pass.
                             import_record.path =
                                 path_as_static(&unsafe { &**resolve_entry.value_ptr }.path);
-                            continue;
+                            import_record.path.text = module_key;
+                            continue 'outer;
                         }
 
                         // For virtual files, use the path text as-is (no relative path computation needed).
@@ -6454,7 +6513,7 @@ pub mod bv2_impl {
                             )
                         };
                         import_record.path = path_as_static(&path_primary);
-                        let _ = path_primary.text; // key already interned by get_or_put
+                        import_record.path.text = module_key;
                         bun_core::scoped_log!(
                             Bundle,
                             "created ParseTask from FileMap: {}",
@@ -6473,19 +6532,27 @@ pub mod bv2_impl {
                         resolve_task.loader = Some(import_record_loader);
                         resolve_task.side_effects = bun_ast::SideEffects::HasSideEffects;
                         *resolve_entry.value_ptr = resolve_task;
-                        continue;
+                        continue 'outer;
                     }
-                }
 
-                let mut had_busted_dir_cache = false;
-                let resolve_result: _resolver::Result = 'inner: loop {
                     match transpiler.resolver.resolve_with_framework(
                         source_dir,
-                        import_record.path.text,
+                        specifier,
                         import_record.kind,
                     ) {
                         Ok(r) => break r,
                         Err(err) => {
+                            // Not for the dev server: its graph has one module for each file path.
+                            if err == _resolver::Error::ModuleNotFound
+                                && ignored_suffix.is_empty()
+                                && self.dev_server.is_none()
+                            {
+                                if let Some(suffix) = IgnoredSuffix::of(import_record.path.text) {
+                                    ignored_suffix = suffix;
+                                    continue 'inner;
+                                }
+                            }
+
                             // borrowck — `log_for_resolution_failures` returns
                             // `&mut Log` tied to `&mut self`, but it's always a raw-ptr
                             // deref (DevServer vtable or `transpiler.log`). Detach via
@@ -6680,6 +6747,8 @@ pub mod bv2_impl {
                         )
                     {
                         import_record.path = path_as_static(&resolve_result.path_pair.primary);
+                        import_record.path.text =
+                            ignored_suffix.append_to(self.arena(), import_record.path.text);
                     }
                     import_record.flags.set(
                         bun_ast::ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS,
@@ -6769,10 +6838,13 @@ pub mod bv2_impl {
                 }
 
                 let import_record_loader = 'brk: {
-                    let resolved_loader = import_record.loader.unwrap_or_else(|| {
-                        path.loader(&transpiler.options.loaders)
-                            .unwrap_or(Loader::File)
-                    });
+                    let resolved_loader = import_record
+                        .loader
+                        .or(ignored_suffix.loader())
+                        .unwrap_or_else(|| {
+                            path.loader(&transpiler.options.loaders)
+                                .unwrap_or(Loader::File)
+                        });
                     // When an HTML file references a URL asset (e.g. <link rel="manifest" href="./manifest.json" />),
                     // the file must be copied to the output directory as-is. If the resolved loader would
                     // parse/transform the file (e.g. .json, .toml) rather than copy it, force the .file loader
@@ -6795,7 +6867,8 @@ pub mod bv2_impl {
                     && target.is_server_side()
                     && self.dev_server.is_none();
 
-                if let Some(id) = self.path_to_source_index_map(target).get(path.text) {
+                let module_key = ignored_suffix.append_to(self.arena(), path.text);
+                if let Some(id) = self.path_to_source_index_map(target).get(module_key) {
                     if self.dev_server.is_some() && loader != Loader::Html {
                         import_record.path =
                             self.graph.input_files.items_source()[id as usize].path;
@@ -6809,11 +6882,12 @@ pub mod bv2_impl {
                     import_record.kind = ImportKind::HtmlManifest;
                 }
 
-                let resolve_entry = resolve_queue.get_or_put(path.text).expect("oom");
+                let resolve_entry = resolve_queue.get_or_put(module_key).expect("oom");
                 if resolve_entry.found_existing {
                     // SAFETY: arena-allocated `ParseTask` stored in the queue; arena outlives the pass.
                     import_record.path =
                         path_as_static(&unsafe { &**resolve_entry.value_ptr }.path);
+                    import_record.path.text = module_key;
                     continue;
                 }
 
@@ -6822,6 +6896,7 @@ pub mod bv2_impl {
                     .expect("oom");
 
                 import_record.path = path_as_static(path);
+                import_record.path.text = module_key;
                 // key already interned by get_or_put — no key_ptr on StringHashMapGetOrPut
                 bun_core::scoped_log!(Bundle, "created ParseTask: {}", bstr::BStr::new(&path.text));
                 // Arena-owned.
@@ -6851,7 +6926,7 @@ pub mod bv2_impl {
                 }
 
                 if is_html_entrypoint {
-                    self.generate_server_html_module(path, target, import_record, path.text)
+                    self.generate_server_html_module(path, target, import_record, module_key)
                         .expect("unreachable");
                 }
             }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6551,17 +6551,6 @@ pub mod bv2_impl {
                     ) {
                         Ok(r) => break r,
                         Err(err) => {
-                            // Not for the dev server: its graph has one module for each file path.
-                            if err == _resolver::Error::ModuleNotFound
-                                && ignored_suffix.is_empty()
-                                && self.dev_server.is_none()
-                            {
-                                if let Some(suffix) = IgnoredSuffix::of(import_record.path.text) {
-                                    ignored_suffix = suffix;
-                                    continue 'inner;
-                                }
-                            }
-
                             // borrowck — `log_for_resolution_failures` returns
                             // `&mut Log` tied to `&mut self`, but it's always a raw-ptr
                             // deref (DevServer vtable or `transpiler.log`). Detach via
@@ -6602,6 +6591,19 @@ pub mod bv2_impl {
                                         )
                                         .expect("oom");
                                     }
+                                }
+                            }
+
+                            // After the dir cache bust above, so that a file name with `?` or
+                            // `#` in it still wins. Not for the dev server: its graph has one
+                            // module for each file path.
+                            if err == _resolver::Error::ModuleNotFound
+                                && ignored_suffix.is_empty()
+                                && self.dev_server.is_none()
+                            {
+                                if let Some(suffix) = IgnoredSuffix::of(import_record.path.text) {
+                                    ignored_suffix = suffix;
+                                    continue 'inner;
                                 }
                             }
 
@@ -6875,6 +6877,12 @@ pub mod bv2_impl {
                 let is_html_entrypoint = import_record_loader == Loader::Html
                     && target.is_server_side()
                     && self.dev_server.is_none();
+
+                // The HTML file is an entry point of the browser build: one module and one
+                // output for the file. The linker finds it through the path of the file.
+                if is_html_entrypoint {
+                    ignored_suffix = IgnoredSuffix::default();
+                }
 
                 let module_key = ignored_suffix.append_to(self.arena(), path.text);
                 if let Some(id) = self.path_to_source_index_map(target).get(module_key) {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -6176,10 +6176,7 @@ pub mod bv2_impl {
         }
     }
 
-    /// The `?query` or `#hash` at the end of an import specifier that does not resolve as
-    /// written (`import text from "./a.txt?raw"`). The bundler resolves the specifier again
-    /// without it, like esbuild. Imports of one file with different suffixes are different
-    /// modules, like in the runtime. Empty for every other import.
+    /// The `?query` or `#hash` cut from an import specifier that resolves only without it.
     #[derive(Clone, Copy, Default)]
     struct IgnoredSuffix<'s>(&'s [u8]);
 
@@ -6203,8 +6200,7 @@ pub mod bv2_impl {
             (self.0 == b"?raw").then_some(Loader::Text)
         }
 
-        /// `path_text` with the suffix back on it. For the path of the resolved file, this is
-        /// the key of the module in `PathToSourceIndexMap` and `ResolveQueue`.
+        /// For the path of the resolved file: the key of the module in `PathToSourceIndexMap`.
         fn append_to(self, arena: &ThreadLocalArena, path_text: &'static [u8]) -> &'static [u8] {
             if self.0.is_empty() {
                 return path_text;
@@ -6217,7 +6213,6 @@ pub mod bv2_impl {
         }
 
         /// An import record finds its module in `PathToSourceIndexMap` through `path.text`.
-        /// `module_key` is that text when the import has a suffix.
         fn set_module_key(self, record: &mut ImportRecord, module_key: &'static [u8]) {
             if !self.0.is_empty() {
                 record.path.text = module_key;
@@ -6594,9 +6589,7 @@ pub mod bv2_impl {
                                 }
                             }
 
-                            // After the dir cache bust above, so that a file name with `?` or
-                            // `#` in it still wins. Not for the dev server: its graph has one
-                            // module for each file path.
+                            // Not for the dev server: its graph has one module for each file path.
                             if err == _resolver::Error::ModuleNotFound
                                 && ignored_suffix.is_empty()
                                 && self.dev_server.is_none()
@@ -6878,8 +6871,7 @@ pub mod bv2_impl {
                     && target.is_server_side()
                     && self.dev_server.is_none();
 
-                // The HTML file is an entry point of the browser build: one module and one
-                // output for the file. The linker finds it through the path of the file.
+                // The linker finds this entry point through the path of the file.
                 if is_html_entrypoint {
                     ignored_suffix = IgnoredSuffix::default();
                 }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2403,6 +2403,7 @@ pub mod bv2_impl {
                             .enqueue_parse_task(
                                 &file_map_result,
                                 &mut tmp_source,
+                                ignored_suffix.in_key(module_key),
                                 loader,
                                 import_record.original_target,
                             )
@@ -2657,6 +2658,7 @@ pub mod bv2_impl {
                     .enqueue_parse_task(
                         &resolve_result,
                         &mut tmp_source,
+                        ignored_suffix.in_key(module_key),
                         loader,
                         import_record.original_target,
                     )
@@ -3735,6 +3737,7 @@ pub mod bv2_impl {
             &mut self,
             resolve_result: &_resolver::Result,
             source: &mut bun_ast::Source,
+            ignored_suffix: &'static [u8],
             loader: Loader,
             known_target: options::Target,
         ) -> Result<IndexInt, AllocError> {
@@ -3743,6 +3746,7 @@ pub mod bv2_impl {
 
             self.graph.input_files.append(crate::Graph::InputFile {
                 source: core::mem::take(source),
+                ignored_suffix,
                 loader,
                 side_effects: loader.side_effects(),
                 ..Default::default()
@@ -3758,6 +3762,7 @@ pub mod bv2_impl {
             // SAFETY: arena outlives the bundle pass; reborrow `*mut` as `&mut`.
             let task: &mut ParseTask = self.arena_create(task_val);
             task.loader = Some(loader);
+            task.ignored_suffix = ignored_suffix;
             task.jsx = self.transpiler_for_target(known_target).options.jsx.clone();
             task.task.node.next = core::ptr::null_mut();
             task.io_task.node.next = core::ptr::null_mut();
@@ -6176,13 +6181,14 @@ pub mod bv2_impl {
         }
     }
 
-    /// The `?query` or `#hash` cut from an import specifier that resolves only without it.
+    /// The `?query` cut from an import specifier that resolves only without it.
     #[derive(Clone, Copy, Default)]
     struct IgnoredSuffix<'s>(&'s [u8]);
 
     impl<'s> IgnoredSuffix<'s> {
+        /// The same cut as the runtime makes (`normalize_specifier_for_resolution`).
         fn of(specifier: &'s [u8]) -> Option<Self> {
-            let start = strings::index_of_any(specifier, b"?#")?;
+            let start = strings::index_of_char_usize(specifier, b'?')?;
             (start > 0).then(|| Self(&specifier[start..]))
         }
 
@@ -6210,6 +6216,11 @@ pub mod bv2_impl {
             key[path_text.len()..].copy_from_slice(self.0);
             // SAFETY: the arena outlives the bundle pass.
             unsafe { interned_slice(key) }
+        }
+
+        /// The suffix as the end of `module_key`, for `InputFile::ignored_suffix`.
+        fn in_key(self, module_key: &'static [u8]) -> &'static [u8] {
+            &module_key[module_key.len() - self.0.len()..]
         }
 
         /// An import record finds its module in `PathToSourceIndexMap` through `path.text`.
@@ -6534,6 +6545,7 @@ pub mod bv2_impl {
                         resolve_task.jsx = transpiler.options.jsx.clone();
                         resolve_task.jsx.development = transpiler.options.forced_jsx_development();
                         resolve_task.loader = Some(import_record_loader);
+                        resolve_task.ignored_suffix = ignored_suffix.in_key(module_key);
                         resolve_task.side_effects = bun_ast::SideEffects::HasSideEffects;
                         *resolve_entry.value_ptr = resolve_task;
                         continue 'outer;
@@ -6924,6 +6936,7 @@ pub mod bv2_impl {
                 resolve_task.jsx.development = transpiler.options.forced_jsx_development();
 
                 resolve_task.loader = Some(import_record_loader);
+                resolve_task.ignored_suffix = ignored_suffix.in_key(module_key);
                 *resolve_entry.value_ptr = resolve_task;
                 if let Some(secondary) = &resolve_result.path_pair.secondary {
                     if !secondary.is_disabled
@@ -7002,6 +7015,7 @@ pub mod bv2_impl {
                     let new_task: &mut ParseTask = value;
                     let mut new_input_file = crate::Graph::InputFile {
                         source: bun_ast::Source::init_empty_file(new_task.path.text),
+                        ignored_suffix: new_task.ignored_suffix,
                         side_effects: new_task.side_effects,
                         secondary_path: if let Some(secondary_path) =
                             &new_task.secondary_path_for_commonjs_interop

--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -66,6 +66,7 @@ pub(crate) fn generate_chunk_json(
 
     let parse_graph = c.parse_graph();
     let sources = parse_graph.input_files.items_source();
+    let ignored_suffixes = parse_graph.input_files.items_ignored_suffix();
 
     // Start chunk entry: "path/to/output.js": {
     write_json_string(&mut json, &chunk.final_rel_path)?;
@@ -109,7 +110,11 @@ pub(crate) fn generate_chunk_json(
         first_chunk_input = false;
 
         json.extend_from_slice(b"\n        ");
-        write_json_string(&mut json, file_path)?;
+        write_input_path(
+            &mut json,
+            file_path,
+            ignored_suffixes[file_source_index as usize],
+        )?;
         write!(
             json,
             ": {{\n          \"bytesInOutput\": {}\n        }}",
@@ -173,7 +178,11 @@ pub(crate) fn generate_chunk_json(
             let entry_source = &sources[entry_source_index as usize];
             if !entry_source.path.text.is_empty() && !entry_source.path.pretty.is_empty() {
                 json.extend_from_slice(b",\n      \"entryPoint\": ");
-                write_json_string(&mut json, entry_source.path.pretty)?;
+                write_input_path(
+                    &mut json,
+                    entry_source.path.pretty,
+                    ignored_suffixes[entry_source_index as usize],
+                )?;
             }
         }
     }
@@ -214,6 +223,7 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
     let mut first_input = true;
     let parse_graph = c.parse_graph();
     let sources = parse_graph.input_files.items_source();
+    let ignored_suffixes = parse_graph.input_files.items_ignored_suffix();
     let loaders = parse_graph.input_files.items_loader();
     let import_records_list = parse_graph.ast.items_import_records();
 
@@ -272,11 +282,7 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
         j.push_static(b"\n    ");
         {
             let mut buf: Vec<u8> = Vec::new();
-            write!(
-                buf,
-                "{}",
-                bfmt::format_json_string_utf8(path, Default::default())
-            )?;
+            write_input_path(&mut buf, path, ignored_suffixes[source_index as usize])?;
             j.push_owned(buf.into_boxed_slice());
         }
         {
@@ -304,7 +310,7 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
                 // Bundled imports use the target source's pretty path (same string as the
                 // "inputs" key). `record.path.text` is unreliable here: dedup can set
                 // `source_index` without rewriting the path. Externals/chunk refs fall through.
-                let import_path: &[u8] = 'path: {
+                let (import_path, import_suffix): (&[u8], &[u8]) = 'path: {
                     if record.source_index.is_valid()
                         && record.source_index.get() != Index::RUNTIME.get()
                     {
@@ -312,19 +318,15 @@ pub(crate) fn generate(c: &mut LinkerContext, chunks: &mut [Chunk]) -> crate::Re
                         if idx < sources.len() {
                             let pretty = sources[idx].path.pretty;
                             if !pretty.is_empty() {
-                                break 'path pretty;
+                                break 'path (pretty, ignored_suffixes[idx]);
                             }
                         }
                     }
-                    record.path.text
+                    (record.path.text, b"")
                 };
                 {
                     let mut buf: Vec<u8> = Vec::new();
-                    write!(
-                        buf,
-                        "{}",
-                        bfmt::format_json_string_utf8(import_path, Default::default())
-                    )?;
+                    write_input_path(&mut buf, import_path, import_suffix)?;
                     j.push_owned(buf.into_boxed_slice());
                 }
                 j.push_static(b",\n          \"kind\": \"");
@@ -468,6 +470,18 @@ fn write_json_string(writer: &mut impl Write, str: &[u8]) -> std::io::Result<()>
         "{}",
         bfmt::format_json_string_utf8(str, Default::default())
     )
+}
+
+/// `pretty` plus the `?query` of the import that made the input, like esbuild.
+fn write_input_path(
+    writer: &mut impl Write,
+    pretty: &[u8],
+    ignored_suffix: &[u8],
+) -> std::io::Result<()> {
+    if ignored_suffix.is_empty() {
+        return write_json_string(writer, pretty);
+    }
+    write_json_string(writer, &[pretty, ignored_suffix].concat())
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/cli/test/ChangedFilesFilter.rs
+++ b/src/runtime/cli/test/ChangedFilesFilter.rs
@@ -191,6 +191,7 @@ pub(crate) fn filter<'a>(
     };
 
     let sources = bundle.graph.input_files.items_source();
+    let ignored_suffixes = bundle.graph.input_files.items_ignored_suffix();
     let import_records = bundle.graph.ast.items_import_records();
 
     // Map absolute source path -> source index for paths that participate in
@@ -221,9 +222,17 @@ pub(crate) fn filter<'a>(
         if !source.path.is_file() {
             continue;
         }
+        // A file that is also imported with a `?query` is more than one source.
+        let seen = path_to_index.contains_key(path_text);
+        if seen && !ignored_suffixes[idx].is_empty() {
+            continue;
+        }
         // All scanned entry points are absolute, and the resolver emits
         // absolute file paths as well.
         path_to_index.put_assume_capacity(path_text, u32::try_from(idx).unwrap());
+        if seen {
+            continue;
+        }
         // Copy out of the bundler's arena so the caller can use these paths
         // after the BundleV2 heap is gone.
         graph_files.push(Box::<[u8]>::from(path_text));
@@ -256,14 +265,11 @@ pub(crate) fn filter<'a>(
     let mut affected = bun_core::handle_oom(DynamicBitSet::init_empty(sources.len()));
     let mut queue: Vec<u32> = Vec::new();
 
-    {
-        for changed_path in changed_files.keys() {
-            if let Some(&idx) = path_to_index.get(changed_path.as_ref()) {
-                if !affected.is_set(idx as usize) {
-                    affected.set(idx as usize);
-                    queue.push(idx);
-                }
-            }
+    // Not through `path_to_index`: a file that is also imported with a `?query` is two sources.
+    for (idx, source) in sources.iter().enumerate() {
+        if source.path.is_file() && changed_files.contains(source.path.text) {
+            affected.set(idx);
+            queue.push(u32::try_from(idx).unwrap());
         }
     }
 

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -339,6 +339,37 @@ describe("bundler files option", () => {
     expect(output).toContain('"b"');
   });
 
+  test("in-memory file imported with a query suffix", async () => {
+    const result = await Bun.build({
+      entrypoints: ["/entry.js"],
+      target: "bun",
+      files: {
+        "/entry.js": `
+          import source from "./lib.js?raw";
+          import { value } from "./lib.js?v=1";
+          console.log(JSON.stringify([source, value]));
+        `,
+        "/lib.js": `export const value = 42;`,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.outputs.length).toBe(1);
+
+    using dir = tempDir("bundler-files-query-suffix", {});
+    await Bun.write(`${dir}/out.js`, result.outputs[0]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), `${dir}/out.js`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe('["export const value = 42;",42]\n');
+    expect(exitCode).toBe(0);
+  });
+
   test("in-memory file overrides real file on disk", async () => {
     // Create a temp directory with a real file
     using dir = tempDir("bundler-files-override", {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -432,6 +432,67 @@ describe("bundler", async () => {
     },
   });
 
+  // The runtime resolves `./a.txt?raw` to `a.txt` and loads it as text. The bundler does the same.
+  itBundled("bun/loader-raw-query", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        import text from "./a.txt?raw";
+        import { x } from "./x.js?v=1";
+        const { x: dynamic } = await import("./x.js?v=2");
+        console.log(text, x, dynamic);
+      `,
+      "/a.txt": "hello",
+      "/x.js": "export const x = 1;",
+    },
+    run: { stdout: "hello 1 1" },
+  });
+
+  itBundled("bun/loader-raw-query-and-module-of-one-file", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        import source from "./lib.js?raw";
+        import { value } from "./lib.js";
+        console.log(JSON.stringify([source, value]));
+      `,
+      "/lib.js": "export const value = 42;",
+    },
+    run: { stdout: '["export const value = 42;",42]' },
+  });
+
+  // Like in the runtime, the `type` attribute wins over `?raw`.
+  itBundled("bun/loader-raw-query-with-type-attribute", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        import parsed from "./data.json?raw" with { type: "json" };
+        console.log(JSON.stringify(parsed));
+      `,
+      "/data.json": `{"a":1}`,
+    },
+    run: { stdout: '{"a":1}' },
+  });
+
+  // Like the runtime, each query gives the file its own module instance.
+  itBundled("bun/import-query-suffix-module-identity", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        import { count as a } from "./counter.js?a";
+        import { count as b } from "./counter.js?b";
+        import { count as aAgain } from "./counter.js?a";
+        import { count as plain } from "./counter.js";
+        console.log(a, b, aAgain, plain);
+      `,
+      "/counter.js": /* js */ `
+        globalThis.instances = (globalThis.instances ?? 0) + 1;
+        export const count = globalThis.instances;
+      `,
+    },
+    run: { stdout: "1 2 1 3" },
+  });
+
   const loaders: Loader[] = ["wasm", "json", "file" /* "napi" */, "text"];
   const exts = ["wasm", "json", "lmao" /*  ".node" */, "txt"];
   for (let i = 0; i < loaders.length; i++) {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -493,6 +493,26 @@ describe("bundler", async () => {
     run: { stdout: "1 2 1 3" },
   });
 
+  // An import of a package with "main" and "module" uses the "main" file when the package
+  // is also required (dual package hazard). The query is part of that match.
+  itBundled("bun/import-query-suffix-dual-package", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        import a from "pkg-a?x";
+        import b from "pkg-b?x";
+        console.log(a, require("pkg-a?x"), b, require("pkg-b"));
+      `,
+      "/node_modules/pkg-a/package.json": `{ "main": "./main.js", "module": "./module.js" }`,
+      "/node_modules/pkg-a/main.js": `module.exports = "main";`,
+      "/node_modules/pkg-a/module.js": `export default "module";`,
+      "/node_modules/pkg-b/package.json": `{ "main": "./main.js", "module": "./module.js" }`,
+      "/node_modules/pkg-b/main.js": `module.exports = "main";`,
+      "/node_modules/pkg-b/module.js": `export default "module";`,
+    },
+    run: { stdout: "main main module main" },
+  });
+
   const loaders: Loader[] = ["wasm", "json", "file" /* "napi" */, "text"];
   const exts = ["wasm", "json", "lmao" /*  ".node" */, "txt"];
   for (let i = 0; i < loaders.length; i++) {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -513,6 +513,50 @@ describe("bundler", async () => {
     run: { stdout: "main main module main" },
   });
 
+  // Each query is its own chunk. The chunks have the same content, so their names must still differ.
+  itBundled("bun/import-query-suffix-splitting", {
+    target: "bun",
+    splitting: true,
+    outdir: "/out",
+    files: {
+      "/entry.js": /* js */ `
+        const a = await import("./x.js?v=1");
+        const b = await import("./x.js?v=2");
+        const plain = await import("./x.js");
+        console.log(a.x, b.x, plain.x, a === b, a === plain);
+      `,
+      "/x.js": "export const x = 1;",
+    },
+    run: { stdout: "1 1 1 false false" },
+  });
+
+  // The query starts at the first "?", like in the runtime. A "#" before it is part of the path.
+  itBundled("bun/import-query-suffix-after-hash-in-path", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        import text from "./dir#1/a.txt?raw";
+        console.log(text);
+      `,
+      "/dir#1/a.txt": "the right file",
+      "/dir.js": `export default "the wrong file";`,
+    },
+    run: { stdout: "the right file" },
+  });
+
+  itBundled("bun/import-query-suffix-package-imports-alias", {
+    target: "bun",
+    files: {
+      "/entry.js": /* js */ `
+        import text from "#alias/a.txt?raw";
+        console.log(text);
+      `,
+      "/package.json": `{ "name": "app", "imports": { "#alias/*": "./src/*" } }`,
+      "/src/a.txt": "aliased",
+    },
+    run: { stdout: "aliased" },
+  });
+
   const loaders: Loader[] = ["wasm", "json", "file" /* "napi" */, "text"];
   const exts = ["wasm", "json", "lmao" /*  ".node" */, "txt"];
   for (let i = 0; i < loaders.length; i++) {

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -170,6 +170,26 @@ describe("bundler", () => {
     },
   });
 
+  // An import that no onResolve plugin handles resolves like it does without plugins.
+  itBundled("plugin/ResolveFallsThroughWithQuerySuffix", {
+    files: {
+      "index.ts": /* ts */ `
+        import text from "./a.txt?raw";
+        import source from "./lib.ts?raw";
+        import { value } from "./lib.ts?v=1";
+        console.log(JSON.stringify([text, source, value]));
+      `,
+      "a.txt": "hello",
+      "lib.ts": "export const value = 42;",
+    },
+    plugins(builder) {
+      builder.onResolve({ filter: /.*/ }, () => undefined);
+    },
+    run: {
+      stdout: '["hello","export const value = 42;",42]',
+    },
+  });
+
   for (const value of [null, undefined, true, 1, "string", {} as never]) {
     const str = JSON.stringify(value) ?? "undefined";
     itBundled(`plugin/ResolveEntryPointReturns${str.charAt(0).toUpperCase() + str.slice(1)}`, {

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -2287,7 +2287,6 @@ describe.concurrent("bundler", () => {
     },
   });
   itBundled("default/ImportWithHashParameter", {
-    todo: true,
     files: {
       "/entry.js": /* js */ `
         // Each of these should have a separate identity (i.e. end up in the output file twice)
@@ -2302,7 +2301,6 @@ describe.concurrent("bundler", () => {
     },
   });
   itBundled("default/ImportWithQueryParameter", {
-    todo: true,
     files: {
       "/entry.js": /* js */ `
         // Each of these should have a separate identity (i.e. end up in the output file twice)
@@ -2317,7 +2315,6 @@ describe.concurrent("bundler", () => {
     },
   });
   itBundled("default/ImportAbsPathWithQueryParameter", {
-    todo: true,
     files: {
       "/Users/user/project/entry.js": /* js */ `
         // Each of these should have a separate identity (i.e. end up in the output file twice)

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -2287,6 +2287,7 @@ describe.concurrent("bundler", () => {
     },
   });
   itBundled("default/ImportWithHashParameter", {
+    todo: true,
     files: {
       "/entry.js": /* js */ `
         // Each of these should have a separate identity (i.e. end up in the output file twice)
@@ -2315,6 +2316,7 @@ describe.concurrent("bundler", () => {
     },
   });
   itBundled("default/ImportAbsPathWithQueryParameter", {
+    todo: true,
     files: {
       "/Users/user/project/entry.js": /* js */ `
         // Each of these should have a separate identity (i.e. end up in the output file twice)

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -727,4 +727,24 @@ console.log("✓ Both import types work correctly");
       expect(entryCode).toContain('\\\"files\\\":[');
     },
   });
+
+  // An HTML import is one entry point for each file. A query on the specifier does not make a second one.
+  itBundled("html-import/with-query-suffix", {
+    outdir: "out/",
+    files: {
+      "/server.js": `
+import versioned from "./client.html?v=1";
+import plain from "./client.html";
+console.log(JSON.stringify([versioned.index, versioned === plain]));
+`,
+      "/client.html": `<!DOCTYPE html><html><head><script src="./client.js"></script></head><body></body></html>`,
+      "/client.js": `console.log("client");`,
+    },
+    entryPoints: ["/server.js"],
+    target: "bun",
+    run: { stdout: '["./client.html",true]' },
+    onAfterBundle(api) {
+      expect(readManifests(api, "out/server.js")).toHaveLength(1);
+    },
+  });
 });

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -177,6 +177,39 @@ describe("bundler metafile", () => {
     expect(imp.original).toBe("./lib/helper.js");
   });
 
+  test("metafile has one input for each query of an imported file", async () => {
+    using dir = tempDir("metafile-query-suffix-test", {
+      "entry.js": `
+        import one from "./a.txt?one";
+        import two from "./a.txt?two";
+        import plain from "./a.txt";
+        console.log(one, two, plain);
+      `,
+      "a.txt": `text`,
+    });
+
+    const result = await Bun.build({
+      entrypoints: [`${dir}/entry.js`],
+      metafile: true,
+    });
+
+    expect(result.success).toBe(true);
+    const metafile = result.metafile as Metafile;
+    // The keys are paths relative to the cwd.
+    const names = (paths: string[]) => paths.map(path => path.slice(path.lastIndexOf("/") + 1));
+    const [output] = Object.values(metafile.outputs);
+    const entryKey = Object.keys(metafile.inputs).find(key => key.endsWith("entry.js"))!;
+    expect({
+      inputs: names(Object.keys(metafile.inputs)).sort(),
+      imports: names(metafile.inputs[entryKey].imports.map(imp => imp.path)),
+      outputInputs: names(Object.keys(output.inputs)).sort(),
+    }).toEqual({
+      inputs: ["a.txt", "a.txt?one", "a.txt?two", "entry.js"],
+      imports: ["a.txt?one", "a.txt?two", "a.txt"],
+      outputInputs: ["a.txt", "a.txt?one", "a.txt?two", "entry.js"],
+    });
+  });
+
   test("metafile without option returns undefined", async () => {
     using dir = tempDir("metafile-disabled-test", {
       "test.js": `console.log("test");`,

--- a/test/cli/test/test-changed.test.ts
+++ b/test/cli/test/test-changed.test.ts
@@ -171,6 +171,25 @@ describe.concurrent("bun test --changed", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("shared dependency imported with a query selects all importers", async () => {
+    using dir = tempDir("test-changed-query", {
+      "package.json": JSON.stringify({ name: "query", type: "module" }),
+      "shared.ts": `export const v = 1;\n`,
+      "plain.test.ts": `import { test, expect } from "bun:test";\nimport { v } from "./shared";\ntest("plain", () => expect(v).toBe(1));\n`,
+      "query.test.ts": `import { test, expect } from "bun:test";\nimport { v } from "./shared.ts?fresh";\ntest("query", () => expect(v).toBe(1));\n`,
+      "other.test.ts": `import { test, expect } from "bun:test";\ntest("other", () => expect(1).toBe(1));\n`,
+    });
+    initRepo(String(dir));
+    appendFileSync(join(String(dir), "shared.ts"), "// touched\n");
+
+    const { stderr, exitCode } = await runTestChanged(String(dir));
+    expect(ranFiles(stderr, ["plain.test.ts", "query.test.ts", "other.test.ts"])).toEqual([
+      "plain.test.ts",
+      "query.test.ts",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
   test("staged changes are picked up", async () => {
     using dir = tempDir("test-changed-staged", fixture);
     initRepo(String(dir));

--- a/test/js/bun/import-attributes/import-attributes.test.ts
+++ b/test/js/bun/import-attributes/import-attributes.test.ts
@@ -346,10 +346,10 @@ describe("other loaders do not crash", () => {
 describe("?raw", () => {
   for (const [name, fn] of [
     ["bun run", testBunRun],
-    // ["bun build", testBunBuild], // TODO: bun.build doesn't support query params at all yet
+    ["bun build", testBunBuild],
     ["bun run await import", testBunRunAwaitImport],
     ["require", testBunRunRequire],
-    // ["bun build require", testBunBuildRequire], // TODO: bun.build doesn't support query params at all yet
+    // ["bun build require", testBunBuildRequire], // a bundled require() of a text file returns the string, not { default }
   ] as const) {
     test(name, async () => {
       const filename = "abcd.js";

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -234,3 +234,52 @@ test("Bun.resolveSync with non-ASCII specifier and query string", async () => {
   expect(resolved).toEndWith("target.js?v=caf\u00e9-\u65e5\u672c\u8a9e");
   expect(exitCode).toBe(0);
 });
+
+// `bun build` cuts the query where the runtime cuts it, so a bundle has the file that `bun run` loads.
+test("bun build resolves an import with a query to the same file as bun run", async () => {
+  using dir = tempDir("import-query-build", {
+    "package.json": JSON.stringify({ name: "app", imports: { "#alias/*": "./src/*" } }),
+    "a.txt": "a",
+    "lib.js": `export default "lib";`,
+    "dir#1/a.txt": "in dir#1",
+    // `./dir#1/a.txt?raw` cut at the "#" is `./dir`, which is this file.
+    "dir.js": `export default "dir.js";`,
+    "src/aliased.txt": "aliased",
+    "node_modules/pkg/package.json": JSON.stringify({ name: "pkg", main: "./index.js" }),
+    "node_modules/pkg/index.js": `module.exports = "pkg";`,
+  });
+  const rows: [specifier: string, value: string][] = [
+    ["./a.txt?raw", "a"],
+    ["./a.txt?raw&x=1", "a"],
+    ["./a.txt?raw#fragment", "a"],
+    ["./lib.js?v=1", "lib"],
+    ["./lib.js?raw", `export default "lib";`],
+    ["./lib.js?redirect=/a/b.js", "lib"],
+    ["./dir#1/a.txt?raw", "in dir#1"],
+    ["#alias/aliased.txt?raw", "aliased"],
+    ["pkg?v=1", "pkg"],
+    [`${dir}/lib.js?absolute`.replaceAll("\\", "/"), "lib"],
+  ];
+  await Bun.write(
+    `${dir}/entry.js`,
+    rows.map(([specifier], i) => `import v${i} from ${JSON.stringify(specifier)};`).join("\n") +
+      `\nconsole.log(JSON.stringify([${rows.map((_, i) => `v${i}`).join(", ")}]));\n`,
+  );
+
+  async function run(...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const expected = { stdout: JSON.stringify(rows.map(([, value]) => value)) + "\n", stderr: "", exitCode: 0 };
+  expect(await run("entry.js")).toEqual(expected);
+  expect((await run("build", "entry.js", "--target=bun", "--outdir=out")).stderr).toBe("");
+  expect(await run("out/entry.js")).toEqual(expected);
+});


### PR DESCRIPTION
Fixes #17580

### Problem
- `bun build` fails on an import that ends in a query: `error: Could not resolve: "./a.txt?raw"`. The runtime resolves the same import. This includes `?raw`, which the runtime loads as text.
- The runtime cuts the specifier at the first `?` before it calls the resolver (`normalize_specifier_for_resolution`, `src/jsc/VirtualMachine.rs:3464`). The bundler passes the specifier as written.

### Fix
- When a specifier does not resolve as written, the bundler resolves it again without the `?query`. The cut is at the first `?`, as in the runtime, so a bundle has the file that `bun run` loads.
- `?raw` selects the text loader. A `with { type }` attribute wins over it. Both match the runtime.
- Each query makes its own module, like in the runtime and esbuild. `./lib.js?raw` and `./lib.js` can be in one bundle. The module stores its query (`InputFile::ignored_suffix`). Its key in `PathToSourceIndexMap` is the file path plus the query. The chunk hash, `--metafile` and `bun test --changed` read the stored query.
- Verified: `test/bundler/bundler_loader.test.ts` (8 new tests, all fail on 1.4.3-canary) and a `bun run` against `bun build` table in `test/js/bun/resolve/import-query.test.ts`.

### Background
- An import record is one `import` or `require` in a parsed file. `resolve_import_records` (`src/bundler/bundle_v2.rs`) resolves its specifier and makes a `ParseTask` for the file.
- `PathToSourceIndexMap` maps a path to a module in the bundle. An import record finds its module there through `path.text`.
- `run_resolver` resolves an import after the `onResolve` plugins that matched it returned nothing.

<details><summary>Notes</summary>

Repro:

```sh
echo 'export const x = 1;' > x.ts
echo 'hello' > a.txt
cat > main.ts <<'EOF'
import { x } from "./x.ts?v=1";
import txt from "./a.txt?raw";
console.log(x, txt.trim(), (await import("./x.ts?v=2")).x);
EOF
bun main.ts                                   # 1 hello 1
bun build main.ts --target=bun --outdir=out   # before: 3x "Could not resolve". after: builds, prints 1 hello 1
```

Changed after the self-review:
- The first version also cut at `#`, like esbuild. That cut can pick another file: `./dir#1/a.txt?raw` resolved a sibling `dir.js`. The runtime does not cut at `#`, and nobody asked for it, so it is gone. `default/ImportWithHashParameter` and `default/ImportAbsPathWithQueryParameter` (it has a `#bar` import) are `todo` again. `#alias/a.txt?raw` (package.json `imports`) now works, because the cut no longer looks at `#`.
- The query was only a string inside the map key and inside `record.path.text`. It is now data on the module (`ParseTask::ignored_suffix`, `InputFile::ignored_suffix`), and these read it:
  - `generate_isolated_hash`: two dynamic imports of one file with different queries get different chunk names under `--splitting` (was the `Multiple files share the same output path` error). A module without a query hashes as before, so no output name changes.
  - `--metafile`: one input for each query (`a.txt?one`, `a.txt?two`), like esbuild. Was the same key more than once.
  - `bun test --changed`: one file can now be two sources. The filter seeds the search from every source of a changed file. A test that imports `./shared.ts?fresh` is now selected when `shared.ts` changes (main misses it).

Scope:
- The retry is in the bundler, not in the resolver. The runtime calls the same resolver and has its own rule, so it does not change.
- The dev server does not change. Its incremental graph has one module for each file path, so it does not do the retry.
- Imports from CSS (`@import`, `url()`) do not change. The resolver already ignores their suffix, and `src/css/printer.rs` puts it back on the printed URL. One asset for each file is the wanted result there.
- In-memory `files` (`FileMap`) get the same retry: exact match first, then disk, then the same two without the query.
- An external import keeps its query in the output (`--external pkg` with `import "pkg?x"` prints `"pkg?x"`).
- A server-side HTML import (`import page from "./index.html?v=1"` with `--target=bun`) is the exception to the identity rule. It is an entry point of the browser build with one output for the file, and the linker finds it through the path of the file. So the query is not part of its key.
- For a package with `main` and `module`, the stored secondary path has the query too. `import x from "pkg?a"` plus `require("pkg?a")` share the `main` file. `import y from "pkg?b"` plus `require("pkg")` do not.
- Under `--watch`, the retry runs after the dir cache bust, so the full specifier gets its second lookup first.
- The display path (`path.pretty`) does not get the query. Source maps and watch mode keep the real file path.

Known limits:
- The `file` loader gives `./img-<hash>.png` for `import url from "./img.png?v=2"`, without the query. The runtime also gives the path without the query, and with `--target=bun` the value is a file path. The asset is in the output list once for each query (same name, same bytes). Two identical files in two folders do the same today.
- An `onLoad` plugin gets the file path without the query. The plugin API has no field for it.
- An import with `#hash` does not resolve, in the bundler and in the runtime.
- The import-attribute form of the same identity problem (`./x.js` with and without `with { type: "text" }`) is #41834. It changes the same keys.

Related: #41938 (HTML attributes keep `?query#fragment`), #38635 (HTML assets through `files`), #41834 (module key has the loader).

Tests:
- `test/bundler/bundler_loader.test.ts`: `bun/loader-raw-query`, `bun/loader-raw-query-and-module-of-one-file`, `bun/loader-raw-query-with-type-attribute`, `bun/import-query-suffix-module-identity`, `bun/import-query-suffix-dual-package`, `bun/import-query-suffix-splitting`, `bun/import-query-suffix-after-hash-in-path`, `bun/import-query-suffix-package-imports-alias`.
- `test/js/bun/resolve/import-query.test.ts`: one entry with 10 specifiers (`?raw`, `?raw&x=1`, `?raw#fragment`, `?v=1`, a query with `/`, `./dir#1/a.txt?raw`, `#alias/...?raw`, `pkg?v=1`, an absolute path). `bun run` and the bundle print the same values.
- `test/bundler/metafile.test.ts`: `metafile has one input for each query of an imported file`.
- `test/cli/test/test-changed.test.ts`: `shared dependency imported with a query selects all importers`.
- `test/bundler/html-import-manifest.test.ts`: `html-import/with-query-suffix`.
- `test/bundler/bundler_plugin.test.ts`: `plugin/ResolveFallsThroughWithQuerySuffix` (the `run_resolver` path).
- `test/bundler/bundler_files.test.ts`: `in-memory file imported with a query suffix`.
- `test/bundler/esbuild/default.test.ts`: removed `todo` from `default/ImportWithQueryParameter`.
- `test/js/bun/import-attributes/import-attributes.test.ts`: enabled `?raw > bun build`. `bun build require` stays off: a bundled `require()` of a text file returns the string, the runtime returns `{ default }`. That difference does not depend on the query.
- Also ran, with the debug build on Linux: `esbuild/default`, `esbuild/loader`, `esbuild/splitting`, `esbuild/packagejson`, `bundler_edgecase`, `bundler_barrel`, `bundler_html`, `metafile`, `test-changed`, `import-attributes`, `bake/dev/{bundle,esm,plugins}`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/test/test-changed.test.ts, test/bundler/metafile.test.ts, test/bundler/bundler_plugin.test.ts

<!-- robobun:evidence:end -->