### PR TITLE
WebAssembly.Exception: format and source-map the traceStack stack like an Error stack (WebKit bump for oven-sh/WebKit#641)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "cf1b36ec8703d8e87436094d21d478d358c7d886";
+export const WEBKIT_VERSION = "autobuild-preview-pr-641-05a48085";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1,7 +1,8 @@
 import { nativeFrameForTesting } from "bun:internal-for-testing";
 import { noInline } from "bun:jsc";
-import { afterEach, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { sep } from "node:path";
 const origPrepareStackTrace = Error.prepareStackTrace;
 afterEach(() => {
   Error.prepareStackTrace = origPrepareStackTrace;
@@ -1223,3 +1224,64 @@ test.concurrent.each([[{}], [{ BUN_JSC_useSourceProviderCache: "0" }]])(
     expect(exitCode).toBe(0);
   },
 );
+
+// The `stack` of `new WebAssembly.Exception(tag, payload, { traceStack: true })` is the stack of an Error created at
+// that point: V8-style, source-mapped, and passed through Error.prepareStackTrace.
+describe("WebAssembly.Exception with traceStack", () => {
+  const tag = new WebAssembly.Tag({ parameters: [] });
+  // Both on one line, so only the column of the first frame differs.
+  // prettier-ignore
+  function createBoth() { return [new WebAssembly.Exception(tag, [], { traceStack: true }), new Error()]; }
+
+  test("stack is formatted and source-mapped like the stack of an Error", () => {
+    const [exception, error] = createBoth();
+    const withoutFirstColumn = stack => stack.replace(/:\d+\)$/m, ")");
+    expect(exception.stack).toStartWith(`Error\n    at createBoth (${import.meta.path}:`);
+    expect(withoutFirstColumn(exception.stack)).toBe(withoutFirstColumn(error.stack));
+  });
+
+  test("stack goes through Error.prepareStackTrace", () => {
+    Error.prepareStackTrace = (_, callSites) => callSites;
+    const [exception, error] = createBoth();
+    const summarize = callSites =>
+      callSites.map(site => [site.getFunctionName(), site.getFileName(), site.getLineNumber()]);
+    expect(summarize(exception.stack)).toEqual(summarize(error.stack));
+    expect(summarize(exception.stack)[0]).toEqual(["createBoth", import.meta.path, expect.any(Number)]);
+  });
+
+  test("stack stays a getter on the prototype", () => {
+    const [exception] = createBoth();
+    expect(Reflect.ownKeys(exception)).toEqual([]);
+    expect(Object.getOwnPropertyDescriptor(WebAssembly.Exception.prototype, "stack").get).toBeFunction();
+    expect(new WebAssembly.Exception(tag, []).stack).toBeUndefined();
+  });
+
+  test("positions are those of the source file, not of the transpiled file", async () => {
+    using dir = tempDir("wasm-exception-stack", {
+      "thrower.ts": `// line 1
+// line 2
+type Erased = { erased: true };
+function thrower(): WebAssembly.Exception {
+  const tag = new WebAssembly.Tag({ parameters: [] });
+  return new WebAssembly.Exception(tag, [], { traceStack: true });
+}
+console.log(thrower().stack);
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "thrower.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.replaceAll(String(dir) + sep, "").replace(/:(\d+):\d+/g, ":$1")).toMatchInlineSnapshot(`
+      "Error
+          at thrower (thrower.ts:6)
+          at thrower.ts:8
+      "
+    `);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
**Blocked on oven-sh/WebKit#641, which waits for oven-sh/bun#42486.**

### Problem
- `new WebAssembly.Exception(tag, [], { traceStack: true }).stack` is `thrower@/t.js:3:35\nmodule code@/t.js:5:35`: JSC's own format, positions of the transpiled file, no `Error.prepareStackTrace`. An `Error` on the next line gives `Error\n    at thrower (/t.js:5:10)`.
- The cause is in JSC. `WebAssemblyExceptionConstructor.cpp:102` builds the string with `Interpreter::stackTraceAsString`, so bun's formatter hook `VM::onComputeErrorInfoJSValue` never runs.

### Fix
- The engine change is oven-sh/WebKit#641. The constructor creates an `Error` at that point and stores its `stack`, so the value takes the path of `new Error().stack`.
- This PR pins the preview build of #641 so that CI runs the tests. It must not merge with the pin. bun prints a wasm frame as `at unknown`, where the old text had `cxx_thrower@wasm-function[1]`, so #641 lands after oven-sh/bun#42486, which names wasm frames.
- To decide, in #641: `Error.prepareStackTrace` receives an `Error`, V8 passes the exception. It runs inside the constructor, V8 runs it on first access. With no frames `stack` is `undefined`, no longer `""`.
- Verified: `test/js/node/v8/capture-stack-trace.test.js` (4 new tests, 50 pass). bun 1.4.3 fails 3 of the 4.

### Background
- `VM::onComputeErrorInfoJSValue` is a bun addition to JSC. `ErrorInstance` calls it on the first read of `stack`. bun formats the frames V8-style there, applies source maps and calls `Error.prepareStackTrace`.
- `traceStack` is an option of the `WebAssembly.Exception` constructor. The spec leaves the text of `stack` to the engine.
- A preview pin is a build the fork's CI made for an open WebKit PR.

<details><summary>Notes</summary>

- Origin: an internal differential-fuzzing note, realism rated low (few toolchains pass `traceStack`). There is no user report.
- The plan for this PR: when #641 is on the fork's `main` and a routine WebKit upgrade carries it, this PR drops the `WEBKIT_VERSION` line and keeps the tests. By then oven-sh/bun#42486 is in, and I add a test for a `traceStack` exception that a JS import creates under a named wasm function: the wasm frame must have its name. Both PRs append to `capture-stack-trace.test.js`, so this one needs a rebase then.
- The pin is `autobuild-preview-pr-641-05a48085`, the build of the first commit of #641. The second commit of #641 changes an include and a JSC test only.
- node v26.3.0 prints `Error\n    at thrower (/t.js:5:10)\n    at Object.<anonymous> (/t.js:7:28)` for the same script.
- The 4 tests: the stack equals the stack of an `Error` created on the same line (first column aside), it goes through `Error.prepareStackTrace`, `Reflect.ownKeys(exception)` stays `[]` with the getter on the prototype, and a spawned `.ts` file with comment lines and a type alias above the function reports lines 6 and 8 of the source.
- Checked with bun linked against the patched JSC, against node: a subclass (`at new MyExc`), async frames (`at async b`), a `node:vm` context, 20000 constructions followed by a full GC, and `BUN_JSC_validateExceptionChecks=1`. A stack that crosses a wasm frame keeps its JS frames and their order.
- Self-reviewed: 4 concerns raised, 3 addressed (the merge order behind #42486, a wrong claim that a stack which crosses wasm matches node, the sibling call sites, which #641 now lists). Not adopted: to drop the pin now. The pin is what lets CI run these tests against the engine change, and the PR is a draft.
- #42508 (oven-sh/WebKit#642) comes from the same note. Both PRs rewrite the `WEBKIT_VERSION` line.

</details>

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/v8/capture-stack-trace.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.3 (6a92015fc)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [7.72ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [22.69ms]
(pass) capture stack trace [9.74ms]
(pass) capture stack trace with message [7.47ms]
(pass) capture stack trace with constructor [5.60ms]
(pass) capture stack trace limit [23.90ms]
(pass) prepare stack trace [13.39ms]
(pass) capture stack trace second argument [18.20ms]
(pass) capture stack trace edge cases [13.40ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [23.10ms]
(pass) prepare stack trace call sites [14.86ms]
(pass) sanity check [14.94ms]
(pass) CallFrame isEval works as expected [9.11ms]
(pass) CallFrame isTopLevel returns false for Function constructor [9.58ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [9.84ms]
(pass) CallFrame.p.isConstructor [3.40ms]
(pass) CallFrame.p.isNative [3.48ms]
(pass) return non-strings from Error.prepareStackTrace [3.59ms]
(pass) CallFrame.p.toString [3.47ms]
(pass) err.stack should invoke prepareStackTrace [16.79ms]
(pass) Error.prepareStackTrace inside a node:vm works [96.83ms]
(pass) Error.captureStackTrace inside error constructor works [8.21ms]
(pass) Error.prepareStackTrace has a default implementation which behaves the same as being unset [429.60ms]
(pass) Error.prepareStackTrace returns a CallSite object [7.37ms]
(pass) Error.captureStackTrace updates the stack property each call, even if Error.prepareStackTrace is set [25.15ms]
(pass) Error.captureStackTrace updates the stack property each call [12.60ms]
(pass) calling .stack later uses the stored StackTrace [10.39ms]
(pass) calling .stack on a non-materialized Error updates the stack properly [11.61ms]
(pass) Error.prepareStackTrace on an array with non-CallSite objects doesn't crash [5.76ms]
(pass) Error.prepareStac
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                |  2 +-
 test/js/node/v8/capture-stack-trace.test.js | 64 ++++++++++++++++++++++++++++-
 2 files changed, 64 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
scripts/build/deps/webkit.ts                     1      0     12
test/js/node/v8/capture-stack-trace.test.js      0      0     12
```

</details>

<!-- robobun:evidence:end -->