### PR TITLE
node:http2: treat a SETTINGS ACK with no SETTINGS outstanding as a connection error

### DIFF
--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -248,8 +248,6 @@ pub struct Connection {
 
     pub local_settings: Settings,
     pub remote_settings: Settings,
-    /// Whether our initial SETTINGS has been ACKed (affects §6.9.2 window grace).
-    pub local_settings_acked: bool,
     /// Maximum decoded header fields per block (node's maxHeaderListPairs session option; not a
     /// SETTINGS parameter). Blocks exceeding it are refused like an oversized header list.
     pub max_header_list_pairs: u32,
@@ -320,7 +318,6 @@ impl Connection {
             is_server,
             local_settings: local,
             remote_settings: Settings::default(),
-            local_settings_acked: false,
             max_header_list_pairs: 128,
             frames_received: 0,
             frames_sent: 0,
@@ -674,23 +671,13 @@ impl Connection {
                 );
                 return true;
             }
-            // An ACK with no outstanding SETTINGS submission is unsolicited; nghttp2 silently
-            // ignores it (it never reaches node's HandleSettingsFrame defensive branch). The
-            // queue can also be empty during the legacy-parser bridge handoff (its
-            // pending_settings_window_submissions is drained into this queue between batches),
-            // so the first ACK falls back to local_settings rather than being dropped.
-            if self.local_settings_acked && self.pending_local_settings_acks.is_empty() {
-                return false;
-            }
-            self.local_settings_acked = true;
             // §6.5.3: this ACK acknowledges the oldest outstanding SETTINGS, whose values may
             // differ from the latest submission when several SETTINGS are in flight.
-            let acked =
-                self.pending_local_settings_acks
-                    .pop_front()
-                    .unwrap_or(PendingLocalSettings {
-                        settings: self.local_settings,
-                    });
+            let Some(acked) = self.pending_local_settings_acks.pop_front() else {
+                // https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L4361-L4366
+                self.send_go_away(sink, ErrorCode::ProtocolError, b"SETTINGS: unexpected ACK");
+                return true;
+            };
             self.acked_local_initial_window = acked.settings.initial_window_size;
             // The peer has acknowledged this submission: header-list enforcement may now use the
             // limit it carried.

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3544,6 +3544,12 @@ impl H2FrameParser {
         }
     }
 
+    /// The engine matches each inbound SETTINGS ACK to the oldest SETTINGS registered here (§6.5.3).
+    fn register_settings_submissions(&self, engine: &mut crate::api::h2::connection::Connection) {
+        self.pending_settings_window_submissions
+            .with_mut(|v| engine.pending_local_settings_acks.extend(v.drain(..)));
+    }
+
     /// Feed inbound bytes through the rewrite engine, buffering the unconsumed tail (design B).
     fn rewrite_read(&self, bytes: &[u8]) {
         bun_output::scoped_log!(H2FrameParser, "rewriteRead {}", bytes.len());
@@ -3599,13 +3605,7 @@ impl H2FrameParser {
                     }
                 });
             });
-            // Register SETTINGS submissions the legacy encoder sent since the last batch, so the
-            // engine attributes each inbound ACK to the right submission (§6.5.3).
-            self.pending_settings_window_submissions.with_mut(|v| {
-                for w in v.drain(..) {
-                    engine.pending_local_settings_acks.push_back(w);
-                }
-            });
+            self.register_settings_submissions(engine);
             // Streams whose legacy lifecycle finished since the last batch: evict the engine
             // entry and free the legacy slot. free_resources already ran for these (it is the
             // only producer of this queue); duplicate ids are fine — remove() yields None.
