### PR TITLE
Keep a lock that Error.prepareStackTrace adds when error.stack is first read (WebKit bump)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-644-7c8a6389"; // oven-sh/WebKit#644, swap for the merged sha before landing
+export const WEBKIT_VERSION = "autobuild-preview-pr-644-6024d7f1"; // oven-sh/WebKit#644, swap for the merged sha before landing
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "cf1b36ec8703d8e87436094d21d478d358c7d886";
+export const WEBKIT_VERSION = "autobuild-preview-pr-644-7c8a6389"; // oven-sh/WebKit#644, swap for the merged sha before landing
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -614,6 +614,79 @@ test("err.stack should invoke prepareStackTrace", () => {
   expect(parentLineNumber).toBe(expectedParentLineNumber);
 });
 
+// The first read of error.stack calls Error.prepareStackTrace, and only then stores "stack", "line", "column"
+// and "sourceURL" on the error. A lock that the callback adds in between has to hold. V8 never writes after
+// the callback: it keeps the result in an internal slot, behind an accessor that the constructor installed.
+test("the first read of error.stack does not undo an integrity level that Error.prepareStackTrace sets", () => {
+  const read = lock => {
+    Error.prepareStackTrace = error => {
+      lock(error);
+      return "from-prepare";
+    };
+    const error = new Error("locked");
+    return { error, stack: error.stack, names: Object.getOwnPropertyNames(error) };
+  };
+  // What the callback is handed as error.stack, and so what it freezes or seals.
+  const defaultStack = expect.stringMatching(/^Error: locked\n    at /);
+
+  const frozen = read(Object.freeze);
+  expect(Object.isFrozen(frozen.error)).toBe(true);
+  expect(frozen.names).toEqual(["message", "stack"]);
+  expect(Object.getOwnPropertyDescriptor(frozen.error, "stack")).toEqual({
+    value: defaultStack,
+    writable: false,
+    enumerable: false,
+    configurable: false,
+  });
+  expect(frozen.stack).toBe(frozen.error.stack);
+
+  const sealed = read(Object.seal);
+  expect(Object.isSealed(sealed.error)).toBe(true);
+  expect(sealed.names).toEqual(["message", "stack"]);
+  expect(sealed.stack).toEqual(defaultStack);
+
+  // "stack" stays configurable here, so it takes the result. No other property is added.
+  const nonExtensible = read(Object.preventExtensions);
+  expect(Object.isExtensible(nonExtensible.error)).toBe(false);
+  expect(nonExtensible.names).toEqual(["message", "stack"]);
+  expect(nonExtensible.stack).toBe("from-prepare");
+});
+
+test("the first read of error.stack does not redefine a property that Error.prepareStackTrace made non-configurable", () => {
+  for (const [name, descriptor, expectedStack] of [
+    ["stack", { value: "locked", writable: false }, "locked"],
+    ["stack", { value: "locked", writable: true }, "locked"],
+    ["stack", { get: () => "from-getter", set: undefined }, "from-getter"],
+    ["line", { value: -1, writable: false }, "from-prepare"],
+  ]) {
+    Error.prepareStackTrace = error => {
+      Object.defineProperty(error, name, { ...descriptor, configurable: false });
+      return "from-prepare";
+    };
+    const error = new Error("locked");
+    expect(error.stack).toBe(expectedStack);
+    expect(Object.getOwnPropertyDescriptor(error, name)).toEqual({
+      ...descriptor,
+      enumerable: false,
+      configurable: false,
+    });
+    // The error is still extensible, so the properties that are not locked arrive.
+    expect(Object.getOwnPropertyNames(error)).toEqual(expect.arrayContaining(["stack", "line", "column"]));
+  }
+});
+
+test("an error that is non-extensible before the first read of error.stack still gets its lazy properties", () => {
+  // In Node "stack" exists from construction. Here it counts as present from construction.
+  const plain = Object.preventExtensions(new Error("plain"));
+  expect(plain.stack).toStartWith("Error: plain\n    at ");
+  expect(Object.getOwnPropertyNames(plain)).toEqual(expect.arrayContaining(["stack", "line", "column"]));
+
+  Error.prepareStackTrace = () => "from-prepare";
+  const prepared = Object.preventExtensions(new Error("prepared"));
+  expect(prepared.stack).toBe("from-prepare");
+  expect(Object.getOwnPropertyNames(prepared)).toEqual(expect.arrayContaining(["stack", "line", "column"]));
+});
+
 test("Error.prepareStackTrace inside a node:vm works", () => {
   const { runInNewContext } = require("node:vm");
   Error.prepareStackTrace = null;

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -618,61 +618,100 @@ test("err.stack should invoke prepareStackTrace", () => {
 // and "sourceURL" on the error. A lock that the callback adds in between has to hold. V8 never writes after
 // the callback: it keeps the result in an internal slot, behind an accessor that the constructor installed.
 test("the first read of error.stack does not undo an integrity level that Error.prepareStackTrace sets", () => {
-  const read = lock => {
+  const read = (lock, create = () => new Error("locked")) => {
     Error.prepareStackTrace = error => {
       lock(error);
       return "from-prepare";
     };
-    const error = new Error("locked");
+    const error = create();
     return { error, stack: error.stack, names: Object.getOwnPropertyNames(error) };
   };
-  // What the callback is handed as error.stack, and so what it freezes or seals.
-  const defaultStack = expect.stringMatching(/^Error: locked\n    at /);
-
+  // The callback is handed the default stack as error.stack. A frozen "stack" cannot take the result, so that
+  // string stays.
   const frozen = read(Object.freeze);
   expect(Object.isFrozen(frozen.error)).toBe(true);
   expect(frozen.names).toEqual(["message", "stack"]);
   expect(Object.getOwnPropertyDescriptor(frozen.error, "stack")).toEqual({
-    value: defaultStack,
+    value: expect.stringMatching(/^Error: locked\n    at /),
     writable: false,
     enumerable: false,
     configurable: false,
   });
   expect(frozen.stack).toBe(frozen.error.stack);
 
+  // A sealed "stack" is still writable, so it takes the result.
   const sealed = read(Object.seal);
   expect(Object.isSealed(sealed.error)).toBe(true);
   expect(sealed.names).toEqual(["message", "stack"]);
-  expect(sealed.stack).toEqual(defaultStack);
+  expect(Object.getOwnPropertyDescriptor(sealed.error, "stack")).toEqual({
+    value: "from-prepare",
+    writable: true,
+    enumerable: false,
+    configurable: false,
+  });
+  expect(sealed.stack).toBe("from-prepare");
 
-  // "stack" stays configurable here, so it takes the result. No other property is added.
+  // No property is added to an error that the callback made non-extensible.
   const nonExtensible = read(Object.preventExtensions);
   expect(Object.isExtensible(nonExtensible.error)).toBe(false);
   expect(nonExtensible.names).toEqual(["message", "stack"]);
   expect(nonExtensible.stack).toBe("from-prepare");
+
+  // Error.captureStackTrace on an error whose "stack" is still lazy leaves it lazy, so the same read follows.
+  const captured = read(Object.freeze, () => {
+    const error = new Error("locked");
+    Error.captureStackTrace(error);
+    return error;
+  });
+  expect(Object.isFrozen(captured.error)).toBe(true);
+  expect(captured.names).toEqual(["message", "stack"]);
 });
 
-test("the first read of error.stack does not redefine a property that Error.prepareStackTrace made non-configurable", () => {
-  for (const [name, descriptor, expectedStack] of [
-    ["stack", { value: "locked", writable: false }, "locked"],
-    ["stack", { value: "locked", writable: true }, "locked"],
-    ["stack", { get: () => "from-getter", set: undefined }, "from-getter"],
-    ["line", { value: -1, writable: false }, "from-prepare"],
+test("a first touch of error.stack by assignment, define or delete keeps a lock that Error.prepareStackTrace adds", () => {
+  // Each of these creates the lazy properties first, and so calls Error.prepareStackTrace. V8 calls it only on a read.
+  Error.prepareStackTrace = error => {
+    Object.freeze(error);
+    return "from-prepare";
+  };
+  for (const touch of [
+    error => Reflect.set(error, "stack", "touched"),
+    error => Reflect.defineProperty(error, "stack", { value: "touched" }),
+    error => Reflect.deleteProperty(error, "stack"),
+  ]) {
+    const error = new Error("locked");
+    expect(touch(error)).toBe(false);
+    expect(Object.isFrozen(error)).toBe(true);
+    expect(error.stack).toStartWith("Error: locked\n    at ");
+  }
+});
+
+test("the first read of error.stack keeps the attributes of a property that Error.prepareStackTrace made non-configurable", () => {
+  const getter = () => "from-getter";
+  const setter = mock(() => {});
+  for (const [name, defined, expected, expectedStack] of [
+    // A read-only property keeps its value.
+    ["stack", { value: "locked", writable: false }, { value: "locked", writable: false }, "locked"],
+    ["line", { value: -1, writable: false }, { value: -1, writable: false }, "from-prepare"],
+    // A writable property takes the result, as it does from an assignment.
+    ["stack", { value: "locked", writable: true }, { value: "from-prepare", writable: true }, "from-prepare"],
+    // An accessor stays, and its setter is not called.
+    ["stack", { get: getter, set: setter }, { get: getter, set: setter }, "from-getter"],
   ]) {
     Error.prepareStackTrace = error => {
-      Object.defineProperty(error, name, { ...descriptor, configurable: false });
+      Object.defineProperty(error, name, { ...defined, configurable: false });
       return "from-prepare";
     };
     const error = new Error("locked");
     expect(error.stack).toBe(expectedStack);
     expect(Object.getOwnPropertyDescriptor(error, name)).toEqual({
-      ...descriptor,
+      ...expected,
       enumerable: false,
       configurable: false,
     });
     // The error is still extensible, so the properties that are not locked arrive.
     expect(Object.getOwnPropertyNames(error)).toEqual(expect.arrayContaining(["stack", "line", "column"]));
   }
+  expect(setter).not.toHaveBeenCalled();
 });
 
 test("an error that is non-extensible before the first read of error.stack still gets its lazy properties", () => {

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -667,36 +667,47 @@ test("the first read of error.stack does not undo an integrity level that Error.
   expect(captured.names).toEqual(["message", "stack"]);
 });
 
-test("a first touch of error.stack by assignment, define or delete keeps a lock that Error.prepareStackTrace adds", () => {
-  // Each of these creates the lazy properties first, and so calls Error.prepareStackTrace. V8 calls it only on a read.
+// Each of these creates the lazy properties first, and so calls Error.prepareStackTrace. V8 calls it only on a read.
+test.each([
+  ["an assignment", error => Reflect.set(error, "stack", "touched")],
+  ["a define", error => Reflect.defineProperty(error, "stack", { value: "touched" })],
+  ["a delete", error => Reflect.deleteProperty(error, "stack")],
+])("a first touch of error.stack by %s keeps a lock that Error.prepareStackTrace adds", (_, touch) => {
   Error.prepareStackTrace = error => {
     Object.freeze(error);
     return "from-prepare";
   };
-  for (const touch of [
-    error => Reflect.set(error, "stack", "touched"),
-    error => Reflect.defineProperty(error, "stack", { value: "touched" }),
-    error => Reflect.deleteProperty(error, "stack"),
-  ]) {
-    const error = new Error("locked");
-    expect(touch(error)).toBe(false);
-    expect(Object.isFrozen(error)).toBe(true);
-    expect(error.stack).toStartWith("Error: locked\n    at ");
-  }
+  const error = new Error("locked");
+  expect(touch(error)).toBe(false);
+  expect(Object.isFrozen(error)).toBe(true);
+  expect(error.stack).toStartWith("Error: locked\n    at ");
 });
 
-test("the first read of error.stack keeps the attributes of a property that Error.prepareStackTrace made non-configurable", () => {
-  const getter = () => "from-getter";
-  const setter = mock(() => {});
-  for (const [name, defined, expected, expectedStack] of [
-    // A read-only property keeps its value.
-    ["stack", { value: "locked", writable: false }, { value: "locked", writable: false }, "locked"],
-    ["line", { value: -1, writable: false }, { value: -1, writable: false }, "from-prepare"],
-    // A writable property takes the result, as it does from an assignment.
-    ["stack", { value: "locked", writable: true }, { value: "from-prepare", writable: true }, "from-prepare"],
-    // An accessor stays, and its setter is not called.
-    ["stack", { get: getter, set: setter }, { get: getter, set: setter }, "from-getter"],
-  ]) {
+const lockedStackGetter = () => "from-getter";
+const lockedStackSetter = mock(() => {});
+test.each([
+  // A read-only property keeps its value.
+  ["a read-only stack", "stack", { value: "locked", writable: false }, { value: "locked", writable: false }, "locked"],
+  ["a read-only line", "line", { value: -1, writable: false }, { value: -1, writable: false }, "from-prepare"],
+  // A writable property takes the result, as it does from an assignment.
+  [
+    "a writable stack",
+    "stack",
+    { value: "locked", writable: true },
+    { value: "from-prepare", writable: true },
+    "from-prepare",
+  ],
+  // An accessor stays, and its setter is not called.
+  [
+    "an accessor stack",
+    "stack",
+    { get: lockedStackGetter, set: lockedStackSetter },
+    { get: lockedStackGetter, set: lockedStackSetter },
+    "from-getter",
+  ],
+])(
+  "the first read of error.stack keeps the attributes of %s that Error.prepareStackTrace made non-configurable",
+  (_, name, defined, expected, expectedStack) => {
     Error.prepareStackTrace = error => {
       Object.defineProperty(error, name, { ...defined, configurable: false });
       return "from-prepare";
@@ -710,9 +721,9 @@ test("the first read of error.stack keeps the attributes of a property that Erro
     });
     // The error is still extensible, so the properties that are not locked arrive.
     expect(Object.getOwnPropertyNames(error)).toEqual(expect.arrayContaining(["stack", "line", "column"]));
-  }
-  expect(setter).not.toHaveBeenCalled();
-});
+    expect(lockedStackSetter).not.toHaveBeenCalled();
+  },
+);
 
 test("an error that is non-extensible before the first read of error.stack still gets its lazy properties", () => {
   // In Node "stack" exists from construction. Here it counts as present from construction.


### PR DESCRIPTION
### Problem
- With `Error.prepareStackTrace` set, the first read of `error.stack` un-freezes an error that the callback froze. It also replaces a `stack` that the callback locked. `Error.prepareStackTrace = e => { Object.freeze(e); return "P" }; const a = new Error("a"); a.stack; Object.isFrozen(a)` is `false` in Bun 1.4.3 and `true` in Node 26.3.
- The cause is `ErrorInstance::materializeErrorInfoIfNeeded` in JSC (`ErrorInstance.cpp:432`). It runs the callback through Bun's hook. Then it stores `line`, `column`, `sourceURL` and `stack` with `putDirect()`, which checks nothing.

### Fix
- The fix is oven-sh/WebKit#644. Bun's hook only returns a value, so Bun cannot stop the writes.
- After the callback, JSC adds no property to an error that became non-extensible during the callback. A non-configurable property keeps its attributes, and takes the value only if it is writable. No write throws. An error that is non-extensible before the first read still gets its lazy properties.
- Draft: `WEBKIT_VERSION` points at `autobuild-preview-pr-644-6024d7f1`, the preview build of that PR. Do not merge with this pin. When oven-sh/WebKit#644 is on the fork's `main` and `main` here pins it, this PR is the tests alone.
- Verified: `test/js/node/v8/capture-stack-trace.test.js` (9 new tests, 55 pass). Bun 1.4.3 fails 8 of the 9. Self-reviewed: the verdict was rework, so this is a draft. The pin stays only so that CI can run the tests. The Notes state the decision that a maintainer has to make, and they name the same-class sites that this PR leaves out.

### Background
- An `ErrorInstance` creates `stack`, `line`, `column` and `sourceURL` on the first lookup of one of them. For `stack` it calls `VM::onComputeErrorInfoJSValue`, a Bun addition. Bun calls `Error.prepareStackTrace` there.
- `putDirect()` is the internal store of JSC. It ignores the integrity level that `Object.freeze` and `Object.preventExtensions` set.
- V8 keeps the formatted stack in an internal slot behind an accessor, so it never writes after the callback.

<details><summary>Notes</summary>

**Decision for a maintainer.** No user reported this, and no code was found that locks an error from inside `Error.prepareStackTrace`. It was found by audit while working on #33412, which is the same class on the `Error.captureStackTrace` path and is also open. The rule that the two PRs follow together: a read of `stack` never throws and skips a write that a lock forbids, and an explicit `Error.captureStackTrace` on a locked target throws the TypeError of V8. If Bun's stack machinery is not meant to honor integrity levels, this PR and oven-sh/WebKit#644 close.

Results with `Error.prepareStackTrace = e => { lock(e); return "P" }`, then `e.stack`:

| `lock` | `stack` after | other lazy properties | Node 26.3 |
| --- | --- | --- | --- |
| `Object.freeze` | the default string the callback was handed, frozen | not added, `isFrozen` is `true` | `isFrozen` is `true`, `stack` is `"P"` |
| `Object.seal` | `"P"`, still non-configurable | not added, `isSealed` is `true` | the same |
| `Object.preventExtensions` | `"P"` | not added | `stack` is `"P"` |
| `defineProperty(e, "stack", { value: "LOCKED", writable: false, configurable: false })` | `"LOCKED"`, attributes kept | added | `"P"` on the first read, then `"LOCKED"`, attributes kept |
| `defineProperty(e, "stack", { value: "LOCKED", writable: true, configurable: false })` | `"P"`, attributes kept | added | `"P"` on the first read, then `"LOCKED"`, attributes kept |
| `defineProperty(e, "stack", { get, set, configurable: false })` | the accessor, `set` is not called | added | `"P"` on the first read, then the accessor |
| `defineProperty(e, "line", { value: -1, configurable: false })` | `"P"` | `line` keeps `-1` | no `line` in V8 |

- Known difference from Node: for a frozen error Node returns the result of the callback on every read. For a `stack` that the callback redefined, Node returns the result on the first read and the defined value after that. Today Bun returns the result too, and breaks the lock. V8 can keep both because its `stack` is an accessor over an internal slot. A data property cannot take a new value once it is read-only and non-configurable, so the string that the callback froze stays. To match Node there, `stack` must become an accessor over a private slot (`m_lazyStackCustomGetterSetter` plus a private name). Nothing asks for that today.
- The writable, non-configurable row returns `"P"`, as Bun does today. Only the attributes are now kept. Node keeps the value of the callback's define.
- The 9 tests: the integrity levels (`freeze`, `seal`, `preventExtensions`, and the same read after `Error.captureStackTrace` on an error whose `stack` is still lazy), a first touch of `stack` by assignment, define or delete with a freezing callback (3 cases), the non-configurable rows of the table (4 cases), and a guard for an error that is non-extensible before the first read. The guard passes on Bun 1.4.3 too.
- A first touch by assignment, define or delete also creates the lazy properties, and so calls the callback. With a freezing callback the touch now fails (`Reflect.set` returns `false`, an assignment in strict mode throws), because the freeze holds. V8 calls the callback only on a read. So in Node the assignment lands and the error is not frozen. Bun 1.4.3 ends in that same state, because it undoes the freeze. This is a new difference from Node. In sloppy mode the assignment is dropped without an error.
- `stack` exists when the callback runs because Bun stores the default string on the error before it calls `Error.prepareStackTrace`, so that `error.stack` inside the callback is a string as in Node.
- Relation to #33412: that PR is Bun-side only. It edits `errorConstructorFuncCaptureStackTrace` and the store of the default string before the callback (`FormatStackTraceForJS.cpp:96`). It does not reach the four writes in `ErrorInstance.cpp`. The two PRs overlap only in the test file. This PR does not depend on #33412.
- One corner is not fixed, and it loses the value: an error that is non-extensible before the first read and that the callback also freezes still gains `line` and `column`, so `isFrozen` is still `false`. Its frozen `stack` now keeps the default string, where Bun 1.4.3 stores `"P"` as Node does. The check compares extensibility before and after the callback.
- Same cause, not covered, and the same in Bun 1.4.3 and on this branch:
  - A `line` or `column` that the callback assigns (`e.line = 42`) is configurable, so JSC overwrites it after the callback. Node keeps `42`. With `Error.prepareStackTrace` set, the values that JSC stores are `0` and `0`, and it stores no `sourceURL`.
  - A `stack` that the callback defines as `{ writable: false, configurable: true }` is replaced and made writable again. Only a non-configurable property keeps its attributes.
- Same class, not covered here, all Bun-side `putDirect()` calls that need no WebKit change:
  - A `message` getter that locks the error. With `Error.prepareStackTrace` set, Bun reads `message` and then stores the default string (`FormatStackTraceForJS.cpp:96`) before the callback runs. #33412 guards that store for a non-configurable `stack`.
  - The lazy `stack` accessor that `Error.captureStackTrace` installs when it captures no frames (`errorInstanceLazyStackCustomGetter`, `FormatStackTraceForJS.cpp:744`, and its setter at `:753`). `const e = new Error(); Error.captureStackTrace(e, functionNotOnTheStack); Object.freeze(e); e.stack; Object.isFrozen(e)` is `false`. It is entered through `Error.captureStackTrace`, so it belongs with #33412.
  - The `node:vm` arrow decoration (`writeArrowHeaderStack`, `NodeVM.cpp:529`). `vm.runInNewContext("const e = new Error('x'); Object.freeze(e); throw e")` un-freezes `e`. No callback is involved.
- The preview tag has prebuilt artifacts for every platform and flavor (42 assets). The preview is built on `cf1b36ec87`, the current pin of `main` here, so it carries this change alone. oven-sh/WebKit `main` is now two commits past `cf1b36ec87` (oven-sh/WebKit#636 and oven-sh/WebKit#634). A pin to the merged sha carries those two as well.
- The change in WebKit is inside the `USE(BUN_JSC_ADDITIONS)` block and touches no line that exists upstream. The `jsc` shell does not set the hook, so the tests are here and not under `JSTests/`.

</details>

