### PR TITLE
react-compiler: keep one copy of each dependency of a phi

### DIFF
--- a/src/react_compiler/validation/validate_exhaustive_dependencies.rs
+++ b/src/react_compiler/validation/validate_exhaustive_dependencies.rs
@@ -492,9 +492,7 @@ fn collect_dependencies(
     for (_block_id, block) in &func.body.blocks {
         // Process phis
         for phi in &block.phis {
-            // TS collects an array and stores `new Set(deps)`, which holds each
-            // object once. `deps` is that set. `deps_len` is the array length,
-            // which TS tests before it builds the set.
+            // TS tests `deps.length`, then stores `new Set(deps)`.
             let mut deps: Vec<InferredDependency> = Vec::new();
             let mut deps_len: usize = 0;
             for (_pred_id, operand) in &phi.operands {
@@ -1604,15 +1602,8 @@ fn is_optional_dependency_inferred(
 // Equality check for temporaries
 // =============================================================================
 
-/// True when `a` and `b` are copies of one dependency. TS keeps the
-/// dependencies of a phi in a `Set`, which compares object identity. This port
-/// clones where TS shares an object, so it compares every field. Without this
-/// a phi that another phi reaches along many paths holds one copy per path,
-/// and the list grows exponentially with the depth of the control flow.
-///
-/// A `Global` has no field that tells two loads of one global apart, so they
-/// are one entry here and two in TS. `add_dependency` merges globals by name
-/// anyway, so the inferred dependencies are the same.
+/// Membership in a TS `Set<InferredDependency>`, which is object identity. The
+/// port clones where TS shares an object, so every field decides, `loc` too.
 fn is_same_dependency(a: &InferredDependency, b: &InferredDependency) -> bool {
     match (a, b) {
         (

--- a/src/react_compiler/validation/validate_exhaustive_dependencies.rs
+++ b/src/react_compiler/validation/validate_exhaustive_dependencies.rs
@@ -492,14 +492,23 @@ fn collect_dependencies(
     for (_block_id, block) in &func.body.blocks {
         // Process phis
         for phi in &block.phis {
+            // TS collects an array and stores `new Set(deps)`, which holds each
+            // object once. `deps` is that set. `deps_len` is the array length,
+            // which TS tests before it builds the set.
             let mut deps: Vec<InferredDependency> = Vec::new();
+            let mut deps_len: usize = 0;
             for (_pred_id, operand) in &phi.operands {
                 if let Some(dep) = temporaries.get(operand.identifier) {
                     match dep {
                         Temporary::Aggregate {
                             dependencies: agg, ..
                         } => {
-                            deps.extend(agg.iter().cloned());
+                            deps_len += agg.len();
+                            for dep in agg {
+                                if !contains_same_dependency(&deps, dep) {
+                                    deps.push(dep.clone());
+                                }
+                            }
                         }
                         Temporary::Local {
                             identifier,
@@ -507,24 +516,32 @@ fn collect_dependencies(
                             context,
                             loc,
                         } => {
-                            deps.push(InferredDependency::Local {
+                            deps_len += 1;
+                            let dep = InferredDependency::Local {
                                 identifier: *identifier,
                                 path: path.clone(),
                                 context: *context,
                                 loc: *loc,
-                            });
+                            };
+                            if !contains_same_dependency(&deps, &dep) {
+                                deps.push(dep);
+                            }
                         }
                         Temporary::Global { binding } => {
-                            deps.push(InferredDependency::Global {
+                            deps_len += 1;
+                            let dep = InferredDependency::Global {
                                 binding: binding.clone(),
-                            });
+                            };
+                            if !contains_same_dependency(&deps, &dep) {
+                                deps.push(dep);
+                            }
                         }
                     }
                 }
             }
-            if deps.is_empty() {
+            if deps_len == 0 {
                 continue;
-            } else if deps.len() == 1 {
+            } else if deps_len == 1 {
                 let dep = &deps[0];
                 match dep {
                     InferredDependency::Local {
@@ -1586,6 +1603,39 @@ fn is_optional_dependency_inferred(
 // =============================================================================
 // Equality check for temporaries
 // =============================================================================
+
+/// True when `a` and `b` are copies of one dependency. TS keeps the
+/// dependencies of a phi in a `Set`, which compares object identity. This port
+/// clones where TS shares an object, so it compares every field. Without this
+/// a phi that another phi reaches along many paths holds one copy per path,
+/// and the list grows exponentially with the depth of the control flow.
+fn is_same_dependency(a: &InferredDependency, b: &InferredDependency) -> bool {
+    match (a, b) {
+        (
+            InferredDependency::Global { binding: ab },
+            InferredDependency::Global { binding: bb },
+        ) => ab.name() == bb.name(),
+        (
+            InferredDependency::Local {
+                identifier: a_id,
+                path: a_path,
+                context: a_context,
+                loc: a_loc,
+            },
+            InferredDependency::Local {
+                identifier: b_id,
+                path: b_path,
+                context: b_context,
+                loc: b_loc,
+            },
+        ) => a_id == b_id && a_context == b_context && a_loc == b_loc && a_path == b_path,
+        _ => false,
+    }
+}
+
+fn contains_same_dependency(deps: &[InferredDependency], dep: &InferredDependency) -> bool {
+    deps.iter().any(|d| is_same_dependency(d, dep))
+}
 
 fn is_equal_temporary(a: &InferredDependency, b: &InferredDependency) -> bool {
     match (a, b) {

--- a/src/react_compiler/validation/validate_exhaustive_dependencies.rs
+++ b/src/react_compiler/validation/validate_exhaustive_dependencies.rs
@@ -1609,6 +1609,10 @@ fn is_optional_dependency_inferred(
 /// clones where TS shares an object, so it compares every field. Without this
 /// a phi that another phi reaches along many paths holds one copy per path,
 /// and the list grows exponentially with the depth of the control flow.
+///
+/// A `Global` has no field that tells two loads of one global apart, so they
+/// are one entry here and two in TS. `add_dependency` merges globals by name
+/// anyway, so the inferred dependencies are the same.
 fn is_same_dependency(a: &InferredDependency, b: &InferredDependency) -> bool {
     match (a, b) {
         (

--- a/src/react_compiler/validation/validate_exhaustive_dependencies.rs
+++ b/src/react_compiler/validation/validate_exhaustive_dependencies.rs
@@ -1602,8 +1602,7 @@ fn is_optional_dependency_inferred(
 // Equality check for temporaries
 // =============================================================================
 
-/// Membership in a TS `Set<InferredDependency>`, which is object identity. The
-/// port clones where TS shares an object, so every field decides, `loc` too.
+/// Stands in for object identity in the TS `Set<InferredDependency>` of a phi.
 fn is_same_dependency(a: &InferredDependency, b: &InferredDependency) -> bool {
     match (a, b) {
         (

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -2095,6 +2095,45 @@ test("react-compiler memory does not grow with the square of the size of a compo
   expect(pattern - empty).toBeLessThan(bound);
 });
 
+// ValidateExhaustiveDependencies gives each phi the dependencies of its
+// operands. TS keeps them in a `Set`. The port appended clones to a `Vec`, so a
+// phi held one copy of a dependency for each path that reaches it. Each `if`
+// below merges `v` twice, which doubled the list: 20 of them took 300 MB, 22
+// took 1 GB and 24 took 4 GB.
+test("react-compiler keeps one copy of each dependency of a phi", async () => {
+  // A debug build takes 7 seconds for 20 and 25 seconds for 22.
+  const statements = isDebug || isASAN ? 20 : 22;
+  using dir = tempDir("react-compiler-phi-dependencies", {
+    "empty.jsx": `export default function App() { return null; }`,
+    "ladder.jsx": `
+      export default function App(p) {
+        let v = "init";
+        ${Array.from({ length: statements }, (_, i) => `if (p.a${i}) { log(${i}); } else if (p.b${i}) { v = "s${i}"; }`).join("\n")}
+        return <div>{v}</div>;
+      }
+    `,
+  });
+
+  const build = async (entry: string) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "--react-compiler", "--target=browser", "--external=*", entry],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return { memoized: /\b_c\(\d+\)/.test(stdout), peakMB: proc.resourceUsage()!.maxRSS / 1024 / 1024 };
+  };
+
+  const [empty, ladder] = await Promise.all([build("empty.jsx"), build("ladder.jsx")]);
+  expect(ladder.memoized).toBe(true);
+  // Above the empty build: 300 MB to 1 GB without the fix, under 20 MB with it.
+  expect(ladder.peakMB - empty.peakMB).toBeLessThan(100);
+});
+
 // validate_locals_not_reassigned_after_render (src/react_compiler/validation)
 // records the locals a component's closures capture while walking the
 // component body, and reports a nested function that assigns to one of them,


### PR DESCRIPTION
### Problem
- In `bun build --react-compiler`, memory doubles with each `if` that reassigns a local on one branch. 22 such statements take 1 GB, 24 take 4.1 GB, more abort with `memory allocation of 1073741824 bytes failed`.
- ValidateExhaustiveDependencies (`collect_dependencies`, `src/react_compiler/validation/validate_exhaustive_dependencies.rs:494`) gives a phi the dependencies of its operands with `deps.extend(agg.iter().cloned())`. TS stores `new Set(deps)`, which holds each object once. Here a phi holds one copy per path that reaches it.

### Fix
- A phi drops a dependency that is a copy of one in its list. `is_same_dependency` compares every field, because the port clones where TS shares one object. The `deps.length` test of TS still uses the count before the set (`deps_len`).
- Correct because this is the set TS builds. `add_dependency` and the phi loop already skip a dependency they have seen, so the inferred dependencies do not change.
- Verified: a new test in `test/bundler/transpiler/react-compiler.test.ts` (989 MB above an empty build on 1.4.3-canary.1, 20 MB with the fix). Also `react-compiler-fixtures.test.ts`.
- Self-reviewed: 1 concern raised, 1 addressed. The first version also changed InferTypes, which #42395 already does, so that part is gone.

### Background
- The pass compares what each `useMemo` and effect callback reads with its dependency array. Bun ships with both checks off, so it only collects.
- A phi joins the SSA versions of a local where control flow merges. Its operands can repeat and can be other phis.
- A `Temporary::Aggregate` is a value with several dependencies: an array literal, a function or a phi.

<details><summary>Notes</summary>

The input of the test (`statements` is 22, or 20 on a debug build):

```js
export default function App(p) {
  let v = "init";
  if (p.a0) { log(0); } else if (p.b0) { v = "s0"; }
  if (p.a1) { log(1); } else if (p.b1) { v = "s1"; }
  // ...
  return <div>{v}</div>;
}
```

Each statement joins `v` from three paths, and two of them carry the phi of the statement before. All the values are string literals, so InferTypes resolves every phi to `Primitive` and takes 5 ms. Peak memory above an empty build, 1.4.3-canary.1 release build:

| statements | time | memory |
| --- | --- | --- |
| 16 | 0.03 s | 4 MB |
| 18 | 0.09 s | 56 MB |
| 20 | 0.34 s | 272 MB |
| 22 | 1.3 s | 1007 MB |
| 24 | 4.9 s | 4081 MB |

With the fix a debug build with ASAN takes 0.7 s and 20 MB for 22 statements, and 1.2 s and 36 MB for 40. At 200 statements the pass takes 93 ms of a 17 s debug build.

The same growth shows with sequential or nested `try`/`catch` that reassign a local, because every instruction of a `try` block has an edge to the handler and the handler phi repeats one operand per edge.

Why every field and not the structural `is_equal_temporary`: two different loads of `props.a` are two objects in TS and both stay in the `Set`, so `deps.length` counts two. Comparing only identifier and path would count one and turn the aggregate of a later phi into a single `Local`, which changes what a property load on it records.

Equivalence: 600 generated components (nested `try`, `switch`, loops, `useMemo`, `useCallback`, effects, with `@validateExhaustiveMemoizationDependencies` and `@validateExhaustiveEffectDependencies:"all"` on) give the same diagnostics and the same output on main and on this branch. 249 of them report dependency errors. The three that differ do not finish on either build (InferTypes, see below) or panic the same way on both.

#42395 fixes the same kind of growth in InferTypes. The two changes do not touch the same source files. A component that reassigns a local in nested `try` blocks needs both: with only #42395 a chain of 10 nested `try` blocks does not finish in this pass.

The upstream Rust port has the same `Vec`. The upstream default for `validateExhaustiveMemoizationDependencies` is `true`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [695.73ms]
(pass) bundler > react-compiler/ComponentWithHooks [278.57ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [281.28ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [276.92ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [131.06ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [114.13ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [362.08ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [102.95ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [709.56ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [106.50ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [104.98ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [398.18ms]
(pass) bundler > reac
... (truncated)

release without fix: 18 failed, 1 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [16.04ms]
(pass) bundler > react-compiler/ComponentWithHooks [7.60ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [7.58ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [6.76ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [6.33ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [3.38ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [11.04ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [4.71ms]
1031 |       ]);
1032 |       const stdout = Buffer.from(stdoutBytes);
1033 |       const stderr = Buffer.from(stderrBytes);
1034 |       const success = exitCode === 0;
1035 |       if (buildProc.signalCode) {
1036 |         throw new Error(
                         ^
error: [react-compiler/SsrObjectMethodShorthand] 'bun build' subprocess killed by SIGABRT
cmd: /workspace/bun/build/release/bun build /tmp/bun-build-tests/bun-wfgjjX/react-compiler/SsrObjectMethodShorthand/entry.jsx --outfile=/tmp/bun-build-tests/bun-
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/react-compiler.test.ts
bun test v1.4.3 (6a92015fc)

test/bundler/transpiler/react-compiler.test.ts:
(pass) bundler > react-compiler/SimpleComponent [765.96ms]
(pass) bundler > react-compiler/ComponentWithHooks [334.12ms]
(pass) bundler > react-compiler/ObjectPatternRestInProps [271.78ms]
(pass) bundler > react-compiler/UnderscoreAndDollarComponentTags [337.65ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Browser [129.46ms]
(pass) bundler > react-compiler/OutputModeDefaultsByTarget-Bun [95.74ms]
(pass) bundler > react-compiler/FullstackHtmlImportCompilesClientGraphInClientMode [345.69ms]
(pass) bundler > react-compiler/OutputModeExplicitSsrOverridesTarget [119.34ms]
(pass) bundler > react-compiler/SsrObjectMethodShorthand [701.20ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client [101.16ms]
(pass) bundler > react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr [102.73ms]
(pass) bundler > react-compiler/BundledReactPreservesImportRefs [279.88ms]
(pass) bundler > react
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 688ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../validation/validate_exhaustive_dependencies.rs | 58 +++++++++++++++++++---
 test/bundler/transpiler/react-compiler.test.ts     | 39 +++++++++++++++
 2 files changed, 90 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…compiler/validation/validate_exhaustive_dependencies.rs      7      2     29
test/bundler/transpiler/react-compiler.test.ts                2      3     26
```

</details>

<!-- robobun:evidence:end -->