### PR TITLE
node:vm: stop a SourceTextModule from running another module's importModuleDynamically hook

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "cf1b36ec8703d8e87436094d21d478d358c7d886";
+export const WEBKIT_VERSION = "autobuild-preview-pr-639-02d80c9d";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -9,6 +9,7 @@ import {
   runInThisContext,
   Script,
   SourceTextModule,
+  SyntheticModule,
 } from "node:vm";
 
 function capture(_: any, _1?: any) {}
@@ -1704,6 +1705,71 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe("ab=B ba=A");
     expect(exitCode).toBe(0);
+  });
+});
+
+describe("node:vm SourceTextModule instances with the same identifier and source text", () => {
+  // JSC lets module records with the same key and source text in one global object run the same
+  // ModuleProgramExecutable. What import() and stack traces report comes from that executable's source,
+  // which is also where node:vm keeps a module's importModuleDynamically hook and its line/column offsets.
+  // JSC finds the executable through a weak map, and a module's functions keep it alive. So every source here
+  // exports a function and every module stays reachable.
+  const modules: SourceTextModule[] = [];
+
+  async function load(tag: string) {
+    const dependency = new SyntheticModule(["tag"], function () {
+      this.setExport("tag", tag);
+    });
+    await dependency.link(() => {});
+    await dependency.evaluate();
+
+    const calls: { specifier: string; referrerIsThisModule: boolean }[] = [];
+    const module = new SourceTextModule(
+      `export const fromTopLevel = import("dep");
+       export function fromFunction() { return import("dep"); }`,
+      {
+        identifier: "same-identifier-and-source.mjs",
+        importModuleDynamically(specifier, referrer) {
+          calls.push({ specifier, referrerIsThisModule: referrer === module });
+          return dependency;
+        },
+      },
+    );
+    modules.push(module);
+    await module.link(() => {});
+    await module.evaluate();
+    const namespace = module.namespace as any;
+    return { calls, imported: [(await namespace.fromTopLevel).tag, (await namespace.fromFunction()).tag] };
+  }
+
+  test("each module calls its own importModuleDynamically", async () => {
+    const first = await load("first");
+    const second = await load("second");
+    const calls = [
+      { specifier: "dep", referrerIsThisModule: true },
+      { specifier: "dep", referrerIsThisModule: true },
+    ];
+    expect({ first, second }).toEqual({
+      first: { calls, imported: ["first", "first"] },
+      second: { calls, imported: ["second", "second"] },
+    });
+  });
+
+  test("each module reports positions with its own lineOffset", async () => {
+    async function lineOfThrow(identifier: string, lineOffset: number) {
+      const module = new SourceTextModule(`export function where() { return new Error("here").stack; }`, {
+        identifier,
+        lineOffset,
+      });
+      modules.push(module);
+      await module.link(() => {});
+      await module.evaluate();
+      return Number(/:(\d+):\d+\)?$/m.exec((module.namespace as any).where())![1]);
+    }
+    const shifted = await lineOfThrow("same-identifier-other-offset.mjs", 100);
+    const unshifted = await lineOfThrow("same-identifier-other-offset.mjs", 0);
+    expect(unshifted).toBe(await lineOfThrow("never-seen-identifier.mjs", 0));
+    expect(shifted).toBeGreaterThan(unshifted);
   });
 });
 


### PR DESCRIPTION
Draft until oven-sh/WebKit#639 lands on `main`. Then `WEBKIT_VERSION` moves to that sha.

