### PR TITLE
Bun.serve: stop the response sink from sending the body tail twice after a partial tryEnd

### DIFF
--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1498,7 +1498,8 @@ impl<const SSL: bool> HTTPServerWritable<SSL> {
                 uws::WriteResult::Backpressure(_)
             );
         }
-        self.handle_wrote(buf_len);
+        // uWS took the `from` bytes in an earlier partial `try_end`; it now owns the whole slice.
+        self.handle_wrote(from + buf_len);
         bun_core::scoped_log!(
             HTTPServerWritableLog,
             "send: {} bytes (backpressure: {})",

--- a/test/js/bun/http/serve-http2-fixture.ts
+++ b/test/js/bun/http/serve-http2-fixture.ts
@@ -179,6 +179,37 @@ async function handler(req: Request, server: Bun.Server<undefined>): Promise<Res
       return Response.json({ ok: true });
     case "/fixed":
       return new Response(Buffer.alloc(Number(url.searchParams.get("n") ?? "264"), "a"));
+    // Bytes 0..99 from a source that produces them in one piece and ends. That is under the
+    // sink's 256-byte high-water mark, so end() still holds the whole body and sends it with
+    // content-length.
+    case "/stream-once": {
+      const body = new Uint8Array(100).map((_, i) => i);
+      const enqueueAndClose = (c: ReadableStreamDefaultController | ReadableByteStreamController) => {
+        c.enqueue(body);
+        c.close();
+      };
+      switch (url.searchParams.get("kind")) {
+        case "default":
+          return new Response(new ReadableStream({ pull: enqueueAndClose }));
+        case "bytes":
+          return new Response(new ReadableStream({ type: "bytes", pull: enqueueAndClose }));
+        case "direct":
+          return new Response(
+            new ReadableStream({
+              type: "direct",
+              pull(c) {
+                c.write(body);
+                c.close();
+              },
+            }),
+          );
+        case "generator":
+          return new Response(async function* () {
+            yield body;
+          });
+      }
+      break;
+    }
     case "/read-report": {
       try {
         await req.text();

--- a/test/js/bun/http/serve-http2-protocol.test.ts
+++ b/test/js/bun/http/serve-http2-protocol.test.ts
@@ -842,6 +842,49 @@ describe.concurrent("Bun.serve http2 protocol", () => {
     raw.close();
   });
 
+  // A streamed body that ends before the sink's first flush goes out through tryEnd() from the
+  // sink's own buffer. onWritable resends what is left each time the window reopens.
+  test.each([
+    ["default", [10, 5, 1000]],
+    ["bytes", [10, 5, 1000]],
+    ["direct", [10, 5, 1000]],
+    ["generator", [10, 5, 1000]],
+    ["default", [1, 1, 1000]],
+    ["default", [20, 1, 1000]],
+    ["default", [10, 5, 7, 2, 1000]],
+    ["default", [10, 1000]], // one partial write only
+  ] as const)(
+    "streamed body (%s source) that ends at once, windows %j: every byte is sent once",
+    async (kind, windows) => {
+      const path = `/stream-once?kind=${kind}`;
+      const expected = Buffer.from(Array.from({ length: 100 }, (_, i) => i)).toString("hex");
+      const raw = await RawH2.connect(fx.port, secure, { settings: setting(4, windows[0]) });
+      try {
+        await raw.waitFor(f => f.type === T.SETTINGS && (f.flags & F.ACK) !== 0);
+        raw.headers(1, baseHeaders(path));
+        let granted: number = windows[0];
+        for (const inc of windows.slice(1)) {
+          // Each window but the last is smaller than what is left: the write was partial.
+          while (received(raw, 1) < granted)
+            await raw.waitFor(f => f.type === T.DATA && f.streamId === 1 && received(raw, 1) >= granted);
+          await barrier(raw, "g" + granted);
+          expect(received(raw, 1)).toBe(granted);
+          raw.write(frame(T.WINDOW_UPDATE, 0, 1, u32(inc)));
+          granted += inc;
+        }
+        expect((await raw.body(1)).toString("hex")).toBe(expected);
+      } finally {
+        raw.close();
+      }
+      // The same response over default windows: it is the content-length path that was exercised.
+      const res = await request(session, { ":path": path });
+      expect({ length: res.headers["content-length"], body: res.body.toString("hex") }).toEqual({
+        length: "100",
+        body: expected,
+      });
+    },
+  );
+
   test("raising SETTINGS_INITIAL_WINDOW_SIZE mid-stream releases exactly the delta", async () => {
     const raw = await RawH2.connect(fx.port, secure, { settings: setting(4, 0) });
     await raw.waitFor(f => f.type === T.SETTINGS && (f.flags & F.ACK) !== 0);


### PR DESCRIPTION
### Problem
- `Bun.serve({ http2: true })` sends bytes past `content-length` for a streamed body under 256 bytes when the peer's window cuts two consecutive writes. Body 0..99, window 10, +5, +1000: `DATA 10, DATA 5, DATA 95+END_STREAM`. The last 10 bytes go out twice. nghttp2 clients answer PROTOCOL_ERROR.
- Cause: `send_readable_without_auto_flusher` (`src/runtime/webcore/streams.rs:1502`). `on_writable` resends from `from = write_offset`, but `handle_wrote` gets only `len - from`. The sink keeps `from` bytes as unsent, and `finalize()` -> `flush_no_wait()` sends them with a second `res.end()`.
- HTTP/1 resends through `try_end`, which credits the whole body. HTTP/2 and HTTP/3 set `HTTP_WRITE_CALLED` in the first `tryEnd`, so their resend uses `res.end()`.

### Fix
- Credit `from + buf_len` in that branch. uWS owns the whole buffer after `res.end()`, so the buffer empties and `finalize()` has nothing to send.
- `from` is non-zero only in the `on_writable` resend, where it counts bytes an earlier `try_end` gave to uWS.
- Verified: `test/js/bun/http/serve-http2-protocol.test.ts` (8 new cases, stock bun fails 7). Also the other `serve-http2*` files, `serve-http3`, `serve-direct-readable-stream`, `serve.test.ts`, `streams.test.js`.

### Background
- `HTTPServerWritable` is the sink behind a streamed `Response` body. It buffers writes below its high-water mark (256 bytes here). `handle_wrote(n)` advances its read position and clears a fully read buffer.
- If the stream ends with the whole body still buffered, the sink calls `try_end(buf, total)`. uWS writes `content-length` and takes only what fits. Later it calls `on_writable(write_offset)` with the byte count it took.
- `Http2Response::internalEnd` parks what the window does not take. Its `localClosed` guard drops a second `end()` once END_STREAM is out, so one partial write looked correct.

<details><summary>Notes</summary>

Measured on 1.4.3-canary.1+6a92015fc (release) and on this branch (debug, ASAN). Body = bytes 0..99, raw HTTP/2 peer, `SETTINGS_INITIAL_WINDOW_SIZE` = first number, then one `WINDOW_UPDATE` per number, each sent after the previous window was used up.

| source | windows | before | after |
| --- | --- | --- | --- |
| `ReadableStream` (default) | 10, +5, +1000 | 10, 5, 95 = 110 bytes | 10, 5, 85 |
| `type: "bytes"` | 10, +5, +1000 | 110 bytes | 10, 5, 85 |
| `type: "direct"`, sync `write(); close()` | 10, +5, +1000 | 110 bytes | 10, 5, 85 |
| async generator | 10, +5, +1000 | 110 bytes | 10, 5, 85 |
| default | 1, +1, +1000 | 1, 1, 99 = 101 bytes | 1, 1, 98 |
| default | 20, +1, +1000 | 20, 1, 99 = 120 bytes | 20, 1, 79 |
| default | 10, +5, +7, +2, +1000 | 10, 5, 7, 2, 86 = 110 bytes | 10, 5, 7, 2, 76 |
| default | 10, +1000 | 10, 90 | 10, 90 |

The extra bytes are always the last `w1` bytes of the body, where `w1` is the size of the first partial write.

Step by step for 10, +5, +1000, before the fix:
1. `end_from_js`: `try_end(buf[0..100], 100)`. HTTP/2 writes HEADERS with `content-length: 100`, sets `HTTP_WRITE_CALLED`, sends 10 bytes, returns false.
2. `WINDOW_UPDATE +5`: `on_writable(10)`, `send_readable(10)`. `HTTP_WRITE_CALLED` is set, so the sink calls `res.end(buf[10..100])`. HTTP/2 sends 5 bytes, parks 85, sets `endAfterDrain`. `handle_wrote(90)` leaves `offset = 90`, `buffer.len() = 100`.
3. Same call: `finalize()` -> `flush_no_wait()` sees 10 readable bytes and calls `res.end(buf[90..100])`. The stream is not `localClosed` yet, so `internalEnd` appends the 10 bytes to the parked 85.
4. `WINDOW_UPDATE +1000`: 95 bytes + END_STREAM.

With one partial write, step 2 sends all 90 bytes and sets `localClosed`, so the second `end()` in step 3 is dropped. That second call is gone now too.

Size threshold: the sink's high-water mark is `max(256, highWaterMark)` (`Start::from_js_with_tag`, `streams.rs:263`), and the debug log shows `start(256)`. A body of 300 bytes or more goes through `res.write()` and is not affected (measured: 200 bytes fails, 300 bytes passes, for each source).

HTTP/3 runs the same sink code and `Http3Response::internalEnd` also sets `HTTP_WRITE_CALLED` on the first `tryEnd`. I did not drive it: the suite's HTTP/3 client (curl) does not expose small flow-control windows. Large `type: "direct"` bodies over curl `--http1.1`, `--http2` and `--http3-only` are byte-exact before and after.

Side effect: the `end()` promise of the sink now resolves with the full byte count. It was `len - from`.

Not changed: `Http2Response::internalEnd` still appends the body of a second `end()` while the first one is parked (`endAfterDrain`). The sink no longer makes that call. A guard there is possible as a separate hardening.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/bun/http/serve-http2-protocol.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/bun/http/serve-http2-protocol.test.ts:
(pass) Bun.serve http2 protocol > first frame not SETTINGS → GOAWAY PROTOCOL_ERROR [545.34ms]
(pass) Bun.serve http2 protocol > SETTINGS with bad length → GOAWAY FRAME_SIZE_ERROR [567.67ms]
(pass) Bun.serve http2 protocol > oversized frame → GOAWAY FRAME_SIZE_ERROR [584.05ms]
(pass) Bun.serve http2 protocol > WINDOW_UPDATE of 0 on the connection → GOAWAY PROTOCOL_ERROR [603.41ms]
(pass) Bun.serve http2 protocol > bad preface closes the connection [1364.00ms]
(pass) Bun.serve http2 protocol > connection WINDOW_UPDATE overflow → GOAWAY FLOW_CONTROL_ERROR [466.14ms]
(pass) Bun.serve http2 protocol > even stream id → GOAWAY PROTOCOL_ERROR [462.72ms]
(pass) Bun.serve http2 protocol > HEADERS interleaved before CONTINUATION → GOAWAY PROTOCOL_ERROR [454.15ms]
(pass) Bun.serve http2 protocol > PUSH_PROMISE from client → GOAWAY PROTOCOL_ERROR [442.65ms]
(pass) Bun.serve http2 protocol > invalid HPACK → GOA
... (truncated)

release without fix: 7 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/bun/http/serve-http2-protocol.test.ts:
(pass) Bun.serve http2 protocol > first frame not SETTINGS → GOAWAY PROTOCOL_ERROR [16.98ms]
(pass) Bun.serve http2 protocol > SETTINGS with bad length → GOAWAY FRAME_SIZE_ERROR [17.27ms]
(pass) Bun.serve http2 protocol > oversized frame → GOAWAY FRAME_SIZE_ERROR [17.41ms]
(pass) Bun.serve http2 protocol > WINDOW_UPDATE of 0 on the connection → GOAWAY PROTOCOL_ERROR [17.54ms]
(pass) Bun.serve http2 protocol > connection WINDOW_UPDATE overflow → GOAWAY FLOW_CONTROL_ERROR [17.67ms]
(pass) Bun.serve http2 protocol > even stream id → GOAWAY PROTOCOL_ERROR [17.81ms]
(pass) Bun.serve http2 protocol > HEADERS interleaved before CONTINUATION → GOAWAY PROTOCOL_ERROR [17.93ms]
(pass) Bun.serve http2 protocol > PUSH_PROMISE from client → GOAWAY PROTOCOL_ERROR [18.04ms]
(pass) Bun.serve http2 protocol > invalid HPACK → GOAWAY COMPRESSION_ERROR [18.15ms]
(pass) Bun.serve http2 protocol > malformed request (missing :path) → RST_STREAM PROTOCOL_ERROR, connection survives [24.44ms]
(pass) Bun.serve http2 protocol > malformed request (unknown pseudo-header) → RST_STREAM PROTOCO
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/bun/http/serve-http2-protocol.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/bun/http/serve-http2-protocol.test.ts:
(pass) Bun.serve http2 protocol > first frame not SETTINGS → GOAWAY PROTOCOL_ERROR [444.54ms]
(pass) Bun.serve http2 protocol > SETTINGS with bad length → GOAWAY FRAME_SIZE_ERROR [457.70ms]
(pass) Bun.serve http2 protocol > oversized frame → GOAWAY FRAME_SIZE_ERROR [467.25ms]
(pass) Bun.serve http2 protocol > WINDOW_UPDATE of 0 on the connection → GOAWAY PROTOCOL_ERROR [485.43ms]
(pass) Bun.serve http2 protocol > bad preface closes the connection [980.87ms]
(pass) Bun.serve http2 protocol > connection WINDOW_UPDATE overflow → GOAWAY FLOW_CONTROL_ERROR [325.25ms]
(pass) Bun.serve http2 protocol > even stream id → GOAWAY PROTOCOL_ERROR [322.48ms]
(pass) Bun.serve http2 protocol > HEADERS interleaved before CONTINUATION → GOAWAY PROTOCOL_ERROR [317.70ms]
(pass) Bun.serve http2 protocol > PUSH_PROMISE from client → GOAWAY PROTOCOL_ERROR [303.92ms]
(pass) Bun.serve http2 protocol > invalid HPACK → GOAW
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     d6553188fc
  features     baseline

23 deps, 131 codegen, 1172 objects in 748ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (6a92015fc)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (6a92015fc)

Checked 1 install across 2 packages (no changes) [6.00ms]
[4/1244] gen bindgenv2
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (6a92015fc)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 KB  (entry point)

[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] gen .bind.ts → GeneratedBindings.cpp
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen JSBuffe
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/streams.rs                |  3 +-
 test/js/bun/http/serve-http2-fixture.ts       | 31 +++++++++++++++++++
 test/js/bun/http/serve-http2-protocol.test.ts | 43 +++++++++++++++++++++++++++
 3 files changed, 76 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/runtime/webcore/streams.rs                     5      1      9
test/js/bun/http/serve-http2-fixture.ts            1      2     10
test/js/bun/http/serve-http2-protocol.test.ts      2      1      9
```

</details>

<!-- robobun:evidence:end -->