### PR TITLE
node:http2: add nghttp2's glitch rate limit for ignored frames

### DIFF
--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -150,6 +150,47 @@ pub struct Feed {
 /// behind a non-reading peer before the session is treated as flooded (NGHTTP2_ERR_FLOODED).
 const MAX_OUTBOUND_ACK_QUEUE: u32 = 1000;
 
+/// nghttp2's NGHTTP2_DEFAULT_GLITCH_BURST / _RATE.
+/// https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.h#L109-L111
+const GLITCH_BURST: u32 = 10_000;
+const GLITCH_RATE: u32 = 330;
+
+/// nghttp2_ratelim: `rate` tokens per whole elapsed second, capped at `burst`.
+struct RateLimit {
+    burst: u32,
+    rate: u32,
+    tokens: u32,
+    last_refill: std::time::Instant,
+}
+
+impl RateLimit {
+    fn new(burst: u32, rate: u32) -> Self {
+        RateLimit {
+            burst,
+            rate,
+            tokens: burst,
+            last_refill: std::time::Instant::now(),
+        }
+    }
+
+    /// Returns false once the bucket is empty.
+    fn drain(&mut self) -> bool {
+        let elapsed = self.last_refill.elapsed().as_secs();
+        if elapsed > 0 {
+            let gain = u32::try_from(elapsed)
+                .unwrap_or(u32::MAX)
+                .saturating_mul(self.rate);
+            self.tokens = self.tokens.saturating_add(gain).min(self.burst);
+            self.last_refill += std::time::Duration::from_secs(elapsed);
+        }
+        if self.tokens == 0 {
+            return false;
+        }
+        self.tokens -= 1;
+        true
+    }
+}
+
 /// What the connection engine calls back into the embedder (the JSC binding) for. Methods take
 /// `&self`: the JSC binding (H2FrameParser) is fully interior-mutable (Cell/JsCell) and its host
 /// functions receive `&Self`, so it can own the `Connection` and pass itself as the sink without an
@@ -301,6 +342,8 @@ pub struct Connection {
     /// obq_flood_counter_). Reset only via note_outbound_drained() when the
     /// embedder confirms its outbound buffer emptied — never per receive().
     obq_ack_pending: u32,
+    /// nghttp2's glitch_ratelim.
+    glitch_limit: RateLimit,
 
     /// Scratch buffer for the outbound HPACK-encoded header block.
     enc_buf: Vec<u8>,
@@ -339,6 +382,7 @@ impl Connection {
             data_in_flight: None,
             terminated: false,
             obq_ack_pending: 0,
+            glitch_limit: RateLimit::new(GLITCH_BURST, GLITCH_RATE),
             enc_buf: Vec::new(),
             replenish_buf: Vec::new(),
             evict_buf: Vec::new(),
@@ -657,10 +701,8 @@ impl Connection {
             Some(FrameType::PushPromise) => self.handle_push_promise(sink, hdr, payload),
             Some(FrameType::AltSvc) => self.handle_altsvc(sink, hdr, payload),
             Some(FrameType::Origin) => self.handle_origin(sink, hdr, payload),
-            // PRIORITY has no scheduling effect here; structurally validated above, otherwise ignored.
-            Some(FrameType::Priority) => false,
-            // §4.1: unknown frame types are silently discarded.
-            _ => false,
+            // Both are ignored (§4.1 for unknown types). nghttp2 charges each one as a glitch.
+            Some(FrameType::Priority) | None => self.note_glitch(sink),
         }
     }
 
@@ -794,6 +836,15 @@ impl Connection {
             wire::lib_error::FLOODED,
             b"too many outbound control frames queued",
         );
+        true
+    }
+
+    /// nghttp2's session_update_glitch_ratelim. Returns true when the session was torn down.
+    fn note_glitch(&mut self, sink: &impl Sink) -> bool {
+        if self.glitch_limit.drain() {
+            return false;
+        }
+        self.send_go_away(sink, ErrorCode::EnhanceYourCalm, b"too many ignored frames");
         true
     }
 
@@ -1760,6 +1811,9 @@ impl Connection {
 
     /// RFC 7838 §4 ALTSVC: optional 2-byte origin-length + origin, then the Alt-Svc field value.
     fn handle_altsvc(&mut self, sink: &impl Sink, hdr: &FrameHeader, payload: &[u8]) -> bool {
+        if self.is_server {
+            return self.note_glitch(sink);
+        }
         if payload.len() < 2 {
             return false; // malformed ALTSVC is ignored (§4)
         }
@@ -1769,12 +1823,9 @@ impl Connection {
         }
         let origin = &payload[2..2 + origin_len];
         let value = &payload[2 + origin_len..];
-        // RFC 7838 4 MUST-ignore rules: a server never accepts ALTSVC; on stream 0 the origin
-        // must be present; on a request stream it must be empty (the stream's own origin applies).
-        if self.is_server
-            || (hdr.stream_id == 0 && origin.is_empty())
-            || (hdr.stream_id != 0 && !origin.is_empty())
-        {
+        // RFC 7838 4 MUST-ignore rules: on stream 0 the origin must be present; on a request
+        // stream it must be empty (the stream's own origin applies).
+        if (hdr.stream_id == 0 && origin.is_empty()) || (hdr.stream_id != 0 && !origin.is_empty()) {
             return false;
         }
         sink.on_altsvc(hdr.stream_id, origin, value);
@@ -1787,7 +1838,7 @@ impl Connection {
         // only - a server receiving it must ignore it. The whole payload is delivered once; the
         // embedder iterates the (2-byte length, origin) entries and surfaces a single event.
         if hdr.stream_id != 0 || self.is_server {
-            return false;
+            return self.note_glitch(sink);
         }
         sink.on_origin(payload);
         false

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -150,8 +150,7 @@ pub struct Feed {
 /// behind a non-reading peer before the session is treated as flooded (NGHTTP2_ERR_FLOODED).
 const MAX_OUTBOUND_ACK_QUEUE: u32 = 1000;
 
-/// nghttp2's NGHTTP2_DEFAULT_GLITCH_BURST / _RATE.
-/// https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.h#L109-L111
+/// nghttp2's NGHTTP2_DEFAULT_GLITCH_BURST and NGHTTP2_DEFAULT_GLITCH_RATE.
 const GLITCH_BURST: u32 = 10_000;
 const GLITCH_RATE: u32 = 330;
 
@@ -1823,8 +1822,7 @@ impl Connection {
         }
         let origin = &payload[2..2 + origin_len];
         let value = &payload[2 + origin_len..];
-        // RFC 7838 4 MUST-ignore rules: on stream 0 the origin must be present; on a request
-        // stream it must be empty (the stream's own origin applies).
+        // RFC 7838 §4: the origin must be present on stream 0 and empty on a request stream.
         if (hdr.stream_id == 0 && origin.is_empty()) || (hdr.stream_id != 0 && !origin.is_empty()) {
             return false;
         }

--- a/src/runtime/api/bun/h2/connection.rs
+++ b/src/runtime/api/bun/h2/connection.rs
@@ -1835,7 +1835,7 @@ impl Connection {
         // §2.1: ORIGIN on a non-zero stream is ignored, and like ALTSVC it is server-to-client
         // only - a server receiving it must ignore it. The whole payload is delivered once; the
         // embedder iterates the (2-byte length, origin) entries and surfaces a single event.
-        if hdr.stream_id != 0 || self.is_server {
+        if hdr.stream_id != 0 || self.is_server || hdr.flags & 0xf0 != 0 {
             return self.note_glitch(sink);
         }
         sink.on_origin(payload);

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1964,28 +1964,24 @@ describe("floods of ignored frames (nghttp2's glitch rate limit)", () => {
     ["PRIORITY", [PRIORITY]],
     ["unknown frame types", [UNKNOWN]],
     ["ALTSVC and ORIGIN", [ALTSVC, ORIGIN]],
-  ])(
-    "server: %s",
-    async (_, kinds) => {
-      let sessionError: any;
-      const server = http2.createServer();
-      server.on("sessionError", e => (sessionError = e));
-      const c = await listenRaw(server);
-      try {
-        c.send(Buffer.concat([flood(kinds, BURST), pingFrame(1)]));
-        await c.waitFor(isPingAck(1), 10_000);
-        expect(c.frames.filter(isFatal)).toEqual([]);
-        c.send(flood(kinds, BURST));
-        expect(goawayErrorCode(await c.waitForGoaway(10_000))).toBe(ErrorCode.ENHANCE_YOUR_CALM);
-        await c.waitClosed(10_000);
-        expect({ code: sessionError?.code, message: sessionError?.message }).toEqual(PROTOCOL_ERROR_SESSION);
-      } finally {
-        c.destroy();
-        server.close();
-      }
-    },
-    30_000,
-  );
+  ])("server: %s", async (_, kinds) => {
+    let sessionError: any;
+    const server = http2.createServer();
+    server.on("sessionError", e => (sessionError = e));
+    const c = await listenRaw(server);
+    try {
+      c.send(Buffer.concat([flood(kinds, BURST), pingFrame(1)]));
+      await c.waitFor(isPingAck(1), 4_000);
+      expect(c.frames.filter(isFatal)).toEqual([]);
+      c.send(flood(kinds, BURST));
+      expect(goawayErrorCode(await c.waitForGoaway(4_000))).toBe(ErrorCode.ENHANCE_YOUR_CALM);
+      await c.waitClosed(4_000);
+      expect({ code: sessionError?.code, message: sessionError?.message }).toEqual(PROTOCOL_ERROR_SESSION);
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  });
 
   test("client: PRIORITY and unknown frame types", async () => {
     const kinds = [PRIORITY, UNKNOWN];
@@ -1997,10 +1993,10 @@ describe("floods of ignored frames (nghttp2's glitch rate limit)", () => {
       raw.sendFrame(FrameType.SETTINGS, 0, 0);
       raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
       raw.socket!.write(Buffer.concat([flood(kinds, BURST), pingFrame(1)]));
-      await raw.waitFor(isPingAck(1), 10_000);
+      await raw.waitFor(isPingAck(1), 4_000);
       expect(raw.frames.filter(isFatal)).toEqual([]);
       raw.socket!.write(flood(kinds, BURST));
-      expect(goawayErrorCode(await raw.waitFor(f => f.type === FrameType.GOAWAY, 10_000))).toBe(
+      expect(goawayErrorCode(await raw.waitFor(f => f.type === FrameType.GOAWAY, 4_000))).toBe(
         ErrorCode.ENHANCE_YOUR_CALM,
       );
       const [err] = await sessionError;
@@ -2009,21 +2005,21 @@ describe("floods of ignored frames (nghttp2's glitch rate limit)", () => {
       client.destroy();
       raw.close();
     }
-  }, 30_000);
+  });
 
   test("an empty bucket gets 330 tokens back per second", async () => {
     const server = http2.createServer();
     const c = await listenRaw(server);
     try {
       c.send(Buffer.concat([flood([PRIORITY], BURST), pingFrame(1)]));
-      await c.waitFor(isPingAck(1), 10_000);
+      await c.waitFor(isPingAck(1), 4_000);
       await Bun.sleep(1100); // the refill under test is per whole second of wall clock
       c.send(Buffer.concat([flood([PRIORITY], 300), pingFrame(2)]));
-      await c.waitFor(isPingAck(2), 10_000);
+      await c.waitFor(isPingAck(2), 4_000);
       expect(c.frames.filter(isFatal)).toEqual([]);
     } finally {
       c.destroy();
       server.close();
     }
-  }, 30_000);
+  });
 });

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1928,3 +1928,102 @@ describe("stream release after a queued END_STREAM", () => {
     }
   });
 });
+
+// nghttp2 keeps one token bucket per session for frames a peer has no reason to send often: 10,000
+// tokens, 330 back per second. A PRIORITY frame, a frame of an unknown type, and an ALTSVC or ORIGIN
+// frame sent to a server each take one. With none left the session ends with
+// GOAWAY(ENHANCE_YOUR_CALM), which node reports as ERR_HTTP2_ERROR "Protocol error".
+describe("floods of ignored frames (nghttp2's glitch rate limit)", () => {
+  const BURST = 10_000;
+  const PRIORITY = encodeFrame(FrameType.PRIORITY, 0, 1001, Buffer.from([0, 0, 0, 0, 16]));
+  const UNKNOWN = encodeFrame(0xfa, 0, 0, Buffer.from("12345"));
+  const ALTSVC = encodeFrame(0x0a, 0, 0, Buffer.concat([Buffer.from([0, 1]), Buffer.from('xh2=":1"')]));
+  const ORIGIN = encodeFrame(0x0c, 0, 0, Buffer.concat([Buffer.from([0, 1]), Buffer.from("x")]));
+  const PROTOCOL_ERROR_SESSION = { code: "ERR_HTTP2_ERROR", message: "Protocol error" };
+  const pingFrame = (id: number) => encodeFrame(FrameType.PING, 0, 0, Buffer.alloc(8, id));
+  const isPingAck = (id: number) => (f: Frame) =>
+    f.type === FrameType.PING && (f.flags & 0x1) !== 0 && f.payload[0] === id;
+  const isFatal = (f: Frame) => f.type === FrameType.RST_STREAM || f.type === FrameType.GOAWAY;
+
+  /** `count` frames that cycle through `kinds`, so each kind makes up an equal share. */
+  const flood = (kinds: Buffer[], count: number) =>
+    Buffer.concat(Array.from({ length: count }, (_, i) => kinds[i % kinds.length]));
+
+  async function listenRaw(server: http2.Http2Server): Promise<RawH2> {
+    server.listen(0);
+    await once(server, "listening");
+    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    c.sendPreface();
+    c.sendEmptySettings();
+    return c;
+  }
+
+  // BURST frames are always tolerated: the bucket starts with that many tokens. BURST more empty it
+  // unless they take 30 seconds to get here. With two kinds, both have to be charged for that.
+  test.each([
+    ["PRIORITY", [PRIORITY]],
+    ["unknown frame types", [UNKNOWN]],
+    ["ALTSVC and ORIGIN", [ALTSVC, ORIGIN]],
+  ])(
+    "server: %s",
+    async (_, kinds) => {
+      let sessionError: any;
+      const server = http2.createServer();
+      server.on("sessionError", e => (sessionError = e));
+      const c = await listenRaw(server);
+      try {
+        c.send(Buffer.concat([flood(kinds, BURST), pingFrame(1)]));
+        await c.waitFor(isPingAck(1), 10_000);
+        expect(c.frames.filter(isFatal)).toEqual([]);
+        c.send(flood(kinds, BURST));
+        expect(goawayErrorCode(await c.waitForGoaway(10_000))).toBe(ErrorCode.ENHANCE_YOUR_CALM);
+        await c.waitClosed(10_000);
+        expect({ code: sessionError?.code, message: sessionError?.message }).toEqual(PROTOCOL_ERROR_SESSION);
+      } finally {
+        c.destroy();
+        server.close();
+      }
+    },
+    30_000,
+  );
+
+  test("client: PRIORITY and unknown frame types", async () => {
+    const kinds = [PRIORITY, UNKNOWN];
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    const sessionError = once(client, "error");
+    try {
+      await raw.waitFor(f => f.type === FrameType.SETTINGS);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      raw.socket!.write(Buffer.concat([flood(kinds, BURST), pingFrame(1)]));
+      await raw.waitFor(isPingAck(1), 10_000);
+      expect(raw.frames.filter(isFatal)).toEqual([]);
+      raw.socket!.write(flood(kinds, BURST));
+      expect(goawayErrorCode(await raw.waitFor(f => f.type === FrameType.GOAWAY, 10_000))).toBe(
+        ErrorCode.ENHANCE_YOUR_CALM,
+      );
+      const [err] = await sessionError;
+      expect({ code: err.code, message: err.message }).toEqual(PROTOCOL_ERROR_SESSION);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  }, 30_000);
+
+  test("an empty bucket gets 330 tokens back per second", async () => {
+    const server = http2.createServer();
+    const c = await listenRaw(server);
+    try {
+      c.send(Buffer.concat([flood([PRIORITY], BURST), pingFrame(1)]));
+      await c.waitFor(isPingAck(1), 10_000);
+      await Bun.sleep(1100); // the refill under test is per whole second of wall clock
+      c.send(Buffer.concat([flood([PRIORITY], 300), pingFrame(2)]));
+      await c.waitFor(isPingAck(2), 10_000);
+      expect(c.frames.filter(isFatal)).toEqual([]);
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  }, 30_000);
+});

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1939,6 +1939,8 @@ describe("floods of ignored frames (nghttp2's glitch rate limit)", () => {
   const UNKNOWN = encodeFrame(0xfa, 0, 0, Buffer.from("12345"));
   const ALTSVC = encodeFrame(0x0a, 0, 0, Buffer.concat([Buffer.from([0, 1]), Buffer.from('xh2=":1"')]));
   const ORIGIN = encodeFrame(0x0c, 0, 0, Buffer.concat([Buffer.from([0, 1]), Buffer.from("x")]));
+  const ORIGIN_ON_STREAM = encodeFrame(0x0c, 0, 1, ORIGIN.subarray(9));
+  const ORIGIN_FLAGGED = encodeFrame(0x0c, 0x10, 0, ORIGIN.subarray(9));
   const PROTOCOL_ERROR_SESSION = { code: "ERR_HTTP2_ERROR", message: "Protocol error" };
   const pingFrame = (id: number) => encodeFrame(FrameType.PING, 0, 0, Buffer.alloc(8, id));
   const isPingAck = (id: number) => (f: Frame) =>
@@ -1983,11 +1985,16 @@ describe("floods of ignored frames (nghttp2's glitch rate limit)", () => {
     }
   });
 
-  test("client: PRIORITY and unknown frame types", async () => {
-    const kinds = [PRIORITY, UNKNOWN];
+  test.each([
+    ["PRIORITY and unknown frame types", [PRIORITY, UNKNOWN]],
+    // nghttp2 drops an ORIGIN frame that is on a stream or has one of the upper four flag bits set.
+    ["ORIGIN on a stream and ORIGIN with a reserved flag", [ORIGIN_ON_STREAM, ORIGIN_FLAGGED]],
+  ])("client: %s", async (_, kinds) => {
     const raw = await RawH2Server.listen();
     const client = http2.connect(`http://127.0.0.1:${raw.port}`);
     const sessionError = once(client, "error");
+    const origins: unknown[] = [];
+    client.on("origin", o => origins.push(o));
     try {
       await raw.waitFor(f => f.type === FrameType.SETTINGS);
       raw.sendFrame(FrameType.SETTINGS, 0, 0);
@@ -2001,6 +2008,7 @@ describe("floods of ignored frames (nghttp2's glitch rate limit)", () => {
       );
       const [err] = await sessionError;
       expect({ code: err.code, message: err.message }).toEqual(PROTOCOL_ERROR_SESSION);
+      expect(origins).toEqual([]);
     } finally {
       client.destroy();
       raw.close();

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1993,8 +1993,6 @@ describe("floods of ignored frames (nghttp2's glitch rate limit)", () => {
     const raw = await RawH2Server.listen();
     const client = http2.connect(`http://127.0.0.1:${raw.port}`);
     const sessionError = once(client, "error");
-    const origins: unknown[] = [];
-    client.on("origin", o => origins.push(o));
     try {
       await raw.waitFor(f => f.type === FrameType.SETTINGS);
       raw.sendFrame(FrameType.SETTINGS, 0, 0);
@@ -2008,7 +2006,6 @@ describe("floods of ignored frames (nghttp2's glitch rate limit)", () => {
       );
       const [err] = await sessionError;
       expect({ code: err.code, message: err.message }).toEqual(PROTOCOL_ERROR_SESSION);
-      expect(origins).toEqual([]);
     } finally {
       client.destroy();
       raw.close();


### PR DESCRIPTION
This needs a maintainer's yes or no first: nothing breaks on main without it. It is the "PRIORITY / unknown frame flood" row of the node:http2 limits that node enforces by default and Bun does not.

### Problem
- `node:http2` charges nothing for frames it ignores: PRIORITY, unknown types, and ALTSVC or ORIGIN sent to a server. `Connection::dispatch` (`src/runtime/api/bun/h2/connection.rs`) returns `false` for them, so 1,000,000 are accepted, in both roles. The cost is CPU only: memory stays flat and nothing is written back.
- Node ends the session after 10,000 with `GOAWAY(ENHANCE_YOUR_CALM)` and `ERR_HTTP2_ERROR` "Protocol error".

### Fix
- Add nghttp2's glitch rate limit: one token bucket per session, 10,000 tokens, 330 back per second. Each of the frames above takes a token. An empty bucket sends `GOAWAY(ENHANCE_YOUR_CALM)` and the session errors like node's.
- `RateLimit` is nghttp2's `nghttp2_ratelim`: whole elapsed seconds times the rate, capped at the burst. It is the same struct #36230 adds for stream resets. Whichever lands second drops its copy.
- Verified: `test/js/node/http2/h2-conformance.test.ts` (6 new tests, 5 fail on main), `test/js/node/http2/`, and the 261 `test-http2-*` node tests.

### Background
- `Connection` is the inbound h2 engine behind `http2.createServer()` and `http2.connect()`.
- nghttp2 calls a valid frame that is suspicious in volume a "glitch". Node uses nghttp2's defaults and has no option for them.
- A GOAWAY that nghttp2 sends on its own reaches node's JS as `NGHTTP2_ERR_PROTO`. That is why the JS error says "Protocol error" while the wire says ENHANCE_YOUR_CALM.

<details><summary>Notes</summary>

**What node does (v26.3.0, nghttp2 1.69.0, `deps/nghttp2/lib/nghttp2_session.c`)**

| inbound | node | main | this PR |
|---|---|---|---|
| PRIORITY, every one ([L5708-L5714](https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L5708-L5714)) | glitch | free | glitch |
| unknown frame type, PRIORITY_UPDATE included ([L6091-L6096](https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L6091-L6096)) | glitch | free | glitch |
| ALTSVC to a server ([L5940-L5956](https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L5940-L5956)) | glitch | free | glitch |
| ORIGIN to a server, on a stream other than 0, or with one of the upper four flag bits set ([L5990-L6007](https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L5990-L6007)) | glitch | free | glitch |

"glitch" is `session_update_glitch_ratelim` ([L3408-L3420](https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.c#L3408-L3420)): burst 10,000 and rate 330 ([nghttp2_session.h L109-L111](https://github.com/nodejs/node/blob/v26.3.0/deps/nghttp2/lib/nghttp2_session.h#L109-L111)), then `nghttp2_session_terminate_session(ENHANCE_YOUR_CALM)`. node sees a GOAWAY it did not ask for ([`internal_goaway_sent_`, node_http2.cc L1263-L1287](https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L1263-L1287)) and raises `NGHTTP2_ERR_PROTO` ([L2020-L2031](https://github.com/nodejs/node/blob/v26.3.0/src/node_http2.cc#L2020-L2031)). `node_http2.cc` sets `nghttp2_option_set_stream_reset_rate_limit` and no glitch option.

Measured with a raw client or a raw server, 20,000 frames after one served request, node v26.3.0 against this branch:
- PRIORITY (open, closed or idle stream), type 0xfa, PRIORITY_UPDATE (0x10), ALTSVC and ORIGIN to a server: both send GOAWAY code 0xb, and `sessionError` is `ERR_HTTP2_ERROR: Protocol error`. main serves the next request.
- `http2.connect()` against a server that floods PRIORITY, type 0xfa, ORIGIN on stream 1, or ORIGIN with flag 0x10 before it answers: both report session `ERR_HTTP2_ERROR: Protocol error`, and the pending request fails with `ERR_HTTP2_ERROR`. main delivers the 200. 9,000 frames pass on both.

**What it does not charge.**
- Stream resets. HEADERS+RST_STREAM pairs and RST_STREAM on a closed stream belong to nghttp2's other bucket, the stream reset limit. #36230 adds that one.
- An empty DATA frame without END_STREAM is a glitch in nghttp2. Bun already charges it to `maxSessionInvalidFrames` (1,000). Unchanged.
- DATA and WINDOW_UPDATE on a closed stream. node does not charge them either, it drops them. #42467 does the same.
- An unexpected SETTINGS ACK is a connection error in nghttp2, not a glitch. #42519.

**Where this differs from node.** The GOAWAY carries debug data `too many ignored frames`. nghttp2 sends none. Every other GOAWAY this engine sends carries a reason.

**False positives.** The limit is node's, so a peer that works against node works here. Firefox sends a few PRIORITY frames per connection and per reprioritization. Chrome sends one frame of a reserved type per connection. A peer has to sustain more than 330 such frames per second after a burst of 10,000 to trip it.

**Related open PRs.**
- #36230 (stream reset rate limit) has the same `RateLimit` struct, with `burst` and `rate` from `streamResetBurst` / `streamResetRate`. The struct here keeps both fields for that reason.
- #42391 (ALTSVC/ORIGIN validation on the client) rewrites `handle_altsvc` and `handle_origin`. Its server branches return `false`. With this PR they return `note_glitch`. Either order is a two-line conflict.
- #36410 (CONTINUATION cap) does not touch these paths.
- #42467 had this change at first. It was split out because it shares no code with that fix.

**Tests.** `floods of ignored frames`: 10,000 frames plus a PING are always tolerated because the bucket starts full. 10,000 more trip it unless they take 30 s to arrive. The ALTSVC+ORIGIN, PRIORITY+unknown and the two client ORIGIN cases interleave two kinds, so the test fails if only one kind is charged. The refill test empties the bucket, waits 1.1 s and sends 300 more. It passes on main, where there is no bucket, and fails if the refill is removed.

**Scope.** `Bun.serve`'s HTTP/2 and `fetch`'s HTTP/2 client are separate code. They are not touched.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [350.42ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [104.29ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [80.38ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [43.18ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [36.82ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [34.39ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [38.35ms]
(pass) PING (checklist §3.7) > a PING on a non-zero str
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (d9978ceba)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [6.37ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [2.37ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [1.70ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [0.86ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [0.73ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [0.66ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [0.70ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [0.59ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [0.70ms]
(pass) WINDOW_UPDATE
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [394.25ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [174.64ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [132.14ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [68.50ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [104.86ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [50.25ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [43.15ms]
(pass) PING (checklist §3.7) > a PING on a non-zero s
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1210ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2/connection.rs      |  73 ++++++++++++++++++----
 test/js/node/http2/h2-conformance.test.ts | 100 ++++++++++++++++++++++++++++++
 2 files changed, 161 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/api/bun/h2/connection.rs           5     14     58
test/js/node/http2/h2-conformance.test.ts      0      0     58
```

</details>

<!-- robobun:evidence:end -->