### PR TITLE
Close a body's stream when a consumer takes its payload without reading it

### DIFF
--- a/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
@@ -199,9 +199,7 @@ extern "C" void ReadableStream__markConsumedAsBody(JSC::EncodedJSValue possibleR
     stream->m_consumedAsBody = true;
 }
 
-// markConsumedAsBody for the consumer that lifted the whole payload out of a stream nothing had started
-// (Rust `to_any_blob`): no reader or controller will ever run it to its end, so it closes here. With no
-// reader, closing only settles the stream-level closed promise: no script runs and nothing throws.
+// markConsumedAsBody for Rust `to_any_blob`, which took the payload of a stream nothing started: no reader exists to close it.
 extern "C" void ReadableStream__closeConsumedAsBody(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject* globalObject)
 {
     auto* stream = dynamicDowncast<JSReadableStream>(JSValue::decode(possibleReadableStream));
@@ -238,9 +236,7 @@ extern "C" JSC::EncodedJSValue ReadableStream__empty(Zig::GlobalObject* globalOb
     return JSValue::encode(stream);
 }
 
-// A stand-in for the stream of a body a consumer owns, locked by a reader nothing holds. `consumed`: that
-// consumer already read the body to its end, so the stand-in is closed and disturbed like the real stream.
-// Otherwise the read is still going, and nothing tells the stand-in how it ends: it stays readable.
+// A locked stand-in for a body's stream. `consumed`: the body was read to its end (closed, disturbed), not still being read.
 extern "C" JSC::EncodedJSValue ReadableStream__used(Zig::GlobalObject* globalObject, bool consumed)
 {
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
@@ -199,6 +199,22 @@ extern "C" void ReadableStream__markConsumedAsBody(JSC::EncodedJSValue possibleR
     stream->m_consumedAsBody = true;
 }
 
+// markConsumedAsBody for the consumer that lifted the whole payload out of a stream nothing had started
+// (Rust `to_any_blob`): no reader or controller will ever run it to its end, so it closes here. With no
+// reader, closing only settles the stream-level closed promise: no script runs and nothing throws.
+extern "C" void ReadableStream__closeConsumedAsBody(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject* globalObject)
+{
+    auto* stream = dynamicDowncast<JSReadableStream>(JSValue::decode(possibleReadableStream));
+    if (!stream) [[unlikely]]
+        return;
+    stream->m_disturbed = true;
+    stream->m_consumedAsBody = true;
+    ASSERT(!stream->m_reader);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(JSC::getVM(globalObject));
+    readableStreamCloseIfPossible(globalObject, stream);
+    scope.assertNoExceptionExceptTermination();
+}
+
 // A native sink (fetch body / S3 / FileSink) has attached directly without a reader.
 // Mark the stream disturbed+locked so .locked, .getReader(), and the body-mixin
 // disturbed checks behave as they do after readStreamIntoSink acquires a reader.
@@ -222,12 +238,20 @@ extern "C" JSC::EncodedJSValue ReadableStream__empty(Zig::GlobalObject* globalOb
     return JSValue::encode(stream);
 }
 
-extern "C" JSC::EncodedJSValue ReadableStream__used(Zig::GlobalObject* globalObject)
+// A stand-in for the stream of a body a consumer owns, locked by a reader nothing holds. `consumed`: that
+// consumer already read the body to its end, so the stand-in is closed and disturbed like the real stream.
+// Otherwise the read is still going, and nothing tells the stand-in how it ends: it stays readable.
+extern "C" JSC::EncodedJSValue ReadableStream__used(Zig::GlobalObject* globalObject, bool consumed)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* stream = createReadableStream(globalObject, SourceKind::Nothing, nullptr, jsUndefined());
     RETURN_IF_EXCEPTION(scope, {});
+    if (consumed) {
+        stream->m_disturbed = true;
+        readableStreamClose(globalObject, stream);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
     acquireReadableStreamDefaultReader(globalObject, stream);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(stream);

--- a/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInternals.h
@@ -721,8 +721,9 @@ void ReadableStream__cancel(JSC::EncodedJSValue possibleReadableStream, Zig::Glo
 void ReadableStream__cancelWithReason(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*, JSC::EncodedJSValue reason); // userJS: yes
 bool ReadableStream__isClosedUnread(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*); // userJS: no
 void ReadableStream__markConsumedAsBody(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*); // userJS: no
+void ReadableStream__closeConsumedAsBody(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*); // userJS: no
 JSC::EncodedJSValue ReadableStream__empty(Zig::GlobalObject*); // userJS: no
-JSC::EncodedJSValue ReadableStream__used(Zig::GlobalObject*); // userJS: no
+JSC::EncodedJSValue ReadableStream__used(Zig::GlobalObject*, bool consumed); // userJS: no
 JSC::EncodedJSValue ReadableStream__errored(Zig::GlobalObject*, JSC::EncodedJSValue reason); // userJS: no
 JSC::EncodedJSValue ReadableStream__fromDecodedText(Zig::GlobalObject*, JSC::EncodedJSValue string); // userJS: no
 JSC::EncodedJSValue ReadableStream__textDecodeFrom(Zig::GlobalObject*, JSC::EncodedJSValue source); // userJS: yes

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -890,7 +890,7 @@ impl Value {
         // producer's remaining callbacks with that foreign context.
         if locked.promise.is_some() || !locked.action.is_none() || locked.on_receive_value.is_some()
         {
-            return ReadableStream::used(global_this);
+            return ReadableStream::in_use(global_this);
         }
         let mut drain_result = DrainResult::EstimatedSize(0);
 

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -142,11 +142,12 @@ unsafe extern "C" {
         global_object: &JSGlobalObject,
     ) -> bool;
     safe fn ReadableStream__empty(global: &JSGlobalObject) -> JSValue;
-    safe fn ReadableStream__used(global: &JSGlobalObject) -> JSValue;
+    safe fn ReadableStream__used(global: &JSGlobalObject, consumed: bool) -> JSValue;
     safe fn ReadableStream__errored(global: &JSGlobalObject, reason: JSValue) -> JSValue;
     safe fn ReadableStream__fromDecodedText(global: &JSGlobalObject, string: JSValue) -> JSValue;
     safe fn ReadableStream__textDecodeFrom(global: &JSGlobalObject, source: JSValue) -> JSValue;
     safe fn ReadableStream__markConsumedAsBody(stream: JSValue, global: &JSGlobalObject);
+    safe fn ReadableStream__closeConsumedAsBody(stream: JSValue, global: &JSGlobalObject);
     safe fn ReadableStream__lockNative(stream: JSValue, global: &JSGlobalObject);
     /// BunStreamSource.cpp: queue the adapter's close on the microtask queue.
     safe fn Bun__NativeStreamSourceAdapter__onClose(global: &JSGlobalObject, adapter: JSValue);
@@ -191,7 +192,7 @@ impl ReadableStream {
         });
     }
 
-    /// Lift the whole payload out of an unread stream. On success the stream is spent (disturbed, locked).
+    /// Lift the whole payload out of an unread stream. On success the stream is spent (closed, disturbed, locked).
     pub fn to_any_blob(&mut self, global_this: &JSGlobalObject) -> Option<webcore::blob::Any> {
         if self.is_disturbed(global_this) || self.is_locked(global_this) {
             return None;
@@ -239,7 +240,7 @@ impl ReadableStream {
         };
 
         self.done();
-        self.mark_consumed_as_body(global_this);
+        ReadableStream__closeConsumedAsBody(self.value, global_this);
         Some(blob)
     }
 
@@ -642,11 +643,18 @@ impl ReadableStream {
         })
     }
 
+    /// A locked stand-in for the stream of a body that was read to its end: closed and disturbed.
     pub fn used(global_this: &JSGlobalObject) -> JsResult<JSValue> {
         bun_jsc::from_js_host_call(global_this, || {
             // SAFETY: FFI call into JSC bindings; global_this is a valid &JSGlobalObject.
-            ReadableStream__used(global_this)
+            ReadableStream__used(global_this, true)
         })
+    }
+
+    /// A locked stand-in for the stream of a body a consumer is still reading. Nothing tells it how
+    /// that read ends, so it stays readable.
+    pub fn in_use(global_this: &JSGlobalObject) -> JsResult<JSValue> {
+        bun_jsc::from_js_host_call(global_this, || ReadableStream__used(global_this, false))
     }
 
     /// A stream already in the `errored` state, so every read rejects with

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -651,8 +651,7 @@ impl ReadableStream {
         })
     }
 
