### PR TITLE
Accept number keys in expect().toContainAllKeys()

### DIFF
--- a/src/runtime/test_runner/expect/toContainAllKeys.rs
+++ b/src/runtime/test_runner/expect/toContainAllKeys.rs
@@ -16,7 +16,10 @@ impl Expect {
                     'outer: while let Some(item) = itr.next()? {
                         let mut i: u32 = 0;
                         while u64::from(i) < count {
-                            if item.jest_deep_equals(expected.get_index(g, i)?, g)? { continue 'outer; }
+                            let mut key = expected.get_index(g, i)?;
+                            // Object.keys() gives strings. hasOwnProperty() converts a number key for the sibling matchers.
+                            if key.is_number() { key = JSValue::from_cell(key.to_js_string(g)?); }
+                            if item.jest_deep_equals(key, g)? { continue 'outer; }
                             i += 1;
                         }
                         pass = false; break;

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -2644,6 +2644,19 @@ describe("expect()", () => {
 
     expect([1, 2, 3]).toContainAllKeys(["0", "1", "2"]);
     expect([1, 2, 3]).not.toContainAllKeys(["0", "1", "2", "3"]);
+
+    if (isBun) {
+      // jest-extended compares with equals(), so the number 1 does not match the key "1" there.
+      expect({ 1: "hello", b: "world" }).toContainAllKeys([1, "b"]);
+      expect({ 1: "hello", 2.5: "world" }).toContainAllKeys([2.5, 1]);
+      expect([1, 2, 3]).toContainAllKeys([0, 1, 2]);
+      expect({ 1: "hello", b: "world" }).not.toContainAllKeys([2, "b"]);
+      expect({ 1: "hello", 2: "world" }).not.toContainAllKeys([1, 1]);
+      expect(() => expect({ 1: "hello", b: "world" }).not.toContainAllKeys([1, "b"])).toThrow(
+        "Expected to not contain all keys",
+      );
+    }
+    expect({ a: "hello", b: "world" }).toContainAllKeys([expect.any(String), "a"]);
   });
 
   test("toContainAnyKeys", () => {


### PR DESCRIPTION
### Problem
- `expect({ 1: "hello", b: "world" }).toContainAllKeys([1, "b"])` fails with `Expected to contain all keys: [ 1, "b" ] Received: [ "1", "b" ]`. The JSDoc of `toContainAllKeys` in `packages/bun-types/test.d.ts` lists this call as a passing example.
- The cause is `src/runtime/test_runner/expect/toContainAllKeys.rs:19`. It compares each entry of `expected` with the strings from `Object.keys()`, so the number `1` never equals the key `"1"`.
- The string form does not type-check. The signature uses `keyof T`, which is the number literal `1` for a numeric key. `toContainAllKeys(["1", "b"])` is error TS2769, so a TypeScript user with numeric or enum keys has no call that type-checks and passes.

### Fix
- The matcher converts an entry of `expected` that is a number to a string (JS `ToString`) before the comparison.
- The comparison stays `jest_deep_equals`. An asymmetric matcher in `expected`, such as `expect.any(String)`, still works.
- `toContainKey`, `toContainKeys` and `toContainAnyKeys` already accept a number, because `hasOwnProperty()` converts its argument to a property key.
- Verified: `test/js/bun/test/expect.test.js`. The `toContainAllKeys` test fails on bun 1.4.3 and passes with this change. Also ran `jest-extended.test.js`.

### Background
- `toContainAllKeys` comes from jest-extended. It passes when `Object.keys(value)` and `expected` have the same length and each key matches an entry of `expected`.
- `Object.keys()` returns strings only. The numeric key `1` becomes `"1"`.
- This change differs from jest-extended 7.0.0. That version also fails the call above, because it compares with `equals("1", 1)`. The JSDoc example came from the jest-extended docs and does not pass there.

<details><summary>Notes</summary>

- One kind of assertion changes from pass to fail: `.not.toContainAllKeys([...])` where a number in `expected` names a real key and all the other keys match. For example `expect({ 1: "a" }).not.toContainAllKeys([1])`.
- The conversion applies to numbers only. `PropertyKey` is `string | number | symbol`, and `Object.keys()` never returns a symbol. A bigint, boolean or `null` entry stays as it is and does not match, the same as before.
- `expect.test.js` also runs under Jest and Vitest with jest-extended. The new assertions that jest-extended fails are inside `if (isBun)`.
- Repro that prints one line per matcher (line 1 fails before this change, lines 2 to 5 pass before and after):

```js
import { expect } from "bun:test";
const pass = f => { try { f(); return "pass"; } catch (e) { return "FAIL"; } };
console.log(pass(() => expect({ 1: "hello", b: "world" }).toContainAllKeys([1, "b"])));
console.log(pass(() => expect({ 1: "hello", b: "world" }).toContainAllKeys(["1", "b"])));
console.log(pass(() => expect({ 1: "hello", b: "world" }).toContainKeys([1, "b"])));
console.log(pass(() => expect({ 1: "hello" }).toContainAnyKeys([1])));
console.log(pass(() => expect({ 1: "hello" }).toContainKey(1)));
```

- TypeScript check against `packages/bun-types`: `expect({ 1: "hello", b: "world" }).toContainAllKeys(["1", "b"])` gives `Type '"1"' is not assignable to type '1 | "b"'`. With `enum Status { Active, Inactive }` and `{ [Status.Active]: 1, [Status.Inactive]: 2 }`, `toContainAllKeys(["0", "1"])` gives `Type 'string' is not assignable to type 'Status'`.
- Ran the whole of `test/js/bun/test/expect.test.js` with the debug build: 416 pass, 2 todo, 0 fail.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
bun test v1.4.3 (6a92015fc)

test/js/bun/test/expect.test.js:
(pass) expect() > () [466.04ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [4.80ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.53ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.64ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.25ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.24ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.28ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.24ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.24ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.34ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.29ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [2.59ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.83ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.52ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.52ms]
(pass) ex
... (truncated)

release without fix: 1 failed, 2 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.95ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.03ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.01ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
bun test v1.4.3 (6a92015fc)

test/js/bun/test/expect.test.js:
(pass) expect() > () [533.35ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [5.34ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.78ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.43ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.46ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.43ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.44ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.41ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.44ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.42ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.44ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [2.40ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.66ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.47ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.50ms]
(pass) ex
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     7df06d4f04
  features     baseline

23 deps, 131 codegen, 1172 objects in 873ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (6a92015fc)

Checked 22 installs across 61 packages (no changes) [8.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (6a92015fc)

Checked 1 install across 2 packages (no changes) [6.00ms]
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (6a92015fc)

Checked 111 installs across 104 packages (no changes) [7.00ms]
[5/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 4ms

  react-refresh.js  4.81 KB  (entry point)

[7/1217] gen .bind.ts → GeneratedBindings.cpp
[8/1217] fetch zlib
[zlib] up to date
[9/1217] gen bindgenv2
[10/1217] fetch tinycc
[tinycc] up to date
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/expect/toContainAllKeys.rs |  5 ++++-
 test/js/bun/test/expect.test.js                    | 13 +++++++++++++
 2 files changed, 17 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/runtime/test_runner/expect/toContainAllKeys.rs      1      2     13
test/js/bun/test/expect.test.js                         1      2     13
```

</details>

**root cause** · written by the author bot

`toContainAllKeys` compared each entry of the expected array against the strings returned by `Object.keys()` using `jest_deep_equals`, so a numeric key such as `1` never equalled the property name `"1"`. The sibling matchers `toContainKey`, `toContainKeys` and `toContainAnyKeys` do not have this problem because they go through `has_own_property_value`, which converts values to property keys. The fix converts a number entry to its string form before the comparison and keeps the deep-equals check, so numeric keys now match and asymmetric matchers such as `expect.any(String)` in the expected a…

<!-- robobun:evidence:end -->