### PR TITLE
XML.stringify: throw for a string `space` that is not XML whitespace

### DIFF
--- a/docs/runtime/xml.mdx
+++ b/docs/runtime/xml.mdx
@@ -161,7 +161,7 @@ await Bun.write(
 
 #### Pretty printing
 
-Pass a `space` argument (a number of spaces or an indent string, as with `JSON.stringify`) to indent element-only content. Bun writes an element that contains text on one line, so indentation does not change character data:
+Pass a `space` argument (a number of spaces or an indent string, as with `JSON.stringify`) to indent element-only content. Bun writes an indent string between elements as is, so the string can only contain XML whitespace: space, tab, newline and carriage return. `stringify` throws for any other string. Bun writes an element that contains text on one line, so indentation does not change character data:
 
 ```ts
 console.log(XML.stringify(data, null, 2));

--- a/docs/runtime/xml.mdx
+++ b/docs/runtime/xml.mdx
@@ -161,7 +161,7 @@ await Bun.write(
 
 #### Pretty printing
 
-Pass a `space` argument (a number of spaces or an indent string, as with `JSON.stringify`) to indent element-only content. Bun writes an indent string between elements as is, so the string can only contain XML whitespace: space, tab, newline and carriage return. `stringify` throws for any other string. Bun writes an element that contains text on one line, so indentation does not change character data:
+Pass a `space` argument (a number of spaces or an indent string, as with `JSON.stringify`) to indent element-only content. Bun writes the first 10 characters of an indent string between elements as is. Those characters can only be XML whitespace: space, tab, newline and carriage return. `stringify` throws for any other character. Bun writes an element that contains text on one line, so indentation does not change character data:
 
 ```ts
 console.log(XML.stringify(data, null, 2));

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1325,7 +1325,8 @@ declare module "bun" {
      * contain (U+0000, other C0 controls except tab/newline/carriage return,
      * U+FFFE, U+FFFF, unpaired surrogates); for `--` inside a comment or `?>`
      * inside processing-instruction data; for an array at the root or inside
-     * another array; and for circular structures.
+     * another array; for a `space` string that is not whitespace; and for
+     * circular structures.
      *
      * Strings, numbers, booleans and bigints become text via `String()`, a
      * `Date` its ISO string; `null` becomes an empty element (or leaves an
@@ -1343,8 +1344,10 @@ declare module "bun" {
      * @param replacer Reserved; must be `undefined` or `null`
      * @param space Indentation for element-only content, as in `JSON.stringify`:
      * a number of spaces (at most 10) or a string (its first 10 characters).
-     * An element with any text child is written on one line so character data
-     * is unchanged.
+     * The string is written between elements as is, so it can only contain
+     * XML whitespace (space, tab, newline, carriage return); anything else
+     * throws. An element with any text child is written on one line so
+     * character data is unchanged.
      * @returns The XML, or `undefined` if `value` is `undefined`, a function, or a symbol
      *
      * @example

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1325,8 +1325,8 @@ declare module "bun" {
      * contain (U+0000, other C0 controls except tab/newline/carriage return,
      * U+FFFE, U+FFFF, unpaired surrogates); for `--` inside a comment or `?>`
      * inside processing-instruction data; for an array at the root or inside
-     * another array; for a `space` string that is not whitespace; and for
-     * circular structures.
+     * another array; for anything but whitespace in the first 10 characters
+     * of a `space` string; and for circular structures.
      *
      * Strings, numbers, booleans and bigints become text via `String()`, a
      * `Date` its ISO string; `null` becomes an empty element (or leaves an
@@ -1344,8 +1344,8 @@ declare module "bun" {
      * @param replacer Reserved; must be `undefined` or `null`
      * @param space Indentation for element-only content, as in `JSON.stringify`:
      * a number of spaces (at most 10) or a string (its first 10 characters).
-     * The string is written between elements as is, so it can only contain
-     * XML whitespace (space, tab, newline, carriage return); anything else
+     * Those characters are written between elements as is, so they can only
+     * be XML whitespace (space, tab, newline, carriage return); anything else
      * throws. An element with any text child is written on one line so
      * character data is unchanged.
      * @returns The XML, or `undefined` if `value` is `undefined`, a function, or a symbol

--- a/src/parsers/xml.rs
+++ b/src/parsers/xml.rs
@@ -362,6 +362,12 @@ pub fn is_xml_char(cp: u32) -> bool {
     matches!(cp, 0x9 | 0xA | 0xD | 0x20..=0xD7FF | 0xE000..=0xFFFD | 0x10000..=0x10FFFF)
 }
 
+/// `S` (§2.3 [3]) for any code point; used by `XML.stringify` to refuse
+/// indentation the parser would read as content.
+pub fn is_whitespace(cp: u32) -> bool {
+    cp < 0x80 && is_ws(cp as u8)
+}
+
 /// `NameStartChar` (§2.3 [4]) for any code point; used by `XML.stringify`
 /// to refuse names the parser would reject.
 pub fn is_name_start_char(cp: u32) -> bool {

--- a/src/parsers/xml.rs
+++ b/src/parsers/xml.rs
@@ -362,8 +362,7 @@ pub fn is_xml_char(cp: u32) -> bool {
     matches!(cp, 0x9 | 0xA | 0xD | 0x20..=0xD7FF | 0xE000..=0xFFFD | 0x10000..=0x10FFFF)
 }
 
-/// `S` (§2.3 [3]) for any code point; used by `XML.stringify` to refuse
-/// indentation the parser would read as content.
+/// `S` (§2.3 [3]) for any code point.
 pub fn is_whitespace(cp: u32) -> bool {
     cp < 0x80 && is_ws(cp as u8)
 }

--- a/src/runtime/api/XMLObject.rs
+++ b/src/runtime/api/XMLObject.rs
@@ -212,7 +212,12 @@ enum Space {
 }
 
 impl Space {
-    /// Same interpretation as `JSON.stringify`'s `space`.
+    /// How many code units of a string `space` are written per level.
+    const MAX_STR_LEN: usize = 10;
+
+    /// Same interpretation as `JSON.stringify`'s `space`, except that a
+    /// string must be XML whitespace: it is written between elements as is,
+    /// so anything else would be markup or character data.
     fn init(global: &JSGlobalObject, space_value: JSValue) -> JsResult<Space> {
         let space = space_value.unwrap_boxed_primitive(global)?;
         if space.is_number() {
@@ -227,6 +232,12 @@ impl Space {
             if str.length() == 0 {
                 return Ok(Space::Minified);
             }
+            let written = str.trunc(Self::MAX_STR_LEN);
+            if !(0..written.length()).all(|i| is_xml_space(written.char_at(i))) {
+                return Err(global.throw(format_args!(
+                    "XML.stringify: a 'space' string can only contain XML whitespace (space, tab, newline, carriage return)"
+                )));
+            }
             return Ok(Space::Str(str));
         }
         Ok(Space::Minified)
@@ -235,6 +246,11 @@ impl Space {
     fn is_pretty(&self) -> bool {
         !matches!(self, Space::Minified)
     }
+}
+
+/// `S` (XML 1.0 §2.3 [3]).
+fn is_xml_space(unit: u16) -> bool {
+    matches!(unit, 0x20 | 0x09 | 0x0A | 0x0D)
 }
 
 /// How a JS value is written as element content or an attribute value.
@@ -925,7 +941,7 @@ impl Stringifier {
             }
             Space::Str(s) => {
                 self.builder.append_lchar(b'\n');
-                let clamped = s.trunc(10);
+                let clamped = s.trunc(Space::MAX_STR_LEN);
                 for _ in 0..self.indent {
                     self.builder.append_string(&clamped);
                 }

--- a/src/runtime/api/XMLObject.rs
+++ b/src/runtime/api/XMLObject.rs
@@ -215,9 +215,7 @@ impl Space {
     /// How many code units of a string `space` are written per level.
     const MAX_STR_LEN: usize = 10;
 
-    /// Same interpretation as `JSON.stringify`'s `space`, except that a
-    /// string must be XML whitespace: it is written between elements as is,
-    /// so anything else would be markup or character data.
+    /// `JSON.stringify`'s `space`, except that a string must be XML whitespace.
     fn init(global: &JSGlobalObject, space_value: JSValue) -> JsResult<Space> {
         let space = space_value.unwrap_boxed_primitive(global)?;
         if space.is_number() {

--- a/src/runtime/api/XMLObject.rs
+++ b/src/runtime/api/XMLObject.rs
@@ -233,7 +233,7 @@ impl Space {
                 return Ok(Space::Minified);
             }
             let written = str.trunc(Self::MAX_STR_LEN);
-            if !(0..written.length()).all(|i| is_xml_space(written.char_at(i))) {
+            if !(0..written.length()).all(|i| xml::is_whitespace(u32::from(written.char_at(i)))) {
                 return Err(global.throw(format_args!(
                     "XML.stringify: a 'space' string can only contain XML whitespace (space, tab, newline, carriage return)"
                 )));
@@ -246,11 +246,6 @@ impl Space {
     fn is_pretty(&self) -> bool {
         !matches!(self, Space::Minified)
     }
-}
-
-/// `S` (XML 1.0 §2.3 [3]).
-fn is_xml_space(unit: u16) -> bool {
-    matches!(unit, 0x20 | 0x09 | 0x0A | 0x0D)
 }
 
 /// How a JS value is written as element content or an attribute value.

--- a/test/js/bun/xml/xml.test.ts
+++ b/test/js/bun/xml/xml.test.ts
@@ -935,8 +935,8 @@ describe("XML.stringify", () => {
     );
     expect(XML.stringify(value, null, "\t")).toBe(XML.stringify(value, null, 2).replaceAll("  ", "\t"));
     expect(XML.stringify(value, null, 100)).toBe(XML.stringify(value, null, 10));
-    expect(XML.stringify(value, null, "abcdefghijklmnop")).toBe(
-      XML.stringify(value, null, 10).replaceAll("          ", "abcdefghij"),
+    expect(XML.stringify(value, null, "\t\t\t\t\t\t\t\t\t\t      ")).toBe(
+      XML.stringify(value, null, 10).replaceAll("          ", "\t\t\t\t\t\t\t\t\t\t"),
     );
     for (const minified of [0, -1, NaN, "", null, undefined, true, {}]) {
       expect(XML.stringify(value, null, minified as any)).toBe(XML.stringify(value));
@@ -948,6 +948,46 @@ describe("XML.stringify", () => {
     expect(XML.stringify(spaced, null, 4)).toBe(`<a>\n  <b/>\n</a>`);
     // Compact values keep their text exactly too, so leaf padding survives a round trip.
     expect(XML.parse(XML.stringify({ a: { v: "  x  ", w: "   " } }, null, 2))).toEqual({ a: { v: "  x  ", w: "   " } });
+  });
+
+  test("a string space must be XML whitespace", () => {
+    const value = { order: { item: ["Tea", "Mug"], paid: null } };
+    // It is written between elements as is: markup in it makes the output
+    // ill-formed, and any other character becomes character data.
+    const rejected = [
+      "x",
+      "--",
+      " x",
+      "<b>",
+      "&",
+      "</order>",
+      "]]>",
+      "<!-- -->",
+      "\0",
+      "\x01",
+      "\x0B",
+      "\x0C",
+      "\x85",
+      "\xA0",
+      "\u2003",
+      "\u2028",
+      "\uFEFF",
+      "\uD800",
+      "         <",
+    ];
+    for (const space of rejected) {
+      expect(() => XML.stringify(value, null, space)).toThrow("a 'space' string can only contain XML whitespace");
+      expect(() => XML.stringify(value, null, new String(space) as any)).toThrow("XML whitespace");
+      // In both shapes, and up front: not only when something gets indented.
+      expect(() => XML.stringify({ name: "a", children: ["1"] }, null, space)).toThrow("XML whitespace");
+    }
+    for (const space of [" ", "\t", "\n", "\r", "\r\n", " \t\r\n"]) {
+      const text = XML.stringify(value, null, space)!;
+      expect(text).toBe(`<order>\n${space}<item>Tea</item>\n${space}<item>Mug</item>\n${space}<paid/>\n</order>`);
+      expect(XML.parse(text)).toEqual({ order: { item: ["Tea", "Mug"], paid: "" } });
+    }
+    // Only the first 10 characters are written, so only they are checked.
+    expect(XML.stringify(value, null, "          <")).toBe(XML.stringify(value, null, 10));
   });
 
   test("parse(stringify(x)) round-trips both shapes", () => {

--- a/test/js/bun/xml/xml.test.ts
+++ b/test/js/bun/xml/xml.test.ts
@@ -1024,5 +1024,6 @@ describe("XML.stringify", () => {
     let node: any = { name: "a", children: ["x"] };
     for (let i = 0; i < depth; i++) node = { name: "a", children: [node] };
     expect(() => XML.stringify(node)).toThrow(RangeError);
-  });
+    // Building the two values takes over 10 s on a debug build.
+  }, 60_000);
 });

--- a/test/js/bun/xml/xml.test.ts
+++ b/test/js/bun/xml/xml.test.ts
@@ -1,5 +1,6 @@
 import { XML } from "bun";
 import { describe, expect, test } from "bun:test";
+import { isDebug } from "harness";
 
 // Hand-written coverage beyond the W3C conformance suite (xml-test-suite.test.ts):
 // the JS-facing API surface, the two result shapes, Bun-specific input types,
@@ -1015,8 +1016,10 @@ describe("XML.stringify", () => {
 
   test("deep values are a catchable error", () => {
     // Must overflow on every build: release frames are far smaller than
-    // debug/ASAN ones, so use a depth no native stack survives.
-    const depth = 1_000_000;
+    // debug/ASAN ones, so use a depth no native stack survives. A debug build
+    // overflows below depth 3,000 (release: below 30,000) and builds each
+    // level about 50 times slower, so it gets a smaller depth.
+    const depth = isDebug ? 100_000 : 1_000_000;
     let deep: any = "x";
     for (let i = 0; i < depth; i++) deep = { a: deep };
     expect(() => XML.stringify(deep)).toThrow(RangeError);
@@ -1024,6 +1027,5 @@ describe("XML.stringify", () => {
     let node: any = { name: "a", children: ["x"] };
     for (let i = 0; i < depth; i++) node = { name: "a", children: [node] };
     expect(() => XML.stringify(node)).toThrow(RangeError);
-    // Building the two values takes over 10 s on a debug build.
-  }, 60_000);
+  });
 });


### PR DESCRIPTION
### Problem

- `Bun.XML.stringify(value, null, space)` writes a string `space` between elements as is. `space = "<b>"` gives `<order>\n<b><item>Tea</item>…`, which `XML.parse` rejects: `XML Parse error: Expected closing tag </b> but found </order>`. `"&"`, `"]]>"` and U+0001 are ill-formed too. `"x"` adds the text `"\nx\nx\nx"`.
- `bun.d.ts` says "The output is well-formed or `stringify` throws". `Space::init` (`src/runtime/api/XMLObject.rs:216`) accepts any non-empty string, and `newline()` appends it once per level.

### Fix

- `Space::init` checks the part of the string that `newline()` writes (its first 10 code units). If a character is not XML whitespace, `stringify` throws `XML.stringify: a 'space' string can only contain XML whitespace (space, tab, newline, carriage return)`.
- The check runs once per call, before any output. Numbers and whitespace strings give the same output as before.
- Behaviour call: the other option is to ignore such a string. Every other input that `stringify` cannot write throws, so this one throws.
- Verified: `test/js/bun/xml/xml.test.ts`, new test "a string space must be XML whitespace". The released bun fails it. The full file passes with the debug build.

### Background

- `space` works as in `JSON.stringify`: a number of spaces (at most 10), or a string (its first 10 characters). `stringify` indents only an element with no text child.
- XML whitespace is the `S` production of XML 1.0: U+0020, U+0009, U+000A, U+000D. Between child elements, any other character is character data or markup.
- `XML.parse` in the compact shape leaves out whitespace-only text between child elements, so a whitespace `space` parses back to the same value.

<details><summary>Notes</summary>

Repro (release 1.4.3-canary 6a92015fc8):

```js
const v = { order: { item: ["Tea", "Mug"], paid: null } };
for (const space of [2, "\t", "x", "<b>", "&", "</order>", "]]>", "<!-- -->", "\^A"]) {
  let text, back;
  try { text = Bun.XML.stringify(v, null, space); back = JSON.stringify(Bun.XML.parse(text)); }
  catch (e) { back = "ERROR: " + e.message; }
  console.log(JSON.stringify(space), JSON.stringify(text), "->", back);
}
```

Before the fix:

```
"x"        -> {"order":{"#text":"\nx\nx\nx","item":["Tea","Mug"],"paid":""}}
"<b>"      -> ERROR: XML Parse error: Expected closing tag </b> but found </order>
"&"        -> ERROR: XML Parse error: Expected an entity name after '&' but found '<'
"</order>" -> ERROR: XML Parse error: Only one root element is allowed
"]]>"      -> ERROR: XML Parse error: ']]>' is only allowed as the end of a CDATA section
"<!-- -->" -> parses, comments injected
"\^A"   -> ERROR: XML Parse error: Invalid character in XML: control character 0x01
```

After the fix each of these throws from `stringify`. `2`, `"\t"`, `" \t\r\n"` and `"\r"` give the same text as before and parse back to the same value.

Options I did not take:

- Ignore a string that is not whitespace (no indentation, no error). The caller gets no signal that the argument did nothing.
- Escape the string (`&` to `&amp;`). The output is well-formed, but the indentation becomes character data of each parent element, and XML 1.0 has no escape for U+0001.

Only the first 10 code units are checked, because only they are written. `"          <"` (10 spaces, then `<`) gives the same output as `10`. The test pins this.

The check uses `bun_parsers::xml::is_whitespace`, which this PR exports next to `is_xml_char`, `is_name_start_char` and `is_name_char`. It wraps the parser's own `is_ws`, so the parser and `stringify` share one definition of the `S` production.

The check is in `Space::init` and not in `newline()`, so the same `space` throws for every value. A value with nothing to indent (`{ name: "a", children: ["1"] }`) throws too.

The existing clamp assertion used `"abcdefghijklmnop"` to show that only the first 10 characters are used. It now uses 10 tabs followed by 6 spaces, which shows the same thing with whitespace.

`bun.d.ts` and `docs/runtime/xml.mdx` state the rule.

`Bun.YAML.stringify` and `Bun.JSON5.stringify` also write a string `space` as is. Their declarations do not promise well-formed output, and JSON5 matches the reference `json5` package. This PR does not change them.

The existing test "deep values are a catchable error" now uses depth 100,000 on a debug build (`isDebug`) and keeps depth 1,000,000 on every other build. It builds two values of that depth. On a debug build that took 7 to 14 s, so `bun bd test test/js/bun/xml/xml.test.ts` failed that test at the default 5 s timeout, with and without this change. `XML.stringify` first throws the `RangeError` at depth 2,832 (compact) and 2,246 (nodes) on a debug build, and at 15,716 and 27,233 on a release build. So the ratio between the depth and the overflow point is about the same on both. The test takes 0.8 s on a debug build now.

Local runs: `bun bd test test/js/bun/xml/xml.test.ts` gives 59 pass, 0 fail. With `src/` and `packages/` at `origin/main` and the same test file, the debug build fails only the new test. `test/js/bun/xml/xml-test-suite.test.ts` does not pass `space`, and it passes too (1995 tests).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/xml/xml.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/xml/xml.test.ts:
(pass) input types > string [2.96ms]
(pass) input types > Buffer [2.24ms]
(pass) input types > Uint8Array subarray respects byteOffset and length [2.31ms]
(pass) input types > DataView [3.69ms]
(pass) input types > ArrayBuffer and SharedArrayBuffer [3.27ms]
(pass) input types > Blob parses synchronously [2.44ms]
(pass) input types > nullish input throws TypeError; other values are stringified [8.39ms]
(pass) input types > options must be an object; compact must be a boolean [8.42ms]
(pass) compact shape > leaf elements are their text; attributes and children make an object [6.67ms]
(pass) compact shape > repeated names become arrays in document order, grouped at the first occurrence [3.58ms]
(pass) compact shape > attributes come first, then children and #text in order of first appearance [3.83ms]
(pass) compact shape > character data is exact; only whitespace-only runs around child elements are layout [20.54ms]
(pass) compact shape > CDATA and referen
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (85c1404c3)

test/js/bun/xml/xml.test.ts:
(pass) input types > string [0.07ms]
(pass) input types > Buffer [0.03ms]
(pass) input types > Uint8Array subarray respects byteOffset and length [0.02ms]
(pass) input types > DataView [0.05ms]
(pass) input types > ArrayBuffer and SharedArrayBuffer [0.05ms]
(pass) input types > Blob parses synchronously [0.02ms]
(pass) input types > nullish input throws TypeError; other values are stringified [0.10ms]
(pass) input types > options must be an object; compact must be a boolean [0.07ms]
(pass) compact shape > leaf elements are their text; attributes and children make an object [0.05ms]
(pass) compact shape > repeated names become arrays in document order, grouped at the first occurrence [0.04ms]
(pass) compact shape > attributes come first, then children and #text in order of first appearance [0.04ms]
(pass) compact shape > character data is exact; only whitespace-only runs around child elements are layout [0.29ms]
(pass) compact shape > CDATA and references are just text [0.03ms]
(pass) compact shape > comments and processing instructions are dropped everywhere [0.02ms]
(pass) compact shape > nothing is
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/xml/xml.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/xml/xml.test.ts:
(pass) input types > string [14.25ms]
(pass) input types > Buffer [3.18ms]
(pass) input types > Uint8Array subarray respects byteOffset and length [2.71ms]
(pass) input types > DataView [3.34ms]
(pass) input types > ArrayBuffer and SharedArrayBuffer [3.18ms]
(pass) input types > Blob parses synchronously [2.48ms]
(pass) input types > nullish input throws TypeError; other values are stringified [7.99ms]
(pass) input types > options must be an object; compact must be a boolean [8.75ms]
(pass) compact shape > leaf elements are their text; attributes and children make an object [6.62ms]
(pass) compact shape > repeated names become arrays in document order, grouped at the first occurrence [3.23ms]
(pass) compact shape > attributes come first, then children and #text in order of first appearance [3.59ms]
(pass) compact shape > character data is exact; only whitespace-only runs around child elements are layout [20.05ms]
(pass) compact shape > CDATA and refere
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 606ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/25] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 9 classes from /workspace/bun/src/runtime/api/html_rewriter.classes.ts
  - HTMLRewriter (3 fields)
  - TextChunk (7 fields)
  - DocType (5 fields)
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/xml.mdx         |  2 +-
 packages/bun-types/bun.d.ts  |  9 +++++---
 src/parsers/xml.rs           |  5 +++++
 src/runtime/api/XMLObject.rs | 13 +++++++++--
 test/js/bun/xml/xml.test.ts  | 51 ++++++++++++++++++++++++++++++++++++++++----
 5 files changed, 70 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                          reads  edits  tests
docs/runtime/xml.mdx              2      3     28
packages/bun-types/bun.d.ts       2      2     27
src/parsers/xml.rs                1      3     27
src/runtime/api/XMLObject.rs      2      6     27
test/js/bun/xml/xml.test.ts       4      6     27
```

</details>

<!-- robobun:evidence:end -->