### PR TITLE
URLPattern: match adjacent named groups in linear time

### DIFF
--- a/bench/snippets/urlpattern-detailed.mjs
+++ b/bench/snippets/urlpattern-detailed.mjs
@@ -24,4 +24,18 @@ group("URLPattern.exec() - hot path", () => {
   bench("exec() match - simple", () => simplePattern.exec("https://example.com/api/items"));
 });
 
+// Several named groups in one segment
+const adjacentPattern = new URLPattern({ pathname: "/:owner-:repo-:ref" });
+const adjacentMatchURL = "https://example.com/oven-bun-main";
+const adjacentLongMatchURL = "https://example.com/" + "a".repeat(1024) + "-bun-main";
+const adjacentLongNoMatchURL = "https://example.com/" + "a-".repeat(128) + "/x";
+
+group("URLPattern - adjacent named groups", () => {
+  bench("test() match", () => adjacentPattern.test(adjacentMatchURL));
+  bench("exec() match", () => adjacentPattern.exec(adjacentMatchURL));
+  bench("test() match - 1 KB group", () => adjacentPattern.test(adjacentLongMatchURL));
+  bench("test() no-match - other route", () => adjacentPattern.test(noMatchURL));
+  bench("test() no-match - 128 separators", () => adjacentPattern.test(adjacentLongNoMatchURL));
+});
+
 await run();

--- a/src/jsc/bindings/webcore/URLPatternParser.cpp
+++ b/src/jsc/bindings/webcore/URLPatternParser.cpp
@@ -30,6 +30,7 @@
 #include "URLPatternCanonical.h"
 #include "URLPatternTokenizer.h"
 #include <ranges>
+#include <wtf/HexNumber.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
@@ -356,6 +357,52 @@ ASCIILiteral convertModifierToString(Modifier modifier)
     }
 }
 
