### PR TITLE
docs, bun-types: restore the YAML.stringify section, document Bun.markdown.ansi, correct two JSDoc statements

### DIFF
--- a/docs/runtime/markdown.mdx
+++ b/docs/runtime/markdown.mdx
@@ -7,9 +7,10 @@ description: Parse and render Markdown with Bun's built-in Markdown API, support
   **Unstable API** — This API is under active development and may change in future versions of Bun.
 </Callout>
 
-Bun includes a fast, built-in Markdown parser written in Rust. It supports GitHub Flavored Markdown (GFM) extensions and provides three APIs:
+Bun includes a fast, built-in Markdown parser written in Rust. It supports GitHub Flavored Markdown (GFM) extensions and provides four APIs:
 
 - `Bun.markdown.html()` — render Markdown to an HTML string
+- `Bun.markdown.ansi()` — render Markdown to an ANSI-colored string for terminals
 - `Bun.markdown.render()` — render Markdown with custom callbacks for each element
 - `Bun.markdown.react()` — render Markdown to React JSX elements
 
@@ -84,6 +85,15 @@ Bun.markdown.html("Visit www.example.com", {
 });
 ```
 
+The autolink rules are the permissive autolinks of [md4c](https://github.com/mity/md4c), the parser that Bun's parser is a port of. They are not the autolink extension as GitHub implements it in [cmark-gfm](https://github.com/github/cmark-gfm). Both link common input such as `www.example.com`, `https://example.com/path`, and `user@example.com`. Unlike cmark-gfm, Bun does not link:
+
+- `mailto:` and `xmpp:` URIs (`mailto:user@example.com`)
+- a URL that contains a non-ASCII character (`https://example.com/å`)
+- a URL that directly follows a quote character (`"https://example.com"`)
+- a URL whose host name has no dot (`http://localhost:3000`)
+
+To link any of these, use the `<https://example.com/å>` or `[text](url)` syntax.
+
 #### Heading IDs
 
 Pass `true` to enable both heading IDs and autolink headings, or an object for granular control:
@@ -96,6 +106,45 @@ Bun.markdown.html("## Hello World", { headings: true });
 // Enable only heading IDs (no autolink)
 Bun.markdown.html("## Hello World", { headings: { ids: true } });
 // '<h2 id="hello-world">Hello World</h2>\n'
