### PR TITLE
bun:test: stop toBeEmpty() from passing for undefined, null, numbers, functions and Dates

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1544,11 +1544,16 @@ declare module "bun:test" {
     /**
      * Asserts that a value is empty.
      *
+     * The value must be a string, an object, or an iterable. With any other
+     * value, such as `undefined`, a number, or a function, both `toBeEmpty()`
+     * and `.not.toBeEmpty()` fail.
+     *
      * @example
      * expect("").toBeEmpty();
      * expect([]).toBeEmpty();
      * expect({}).toBeEmpty();
      * expect(new Set()).toBeEmpty();
+     * expect(new Date()).not.toBeEmpty();
      */
     toBeEmpty(): void;
 

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2426,8 +2426,7 @@ impl JSValue {
         }
         JSC__JSValue__isClass(self, global)
     }
-    /// `Object.prototype.toString.call(value) === "[object Object]"`. Reads
-    /// `Symbol.toStringTag`, so it can run user code.
+    /// `Object.prototype.toString.call(self) === "[object Object]"`. It reads `Symbol.toStringTag`, so it can run user code.
     pub fn to_string_tag_is_object(self, global: &JSGlobalObject) -> JsResult<bool> {
         crate::cpp::JSC__JSValue__toStringTagIsObject(self, global)
     }

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2426,6 +2426,11 @@ impl JSValue {
         }
         JSC__JSValue__isClass(self, global)
     }
+    /// `Object.prototype.toString.call(value) === "[object Object]"`. Reads
+    /// `Symbol.toStringTag`, so it can run user code.
+    pub fn to_string_tag_is_object(self, global: &JSGlobalObject) -> JsResult<bool> {
+        crate::cpp::JSC__JSValue__toStringTagIsObject(self, global)
+    }
 
     // ── Iteration. ────────────────────────────────
     /// `JSValue.isIterable`.

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4251,6 +4251,21 @@ bool JSC__JSValue__isIterable(JSC::EncodedJSValue JSValue, JSC::JSGlobalObject* 
     return JSC::hasIteratorMethod(global, JSC::JSValue::decode(JSValue));
 }
 