+static bool mayContainBackreference(StringView regexp)
+{
+    for (unsigned index = 0; index + 1 < regexp.length(); ++index) {
+        if (regexp[index] != '\\')
+            continue;
+        ++index;
+        if (regexp[index] >= '1' && regexp[index] <= '9')
+            return true;
+    }
+    return false;
+}
+
+// In "/:a-:b" the spec regexp for :a is the lazy `[^/]+?`. It stops at the first "-" that lets the rest match, and each
+// time the rest fails it moves on to the next "-". With k such groups in one segment a non-matching input costs O(n^k).
+// :b accepts every character that :a and "-" can match, so if the rest matches after a later "-" it also matches after
+// the first "-" that leaves :a non-empty. The regexp returned here stops only there. The match and its groups are the
+// same as with the spec regexp, and a non-matching input costs O(n).
+static String generateSegmentWildcardRegexpForPart(const Vector<Part>& partList, size_t index, const URLPatternStringOptions& options)
+{
+    auto& part = partList[index];
+    if (part.modifier != Modifier::None || !part.suffix.isEmpty() || index + 2 >= partList.size())
+        return generateSegmentWildcardRegexp(options);
+
+    auto& separator = partList[index + 1];
+    if (separator.type != PartType::FixedText || separator.modifier != Modifier::None)
+        return generateSegmentWildcardRegexp(options);
+    if (!options.delimiterCodepoint.isEmpty() && separator.value.contains(options.delimiterCodepoint))
+        return generateSegmentWildcardRegexp(options);
+
+    auto& nextPart = partList[index + 2];
+    if (nextPart.type != PartType::SegmentWildcard || nextPart.modifier != Modifier::None || !nextPart.prefix.isEmpty())
+        return generateSegmentWildcardRegexp(options);
+
+    // With a backreference to :a or :b in a later regexp group, the rest can match after a later "-" only.
+    for (size_t laterIndex = index + 3; laterIndex < partList.size(); ++laterIndex) {
+        if (partList[laterIndex].type == PartType::Regexp && mayContainBackreference(partList[laterIndex].value))
+            return generateSegmentWildcardRegexp(options);
+    }
+
+    // One character of the segment, then every character up to the first place where the separator matches.
+    auto delimiter = escapeRegexString(options.delimiterCodepoint);
+    if (separator.value.length() == 1 && isASCII(separator.value[0]))
+        return makeString("[^"_s, delimiter, "][^"_s, delimiter, "\\x"_s, hex(static_cast<unsigned>(separator.value[0]), 2), "]*"_s);
+    return makeString("[^"_s, delimiter, "](?:(?!"_s, escapeRegexString(separator.value), ")[^"_s, delimiter, "])*"_s);
+}
+
 // https://urlpattern.spec.whatwg.org/#generate-a-regular-expression-and-name-list
 std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& partList, const URLPatternStringOptions& options)
 {
@@ -364,7 +411,9 @@ std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& p
 
     Vector<String> nameList;
 
-    for (auto& part : partList) {
+    for (size_t index = 0; index < partList.size(); ++index) {
+        auto& part = partList[index];
+
         if (part.type == PartType::FixedText) {
             if (part.modifier == Modifier::None)
                 result.append(escapeRegexString(part.value));
@@ -381,7 +430,7 @@ std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& p
         String regexpValue;
 
         if (part.type == PartType::SegmentWildcard)
-            regexpValue = generateSegmentWildcardRegexp(options);
+            regexpValue = generateSegmentWildcardRegexpForPart(partList, index, options);
         else if (part.type == PartType::FullWildcard)
             regexpValue = ".*"_s;
         else

--- a/src/jsc/bindings/webcore/URLPatternParser.cpp
+++ b/src/jsc/bindings/webcore/URLPatternParser.cpp
@@ -378,16 +378,7 @@ static size_t lastPartWithBackreference(const Vector<Part>& partList)
     return notFound;
 }
 
-// In "/:a-:b" the spec regexp for :a is the lazy `[^/]+?`. It stops at the first "-" that lets the rest match, and each
-// time the rest fails it moves on to the next "-". With k such groups in one segment a non-matching input costs O(n^k).
-// :b accepts every character that :a and "-" can match, so if the rest matches after a later "-" it also matches after
-// the first "-" that leaves :a non-empty. The regexp returned here stops only there. The match and its groups are the
-// same as with the spec regexp, and a non-matching input costs O(n).
-//
-// The text between the two groups is the suffix of :a, one fixed text part and the prefix of :b, so "/:a{-:b}" and
-// "/{:a-}:b" are the same case. With no text in between, as in "/:a:b", :a is always one character. Text of more than
-// one character keeps the spec regexp: a regexp that stops at its first match needs a group inside a loop, and YARR
-// gives up on such a loop after about a million iterations where `[^/]+?` has no limit.
+// The spec's lazy `[^/]+?` for :a in "/:a-:b" retries at every later "-", O(n^k) for k groups. :b accepts whatever a later "-" would give :a, so stopping at the first "-" finds the same match and groups.
 static String generateSegmentWildcardRegexpForPart(const Vector<Part>& partList, size_t index, size_t lastBackreferenceIndex, const URLPatternStringOptions& options)
 {
     auto wildcard = generateSegmentWildcardRegexp(options);
@@ -407,6 +398,7 @@ static String generateSegmentWildcardRegexpForPart(const Vector<Part>& partList,
     if (nextPart.type != PartType::SegmentWildcard || nextPart.modifier != Modifier::None)
         return wildcard;
 
+    // To stop at the first match of a longer separator takes a group inside a loop, and YARR gives up on such a loop after about a million iterations.
     if (part.suffix.length() + fixedText.length() + nextPart.prefix.length() > 1)
         return wildcard;
     auto separator = makeString(part.suffix, fixedText, nextPart.prefix);

--- a/src/jsc/bindings/webcore/URLPatternParser.cpp
+++ b/src/jsc/bindings/webcore/URLPatternParser.cpp
@@ -369,38 +369,64 @@ static bool mayContainBackreference(StringView regexp)
     return false;
 }
 
+static size_t lastPartWithBackreference(const Vector<Part>& partList)
+{
+    for (size_t index = partList.size(); index--;) {
+        if (partList[index].type == PartType::Regexp && mayContainBackreference(partList[index].value))
+            return index;
+    }
+    return notFound;
+}
+
 // In "/:a-:b" the spec regexp for :a is the lazy `[^/]+?`. It stops at the first "-" that lets the rest match, and each
 // time the rest fails it moves on to the next "-". With k such groups in one segment a non-matching input costs O(n^k).
 // :b accepts every character that :a and "-" can match, so if the rest matches after a later "-" it also matches after
 // the first "-" that leaves :a non-empty. The regexp returned here stops only there. The match and its groups are the
 // same as with the spec regexp, and a non-matching input costs O(n).
-static String generateSegmentWildcardRegexpForPart(const Vector<Part>& partList, size_t index, const URLPatternStringOptions& options)
+//
+// The text between the two groups is the suffix of :a, one fixed text part and the prefix of :b, so "/:a{-:b}" and
+// "/{:a-}:b" are the same case. With no text in between, as in "/:a:b", :a is always one character. Text of more than
+// one character keeps the spec regexp: a regexp that stops at its first match needs a group inside a loop, and YARR
+// gives up on such a loop after about a million iterations where `[^/]+?` has no limit.
+static String generateSegmentWildcardRegexpForPart(const Vector<Part>& partList, size_t index, size_t lastBackreferenceIndex, const URLPatternStringOptions& options)
 {
+    auto wildcard = generateSegmentWildcardRegexp(options);
+
     auto& part = partList[index];
-    if (part.modifier != Modifier::None || !part.suffix.isEmpty() || index + 2 >= partList.size())
-        return generateSegmentWildcardRegexp(options);
+    if (part.modifier != Modifier::None)
+        return wildcard;
 
-    auto& separator = partList[index + 1];
-    if (separator.type != PartType::FixedText || separator.modifier != Modifier::None)
-        return generateSegmentWildcardRegexp(options);
-    if (!options.delimiterCodepoint.isEmpty() && separator.value.contains(options.delimiterCodepoint))
-        return generateSegmentWildcardRegexp(options);
+    size_t nextIndex = index + 1;
+    StringView fixedText;
+    if (nextIndex < partList.size() && partList[nextIndex].type == PartType::FixedText && partList[nextIndex].modifier == Modifier::None)
+        fixedText = partList[nextIndex++].value;
+    if (nextIndex >= partList.size())
+        return wildcard;
 
-    auto& nextPart = partList[index + 2];
-    if (nextPart.type != PartType::SegmentWildcard || nextPart.modifier != Modifier::None || !nextPart.prefix.isEmpty())
-        return generateSegmentWildcardRegexp(options);
+    auto& nextPart = partList[nextIndex];
+    if (nextPart.type != PartType::SegmentWildcard || nextPart.modifier != Modifier::None)
+        return wildcard;
+
+    if (part.suffix.length() + fixedText.length() + nextPart.prefix.length() > 1)
+        return wildcard;
+    auto separator = makeString(part.suffix, fixedText, nextPart.prefix);
 
     // With a backreference to :a or :b in a later regexp group, the rest can match after a later "-" only.
-    for (size_t laterIndex = index + 3; laterIndex < partList.size(); ++laterIndex) {
-        if (partList[laterIndex].type == PartType::Regexp && mayContainBackreference(partList[laterIndex].value))
-            return generateSegmentWildcardRegexp(options);
-    }
+    if (lastBackreferenceIndex != notFound && lastBackreferenceIndex > nextIndex)
+        return wildcard;
 
-    // One character of the segment, then every character up to the first place where the separator matches.
-    auto delimiter = escapeRegexString(options.delimiterCodepoint);
-    if (separator.value.length() == 1 && isASCII(separator.value[0]))
-        return makeString("[^"_s, delimiter, "][^"_s, delimiter, "\\x"_s, hex(static_cast<unsigned>(separator.value[0]), 2), "]*"_s);
-    return makeString("[^"_s, delimiter, "](?:(?!"_s, escapeRegexString(separator.value), ")[^"_s, delimiter, "])*"_s);
+    // `wildcard` is "[^d]+?" for the delimiter d. Without the quantifier it is the class of one segment character.
+    ASSERT(wildcard.endsWith("]+?"_s));
+    StringView wildcardView { wildcard };
+    auto segmentCharacter = wildcardView.left(wildcardView.length() - 2);
+    if (separator.isEmpty())
+        return segmentCharacter.toString();
+
+    if (!isASCII(separator[0]) || separator == options.delimiterCodepoint)
+        return wildcard;
+
+    // The separator goes in as \xHH so that it needs no escape that depends on the `v` flag.
+    return makeString(segmentCharacter, wildcardView.left(wildcardView.length() - 3), "\\x"_s, hex(static_cast<unsigned>(separator[0]), 2), "]*"_s);
 }
 
 // https://urlpattern.spec.whatwg.org/#generate-a-regular-expression-and-name-list
@@ -410,6 +436,7 @@ std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& p
     result.append('^');
 
     Vector<String> nameList;
+    size_t lastBackreferenceIndex = lastPartWithBackreference(partList);
 
     for (size_t index = 0; index < partList.size(); ++index) {
         auto& part = partList[index];
@@ -430,7 +457,7 @@ std::pair<String, Vector<String>> generateRegexAndNameList(const Vector<Part>& p
         String regexpValue;
 
         if (part.type == PartType::SegmentWildcard)
-            regexpValue = generateSegmentWildcardRegexpForPart(partList, index, options);
+            regexpValue = generateSegmentWildcardRegexpForPart(partList, index, lastBackreferenceIndex, options);
         else if (part.type == PartType::FullWildcard)
             regexpValue = ".*"_s;
         else

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -206,4 +206,135 @@ describe("URLPattern", () => {
       expect(new URLPattern({ pathname: "/a/:foo/:baz([a-z]+)?/b/*" }).hasRegExpGroups).toBe(true);
     });
   });
+
+  // A named group that is followed by fixed text and then another named group, as in "/:a-:b", compiles to a regexp
+  // that is not the one the spec writes down. It has to match the same inputs with the same groups.
+  describe("named groups separated by fixed text", () => {
+    // Every string over `alphabet` that is at most `maxLength` long.
+    function words(alphabet: string, maxLength: number): string[] {
+      const result = [""];
+      let start = 0;
+      for (let length = 0; length < maxLength; length++) {
+        const end = result.length;
+        for (let i = start; i < end; i++) {
+          for (const character of alphabet) result.push(result[i] + character);
+        }
+        start = end;
+      }
+      return result;
+    }
+
+    // `spec` is the regexp the URLPattern spec generates for the component.
+    const cases: {
+      init: URLPatternInit;
+      options?: URLPatternOptions;
+      component: Component;
+      spec: RegExp;
+      names: string[];
+      inputs: string[];
+    }[] = [
+      {
+        init: { pathname: "/:a-:b-:c" },
+        component: "pathname",
+        spec: /^(?:\/([^\/]+?))-([^\/]+?)-([^\/]+?)$/v,
+        names: ["a", "b", "c"],
+        inputs: words("a-", 7).map(word => "/" + word),
+      },
+      {
+        init: { pathname: "/:a-:b/:c-:d/x" },
+        component: "pathname",
+        spec: /^(?:\/([^\/]+?))-([^\/]+?)(?:\/([^\/]+?))-([^\/]+?)\/x$/v,
+        names: ["a", "b", "c", "d"],
+        inputs: words("a-", 3).flatMap(first => words("a-", 3).map(second => "/" + first + "/" + second + "/x")),
+      },
+      {
+        // The separator after :a starts with the separator after :b.
+        init: { pathname: "/:a--:b-:c" },
+        component: "pathname",
+        spec: /^(?:\/([^\/]+?))--([^\/]+?)-([^\/]+?)$/v,
+        names: ["a", "b", "c"],
+        inputs: words("a-", 7).map(word => "/" + word),
+      },
+      {
+        init: { pathname: "/:a{x}:b{x}:c" },
+        options: { ignoreCase: true },
+        component: "pathname",
+        spec: /^(?:\/([^\/]+?))x([^\/]+?)x([^\/]+?)$/iv,
+        names: ["a", "b", "c"],
+        inputs: words("aX", 6).map(word => "/" + word),
+      },
+      {
+        // The search component has no delimiter, so a group matches any character.
+        init: { search: ":a-:b-:c,x" },
+        component: "search",
+        spec: /^([^]+?)-([^]+?)-([^]+?),x$/v,
+        names: ["a", "b", "c"],
+        inputs: words("a-", 6).map(word => word + ",x"),
+      },
+      {
+        init: { hostname: ":a-:b.:c-:d" },
+        component: "hostname",
+        spec: /^([^\.]+?)-([^\.]+?)(?:\.([^\.]+?))-([^\.]+?)$/v,
+        names: ["a", "b", "c", "d"],
+        inputs: words("a-", 3).flatMap(first => words("a-", 2).map(second => "a" + first + "." + second + "a")),
+      },
+    ];
+
+    for (const { init, options, component, spec, names, inputs } of cases) {
+      test(`${JSON.stringify(init)} matches like the spec regexp`, () => {
+        const pattern = new URLPattern(init, options);
+        const mismatches: unknown[] = [];
+        let matched = 0;
+        for (const input of inputs) {
+          const match = spec.exec(input);
+          const expected = match && Object.fromEntries(names.map((name, i) => [name, match[i + 1]]));
+          const actual = pattern.exec({ [component]: input })?.[component].groups ?? null;
+          if (match) matched++;
+          if (!Bun.deepEquals(actual, expected)) mismatches.push({ input, actual, expected });
+        }
+        expect({ mismatches, matchedSome: matched > 0 }).toEqual({ mismatches: [], matchedSome: true });
+      });
+    }
+
+    test("a group keeps a separator it has to contain", () => {
+      const pattern = new URLPattern({ pathname: "/:a-:b-:c" });
+      expect([
+        pattern.exec({ pathname: "/x-y-z-w" })?.pathname.groups,
+        pattern.exec({ pathname: "/x--y-z" })?.pathname.groups,
+        pattern.exec({ pathname: "/--x-y" })?.pathname.groups,
+        pattern.exec({ pathname: "/x-y-" }),
+      ]).toEqual([{ a: "x", b: "y", c: "z-w" }, { a: "x", b: "-y", c: "z" }, { a: "-", b: "x", c: "y" }, null]);
+    });
+
+    test("a backreference in a later regexp group sees every split", () => {
+      // Only a = "x-y" lets \1 match, and the regexp finds it after a = "x" fails.
+      const pattern = new URLPattern({ pathname: "/:a-:b/(\\1)" });
+      expect(pattern.exec({ pathname: "/x-y-z/x-y" })?.pathname.groups).toEqual({ a: "x-y", b: "z", "0": "x-y" });
+    });
+
+    test("matching a long input is not polynomial", () => {
+      // Every input fails to match only at its end. The spec regexp then retries every way to split the input over the
+      // groups: with three groups, 2048 separators take about 4 s and 3072 take about 13 s. The compiled regexp looks
+      // at each character a fixed number of times, which takes a few milliseconds in a debug build.
+      const budgetMs = 1000;
+      const repeat = (text: string, count: number) => Buffer.alloc(text.length * count, text).toString();
+
+      for (const [init, input] of [
+        [{ pathname: "/:owner-:repo-:ref" }, { pathname: "/" + repeat("a-", 3072) + "/x" }],
+        [{ pathname: "/:a--:b--:c" }, { pathname: "/" + repeat("a--", 2048) + "/x" }],
+        [{ search: ":a-:b-:c,x" }, { search: repeat("a-", 2048) }],
+        [{ hostname: ":a-:b-:c.example.com" }, { hostname: repeat("a-", 2048) + "a.example.org" }],
+      ] as [URLPatternInit, URLPatternInit][]) {
+        const pattern = new URLPattern(init);
+        const start = performance.now();
+        const result = pattern.test(input);
+        const elapsed = performance.now() - start;
+        if (result || elapsed >= budgetMs) {
+          throw new Error(
+            `${JSON.stringify(init)}: test() returned ${result} after ${elapsed.toFixed(0)} ms (budget ${budgetMs} ms)`,
+          );
+        }
+      }
+    });
+  });
 });

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -304,8 +304,9 @@ describe("URLPattern", () => {
       },
     ];
 
-    for (const { init, options, component, spec, names, inputs } of cases) {
-      test(`${JSON.stringify(init)} matches like the spec regexp`, () => {
+    test.each(cases.map(entry => [JSON.stringify(entry.init), entry] as const))(
+      "%s matches like the spec regexp",
+      (_, { init, options, component, spec, names, inputs }) => {
         const pattern = new URLPattern(init, options);
         const mismatches: unknown[] = [];
         let matched = 0;
@@ -317,8 +318,8 @@ describe("URLPattern", () => {
           if (!Bun.deepEquals(actual, expected)) mismatches.push({ input, actual, expected });
         }
         expect({ mismatches, matchedSome: matched > 0 }).toEqual({ mismatches: [], matchedSome: true });
-      });
-    }
+      },
+    );
 
     test("a group keeps a separator it has to contain", () => {
       const pattern = new URLPattern({ pathname: "/:a-:b-:c" });

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -207,9 +207,9 @@ describe("URLPattern", () => {
     });
   });
 
-  // A named group that is followed by fixed text and then another named group, as in "/:a-:b", compiles to a regexp
-  // that is not the one the spec writes down. It has to match the same inputs with the same groups.
-  describe("named groups separated by fixed text", () => {
+  // Two named groups with at most one character between them, as in "/:a-:b", compile to a regexp that is not the one
+  // the spec writes down. It has to match the same inputs with the same groups.
+  describe("adjacent named groups", () => {
     // Every string over `alphabet` that is at most `maxLength` long.
     function words(alphabet: string, maxLength: number): string[] {
       const result = [""];
@@ -245,10 +245,34 @@ describe("URLPattern", () => {
         component: "pathname",
         spec: /^(?:\/([^\/]+?))-([^\/]+?)(?:\/([^\/]+?))-([^\/]+?)\/x$/v,
         names: ["a", "b", "c", "d"],
-        inputs: words("a-", 3).flatMap(first => words("a-", 3).map(second => "/" + first + "/" + second + "/x")),
+        inputs: words("a-", 3).flatMap(first => words("a-", 2).map(second => "/" + first + "/a" + second + "/x")),
       },
       {
-        // The separator after :a starts with the separator after :b.
+        // The separator is the prefix of the next group.
+        init: { pathname: "/:a{-:b}{-:c}" },
+        component: "pathname",
+        spec: /^(?:\/([^\/]+?))(?:-([^\/]+?))(?:-([^\/]+?))$/v,
+        names: ["a", "b", "c"],
+        inputs: words("a-", 6).map(word => "/" + word),
+      },
+      {
+        // The separator is the suffix of the group.
+        init: { pathname: "/{:a-}{:b-}:c" },
+        component: "pathname",
+        spec: /^\/(?:([^\/]+?)-)(?:([^\/]+?)-)([^\/]+?)$/v,
+        names: ["a", "b", "c"],
+        inputs: words("a-", 6).map(word => "/" + word),
+      },
+      {
+        // No separator.
+        init: { pathname: "/:a:b:c" },
+        component: "pathname",
+        spec: /^(?:\/([^\/]+?))([^\/]+?)([^\/]+?)$/v,
+        names: ["a", "b", "c"],
+        inputs: words("a-", 6).map(word => "/" + word),
+      },
+      {
+        // A separator of two characters keeps the spec regexp. The group after it does not.
         init: { pathname: "/:a--:b-:c" },
         component: "pathname",
         spec: /^(?:\/([^\/]+?))--([^\/]+?)-([^\/]+?)$/v,
@@ -312,17 +336,32 @@ describe("URLPattern", () => {
       expect(pattern.exec({ pathname: "/x-y-z/x-y" })?.pathname.groups).toEqual({ a: "x-y", b: "z", "0": "x-y" });
     });
 
+    test("a group of more than a million characters matches", () => {
+      // A regexp that loops over a parenthesized group gives up after about a million iterations. A plain class does not.
+      const long = Buffer.alloc(1_200_000, "a").toString();
+      const groups = new URLPattern({ pathname: "/:a-:b-:c" }).exec({ pathname: `/${long}-${long}-${long}` })?.pathname
+        .groups;
+      expect({ a: groups?.a === long, b: groups?.b === long, c: groups?.c === long }).toEqual({
+        a: true,
+        b: true,
+        c: true,
+      });
+    });
+
     test("matching a long input is not polynomial", () => {
       // Every input fails to match only at its end. The spec regexp then retries every way to split the input over the
-      // groups: with three groups, 2048 separators take about 4 s and 3072 take about 13 s. The compiled regexp looks
-      // at each character a fixed number of times, which takes a few milliseconds in a debug build.
+      // three groups: 2048 separators take about 4 s and 3072 take about 13 s. The compiled regexp looks at each
+      // character a fixed number of times, which takes a few milliseconds in a debug build.
       const budgetMs = 1000;
       const repeat = (text: string, count: number) => Buffer.alloc(text.length * count, text).toString();
 
       for (const [init, input] of [
         [{ pathname: "/:owner-:repo-:ref" }, { pathname: "/" + repeat("a-", 3072) + "/x" }],
-        [{ pathname: "/:a--:b--:c" }, { pathname: "/" + repeat("a--", 2048) + "/x" }],
+        [{ pathname: "/:a{-:b}{-:c}" }, { pathname: "/" + repeat("a-", 2048) + "/x" }],
+        [{ pathname: "/{:a-}{:b-}:c" }, { pathname: "/" + repeat("a-", 2048) + "/x" }],
+        [{ pathname: "/:a:b:c" }, { pathname: "/" + repeat("a", 4096) + "/x" }],
         [{ search: ":a-:b-:c,x" }, { search: repeat("a-", 2048) }],
+        [{ hash: "/:a/:b/:c/end" }, { hash: "/" + repeat("a/", 2048) + "x" }],
         [{ hostname: ":a-:b-:c.example.com" }, { hostname: repeat("a-", 2048) + "a.example.org" }],
       ] as [URLPatternInit, URLPatternInit][]) {
         const pattern = new URLPattern(init);


### PR DESCRIPTION
### Problem

- A `URLPattern` with several named groups in one segment, such as `/:owner-:repo-:ref`, takes polynomial time on a path that does not match: 3.3 s for a 4 KB path, about 30 s for 8 KB. Same class as path-to-regexp CVE-2024-45296, also in Node 26. No user reported it.
- `generateRegexAndNameList` (`src/jsc/bindings/webcore/URLPatternParser.cpp`) emits the lazy `[^/]+?` for every group, as the spec says. When the rest fails, the engine retries each group at every later `-`: O(n^k) for k groups.

### Fix

- A group with at most one character between it and the next plain named group compiles to `[^/][^/\x2D]*` (`[^/]` with nothing between). It stops at the first separator. Covers `/:a-:b`, `/:a{-:b}`, `/{:a-}:b`, `/:a:b`.
- Match and groups do not change. The next group accepts every character that this group and the separator can match. So if the rest matches after a later separator, it also matches after the first one.
- Every other shape keeps the spec regexp (timings in Notes).
- Verified: `test/js/web/urlpattern/urlpattern.test.ts` (13 new tests, stock bun fails the timing test after 12 s, fixed: 60 ms in debug). WPT cases and `test-urlpattern.js` pass. Self-reviewed: 6 concerns raised, 5 addressed (Notes).

### Background

- `:name` is a segment wildcard: a non-empty run of any character except the delimiter (`/` in a pathname, `.` in a hostname, none elsewhere).
- A lazy quantifier (`+?`) tries the shortest match first and grows when the rest fails.
- path-to-regexp excludes the separator from the whole group. That changes captures (`/a--b-c` stops matching), so it cannot be used.

<details><summary>Notes</summary>

**Why the rewrite is exact.** Take `G1 S G2 REST`. `G1` and `G2` are segment wildcards with no modifier. `S` is the text between them: the suffix of `G1`, one fixed text part, the prefix of `G2`. `S` does not hold the delimiter. The spec regexp tries `G1` shortest first, so it visits the places where `S` matches in order. Suppose the rest matches with `S` at position p and `G2` ending at r. Let e be the first place, at offset 1 or more, where `S` matches. Then `G2` can also span from e + |S| to r. That range holds characters of the old `G1`, the old `S` match and the old `G2`. None of them is the delimiter, and the range is not empty. So the rest also matches with `S` at e. The spec regexp therefore always ends `G1` at e, and a regexp that only tries e finds the same match. Captures after `G2` are the same because `G2` ends at the same place. With an empty `S`, e is offset 1, so `G1` is one character. A backreference to `G1` or `G2` in a later regexp group breaks the "rest also matches" step, so those patterns keep the spec regexp: `/:a-:b/(\\1)` on `/x-y-z/x-y` needs `a = "x-y"`. The argument applies one group at a time from the right, so a chain of any length works.

**Why only one character.** A separator of two or more characters needs `[^/](?:(?!sep)[^/])*` to stop at its first match. YARR runs a group inside a loop in its interpreter once the input is long, about 100 times slower, and gives up after about a million iterations: `/:a--:b` with a 4,000,000 character group returned `null` with that form, where the spec regexp matches in 6 ms. The class form is a plain character class loop and has no such limit (covered by the "more than a million characters" test). The class holds the separator as `\xHH` so that no character needs a `v`-flag class escape.

**Differential checks, 0 mismatches in all of them.**
- A JS model of the generator, spec regexp against rewritten regexp: every string up to length 7 to 10 over alphabets of 3 to 5 characters, 31 pattern shapes (19 rewritten, 12 that must stay), flags `v` and `iv`. 22.5 million comparisons.
- The real implementation in the debug build, named groups against the same pattern written with `([^\\/]{1,}?)` custom groups (these stay on the spec path): every printable ASCII separator plus the empty one, in four spellings (fixed text, prefix, suffix, mixed), in pathname, hostname, search, hash, username and password. 513,676 comparisons, and 234,322 more with `ignoreCase` over both cases of the separator.
- Mutation check. With the path-to-regexp narrowing (`[^/\x2D]+`), a greedy `[^/]+` for the empty separator, or the backreference check removed, 12 of the 13 new tests fail.

**Bench** (`bench/snippets/urlpattern-detailed.mjs`, release builds, same machine, two runs each, ns or µs per iteration). The seven existing cases compile to the same regexp as before. They measure within run-to-run noise (for example `test() match - named groups` 882 and 909 before, 874 and 934 after).

| new case (`/:owner-:repo-:ref`) | before | after | node 26.3 |
| --- | --- | --- | --- |
| `test()` match `/oven-bun-main` | 957 ns, 953 ns | 930 ns, 931 ns | 652 ns |
| `exec()` match | 3.61 µs, 3.70 µs | 3.53 µs, 3.57 µs | 10.6 µs |
| `test()` match, 1 KB first group | 2.70 µs, 2.83 µs | 1.65 µs, 1.79 µs | 3.63 µs |
| `test()` no match, other route | 637 ns, 577 ns | 581 ns, 547 ns | 593 ns |
| `test()` no match, 128 separators (259 B) | 738 µs, 865 µs | 1.12 µs, 1.11 µs | 2.45 ms |

**Doubling** (`test()` on `"/" + "a-".repeat(n) + "/x"`, release builds). Before: 259 B 0.72 ms, 515 B 5.7 ms, 1027 B 46.8 ms, 2051 B 366 ms (x8 per step). After: 2051 B 0.007 ms, 4099 B 0.023 ms, 8195 B 0.032 ms, 16 KB 0.074 ms, 32 KB 0.158 ms, 64 KB 0.353 ms, 128 KB 0.640 ms (x2 per step). `/:a{-:b}{-:c}` and `/:a:b:c` give the same curves.

**Shapes that stay polynomial** (after build, `test()` on a 2 KB path that does not match): `/:a-:b?-:c` 343 ms, `/:a{-:b}?{-:c}?` 336 ms, `/:a--:b--:c` 623 ms at 3 KB, `/:a-:b-:c/(\\1)` 517 ms, `/*-*-*x` 562 ms. The proof above does not cover an optional or repeated neighbor, and full wildcards and custom regexp groups are the author's own regexps. An application that needs one of these shapes on untrusted paths can write the narrow class itself, for example `:owner([^\\/\\-]+)`, or cap the URL length.

**Self-review.** Addressed: the lookahead form failed on groups of millions of characters (removed), sibling spellings with the same proof were not covered (the gate now reads the joined separator), the backreference scan ran once per group (now once per component), no bench numbers (added), and the helper called `escapeRegexString`, which open PR #42191 deletes. The two PRs merged without a textual conflict into a tree that did not compile. The helper now derives the class from `generateSegmentWildcardRegexp`, and the merged tree builds and passes this test file in either order. Not done here: `:name+` and `**` with no prefix compile to nested quantifiers and cost about 1 s on a 28 byte input. That is a different mechanism in the same function and is a separate fix.

`Bun.serve({ routes })` does not use regexps and was never affected.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/urlpattern/urlpattern.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/66] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/66] gen cpp.rs (cppbind)
[3/66] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 9 
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (f5aa36bc3)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [0.55ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [0.04ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [0.05ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [0.04ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [0.13ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [0.08ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [0.06ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar/baz"}] [0.03ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar","baseURL":"https://example.com"}] [0.05ms]
(pass) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/web/urlpattern/urlpattern.test.ts
bun test v1.4.3 (6a92015fc)

test/js/web/urlpattern/urlpattern.test.ts:
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar"}] [40.86ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/ba"}] [9.75ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/"}] [7.88ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"pathname":"/foo/bar/baz"}] [9.37ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar"] [13.76ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: ["https://example.com/foo/bar/baz"] [9.22ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/bar"}] [14.52ms]
(pass) URLPattern > WPT tests > Pattern: [{"pathname":"/foo/bar"}] Inputs: [{"hostname":"example.com","pathname":"/foo/b
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 781ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/61] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/61] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/61] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
bench/snippets/urlpattern-detailed.mjs        |  14 +++
 src/jsc/bindings/webcore/URLPatternParser.cpp |  72 ++++++++++-
 test/js/web/urlpattern/urlpattern.test.ts     | 171 ++++++++++++++++++++++++++
 3 files changed, 255 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
bench/snippets/urlpattern-detailed.mjs             1      1     26
src/jsc/bindings/webcore/URLPatternParser.cpp      4      8     26
test/js/web/urlpattern/urlpattern.test.ts          3      2     26
```

</details>

<!-- robobun:evidence:end -->