### PR TITLE
Do not abort from a working directory close to PATH_MAX (package.json, tsconfig.json)

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1582,21 +1582,19 @@ pub fn init(
             // the underlying directory and node_modules isn't either.
             let need_write = subcommand != Subcommand::Install || cli.positionals.len() > 1;
 
+            // Not a path buffer: the cwd can be up to PATH_MAX - 1 bytes, and
+            // `File::openat` reports ENAMETOOLONG for a path that does not fit one.
+            let mut package_json_path: Vec<u8> =
+                Vec::with_capacity(original_cwd.len() + b"/package.json".len());
+
             loop {
-                let mut package_json_path_buf = bun_paths::path_buffer_pool::get();
-                package_json_path_buf[..this_cwd.len()].copy_from_slice(this_cwd);
-                package_json_path_buf[this_cwd.len()..this_cwd.len() + b"/package.json".len()]
-                    .copy_from_slice(b"/package.json");
-                package_json_path_buf[this_cwd.len() + b"/package.json".len()] = 0;
-                // SAFETY: NUL written above
-                let package_json_path = ZStr::from_buf(
-                    &package_json_path_buf[..],
-                    this_cwd.len() + b"/package.json".len(),
-                );
+                package_json_path.clear();
+                package_json_path.extend_from_slice(this_cwd);
+                package_json_path.extend_from_slice(b"/package.json");
 
                 match bun_sys::File::openat(
                     bun_sys::Fd::cwd(),
-                    package_json_path.as_bytes(),
+                    &package_json_path,
                     if need_write {
                         bun_sys::O::RDWR
                     } else {
@@ -1617,7 +1615,7 @@ pub fn init(
                         Output::err(
                             "EACCES",
                             "Permission denied while opening \"{s}\"",
-                            &[&bstr::BStr::new(package_json_path.as_bytes())],
+                            &[&bstr::BStr::new(&package_json_path)],
                         );
                         if need_write {
                             bun_core::note!("package.json must be writable to add packages");
@@ -1633,7 +1631,7 @@ pub fn init(
                         Output::err(
                             &e,
                             "could not open \"{s}\"",
-                            &[&bstr::BStr::new(package_json_path.as_bytes())],
+                            &[&bstr::BStr::new(&package_json_path)],
                         );
                         return Err(e.into());
                     }

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -382,7 +382,11 @@ impl PackageJSON {
 
         // TODO: remove this extra copy
         let parts: [&[u8]; 2] = [input_path, b"package.json"];
-        let package_json_path_ = r_fs.abs(&parts);
+        // Longer than the thread-local join buffer when `input_path` is close to PATH_MAX.
+        let mut spill: Vec<u8> = Vec::new();
+        let package_json_path_ = resolve_path::resolve_path::join_abs_string_spill::<
+            resolve_path::platform::Loose,
+        >(r_fs.top_level_dir(), &mut spill, &parts);
         let package_json_path = r_fs
             .dirname_store
             .append_slice(package_json_path_)

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6397,11 +6397,12 @@ impl<'a> Resolver<'a> {
                     if unsafe { entry.kind(rfs_ptr, self.store_fd) }
                         == Fs::file_system::EntryKind::File
                     {
+                        // `None` when it does not fit. `baseUrl`, `paths` and `extends` are
+                        // joined onto this path in path buffers, so such a config is skipped.
                         let parts = [path, b"tsconfig.json".as_slice()];
-                        tsconfig_path = Some(
-                            self.fs_ref()
-                                .abs_buf(&parts, bufs!(dir_info_uncached_filename)),
-                        );
+                        tsconfig_path = self
+                            .fs_ref()
+                            .abs_buf_checked(&parts, bufs!(dir_info_uncached_filename));
                     }
                 }
                 if tsconfig_path.is_none() {
@@ -6414,10 +6415,9 @@ impl<'a> Resolver<'a> {
                             == Fs::file_system::EntryKind::File
                         {
                             let parts = [path, b"jsconfig.json".as_slice()];
-                            tsconfig_path = Some(
-                                self.fs_ref()
-                                    .abs_buf(&parts, bufs!(dir_info_uncached_filename)),
-                            );
+                            tsconfig_path = self
+                                .fs_ref()
+                                .abs_buf_checked(&parts, bufs!(dir_info_uncached_filename));
                         }
                     }
                 }

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1,9 +1,18 @@
 import { spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { exists, mkdir, writeFile } from "fs/promises";
-import { bunEnv, bunExe, bunEnv as env, normalizeBunSnapshot, readdirSorted, tempDir, tmpdirSync } from "harness";
-import { cpSync } from "node:fs";
-import { join } from "path";
+import {
+  bunEnv,
+  bunExe,
+  bunEnv as env,
+  isWindows,
+  normalizeBunSnapshot,
+  readdirSorted,
+  tempDir,
+  tmpdirSync,
+} from "harness";
+import { cpSync, mkdirSync, renameSync } from "node:fs";
+import { dirname, join } from "path";
 import {
   dummyAfterAll,
   dummyAfterEach,
@@ -1083,4 +1092,74 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stdout).toInclude("Cleared 'bun install' cache");
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
+});
+
+// Every package manager command starts by opening the nearest package.json by its absolute
+// path, walking up from the working directory. A working directory can be PATH_MAX - 1 bytes
+// long, and `<cwd>/package.json` is 13 bytes longer than that, so from the deepest directories
+// the OS allows it does not fit the PATH_MAX bytes (NUL included) a path may take.
+//
+// On Windows the path buffer is longer than any path the OS accepts.
+describe.skipIf(isWindows)("working directory close to PATH_MAX", () => {
+  const PATH_MAX = process.platform === "linux" || process.platform === "android" ? 4096 : 1024;
+  const SEGMENT = Buffer.alloc(200, "d").toString();
+
+  /** An absolute path below `root` whose UTF-8 encoding is exactly `length` bytes long. */
+  function pathOfLength(root: string, length: number): string {
+    let path = root;
+    // Leave room for the final component, which has to stay under NAME_MAX (255).
+    while (length - Buffer.byteLength(path) > 256) path = join(path, SEGMENT);
+    path = join(path, Buffer.alloc(length - Buffer.byteLength(path) - 1, "L").toString());
+    expect(Buffer.byteLength(path)).toBe(length);
+    return path;
+  }
+
+  /** A project below a new temporary directory, in a directory whose path is exactly `cwdBytes` bytes long. */
+  function deepProject(cwdBytes: number) {
+    const dir = tempDir("pm-deep-cwd", {
+      "project/package.json": JSON.stringify({ name: "deep", version: "1.0.0" }),
+    });
+    // package.json may be too long to write by its final path, so the directory is moved there with it inside.
+    const cwd = pathOfLength(String(dir), cwdBytes);
+    mkdirSync(dirname(cwd), { recursive: true });
+    renameSync(join(String(dir), "project"), cwd);
+    return { cwd, [Symbol.dispose]: () => dir[Symbol.dispose]() };
+  }
+
+  async function runBun(args: string[], cwd: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr: stderr.replaceAll(cwd, "<cwd>"), exitCode };
+  }
+
+  test("the longest <cwd>/package.json that can be opened is read", async () => {
+    using project = deepProject(PATH_MAX - 1 - "/package.json".length);
+
+    expect(await runBun(["pm", "pkg", "get", "name"], project.cwd)).toEqual({
+      stdout: '"deep"\n',
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  describe.each([
+    ["PATH_MAX bytes long, leaving no room for the NUL", PATH_MAX - "/package.json".length],
+    ["as long as it can be", PATH_MAX - 1],
+  ])("<cwd>/package.json is %s", (_, cwdBytes) => {
+    test.each(["install", "pm cache"])("bun %s fails with ENAMETOOLONG", async command => {
+      using project = deepProject(cwdBytes);
+
+      const { stdout, stderr, exitCode } = await runBun(command.split(" "), project.cwd);
+
+      expect(stderr).toContain('ENAMETOOLONG: File name too long: could not open "<cwd>/package.json" (open)\n');
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
+    });
+  });
 });

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -1,9 +1,9 @@
 import { spawnSync } from "bun";
 import { dlopen } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, bunRun, isWindows, tempDir } from "harness";
-import { join } from "path";
+import { dirname, join } from "path";
 
 let cwd: string;
 
@@ -39,6 +39,54 @@ describe("bun", () => {
     expect(stdout.toString()).toBeEmpty();
     expect(stderr.toString()).toMatch(/Script not found/);
     expect(exitCode).toBe(1);
+  });
+});
+
+// A working directory can be up to PATH_MAX - 1 bytes long. The files the resolver reads
+// from it are then at paths longer than PATH_MAX, which do not fit a path buffer:
+// package.json is read relative to the open directory, tsconfig.json and jsconfig.json
+// are skipped.
+describe.skipIf(isWindows)("a working directory close to PATH_MAX", () => {
+  const PATH_MAX = process.platform === "linux" || process.platform === "android" ? 4096 : 1024;
+  const SEGMENT = Buffer.alloc(200, "d").toString();
+
+  /** An absolute path below `root` whose UTF-8 encoding is exactly `length` bytes long. */
+  function pathOfLength(root: string, length: number): string {
+    let path = root;
+    // Leave room for the final component, which has to stay under NAME_MAX (255).
+    while (length - Buffer.byteLength(path) > 256) path = join(path, SEGMENT);
+    path = join(path, Buffer.alloc(length - Buffer.byteLength(path) - 1, "L").toString());
+    expect(Buffer.byteLength(path)).toBe(length);
+    return path;
+  }
+
+  describe.each(["package.json", "tsconfig.json", "jsconfig.json"])("<cwd>/%s", name => {
+    test.concurrent.each([
+      ["one byte longer than PATH_MAX", PATH_MAX - `/${name}`.length + 1],
+      ["as long as it can be", PATH_MAX - 1],
+    ])("is %s and bun run runs the script", async (_, cwdBytes) => {
+      using dir = tempDir("run-deep-cwd", {
+        project: {
+          [name]: "{}",
+          "package.json": JSON.stringify({ name: "deep", scripts: { hi: "echo hi" } }),
+        },
+      });
+      // The files cannot be written by their final paths, so the directory is moved there with them inside.
+      const cwd = pathOfLength(String(dir), cwdBytes);
+      mkdirSync(dirname(cwd), { recursive: true });
+      renameSync(join(String(dir), "project"), cwd);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "hi"],
+        cwd,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "hi\n", stderr: "$ echo hi\n", exitCode: 0 });
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- From a working directory of 4083..4095 bytes (legal on Linux), `bun run <script>`, `bun -e`, `bun test`, `bun install` and every `bun pm` command abort. `bun run`: `panic: range end index 4102 out of range for slice of length 4095`. `bun install`, `bun pm cache`: `panic: range end index 4103 out of range for slice of length 4096`.
- Three unchecked joins of `<cwd>/<name>`: `package.json` in `PackageJSON::parse` (`src/resolver/package_json.rs:385`), `tsconfig.json` and `jsconfig.json` in `dir_info_uncached` (`src/resolver/resolver.rs:6400`), `package.json` in `PackageManager::init` (`src/install/PackageManager.rs:1586`).

### Fix
- `PackageJSON::parse` uses `join_abs_string_spill`. The resolver opens the file relative to the directory fd, so `bun run <script>` works. #39626 hides such a `package.json` from the resolver instead. A maintainer has to pick one (see notes).
- `dir_info_uncached` uses `abs_buf_checked` and skips a `tsconfig.json` or `jsconfig.json` whose path does not fit: `baseUrl`, `paths` and `extends` are joined onto that path.
- `PackageManager::init` builds the path in a `Vec`. `File::openat` returns `ENAMETOOLONG` for it, which takes the existing route: `ENAMETOOLONG: File name too long: could not open "<cwd>/package.json" (open)`, exit 1.
- Verified: 6 new tests in `test/cli/run/run_command.test.ts`, 5 in `test/cli/install/bun-pm.test.ts`. The unfixed build fails 10.

### Background
- `PathBuffer` is bun's fixed buffer for one path: `MAX_PATH_BYTES` long, NUL included (4096 on Linux, 1024 on macOS).
- `join_abs_string` and `abs_buf` are `path.resolve` into a fixed buffer and assume the result fits. `join_abs_string_spill` falls back to the heap. `abs_buf_checked` returns `None`.
- `PackageManager::init` runs first in every package manager command. It opens the nearest `package.json` by absolute path.

<details><summary>Notes</summary>

**Origin.** Found by an internal report, reproduced on the 1.4.3-canary release build. There is no GitHub issue.

**Behavior by cwd length**, Linux x64, release build of main against this branch. The project has a `package.json` with `"scripts": {"hi": "echo hi"}`.

| cwd bytes | `bun run hi` before | after | `bun install`, `bun pm cache` before | after |
| --- | --- | --- | --- | --- |
| 4082 | ok | ok | ok | ok |
| 4083 | ok, or `panic: range end index 4096 out of range for slice of length 4095` with a `tsconfig.json` | ok | `panic: index out of bounds: the len is 4096 but the index is 4096` | ENAMETOOLONG, exit 1 |
| 4084 | `panic: range end index 4096 out of range for slice of length 4095` | ok | `panic: range end index 4097 out of range for slice of length 4096` | ENAMETOOLONG, exit 1 |
| 4095 | `panic: range end index 4107 out of range for slice of length 4095` | ok | `panic: range end index 4108 out of range for slice of length 4096` | ENAMETOOLONG, exit 1 |

- With the fix, `bun run hi` and `bun -e` print their output and exit 0 at every length from 4079 to 4095, with and without a `bun init` style `tsconfig.json`.
- The `tsconfig.json` boundary is exact. With `"jsxImportSource": "zzfoo"`, `bun -e 'console.log(<div/>)'` fails on `zzfoo/jsx-runtime` at a cwd of 4082 bytes (config loaded) and prints `<div />` at 4083 (config skipped).

**The contract choice against #39626.** #39626 (open) makes `DirEntry::add_entry` drop every directory entry whose absolute path does not fit a path buffer. With it, `package.json`, `tsconfig.json` and `jsconfig.json` in such a directory do not exist for the resolver, and `bun run hi` reports `Script not found "hi"`. This PR has the same result for the two config files and a different result for `package.json`: the resolver reads it through `openat(dir_fd, "package.json")`, as it already does on macOS for a path between 1024 and 4096 bytes. If #39626 lands in its current shape after this PR, the two `package.json` rows of the new `bun run` tests must expect `Script not found`. If a maintainer prefers that contract now, the `PackageManager.rs` hunk and the `bun-pm.test.ts` tests stand alone.

**Why `PackageManager::init` stops and does not continue upward.** A `package.json` can exist in that directory, and the command would then run against a parent project without a word. The function already stops on `EACCES`, `EISDIR`, `ELOOP` and every other error that is not `ENOENT`. The full output is the existing two lines for a failed open in `init`. The second line is `error: An internal error occurred (ENAMETOOLONG)` in a release build, the same as for a `package.json` directory (`EISDIR`) today. #39650 makes the `--filter` walk in `filter_arg.rs` continue upward for the same condition. That walk already continues on `ENOENT`, `EACCES` and `EPERM`, so each function keeps its own rule for an unreadable file.

**What still does not work from such a directory.**
- `bun run <script>` fails with `E2BIG: /usr/bin/bash: Argument list too long (posix_spawn())` when the path has many short components (81 components at 4090 bytes fail, 61 pass). `bun run` adds `<ancestor>/node_modules/.bin` to `PATH` for each ancestor. This is not new and not tied to `PATH_MAX`: main does the same from a 2000-byte cwd with 10-byte components.
- An entry point in the directory is still `Module not found`, because its absolute path does not fit.
- A `package.json` with a `sideEffects` array still aborts in the `sideEffects` join (#37529).
- `bun run --filter` still aborts (#39650). `file:` and `link:` dependencies: #38359. `$HOME/.npmrc`: #38372.
- `bun exec` aborts from a cwd of 4090 bytes or more (`src/runtime/cli/exec_command.rs:69`, the `<cwd>/[eval]` label). `bun pm bin` aborts from a cwd of 4079..4082 bytes (`src/runtime/cli/package_manager_command.rs:366`, `<cwd>/node_modules/.bin`). No open PR covers these two.
- The `baseUrl` and `extends` joins of a `tsconfig.json` that is loaded (cwd of 4082 bytes or less) are unchanged. #39626 and #41760 both change them.
- #39658 bounds-checks the thread-local joins themselves. It would make the `package_json.rs` hunk redundant and harmless. #40372 rewrites other parts of `PackageManager::init` and leaves this loop as it is.

**Other details.**
- The second loop in `init` (the workspace root search) copies `<parent>/package.json` into a `PathBuffer` in the same way. It needs no change: each parent is shorter than the directory whose `package.json` the first loop opened.
- When the resolver has no directory fd (`bun run --filter` passes `Fd::invalid()`), `read_file_with_allocator` opens the absolute path, gets `ENAMETOOLONG` from `openat_a`, and `PackageJSON::parse` logs `Cannot read file "<dir>": ENAMETOOLONG` and returns `None`. That is its existing route for a failed open.
- macOS: `PATH_MAX` is 1024. The 4096-byte thread-local join buffer cannot overflow from a legal directory there, but the two `PathBuffer` sites can (cwd of 1010..1023 bytes). The tests size the directory from `PATH_MAX` per platform. Windows is skipped: the path buffer there is longer than any path the OS accepts.
- The tests move a prepared directory into place with `renameSync`, because a file in the final directory is too long to write by its absolute path.
- Suites that pass with the fix: `test/cli/run/run_command.test.ts`, `filter-workspace.test.ts`, `tsconfig-override.test.ts`, `test/cli/install/bun-pm.test.ts`, `bun-pm-pkg.test.ts`, `bun-add.test.ts`, `bun-remove.test.ts`, `bun-workspaces.test.ts`, `bad-workspace.test.ts`, `test/config/bunfig/bunfig-errors.test.ts`, `test/bundler/esbuild/tsconfig.test.ts`, `test/js/bun/resolve/resolve.test.ts`, `resolve-error.test.ts`, `import-meta.test.js`, `tsconfig-extends-leak.test.ts`. `cargo clippy -p bun_resolver -p bun_install` and `cargo fmt --check` are clean.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run_command.test.ts, test/cli/install/bun-pm.test.ts

<!-- robobun:evidence:end -->