### PR TITLE
Check both directions in expect().toContainAllValues()

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1194,15 +1194,16 @@ declare module "bun:test" {
     toContainValues(expected: Array<unknown>): void;
 
     /**
-     * Asserts that an `object` contains all the provided values.
+     * Asserts that an `object` contains all the provided values and no other value.
      *
-     * The value must be an object.
+     * The value must be an object. The object must have as many values as `expected` has items.
      *
      * @example
      * const o = { a: 'foo', b: 'bar', c: 'baz' };
      * expect(o).toContainAllValues(['foo', 'bar', 'baz']);
      * expect(o).toContainAllValues(['baz', 'bar', 'foo']);
      * expect(o).not.toContainAllValues(['bar', 'foo']);
+     * expect({ a: 1, b: 2 }).not.toContainAllValues([1, 1]);
      * @param expected the expected value
      */
     toContainAllValues(expected: Array<unknown>): void;

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1194,16 +1194,15 @@ declare module "bun:test" {
     toContainValues(expected: Array<unknown>): void;
 
     /**
-     * Asserts that an `object` contains all the provided values and no other value.
+     * Asserts that an `object` contains all the provided values.
      *
-     * The value must be an object. The object must have as many values as `expected` has items.
+     * The value must be an object.
      *
      * @example
      * const o = { a: 'foo', b: 'bar', c: 'baz' };
      * expect(o).toContainAllValues(['foo', 'bar', 'baz']);
      * expect(o).toContainAllValues(['baz', 'bar', 'foo']);
      * expect(o).not.toContainAllValues(['bar', 'foo']);
-     * expect({ a: 1, b: 2 }).not.toContainAllValues([1, 1]);
      * @param expected the expected value
      */
     toContainAllValues(expected: Array<unknown>): void;

--- a/src/runtime/test_runner/expect/toContainAllValues.rs
+++ b/src/runtime/test_runner/expect/toContainAllValues.rs
@@ -9,19 +9,29 @@ impl Expect {
             |g, value, expected| {
                 if value.is_undefined_or_null() { return Ok(ContainOutcome::pass(false)); }
                 let values = value.values(g)?;
-                let count = values.get_length(g)?;
-                if count != expected.get_length(g)? { return Ok(ContainOutcome::pass(false)); }
-                let mut itr = expected.array_iterator(g)?;
-                let mut pass = false;
-                'outer: while let Some(item) = itr.next()? {
-                    let mut i: u32 = 0;
-                    while u64::from(i) < count {
-                        if values.get_index(g, i)?.jest_deep_equals(item, g)? { pass = true; continue 'outer; }
-                        i += 1;
-                    }
-                    return Ok(ContainOutcome::pass(false));
-                }
+                if values.get_length(g)? != expected.get_length(g)? { return Ok(ContainOutcome::pass(false)); }
+                // jest-extended only walks values -> expected; the reverse walk keeps { a: 1, b: 1 } from matching [1, 2].
+                let pass = each_has_match(g, values, expected, |object_value, item| object_value.jest_deep_equals(item, g))?
+                    && each_has_match(g, expected, values, |item, object_value| object_value.jest_deep_equals(item, g))?;
                 Ok(ContainOutcome::pass(pass))
             })
     }
+}
+
+/// Whether `matches(item, candidate)` holds for each element of the array `items` with some element of the array `candidates`.
+fn each_has_match(
+    g: &JSGlobalObject,
+    items: JSValue,
+    candidates: JSValue,
+    matches: impl Fn(JSValue, JSValue) -> JsResult<bool>,
+) -> JsResult<bool> {
+    let mut items = items.array_iterator(g)?;
+    'items: while let Some(item) = items.next()? {
+        let mut candidates = candidates.array_iterator(g)?;
+        while let Some(candidate) = candidates.next()? {
+            if matches(item, candidate)? { continue 'items; }
+        }
+        return Ok(false);
+    }
+    Ok(true)
 }

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -2832,6 +2832,44 @@ describe("expect()", () => {
     expect(deepArray).not.toContainAllValues(["duck", [{ foo: "bar" }]]);
   });
 
