### PR TITLE
Bump WebKit (oven-sh/WebKit#640 preview): Error.stackTraceLimit assignments from JIT code keep applying

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "cf1b36ec8703d8e87436094d21d478d358c7d886";
+export const WEBKIT_VERSION = "autobuild-preview-pr-640-0cff36bc";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -566,6 +566,32 @@ describe("util", () => {
       }
     });
 
+    it("keeps honoring frameCount after many calls", async () => {
+      // getCallSites assigns Error.stackTraceLimit from one site. Runs in a fresh process so
+      // that the JIT state of that site starts cold.
+      const fixture = `
+        const util = require("node:util");
+        // try/finally keeps each call out of tail position, so every frame stays on the stack.
+        function deep(n, k) { try { return n <= 0 ? util.getCallSites(k).length : deep(n - 1, k); } finally {} }
+        const failures = [];
+        for (let i = 0; i < 400 && failures.length === 0; i++) {
+          const k = 1 + (i % 5);
+          const got = deep(8, k);
+          if (got !== k) failures.push({ call: i, frameCount: k, callSites: got });
+        }
+        process.stdout.write(JSON.stringify(failures));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        // Without compiler threads getCallSites reaches the optimizing JIT at a fixed call.
+        env: { ...bunEnv, BUN_JSC_useConcurrentJIT: "0" },
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("[]");
+      expect(exitCode).toBe(0);
+    });
+
     it("each frame has the node v26 shape", () => {
       const sites = util.getCallSites(3);
       expect(sites.length).toBeGreaterThan(0);

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -570,7 +570,7 @@ describe("util", () => {
       // getCallSites assigns Error.stackTraceLimit from one site. Runs in a fresh process so
       // that the JIT state of that site starts cold.
       const fixture = `
-        const util = require("node:util");
+        import util from "node:util";
         // try/finally keeps each call out of tail position, so every frame stays on the stack.
         function deep(n, k) { try { return n <= 0 ? util.getCallSites(k).length : deep(n - 1, k); } finally {} }
         const failures = [];

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1019,6 +1019,48 @@ test("Error.stackTraceLimit default matches the limit captureStackTrace applies"
   expect({ reported, before, after, exitCode }).toEqual({ reported: 10, before: 10, after: 10, exitCode: 0 });
 });
 
+test("Error.stackTraceLimit assignments keep applying after the assignment site gets hot", async () => {
+  // Runs in a fresh process so that the JIT state of each assignment site starts cold.
+  const src = `
+    // try/finally keeps each call out of tail position, so every helper stays on the stack.
+    function f3() { return new Error("L").stack.split("\\n").length - 1; }
+    function f2() { try { return f3(); } finally {} }
+    function f1() { try { return f2(); } finally {} }
+    function f0() { try { return f1(); } finally {} }
+
+    function store(n) { Error.stackTraceLimit = n; }
+    const key = "stackTraceLimit";
+    function storeByVal(n) { Error[key] = n; }
+    // The load gives the optimizing JIT a proven structure for the base of the store.
+    function loadThenStore(n) { const previous = Error.stackTraceLimit; Error.stackTraceLimit = n; return previous; }
+
+    const failures = [];
+    for (const site of [store, storeByVal, loadThenStore]) {
+      for (let i = 0; i < 3000; i++) {
+        const want = 1 + (i % 3);
+        site(want);
+        // Creating an Error is slow in debug builds. Check the first iterations, then a sample.
+        if (i >= 64 && i % 199 !== 0) continue;
+        const got = f0();
+        if (got !== want) {
+          failures.push({ site: site.name, iteration: i, assigned: want, readback: Error.stackTraceLimit, frames: got });
+          break;
+        }
+      }
+    }
+    process.stdout.write(JSON.stringify(failures));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    // Without compiler threads each site reaches the optimizing JIT at a fixed iteration.
+    env: { ...bunEnv, BUN_JSC_useConcurrentJIT: "0" },
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("[]");
+  expect(exitCode).toBe(0);
+});
+
 test("call sites inside a WebSocket message listener only contain script frames when the message arrives with the upgrade response", async () => {
   // Runs in its own process: which dispatch path delivers the message (and therefore
   // which frames are on the stack under the listener) depends on prior event-loop state.


### PR DESCRIPTION
### Problem
- `Error.stackTraceLimit = n` from a hot assignment site stops reaching the engine. The property reads back `n`, but new errors keep the old limit: `iteration 101: Error.stackTraceLimit = 3 (readback 3) but a new Error has 2 frames`. `util.getCallSites(3)` returns 10 call sites after about 50 calls.
- JSC keeps a copy of the limit in `JSGlobalObject::m_stackTraceLimit`. Only `ErrorConstructor::put()` updates it. The Baseline put inline cache, and then the DFG, store to the property without a call to `put()` (`runtime/ErrorConstructor.cpp:82`, `bytecode/PutByStatus.cpp:379`).

### Fix
- Engine fix: oven-sh/WebKit#640. This PR pins `WEBKIT_VERSION` to the preview build of its head, `autobuild-preview-pr-640-0cff36bc` (`cf1b36ec8703` plus one commit).
- The preview tag goes away when oven-sh/WebKit#640 merges. Move the pin to the `autobuild-<merge sha>` release before you merge this PR.
- No change under `src/`.
- Verified: new tests in `test/js/node/v8/capture-stack-trace.test.js` and `test/js/node/util/util.test.js`. Bun 1.4.3 canary (`6a92015fc`) fails both at iteration 35. The pinned build passes both files.

### Background
- `Error.stackTraceLimit` is a plain data property. JSC copies each stored value into the global object from the `put()` override of the `Error` constructor. Stack capture reads the copy.
- A put inline cache records the structure (hidden class) and the property offset at one store site. Later stores write the slot directly. A `put()` override calls `slot.disableCaching()` to stop that. `ErrorConstructor::put()` did not.
- The DFG can also fold a store from the structure alone. That path had no check for a `put()` override.

<details><summary>Notes</summary>

Repro 1:

```js
function f3() { return new Error('L').stack.split('\n').length - 1; }
function f2() { try { return f3(); } finally {} } function f1() { try { return f2(); } finally {} } function f0() { try { return f1(); } finally {} }
function set(n) { Error.stackTraceLimit = n; }
for (let i = 0; i < 100000; i++) { const want = 1 + (i % 3); set(want); const got = f0(); if (got !== want) { console.log(`iteration ${i}: Error.stackTraceLimit = ${want} (readback ${Error.stackTraceLimit}) but a new Error has ${got} frames`); process.exit(1); } }
console.log('ok');
```

Repro 2 (no user assignment):

```js
import util from 'node:util';
function d(n, k) { try { return n <= 0 ? util.getCallSites(k).length : d(n - 1, k); } finally {} }
for (let i = 0; i < 20000; i++) { const k = 1 + (i % 5); const got = d(8, k); if (got !== k) { console.log(`call ${i}: util.getCallSites(${k}) returned ${got} call sites`); process.exit(1); } }
console.log('ok');
```

| build | repro 1 | repro 2 |
| --- | --- | --- |
| 1.4.3 canary `6a92015fc` (WebKit `cf1b36ec8703`) | fails at iteration 101 | fails at call 56 |
| `slot.disableCaching()` only | ok | fails at call 275 (`BUN_JSC_useDFGJIT=0`: ok) |
| oven-sh/WebKit#640 | ok | ok |

- `BUN_JSC_useJIT=0` and `BUN_JSC_useBaselineJIT=0` make both repros print `ok` on the stock build. The LLInt cache skips `Error` because its structure may be a prototype (`TypeError` and the other native error constructors inherit from it).
- The second row is why the WebKit PR has two changes. `util.getCallSites` loads `Error.stackTraceLimit` and then stores to it. The load gives the DFG what it needs to fold the store.

Tests:
- Both tests run their loop in a fresh process, so the JIT state of each assignment site starts cold. The child runs with `BUN_JSC_useConcurrentJIT=0`. Then each site reaches the Baseline JIT and the DFG at a fixed iteration, in release and in debug builds.
- `capture-stack-trace.test.js` has three assignment sites: `Error.stackTraceLimit = n`, `Error[key] = n`, and a load followed by a store. It checks the frame count of a new error for the first 64 iterations, then for one iteration in 199, up to 3000. The stock canary fails all three sites at iteration 35. With `slot.disableCaching()` only, the third site fails at iteration 199.
- `util.test.js` calls `util.getCallSites(k)` 400 times with `k` from 1 to 5. The stock canary fails at call 35. With `slot.disableCaching()` only it fails at call 166.
- On the debug ASAN build each test takes about 1.4 s.

The fail-before proof for this PR is the stock canary, not a checkout of `src/` from main. The fix is in the WebKit prebuilt that `scripts/build/deps/webkit.ts` names.

Same kind of bug in Bun's own bindings, with open PRs: #38871 (`process.env`), #38854 (`require.extensions`). The second change in oven-sh/WebKit#640 also closes the DFG fold for those two classes.

Not in this PR, and not new:
- `Object.defineProperty(Error, "stackTraceLimit", { value: 1 })` does not change the limit (Node: it does).
- `TypeError.stackTraceLimit = 4` changes the limit of the realm (Node: it does not).

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/util/util.test.js' 'test/js/node/v8/capture-stack-trace.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/util/util.test.js "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.3 (6a92015fc)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [15.71ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [23.58ms]
(pass) capture stack trace [9.15ms]
(pass) capture stack trace with message [7.89ms]
(pass) capture stack trace with constructor [6.42ms]
(pass) capture stack trace limit [22.74ms]
(pass) prepare stack trace [11.63ms]
(pass) capture stack trace second argument [17.91ms]
(pass) capture stack trace edge cases [13.29ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [22.85ms]
(pass) prepare stack trace call sites [14.39ms]
(pass) sanity check [14.78ms]
(pass) CallFrame isEval works as expected [8.21ms]
(pass) CallFrame isTopLevel returns false for Function constructor [8.54ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [9.63ms]
(pass) CallFrame.p.isConstructor [3.79ms]
(pass) CallFrame.p.isNative [3.42ms]
(pass) return non-strings from Error.prepareStackTrace [3.48ms]
(pass) CallFrame.p.toString [3.46ms]
(pass) err.stack should invoke prepareStackTrace [17.54ms]
(pass) Error.prepareStackTrace inside a node:vm works [71.29ms]
(pass) Error.captureStackTrace inside error constructor works [7.29ms]
(pass) Error.prepareStackTrace has a default implementation which behaves the same as being unset [278.19ms]
(pass) Error.prepareStackTrace returns a CallSite object [4.44ms]
(pass) Error.captureStackTrace updates the stack property each call, even if Error.prepareStackTrace is set [14.14ms]
(pass) Error.captureStackTrace updates the stack property each call [7.50ms]
(pass) calling .stack later uses the stored StackTrace [5.95ms]
(pass) calling .stack on a non-materialized Error updates the stack properly [7.51ms]
(pass) Error.prepareStackTrace on an array with non-CallSite objects doesn't crash [3.4
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                |  2 +-
 test/js/node/util/util.test.js              | 26 ++++++++++++++++++
 test/js/node/v8/capture-stack-trace.test.js | 42 +++++++++++++++++++++++++++++
 3 files changed, 69 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
scripts/build/deps/webkit.ts                     1      1     22
test/js/node/util/util.test.js                   2      3     18
test/js/node/v8/capture-stack-trace.test.js      2      4     18
```

</details>

<!-- robobun:evidence:end -->