### PR TITLE
bun:test: compare string matchers by UTF-16 code unit

### DIFF
--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1,6 +1,7 @@
 use crate::test_runner::jest::FileColumns as _;
 use core::cell::Cell;
 use core::fmt;
+use std::borrow::Cow;
 
 use bun_core::Output;
 use bun_jsc::bun_string_jsc;
@@ -2000,13 +2001,12 @@ impl Expect {
 
     /// Shared scaffold for one-arg `expect(v).toStartWith/toEndWith/toInclude(expected)`
     /// matchers: received and expected must both be strings, pass/fail is a pure
-    /// `&[u8]`×`&[u8]` predicate (with empty `expected` always passing), and the
-    /// failure message is the stock two-liner
+    /// predicate on their code units, and the failure message is the stock two-liner
     /// `"Expected to [not ]{verb}: <green>{expected}<r>\nReceived: <red>{value}<r>\n"`.
     ///
     /// Replaces ~100 LOC of byte-identical boilerplate per matcher: post_match
     /// guard, 1-arg check, expected-is-string check, `get_value`,
-    /// `increment_expect_call_counter`, UTF-8 slice + predicate, `not`-xor, dual
+    /// `increment_expect_call_counter`, code units + predicate, `not`-xor, dual
     /// formatter, `get_signature`, `throw`.
     ///
     /// Normalizes an inherited inconsistency where `toInclude` passed `""`
@@ -2019,7 +2019,7 @@ impl Expect {
         frame: &CallFrame,
         matcher_name: &'static str,
         verb: &'static str,
-        pred: fn(&[u8], &[u8]) -> bool,
+        pred: fn(&CodeUnitPair<'_>) -> bool,
     ) -> JsResult<JSValue> {
         let this = self.post_match_guard(global);
 
@@ -2040,10 +2040,9 @@ impl Expect {
 
         let mut pass = value.is_string();
         if pass {
-            let value_string = value.to_utf8(global)?;
-            let expected_string = expected.to_utf8(global)?;
-            pass = expected_string.slice().is_empty()
-                || pred(value_string.slice(), expected_string.slice());
+            let value_view = value.to_js_string_view(global)?;
+            let expected_view = expected.to_js_string_view(global)?;
+            pass = pred(&CodeUnitPair::new(&value_view, &expected_view));
         }
 
         let not = this.flags.get().not();
@@ -2073,6 +2072,73 @@ impl Expect {
                 expected.to_fmt(&mut f1),
                 value.to_fmt(&mut f2),
             )
+        }
+    }
+}
+
+/// The received and the expected string of a string matcher, as code units of
+/// one width. The matchers compare code units, like `String.prototype.startsWith`,
+/// `endsWith` and `indexOf`, so an unpaired surrogate equals itself and nothing
+/// else. A UTF-8 copy turns every unpaired surrogate into U+FFFD.
+pub(crate) enum CodeUnitPair<'a> {
+    Latin1(&'a [u8], &'a [u8]),
+    Utf16(Cow<'a, [u16]>, Cow<'a, [u16]>),
+}
+
+impl<'a> CodeUnitPair<'a> {
+    pub(crate) fn new(received: &'a bun_core::String, expected: &'a bun_core::String) -> Self {
+        if !received.is_utf16() && !expected.is_utf16() {
+            return Self::Latin1(received.latin1(), expected.latin1());
+        }
+        let utf16 = |string: &'a bun_core::String| -> Cow<'a, [u16]> {
+            if string.is_utf16() {
+                Cow::Borrowed(string.utf16())
+            } else {
+                Cow::Owned(string.latin1().iter().map(|&unit| u16::from(unit)).collect())
+            }
+        };
+        Self::Utf16(utf16(received), utf16(expected))
+    }
+
+    pub(crate) fn starts_with(&self) -> bool {
+        match self {
+            Self::Latin1(received, expected) => received.starts_with(expected),
+            Self::Utf16(received, expected) => received.starts_with(expected),
+        }
+    }
+
+    pub(crate) fn ends_with(&self) -> bool {
+        match self {
+            Self::Latin1(received, expected) => received.ends_with(expected),
+            Self::Utf16(received, expected) => received.ends_with(expected),
+        }
+    }
+
+    pub(crate) fn includes(&self) -> bool {
+        match self {
+            Self::Latin1(received, expected) => {
+                expected.is_empty() || strings::contains(received, expected)
+            }
+            Self::Utf16(received, expected) => bun_highway::memmem16(received, expected).is_some(),
+        }
+    }
+
+    /// How many times `expected` is in `received`, without overlap. 0 for an empty `expected`.
+    pub(crate) fn count(&self) -> usize {
+        match self {
+            Self::Latin1(received, expected) => strings::count(received, expected),
+            Self::Utf16(received, expected) => {
+                if expected.is_empty() {
+                    return 0;
+                }
+                let mut total = 0;
+                let mut rest: &[u16] = received;
+                while let Some(at) = bun_highway::memmem16(rest, expected) {
+                    total += 1;
+                    rest = &rest[at + expected.len()..];
+                }
+                total
+            }
         }
     }
 }

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2076,10 +2076,7 @@ impl Expect {
     }
 }
 