-    /// A locked stand-in for the stream of a body a consumer is still reading. Nothing tells it how
-    /// that read ends, so it stays readable.
+    /// A locked stand-in for the stream of a body a consumer is still reading: it stays readable.
     pub fn in_use(global_this: &JSGlobalObject) -> JsResult<JSValue> {
         bun_jsc::from_js_host_call(global_this, || ReadableStream__used(global_this, false))
     }

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -2,7 +2,9 @@ import { file, spawn, version, type Socket } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, exampleSite, tempDir } from "harness";
 import net from "net";
-import { Readable } from "node:stream";
+import { join } from "node:path";
+import { isDisturbed, isErrored, isReadable, Readable } from "node:stream";
+import { finished } from "node:stream/promises";
 
 const exampleServer = exampleSite("http");
 
@@ -1575,6 +1577,13 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
     }
   };
   const settled = (p: Promise<unknown>) => p.then(String, e => (e as Error).constructor.name);
+  const streamState = (stream: ReadableStream) => ({
+    readable: isReadable(stream),
+    errored: isErrored(stream),
+    disturbed: isDisturbed(stream),
+    locked: stream.locked,
+  });
+  const consumedState = { readable: false, errored: false, disturbed: true, locked: true };
 
   for (const [ownerName, make] of owners) {
     describe(ownerName, () => {
@@ -1669,6 +1678,41 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
             bodyUsed: owner.bodyUsed,
             getReader: errorName(() => stream.getReader()),
           }).toEqual({ locked: true, bodyUsed: true, getReader: "TypeError" });
+        });
+      });
+
+      // That reader ran the stream to its end, so the stream is closed. node:stream's
+      // helpers read the stream's own state, and finished() waits for it to close.
+      describe("a consumed body's stream is closed", () => {
+        for (const [name, init] of sources) {
+          const methods = ["text", "json", "arrayBuffer", "bytes", "blob"] as const;
+          for (const method of name === "URLSearchParams" ? ([...methods, "formData"] as const) : methods) {
+            test(`${name} .body then ${method}()`, async () => {
+              const owner = make(init());
+              const stream = owner.body!;
+              await owner[method]().catch(() => {});
+              expect(streamState(stream)).toEqual(consumedState);
+              await finished(stream);
+            });
+          }
+        }
+        for (const method of ["text", "json", "arrayBuffer", "bytes", "blob"] as const) {
+          test(`${method}() then .body`, async () => {
+            const owner = make("[1]");
+            await owner[method]();
+            const stream = owner.body!;
+            expect(streamState(stream)).toEqual(consumedState);
+            await finished(stream);
+          });
+        }
+        test("clone() takes an unread native stream's content", async () => {
+          const owner = make("payload");
+          const stream = owner.body!;
+          const clone = owner.clone();
+          expect(owner.body).not.toBe(stream);
+          expect(streamState(stream)).toEqual(consumedState);
+          await finished(stream);
+          expect([await owner.text(), await clone.text()]).toEqual(["payload", "payload"]);
         });
       });
 
