### PR TITLE
perf_hooks: fix crash when a PerformanceObserver callback comes from a node:vm context

### DIFF
--- a/src/jsc/bindings/webcore/JSCallbackData.cpp
+++ b/src/jsc/bindings/webcore/JSCallbackData.cpp
@@ -50,7 +50,8 @@ JSValue JSCallbackData::invokeCallback(VM& vm, JSObject* callback, JSValue thisV
     JSGlobalObject* lexicalGlobalObject = callback->globalObject();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
-    ScriptExecutionContext* context = uncheckedDowncast<JSDOMGlobalObject>(lexicalGlobalObject)->scriptExecutionContext();
+    // The callback's realm may be a node:vm context, which has no ScriptExecutionContext of its own.
+    ScriptExecutionContext* context = defaultGlobalObject(lexicalGlobalObject)->scriptExecutionContext();
     // We will fail to get the context if the frame has been detached. Once the VM's stop was
     // requested this is a silent no-op, as at the other native→JS boundaries
     // (JSEventListener::handleEvent, Bun__JSValue__call).

--- a/src/jsc/bindings/webcore/JSPerformanceObserverCallback.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceObserverCallback.cpp
@@ -60,7 +60,8 @@ CallbackResult<typename IDLUndefined::ImplementationType> JSPerformanceObserverC
 
     Ref<JSPerformanceObserverCallback> protectedThis(*this);
 
-    auto& globalObject = *uncheckedDowncast<JSDOMGlobalObject>(m_data->callback()->globalObject());
+    // The callback's realm may be a node:vm context, which has no DOM wrapper structures.
+    auto& globalObject = *defaultGlobalObject(m_data->callback()->globalObject());
     auto& vm = globalObject.vm();
 
     JSLockHolder lock(vm);

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -206,6 +206,92 @@ test("re-wrapped native entries, timing and observer keep JS identity", async ()
   expect(await promise).toBe(true);
 });
 