@@ -3676,7 +3676,10 @@ impl H2FrameParser {
             let pending = self.rewrite_tail.with_mut(std::mem::take);
             let feed = {
                 let mut guard = self.engine.borrow_mut();
-                guard.as_mut().unwrap().receive(self, &pending)
+                let engine = guard.as_mut().unwrap();
+                // A dispatch above may have sent SETTINGS whose ACK is already in these bytes.
+                self.register_settings_submissions(engine);
+                engine.receive(self, &pending)
             };
             if feed.fatal {
                 self.rewrite_tail.with_mut(|t| t.clear());

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -12,7 +12,7 @@ import { bunEnv, bunExe, gcTick, normalizeBunSnapshot } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
 import net from "node:net";
-import { Writable } from "node:stream";
+import { Duplex, Writable } from "node:stream";
 
 const PREFACE = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "latin1");
 
@@ -1925,6 +1925,120 @@ describe("stream release after a queued END_STREAM", () => {
     } finally {
       client.close();
       server.close();
+    }
+  });
+});
+
+// nghttp2 answers a SETTINGS ACK that acknowledges nothing with a connection error
+// ("SETTINGS: unexpected ACK"), which node reports as ERR_HTTP2_ERROR "Protocol error".
+describe("SETTINGS ACK with no SETTINGS outstanding", () => {
+  const PING = encodeFrame(FrameType.PING, 0, 0, Buffer.alloc(8, 1));
+  const isPingAck = (f: Frame) => f.type === FrameType.PING && (f.flags & 0x1) !== 0;
+  const isFatal = (f: Frame) => f.type === FrameType.RST_STREAM || f.type === FrameType.GOAWAY;
+  const PROTOCOL_ERROR_SESSION = { code: "ERR_HTTP2_ERROR", message: "Protocol error" };
+
+  test("server", async () => {
+    let sessionError: any;
+    const server = http2.createServer();
+    server.on("sessionError", e => (sessionError = e));
+    server.listen(0);
+    await once(server, "listening");
+    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      // This one acknowledges the SETTINGS frame the server opened the connection with.
+      c.sendSettingsAck();
+      c.send(PING);
+      await c.waitFor(isPingAck);
+      expect(c.frames.filter(isFatal)).toEqual([]);
+      c.sendSettingsAck();
+      expect(goawayErrorCode(await c.waitForGoaway())).toBe(ErrorCode.PROTOCOL_ERROR);
+      await c.waitClosed();
+      expect({ code: sessionError?.code, message: sessionError?.message }).toEqual(PROTOCOL_ERROR_SESSION);
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  });
+
+  test("client", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    const sessionError = once(client, "error");
+    try {
+      await raw.waitFor(f => f.type === FrameType.SETTINGS);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      // This one acknowledges the SETTINGS frame the client opened the connection with.
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      raw.socket!.write(PING);
+      await raw.waitFor(isPingAck);
+      expect(raw.frames.filter(isFatal)).toEqual([]);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      expect(goawayErrorCode(await raw.waitFor(f => f.type === FrameType.GOAWAY))).toBe(ErrorCode.PROTOCOL_ERROR);
+      const [err] = await sessionError;
+      expect({ code: err.code, message: err.message }).toEqual(PROTOCOL_ERROR_SESSION);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  test("client: SETTINGS sent from a frame listener are outstanding for the rest of that read", async () => {
+    // A JS transport whose peer acknowledges a SETTINGS frame from inside the write that delivers
+    // it, so the ACK is parsed by the read() that is still running the listener's frame batch.
+    const events: string[] = [];
+    const prefaceWritten = Promise.withResolvers<void>();
+    let written = Buffer.alloc(0);
+    let sawPreface = false;
+    let reading = false;
+    const transport = new Duplex({
+      read() {},
+      write(chunk: Buffer, _encoding, callback) {
+        written = Buffer.concat([written, chunk]);
+        if (!sawPreface && written.length >= PREFACE.length) {
+          written = written.subarray(PREFACE.length);
+          sawPreface = true;
+        }
+        while (sawPreface && written.length >= 9 && written.length >= 9 + written.readUIntBE(0, 3)) {
+          const isSettings = written[3] === FrameType.SETTINGS && (written[4] & 0x1) === 0;
+          written = written.subarray(9 + written.readUIntBE(0, 3));
+          if (!isSettings) continue;
+          // The first SETTINGS frame belongs to the connection preface; the read below acknowledges it.
+          if (reading) {
+            events.push("ACK sent during the read");
+            this.push(encodeFrame(FrameType.SETTINGS, 0x1, 0));
+          } else {
+            prefaceWritten.resolve();
+          }
+        }
+        callback();
+      },
+    });
+    const client = http2.connect("http://127.0.0.1:1", { createConnection: () => transport });
+    client.on("error", err => events.push(`error ${(err as any).code}`));
+    try {
+      // With the preface out and its write finished, a flush inside a read reaches write() at once.
+      await prefaceWritten.promise;
+      await new Promise(resolve => setImmediate(resolve));
+      client.on("localSettings", settings => events.push(`localSettings ${settings.initialWindowSize}`));
+      client.on("altsvc", () => client.settings({ initialWindowSize: 1000 }));
+      // One read: the peer's SETTINGS, its ACK of the preface SETTINGS, an ALTSVC whose listener
+      // sends new SETTINGS, and a WINDOW_UPDATE, which makes the client flush what it has queued.
+      reading = true;
+      transport.push(
+        Buffer.concat([
+          encodeFrame(FrameType.SETTINGS, 0, 0),
+          encodeFrame(FrameType.SETTINGS, 0x1, 0),
+          encodeFrame(0x0a, 0, 0, Buffer.concat([Buffer.from([0, 1]), Buffer.from('xh2=":1"')])),
+          encodeFrame(FrameType.WINDOW_UPDATE, 0, 0, Buffer.from([0, 0, 0, 1])),
+        ]),
+      );
+      reading = false;
+      await new Promise(resolve => setImmediate(resolve));
+      expect(events).toEqual(["localSettings 65535", "ACK sent during the read", "localSettings 1000"]);
+    } finally {
+      client.destroy();
     }
   });
 });


### PR DESCRIPTION
This needs a yes or no from @cirospaciari: it reverses a choice from #32488, where the engine was made to ignore a SETTINGS ACK that acknowledges nothing.

### Problem
- `node:http2` ignores a SETTINGS ACK when no SETTINGS frame is outstanding (`Connection::handle_settings` in `src/runtime/api/bun/h2/connection.rs`). Node ends the session on the first one with `ERR_HTTP2_ERROR` "Protocol error".
- The comment there says nghttp2 ignores it. nghttp2 does not: [`"SETTINGS: unexpected ACK"`](https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L4361-L4366) is a connection error. node's `test-http2-settings-unsolicited-ack.js` says "ignored" but never looks at the session.
- A real ACK can be dropped too. `H2FrameParser` registers sent SETTINGS with the engine only at the start of a read. `session.settings()` from a frame listener, flushed in the same read over a synchronous transport, gets its ACK back earlier. `localSettings` never fires and later ACKs match the wrong submission.

### Fix
- An ACK with an empty `pending_local_settings_acks` queue sends `GOAWAY(PROTOCOL_ERROR)` "SETTINGS: unexpected ACK". The JS session errors like node's.
- `register_settings_submissions` moves sent SETTINGS to the engine. `rewrite_read` calls it before every `receive()`, the tail loop included.
- `local_settings_acked` has no reader left and is removed.
- Verified: `test/js/node/http2/h2-conformance.test.ts` (3 new tests, all fail on main), `test/js/node/http2/`, and the 261 `test-http2-*` node tests.

### Background
- `Connection` is the inbound h2 engine. `H2FrameParser` embeds it and still encodes outbound frames, SETTINGS included.
- RFC 9113 §6.5.3: ACKs apply to SETTINGS frames in the order they were sent. The engine keeps that order in `pending_local_settings_acks`.
- While `receive()` runs, a read that re-enters the parser is queued in `rewrite_tail` and parsed after it.

<details><summary>Notes</summary>

**Real node output.** The scenario of `test-http2-settings-unsolicited-ack.js` (raw client: preface, SETTINGS, the expected ACK, a second ACK), with a `sessionError` listener and the wire observed:

```
node v26.3.0
  server remoteSettings
  server sessionError: ERR_HTTP2_ERROR "Protocol error"
  server session close
  client got GOAWAY code 2 debug ""
bun 1.4.3 (6a92015fc)
  server remoteSettings
  (nothing else, the session stays open)
this branch
  server remoteSettings
  server sessionError: ERR_HTTP2_ERROR "Protocol error"
  server session close
  client got GOAWAY code 1 debug "SETTINGS: unexpected ACK"
  client got GOAWAY code 2 debug ""
```

`http2.connect()` against a raw server that sends a second ACK: node and this branch report session `ERR_HTTP2_ERROR` "Protocol error" and the pending request fails with `ERR_HTTP2_ERROR`. main answers the request with 200 after 100,000 of them. The node test itself still passes on this branch, because it only counts the two write callbacks and one `remoteSettings`.

**Wire difference.** nghttp2 queues `GOAWAY(PROTOCOL_ERROR)`, but node's `OnInvalidFrame` raises the error first and the JS destroy writes the only GOAWAY, with INTERNAL_ERROR. Bun writes the engine's GOAWAY and then the destroy's, as for every other connection error the engine detects.

**Why the queue can be trusted.** Only two places send a non-ACK SETTINGS frame: `set_settings` and `send_preface_and_settings`. Both push to `pending_settings_window_submissions`. Both sides send their first SETTINGS in the constructor, so the queue is not empty when a peer's first ACK arrives, even from a client that sends the ACK before it has read the server's SETTINGS. That makes the old "first ACK falls back to `local_settings`" path dead.

**The dropped ACK, step by step.** One read carries the peer's SETTINGS, its ACK of the preface SETTINGS, an ALTSVC frame and a WINDOW_UPDATE. The `altsvc` listener calls `session.settings()`. The WINDOW_UPDATE handler flushes the write buffer to a JS `Duplex`, whose `write()` answers the new SETTINGS with an ACK at once (`this.push`). The parser is inside `receive()`, so the ACK goes to `rewrite_tail`. On main the tail is parsed with an engine queue that does not hold the new submission yet: `local_settings_acked && queue.is_empty()` drops the ACK. node fires `localSettings` with the new values. The third test does exactly this and checks that the ACK was sent during the read, so it cannot pass by accident.

**Related open PRs.**
- #41329 pulls the whole sync block of `rewrite_read` into `sync_engine()` and calls it before the tail `receive()` too. That covers the registration. If it lands first, `register_settings_submissions` goes away and only the `handle_settings` change and the tests remain.
- #40180 changes what `setLocalWindowSize()` puts into `local_settings`. It does not touch the ACK path.
- #42467 had this change at first. It was split out because it shares no code with that fix.

**Scope.** `Bun.serve`'s HTTP/2 and `fetch`'s HTTP/2 client are separate code. They are not touched.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [362.64ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [107.78ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [81.64ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [45.97ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [37.52ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [34.43ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [38.58ms]
(pass) PING (checklist §3.7) > a PING on a non-zero str
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [7.52ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [2.21ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [1.54ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [0.84ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [0.73ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [0.65ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [0.71ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [0.63ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [0.63ms]
(pass) WINDOW_UPDATE
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [398.26ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [102.48ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [79.79ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [42.36ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [36.48ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [33.24ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [37.88ms]
(pass) PING (checklist §3.7) > a PING on a non-zero str
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 633ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 23s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.3-canary.1+231685649
[build] done
bun test v1.4.3-canary.1 (231685649)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [9.63ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [2.66ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [1.94ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is n
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2/connection.rs      |  23 ++----
 src/runtime/api/bun/h2_frame_parser.rs    |  19 ++---
 test/js/node/http2/h2-conformance.test.ts | 116 +++++++++++++++++++++++++++++-
 3 files changed, 131 insertions(+), 27 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/api/bun/h2/connection.rs           5     14     54
src/runtime/api/bun/h2_frame_parser.rs         6      3     55
test/js/node/http2/h2-conformance.test.ts      0      0     54
```

</details>

<!-- robobun:evidence:end -->