@@ -1837,5 +1881,95 @@ describe("body stream bookkeeping does not depend on the body's source", () => {
       expect(response.toLowerCase()).not.toContain("transfer-encoding");
       expect(response.endsWith(`\r\n\r\n${expected}`)).toBe(true);
     }
+  });
+
+  // Lifting the payload back out of an unread native stream is not a read through
+  // a reader, so the stream has nothing left to close it: whoever lifts it does.
+  describe("lifting the payload out of an unread native stream closes it", () => {
+    const expectClosed = async (stream: ReadableStream) => {
+      expect(streamState(stream)).toEqual(consumedState);
+      await finished(stream);
+    };
+
+    test("Blob.stream() behind a new Response", async () => {
+      const stream = new Blob(["payload"]).stream();
+      // Registered first, so the lift has a pending promise to settle.
+      const closed = finished(stream);
+      expect(await new Response(stream).bytes()).toEqual(new TextEncoder().encode("payload"));
+      expect(streamState(stream)).toEqual(consumedState);
+      await closed;
+    });
+
+    test("a Bun.file() stream", async () => {
+      using dir = tempDir("body-stream-closed", { "payload.txt": "payload" });
+      const path = join(String(dir), "payload.txt");
+
+      const stream = file(path).stream();
+      expect((await new Response(stream).arrayBuffer()).byteLength).toBe(7);
+      await expectClosed(stream);
+
+      const response = new Response(file(path));
+      const body = response.body!;
+      expect((await response.blob()).size).toBe(7);
+      await expectClosed(body);
+    });
+
+    test("Bun.serve sending a Response whose .body was accessed", async () => {
+      let body!: ReadableStream;
+      await using server = Bun.serve({
+        port: 0,
+        fetch() {
+          const response = new Response("payload");
+          body = response.body!;
+          return response;
+        },
+      });
+      expect(await (await fetch(server.url)).text()).toBe("payload");
+      await expectClosed(body);
+    });
+
+    test("fetch() uploading it and Bun.write() writing it", async () => {
+      using dir = tempDir("body-stream-closed", {});
+      await using server = Bun.serve({ port: 0, fetch: async req => new Response(await req.text()) });
+
+      const uploaded = new Blob(["payload"]).stream();
+      expect(await (await fetch(server.url, { method: "POST", body: uploaded })).text()).toBe("payload");
+      await expectClosed(uploaded);
+
+      const response = new Response("payload");
+      const written = response.body!;
+      expect(await Bun.write(join(String(dir), "out.txt"), response)).toBe(7);
+      await expectClosed(written);
+    });
+  });
+
+  // While a consumer still reads a body that never had a stream, .body is a locked
+  // stand-in that nothing updates. It must not report the end of a read that can still fail.
+  test(".body of a body that is still being read is not closed", async () => {
+    const { promise: released, resolve: release } = Promise.withResolvers<void>();
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () =>
+        new Response(
+          new ReadableStream({
+            async pull(controller) {
+              controller.enqueue(new TextEncoder().encode("pay"));
+              await released;
+              controller.enqueue(new TextEncoder().encode("load"));
+              controller.close();
+            },
+          }),
+        ),
+    });
+    const response = await fetch(server.url);
+    const text = response.text();
+    const body = response.body!;
+    expect({ readable: isReadable(body), locked: body.locked, bodyUsed: response.bodyUsed }).toEqual({
+      readable: true,
+      locked: true,
+      bodyUsed: true,
+    });
+    release();
+    expect(await text).toBe("payload");
   });
 });


