### PR TITLE
bun:test: run an asymmetric matcher at a key or index the other side lacks

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -626,6 +626,25 @@ AsymmetricMatcherResult matchAsymmetricMatcher(JSGlobalObject* globalObject, JSV
     return result;
 }
 
+// The values matchAsymmetricMatcherAndGetFlags handles. Runs no user code, so it is safe
+// inside a Structure walk.
+static bool isAsymmetricMatcher(JSValue value)
+{
+    if (value.isEmpty() || !value.isCell())
+        return false;
+    JSCell* cell = value.asCell();
+    if (cell->type() != JSC::JSType(JSDOMWrapperType))
+        return false;
+    return cell->inherits<JSExpectAnything>()
+        || cell->inherits<JSExpectAny>()
+        || cell->inherits<JSExpectStringContaining>()
+        || cell->inherits<JSExpectStringMatching>()
+        || cell->inherits<JSExpectArrayContaining>()
+        || cell->inherits<JSExpectObjectContaining>()
+        || cell->inherits<JSExpectCloseTo>()
+        || cell->inherits<JSExpectCustomAsymmetricMatcher>();
+}
+
 template<typename PromiseType, bool isInternal>
 static void handlePromise(PromiseType* promise, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue ctx, Zig::FFIFunction resolverFunction, Zig::FFIFunction rejecterFunction)
 {
@@ -1001,7 +1020,13 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             }
 
             if constexpr (!isStrict) {
-                if (((left.isEmpty() || right.isEmpty()) && (left.isUndefined() || right.isUndefined()))) {
+                // A hole or an index past the end reads as undefined, which is what an
+                // asymmetric matcher on the other side receives.
+                if (left.isEmpty())
+                    left = jsUndefined();
+                if (right.isEmpty())
+                    right = jsUndefined();
+                if (left.isUndefined() && right.isUndefined()) {
                     continue;
                 }
             }
@@ -1017,6 +1042,15 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
 
             if (((right.isEmpty() || right.isUndefined()))) {
                 continue;
+            }
+
+            if constexpr (!isStrict && enableAsymmetricMatchers) {
+                if (isAsymmetricMatcher(right)) {
+                    auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, jsUndefined(), right, gcBuffer, stack, scope, true);
+                    RETURN_IF_EXCEPTION(scope, false);
+                    if (!eql) return false;
+                    continue;
+                }
             }
 
             return false;
@@ -1061,6 +1095,11 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                 if (prop1.isUndefined() && prop2.isEmpty()) {
                     continue;
                 }
