### PR TITLE
node:util: util.types.isProxy returns false for the global object

### DIFF
--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -1077,7 +1077,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsSharedArrayBuffer,
 JSC_DEFINE_HOST_FUNCTION(jsFunctionIsProxy, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
     GET_FIRST_CELL
-    return JSValue::encode(jsBoolean(cell->type() == GlobalProxyType || cell->type() == ProxyObjectType));
+    return JSValue::encode(jsBoolean(cell->type() == ProxyObjectType));
 }
 JSC_DEFINE_HOST_FUNCTION(jsFunctionIsModuleNamespaceObject,
     (JSC::JSGlobalObject * globalObject,

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -2361,3 +2361,40 @@ describe.concurrent("node:repl prints a frozen thrown error and continues", () =
     interactiveTimeout,
   );
 });
+
+// The completer returns nothing for a chain rooted at a Proxy, so that it does
+// not run a trap. util.types.isProxy must answer false for the global object.
+test.concurrent(
+  "node:repl completes a property of globalThis",
+  async () => {
+    const script = `
+      const repl = require("node:repl");
+      const { PassThrough } = require("node:stream");
+      const complete = useGlobal => new Promise((resolve, reject) => {
+        const inp = new PassThrough(), out = new PassThrough(); out.resume();
+        const r = repl.start({ input: inp, output: out, terminal: false, prompt: "", useGlobal });
+        r.complete("globalThis.JSO", (err, data) => {
+          r.close();
+          err ? reject(err) : resolve(data);
+        });
+      });
+      (async () => {
+        console.log(JSON.stringify({ useGlobal: await complete(true), ownContext: await complete(false) }));
+      })();
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, NO_COLOR: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      useGlobal: [["globalThis.JSON"], "globalThis.JSO"],
+      ownContext: [["globalThis.JSON"], "globalThis.JSO"],
+    });
+    expect(exitCode).toBe(0);
+  },
+  interactiveTimeout,
+);

--- a/test/js/node/util/test-util-types.test.js
+++ b/test/js/node/util/test-util-types.test.js
@@ -1,5 +1,6 @@
 import assert from "assert";
 import { expect, test } from "bun:test";
+import vm from "node:vm";
 import def, * as ns from "util/types";
 const req = require("util/types");
 const types = def;
@@ -123,6 +124,38 @@ test("isBigIntObject/isSymbolObject/isBoxedPrimitive survive structure and proto
       },
     });
   }
+});
+
+// `globalThis` evaluates to the engine's global proxy cell, which is not a Proxy instance.
+test("isProxy is false for a global object", () => {
+  const revocable = Proxy.revocable({}, {});
+  revocable.revoke();
+  const proxySandbox = new Proxy({}, {});
+  const proxyContext = vm.createContext(proxySandbox);
+
+  expect({
+    globalThis: types.isProxy(globalThis),
+    newContextGlobal: types.isProxy(vm.runInNewContext("globalThis")),
+    contextGlobal: types.isProxy(vm.runInContext("globalThis", vm.createContext({}))),
+    proxySandboxGlobal: types.isProxy(vm.runInContext("globalThis", proxyContext)),
+    calledInsideContext: vm.runInNewContext("isProxy(globalThis)", { isProxy: types.isProxy }),
+    proxySandbox: types.isProxy(proxySandbox),
+    callableProxy: types.isProxy(new Proxy(function () {}, {})),
+    revokedProxy: types.isProxy(revocable.proxy),
+    crossRealmProxy: types.isProxy(vm.runInNewContext("new Proxy({}, {})")),
+    proxyOfGlobal: types.isProxy(new Proxy(globalThis, {})),
+  }).toEqual({
+    globalThis: false,
+    newContextGlobal: false,
+    contextGlobal: false,
+    proxySandboxGlobal: false,
+    calledInsideContext: false,
+    proxySandbox: true,
+    callableProxy: true,
+    revokedProxy: true,
+    crossRealmProxy: true,
+    proxyOfGlobal: true,
+  });
 });
 
 {


### PR DESCRIPTION
### Problem
- `util.types.isProxy(globalThis)` returns `true`. Node returns `false`. The `globalThis` of a `node:vm` context gives the same wrong answer.
- The cause is `jsFunctionIsProxy` (`src/jsc/modules/NodeUtilTypesModule.cpp:1080`). It returns `cell->type() == GlobalProxyType || cell->type() == ProxyObjectType`. `globalThis` evaluates to a `JSGlobalProxy` cell, and the first arm matches it.
- One effect shows in `node:repl`. The completer returns nothing when `isProxy(obj)` is true, so `globalThis.JSO` + Tab gives no result. Node gives `globalThis.JSON`.

### Fix
- Remove the `GlobalProxyType` arm. Only `ProxyObjectType` answers `true`.
- Correct because Node calls V8's `Value::IsProxy()` ([node_types.cc](https://github.com/nodejs/node/blob/v26.3.0/src/node_types.cc#L43-L44), [api.cc](https://github.com/nodejs/node/blob/v26.3.0/deps/v8/src/api/api.cc#L3773-L3775)). That is true for a `JSProxy` only. V8's `globalThis` is a `JSGlobalProxy`, a different instance type.
- Each real Proxy still answers `true`: callable, revoked, cross-realm, a Proxy of `globalThis`, a Proxy used as a vm sandbox.
- Verified: one new test in `test/js/node/util/test-util-types.test.js` and one in `test/js/bun/repl/repl.test.ts`. Both fail on the unfixed build. The node `test-util-types.js` and `test-repl-tab-complete-*.js` files still pass.

### Background
- `ProxyObjectType` is the JSC cell type of an object that `new Proxy(target, handler)` creates.
- `JSGlobalProxy` (`GlobalProxyType`) is an engine-internal wrapper around the global object. Code that reads `globalThis` gets this wrapper. It has no handler and runs no trap.
- The arm dates from the first `node:util/types` commit (24be0f4fc5). It copied JSC's `JSCell::isProxy()`, which counts both types.

<details><summary>Notes</summary>

Repro:

```js
// isproxy.cjs
const { types } = require("node:util");
console.log(
  types.isProxy(globalThis),
  types.isProxy(require("node:vm").runInNewContext("globalThis")),
  types.isProxy(new Proxy({}, {})),
  types.isProxy({}));
```

| runtime | output |
| --- | --- |
| node v26.3.0 | `false false true false` |
| bun 1.4.3-canary.1+6a92015fc | `true true true false` |
| this branch (debug build) | `false false true false` |

The new `test-util-types.test.js` test checks ten values. Node v26.3.0 and this branch agree on all of them. The unfixed build differs on the five global-object rows:

| value | node | bun before |
| --- | --- | --- |
| `globalThis` | false | true |
| `vm.runInNewContext("globalThis")` | false | true |
| `vm.runInContext("globalThis", vm.createContext({}))` | false | true |
| `vm.runInContext("globalThis", vm.createContext(new Proxy({}, {})))` | false | true |
| `vm.runInNewContext("isProxy(globalThis)", { isProxy })` | false | true |
| the Proxy passed to `vm.createContext` | true | true |
| `new Proxy(function () {}, {})` | true | true |
| revoked proxy | true | true |
| `vm.runInNewContext("new Proxy({}, {})")` | true | true |
| `new Proxy(globalThis, {})` | true | true |

`node:repl` completion, `repl.start({ useGlobal })` then `r.complete("globalThis.JSO", cb)`:

| runtime | `useGlobal: true` | `useGlobal: false` |
| --- | --- | --- |
| node v26.3.0 | `[["globalThis.JSON"],"globalThis.JSO"]` | `[["globalThis.JSON"],"globalThis.JSO"]` |
| bun before | `[[],"globalThis.JSO"]` | `[[],"globalThis.JSO"]` |
| this branch | `[["globalThis.JSON"],"globalThis.JSO"]` | `[["globalThis.JSON"],"globalThis.JSO"]` |

The bail-out is in `src/js/internal/repl/completion.js` (`includesProxiesOrGetters`). It exists so that completion never runs a Proxy trap. The node test `test-repl-completion-on-getters-disabled.js` ("no completions are generated for a proxy object") still passes, so a real Proxy still suppresses completion.

No other code in `src/js` calls `util.types.isProxy`. `util.inspect` uses the `$isProxyObject` intrinsic, which already checks `ProxyObjectType` only.

Suites run with the debug build: `test/js/node/util/test-util-types.test.js`, `test/js/node/util/util.test.js`, `test/js/bun/repl/repl.test.ts`, and from `test/js/node/test/parallel`: `test-util-types.js`, `test-util-types-exists.js`, `test-util-inspect-proxy.js`, `test-vm-proxies.js`, `test-vm-proxy-failure-CP.js`, `test-vm-global-identity.js`, `test-repl-tab.js`, `test-repl-completion-on-getters-disabled.js`, and `test-repl-tab-complete-{buffer,computed-props,crash,custom-completer,files,new-expression,no-warn,nosideeffects,on-editor-mode}.js`.

`test-repl-tab-complete-nested-repls.js` fails with the debug build with and without this change (the debug build prints `Uncaught Error` without the message). It passes with the release build. It does not involve `isProxy`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts

<!-- robobun:evidence:end -->