### PR DESCRIPTION
### Problem
- `const body = res.body; await res.arrayBuffer()` (or `bytes()`, `blob()`, `json()`, `formData()`) leaves `body` `readable` when a string, `Blob`, typed array or file backs it. `isReadable(body)` returns `true`, `Bun.inspect(body)` prints `state: 'readable'`, and `await finished(body)` never settles. Node v26.3.0 and `text()` close the stream.
- The cause is `ReadableStream::to_any_blob` (`src/runtime/webcore/ReadableStream.rs:195`). It takes the payload out of the native source and marks the stream disturbed and locked, but never changes `m_state`. Since #42116 (not released) the stream stays locked, so nothing can drain it either.
- `.body` read after the consume returns a stand-in stream that is `readable` and not disturbed.

### Fix
- `to_any_blob` calls the new `ReadableStream__closeConsumedAsBody`: the `markConsumedAsBody` flags, then a close.
- Correct because `to_any_blob` first rejects a disturbed or locked stream. No reader or controller exists, so the close only sets the state and settles the closed promise.
- `ReadableStream__used` makes the stand-in for a consumed body closed and disturbed. The stand-in for a body still being read is unchanged.
- Verified: `test/js/web/fetch/body.test.ts` (99 new cases, 50 fail on main), plus the suites in Notes. Self-reviewed: 3 changes asked, 3 made.

### Background
- Such a body gets a lazy native `ReadableStream`. It gets a controller only when something reads it.
- Until then a consumer can take the whole payload back as a `Blob`. The body methods, `clone()`, `Bun.serve`, `fetch()` uploads, `Bun.write` and `Bun.spawn` stdin do so when the payload is in memory or is a file.
- #42416 made `isReadable()`, `isErrored()` and `isDisturbed()` read the stream's own state. `finished()` waits on a closed promise that each terminal transition settles.

<details><summary>Notes</summary>

**Origin.** A differential run against node v26.3.0 after #42416 found this. No user reported it. On 1.4.2 the stream was also left `readable`, but it was unlocked, so `body.getReader().read()` returned `done` and closed it. #42116 keeps the stream locked (as undici and Chromium do), which removed that way out. This PR should land before the next release.

**Repro.**

```js
import { isReadable, isDisturbed } from "node:stream";
import { finished } from "node:stream/promises";
const res = new Response("hello world");
const body = res.body;
await res.arrayBuffer();
console.log(isReadable(body), isDisturbed(body), body.locked, Bun.inspect(body));
await finished(body); // main: never settles
```

