### PR TITLE
json5: reject a NUL byte outside a string instead of treating it as the end of input

### DIFF
--- a/src/parsers/json5.rs
+++ b/src/parsers/json5.rs
@@ -270,24 +270,21 @@ impl<'a> JSON5Parser<'a> {
 
     // ── Scanner ──
 
-    /// Returns the byte at the current position, or 0 if at EOF.
-    /// All source access in scan() goes through this to avoid bounds checks.
-    fn peek(&self) -> u8 {
-        if self.pos < self.source.len() {
-            return self.source[self.pos];
-        }
-        0
+    /// Returns the byte at the current position, or `None` at the end of the
+    /// source. A NUL byte in the source is `Some(0)`, not the end.
+    fn peek(&self) -> Option<u8> {
+        self.source.get(self.pos).copied()
     }
 
     fn scan(&mut self) -> Result<(), ParseError> {
         self.token.data = 'next: loop {
-            match self.peek() {
-                0 => {
-                    self.token.loc = Loc {
-                        start: i32::try_from(self.pos).expect("int cast"),
-                    };
-                    break 'next TokenData::Eof;
-                }
+            let Some(c) = self.peek() else {
+                self.token.loc = Loc {
+                    start: i32::try_from(self.pos).expect("int cast"),
+                };
+                break 'next TokenData::Eof;
+            };
+            match c {
                 // Whitespace — skip without setting loc
                 b'\t' | b'\n' | b'\r' | b' ' | 0x0B | 0x0C => {
                     self.pos += 1;
@@ -382,7 +379,7 @@ impl<'a> JSON5Parser<'a> {
                     }
                     return Err(ParseError::UnexpectedCharacter);
                 }
-                c => {
+                _ => {
                     if c == b't' {
                         self.token.loc = Loc {
                             start: i32::try_from(self.pos).expect("int cast"),
@@ -467,11 +464,11 @@ impl<'a> JSON5Parser<'a> {
 
     fn scan_signed_value(&mut self, is_negative: bool) -> Result<f64, ParseError> {
         match self.peek() {
-            b'0'..=b'9' | b'.' => {
+            Some(b'0'..=b'9' | b'.') => {
                 let n = self.scan_number()?;
                 Ok(if is_negative { -n } else { n })
             }
-            b'I' => {
+            Some(b'I') => {
                 if self.scan_keyword(b"Infinity") {
                     return Ok(if is_negative {
                         f64::NEG_INFINITY
@@ -481,15 +478,15 @@ impl<'a> JSON5Parser<'a> {
                 }
                 Err(ParseError::UnexpectedCharacter)
             }
-            b'N' => {
+            Some(b'N') => {
                 if self.scan_keyword(b"NaN") {
                     let nan = f64::NAN;
                     return Ok(if is_negative { -nan } else { nan });
                 }
                 Err(ParseError::UnexpectedCharacter)
             }
-            0 => Err(ParseError::UnexpectedEof),
-            _ => Err(ParseError::UnexpectedCharacter),
+            None => Err(ParseError::UnexpectedEof),
+            Some(_) => Err(ParseError::UnexpectedCharacter),
         }
     }
 
@@ -801,7 +798,7 @@ impl<'a> JSON5Parser<'a> {
         let start = self.pos;
 
         // Leading zero: check for hex prefix or invalid leading zeros
-        if self.peek() == b'0' && self.pos + 1 < self.source.len() {
+        if self.peek() == Some(b'0') && self.pos + 1 < self.source.len() {
             match self.source[self.pos + 1] {
                 b'x' | b'X' => return self.scan_hex_number(),
                 b'0'..=b'9' => return Err(ParseError::LeadingZeros),
@@ -822,7 +819,7 @@ impl<'a> JSON5Parser<'a> {
         }
 
         // Fractional part
-        if self.peek() == b'.' {
+        if self.peek() == Some(b'.') {
             self.pos += 1;
             let mut has_frac_digits = false;
             while self.pos < self.source.len() {
@@ -846,14 +843,14 @@ impl<'a> JSON5Parser<'a> {
 
         // Exponent part
         match self.peek() {
-            b'e' | b'E' => {
+            Some(b'e' | b'E') => {
                 self.pos += 1;
                 match self.peek() {
-                    b'+' | b'-' => self.pos += 1,
+                    Some(b'+' | b'-') => self.pos += 1,
                     _ => {}
                 }
                 match self.peek() {
-                    b'0'..=b'9' => self.pos += 1,
+                    Some(b'0'..=b'9') => self.pos += 1,
                     _ => return Err(ParseError::InvalidNumber),
                 }
                 while self.pos < self.source.len() {

--- a/src/parsers/json5.rs
+++ b/src/parsers/json5.rs
@@ -270,8 +270,7 @@ impl<'a> JSON5Parser<'a> {
 
     // ── Scanner ──
 
-    /// Returns the byte at the current position, or `None` at the end of the
-    /// source. A NUL byte in the source is `Some(0)`, not the end.
+    /// The byte at the current position, or `None` at the end of the source.
     fn peek(&self) -> Option<u8> {
         self.source.get(self.pos).copied()
     }

--- a/test/js/bun/json5/json5.test.ts
+++ b/test/js/bun/json5/json5.test.ts
@@ -3,6 +3,7 @@
 import { JSON5 } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 
 describe("escape sequences", () => {
   test("\\v vertical tab", () => {
@@ -518,6 +519,40 @@ describe("error messages", () => {
     expect(() => JSON5.parse("@")).toThrow("Unexpected character");
     expect(() => JSON5.parse("undefined")).toThrow("Unexpected token");
     expect(() => JSON5.parse("{a: hello}")).toThrow("Unexpected token");
+  });
+
+  // -- U+0000 outside a string or a comment --
+  test("NUL after a value is not the end of input", () => {
+    expect(() => JSON5.parse("123\0")).toThrow("Unexpected character");
+    expect(() => JSON5.parse("1.\0")).toThrow("Unexpected character");
+    expect(() => JSON5.parse("true\0false")).toThrow("Unexpected character");
+    expect(() => JSON5.parse("{a:1}\0{b:2}")).toThrow("Unexpected character");
+    expect(() => JSON5.parse("[1]\0]]] anything")).toThrow("Unexpected character");
+  });
+
+  test("NUL in place of a token", () => {
+    expect(() => JSON5.parse("\0")).toThrow("Unexpected character");
+    expect(() => JSON5.parse("\0true")).toThrow("Unexpected character");
+    expect(() => JSON5.parse("[1,\0]")).toThrow("Unexpected character");
+    expect(() => JSON5.parse("{a\0:1}")).toThrow("Unexpected character");
+    expect(() => JSON5.parse("{a:\0}")).toThrow("Unexpected character");
+    expect(() => JSON5.parse("+\0")).toThrow("Unexpected character");
+    expect(() => JSON5.parse("-\0")).toThrow("Unexpected character");
+  });
+
+  test("NUL inside a string or a comment is kept", () => {
+    expect(JSON5.parse("'a\0b'")).toBe("a\0b");
+    expect(JSON5.parse("1 //\0\n")).toBe(1);
+    expect(JSON5.parse("1 /*\0*/")).toBe(1);
+  });
+
+  test("NUL after a value in an imported .json5 file is an error at the NUL", async () => {
+    using dir = tempDir("json5-nul", { "nul.json5": "{a:1}\0{b:2}" });
+    const result = await import(join(String(dir), "nul.json5")).then(
+      mod => ({ parsed: mod.default }),
+      e => ({ message: e.message, line: e.position?.line, column: e.position?.column }),
+    );
+    expect(result).toEqual({ message: "Unexpected character", line: 1, column: 6 });
   });
 
   // -- Unterminated multi-line comment --


### PR DESCRIPTION
### Problem
- `Bun.JSON5.parse` and the `.json5` loader treat a NUL byte outside a string as the end of input and drop the rest of the document. `JSON5.parse("{a:1}\0{b:2}")` returns `{a: 1}`. `"123\0"`, `"true\0false"` and `"[1]\0]]] anything"` parse too.
- The cause: `peek()` (`src/parsers/json5.rs:275`) returns 0 past the end of the source, and `scan()` (`:285`) maps byte 0 to `TokenData::Eof`. A NUL byte and the real end of the source give the same token.
- U+0000 is not JSON5 white space. The reference `json5@2.2.3` throws `invalid character '\0'` on each input. `JSON.parse`, `Bun.YAML.parse` and `Bun.TOML.parse` reject it too.

### Fix
- `peek()` returns `Option<u8>`. `scan()` returns `Eof` only for `None`. A NUL byte reaches the existing `Unexpected character` arm, and the error position is the NUL.
- `scan_signed_value` had the same `0 => UnexpectedEof` arm. It now matches `None`.
- A NUL byte inside a string or a comment is still kept. Those paths do not use `peek()`, and the reference package accepts both.
- Verified: `test/js/bun/json5/json5.test.ts` (4 new tests, released bun fails 3, the fourth is the control for strings and comments). Also `test/js/bun/json5/`, `test/js/bun/resolve/json5/`, `test/bundler/bundler_loader.test.ts`.

### Background
- The scanner reads source bytes and produces one token at a time. The parser reads only tokens.
- `TokenData::Eof` is the token for the end of the source. `parse_root` accepts a document when the token after the root value is `Eof`.
- `Bun.JSON5.parse`, the runtime `.json5` loader and the bundler all call `JSON5Parser::parse`. One change covers the three.

<details><summary>Notes</summary>

Corpus case: nst/JSONTestSuite `test_parsing/n_multidigit_number_then_00.json` (`123` followed by a NUL byte).

Each input against `json5@2.2.3`, bun 1.4.3-canary.1+6a92015fc, and this branch. `\0` is one NUL byte.

| input | json5@2.2.3 | before | after |
| --- | --- | --- | --- |
| `123\0` | throws | `123` | `Unexpected character` |
| `{a:1}\0{b:2}` | throws | `{a:1}` | `Unexpected character` |
| `[1]\0]]] anything` | throws | `[1]` | `Unexpected character` |
| `true\0false` | throws | `true` | `Unexpected character` |
| `1.\0` | throws | `1` | `Unexpected character` |
| `\0` | throws | `Unexpected end of input` | `Unexpected character` |
| `\01` | throws | `Unexpected end of input` | `Unexpected character` |
| `[1,\02]` | throws | `Unexpected end of input` | `Unexpected character` |
| `{a\0:1}` | throws | `Expected ':' after object key` | `Unexpected character` |
| `{a:\01}` | throws | `Unexpected end of input` | `Unexpected character` |
| `+\0`, `-\0` | throws | `Unexpected end of input` | `Unexpected character` |
| `[\0`, `{\0` | throws | `Unexpected end of input` | `Unexpected character` |
| `1e\0` | throws | `Invalid number` | `Invalid number` |
| `0x\0` | throws | `Invalid hex number` | `Invalid hex number` |
| `.\0` | throws | `Invalid number` | `Invalid number` |
| `1 //\0\n` | `1` | `1` | `1` |
| `1 /*\0*/` | `1` | `1` | `1` |
| `'a\0b'` | `"a\0b"` | `"a\0b"` | `"a\0b"` |

`import("./nul.json5")` of `{a:1}\0{b:2}`: before, the default export is `{a: 1}`. After, the import rejects with `Unexpected character` at line 1, column 6.

The inputs that threw before still throw. Only the message changes, from an end-of-input message to `Unexpected character`.

`Bun.JSONC.parse` ignores all content after the root value, with or without a NUL byte. That is a different parser and is not part of this change.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/bun/json5/json5.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/bun/json5/json5.test.ts:
(pass) escape sequences > \v vertical tab [3.01ms]
(pass) escape sequences > \0 null character [1.73ms]
(pass) escape sequences > \0 followed by non-digit [1.99ms]
(pass) escape sequences > \0 followed by digit throws [7.66ms]
(pass) escape sequences > \1 through \9 throw [9.25ms]
(pass) escape sequences > \xHH hex escape [1.94ms]
(pass) escape sequences > \xHH hex escape lowercase [1.92ms]
(pass) escape sequences > \xHH hex escape high byte [1.95ms]
(pass) escape sequences > \xHH hex escape null [1.54ms]
(pass) escape sequences > \x with insufficient hex digits throws [6.78ms]
(pass) escape sequences > \uHHHH unicode escape A [1.67ms]
(pass) escape sequences > \uHHHH unicode escape e-acute [2.00ms]
(pass) escape sequences > \uHHHH unicode escape CJK [1.97ms]
(pass) escape sequences > \u with insufficient hex digits throws [6.71ms]
(pass) escape sequences > hex and unicode escape errors point at the first byte that is not a hex digit [462.35m
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (e2dea36c4)

test/js/bun/json5/json5.test.ts:
(pass) escape sequences > \v vertical tab [0.06ms]
(pass) escape sequences > \0 null character [0.02ms]
(pass) escape sequences > \0 followed by non-digit [0.01ms]
(pass) escape sequences > \0 followed by digit throws [0.09ms]
(pass) escape sequences > \1 through \9 throw [0.10ms]
(pass) escape sequences > \xHH hex escape [0.03ms]
(pass) escape sequences > \xHH hex escape lowercase [0.02ms]
(pass) escape sequences > \xHH hex escape high byte [0.01ms]
(pass) escape sequences > \xHH hex escape null [0.01ms]
(pass) escape sequences > \x with insufficient hex digits throws [0.06ms]
(pass) escape sequences > \uHHHH unicode escape A [0.01ms]
(pass) escape sequences > \uHHHH unicode escape e-acute [0.01ms]
(pass) escape sequences > \uHHHH unicode escape CJK [0.01ms]
(pass) escape sequences > \u with insufficient hex digits throws [0.05ms]
(pass) escape sequences > hex and unicode escape errors point at the first byte that is not a hex digit [15.33ms]
(pass) escape sequences > surrogate pairs [0.06ms]
(pass) escape sequences > identity escapes [0.02ms]
(pass) escape sequences > identity escape single cha
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/bun/json5/json5.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/bun/json5/json5.test.ts:
(pass) escape sequences > \v vertical tab [5.07ms]
(pass) escape sequences > \0 null character [2.73ms]
(pass) escape sequences > \0 followed by non-digit [3.09ms]
(pass) escape sequences > \0 followed by digit throws [11.53ms]
(pass) escape sequences > \1 through \9 throw [13.85ms]
(pass) escape sequences > \xHH hex escape [2.81ms]
(pass) escape sequences > \xHH hex escape lowercase [3.13ms]
(pass) escape sequences > \xHH hex escape high byte [3.14ms]
(pass) escape sequences > \xHH hex escape null [2.62ms]
(pass) escape sequences > \x with insufficient hex digits throws [11.39ms]
(pass) escape sequences > \uHHHH unicode escape A [2.67ms]
(pass) escape sequences > \uHHHH unicode escape e-acute [3.37ms]
(pass) escape sequences > \uHHHH unicode escape CJK [3.18ms]
(pass) escape sequences > \u with insufficient hex digits throws [11.88ms]
(pass) escape sequences > hex and unicode escape errors point at the first byte that is not a hex digit [379
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 885ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/j
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/parsers/json5.rs            | 46 +++++++++++++++++++----------------------
 test/js/bun/json5/json5.test.ts | 35 +++++++++++++++++++++++++++++++
 2 files changed, 56 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/parsers/json5.rs                 3      7     12
test/js/bun/json5/json5.test.ts      1      3     11
```

</details>

<!-- robobun:evidence:end -->