### PR TITLE
Honor newTarget in Bun.Cookie, Bun.CookieMap, crypto.ECDH, crypto.DiffieHellman, dns.Resolver, $.Shell, HTTPParser and ConnectionsList

### DIFF
--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -33,7 +33,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:dns`](https://nodejs.org/api/dns.html)
 
-🟢 Fully implemented. Missing `resolveTlsa`. Bun ignores the `Resolver` `maxTimeout` option, and the callback-style `Resolver` class cannot be subclassed (`dns.promises.Resolver` can).
+🟢 Fully implemented. Missing `resolveTlsa`. Bun ignores the `Resolver` `maxTimeout` option.
 
 ### [`node:events`](https://nodejs.org/api/events.html)
 

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -341,7 +341,8 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
       return new ShellPromise(parsed_shell_script, throws);
     };
 
-    Object.setPrototypeOf(Shell, ShellPrototype.prototype);
+    const prototype = new.target.prototype;
+    Object.setPrototypeOf(Shell, $isObject(prototype) ? prototype : ShellPrototype.prototype);
     Object.defineProperty(Shell, "name", { value: "Shell", configurable: true, enumerable: true });
 
     Shell[cwdSymbol] = defaultCwd;

--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -383,7 +383,7 @@ function validateResolverOptions(options) {
   return { timeout, tries };
 }
 
-var InternalResolver = class Resolver {
+class Resolver {
   #resolver;
 
   constructor(options) {
@@ -689,12 +689,7 @@ var InternalResolver = class Resolver {
   setServers(servers) {
     return setServersOn(servers, Resolver.#getResolver(this));
   }
-};
-
-function Resolver(options) {
-  return new InternalResolver(options);
 }
-$toClass(Resolver, "Resolver", InternalResolver);
 
 var {
   resolve,
@@ -711,7 +706,7 @@ var {
   resolveSrv,
   reverse,
   resolveTxt,
-} = InternalResolver.prototype;
+} = Resolver.prototype;
 
 const mapLookupAll = res => {
   const { address, family } = res;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4701,3 +4701,17 @@ const JSC::ClassInfo GlobalObject::s_info = { "GlobalObject"_s, &Base::s_info, &
     CREATE_METHOD_TABLE(GlobalObject) };
 
 } // namespace Zig
+
+JSC::Structure* structureForNewTarget(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue newTarget, JSC::LazyClassStructure Zig::GlobalObject::* classStructure)
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    if ((globalObject->*classStructure).constructor(globalObject) == newTarget) [[likely]]
+        return (globalObject->*classStructure).get(globalObject);
+
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    // The realm of newTarget can be a node:vm context, which is not a Zig::GlobalObject.
+    auto* newTargetGlobalObject = defaultGlobalObject(JSC::getFunctionRealm(lexicalGlobalObject, newTarget.getObject()));
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    RELEASE_AND_RETURN(scope, JSC::InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget.getObject(), (newTargetGlobalObject->*classStructure).get(newTargetGlobalObject)));
+}

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -908,6 +908,11 @@ inline Zig::GlobalObject* defaultGlobalObject()
     return ___private___::getDefaultGlobalObject();
 }
 
+// The instance Structure for a native constructor whose class is a LazyClassStructure member of
+// Zig::GlobalObject: the base Structure when `newTarget` is the constructor itself, otherwise a
+// subclass Structure (`class X extends C`, `Reflect.construct`). Returns nullptr with an exception pending.
+JSC::Structure* structureForNewTarget(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue newTarget, JSC::LazyClassStructure Zig::GlobalObject::* classStructure);
+
 inline void* bunVM(JSC::JSGlobalObject* lexicalGlobalObject)
 {
     if (auto* globalObject = dynamicDowncast<Zig::GlobalObject>(lexicalGlobalObject)) {

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -908,9 +908,7 @@ inline Zig::GlobalObject* defaultGlobalObject()
     return ___private___::getDefaultGlobalObject();
 }
 
-// The instance Structure for a native constructor whose class is a LazyClassStructure member of
-// Zig::GlobalObject: the base Structure when `newTarget` is the constructor itself, otherwise a
-// subclass Structure (`class X extends C`, `Reflect.construct`). Returns nullptr with an exception pending.
+// The Structure a LazyClassStructure constructor allocates with for this newTarget. nullptr on exception.
 JSC::Structure* structureForNewTarget(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSValue newTarget, JSC::LazyClassStructure Zig::GlobalObject::* classStructure);
 
 inline void* bunVM(JSC::JSGlobalObject* lexicalGlobalObject)

--- a/src/jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp
@@ -34,6 +34,17 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
     JSC::VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    auto* zigGlobalObject = defaultGlobalObject(globalObject);
+    JSC::Structure* structure = zigGlobalObject->m_JSDiffieHellmanClassStructure.get(zigGlobalObject);
+
+    JSC::JSValue newTarget = callFrame->newTarget();
+    if (zigGlobalObject->m_JSDiffieHellmanClassStructure.constructor(zigGlobalObject) != newTarget) [[unlikely]] {
+        auto* functionGlobalObject = defaultGlobalObject(JSC::getFunctionRealm(globalObject, newTarget.getObject()));
+        RETURN_IF_EXCEPTION(scope, {});
+        structure = JSC::InternalFunction::createSubclassStructure(globalObject, newTarget.getObject(), functionGlobalObject->m_JSDiffieHellmanClassStructure.get(functionGlobalObject));
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
     JSValue sizeOrKey = callFrame->argument(0);
 
     if (!sizeOrKey.isNumber() && !sizeOrKey.isString() && !isArrayBufferOrView(sizeOrKey)) {
@@ -185,10 +196,6 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
     if (checkResult == ncrypto::DHPointer::CheckResult::CHECK_FAILED) {
         return Bun::ERR::CRYPTO_OPERATION_FAILED(scope, globalObject, "Checking DH parameters failed"_s);
     }
-
-    // Get the appropriate structure and create the DiffieHellman object
-    auto* zigGlobalObject = defaultGlobalObject(globalObject);
-    JSC::Structure* structure = zigGlobalObject->m_JSDiffieHellmanClassStructure.get(zigGlobalObject);
 
     return JSC::JSValue::encode(JSDiffieHellman::create(vm, structure, globalObject, WTF::move(dh), static_cast<int>(checkResult)));
 }

--- a/src/jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp
@@ -34,16 +34,8 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellman, (JSC::JSGlobalObject * globalOb
     JSC::VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* zigGlobalObject = defaultGlobalObject(globalObject);
-    JSC::Structure* structure = zigGlobalObject->m_JSDiffieHellmanClassStructure.get(zigGlobalObject);
-
-    JSC::JSValue newTarget = callFrame->newTarget();
-    if (zigGlobalObject->m_JSDiffieHellmanClassStructure.constructor(zigGlobalObject) != newTarget) [[unlikely]] {
-        auto* functionGlobalObject = defaultGlobalObject(JSC::getFunctionRealm(globalObject, newTarget.getObject()));
-        RETURN_IF_EXCEPTION(scope, {});
-        structure = JSC::InternalFunction::createSubclassStructure(globalObject, newTarget.getObject(), functionGlobalObject->m_JSDiffieHellmanClassStructure.get(functionGlobalObject));
-        RETURN_IF_EXCEPTION(scope, {});
-    }
+    JSC::Structure* structure = structureForNewTarget(globalObject, callFrame->newTarget(), &Zig::GlobalObject::m_JSDiffieHellmanClassStructure);
+    RETURN_IF_EXCEPTION(scope, {});
 
     JSValue sizeOrKey = callFrame->argument(0);
 

--- a/src/jsc/bindings/node/crypto/JSDiffieHellmanGroupConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellmanGroupConstructor.cpp
@@ -48,22 +48,8 @@ JSC_DEFINE_HOST_FUNCTION(constructDiffieHellmanGroup, (JSC::JSGlobalObject * glo
         return Bun::ERR::CRYPTO_OPERATION_FAILED(scope, globalObject, "Checking DH parameters failed"_s);
     }
 
-    // Get the appropriate structure and create the DiffieHellmanGroup object
-    auto* zigGlobalObject = dynamicDowncast<Zig::GlobalObject>(globalObject);
-    JSC::Structure* structure = zigGlobalObject->m_JSDiffieHellmanGroupClassStructure.get(zigGlobalObject);
-    JSC::JSValue newTarget = callFrame->newTarget();
-
-    if (zigGlobalObject->m_JSDiffieHellmanGroupClassStructure.constructor(zigGlobalObject) != newTarget) [[unlikely]] {
-        if (!newTarget) {
-            throwError(globalObject, scope, ErrorCode::ERR_INVALID_THIS, "Class constructor DiffieHellmanGroup cannot be invoked without 'new'"_s);
-            return {};
-        }
-
-        auto* functionGlobalObject = defaultGlobalObject(JSC::getFunctionRealm(globalObject, newTarget.getObject()));
-        RETURN_IF_EXCEPTION(scope, {});
-        structure = JSC::InternalFunction::createSubclassStructure(globalObject, newTarget.getObject(), functionGlobalObject->m_JSDiffieHellmanGroupClassStructure.get(functionGlobalObject));
-        RETURN_IF_EXCEPTION(scope, {});
-    }
+    JSC::Structure* structure = structureForNewTarget(globalObject, callFrame->newTarget(), &Zig::GlobalObject::m_JSDiffieHellmanGroupClassStructure);
+    RETURN_IF_EXCEPTION(scope, {});
 
     return JSC::JSValue::encode(JSDiffieHellmanGroup::create(vm, structure, globalObject, WTF::move(dh), static_cast<int>(checkResult)));
 }

--- a/src/jsc/bindings/node/crypto/JSECDHConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSECDHConstructor.cpp
@@ -48,16 +48,8 @@ JSC_DEFINE_HOST_FUNCTION(constructECDH, (JSC::JSGlobalObject * globalObject, JSC
     JSC::VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* zigGlobalObject = defaultGlobalObject(globalObject);
-    JSC::Structure* structure = zigGlobalObject->m_JSECDHClassStructure.get(zigGlobalObject);
-
-    JSC::JSValue newTarget = callFrame->newTarget();
-    if (zigGlobalObject->m_JSECDHClassStructure.constructor(zigGlobalObject) != newTarget) [[unlikely]] {
-        auto* functionGlobalObject = defaultGlobalObject(JSC::getFunctionRealm(globalObject, newTarget.getObject()));
-        RETURN_IF_EXCEPTION(scope, {});
-        structure = JSC::InternalFunction::createSubclassStructure(globalObject, newTarget.getObject(), functionGlobalObject->m_JSECDHClassStructure.get(functionGlobalObject));
-        RETURN_IF_EXCEPTION(scope, {});
-    }
+    JSC::Structure* structure = structureForNewTarget(globalObject, callFrame->newTarget(), &Zig::GlobalObject::m_JSECDHClassStructure);
+    RETURN_IF_EXCEPTION(scope, {});
 
     JSValue curveValue = callFrame->argument(0);
 

--- a/src/jsc/bindings/node/crypto/JSECDHConstructor.cpp
+++ b/src/jsc/bindings/node/crypto/JSECDHConstructor.cpp
@@ -48,6 +48,17 @@ JSC_DEFINE_HOST_FUNCTION(constructECDH, (JSC::JSGlobalObject * globalObject, JSC
     JSC::VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    auto* zigGlobalObject = defaultGlobalObject(globalObject);
+    JSC::Structure* structure = zigGlobalObject->m_JSECDHClassStructure.get(zigGlobalObject);
+
+    JSC::JSValue newTarget = callFrame->newTarget();
+    if (zigGlobalObject->m_JSECDHClassStructure.constructor(zigGlobalObject) != newTarget) [[unlikely]] {
+        auto* functionGlobalObject = defaultGlobalObject(JSC::getFunctionRealm(globalObject, newTarget.getObject()));
+        RETURN_IF_EXCEPTION(scope, {});
+        structure = JSC::InternalFunction::createSubclassStructure(globalObject, newTarget.getObject(), functionGlobalObject->m_JSECDHClassStructure.get(functionGlobalObject));
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
     JSValue curveValue = callFrame->argument(0);
 
     Bun::V::validateString(scope, globalObject, curveValue, "curve"_s);
@@ -67,9 +78,6 @@ JSC_DEFINE_HOST_FUNCTION(constructECDH, (JSC::JSGlobalObject * globalObject, JSC
     if (!key) {
         return Bun::ERR::CRYPTO_OPERATION_FAILED(scope, globalObject, "Failed to create key using named curve"_s);
     }
-
-    auto* zigGlobalObject = defaultGlobalObject(globalObject);
-    JSC::Structure* structure = zigGlobalObject->m_JSECDHClassStructure.get(zigGlobalObject);
 
     const EC_GROUP* group = key.getGroup();
     return JSC::JSValue::encode(JSECDH::create(vm, structure, globalObject, WTF::move(key), group));

--- a/src/jsc/bindings/node/http/JSConnectionsListConstructor.cpp
+++ b/src/jsc/bindings/node/http/JSConnectionsListConstructor.cpp
@@ -20,7 +20,8 @@ JSC_DEFINE_HOST_FUNCTION(constructConnectionsList, (JSGlobalObject * lexicalGlob
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
 
-    Structure* structure = globalObject->m_JSConnectionsListClassStructure.get(globalObject);
+    Structure* structure = structureForNewTarget(lexicalGlobalObject, callFrame->newTarget(), &Zig::GlobalObject::m_JSConnectionsListClassStructure);
+    RETURN_IF_EXCEPTION(scope, {});
 
     JSSet* allConnections = JSSet::create(vm, lexicalGlobalObject->setStructure());
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/node/http/JSHTTPParserConstructor.cpp
+++ b/src/jsc/bindings/node/http/JSHTTPParserConstructor.cpp
@@ -20,7 +20,8 @@ JSC_DEFINE_HOST_FUNCTION(constructHTTPParser, (JSGlobalObject * lexicalGlobalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
 
-    Structure* structure = globalObject->m_JSHTTPParserClassStructure.get(globalObject);
+    Structure* structure = structureForNewTarget(lexicalGlobalObject, callFrame->newTarget(), &Zig::GlobalObject::m_JSHTTPParserClassStructure);
+    RETURN_IF_EXCEPTION(scope, {});
     JSHTTPParser* HTTPParser = JSHTTPParser::create(vm, structure, globalObject);
 
     return JSValue::encode(HTTPParser);

--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -295,6 +295,8 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCookieDOMConstructor::
     if (!callFrame->thisValue().isObject()) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotAConstructorError(lexicalGlobalObject, callFrame->jsCallee()));
 
+    RefPtr<Cookie> cookie;
+
     // Static method: parse(cookieString)
     if (callFrame->argumentCount() == 1 && callFrame->argument(0).isString()) {
         // new Bun.Cookie.parse("foo=bar")
@@ -311,10 +313,7 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCookieDOMConstructor::
             WebCore::propagateException(lexicalGlobalObject, throwScope, cookie_exception.releaseException());
             RELEASE_AND_RETURN(throwScope, {});
         }
-        auto cookie = cookie_exception.releaseReturnValue();
-
-        auto* globalObject = castedThis->globalObject();
-        RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS(lexicalGlobalObject, globalObject, WTF::move(cookie))));
+        cookie = cookie_exception.releaseReturnValue();
     } else if (callFrame->argumentCount() == 1 && callFrame->argument(0).isObject()) {
         // new Bun.Cooke({
         //     name: "name",
@@ -333,9 +332,7 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCookieDOMConstructor::
             WebCore::propagateException(lexicalGlobalObject, throwScope, cookie_exception.releaseException());
             RELEASE_AND_RETURN(throwScope, {});
         }
-        auto cookie = cookie_exception.releaseReturnValue();
-        auto* globalObject = castedThis->globalObject();
-        RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS(lexicalGlobalObject, globalObject, WTF::move(cookie))));
+        cookie = cookie_exception.releaseReturnValue();
     } else if (callFrame->argumentCount() >= 2) {
         // new Bun.Cookie("name", "value", {
         //     domain: "domain",
@@ -368,13 +365,15 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCookieDOMConstructor::
             WebCore::propagateException(lexicalGlobalObject, throwScope, cookie_exception.releaseException());
             RELEASE_AND_RETURN(throwScope, {});
         }
-        auto cookie = cookie_exception.releaseReturnValue();
-
-        auto* globalObject = castedThis->globalObject();
-        RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS(lexicalGlobalObject, globalObject, WTF::move(cookie))));
+        cookie = cookie_exception.releaseReturnValue();
+    } else {
+        return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     }
 
-    return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
+    JSValue jsValue = toJSNewlyCreated(lexicalGlobalObject, castedThis->globalObject(), cookie.releaseNonNull());
+    setSubclassStructureIfNeeded<Cookie>(lexicalGlobalObject, callFrame, asObject(jsValue));
+    RETURN_IF_EXCEPTION(throwScope, {});
+    return JSValue::encode(jsValue);
 }
 
 JSC_ANNOTATE_HOST_FUNCTION(JSCookieDOMConstructorConstruct, JSCookieDOMConstructor::construct);

--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -198,7 +198,10 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSCookieMapDOMConstructo
     }
     auto result = result_exception.releaseReturnValue();
 
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJSNewlyCreated(lexicalGlobalObject, castedThis->globalObject(), WTF::move(result))));
+    JSValue jsValue = toJSNewlyCreated(lexicalGlobalObject, castedThis->globalObject(), WTF::move(result));
+    setSubclassStructureIfNeeded<CookieMap>(lexicalGlobalObject, callFrame, asObject(jsValue));
+    RETURN_IF_EXCEPTION(throwScope, {});
+    return JSValue::encode(jsValue);
 }
 
 JSC_ANNOTATE_HOST_FUNCTION(JSCookieMapDOMConstructorConstruct, JSCookieMapDOMConstructor::construct);

--- a/test/js/bun/cookie/cookie-map.test.ts
+++ b/test/js/bun/cookie/cookie-map.test.ts
@@ -455,6 +455,67 @@ describe("delete with prefixed cookie names", () => {
   });
 });
 
+describe("subclassing", () => {
+  class SessionCookie extends Bun.Cookie {
+    pair() {
+      return `${this.name}=${this.value}`;
+    }
+  }
+  class Jar extends Bun.CookieMap {
+    names() {
+      return [...this.keys()];
+    }
+  }
+
+  test.each([
+    ["(name, value)", ["id", "1"]],
+    ["(name, value, options)", ["id", "1", { path: "/app" }]],
+    ["(cookieString)", ["id=1; Path=/app"]],
+    ["(options)", [{ name: "id", value: "1", path: "/app" }]],
+  ])("new (class extends Bun.Cookie)%s returns an instance of the subclass", (_overload, args) => {
+    const cookie = new SessionCookie(...(args as any));
+    expect(Object.getPrototypeOf(cookie)).toBe(SessionCookie.prototype);
+    expect(cookie).toBeInstanceOf(Bun.Cookie);
+    expect(cookie.pair()).toBe("id=1");
+    expect(cookie.serialize()).toStartWith("id=1; Path=/");
+  });
+
+  test.each([
+    ["(string)", "a=1; b=2"],
+    ["(object)", { a: "1", b: "2" }],
+    [
+      "(pairs)",
+      [
+        ["a", "1"],
+        ["b", "2"],
+      ],
+    ],
+  ])("new (class extends Bun.CookieMap)%s returns an instance of the subclass", (_overload, init) => {
+    const jar = new Jar(init as any);
+    expect(Object.getPrototypeOf(jar)).toBe(Jar.prototype);
+    expect(jar).toBeInstanceOf(Bun.CookieMap);
+    expect(jar.names()).toEqual(["a", "b"]);
+    jar.set("c", "3");
+    expect(jar.toJSON()).toEqual({ a: "1", b: "2", c: "3" });
+  });
+
+  test("Reflect.construct takes the prototype from newTarget", () => {
+    function NewTarget() {}
+    const cookie = Reflect.construct(Bun.Cookie, ["id", "1"], NewTarget);
+    expect(Object.getPrototypeOf(cookie)).toBe(NewTarget.prototype);
+    expect(Bun.Cookie.prototype.serialize.call(cookie)).toStartWith("id=1;");
+
+    const map = Reflect.construct(Bun.CookieMap, ["a=1"], NewTarget);
+    expect(Object.getPrototypeOf(map)).toBe(NewTarget.prototype);
+    expect(Bun.CookieMap.prototype.get.call(map, "a")).toBe("1");
+  });
+
+  test("the base constructors still return the base prototype", () => {
+    expect(Object.getPrototypeOf(new Bun.Cookie("id", "1"))).toBe(Bun.Cookie.prototype);
+    expect(Object.getPrototypeOf(new Bun.CookieMap("a=1"))).toBe(Bun.CookieMap.prototype);
+  });
+});
+
 describe("invalid delete usage", () => {
   test("invalid usage does not crash", () => {
     expect(() => {

--- a/test/js/bun/shell/bunshell-instance.test.ts
+++ b/test/js/bun/shell/bunshell-instance.test.ts
@@ -53,6 +53,21 @@ test("$$", async () => {
   expect((await $`echo $BUN`).stdout.toString()).toBe("bun2\n");
 });
 
+test("new (class extends $.Shell) returns an instance of the subclass", async () => {
+  class GreetingShell extends $.Shell {
+    greet(name: string) {
+      return this`echo $GREETING ${name}`.text();
+    }
+  }
+
+  const $$ = new GreetingShell();
+  expect(Object.getPrototypeOf($$)).toBe(GreetingShell.prototype);
+  expect($$).toBeInstanceOf($.Shell);
+
+  $$.env({ GREETING: "hello" });
+  expect(await $$.greet("bun")).toBe("hello bun\n");
+});
+
 test("$.text", async () => {
   expect(await $`echo hello`.text()).toBe("hello\n");
 });

--- a/test/js/node/crypto/ecdh.test.ts
+++ b/test/js/node/crypto/ecdh.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { createECDH, ECDH, getCurves } from "node:crypto";
+import { createContext, runInContext } from "node:vm";
 
 // Helper function to generate test key pairs for various curves
 function generateTestKeyPairs() {
@@ -265,4 +266,36 @@ test("ECDH - computeSecret throws when only a public key is set (no private key)
   expect(carolSecret).toBeInstanceOf(Buffer);
   expect(carolSecret.length).toBeGreaterThan(0);
   expect(carolSecret.toString("hex")).toBe(aliceSecret.toString("hex"));
+});
+
+test.each([
+  [
+    "the main realm",
+    () =>
+      class MyECDH extends ECDH {
+        publicKeyHex() {
+          return this.getPublicKey("hex");
+        }
+      },
+  ],
+  [
+    "a node:vm context",
+    () =>
+      runInContext(
+        `(class MyECDH extends ECDH { publicKeyHex() { return this.getPublicKey("hex"); } })`,
+        createContext({ ECDH }),
+      ),
+  ],
+])("ECDH - a subclass declared in %s has the subclass prototype and working keys", (_realm, declare) => {
+  const MyECDH = declare();
+
+  const alice = new MyECDH("prime256v1");
+  expect(Object.getPrototypeOf(alice)).toBe(MyECDH.prototype);
+  expect(alice).toBeInstanceOf(ECDH);
+
+  const bob = createECDH("prime256v1");
+  alice.generateKeys();
+  bob.generateKeys();
+  expect(alice.publicKeyHex()).toBe(alice.getPublicKey("hex"));
+  expect(alice.computeSecret(bob.getPublicKey())).toEqual(bob.computeSecret(alice.getPublicKey()));
 });

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -4,6 +4,7 @@ import { bunEnv, bunExe } from "harness";
 import crypto from "node:crypto";
 import { PassThrough, Readable } from "node:stream";
 import util from "node:util";
+import vm from "node:vm";
 
 it("crypto.randomBytes should return a Buffer", () => {
   expect(crypto.randomBytes(1) instanceof Buffer).toBe(true);
@@ -766,6 +767,39 @@ describe("DiffieHellman", () => {
       threw: true,
       value: expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
     });
+  });
+
+  it.each([
+    [
+      "the main realm",
+      () =>
+        class MyDH extends crypto.DiffieHellman {
+          publicKeyHex() {
+            return this.getPublicKey("hex");
+          }
+        },
+    ],
+    [
+      "a node:vm context",
+      () =>
+        vm.runInContext(
+          `(class MyDH extends DiffieHellman { publicKeyHex() { return this.getPublicKey("hex"); } })`,
+          vm.createContext({ DiffieHellman: crypto.DiffieHellman }),
+        ),
+    ],
+  ])("a subclass declared in %s has the subclass prototype and working keys", (_realm, declare) => {
+    const MyDH = declare();
+    const bob = crypto.getDiffieHellman("modp5");
+
+    const alice = new MyDH(bob.getPrime(), bob.getGenerator());
+    expect(Object.getPrototypeOf(alice)).toBe(MyDH.prototype);
+    expect(alice).toBeInstanceOf(crypto.DiffieHellman);
+
+    expect(alice.verifyError).toBe(bob.verifyError);
+    alice.generateKeys();
+    bob.generateKeys();
+    expect(alice.publicKeyHex()).toBe(alice.getPublicKey("hex"));
+    expect(alice.computeSecret(bob.getPublicKey())).toEqual(bob.computeSecret(alice.getPublicKey()));
   });
 });
 

--- a/test/js/node/dns/dns-resolver-class.test.ts
+++ b/test/js/node/dns/dns-resolver-class.test.ts
@@ -1,0 +1,34 @@
+// node-dns.test.js resolves public hostnames. These tests need no network.
+import { describe, expect, test } from "bun:test";
+import dns from "node:dns";
+
+describe.each([
+  ["dns.Resolver", dns.Resolver],
+  ["dns.promises.Resolver", dns.promises.Resolver],
+])("%s", (_name, Resolver: any) => {
+  test("an instance has Resolver.prototype", () => {
+    const resolver = new Resolver();
+    expect(Object.getPrototypeOf(resolver)).toBe(Resolver.prototype);
+    expect(resolver.constructor).toBe(Resolver);
+  });
+
+  test("a subclass instance has the subclass prototype and its own servers", () => {
+    class PinnedResolver extends Resolver {
+      getServers() {
+        return super.getServers().map((server: string) => `pinned ${server}`);
+      }
+    }
+
+    const resolver = new PinnedResolver({ timeout: 1000, tries: 1 });
+    expect(Object.getPrototypeOf(resolver)).toBe(PinnedResolver.prototype);
+    expect(resolver).toBeInstanceOf(Resolver);
+
+    resolver.setServers(["192.0.2.1"]);
+    expect(resolver.getServers()).toEqual(["pinned 192.0.2.1"]);
+    expect(dns.getServers()).not.toContain("192.0.2.1");
+  });
+
+  test("throws a TypeError when called without new", () => {
+    expect(() => Resolver()).toThrow(TypeError);
+  });
+});

--- a/test/js/node/http/node-http-parser.test.ts
+++ b/test/js/node/http/node-http-parser.test.ts
@@ -339,6 +339,33 @@ describe("ConnectionsList", () => {
   });
 });
 
+test("subclasses of HTTPParser and ConnectionsList return instances of the subclass", () => {
+  class RequestParser extends HTTPParser {
+    start(list) {
+      this.initialize(HTTPParser.REQUEST, {}, 0, 0, list);
+      return this;
+    }
+  }
+  class ParserList extends ConnectionsList {
+    count() {
+      return this.all().length;
+    }
+  }
+
+  const list = new ParserList();
+  expect(Object.getPrototypeOf(list)).toBe(ParserList.prototype);
+  expect(list).toBeInstanceOf(ConnectionsList);
+
+  const parser = new RequestParser().start(list);
+  expect(Object.getPrototypeOf(parser)).toBe(RequestParser.prototype);
+  expect(parser).toBeInstanceOf(HTTPParser);
+
+  expect(list.count()).toBe(1);
+  expect(list.all()).toEqual([parser]);
+  parser.execute(Buffer.from("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"));
+  expect(parser.headersCompleted()).toBe(true);
+});
+
 describe("parserOnHeaders maxHeaderPairs clamp (nodejs/node#61285)", () => {
   test("only fills remaining capacity instead of pushing the whole batch", () => {
     const parser = parsers.alloc();


### PR DESCRIPTION
### Problem
- `class X extends C {}; new X()` returns an instance of `C`, not of `X`, for `Bun.Cookie`, `Bun.CookieMap`, `crypto.ECDH`, `crypto.DiffieHellman`, `dns.Resolver`, `$.Shell`, and `HTTPParser` and `ConnectionsList` of the `http_parser` binding. `new X() instanceof X` is `false` and the methods of `X` are missing. Node v26.3.0 returns an `X`.
- The native constructors ignore `newTarget` and always use the base structure (`JSCookie.cpp`, `JSCookieMap.cpp`, `JSECDHConstructor.cpp:75`, `JSDiffieHellmanConstructor.cpp:193`, `JSHTTPParserConstructor.cpp:23`, `JSConnectionsListConstructor.cpp:23`). `$.Shell` (`shell.ts:344`) always sets `ShellPrototype.prototype`.
- `dns.Resolver` (`dns.ts:694`) returns `new InternalResolver(options)`. So `new dns.Resolver() instanceof dns.Resolver` is `false` too, and a method patched on `dns.Resolver.prototype` never runs.

### Fix
- `Bun.Cookie` and `Bun.CookieMap` call `setSubclassStructureIfNeeded`, like the other 22 `JSDOMConstructor` bindings.
- `structureForNewTarget` (new, beside `defaultGlobalObject`) holds the `newTarget` block that `crypto.DiffieHellmanGroup` had. `ECDH`, `DiffieHellman`, `DiffieHellmanGroup`, `HTTPParser` and `ConnectionsList` call it. `$.Shell` uses `new.target.prototype`.
- `dns.Resolver` is the class itself, like `dns.promises.Resolver`. `dns.Resolver()` without `new` now throws a `TypeError`, as in Node. The compat page drops its note about this class.
- Verified: tests in `cookie-map.test.ts`, `ecdh.test.ts`, `node-crypto.test.js`, `node-http-parser.test.ts`, `bunshell-instance.test.ts` and `dns-resolver-class.test.ts`. 1.4.3-canary.1 fails 17 of them.

### Background
- `newTarget` is the constructor that `new` was applied to. In `new X()`, `C` runs with `newTarget === X`. The object must get `X.prototype`.
- A JSC `Structure` holds the prototype of an object. `InternalFunction::createSubclassStructure(newTarget, base)` returns the base structure with `newTarget.prototype`.
- `getFunctionRealm(newTarget)` is the global of `newTarget`. For a class from a `node:vm` context it is not a Bun global, so the code passes it through `defaultGlobalObject`.

<details><summary>Notes</summary>

Repro:

```js
const crypto = require("node:crypto"), dns = require("node:dns"), { HTTPParser, ConnectionsList } = process.binding("http_parser");
const T = [["Bun.Cookie", Bun.Cookie, ["a", "b"]], ["Bun.CookieMap", Bun.CookieMap, ["a=b"]], ["crypto.ECDH", crypto.ECDH, ["prime256v1"]],
  ["crypto.DiffieHellman", crypto.DiffieHellman, [Buffer.from("17", "hex")]], ["dns.Resolver", dns.Resolver, []], ["$.Shell", Bun.$.Shell, []],
  ["HTTPParser", HTTPParser, []], ["ConnectionsList", ConnectionsList, []],
  ["control crypto.DiffieHellmanGroup", crypto.DiffieHellmanGroup, ["modp14"]], ["control dns.promises.Resolver", dns.promises.Resolver, []], ["control URL", URL, ["http://a/"]]];