| | main b99371011f | this PR | node v26.3.0 |
| --- | --- | --- | --- |
| `.body` then `arrayBuffer()` / `bytes()` / `blob()` / `json()` / `formData()` | readable, `finished()` pending | closed | closed |
| `.body` then `text()` | closed | closed | closed |
| `new Response(blob.stream()).bytes()`, `Bun.file().stream()`, `new Response(Bun.file()).body` | readable | closed | closed |
| `fetch()` response, `.body` taken, whole body arrived, then `arrayBuffer()` | readable | closed | closed |
| `Bun.serve` sends it, `fetch()` uploads it, `Bun.write` writes it, `Bun.spawn` stdin (payload in memory or a file) | readable | closed | n/a |
| `await res.text(); res.body` (stand-in) | readable, not disturbed | closed, disturbed | closed, disturbed |
| old `.body` after `clone()` | readable forever | closed at `clone()` | readable until a branch is drained, then closed |
| JS-source stream | closed | closed | closed |

The error messages of `getReader()`, `cancel()`, `tee()`, `pipeTo()`, `text()`, `Bun.readableStreamToText()` and `new Response(body)` on the consumed stream are the same as before. `finished()` registered before the consume settles too.

**Not in this PR.**
- A stream that a native sink attaches to while the payload still arrives (`ReadableStream__lockNative`: a `fetch()` upload, `Bun.write`, `Bun.spawn` stdin or `Bun.serve` response of a body that still streams). It does not go through `to_any_blob`. #42477 fixes it. This PR should land first. The conflict in `WebStreamsExports.cpp` is keep-both, and both use `readableStreamCloseIfPossible` for the close.
- `Readable.fromWeb()` on a native stream (`m_transferred`): the web stream stays `readable` after the node stream ends. It is the same on 1.4.2. The fix touches the code that #42281 changes, so it follows that PR.
- The `node-fetch` and `undici` shims wrap `res.body` in a node `Readable`. Since #42116, `res.body.resume()` or `destroy()` after a body method emits `'error'` (the stream is locked). 1.4.2 emits `'end'` / `'close'`. This PR does not change that. It is tracked separately.
- `.body` read while `text()` is still pending returns a stand-in that stays `readable` and locked. Nothing tells it how the read ends, so it must not report closed. A new test pins this.
- `getReader().releaseLock()` marks a native stream disturbed: #33461. `WritableStream` state: #42457.

**The stand-in for a consumed body** is also what `.body` returns once a native consumer took a body that still streams (`Bun.write(path, res)` sets the body to used at once). It reads closed from then on. Before, `finished()` on it never settled.

**Self-review.** It asked for three changes. The stand-in for a body still being read keeps its old state (`ReadableStream::in_use`). The close goes through `readableStreamCloseIfPossible`, not a hand-written state write. The commit message and this body name the excluded paths and say that the native consumers take this path only when the payload is in memory or is a file.

