### PR TITLE
Validate GET/HEAD bodies in new Request() and statusText in new Response()

### DIFF
--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -765,10 +765,7 @@ impl Value {
         }
     }
 
-    /// Whether a GET/HEAD request carrying this body must be rejected. Mirrors
-    /// `HTTPRequestBody::has_body` in `fetch_impl`: a zero-byte body (`""`,
-    /// `new Uint8Array(0)`, `new Blob([])`, `new URLSearchParams()`) counts as
-    /// no body so `new Request(url, init)` and `fetch(url, init)` agree.
+    /// Same rule as `HTTPRequestBody::has_body` in `fetch_impl`: a zero-byte body is no body.
     pub(crate) fn has_request_body(&mut self) -> bool {
         match self {
             Value::Null | Value::Empty => false,

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -765,6 +765,18 @@ impl Value {
         }
     }
 
+    /// Whether a GET/HEAD request carrying this body must be rejected. Mirrors
+    /// `HTTPRequestBody::has_body` in `fetch_impl`: a zero-byte body (`""`,
+    /// `new Uint8Array(0)`, `new Blob([])`, `new URLSearchParams()`) counts as
+    /// no body so `new Request(url, init)` and `fetch(url, init)` agree.
+    pub(crate) fn has_request_body(&mut self) -> bool {
+        match self {
+            Value::Null | Value::Empty => false,
+            Value::Blob(_) | Value::InternalBlob(_) | Value::WTFStringImpl(_) => self.size() > 0,
+            Value::Locked(_) | Value::Used | Value::Error(_) => true,
+        }
+    }
+
     pub(crate) fn memory_cost(&self) -> usize {
         match self {
             Value::InternalBlob(b) => b.memory_cost(),

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1398,9 +1398,7 @@ impl Request {
 
         req.url.set(href);
 
-        // Fetch spec `new Request()` step 36. Looser than the spec (which
-        // rejects any non-null body) to match `fetch_impl`: a zero-byte body
-        // is treated as absent by both entry points.
+        // Fetch spec `new Request()` step 36, with the zero-byte rule `fetch()` uses.
         if matches!(req.method, Method::GET | Method::HEAD)
             && req.body_value_mut().has_request_body()
         {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1401,7 +1401,8 @@ impl Request {
         // Fetch spec `new Request()` step 36. Looser than the spec (which
         // rejects any non-null body) to match `fetch_impl`: a zero-byte body
         // is treated as absent by both entry points.
-        if matches!(req.method, Method::GET | Method::HEAD) && req.body_value_mut().has_request_body()
+        if matches!(req.method, Method::GET | Method::HEAD)
+            && req.body_value_mut().has_request_body()
         {
             bail!(Err(global_this.throw_type_error(format_args!(
                 "Request with GET/HEAD method cannot have body."

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1343,10 +1343,12 @@ impl Request {
                             if !fields.contains(Fields::Method) {
                                 req.method = response_init.method;
                                 fields.insert(Fields::Method);
-                                match Self::init_method_is_unknown(global_this, value) {
-                                    Ok(true) => skip_body_check = true,
-                                    Ok(false) => {}
-                                    Err(e) => bail!(Err(e)),
+                                if req.method == Method::GET {
+                                    match Self::init_method_is_unknown(global_this, value) {
+                                        Ok(true) => skip_body_check = true,
+                                        Ok(false) => {}
+                                        Err(e) => bail!(Err(e)),
+                                    }
                                 }
                             }
                         }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1400,8 +1400,7 @@ impl Request {
 
         req.url.set(href);
 
-        // Fetch spec `new Request()` step 36, with the zero-byte rule `fetch()` uses.
-        // A body taken from a Response init is a Bun extension outside the spec.
+        // Fetch spec `new Request()` step 36. A Response init body is a Bun extension.
         if !body_from_response
             && matches!(req.method, Method::GET | Method::HEAD)
             && req.body_value_mut().has_request_body()

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1313,7 +1313,7 @@ impl Request {
             }
 
             if !fields.contains(Fields::Method) || !fields.contains(Fields::Headers) {
-                match crate::webcore::response::Init::init(global_this, value) {
+                match crate::webcore::response::Init::init::<false>(global_this, value) {
                     Ok(Some(response_init)) => {
                         let header_check = !explicit_check
                             || (explicit_check

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1037,6 +1037,7 @@ impl Request {
         let url_or_object = arguments[0];
         let url_or_object_type = url_or_object.js_type();
         let mut fields: EnumSet<Fields> = EnumSet::empty();
+        let mut body_from_response = false;
 
         let is_first_argument_a_url =
             // fastest path:
@@ -1191,6 +1192,7 @@ impl Request {
                                     Err(e) => bail!(Err(e)),
                                 }
                                 fields.insert(Fields::Body);
+                                body_from_response = true;
                             }
                         }
                     }
@@ -1399,7 +1401,9 @@ impl Request {
         req.url.set(href);
 
         // Fetch spec `new Request()` step 36, with the zero-byte rule `fetch()` uses.
-        if matches!(req.method, Method::GET | Method::HEAD)
+        // A body taken from a Response init is a Bun extension outside the spec.
+        if !body_from_response
+            && matches!(req.method, Method::GET | Method::HEAD)
             && req.body_value_mut().has_request_body()
         {
             bail!(Err(global_this.throw_type_error(format_args!(

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -973,6 +973,20 @@ impl Request {
         <Self as BodyMixin>::check_body_stream_ref(self, global_object)
     }
 
+    /// `Init::init` maps a method token it does not know to `GET`. Tell that
+    /// fallback apart from a real `GET`/`HEAD` so the body check skips it.
+    fn init_method_is_unknown(global_this: &JSGlobalObject, init: JSValue) -> JsResult<bool> {
+        let Some(method) = init.fast_get_truthy(global_this, bun_jsc::BuiltinName::method)? else {
+            return Ok(false);
+        };
+        let str = BunString::from_js(method, global_this)?;
+        let utf8 = str.to_utf8();
+        let token: &[u8] = &utf8;
+        Ok(Method::which(token).is_none()
+            && !token.eq_ignore_ascii_case(b"GET")
+            && !token.eq_ignore_ascii_case(b"HEAD"))
+    }
+
     pub(crate) fn construct_into(
         global_this: &JSGlobalObject,
         arguments: &[JSValue],
@@ -1037,7 +1051,7 @@ impl Request {
         let url_or_object = arguments[0];
         let url_or_object_type = url_or_object.js_type();
         let mut fields: EnumSet<Fields> = EnumSet::empty();
-        let mut body_from_response = false;
+        let mut skip_body_check = false;
 
         let is_first_argument_a_url =
             // fastest path:
@@ -1192,7 +1206,7 @@ impl Request {
                                     Err(e) => bail!(Err(e)),
                                 }
                                 fields.insert(Fields::Body);
-                                body_from_response = true;
+                                skip_body_check = true;
                             }
                         }
                     }
@@ -1330,6 +1344,11 @@ impl Request {
                             if !fields.contains(Fields::Method) {
                                 req.method = response_init.method;
                                 fields.insert(Fields::Method);
+                                match Self::init_method_is_unknown(global_this, value) {
+                                    Ok(true) => skip_body_check = true,
+                                    Ok(false) => {}
+                                    Err(e) => bail!(Err(e)),
+                                }
                             }
                         }
                     }
@@ -1401,7 +1420,7 @@ impl Request {
         req.url.set(href);
 
         // Fetch spec `new Request()` step 36. A Response init body is a Bun extension.
-        if !body_from_response
+        if !skip_body_check
             && matches!(req.method, Method::GET | Method::HEAD)
             && req.body_value_mut().has_request_body()
         {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1398,10 +1398,10 @@ impl Request {
 
         req.url.set(href);
 
-        // Fetch spec `new Request()` step 36. `fetch()` has the same check in
-        // `fetch_impl`, and an empty string body counts as no body in both.
-        if matches!(req.method, Method::GET | Method::HEAD)
-            && !matches!(req.body_value(), BodyValue::Null | BodyValue::Empty)
+        // Fetch spec `new Request()` step 36. Looser than the spec (which
+        // rejects any non-null body) to match `fetch_impl`: a zero-byte body
+        // is treated as absent by both entry points.
+        if matches!(req.method, Method::GET | Method::HEAD) && req.body_value_mut().has_request_body()
         {
             bail!(Err(global_this.throw_type_error(format_args!(
                 "Request with GET/HEAD method cannot have body."

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -973,8 +973,7 @@ impl Request {
         <Self as BodyMixin>::check_body_stream_ref(self, global_object)
     }
 
-    /// `Init::init` maps a method token it does not know to `GET`. Tell that
-    /// fallback apart from a real `GET`/`HEAD` so the body check skips it.
+    /// True when `Init::init` fell back to `GET` for a method token it does not know.
     fn init_method_is_unknown(global_this: &JSGlobalObject, init: JSValue) -> JsResult<bool> {
         let Some(method) = init.fast_get_truthy(global_this, bun_jsc::BuiltinName::method)? else {
             return Ok(false);

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1398,6 +1398,16 @@ impl Request {
 
         req.url.set(href);
 
+        // Fetch spec `new Request()` step 36. `fetch()` has the same check in
+        // `fetch_impl`, and an empty string body counts as no body in both.
+        if matches!(req.method, Method::GET | Method::HEAD)
+            && !matches!(req.body_value(), BodyValue::Null | BodyValue::Empty)
+        {
+            bail!(Err(global_this.throw_type_error(format_args!(
+                "Request with GET/HEAD method cannot have body."
+            ))));
+        }
+
         if matches!(req.body_value(), BodyValue::Blob(_)) && req.headers.get().is_some() {
             if let BodyValue::Blob(blob) = req.body_value() {
                 let ct: &[u8] = blob.content_type_slice();

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -973,19 +973,6 @@ impl Request {
         <Self as BodyMixin>::check_body_stream_ref(self, global_object)
     }
 
-    /// True when `Init::init` fell back to `GET` for a method token it does not know.
-    fn init_method_is_unknown(global_this: &JSGlobalObject, init: JSValue) -> JsResult<bool> {
-        let Some(method) = init.fast_get_truthy(global_this, bun_jsc::BuiltinName::method)? else {
-            return Ok(false);
-        };
-        let str = BunString::from_js(method, global_this)?;
-        let utf8 = str.to_utf8();
-        let token: &[u8] = &utf8;
-        Ok(Method::which(token).is_none()
-            && !token.eq_ignore_ascii_case(b"GET")
-            && !token.eq_ignore_ascii_case(b"HEAD"))
-    }
-
     pub(crate) fn construct_into(
         global_this: &JSGlobalObject,
         arguments: &[JSValue],
@@ -1343,12 +1330,8 @@ impl Request {
                             if !fields.contains(Fields::Method) {
                                 req.method = response_init.method;
                                 fields.insert(Fields::Method);
-                                if req.method == Method::GET {
-                                    match Self::init_method_is_unknown(global_this, value) {
-                                        Ok(true) => skip_body_check = true,
-                                        Ok(false) => {}
-                                        Err(e) => bail!(Err(e)),
-                                    }
+                                if response_init.method_unknown {
+                                    skip_body_check = true;
                                 }
                             }
                         }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1102,7 +1102,8 @@ impl Request {
                         return Ok(req);
                     }
 
-                    if !fields.contains(Fields::Method) {
+                    let method_from_input = !fields.contains(Fields::Method);
+                    if method_from_input {
                         req.method = request.method;
                         fields.insert(Fields::Method);
                     }
@@ -1144,6 +1145,10 @@ impl Request {
                                     Err(e) => bail!(Err(e)),
                                 }
                                 fields.insert(Fields::Body);
+                                // The input passed this check when it was built.
+                                if method_from_input {
+                                    skip_body_check = true;
+                                }
                             }
                         }
                     }

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1004,7 +1004,6 @@ impl Response {
                     response.init.with_mut(|i| i.status_code = status);
                 } else if let Some(init) = Init::init(global_this, arg_init)? {
                     // cleanup is handled by Init's drop glue on `?` below
-                    init.validate_status_text(global_this)?;
                     response.init.set(init);
 
                     let status = response.init.get().status_code;
@@ -1013,6 +1012,7 @@ impl Response {
                             Self::validate_redirect_status_code(global_this, i32::from(status))?;
                         response.init.with_mut(|i| i.status_code = status);
                     }
+                    response.init.get().validate_status_text(global_this)?;
                 }
             }
 

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -921,8 +921,7 @@ impl Response {
                         u16::try_from(0.max(arg_init.to_int32()).min(i32::from(u16::MAX))).unwrap();
                 });
             } else {
-                if let Some(init) = Init::init(global_this, arg_init)? {
-                    init.validate_status_text(global_this)?;
+                if let Some(init) = Init::init::<true>(global_this, arg_init)? {
                     response.init.set(init);
                 }
             }
@@ -1002,7 +1001,7 @@ impl Response {
                     let status =
                         Self::validate_redirect_status_code(global_this, arg_init.to_int32())?;
                     response.init.with_mut(|i| i.status_code = status);
-                } else if let Some(init) = Init::init(global_this, arg_init)? {
+                } else if let Some(init) = Init::init::<true>(global_this, arg_init)? {
                     // cleanup is handled by Init's drop glue on `?` below
                     response.init.set(init);
 
@@ -1012,7 +1011,6 @@ impl Response {
                             Self::validate_redirect_status_code(global_this, i32::from(status))?;
                         response.init.with_mut(|i| i.status_code = status);
                     }
-                    response.init.get().validate_status_text(global_this)?;
                 }
             }
 
@@ -1130,9 +1128,7 @@ impl Response {
                 };
             }
             if arguments[1].is_object() {
-                let init = Init::init(global_this, arguments[1])?.expect("unreachable");
-                init.validate_status_text(global_this)?;
-                break 'brk init;
+                break 'brk Init::init::<true>(global_this, arguments[1])?.expect("unreachable");
             }
             return Err(global_this.throw_invalid_arguments(format_args!(
                 "Failed to construct 'Response': The provided body value is not of type 'ResponseInit'",
@@ -1231,7 +1227,9 @@ impl Init {
         })
     }
 
-    pub(crate) fn init(
+    /// `FOR_RESPONSE` applies the `ResponseInit` checks that `new Request()`,
+    /// which parses its `RequestInit` through this too, must not run.
+    pub(crate) fn init<const FOR_RESPONSE: bool>(
         global_this: &JSGlobalObject,
         response_init: JSValue,
     ) -> JsResult<Option<Init>> {
@@ -1312,6 +1310,9 @@ impl Init {
             response_init.fast_get_truthy(global_this, BuiltinName::statusText)?
         {
             result.status_text = status_text.to_bun_string(global_this)?;
+            if FOR_RESPONSE && !is_reason_phrase(&result.status_text) {
+                return Err(global_this.throw_type_error(format_args!("Invalid statusText")));
+            }
         }
 
         if let Some(method_value) =
@@ -1324,28 +1325,17 @@ impl Init {
 
         Ok(Some(result))
     }
+}
 
-    /// Fetch spec: `statusText` must match `reason-phrase` (HTAB, 0x20-0x7E, 0x80-0xFF).
-    pub(crate) fn validate_status_text(&self, global_this: &JSGlobalObject) -> JsResult<()> {
-        fn is_reason_phrase_unit(c: u32) -> bool {
-            c == 0x09 || (0x20..=0x7E).contains(&c) || (0x80..=0xFF).contains(&c)
-        }
-        let status_text = &self.status_text;
-        let valid = if status_text.is_utf16() {
-            status_text
-                .utf16()
-                .iter()
-                .all(|&c| is_reason_phrase_unit(u32::from(c)))
-        } else {
-            status_text
-                .byte_slice()
-                .iter()
-                .all(|&c| is_reason_phrase_unit(u32::from(c)))
-        };
-        if valid {
-            return Ok(());
-        }
-        Err(global_this.throw_type_error(format_args!("Invalid statusText")))
+/// Fetch spec `reason-phrase`: HTAB, 0x20-0x7E, 0x80-0xFF, per code unit.
+fn is_reason_phrase(status_text: &BunString) -> bool {
+    fn ok(c: u32) -> bool {
+        c == 0x09 || (0x20..=0x7E).contains(&c) || (0x80..=0xFF).contains(&c)
+    }
+    if status_text.is_utf16() {
+        status_text.utf16().iter().all(|&c| ok(u32::from(c)))
+    } else {
+        status_text.byte_slice().iter().all(|&c| ok(u32::from(c)))
     }
 }
 

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1227,8 +1227,7 @@ impl Init {
         })
     }
 
-    /// `FOR_RESPONSE` applies the `ResponseInit` checks that `new Request()`,
-    /// which parses its `RequestInit` through this too, must not run.
+    /// `FOR_RESPONSE` is false when `new Request()` parses its `RequestInit` through this.
     pub(crate) fn init<const FOR_RESPONSE: bool>(
         global_this: &JSGlobalObject,
         response_init: JSValue,

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1325,10 +1325,7 @@ impl Init {
         Ok(Some(result))
     }
 
-    /// Fetch spec: `ResponseInit["statusText"]` must match the `reason-phrase`
-    /// production (HTAB, SP / VCHAR 0x20-0x7E, obs-text 0x80-0xFF). Only the
-    /// `Response` constructors call this: `Request` also parses its init
-    /// through `Init::init` and ignores `statusText`.
+    /// Fetch spec: `statusText` must match `reason-phrase` (HTAB, 0x20-0x7E, 0x80-0xFF).
     pub(crate) fn validate_status_text(&self, global_this: &JSGlobalObject) -> JsResult<()> {
         fn is_reason_phrase_unit(c: u32) -> bool {
             c == 0x09 || (0x20..=0x7E).contains(&c) || (0x80..=0xFF).contains(&c)

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -922,6 +922,7 @@ impl Response {
                 });
             } else {
                 if let Some(init) = Init::init(global_this, arg_init)? {
+                    init.validate_status_text(global_this)?;
                     response.init.set(init);
                 }
             }
@@ -1003,6 +1004,7 @@ impl Response {
                     response.init.with_mut(|i| i.status_code = status);
                 } else if let Some(init) = Init::init(global_this, arg_init)? {
                     // cleanup is handled by Init's drop glue on `?` below
+                    init.validate_status_text(global_this)?;
                     response.init.set(init);
 
                     let status = response.init.get().status_code;
@@ -1128,7 +1130,9 @@ impl Response {
                 };
             }
             if arguments[1].is_object() {
-                break 'brk Init::init(global_this, arguments[1])?.expect("unreachable");
+                let init = Init::init(global_this, arguments[1])?.expect("unreachable");
+                init.validate_status_text(global_this)?;
+                break 'brk init;
             }
             return Err(global_this.throw_invalid_arguments(format_args!(
                 "Failed to construct 'Response': The provided body value is not of type 'ResponseInit'",
@@ -1319,6 +1323,32 @@ impl Init {
         }
 
         Ok(Some(result))
+    }
+
+    /// Fetch spec: `ResponseInit["statusText"]` must match the `reason-phrase`
+    /// production (HTAB, SP / VCHAR 0x20-0x7E, obs-text 0x80-0xFF). Only the
+    /// `Response` constructors call this: `Request` also parses its init
+    /// through `Init::init` and ignores `statusText`.
+    pub(crate) fn validate_status_text(&self, global_this: &JSGlobalObject) -> JsResult<()> {
+        fn is_reason_phrase_unit(c: u32) -> bool {
+            c == 0x09 || (0x20..=0x7E).contains(&c) || (0x80..=0xFF).contains(&c)
+        }
+        let status_text = &self.status_text;
+        let valid = if status_text.is_utf16() {
+            status_text
+                .utf16()
+                .iter()
+                .all(|&c| is_reason_phrase_unit(u32::from(c)))
+        } else {
+            status_text
+                .byte_slice()
+                .iter()
+                .all(|&c| is_reason_phrase_unit(u32::from(c)))
+        };
+        if valid {
+            return Ok(());
+        }
+        Err(global_this.throw_type_error(format_args!("Invalid statusText")))
     }
 }
 

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1197,6 +1197,8 @@ pub struct Init {
     pub(crate) status_code: u16,
     pub(crate) status_text: BunString,
     pub method: Method,
+    /// `method` is the `GET` fallback for a token `Method::which` does not know (#42497).
+    pub(crate) method_unknown: bool,
 }
 
 impl Default for Init {
@@ -1206,6 +1208,7 @@ impl Default for Init {
             status_code: 0,
             status_text: BunString::EMPTY,
             method: Method::GET,
+            method_unknown: false,
         }
     }
 }
@@ -1224,6 +1227,7 @@ impl Init {
             status_code: self.status_code,
             status_text: self.status_text.clone(),
             method: self.method,
+            method_unknown: self.method_unknown,
         })
     }
 
@@ -1317,8 +1321,14 @@ impl Init {
         if let Some(method_value) =
             response_init.fast_get_truthy(global_this, BuiltinName::method)?
         {
-            if let Some(method) = bun_http_jsc::method_jsc::from_js(global_this, method_value)? {
-                result.method = method;
+            let token = method_value.to_utf8(global_this)?;
+            match Method::which(&token) {
+                Some(method) => result.method = method,
+                // A case variant of GET or HEAD keeps the fallback on purpose.
+                None => {
+                    result.method_unknown =
+                        !token.eq_ignore_ascii_case(b"GET") && !token.eq_ignore_ascii_case(b"HEAD")
+                }
             }
         }
 

--- a/test/js/bun/http/async-iterator-stream.test.ts
+++ b/test/js/bun/http/async-iterator-stream.test.ts
@@ -332,7 +332,7 @@ describe.concurrent("Streaming body via", () => {
       for (let bodyInit of [fn, { [Symbol.asyncIterator]: fn }] as const) {
         for (let [label, constructFn] of [
           ["Response", () => new Response(bodyInit)],
-          ["Request", () => new Request({ "url": "https://example.com", body: bodyInit })],
+          ["Request", () => new Request({ "url": "https://example.com", method: "POST", body: bodyInit })],
         ]) {
           for (let method of ["arrayBuffer", "bytes", "text"]) {
             test(`${label}(${method})`, async () => {

--- a/test/js/bun/util/heap-snapshot.test.ts
+++ b/test/js/bun/util/heap-snapshot.test.ts
@@ -34,6 +34,7 @@ describe("Native types report their size correctly", () => {
 
   it("Request", () => {
     var request = new Request("https://example.com", {
+      method: "POST",
       body: Buffer.alloc(1024 * 1024 * 2, "yoo"),
     });
     globalThis.request = request;

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1050,10 +1050,9 @@ test("new Request(src, init) with a user ReadableStream body: both derived and s
   const twoArg = new Request(twoArgSrc, { headers: { "x-a": "1" } });
   const oneArgSrc = make();
   const oneArg = new Request(oneArgSrc);
-  // Bun extension: a Response as the second argument contributes its body and
-  // method via the sibling Response-source branch in construct_into.
-  // @ts-expect-error method is a Bun extension on ResponseInit
-  const responseSrc = new Response(stream(), { method: "POST" });
+  // Bun extension: a Response as the second argument contributes its body via
+  // the sibling Response-source branch in construct_into.
+  const responseSrc = new Response(stream());
   // @ts-expect-error Bun accepts a Response as init
   const fromResponse = new Request("http://example.com/", responseSrc);
   expect({

--- a/test/js/web/fetch/body-clone.test.ts
+++ b/test/js/web/fetch/body-clone.test.ts
@@ -1050,9 +1050,10 @@ test("new Request(src, init) with a user ReadableStream body: both derived and s
   const twoArg = new Request(twoArgSrc, { headers: { "x-a": "1" } });
   const oneArgSrc = make();
   const oneArg = new Request(oneArgSrc);
-  // Bun extension: a Response as the second argument contributes its body via
-  // the sibling Response-source branch in construct_into.
-  const responseSrc = new Response(stream());
+  // Bun extension: a Response as the second argument contributes its body and
+  // method via the sibling Response-source branch in construct_into.
+  // @ts-expect-error method is a Bun extension on ResponseInit
+  const responseSrc = new Response(stream(), { method: "POST" });
   // @ts-expect-error Bun accepts a Response as init
   const fromResponse = new Request("http://example.com/", responseSrc);
   expect({

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -1269,7 +1269,11 @@ describe("Blob", () => {
           const data = new TypedArray(sample);
           if (withGC) gc();
           const input =
-            Constructor === Blob ? [data] : Constructor === Request ? { body: data, url: "http://example.com" } : data;
+            Constructor === Blob
+              ? [data]
+              : Constructor === Request
+                ? { body: data, url: "http://example.com", method: "POST" }
+                : data;
           if (withGC) gc();
           const blob = new Constructor(input as any);
           if (withGC) gc();
@@ -1596,6 +1600,7 @@ describe("Request", () => {
   it("clone", async () => {
     gc();
     var body = new Request("https://hello.com", {
+      method: "POST",
       headers: {
         "content-type": "text/html; charset=utf-8",
       },
@@ -1654,7 +1659,7 @@ describe("Request", () => {
     expect(cloned.signal.aborted).toBe(true);
   });
 
-  testBlobInterface(data => new Request("https://hello.com", { body: data }), true);
+  testBlobInterface(data => new Request("https://hello.com", { method: "POST", body: data }), true);
 });
 
 describe("Headers", () => {

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -49,7 +49,7 @@ describe("2-arg form", () => {
 test("print size", () => {
   expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
     .toMatchInlineSnapshot(`
-    "Response (9.87 KB) {
+    "Response (10.75 KB) {
       ok: true,
       url: "",
       status: 200,
@@ -174,6 +174,24 @@ describe("statusText reason-phrase validation", () => {
 
   test("a status out of range is reported before an invalid statusText", () => {
     expect(() => new Response(null, { status: 600, statusText: "a\nb" })).toThrow(RangeError);
+    expect(() => Response.redirect("http://example.com/", { status: 404, statusText: "a\nb" })).toThrow(RangeError);
+  });
+
+  test("a fetched Response with a non-Latin-1 reason phrase is rejected as an init", async () => {
+    using listener = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        data(socket) {
+          socket.end(Buffer.from("HTTP/1.1 200 \x80OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", "latin1"));
+        },
+      },
+    });
+    const fetched = await fetch(`http://127.0.0.1:${listener.port}/`);
+    // The lone 0x80 byte is not valid UTF-8, so it decodes to U+FFFD.
+    expect(fetched.statusText).toBe("\uFFFDOK");
+    expect(() => new Response(null, fetched)).toThrow(new TypeError("Invalid statusText"));
+    expect(() => new Response(null, { statusText: fetched.statusText })).toThrow(new TypeError("Invalid statusText"));
   });
 
   test.each([

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -49,7 +49,7 @@ describe("2-arg form", () => {
 test("print size", () => {
   expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
     .toMatchInlineSnapshot(`
-    "Response (10.75 KB) {
+    "Response (10.71 KB) {
       ok: true,
       url: "",
       status: 200,
@@ -174,10 +174,9 @@ describe("statusText reason-phrase validation", () => {
 
   test("a status out of range is reported before an invalid statusText", () => {
     expect(() => new Response(null, { status: 600, statusText: "a\nb" })).toThrow(RangeError);
-    expect(() => Response.redirect("http://example.com/", { status: 404, statusText: "a\nb" })).toThrow(RangeError);
   });
 
-  test("a fetched Response with a non-Latin-1 reason phrase is rejected as an init", async () => {
+  test("a fetched Response with a non-Latin-1 reason phrase can still be re-wrapped", async () => {
     using listener = Bun.listen({
       hostname: "127.0.0.1",
       port: 0,
@@ -190,7 +189,8 @@ describe("statusText reason-phrase validation", () => {
     const fetched = await fetch(`http://127.0.0.1:${listener.port}/`);
     // The lone 0x80 byte is not valid UTF-8, so it decodes to U+FFFD.
     expect(fetched.statusText).toBe("\uFFFDOK");
-    expect(() => new Response(null, fetched)).toThrow(new TypeError("Invalid statusText"));
+    // The check applies to a ResponseInit dictionary, not to a Response used as the init.
+    expect(new Response("proxied", fetched).statusText).toBe("\uFFFDOK");
     expect(() => new Response(null, { statusText: fetched.statusText })).toThrow(new TypeError("Invalid statusText"));
   });
 

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -49,7 +49,7 @@ describe("2-arg form", () => {
 test("print size", () => {
   expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
     .toMatchInlineSnapshot(`
-    "Response (8.0 KB) {
+    "Response (9.87 KB) {
       ok: true,
       url: "",
       status: 200,
@@ -142,6 +142,53 @@ test("Response.redirect rejects a non-absolute url that is not a valid header va
 test("new Response(123, { statusText: 123 }) does not throw", () => {
   // @ts-expect-error
   expect(new Response("123", { statusText: 123 }).statusText).toBe("123");
+});
+
+// https://github.com/oven-sh/bun/issues/42499
+describe("statusText reason-phrase validation", () => {
+  const invalid: [string, string][] = [
+    ["CR LF", "a\r\nb"],
+    ["LF", "a\nb"],
+    ["CR", "a\rb"],
+    ["NUL", "a\0b"],
+    ["DEL", "a\x7fb"],
+    ["control byte", "a\x01b"],
+    ["non-Latin-1 code unit", "a\u0100b"],
+    ["NUL in a UTF-16 string", "\u00ff\u0100\0"],
+  ];
+
+  test.each(invalid)("new Response() rejects %s", (_name, statusText) => {
+    expect(() => new Response(null, { statusText })).toThrow(new TypeError("Invalid statusText"));
+    expect(() => new Response("body", { status: 201, statusText })).toThrow(new TypeError("Invalid statusText"));
+  });
+
+  test.each(invalid)("Response.json() rejects %s", (_name, statusText) => {
+    expect(() => Response.json({ a: 1 }, { statusText })).toThrow(new TypeError("Invalid statusText"));
+  });
+
+  test.each(invalid)("Response.redirect() rejects %s", (_name, statusText) => {
+    expect(() => Response.redirect("http://example.com/", { status: 301, statusText })).toThrow(
+      new TypeError("Invalid statusText"),
+    );
+  });
+
+  test("a status out of range is reported before an invalid statusText", () => {
+    expect(() => new Response(null, { status: 600, statusText: "a\nb" })).toThrow(RangeError);
+  });
+
+  test.each([
+    ["HTAB and SP", "a\tb c"],
+    ["VCHAR range", " !\"#$%&'()*+,-./0123456789:;<=>?@ABCXYZ[\\]^_`abcxyz{|}~"],
+    ["obs-text", "\u0080\u00a9\u00ff"],
+    ["empty", ""],
+  ])("new Response() keeps %s", (_name, statusText) => {
+    expect(new Response(null, { statusText }).statusText).toBe(statusText);
+    expect(Response.json(1, { statusText }).statusText).toBe(statusText);
+  });
+
+  test("new Request() ignores statusText", () => {
+    expect(() => new Request("http://example.com/", { statusText: "a\nb" } as RequestInit)).not.toThrow();
+  });
 });
 
 test("new Response(123, { method: 456 }) does not throw", () => {

--- a/test/js/web/fetch/utf8-bom.test.ts
+++ b/test/js/web/fetch/utf8-bom.test.ts
@@ -76,6 +76,7 @@ describe("UTF-8 BOM should be ignored", () => {
   describe("Request", () => {
     it("in text()", async () => {
       const request = new Request("https://example.com", {
+        method: "POST",
         body: Buffer.from("\uFEFFHello, World!"),
         headers: { "content-type": "text/plain" },
       });
@@ -84,6 +85,7 @@ describe("UTF-8 BOM should be ignored", () => {
 
     it("in json()", async () => {
       const request = new Request("https://example.com", {
+        method: "POST",
         body: Buffer.from('\uFEFF{"hello":"World"}'),
         headers: { "content-type": "application/json" },
       });
@@ -92,6 +94,7 @@ describe("UTF-8 BOM should be ignored", () => {
 
     it("in formData()", async () => {
       const request = new Request("https://example.com", {
+        method: "POST",
         body: Buffer.from("\uFEFFhello=world"),
         headers: { "content-type": "application/x-www-form-urlencoded" },
       });

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -163,7 +163,9 @@ describe("FormData", () => {
     for (const C of Class) {
       it(`should parse multipart/form-data (${name}) with ${C.name}`, async () => {
         const response =
-          C === Response ? new Response(body, { headers }) : new Request({ headers, body, url: "http://hello.com" });
+          C === Response
+            ? new Response(body, { headers })
+            : new Request({ headers, body, url: "http://hello.com", method: "POST" });
         const formData = await response.formData();
         expect(formData instanceof FormData).toBe(true);
         const entry: { [k: string]: any } = {};
@@ -192,7 +194,9 @@ describe("FormData", () => {
 
       it(`should roundtrip multipart/form-data (${name}) with ${C.name}`, async () => {
         const response =
-          C === Response ? new Response(body, { headers }) : new Request({ headers, body, url: "http://hello.com" });
+          C === Response
+            ? new Response(body, { headers })
+            : new Request({ headers, body, url: "http://hello.com", method: "POST" });
         const formData = await response.formData();
         expect(formData instanceof FormData).toBe(true);
 
@@ -584,7 +588,9 @@ describe("FormData", () => {
           const formData = new FormData();
           formData.append("foo", Bun.file(path));
           const response =
-            C === Response ? new Response(formData) : new Request({ body: formData, url: "http://example.com" });
+            C === Response
+              ? new Response(formData)
+              : new Request({ body: formData, url: "http://example.com", method: "POST" });
           expect(response.headers.get("content-type")?.startsWith("multipart/form-data;")).toBe(true);
 
           const formData2 = await response.formData();

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -132,6 +132,13 @@ describe("new Request() with a GET/HEAD method and a body", () => {
     expect(await new Request("http://example.com/", { method: "GET", body: body() }).text()).toBe("");
   });
 
+  test("a body taken from a Response init is kept (Bun extension)", async () => {
+    // @ts-expect-error Bun accepts a Response as init
+    const request = new Request("http://example.com/", new Response("from response"));
+    expect(request.method).toBe("GET");
+    expect(await request.text()).toBe("from response");
+  });
+
   test("other methods keep their body", async () => {
     for (const method of ["POST", "PUT", "PATCH", "DELETE", "OPTIONS"]) {
       const request = new Request("http://example.com/", { method, body: "x" });

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -76,6 +76,61 @@ test("clone() does not lock original body when body was accessed before clone", 
   expect(clonedText).toBe("Hello, world!");
 });
 
+// https://github.com/oven-sh/bun/issues/42499
+describe("new Request() with a GET/HEAD method and a body", () => {
+  const message = "Request with GET/HEAD method cannot have body.";
+
+  test.each(["GET", "HEAD", "get", "head"])("method %s with a string body throws TypeError", method => {
+    expect(() => new Request("http://example.com/", { method, body: "x" })).toThrow(new TypeError(message));
+  });
+
+  test("default method with a body throws TypeError", () => {
+    expect(() => new Request("http://example.com/", { body: "x" })).toThrow(new TypeError(message));
+  });
+
+  test.each([
+    ["Uint8Array", () => new Uint8Array([1])],
+    ["Blob", () => new Blob(["x"])],
+    ["ReadableStream", () => new ReadableStream()],
+    ["URLSearchParams", () => new URLSearchParams("a=1")],
+    [
+      "FormData",
+      () => {
+        const fd = new FormData();
+        fd.set("a", "1");
+        return fd;
+      },
+    ],
+  ])("GET with a %s body throws TypeError", (_name, body) => {
+    expect(() => new Request("http://example.com/", { method: "GET", body: body() })).toThrow(new TypeError(message));
+  });
+
+  test("a POST input Request combined with method GET throws TypeError", () => {
+    const post = new Request("http://example.com/", { method: "POST", body: "x" });
+    expect(() => new Request(post, { method: "GET" })).toThrow(new TypeError(message));
+    // The failed construction does not consume the input body.
+    expect(post.bodyUsed).toBe(false);
+  });
+
+  test("an invalid URL wins over the body check", () => {
+    expect(() => new Request("not a url", { method: "GET", body: "x" })).toThrow(/Invalid URL/);
+  });
+
+  test("a null, undefined or empty body is accepted", async () => {
+    expect(new Request("http://example.com/", { method: "GET", body: null }).body).toBeNull();
+    expect(new Request("http://example.com/", { method: "HEAD", body: undefined }).body).toBeNull();
+    // fetch() treats an empty string as no body. The constructor does the same.
+    expect(await new Request("http://example.com/", { method: "GET", body: "" }).text()).toBe("");
+  });
+
+  test("other methods keep their body", async () => {
+    for (const method of ["POST", "PUT", "PATCH", "DELETE", "OPTIONS"]) {
+      const request = new Request("http://example.com/", { method, body: "x" });
+      expect(await request.text()).toBe("x");
+    }
+  });
+});
+
 describe("RequestInit signal presence", () => {
   // Fetch spec step 27: "If init['signal'] exists, then set signal to it."
   // A present `signal: null` must replace (detach from) the input Request's signal.

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -123,6 +123,15 @@ describe("new Request() with a GET/HEAD method and a body", () => {
     expect(await new Request("http://example.com/", { method: "GET", body: "" }).text()).toBe("");
   });
 
+  test.each([
+    ["Uint8Array(0)", () => new Uint8Array(0)],
+    ["Blob([])", () => new Blob([])],
+    ["URLSearchParams()", () => new URLSearchParams()],
+  ])("a zero-byte %s body is accepted, matching fetch()", async (_name, body) => {
+    // fetch_impl only rejects a GET/HEAD body with size > 0; the constructor uses the same rule.
+    expect(await new Request("http://example.com/", { method: "GET", body: body() }).text()).toBe("");
+  });
+
   test("other methods keep their body", async () => {
     for (const method of ["POST", "PUT", "PATCH", "DELETE", "OPTIONS"]) {
       const request = new Request("http://example.com/", { method, body: "x" });

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -132,6 +132,15 @@ describe("new Request() with a GET/HEAD method and a body", () => {
     expect(await new Request("http://example.com/", { method: "GET", body: body() }).text()).toBe("");
   });
 
+  test.each(["Get", "Head", "gEt"])("mixed-case %s with a body throws TypeError", method => {
+    expect(() => new Request("http://example.com/", { method, body: "x" })).toThrow(new TypeError(message));
+  });
+
+  test.each(["Post", "LIST", "Purge"])("a method token Bun does not know (%s) keeps its body", async method => {
+    const request = new Request("http://example.com/", { method, body: "x" });
+    expect(await request.text()).toBe("x");
+  });
+
   test("a body taken from a Response init is kept (Bun extension)", async () => {
     // @ts-expect-error Bun accepts a Response as init
     const request = new Request("http://example.com/", new Response("from response"));

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -153,6 +153,16 @@ describe("new Request() with a GET/HEAD method and a body", () => {
     expect(reads).toBe(1);
   });
 
+  test("a Request built under an exemption can be wrapped again with an init", async () => {
+    // @ts-expect-error Bun accepts a Response as init
+    const fromResponse = new Request("http://example.com/", new Response("from response"));
+    expect(await new Request(fromResponse, { headers: { "x-a": "1" } }).text()).toBe("from response");
+    const unknownMethod = new Request("http://example.com/", { method: "LIST", body: "x" });
+    expect(await new Request(unknownMethod, {}).text()).toBe("x");
+    // An explicit GET in the init still applies the check.
+    expect(() => new Request(unknownMethod, { method: "GET" })).toThrow(new TypeError(message));
+  });
+
   test("a body taken from a Response init is kept (Bun extension)", async () => {
     // @ts-expect-error Bun accepts a Response as init
     const request = new Request("http://example.com/", new Response("from response"));

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -141,6 +141,18 @@ describe("new Request() with a GET/HEAD method and a body", () => {
     expect(await request.text()).toBe("x");
   });
 
+  test("init.method is read once, so a getter cannot change the answer", () => {
+    let reads = 0;
+    const init = {
+      get method() {
+        return reads++ === 0 ? "GET" : "LIST";
+      },
+      body: "x",
+    };
+    expect(() => new Request("http://example.com/", init)).toThrow(new TypeError(message));
+    expect(reads).toBe(1);
+  });
+
   test("a body taken from a Response init is kept (Bun extension)", async () => {
     // @ts-expect-error Bun accepts a Response as init
     const request = new Request("http://example.com/", new Response("from response"));

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -514,7 +514,7 @@ it("new Request({body: stream}).body", async () => {
     },
     cancel() {},
   });
-  var response = new Request({ body: stream, url: "https://example.com" });
+  var response = new Request({ method: "POST", body: stream, url: "https://example.com" });
   expect(response.body).toBe(stream);
   expect(await response.text()).toBe("helloworld");
 });


### PR DESCRIPTION
### Problem
- `new Request(url, { method: "GET", body: "x" })` is accepted. Node, browsers and Deno throw `TypeError: Request with GET/HEAD method cannot have body.` Bun's `fetch()` already rejects the same input (`src/runtime/webcore/fetch.rs:1349`).
- `new Response(null, { statusText: "a\r\nb" })` keeps the text. Node throws `TypeError: Invalid statusText`. `Init::init` (`src/runtime/webcore/Response.rs:1307`) stores it verbatim.
- #42499 reports two more cases. Forbidden methods: #33469. A body with a null body status: #32044 (drops the body, Elysia builds such responses).

### Fix
- `Request::construct_into` throws a `TypeError` when the method is `GET` or `HEAD` and `Body::Value::has_request_body()` is true. An invalid URL still wins. A zero-byte body (`""`, `new Uint8Array(0)`, `new Blob([])`, `new URLSearchParams()`) counts as no body, the same size rule `fetch_impl` applies through `HTTPRequestBody::has_body`, so `new Request(url, init)` and `fetch(url, init)` accept and reject the same inputs. This is looser than the spec, which rejects any non-null body.
- `Init::init` throws a `TypeError` when a code unit of the `statusText` it reads from the init dictionary is outside HTAB, 0x20-0x7E, 0x80-0xFF (undici's `isValidReasonPhrase`). A `FOR_RESPONSE` flag turns the check off for `new Request()`, which parses its init through the same function. A `Response` used as the init is cloned before the dictionary parse, so `new Response(body, upstream)` keeps an upstream reason phrase the wire decoded to a code unit above 0xFF.
- Two deliberate exemptions keep existing Bun behavior: a body that a `Response` passed as the init contributes (`new Request(url, response)`, a Bun extension), and a method token Bun does not know (`"Post"`, `"LIST"`), which `Init::init` still maps to `GET` (#42497). Mixed-case `Get` and `Head` throw, as in Node. A Request built under either exemption can be wrapped again with `new Request(r, init)`: a method and body copied together from the input are not checked again, an init that sets the method is.
- Seven test files built a `Request` with a body and the default `GET` method. They now pass `method: "POST"`. The vendored Elysia suite has no new failure.
- Verified: `test/js/web/request/request.test.ts` and `test/js/web/fetch/response.test.ts` (new blocks, 38 cases fail on stock bun). Also `test/js/web/fetch/`, `FormData.test.ts`, `serve.test.ts`.

### Background
- Fetch spec `Request` constructor, step 36: if the body is non-null and the method is `GET` or `HEAD`, throw a `TypeError`.
- Fetch spec `Response` constructor: if `statusText` does not match the HTTP `reason-phrase` production, `*( HTAB / SP / VCHAR / obs-text )`, throw a `TypeError`.
- `Init` is the parsed `ResponseInit`. `new Request()` reuses `Init::init` for `method` and `headers`.

<details><summary>Notes</summary>

- `new Request(postRequest, { method: "GET" })` throws too, and the input body stays unused (the cleanup path drops the teed body).
- A review pointed out that the Response-as-init branch copies the Response's default `GET` method and then its body, so the first draft threw for every `new Request(url, response)` with a body. `construct_into` now tracks that the body came from a Response and skips the check for it. `request.test.ts` pins `new Request(url, new Response(body))`.
- A second review finding: `Method::which` returns `None` for `"Post"` or `"LIST"`, so `Init::init` fell back to `GET` and the check threw for a request Node accepts. `init_method_is_unknown` reads the raw token and skips the check when it is unknown and not `GET`/`HEAD` case-insensitively. Fixing the fallback itself is #33469.
- Self-review: 5 concerns raised, 4 addressed (the Response-init exemptions are stated above as deliberate, a test pins `new Response(body, fetchedResponse)` with a U+FFFD reason phrase re-wrapping without error, the check moved into `Init::init` behind `FOR_RESPONSE`). Rejected: throwing for a `statusText` that came from a `Response` object rather than from a dictionary. Node throws there too, but the value is not user input and the re-wrap idiom `new Response(body, upstream)` would start failing on a rare upstream reason phrase.
- A review pass found the first draft used a type-based predicate (`Null | Empty`) that rejected `new Blob([])` and `new URLSearchParams()` while `fetch(url, init)` accepted them. The check now uses `Value::size() > 0` for blob/string bodies (streams always count), and `request.test.ts` pins the three zero-byte cases.
- `Bun.serve` hands a `GET` request with a `Content-Length` body to the handler with `body === null`, so `new Request(serverRequest, init)` does not hit the new check.
- `statusText` can be a Latin-1 or a UTF-16 WTF string. The check iterates code units of either form. A byte of a UTF-8 encoded slice is either ASCII or >= 0x80, so the byte path is also correct for that form.
- #36003 adds a separate wire-side `is_valid_reason_phrase` in `src/runtime/server/HTTPStatusText.rs`. This constructor check is a prerequisite for it.
- The `print size` inline snapshot in `response.test.ts` depends on the test file's byte size and was updated, as in earlier commits to that file.
- Elysia 1.4.28 suite with this build: 1516 pass, 9 fail. The 9 are the four skips listed in `test/vendor.json`, four `Native Static Response` tests that gate on `Bun.semver.satisfies(Bun.version, ">=1.2.14")` and fail on any `-debug` version string, and one timing test (`Stream > stop stream on canceled request`). None mention the new errors.
- `test/integration/bun-types/fixture/{fetch,index}.ts` still write `new Request(url, { body })` without a method. Those are type-check fixtures and do not run.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/streams/streams.test.js, test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->