### Problem
- A second `vm.SourceTextModule` with the same identifier and source text as an earlier one never calls its own `importModuleDynamically` hook. Its `import()` calls the first module's hook and gets the wrong module: `hook-calls=0 got=first want=second`. Its stack traces report the first module's `lineOffset`. Regression from #42319. Bun 1.4.2 and Node are correct.
- The cause is in JSC (oven-sh/WebKit#522). `JSModuleRecord::getOrMakeExecutable` lets records with the same key and source text run one `ModuleProgramExecutable`, which keeps the first module's source. `node:vm` finds the hook through that source (`NodeVM.cpp:297`, `sourceOrigin.fetcher()`).

### Fix
- Bump `WEBKIT_VERSION` to the preview build of oven-sh/WebKit#639. Records share an executable only when their sources also have the same `SourceOrigin` (URL and fetcher) and start position.
- Each `vm.SourceTextModule` has its own fetcher, so each links its own executable again, as in 1.4.2. Modules from Bun's own loader still share.
- Verified: two new tests in `test/js/node/vm/vm.test.ts`. The current build fails both. A debug build with the patched WebKit passes them, the rest of `vm.test.ts`, and Node's `test-vm-module-*`.

### Background
- `importModuleDynamically` is the hook that `node:vm` calls for an `import()` inside a `vm.SourceTextModule`. It receives the specifier and the referrer module, and returns the module to use.
- JSC hands an `import()` to the embedder with the `SourceOrigin` of the running code: a URL plus an optional `ScriptFetcher`, an object the embedder attached to the source.
- `node:vm` creates one `NodeVMScriptFetcher` per module. It holds the hook and the module object.

<details><summary>Notes</summary>

Repro (`bun repro.mjs`, or `node --experimental-vm-modules repro.mjs`):

```js
import vm from "node:vm";
const mk = async tag => {
  const m = new vm.SourceTextModule(`export const who = ${JSON.stringify(tag)};`, { identifier: "dep-" + tag });
  await m.link(() => {});
  await m.evaluate();
  return m;
};
async function once(identifier, tag) {
  const d = await mk(tag);
  let calls = 0;
  const m = new vm.SourceTextModule("export const p = import('z');", {
    identifier,
    importModuleDynamically() {
      calls++;
      return d;
    },
  });
  await m.link(() => {});
  await m.evaluate();
  const ns = await m.namespace.p;
  return `hook-calls=${calls} got=${ns.who} want=${tag}`;
}
console.log(await once("same", "first"));
console.log(await once("same", "second"));
```

- Fail-before: the release canary `1.4.3-canary.1+6a92015fc` (the #42319 commit) fails both new tests, and an ASAN debug build of `main` fails both in 3 of 3 runs. Both builds print `hook-calls=0 got=first want=second` for the second line. Node 26.3.0 and a build with the patched WebKit print `hook-calls=1 got=second want=second`.
- Extent: only the same identifier with the same source text in one context. A different identifier, a different text, no identifier, one context per module, `vm.Script` and `vm.compileFunction` are correct, because the map of executables is per global object and compares the key and the text.
- The map (`JSGlobalObject::m_moduleProgramExecutables`) is a `WeakGCMap`. After a full collection the first executable can be dead, and then the second module links its own. That is why the wrong hook shows in most iterations of a loop and not in all of them. The tests keep every module reachable and export a function from every source, because a module's functions are what keeps its executable alive after evaluation.
- `import()` inside an exported function of the second module also reached the first module's hook. The first test covers a top-level `import()` and one inside a function.
- Position leak: with `lineOffset: 100` on the first module and `lineOffset: 0` on the second, a stack trace in the second module reported line 100. The second test compares against a module with an identifier that was never seen, so it does not depend on the absolute line numbers (#38235 changes those).
- Also correct again, not tested here: a tagged template in the two modules yields two template objects, as in Node. With the shared executable it was one object.
- Sharing in Bun's own loader is unchanged. Probe: import a module, `delete require.cache[path]`, import it again. The namespaces are distinct and a tagged template yields the same template object for both, before and after the bump.
- Local verification used WebKit built from the oven-sh/WebKit#639 branch (debug + ASAN, Linux x64) through the `debug-local` profile.
- Suites on that build: `test/js/node/vm/vm.test.ts` (283 pass, 0 fail), `sourcetextmodule-leak`, `sourcetextmodule-link-gc`, `vm-script-fetcher-leak`, `vm-sourceUrl`, `happy-dom-vm-16277`, and the 23 `test-vm-module-*` / `test-vm-source-map-url` files in `test/js/node/test/parallel`. `script-leak.test.ts` (a `vm.Script` test) exceeds its 5 s timeout on debug builds with and without the bump.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts

<!-- robobun:evidence:end -->