### PR TITLE
node:net: run a nextTick and microtask checkpoint between the onread callbacks of one native read

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1779,9 +1779,7 @@ function Socket(options?) {
         }
         if (self.destroyed) return;
         let stop = ret === false || !self[kOnreadReading];
-        // Each read is its own MakeCallback in node, which ends with the tick queue and the microtasks drained. A nested
-        // scope skips that, and a socket that wraps a stream is called from inside that stream's 'data' emit.
-        // https://github.com/nodejs/node/blob/v26.3.0/src/api/callback.cc#L165-L207
+        // Node drains ticks and microtasks after each read, except in a nested scope (a wrapped stream's 'data' emit): https://github.com/nodejs/node/blob/v26.3.0/src/api/callback.cc#L165-L207
         if (!stop && offset < total && !self[kupgraded]) {
           const handle = self._handle;
           onreadCheckpoints++;
@@ -2370,8 +2368,7 @@ function drainOnreadTail(self) {
 }
 
 function drainOnreadTailNT(socket) {
-  // This tick came due inside the checkpoint between two slices of another socket. Its own slices and checkpoints
-  // would nest in there, one level per socket with a tail, so it runs from the event loop instead.
+  // Inside the checkpoint of another socket this drain would nest, one level per socket with a tail.
   if (onreadCheckpoints !== 0) {
     setImmediate(drainOnreadTailNT, socket);
     return;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -122,6 +122,7 @@ function lazyBlockList() {
 }
 const newDetachedSocket = $newRustFunction("node_net_binding.rs", "newDetachedSocket", 1);
 const doConnect = $newRustFunction("node_net_binding.rs", "doConnect", 2);
+const drainMicrotasksAndNextTicks = $newRustFunction("node_net_binding.rs", "drainMicrotasksAndNextTicks", 0);
 
 const addServerName = $newRustFunction("Listener.rs", "jsAddServerName", 3);
 const upgradeDuplexToTLS = $newRustFunction("runtime/socket/socket.rs", "jsUpgradeDuplexToTLS", 2);
@@ -194,6 +195,8 @@ const kOnreadPendingEnd = Symbol("kOnreadPendingEnd");
 // Node's handle.reading: https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L817-L845
 const kOnreadReading = Symbol("kOnreadReading");
 const kOnreadEmptyTail = Buffer.alloc(0);
+// Not zero while the checkpoint between two onread slices runs: see drainOnreadTailNT.
+let onreadCheckpoints = 0;
 const kwriteCallback = Symbol("writeCallback");
 const kSocketClass = Symbol("kSocketClass");
 
@@ -1775,7 +1778,23 @@ function Socket(options?) {
           reportError(e);
         }
         if (self.destroyed) return;
-        if (ret === false || !self[kOnreadReading]) {
+        let stop = ret === false || !self[kOnreadReading];
+        // Each read is its own MakeCallback in node, which ends with the tick queue and the microtasks drained. A nested
+        // scope skips that, and a socket that wraps a stream is called from inside that stream's 'data' emit.
+        // https://github.com/nodejs/node/blob/v26.3.0/src/api/callback.cc#L165-L207
+        if (!stop && offset < total && !self[kupgraded]) {
+          const handle = self._handle;
+          onreadCheckpoints++;
+          try {
+            drainMicrotasksAndNextTicks();
+          } finally {
+            onreadCheckpoints--;
+          }
+          // The rest of the chunk belongs to the connection that read it.
+          if (self.destroyed || self.connecting || self._handle !== handle) return;
+          stop = !self[kOnreadReading];
+        }
+        if (stop) {
           const rest = buffer.subarray(offset);
           self[kOnreadTail] = rest.length !== 0 ? rest : kOnreadEmptyTail;
           readStop(self, self._handle);
@@ -2351,6 +2370,12 @@ function drainOnreadTail(self) {
 }
 
 function drainOnreadTailNT(socket) {
+  // This tick came due inside the checkpoint between two slices of another socket. Its own slices and checkpoints
+  // would nest in there, one level per socket with a tail, so it runs from the event loop instead.
+  if (onreadCheckpoints !== 0) {
+    setImmediate(drainOnreadTailNT, socket);
+    return;
+  }
   socket[kOnreadDraining] = false;
   const tail = socket[kOnreadTail];
   if (tail === undefined || socket.destroyed) return;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1788,8 +1788,7 @@ function Socket(options?) {
           } finally {
             onreadCheckpoints--;
           }
-          // The rest of the chunk belongs to the connection that read it.
-          if (self.destroyed || self.connecting || self._handle !== handle) return;
+          if (onreadConnectionGone(self, handle)) return;
           stop = !self[kOnreadReading];
         }
         if (stop) {
@@ -2356,6 +2355,11 @@ function hasUnflushedWrites(connection) {
   return connection.writableLength > 0 || connection[kwriteCallback] != null;
 }
 
+// The rest of a chunk, and a FIN that waits behind it, belong to the connection that read them.
+function onreadConnectionGone(self, handle) {
+  return self.destroyed || self.connecting || self._handle !== handle;
+}
+
 // The tail is delivered on the next tick. A pause() before then clears kOnreadReading and the tick delivers nothing.
 function drainOnreadTail(self) {
   if (self[kOnreadTail] === undefined) return false;
@@ -2378,8 +2382,13 @@ function drainOnreadTailNT(socket) {
   if (tail === undefined || socket.destroyed) return;
   if (!socket[kOnreadReading]) return;
   socket[kOnreadTail] = undefined;
+  const handle = socket._handle;
   socket[kOnreadDeliver](tail);
-  if (socket[kOnreadTail] !== undefined || socket.destroyed) return;
+  if (onreadConnectionGone(socket, handle)) {
+    socket[kOnreadPendingEnd] = false;
+    return;
+  }
+  if (socket[kOnreadTail] !== undefined) return;
   if (socket[kOnreadPendingEnd]) {
     socket[kOnreadPendingEnd] = false;
     finishSocketEnd(socket);

--- a/src/runtime/node/node_net_binding.rs
+++ b/src/runtime/node/node_net_binding.rs
@@ -173,3 +173,16 @@ pub(crate) fn do_connect(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
     let maybe_tls = prev.as_::<TLSSocket>();
     Listener::connect_inner(global, maybe_tcp, maybe_tls, opts)
 }
+
+/// The checkpoint that ends a callback scope, for net.ts to run between two `onread` callbacks that
+/// it slices out of one native read: node makes one read, and so one callback scope, per callback.
+#[bun_jsc::host_fn]
+pub(crate) fn drain_microtasks_and_next_ticks(
+    global: &JSGlobalObject,
+    _frame: &CallFrame,
+) -> JsResult<JSValue> {
+    global
+        .drain_microtasks_and_next_ticks()
+        .map_err(|stopped| stopped.throw(global))?;
+    Ok(JSValue::UNDEFINED)
+}

--- a/src/runtime/node/node_net_binding.rs
+++ b/src/runtime/node/node_net_binding.rs
@@ -174,8 +174,7 @@ pub(crate) fn do_connect(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
     Listener::connect_inner(global, maybe_tcp, maybe_tls, opts)
 }
 
-/// The checkpoint that ends a callback scope, for net.ts to run between two `onread` callbacks that
-/// it slices out of one native read: node makes one read, and so one callback scope, per callback.
+/// net.ts calls this between two `onread` callbacks of one native read, where node ends a callback scope.
 #[bun_jsc::host_fn]
 pub(crate) fn drain_microtasks_and_next_ticks(
     global: &JSGlobalObject,

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -30,7 +30,8 @@ import {
   Stream,
 } from "node:net";
 import { join } from "node:path";
-import { TLSSocket } from "node:tls";
+import { Duplex } from "node:stream";
+import { createServer as createTLSServer, connect as tlsConnect, TLSSocket } from "node:tls";
 
 const socket_domain = tmpdirSync();
 
@@ -2957,6 +2958,405 @@ it("onread: a swallowed throw does not drop the rest of the current native read"
   // read were delivered with no gap and no socket 'error'.
   expect(stdout.split("\n").filter(Boolean)).toEqual(["uncaught:onread-boom", "calls:abcd,efgh,ijkl"]);
   expect(exitCode).toBe(0);
+});
+
+// Node reads one onread buffer per callback scope (MakeCallback), and a scope
+// ends with the tick queue and the microtasks drained. Bun slices one larger
+// native read into several callbacks, so it runs that checkpoint between two
+// slices. Every expectation below is what node v26.3.0 does.
+// https://github.com/nodejs/node/blob/v26.3.0/src/api/callback.cc#L165-L207
+describe("net.Socket onread: the callbacks of one native read are separate callback scopes", () => {
+  // One 12-byte write is one native read; a 4-byte onread buffer makes three callbacks out of it.
+  const payload = "abcdefghijkl";
+  const slices = ["abcd", "efgh", "ijkl"];
+  const transports = ["tcp", "tls"] as const;
+
+  async function startServer(transport: (typeof transports)[number]) {
+    const onConnection = (c: Socket) => {
+      c.on("error", () => {});
+      c.end(payload);
+    };
+    const server =
+      transport === "tls"
+        ? createTLSServer({ key: tlsCert.key, cert: tlsCert.cert }, onConnection)
+        : createServer(onConnection);
+    const listening = Promise.withResolvers<void>();
+    server.once("error", listening.reject);
+    server.listen(0, "127.0.0.1", () => listening.resolve());
+    await listening.promise;
+    server.off("error", listening.reject);
+    return server;
+  }
+
+  function dial(
+    transport: (typeof transports)[number],
+    server: Server,
+    callback: (this: unknown, nread: number, buf: Buffer) => boolean | void,
+  ): Socket {
+    const options = {
+      port: (server.address() as import("node:net").AddressInfo).port,
+      host: "127.0.0.1",
+      onread: { buffer: Buffer.alloc(4), callback },
+    };
+    return transport === "tls" ? tlsConnect({ ...options, rejectUnauthorized: false }) : createConnection(options);
+  }
+
+  const immediate = () => new Promise<void>(resolve => setImmediate(resolve));
+
+  it.each(transports)(
+    "%s: the ticks and microtasks a callback queued run before the next callback",
+    async transport => {
+      const server = await startServer(transport);
+      const log: string[] = [];
+      const closed = Promise.withResolvers<void>();
+      let socket: Socket | undefined;
+      try {
+        socket = dial(transport, server, (n, buf) => {
+          log.push(`callback ${buf.toString("latin1", 0, n)}`);
+          // The tick and the microtask read the static buffer: it still holds the bytes of their own callback.
+          process.nextTick(() => log.push(`tick ${buf.toString("latin1", 0, n)}`));
+          queueMicrotask(() => log.push(`microtask ${buf.toString("latin1", 0, n)}`));
+        });
+        socket.on("error", closed.reject);
+        socket.on("close", () => closed.resolve());
+        await closed.promise;
+        expect(log).toEqual(slices.flatMap(slice => [`callback ${slice}`, `tick ${slice}`, `microtask ${slice}`]));
+      } finally {
+        socket?.destroy();
+        server.close();
+      }
+    },
+  );
+
+  it.each([
+    ["queueMicrotask", (fn: () => void) => queueMicrotask(fn)],
+    ["process.nextTick", (fn: () => void) => process.nextTick(fn)],
+    ["a promise reaction", (fn: () => void) => void Promise.resolve().then(fn)],
+  ])("a pause() deferred with %s stops the rest of the read until resume()", async (_name, defer) => {
+    const server = await startServer("tcp");
+    const received: string[] = [];
+    const paused = Promise.withResolvers<string[]>();
+    const done = Promise.withResolvers<void>();
+    let socket: Socket | undefined;
+    try {
+      socket = dial("tcp", server, (n, buf) => {
+        received.push(buf.toString("latin1", 0, n));
+        if (received.length === 1) {
+          defer(() => {
+            socket!.pause();
+            paused.resolve([...received]);
+          });
+        }
+        if (received.length === slices.length) done.resolve();
+      });
+      socket.on("error", done.reject);
+      socket.on("close", () => done.reject(new Error(`closed before all data was delivered: ${received.join("|")}`)));
+      expect(await paused.promise).toEqual(["abcd"]);
+      // The rest of the read waits for resume(), it is not delivered on a later turn.
+      for (let i = 0; i < 4; i++) await immediate();
+      expect(received).toEqual(["abcd"]);
+      socket.resume();
+      await done.promise;
+      expect(received).toEqual(slices);
+    } finally {
+      socket?.destroy();
+      server.close();
+    }
+  });
+
+  it("a deferred destroy() drops the rest of the read", async () => {
+    const server = await startServer("tcp");
+    const received: string[] = [];
+    const closed = Promise.withResolvers<void>();
+    let socket: Socket | undefined;
+    try {
+      socket = dial("tcp", server, (n, buf) => {
+        received.push(buf.toString("latin1", 0, n));
+        queueMicrotask(() => socket!.destroy());
+      });
+      socket.on("error", closed.reject);
+      socket.on("close", () => closed.resolve());
+      await closed.promise;
+      expect(received).toEqual(["abcd"]);
+    } finally {
+      socket?.destroy();
+      server.close();
+    }
+  });
+
+  it("a deferred destroy() then connect() does not hand the rest of the old read to the new connection", async () => {
+    const first = await startServer("tcp");
+    const second = createServer(c => {
+      c.on("error", () => {});
+      c.end("XXXXYYYY");
+    });
+    const listening = Promise.withResolvers<void>();
+    second.once("error", listening.reject);
+    second.listen(0, "127.0.0.1", () => listening.resolve());
+    await listening.promise;
+    const received: [number, string][] = [];
+    const done = Promise.withResolvers<void>();
+    let generation = 1;
+    const socket = new Socket({
+      onread: {
+        buffer: Buffer.alloc(4),
+        callback(n: number, buf: Buffer) {
+          const slice = buf.toString("latin1", 0, n);
+          received.push([generation, slice]);
+          if (received.length === 1) {
+            process.nextTick(() => {
+              socket.destroy();
+              generation = 2;
+              socket.connect((second.address() as import("node:net").AddressInfo).port, "127.0.0.1");
+            });
+          }
+          if (slice === "YYYY") done.resolve();
+        },
+      },
+    });
+    try {
+      socket.on("error", done.reject);
+      socket.connect((first.address() as import("node:net").AddressInfo).port, "127.0.0.1");
+      await done.promise;
+      expect(received).toEqual([
+        [1, "abcd"],
+        [2, "XXXX"],
+        [2, "YYYY"],
+      ]);
+    } finally {
+      socket.destroy();
+      first.close();
+      second.close();
+    }
+  });
+
+  it("the tail that resume() redelivers gets the same checkpoints", async () => {
+    const server = await startServer("tcp");
+    const log: string[] = [];
+    const declined = Promise.withResolvers<void>();
+    const closed = Promise.withResolvers<void>();
+    let socket: Socket | undefined;
+    try {
+      socket = dial("tcp", server, (n, buf) => {
+        const slice = buf.toString("latin1", 0, n);
+        log.push(`callback ${slice}`);
+        process.nextTick(() => log.push(`tick ${slice}`));
+        queueMicrotask(() => log.push(`microtask ${slice}`));
+        if (slice === "abcd") {
+          declined.resolve();
+          return false;
+        }
+      });
+      socket.on("error", closed.reject);
+      socket.on("close", () => closed.resolve());
+      await declined.promise;
+      await immediate();
+      log.push("resume");
+      socket.resume();
+      await closed.promise;
+      expect(log).toEqual([
+        "callback abcd",
+        "tick abcd",
+        "microtask abcd",
+        "resume",
+        ...slices.slice(1).flatMap(slice => [`callback ${slice}`, `tick ${slice}`, `microtask ${slice}`]),
+      ]);
+    } finally {
+      socket?.destroy();
+      server.close();
+    }
+  });
+
+  // The checkpoint runs user code while the loop still holds the rest of the read.
+  it.each([
+    ["pause() then resume() in one tick", (socket: Socket) => process.nextTick(() => socket.pause().resume())],
+    [
+      "pause() in a tick, resume() in the microtask after it",
+      (socket: Socket) =>
+        process.nextTick(() => {
+          socket.pause();
+          queueMicrotask(() => socket.resume());
+        }),
+    ],
+    ["read() in a microtask", (socket: Socket) => queueMicrotask(() => socket.read())],
+    // pause() stops the handle and read() starts it again: https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L817-L845
+    ["pause() then read() in one tick", (socket: Socket) => process.nextTick(() => void socket.pause().read())],
+    ["pause() then read() in one microtask", (socket: Socket) => queueMicrotask(() => void socket.pause().read())],
+    [
+      "pause() then read() in one promise reaction",
+      (socket: Socket) => void Promise.resolve().then(() => void socket.pause().read()),
+    ],
+  ])("%s keeps the read going, each slice once and in order", async (_name, reenter) => {
+    const server = await startServer("tcp");
+    const received: string[] = [];
+    const closed = Promise.withResolvers<void>();
+    let socket: Socket | undefined;
+    try {
+      socket = dial("tcp", server, (n, buf) => {
+        received.push(buf.toString("latin1", 0, n));
+        reenter(socket!);
+      });
+      socket.on("error", closed.reject);
+      socket.on("close", () => closed.resolve());
+      await closed.promise;
+      expect(received).toEqual(slices);
+    } finally {
+      socket?.destroy();
+      server.close();
+    }
+  });
+
+  // A tail drain is a tick, so the checkpoint of one socket would run the tail drain of the next one inside it.
+  it("tail drains of several sockets that come due in one turn do not nest", async () => {
+    const server = await startServer("tcp");
+    const count = 3;
+    const received: string[][] = [];
+    const sockets: Socket[] = [];
+    const closed: Promise<void>[] = [];
+    const allDeclined = Promise.withResolvers<void>();
+    let declined = 0;
+    // Callbacks whose tick did not run yet: 1 when every callback is followed by its own checkpoint.
+    let pending = 0;
+    let maxPending = 0;
+    try {
+      for (let i = 0; i < count; i++) {
+        const mine: string[] = [];
+        received.push(mine);
+        const { promise, resolve, reject } = Promise.withResolvers<void>();
+        closed.push(promise);
+        const socket = dial("tcp", server, (n, buf) => {
+          mine.push(buf.toString("latin1", 0, n));
+          if (mine.length === 1) {
+            if (++declined === count) allDeclined.resolve();
+            return false;
+          }
+          maxPending = Math.max(maxPending, ++pending);
+          process.nextTick(() => pending--);
+        });
+        socket.on("error", reject);
+        socket.on("close", () => resolve());
+        sockets.push(socket);
+      }
+      await allDeclined.promise;
+      await immediate();
+      for (const socket of sockets) socket.resume();
+      await Promise.all(closed);
+      expect(received).toEqual([slices, slices, slices]);
+      expect(maxPending).toBe(1);
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      server.close();
+    }
+  });
+
+  // A socket that wraps another stream reads from inside that stream's 'data' emit: a nested scope, which does not
+  // drain. Holds the same if `onread` is ignored for a wrapped socket, as in node.
+  it("a TLS socket over a generic Duplex does not run the Duplex's ticks inside its 'data' emit", async () => {
+    const server = createTLSServer({ key: tlsCert.key, cert: tlsCert.cert }, c => {
+      c.on("error", () => {});
+      c.once("data", () => c.end(payload));
+    });
+    const listening = Promise.withResolvers<void>();
+    server.once("error", listening.reject);
+    server.listen(0, "127.0.0.1", () => listening.resolve());
+    await listening.promise;
+    const log: string[] = [];
+    let received = "";
+    let secure = false;
+    const closed = Promise.withResolvers<void>();
+    const raw = createConnection({
+      port: (server.address() as import("node:net").AddressInfo).port,
+      host: "127.0.0.1",
+    });
+    const transport = new Duplex({
+      read() {},
+      write(chunk, _encoding, callback) {
+        raw.write(chunk, callback);
+      },
+      final(callback) {
+        raw.end(callback);
+      },
+    });
+    let client: Socket | undefined;
+    try {
+      raw.on("error", closed.reject);
+      raw.on("end", () => transport.push(null));
+      raw.on("data", chunk => {
+        if (!secure) return void transport.push(chunk);
+        // One tick emits 'data' on the transport, a second one is queued right behind it.
+        process.nextTick(() => {
+          log.push("push begin");
+          transport.push(chunk);
+          log.push("push end");
+        });
+        process.nextTick(() => log.push("next tick"));
+      });
+      client = tlsConnect({
+        socket: transport,
+        rejectUnauthorized: false,
+        onread: {
+          buffer: Buffer.alloc(4),
+          callback(n: number, buf: Buffer) {
+            received += buf.toString("latin1", 0, n);
+          },
+        },
+      });
+      client.on("data", chunk => (received += chunk.toString("latin1")));
+      client.on("secureConnect", () => {
+        secure = true;
+        client!.write("go");
+      });
+      client.on("error", closed.reject);
+      client.on("close", () => closed.resolve());
+      await closed.promise;
+      expect(received).toBe(payload);
+      expect(log.slice(0, 3)).toEqual(["push begin", "push end", "next tick"]);
+      expect(log.join(",")).not.toContain("push begin,next tick");
+    } finally {
+      client?.destroy();
+      raw.destroy();
+      server.close();
+    }
+  });
+
+  it("a tick that throws during the checkpoint is an uncaught exception and the read goes on", async () => {
+    const fixture = /* js */ `
+      const log = [];
+      process.on("uncaughtException", e => log.push("uncaught " + e.message));
+      const net = require("net");
+      const server = net.createServer(c => c.end("abcdefghijkl"));
+      server.listen(0, "127.0.0.1", () => {
+        const client = net.connect({
+          port: server.address().port,
+          host: "127.0.0.1",
+          onread: {
+            buffer: Buffer.alloc(4),
+            callback(n, buf) {
+              const slice = buf.toString("latin1", 0, n);
+              log.push("callback " + slice);
+              process.nextTick(() => { throw new Error("tick-boom " + slice); });
+            },
+          },
+        });
+        client.on("error", e => log.push("socket-error " + e.message));
+        client.on("close", () => { console.log(JSON.stringify(log)); server.close(); });
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ log: stdout.trim() && JSON.parse(stdout), exitCode, failureDetail: exitCode === 0 ? "" : stderr }).toEqual(
+      {
+        log: slices.flatMap(slice => [`callback ${slice}`, `uncaught tick-boom ${slice}`]),
+        exitCode: 0,
+        failureDetail: "",
+      },
+    );
+  });
 });
 
 // On Windows the native layer does not report fatal send errors yet (the WSA

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -3130,6 +3130,82 @@ describe("net.Socket onread: the callbacks of one native read are separate callb
     }
   });
 
+  // The peer resets the first connection while the declined tail waits. With no 'error' listener bun keeps that close
+  // behind the tail, like a FIN (kOnreadPendingEnd). A connection that replaces the first one must not inherit it.
+  it.each([
+    ["destroy() then connect() in one tick", true],
+    ["destroy(), then connect() after 'close'", false],
+  ])("inside a redelivered tail, a deferred %s does not end the next connection", async (_name, sameTick) => {
+    let peer: Socket | undefined;
+    const first = createServer(c => {
+      peer = c;
+      c.on("error", () => {});
+      c.write(payload);
+    });
+    const second = createServer(c => {
+      c.on("error", () => {});
+      c.write("mnopqrst");
+    });
+    const listening = [Promise.withResolvers<void>(), Promise.withResolvers<void>()];
+    [first, second].forEach((server, i) => {
+      server.once("error", listening[i].reject);
+      server.listen(0, "127.0.0.1", () => listening[i].resolve());
+    });
+    await Promise.all(listening.map(l => l.promise));
+    const port = (server: Server) => (server.address() as import("node:net").AddressInfo).port;
+    const events: string[] = [];
+    const declined = [Promise.withResolvers<void>(), Promise.withResolvers<void>()];
+    const delivered = Promise.withResolvers<void>();
+    let generation = 1;
+    let endedAtConnect: boolean | undefined;
+    const reconnect = () => {
+      generation = 2;
+      socket.on("error", delivered.reject);
+      socket.connect(port(second), "127.0.0.1", () => {
+        endedAtConnect = (socket as any)._readableState.ended;
+      });
+    };
+    const socket = new Socket({
+      onread: {
+        buffer: Buffer.alloc(4),
+        callback(n: number, buf: Buffer) {
+          const slice = buf.toString("latin1", 0, n);
+          events.push(`${generation} ${slice}`);
+          if (slice === "abcd" || slice === "mnop") {
+            declined[generation - 1].resolve();
+            return false;
+          }
+          if (generation === 2) return void delivered.resolve();
+          process.nextTick(() => {
+            socket.destroy();
+            if (sameTick) reconnect();
+            else socket.once("close", reconnect);
+          });
+        },
+      },
+    });
+    try {
+      socket.on("end", () => generation === 2 && events.push("end 2"));
+      socket.connect(port(first), "127.0.0.1");
+      await declined[0].promise;
+      peer!.resetAndDestroy();
+      while ((socket as any)._handle?.readyState === 1) await immediate();
+      socket.resume();
+      await declined[1].promise;
+      socket.resume();
+      await delivered.promise;
+      for (let i = 0; i < 4; i++) await immediate();
+      expect({ events, endedAtConnect }).toEqual({
+        events: ["1 abcd", "1 efgh", "2 mnop", "2 qrst"],
+        endedAtConnect: false,
+      });
+    } finally {
+      socket.destroy();
+      first.close();
+      second.close();
+    }
+  });
+
   it("the tail that resume() redelivers gets the same checkpoints", async () => {
     const server = await startServer("tcp");
     const log: string[] = [];

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -3088,7 +3088,7 @@ describe("net.Socket onread: the callbacks of one native read are separate callb
     const first = await startServer("tcp");
     const second = createServer(c => {
       c.on("error", () => {});
-      c.end("XXXXYYYY");
+      c.end("mnopqrst");
     });
     const listening = Promise.withResolvers<void>();
     second.once("error", listening.reject);
@@ -3110,7 +3110,7 @@ describe("net.Socket onread: the callbacks of one native read are separate callb
               socket.connect((second.address() as import("node:net").AddressInfo).port, "127.0.0.1");
             });
           }
-          if (slice === "YYYY") done.resolve();
+          if (slice === "qrst") done.resolve();
         },
       },
     });
@@ -3120,8 +3120,8 @@ describe("net.Socket onread: the callbacks of one native read are separate callb
       await done.promise;
       expect(received).toEqual([
         [1, "abcd"],
-        [2, "XXXX"],
-        [2, "YYYY"],
+        [2, "mnop"],
+        [2, "qrst"],
       ]);
     } finally {
       socket.destroy();


### PR DESCRIPTION
### Problem
- With `onread`, bun runs the callbacks for all slices of one native read in one loop (`deliver`, `src/js/node/net.ts`). Ticks and microtasks that a callback queued, a `pause()` for example, run after the whole read. A callback that reads its static buffer after an `await` sees the last slice each time (bun 1.4.3: 1 distinct block of 16, node v26.3.0: 16).
- Node makes one read per `onread` buffer, each in its own callback scope, which ends with the tick queue and the microtasks drained ([callback.cc#L165-L207](https://github.com/nodejs/node/blob/v26.3.0/src/api/callback.cc#L165-L207)).

### Fix
- Stacked on #42444. Between two callbacks the loop calls the new `drainMicrotasksAndNextTicks()` (`node_net_binding.rs`), returns if the connection is gone, and stops on `kOnreadReading` as before.
- A socket that wraps another stream is skipped: its reads come from inside that stream's `'data'` emit, a nested scope, which node does not drain. A tail drain that comes due inside a checkpoint moves to `setImmediate`, else the drains of many sockets nest (1000 overflowed the stack).
- Verified: `test/js/node/net/node-net.test.ts` (19 new tests, 12 fail without the change). Also node's `test-net-*` and `test-tls-*`.
- Self-reviewed: 3 concerns raised, 2 addressed with tests. Rejected: `destroySoon()` in a callback now destroys between two slices, the timing of bun's `_final` (Notes).

### Background
- `onread: { buffer, callback }` hands each read to `callback(nread, buffer)` in a caller-owned buffer. `false` or `pause()` stops the reads.
- Bun reads bigger native chunks and slices them in JS. Bytes after a stop wait in `kOnreadTail` for the `drainOnreadTailNT` tick.
- The end of the outermost callback scope runs the `process.nextTick` queue, then the microtasks. `drain_microtasks_and_next_ticks` runs exactly that, as `MessagePortPipe` does per message.

<details><summary>Notes</summary>

**Origin.** Found by a read of the loop during other work on it. There is no user report. Pre-existing since #32630 (v1.4.0) made the loop slice by the `onread` buffer size.

**Stack order.** #42444 (`kOnreadReading`, node's `handle.reading`) is the base of this branch. The dependency is real: after a checkpoint the loop must know if the handle still reads. With `isPaused()` a deferred `pause(); read()` stalls after the first slice, because `read()` does not clear the paused flag. #42425 (ignore `onread` on a wrapped socket) makes the `!self[kupgraded]` condition dead. It can go when #42425 is in. #42313 and #42305 edit the same loop (bytesRead, the tail on reconnect). They conflict in text only.

**Wrapped sockets.** The `!self[kupgraded]` condition covers both ways bun wraps a socket for `tls.connect({ socket, onread })`. Only the `upgradeDuplexToTLS` way delivers from inside the wrapped stream's `'data'` emit. The adopted-fd way (`upgradeTLSDeferred`) is a top-level dispatch. It keeps the old order, with no checkpoint between slices. Nothing on the socket records which way it took. Node ignores `onread` on both, and #42425 makes bun do the same, so this PR leaves both as they are.

**Repro 1, the static buffer.** One 12-byte read through a 4-byte buffer. Each callback queues a tick and a microtask that read the buffer again.

```js
const net = require("node:net");
const order = [];
const server = net.createServer(c => { c.on("error", () => {}); c.end("abcdefghijkl"); });
server.listen(0, "127.0.0.1", () => {
  const socket = net.connect({ port: server.address().port, host: "127.0.0.1", onread: { buffer: Buffer.alloc(4), callback(n, buf) {
    order.push("cb:" + buf.toString("latin1", 0, n));
    queueMicrotask(() => order.push("mt:" + buf.toString("latin1", 0, n)));
    process.nextTick(() => order.push("nt:" + buf.toString("latin1", 0, n)));
  } } });
  socket.on("close", () => { console.log(JSON.stringify(order)); server.close(); });
});
```

- node v26.3.0 and this branch: `cb:abcd, nt:abcd, mt:abcd, cb:efgh, nt:efgh, mt:efgh, cb:ijkl, nt:ijkl, mt:ijkl`
- bun 1.4.3: `cb:abcd, cb:efgh, cb:ijkl, nt:ijkl, nt:ijkl, nt:ijkl, mt:ijkl, mt:ijkl, mt:ijkl`

**Repro 2, the deferred pause** (`<runtime> slice-checkpoint.cjs <microtask|nextTick>`):

```js
const net = require("net");
const how = process.argv[2] || "microtask";
const srv = net.createServer(c => { c.on("error", () => {}); c.end(Buffer.alloc(65536, 97)); });
srv.listen(0, "127.0.0.1", () => {
  let calls = 0, callsAtPause = -1;
  const s = net.connect({ port: srv.address().port, host: "127.0.0.1", onread: { buffer: Buffer.alloc(4096), callback() {
    if (++calls === 1) {
      const stop = () => { callsAtPause = calls; s.pause(); };
      if (how === "microtask") queueMicrotask(stop); else process.nextTick(stop);
    }
  } } });
  setTimeout(() => { console.log(how + ": callbacks before the queued pause() ran = " + callsAtPause + ", total callbacks = " + calls); process.exit(0); }, 500);
});
```

node v26.3.0 and this branch print 1 and 1 for both modes. bun 1.4.3 prints 16 and 16.

**Node comparison.** Every scenario of the new `describe` block also ran as a plain script under node v26.3.0. The expectations in the tests are node's output. The same holds for `tls.connect` and for the tail after `false` then `resume()`.

**Tests.** 12 of the 19 fail without the change: the order of ticks and microtasks with the static buffer (tcp, tls), `pause()` deferred three ways, a deferred `destroy()`, a deferred `destroy(); connect()`, the same two inside a redelivered tail with a pending end, the redelivered tail, the tail drains of three sockets, a tick that throws. The other 7 pass both ways. They guard what the checkpoint can re-enter: `pause().resume()`, `pause()` then `resume()` in the next microtask, `read()`, `pause().read()` three ways (these stall if the loop stops on `isPaused()`), and a TLS socket over a generic `Duplex`. The `Duplex` test fails when the `kupgraded` condition is removed. The three-socket test fails (`maxPending` 3) when the `setImmediate` move is removed.

**Why in JS and not in the native dispatch.** The tail redelivery has no native dispatch around it. A native loop (one `on_data` scope per slice) covers only one of the two paths. Precedent for a checkpoint per callback inside one dispatch: `MessagePortPipe.cpp` (same `MakeCallback` reason), the UDP receive loop (`enter()` / `exit()` per packet).

**Re-entrancy.** While the checkpoint runs, the loop holds the rest of the chunk in locals and `kOnreadTail` is `undefined`. `resume()` / `read()` in a tick find no tail and start the handle. `pause()` stops it, and the loop stores the tail when the checkpoint returns. `destroy()`, `connect()` or a new `_handle` make the loop return: the rest belongs to the old connection. `drainOnreadTailNT` makes the same check (`onreadConnectionGone`) after `deliver(tail)` and drops a pending end (`kOnreadPendingEnd`) of the old connection. Without it the end of the old connection was applied to the new one (review finding, two tests). A worker that is terminated inside the checkpoint unwinds through `Stopped::throw` (checked by hand with a tick that spins, debug build, also with `BUN_JSC_validateExceptionChecks=1`).

**Known difference that stays.** `destroySoon()` in a callback now destroys the socket between two slices: `['cb abcd', 'destroySoon()', 'finish', 'end', 'close']`. Node and bun 1.4.3 deliver `efgh` and `ijkl` first. In node that is timing: `'finish'` waits for the shutdown request, one loop iteration. Bun's `_final` completes in a tick, so `'finish'` and the `destroy()` behind it run inside the checkpoint. A `destroy()` between two reads drops the rest in node too. A fix belongs in `_final`, not in this loop. Also unchanged: after the last slice of a redelivered tail, `drainOnreadTailNT` finishes a pending FIN with no checkpoint before it. The order of ticks, microtasks and `'end'` already matches node there.

**Found on the way, not fixed here.** `destroy(); connect()` in one tick breaks writes on the new connection, with or without `onread`: `['data 1 hello', 'reconnect', 'end 2', 'close 2', 'write go -> false', 'error This socket has been ended by the other party']`. Node prints `['data 1 hello', 'reconnect', 'close 2', 'write go -> true', 'data 2 echo:go']`. The close handler of the old handle pushes EOF inside `destroy()`, the `'end'` lands after `connect()` reset the stream, and `onSocketEnd` swaps `write` for `writeAfterFIN`. It is on main and on bun 1.4.3. The tests here avoid that path.

**Cost.** Release build, loopback, same build with and without the call. 1 KiB buffer: about 1240 to 1440 ns per callback (one empty checkpoint is about 200 ns). 4 KiB: 4660 and 4780 ns, within noise. 64 KiB: 1673 and 1622 MiB/s, within noise. A buffer that holds the whole native read makes no call.

**Other suites** on the debug build: node's `test-net-*` and `test-tls-*` (324 of 325, `test-tls-client-allow-partial-trust-chain.js` needs the test runner on every build), upstream `test-tls-onread-static-buffer.js`, `node-tls-connect`, `node-tls-upgrade`, `node-tls-server` (`SNICallback runs even when...` fails with ECONNREFUSED on the released bun too), `socket-reconnect-live`, `double-connect`, `net-syscall-fault`, `socket-syscall-fault`. In `node-net.test.ts` the `net.Socket read` block, `unref should exit when no more work pending` and `#13126` fail in this container on the released bun too.

**Self-review.** The first version sat on main and stopped on `isPaused()`. The review found three regressions for deferred calls: `pause(); read()` stalled, `destroy(); connect()` handed old bytes to the new connection, `destroySoon()` lost bytes. The first two are fixed here (base on #42444, return when the connection changed) and have tests. The third is the `_final` timing above.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->