-/// The received and the expected string of a string matcher, as code units of
-/// one width. The matchers compare code units, like `String.prototype.startsWith`,
-/// `endsWith` and `indexOf`, so an unpaired surrogate equals itself and nothing
-/// else. A UTF-8 copy turns every unpaired surrogate into U+FFFD.
+/// Two JS strings as code units of one width. A UTF-8 copy turns each unpaired surrogate into U+FFFD.
 pub(crate) enum CodeUnitPair<'a> {
     Latin1(&'a [u8], &'a [u8]),
     Utf16(Cow<'a, [u16]>, Cow<'a, [u16]>),

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -2040,9 +2040,9 @@ impl Expect {
 
         let mut pass = value.is_string();
         if pass {
-            let value_view = value.to_js_string_view(global)?;
-            let expected_view = expected.to_js_string_view(global)?;
-            pass = pred(&CodeUnitPair::new(&value_view, &expected_view));
+            let value_string = value.to_bun_string(global)?;
+            let expected_string = expected.to_bun_string(global)?;
+            pass = pred(&CodeUnitPair::new(&value_string, &expected_string));
         }
 
         let not = this.flags.get().not();

--- a/src/runtime/test_runner/expect/simple_matchers.rs
+++ b/src/runtime/test_runner/expect/simple_matchers.rs
@@ -4,7 +4,6 @@
 //! `Expect` all the same.
 
 use super::{Expect, OrderingRelation};
-use bun_core::strings;
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
 // ── unary predicates: expect(x).toBe<Kind>() ───────────────────────────────
@@ -68,11 +67,11 @@ impl Expect {
 
 // ── string affix: toStartWith / toEndWith / toInclude ──────────────────────
 pub(crate) fn to_start_with(this: &Expect, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
-    this.run_string_affix_matcher(g, f, "toStartWith", "start with", strings::starts_with)
+    this.run_string_affix_matcher(g, f, "toStartWith", "start with", |pair| pair.starts_with())
 }
 pub(crate) fn to_end_with(this: &Expect, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
-    this.run_string_affix_matcher(g, f, "toEndWith", "end with", strings::ends_with)
+    this.run_string_affix_matcher(g, f, "toEndWith", "end with", |pair| pair.ends_with())
 }
 pub(crate) fn to_include(this: &Expect, g: &JSGlobalObject, f: &CallFrame) -> JsResult<JSValue> {
-    this.run_string_affix_matcher(g, f, "toInclude", "include", strings::contains)
+    this.run_string_affix_matcher(g, f, "toInclude", "include", |pair| pair.includes())
 }

--- a/src/runtime/test_runner/expect/toContain.rs
+++ b/src/runtime/test_runner/expect/toContain.rs
@@ -1,8 +1,8 @@
 use core::ffi::c_void;
 
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, VM};
-use bun_core::strings;
 
+use super::CodeUnitPair;
 use super::Expect;
 use super::get_signature;
 use super::throw;
@@ -46,18 +46,9 @@ impl Expect {
                 }
             }
         } else if value.is_string_literal() && expected.is_string_literal() {
-            let value_string = value.to_utf8(global)?;
-            let expected_string = expected.to_utf8(global)?;
-
-            if expected_string.slice().is_empty() {
-                // edge case empty string is always contained
-                pass = true;
-            } else if strings::contains(value_string.slice(), expected_string.slice()) {
-                pass = true;
-            } else if value_string.slice().is_empty() && expected_string.slice().is_empty() {
-                // edge case two empty strings are true
-                pass = true;
-            }
+            let value_view = value.to_js_string_view(global)?;
+            let expected_view = expected.to_js_string_view(global)?;
+            pass = CodeUnitPair::new(&value_view, &expected_view).includes();
         } else if value.is_iterable(global)? {
             let mut expected_entry = ExpectedEntry {
                 global: std::ptr::from_ref(global),

--- a/src/runtime/test_runner/expect/toContain.rs
+++ b/src/runtime/test_runner/expect/toContain.rs
@@ -46,9 +46,9 @@ impl Expect {
                 }
             }
         } else if value.is_string_literal() && expected.is_string_literal() {
-            let value_view = value.to_js_string_view(global)?;
-            let expected_view = expected.to_js_string_view(global)?;
-            pass = CodeUnitPair::new(&value_view, &expected_view).includes();
+            let value_string = value.to_bun_string(global)?;
+            let expected_string = expected.to_bun_string(global)?;
+            pass = CodeUnitPair::new(&value_string, &expected_string).includes();
         } else if value.is_iterable(global)? {
             let mut expected_entry = ExpectedEntry {
                 global: std::ptr::from_ref(global),

--- a/src/runtime/test_runner/expect/toContainEqual.rs
+++ b/src/runtime/test_runner/expect/toContainEqual.rs
@@ -5,9 +5,7 @@ use bun_core::strings;
 
 use super::{get_signature, throw, CodeUnitPair, Expect};
 
-/// jest does not have a `typeof === "string"` check for `toContainEqual`.
-/// it immediately spreads the value into an array, so a string becomes its code
-/// points. An unpaired surrogate is a code point of its own.
+/// Jest spreads the received string into code points. An unpaired surrogate is one of its own.
 fn has_code_point<T: Copy + PartialEq + Into<u16>>(units: &[T], code_point: &[T]) -> bool {
     let mut at = 0;
     while at < units.len() {

--- a/src/runtime/test_runner/expect/toContainEqual.rs
+++ b/src/runtime/test_runner/expect/toContainEqual.rs
@@ -3,7 +3,26 @@ use core::ffi::c_void;
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, VM};
 use bun_core::strings;
 
-use super::{get_signature, throw, Expect};
+use super::{get_signature, throw, CodeUnitPair, Expect};
+
+/// jest does not have a `typeof === "string"` check for `toContainEqual`.
+/// it immediately spreads the value into an array, so a string becomes its code
+/// points. An unpaired surrogate is a code point of its own.
+fn has_code_point<T: Copy + PartialEq + Into<u16>>(units: &[T], code_point: &[T]) -> bool {
+    let mut at = 0;
+    while at < units.len() {
+        let is_pair = strings::u16_is_lead(units[at].into())
+            && units
+                .get(at + 1)
+                .is_some_and(|&next| strings::u16_is_trail(next.into()));
+        let len = if is_pair { 2 } else { 1 };
+        if units[at..at + len] == *code_point {
+            return true;
+        }
+        at += len;
+    }
+    false
+}
 
 struct ExpectedEntry<'a> {
     global_this: &'a JSGlobalObject,
@@ -63,20 +82,11 @@ pub(crate) fn to_contain_equal(
         if expected_type.is_string_object_like() && value_type.is_string() {
             pass = false;
         } else {
-            let value_string = value.to_utf8(global)?;
-            let expected_string = expected.to_utf8(global)?;
-
-            // jest does not have a `typeof === "string"` check for `toContainEqual`.
-            // it immediately spreads the value into an array.
-
-            let mut expected_codepoint_cursor = strings::Cursor::default();
-            let expected_iter = strings::CodepointIterator::init(expected_string.slice());
-            let _ = expected_iter.next(&mut expected_codepoint_cursor);
-
-            pass = if expected_iter.next(&mut expected_codepoint_cursor) {
-                false
-            } else {
-                strings::index_of(value_string.slice(), expected_string.slice()).is_some()
+            let value_view = value.to_js_string_view(global)?;
+            let expected_view = expected.to_js_string_view(global)?;
+            pass = match CodeUnitPair::new(&value_view, &expected_view) {
+                CodeUnitPair::Latin1(units, code_point) => has_code_point(units, code_point),
+                CodeUnitPair::Utf16(units, code_point) => has_code_point(&units, &code_point),
             };
         }
     } else if value.is_iterable(global)? {

--- a/src/runtime/test_runner/expect/toContainEqual.rs
+++ b/src/runtime/test_runner/expect/toContainEqual.rs
@@ -80,9 +80,9 @@ pub(crate) fn to_contain_equal(
         if expected_type.is_string_object_like() && value_type.is_string() {
             pass = false;
         } else {
-            let value_view = value.to_js_string_view(global)?;
-            let expected_view = expected.to_js_string_view(global)?;
-            pass = match CodeUnitPair::new(&value_view, &expected_view) {
+            let value_string = value.to_bun_string(global)?;
+            let expected_string = expected.to_bun_string(global)?;
+            pass = match CodeUnitPair::new(&value_string, &expected_string) {
                 CodeUnitPair::Latin1(units, code_point) => has_code_point(units, code_point),
                 CodeUnitPair::Utf16(units, code_point) => has_code_point(&units, &code_point),
             };

--- a/src/runtime/test_runner/expect/toEqualIgnoringWhitespace.rs
+++ b/src/runtime/test_runner/expect/toEqualIgnoringWhitespace.rs
@@ -1,12 +1,17 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
+use super::CodeUnitPair;
 use super::Expect;
 use super::throw;
 
 // Matches ' ' and '\t'..'\r' (0x09–0x0D) — includes VT (0x0B), which Rust's
 // u8::is_ascii_whitespace does not.
 #[inline]
-fn is_zig_whitespace(b: u8) -> bool {
-    matches!(b, b' ' | b'\t' | b'\n' | 0x0B | 0x0C | b'\r')
+fn is_zig_whitespace(unit: u16) -> bool {
+    matches!(unit, 0x20 | 0x09..=0x0D)
+}
+
+fn without_whitespace<T: Copy + Into<u16>>(units: &[T]) -> impl Iterator<Item = u16> + '_ {
+    units.iter().map(|&unit| unit.into()).filter(|&unit| !is_zig_whitespace(unit))
 }
 
 // Free fn (this module can't open `impl Expect`); bridged into `impl Expect` by the
@@ -38,47 +43,16 @@ pub(crate) fn to_equal_ignoring_whitespace(
     let mut pass = value.is_string() && expected.is_string();
 
     if pass {
-        let value_slice = value.to_utf8(global)?;
-        let expected_slice = expected.to_utf8(global)?;
-
-        let value_utf8: &[u8] = value_slice.slice();
-        let expected_utf8: &[u8] = expected_slice.slice();
-
-        let mut left: usize = 0;
-        let mut right: usize = 0;
-
-        // Skip leading whitespaces
-        while left < value_utf8.len() && is_zig_whitespace(value_utf8[left]) {
-            left += 1;
-        }
-        while right < expected_utf8.len() && is_zig_whitespace(expected_utf8[right]) {
-            right += 1;
-        }
-
-        while left < value_utf8.len() && right < expected_utf8.len() {
-            let left_char = value_utf8[left];
-            let right_char = expected_utf8[right];
-
-            if left_char != right_char {
-                pass = false;
-                break;
+        let value_view = value.to_js_string_view(global)?;
+        let expected_view = expected.to_js_string_view(global)?;
+        pass = match CodeUnitPair::new(&value_view, &expected_view) {
+            CodeUnitPair::Latin1(left, right) => {
+                without_whitespace(left).eq(without_whitespace(right))
             }
-
-            left += 1;
-            right += 1;
-
-            // Skip trailing whitespaces
-            while left < value_utf8.len() && is_zig_whitespace(value_utf8[left]) {
-                left += 1;
+            CodeUnitPair::Utf16(left, right) => {
+                without_whitespace(&left).eq(without_whitespace(&right))
             }
-            while right < expected_utf8.len() && is_zig_whitespace(expected_utf8[right]) {
-                right += 1;
-            }
-        }
-
-        if left < value_utf8.len() || right < expected_utf8.len() {
-            pass = false;
-        }
+        };
     }
 
     if not {

--- a/src/runtime/test_runner/expect/toEqualIgnoringWhitespace.rs
+++ b/src/runtime/test_runner/expect/toEqualIgnoringWhitespace.rs
@@ -43,9 +43,9 @@ pub(crate) fn to_equal_ignoring_whitespace(
     let mut pass = value.is_string() && expected.is_string();
 
     if pass {
-        let value_view = value.to_js_string_view(global)?;
-        let expected_view = expected.to_js_string_view(global)?;
-        pass = match CodeUnitPair::new(&value_view, &expected_view) {
+        let value_string = value.to_bun_string(global)?;
+        let expected_string = expected.to_bun_string(global)?;
+        pass = match CodeUnitPair::new(&value_string, &expected_string) {
             CodeUnitPair::Latin1(left, right) => {
                 without_whitespace(left).eq(without_whitespace(right))
             }

--- a/src/runtime/test_runner/expect/toIncludeRepeated.rs
+++ b/src/runtime/test_runner/expect/toIncludeRepeated.rs
@@ -1,6 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
-use super::{Expect, get_signature, throw};
+use super::{CodeUnitPair, Expect, get_signature, throw};
 
 impl Expect {
     #[bun_jsc::host_fn(method)]
@@ -58,20 +58,16 @@ impl Expect {
 
         let not = this.flags.get().not();
 
-        let expect_string_as_str_owned = expect_string.to_utf8(global)?;
-        let sub_string_as_str_owned = substring.to_utf8(global)?;
+        let expect_string_view = expect_string.to_js_string_view(global)?;
+        let substring_view = substring.to_js_string_view(global)?;
 
-        let expect_string_as_str = expect_string_as_str_owned.slice();
-        let sub_string_as_str = sub_string_as_str_owned.slice();
-
-        if sub_string_as_str.is_empty() {
+        if substring_view.is_empty() {
             return Err(global.throw(format_args!(
                 "toIncludeRepeated() requires the first argument to be a non-empty string"
             )));
         }
 
-        // Non-overlapping occurrence count.
-        let actual_count = bun_core::strings::count(expect_string_as_str, sub_string_as_str);
+        let actual_count = CodeUnitPair::new(&expect_string_view, &substring_view).count();
         let mut pass = actual_count == count_as_num as usize;
 
         if not {

--- a/src/runtime/test_runner/expect/toIncludeRepeated.rs
+++ b/src/runtime/test_runner/expect/toIncludeRepeated.rs
@@ -58,16 +58,16 @@ impl Expect {
 
         let not = this.flags.get().not();
 
-        let expect_string_view = expect_string.to_js_string_view(global)?;
-        let substring_view = substring.to_js_string_view(global)?;
+        let received = expect_string.to_bun_string(global)?;
+        let needle = substring.to_bun_string(global)?;
 
-        if substring_view.is_empty() {
+        if needle.is_empty() {
             return Err(global.throw(format_args!(
                 "toIncludeRepeated() requires the first argument to be a non-empty string"
             )));
         }
 
-        let actual_count = CodeUnitPair::new(&expect_string_view, &substring_view).count();
+        let actual_count = CodeUnitPair::new(&received, &needle).count();
         let mut pass = actual_count == count_as_num as usize;
 
         if not {

--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -3,8 +3,8 @@ use super::JSValueTestExt;
 use super::FormatterTestExt;
 use bun_jsc::console_object::Formatter;
 use bun_jsc::JsClass;
-use bun_core::strings;
 
+use super::CodeUnitPair;
 use super::Expect;
 use super::ExpectAny;
 use super::expect_any_js;
@@ -114,12 +114,11 @@ pub(crate) fn to_throw(
             })
             .unwrap_or(JSValue::UNDEFINED);
 
-            // TODO: remove this allocation
             // partial match
             {
-                let expected_slice = expected_value.to_utf8(global)?;
-                let received_slice = received_message.to_utf8(global)?;
-                if !strings::contains(received_slice.slice(), expected_slice.slice()) {
+                let expected_view = expected_value.to_js_string_view(global)?;
+                let received_view = received_message.to_js_string_view(global)?;
+                if !CodeUnitPair::new(&received_view, &expected_view).includes() {
                     return Ok(JSValue::UNDEFINED);
                 }
             }
@@ -221,11 +220,10 @@ pub(crate) fn to_throw(
 
         if expected_value.is_string() {
             if let Some(received_message) = received_message_opt {
-                // TODO: remove this allocation
                 // partial match
-                let expected_slice = expected_value.to_utf8(global)?;
-                let received_slice = received_message.to_utf8(global)?;
-                if strings::contains(received_slice.slice(), expected_slice.slice()) {
+                let expected_view = expected_value.to_js_string_view(global)?;
+                let received_view = received_message.to_js_string_view(global)?;
+                if CodeUnitPair::new(&received_view, &expected_view).includes() {
                     return Ok(JSValue::UNDEFINED);
                 }
             }

--- a/src/runtime/test_runner/expect/toThrow.rs
+++ b/src/runtime/test_runner/expect/toThrow.rs
@@ -116,9 +116,9 @@ pub(crate) fn to_throw(
 
             // partial match
             {
-                let expected_view = expected_value.to_js_string_view(global)?;
-                let received_view = received_message.to_js_string_view(global)?;
-                if !CodeUnitPair::new(&received_view, &expected_view).includes() {
+                let expected_string = expected_value.to_bun_string(global)?;
+                let received_string = received_message.to_bun_string(global)?;
+                if !CodeUnitPair::new(&received_string, &expected_string).includes() {
                     return Ok(JSValue::UNDEFINED);
                 }
             }
@@ -221,9 +221,9 @@ pub(crate) fn to_throw(
         if expected_value.is_string() {
             if let Some(received_message) = received_message_opt {
                 // partial match
-                let expected_view = expected_value.to_js_string_view(global)?;
-                let received_view = received_message.to_js_string_view(global)?;
-                if CodeUnitPair::new(&received_view, &expected_view).includes() {
+                let expected_string = expected_value.to_bun_string(global)?;
+                let received_string = received_message.to_bun_string(global)?;
+                if CodeUnitPair::new(&received_string, &expected_string).includes() {
                     return Ok(JSValue::UNDEFINED);
                 }
             }

--- a/test/js/bun/test/expect-string-coercion-gc.test.ts
+++ b/test/js/bun/test/expect-string-coercion-gc.test.ts
@@ -66,7 +66,15 @@ test.skipIf(!isASAN)("string matchers own the received string before they coerce
   });
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   expect(stdout).toBe(
-    ["toStartWith", "toEndWith", "toInclude", "toIncludeRepeated", "toEqualIgnoringWhitespace", "toContainEqual", "toThrow"]
+    [
+      "toStartWith",
+      "toEndWith",
+      "toInclude",
+      "toIncludeRepeated",
+      "toEqualIgnoringWhitespace",
+      "toContainEqual",
+      "toThrow",
+    ]
       .map(name => name + " ok\n")
       .join(""),
   );

--- a/test/js/bun/test/expect-string-coercion-gc.test.ts
+++ b/test/js/bun/test/expect-string-coercion-gc.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN } from "harness";
+
+// The expected value can be a String object. Its toString() is user code, and it runs after the
+// matcher has read the received string. The matcher must own the received characters by then.
+const fixture = /* js */ `
+const { expect } = Bun.jest();
+
+function deep(n, fn) {
+  return n === 0 ? fn() : deep(n - 1, fn);
+}
+// Overwrites stale stack slots, so that no dead frame keeps the base string reachable.
+function clobber(n) {
+  let a = 1, b = 2, c = 3, d = 4, e = 5, f = 6, g = 7, h = 8;
+  return n === 0 ? a + b + c + d + e + f + g + h : clobber(n - 1) + a + b + c + d + e + f + g + h;
+}
+let counter = 0;
+// slice(2) of a 16-bit string is a substring rope. Its characters live in the base string,
+// and only the rope references the base.
+function makeReceived() {
+  return deep(200, () => ("\\u{1F642}" + "probe_unique_" + counter++ + "_" + "x".repeat(64)).slice(2));
+}
+// A String object whose toString() resolves \`received\` (the rope drops its base) and collects the base.
+function makeExpected(received, result) {
+  const expected = new String(result);
+  expected.toString = () => {
+    ({})[received];
+    Bun.gc(true);
+    const junk = [];
+    for (let i = 0; i < 500; i++) junk.push(("\\u{1F600}" + "zzzzzzzz".repeat(12) + i).slice(1).toUpperCase());
+    Bun.gc(true);
+    return result;
+  };
+  return expected;
+}
+
+const cases = {
+  toStartWith: (received, copy) => expect(received).toStartWith(makeExpected(received, "probe_unique_")),
+  toEndWith: (received, copy) => expect(received).toEndWith(makeExpected(received, "xxxx")),
+  toInclude: (received, copy) => expect(received).toInclude(makeExpected(received, "_unique_")),
+  toIncludeRepeated: (received, copy) => expect(received).toIncludeRepeated(makeExpected(received, "probe"), 1),
+  toEqualIgnoringWhitespace: (received, copy) => expect(received).toEqualIgnoringWhitespace(makeExpected(received, copy)),
+  toContainEqual: (received, copy) => expect(new String(received)).toContainEqual(makeExpected(received, "p")),
+  // Here the thrown message is the String object, and the expected string is the rope.
+  toThrow: (received, copy) =>
+    expect(() => {
+      throw { message: makeExpected(received, "message: " + copy.replaceAll(" ", "")) };
+    }).toThrow(received),
+};
+for (const [name, run] of Object.entries(cases)) {
+  const received = makeReceived();
+  const copy = Array.from(received).join(" ");
+  clobber(400);
+  run(received, copy);
+  console.log(name, "ok");
+}
+`;
+
+// Malloc=1 makes bmalloc use the system heap, so that ASAN sees a read of a freed StringImpl.
+test.skipIf(!isASAN)("string matchers own the received string before they coerce the expected value", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...bunEnv, Malloc: "1" },
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe(
+    ["toStartWith", "toEndWith", "toInclude", "toIncludeRepeated", "toEqualIgnoringWhitespace", "toContainEqual", "toThrow"]
+      .map(name => name + " ok\n")
+      .join(""),
+  );
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -2622,6 +2622,36 @@ describe("expect()", () => {
     expect(value).not.toContainEqual(expected);
   });
 
+  test("toContain() and toContainEqual() compare the UTF-16 code units of a string", () => {
+    // "🙂" is the surrogate pair \ud83d \ude42.
+    expect("🙂x").toContain("\ud83d");
+    expect("🙂x").toContain("\ude42x");
+    expect("🙂x").not.toContain("\ud83dx");
+    // An unpaired surrogate equals itself. It does not equal U+FFFD or another unpaired surrogate.
+    expect("a\ud83db").toContain("\ud83d");
+    expect("a\ud83db").not.toContain("\ud83e");
+    expect("a\ud83db").not.toContain("\ufffd");
+    expect("a\ufffdb").not.toContain("\ud83d");
+    // A slice of a 16-bit string keeps the 16-bit storage.
+    expect("du café au lait").toContain("🙂café".slice(2));
+    expect("🙂 du café".slice(2)).toContain("café");
+    expect("café").not.toContain("🙂");
+
+    // toContainEqual() spreads the string into code points. An unpaired surrogate is one code point.
+    expect("a\ud83db").toContainEqual("\ud83d");
+    expect("a\ud83db").not.toContainEqual("\ud83e");
+    expect("a\ud83db").not.toContainEqual("\ufffd");
+    expect("a\ufffdb").not.toContainEqual("\ud83d");
+    expect("🙂x").toContainEqual("🙂");
+    expect("🙂x").not.toContainEqual("\ud83d");
+    expect("🙂x").not.toContainEqual("\ude42");
+    expect("\ud83d🙂").toContainEqual("\ud83d");
+    expect("🙂\ude42").toContainEqual("\ude42");
+    expect("🙂 café".slice(2)).toContainEqual("é");
+    expect("café").toContainEqual("🙂é!".slice(2, 3));
+    expect("café").not.toContainEqual("🙂");
+  });
+
   test("toContainKey", () => {
     const o = { a: "foo", b: "bar", c: "baz" };
     expect(o).toContainKey("a");

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -997,6 +997,30 @@ describe("expect()", () => {
     }
   });
 
+  test("toThrow(string) compares the UTF-16 code units of the message", async () => {
+    const thrower = (/** @type {string} */ message) => () => {
+      throw new Error(message);
+    };
+    // "🙂" is the surrogate pair \ud83d \ude42.
+    expect(thrower("🙂x")).toThrow("\ud83d");
+    expect(thrower("🙂x")).toThrow("\ude42x");
+    expect(thrower("🙂x")).not.toThrow("\ud83dx");
+    // An unpaired surrogate equals itself. It does not equal U+FFFD or another unpaired surrogate.
+    expect(thrower("a\ud83db")).toThrow("\ud83d");
+    expect(thrower("a\ud83db")).not.toThrow("\ud83e");
+    expect(thrower("a\ud83db")).not.toThrow("\ufffd");
+    expect(thrower("a\ufffdb")).not.toThrow("\ud83d");
+    expect(() => expect(thrower("a\ud83db")).toThrow("\ud83e")).toThrow("toThrow");
+    expect(() => expect(thrower("🙂x")).not.toThrow("\ud83d")).toThrow("toThrow");
+    // A slice of a 16-bit string keeps the 16-bit storage.
+    expect(thrower("du café au lait")).toThrow("🙂café".slice(2));
+    expect(thrower("🙂 du café".slice(2))).toThrow("café");
+    expect(thrower("café")).not.toThrow("🙂");
+
+    await expect(Promise.reject(new Error("🙂x"))).rejects.toThrow("\ud83d");
+    await expect(Promise.reject(new Error("a\ud83db"))).rejects.not.toThrow("\ud83e");
+  });
+
   test("deepEquals derived strings and strings", () => {
     let a = new String("hello");
     let b = "hello";

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -662,6 +662,64 @@ describe("jest-extended", () => {
     }).toThrow("requires argument to be a string");
   });
 
+  test("string matchers compare UTF-16 code units", () => {
+    // "🙂" is the surrogate pair \ud83d \ude42. A string can start or end with one half of it.
+    expect("🙂x").toStartWith("\ud83d");
+    expect("🙂x").not.toStartWith("\ude42");
+    expect("x🙂").toEndWith("\ude42");
+    expect("x🙂").not.toEndWith("\ud83d");
+    expect("🙂x").toInclude("\ud83d");
+    expect("🙂x").toInclude("\ude42x");
+    expect("🙂x").not.toInclude("\ud83dx");
+    expect("🙂🙂x").toIncludeRepeated("\ud83d", 2);
+    expect("🙂🙂x").toIncludeRepeated("\ude42\ud83d", 1);
+    expect("🙂🙂x").not.toIncludeRepeated("\ud83d", 0);
+
+    // An unpaired surrogate equals itself. It does not equal U+FFFD or another unpaired surrogate.
+    expect("\ud83dx").toStartWith("\ud83d");
+    expect("\ud83dx").not.toStartWith("\ud83e");
+    expect("\ud83dx").not.toStartWith("\ufffd");
+    expect("\ufffdx").not.toStartWith("\ud83d");
+    expect("x\ude42").toEndWith("\ude42");
+    expect("x\ude42").not.toEndWith("\ude43");
+    expect("x\ude42").not.toEndWith("\ufffd");
+    expect("a\ud83db").toInclude("\ud83d");
+    expect("a\ud83db").not.toInclude("\ud83e");
+    expect("a\ud83db").not.toInclude("\ufffd");
+    expect("a\ufffdb").not.toInclude("\ud83d");
+    expect("\ud83d\ud83e\ud83d").toIncludeRepeated("\ud83d", 2);
+    expect("\ud83d\ud83e\ud83d").toIncludeRepeated("\ufffd", 0);
+    expect("\ud83d x").toEqualIgnoringWhitespace("\ud83dx");
+    expect("\ud83d x").not.toEqualIgnoringWhitespace("\ud83ex");
+    expect("\ud83d x").not.toEqualIgnoringWhitespace("\ufffdx");
+    expect(() => expect("🙂x").not.toStartWith("\ud83d")).toThrow("toStartWith");
+  });
+
+  test("string matchers compare an 8-bit string with a 16-bit string", () => {
+    // A slice of a 16-bit string keeps the 16-bit storage, even when every character fits in 8 bits.
+    const wide = "🙂café au lait".slice(2);
+    expect(wide).toBe("café au lait");
+
+    expect(wide).toStartWith("café");
+    expect("café au lait").toStartWith(wide.slice(0, 4));
+    expect(wide).not.toStartWith("cafe");
+    expect("café").not.toStartWith(wide);
+    expect(wide).toEndWith("lait");
+    expect("du café au lait").toEndWith(wide);
+    expect(wide).not.toEndWith("laît");
+    expect(wide).toInclude("é au");
+    expect("du café au lait !").toInclude(wide);
+    expect(wide).not.toInclude("è");
+    expect("café").not.toInclude("🙂");
+    expect("café").not.toInclude("\u0100");
+    expect(wide + wide).toIncludeRepeated("café", 2);
+    expect("café café").toIncludeRepeated(wide.slice(0, 4), 2);
+    expect("café café").toIncludeRepeated("🙂", 0);
+    expect(wide).toEqualIgnoringWhitespace("caféaulait");
+    expect("caféaulait").toEqualIgnoringWhitespace(wide);
+    expect("cafeaulait").not.toEqualIgnoringWhitespace(wide);
+  });
+
   // Symbol
 
   test("toBeSymbol()", () => {

--- a/test/js/bun/util/sliceAnsi-fuzz.test.ts
+++ b/test/js/bun/util/sliceAnsi-fuzz.test.ts
@@ -81,18 +81,10 @@ describe("sliceAnsi invariants", () => {
       const a = Math.floor(rng() * 50) - 10;
       const b = Math.floor(rng() * 50) - 10;
       const out = Bun.sliceAnsi(s, a, b);
-      // Iterating codepoints should not throw; no lone surrogates at boundaries.
-      // Note: lone surrogates in INPUT may pass through (we don't sanitize input),
-      // but we should never CREATE new lone surrogates by splitting a pair.
-      for (const cp of out) {
-        const c = cp.codePointAt(0)!;
-        if (c >= 0xd800 && c <= 0xdfff) {
-          // If input didn't have this lone surrogate at an index the slice touched,
-          // we created it — that's a bug. But for fuzz purposes, just assert it
-          // existed in input (conservative check).
-          expect(s).toContain(cp);
-        }
-      }
+      // randomString() never makes a lone surrogate, so one in the output means
+      // that the slice split a pair.
+      expect(s.isWellFormed()).toBe(true);
+      expect(out.isWellFormed()).toBe(true);
     }
   });
 


### PR DESCRIPTION
### Problem
- `expect("🙂x").toStartWith("\ud83d")` fails, although `"🙂x".startsWith("\ud83d")` is `true`. `toEndWith`, `toInclude`, `toContain`, `toThrow(string)` and `toIncludeRepeated` fail the same way. Jest and jest-extended call the `String` methods, so they pass.
- The opposite error also occurs. `expect("\ud83d x").toEqualIgnoringWhitespace("\ud83ex")` and `expect("a\ud83db").toContainEqual("\ud83e")` pass, although the strings differ.
- The cause: these matchers compare `to_utf8()` copies of the two strings (`run_string_affix_matcher` in `src/runtime/test_runner/expect.rs`, and five matcher files). The copy replaces every unpaired surrogate with U+FFFD.

### Fix
- Each matcher takes both strings with `to_bun_string` (owned, no transcode). `CodeUnitPair` (`expect.rs`) reads them as code units of one width: Latin-1 bytes when both are 8-bit, UTF-16 units otherwise. It uses slice compares, `strings::index_of` and `bun_highway::memmem16`.
- Correct because `startsWith`, `endsWith` and `indexOf` compare UTF-16 code units. `toContainEqual` keeps the Jest rule: it spreads the string into code points.
- Side effect: `expect(s).toContain("\uFFFD")` no longer matches an unpaired surrogate in `s`. `sliceAnsi-fuzz.test.ts` used that to detect a split pair. It now asserts `isWellFormed()`.
- Verified: `jest-extended.test.js` and `expect.test.js` (Bun 1.4.3 fails three of the four new blocks), and the new ASAN-only `expect-string-coercion-gc.test.ts`. More suites are in Notes.

### Background
- A JS string holds UTF-16 code units. A character above U+FFFF is two units, a surrogate pair: `"🙂"` is `\ud83d\ude42`. One half alone is an unpaired surrogate. UTF-8 cannot encode it.
- JavaScriptCore stores a string as 8-bit Latin-1 or as 16-bit UTF-16. `to_bun_string` takes a reference on that storage. It does not copy the characters.
- jest-extended is the reference for the `toStartWith` family. Bun implements these matchers natively.

<details><summary>Notes</summary>

- Found by an automated census of rarely tested APIs. No user report.
- Why owned strings and not `to_js_string_view`: the expected value can be a String object, so its `toString()` is user code that runs after the matcher has read the received string. It can resolve a received substring rope and collect the rope's base string. An earlier revision of this PR held a borrowed view across that call, and ASAN reported a heap-use-after-free in `CodeUnitPair::starts_with`. `expect-string-coercion-gc.test.ts` runs that scenario for all seven matcher paths in a child with `Malloc=1`. Each case hit the use-after-free on that revision. The view guard itself (it pins the rope, not the base) is a separate fix.
- Verdicts that change: a needle that is one half of a pair now matches (six matchers). An unpaired surrogate no longer equals U+FFFD or another unpaired surrogate (eight matchers). So `toContain("\uFFFD")` and `.not.toContain("\uFFFD")` no longer detect an unpaired surrogate. I checked the other uses of that idiom in `test/` (`bunshell`, `md-edge-cases`, `text-encoder`, `markdown-entrypoint`, `yarn-lock-migration`, `index-of-line`). They look for a real U+FFFD.
- One new test block compares an 8-bit string with a 16-bit string (`"🙂café au lait".slice(2)` is a 16-bit rope, checked with `jscDescribe`). It passes before and after. It guards the mixed-width path, where `CodeUnitPair::new` widens the 8-bit string once.
- `toMatch("string")` already compares code units through `JSC__JSValue__stringIncludes`. It is not changed. It can move to `CodeUnitPair` later, which would remove that binding.
- Not changed: `toEqualIgnoringWhitespace` strips only ASCII whitespace. jest-extended strips `\s`, which also covers U+00A0, U+2028 and others. `toIncludeRepeated` treats its argument as a literal string. jest-extended builds a `RegExp` from it.
- `toContainEqual` with an empty string, or with more than one code point, is still `false`, as before.
- Other suites run with the debug build: `sliceAnsi-fuzz`, `expect-extend`, `expect-label`, `expect-failure-message-angle-brackets`, `bun_test`, `spyMatchers`, `stack`, `mock-fn`, `describe`, `jest-each`, `printing/diffexample`, `expect/huge-failure-message`.
- `cargo clippy -p bun_jsc -p bun_runtime --no-deps` and `cargo fmt --all -- --check` are clean. The source lints in `test/internal/source-lints/` pass.

</details>
