### PR TITLE
node:https: key the Agent pool name by what object-valued and file TLS options hold

### DIFF
--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -8,7 +8,7 @@ const { kEmptyObject, once } = require("internal/shared");
 const { validateObject } = require("internal/validators");
 const { kProxyConfig, checkShouldUseProxy, kWaitForProxyTunnel } = require("internal/http");
 const { validateHeaderValue } = require("node:_http_common");
-const { isAnyArrayBuffer } = require("node:util/types");
+const { isAnyArrayBuffer, isDataView } = require("node:util/types");
 
 const ArrayPrototypeShift = Array.prototype.shift;
 const ArrayPrototypeJoin = Array.prototype.join;
@@ -374,24 +374,42 @@ Agent.prototype.createConnection = createConnection;
 // A { buf | pem, passphrase } entry, an ArrayBuffer and a Blob all stringify to "[object ...]".
 const poolKeyObjectIds = new WeakMap<object, number>();
 let poolKeyObjectCount = 0;
-function poolKeyPart(value: unknown, passphrase?: unknown): unknown {
+function poolKeyPart(value: unknown): unknown {
   if (typeof value !== "object" || value === null || $isTypedArrayView(value)) return value;
-  if ($isArray(value)) {
-    return ArrayPrototypeJoin.$call(
-      ArrayPrototypeMap.$call(value, element => poolKeyPart(element, passphrase)),
-      ",",
-    );
-  }
+  // Array.prototype.toString() of the keyed elements: Node's name for an array of strings or Buffers.
+  if ($isArray(value)) return ArrayPrototypeJoin.$call(ArrayPrototypeMap.$call(value, poolKeyPart), ",");
   if (isAnyArrayBuffer(value)) return Buffer.from(value as ArrayBufferLike);
-  const { buf, pem, passphrase: ownPassphrase } = value as { buf?: unknown; pem?: unknown; passphrase?: unknown };
-  // A pfx entry, in the format of Node's getPfxAgentKey() (CVE-2026-56850).
-  if (buf != null) return `:${poolKeyPart(buf)}:${ownPassphrase || passphrase}`;
+  // $isTypedArrayView() is false for a DataView.
+  if (isDataView(value)) {
+    const { buffer, byteOffset, byteLength } = value as DataView;
+    return Buffer.from(buffer, byteOffset, byteLength);
+  }
   // A key entry. Its passphrase only decrypts the pem, so it stays out of the name.
+  const { pem } = value as { pem?: unknown };
   if (pem != null) return poolKeyPart(pem);
   // Any other object (a Blob, a BunFile) has no contents to read here: key it by identity.
   let id = poolKeyObjectIds.get(value);
   if (id === undefined) poolKeyObjectIds.set(value, (id = ++poolKeyObjectCount));
   return `[object #${id}]`;
+}
+
+// Node's getPfxAgentKey() (CVE-2026-56850), with each buf keyed by poolKeyPart().
+type PfxEntry = { buf?: unknown; passphrase?: unknown } | null | undefined;
+function pfxPoolKey(pfx: unknown, passphrase: unknown) {
+  let entries: unknown[];
+  if ($isArray(pfx)) entries = pfx;
+  // Bun also takes one { buf, passphrase } entry outside an array.
+  else if ($isObject(pfx) && !$isTypedArrayView(pfx) && (pfx as PfxEntry)!.buf !== undefined) entries = [pfx];
+  else return poolKeyPart(pfx);
+
+  let key = "";
+  for (let i = 0; i < entries.length; i++) {
+    const value = entries[i] as PfxEntry;
+    const raw = value?.buf || value;
+    const pass = value?.passphrase || passphrase;
+    key += `:${poolKeyPart(raw)}:${pass}`;
+  }
+  return key;
 }
 
 /**
@@ -444,7 +462,7 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
   if (key) name += poolKeyPart(key);
 
   name += ":";
-  if (pfx) name += poolKeyPart(pfx, passphrase);
+  if (pfx) name += pfxPoolKey(pfx, passphrase);
 
   name += ":";
   if (rejectUnauthorized !== undefined) name += rejectUnauthorized;
@@ -490,9 +508,9 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
 
   // Bun-only options: paths that the TLS layer reads the client certificate, its key and the
   // CA from. Node has no such options, so a name without them stays Node's name.
-  if (certFile) name += `:certFile=${certFile}`;
-  if (keyFile) name += `:keyFile=${keyFile}`;
-  if (caFile) name += `:caFile=${caFile}`;
+  if (certFile) name += `:certFile=${JSONStringify(certFile)}`;
+  if (keyFile) name += `:keyFile=${JSONStringify(keyFile)}`;
+  if (caFile) name += `:caFile=${JSONStringify(caFile)}`;
 
   return name;
 };

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -8,8 +8,11 @@ const { kEmptyObject, once } = require("internal/shared");
 const { validateObject } = require("internal/validators");
 const { kProxyConfig, checkShouldUseProxy, kWaitForProxyTunnel } = require("internal/http");
 const { validateHeaderValue } = require("node:_http_common");
+const { isAnyArrayBuffer } = require("node:util/types");
 
 const ArrayPrototypeShift = Array.prototype.shift;
+const ArrayPrototypeJoin = Array.prototype.join;
+const ArrayPrototypeMap = Array.prototype.map;
 const ObjectAssign = Object.assign;
 const ArrayPrototypeUnshift = Array.prototype.unshift;
 const JSONStringify = JSON.stringify;
@@ -365,6 +368,32 @@ function Agent(options) {
 $toClass(Agent, "Agent", http.Agent);
 Agent.prototype.createConnection = createConnection;
 
+// The pool name also keys the TLS session cache, so it has to differ whenever the client
+// certificate or the trusted CA does. `name += value` only manages that when the value's
+// string form is its contents: a string, a Buffer, a TypedArray, or an array of those.
+// A { buf | pem, passphrase } entry, an ArrayBuffer and a Blob all stringify to "[object ...]".
+const poolKeyObjectIds = new WeakMap<object, number>();
+let poolKeyObjectCount = 0;
+function poolKeyPart(value: unknown, passphrase?: unknown): unknown {
+  if (typeof value !== "object" || value === null || $isTypedArrayView(value)) return value;
+  if ($isArray(value)) {
+    return ArrayPrototypeJoin.$call(
+      ArrayPrototypeMap.$call(value, element => poolKeyPart(element, passphrase)),
+      ",",
+    );
+  }
+  if (isAnyArrayBuffer(value)) return Buffer.from(value as ArrayBufferLike);
+  const { buf, pem, passphrase: ownPassphrase } = value as { buf?: unknown; pem?: unknown; passphrase?: unknown };
+  // A pfx entry, in the format of Node's getPfxAgentKey() (CVE-2026-56850).
+  if (buf != null) return `:${poolKeyPart(buf)}:${ownPassphrase || passphrase}`;
+  // A key entry. Its passphrase only decrypts the pem, so it stays out of the name.
+  if (pem != null) return poolKeyPart(pem);
+  // Any other object (a Blob, a BunFile) has no contents to read here: key it by identity.
+  let id = poolKeyObjectIds.get(value);
+  if (id === undefined) poolKeyObjectIds.set(value, (id = ++poolKeyObjectCount));
+  return `[object #${id}]`;
+}
+
 /**
  * Gets a unique name for a set of options.
  */
@@ -378,6 +407,7 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
     ciphers,
     key,
     pfx,
+    passphrase,
     rejectUnauthorized,
     servername,
     host,
@@ -393,13 +423,16 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
     sigalgs,
     privateKeyIdentifier,
     privateKeyEngine,
+    certFile,
+    keyFile,
+    caFile,
   } = options;
 
   name += ":";
