### PR TITLE
Bun.gc(true): do not skip the purge when mimalloc's scavenger thread is in a pass (fixes spawn-pipe-leak.test.ts on main)

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "6a64e1ba7f5b2130d4efccb67ec87fd0003f0f6a";
+const MIMALLOC_COMMIT = "8565de27fbfecafbfc1ea27e95493d39ea454ca0";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/test/js/bun/gc/gc-controller-cadence.test.ts
+++ b/test/js/bun/gc/gc-controller-cadence.test.ts
@@ -288,3 +288,43 @@ test.skipIf(!isLinux || isASAN)("Bun.gc(true) returns what it freed to the OS be
   expect(JSON.parse(stdout).released).toBeGreaterThan(200);
   expect(exitCode).toBe(0);
 });
+
+// One thread at a time hands the allocator's free ranges back, and its own purge thread is often the one: it starts on what
+// was freed once the purge delay has passed, and a few hundred MB keep it busy for tens of milliseconds. Bun.gc(true) in the
+// middle of that found the purge taken, skipped its own, and returned with all of it still resident.
+test.skipIf(!isLinux || isASAN)(
+  "Bun.gc(true) returns what is free to the OS while the purge thread is at work",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const rss = () => process.memoryUsage.rss() / 1048576;
+          // The allocator starts its purge thread the first time a thread blocks.
+          await Bun.sleep(1);
+          const rounds = [];
+          for (let round = 0; round < 3; round++) {
+            const arrays = [];
+            for (let i = 0; i < 48; i++) arrays.push(new Uint8Array(8 * 1024 * 1024).fill(1));
+            const held = rss();
+            // transfer(0) frees the 8 MB here and now, no collection involved. They stay resident until they are purged.
+            for (const array of arrays) array.buffer.transfer(0);
+            // Wait for the purge thread to start on them. If it never does, Bun.gc(true) has all of it to return by itself.
+            const deadline = performance.now() + 1000;
+            while (rss() > held - 32 && performance.now() < deadline);
+            Bun.gc(true);
+            rounds.push({ held, released: held - rss() });
+          }
+          console.log(JSON.stringify(rounds));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    for (const { released } of JSON.parse(stdout)) expect(released, stdout).toBeGreaterThan(300);
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
**Merge order:** oven-sh/mimalloc#38 first. Then this PR moves the pin to the merged sha. Do not merge this PR with the pin on the PR head.

### Problem
- `test/js/bun/spawn/spawn-pipe-leak.test.ts` fails on main since #42428: `expect(pct).toBeLessThan(0.8)`, `Peak RSS: warmup 46 MB -> main 312 MB (573%)`. One batch reads 250 to 800 MB after `Bun.gc(true)`, the others about 50 MB.
- It is not a leak. #42428 ends `Bun.gc(true)` with `mi_collect(true)`. mimalloc's `_mi_arenas_try_purge` (`src/arena.c`) drops that purge when another thread holds its purge guard. The scavenger thread holds it for 36 to 47 ms while it purges what the batch already freed.
- The test wakes on the last child exit and calls `Bun.gc(true)` in that window.

### Fix
- Bump `MIMALLOC_COMMIT` to the head of oven-sh/mimalloc#38. A forced purge now waits for the pass in progress, then runs its own.
- Correct because the one caller of `mi_collect(true)` in bun, `garbage_collect_from_js`, promises the memory is back with the OS on return. The wait is bounded: the holder takes no lock.
- The pin is the head of oven-sh/mimalloc#38 so that CI can run. It moves to the merged sha before this PR merges.
- Verified (release, Linux x64): `spawn-pipe-leak.test.ts` passes 25 of 25 runs, 7 of 10 on main. The new test in `test/js/bun/gc/gc-controller-cadence.test.ts` fails 3 of 3 on main and passes here.

### Background
- A purge returns freed mimalloc memory to the OS with `madvise`, 100 ms after the free.
- The scavenger is the thread in bun's mimalloc fork that runs those purges. The event loop also hands it the main thread's heaps on each `epoll_wait`. That sweep ends with a purge pass.
- `Bun.gc(true)` runs a synchronous full collection, then forces a purge.

<details><summary>Notes</summary>

Evidence for the cause. A release build with two `fprintf`s in `_mi_arenas_try_purge` printed `purge SKIPPED: guard held by another thread, force=1` in each batch where RSS stayed high, and `purge pass force=1 took 21 ms` in each batch where it fell to about 40 MB. The scavenger printed `purge pass force=0 visit_all=1 took 36..47 ms` right after each skipped one. `heapStats().objectTypeCounts` after `Bun.gc(true)` was the same in both kinds of batch (`Blob: 1`, `Subprocess: 2`, `ReadableStream: 2`), so no JS object holds the bytes. `MIMALLOC_SCAVENGER=0` gave 0 high batches in 15. `MIMALLOC_PURGE_DELAY=0` kept RSS under 75 MB before the collection, so the batch's memory was already free each time.

Why the test went red only now. Before #42428 nothing forced a purge, so RSS sat near the high-water mark in warmup and in the main phase, and the peaks were about equal. Now the floor is about 50 MB and one skipped purge in the main phase reads as a 4x to 8x jump. A skipped purge in warmup hides it, which is why the test still passed 7 of 10 times.

Numbers with this branch (release, Linux x64, 16 cores). `spawn-pipe-leak.test.ts`: peaks of 54 to 71 MB (read after exit), 52 to 60 MB (not read), 100 to 127 MB (read before exit) in 25 runs. On main the same peaks range from 50 to 688 MB. 60 of 60 batches of a standalone copy of the loop read 39 to 100 MB after `Bun.gc(true)`. `Bun.gc(true)` takes 29 to 47 ms when it collides with a pass over 384 MB, 1 to 2 ms on main (where it returns without the purge).

The new test. A child frees 384 MB with `ArrayBuffer.prototype.transfer(0)` (no collection involved), spins until RSS starts to fall (the scavenger is in its pass), calls `Bun.gc(true)`, and reports how much RSS fell. It expects more than 300 MB in each of 3 rounds. Main releases 38 to 42 MB. `await Bun.sleep(1)` at the top is there because mimalloc starts the scavenger the first time a thread blocks, and a `-e` script has one thread. Linux only and not ASAN, like the #42428 test next to it: ASAN builds do not route `malloc` to mimalloc.

The fail-before check needs a release build of main (`bun-linux-x64` canary at 5822b7649 here). A debug ASAN build skips both tests, and the change is under `scripts/`, so a checkout of `src/` from main does not undo it.

The bump also picks up one fork commit that was already on `bun-dev3-v2` (a 32-bit shift fix in `src/prof.c`).

Seen on the way and not changed: a scavenger pass in which each arena had something to purge skips its `purge_expire` update, and `mi_scavenger_run` then clears `subproc->purge_expire`. Ranges freed during that pass stay resident until a thread parks or something forces a collect (a standalone repro still has 64 of 320 MiB unpurged after 35 s). bun's main thread parks often, which hides it. Details are in oven-sh/mimalloc#38. This is tracked separately.

Suites run with this branch (release): `test/js/bun/spawn/spawn-pipe-leak.test.ts` (25 runs), `test/js/bun/gc/gc-controller-cadence.test.ts`, `test/cli/run/require-cache.test.ts` (2 runs), `test/js/bun/spawn/spawn-noread-leak.test.ts`, `test/js/web/fetch/abort-signal-leak.test.ts`, `test/js/bun/http/serve-body-leak.test.ts`. In the fork: full ctest in Release and Debug, and the new `test-forced-purge` with ASAN, `MI_GUARDED` and `MI_SECURE`.

Culprit: #42428.

</details>