+// `Object.prototype.toString.call(value) === "[object Object]"`. Jest's `equals()` compares this string first, so no object of another class equals `{}`.
+[[ZIG_EXPORT(check_slow)]] bool JSC__JSValue__toStringTagIsObject(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* globalObject)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSC::JSString* tag = JSC::objectPrototypeToString(globalObject, JSC::JSValue::decode(JSValue0));
+    RETURN_IF_EXCEPTION(scope, false);
+
+    JSC::JSString* objectObject = vm.smallStrings.objectObjectString();
+    if (tag == objectObject)
+        return true;
+    RELEASE_AND_RETURN(scope, tag->equal(globalObject, objectObject));
+}
+
 void JSC__JSValue__forEach(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, void* ctx, void (*ArgFn3)(JSC::VM* arg0, JSC::JSGlobalObject* arg1, void* arg2, JSC::EncodedJSValue JSValue3))
 {
     JSC::forEachInIterable(

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -254,6 +254,7 @@ CPP_DECL bool JSC__JSValue__toMatch(JSC::EncodedJSValue JSValue0, JSC::JSGlobalO
 CPP_DECL JSC::JSObject* JSC__JSValue__toObject(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
 CPP_DECL JSC::JSString* JSC__JSValue__toString(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
 CPP_DECL JSC::JSString* JSC__JSValue__toStringOrNull(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
+CPP_DECL bool JSC__JSValue__toStringTagIsObject(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
 CPP_DECL JSC::JSString* JSC__JSValue__toJSStringView(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* global, BunString* view);
 CPP_DECL uint64_t JSC__JSValue__toUInt64NoTruncate(JSC::EncodedJSValue JSValue0);
 CPP_DECL void JSC__JSValue__toZigException(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, ZigException* arg2);

--- a/src/runtime/test_runner/expect/toBeEmpty.rs
+++ b/src/runtime/test_runner/expect/toBeEmpty.rs
@@ -16,10 +16,16 @@ pub(crate) fn to_be_empty(
     let mut formatter = super::make_formatter(global);
     // `defer formatter.deinit()` — handled by Drop.
 
-    let actual_length = value.get_length_if_property_exists_internal(global)?;
+    // The length probe reports 0 for a value that is not a cell, and a function has a `length`.
+    let is_string_or_object = value.is_string() || (value.is_object() && !value.is_callable());
+    let actual_length = if is_string_or_object {
+        value.get_length_if_property_exists_internal(global)?
+    } else {
+        f64::INFINITY
+    };
 
     if actual_length == f64::INFINITY {
-        if value.js_type_loose().is_object() {
+        if is_string_or_object {
             if value.is_iterable(global)? {
                 let mut any_properties_in_iterator = false;
 
@@ -39,6 +45,10 @@ pub(crate) fn to_be_empty(
                     anything_in_iterator,
                 )?;
                 pass = !any_properties_in_iterator;
+            } else if !value.to_string_tag_is_object(global)? {
+                // jest-extended compares against `{}`, and no Date, RegExp, Error
+                // or other object of another class equals `{}`.
+                pass = false;
             } else {
                 let Some(_cell) = value.to_cell() else {
                     return Err(global.throw_type_error(format_args!(
@@ -65,7 +75,7 @@ pub(crate) fn to_be_empty(
                 pass = props_iter.len == 0;
             }
         } else {
-            let signature = Expect::get_signature("toBeEmpty", "", false);
+            let signature = Expect::get_signature("toBeEmpty", "", not);
             return throw!(
                 this,
                 global,
@@ -81,17 +91,6 @@ pub(crate) fn to_be_empty(
         )));
     } else {
         pass = actual_length == 0.0;
-    }
-
-    if not && pass {
-        let signature = Expect::get_signature("toBeEmpty", "", true);
-        return throw!(
-            this,
-            global,
-            signature,
-            "\n\nExpected value <b>not<r> to be a string, object, or iterable\n\nReceived: <red>{}<r>\n",
-            value.to_fmt(&mut formatter)
-        );
     }
 
     if not {

--- a/src/runtime/test_runner/expect/toBeEmpty.rs
+++ b/src/runtime/test_runner/expect/toBeEmpty.rs
@@ -46,8 +46,7 @@ pub(crate) fn to_be_empty(
                 )?;
                 pass = !any_properties_in_iterator;
             } else if !value.to_string_tag_is_object(global)? {
-                // jest-extended compares against `{}`, and no Date, RegExp, Error
-                // or other object of another class equals `{}`.
+                // jest-extended: `equals({}, value)` is false for an object of another class, like a Date.
                 pass = false;
             } else {
                 let Some(_cell) = value.to_cell() else {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3811,6 +3811,122 @@ describe("expect()", () => {
     }
   });
 
+  // https://github.com/oven-sh/bun/issues/17074
+  describe("toBeEmpty() with a value that is not a string, object, or iterable", () => {
+    /** @type {{ label: string, value: any }[]} */
+    const values = [
+      { label: `undefined`, value: undefined },
+      { label: `null`, value: null },
+      { label: `0`, value: 0 },
+      { label: `5`, value: 5 },
+      { label: `NaN`, value: NaN },
+      { label: `true`, value: true },
+      { label: `false`, value: false },
+      { label: `10n`, value: 10n },
+      { label: `Symbol()`, value: Symbol() },
+      { label: `() => {}`, value: () => {} },
+      { label: `(a, b) => {}`, value: (/** @type {any} */ a, /** @type {any} */ b) => {} },
+      { label: `async () => {}`, value: async () => {} },
+      { label: `class A {}`, value: class A {} },
+      { label: `new Proxy(() => {}, {})`, value: new Proxy(() => {}, {}) },
+    ];
+    for (const { label, value } of values) {
+      test(label, () => {
+        // jest-extended fails toBeEmpty() for each of these too: with a TypeError for undefined and null,
+        // with "Expected value to be empty" for the rest. It passes not.toBeEmpty() for the rest.
+        expect(() => expect(value).toBeEmpty()).toThrow(
+          isBun ? "Expected value to be a string, object, or iterable" : undefined,
+        );
+        if (isBun) {
+          expect(() => expect(value).not.toBeEmpty()).toThrow("Expected value to be a string, object, or iterable");
+        }
+      });
+    }
+
+    if (isBun) {
+      test("the message has the matcher and the received value", () => {
+        const message = (/** @type {() => void} */ fn) => {
+          try {
+            fn();
+          } catch (e) {
+            return ANY(e).message.replaceAll(/\x1B\[[0-9;]*m/g, "");
+          }
+          return "did not throw";
+        };
+        expect(message(() => expect(undefined).toBeEmpty())).toBe(
+          "expect(received).toBeEmpty()\n\nExpected value to be a string, object, or iterable\n\nReceived: undefined\n",
+        );
+        expect(message(() => expect(5).not.toBeEmpty())).toBe(
+          "expect(received).not.toBeEmpty()\n\nExpected value to be a string, object, or iterable\n\nReceived: 5\n",
+        );
+      });
+    }
+  });
+
+  // jest-extended compares against `{}`, and Jest's equality first compares `Object.prototype.toString.call()` of both sides.
+  describe("toBeEmpty() with an object of another class than Object", () => {
+    class Tagged {
+      get [Symbol.toStringTag]() {
+        return "Tagged";
+      }
+    }
+    /** @type {{ label: string, value: any }[]} */
+    const values = [
+      { label: `new Date(0)`, value: new Date(0) },
+      { label: `/x/`, value: /x/ },
+      { label: `new Error("boom")`, value: new Error("boom") },
+      { label: `new Number(5)`, value: new Number(5) },
+      { label: `new Boolean(false)`, value: new Boolean(false) },
+      { label: `Object(Symbol())`, value: Object(Symbol()) },
+      { label: `Promise.resolve()`, value: Promise.resolve() },
+      { label: `new WeakSet()`, value: new WeakSet() },
+      { label: `new DataView(new ArrayBuffer(8))`, value: new DataView(new ArrayBuffer(8)) },
+      { label: `Math`, value: Math },
+      { label: `an instance of a class with Symbol.toStringTag`, value: new Tagged() },
+    ];
+    for (const { label, value } of values) {
+      test(label, () => {
+        expect(value).not.toBeEmpty();
+        expect(() => expect(value).toBeEmpty()).toThrow("Expected value to be empty");
+      });
+    }
+
+    test("a Symbol.toStringTag getter that throws", () => {
+      const value = {};
+      Object.defineProperty(value, Symbol.toStringTag, {
+        get() {
+          throw new Error("from the getter");
+        },
+      });
+      expect(() => expect(value).toBeEmpty()).toThrow("from the getter");
+    });
+  });
+
+  describe("toBeEmpty() with an object that has no enumerable properties", () => {
+    class Foo {}
+    /** @type {{ label: string, value: any }[]} */
+    const values = [
+      { label: `new Foo()`, value: new Foo() },
+      { label: `Object.create(null)`, value: Object.create(null) },
+      { label: `new Proxy({}, {})`, value: new Proxy({}, {}) },
+      { label: `Object.defineProperty({}, "a", { value: 1 })`, value: Object.defineProperty({}, "a", { value: 1 }) },
+    ];
+    for (const { label, value } of values) {
+      test(label, () => {
+        expect(value).toBeEmpty();
+        expect(() => expect(value).not.toBeEmpty()).toThrow(
+          isBun ? "Expected value not to be empty" : "Expected value to not be empty",
+        );
+      });
+    }
+
+    test(`""`, () => {
+      expect(() => expect("").not.toBeEmpty()).toThrow(
+        isBun ? "Expected value not to be empty" : "Expected value to not be empty",
+      );
+    });
+  });
+
   test("toBeEmptyObject()", () => {
     // Map and Set are not considered as object in jest-extended
     // https://github.com/jestjs/jest/blob/main/packages/jest-get-type/src/index.ts#L26

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3811,6 +3811,16 @@ describe("expect()", () => {
     }
   });
 
+  // The message of the error that `fn` throws, without ANSI colors. Bun prints the "not" of a failed `.not` in bold.
+  const failureMessage = (/** @type {() => void} */ fn) => {
+    try {
+      fn();
+    } catch (e) {
+      return ANY(e).message.replaceAll(/\x1B\[[0-9;]*m/g, "");
+    }
+    return "did not throw";
+  };
+
   // https://github.com/oven-sh/bun/issues/17074
   describe("toBeEmpty() with a value that is not a string, object, or iterable", () => {
     /** @type {{ label: string, value: any }[]} */
@@ -3845,18 +3855,10 @@ describe("expect()", () => {
 
     if (isBun) {
       test("the message has the matcher and the received value", () => {
-        const message = (/** @type {() => void} */ fn) => {
-          try {
-            fn();
-          } catch (e) {
-            return ANY(e).message.replaceAll(/\x1B\[[0-9;]*m/g, "");
-          }
-          return "did not throw";
-        };
-        expect(message(() => expect(undefined).toBeEmpty())).toBe(
+        expect(failureMessage(() => expect(undefined).toBeEmpty())).toBe(
           "expect(received).toBeEmpty()\n\nExpected value to be a string, object, or iterable\n\nReceived: undefined\n",
         );
-        expect(message(() => expect(5).not.toBeEmpty())).toBe(
+        expect(failureMessage(() => expect(5).not.toBeEmpty())).toBe(
           "expect(received).not.toBeEmpty()\n\nExpected value to be a string, object, or iterable\n\nReceived: 5\n",
         );
       });
@@ -3914,14 +3916,14 @@ describe("expect()", () => {
     for (const { label, value } of values) {
       test(label, () => {
         expect(value).toBeEmpty();
-        expect(() => expect(value).not.toBeEmpty()).toThrow(
+        expect(failureMessage(() => expect(value).not.toBeEmpty())).toContain(
           isBun ? "Expected value not to be empty" : "Expected value to not be empty",
         );
       });
     }
 
     test(`""`, () => {
-      expect(() => expect("").not.toBeEmpty()).toThrow(
+      expect(failureMessage(() => expect("").not.toBeEmpty())).toContain(
         isBun ? "Expected value not to be empty" : "Expected value to not be empty",
       );
     });


### PR DESCRIPTION
Fixes #17074. That issue asks for `expect(undefined).not.toBeEmpty()` to pass, or "alternatively" for an error. This PR gives the error.

**To decide on:** `expect(null).toBeEmpty()` and `expect(undefined).toBeEmpty()` pass today. After this PR they throw. This break is deliberate. [brisa](https://github.com/brisa-build/brisa) uses them to mean "absent": 7 assertions in 4 test files go red, for example `expect(res.headers.get("x-reset")).toBeEmpty()`. The options for `undefined`, `null`, a number, a boolean and a function:

1. `undefined` and `null` stay empty. brisa stays green. A missing value still passes.
2. Not empty: `toBeEmpty()` fails, `.not.toBeEmpty()` passes. #17074 asks for this first.
3. Throw with and without `.not` (this PR). jest-extended does this for `undefined` and `null`. chai's `.empty` does it for all of these. Bun already does it for a bigint and a symbol.

Options 2 and 3 break the same brisa assertions. Option 1 or 2 is a small edit to this PR.

### Problem
- `expect(v).toBeEmpty()` passes when `v` is `undefined`, `null`, a number, a boolean, a zero-argument function, a `Date`, a `RegExp` or an `Error`. `expect(items.length).toBeEmpty()` is green for every length.
- The matcher reads a length first. The probe (`src/jsc/bindings/bindings.cpp:2929`) returns 0 for a value that is not a cell, and a function has a `length`, so `pass = (0 == 0)`. `toHaveLength()` rejects such values before it calls the same probe.
- An object with no length and no iterator is empty when it has no enumerable properties. A `Date`, `RegExp`, `Error` or `Promise` has none.

### Fix
- `toBeEmpty()` reads the length only from a string, or from an object that is not a function. For any other value it throws its existing error, `Expected value to be a string, object, or iterable`, with or without `.not`.
- An object with no length and no iterator is empty only when `Object.prototype.toString.call(value)` is `"[object Object]"`. jest-extended defines the matcher as `equals({}, value) || isEmptyIterable(value)`, and Jest's `equals` compares that string first. So `expect(new Date()).not.toBeEmpty()` passes, as in jest-extended.
- `.not.toBeEmpty()` on an empty value now says `Expected value not to be empty`, not `Expected value not to be a string, object, or iterable`. For `undefined`, `null`, numbers and booleans, `.not` threw that wrong message before, so only the text changes. A function with parameters passed `.not` and now throws.
- Verified: `test/js/bun/test/expect.test.js` (32 new tests, 30 fail on bun 1.4.3). Also `jest-extended.test.js`, `mock-fn.test.js`, and the `toBeEmpty()` users in `websocket-server.test.ts`. Self-reviewed: 4 concerns raised, 3 addressed. Rejected: use `jest_deep_equals({}, value)` for the object check, see Notes.

### Background
- `toBeEmpty()` comes from jest-extended. Bun's version also measures a `Blob`, an `ArrayBuffer`, `Headers` and any object with a `length`. This PR does not change those.
- `Object.prototype.toString.call(value)` gives `"[object Date]"` for a `Date`, and `"[object Object]"` for a plain object, a class instance, a null-prototype object and a `Proxy` of one.
- `toEqual({})` passes for a `Promise`, `WeakSet`, `DataView` and `Math` in Bun and fails in Jest (#42539). So after this PR `toBeEmpty()` and `toEqual({})` disagree on them.

<details><summary>Notes</summary>

- Before and after, `toBeEmpty()` / `.not.toBeEmpty()`:

  | received | 1.4.3 | this PR | jest-extended 7 |
  | --- | --- | --- | --- |
  | `undefined`, `null` | pass / throws | throws / throws | TypeError / TypeError |
  | `5`, `NaN`, `true` | pass / throws | throws / throws | fails / pass |
  | `10n`, `Symbol()` | throws / throws | same | fails / pass |
  | `() => 1`, `class A {}` | pass / throws | throws / throws | fails / pass |
  | `(a) => 1` | fails / pass | throws / throws | fails / pass |
  | `new Date(0)`, `/x/`, `new Error("boom")`, `new Number(5)` | pass / throws | fails / pass | fails / pass |
  | `Promise.resolve()`, `new WeakSet()`, `new DataView(buf)`, `Math` | pass / throws | fails / pass | fails / pass |
  | instance of a class with `Symbol.toStringTag` | pass / throws | fails / pass | fails / pass |
  | `new Foo()`, `Object.create(null)`, `new Proxy({}, {})` | pass / throws | pass / throws | pass / fails |

- brisa at 555b635, receivers recorded with a preload that replaces `toBeEmpty`: `null` at `utils/response-action/index.test.ts:119` and `:197` and at `cli/serve/serve-options.test.tsx:1075` and `:1097` (a header that is not set). `undefined` at `utils/render-to-readable-stream/index.test.tsx:114` and `utils/rerender-in-action/index.test.tsx:59` and `:78`. These run in 13 test cases. All other recorded receivers are strings, arrays and `Set`s.
- `expect(x.length).toBeEmpty()` in public `bun:test` suites: `tchak/tableur` `app/core/row.test.ts:47`, `NeumontAGrover/food-order-system` `tests/tests.spec.ts:261`. Today these cannot fail. After this PR they throw, also when the length is 0.
- Not changed, and different from jest-extended: `{ a: undefined }` and an object with an inherited enumerable property are not empty in Bun. `{ length: 0 }`, `new ArrayBuffer(0)`, `new Blob([])` and `new WeakMap()` are empty in Bun.
- An alternative was `jest_deep_equals({}, value)` in place of the string comparison. It does not work: `Bun__deepEquals` has no class comparison in the Jest modes (#42539), so a `Promise`, `WeakSet` and most host objects stay empty.
- The new C++ function is in `bindings.cpp` next to `JSC__JSValue__isIterable`. That file already includes `ObjectPrototypeInlines.h`, which holds the inline body of `JSC::objectPrototypeToString`, and `Bun__deepEquals` already calls it. Rust calls it through the generated `bun_jsc::cpp` binding (`ZIG_EXPORT(check_slow)`).
- Checked with `BUN_JSC_validateExceptionChecks=1`: a `Symbol.toStringTag` getter that throws, a `Proxy` `get` trap that throws, and a revoked `Proxy`.
- `toBeEmpty.rs` keeps its nesting so that the diff stays small. #42356 and #40235 rewrite the iterator hunk of the same file. This PR does not touch that hunk.
- If the answer to "To decide on" is option 1 or 2, the message fix (the removed `if not && pass` block and its test) can go in its own PR.

</details>