+test("PerformanceObserver delivers entries to a callback created in a node:vm context", async () => {
+  // A context has no PerformanceObserver of its own. A test runner or a sandbox hands it the host class,
+  // and the callback is then a function of the context's realm. Delivery used to crash the process.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const vm = require("node:vm");
+       const perfHooks = require("node:perf_hooks");
+
+       // Only its source is used: a context evaluates it, so the function belongs to the context's realm.
+       function contextCallback(list, observer) {
+         observer.disconnect();
+         report({ receiver: this, passed: observer, list, names: list.getEntries().map(entry => entry.name) });
+       }
+       const callbackSource = "(" + contextCallback + ")";
+       const check = ({ receiver, passed, list, names }, observer, callback) => ({
+         foreignCallback: !(callback instanceof Function),
+         receiver: receiver === observer,
+         observer: passed === observer,
+         list: list instanceof PerformanceObserverEntryList,
+         names,
+       });
+
+       // The context gets the host class and constructs the observer itself.
+       function insideTheContext() {
+         const { promise, resolve } = Promise.withResolvers();
+         const context = vm.createContext({
+           PerformanceObserver,
+           performance,
+           report: result => resolve(check(result, observer, callback)),
+         });
+         const { observer, callback } = vm.runInContext(
+           "const callback = " + callbackSource + ";" +
+           "const observer = new PerformanceObserver(callback);" +
+           "observer.observe({ entryTypes: ['mark'] });" +
+           "performance.mark('inside-the-context');" +
+           "({ observer, callback });",
+           context,
+         );
+         return promise;
+       }
+
+       // The host constructs the observer around a function that a context returned.
+       function fromTheHost(Observer, options, trigger) {
+         const { promise, resolve } = Promise.withResolvers();
+         const callback = vm.runInNewContext(callbackSource, {
+           report: result => resolve(check(result, observer, callback)),
+         });
+         const observer = new Observer(callback);
+         observer.observe(options);
+         trigger?.();
+         return promise;
+       }
+
+       (async () => {
+         performance.measure("buffered", { start: 0, end: 1 });
+         console.log(
+           JSON.stringify({
+             insideTheContext: await insideTheContext(),
+             globalClass: await fromTheHost(PerformanceObserver, { entryTypes: ["mark"] }, () => performance.mark("global")),
+             perfHooksClass: await fromTheHost(perfHooks.PerformanceObserver, { entryTypes: ["mark"] }, () =>
+               performance.mark("perf_hooks"),
+             ),
+             // observe({ buffered: true }) delivers before it returns, not from a task.
+             buffered: await fromTheHost(PerformanceObserver, { type: "measure", buffered: true }),
+           }),
+         );
+       })();`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const delivered = { foreignCallback: true, receiver: true, observer: true, list: true };
+  expect(JSON.parse(stdout)).toEqual({
+    insideTheContext: { ...delivered, names: ["inside-the-context"] },
+    globalClass: { ...delivered, names: ["global"] },
+    perfHooksClass: { ...delivered, names: ["perf_hooks"] },
+    buffered: { ...delivered, names: ["buffered"] },
+  });
+  expect(exitCode).toBe(0);
+});
+
 test("mark/measure toJSON and inspection include detail without perf_hooks being loaded", async () => {
   // These used to be patched onto the prototypes when node:perf_hooks was first required,
   // so JSON.stringify(performance.mark(...)) dropped `detail` until then.


### PR DESCRIPTION
### Problem
- A `PerformanceObserver` whose callback was created in a `node:vm` context crashes the process when it delivers entries. Release 1.4.2 and canary: `panic(main thread): Segmentation fault at address 0x18`. Debug: `ASSERTION FAILED: !source || is<Target>(*source)`, `uncheckedDowncast [Target = Zig::GlobalObject, Source = JSC::JSGlobalObject]`. Node v26.3.0 delivers.
- `JSPerformanceObserverCallback::handleEvent` (`JSPerformanceObserverCallback.cpp:63`) casts `callback->globalObject()` to `Zig::GlobalObject` with no check and builds the wrappers for the observer and the entry list from it. `JSCallbackData::invokeCallback` (`JSCallbackData.cpp:53`) repeats the cast to read `scriptExecutionContext()`. The global of a context is a `NodeVMGlobalObject`. It has neither.

### Fix
- Both sites map the realm through `defaultGlobalObject()`. A `Zig::GlobalObject` maps to itself. A context maps to the default global of the thread.
- Correct because that global owns `PerformanceObserver`, so the wrappers come from the realm of the class. Node also builds the entry list in the main realm. The callback still runs in its own realm.
- Verified: new case in `test/js/node/perf_hooks/perf_hooks.test.ts`. It fails on canary (segfault) and on a debug build of main (assertion). Notes lists the other suites.

### Background
- The main realm and each worker have a `Zig::GlobalObject`. It holds the DOM wrapper structures and the `ScriptExecutionContext`. `vm.createContext()` makes a `NodeVMGlobalObject`, a bare realm without them.
- A context has no `PerformanceObserver`. A test runner or a sandbox hands it the host class, so the callback is a function of the context's realm.
- `defaultGlobalObject(global)` (`ZigGlobalObject.h:898`) returns `global` if it is a `Zig::GlobalObject`, else the default global of the thread. Other bindings already use it for contexts.

<details><summary>Notes</summary>

Repro from the report (`bun p.js`). Confirmed here on 1.4.3-canary.1: exit 139. The report has the same on release 1.4.2. Node v26.3.0 prints `survived, entries seen: 1`.

```js
const vm = require("vm");
const ctx = vm.createContext({ PerformanceObserver, performance });
vm.runInContext(`
  new PerformanceObserver(list => { globalThis.seen = list.getEntries().length; }).observe({ entryTypes: ["mark"] });
  performance.mark("hello");
`, ctx);
setTimeout(() => console.log("survived, entries seen:", vm.runInContext("globalThis.seen", ctx)), 100);
```

The same crash from the host side, all confirmed on 1.4.3-canary.1 before the fix and delivered after it:

- `new PerformanceObserver(vm.runInNewContext("(function(){})")).observe({ entryTypes: ["mark"] }); performance.mark("x")`
- the same with the `PerformanceObserver` class of `node:perf_hooks` (it extends the global class and passes the callback to it)
- `observe({ type: "measure", buffered: true })`, which delivers before `observe()` returns and not from a task

The new test runs these four shapes in one child. For each one it checks that the callback is not an instance of the host `Function`, that `this` and the second argument are the observer, that the list is an instance of the host `PerformanceObserverEntryList`, and the entry names that `list.getEntries()` returns inside the context. Node v26.3.0 prints the same JSON for the child script.

In a worker, the default global is the global of the worker (`Bun__getDefaultGlobalObject` reads a thread-local). Checked by hand on the fixed debug build: a context callback inside a `worker_threads` Worker gets a list that is an instance of the `PerformanceObserverEntryList` of the worker.

Not in this PR: a context callback that throws. `handleEvent` then calls `reportException` with the realm of the callback, and `reportException` (`JSDOMExceptionHandling.cpp:61`) has the same cast. A debug build asserts there (checked on the fixed build). In a release build that cast compiles to nothing, so the exception takes the reporting path that #39992 describes. #39992 removes the cast and routes the exception to `process`, for this path and for the `EventTarget` listener path. This PR leaves the call as it is so that the two do not overlap.

`JSAbortAlgorithm.cpp:33` and `:64` have the same unchecked cast. They are not changed. Its callbacks are never user functions: `startPipeToOperation` (`JSStreamPipeToOperation.cpp:581`) passes a bound builtin made in the global of the stream, and `$addAbortAlgorithmToSignal` has no caller in `src/js`.

Suites run with the fixed debug build (ASAN, assertions on), all pass: `test/js/node/perf_hooks/perf_hooks.test.ts`, `test/js/node/vm/vm.test.ts`, `test/js/web/workers/performance-observer-leak.test.ts`, `test/js/deno/performance/performance.test.ts`, `test/js/web/abort/`, `test/js/web/streams/pipeTo-signal-leak.test.ts`, `test/js/web/streams/pipeTo-shutdown-gc.test.ts` (the abort algorithm of `pipeTo` goes through `JSCallbackData::invokeCallback`). Upstream files, all exit 0: test-performanceobserver-gc, test-performance-measure, test-performance-measure-detail, test-performance-function-async, test-perf-hooks-timerify-basic, test-perf-hooks-timerify-error, test-perf-hooks-timerify-constructor, test-perf-gc-crash, test-net-perf_hooks, test-http-perf_hooks. The child script of the new test also runs clean with `BUN_JSC_validateExceptionChecks=1`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [17.49ms]
(pass) doesn't throw [49.64ms]
(pass) Symbol name argument throws V8 wording [14.02ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [6.73ms]
(pass) timerify entry shape [95.69ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [3.17ms]
(pass) export surface matches Node v26.3.0 [11.30ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [511.64ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [701.65ms]
(pass) net entries are instanceof PerformanceEntry [496.08ms]
(pass) re-wrapped native entries, timing and observer keep JS identity [20.26ms]
279 |     env: bunEnv,
280 |     stdout: "pipe",
281 |     stderr: "pipe",
282 |   });
283 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
284 |   expect(stder
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [0.06ms]
(pass) doesn't throw [0.14ms]
(pass) Symbol name argument throws V8 wording [0.11ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [0.09ms]
(pass) timerify entry shape [1.06ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [0.03ms]
(pass) export surface matches Node v26.3.0 [0.12ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [9.42ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [10.13ms]
(pass) net entries are instanceof PerformanceEntry [7.02ms]
(pass) re-wrapped native entries, timing and observer keep JS identity [0.29ms]
279 |     env: bunEnv,
280 |     stdout: "pipe",
281 |     stderr: "pipe",
282 |   });
283 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
284 |   expect(stderr).toBe("");
                       ^
error: expect(received).toBe(expected)

- ""
+ "============================================================
+ Bun Canary v1.4.3-canary.1 (
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/perf_hooks/perf_hooks.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/perf_hooks/perf_hooks.test.ts:
(pass) stubs [13.18ms]
(pass) doesn't throw [35.30ms]
(pass) Symbol name argument throws V8 wording [10.58ms]
(pass) measure(name, optionsWithoutStartOrEnd, endMark) honours the trailing endMark [5.53ms]
(pass) timerify entry shape [54.00ms]
(pass) timerify is exposed on both performance and as a top-level export (Node v25.2+) [2.02ms]
(pass) export surface matches Node v26.3.0 [8.04ms]
(pass) timerify and createHistogram survive Object.prototype option pollution [405.22ms]
(pass) timerify and AsyncResource.bind survive Object.prototype.get pollution [508.57ms]
(pass) net entries are instanceof PerformanceEntry [418.48ms]
(pass) re-wrapped native entries, timing and observer keep JS identity [15.11ms]
(pass) PerformanceObserver delivers entries to a callback created in a node:vm context [611.63ms]
(pass) mark/measure toJSON and inspection include detail without perf_hooks being loaded [931.56ms]

 13 pass
 0 fail
 76 expec
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     558e6eed8e
  features     baseline

23 deps, 131 codegen, 1172 objects in 687ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (6a92015fc)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (6a92015fc)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (6a92015fc)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[5/1244] gen ErrorCode+*.h
[6/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 11ms

  react-refresh.js  4.81 KB  (entry point)

[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] fetch zlib
[zlib] up to date
[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/JSCallbackData.cpp        |  3 +-
 .../webcore/JSPerformanceObserverCallback.cpp      |  3 +-
 test/js/node/perf_hooks/perf_hooks.test.ts         | 86 ++++++++++++++++++++++
 3 files changed, 90 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/bindings/webcore/JSCallbackData.cpp                   1      1      6
…/jsc/bindings/webcore/JSPerformanceObserverCallback.cpp      1      1      6
test/js/node/perf_hooks/perf_hooks.test.ts                    2      1      6
```

</details>

**root cause** · written by the author bot

The callback delivery path in `JSPerformanceObserverCallback::handleEvent` and `JSCallbackData::invokeCallback` took the callback's own global object and unchecked-downcast it to the Bun global, which is invalid when the callback was created inside a `node:vm` context, since a `NodeVMGlobalObject` is a `Bun::GlobalScope` rather than a `Zig::GlobalObject`. Reading the wrapper caches and script execution context off that mis-typed pointer produced a segfault in release builds and a downcast assertion in debug builds. Both cast sites now route through `defaultGlobalObject(callback->globalObjec…

<!-- robobun:evidence:end -->