### PR TITLE
markdown: print the local part of an e-mail autolink once

### DIFF
--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -339,12 +339,19 @@ impl Parser<'_> {
                     }
 
                     if delim_cursor < resolved.len() && resolved[delim_cursor].pos == i {
+                        let d = &resolved[delim_cursor];
+                        let run_end = d.pos + d.count;
+
+                        // An unpaired run stays in the pending text: an e-mail autolink scans back over `_` and must not start before `text_start`.
+                        if d.open_count + d.close_count == 0 {
+                            delim_cursor += 1;
+                            i = run_end;
+                            continue;
+                        }
+
                         if i > text_start {
                             self.emit_text(TextType::Normal, &content[text_start..i])?;
                         }
-
-                        let d = &resolved[delim_cursor];
-                        let run_end = d.pos + d.count;
 
                         // Emit closing tags first (innermost to outermost)
                         if d.emph_char == b'~' {
@@ -486,6 +493,7 @@ impl Parser<'_> {
                         }
                     }
                     if let Some(a) = al {
+                        debug_assert!(a.beg >= text_start);
                         if a.beg > text_start {
                             self.emit_text(TextType::Normal, &content[text_start..a.beg])?;
                         }

--- a/test/js/bun/md/gfm-compat.test.ts
+++ b/test/js/bun/md/gfm-compat.test.ts
@@ -573,6 +573,35 @@ describe("autolink parentheses and trailing punctuation", () => {
     const expected = `<p>Contact <a href="mailto:foo@bar.baz">foo@bar.baz</a> for info</p>`;
     expect(normalize(render(md, { autolinks: true }))).toBe(normalize(expected));
   });
+
+  test("email autolink with underscore in the local part (GFM spec example 631)", () => {
+    const md = `a.b-c_d@a.b
+
+a.b-c_d@a.b.
+
+a.b-c_d@a.b-
+
+a.b-c_d@a.b_`;
+    const expected = `<p><a href="mailto:a.b-c_d@a.b">a.b-c_d@a.b</a></p>
+<p><a href="mailto:a.b-c_d@a.b">a.b-c_d@a.b</a>.</p>
+<p>a.b-c_d@a.b-</p>
+<p>a.b-c_d@a.b_</p>`;
+    expect(normalize(render(md, { autolinks: true }))).toBe(normalize(expected));
+  });
+
+  test.each([
+    ["john_doe@example.com", `<p><a href="mailto:john_doe@example.com">john_doe@example.com</a></p>`],
+    ["a_b_c@d.e", `<p><a href="mailto:a_b_c@d.e">a_b_c@d.e</a></p>`],
+    ["x a+b_c@d.e y", `<p>x <a href="mailto:a+b_c@d.e">a+b_c@d.e</a> y</p>`],
+    ["*john_doe@example.com*", `<p><em><a href="mailto:john_doe@example.com">john_doe@example.com</a></em></p>`],
+    ["_john_doe@example.com_", `<p><em><a href="mailto:john_doe@example.com">john_doe@example.com</a></em></p>`],
+    [
+      "mail first_last@company.com, or\nother_one@company.com.",
+      `<p>mail <a href="mailto:first_last@company.com">first_last@company.com</a>, or\n<a href="mailto:other_one@company.com">other_one@company.com</a>.</p>`,
+    ],
+  ])("email autolink prints the local part once: %j", (md, expected) => {
+    expect(normalize(render(md, { autolinks: true }))).toBe(normalize(expected));
+  });
 });
 
 // ============================================================================

--- a/test/js/bun/md/md-react.test.ts
+++ b/test/js/bun/md/md-react.test.ts
@@ -79,6 +79,18 @@ describe("Bun.markdown.react", () => {
     expect(link.props.children).toEqual(["click"]);
   });
 
