### PR TITLE
fs.Stats: make the date accessors define the property like Object.defineProperty

### DIFF
--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -221,8 +221,10 @@ inline JSC::JSValue getDateField(JSC::JSGlobalObject* globalObject, JSC::Encoded
     if (!thisObject)
         return JSC::jsUndefined();
 
+    const JSC::StructureID classStructureID = getStructure<isBigInt>(defaultGlobalObject(globalObject))->id();
+
     JSValue value;
-    if (thisObject->structureID() == getStructure<isBigInt>(defaultGlobalObject(globalObject))->id()) {
+    if (thisObject->structureID() == classStructureID) {
         value = thisObject->getDirect(static_cast<int>(field));
         ASSERT(thisObject->getDirectOffset(vm, identifier(vm, field)) == static_cast<int>(field));
     } else {
@@ -234,8 +236,14 @@ inline JSC::JSValue getDateField(JSC::JSGlobalObject* globalObject, JSC::Encoded
     RETURN_IF_EXCEPTION(scope, {});
 
     JSValue result = JSC::DateInstance::create(vm, globalObject->dateStructure(), internalNumber);
-    if (!thisObject->structure()->mayBePrototype()) {
+    // The number conversion above can run user code, so the structure is checked again. An object
+    // with the class structure is ordinary, extensible and has no own `propertyName`: putDirect
+    // does what [[DefineOwnProperty]] would. Any other receiver gets to accept or reject the property.
+    if (thisObject->structureID() == classStructureID) {
         thisObject->putDirect(vm, propertyName, result, 0);
+    } else if (!thisObject->structure()->mayBePrototype()) {
+        thisObject->createDataProperty(globalObject, propertyName, result, true);
+        RETURN_IF_EXCEPTION(scope, {});
     }
     return result;
 }
@@ -279,12 +287,15 @@ JSC_DEFINE_CUSTOM_GETTER(jsBigIntStatsPrototypeGetter_atime, (JSGlobalObject * g
 JSC_DEFINE_CUSTOM_SETTER(jsStatsPrototypeFunction_DatePutter, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName propertyName))
 {
     auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     JSObject* thisObject = dynamicDowncast<JSObject>(JSValue::decode(thisValue).toThis(globalObject, JSC::ECMAMode::strict()));
     if (!thisObject)
         return false;
 
-    thisObject->putDirect(vm, propertyName, JSValue::decode(encodedValue), 0);
-    return true;
+    // Node: setOwnProperty(this, name, value), which is Object.defineProperty() and throws when
+    // `this` rejects the property (a frozen object, a Proxy trap, a WebAssembly GC reference).
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L472-L517
+    RELEASE_AND_RETURN(scope, thisObject->createDataProperty(globalObject, propertyName, JSValue::decode(encodedValue), true));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsStatsPrototypeFunction_isBlockDevice, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))

--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -221,6 +221,7 @@ inline JSC::JSValue getDateField(JSC::JSGlobalObject* globalObject, JSC::Encoded
     if (!thisObject)
         return JSC::jsUndefined();
 
+    // An object with the class structure is ordinary, extensible and has no own date property.
     const JSC::StructureID classStructureID = getStructure<isBigInt>(defaultGlobalObject(globalObject))->id();
 
     JSValue value;
@@ -236,9 +237,7 @@ inline JSC::JSValue getDateField(JSC::JSGlobalObject* globalObject, JSC::Encoded
     RETURN_IF_EXCEPTION(scope, {});
 
     JSValue result = JSC::DateInstance::create(vm, globalObject->dateStructure(), internalNumber);
-    // The number conversion above can run user code, so the structure is checked again. An object
-    // with the class structure is ordinary, extensible and has no own `propertyName`: putDirect
-    // does what [[DefineOwnProperty]] would. Any other receiver gets to accept or reject the property.
+    // The number conversion above can run user code, so this compares the structure again.
     if (thisObject->structureID() == classStructureID) {
         thisObject->putDirect(vm, propertyName, result, 0);
     } else if (!thisObject->structure()->mayBePrototype()) {
@@ -292,9 +291,7 @@ JSC_DEFINE_CUSTOM_SETTER(jsStatsPrototypeFunction_DatePutter, (JSGlobalObject * 
     if (!thisObject)
         return false;
 
-    // Node: setOwnProperty(this, name, value), which is Object.defineProperty() and throws when
-    // `this` rejects the property (a frozen object, a Proxy trap, a WebAssembly GC reference).
-    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L472-L517
+    // Node: setOwnProperty(this, name, value), https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L472-L517
     RELEASE_AND_RETURN(scope, thisObject->createDataProperty(globalObject, propertyName, JSValue::decode(encodedValue), true));
 }
 

--- a/test/js/node/fs/fs-stats-constructor.test.ts
+++ b/test/js/node/fs/fs-stats-constructor.test.ts
@@ -131,3 +131,173 @@ describe("Stats methods and accessors called without a receiver", () => {
     });
   });
 });
+
+// Node's date accessors end in setOwnProperty(this, name, value), that is Object.defineProperty().
+// The native accessors used to write the property onto the receiver directly, which skipped the
+// receiver's own [[DefineOwnProperty]]: a frozen object gained a property, a Proxy saw no trap, and
+// a WebAssembly GC reference aborted the process.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L472-L517
+describe("Stats date accessors define the property the way Object.defineProperty does", () => {
+  const fields = ["atime", "mtime", "ctime", "birthtime"] as const;
+  // [name, prototype, a value for the `${field}Ms` property that the getter reads]
+  const kinds = [
+    ["Stats", Stats.prototype, 5],
+    ["BigIntStats", Object.getPrototypeOf(statSync(import.meta.path, { bigint: true })), 5n],
+  ] as const;
+  const dataProperty = (value: unknown) => ({ value, writable: true, enumerable: true, configurable: true });
+
+  test.each(kinds)("%s: an ordinary receiver gets a writable, enumerable, configurable property", (_, proto, ms) => {
+    const bigint = typeof ms === "bigint";
+    // The first read takes the class structure fast path, the others the generic path.
+    const read: any = statSync(import.meta.path, { bigint });
+    for (const field of fields) {
+      const date = read[field];
+      expect(date).toBeInstanceOf(Date);
+      expect(Object.getOwnPropertyDescriptor(read, field)).toEqual(dataProperty(date));
+    }
+
+    const assigned: any = statSync(import.meta.path, { bigint });
+    for (const field of fields) {
+      assigned[field] = 42;
+      expect(Object.getOwnPropertyDescriptor(assigned, field)).toEqual(dataProperty(42));
+    }
+
+    const inherited = Object.create(proto);
+    inherited.mtimeMs = ms;
+    expect(inherited.mtime).toEqual(new Date(5));
+    expect(Object.getOwnPropertyDescriptor(inherited, "mtime")).toEqual(dataProperty(new Date(5)));
+  });
+
+  test("the prototype as the receiver keeps its accessor", () => {
+    expect(Stats.prototype.mtime.getTime()).toBeNaN();
+    expect(Object.getOwnPropertyDescriptor(Stats.prototype, "mtime")!.get).toBeFunction();
+  });
+
+  test.each(kinds)("%s: a receiver that is not extensible rejects the property", (_, proto, ms) => {
+    for (const lock of [Object.freeze, Object.seal, Object.preventExtensions]) {
+      for (const field of fields) {
+        const { get, set } = Object.getOwnPropertyDescriptor(proto, field)!;
+        const receiver = lock({ [`${field}Ms`]: ms });
+        expect(() => set!.call(receiver, new Date(0))).toThrow(TypeError);
+        expect(() => get!.call(receiver)).toThrow(TypeError);
+        expect(Reflect.ownKeys(receiver)).toEqual([`${field}Ms`]);
+      }
+    }
+
+    // Node also throws for the read of a frozen Stats object.
+    const frozen: any = Object.freeze(statSync(import.meta.path, { bigint: typeof ms === "bigint" }));
+    expect(() => frozen.mtime).toThrow(TypeError);
+    expect(() => {
+      frozen.mtime = new Date(0);
+    }).toThrow(TypeError);
+    expect(() => Reflect.set(proto, "mtime", new Date(0), frozen)).toThrow(TypeError);
+    expect(Object.isFrozen(frozen)).toBe(true);
+    expect(Object.hasOwn(frozen, "mtime")).toBe(false);
+  });
+
+  test("an own property that is not configurable is not redefined", () => {
+    const { get, set } = Object.getOwnPropertyDescriptor(Stats.prototype, "mtime")!;
+    const receiver = Object.defineProperty({ mtimeMs: 5 }, "mtime", { value: 1 });
+    expect(() => set!.call(receiver, 2)).toThrow(TypeError);
+    expect(() => get!.call(receiver)).toThrow(TypeError);
+    expect(Object.getOwnPropertyDescriptor(receiver, "mtime")).toEqual({
+      value: 1,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+  });
+
+  test("a Proxy receiver gets its defineProperty trap called", () => {
+    const { get, set } = Object.getOwnPropertyDescriptor(Stats.prototype, "mtime")!;
+    const calls: unknown[] = [];
+    const target: { mtimeMs: number; mtime?: unknown } = { mtimeMs: 5 };
+    const proxy = new Proxy(target, {
+      defineProperty(target, key, descriptor) {
+        calls.push([key, descriptor]);
+        return Reflect.defineProperty(target, key, descriptor);
+      },
+    });
+
+    set!.call(proxy, 42);
+    expect(calls).toEqual([["mtime", dataProperty(42)]]);
+    expect(target).toEqual({ mtimeMs: 5, mtime: 42 });
+
+    calls.length = 0;
+    delete target.mtime;
+    const date = get!.call(proxy);
+    expect(calls).toEqual([["mtime", dataProperty(new Date(5))]]);
+    expect(target.mtime).toBe(date);
+
+    const refusing = new Proxy({ mtimeMs: 5 }, { defineProperty: () => false });
+    expect(() => set!.call(refusing, 42)).toThrow(TypeError);
+    expect(() => get!.call(refusing)).toThrow(TypeError);
+  });
+
+  test("a Stats object frozen while the getter converts the timestamp stays frozen", () => {
+    const freezeDuringConversion = {
+      valueOf() {
+        Object.freeze(stats);
+        return 5;
+      },
+    };
+    // @ts-expect-error DEP0180
+    const stats = new Stats(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, freezeDuringConversion, 11, 12, 13);
+    expect(() => stats.atime).toThrow(TypeError);
+    expect(Object.isFrozen(stats)).toBe(true);
+    expect(Object.hasOwn(stats, "atime")).toBe(false);
+  });
+
+  // In a subprocess because this aborted the process.
+  test("a WebAssembly GC reference as the receiver of a setter throws a TypeError", async () => {
+    const src = `
+      // (module (type $s (struct (field (mut i32))))
+      //   (func (export "mk") (result (ref null $s)) struct.new_default $s))
+      const bytes = new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x0a, 0x02, 0x5f, 0x01, 0x7f, 0x01, 0x60, 0x00, 0x01, 0x63, 0x00,
+        0x03, 0x02, 0x01, 0x01,
+        0x07, 0x06, 0x01, 0x02, 0x6d, 0x6b, 0x00, 0x00,
+        0x0a, 0x07, 0x01, 0x05, 0x00, 0xfb, 0x01, 0x00, 0x0b,
+      ]);
+      const ref = new WebAssembly.Instance(new WebAssembly.Module(bytes)).exports.mk();
+      const { Stats, statSync } = require("node:fs");
+      const prototypes = {
+        Stats: Stats.prototype,
+        BigIntStats: Object.getPrototypeOf(statSync(${JSON.stringify(import.meta.path)}, { bigint: true })),
+      };
+      const result = {};
+      for (const [name, proto] of Object.entries(prototypes)) {
+        for (const field of ["atime", "mtime", "ctime", "birthtime"]) {
+          const { set } = Object.getOwnPropertyDescriptor(proto, field);
+          try {
+            set.call(ref, new Date(0));
+            result[name + "." + field] = "no error";
+          } catch (e) {
+            result[name + "." + field] = e.constructor.name;
+          }
+        }
+      }
+      console.log(JSON.stringify(result));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      "Stats.atime": "TypeError",
+      "Stats.mtime": "TypeError",
+      "Stats.ctime": "TypeError",
+      "Stats.birthtime": "TypeError",
+      "BigIntStats.atime": "TypeError",
+      "BigIntStats.mtime": "TypeError",
+      "BigIntStats.ctime": "TypeError",
+      "BigIntStats.birthtime": "TypeError",
+    });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- The `atime`, `mtime`, `ctime` and `birthtime` setters of `fs.Stats` and `BigIntStats` abort the process when `this` is a WebAssembly GC reference. Release: `panic(main thread): abort() called`. Debug: `ASSERTION FAILED: WebAssemblyGCStructure should not do transition`.
- The cause is `jsStatsPrototypeFunction_DatePutter` (`src/jsc/bindings/NodeFSStatBinding.cpp:286`). It writes onto any receiver with `putDirect()`, which skips the receiver's own `[[DefineOwnProperty]]`. The getter `getDateField` (`:238`) does the same.
- The same write is wrong for ordinary receivers. A frozen object gains the property, and a `Proxy` runs no trap.

### Fix
- The setter calls `createDataProperty()` with `shouldThrow`, which calls the receiver's `defineOwnProperty`. Node.js implements both accessors with `Object.defineProperty()` ([source](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L472-L517)).
- The getter keeps `putDirect()` only while the receiver has the Stats class structure, where the result is the same. Every other receiver goes through `createDataProperty()`. The first date read on a Stats object costs the same as before.
- One visible change: `Object.freeze(stats).mtime` now throws `TypeError`, as in Node.js v26.3.0. Before, it returned the date and unfroze the object.
- Verified: 7 new tests in `test/js/node/fs/fs-stats-constructor.test.ts`, 6 fail without the fix. Also ran `fs.test.ts` and the Node.js stat, utimes and watchfile tests.

### Background
- The date fields are lazy accessors on the prototype. The first read stores a `Date` on the object as an own property.
- `putDirect()` adds a property through a Structure transition and calls no hook. `createDataProperty()` is the spec CreateDataProperty: it asks the object.
- A WebAssembly GC reference is the JS view of a wasm `struct` or `array`. Its Structure refuses every transition.
- A Stats object from `fs.stat()` starts with one fixed Structure, the class structure: ordinary, extensible, no own date property. Any change moves the object to another Structure.

<details><summary>Notes</summary>

Repro (`bun s.js`, any of `atime`, `mtime`, `ctime`, `birthtime`):

```js
const bytes = new Uint8Array([0,0x61,0x73,0x6d,1,0,0,0, 1,10,2, 0x5f,1,0x7f,1, 0x60,0,1,0x63,0, 3,2,1,1, 7,6,1,2,0x6d,0x6b,0,0, 10,7,1,5,0,0xfb,1,0,0x0b]);
const obj = new WebAssembly.Instance(new WebAssembly.Module(bytes)).exports.mk(); // (struct (field (mut i32)))
const set = Object.getOwnPropertyDescriptor(require("fs").Stats.prototype, "mtime").set;
set.call(obj, new Date(0));
console.log("survived");
```

Before: bun 1.4.3-canary.1 aborts with exit code 134 (debug build: the assertion is in `JSC::Structure::create`, `StructureInlines.h(66)`). After: `TypeError: Cannot define property for WebAssembly GC object`. Node.js v26.3.0: `TypeError: WebAssembly objects are opaque`.

Receivers compared with Node.js v26.3.0 (`get.call(r)` and `set.call(r, v)` with the accessors of `Stats.prototype.mtime`). After this change every row matches Node.js, apart from the engine's message text:

| receiver | Node.js | bun before | bun after |
| --- | --- | --- | --- |
| WebAssembly GC reference, setter | TypeError | abort | TypeError |
| frozen, sealed or non-extensible object | TypeError | property added | TypeError |
| frozen real Stats object, `stats.mtime` | TypeError | date returned, object unfrozen | TypeError |
| own non-configurable `mtime` | TypeError | redefined as writable, configurable | TypeError |
| Proxy | `defineProperty` trap runs | no trap, property on the proxy cell | `defineProperty` trap runs |
| Proxy whose trap returns false | TypeError | no error | TypeError |
| plain object, array, function, `Object.create(Stats.prototype)`, subclass | own data property | same | same |

- Not changed: a primitive or `undefined` receiver still returns `undefined` (#39525). Node.js throws there. `Stats.prototype.mtime` (the prototype as the receiver) still returns an Invalid Date and keeps the accessor. Node.js replaces the accessor on the prototype in that case, which breaks every later Stats object. The getter's `mayBePrototype()` guard is the one on main. It also covers a subclass prototype (`class MyStats extends fs.Stats {}`, then `MyStats.prototype.mtime`) and, as on main, a Stats object that was used as a prototype: such an object gets a new `Date` for each read and no own property.
- The getter with a WebAssembly GC receiver did not abort before this change and does not now. The GC Structure reports `mayBePrototype()`, so the getter never caches on it. The BigInt getter throws in `ToBigInt(undefined)` first.
- The getter checks the structure a second time after the number conversion. `new Stats(...)` stores its arguments as given, so `valueOf()` of a timestamp can run user code that freezes the object in between. A test covers that.
- Cost: the first date read on an object from `fs.stat()` still takes `getDirect()` by offset and `putDirect()`. A second date read on the same object already took the generic `get()` path. It now also takes the generic `defineOwnProperty()` path, which for a plain object is one more lookup and then the same `putDirect()`.
- This is the fourth entry point of one family: a native write with `putDirect()` onto a caller-supplied object. The others are `worker_threads.markAsUntransferable()` (#42479), `spyOn` (#34976) and `Error.captureStackTrace` (#33412).
- Suites run with the debug build: `test/js/node/fs/fs-stats-constructor.test.ts`, `test/js/node/fs/fs.test.ts` (565 pass), and in `test/js/node/test/parallel/`: `test-fs-stat.js`, `test-fs-stat-bigint.js`, `test-fs-stat-date.mjs`, `test-fs-stat-temporal.mjs`, `test-fs-stat-abort-test.js`, `test-fs-statfs.js`, `test-fs-utimes.js`, `test-fs-utimes-y2K38.js`, `test-fs-watchfile.js`, `test-fs-watchfile-bigint.js`, `test-fs-watchfile-ref-unref.js`, `test-fs-promises-file-handle-stat.js`, `test-fs-cp-*-preserve-timestamps*`. The new tests also pass with `BUN_JSC_validateExceptionChecks=1`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/fs/fs-stats-constructor.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/fs/fs-stats-constructor.test.ts:
(pass) new Stats(...) assigns fields in Node's order [3.87ms]
(pass) Stats(...) without new assigns fields in Node's order [1.56ms]
(pass) Stats instances share Stats.prototype [7.84ms]
(pass) Stats methods and accessors called without a receiver > a mode method called through a captured binding is treated like an undefined receiver [6.79ms]
(pass) Stats methods and accessors called without a receiver > a date getter called through a captured binding is treated like an undefined receiver [7.35ms]
(pass) Stats methods and accessors called without a receiver > calls through a scope whose `mode` and `atimeMs` bindings are in their TDZ do not crash [509.53ms]
(pass) Stats date accessors define the property the way Object.defineProperty does > Stats: an ordinary receiver gets a writable, enumerable, configurable property [13.45ms]
(pass) Stats date accessors define the property the way Object.defineProperty does > BigIntSta
... (truncated)

release without fix: 6 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/node/fs/fs-stats-constructor.test.ts:
(pass) new Stats(...) assigns fields in Node's order [0.05ms]
(pass) Stats(...) without new assigns fields in Node's order [0.02ms]
(pass) Stats instances share Stats.prototype [0.10ms]
(pass) Stats methods and accessors called without a receiver > a mode method called through a captured binding is treated like an undefined receiver [0.11ms]
(pass) Stats methods and accessors called without a receiver > a date getter called through a captured binding is treated like an undefined receiver [0.12ms]
(pass) Stats methods and accessors called without a receiver > calls through a scope whose `mode` and `atimeMs` bindings are in their TDZ do not crash [13.57ms]
(pass) Stats date accessors define the property the way Object.defineProperty does > Stats: an ordinary receiver gets a writable, enumerable, configurable property [0.25ms]
(pass) Stats date accessors define the property the way Object.defineProperty does > BigIntStats: an ordinary receiver gets a writable, enumerable, configurable property [0.04ms]
(pass) Stats date accessors define the property the way Object.defineProperty does > 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/fs/fs-stats-constructor.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/fs/fs-stats-constructor.test.ts:
(pass) new Stats(...) assigns fields in Node's order [5.14ms]
(pass) Stats(...) without new assigns fields in Node's order [2.48ms]
(pass) Stats instances share Stats.prototype [9.95ms]
(pass) Stats methods and accessors called without a receiver > a mode method called through a captured binding is treated like an undefined receiver [9.19ms]
(pass) Stats methods and accessors called without a receiver > a date getter called through a captured binding is treated like an undefined receiver [9.24ms]
(pass) Stats methods and accessors called without a receiver > calls through a scope whose `mode` and `atimeMs` bindings are in their TDZ do not crash [510.12ms]
(pass) Stats date accessors define the property the way Object.defineProperty does > Stats: an ordinary receiver gets a writable, enumerable, configurable property [18.40ms]
(pass) Stats date accessors define the property the way Object.defineProperty does > BigIntSta
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     78b5a60eab
  features     baseline

23 deps, 131 codegen, 1172 objects in 662ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (6a92015fc)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (6a92015fc)

Checked 1 install across 2 packages (no changes) [2.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1217] fetch tinycc
[tinycc] up to date
[7/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (6a92015fc)

Checked 111 installs across 104 packages (no changes) [14.00ms]
[8/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 4ms

  react-refresh.js  4.81 KB  (entry point)

[9/1216] fetch zlib
[zlib] up to date
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen .bind.ts → Gen
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeFSStatBinding.cpp       |  19 ++-
 test/js/node/fs/fs-stats-constructor.test.ts | 170 +++++++++++++++++++++++++++
 2 files changed, 185 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/bindings/NodeFSStatBinding.cpp            1      2     10
test/js/node/fs/fs-stats-constructor.test.ts      2      2     10
```

</details>

<!-- robobun:evidence:end -->
