### PR TITLE
minify: keep known-global constructors that a with object or a direct eval can shadow

### DIFF
--- a/src/ast/known_global.rs
+++ b/src/ast/known_global.rs
@@ -87,6 +87,10 @@ impl KnownGlobal {
         minify_whitespace: bool,
     ) -> Option<js_ast::Expr> {
         let id = if let js_ast::ExprData::EIdentifier(ident) = e.target.data {
+            // Inside a `with` body the name can be a property of the object.
+            if ident.must_keep_due_to_with_stmt() {
+                return None;
+            }
             ident.ref_
         } else {
             return None;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -174,6 +174,7 @@ pub(crate) struct ParserSnapshot<'a> {
     allow_in: bool,
     allow_private_identifiers: bool,
     has_classic_runtime_warned: bool,
+    parse_pass_saw_direct_eval: bool,
     has_non_local_export_declare_inside_namespace: bool,
     should_fold_typescript_constant_expressions: bool,
     fn_or_arrow_data_parse: FnOrArrowDataParse,
@@ -303,6 +304,12 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
 
     // Used for forcing CommonJS
     pub(crate) has_with_scope: bool,
+
+    /// A call to the identifier `eval` is somewhere in the file. A sloppy direct eval can
+    /// declare a `var` in any function around it, so an unbound name is not always the
+    /// global. `Scope::contains_direct_eval` cannot tell the visit pass this: it is set
+    /// when the visit reaches the call, after earlier code is rewritten.
+    pub(crate) parse_pass_saw_direct_eval: bool,
 
     /// A module-scope `var` has the name of a top-level function, which module code rejects.
     pub(crate) has_top_level_function_merged_with_var: bool,
@@ -8297,6 +8304,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             allow_in: self.allow_in,
             allow_private_identifiers: self.allow_private_identifiers,
             has_classic_runtime_warned: self.has_classic_runtime_warned,
+            parse_pass_saw_direct_eval: self.parse_pass_saw_direct_eval,
             has_non_local_export_declare_inside_namespace: self
                 .has_non_local_export_declare_inside_namespace,
             should_fold_typescript_constant_expressions: self
@@ -8331,6 +8339,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.allow_in = snapshot.allow_in;
         self.allow_private_identifiers = snapshot.allow_private_identifiers;
         self.has_classic_runtime_warned = snapshot.has_classic_runtime_warned;
+        self.parse_pass_saw_direct_eval = snapshot.parse_pass_saw_direct_eval;
         self.has_non_local_export_declare_inside_namespace =
             snapshot.has_non_local_export_declare_inside_namespace;
         self.should_fold_typescript_constant_expressions =
@@ -9809,6 +9818,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             macro_call_count: 0,
             hoisted_ref_for_sloppy_mode_block_fn: Default::default(),
             has_with_scope: false,
+            parse_pass_saw_direct_eval: false,
             has_top_level_function_merged_with_var: false,
             is_file_considered_to_have_esm_exports: false,
             has_called_runtime: false,

--- a/src/js_parser/parse/parse_suffix.rs
+++ b/src/js_parser/parse/parse_suffix.rs
@@ -388,6 +388,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let list_loc = p.parse_call_args()?;
         let loc = left.loc;
         let target = *left;
+        if let ExprData::EIdentifier(id) = target.data {
+            if p.load_name_from_ref(id.ref_) == b"eval" {
+                p.parse_pass_saw_direct_eval = true;
+            }
+        }
         *left = p.new_expr(
             E::Call {
                 target,

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -2457,7 +2457,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.visit_expr(arg);
         }
 
-        if p.options.features.minify_syntax {
+        // A sloppy direct eval can declare `var Array` in a function around this expression.
+        if p.options.features.minify_syntax && !p.parse_pass_saw_direct_eval {
             if let Some(minified) = js_ast::known_global::KnownGlobal::minify_global_constructor(
                 p.arena,
                 &mut *e_,

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -59,7 +59,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
 /// Version 30: String enum members are stored flat, so folds no longer append onto an inlined member.
 /// Version 31: Standard decorator lowering temporaries have a per-file counter in their name (`_init$1`).
-const EXPECTED_VERSION: u32 = 31;
+/// Version 32: `new Array(...)` and the other known-global constructor folds are skipped in a `with` body and in a file with a direct `eval`.
+const EXPECTED_VERSION: u32 = 32;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/bundler_bytecode_portable.test.ts
+++ b/test/bundler/bundler_bytecode_portable.test.ts
@@ -448,24 +448,24 @@ describe("bytecode cache portability", () => {
           "sha256": "2a5d62fb4ca9d107e3a5bb2abe6a73f3c859a6f1a91c6c3d77653cb8c2053361",
         },
         "bun build --bytecode --minify all.js": {
-          "js": "50b3e5192dd86a205c73583d585884c1b414467b14db54d03c77d3026bf236ff",
+          "js": "43556c41ff6eeb9a31284d51a288496209c4d1e42629b75f378e9e92fd4c4916",
           "jsc": {
-            "bytes": 1781360,
-            "sha256": "bd390a86e3399c8931a1b222b2600235e56a5f894080081315ab0a4a974278e9",
+            "bytes": 1781416,
+            "sha256": "6acd4baafa0e70023acbe4a6095e397c226d23ac002d8902f151f92d8991aed9",
           },
         },
         "bun build --bytecode --minify features.js": {
-          "js": "d30a5febed53e316cc2dd2b076502079e809bb0c201ef1671e9a190ecdcf093d",
+          "js": "268d3d7105a144e3b8d7ee6abafac7777c8c738ca7c59d6ffc6549a6e7a2dca0",
           "jsc": {
-            "bytes": 42568,
-            "sha256": "291ad88ef104860bc7601519b60269e32d2a3ee15b7810922008912d6c881c1f",
+            "bytes": 42608,
+            "sha256": "84d32206f4bb85f480e77e738d6b379b8cbf21a94eed3f35e516ff75979bc5e9",
           },
         },
         "bun build --bytecode --minify records.js": {
-          "js": "889cbb2c9525ff69a2676a6e81d97bb87760bdee65178b836c9c1d6808ac7c6e",
+          "js": "326e7c81d529624e9c93e1df2e9fb14cbdc71737a2396470e08a97ddfbad2669",
           "jsc": {
-            "bytes": 82248,
-            "sha256": "02d3a49ac8ffa02925676f7de749827f0a16d8150fec68d9f5d1dc1eadf87fab",
+            "bytes": 82280,
+            "sha256": "179be964b4d2d7d6daa102d708812a1642be45a37c40cecef09d3da91ff1f92d",
           },
         },
         "bun build --bytecode acorn/dist/acorn.mjs": {

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1383,6 +1383,86 @@ describe("bundler", () => {
     },
   });
 
+  // A sloppy direct eval can declare `var Array` in the function that calls it, so
+  // the unbound name is not always the global. The eval can run after the function
+  // that holds the `new` expression is created.
+  itBundled("minify/GlobalConstructorKeptWithDirectEval", {
+    files: {
+      "/entry.cjs": /* js */ `
+        function array() { eval("var Array = function () { return { mine: 1 } }"); return new Array(1, 2); }
+        function object() { eval("var Object = function () { return { mine: 2 } }"); return new Object(); }
+        function error() { eval("var Error = function (m) { this.mine = m }"); return new Error(3); }
+        function closureBeforeEval() {
+          var make = () => new Array(1, 2);
+          eval("var Array = function () { return { mine: 4 } }");
+          return make();
+        }
+        function closureAfterEval() {
+          eval("var Array = function () { return { mine: 5 } }");
+          return [0].map(() => new Array(1, 2))[0];
+        }
+        var calls = [];
+        function unused() { eval("var Set = function () { calls.push(6) }"); new Set(); return calls; }
+        console.log(JSON.stringify([array(), object(), error(), closureBeforeEval(), closureAfterEval(), unused()]));
+      `,
+    },
+    format: "cjs",
+    outfile: "/out.cjs",
+    minifySyntax: true,
+    onAfterBundle(api) {
+      const out = api.readFile("/out.cjs");
+      expect([...out.matchAll(/new Array\(1, 2\)/g)]).toHaveLength(3);
+      expect(out).toContain("new Object");
+      expect(out).toContain("new Error(3)");
+      expect(out).toContain("new Set");
+    },
+    run: {
+      stdout: '[{"mine":1},{"mine":2},{"mine":3},{"mine":4},{"mine":5},[6]]',
+    },
+  });
+
+  // In a `with` body the name can be a property of the object. Code outside the body
+  // is still folded, and so is a file where every eval is indirect.
+  itBundled("minify/GlobalConstructorKeptInWithBody", {
+    files: {
+      "/entry.cjs": /* js */ `
+        var calls = [];
+        var scope = {
+          Array: function () { return { mine: 1 } },
+          Object: function () { return { mine: 2 } },
+          Error: function (m) { this.mine = m },
+          Set: function () { calls.push(4) },
+        };
+        function inside(o) {
+          with (o) {
+            new Set();
+            return [new Array(1, 2), new Object(), new Error(3), (() => new Array(1, 2))()];
+          }
+        }
+        function outside() { return new Error("outside").message; }
+        function indirectEval() { (0, eval)("1"); eval?.("2"); return new Error("indirect").message; }
+        console.log(JSON.stringify([inside(scope), calls, outside(), indirectEval()]));
+      `,
+    },
+    format: "cjs",
+    outfile: "/out.cjs",
+    minifySyntax: true,
+    onAfterBundle(api) {
+      const out = api.readFile("/out.cjs");
+      expect([...out.matchAll(/new Array\(1, 2\)/g)]).toHaveLength(2);
+      expect(out).toContain("new Object");
+      expect(out).toContain("new Error(3)");
+      expect(out).toContain("new Set");
+      expect(out).toContain('Error("outside")');
+      expect(out).not.toContain('new Error("outside")');
+      expect(out).toContain('Error("indirect")');
+      expect(out).not.toContain('new Error("indirect")');
+    },
+    run: {
+      stdout: '[[{"mine":1},{"mine":2},{"mine":3},{"mine":1}],[4],"outside","indirect"]',
+    },
+  });
+
   itBundled("minify/TypeofUndefinedOptimization", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -195,6 +195,58 @@ describe("with statement", () => {
   });
 });
 
+// The runtime transpiler rewrites `new Array(1, 2)` to `[1, 2]` and `new Error(x)` to
+// `Error(x)` when the name is the global. A sloppy direct eval or a `with` object can
+// shadow the name.
+describe.concurrent("known-global constructors that can be shadowed", () => {
+  async function run(source: string) {
+    using dir = tempDir("runtime-known-global-shadow", { "index.cjs": source });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("direct eval", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      function f() { eval("var Array = function () { return { mine: 1 } }"); return new Array(1, 2); }
+      function g() { eval("var Object = function () { return { mine: 2 } }"); return new Object(); }
+      function k() { eval("var Error = function (m) { this.custom = m }"); return new Error("x"); }
+      function before() { var make = () => new Array(1, 2); eval("var Array = function () { return { mine: 3 } }"); return make(); }
+      eval("var RangeError = function (m) { this.custom = m }");
+      function top() { return new RangeError("y"); }
+      console.log(JSON.stringify([f(), g(), k(), before(), top()]));
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe('[{"mine":1},{"mine":2},{"custom":"x"},{"mine":3},{"custom":"y"}]\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test("with statement", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      var calls = [];
+      function h(o) { with (o) { new Set(); return [new Array(1, 2), new Object(), new Error("x")]; } }
+      console.log(JSON.stringify([
+        h({
+          Array: function () { return { mine: 1 } },
+          Object: function () { return { mine: 2 } },
+          Error: function (m) { this.custom = m },
+          Set: function () { calls.push("Set") },
+        }),
+        calls,
+      ]));
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe('[[{"mine":1},{"mine":2},{"custom":"x"}],["Set"]]\n');
+    expect(exitCode).toBe(0);
+  });
+});
+
 test("math.pow", () => {
   function foo1(foo) {
     return 10 ** (foo / 20);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3909,6 +3909,16 @@ class Foo {
       expectPrinted("a = !(b, c)", "a = (b, !c)");
     });
 
+    it("known-global constructors that a with object or a direct eval can shadow", () => {
+      expectPrinted_("with (o) x = new Array(1, 2)", "with (o)\n  x = new Array(1, 2)");
+      expectPrinted_("with (o) x = () => new Object()", "with (o)\n  x = () => new Object");
+      expectPrinted_("with (o) new Set()", "with (o)\n  new Set");
+
+      expectPrinted_("eval(a); x = new Array(1, 2)", "eval(a);\nx = new Array(1, 2)");
+      expectPrinted_("x = () => new Error(b); eval(a)", "x = () => new Error(b);\neval(a)");
+      expectPrinted_("(eval)(a); x = new Object()", "eval(a);\nx = new Object");
+    });
+
     it.todo("const inlining", () => {
       var transpiler = new Bun.Transpiler({
         inline: true,


### PR DESCRIPTION
### Problem
- With `minify_syntax` (default in `bun run`), `new Array(1, 2)` becomes `[1, 2]`, `new Error(x)` becomes `Error(x)` and an unused `new Set()` is dropped, also where the name is not the global. After `eval("var Array = F")` in the same function, `new Array(1, 2)` still gives `[1, 2]`. Node calls `F`. `with (o) { return new Array(1, 2) }` ignores `o.Array`.
- `KnownGlobal::minify_global_constructor` (`src/ast/known_global.rs:82`) only checks that the symbol is unbound. `bun run`, `bun build --minify-syntax`, `--no-bundle` and `Bun.Transpiler` all use it.

### Fix
- `with`: return early when the identifier has `must_keep_due_to_with_stmt`. `find_symbol` sets it when the lookup crosses a `with` scope.
- Direct eval: the parse pass sets `P::parse_pass_saw_direct_eval` at a call to the identifier `eval`. `e_new` skips the rewrite for that file.
- A visit-time check is not enough. `Scope::contains_direct_eval` is set when the visit reaches the call. A closure written before the `eval(...)` line is already rewritten.
- Verified: new cases in `bundler_minify.test.ts`, `runtime-transpiler.test.ts` and `transpiler.test.js` fail on 1.4.3-canary. Three `--minify` hashes in `bundler_bytecode_portable.test.ts` move.

### Background
- An unbound symbol is a name the file does not declare. The minifier treats unbound `Array`, `Error` and similar names as the globals.
- A direct eval is a call written `eval(...)`. In sloppy mode, `eval("var x")` declares `x` in the calling function. `eval?.(x)` and `(0, eval)(x)` are indirect.
- These rewrites are Bun's own: esbuild does not rewrite `new Array(1, 2)`.
- The runtime transpiler caches output on disk, so `EXPECTED_VERSION` moves to 32.

<details><summary>Notes</summary>

- Source: a differential fuzz run against Node. No user report.
- Repro (`bun evalshadow.cjs`, no flags):

  ```js
  function f() { eval("var Array = function () { return { mine: 1 } }"); return new Array(1, 2); }
  function g() { eval("var Object = function () { return { mine: 2 } }"); return new Object(); }
  function h(o) { with (o) { return new Array(1, 2); } }
  function k() { eval("var Error = function (m) { this.custom = m }"); return new Error("x"); }
  console.log(JSON.stringify([f(), g(), h({ Array: function () { return { mine: 3 } } }), k()]));
  ```

  Node 26.3.0 and this branch print `[{"mine":1},{"mine":2},{"mine":3},{"custom":"x"}]`. 1.4.2, canary and main print `[[1,2],{},[1,2],null]`. `new Error("x")` calls the shadowing function without `new`, so `k()` is `undefined`.
- More forms that were wrong on main and match Node here: a closure created before the eval (`var make = () => new Array(1, 2); eval("var Array = ..."); make()`), a closure created after it, an eval in a loop body after the `new`, a top-level `eval("var RangeError = ...")` in a CommonJS file, and `with (o) { new Set(); new Map(); new Date(); new WeakMap(); }`, where the four calls were removed as unused.
- Why per file. A per-function mark has to be set in the parse pass too, on a scope that survives `pop_and_flatten_scope` (the parser pushes a `FunctionArgs` scope at every `(` and flattens it when no `=>` follows). A file with a direct eval already pins its top-level names and keeps every part that declares one, so the cost is a few bytes in a file that is already not minified well. The flag is also set in strict code, where an eval cannot declare a `var` in the caller. That only skips a rewrite.
- `ParserSnapshot` saves and restores the flag, like the other parse-pass state, so a discarded TypeScript arrow-function attempt does not leave it set.
- Scope: `minify_global_constructor` and its one caller. The constructor rewrites are Bun's own and change values in used positions, so they get the guard. Defines and dead-code elimination keep esbuild's rule that a known global name is the global, also next to a direct eval. Those sites are not changed. Checked on this branch against Node 26.3.0:
  - Direct eval, built-in defines in `e_identifier`: `eval("var undefined = 1"); return undefined` gives `undefined`. `Infinity`, `typeof undefined` and `x === undefined` fold the same way. `NaN` is correct. In a `with` body all of these are already correct (`!is_inside_with_scope`).
  - Direct eval, unused reads of known globals: `eval("var Math = { get PI() { ... } }"); Math.PI;` drops the read. The same-target destructuring fold from #40792 keeps `Math` as a stable target next to a direct eval on purpose, and has tests for it.
  - `with`, const inlining in `handle_identifier`: `const x = 1; with (o) { return x }` returns `1` for `o = { x: 2 }`. #42524 is open for that.
  - Gating the built-in arm of `Define::for_identifier` on the new flag would cover the first two. It reverses the #40792 expectations (`transpiler.test.js`, `bundler_minify.test.ts` `SameTargetDestructuringSkipsUnstableTarget`), so it is a policy change and not part of this fix.
- `bundler_bytecode_portable.test.ts`: `features.js` and `records.js` contain a direct eval, so their `new Array(n)`, `new Error(...)` and similar stay as written under `--minify`. The `js` and `jsc` values of `--minify features.js`, `--minify records.js` and `--minify all.js` move on every platform. No other entry moves. Regenerated with the whole file, no name filter.
- Found while testing: a function-level `"use strict"` directive is not printed, so `function s() { "use strict"; eval("var x = 1"); return typeof x }` returns `"number"`. #40838 and #31807 are open for that.
- #41580 (open) adds `&& p.options.bundle` to the same `if` in `e_new`. That hides the `bun run`, `--no-bundle` and `Bun.Transpiler` cases and leaves `bun build --minify`. The conditions combine as `minify_syntax && p.options.bundle && !p.parse_pass_saw_direct_eval`. The tests here hold in either order: every case that expects a rewrite is a bundler case, and the other cases only expect `new X` to stay. If #41580 lands first, the cache version bump here is not needed.
- #41158 (open) adds a flag with the same name at the same parse-pass hook, set only when bundling. This one is set in every mode and is part of `ParserSnapshot`. Whichever lands second keeps one field.
- Self-reviewed: 6 concerns raised, 4 addressed (test order independence, the bytecode snapshot, the flag name, the wrong claim that #41580 does not overlap). Not taken: extending the flag to the defines (policy change, see above), and a test table with `todo` rows for the excluded sites.
- Suites run against the debug build: `bundler_minify`, `transpiler/transpiler.test.js`, `transpiler/runtime-transpiler.test.ts`, `bundler_bytecode_portable`, `bundler_npm`, `esbuild/dce`, `esbuild/default`, `esbuild/extra`, `bundler_splitting`, `bundler_edgecase`, `bundler_cjs2esm`, `bundler_dynamic_import_dce`, `regression/issue/minify-new-array-with-if`, `cli/run/transpiler-cache`. One test in `transpiler-cache.test.ts` (`--drop invalidates cache`, four spawns of the debug binary) hits its 5 s timeout in this container. It does not involve this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_bytecode_portable.test.ts

<!-- robobun:evidence:end -->