-  if (ca) name += ca;
+  if (ca) name += poolKeyPart(ca);
 
   name += ":";
-  if (cert) name += cert;
+  if (cert) name += poolKeyPart(cert);
 
   name += ":";
   if (clientCertEngine) name += clientCertEngine;
@@ -408,10 +441,10 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
   if (ciphers) name += ciphers;
 
   name += ":";
-  if (key) name += key;
+  if (key) name += poolKeyPart(key);
 
   name += ":";
-  if (pfx) name += pfx;
+  if (pfx) name += poolKeyPart(pfx, passphrase);
 
   name += ":";
   if (rejectUnauthorized !== undefined) name += rejectUnauthorized;
@@ -429,7 +462,7 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
   if (secureProtocol) name += secureProtocol;
 
   name += ":";
-  if (crl) name += crl;
+  if (crl) name += poolKeyPart(crl);
 
   name += ":";
   if (honorCipherOrder !== undefined) name += honorCipherOrder;
@@ -438,7 +471,7 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
   if (ecdhCurve) name += ecdhCurve;
 
   name += ":";
-  if (dhparam) name += dhparam;
+  if (dhparam) name += poolKeyPart(dhparam);
 
   name += ":";
   if (secureOptions !== undefined) name += secureOptions;
@@ -454,6 +487,12 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
 
   name += ":";
   if (privateKeyEngine) name += privateKeyEngine;