+  test("toContainAllValues with a repeated value", () => {
+    // A repeated expected value does not stand in for an object value that expected lacks.
+    expect({ a: 1, b: 2 }).not.toContainAllValues([1, 1]);
+    expect({ id: 7, role: "admin", ok: true }).not.toContainAllValues([7, 7, 7]);
+    expect({ a: 1, b: "x" }).not.toContainAllValues([expect.any(Number), 1]);
+    expect(() => expect({ a: 1, b: 2 }).toContainAllValues([1, 1])).toThrow(
+      isBun ? "Expected to contain all values" : "Expected object to contain all values",
+    );
+
+    // Repeated values that are on both sides still match.
+    expect({ a: 1, b: 1 }).toContainAllValues([1, 1]);
+    expect({ a: 1, b: 1, c: 2 }).toContainAllValues([2, 1, 1]);
+    expect({ a: { x: 1 }, b: { x: 1 } }).toContainAllValues([{ x: 1 }, { x: 1 }]);
+    expect({ a: 1, b: "x" }).toContainAllValues([expect.any(String), expect.any(Number)]);
+    expect(() => expect({ a: 1, b: 1 }).not.toContainAllValues([1, 1])).toThrow(
+      isBun ? "Expected to not contain all values" : "Expected object to not contain all values",
+    );
+
+    // The same set of values with a different count does not match.
+    expect({ a: 1, b: 1 }).not.toContainAllValues([1]);
+    expect({ a: 1 }).not.toContainAllValues([1, 1]);
+
+    expect({}).toContainAllValues([]);
+    expect({}).not.toContainAllValues([1]);
+    expect({ a: 1 }).not.toContainAllValues([]);
+    if (isBun) {
+      // jest-extended 5.0.0 and later fail a received value that is not a plain object.
+      expect([]).toContainAllValues([]);
+      expect([1, 2]).toContainAllValues([2, 1]);
+    }
+
+    if (isBun) {
+      // jest-extended only checks that each object value is in expected, so it passes these.
+      expect({ a: 1, b: 1 }).not.toContainAllValues([1, 2]);
+      expect({ a: 1, b: 2 }).not.toContainAllValues([expect.any(Number), "zzz"]);
+    }
+  });
+
   test("toContainAnyValues", () => {
     let o = { a: "foo", b: "bar", c: "baz" };
     expect(o).toContainAnyValues(["qux", "foo"]);


### PR DESCRIPTION
### Problem
- `expect({ a: 1, b: 2 }).toContainAllValues([1, 1])` passes, although `expected` has no `2`. jest-extended fails it.
- The cause is `src/runtime/test_runner/expect/toContainAllValues.rs:16`. After the count check, the matcher searches each `expected` item among the object's values. A repeated item matches the same object value each time, so nothing looks at `2`.
- The loop starts from `let mut pass = false`, so `expect({}).toContainAllValues([])` fails. #42504 fixes only this case and keeps the direction.

### Fix
- After the count check, each object value must deep-equal an `expected` item (the jest-extended check), and each `expected` item must deep-equal an object value (the old check).
- Pass changes to fail only where jest-extended also fails. `{}`, `[]`, `""` and `5` against `[]` change from fail to pass, as in jest-extended 4.
- Open question: the old check stays. `expect({ a: 1, b: 1 }).toContainAllValues([1, 2])` still fails, and jest-extended passes it. For exact parity, remove the second `each_has_match` call and the last `if (isBun)` test block.
- Verified: new test `toContainAllValues with a repeated value` in `test/js/bun/test/expect.test.js` fails on bun 1.4.3-canary.1. Also ran `jest-extended.test.js`. Self-reviewed: 4 concerns raised, 4 addressed.

### Background
- `toContainAllValues` comes from jest-extended: "Use .toContainAllValues when checking if an object only contains all of the provided values."
- jest-extended 4.0.0 (pinned in `test/package.json`) implements it as `values.length === expected.length && values.every(v => contains(equals, expected, v))`. 5.0.0 and later also fail a received value that is not a plain object.
- The comparison is `jest_deep_equals`, the same as `toEqual`. One asymmetric matcher such as `expect.any(Number)` can match several values.

<details><summary>Notes</summary>

Results for `expect(object).toContainAllValues(expected)`. The jest-extended column is 4.0.0 on `expect` 29.7.0.

| object | expected | bun 1.4.3-canary.1 | this PR | jest-extended 4.0.0 |
| --- | --- | --- | --- | --- |
| `{ a: 1, b: 2 }` | `[1, 1]` | pass | fail | fail |
| `{ id: 7, role: "admin", ok: true }` | `[7, 7, 7]` | pass | fail | fail |
| `{ a: 1, b: "x" }` | `[expect.any(Number), 1]` | pass | fail | fail |
| `{}` | `[]` | fail | pass | pass |
| `[]`, `""`, `5`, `function () {}` | `[]` | fail | pass | pass (5.0.0 and later: fail) |
| `[1, 2]` | `[2, 1]` | pass | pass | pass (5.0.0 and later: fail) |
| `{ a: 1, b: 2 }` | `[2, 1]` | pass | pass | pass |
| `{ a: 1, b: 1 }` | `[1, 1]` | pass | pass | pass |
| `{ a: 1, b: 2 }` | `[1, 9]` | fail | fail | fail |
| `{ a: 1, b: 1 }` | `[1, 2]` | fail | fail | pass |
| `{ a: 1, b: 2 }` | `[expect.any(Number), "zzz"]` | fail | fail | pass |
| `{ a: 1, b: 1, c: 2 }` | `[1, 2, 2]` | pass | pass | pass |

- #42504 (open) edits the same loop. It removes the `pass = false` start value and keeps the walk from `expected` to the values, so the `[1, 1]` assertion still passes with it alone. The loop in this PR includes that case. The two PRs conflict in `toContainAllValues.rs` and at the same place in `expect.test.js`. The second one to land needs a rebase: keep the loop of this PR and both test blocks.
- The rows with a received value that is not a plain object pass because bun has no receiver check, the same as `toContainValues`, `toContainKeys` and `toContainAllKeys` (`expect(5).toContainValues([])` passes on bun 1.4.3). They failed before only because of the `pass = false` start value. The test has one `if (isBun)` block for them, so a later jest-extended version in `test/package.json` does not break the Jest run.
- Why the old check stays: with only the jest-extended walk, a repeated object value stands in for an expected value that the object does not have. That is the mirror image of the reported false pass.
- The last row shows that the matcher does not compare multisets. jest-extended does not either. An exact pairing with asymmetric matchers is a bipartite matching problem, and nobody asked for it.
- `toContainValues` (no `All`) has no count check and does not change.
- `expect.test.js` also runs under Jest and Vitest with jest-extended. The assertions where bun and jest-extended differ are inside `if (isBun)`.
- Each clause of the fix is covered. Without the walk from the values to `expected`, the `[1, 1]` assertion fails. Without the walk from `expected` to the values, the `[1, 2]` assertion fails. Without the count check, `expect({ a: 1, b: 1 }).not.toContainAllValues([1])` fails.
- The received value stays on the left of `jest_deep_equals` in both walks, as before.
- Not in this PR, tracked in #42537: `expect({ a: 1, b: 2 }).toContainAllKeys([expect.any(String), "zzz"])` passes, and `expect(null).toContainValues([1])` passes. `toContainAllKeys` walks from the keys to `expected`. Object keys are unique strings, so that is exact for plain keys, and only an asymmetric matcher that matches two keys gives a false pass. #42495 edits that loop now, so the change must come after it.
- The four concerns of the self-review: cross-link to #42504, name jest-extended 4.0.0 as the reference and list the other changes from fail to pass, link a tracker for the two sibling false passes, state the second walk as an open question.
- Ran with the debug build: all of `test/js/bun/test/expect.test.js` (417 pass, 2 todo), `test/js/bun/test/jest-extended.test.js` (58 pass), the two `toContainAllValues` tests with `BUN_JSC_validateExceptionChecks=1`, `cargo clippy -p bun_runtime`, and `test/internal/source-lints/`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
ninja: Entering directory `/workspace/bun/build/debug'
[1/66] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/66] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/66] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields
... (truncated)

release without fix: 1 failed, 2 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/js/bun/test/expect.test.js:
(pass) expect() > () [0.69ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.02ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.01ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
bun test v1.4.3 (6a92015fc)

test/js/bun/test/expect.test.js:
(pass) expect() > () [357.69ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [3.33ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.48ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.25ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.25ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.23ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.23ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.26ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.24ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.24ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.26ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.44ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.52ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.31ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.32ms]
(pass) ex
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 727ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/60] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/60] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 9 classes from /workspace/bun/src/runtime/api/html_rewriter.classes.ts
  - HTMLRewriter (3 field
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../test_runner/expect/toContainAllValues.rs       | 34 ++++++++++++-------
 test/js/bun/test/expect.test.js                    | 38 ++++++++++++++++++++++
 2 files changed, 60 insertions(+), 12 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/runtime/test_runner/expect/toContainAllValues.rs      1      2     21
test/js/bun/test/expect.test.js                           2      3     21
```

</details>

<!-- robobun:evidence:end -->