for (const [n, C, a] of T) { class X extends C { extra() { return 1; } } const r = new X(...a);
  console.log(n.padEnd(34), "instanceof X:", r instanceof X, "| instanceof C:", r instanceof C, "| extra:", typeof r.extra); }
```

| | 1.4.3-canary.1 | this branch | node v26.3.0 |
| --- | --- | --- | --- |
| `Bun.Cookie`, `Bun.CookieMap`, `$.Shell` | `false`, `true`, `undefined` | `true`, `true`, `function` | |
| `crypto.ECDH`, `crypto.DiffieHellman`, `_http_common.HTTPParser` | `false`, `true`, `undefined` | `true`, `true`, `function` | `true`, `true`, `function` |
| `ConnectionsList` | `false`, `true`, `undefined` | `true`, `true`, `function` | not reachable |
| `dns.Resolver` | `false`, `false`, `undefined` | `true`, `true`, `function` | `true`, `true`, `function` |
| the three controls | `true`, `true`, `function` | `true`, `true`, `function` | `true`, `true`, `function` |

`dns.Resolver`:
- The wrapper function is from the first `node:dns` implementation (2b1b897375). `$toClass` gave it a prototype that inherits from `InternalResolver.prototype`, but the returned object had `InternalResolver.prototype` itself. No object ever had `dns.Resolver.prototype`.
- dd-trace wraps `dns.Resolver.prototype.resolve`, `reverse` and the shorthands. On 1.4.3-canary.1 a wrapper installed there is never called on an instance. It is called on this branch and on Node.
- Node declares `class Resolver extends ResolverBase {}`, so `dns.Resolver()` without `new` throws there too: `Class constructor Resolver cannot be invoked without 'new'`. No test in the repo called it without `new`.
- The test is in a new file because `node-dns.test.js` resolves public hostnames. 29 of its tests fail in a sandbox with no outbound DNS, before and after this change (the same 29).
- `docs/runtime/nodejs-compat.mdx` said "the callback-style `Resolver` class cannot be subclassed (`dns.promises.Resolver` can)" since #38441. This PR removes that clause.

`structureForNewTarget`:
- It takes the lexical global, `newTarget`, and a pointer to the `LazyClassStructure` member of `Zig::GlobalObject`. It returns the base structure when `newTarget` is the constructor, and the subclass structure otherwise.
- `DiffieHellmanGroup` calls it at the place where its block was, after the argument checks, so its behaviour does not change. Its `if (!newTarget)` branch is gone. A host `construct` function always has a `newTarget`. `callDiffieHellmanGroup` goes through `JSC::construct`, which sets it to the constructor.
- In `ECDH` and `DiffieHellman` the call is at the top of the constructor. Node's `function ECDH(curve)` gets its `this` before `validateString(curve)` runs, so a `prototype` getter on `newTarget` runs before the argument error. `Reflect.construct(ECDH, [{}], proxyWithThrowingPrototypeGetter)` throws the getter's error on Node and on this branch.
- The other constructors that have the same block by hand (`Hash`, `Hmac`, `Sign`, `X509Certificate`, `MIMEType`, `MIMEParams`, `Dirent`, `vm.Script`, `DatabaseSync`) already honor `newTarget`. This PR does not move them to the helper. That is a refactor with no change in behaviour.
- One difference from Node remains, and `DiffieHellmanGroup`, `Hash`, `Hmac` and `Sign` already have it. For `Reflect.construct(ECDH, args, F)` where `F.prototype` does not inherit from `ECDH.prototype`, Node's `if (!(this instanceof ECDH)) return new ECDH(curve)` returns a plain `ECDH`. Bun returns an object with `F.prototype`. The tests only assert what is the same on Node.

Other cases checked by hand on this branch, for all the classes. None crashes. `BUN_JSC_validateExceptionChecks=1` is clean on the subclass, revoked Proxy and throwing getter paths.
- `Reflect.construct(C, args, F)` with a plain function, a bound function (no `prototype`, so the base prototype is used), a Proxy, and a function whose `prototype` is not an object.
- A revoked Proxy as `newTarget` throws `TypeError: Cannot get function realm from revoked Proxy` (a `TypeError` on Node too).
- A subclass declared in a `node:vm` context, and `Reflect.construct` with a `newTarget` from a context. The crypto tests cover the first case.
- `ECDH("prime256v1")` and `DiffieHellman(prime)` without `new` still return a base instance.

Census: I walked every constructible function reachable from `globalThis`, `Bun`, `node:*` and `bun:*` to depth 3 and constructed a subclass of each with a list of guessed arguments. 772 functions are constructible. 210 returned an object for the subclass. On this branch the ones that are still not an instance of the subclass are:
- `string_decoder.StringDecoder`. It returns the subclass constructor itself. It has a separate change.
- `Buffer` and `SlowBuffer`. Node also returns a plain `Buffer`.
- `diagnostics_channel.Channel`. It overrides `Symbol.hasInstance`. The prototype is correct, and Node prints the same.
- `module.Module`, `ShadowRealm` and `WebAssembly.Suspending`. Known, and the last two are in JavaScriptCore.

The census has blind spots:
- 506 of the 772 did not construct with any guessed argument list.
- It skipped modules whose name starts with `_` and everything behind `process.binding`. A review found `HTTPParser` and `ConnectionsList` there, and this PR fixes them.
- It did not report a constructor whose `extends` clause throws. `tls.SecureContext`, `Bun.ArrayBufferSink` and `Bun.SQL` have no `prototype` object, so `class X extends C` throws `The value of the superclass's prototype property is not an object or null`, and `new C() instanceof C` throws too. #41696 (SecureContext) and #39936 (the sinks) are open for the first two. `Bun.SQL` is a separate follow-up.
- A class from a native addon that uses the V8 API directly is not reachable from JS globals. `FunctionTemplate::functionConstruct` (`src/jsc/bindings/v8/shim/FunctionTemplate.cpp`) takes the prototype from the callee and not from `newTarget`. That is a separate follow-up.

