### PR TITLE
Check both directions in expect().toContainAllKeys() and fail toContainValues() on null

### DIFF
--- a/src/runtime/test_runner/expect/toContainAllKeys.rs
+++ b/src/runtime/test_runner/expect/toContainAllKeys.rs
@@ -1,6 +1,16 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 use super::{Expect, ExpectedArray, ContainMsgs, ContainOutcome};
 
+/// True when some element of `array` (of length `len`) passes `matches`.
+fn any_index(g: &JSGlobalObject, array: JSValue, len: u64, mut matches: impl FnMut(JSValue) -> JsResult<bool>) -> JsResult<bool> {
+    let mut i: u32 = 0;
+    while u64::from(i) < len {
+        if matches(array.get_index(g, i)?)? { return Ok(true); }
+        i += 1;
+    }
+    Ok(false)
+}
+
 impl Expect {
     #[bun_jsc::host_fn(method)]
     pub(crate) fn to_contain_all_keys(&self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
@@ -9,17 +19,19 @@ impl Expect {
             |g, value, expected| {
                 let count = expected.get_length(g)?;
                 let keys = value.keys(g)?;
-                let mut pass = false;
-                if keys.get_length(g)? == count {
-                    pass = true;
+                let mut pass = keys.get_length(g)? == count;
+                // Every key must match an expected item, and every expected item must match a key.
+                // One asymmetric matcher can match several keys, so one direction alone is not enough.
+                if pass {
                     let mut itr = keys.array_iterator(g)?;
-                    'outer: while let Some(item) = itr.next()? {
-                        let mut i: u32 = 0;
-                        while u64::from(i) < count {
-                            if item.jest_deep_equals(expected.get_index(g, i)?, g)? { continue 'outer; }
-                            i += 1;
-                        }
-                        pass = false; break;
+                    while let Some(key) = itr.next()? {
+                        if !any_index(g, expected, count, |item| key.jest_deep_equals(item, g))? { pass = false; break; }
+                    }
+                }
+                if pass {
+                    let mut itr = expected.array_iterator(g)?;
+                    while let Some(item) = itr.next()? {
+                        if !any_index(g, keys, count, |key| key.jest_deep_equals(item, g))? { pass = false; break; }
                     }
                 }
                 Ok(ContainOutcome { pass, received_override: Some(keys) })

--- a/src/runtime/test_runner/expect/toContainValues.rs
+++ b/src/runtime/test_runner/expect/toContainValues.rs
@@ -6,7 +6,7 @@ impl Expect {
     pub(crate) fn to_contain_values(&self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         self.contain_matcher(global, frame, "toContainValues", ExpectedArray::BeforeValue, ContainMsgs::CONTAIN,
             |g, value, expected| {
-                if value.is_undefined_or_null() { return Ok(ContainOutcome::pass(true)); }
+                if value.is_undefined_or_null() { return Ok(ContainOutcome::pass(false)); }
                 let values = value.values(g)?;
                 let count = values.get_length(g)?;
                 let mut itr = expected.array_iterator(g)?;

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -2644,6 +2644,17 @@ describe("expect()", () => {
 
     expect([1, 2, 3]).toContainAllKeys(["0", "1", "2"]);
     expect([1, 2, 3]).not.toContainAllKeys(["0", "1", "2", "3"]);
+
+    // An asymmetric matcher can match several keys. Every expected item must still match a key.
+    expect({ a: "hello", b: "world" }).toContainAllKeys([expect.any(String), "a"]);
+    expect({ a: "hello", b: "world" }).toContainAllKeys([expect.any(String), expect.any(String)]);
+    expect({ a: 1, b: 2 }).not.toContainAllKeys([expect.any(String), "zzz"]);
+    expect({ a: 1, b: 2 }).not.toContainAllKeys([expect.any(String), expect.any(Number)]);
+    expect(() => expect({ a: 1, b: 2 }).toContainAllKeys([expect.any(String), "zzz"])).toThrow();
+    if (isBun) {
+      // jest-extended only walks from expected to the keys, so it passes this one.
+      expect({ a: 1, b: 2 }).not.toContainAllKeys(["a", "a"]);
+    }
   });
 
   test("toContainAnyKeys", () => {
@@ -2786,6 +2797,14 @@ describe("expect()", () => {
     expect(data).toContainValues([]);
     expect(data).toContainValues(["baz", "bar", "foo"]);
     expect(data).not.toContainValues(["qux", "foo"]);
+
+    expect(() => expect(null).toContainValues([1])).toThrow();
+    expect(() => expect(undefined).toContainValues([1])).toThrow();
+    if (isBun) {
+      // jest-extended throws a TypeError from Object.keys(null) here.
+      expect(null).not.toContainValues([1]);
+      expect(undefined).not.toContainValues([1]);
+    }
   });
 
   test("toContainAllValues", () => {


### PR DESCRIPTION
Fixes #42537

### Problem
- `expect({ a: 1, b: 2 }).toContainAllKeys([expect.any(String), "zzz"])` passes. `"zzz"` is not a key, so it must fail. `src/runtime/test_runner/expect/toContainAllKeys.rs` compares the lengths, then checks that every key matches some expected item. It never checks that every expected item matches a key. `expect.any(String)` matches both keys, so `"zzz"` is never examined.
- `expect(null).toContainValues([1])` and `expect(undefined).toContainValues([1])` pass. `src/runtime/test_runner/expect/toContainValues.rs:9` returns a pass for a `null` or `undefined` received value. The sibling matchers (`toContainValue`, `toContainAnyValues`, `toContainAllValues`) return a fail in the same spot.

### Fix
- `toContainAllKeys` now walks both directions: every key must match an expected item, and every expected item must match a key. The length check stays. The first walk is kept so that `expect({ a: 1, b: 2 }).not.toContainAllKeys(["a", "a"])` still passes, as the issue asks.
- `toContainValues` returns a fail for `null` and `undefined`, like its siblings. jest-extended throws a `TypeError` there, so the assertion fails there too.
- Verified: `test/js/bun/test/expect.test.js` (new cases in `toContainAllKeys` and `toContainValues`, both fail on stock bun). Also `test/js/bun/test/jest-extended.test.js`.

### Background
- These matchers come from jest-extended. jest-extended 4 checks `objectKeys.length === expected.length && expected.every(key => contains(equals, objectKeys, key))`. That is the walk from `expected` to the keys, which bun was missing.
- `jest_deep_equals` handles asymmetric matchers such as `expect.any(String)`. One such matcher can match several keys, so a one-directional walk is not exact.
- #42495 edits the same loop to accept number keys. This PR does not touch that conversion. If #42495 lands first, the second walk needs the same number-to-string conversion.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
bun test v1.4.3 (6a92015fc)

test/js/bun/test/expect.test.js:
(pass) expect() > () [301.77ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [2.71ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.45ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.26ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.24ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.23ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.23ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.25ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.23ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.23ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.25ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.83ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.45ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.30ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.30ms]
(pass) ex
... (truncated)

release without fix: 2 failed, 2 skipped
bun test v1.4.3-canary.1 (6a92015fc)

test/js/bun/test/expect.test.js:
(pass) expect() > () [1.15ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.04ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(0).toBe(0) == true
(pass) expect() > toBe() > expect(-0).toBe(-0) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(1).toBe(1) == true
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true
(pass) expect() > toBe() > expect({}).toBe({}) == true
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true
(pass) expect() > toBe() > expect(0).toBe(false) == false [0.03ms]
(pass) expect() > toBe() > expect(0).toBe("") == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(0).toBe(-0) == false
(pass) expect() > toBe() > expect(1).toBe(2) == false
(pass) expect() > toBe() > expect(1).toBe(true) == false
(pass) expect() > toBe() > expect(1).toBe("1") == false
(pass) expect() > toBe() > expect(Infinity).toBe(-Infinity) == false
(pass) expect() > toBe() > expect("foo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect.test.js
bun test v1.4.3 (6a92015fc)

test/js/bun/test/expect.test.js:
(pass) expect() > () [345.21ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [3.54ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.47ms]
(pass) expect() > toBe() > expect(0).toBe(0) == true [0.27ms]
(pass) expect() > toBe() > expect(-0).toBe(-0) == true [0.24ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.24ms]
(pass) expect() > toBe() > expect(1).toBe(1) == true [0.26ms]
(pass) expect() > toBe() > expect(NaN).toBe(NaN) == true [0.23ms]
(pass) expect() > toBe() > expect(Infinity).toBe(Infinity) == true [0.23ms]
(pass) expect() > toBe() > expect({}).toBe({}) == true [0.26ms]
(pass) expect() > toBe() > expect(Symbol(a)).toBe(Symbol(a)) == true [0.24ms]
(pass) expect() > toBe() > expect(0).toBe(false) == false [1.52ms]
(pass) expect() > toBe() > expect(0).toBe("") == false [0.46ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.31ms]
(pass) expect() > toBe() > expect(0).toBe(-0) == false [0.30ms]
(pass) ex
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 708ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/45] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/45] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_install_jsc v0.0.0 (/workspace/bun/src/install_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/expect/toContainAllKeys.rs | 32 +++++++++++++++-------
 src/runtime/test_runner/expect/toContainValues.rs  |  2 +-
 test/js/bun/test/expect.test.js                    | 19 +++++++++++++
 3 files changed, 42 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/runtime/test_runner/expect/toContainAllKeys.rs      1      2      4
src/runtime/test_runner/expect/toContainValues.rs       1      2      4
test/js/bun/test/expect.test.js                         1      2      4
```

</details>

**root cause** · written by the author bot

`toContainAllKeys` only verified that every object key matched some expected item, so a single asymmetric matcher such as `expect.any(String)` could stand in for several keys and leave other expected items unchecked; the fix adds the reverse walk so every expected item must also match a key. `toContainValues` short-circuited to a pass when the received value was `null` or `undefined`, a leftover from the Zig version's `var pass = true` default, so it now returns a failure there to match its three sibling matchers.

<!-- robobun:evidence:end -->