+  test("email autolink with underscore in the local part is one link element", () => {
+    const p = children("mail first_last@company.com now\n", undefined, { autolinks: true })[0];
+    expect(p.props.children).toHaveLength(3);
+    const [before, link, after] = p.props.children;
+    expect({ before, type: link.type, children: link.props.children, after }).toEqual({
+      before: "mail ",
+      type: "a",
+      children: ["first_last@company.com"],
+      after: " now",
+    });
+  });
+
   test("image has src and alt in props", () => {
     const img = children("![alt](img.png)\n")[0].props.children[0];
     expect(img.$$typeof).toBe(REACT_TRANSITIONAL_SYMBOL);

--- a/test/js/bun/md/md-render-callback.test.ts
+++ b/test/js/bun/md/md-render-callback.test.ts
@@ -375,6 +375,23 @@ describe("Bun.markdown.render", () => {
     expect(result).toContain("[www.example.com]");
   });
 
+  test("email autolink with underscore in the local part reaches the callbacks once", () => {
+    const texts: string[] = [];
+    const result = Markdown.render(
+      "mail first_last@company.com now\n",
+      {
+        text: (text: string) => {
+          texts.push(text);
+          return text;
+        },
+        link: (children: string) => `[${children}]`,
+      },
+      { autolinks: true },
+    );
+    expect(result).toBe("mail [first_last@company.com] now");
+    expect(texts).toEqual(["mail ", "first_last@company.com", " now"]);
+  });
+
   test("headings option provides id in heading meta", () => {
     const result = Markdown.render(
       "## Hello World\n",


### PR DESCRIPTION
### Problem
- With `autolinks: true`, `Bun.markdown.html("john_doe@example.com")` returns `<p>john_<a href="mailto:john_doe@example.com">john_doe@example.com</a></p>`. The text up to the last `_` of the local part is printed two times (GFM spec example 631). `render()`, `react()` and `ansi()` do the same.
- The inline walk (`process_inline_content`, `src/md/inlines.rs:341`) flushes the pending text at each `*`, `_` or `~` run, paired or not. At the `@`, `find_permissive_autolink` scans back over the `_`. The link starts before `text_start`, so the walk emits flushed bytes again.

### Fix
- An unpaired delimiter run stays in the pending text. The walk flushes only at a run that opens or closes a span. md4c also skips unresolved marks.
- Correct because the backward scan crosses a `_` only between two ASCII alphanumeric characters. Such a run is never paired. A `debug_assert!` states the invariant.
- `html()` output changes only for the bug. The `render()` `text` callback and the `react()` `children` now get `"snake_case"` as one string, not three. `ansi()` no longer wraps inside such a word.
- Verified: the `gfm-compat`, `md-render-callback` and `md-react` tests in `test/js/bun/md/` (9 new tests, all fail on 1.4.3). Also all of `test/js/bun/md/` and `test/cli/run/markdown-entrypoint.test.ts`.

### Background
- A permissive autolink is a bare `http://...`, `www....` or `a@b.c` (option `autolinks`). The walk finds an e-mail at its `@` and scans back for the local part.
- A delimiter run is a sequence of one of `*`, `_`, `~`. The parser pairs the runs first. Then the walk emits text, and tags for the paired runs.
- `text_start` is the offset of the first byte that the walk did not emit yet.

<details><summary>Notes</summary>

**Reported inputs, after the fix.**
```
"john_doe@example.com" -> <p><a href="mailto:john_doe@example.com">john_doe@example.com</a></p>
"a.b-c_d@a.b"          -> <p><a href="mailto:a.b-c_d@a.b">a.b-c_d@a.b</a></p>
"a_b_c@d.e"            -> <p><a href="mailto:a_b_c@d.e">a_b_c@d.e</a></p>
"x a+b_c@d.e y"        -> <p>x <a href="mailto:a+b_c@d.e">a+b_c@d.e</a> y</p>
```

**Relation to #42327.** That PR names this bug as "Separate bug, not fixed here". It changes how a link ends next to emphasis delimiters. This PR changes where the walk flushes text in front of a link. The two diffs touch different hunks of `process_inline_content`.

**Why the link can not start before `text_start` now.** The backward scan accepts `[A-Za-z0-9]`, and one of `.`, `-`, `_`, `+` only between two ASCII alphanumeric characters. Each place that moves `text_start` leaves a byte in front of it that the scan does not cross:
- line break: `\n`
- backslash escape: `\` in front of the escaped byte
- code span: a backtick
- entity: `;`
- raw HTML and `<...>` autolinks: `>`
- link, image and wiki link: `)` or `]`, and a failed `[` or `!`
- an earlier permissive autolink: its right boundary is whitespace, one of `)}]<.!?,;&`, or a paired delimiter. The forward scan does not stop at a `.` that stands between two alphanumeric characters.
- a paired `*`, `_` or `~` run: a `_` between two ASCII alphanumeric characters is left-flanking and right-flanking, so `can_open_emphasis` and `can_close_emphasis` return false for it.

**Differential run against 1.4.3** (the parser is the same on 1.4.3 and on `main`). Generated inputs that mix alphanumerics, `_ * ~ @ . - + :`, brackets, backticks, escapes, entities, raw HTML, `www.` and `http://` pieces, six option sets, `html()`, `render()` with and without callbacks, `ansi()`:
- 223,000 inputs in total: two random mixes (63,000), two mixes that are biased to e-mail shapes (120,000), and 40,000 of the form `<prefix><local part>@<domain><suffix>`, where the prefix is one of the constructs that move `text_start`.
- 10,040 `html()` outputs differ. A script checked each one: the new output equals the old output with the repeated prefix removed (10,021 in front of an `<a href="mailto:...">`, 19 in an image `alt`).
- Each `render()` or `ansi()` output that differs comes from an input that holds `[A-Za-z0-9]_[A-Za-z0-9]...@` (`ansi()` ran on the first 183,000 inputs).
- The text chunks that `render()` passes to `text` differ in their split for about 70% of the inputs. Their concatenation is the same for each input that does not hold that shape.
- The debug build (debug assertions on) ran every input. The new `debug_assert!` did not fire.

**Text chunks.** On 1.4.3 `render("2 * 3", { text })` calls `text` with `"2 "`, `"*"`, `" 3"`. It now calls it one time with `"2 * 3"`. `ansi()` with `columns: 20` printed `aaaa bbbb cccc dddd_\neeee_ffff gggg` for `aaaa bbbb cccc dddd_eeee_ffff gggg`. It now prints `aaaa bbbb cccc\ndddd_eeee_ffff gggg`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/gfm-compat.test.ts test/js/bun/md/md-react.test.ts test/js/bun/md/md-render-callback.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/md/gfm-compat.test.ts:
(pass) tables interrupting paragraphs > table immediately after paragraph text [35.68ms]
(pass) tables interrupting paragraphs > table after blank line works in both [7.82ms]
(pass) tables interrupting paragraphs > table interrupts paragraph with multiple rows [8.88ms]
(pass) table column count mismatch > more header columns than delimiter columns [4.42ms]
(pass) table column count mismatch > fewer header columns than delimiter columns [4.97ms]
(pass) table column count mismatch > three header columns, two delimiter columns [4.08ms]
(pass) table column count mismatch > one header column, three delimiter columns [5.18ms]
(pass) pipes in code spans in tables > pipe in code span splits cell in GFM [6.85ms]
(pass) pipes in code spans in tables > escaped pipe in code span preserves code span [7.58ms]
(pass) pipes in code spans in tables > multiple pipes in code span [7.85m
... (truncated)

release without fix: 9 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/bun/md/gfm-compat.test.ts:
(pass) tables interrupting paragraphs > table immediately after paragraph text [0.25ms]
(pass) tables interrupting paragraphs > table after blank line works in both [0.04ms]
(pass) tables interrupting paragraphs > table interrupts paragraph with multiple rows [0.03ms]
(pass) table column count mismatch > more header columns than delimiter columns [0.02ms]
(pass) table column count mismatch > fewer header columns than delimiter columns [0.02ms]
(pass) table column count mismatch > three header columns, two delimiter columns [0.02ms]
(pass) table column count mismatch > one header column, three delimiter columns [0.03ms]
(pass) pipes in code spans in tables > pipe in code span splits cell in GFM [0.04ms]
(pass) pipes in code spans in tables > escaped pipe in code span preserves code span [0.04ms]
(pass) pipes in code spans in tables > multiple pipes in code span [0.03ms]
(pass) pipes in code spans in tables > code span with pipe as second cell value [0.03ms]
(pass) empty table body > table with header only omits tbody [0.03ms]
(pass) empty table body > table with header followed by blank line omi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/gfm-compat.test.ts test/js/bun/md/md-react.test.ts test/js/bun/md/md-render-callback.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/md/gfm-compat.test.ts:
(pass) tables interrupting paragraphs > table immediately after paragraph text [30.41ms]
(pass) tables interrupting paragraphs > table after blank line works in both [4.85ms]
(pass) tables interrupting paragraphs > table interrupts paragraph with multiple rows [5.23ms]
(pass) table column count mismatch > more header columns than delimiter columns [3.73ms]
(pass) table column count mismatch > fewer header columns than delimiter columns [4.20ms]
(pass) table column count mismatch > three header columns, two delimiter columns [4.49ms]
(pass) table column count mismatch > one header column, three delimiter columns [3.85ms]
(pass) pipes in code spans in tables > pipe in code span splits cell in GFM [5.35ms]
(pass) pipes in code spans in tables > escaped pipe in code span preserves code span [5.70ms]
(pass) pipes in code spans in tables > multiple pipes in code span [5.59m
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4763d14aa9
  features     baseline

23 deps, 131 codegen, 1172 objects in 748ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (6a92015fc)

Checked 22 installs across 61 packages (no changes) [10.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (6a92015fc)

Checked 1 install across 2 packages (no changes) [4.00ms]
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (6a92015fc)

Checked 111 installs across 104 packages (no changes) [7.00ms]
[5/1244] gen bindgenv2
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 20ms

  react-refresh.js  4.81 KB  (entry point)

[9/1216] fetch zlib
[zlib] up to date
[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.serve
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/md/inlines.rs                         | 14 +++++++++++---
 test/js/bun/md/gfm-compat.test.ts         | 29 +++++++++++++++++++++++++++++
 test/js/bun/md/md-react.test.ts           | 12 ++++++++++++
 test/js/bun/md/md-render-callback.test.ts | 17 +++++++++++++++++
 4 files changed, 69 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/md/inlines.rs                              3      4     12
test/js/bun/md/gfm-compat.test.ts              1      2      8
test/js/bun/md/md-react.test.ts                1      1      8
test/js/bun/md/md-render-callback.test.ts      1      1      8
```

</details>

**root cause** · written by the author bot

The inline walk in `process_inline_content` (`src/md/inlines.rs`) flushed pending text at every `*`, `_` or `~` delimiter run, even an unpaired one, which advanced `text_start` past the `_` in an e-mail local part. When the permissive autolink scan reached the `@`, it walked back to the start of the local part, so the link began before `text_start` and repeated text that had already been emitted. The fix leaves unpaired delimiter runs in the pending text, as md4c does for unresolved marks, so the e-mail scan never crosses a flush point, and a `debug_assert!` now checks that a link cannot st…

<!-- robobun:evidence:end -->