+```
+
+---
+
+## `Bun.markdown.ansi()`
+
+Render a Markdown string to an ANSI-colored string for the terminal. `bun ./file.md` uses the same renderer.
+
+```ts
+const out = Bun.markdown.ansi("# Hello\n\n**bold** and *italic*\n");
+process.stdout.write(out);
+```
+
+`ansi()` renders headings, lists, tables, blockquotes, links, images, inline styles, and fenced code blocks. It highlights the syntax of JavaScript and TypeScript code blocks.
+
+`ansi()` takes no parser options. It always enables tables, strikethrough, task lists, autolinks, wiki links, underline, and LaTeX math.
+
+### Theme
+
+Pass a theme object as the second argument:
+
+| Option          | Default  | Description                                                                                         |
+| --------------- | -------- | --------------------------------------------------------------------------------------------------- |
+| `colors`        | `true`   | Emit ANSI color and style escape codes. When `false`, the output is plain text with ASCII borders   |
+| `hyperlinks`    | `false`  | Emit OSC 8 hyperlinks, which modern terminals make clickable. When `false`, a link is `text (url)`  |
+| `light`         | detected | Use the palette for a light terminal background. Detected from the `COLORFGBG` environment variable |
+| `columns`       | `80`     | Line width for word wrapping. Pass `0` to disable wrapping                                          |
+| `kittyGraphics` | `false`  | Show images from local files inline with the Kitty Graphics Protocol                                |
+
+```ts
+// Plain text, no escape codes
+Bun.markdown.ansi("# Hello\n\n[docs](https://bun.com)\n", { colors: false });
+// "Hello\n=====\n\ndocs (https://bun.com)\n"
+
+// Clickable links
+Bun.markdown.ansi("[docs](https://bun.com)", { hyperlinks: true });
+
+// Wrap at 60 columns
+Bun.markdown.ansi(longText, { columns: 60 });
 ```
 
 ---

--- a/docs/runtime/yaml.mdx
+++ b/docs/runtime/yaml.mdx
@@ -5,7 +5,7 @@ description: Use Bun's built-in support for YAML files through both runtime APIs
 
 In Bun, YAML is a first-class citizen alongside JSON and TOML. You can:
 
-- Parse YAML strings with `Bun.YAML.parse`
+- Parse and stringify YAML with `Bun.YAML.parse` and `Bun.YAML.stringify`
 - `import` & `require` YAML files as modules at runtime (including hot reloading & watch mode support)
 - `import` & `require` YAML files in frontend apps with Bun's bundler
 
@@ -119,6 +119,175 @@ try {
 } catch (error) {
   console.error("Failed to parse YAML:", error.message);
 }
+```
+
+### `Bun.YAML.stringify()`
+
+Convert a JavaScript value into a YAML string. The signature matches `JSON.stringify`:
+
+```ts
+YAML.stringify(value, replacer?, space?)
+```
+
+- `value`: the value to convert to YAML
+- `replacer`: not supported. Pass `null` or `undefined`. Any other value throws an error.
+- `space`: the number of spaces for each level of indentation (for example `2`), or a string to use as the indentation. Bun clamps a number to the range 0 to 10 and uses the first 10 characters of a string. YAML indentation must be spaces, so use a string of spaces.
+
+Without `space`, Bun writes flow-style YAML on one line. With `space`, Bun writes block-style YAML on multiple lines.
+
+#### Basic Usage
+
+```ts
+import { YAML } from "bun";
+
+const data = {
+  name: "John Doe",
+  age: 30,
+  hobbies: ["reading", "coding"],
+};
+
+// Without space: flow style (single line)
+console.log(YAML.stringify(data));
+// {name: John Doe,age: 30,hobbies: [reading,coding]}
+
+// With space: block style (multiple lines)
+console.log(YAML.stringify(data, null, 2));
+// name: John Doe
+// age: 30
+// hobbies:
+//   - reading
+//   - coding
+```
+
+Arrays follow the same rule:
+
+```ts
+const arr = [1, 2, 3];
+
+console.log(YAML.stringify(arr));
+// [1,2,3]
+
+console.log(YAML.stringify(arr, null, 2));
+// - 1
+// - 2
+// - 3
+```
+
+#### String Quoting
+
+`YAML.stringify()` double-quotes a string when a YAML parser would otherwise read it as something else:
+
+- Strings that YAML reads as keywords (`true`, `false`, `null`, `yes`, `no`, `~`, and so on)
+- Strings that YAML reads as numbers
+- Empty strings, and strings with special characters or escape sequences
+
+```ts
+const examples = {
+  keyword: "true",
+  number: "123",
+  text: "hello world",
+  empty: "",
+};
+
+console.log(YAML.stringify(examples, null, 2));
+// keyword: "true"
+// number: "123"
+// text: hello world
+// empty: ""
+```
+
+#### Cycles and References
+
+`YAML.stringify()` writes an object that appears more than once as a YAML anchor (`&name`) and aliases (`*name`). Circular references use the same syntax:
+
+```ts
+const obj: Record<string, unknown> = { name: "root" };
+obj.self = obj; // Circular reference
+
+console.log(YAML.stringify(obj, null, 2));
+// &root
+// name: root
+// self:
+//   *root
+
+// Objects with shared references
+const shared = { id: 1 };
+const data = {
+  first: shared,
+  second: shared,
+};
+
+console.log(YAML.stringify(data, null, 2));
+// first:
+//   &first
+//   id: 1
+// second:
+//   *first
+```
+
+`Bun.YAML.parse()` reads the anchors back, so the parsed objects share identity again.
+
+#### Special Values
+
+```ts
+// Special numeric values
+console.log(YAML.stringify(Infinity)); // .inf
+console.log(YAML.stringify(-Infinity)); // -.inf
+console.log(YAML.stringify(NaN)); // .nan
+console.log(YAML.stringify(0)); // 0
+console.log(YAML.stringify(-0)); // -0
+
+// null and undefined
+console.log(YAML.stringify(null)); // null
+console.log(YAML.stringify(undefined)); // undefined (the return value is undefined, not a string)
+
+// Booleans
+console.log(YAML.stringify(true)); // true
+console.log(YAML.stringify(false)); // false
+```
+
+#### Complex Objects
+
+```ts
+const config = {
+  server: {
+    port: 3000,
+    host: "localhost",
+    ssl: {
+      enabled: true,
+      cert: "/path/to/cert.pem",
+      key: "/path/to/key.pem",
+    },
+  },
+  database: {
+    connections: [
+      { name: "primary", host: "db1.example.com" },
+      { name: "replica", host: "db2.example.com" },
+    ],
+  },
+  features: {
+    auth: true,
+    "rate-limit": 100,
+  },
+};
+
+console.log(YAML.stringify(config, null, 2));
+// server:
+//   port: 3000
+//   host: localhost
+//   ssl:
+//     enabled: true
+//     cert: /path/to/cert.pem
+//     key: /path/to/key.pem
+// database:
+//   connections:
+//     - name: primary
+//       host: db1.example.com
+//     - name: replica
+//       host: db2.example.com
+// features:
+//   auth: true
+//   rate-limit: 100
 ```
 
 ---

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1548,8 +1548,9 @@ declare module "bun" {
      * const cycle = {};
      * cycle.obj = cycle;
      * console.log(YAML.stringify(cycle, null, 2));
-     * // &1
-     * // obj: *1
+     * // &root
+     * // obj:
+     * //   *root
      * ```
      */
     export function stringify(input: unknown, replacer?: undefined | null, space?: string | number): string;
@@ -1564,8 +1565,9 @@ declare module "bun" {
    * - `render()` — render with custom callbacks for each element
    * - `react()` — parse to React-compatible JSX elements
    *
-   * Supports GFM extensions (tables, strikethrough, task lists, autolinks) and
-   * component overrides to replace default HTML tags with custom components.
+   * Supports GFM extensions (tables, strikethrough, task lists), md4c's
+   * permissive autolinks, and component overrides to replace default HTML tags
+   * with custom components.
    *
    * @example
    * ```tsx
@@ -1627,7 +1629,11 @@ declare module "bun" {
       tagFilter?: boolean;
       /**
        * Enable autolinks. Pass `true` to enable all autolink types (URL, WWW, email),
-       * or an object to enable individually.
+       * or an object to enable individually. Default: `false`.
+       *
+       * The rules are md4c's permissive autolinks, not the GFM autolink extension as
+       * cmark-gfm implements it. For example, `mailto:` URIs, URLs with a non-ASCII
+       * character, and URLs that directly follow a quote character are not linked.
        *
        * @example
        * ```ts

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2717,6 +2717,30 @@ config:
   });
 
   describe("stringify", () => {
+    // Editors show this example for `YAML.stringify`. It runs here as written, and each console.log()
+    // must print the `// ...` lines under it. A comment cannot show the space that follows `key:`
+    // in front of a nested block, so trailing spaces are not compared.
+    test("the example in bun.d.ts prints what its comments say", async () => {
+      const dts = await file(join(import.meta.dir, "../../../../packages/bun-types/bun.d.ts")).text();
+      const declaration = dts.indexOf("export function stringify(", dts.indexOf("namespace YAML {"));
+      const jsdoc = dts.slice(dts.lastIndexOf("/**", declaration), declaration).replace(/^ *\* ?/gm, "");
+      const example = /```ts\n([\s\S]*?)```/.exec(jsdoc)![1];
+
+      const documented: string[] = [];
+      const lines = example.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        if (!lines[i].startsWith("console.log(")) continue;
+        while (lines[i + 1]?.startsWith("// ")) documented.push(lines[++i].slice(3));
+      }
+
+      await using proc = Bun.spawn({ cmd: [bunExe(), "-e", example], env: bunEnv, stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(stdout.split("\n").map(line => line.trimEnd())).toEqual([...documented, ""]);
+      expect(exitCode).toBe(0);
+    });
+
     // Basic data type tests
     test("stringifies null", () => {
       expect(YAML.stringify(null)).toBe("null");
@@ -3860,11 +3884,16 @@ config:
         expect(parsed).toEqual([{ a: 1, c: 2 }, { y: 3 }, { valid: "data" }]);
       });
 
+      // A Linux release build overflows between 30,000 and 50,000 levels, a debug or ASAN build below
+      // 5,000. The loop that builds 1,000,000 levels takes 2.8 s on a debug build, which put the second
+      // test over the 5 s limit in a whole-file run.
+      const overflowDepth = isDebug || isASAN ? 100_000 : 1_000_000;
+
       test("handles stack overflow protection", () => {
         // Create deeply nested structure approaching stack limit
         let deep = {};
         let current = deep;
-        for (let i = 0; i < 1000000; i++) {
+        for (let i = 0; i < overflowDepth; i++) {
           current.next = {};
           current = current.next;
         }
@@ -3876,7 +3905,7 @@ config:
       test("stack overflow protection in the write pass", () => {
         let deep = {};
         let current = deep;
-        for (let i = 0; i < 1000000; i++) {
+        for (let i = 0; i < overflowDepth; i++) {
           current.next = {};
           current = current.next;
         }


### PR DESCRIPTION
### Problem

- `docs/runtime/yaml.mdx` has no `Bun.YAML.stringify()` section. #22921 added one (172 lines) to `docs/api/yaml.md`. The docs move (#24201) did not carry it over.
- `docs/runtime/markdown.mdx:10` says Bun "provides three APIs". `Bun.markdown.ansi()` is the fourth, and `bun.d.ts` already lists four. The page has no section for it.
- Two JSDoc statements in `packages/bun-types/bun.d.ts` do not match the runtime. The `YAML.stringify` cycle sample shows `&1` / `obj: *1`, and the output is `&root` / `obj:` / `  *root`. The `Bun.markdown` summary lists autolinks under "GFM extensions", and the rules are md4c's permissive autolinks.

### Fix

- Restore the `Bun.YAML.stringify()` section in `yaml.mdx`. The `replacer` and `space` bullets say what the runtime does today.
- Add `Bun.markdown.ansi()` to the list in `markdown.mdx`, with a section for it. Under "Autolinks", name the rules and list four inputs that cmark-gfm links and Bun does not.
- Correct the two JSDoc statements. Add `Default: false` and the same note to `Options.autolinks`.
- Verified: a new test in `test/js/bun/yaml/yaml.test.ts` runs the `bun.d.ts` example and compares the output with its comments. It fails on `main`. I ran every other new sample on `1.4.3-canary.1+6a92015fc`. There is no runtime change.

### Background

- md4c is the C Markdown parser that `src/md/` is a port of (#26440). Its "permissive autolinks" link bare URLs, `www.` names and e-mail addresses.
- cmark-gfm is GitHub's parser. Its autolink extension has more rules, for example `mailto:` and `xmpp:` URIs.
- `Bun.markdown.ansi(input, theme?)` shipped with #28833, with JSDoc only.

<details><summary>Notes</summary>

**YAML samples.** A script takes the six runnable `ts` blocks of the new section from the `.mdx` file, runs each one, and compares the output with the comment lines. All six match. The only difference from the page is a space after `key:` before a line break, which a comment cannot show. A round trip through `Bun.YAML.parse` gives back shared identity for the shared-reference sample and for the cycle, in flow style and in block style.

**`replacer`.** `null` and `undefined` are accepted. `0`, `5`, `"x"`, `true`, `{}`, `[]` and a function all throw `YAML.stringify does not support the replacer argument`.

**`space`.** `20` gives 10 spaces. A string of 15 spaces gives 10. `0`, `""` and `-3` give flow style. `"\t"` gives `a: \n\tb: 1`, which `Bun.YAML.parse` rejects with `Tab characters cannot be used as indentation`. The bullet tells the reader to use spaces. It does not say what Bun does with other strings, so it stays true whichever way that is decided. `bun.d.ts:1524` is not changed here. #42483 fixes the indent of a collection in a sequence item for a `space` other than 2. The samples on the page all use 2.

**Autolinks.** cmark-gfm's own 32-paragraph autolink example (`test/extensions.txt`) gives different HTML for 23 of the 32 paragraphs with `{ autolinks: true }`. The four cases on the page are from that run, and I checked each one on its own: `mailto:user@example.com`, `https://example.com/å`, `"https://example.com"`, `http://localhost:3000`. The 11 examples of the GFM spec's autolink section match in 10 cases. The other one is the doubled local part that #42510 fixes. `<https://example.com/å>`, `<mailto:user@example.com>` and `<http://localhost:3000>` all link.

**`ansi()`.** `src/runtime/api/MarkdownObject.rs:115` reads `colors`, `hyperlinks`, `kittyGraphics`, `light` and `columns` from the second argument and always parses with `Options::TERMINAL` (`src/md/root.rs:94`): tables, strikethrough, task lists, the three autolink kinds, wiki links, underline, LaTeX math. `bun ./file.md` calls the same `md::render_to_ansi` (`src/runtime/cli/run_command.rs:3467`). The `{ colors: false }` sample prints exactly `"Hello\n=====\n\ndocs (https://bun.com)\n"`.

**Overlap.** #39925 (the `replacer` argument) adds its own `Bun.YAML.stringify()` section to `yaml.mdx` at the same place. Whichever lands second needs a small merge.

**The new test.** It takes the `@example` block from the JSDoc of `YAML.stringify` in `packages/bun-types/bun.d.ts`, runs it with `bun -e`, and compares stdout with the `// ...` lines under each `console.log()`. Trailing spaces are not compared. With the `bun.d.ts` of `main` it fails: the comments say `&1` and `obj: *1`, and the run prints `&root`, `obj:` and `  *root`.

**Two older tests in the same file.** `handles stack overflow protection` and `stack overflow protection in the write pass` each build a 1,000,000-deep object chain. That loop takes 2.8 s on a debug build with ASAN. In a whole-file run there, the second test took 4.7 to 6.5 s and hit the 5 s limit in 3 of 4 runs, with and without this change. On debug and ASAN builds both tests now build 100,000 levels and take 0.3 s and 0.6 s. `YAML.stringify` overflows below 5,000 levels on those builds. A Linux release build overflows between 30,000 and 50,000 levels and keeps the 1,000,000.

**Return type.** A review comment is correct that `YAML.stringify()` returns `undefined` for `undefined`, a function and a symbol, and that the declaration says `string`. #39925 already changes the signature to `string | undefined` and updates `fixture/yaml.ts`. This PR leaves the signature alone.

**Types test.** `bun test test/integration/bun-types/bun-types.test.ts` gives the same 11 pass and 10 fail with and without this change. The 10 failures are `@types/node` shape errors in files this PR does not touch. The `bun-types` workflow fails the same way on `main` (runs 34683714288 and 34726049611), and #42230 is the open fix. The `bun.d.ts` edits are inside comments.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/yaml/yaml.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/51] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[3/51] cxx obj/src/jsc/bindings/sqlite/JSSQLStatement.cpp.o
[4/51] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[5/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-7.cpp.o
[6/51] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[7/51] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[8/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-13.cpp.o
[9/51] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-9.cpp.o
[10/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-16.cpp.o
[11/51] cxx obj/unified/UnifiedSource-src_jsc_bindings-21.cpp.o
[12/51] cxx obj/src/jsc/bindings/bindings.cpp.o
[13/51] cxx obj/src/jsc/bindings/webcore/streams/CrossRealmTransform.cpp.o
[14/51] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[15/51] cxx obj/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp.o
[
... (truncated)

release without fix: 1 failed, 18 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [0.12ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [0.04ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [0.06ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [0.07ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from DataView [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Blob [0.06ms]
(pass) Bun.YAML > parse > i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [4.81ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.45ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.83ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [2.08ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [4.78ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [3.36ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [4.66ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [5.08ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [5.45ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [5.76ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [3.44ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [3.28ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [3.39ms]
(pass) Bun
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 742ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/52] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[3/52] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[4/52] cxx obj/src/jsc/bindings/sqlite/JSSQLStatement.cpp.o
[5/52] cxx obj/src/jsc/bindings/bindings.cpp.o
[6/52] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-1.cpp.o
[7/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[8/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[9/52] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[10/52] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[11/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[12/52] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[13/52] cxx obj/src/jsc/bindings/sqlite/NodeSqlite.cpp.o
[14/52] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[15/52] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[16/52] cxx obj/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/markdown.mdx     |  51 ++++++++++++-
 docs/runtime/yaml.mdx         | 171 +++++++++++++++++++++++++++++++++++++++++-
 packages/bun-types/bun.d.ts   |  16 ++--
 test/js/bun/yaml/yaml.test.ts |  33 +++++++-
 4 files changed, 262 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
docs/runtime/markdown.mdx          1      4     16
docs/runtime/yaml.mdx              2      4     16
packages/bun-types/bun.d.ts        2      3     18
test/js/bun/yaml/yaml.test.ts      2      2     16
```

</details>

<!-- robobun:evidence:end -->