### PR TITLE
node: resolve the Bun global before rendering a value into an error message

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -275,7 +275,7 @@ JSObject* createError(Zig::JSGlobalObject* globalObject, ErrorCode code, JSC::JS
 // `Bun.inspect` with `single_line` + `quote_strings` — the same renderer
 // JSBuffer uses to inline a value into an error message; it renders objects
 // on one line ("Received { abc: 123 }") the way Node does.
-extern "C" BunString Bun__inspect_singleline(JSC::JSGlobalObject* globalObject, JSValue value);
+extern "C" BunString Bun__inspect_singleline(Zig::GlobalObject* globalObject, JSValue value);
 
 // util.inspect's quoted-string escaping (https://github.com/nodejs/node/blob/main/lib/internal/util/inspect.js
 // strEscape). Bun.inspect double-quotes; Node's messages use single quotes.
@@ -382,7 +382,7 @@ void JSValueToStringSafe(JSC::JSGlobalObject* globalObject, WTF::StringBuilder& 
     }
 
     // Node renders objects inline in error messages ("Received { abc: 123 }").
-    builder.append(Bun__inspect_singleline(globalObject, arg).transferToWTFString());
+    builder.append(Bun__inspect_singleline(defaultGlobalObject(globalObject), arg).transferToWTFString());
 }
 
 void determineSpecificType(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WTF::StringBuilder& builder, JSValue value)

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -97,7 +97,7 @@ extern "C" size_t highway_last_index_of_char(const uint8_t* haystack, size_t hay
 static constexpr size_t kHighwayNotFound = ~static_cast<size_t>(0);
 
 // export fn Bun__inspect_singleline(globalThis: *JSGlobalObject, value: JSValue) bun.String
-extern "C" BunString Bun__inspect_singleline(JSC::JSGlobalObject* globalObject, JSC::JSValue value);
+extern "C" BunString Bun__inspect_singleline(Zig::GlobalObject* globalObject, JSC::JSValue value);
 
 using namespace JSC;
 using namespace WebCore;

--- a/src/jsc/bindings/webcore/JSMessageEvent.cpp
+++ b/src/jsc/bindings/webcore/JSMessageEvent.cpp
@@ -45,7 +45,7 @@
 #include "ScriptExecutionContext.h"
 #include "WebCoreJSClientData.h"
 
-extern "C" BunString Bun__inspect_singleline(JSC::JSGlobalObject* globalObject, JSC::JSValue value);
+extern "C" BunString Bun__inspect_singleline(Zig::GlobalObject* globalObject, JSC::JSValue value);
 #include <JavaScriptCore/HeapAnalyzer.h>
 #include <JavaScriptCore/JSArray.h>
 #include <JavaScriptCore/JSCInlines.h>
@@ -163,7 +163,7 @@ template<> MessageEvent::Init convertDictionary<MessageEvent::Init>(JSGlobalObje
             iterable = iterFn.isCallable();
         }
         if (!iterable) {
-            auto inspected = Bun__inspect_singleline(&lexicalGlobalObject, portsValue).transferToWTFString();
+            auto inspected = Bun__inspect_singleline(defaultGlobalObject(&lexicalGlobalObject), portsValue).transferToWTFString();
             RETURN_IF_EXCEPTION(throwScope, {});
             throwTypeError(&lexicalGlobalObject, throwScope, makeString("MessageEvent constructor: eventInitDict.ports ("_s, inspected, ") is not iterable."_s));
             return {};
@@ -173,7 +173,7 @@ template<> MessageEvent::Init convertDictionary<MessageEvent::Init>(JSGlobalObje
             auto scope = DECLARE_THROW_SCOPE(vm);
             auto* wrapped = item.isCell() ? JSMessagePort::toWrapped(vm, item) : nullptr;
             if (!wrapped) {
-                auto inspected = Bun__inspect_singleline(&g, item).transferToWTFString();
+                auto inspected = Bun__inspect_singleline(defaultGlobalObject(&g), item).transferToWTFString();
                 RETURN_IF_EXCEPTION(scope, );
                 throwTypeError(&g, scope, makeString("MessageEvent constructor: Expected eventInitDict.ports["_s, i, "] (\""_s, inspected, "\") to be an instance of MessagePort."_s));
                 return;
@@ -193,7 +193,7 @@ template<> MessageEvent::Init convertDictionary<MessageEvent::Init>(JSGlobalObje
     }
     if (!sourceValue.isUndefinedOrNull()) {
         result.source = convert<IDLNullable<IDLInterface<MessagePort>>>(lexicalGlobalObject, sourceValue, [&sourceValue](JSGlobalObject& lexicalGlobalObject, ThrowScope& throwScope) {
-            auto inspected = Bun__inspect_singleline(&lexicalGlobalObject, sourceValue).transferToWTFString();
+            auto inspected = Bun__inspect_singleline(defaultGlobalObject(&lexicalGlobalObject), sourceValue).transferToWTFString();
             if (throwScope.exception()) [[unlikely]]
                 return;
             throwTypeError(&lexicalGlobalObject, throwScope, makeString("MessageEvent constructor: Expected eventInitDict.source (\""_s, inspected, "\") to be an instance of MessagePort."_s));

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1194,6 +1194,98 @@ describe("the options argument", () => {
   });
 });
 
+describe("a run option rejected with a vm context's global", () => {
+  // Script#runInContext and Script#runInNewContext validate displayErrors,
+  // timeout and breakOnSigint with the context's global object, which is not a
+  // Bun global. The message renders the rejected value through the console
+  // formatter, and the formatter needs a Bun global, so it read past the end of
+  // the context's cell: ASAN reports a heap-buffer-overflow and a release build
+  // segfaults. Each case gets its own process.
+  //
+  // The vm.* wrappers build the Script first, and that rejects a bad timeout
+  // with the main global, so only the Script methods reach the bug with it.
+  const types = { displayErrors: "boolean", timeout: "number", breakOnSigint: "boolean" } as const;
+  type Option = keyof typeof types;
+  const entryPoints: [name: string, call: string, options: Option[]][] = [
+    ["vm.runInContext()", `vm.runInContext("1", vm.createContext({}), options)`, ["displayErrors", "breakOnSigint"]],
+    ["vm.runInNewContext()", `vm.runInNewContext("1", {}, options)`, ["displayErrors", "breakOnSigint"]],
+    [
+      "Script#runInContext()",
+      `new vm.Script("1").runInContext(vm.createContext({}), options)`,
+      ["displayErrors", "timeout", "breakOnSigint"],
+    ],
+    [
+      "Script#runInNewContext()",
+      `new vm.Script("1").runInNewContext({}, options)`,
+      ["displayErrors", "timeout", "breakOnSigint"],
+    ],
+  ];
+
+  async function run(fixture: string) {
+    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", fixture], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // A custom inspect function reaches the Bun global's inspect builtins. The
+  // function reports what it was handed, so a wrong global is visible in the
+  // output instead of only as a crash. It sits on the null-prototype object
+  // itself because Node renders the value with `depth: -1`, which runs no
+  // nested inspect function, so this message is Node's byte for byte.
+  test.concurrent.each(
+    entryPoints.flatMap(([name, call, options]) => options.map(option => [name, option, call] as const)),
+  )("%s renders a bad %s through a custom inspect function", async (_, option, call) => {
+    const { stdout, stderr, exitCode } = await run(`
+      const vm = require("node:vm");
+      const util = require("node:util");
+      const seen = [];
+      const bad = Object.create(null);
+      bad[util.inspect.custom] = function (depth, opts, inspect) {
+        seen.push(typeof opts, typeof opts.stylize, typeof inspect, opts.colors);
+        return "CUSTOM";
+      };
+      const options = { ${option}: bad };
+      try {
+        ${call};
+      } catch (e) {
+        console.log([e.code, e.message, seen.join(",")].join(" | "));
+      }
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(
+      `ERR_INVALID_ARG_TYPE | The "options.${option}" property must be of type ${types[option]}. ` +
+        `Received CUSTOM | object,function,function,false\n`,
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  // A value that owns a DOM wrapper reaches a second Bun-global-only read:
+  // printing one builds its wrapper, which needs the global's DOM world. These
+  // need no user hook. The rendering of the value itself is not asserted, only
+  // that the message is produced and the process lives.
+  test.concurrent.each([
+    ["a Response", `new Response("body")`],
+    ["a Request", `new Request("http://127.0.0.1:9/")`],
+    ["a Response.json", `Response.json({ a: 1 })`],
+  ])("renders a bad displayErrors holding %s", async (_, valueExpression) => {
+    const { stdout, stderr, exitCode } = await run(`
+      const vm = require("node:vm");
+      const bad = Object.create(null);
+      bad.value = ${valueExpression};
+      try {
+        vm.runInContext("1", vm.createContext({}), { displayErrors: bad });
+      } catch (e) {
+        console.log([e.code, e.message].join(" | "));
+      }
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toStartWith(
+      `ERR_INVALID_ARG_TYPE | The "options.displayErrors" property must be of type boolean. Received `,
+    );
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("context options with throwing getters", () => {
   // Without the fix, reading these options with a pending exception aborted
   // the process, so run the matrix in a subprocess.


### PR DESCRIPTION
### Problem
- `new vm.Script("1").runInContext(vm.createContext({}), { displayErrors: bad })` crashes: `AddressSanitizer: heap-buffer-overflow`, past the cell from `allocateCell<Bun::NodeVMGlobalObject>`. The release canary segfaults. Node v26.3.0 throws the `TypeError`.
- `Script#runInContext` and `Script#runInNewContext` validate options with the context's global. `JSValueToStringSafe` (`src/jsc/bindings/ErrorCode.cpp:385`) renders the rejected value through the console formatter with that global.
- The formatter needs a Bun global. Two reads went out of bounds: `utilInspectStylizeNoColorFunction()` for a value with a custom inspect function, and `world()` for a value holding a DOM wrapper, such as a `Response`.

### Fix
- Resolve the Bun global where an error message enters the formatter.
- Declare `Bun__inspect_singleline` with a `Zig::GlobalObject*` in its three call files. Rust accepts any `JSGlobalObject`, so the C++ declaration is where the check can live. The old call now fails to build: `no matching function for call to 'Bun__inspect_singleline'`.
- `defaultGlobalObject(x)` returns `x` for a Bun global, so only the vm-context path changes. The `MessageEvent` call sites get the same wrap and behave as before.
- Verified: `test/js/node/vm/vm.test.ts`, 13 cases, all fail on the unfixed debug build. The notes list the other suites.

### Background
- A `node:vm` context has its own global, `Bun::NodeVMGlobalObject`. It derives from `Bun::GlobalScope`, not `Zig::GlobalObject`, so it has none of the Bun global's members and no DOM world.
- `Zig::GlobalObject` keeps bun's built-in JS in `LazyProperty` members and its DOM world in a `Ref`. Reading either is a load at a fixed offset. A wrongly typed pointer reads whatever follows the smaller cell.
- `defaultGlobalObject()` is a `dynamicDowncast<Zig::GlobalObject>` that falls back to the thread's Bun global. `ErrorCode.cpp` already guards error creation this way.

<details><summary>Notes</summary>

**Repro.** The inspect function must read its `options` argument. One that ignores its arguments gets an empty value and exits 0 on a release build, although ASAN still reports the read.

```js
const vm = require("vm"), util = require("util");
const bad = Object.create(null);
bad[util.inspect.custom] = (depth, opts) => `stylize is a ${typeof opts.stylize}`;
try { new vm.Script("1").runInContext(vm.createContext({}), { displayErrors: bad }); }
catch (e) { console.log(e.code, e.message); }
console.log("survived");
```

- Release canary `6a92015fc`: `panic(main thread): Segmentation fault at address 0x0`, rc 139, 3 of 3 runs.
- Debug plus ASAN at `b99371011f`, `Malloc=1`: "located 1944 bytes after 4184-byte region". Frames: `LazyProperty<JSGlobalObject, JSFunction>::getInitializedOnMainThread` (LazyProperty.h:95), `Zig::GlobalObject::utilInspectStylizeNoColorFunction()`, `Bun::createInspectOptionsObject` (UtilInspect.cpp:33), `JSC__JSValue__callCustomInspectFunction`. The original report measured a 4072-byte region on `df573dace6`. The distance past the end is 1944 on both.
- Node v26.3.0 and this PR both print `The "options.displayErrors" property must be of type boolean. Received stylize is a function`, then `survived`.
- For the second read use `bad.value = new Response("body")` (or a `Request`, or `Response.json(...)`) and no inspect function. Frames: `WTF::Ref<WebCore::DOMWrapperWorld>::get()`, `Zig::GlobalObject::world()`, `WebCore::wrap<WebCore::FetchHeaders>`, `WebCore__FetchHeaders__toJS` (bindings.cpp:2400).

**Since when.** This is not a recent regression. `JSValueToStringSafe` has passed the validator's global to the formatter since #16009 (`Bun__inspect(globalObject, arg)`, first released in v1.1.43). #31831 (v1.4.0) only switched that call to `Bun__inspect_singleline`. Release binaries for linux x64, 3 runs each, every cell 3 of 3:

| release | repro above (function reads `opts`) | function that ignores its arguments | `Response` in the value |
| --- | --- | --- | --- |
| 1.3.14 | segfault at 0x0 | clean | segfault at 0x18 |
| 1.4.0 | segfault at 0x0 | clean | no fault |
| 1.4.1 | segfault at 0x0 | segfault at 0x0 | no fault |
| 1.4.2 | segfault at 0x0 | segfault at 0x0 | no fault |
| canary `6a92015fc` | segfault at 0x0 | clean | no fault |

ASAN reports the read on main for all three columns. Whether a release build faults depends on what lies after the context's cell, so the last two columns are uneven. A function that reads its `options` argument faults on every release tested.

**Which doors reach it.** One process per case, unfixed ASAN build.

| entry point | displayErrors | timeout | breakOnSigint |
| --- | --- | --- | --- |
| `vm.runInContext` | crash | clean | crash |
| `vm.runInNewContext` | crash | clean | crash |
| `Script#runInContext` | crash | crash | crash |
| `Script#runInNewContext` | crash | crash | crash |
| `vm.runInThisContext`, `Script#runInThisContext` | clean | clean | clean |

`timeout` is clean for the two `vm.*` wrappers only because they build the `Script` first, and that constructor rejects a bad `timeout` with the main global. #38426 removes that check from the constructor, which opens the wrappers too. This change covers them.

The same line also closes four more doors on `Script#runInContext`: the `options` argument itself, `filename`, `lineOffset` and `columnOffset`. All four overflow under ASAN, segfault on the release canary (rc 139) and are clean with this change. The tests do not pin the last three on purpose: Node runs the script for them and never validates them on a run call, so a test would pin a throw that Node does not make. That difference is tracked as its own bug.

**One visible change in a path that did not crash.** The formatter prints `Object.prototype`'s methods for a plain object from another realm (#1713). It now runs with the main global, so that flips. For `{ displayErrors: bad }` with `bad.nested = { b: 1 }`:

| `nested` made in | before | after | Node |
| --- | --- | --- | --- |
| the main realm | `{ nested: { b: 1, toString: [Function: toString], ... } }` (485 chars) | `{ nested: { b: 1 } }` (45 chars) | `[Object: null prototype]` |
| the context | 45 chars | 485 chars | `[Object: null prototype]` |

The host builds run options, so the main-realm row is the common one and it gets shorter. #38642 renders this arm at `depth: -1` like Node, which removes the difference.

**Related open PRs.** None is a duplicate. The typed declaration exists because of the first two.
- #41776 adds a re-entry guard above this call and keeps the raw `globalObject` on the line this PR changes. Its rebase must keep `defaultGlobalObject(...)`.
- #38637 adds a second `Bun__inspect_singleline(globalObject, nameValue)` call in `ErrorCode.cpp`. It merges without a conflict and would pass the unresolved global. It must wrap it the same way.
- With the typed declaration, both mistakes fail to build. I checked: putting the old call back gives `cannot convert from base class pointer 'JSC::JSGlobalObject *' to derived class pointer 'Zig::GlobalObject *'`.
- #38642 routes constructor-less objects in `ERR_INVALID_ARG_TYPE` through `util.inspect` at `depth: -1`. After it, these 13 tests no longer reach this line, so they can no longer catch a revert of it. They still pin the behavior end to end (no crash, Node's message) for whichever renderer runs. The declaration is what keeps guarding this entry.

**Why this layer.** A narrower fix inside `JSC__JSValue__callCustomInspectFunction` covers the custom-inspect read but not `world()`. I built that first and measured it: the three DOM-wrapper cases still abort in `WebCore__FetchHeaders__toJS`. With that change reverted and only this one applied, all 13 pass. Other ways into the formatter from inside a context (`console.log`, a `Buffer` type error, an unhandled rejection, a throw) arrive with the main global, because their host functions are main-realm. I probed all four.

Validating with `defaultGlobalObject(globalObject)` in `RunningScriptOptions::fromJS` would also cover both reads and matches where Node validates. I left it alone: it changes nothing observable (`e instanceof TypeError` and `e.constructor === TypeError` are already true, as in Node), and it leaves the formatter enterable by the next validator that holds a context global.

`bindings.cpp` still holds five bare `static_cast<Zig::GlobalObject*>` casts, including the one behind `world()`. This change makes them unreachable from error-message rendering. Retyping them is a separate cleanup.

**Tests.** The 10 custom-inspect cases put the function on the null-prototype object itself, because Node renders the value at `depth: -1` and runs no nested inspect function. Their expected strings match node v26.3.0 byte for byte, checked in a loop for all 10. They also fail on the release canary, with `Segmentation fault at address 0x5`. The 3 DOM-wrapper cases assert the message prefix and that the process lives, not the rendered tree, because #38642 will collapse that rendering.

Suites run on the final diff: `test/js/node/vm/vm.test.ts`, `test/js/node/errors/`, `test/js/node/buffer.test.js`, `test/js/web/workers/message-event.test.ts`, `test/js/node/test/parallel/test-worker-message-event.js`, `test/js/node/util/`, `test/js/bun/util/inspect*`, `test/js/bun/console/`, `test/js/web/console/`. One failure, which also fails on the unfixed build: `parseArgs extra tests > stress test > 100 mixed several times` times out at 5 s under debug plus ASAN.

</details>