+
+  // Bun-only options: paths that the TLS layer reads the client certificate, its key and the
+  // CA from. Node has no such options, so a name without them stays Node's name.
+  if (certFile) name += `:certFile=${certFile}`;
+  if (keyFile) name += `:keyFile=${keyFile}`;
+  if (caFile) name += `:caFile=${caFile}`;
 
   return name;
 };

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -368,10 +368,7 @@ function Agent(options) {
 $toClass(Agent, "Agent", http.Agent);
 Agent.prototype.createConnection = createConnection;
 
-// The pool name also keys the TLS session cache, so it has to differ whenever the client
-// certificate or the trusted CA does. `name += value` only manages that when the value's
-// string form is its contents: a string, a Buffer, a TypedArray, or an array of those.
-// A { buf | pem, passphrase } entry, an ArrayBuffer and a Blob all stringify to "[object ...]".
+// `"" + value` is "[object ...]" for every value but a string, a Buffer, a TypedArray or an array of those.
 const poolKeyObjectIds = new WeakMap<object, number>();
 let poolKeyObjectCount = 0;
 function poolKeyPart(value: unknown): unknown {
@@ -506,8 +503,7 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
   name += ":";
   if (privateKeyEngine) name += privateKeyEngine;
 
-  // Bun-only options: paths that the TLS layer reads the client certificate, its key and the
-  // CA from. Node has no such options, so a name without them stays Node's name.
+  // Bun-only options. Node has none of them, so a name without them stays Node's name.
   if (certFile) name += `:certFile=${JSONStringify(certFile)}`;
   if (keyFile) name += `:keyFile=${JSONStringify(keyFile)}`;
   if (caFile) name += `:caFile=${JSONStringify(caFile)}`;

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -16,6 +16,8 @@ const ArrayPrototypeMap = Array.prototype.map;
 const ObjectAssign = Object.assign;
 const ArrayPrototypeUnshift = Array.prototype.unshift;
 const JSONStringify = JSON.stringify;
+const WeakMapPrototypeGet = WeakMap.prototype.get;
+const WeakMapPrototypeSet = WeakMap.prototype.set;
 
 function request(...args) {
   let options = {};
@@ -385,8 +387,8 @@ function poolKeyPart(value: unknown): unknown {
   const { pem } = value as { pem?: unknown };
   if (pem != null) return poolKeyPart(pem);
   // Any other object (a Blob, a BunFile) has no contents to read here: key it by identity.
-  let id = poolKeyObjectIds.get(value);
-  if (id === undefined) poolKeyObjectIds.set(value, (id = ++poolKeyObjectCount));
+  let id = WeakMapPrototypeGet.$call(poolKeyObjectIds, value);
+  if (id === undefined) WeakMapPrototypeSet.$call(poolKeyObjectIds, value, (id = ++poolKeyObjectCount));
   return `[object #${id}]`;
 }
 
@@ -441,6 +443,7 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
     certFile,
     keyFile,
     caFile,
+    allowPartialTrustChain,
   } = options;
 
   name += ":";
@@ -507,6 +510,8 @@ Agent.prototype.getName = function getName(options = kEmptyObject) {
   if (certFile) name += `:certFile=${JSONStringify(certFile)}`;
   if (keyFile) name += `:keyFile=${JSONStringify(keyFile)}`;
   if (caFile) name += `:caFile=${JSONStringify(caFile)}`;
+  // The TLS layer takes any truthy value as true. A strict request keeps Node's name.
+  if (allowPartialTrustChain) name += ":allowPartialTrustChain";
 
   return name;
 };

--- a/test/js/node/http/node-https-agent-getname.test.ts
+++ b/test/js/node/http/node-https-agent-getname.test.ts
@@ -161,6 +161,19 @@ describe("https.Agent#getName", () => {
     );
   });
 
+  // The names Node v26.5.1 gives, from getPfxAgentKey().
+  fixedTest("a pfx array has Node's name", () => {
+    assert.strictEqual(
+      name({ pfx: [Buffer.from("a"), { buf: "b", passphrase: "p" }], passphrase: "q" }),
+      "localhost:443::::::::a:q:b:p::::::::::::::",
+    );
+    assert.strictEqual(
+      name({ pfx: [Buffer.from("a"), Buffer.from("b")] }),
+      "localhost:443::::::::a:undefined:b:undefined::::::::::::::",
+    );
+    assert.strictEqual(name({ pfx: Buffer.from("a"), passphrase: "q" }), "localhost:443:::::::a::::::::::::::");
+  });
+
   fixedTest("`pfx: [{ buf, passphrase }]` is keyed by buf and passphrase", () => {
     const buf = read("agent1.pfx");
     const base = name({ pfx: [{ buf, passphrase: "sample" }] });
@@ -191,7 +204,7 @@ describe("https.Agent#getName", () => {
     assert.notStrictEqual(name({ key: [{ pem: read("agent10-key.pem"), passphrase: "a" }] }), base);
   });
 
-  bunTest("equal bytes share a name across string, Buffer, ArrayBuffer and array forms", () => {
+  bunTest("equal bytes share a name across string, Buffer, ArrayBuffer, DataView and array forms", () => {
     const cert = read("agent1-cert.pem");
     const base = name({ cert: cert.toString() });
     assert.strictEqual(name({ cert }), base);
@@ -201,13 +214,20 @@ describe("https.Agent#getName", () => {
       name({ pfx: [{ buf: readArrayBuffer("agent1.pfx"), passphrase: "sample" }] }),
       name({ pfx: [{ buf: read("agent1.pfx"), passphrase: "sample" }] }),
     );
+    const pfx = read("agent1.pfx");
+    assert.strictEqual(name({ pfx: new DataView(pfx.buffer, pfx.byteOffset, pfx.byteLength) }), name({ pfx }));
   });
 
   bunTest("certFile, keyFile and caFile are labelled parts of the name", () => {
     const base = name({});
-    assert.strictEqual(name({ certFile: "a", keyFile: "b", caFile: "c" }), `${base}:certFile=a:keyFile=b:caFile=c`);
+    assert.strictEqual(
+      name({ certFile: "a", keyFile: "b", caFile: "c" }),
+      `${base}:certFile="a":keyFile="b":caFile="c"`,
+    );
     assert.notStrictEqual(name({ certFile: "a" }), name({ keyFile: "a" }));
     assert.notStrictEqual(name({ caFile: "a" }), name({ caFile: "b" }));
+    // A path cannot spell the next part.
+    assert.notStrictEqual(name({ certFile: 'a":keyFile="b' }), name({ certFile: "a", keyFile: "b" }));
   });
 });
 

--- a/test/js/node/http/node-https-agent-getname.test.ts
+++ b/test/js/node/http/node-https-agent-getname.test.ts
@@ -143,6 +143,48 @@ describe("https.Agent keeps client certificates apart", () => {
   });
 });
 
+// agent6-cert.pem is signed by ca3, an intermediate that ca1 signed. The client trusts ca3 only, so
+// the chain verifies with allowPartialTrustChain and fails with UNABLE_TO_GET_ISSUER_CERT without.
+describe("https.Agent keeps allowPartialTrustChain apart", () => {
+  for (const keepAlive of [true, false]) {
+    bunTest(`a strict request is verified again, keepAlive: ${keepAlive}`, async () => {
+      const server = tls.createServer(
+        { ca: read("ca3-cert.pem"), key: read("agent6-key.pem"), cert: read("agent6-cert.pem") },
+        socket => {
+          socket.on("error", () => {});
+          socket.on("data", () => socket.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"));
+        },
+      );
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      const agent = new https.Agent({ keepAlive });
+      const outcome = async (allowPartialTrustChain: boolean) => {
+        const req = https.get({
+          host: "127.0.0.1",
+          port: (server.address() as AddressInfo).port,
+          agent,
+          ca: read("ca3-cert.pem"),
+          checkServerIdentity: () => undefined,
+          allowPartialTrustChain,
+        });
+        try {
+          const [res] = await once(req, "response");
+          res.resume();
+          await once(res, "end");
+          return res.statusCode;
+        } catch (error) {
+          return (error as NodeJS.ErrnoException).code;
+        }
+      };
+      try {
+        assert.deepStrictEqual([await outcome(true), await outcome(false)], [200, "UNABLE_TO_GET_ISSUER_CERT"]);
+      } finally {
+        agent.destroy();
+        server.close();
+      }
+    });
+  }
+});
+
 describe("https.Agent#getName", () => {
   const agent = new https.Agent();
   const name = (options: object) => agent.getName({ host: "localhost", port: 443, ...options });
@@ -228,6 +270,12 @@ describe("https.Agent#getName", () => {
     assert.notStrictEqual(name({ caFile: "a" }), name({ caFile: "b" }));
     // A path cannot spell the next part.
     assert.notStrictEqual(name({ certFile: 'a":keyFile="b' }), name({ certFile: "a", keyFile: "b" }));
+  });
+
+  bunTest("allowPartialTrustChain is a part of the name when it is set", () => {
+    const base = name({});
+    assert.strictEqual(name({ allowPartialTrustChain: true }), `${base}:allowPartialTrustChain`);
+    assert.strictEqual(name({ allowPartialTrustChain: false }), base);
   });
 });
 

--- a/test/js/node/http/node-https-agent-getname.test.ts
+++ b/test/js/node/http/node-https-agent-getname.test.ts
@@ -1,0 +1,233 @@
+/**
+ * `bun test` runs every test in this file. The last test runs this same file under Node.js,
+ * where the cases that need Bun-only values or a Node.js release with the fix are skipped.
+ *
+ * https.Agent#getName() names the socket pool and the TLS session cache. Two requests that
+ * present different client certificates must get different names, whatever form the
+ * certificate option takes. Node fixed the `pfx: [{ buf, passphrase }]` form in
+ * nodejs/node 9f03017f38 (CVE-2026-56850). ArrayBuffer and BunFile values, a bare
+ * `pfx: { buf }` entry and the certFile / keyFile / caFile options only exist in Bun.
+ */
+import assert from "node:assert";
+import { once } from "node:events";
+import { readFileSync } from "node:fs";
+import https from "node:https";
+import type { AddressInfo } from "node:net";
+import { dirname, join } from "node:path";
+import { describe, test } from "node:test";
+import tls from "node:tls";
+import { fileURLToPath } from "node:url";
+
+const isBun = !!process.versions.bun;
+// Node ships the fix from v22.23.2, v24.18.1 and v26.5.1. An older Node shares the pool, so
+// the pfx cases only describe it from those versions on. Bun always runs them.
+const runtimeHasFix = (() => {
+  if (isBun) return true;
+  const [major, minor, patch] = process.versions.node.split(".").map(Number);
+  const atLeast = (fixedMinor: number, fixedPatch: number) =>
+    minor > fixedMinor || (minor === fixedMinor && patch >= fixedPatch);
+  if (major === 22) return atLeast(23, 2);
+  if (major === 24) return atLeast(18, 1);
+  if (major === 26) return atLeast(5, 1);
+  return major > 26;
+})();
+const fixedTest = runtimeHasFix ? test : test.skip;
+const bunTest = isBun ? test : test.skip;
+
+const keys = join(dirname(fileURLToPath(import.meta.url)), "..", "test", "fixtures", "keys");
+const read = (name: string) => readFileSync(join(keys, name));
+const readArrayBuffer = (name: string) => {
+  const buffer = read(name);
+  return buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+};
+
+// agent1 is CN=agent1, agent10 is CN=agent10.example.com. Both .pfx files use "sample".
+type Identity = "agent1" | "agent10";
+type Forms = Record<string, (id: Identity) => object>;
+const commonName = { agent1: "agent1", agent10: "agent10.example.com" };
+
+const nodeForms: Forms = {
+  "pfx: [{ buf, passphrase }]": id => ({ pfx: [{ buf: read(`${id}.pfx`), passphrase: "sample" }] }),
+};
+const bunForms: Forms = {
+  "pfx: { buf, passphrase }": id => ({ pfx: { buf: read(`${id}.pfx`), passphrase: "sample" } }),
+  "pfx: [ArrayBuffer]": id => ({ pfx: [readArrayBuffer(`${id}.pfx`)], passphrase: "sample" }),
+  "cert, key: ArrayBuffer": id => ({
+    cert: readArrayBuffer(`${id}-cert.pem`),
+    key: readArrayBuffer(`${id}-key.pem`),
+  }),
+  "cert, key: BunFile": id => ({
+    cert: Bun.file(join(keys, `${id}-cert.pem`)),
+    key: Bun.file(join(keys, `${id}-key.pem`)),
+  }),
+  "certFile, keyFile": id => ({ certFile: join(keys, `${id}-cert.pem`), keyFile: join(keys, `${id}-key.pem`) }),
+};
+const forms: Forms = isBun ? { ...nodeForms, ...bunForms } : nodeForms;
+
+// Answers every request with the CN of the client certificate the connection authenticated with.
+async function listen() {
+  const server = tls.createServer(
+    { key: read("agent2-key.pem"), cert: read("agent2-cert.pem"), requestCert: true, rejectUnauthorized: false },
+    socket => {
+      socket.on("error", () => {});
+      socket.on("data", () => {
+        const body = String(socket.getPeerCertificate().subject?.CN);
+        socket.write(`HTTP/1.1 200 OK\r\nContent-Length: ${body.length}\r\n\r\n${body}`);
+      });
+    },
+  );
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  return { server, port: (server.address() as AddressInfo).port };
+}
+
+async function get(agent: https.Agent, port: number, options: object) {
+  const req = https.get({ host: "127.0.0.1", port, agent, rejectUnauthorized: false, ...options });
+  const [res] = await once(req, "response");
+  res.setEncoding("utf8");
+  let peer = "";
+  res.on("data", (chunk: string) => (peer += chunk));
+  await once(res, "end");
+  return { peer, reusedSocket: req.reusedSocket };
+}
+
+// One agent per form, all forms at once: { [form]: the answers to `identities` in order }.
+async function answersByForm(agentOptions: https.AgentOptions, identities: Identity[], reuseOptions: boolean) {
+  const { server, port } = await listen();
+  try {
+    const entries = await Promise.all(
+      Object.entries(forms).map(async ([form, optionsFor]) => {
+        const agent = new https.Agent(agentOptions);
+        const cached: Partial<Record<Identity, object>> = {};
+        try {
+          const answers: object[] = [];
+          for (const id of identities) {
+            const options = reuseOptions ? (cached[id] ??= optionsFor(id)) : optionsFor(id);
+            answers.push(await get(agent, port, options));
+          }
+          return [form, answers];
+        } finally {
+          agent.destroy();
+        }
+      }),
+    );
+    return Object.fromEntries(entries);
+  } finally {
+    server.close();
+  }
+}
+const expectedByForm = (answers: object[]) => Object.fromEntries(Object.keys(forms).map(form => [form, answers]));
+
+describe("https.Agent keeps client certificates apart", () => {
+  fixedTest("a pooled socket is not shared across client certificates", async () => {
+    // The third request passes the first request's option values again, so it pools.
+    assert.deepStrictEqual(
+      await answersByForm({ keepAlive: true }, ["agent1", "agent10", "agent1"], true),
+      expectedByForm([
+        { peer: commonName.agent1, reusedSocket: false },
+        { peer: commonName.agent10, reusedSocket: false },
+        { peer: commonName.agent1, reusedSocket: true },
+      ]),
+    );
+  });
+
+  // Without keepAlive every request opens a connection, but the agent still offers the
+  // session it cached under the same name, and a resumed session keeps its first identity.
+  fixedTest("a cached TLS session is not resumed across client certificates", async () => {
+    assert.deepStrictEqual(
+      await answersByForm({ keepAlive: false }, ["agent1", "agent10"], false),
+      expectedByForm([
+        { peer: commonName.agent1, reusedSocket: false },
+        { peer: commonName.agent10, reusedSocket: false },
+      ]),
+    );
+  });
+});
+
+describe("https.Agent#getName", () => {
+  const agent = new https.Agent();
+  const name = (options: object) => agent.getName({ host: "localhost", port: 443, ...options });
+
+  test("a value that stringifies to its contents keeps Node's name", () => {
+    assert.strictEqual(
+      name({
+        ca: ["a", null, undefined, Buffer.from("b")],
+        cert: Buffer.from("cert"),
+        key: ["k1", new Uint8Array([1, 2])],
+        pfx: "pfx",
+        crl: [Buffer.from("c"), Buffer.from("r"), Buffer.from("l")],
+        dhparam: "dhparam",
+      }),
+      "localhost:443::a,,,b:cert:::k1,1,2:pfx::::::c,r,l:::dhparam:::::",
+    );
+  });
+
+  fixedTest("`pfx: [{ buf, passphrase }]` is keyed by buf and passphrase", () => {
+    const buf = read("agent1.pfx");
+    const base = name({ pfx: [{ buf, passphrase: "sample" }] });
+    assert.strictEqual(name({ pfx: [{ buf: Buffer.from(buf), passphrase: "sample" }] }), base);
+    assert.strictEqual(name({ pfx: [{ buf }], passphrase: "sample" }), base);
+    assert.notStrictEqual(name({ pfx: [{ buf: read("agent10.pfx"), passphrase: "sample" }] }), base);
+    assert.notStrictEqual(name({ pfx: [{ buf, passphrase: "different" }] }), base);
+    assert.notStrictEqual(
+      name({ pfx: [{ __proto__: { buf, passphrase: "sample" } }] }),
+      name({ pfx: [{ __proto__: { buf: read("agent10.pfx"), passphrase: "sample" } }] }),
+    );
+  });
+
+  for (const form of Object.keys(bunForms)) {
+    bunTest(`differs by content or identity, ${form}`, () => {
+      const agent1 = bunForms[form]("agent1");
+      assert.strictEqual(name(agent1), name(agent1));
+      assert.notStrictEqual(name(agent1), name(bunForms[form]("agent10")));
+    });
+  }
+
+  bunTest("`key: [{ pem, passphrase }]` is keyed by pem and not by passphrase", () => {
+    const pem = read("agent1-key.pem");
+    const base = name({ key: pem });
+    assert.strictEqual(name({ key: [{ pem, passphrase: "a" }] }), base);
+    assert.strictEqual(name({ key: [{ pem: readArrayBuffer("agent1-key.pem"), passphrase: "b" }] }), base);
+    assert.strictEqual(name({ key: { pem } }), base);
+    assert.notStrictEqual(name({ key: [{ pem: read("agent10-key.pem"), passphrase: "a" }] }), base);
+  });
+
+  bunTest("equal bytes share a name across string, Buffer, ArrayBuffer and array forms", () => {
+    const cert = read("agent1-cert.pem");
+    const base = name({ cert: cert.toString() });
+    assert.strictEqual(name({ cert }), base);
+    assert.strictEqual(name({ cert: readArrayBuffer("agent1-cert.pem") }), base);
+    assert.strictEqual(name({ cert: [readArrayBuffer("agent1-cert.pem")] }), base);
+    assert.strictEqual(
+      name({ pfx: [{ buf: readArrayBuffer("agent1.pfx"), passphrase: "sample" }] }),
+      name({ pfx: [{ buf: read("agent1.pfx"), passphrase: "sample" }] }),
+    );
+  });
+
+  bunTest("certFile, keyFile and caFile are labelled parts of the name", () => {
+    const base = name({});
+    assert.strictEqual(name({ certFile: "a", keyFile: "b", caFile: "c" }), `${base}:certFile=a:keyFile=b:caFile=c`);
+    assert.notStrictEqual(name({ certFile: "a" }), name({ keyFile: "a" }));
+    assert.notStrictEqual(name({ caFile: "a" }), name({ caFile: "b" }));
+  });
+});
+
+// Only in Bun: when Node.js runs this file it must not spawn itself again.
+if (typeof Bun !== "undefined") {
+  const { bunEnv, nodeExe } = await import("harness");
+  const node = nodeExe();
+
+  describe("Node.js compatibility", () => {
+    (node ? test : test.skip)("all tests pass in Node.js", async () => {
+      // A direct run, not `node --test`: the runner mode forks a second node
+      // process per file. node:test still exits non-zero on any failure.
+      await using proc = Bun.spawn({
+        cmd: [node!, "--v8-pool-size=1", fileURLToPath(import.meta.url)],
+        env: { ...bunEnv, UV_THREADPOOL_SIZE: "2" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      assert.deepStrictEqual({ exitCode, output: exitCode === 0 ? "" : stdout + stderr }, { exitCode: 0, output: "" });
+    });
+  });
+}

--- a/test/js/node/test/parallel/test-https-agent-getname.js
+++ b/test/js/node/test/parallel/test-https-agent-getname.js
@@ -6,6 +6,7 @@ if (!common.hasCrypto)
 
 const assert = require('assert');
 const https = require('https');
+const fixtures = require('../common/fixtures');
 
 const agent = new https.Agent();
 
@@ -52,3 +53,46 @@ assert.strictEqual(
     '::secureProtocol:c,r,l:false:ecdhCurve:dhparam:0:sessionIdContext:' +
     '"sigalgs":privateKeyIdentifier:privateKeyEngine'
 );
+
+{
+  const baseOptions = {
+    host: '0.0.0.0',
+    port: 443,
+  };
+
+  const agent1 = fixtures.readKey('agent1.pfx');
+  const agent6 = fixtures.readKey('agent6.pfx');
+
+  assert.notStrictEqual(
+    agent.getName({
+      ...baseOptions,
+      pfx: [{ buf: agent1, passphrase: 'sample' }],
+    }),
+    agent.getName({
+      ...baseOptions,
+      pfx: [{ buf: agent6, passphrase: 'sample' }],
+    })
+  );
+
+  assert.notStrictEqual(
+    agent.getName({
+      ...baseOptions,
+      pfx: [{ buf: agent1, passphrase: 'sample' }],
+    }),
+    agent.getName({
+      ...baseOptions,
+      pfx: [{ buf: agent1, passphrase: 'different' }],
+    })
+  );
+
+  assert.notStrictEqual(
+    agent.getName({
+      ...baseOptions,
+      pfx: [{ __proto__: { buf: agent1, passphrase: 'sample' } }],
+    }),
+    agent.getName({
+      ...baseOptions,
+      pfx: [{ __proto__: { buf: agent6, passphrase: 'sample' } }],
+    })
+  );
+}


### PR DESCRIPTION
### Problem
- `https.Agent#getName()` (`src/js/node/https.ts`) builds the pool name with `name += value`. A `pfx: [{ buf, passphrase }]` or `key: [{ pem, passphrase }]` entry, an `ArrayBuffer` and a `Bun.file()` all coerce to `"[object ...]"`. The Bun-only `certFile`, `keyFile`, `caFile` options and `allowPartialTrustChain` are not in the name.
- Two requests with different client certificates then share one name. The second rides the first one's keep-alive connection, or with `keepAlive: false` resumes its cached TLS session. The server sees client A twice.
- Node fixed the `pfx` array form as CVE-2026-56850 (nodejs/node 9f03017f38). Client-side only.

### Fix
- `poolKeyPart()` keys `ca`, `cert`, `key`, `crl`, `dhparam` and each pfx `buf`. Every Node-valid name stays byte-identical.
- `pfxPoolKey()` follows Node's `getPfxAgentKey()`. A key entry is keyed by its `pem`, an `ArrayBuffer` or `DataView` by its bytes, any other object (Blob, BunFile) by an identity id from a `WeakMap` counter.
- `certFile`, `keyFile`, `caFile` (JSON-quoted) and a truthy `allowPartialTrustChain` are labelled parts at the end of the name.
- Verified: `test/js/node/http/node-https-agent-getname.test.ts` (stock bun fails 15 of 17, the same `node:test` file passes on Node v26.5.1). `test-https-agent-getname.js` is synced to upstream. Self-reviewed: 9 concerns raised, 8 addressed (see Notes).

### Background
- `https.Agent` pools sockets by `getName(options)`. The same name keys `_sessionCache`, the TLS sessions it offers on new connections.
- A resumed TLS session keeps the peer identity and the verification result of its first handshake.
- Bun accepts `ArrayBuffer` and `Bun.file()` values, a bare `pfx: { buf }` entry and the `certFile` / `keyFile` / `caFile` paths. Node rejects or ignores these, so its fix does not cover them.
- `allowPartialTrustChain` lets a chain end at a trusted intermediate certificate and not only at a self-signed root.

<details><summary>Notes</summary>

Before the fix (vendored fixtures, `agent1` is CN=agent1, `agent10` is CN=agent10.example.com):

```
pool key A: localhost:35647:::::::[object Object]::::::::::::::
pool key B: localhost:35647:::::::[object Object]::::::::::::::
pfx array A -> peer=agent1 conn=33474 reused=false
pfx array B -> peer=agent1 conn=33474 reused=true
BunFile B -> peer=agent1 conn=54538 reused=true            name: h:1:::[object Blob]:::[object Blob]:::::::::::::::
ArrayBuffer B -> peer=agent1 conn=54552 reused=true        name: h:1:::[object ArrayBuffer]:::[object ArrayBuffer]:::::::::::::::
certFile/keyFile B -> peer=agent1 conn=43504 reused=true   name: h:1:::::::::::::::::::::
caFile=ca1 -> ok, then caFile=ca2 -> ok reused=true        (a new agent gives UNABLE_TO_VERIFY_LEAF_SIGNATURE)
keepAlive:false, TLSv1.2 and TLSv1.3: pfx array B -> peer=agent1 resumed=true reusedSocket=false
```

The test file under each runtime:

| runtime | pass | fail | skipped |
|---|---|---|---|
| this branch (debug build) | 17 | 0 | 0 |
| bun 1.4.3-canary | 2 | 15 | 0 |
| node v26.5.1 (has 9f03017f38) | 5 | 0 | 11 (Bun-only cases) |
| node v26.3.0 (does not) | 1 | 0 | 15 |

- Identity keys mean that a request that builds a new `Bun.file()` per request no longer shares a pool with the previous request. The same object passed again does. Agent-level options are one object for every request, so they pool as before.
- `key: [{ pem, passphrase }]` collided the same way. `cert` is in the name and a key has to match its certificate, so this could not change the presented identity. The passphrase only decrypts the pem, so it stays out of the name. The result is the same name as `key: pem`.
- A pfx entry keeps the passphrase in the name, as Node's fix does. The upstream test asserts it.
- A pfx array renders exactly as in Node v26.5.1. The test asserts the literal names, for example `pfx: [Buffer('a'), { buf: 'b', passphrase: 'p' }], passphrase: 'q'` gives `...:a:q:b:p...`.
- The comma join for `ca` / `cert` / `key` / `crl` arrays is Node's own format (`['a,b']` and `['a', 'b']` share a name there too). It is kept so that every Node-valid name stays byte-identical. The vendored upstream test asserts `c,r,l`.
- `allowPartialTrustChain`: the client trusts only the intermediate `ca3`, the server presents `agent6 -> ca3 -> ca1`. A new agent gives `UNABLE_TO_GET_ISSUER_CERT` for a strict request. Before the fix the strict request answered 200 after a relaxed one, on the pooled connection (`keepAlive: true`) and on the resumed session (`keepAlive: false`).
- The identity ids use `WeakMap.prototype.get` and `set` captured at module load and called with `.$call`, like the other captured prototype methods in this file.
- SSLConfig options that stay out of the name because they do not change what a client connection presents or trusts: `passphrase`, `dhParamsFile`, `lowMemoryMode`, `requestCert`, `clientRenegotiationLimit`, `clientRenegotiationWindow`, `sessionTimeout`.
- The upstream end-to-end test `test-https-agent-pfx-object-array-reuse.js` is not vendored here. It reads `req.socket.getPeerCertificate()` on an `https.Server` request, which Bun does not have yet (#37255). The new test covers the same flow through `tls.createServer`.
- Land order with #37223 (open, digests pool-name parts over 1 KiB through `"" + value`): this PR first. #37223 then wraps the value that `poolKeyPart()` returns, and the collision stays fixed.
- Suites run on the debug build: `node-https-agent-getname.test.ts`, `node-http-agent-free-socket.test.ts`, `node-http-agent-tls-options.test.mts`, `node-https-checkServerIdentity.test.ts`, `node-http-proxy-url.test.ts`, and `test/js/node/test/parallel/test-https-agent*.js`, `test-http-agent-getname.js`, `test-https-pfx.js`, `test-tls-pfx-authorizationerror.js`, `test-tls-multi-pfx.js`, `test-tls-multi-key.js`, `test-tls-passphrase.js`.
- Self-review: addressed by keying the file options, keeping the key passphrase out of the name, making the tests run on Node, stating the land order with #37223, and correcting a comment. Not done here: a test that walks the option names in `SSLConfig.bindv2.ts` and fails on one that `getName()` does not classify. It is a follow-up, so that this PR stays the Node port plus the Bun-only forms.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 15 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-https-agent-getname.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/http/node-https-agent-getname.test.ts:
118 | const expectedByForm = (answers: object[]) => Object.fromEntries(Object.keys(forms).map(form => [form, answers]));
119 | 
120 | describe("https.Agent keeps client certificates apart", () => {
121 |   fixedTest("a pooled socket is not shared across client certificates", async () => {
122 |     // The third request passes the first request's option values again, so it pools.
123 |     assert.deepStrictEqual(
                 ^
AssertionError: Expected values to be strictly deep-equal:
+ actual - expected
... Skipped lines

  {
    'cert, key: ArrayBuffer': [
      {
        peer: 'agent1',
        reusedSocket: false
      },
      {
+       peer: 'agent1',
+       reusedSocket: true
-       peer: 'agent10.example.com',
-       reusedSocket: false
      },
      {
        peer: 'agent1',
        reusedSocket: true
      }
...
      {
+       peer: 'agent1',
+       reusedSocket: true
-       peer: 'agen
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (a74b10e6f)

test/js/node/http/node-https-agent-getname.test.ts:
(pass) https.Agent keeps client certificates apart > a pooled socket is not shared across client certificates [113.48ms]
(pass) https.Agent keeps client certificates apart > a cached TLS session is not resumed across client certificates [63.41ms]
(pass) https.Agent keeps allowPartialTrustChain apart > a strict request is verified again, keepAlive: true [8.09ms]
(pass) https.Agent keeps allowPartialTrustChain apart > a strict request is verified again, keepAlive: false [5.64ms]
(pass) https.Agent#getName > a value that stringifies to its contents keeps Node's name [0.22ms]
(pass) https.Agent#getName > a pfx array has Node's name [0.10ms]
(pass) https.Agent#getName > `pfx: [{ buf, passphrase }]` is keyed by buf and passphrase [0.62ms]
(pass) https.Agent#getName > differs by content or identity, pfx: { buf, passphrase } [0.38ms]
(pass) https.Agent#getName > differs by content or identity, pfx: [ArrayBuffer] [0.34ms]
(pass) https.Agent#getName > differs by content or identity, cert, key: ArrayBuffer [0.15ms]
(pass) https.Agent#getName > differs by content or identity, cert, key: Bu
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-https-agent-getname.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/http/node-https-agent-getname.test.ts:
(pass) https.Agent keeps client certificates apart > a pooled socket is not shared across client certificates [2258.29ms]
(pass) https.Agent keeps client certificates apart > a cached TLS session is not resumed across client certificates [958.15ms]
(pass) https.Agent keeps allowPartialTrustChain apart > a strict request is verified again, keepAlive: true [224.79ms]
(pass) https.Agent keeps allowPartialTrustChain apart > a strict request is verified again, keepAlive: false [149.07ms]
(pass) https.Agent#getName > a value that stringifies to its contents keeps Node's name [11.00ms]
(pass) https.Agent#getName > a pfx array has Node's name [8.44ms]
(pass) https.Agent#getName > `pfx: [{ buf, passphrase }]` is keyed by buf and passphrase [24.04ms]
(pass) https.Agent#getName > differs by content or identity, pfx: { buf, passphrase } [12.25ms]
(pass) https.Agent#getName > differs by content or identity, pfx: [ArrayB
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 642ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/30] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/30] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/30] gen cpp.rs (cppbind)
[4/30] gen JS modules (bundle-modules)
Preprocess modules (7346ms)
Bundle modules (114ms)
Postprocesss modules (136ms)
Bundle Functions (451ms)
Generate Code (41ms)

[8.09s] Bundled "src/js" for production
  2601 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[4/19] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/https.ts                               |  70 ++++-
 test/js/node/http/node-https-agent-getname.test.ts | 301 +++++++++++++++++++++
 .../node/test/parallel/test-https-agent-getname.js |  44 +++
 3 files changed, 409 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/js/node/https.ts                                        5     11     30
test/js/node/http/node-https-agent-getname.test.ts          3      5     28
test/js/node/test/parallel/test-https-agent-getname.js      0      0     33
```

</details>

<!-- robobun:evidence:end -->