`$.Shell` was not in the original report. The census found it.

Separate from this PR: `Object.getPrototypeOf(Bun.Cookie)` and `Object.getPrototypeOf(Bun.CookieMap)` are `Object.prototype`, not `Function.prototype` (`prototypeForStructure` in both files). So `Bun.Cookie.bind` is `undefined`, also on a subclass. This PR does not change that.

Suites run on the debug build: `test/js/bun/cookie/`, `test/js/node/crypto/node-crypto.test.js`, `ecdh.test.ts`, `crypto-invalid-this.test.ts`, `test/js/node/dns/dns-resolver-class.test.ts`, `node-dns.test.js`, `test/js/node/http/node-http-parser.test.ts`, `test/js/bun/shell/bunshell-instance.test.ts`, `bunshell-default.test.ts`, `env.positionals.test.ts`, and the Node tests `test-crypto-dh*.js` (13 files), `test-crypto-ecdh*.js`, `test-crypto-classes.js`, `test-dns*.js` (25 files), `test-worker-dns-terminate*.js`, `test-http-parser*.js`, `test-http-common.js`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 18 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/cookie/cookie-map.test.ts test/js/bun/shell/bunshell-instance.test.ts test/js/node/crypto/ecdh.test.ts test/js/node/crypto/node-crypto.test.js test/js/node/dns/dns-resolver-class.test.ts test/js/node/http/node-http-parser.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/166] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/166] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/166] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/fil
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (138f46d59)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [0.08ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [0.07ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [0.10ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [7.65ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [0.15ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [0.11ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [0.10ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [0.12ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse takes the last value of a repeated attribute [0.04ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse reads every attribute in any order [0.17ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.serialize creates cookie string [0.09ms]
(pass) Bun.Cookie and Bun.CookieMap > can create an empty CookieMap [0.06ms]
(pass) Bun.Cookie and Bun.CookieMap > can create Cooki
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/cookie/cookie-map.test.ts test/js/bun/shell/bunshell-instance.test.ts test/js/node/crypto/ecdh.test.ts test/js/node/crypto/node-crypto.test.js test/js/node/dns/dns-resolver-class.test.ts test/js/node/http/node-http-parser.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/cookie/cookie-map.test.ts:
(pass) Bun.Cookie and Bun.CookieMap > can create a basic Cookie [4.56ms]
(pass) Bun.Cookie and Bun.CookieMap > can create a Cookie with options [5.05ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.toString() formats properly [5.87ms]
(pass) Bun.Cookie and Bun.CookieMap > can set Cookie expires as Date [160.37ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() returns correct value [4.67ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.isExpired() gives Max-Age precedence over Expires [6.09ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse works with all attributes [6.01ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse keeps Expires when Max-Age comes first [8.01ms]
(pass) Bun.Cookie and Bun.CookieMap > Cookie.parse
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 726ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/127] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/127] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/127] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/nodejs-compat.mdx                     |  2 +-
 src/js/builtins/shell.ts                           |  3 +-
 src/js/node/dns.ts                                 |  9 +---
 src/jsc/bindings/ZigGlobalObject.cpp               | 14 +++++
 src/jsc/bindings/ZigGlobalObject.h                 |  3 ++
 .../node/crypto/JSDiffieHellmanConstructor.cpp     |  7 ++-
 .../crypto/JSDiffieHellmanGroupConstructor.cpp     | 18 +------
 src/jsc/bindings/node/crypto/JSECDHConstructor.cpp |  6 +--
 .../node/http/JSConnectionsListConstructor.cpp     |  3 +-
 .../bindings/node/http/JSHTTPParserConstructor.cpp |  3 +-
 src/jsc/bindings/webcore/JSCookie.cpp              | 23 ++++----
 src/jsc/bindings/webcore/JSCookieMap.cpp           |  5 +-
 test/js/bun/cookie/cookie-map.test.ts              | 61 ++++++++++++++++++++++
 test/js/bun/shell/bunshell-instance.test.ts        | 15 ++++++
 test/js/node/crypto/ecdh.test.ts                   | 33 ++++++++++++
 test/js/node/crypto/node-crypto.test.js            | 34 ++++++++++++
 test/js/node/dns/dns-resolver-class.test.ts        | 34 ++++++++++++
 test/js/node/http/node-http-parser.test.ts         | 27 ++++++++++
 18 files changed, 253 insertions(+), 47 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
docs/runtime/nodejs-compat.mdx                                1      1     29
src/js/builtins/shell.ts                                      1      1     29
src/js/node/dns.ts                                            2      0     29
src/jsc/bindings/ZigGlobalObject.cpp                          0      0     29
src/jsc/bindings/ZigGlobalObject.h                            3      2     29
…jsc/bindings/node/crypto/JSDiffieHellmanConstructor.cpp      0      0     29
…indings/node/crypto/JSDiffieHellmanGroupConstructor.cpp      0      0     29
src/jsc/bindings/node/crypto/JSECDHConstructor.cpp            1      1     29
…jsc/bindings/node/http/JSConnectionsListConstructor.cpp      0      0     29
src/jsc/bindings/node/http/JSHTTPParserConstructor.cpp        0      0     29
src/jsc/bindings/webcore/JSCookie.cpp                         1      0     29
src/jsc/bindings/webcore/JSCookieMap.cpp                      1      1     29
test/js/bun/cookie/cookie-map.test.ts                         1      2      7
test/js/bun/shell/bunshell-instance.test.ts                   1      2      6
test/js/node/crypto/ecdh.test.ts                              0      0      9
test/js/node/crypto/node-crypto.test.js                       0      0      9
(+ 2 more files)
```

</details>

<!-- robobun:evidence:end -->