### PR TITLE
WebSocket client: keep the close code when a Close frame is split across reads

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -839,14 +839,16 @@ impl<const SSL: bool> WebSocket<SSL> {
     /// Assemble the (optional) close payload, echo a close frame back, and
     /// stop reading: a received Close always terminates the parse loop.
     fn recv_close(&self, cursor: &mut RecvCursor<'_>) -> Step {
-        if cursor.body_remain == 1 || cursor.body_remain > MAX_CONTROL_PAYLOAD {
-            return self.recv_failed(ErrorCode::InvalidControlFrame);
-        }
+        if !self.control_frame_started.get() {
+            if cursor.body_remain == 1 || cursor.body_remain > MAX_CONTROL_PAYLOAD {
+                return self.recv_failed(ErrorCode::InvalidControlFrame);
+            }
 
-        if cursor.body_remain == 0 {
-            self.close_received.set(true);
-            self.send_close();
-            return Step::Terminated;
+            if cursor.body_remain == 0 {
+                self.close_received.set(true);
+                self.send_close();
+                return Step::Terminated;
+            }
         }
 
         let Some((payload, payload_len)) = self.buffer_control_payload(cursor) else {

--- a/test/js/web/websocket/websocket-close-fragmented.test.ts
+++ b/test/js/web/websocket/websocket-close-fragmented.test.ts
@@ -125,3 +125,99 @@ describe("WebSocket", () => {
     }
   });
 });
+
+describe("WebSocket close frame split across two reads", () => {
+  // FIN + Close opcode, 5-byte payload: status code 4000, reason "bye".
+  const closeFrame = Buffer.from([0x88, 0x05, 0x0f, 0xa0, 0x62, 0x79, 0x65]);
+  const emptyPing = Buffer.from([0x89, 0x00]);
+
+  // Unmasks the client-to-server frames in `buf`. Control frames only, so 7-bit lengths.
+  function readClientFrames(buf: Buffer) {
+    const frames: { opcode: number; payload: Buffer }[] = [];
+    while (buf.length >= 6 && buf.length >= 6 + (buf[1] & 0x7f)) {
+      const len = buf[1] & 0x7f;
+      const mask = buf.subarray(2, 6);
+      const payload = Buffer.from(buf.subarray(6, 6 + len));
+      for (let i = 0; i < len; i++) payload[i] ^= mask[i & 3];
+      frames.push({ opcode: buf[0] & 0x0f, payload });
+      buf = buf.subarray(6 + len);
+    }
+    return { frames, rest: buf };
+  }
+
+  test.concurrent.each([1, 2, 3, 4, 5, 6])("after byte %d of 7", async cut => {
+    const echoed = Promise.withResolvers<{ code: number | null; reason: string } | null>();
+
+    using server = Bun.listen<{ buf: Buffer; upgraded: boolean; sentTail: boolean }>({
+      hostname,
+      port,
+      socket: {
+        open(socket) {
+          socket.data = { buf: Buffer.alloc(0), upgraded: false, sentTail: false };
+        },
+        data(socket, chunk) {
+          const st = socket.data;
+          st.buf = Buffer.concat([st.buf, chunk]);
+
+          if (!st.upgraded) {
+            const end = st.buf.indexOf("\r\n\r\n");
+            if (end === -1) return;
+            const key = /Sec-WebSocket-Key:\s*(\S+)/i.exec(st.buf.toString("latin1", 0, end))![1];
+            st.buf = st.buf.subarray(end + 4);
+            st.upgraded = true;
+
+            const hasher = new Bun.CryptoHasher("sha1");
+            hasher.update(key);
+            hasher.update("258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+            socket.write(
+              "HTTP/1.1 101 Switching Protocols\r\n" +
+                "Upgrade: websocket\r\n" +
+                "Connection: Upgrade\r\n" +
+                `Sec-WebSocket-Accept: ${hasher.digest("base64")}\r\n` +
+                "\r\n",
+            );
+            // A Ping goes out in front of the first part of the Close frame. The
+            // Pong that answers it proves the client has read that part, so the
+            // rest of the frame below always lands in a later read.
+            socket.write(Buffer.concat([emptyPing, closeFrame.subarray(0, cut)]));
+            socket.flush();
+          }
+
+          const { frames, rest } = readClientFrames(st.buf);
+          st.buf = rest;
+          for (const { opcode, payload } of frames) {
+            if (opcode === 0xa && !st.sentTail) {
+              st.sentTail = true;
+              socket.write(closeFrame.subarray(cut));
+              socket.flush();
+            } else if (opcode === 0x8) {
+              echoed.resolve({
+                code: payload.length >= 2 ? payload.readUInt16BE(0) : null,
+                reason: payload.toString("utf8", 2),
+              });
+              socket.end();
+            }
+          }
+        },
+        close() {
+          echoed.resolve(null);
+        },
+        error() {
+          echoed.resolve(null);
+        },
+      },
+    });
+
+    const closed = Promise.withResolvers<{ code: number; reason: string; wasClean: boolean }>();
+    const ws = new WebSocket(`ws://${server.hostname}:${server.port}`);
+    ws.onclose = ev => closed.resolve({ code: ev.code, reason: ev.reason, wasClean: ev.wasClean });
+
+    try {
+      expect(await closed.promise).toEqual({ code: 4000, reason: "bye", wasClean: true });
+      // The client echoes the status code it received (RFC 6455 section 5.5.1).
+      expect(await echoed.promise).toEqual({ code: 4000, reason: "bye" });
+    } finally {
+      ws.close();
+    }
+  });
+});


### PR DESCRIPTION
### Problem

- A server Close frame can span two TCP reads. If the first read ends after the 2-byte header, the `close` event reports `1005 ""`, not the real `4000 "bye"`. If it ends one byte later, the client fails with `1002 "Protocol error - invalid control frame"`.
- `recv_close` (`src/http_jsc/websocket_client.rs:841`) tests `cursor.body_remain == 0` (empty Close) and `== 1` (illegal payload) on every entry. Once `buffer_control_payload` starts a frame, `cursor.body_remain` counts the bytes buffered so far, not the declared length. On the second read, 0 or 1 buffered bytes trip those tests.

### Fix

- `recv_close` runs its length checks only when `!control_frame_started`, the first entry for a frame. `recv_ping_or_pong` already has this guard, so Ping and Pong splits are not affected.
- Correct because the declared length is checked once, while `cursor.body_remain` still holds it.
- #35529 carries the same guard next to two changes to the echoed close code. This PR splits the guard out so that it can land alone.
- Verified: a new block in `test/js/web/websocket/websocket-close-fragmented.test.ts` cuts a 7-byte Close frame at every position. Stock bun fails cuts 2 and 3. The other close, ping and `ws` suites pass (list in Notes).

### Background

- A Close frame is a control frame: a 2-byte header, then an optional payload of a 2-byte status code and a UTF-8 reason. A 1-byte payload is illegal.
- `CloseEvent.code` is `1005` when the Close frame has no payload.
- `buffer_control_payload` collects a control payload that spans reads. It parks the declared length in `ping_len` and sets `control_frame_started` until the payload is complete.

<details><summary>Notes</summary>

Standalone repro (public APIs only). The server writes the first `cut` bytes of a 7-byte Close frame (code 4000, reason "bye"), waits 5 ms, then writes the rest.

```js
import net from "node:net";
import { createHash } from "node:crypto";
const close = Buffer.from([0x88, 0x05, 0x0f, 0xa0, 0x62, 0x79, 0x65]);
for (const cut of [7, 1, 2, 3, 4, 5, 6]) {
  const srv = net.createServer(s => {
    s.setNoDelay(true);
    s.once("data", d => {
      const key = /sec-websocket-key: *(.+)\r\n/i.exec(d.toString())[1];
      s.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: " +
        createHash("sha1").update(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").digest("base64") + "\r\n\r\n");
      setTimeout(() => {
        s.write(close.subarray(0, cut));
        setTimeout(() => { if (cut < 7) s.write(close.subarray(cut)); setTimeout(() => s.end(), 30); }, 5);
      }, 5);
    });
    s.on("error", () => {});
  }).listen(0, "127.0.0.1");
  await new Promise(r => srv.once("listening", r));
  const ws = new WebSocket("ws://127.0.0.1:" + srv.address().port);
  const ev = await new Promise(r => { ws.onclose = r; });
  console.log(`close frame split at byte ${cut}/7 -> code=${ev.code} reason=${JSON.stringify(ev.reason)} wasClean=${ev.wasClean}`);
  srv.close();
}
```

Before (1.4.3-canary.1+6a92015fc, also reported on 1.4.0, 1.4.1 and 1.4.2):

```
close frame split at byte 7/7 -> code=4000 reason="bye" wasClean=true
close frame split at byte 1/7 -> code=4000 reason="bye" wasClean=true
close frame split at byte 2/7 -> code=1005 reason="" wasClean=true
close frame split at byte 3/7 -> code=1002 reason="Protocol error - invalid control frame" wasClean=false
close frame split at byte 4/7 -> code=4000 reason="bye" wasClean=true
close frame split at byte 5/7 -> code=4000 reason="bye" wasClean=true
close frame split at byte 6/7 -> code=4000 reason="bye" wasClean=true
```

After (this branch, debug build): all seven lines print `code=4000 reason="bye" wasClean=true`. Node v26.3.0 prints the same seven lines.

Trace of the two cuts that fail:

- Cut 2. Read 1 is the header. `recv_close` sees `body_remain == 5`, `buffer_control_payload` parks 5 in `ping_len`, sets `body_remain = 0` and waits. Read 2 enters `recv_close` with `body_remain == 0`, takes the empty-Close branch and calls `send_close()`, which reports 1005.
- Cut 3. Read 1 is the header plus one payload byte. `buffer_control_payload` copies that byte and leaves `body_remain == 1`. Read 2 enters `recv_close` with `body_remain == 1` and fails with `InvalidControlFrame`.

The `ws` package shim sits on the same native client, so it gets the same fix.

Test design. The test uses no timers. The server writes an empty Ping and the first part of the Close frame in one write. It writes the rest only after it receives the Pong. The Pong proves that the client already read the first part, so the two parts cannot arrive in one read. Each case also checks that the client echoes `4000 "bye"` on the wire. On stock bun the new block gives the same result in 25 of 25 runs: cuts 2 and 3 fail, cuts 1, 4, 5 and 6 pass.

Suites run with the debug build, all pass:

- `test/js/web/websocket/websocket-close-fragmented.test.ts` (7)
- `test/js/web/websocket/websocket-close-code.test.ts` (24)
- `test/js/web/websocket/websocket-pong-fragmented.test.ts` (4)
- `test/js/web/websocket/websocket-client-short-read.test.ts` (4)
- `test/js/web/websocket/websocket-close-async-dispatch.test.ts` (5)
- `test/js/web/websocket/websocket-close-connecting.test.ts` (4)
- `test/js/web/websocket/websocket-client.test.ts` (37)
- `test/js/web/websocket/websocket-buffered-amount.test.ts` (7)
- `test/js/web/websocket/websocket-permessage-deflate.test.ts` (10, 1 skip)
- `test/js/web/websocket/websocket.test.js -t close` (23)
- `test/js/first_party/ws/ws.test.ts` (65)

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/websocket/websocket-close-fragmented.test.ts
bun test v1.4.3 (6a92015fc)

test/js/web/websocket/websocket-close-fragmented.test.ts:
(pass) WebSocket > fragmented close frame [71.02ms]
211 |     const closed = Promise.withResolvers<{ code: number; reason: string; wasClean: boolean }>();
212 |     const ws = new WebSocket(`ws://${server.hostname}:${server.port}`);
213 |     ws.onclose = ev => closed.resolve({ code: ev.code, reason: ev.reason, wasClean: ev.wasClean });
214 | 
215 |     try {
216 |       expect(await closed.promise).toEqual({ code: 4000, reason: "bye", wasClean: true });
                                         ^
error: expect(received).toEqual(expected)

  {
-   "code": 4000,
-   "reason": "bye",
+   "code": 1005,
+   "reason": "",
    "wasClean": true,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/web/websocket/websocket-close-fragmented.test.ts:216:36)
211 |     const closed = Promise.withResolvers<{ code: number; reason: string; wasClean: boolean }>();
212 |     const ws 
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/web/websocket/websocket-close-fragmented.test.ts:
(pass) WebSocket > fragmented close frame [11.55ms]
211 |     const closed = Promise.withResolvers<{ code: number; reason: string; wasClean: boolean }>();
212 |     const ws = new WebSocket(`ws://${server.hostname}:${server.port}`);
213 |     ws.onclose = ev => closed.resolve({ code: ev.code, reason: ev.reason, wasClean: ev.wasClean });
214 | 
215 |     try {
216 |       expect(await closed.promise).toEqual({ code: 4000, reason: "bye", wasClean: true });
                                         ^
error: expect(received).toEqual(expected)

  {
-   "code": 4000,
-   "reason": "bye",
+   "code": 1005,
+   "reason": "",
    "wasClean": true,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/web/websocket/websocket-close-fragmented.test.ts:216:36)
211 |     const closed = Promise.withResolvers<{ code: number; reason: string; wasClean: boolean }>();
212 |     const ws = new WebSocket(`ws://${server.hostname}:${server.port}`);
213 |     ws.onclose = ev => closed.resolve({ code: ev.code, reason: ev.reason, wasClean: ev.wasClean });
214 | 
215 |   
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/websocket/websocket-close-fragmented.test.ts
bun test v1.4.3 (6a92015fc)

test/js/web/websocket/websocket-close-fragmented.test.ts:
(pass) WebSocket > fragmented close frame [77.15ms]
(pass) WebSocket close frame split across two reads > after byte 1 of 7 [76.69ms]
(pass) WebSocket close frame split across two reads > after byte 2 of 7 [56.71ms]
(pass) WebSocket close frame split across two reads > after byte 3 of 7 [53.98ms]
(pass) WebSocket close frame split across two reads > after byte 4 of 7 [52.51ms]
(pass) WebSocket close frame split across two reads > after byte 5 of 7 [51.13ms]
(pass) WebSocket close frame split across two reads > after byte 6 of 7 [5.78ms]

 7 pass
 0 fail
 14 expect() calls
Ran 7 tests across 1 file. [2.88s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4b652edd59
  features     baseline

23 deps, 131 codegen, 1172 objects in 768ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (6a92015fc)

Checked 22 installs across 61 packages (no changes) [8.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (6a92015fc)

Checked 1 install across 2 packages (no changes) [5.00ms]
[3/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (6a92015fc)

Checked 111 installs across 104 packages (no changes) [14.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[6/1244] fetch tinycc
[tinycc] up to date
[7/1243] fetch zlib
[zlib] up to date
[8/1243] gen bindgenv2
[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http_jsc/websocket_client.rs                   | 16 ++--
 .../websocket/websocket-close-fragmented.test.ts   | 96 ++++++++++++++++++++++
 2 files changed, 105 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/http_jsc/websocket_client.rs                              2      1      9
test/js/web/websocket/websocket-close-fragmented.test.ts      1      1      8
```

</details>

<!-- robobun:evidence:end -->