### PR TITLE
js_parser: let a `with` object shadow a const

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2179,8 +2179,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Expr {
         let ref_ = ident.ref_;
 
-        // Inside a `with` body the name can resolve to a property of the
-        // `with` object, which shadows the const.
+        // A property of the `with` object can shadow the const.
         if self.options.features.inlining && !ident.must_keep_due_to_with_stmt() {
             if let Some(replacement) = self.const_values.get(&ref_) {
                 let replacement = *replacement;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2179,7 +2179,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Expr {
         let ref_ = ident.ref_;
 
-        if self.options.features.inlining {
+        // Inside a `with` body the name can resolve to a property of the
+        // `with` object, which shadows the const.
+        if self.options.features.inlining && !ident.must_keep_due_to_with_stmt() {
             if let Some(replacement) = self.const_values.get(&ref_) {
                 let replacement = *replacement;
                 self.ignore_usage(ref_);

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1807,7 +1807,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // encounter the constant because we haven't encountered the eval() yet.
             // Inlined constants are not removed if they are in a top-level scope or
             // if they are exported (which could be in a nested TypeScript namespace).
-            if p.const_values.count() > 0 {
+            //
+            // The cases of a switch share this scope and the later ones are not visited
+            // yet. One of them can read the constant in a `with` body, which is not inlined.
+            if p.const_values.count() > 0 && kind != StmtsKind::SwitchStmt {
                 let items: &mut [Stmt] = stmts.as_mut_slice();
                 for stmt in items.iter_mut() {
                     match stmt.data {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1807,10 +1807,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // encounter the constant because we haven't encountered the eval() yet.
             // Inlined constants are not removed if they are in a top-level scope or
             // if they are exported (which could be in a nested TypeScript namespace).
-            //
-            // The cases of a switch share this scope and the later ones are not visited
-            // yet. One of them can read the constant in a `with` body, which is not inlined.
-            if p.const_values.count() > 0 && kind != StmtsKind::SwitchStmt {
+            if p.const_values.count() > 0
+                // A later case of the switch shares this scope, and its reads are not counted yet.
+                && kind != StmtsKind::SwitchStmt
+            {
                 let items: &mut [Stmt] = stmts.as_mut_slice();
                 for stmt in items.iter_mut() {
                     match stmt.data {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -198,10 +198,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // Handle assigning to a constant
         if in_.assign_target != js_ast::AssignTarget::None {
             // Inside a `with` body the target can be a property of the `with`
-            // object. The bundler still rejects it: it can print `const` as
-            // `let` or `var`, which is only safe if nothing assigns to it.
+            // object. The error stays when `select_local_kind` can print a
+            // `const` as `let` or `var`, which is only safe if nothing assigns to it.
             if p.symbols[result.r#ref.inner_index() as usize].kind == js_ast::symbol::Kind::Constant
-                && (!result.is_inside_with_scope || p.options.bundle)
+                && (!result.is_inside_with_scope
+                    || p.options.bundle
+                    || p.will_wrap_module_in_try_catch_for_using)
             {
                 // TODO: silence this for runtime transpiler
                 let r = js_lexer::range_of_identifier(p.source, expr.loc);

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -197,11 +197,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Handle assigning to a constant
         if in_.assign_target != js_ast::AssignTarget::None {
-            // Inside a `with` body the target can be a property of the `with`
-            // object. The error stays when `select_local_kind` can print a
-            // `const` as `let` or `var`, which is only safe if nothing assigns to it.
             if p.symbols[result.r#ref.inner_index() as usize].kind == js_ast::symbol::Kind::Constant
+                // In a `with` body the target can be a property of the `with` object.
                 && (!result.is_inside_with_scope
+                    // `select_local_kind` can print the `const` as `let` or `var` in these cases.
                     || p.options.bundle
                     || p.will_wrap_module_in_try_catch_for_using)
             {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -197,7 +197,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Handle assigning to a constant
         if in_.assign_target != js_ast::AssignTarget::None {
+            // Inside a `with` body the target can be a property of the `with`
+            // object. The bundler still rejects it: it can print `const` as
+            // `let` or `var`, which is only safe if nothing assigns to it.
             if p.symbols[result.r#ref.inner_index() as usize].kind == js_ast::symbol::Kind::Constant
+                && (!result.is_inside_with_scope || p.options.bundle)
             {
                 // TODO: silence this for runtime transpiler
                 let r = js_lexer::range_of_identifier(p.source, expr.loc);

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -58,7 +58,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
 /// Version 30: String enum members are stored flat, so folds no longer append onto an inlined member.
-const EXPECTED_VERSION: u32 = 30;
+/// Version 31: A `const` read inside a `with` body is no longer replaced by its value.
+const EXPECTED_VERSION: u32 = 31;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -19,6 +19,46 @@ describe("bundler", () => {
     },
     run: { stdout: "top fn" },
   });
+  // The `with` object can have a property with the name of a `const` from an
+  // enclosing scope. That property shadows the const, so a read inside the
+  // `with` body is not inlined. The `.cjs` names keep the code sloppy.
+  itBundled("minify/ConstReadInsideWithIsNotInlined", {
+    files: {
+      "/entry.cjs": /* js */ `
+        function f(o) { const x = "const"; with (o) { return x; } }
+        // The cases of a switch share one scope, and the read is in a later case.
+        function g(k, o) { switch (k) { case 1: const y = "const"; case 2: with (o) { return y; } } }
+        console.log(f({ x: "with" }), f({}), g(1, { y: "with" }), g(1, {}));
+      `,
+    },
+    minifySyntax: true,
+    format: "cjs",
+    outfile: "/out.cjs",
+    onAfterBundle(api) {
+      // The bundler prints the declarations as `let`.
+      api.expectFile("/out.cjs").toContain('x = "const"');
+      api.expectFile("/out.cjs").toContain("return x");
+      api.expectFile("/out.cjs").toContain('y = "const"');
+      api.expectFile("/out.cjs").toContain("return y");
+    },
+    run: { stdout: "with const with const" },
+  });
+  // The bundler can print `const` as `let` or `var`, which is only safe when
+  // nothing assigns to the name. So it still rejects the assignment, although
+  // the target can be a property of the `with` object.
+  itBundled("minify/ConstAssignInsideWithIsStillABundleError", {
+    files: {
+      "/entry.cjs": /* js */ `
+        function f(o) { const x = 1; with (o) { x = 5; } return o.x; }
+        console.log(f({ x: 2 }));
+      `,
+    },
+    format: "cjs",
+    outfile: "/out.cjs",
+    bundleErrors: {
+      "/entry.cjs": ['Cannot assign to "x" because it is a constant'],
+    },
+  });
   itBundled("minify/TemplateStringFolding", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -193,6 +193,110 @@ describe("with statement", () => {
 
     expect(exitCode).toBe(0);
   });
+
+  // The `with` object can have a property with the name of a `const` from an
+  // enclosing scope. Inside the `with` body that property shadows the const.
+  // Each fixture prints JSON, and each expected value is what Node prints.
+  // A `.cjs` file runs in sloppy mode, which `with` needs.
+  async function runSloppy(source: string) {
+    using dir = tempDir("with-shadows-const", { "index.cjs": source });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.concurrent("a read in the body is not replaced by the value of a shadowed const", async () => {
+    const { stdout, stderr, exitCode } = await runSloppy(/* js */ `
+      const top = "const";
+      function read(o) { const x = "const"; with (o) { return x; } }
+      function closure(o) { const x = "const"; with (o) { return (() => x)(); } }
+      function nested(a, b) { const x = "const"; with (a) { with (b) { return x; } } }
+      function outsideAndInside(o) { const x = "const"; const before = x; with (o) { return [before, x]; } }
+      function typeOf(o) { const x = "const"; with (o) { return typeof x; } }
+      function topLevel(o) { with (o) { return top; } }
+      // A const declared in the body's own block shadows the with object.
+      function declaredInBody(o) { with (o) { const x = "const"; return x; } }
+      // The cases of a switch share one scope, and the read is in a later case.
+      function laterCase(k, o) { switch (k) { case 1: const x = "const"; case 2: with (o) { return x; } } }
+      console.log(
+        JSON.stringify({
+          read: [read({ x: "with" }), read({})],
+          closure: [closure({ x: "with" }), closure({})],
+          nested: [nested({ x: "outer" }, {}), nested({ x: "outer" }, { x: "inner" }), nested({}, {})],
+          outsideAndInside: outsideAndInside({ x: "with" }),
+          typeOf: [typeOf({ x: 1 }), typeOf({})],
+          topLevel: [topLevel({ top: "with" }), topLevel({})],
+          declaredInBody: declaredInBody({ x: "with" }),
+          laterCase: [laterCase(1, { x: "with" }), laterCase(1, {})],
+        }),
+      );
+    `);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      read: ["with", "const"],
+      closure: ["with", "const"],
+      nested: ["outer", "inner", "const"],
+      outsideAndInside: ["const", "with"],
+      typeOf: ["number", "string"],
+      topLevel: ["with", "const"],
+      declaredInBody: "const",
+      laterCase: ["with", "const"],
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("an assignment in the body can target the with object instead of a const", async () => {
+    const { stdout, stderr, exitCode } = await runSloppy(/* js */ `
+      function assign(o) { const x = 1; with (o) { x = 5; } return [o.x, x]; }
+      function compound(o) { const x = 1; with (o) { x += 5; } return [o.x, x]; }
+      function update(o) { const x = 1; with (o) { x++; } return [o.x, x]; }
+      function destructure(o) { const x = 1; with (o) { [x] = [7]; } return [o.x, x]; }
+      function forIn(o) { const x = 1; with (o) { for (x in { key: 0 }); } return [o.x, x]; }
+      function closure(o) { const x = 1; with (o) { (() => { x = 5; })(); } return [o.x, x]; }
+      function notLiteral(o) { const x = {}; with (o) { x = 5; } return [o.x, typeof x]; }
+      // Without the property, the assignment reaches the const and throws at run time.
+      function noProperty(o) { const x = 1; try { with (o) { x = 5; } } catch (e) { return [e.constructor.name, x]; } }
+      // https://github.com/oven-sh/bun/issues/13992, the fourth snippet
+      const obj = { obj: 2 };
+      with (obj) {
+        obj = 10;
+      }
+      console.log(
+        JSON.stringify({
+          assign: assign({ x: 2 }),
+          compound: compound({ x: 2 }),
+          update: update({ x: 2 }),
+          destructure: destructure({ x: 2 }),
+          forIn: forIn({ x: 2 }),
+          closure: closure({ x: 2 }),
+          notLiteral: notLiteral({ x: 2 }),
+          noProperty: noProperty({}),
+          obj,
+        }),
+      );
+    `);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      assign: [5, 1],
+      compound: [7, 1],
+      update: [3, 1],
+      destructure: [7, 1],
+      forIn: ["key", 1],
+      closure: [5, 1],
+      notLiteral: [5, "object"],
+      noProperty: ["TypeError", 1],
+      obj: { obj: 10 },
+    });
+    expect(exitCode).toBe(0);
+  });
 });
 
 test("math.pow", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4001,6 +4001,82 @@ console.log(foo, array);
       );
     });
 
+    // The `with` object can have a property with the name of the const. That
+    // property shadows the const, so the read must stay a read.
+    it("const inlining keeps a read inside a with statement", () => {
+      var transpiler = new Bun.Transpiler({
+        inline: true,
+        platform: "bun",
+        allowBunRuntime: false,
+        minify: { syntax: true },
+      });
+
+      function check(input, output) {
+        expect(transpiler.transformSync(input)).toBe(output);
+      }
+      hideFromStackTrace(check);
+
+      check(
+        "function f(o) { const x = 1; with (o) { return x; } }",
+        "function f(o) {\n  const x = 1;\n  with (o)\n    return x;\n}\n",
+      );
+      check(
+        "function f(o) { const x = 1; with (o) { return typeof x; } }",
+        "function f(o) {\n  const x = 1;\n  with (o)\n    return typeof x;\n}\n",
+      );
+      // A function created in the body captures the `with` object.
+      check(
+        "function f(o) { const x = 1; with (o) { return () => x; } }",
+        "function f(o) {\n  const x = 1;\n  with (o)\n    return () => x;\n}\n",
+      );
+      check(
+        "function f(a, b) { const x = 1; with (a) { with (b) { return x; } } }",
+        "function f(a, b) {\n  const x = 1;\n  with (a)\n    with (b)\n      return x;\n}\n",
+      );
+      check("const x = 1; with (o) { console.log(x); }", "const x = 1;\nwith (o)\n  console.log(x);\n");
+
+      // A read outside the body is still inlined. The read inside keeps the declaration.
+      check(
+        "function f(o) { const x = 1; g(x); with (o) { return x; } }",
+        "function f(o) {\n  const x = 1;\n  g(1);\n  with (o)\n    return x;\n}\n",
+      );
+      // The cases of a switch share one scope. A read in a later case keeps the declaration.
+      check(
+        "function f(k, o) { switch (k) { case 1: const x = 1; case 2: with (o) { return x; } } }",
+        "function f(k, o) {\n  switch (k) {\n    case 1:\n      const x = 1;\n    case 2:\n      with (o)\n        return x;\n  }\n}\n",
+      );
+      // The `with` object expression is evaluated outside the body.
+      check("function f() { const x = 1; with (x) { return y; } }", "function f() {\n  with (1)\n    return y;\n}\n");
+      // A const declared in the body's own block shadows the `with` object.
+      check("function f(o) { with (o) { const x = 1; return x; } }", "function f(o) {\n  with (o)\n    return 1;\n}\n");
+    });
+
+    // The target can be a property of the `with` object, so the assignment is
+    // not a const assignment error and the name is not replaced by the value.
+    it("allows an assignment to the name of a const inside a with statement", () => {
+      var transpiler = new Bun.Transpiler({
+        inline: true,
+        platform: "bun",
+        allowBunRuntime: false,
+        minify: { syntax: true },
+      });
+
+      expect(transpiler.transformSync("function f(o) { const x = 1; with (o) { x = 5; } }")).toBe(
+        "function f(o) {\n  const x = 1;\n  with (o)\n    x = 5;\n}\n",
+      );
+      expect(transpiler.transformSync("function f(o) { const x = {}; with (o) { x++; } }")).toBe(
+        "function f(o) {\n  const x = {};\n  with (o)\n    x++;\n}\n",
+      );
+
+      // Outside the body the assignment is still an error.
+      expect(() => transpiler.transformSync("function f(o) { const x = 1; with (o) {} x = 5; }")).toThrow(
+        'Cannot assign to "x" because it is a constant',
+      );
+      expect(() => transpiler.transformSync("function f(o) { const x = {}; with (o) {} x++; }")).toThrow(
+        'This assignment will throw because "x" is a constant',
+      );
+    });
+
     it("constant folding scopes", () => {
       var transpiler = new Bun.Transpiler({
         inline: true,

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4075,6 +4075,16 @@ console.log(foo, array);
       expect(() => transpiler.transformSync("function f(o) { const x = {}; with (o) {} x++; }")).toThrow(
         'This assignment will throw because "x" is a constant',
       );
+
+      // A lowered top-level `using` prints each top-level `const` as `var`. Nothing
+      // would stop the assignment then, so the error stays.
+      const source = "using r = null; const x = 1; function f(o) { with (o) { x = 5; } }";
+      expect(() => new Bun.Transpiler({ target: "browser" }).transformSync(source)).toThrow(
+        'This assignment will throw because "x" is a constant',
+      );
+      expect(new Bun.Transpiler({ target: "bun" }).transformSync(source)).toBe(
+        "let r = null;\nconst x = 1;\nfunction f(o) {\n  with (o)\n    x = 5;\n}\n",
+      );
     });
 
     it("constant folding scopes", () => {


### PR DESCRIPTION
### Problem
- `function f(o) { const x = 1; with (o) { return x; } }` returns `1` for `f({ x: 2 })` under `bun file.cjs`. Node returns `2`: `o.x` shadows the const. `P::handle_identifier` (`src/js_parser/p.rs:2182`) replaces every read of a symbol in `const_values` and ignores the `with` scope.
- `const obj = { obj: 2 }; with (obj) { obj = 10; }` does not load: `error: This assignment will throw because "obj" is a constant`. Node assigns to the property. This is the fourth snippet of #13992. The check is in `e_identifier` (`src/js_parser/visit/visit_expr.rs:200`).

### Fix
- `handle_identifier` skips the substitution when `ident.must_keep_due_to_with_stmt()` is set. `EXPECTED_VERSION` moves to 31: the runtime transpiler's cached output changes.
- `e_identifier` skips the const assignment error inside a `with` body. The error stays where `select_local_kind` can print `const` as `let` or `var`: in the bundler, and below a lowered top-level `using`.
- The pass that removes inlined `const` declarations (`src/js_parser/visit/mod.rs:1810`) skips switch case lists. It runs per case, before later cases are visited. A kept read in a later case would lose its declaration.
- Verified: new cases in `runtime-transpiler.test.ts`, `transpiler.test.js`, `bundler_minify.test.ts`. Five fail on bun 1.4.3. Also ran `test/bundler/transpiler/`, `esbuild/default`, `esbuild/dce`.

### Background
- Const inlining: the visit pass records a literal `const` in `const_values` and replaces later reads. A declaration with no reads left is removed.
- `with (o) { ... }` puts `o` in the scope chain of its body. A bare name there reads or writes `o.name` when `o` has that property.
- `find_symbol` sets `is_inside_with_scope` when the lookup passes a `with` scope before the declaration. `e_identifier` copies it to the identifier. User defines already skip such identifiers (`visit_expr.rs:257`).
- The cases of a `switch` share one scope. Each case body is visited as its own statement list.

<details><summary>Notes</summary>

**Origin.** The read half comes from a read of the code, not from a user report. The assignment half is the fourth snippet of #13992 ("the const reassignment error shouldn't be triggering when not in strict mode"). The other three snippets of #13992 are not changed. esbuild has the same gap in `handleIdentifier` (checked against `evanw/esbuild` main), so the read half is a deviation from esbuild toward Node on purpose.

**What still inlines.** A const declared in the body's own block (`with (o) { const x = 1; return x; }`) is found before the lookup reaches the `with` scope, so it is still inlined. A read outside the body is still inlined. The `with (expr)` object expression is outside the body and is still inlined.

**The assignment check and `select_local_kind`.** When bundling, `select_local_kind` prints a top-level `const` as `var`, and with `--minify-syntax` a nested `const` as `let`. Without the bundler it also prints a top-level `const` as `var` when a lowered top-level `using` wraps the module in a `try` block (`will_wrap_module_in_try_catch_for_using`, for example `--target=browser`). That is only safe when nothing assigns to the name. So in both cases the const assignment error stays inside a `with` body. Otherwise `bun run`, `bun build --no-bundle`, and `Bun.Transpiler` accept the assignment. If `o` does not have the property, the assignment reaches the const and JSC throws a `TypeError` at run time, as in Node. Without the `handle_identifier` change, the accepted assignment would print as `1 = 5`.

**The switch case guard.** On main every read of an inlined const that is visited after its declaration is replaced, so the early removal in a switch case was harmless. With this PR a read inside a `with` body stays. For `switch (k) { case 1: const x = "const"; case 2: with (o) { return x; } }` the declaration was removed when case 1 ended, and the read in case 2 threw `ReferenceError: x is not defined`. The guard costs one dead statement in minified output: `switch (k) { case 1: const x = 1; return x; }` prints `case 1: const x = 1; return 1;`. Braced case bodies have their own scope and are not affected. No existing test depends on the removal. esbuild now disables const inlining in switch cases entirely. #41848 runs the removal after every case is visited, which makes this guard unnecessary. #40791 and #30936 touch the same area. Each of them conflicts with main today, so this PR does not build on them.

**TypeScript is not changed.** `with (o) { return E.A; }` in a `.cts` file still prints `1 /* A */`. TypeScript rejects `with` (TS2410, and TS1101 because TS 6 files are strict), and tsc 6.0.2 itself inlines `const enum` members inside a `with` body (`return 7 /* C.X */`).

**Adjacent sites, not changed here.**
- #40801 adds a direct `eval` check to the same `if` line in `handle_identifier`. The conflict is textual only.
- Folds of known global constructors (`new Array(1, 2)`) inside `with` are handled in a separate change in `src/ast/known_global.rs`.
- `function f() { const x = 1; return delete x; }` prints `delete 1`. This does not depend on `with`.
- Other open PRs also move `EXPECTED_VERSION` to 31. The one that lands second moves it again.

**Test matrix.** The run-time fixtures are sloppy `.cjs` files. Each expected value is what Node v26.3.0 prints. Reads: plain, in a closure, nested `with`, `typeof`, top-level const, const in the body's own block, switch fall-through. Assignments: `=`, `+=`, `++`, array destructuring, `for-in` target, in a closure, a const that is not a literal, the missing-property `TypeError`, and the #13992 snippet. `minify/ConstAssignInsideWithIsStillABundleError` pins the bundler exception. It passes with and without this change. `transpiler.test.js` pins the lowered `using` exception (`target: "browser"` throws, `target: "bun"` accepts).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_minify.test.ts test/bundler/transpiler/runtime-transpiler.test.ts test/bundler/transpiler/transpiler.test.js
ninja: Entering directory `/workspace/bun/build/debug'
[1/51] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[3/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-16.cpp.o
[4/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-21.cpp.o
[5/51] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[6/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-7.cpp.o
[7/51] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[8/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-13.cpp.o
[9/51] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[10/51] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-9.cpp.o
[11/51] cxx obj/src/jsc/bindings/bindings.cpp.o
[12/51] cxx obj/src/jsc/bindings/webcore/streams/CrossRealmTransform.cpp.o
[13/51] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[14/51] cxx obj/src/jsc/bindings/webco
... (truncated)

release without fix: 5 failed, 22 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/DirectEvalKeepsTopLevelNamesOfWrappedFile [25.80ms]
34 |     minifySyntax: true,
35 |     format: "cjs",
36 |     outfile: "/out.cjs",
37 |     onAfterBundle(api) {
38 |       // The bundler prints the declarations as `let`.
39 |       api.expectFile("/out.cjs").toContain('x = "const"');
                                      ^
error: expect(received).toContain(expected)

Expected to contain: "x = \"const\""
Received: "// entry.cjs\nfunction f(o) {\n  with (o)\n    return \"const\";\n}\nfunction g(k, o) {\n  switch (k) {\n    case 1:\n    case 2:\n      with (o)\n        return \"const\";\n  }\n}\nconsole.log(f({ x: \"with\" }), f({}), g(1, { y: \"with\" }), g(1, {}));\n"

      at onAfterBundle (/workspace/bun/test/bundler/bundler_minify.test.ts:39:34)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1658:13)
(fail) bundler > minify/ConstReadInsideWithIsNotInlined [5.73ms]
(pass) bundler > minify/ConstAssignInsideWithIsStillABundleError [4.12ms]
(pass) bundler > minify/TemplateStringFolding [4.26ms]
(pass) bundler > minify/StringAdditionFolding [3.91m
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_minify.test.ts test/bundler/transpiler/runtime-transpiler.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (6a92015fc)

test/bundler/bundler_minify.test.ts:
(pass) bundler > minify/DirectEvalKeepsTopLevelNamesOfWrappedFile [882.84ms]
(pass) bundler > minify/ConstReadInsideWithIsNotInlined [395.78ms]
(pass) bundler > minify/ConstAssignInsideWithIsStillABundleError [111.96ms]
(pass) bundler > minify/TemplateStringFolding [162.22ms]
(pass) bundler > minify/StringAdditionFolding [127.91ms]
(pass) bundler > minify/FunctionExpressionRemoveName [107.80ms]
(pass) bundler > minify/KeepNamesPreservesNames [100.40ms]
(pass) bundler > minify/KeepNamesWithMinifyIdentifiers [96.14ms]
(pass) bundler > minify/PrivateIdentifiersNameCollision [1251.71ms]
(pass) bundler > minify/MergeAdjacentVars [384.65ms]
(pass) bundler > minify/UnusedCommaAndStrictEqChains [448.23ms]
(pass) bundler > minify/Infinity [147.52ms]
(pass) bundler > minify+whitespace/Infinity [112.22ms]
(pass) bundler > minify/NumericPropertyKeysPrinted
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 629ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/52] cxx obj/src/jsc/bindings/sqlite/JSSQLStatement.cpp.o
[2/52] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[3/52] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[4/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[5/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[6/52] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[7/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[8/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[9/52] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[10/52] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-1.cpp.o
[11/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[12/52] cxx obj/src/jsc/bindings/bindings.cpp.o
[13/52] cxx obj/src/jsc/bindings/webcore/streams/CrossRealmTransform.cpp.o
[14/52] cxx obj/src/jsc/bindings/sqlite/NodeSqlite.cpp.o
[15/52] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[16/52] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[17/52
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                                 |   3 +-
 src/js_parser/visit/mod.rs                         |   5 +-
 src/js_parser/visit/visit_expr.rs                  |   5 +
 src/jsc/RuntimeTranspilerCache.rs                  |   3 +-
 test/bundler/bundler_minify.test.ts                |  40 ++++++++
 test/bundler/transpiler/runtime-transpiler.test.ts | 104 +++++++++++++++++++++
 test/bundler/transpiler/transpiler.test.js         |  86 +++++++++++++++++
 7 files changed, 243 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js_parser/p.rs                                      3      2     27
src/js_parser/visit/mod.rs                              3      3     27
src/js_parser/visit/visit_expr.rs                       3      3     27
src/jsc/RuntimeTranspilerCache.rs                       1      1     27
test/bundler/bundler_minify.test.ts                     2      3     15
test/bundler/transpiler/runtime-transpiler.test.ts      2      2     13
test/bundler/transpiler/transpiler.test.js              3      4     17
```

</details>

<!-- robobun:evidence:end -->