### PR TITLE
bun:test: stop rounding in toBePositive and toBeNegative

### DIFF
--- a/src/runtime/test_runner/expect/simple_matchers.rs
+++ b/src/runtime/test_runner/expect/simple_matchers.rs
@@ -35,11 +35,11 @@ crate::unary_predicate_matcher!(to_be_finite, "toBeFinite", |v| v.is_number() &&
 });
 crate::unary_predicate_matcher!(to_be_negative, "toBeNegative", |v| v.is_number() && {
     let n = v.as_number();
-    n.round() < 0.0 && !n.is_infinite() && !n.is_nan()
+    n.is_finite() && n < 0.0
 });
 crate::unary_predicate_matcher!(to_be_positive, "toBePositive", |v| v.is_number() && {
     let n = v.as_number();
-    n.round() > 0.0 && !n.is_infinite() && !n.is_nan()
+    n.is_finite() && n > 0.0
 });
 
 // ── numeric ordering: toBe{Greater,Less}Than[OrEqual] ──────────────────────

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3971,6 +3971,13 @@ describe("expect()", () => {
   test("toBePositive()", () => {
     expect(1).toBePositive();
     expect(1.23).toBePositive();
+    expect(0.5).toBePositive();
+    expect(0.49).toBePositive();
+    expect(0.1).toBePositive();
+    expect(1e-300).toBePositive();
+    expect(Number.MIN_VALUE).toBePositive();
+    expect(-0.1).not.toBePositive();
+    expect(-0).not.toBePositive();
     expect(Infinity).not.toBePositive();
     expect(0).not.toBePositive();
     expect(-Infinity).not.toBePositive();
@@ -3982,6 +3989,13 @@ describe("expect()", () => {
   test("toBeNegative()", () => {
     expect(-1).toBeNegative();
     expect(-1.23).toBeNegative();
+    expect(-0.5).toBeNegative();
+    expect(-0.49).toBeNegative();
+    expect(-0.1).toBeNegative();
+    expect(-1e-300).toBeNegative();
+    expect(-Number.MIN_VALUE).toBeNegative();
+    expect(0.1).not.toBeNegative();
+    expect(-0).not.toBeNegative();
     expect(-Infinity).not.toBeNegative();
     expect(0).not.toBeNegative();
     expect(Infinity).not.toBeNegative();

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -325,6 +325,13 @@ describe("jest-extended", () => {
   test("toBePositive()", () => {
     expect(1).toBePositive();
     expect(1.23).toBePositive();
+    expect(0.5).toBePositive();
+    expect(0.49).toBePositive();
+    expect(0.1).toBePositive();
+    expect(1e-300).toBePositive();
+    expect(Number.MIN_VALUE).toBePositive();
+    expect(-0.1).not.toBePositive();
+    expect(-0).not.toBePositive();
     expect(Infinity).not.toBePositive();
     expect(0).not.toBePositive();
     expect(-Infinity).not.toBePositive();
@@ -336,6 +343,13 @@ describe("jest-extended", () => {
   test("toBeNegative()", () => {
     expect(-1).toBeNegative();
     expect(-1.23).toBeNegative();
+    expect(-0.5).toBeNegative();
+    expect(-0.49).toBeNegative();
+    expect(-0.1).toBeNegative();
+    expect(-1e-300).toBeNegative();
+    expect(-Number.MIN_VALUE).toBeNegative();
+    expect(0.1).not.toBeNegative();
+    expect(-0).not.toBeNegative();
     expect(-Infinity).not.toBeNegative();
     expect(0).not.toBeNegative();
     expect(Infinity).not.toBeNegative();


### PR DESCRIPTION
### Problem
- `expect(0.1).toBePositive()` and `expect(-0.1).toBeNegative()` fail. Every number with 0 < |n| < 0.5 fails both matchers, for example 0.49, 1e-300 and `Number.MIN_VALUE`. `test.d.ts` documents "a positive `number`" and "a negative `number`". jest-extended compares `actual > 0` and `actual < 0`.
- The cause is `src/runtime/test_runner/expect/simple_matchers.rs:36-43`. The predicates were `n.round() > 0.0` and `n.round() < 0.0`. `round()` maps every |n| < 0.5 to zero.

### Fix
- The predicates are now `n.is_finite() && n > 0.0` and `n.is_finite() && n < 0.0`. `is_finite()` is false for NaN and for ±Infinity, so it replaces the two explicit checks.
- The matchers still reject ±Infinity, NaN, ±0 and every value that is not a number. The existing assertions for those cases are unchanged.
- Verified: `test/js/bun/test/expect.test.js` and `test/js/bun/test/jest-extended.test.js`. The `toBePositive()` and `toBeNegative()` blocks gain 0.5, 0.49, 0.1, 1e-300, `Number.MIN_VALUE`, the opposite sign, and -0. Stock bun fails both blocks in both files. Both files pass in full with the debug build.

### Background
- `toBePositive` and `toBeNegative` come from jest-extended. bun:test implements them natively with the `unary_predicate_matcher!` macro: one closure over the received `JSValue` that returns pass or fail.
- `f64::round` rounds half away from zero. 0.5 rounds to 1 and passes. 0.49 rounds to 0 and fails. That is the observed threshold.
- The `@round` is in the first Zig version of these matchers (#3071, May 2023). The behavior was never correct, so the tests go in the existing files and not in `test/regression/`.

<details><summary>Notes</summary>

Repro, bun 1.4.3-canary.1 (`toBePositive(x)` / `toBeNegative(-x)`):

```
0.1     false / false
0.4     false / false
0.49    false / false
0.5     true  / true
1e-300  false / false
5e-324  false / false
1       true  / true
```

- jest-extended 4.0.0 (the version in `test/node_modules`) agrees with every new assertion. I called its `toBePositive` and `toBeNegative` directly on the same values. `jest-extended.test.js` says it must run under Jest too, so the new lines hold there.
- jest-extended 4.0.0 rejects `Infinity` in `toBePositive` and `-Infinity` in `toBeNegative`. jest-extended main now accepts `-Infinity` in `toBeNegative` and accepts BigInt in both. This PR does not change either point. `expect(-Infinity).not.toBeNegative()` stays an existing assertion.
- The other `.round()` calls in `src/runtime/test_runner` (`expect/toHaveLength.rs:40`, `expect.rs:1649`) are `x.round() != x` integer checks. They are correct.
- #41547 (open) changes `toBeInteger` in the same file on a different line.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js test/js/bun/test/jest-extended.test.js
bun test v1.4.3 (6a92015fc)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [12.11ms]
(pass) jest-extended > fail() [10.75ms]
(pass) jest-extended > toBeEmpty() > "" [1.28ms]
(pass) jest-extended > toBeEmpty() > [] [0.39ms]
(pass) jest-extended > toBeEmpty() > {} [0.33ms]
(pass) jest-extended > toBeEmpty() > Set {} [0.25ms]
(pass) jest-extended > toBeEmpty() > Map {} [0.20ms]
(pass) jest-extended > toBeEmpty() > "" [0.23ms]
(pass) jest-extended > toBeEmpty() > [] [0.18ms]
(pass) jest-extended > toBeEmpty() > Uint8Array(0) [] [0.18ms]
(pass) jest-extended > toBeEmpty() > {} [0.25ms]
(pass) jest-extended > toBeEmpty() > <Buffer > [0.16ms]
(pass) jest-extended > toBeEmpty() > Headers {} [0.17ms]
(pass) jest-extended > toBeEmpty() > URLSearchParams {} [0.19ms]
(pass) jest-extended > toBeEmpty() > {} [0.20ms]
(pass) jest-extended > toBeEmpty() > {} [10.62ms]
(pass) jest-extended > toBeEmpty() > FileRef ("/tmp/jest-extended-P59O6l/empty.txt") {  type
... (truncated)

release without fix: 2 skipped
bun test v1.4.3-canary.1 (088877321)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [0.13ms]
(pass) jest-extended > fail() [0.10ms]
(pass) jest-extended > toBeEmpty() > "" [0.02ms]
(pass) jest-extended > toBeEmpty() > []
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extended > toBeEmpty() > Set {}
(pass) jest-extended > toBeEmpty() > Map {}
(pass) jest-extended > toBeEmpty() > ""
(pass) jest-extended > toBeEmpty() > []
(pass) jest-extended > toBeEmpty() > Uint8Array(0) []
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extended > toBeEmpty() > <Buffer >
(pass) jest-extended > toBeEmpty() > Headers {}
(pass) jest-extended > toBeEmpty() > URLSearchParams {}
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extended > toBeEmpty() > {} [0.14ms]
(pass) jest-extended > toBeEmpty() > FileRef ("/tmp/jest-extended-dVANos/empty.txt") {  type: "text/plain;charset=utf-8"} [0.01ms]
(pass) jest-extended > not.toBeEmpty() > " " [0.01ms]
(pass) jest-extended > not.toBeEmpty() > [ "" ]
(pass) jest-extended > not.toBeEmpty() > [ undefined ]
(pass) jest-extended > not.toBeEmpty() > {  "": "",}
(pass) jest-extended > not.toBeEmpty() > Set(1) {  "",}

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js test/js/bun/test/jest-extended.test.js
bun test v1.4.3 (6a92015fc)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [12.58ms]
(pass) jest-extended > fail() [9.06ms]
(pass) jest-extended > toBeEmpty() > "" [1.16ms]
(pass) jest-extended > toBeEmpty() > [] [0.30ms]
(pass) jest-extended > toBeEmpty() > {} [0.23ms]
(pass) jest-extended > toBeEmpty() > Set {} [0.16ms]
(pass) jest-extended > toBeEmpty() > Map {} [0.17ms]
(pass) jest-extended > toBeEmpty() > "" [0.15ms]
(pass) jest-extended > toBeEmpty() > [] [0.16ms]
(pass) jest-extended > toBeEmpty() > Uint8Array(0) [] [0.14ms]
(pass) jest-extended > toBeEmpty() > {} [0.24ms]
(pass) jest-extended > toBeEmpty() > <Buffer > [0.15ms]
(pass) jest-extended > toBeEmpty() > Headers {} [0.16ms]
(pass) jest-extended > toBeEmpty() > URLSearchParams {} [0.16ms]
(pass) jest-extended > toBeEmpty() > {} [0.19ms]
(pass) jest-extended > toBeEmpty() > {} [7.39ms]
(pass) jest-extended > toBeEmpty() > FileRef ("/tmp/jest-extended-mt87Jr/empty.txt") {  type: 
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 830ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/expect/simple_matchers.rs |  4 ++--
 test/js/bun/test/expect.test.js                   | 14 ++++++++++++++
 test/js/bun/test/jest-extended.test.js            | 14 ++++++++++++++
 3 files changed, 30 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/runtime/test_runner/expect/simple_matchers.rs      1      1      9
test/js/bun/test/expect.test.js                        1      1      6
test/js/bun/test/jest-extended.test.js                 1      1      8
```

</details>

**root cause** · written by the author bot

The `toBePositive()` and `toBeNegative()` matchers in `src/runtime/test_runner/expect/simple_matchers.rs` called `n.round()` before comparing against zero, so any value with a magnitude below 0.5 (such as 0.1, 1e-300 or `Number.MIN_VALUE`) rounded to zero and was reported as neither positive nor negative. The fix removes the rounding and compares the value directly against zero, keeping the existing exclusion of NaN and infinite values. New cases in `expect.test.js` and `jest-extended.test.js` cover fractional values, subnormal values, `Number.MIN_VALUE` and signed zero for both matchers.

<!-- robobun:evidence:end -->