+                if constexpr (enableAsymmetricMatchers) {
+                    if (prop2.isEmpty() && isAsymmetricMatcher(prop1)) {
+                        prop2 = jsUndefined();
+                    }
+                }
             }
 
             if (!prop2) {
@@ -1094,6 +1133,10 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             bool sameStructure = o2Structure->id() == o1Structure->id();
             // Comparing values runs user getters that can rehash this PropertyTable mid-walk (use-after-free), so collect the pairs first and compare after.
             MarkedArgumentBuffer pairs;
+            // Keys where one side holds an asymmetric matcher and the other side has no own
+            // property. Like Jest, the matcher receives an ordinary read of the missing side
+            // (undefined, or an inherited value), so these are looked up after the walks.
+            Vector<Identifier, 4> matcherOnlyKeys;
             if (sameStructure) {
                 o1Structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {
                     if (entry.attributes() & PropertyAttribute::DontEnum || PropertyName(entry.key()).isPrivateName()) {
@@ -1146,6 +1189,12 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                         if (left.isUndefined() && right.isEmpty()) {
                             return true;
                         }
+                        if constexpr (enableAsymmetricMatchers) {
+                            if (right.isEmpty() && isAsymmetricMatcher(left)) {
+                                matcherOnlyKeys.append(Identifier::fromUid(vm, entry.key()));
+                                return true;
+                            }
+                        }
                     }
 
                     if (!right) {
@@ -1173,6 +1222,12 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
 
                         // Membership check only; every left property is in `pairs` and compared below.
                         if (o1->getDirectOffset(vm, JSC::PropertyName(entry.key())) == invalidOffset) {
+                            if constexpr (!isStrict && enableAsymmetricMatchers) {
+                                if (isAsymmetricMatcher(o2->getDirect(entry.offset()))) {
+                                    matcherOnlyKeys.append(Identifier::fromUid(vm, entry.key()));
+                                    return true;
+                                }
+                            }
                             result = false;
                             return false;
                         }
@@ -1201,6 +1256,18 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
                 RETURN_IF_EXCEPTION(scope, false);
                 if (same) continue;
 
+                auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, left, right, gcBuffer, stack, scope, true);
+                RETURN_IF_EXCEPTION(scope, false);
+                if (!eql) {
+                    return false;
+                }
+            }
+
+            for (const Identifier& key : matcherOnlyKeys) {
+                JSValue left = o1->get(globalObject, key);
+                RETURN_IF_EXCEPTION(scope, false);
+                JSValue right = o2->get(globalObject, key);
+                RETURN_IF_EXCEPTION(scope, false);
                 auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, left, right, gcBuffer, stack, scope, true);
                 RETURN_IF_EXCEPTION(scope, false);
                 if (!eql) {
@@ -1270,6 +1337,11 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             if (prop1.isUndefined() && prop2.isEmpty()) {
                 continue;
             }
+            if constexpr (enableAsymmetricMatchers) {
+                if (prop2.isEmpty() && isAsymmetricMatcher(prop1)) {
+                    prop2 = jsUndefined();
+                }
+            }
         }
 
         if (!prop2) {
@@ -1282,6 +1354,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     }
 
     // for the remaining properties in the other object, make sure they are undefined
+    // or an asymmetric matcher that accepts what the first object reads at that key
     for (; i < propertyArrayLength2; i++) {
         Identifier i2 = a2[i];
         PropertyName propertyName2 = PropertyName(i2);
@@ -1289,9 +1362,22 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         JSValue prop2 = o2->getIfPropertyExists(globalObject, propertyName2);
         RETURN_IF_EXCEPTION(scope, false);
 
-        if (!prop2.isUndefined()) {
-            return false;
+        if (prop2.isUndefined()) {
+            continue;
         }
+
+        if constexpr (!isStrict && enableAsymmetricMatchers) {
+            if (isAsymmetricMatcher(prop2)) {
+                JSValue prop1 = o1->get(globalObject, propertyName2);
+                RETURN_IF_EXCEPTION(scope, false);
+                auto eql = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, prop1, prop2, gcBuffer, stack, scope, true);
+                RETURN_IF_EXCEPTION(scope, false);
+                if (!eql) return false;
+                continue;
+            }
+        }
+
+        return false;
     }
 
     return true;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1131,8 +1131,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             bool sameStructure = o2Structure->id() == o1Structure->id();
             // Comparing values runs user getters that can rehash this PropertyTable mid-walk (use-after-free), so collect the pairs first and compare after.
             MarkedArgumentBuffer pairs;
-            // Keys with an asymmetric matcher on one side and no own property on the other.
-            // Read with get() after the walks, as Jest does (undefined or an inherited value).
+            // matcher on one side, no own property on the other: read with get() after the walks
             Vector<Identifier, 4> matcherOnlyKeys;
             if (sameStructure) {
                 o1Structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -626,8 +626,7 @@ AsymmetricMatcherResult matchAsymmetricMatcher(JSGlobalObject* globalObject, JSV
     return result;
 }
 
-// The values matchAsymmetricMatcherAndGetFlags handles. Runs no user code, so it is safe
-// inside a Structure walk.
+// The values matchAsymmetricMatcherAndGetFlags handles. Runs no user code.
 static bool isAsymmetricMatcher(JSValue value)
 {
     if (value.isEmpty() || !value.isCell())
@@ -1020,8 +1019,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             }
 
             if constexpr (!isStrict) {
-                // A hole or an index past the end reads as undefined, which is what an
-                // asymmetric matcher on the other side receives.
+                // a hole or an index past the end reads as undefined
                 if (left.isEmpty())
                     left = jsUndefined();
                 if (right.isEmpty())
@@ -1133,9 +1131,8 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
             bool sameStructure = o2Structure->id() == o1Structure->id();
             // Comparing values runs user getters that can rehash this PropertyTable mid-walk (use-after-free), so collect the pairs first and compare after.
             MarkedArgumentBuffer pairs;
-            // Keys where one side holds an asymmetric matcher and the other side has no own
-            // property. Like Jest, the matcher receives an ordinary read of the missing side
-            // (undefined, or an inherited value), so these are looked up after the walks.
+            // Keys with an asymmetric matcher on one side and no own property on the other.
+            // Read with get() after the walks, as Jest does (undefined or an inherited value).
             Vector<Identifier, 4> matcherOnlyKeys;
             if (sameStructure) {
                 o1Structure->forEachProperty(vm, [&](const PropertyTableEntry& entry) -> bool {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1699,6 +1699,9 @@ static std::optional<bool> specialObjectsDequalSlow(const DeepEqualsMode& mode, 
                     if (prop1.isUndefined() && prop2.isEmpty()) {
                         continue;
                     }
+                    if (mode.enableAsymmetricMatchers && prop2.isEmpty() && isAsymmetricMatcher(prop1)) {
+                        prop2 = jsUndefined();
+                    }
                 }
 
                 if (!prop2) {
@@ -1713,6 +1716,7 @@ static std::optional<bool> specialObjectsDequalSlow(const DeepEqualsMode& mode, 
             }
 
             // for the remaining properties in the other object, make sure they are undefined
+            // or an asymmetric matcher that accepts what the first object reads at that key
             for (; i < propertyArrayLength2; i++) {
                 Identifier i2 = a2[i];
                 if (i2 == vm.propertyNames->stack) continue;
@@ -1721,9 +1725,22 @@ static std::optional<bool> specialObjectsDequalSlow(const DeepEqualsMode& mode, 
                 JSValue prop2 = right->getIfPropertyExists(globalObject, propertyName2);
                 RETURN_IF_EXCEPTION(scope, {});
 
-                if (!prop2.isUndefined()) {
-                    return false;
+                if (prop2.isUndefined()) {
+                    continue;
                 }
+
+                if (!mode.isStrict && mode.enableAsymmetricMatchers && isAsymmetricMatcher(prop2)) {
+                    JSValue prop1 = left->get(globalObject, propertyName2);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    bool propertiesEqual = mode.deepEquals(globalObject, prop1, prop2, gcBuffer, stack, scope, true);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    if (!propertiesEqual) {
+                        return false;
+                    }
+                    continue;
+                }
+
+                return false;
             }
 
             return true;

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -915,6 +915,26 @@ describe("expect()", () => {
         expect([, 1]).toEqual([optionalFn(), 1]);
         expect([optionalFn(), 1]).toEqual([, 1]);
         expect([, 1]).not.toEqual([expect.any(Function), 1]);
+        expect({ x: [, 1] }).not.toEqual({ x: [expect.any(Date), 1] });
+        expect(Array(2)).not.toEqual([expect.any(Date), expect.any(Number)]);
+        expect(Array(2)).toEqual([optionalFn(), optionalFn()]);
+      });
+
+      it("does not crash when the side with the matcher is longer", () => {
+        expect([expect.any(Number)]).not.toEqual([]);
+        expect([]).not.toBeOneOf([[expect.any(Number)]]);
+        expect([[expect.any(Number)]]).not.toContainEqual([]);
+        expect(new Map([[expect.any(Number), 2]])).not.toContainEqual([]);
+        const withAccessor = [0];
+        Object.defineProperty(withAccessor, 0, { get: () => "s", enumerable: true });
+        expect(withAccessor).not.toEqual([expect.any(Number)]);
+      });
+
+      it("applies to the enumerable properties of an Error", () => {
+        const received = Object.assign(new Error("boom"), { code: "E1" });
+        expect(received).toEqual(Object.assign(new Error("boom"), { code: "E1", cb: optionalFn() }));
+        expect(Object.assign(new Error("boom"), { code: "E1", cb: optionalFn() })).toEqual(received);
+        expect(received).not.toEqual(Object.assign(new Error("boom"), { code: "E1", cb: expect.any(Function) }));
       });
 
       it("uses the verdict of a built-in matcher on undefined", () => {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -880,6 +880,93 @@ describe("expect()", () => {
       expect({ a: 123n }).toEqual({ a: expect.any(BigInt) });
       expect({ a: 123n }).not.toEqual({ a: expect.any(g) });
     });
+
+    // https://github.com/oven-sh/bun/issues/42529
+    describe("a matcher at a key or index the other side lacks", () => {
+      expect.extend({
+        optionalFn(received) {
+          return { pass: received === undefined || typeof received === "function", message: () => "" };
+        },
+      });
+      const optionalFn = () => ANY(expect).optionalFn();
+
+      it("receives undefined when an object lacks the key", () => {
+        expect({ a: 1 }).toEqual({ a: 1, cb: optionalFn() });
+        expect({ a: 1, cb: () => {} }).toEqual({ a: 1, cb: optionalFn() });
+        expect({ a: 1, cb: 2 }).not.toEqual({ a: 1, cb: optionalFn() });
+        expect({ a: 1 }).not.toEqual({ a: 1, cb: expect.any(Function) });
+        expect({ a: 1 }).not.toEqual({ a: 1, cb: expect.anything() });
+      });
+
+      it("receives undefined when the matcher is on the received side", () => {
+        expect({ a: 1, cb: optionalFn() }).toEqual({ a: 1 });
+        expect({ a: 1, cb: expect.any(Function) }).not.toEqual({ a: 1 });
+      });
+
+      it("receives undefined past the end of a shorter array", () => {
+        expect([1]).toEqual([1, optionalFn()]);
+        expect([1, optionalFn()]).toEqual([1]);
+        expect([1]).not.toEqual([1, expect.any(Function)]);
+        expect([1, expect.any(Function)]).not.toEqual([1]);
+        expect([optionalFn(), optionalFn()]).toEqual([]);
+      });
+
+      it("receives undefined at a hole", () => {
+        expect([, 1]).toEqual([optionalFn(), 1]);
+        expect([optionalFn(), 1]).toEqual([, 1]);
+        expect([, 1]).not.toEqual([expect.any(Function), 1]);
+      });
+
+      it("uses the verdict of a built-in matcher on undefined", () => {
+        expect({}).toEqual({ a: expect.not.stringContaining("x") });
+        expect({}).toEqual({ a: expect.not.stringMatching(/x/) });
+        expect({}).toEqual({ a: expect.not.arrayContaining([1]) });
+        expect({}).not.toEqual({ a: expect.stringContaining("x") });
+        expect({}).not.toEqual({ a: expect.any(String) });
+      });
+
+      it("reads an inherited value for the missing key", () => {
+        class P {
+          get name() {
+            return "abc";
+          }
+        }
+        expect(new P()).toEqual({ name: expect.any(String) });
+        expect(new P()).not.toEqual({ name: expect.any(Number) });
+        expect({ name: expect.any(String) }).toEqual(new P());
+      });
+
+      it("reads an inherited value when the object has a getter of its own", () => {
+        // an own accessor keeps the object off the structure fast path
+        const received = {
+          get a() {
+            return 1;
+          },
+        };
+        expect(received).toEqual({ a: 1, cb: optionalFn() });
+        expect({ a: 1, cb: optionalFn() }).toEqual(received);
+        expect(received).not.toEqual({ a: 1, cb: expect.any(Function) });
+        expect(Object.create(received)).toEqual({ a: expect.any(Number), cb: optionalFn() });
+      });
+
+      it("applies inside nested comparisons", () => {
+        expect([{ a: 1 }]).toContainEqual({ a: 1, cb: optionalFn() });
+        expect(new Set([{ a: 1 }])).toEqual(new Set([{ a: 1, cb: optionalFn() }]));
+        expect(new Map([["k", { a: 1 }]])).toEqual(new Map([["k", { a: 1, cb: optionalFn() }]]));
+        expect({ list: [{ a: 1 }] }).toEqual({ list: expect.arrayContaining([{ a: 1, cb: optionalFn() }]) });
+        expect({ list: [{ a: 1 }] }).not.toEqual({
+          list: expect.arrayContaining([{ a: 1, cb: expect.any(Function) }]),
+        });
+      });
+
+      it("stays a mismatch for toStrictEqual", () => {
+        expect({ a: 1 }).not.toStrictEqual({ a: 1, cb: optionalFn() });
+        expect({ a: 1, cb: optionalFn() }).not.toStrictEqual({ a: 1 });
+        expect([1]).not.toStrictEqual([1, optionalFn()]);
+        expect([1, optionalFn()]).not.toStrictEqual([1]);
+        expect([, 1]).not.toStrictEqual([optionalFn(), 1]);
+      });
+    });
   });
 
   test("toThrow asymmetric matchers", () => {


### PR DESCRIPTION
### Problem
- `toEqual` returns a mismatch before it calls an asymmetric matcher placed at a key or index that the other side lacks. `expect({ a: 1 }).toEqual({ a: 1, cb: expect.optionalFn() })` fails in Bun and passes in Jest 30. The same holds for `toContainEqual`, Set and Map members, and nested `expect.arrayContaining`.
- The reverse array direction, `expect([1, expect.any(Number)]).toEqual([1])`, crashes with `Segmentation fault at address 0x5`. The matcher receives the empty `JSValue`.
- The cause is `Bun__deepEquals` (`src/jsc/bindings/bindings.cpp`). The array loops, the structure fast path, and the property name slow path each return `false` on a missing key. Jest (`jasmineUtils.ts`, `eq`, added in jestjs/jest#12579) reads the missing side with an ordinary property read and gives the matcher that value.

### Fix
- `isAsymmetricMatcher` names the values `matchAsymmetricMatcherAndGetFlags` handles. It runs no user code, so it is safe inside a `Structure` walk.
- In the non-strict path with matchers enabled, a missing key that faces a matcher is compared with an ordinary `get` of the missing side. The fast path collects these keys in `matcherOnlyKeys` and reads them after the walks, because a getter can rehash the property table. The array loops read a hole or a past-the-end index as `undefined`. The Error property walk gets the same rule.
- `toStrictEqual` keeps its mismatch. Node's `assert.deepEqual` path (`enableAsymmetricMatchers` off) is untouched.
- Verified: `test/js/bun/test/expect.test.js`, 11 new tests under "a matcher at a key or index the other side lacks" (stock bun fails 8 and crashes on the array case). Also ran `expect-extend.test.js`, `jest-extended.test.js`, `spyMatchers.test.ts`, `bun-object/deep-equals.test.ts`, `deep-match.spec.ts`, and `node/assert/`.

### Background
- An asymmetric matcher is the object `expect.any(Number)` or a custom `expect.extend` matcher returns. `toEqual` hands it the value on the other side and uses its verdict.
- The verdict changes only for a matcher that accepts `undefined`: `expect.not.stringContaining`, `expect.not.arrayContaining`, or a custom optional matcher. No passing test flips.
- The empty `JSValue` is JavaScriptCore's "no value", not `undefined`. `isCell()` is true for it and `asCell()` is null. That is the crash.

<details><summary>Notes</summary>

Supersedes #34647, which fixes the crash only. Its crash-shape assertions (`toBeOneOf`, `toContainEqual`, `Map`, an accessor at an index) are carried into the new describe block.

Issue #42529 was filed from triage, not by a user. The demand signal is jestjs/jest#12579, where Jest added this rule for a custom `optionalFn` matcher.

The property name slow path compares the "remaining properties" of the second object by position, not by name (#32485). That limitation exists before this change and is left to #41540. The fix applies there when the matcher key enumerates after the shared keys.

Other open PRs that change `Bun__deepEquals`: #41540, #32486, #42238, #35387. Whichever lands second needs a rebase.

Jest hands an accessor at an array index to the matcher. Bun skips accessors at indexes (`getIndexWithoutAccessors`), as before. `expect(arrWithGetter).not.toEqual([expect.any(Number)])` is asserted, the positive case is not.

Probes that pass with the change: `expect({ a: 1 }).not.toEqual({ a: 1, b: 2 })`, `expect({ h: new Headers() }).not.toEqual({})` (a non-matcher DOM wrapper at a missing key), a getter that throws on the missing side propagates, a custom matcher that throws on `undefined` propagates, `toHaveBeenCalledWith` with fewer arguments still fails.
</details>