**Suites run** with the debug build and `BUN_JSC_validateExceptionChecks=1`: `test/js/web/fetch/body.test.ts` (734 pass), `body-stream.test.ts` (9086 pass), `body-clone.test.ts`, `body-mixin-errors.test.ts`, `blob.test.ts`, `fetch.stream.test.ts`, `test/js/web/streams/streams.test.js` (549 pass), `readable-stream-blob-consumed.test.ts`, `test/js/node/stream/web-stream-state.test.ts`, `test/js/third_party/wpt-streams/wpt-streams.test.ts` (1175 pass), `test/js/bun/spawn/spawn-stdin-readable-stream.test.ts`, `test/js/bun/io/bun-write.test.js`, `test/js/bun/util/inspect.test.js`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 50 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/body.test.ts
bun test v1.4.3 (6a92015fc)

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [6.84ms]
(pass) Request > constructor > null [3.58ms]
(pass) Request > constructor > string > "" [6.59ms]
(pass) Request > constructor > string > "Hello world" [1.39ms]
(pass) Request > constructor > string > "🫠" [1.30ms]
(pass) Request > constructor > string > "⁉️" [1.21ms]
(pass) Request > constructor > ArrayBuffer > empty buffer [11.00ms]
(pass) Request > constructor > ArrayBuffer > small buffer [5.11ms]
(pass) Request > constructor > ArrayBuffer > large buffer [4.31ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [1.90ms]
(pass) Request > constructor > SharedArrayBuffer > small buffer [1.58ms]
(pass) Request > constructor > SharedArrayBuffer > large buffer [8.91ms]
(pass) Request > constructor > Buffer > empty buffer [1.49ms]
(pass) Request > constructor > Buffer > small buffer [12.96ms]
(pass) Request > constructor > Buffer > large buffer [3.37ms]
(pass) Request > constructor
... (truncated)

release without fix: 4 skipped
bun test v1.4.3-canary.1 (2c1543d6f)

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [0.08ms]
(pass) Request > constructor > null [0.05ms]
(pass) Request > constructor > string > "" [0.12ms]
(pass) Request > constructor > string > "Hello world" [0.01ms]
(pass) Request > constructor > string > "🫠" [0.02ms]
(pass) Request > constructor > string > "⁉️"
(pass) Request > constructor > ArrayBuffer > empty buffer [0.14ms]
(pass) Request > constructor > ArrayBuffer > small buffer [1.40ms]
(pass) Request > constructor > ArrayBuffer > large buffer [1.62ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [0.03ms]
(pass) Request > constructor > SharedArrayBuffer > small buffer [0.02ms]
(pass) Request > constructor > SharedArrayBuffer > large buffer [2.61ms]
(pass) Request > constructor > Buffer > empty buffer [0.61ms]
(pass) Request > constructor > Buffer > small buffer [0.02ms]
(pass) Request > constructor > Buffer > large buffer [0.47ms]
(pass) Request > constructor > Uint8Array > empty buffer [0.02ms]
(pass) Request > constructor > Uint8Array > small buffer [0.03ms]
(pass) Request > constructor > Uint8Array > large buffer [1.6
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/fetch/body.test.ts
bun test v1.4.3 (6a92015fc)

test/js/web/fetch/body.test.ts:
(pass) Request > constructor > undefined [7.98ms]
(pass) Request > constructor > null [3.44ms]
(pass) Request > constructor > string > "" [6.99ms]
(pass) Request > constructor > string > "Hello world" [1.36ms]
(pass) Request > constructor > string > "🫠" [1.41ms]
(pass) Request > constructor > string > "⁉️" [1.13ms]
(pass) Request > constructor > ArrayBuffer > empty buffer [10.53ms]
(pass) Request > constructor > ArrayBuffer > small buffer [5.26ms]
(pass) Request > constructor > ArrayBuffer > large buffer [4.52ms]
(pass) Request > constructor > SharedArrayBuffer > empty buffer [1.81ms]
(pass) Request > constructor > SharedArrayBuffer > small buffer [1.74ms]
(pass) Request > constructor > SharedArrayBuffer > large buffer [10.36ms]
(pass) Request > constructor > Buffer > empty buffer [10.14ms]
(pass) Request > constructor > Buffer > small buffer [2.11ms]
(pass) Request > constructor > Buffer > large buffer [3.02ms]
(pass) Request > constructo
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 615ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/40] cxx obj/src/jsc/bindings/webcore/streams/CrossRealmTransform.cpp.o
[2/40] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[3/40] cxx obj/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp.o
[4/40] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[5/40] cxx obj/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp.o
[6/40] cxx obj/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp.o
[7/40] cxx obj/src/jsc/bindings/webcore/streams/JSCompressionStreamShared.cpp.o
[8/40] cxx obj/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp.o
[9/40] cxx obj/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp.o
[10/40] cxx obj/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp.o
[11/40] cxx obj/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp.o
[12/40] cxx obj/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.cpp.o
[13/40] cxx obj/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp.o
[14/4
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../bindings/webcore/streams/WebStreamsExports.cpp |  22 +++-
 .../bindings/webcore/streams/WebStreamsInternals.h |   3 +-
 src/runtime/webcore/Body.rs                        |   2 +-
 src/runtime/webcore/ReadableStream.rs              |  15 ++-
 test/js/web/fetch/body.test.ts                     | 136 ++++++++++++++++++++-
 5 files changed, 170 insertions(+), 8 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/jsc/bindings/webcore/streams/WebStreamsExports.cpp      4      6     19
src/jsc/bindings/webcore/streams/WebStreamsInternals.h      3      3     19
src/runtime/webcore/Body.rs                                 5      1     19
src/runtime/webcore/ReadableStream.rs                       5      3     19
test/js/web/fetch/body.test.ts                              4      7     19
```

</details>

<!-- robobun:evidence:end -->