### PR TITLE
Keep the embedded source text of a compiled executable when its pages are not file-backed

### DIFF
--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -651,15 +651,22 @@ mod elf {
     /// memory instead, and `MADV_DONTNEED` on an anonymous private page makes
     /// the next read return zeros rather than the bytes the file holds
     /// (#42509). A range that cannot be read or parsed counts as not backed.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub(super) fn is_file_backed(lo: usize, hi: usize) -> bool {
-        let Ok(maps) = bun_sys::File::open(
+        let Ok(file) = bun_sys::File::open(
             bun_core::zstr!("/proc/self/maps"),
             bun_sys::O::RDONLY | bun_sys::O::CLOEXEC,
             0,
-        )
-        .and_then(|file| file.read_to_end_small()) else {
+        ) else {
             return false;
         };
+        // `fstat` reports size 0 for procfs, so presize for the typical
+        // process instead and read sequentially: the kernel builds the
+        // listing incrementally across `read` calls.
+        let mut maps = Vec::new();
+        if maps.try_reserve(16 * 1024).is_err() || file.read_to_end_into(&mut maps).is_err() {
+            return false;
+        }
         // One mapping per line, sorted by address:
         // `start-end perms offset dev inode [path]`. Anonymous mappings have
         // inode 0, whatever their path field says.

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -644,6 +644,56 @@ mod elf {
             hi - lo
         );
     }
+
+    /// Whether `/proc/self/maps` shows `[lo, hi)` inside mappings that have a
+    /// backing file. The kernel maps the payload from the executable, but an
+    /// executable packer such as UPX unpacks the segments into anonymous
+    /// memory instead, and `MADV_DONTNEED` on an anonymous private page makes
+    /// the next read return zeros rather than the bytes the file holds
+    /// (#42509). A range that cannot be read or parsed counts as not backed.
+    pub(super) fn is_file_backed(lo: usize, hi: usize) -> bool {
+        let Ok(maps) = bun_sys::File::open(
+            bun_core::zstr!("/proc/self/maps"),
+            bun_sys::O::RDONLY | bun_sys::O::CLOEXEC,
+            0,
+        )
+        .and_then(|file| file.read_to_end_small()) else {
+            return false;
+        };
+        // One mapping per line, sorted by address:
+        // `start-end perms offset dev inode [path]`. Anonymous mappings have
+        // inode 0, whatever their path field says.
+        let mut next = lo;
+        for line in bun_core::strings::split(&maps, b"\n") {
+            let mut fields = bun_core::strings::tokenize(line, b" ");
+            let Some((start, end)) = fields
+                .next()
+                .and_then(|range| bun_core::strings::split_once_char(range, b'-'))
+            else {
+                continue;
+            };
+            let (Ok(start), Ok(end)) = (
+                bun_core::fmt::parse_int::<usize>(start, 16),
+                bun_core::fmt::parse_int::<usize>(end, 16),
+            ) else {
+                continue;
+            };
+            if end <= next {
+                continue;
+            }
+            if start > next {
+                return false;
+            }
+            if fields.nth(3).is_none_or(|inode| inode == b"0") {
+                return false;
+            }
+            next = end;
+            if next >= hi {
+                return true;
+            }
+        }
+        false
+    }
 }
 
 pub struct File {
@@ -2972,6 +3022,12 @@ impl StandaloneModuleGraph {
     /// every first call into a page fault. Only applies when running as a
     /// compiled standalone binary; `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1`
     /// skips the hint.
+    ///
+    /// On Linux the hint is skipped when the pages are not file-backed: an
+    /// executable packer (UPX) unpacks the payload into anonymous memory,
+    /// where `MADV_DONTNEED` zero-fills on the next read. JSC parses function
+    /// bodies lazily out of these pages, so dropping them would turn the
+    /// first call after startup into `SyntaxError: Invalid character: '\0'`.
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
     pub fn hint_source_pages_dont_need() {
         let Some(graph) = Self::get_ref() else {
@@ -2989,6 +3045,15 @@ impl StandaloneModuleGraph {
             );
             return;
         };
+
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        if !elf::is_file_backed(start, end) {
+            bun_core::scoped_log!(
+                StandaloneModuleGraph,
+                "hintSourcePagesDontNeed: source text is not file-backed, keeping it"
+            );
+            return;
+        }
 
         // This is a best-effort hint, so call libc madvise directly and
         // just log on failure rather than treating errors as fatal.

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -645,12 +645,9 @@ mod elf {
         );
     }
 
-    /// Whether `/proc/self/maps` shows `[lo, hi)` inside mappings that have a
-    /// backing file. The kernel maps the payload from the executable, but an
-    /// executable packer such as UPX unpacks the segments into anonymous
-    /// memory instead, and `MADV_DONTNEED` on an anonymous private page makes
-    /// the next read return zeros rather than the bytes the file holds
-    /// (#42509). A range that cannot be read or parsed counts as not backed.
+    /// Whether every mapping covering `[lo, hi)` in `/proc/self/maps` has a
+    /// backing file. A packer such as UPX unpacks the payload into anonymous
+    /// memory, where `MADV_DONTNEED` zero-fills the pages (#42509).
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub(super) fn is_file_backed(lo: usize, hi: usize) -> bool {
         let Ok(file) = bun_sys::File::open(
@@ -660,16 +657,12 @@ mod elf {
         ) else {
             return false;
         };
-        // `fstat` reports size 0 for procfs, so presize for the typical
-        // process instead and read sequentially: the kernel builds the
-        // listing incrementally across `read` calls.
+        // procfs reports size 0 to `fstat`, so presize instead.
         let mut maps = Vec::new();
         if maps.try_reserve(16 * 1024).is_err() || file.read_to_end_into(&mut maps).is_err() {
             return false;
         }
-        // One mapping per line, sorted by address:
-        // `start-end perms offset dev inode [path]`. Anonymous mappings have
-        // inode 0, whatever their path field says.
+        // `start-end perms offset dev inode [path]`, sorted by address; inode 0 is anonymous.
         let mut next = lo;
         for line in bun_core::strings::split(&maps, b"\n") {
             let mut fields = bun_core::strings::tokenize(line, b" ");
@@ -3028,13 +3021,8 @@ impl StandaloneModuleGraph {
     /// bytecode regions for the life of the process, and dropping those turns
     /// every first call into a page fault. Only applies when running as a
     /// compiled standalone binary; `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1`
-    /// skips the hint.
-    ///
-    /// On Linux the hint is skipped when the pages are not file-backed: an
-    /// executable packer (UPX) unpacks the payload into anonymous memory,
-    /// where `MADV_DONTNEED` zero-fills on the next read. JSC parses function
-    /// bodies lazily out of these pages, so dropping them would turn the
-    /// first call after startup into `SyntaxError: Invalid character: '\0'`.
+    /// skips the hint, and so does a Linux payload that is not file-backed
+    /// (`elf::is_file_backed`).
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
     pub fn hint_source_pages_dont_need() {
         let Some(graph) = Self::get_ref() else {

--- a/test/js/bun/compile/standalone-madvise-tla.test.ts
+++ b/test/js/bun/compile/standalone-madvise-tla.test.ts
@@ -5,7 +5,7 @@
 // BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE, read by the compiled binary at
 // runtime, skips the hint.
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux, isWindows, libcPathForDlopen, tempDir } from "harness";
 import path from "node:path";
 
 // Relies on the StandaloneModuleGraph scoped logger which is compiled out in
@@ -128,3 +128,153 @@ test.concurrent.skipIf(isWindows || !isDebug)(
   },
   30_000,
 );
+
+// Issue #42509: an executable packer (UPX) unpacks the payload into anonymous
+// memory. MADV_DONTNEED on anonymous pages zero-fills them on the next read,
+// so a function JSC parses lazily after startup threw
+// `SyntaxError: Invalid character: '\0'`. The fixture reproduces the packer's
+// layout without UPX: before the hint runs it swaps the `.bun` payload pages
+// for an anonymous copy (mmap + memcpy + mremap(MREMAP_FIXED)), then calls a
+// function whose body spans several pages from a timer.
+test.concurrent.skipIf(!isLinux)("standalone madvise hint keeps source text that is not file-backed", async () => {
+  const body: string[] = ["export function lazy(n: number): number {", "  let acc = n;"];
+  for (let i = 0; i < 1500; i++) body.push(`  acc = (acc * 31 + ${i}) % 1000003;`);
+  body.push("  return acc;", "}");
+
+  using dir = tempDir("standalone-madvise-anon", {
+    "lazy.ts": body.join("\n") + "\n",
+    "entry.ts": `
+      import { lazy } from "./lazy";
+      import { makePayloadAnonymous } from "./remap";
+      makePayloadAnonymous();
+      setTimeout(() => {
+        const source = lazy.toString();
+        console.log("nul=" + (source.match(/\\0/g) ?? []).length + " result=" + lazy(1));
+      }, 0);
+    `,
+    "remap.ts": `
+      import { dlopen, FFIType } from "bun:ffi";
+      import { closeSync, openSync, readFileSync, readSync } from "node:fs";
+
+      const PAGE = 4096;
+
+      function readAt(fd: number, offset: number, length: number): Buffer {
+        const buf = Buffer.alloc(length);
+        let done = 0;
+        while (done < length) {
+          const n = readSync(fd, buf, done, length - done, offset + done);
+          if (n <= 0) throw new Error("short read");
+          done += n;
+        }
+        return buf;
+      }
+
+      // [start, end) of the pages holding the \`.bun\` section, read from the
+      // executable's own ELF headers.
+      function payloadRange(): [number, number] {
+        const exe = process.execPath;
+        const fd = openSync(exe, "r");
+        try {
+          const ehdr = readAt(fd, 0, 64);
+          const eType = ehdr.readUInt16LE(0x10);
+          const phoff = Number(ehdr.readBigUInt64LE(0x20));
+          const shoff = Number(ehdr.readBigUInt64LE(0x28));
+          const phentsize = ehdr.readUInt16LE(0x36);
+          const phnum = ehdr.readUInt16LE(0x38);
+          const shentsize = ehdr.readUInt16LE(0x3a);
+          const shnum = ehdr.readUInt16LE(0x3c);
+          const shstrndx = ehdr.readUInt16LE(0x3e);
+
+          const shdrs = readAt(fd, shoff, shentsize * shnum);
+          const shdr = (i: number) => shdrs.subarray(i * shentsize, (i + 1) * shentsize);
+          const strtab = shdr(shstrndx);
+          const names = readAt(fd, Number(strtab.readBigUInt64LE(24)), Number(strtab.readBigUInt64LE(32)));
+
+          let addr = -1;
+          let size = 0;
+          for (let i = 0; i < shnum; i++) {
+            const s = shdr(i);
+            const nameOff = s.readUInt32LE(0);
+            if (names.toString("latin1", nameOff, names.indexOf(0, nameOff)) === ".bun") {
+              addr = Number(s.readBigUInt64LE(16));
+              size = Number(s.readBigUInt64LE(32));
+            }
+          }
+          if (addr < 0) throw new Error("no .bun section");
+
+          let bias = 0;
+          if (eType === 3) {
+            // ET_DYN: load bias = where the first PT_LOAD landed minus its link address.
+            const phdrs = readAt(fd, phoff, phentsize * phnum);
+            let firstVaddr = -1;
+            for (let i = 0; i < phnum; i++) {
+              const p = phdrs.subarray(i * phentsize, (i + 1) * phentsize);
+              if (p.readUInt32LE(0) === 1 && p.readBigUInt64LE(8) === 0n) {
+                firstVaddr = Number(p.readBigUInt64LE(16));
+                break;
+              }
+            }
+            const line = readFileSync("/proc/self/maps", "utf8")
+              .split("\\n")
+              .find(l => l.endsWith(" " + exe) && l.split(/\\s+/)[2] === "00000000");
+            if (!line || firstVaddr < 0) throw new Error("cannot compute load bias");
+            bias = parseInt(line.split("-")[0], 16) - firstVaddr;
+          }
+
+          return [Math.floor((addr + bias) / PAGE) * PAGE, Math.ceil((addr + bias + size) / PAGE) * PAGE];
+        } finally {
+          closeSync(fd);
+        }
+      }
+
+      export function makePayloadAnonymous(): void {
+        const [start, end] = payloadRange();
+        const len = end - start;
+        const { symbols } = dlopen(${JSON.stringify(libcPathForDlopen())}, {
+          mmap: {
+            args: [FFIType.ptr, FFIType.u64, FFIType.i32, FFIType.i32, FFIType.i32, FFIType.i64],
+            returns: FFIType.ptr,
+          },
+          memcpy: { args: [FFIType.ptr, FFIType.ptr, FFIType.u64], returns: FFIType.ptr },
+          mremap: { args: [FFIType.ptr, FFIType.u64, FFIType.u64, FFIType.i32, FFIType.ptr], returns: FFIType.ptr },
+        });
+        const PROT_READ = 1, PROT_WRITE = 2;
+        const MAP_PRIVATE = 2, MAP_ANONYMOUS = 0x20;
+        const MREMAP_MAYMOVE = 1, MREMAP_FIXED = 2;
+
+        const copy = symbols.mmap(0, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (!copy || Number(copy) === -1) throw new Error("mmap failed");
+        symbols.memcpy(copy, start, len);
+        // MREMAP_FIXED replaces the file-backed payload mapping in one step.
+        if (Number(symbols.mremap(copy, len, len, MREMAP_MAYMOVE | MREMAP_FIXED, start)) !== start) {
+          throw new Error("mremap failed");
+        }
+      }
+    `,
+  });
+
+  const out = path.join(String(dir), "compiled");
+  const build = Bun.spawnSync({
+    cmd: [bunExe(), "build", "--compile", path.join(String(dir), "entry.ts"), "--outfile", out],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  expect(build.stderr.toString()).not.toContain("error:");
+  expect(build.exitCode).toBe(0);
+
+  await using proc = Bun.spawn({
+    cmd: [out],
+    env: { ...bunEnv, BUN_DEBUG_StandaloneModuleGraph: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("nul=0 result=195229");
+  if (isDebug) {
+    expect(stdout).toContain("hintSourcePagesDontNeed: source text is not file-backed, keeping it");
+  }
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/compile/standalone-madvise-tla.test.ts
+++ b/test/js/bun/compile/standalone-madvise-tla.test.ts
@@ -156,7 +156,16 @@ test.concurrent.skipIf(!isLinux)("standalone madvise hint keeps source text that
       import { dlopen, FFIType } from "bun:ffi";
       import { closeSync, openSync, readFileSync, readSync } from "node:fs";
 
-      const PAGE = 4096;
+      const libc = dlopen(${JSON.stringify(libcPathForDlopen())}, {
+        getpagesize: { args: [], returns: FFIType.i32 },
+        mmap: {
+          args: [FFIType.ptr, FFIType.u64, FFIType.i32, FFIType.i32, FFIType.i32, FFIType.i64],
+          returns: FFIType.ptr,
+        },
+        memcpy: { args: [FFIType.ptr, FFIType.ptr, FFIType.u64], returns: FFIType.ptr },
+        mremap: { args: [FFIType.ptr, FFIType.u64, FFIType.u64, FFIType.i32, FFIType.ptr], returns: FFIType.ptr },
+      }).symbols;
+      const PAGE = libc.getpagesize();
 
       function readAt(fd: number, offset: number, length: number): Buffer {
         const buf = Buffer.alloc(length);
@@ -230,23 +239,15 @@ test.concurrent.skipIf(!isLinux)("standalone madvise hint keeps source text that
       export function makePayloadAnonymous(): void {
         const [start, end] = payloadRange();
         const len = end - start;
-        const { symbols } = dlopen(${JSON.stringify(libcPathForDlopen())}, {
-          mmap: {
-            args: [FFIType.ptr, FFIType.u64, FFIType.i32, FFIType.i32, FFIType.i32, FFIType.i64],
-            returns: FFIType.ptr,
-          },
-          memcpy: { args: [FFIType.ptr, FFIType.ptr, FFIType.u64], returns: FFIType.ptr },
-          mremap: { args: [FFIType.ptr, FFIType.u64, FFIType.u64, FFIType.i32, FFIType.ptr], returns: FFIType.ptr },
-        });
         const PROT_READ = 1, PROT_WRITE = 2;
         const MAP_PRIVATE = 2, MAP_ANONYMOUS = 0x20;
         const MREMAP_MAYMOVE = 1, MREMAP_FIXED = 2;
 
-        const copy = symbols.mmap(0, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        const copy = libc.mmap(0, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         if (!copy || Number(copy) === -1) throw new Error("mmap failed");
-        symbols.memcpy(copy, start, len);
+        libc.memcpy(copy, start, len);
         // MREMAP_FIXED replaces the file-backed payload mapping in one step.
-        if (Number(symbols.mremap(copy, len, len, MREMAP_MAYMOVE | MREMAP_FIXED, start)) !== start) {
+        if (Number(libc.mremap(copy, len, len, MREMAP_MAYMOVE | MREMAP_FIXED, start)) !== start) {
           throw new Error("mremap failed");
         }
       }


### PR DESCRIPTION
### Problem
- A compiled executable packed with UPX throws `SyntaxError: Invalid character: '\0'` the first time it calls a function JSC has not parsed yet. The NUL bytes come from the embedded source text, not from stdin. Fixes #42509.
- The cause is `hint_source_pages_dont_need` (`src/standalone_graph/StandaloneModuleGraph.rs:3030`). It calls `madvise(MADV_DONTNEED)` on the source-text pages after startup and assumes they are file-backed. UPX unpacks the payload into anonymous memory, where `MADV_DONTNEED` zero-fills on the next read.

### Fix
- On Linux, read `/proc/self/maps` before the hint. Skip the hint when a mapping that covers the source-text run has inode 0 (anonymous), or when the file cannot be read. A file-backed run gets `MADV_DONTNEED` as before.
- `MADV_PAGEOUT` was rejected: the kernel skips file pages the caller cannot open for writing, so the hint would silently stop for root-owned binaries.
- Verified: `test/js/bun/compile/standalone-madvise-tla.test.ts` (the new test fails on the unfixed build with the `SyntaxError` from the issue). Also `test/js/bun/compile/` and the UPX reproduction on release binaries. Self-reviewed: the maps file is now read in one sequential pass, and the test fixture uses the system page size.

### Background
- A compiled executable is the bun binary with a payload appended inside the writable `PT_LOAD` (`src/exe_format/elf.rs`), so the kernel maps it from the file. Bun supports UPX-packed executables (#40752), and UPX's stub copies the segments into anonymous memory instead.
- `MADV_DONTNEED` on a private file mapping drops the pages. The next read faults them back in from the file. On an anonymous mapping the next read returns a zero page.
- JSC parses a function body on its first call, straight from the payload bytes. So only functions that first run after startup fail.

<details><summary>Notes</summary>

- The reporter's bare stdin test did not reproduce because its source was smaller than one page (the hint only drops whole pages inside the source-text run) and it was not UPX-packed. The beadbox sidecar is packed by `src-tauri/scripts/copy-sidecar.sh` on Linux and Windows only, which is why macOS was unaffected.
- 1.3.14 issued the same hint and zeroed the same pages, but JSC parsed from a separate copy of the source there. 1.4.x reads the image directly.
- The test does not need UPX. Before the hint runs, the fixture finds the `.bun` section through the executable's ELF section headers, copies those pages to an anonymous mapping, and places the copy over the original with `mremap(MREMAP_FIXED)`. That is the layout a packer leaves behind. It then calls a function whose body spans several pages from a timer, after the hint has run. On the unfixed build `lazy.toString()` holds 57344 NUL characters and the call throws.
- Release UPX results with the reproduction from the investigation: 1.3.14 plain and UPX pass, 1.4.0 plain passes, 1.4.0 / 1.4.2 / 1.4.3 UPX throw `SyntaxError: Invalid character: '\0'`. `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1` makes the UPX binaries work, which pins the cause to this hint.
- `/proc/self/maps` is about 4 KB and 50 lines for a compiled executable at this point in startup, so the check is one small read.
- The debug build is too large for UPX (813 MB), so the UPX check ran against release binaries only.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/compile/standalone-madvise-tla.test.ts

<!-- robobun:evidence:end -->