### PR TITLE
markdown: index a block's backtick runs when a code span opener has no closer

### DIFF
--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -696,6 +696,7 @@ impl Parser<'_> {
     /// Find the matching closing backtick run. Returns end position of content (before closing ticks),
     /// or null if no matching closer found.
     /// `start` is the end of the opening run. `content` is `block[base..]`, cut at the end of a link label.
+    #[inline(never)] // Inlined into the five scanners, it made their loops measurably slower.
     pub(crate) fn find_code_span_end(
         &self,
         content: &[u8],

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -1,8 +1,10 @@
+use core::cell::{Cell, RefCell};
+
 use crate::autolinks::{find_permissive_autolink, is_emph_boundary_resolved};
 use crate::helpers;
 use crate::links::{BracketMatches, LabelLeave};
 use crate::parser::{self, Parser};
-use crate::types::{SpanType, TextType, VerbatimLine};
+use crate::types::{OFF, SpanType, TextType, VerbatimLine};
 
 /// Emphasis delimiter entry for CommonMark emphasis algorithm.
 pub(crate) const MAX_EMPH_MATCHES: usize = 6;
@@ -123,6 +125,61 @@ impl HtmlScanMemo {
     }
 }
 
+/// Backtick runs in `from..to` of the block's inline slice, sorted by `(length, start)`.
+pub(crate) struct BacktickRuns {
+    // `Cell`s: the range check in every `find_code_span_end` call must not borrow `runs`.
+    from: Cell<usize>,
+    to: Cell<usize>,
+    runs: RefCell<Vec<(OFF, OFF)>>,
+}
+
+impl BacktickRuns {
+    pub(crate) const fn new() -> BacktickRuns {
+        BacktickRuns {
+            from: Cell::new(0),
+            to: Cell::new(0),
+            runs: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn clear(&self) {
+        self.from.set(0);
+        self.to.set(0);
+    }
+
+    fn covers(&self, from: usize, to: usize) -> bool {
+        to <= self.to.get() && self.from.get() <= from
+    }
+
+    /// Index `content`, which starts at offset `base` of the block's inline slice.
+    #[cold]
+    fn index(&self, content: &[u8], base: usize) {
+        debug_assert!(base + content.len() <= OFF::MAX as usize);
+        let mut runs = self.runs.borrow_mut();
+        runs.clear();
+        let mut pos: usize = 0;
+        while let Some(run_start) = bun_core::strings::index_of_char_pos(content, b'`', pos) {
+            let len = count_backticks(content, run_start);
+            runs.push((len as OFF, (base + run_start) as OFF));
+            pos = run_start + len;
+        }
+        runs.sort_unstable();
+        self.from.set(base);
+        self.to.set(base + content.len());
+    }
+
+    /// Start of the first run of exactly `count` backticks within `from..to`, which the index covers.
+    #[cold]
+    fn first_run(&self, count: usize, from: usize, to: usize) -> Option<usize> {
+        let runs = self.runs.borrow();
+        let key = (count as OFF, from as OFF);
+        let idx = runs.partition_point(|&run| run < key);
+        let &(len, pos) = runs.get(idx)?;
+        // `to` is the end of the block or the `]` that ends a link label, so it never splits a run.
+        (len as usize == count && pos as usize + count <= to).then_some(pos as usize)
+    }
+}
+
 impl Parser<'_> {
     /// Merge all lines into buffer with \n between them (unmodified),
     /// then process inlines on the merged text. Hard/soft breaks are detected
@@ -182,6 +239,8 @@ impl Parser<'_> {
         // Label frames below are subslices of `content`, so the memo stays
         // valid for them via `offset_within`.
         self.html_scan_memo.set(HtmlScanMemo::EMPTY);
+
+        self.backtick_runs.clear();
 
         // Bracket-pair map for the whole slice: link processing looks up the
         // ']' matching a '[' here instead of rescanning the rest of the slice
@@ -315,7 +374,8 @@ impl Parser<'_> {
                         self.emit_text(TextType::Normal, &content[text_start..i])?;
                     }
                     let count = count_backticks(content, i);
-                    if let Some(end_pos) = self.find_code_span_end(content, i + count, count) {
+                    if let Some(end_pos) = self.find_code_span_end(content, i + count, count, base)
+                    {
                         self.enter_span(SpanType::Code)?;
                         let code_content =
                             self.normalize_code_span_content(&content[i + count..end_pos]);
@@ -640,12 +700,22 @@ impl Parser<'_> {
 
     /// Find the matching closing backtick run. Returns end position of content (before closing ticks),
     /// or null if no matching closer found.
+    /// `start` is the end of the opening run, `base` the offset of `content` in the block's inline slice.
     pub(crate) fn find_code_span_end(
         &self,
         content: &[u8],
         start: usize,
         count: usize,
+        base: usize,
     ) -> Option<usize> {
+        debug_assert!(content.get(start) != Some(&b'`'));
+        let end = base + content.len();
+        if self.backtick_runs.covers(base, end) {
+            return self
+                .backtick_runs
+                .first_run(count, base + start, end)
+                .map(|pos| pos - base);
+        }
         let mut pos = start;
         while let Some(backtick_pos) = bun_core::strings::index_of_char_pos(content, b'`', pos) {
             pos = backtick_pos + 1;
@@ -656,6 +726,8 @@ impl Parser<'_> {
                 return Some(backtick_pos);
             }
         }
+        // R openers with no closer would walk R x bytes: index the slice so the rest binary-search.
+        self.backtick_runs.index(content, base);
         None
     }
 
@@ -697,7 +769,7 @@ impl Parser<'_> {
             // Skip code spans
             if c == b'`' {
                 let count = count_backticks(content, i);
-                if let Some(end_pos) = self.find_code_span_end(content, i + count, count) {
+                if let Some(end_pos) = self.find_code_span_end(content, i + count, count, base) {
                     i = end_pos + count;
                 } else {
                     i += count;

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -125,50 +125,44 @@ impl HtmlScanMemo {
     }
 }
 
-/// Backtick runs in `from..to` of the block's inline slice, sorted by `(length, start)`.
+/// Backtick runs of the block's inline slice, sorted by `(length, start)`, once an opener found no closer.
 pub(crate) struct BacktickRuns {
-    // `Cell`s: the range check in every `find_code_span_end` call must not borrow `runs`.
-    from: Cell<usize>,
-    to: Cell<usize>,
+    built: Cell<bool>,
     runs: RefCell<Vec<(OFF, OFF)>>,
 }
 
 impl BacktickRuns {
     pub(crate) const fn new() -> BacktickRuns {
         BacktickRuns {
-            from: Cell::new(0),
-            to: Cell::new(0),
+            built: Cell::new(false),
             runs: RefCell::new(Vec::new()),
         }
     }
 
     fn clear(&self) {
-        self.from.set(0);
-        self.to.set(0);
+        self.built.set(false);
     }
 
-    fn covers(&self, from: usize, to: usize) -> bool {
-        to <= self.to.get() && self.from.get() <= from
+    fn is_built(&self) -> bool {
+        self.built.get()
     }
 
-    /// Index `content`, which starts at offset `base` of the block's inline slice.
     #[cold]
-    fn index(&self, content: &[u8], base: usize) {
-        debug_assert!(base + content.len() <= OFF::MAX as usize);
+    fn index(&self, block: &[u8]) {
+        debug_assert!(block.len() <= OFF::MAX as usize);
         let mut runs = self.runs.borrow_mut();
         runs.clear();
         let mut pos: usize = 0;
-        while let Some(run_start) = bun_core::strings::index_of_char_pos(content, b'`', pos) {
-            let len = count_backticks(content, run_start);
-            runs.push((len as OFF, (base + run_start) as OFF));
+        while let Some(run_start) = bun_core::strings::index_of_char_pos(block, b'`', pos) {
+            let len = count_backticks(block, run_start);
+            runs.push((len as OFF, run_start as OFF));
             pos = run_start + len;
         }
         runs.sort_unstable();
-        self.from.set(base);
-        self.to.set(base + content.len());
+        self.built.set(true);
     }
 
-    /// Start of the first run of exactly `count` backticks within `from..to`, which the index covers.
+    /// Start of the first run of exactly `count` backticks within `from..to` of the block.
     #[cold]
     fn first_run(&self, count: usize, from: usize, to: usize) -> Option<usize> {
         let runs = self.runs.borrow();
@@ -374,7 +368,8 @@ impl Parser<'_> {
                         self.emit_text(TextType::Normal, &content[text_start..i])?;
                     }
                     let count = count_backticks(content, i);
-                    if let Some(end_pos) = self.find_code_span_end(content, i + count, count, base)
+                    if let Some(end_pos) =
+                        self.find_code_span_end(content, i + count, count, base, brackets.block)
                     {
                         self.enter_span(SpanType::Code)?;
                         let code_content =
@@ -700,20 +695,21 @@ impl Parser<'_> {
 
     /// Find the matching closing backtick run. Returns end position of content (before closing ticks),
     /// or null if no matching closer found.
-    /// `start` is the end of the opening run, `base` the offset of `content` in the block's inline slice.
+    /// `start` is the end of the opening run. `content` is `block[base..]`, cut at the end of a link label.
     pub(crate) fn find_code_span_end(
         &self,
         content: &[u8],
         start: usize,
         count: usize,
         base: usize,
+        block: &[u8],
     ) -> Option<usize> {
         debug_assert!(content.get(start) != Some(&b'`'));
-        let end = base + content.len();
-        if self.backtick_runs.covers(base, end) {
+        debug_assert!(content.as_ptr() == block[base..base + content.len()].as_ptr());
+        if self.backtick_runs.is_built() {
             return self
                 .backtick_runs
-                .first_run(count, base + start, end)
+                .first_run(count, base + start, base + content.len())
                 .map(|pos| pos - base);
         }
         let mut pos = start;
@@ -726,8 +722,8 @@ impl Parser<'_> {
                 return Some(backtick_pos);
             }
         }
-        // R openers with no closer would walk R x bytes: index the slice so the rest binary-search.
-        self.backtick_runs.index(content, base);
+        // R openers with no closer would walk R x bytes: index the block once so the rest binary-search.
+        self.backtick_runs.index(block);
         None
     }
 
@@ -753,7 +749,7 @@ impl Parser<'_> {
     pub(crate) fn collect_emphasis_delimiters(
         &mut self,
         content: &[u8],
-        brackets: &BracketMatches,
+        brackets: &BracketMatches<'_>,
         base: usize,
     ) {
         self.emph_delims.clear();
@@ -769,7 +765,9 @@ impl Parser<'_> {
             // Skip code spans
             if c == b'`' {
                 let count = count_backticks(content, i);
-                if let Some(end_pos) = self.find_code_span_end(content, i + count, count, base) {
+                if let Some(end_pos) =
+                    self.find_code_span_end(content, i + count, count, base, brackets.block)
+                {
                     i = end_pos + count;
                 } else {
                     i += count;

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -174,7 +174,7 @@ impl Parser<'_> {
                 // Code spans take precedence over brackets (CommonMark §6.3)
                 b'`' => {
                     let count = inlines::count_backticks(content, pos);
-                    if let Some(end_pos) = self.find_code_span_end(content, pos + count, count) {
+                    if let Some(end_pos) = self.find_code_span_end(content, pos + count, count, 0) {
                         pos = end_pos + count;
                     } else {
                         pos += count;
@@ -245,14 +245,14 @@ impl Parser<'_> {
                 })
             }
             BracketLookup::Unmatched => None,
-            _ => self.scan_bracket_close(content, start),
+            _ => self.scan_bracket_close(content, start, base),
         }
     }
 
     /// Forward scan for the `]` matching the `[` at `start`, skipping code
     /// spans, HTML tags/autolinks and backslash escapes. Only used when the
     /// opener is missing from the precomputed bracket map.
-    fn scan_bracket_close(&self, content: &[u8], start: usize) -> Option<BracketScan> {
+    fn scan_bracket_close(&self, content: &[u8], start: usize, base: usize) -> Option<BracketScan> {
         let mut pos = start + 1;
         let mut bracket_depth: u32 = 1;
         let mut has_inner_bracket = false;
@@ -264,7 +264,7 @@ impl Parser<'_> {
             // Skip code spans — they take precedence over brackets (CommonMark §6.3)
             if content[pos] == b'`' {
                 let count = inlines::count_backticks(content, pos);
-                if let Some(end_pos) = self.find_code_span_end(content, pos + count, count) {
+                if let Some(end_pos) = self.find_code_span_end(content, pos + count, count, base) {
                     pos = end_pos + count;
                 } else {
                     pos += count;
@@ -806,7 +806,7 @@ impl Parser<'_> {
             // Skip code spans
             if label[pos] == b'`' {
                 let count = inlines::count_backticks(label, pos);
-                if let Some(end_pos) = self.find_code_span_end(label, pos + count, count) {
+                if let Some(end_pos) = self.find_code_span_end(label, pos + count, count, base) {
                     pos = end_pos + count;
                 } else {
                     // No closer: skip the whole run so it isn't re-counted per

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -86,7 +86,9 @@ enum BracketLookup {
 /// the rest of the slice for every opener — that rescan is quadratic on
 /// inputs like `"[".repeat(n)`. The backing vec is recycled through
 /// `Parser.bracket_pairs`, so steady-state rendering does not allocate here.
-pub(crate) struct BracketMatches {
+pub(crate) struct BracketMatches<'a> {
+    /// The slice the map was built for: the block's whole inline content.
+    pub(crate) block: &'a [u8],
     /// `(open, close)` position of every `[` seen outside code spans, HTML
     /// tags/autolinks and backslash escapes, ordered by `open`.
     /// `close == UNMATCHED` marks an opener with no matching `]`.
@@ -96,7 +98,7 @@ pub(crate) struct BracketMatches {
     no_closers: bool,
 }
 
-impl BracketMatches {
+impl BracketMatches<'_> {
     const UNMATCHED: OFF = OFF::MAX;
 
     /// Hand the backing storage back for reuse by the next inline slice.
@@ -133,11 +135,11 @@ impl Parser<'_> {
     /// same tokenization as the matching scan (code spans, HTML tags,
     /// autolinks and backslash escapes hide brackets). `storage` is the
     /// recycled backing vec from `Parser.bracket_pairs`.
-    pub(crate) fn compute_bracket_matches(
+    pub(crate) fn compute_bracket_matches<'a>(
         &self,
-        content: &[u8],
+        content: &'a [u8],
         mut storage: Vec<(OFF, OFF)>,
-    ) -> BracketMatches {
+    ) -> BracketMatches<'a> {
         storage.clear();
         debug_assert!(content.len() <= OFF::MAX as usize);
 
@@ -145,12 +147,14 @@ impl Parser<'_> {
         // opener is trivially unmatched (e.g. "[".repeat(n)) — skip the walk.
         if bun_core::strings::index_of_char(content, b'[').is_none() {
             return BracketMatches {
+                block: content,
                 pairs: storage,
                 no_closers: false,
             };
         }
         if bun_core::strings::index_of_char(content, b']').is_none() {
             return BracketMatches {
+                block: content,
                 pairs: storage,
                 no_closers: true,
             };
@@ -174,7 +178,9 @@ impl Parser<'_> {
                 // Code spans take precedence over brackets (CommonMark §6.3)
                 b'`' => {
                     let count = inlines::count_backticks(content, pos);
-                    if let Some(end_pos) = self.find_code_span_end(content, pos + count, count, 0) {
+                    if let Some(end_pos) =
+                        self.find_code_span_end(content, pos + count, count, 0, content)
+                    {
                         pos = end_pos + count;
                     } else {
                         pos += count;
@@ -221,6 +227,7 @@ impl Parser<'_> {
         }
 
         BracketMatches {
+            block: content,
             pairs: storage,
             no_closers: false,
         }
@@ -234,7 +241,7 @@ impl Parser<'_> {
         &self,
         content: &[u8],
         start: usize,
-        brackets: &BracketMatches,
+        brackets: &BracketMatches<'_>,
         base: usize,
     ) -> Option<BracketScan> {
         match brackets.get(base + start) {
@@ -245,14 +252,20 @@ impl Parser<'_> {
                 })
             }
             BracketLookup::Unmatched => None,
-            _ => self.scan_bracket_close(content, start, base),
+            _ => self.scan_bracket_close(content, start, base, brackets.block),
         }
     }
 
     /// Forward scan for the `]` matching the `[` at `start`, skipping code
     /// spans, HTML tags/autolinks and backslash escapes. Only used when the
     /// opener is missing from the precomputed bracket map.
-    fn scan_bracket_close(&self, content: &[u8], start: usize, base: usize) -> Option<BracketScan> {
+    fn scan_bracket_close(
+        &self,
+        content: &[u8],
+        start: usize,
+        base: usize,
+        block: &[u8],
+    ) -> Option<BracketScan> {
         let mut pos = start + 1;
         let mut bracket_depth: u32 = 1;
         let mut has_inner_bracket = false;
@@ -264,7 +277,9 @@ impl Parser<'_> {
             // Skip code spans — they take precedence over brackets (CommonMark §6.3)
             if content[pos] == b'`' {
                 let count = inlines::count_backticks(content, pos);
-                if let Some(end_pos) = self.find_code_span_end(content, pos + count, count, base) {
+                if let Some(end_pos) =
+                    self.find_code_span_end(content, pos + count, count, base, block)
+                {
                     pos = end_pos + count;
                 } else {
                     pos += count;
@@ -344,7 +359,7 @@ impl Parser<'_> {
         content: &[u8],
         start: usize,
         is_image: bool,
-        brackets: &BracketMatches,
+        brackets: &BracketMatches<'_>,
         base: usize,
     ) -> Result<Option<LabelParse>, parser::Error> {
         // start points at '['
@@ -603,7 +618,7 @@ impl Parser<'_> {
         &mut self,
         content: &[u8],
         start: usize,
-        brackets: &BracketMatches,
+        brackets: &BracketMatches<'_>,
         base: usize,
     ) -> BracketLinkMatch {
         let Some(bracket) = self.match_bracket(content, start, brackets, base) else {
@@ -794,7 +809,7 @@ impl Parser<'_> {
     pub(crate) fn label_contains_link(
         &mut self,
         label: &[u8],
-        brackets: &BracketMatches,
+        brackets: &BracketMatches<'_>,
         base: usize,
     ) -> bool {
         let mut pos: usize = 0;
@@ -806,7 +821,9 @@ impl Parser<'_> {
             // Skip code spans
             if label[pos] == b'`' {
                 let count = inlines::count_backticks(label, pos);
-                if let Some(end_pos) = self.find_code_span_end(label, pos + count, count, base) {
+                if let Some(end_pos) =
+                    self.find_code_span_end(label, pos + count, count, base, brackets.block)
+                {
                     pos = end_pos + count;
                 } else {
                     // No closer: skip the whole run so it isn't re-counted per

--- a/src/md/parser.rs
+++ b/src/md/parser.rs
@@ -23,7 +23,7 @@ use crate::RenderOptions;
 
 // Rust has no struct-scoped type
 // aliases, so these live at module scope as `parser::EmphDelim` etc.
-pub(crate) use super::inlines::{EmphDelim, HtmlScanMemo};
+pub(crate) use super::inlines::{BacktickRuns, EmphDelim, HtmlScanMemo};
 pub(crate) use super::ref_defs::RefDef;
 
 /// Parser context holding all state during parsing.
@@ -67,6 +67,8 @@ pub(crate) struct Parser<'a> {
     // Cell because find_html_tag is a &self query reached from both &self and
     // &mut self scanners.
     pub(crate) html_scan_memo: Cell<HtmlScanMemo>,
+    // Built by find_code_span_end (inlines.rs) when a code-span opener has no closer.
+    pub(crate) backtick_runs: BacktickRuns,
 
     // Number of active containers
     pub(crate) n_containers: u32,
@@ -278,6 +280,7 @@ impl<'a> Parser<'a> {
             bracket_pairs: Vec::new(),
             label_frames: Vec::new(),
             html_scan_memo: Cell::new(HtmlScanMemo::EMPTY),
+            backtick_runs: BacktickRuns::new(),
             n_containers: 0,
             current_block: None,
             current_block_lines: Vec::new(),

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1255,7 +1255,7 @@ describe("pathological code span inputs", () => {
         const r2 = runs(4000, 2);
         // Nested image labels with a wiki link in each. Neither "\`a" in the wiki link label nor
         // "\`b" in the image label around it has a closer inside its label.
-        const nested = fill(16000, "![") + "z" + fill(16000, " [[u|\`a]] \`b ]]](u)");
+        const nested = fill(40000, "![") + "z" + fill(40000, " [[u|\`a]] \`b ]]](u)");
         const cases = [
           ["paragraph", r, {}, "<p>" + r + "</p>\\n"],
           ["paragraph with a bracket pair", "[x] " + r, {}, "<p>[x] " + r + "</p>\\n"],
@@ -1270,13 +1270,13 @@ describe("pathological code span inputs", () => {
           ["brackets inside a code span of the bracket map", "[x](\`y) [" + r2 + "] \`", {}, '<p><a href="%60y">x</a> [' + r2 + "] \`</p>\\n"],
           // md4c's pathological input: the escaped backtick makes every opener one shorter than every run.
           ["escaped backtick before each backtick", fill(40000, "\\\\\`\`"), {}, "<p>" + fill(40000, "\`\`") + "</p>\\n"],
-          ["nested image labels around wiki links", nested, { wikiLinks: true }, '<p><img src="u" alt="z' + fill(16000, " \`a \`b ]]") + '" /></p>\\n'],
+          ["nested image labels around wiki links", nested, { wikiLinks: true }, '<p><img src="u" alt="z' + fill(40000, " \`a \`b ]]") + '" /></p>\\n'],
         ];
         for (const [name, input, options, expected] of cases) {
           if (Bun.markdown.html(input, options) !== expected) throw new Error("unexpected html for " + name);
           console.log("OK " + name);
         }
-        if (Bun.markdown.ansi(nested, { colors: false, columns: 0 }) !== "[img] z" + fill(16000, " [[\`a]] \`b ]]") + "\\n") throw new Error("unexpected ansi() output");
+        if (Bun.markdown.ansi(nested, { colors: false, columns: 0 }) !== "[img] z" + fill(40000, " [[\`a]] \`b ]]") + "\\n") throw new Error("unexpected ansi() output");
         console.log("OK ansi");
         if (Bun.markdown.render(r, {}) !== r) throw new Error("unexpected render() output");
         console.log("OK render");

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1219,6 +1219,180 @@ describe("pathological autolink opener inputs", () => {
   }, 90_000);
 });
 
+// ============================================================================
+// Pathological inputs: backtick runs of pairwise different lengths (cmark's
+// pathological_tests.py "backticks"). No run has a closer, and every opener
+// used to walk to the end of the block looking for one, in each pass that
+// tokenizes the block, so R runs cost O(R x bytes): an 8 MB paragraph took
+// 14 s in a release build. The first walk that finds no closer now indexes
+// the backtick runs of the slice it walked, and later openers look their
+// closer up there. The child process is killed after 30s so a regression
+// fails fast instead of hanging the test runner.
+// ============================================================================
+
+describe("pathological code span inputs", () => {
+  test("backtick runs of pairwise different lengths render in linear time", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        // "e" + a run of "first" backticks, "e" + a run of "first + 1" backticks, ... (n runs)
+        const runs = (n, first) => {
+          let total = 0;
+          for (let k = first; k < first + n; k++) total += k + 1;
+          const buf = Buffer.alloc(total, "\`");
+          let p = 0;
+          for (let k = first; k < first + n; k++) {
+            buf[p] = 0x65;
+            p += k + 1;
+          }
+          return buf.toString("latin1");
+        };
+        const r = runs(4000, 1);
+        const r2 = runs(4000, 2);
+        const cases = [
+          ["paragraph", r, {}, "<p>" + r + "</p>\\n"],
+          ["paragraph with a bracket pair", "[x] " + r, {}, "<p>[x] " + r + "</p>\\n"],
+          ["link label", "[" + r + "](u)", {}, '<p><a href="u">' + r + "</a></p>\\n"],
+          ["image label", "![" + r + "](u)", {}, '<p><img src="u" alt="' + r + '" /></p>\\n'],
+          ["wiki link label", "[[t|" + r + "]]", { wikiLinks: true }, '<p><x-wikilink data-target="t">' + r + "</x-wikilink></p>\\n"],
+          // Every run in the label has a run of its length after the label, which must not close it.
+          ["wiki link label, then the same runs", "[[t|" + r + "]] " + r, { wikiLinks: true }, '<p><x-wikilink data-target="t">' + r + "</x-wikilink> " + r + "</p>\\n"],
+          ["table cell", "| h |\\n|---|\\n| " + r + " |\\n", { tables: true }, "<table>\\n<thead>\\n<tr><th>h</th></tr>\\n</thead>\\n<tbody>\\n<tr><td>" + r + "</td></tr>\\n</tbody>\\n</table>\\n"],
+          // The bracket map reads the destination's backtick as a code span up to
+          // the last backtick, so the link parser scans for this "]" itself.
+          ["brackets inside a code span of the bracket map", "[x](\`y) [" + r2 + "] \`", {}, '<p><a href="%60y">x</a> [' + r2 + "] \`</p>\\n"],
+        ];
+        for (const [name, input, options, expected] of cases) {
+          if (Bun.markdown.html(input, options) !== expected) throw new Error("unexpected html for " + name);
+          console.log("OK " + name);
+        }
+        if (Bun.markdown.render(r, {}) !== r) throw new Error("unexpected render() output");
+        console.log("OK render");
+        if (Bun.markdown.react(r).props.children[0].props.children.join("") !== r) throw new Error("unexpected react() output");
+        console.log("OK react");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.split("\n"), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: [
+        "OK paragraph",
+        "OK paragraph with a bracket pair",
+        "OK link label",
+        "OK image label",
+        "OK wiki link label",
+        "OK wiki link label, then the same runs",
+        "OK table cell",
+        "OK brackets inside a code span of the bracket map",
+        "OK render",
+        "OK react",
+        "",
+      ],
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  }, 90_000);
+
+  test("a code span closes at the first later run of the same length", () => {
+    expect(Markdown.html("`` a ` b ``` c `` d\n")).toBe("<p><code>a ` b ``` c</code> d</p>\n");
+    expect(Markdown.html("`a` `b` `c\n")).toBe("<p><code>a</code> <code>b</code> `c</p>\n");
+    // The ``` run has no closer and stays text. The `` run after it still closes.
+    expect(Markdown.html("``` a `` b ` c `` d\n")).toBe("<p>``` a <code>b ` c</code> d</p>\n");
+  });
+
+  test("backtick runs of pairwise different lengths stay text", () => {
+    expect(Markdown.html("`a ``b ```c\n")).toBe("<p>`a ``b ```c</p>\n");
+    expect(Markdown.html("e`e``e```e````\n")).toBe("<p>e`e``e```e````</p>\n");
+  });
+
+  test("a backslash-escaped backtick shortens the opener but not the closer", () => {
+    expect(Markdown.html("\\```a``\n")).toBe("<p>`<code>a</code></p>\n");
+    expect(Markdown.html("``a\\```\n")).toBe("<p>``a```</p>\n");
+  });
+
+  test("code spans in link, image and wiki link labels close inside the label", () => {
+    expect(Markdown.html("x `y` [`` ` `` z](u) `w`\n")).toBe(
+      '<p>x <code>y</code> <a href="u"><code>`</code> z</a> <code>w</code></p>\n',
+    );
+    expect(Markdown.html("[a `b`](u) [c ``d](v) ``e\n")).toBe(
+      '<p><a href="u">a <code>b</code></a> [c <code>d](v) </code>e</p>\n',
+    );
+    expect(Markdown.html("![`a` ``b](u) ``c\n")).toBe("<p>![<code>a</code> <code>b](u) </code>c</p>\n");
+    expect(Markdown.html("[x ![`a` ``b](u) `c](v) ``d\n")).toBe(
+      "<p>[x ![<code>a</code> <code>b](u) `c](v) </code>d</p>\n",
+    );
+    // A wiki link is found before code spans are. The `` run in its label
+    // does not close at the `` run after the label.
+    expect(Markdown.html("[[t|`a` ``b]] ``c\n", { wikiLinks: true })).toBe(
+      '<p><x-wikilink data-target="t"><code>a</code> ``b</x-wikilink> ``c</p>\n',
+    );
+  });
+
+  test("a code span that starts in a link label and ends after it wins over the link", () => {
+    expect(Markdown.html("[`a](u) `b\n")).toBe("<p>[<code>a](u) </code>b</p>\n");
+    expect(Markdown.html("[``a](u) `b` ``\n")).toBe("<p>[<code>a](u) `b` </code></p>\n");
+    expect(Markdown.html('[x](u) [`a](v "t") `b\n')).toBe(
+      '<p><a href="u">x</a> [<code>a](v &quot;t&quot;) </code>b</p>\n',
+    );
+  });
+
+  test("consecutive paragraphs and table cells do not share backtick runs", () => {
+    // Both paragraphs merge to 6-byte inline slices in the same recycled buffer.
+    expect(Markdown.html("`a bcd\n\n`a` bc\n")).toBe("<p>`a bcd</p>\n<p><code>a</code> bc</p>\n");
+    expect(Markdown.html("`a` bc\n\n`a bcd\n")).toBe("<p><code>a</code> bc</p>\n<p>`a bcd</p>\n");
+    expect(Markdown.html("| a | b |\n|---|---|\n| `x | y` |\n| ``p`` | `q |\n", { tables: true })).toBe(
+      "<table>\n<thead>\n<tr><th>a</th><th>b</th></tr>\n</thead>\n<tbody>\n" +
+        "<tr><td>`x</td><td>y`</td></tr>\n<tr><td><code>p</code></td><td>`q</td></tr>\n</tbody>\n</table>\n",
+    );
+    expect(Markdown.html("| a |\n|---|\n| `x \\| y` |\n", { tables: true })).toBe(
+      "<table>\n<thead>\n<tr><th>a</th></tr>\n</thead>\n<tbody>\n<tr><td><code>x | y</code></td></tr>\n</tbody>\n</table>\n",
+    );
+  });
+
+  test("brackets inside a code span of the bracket map still form links", () => {
+    expect(Markdown.html("[x](`y) [``a] ```b [c](d) `\n")).toBe(
+      '<p><a href="%60y">x</a> [``a] ```b <a href="d">c</a> `</p>\n',
+    );
+  });
+
+  test("code spans after a run with no closer, in the block and in labels inside it", () => {
+    // The ```` run has no closer, so the runs of the whole block are indexed
+    // before the label is rendered.
+    expect(Markdown.html("```` x [a `b` ``c`` d](u) `e` ``f\n")).toBe(
+      '<p>```` x <a href="u">a <code>b</code> <code>c</code> d</a> <code>e</code> ``f</p>\n',
+    );
+    expect(Markdown.html("``` x ![a `b` [c ``d``](v)](u) `e\n")).toBe(
+      '<p>``` x <img src="u" alt="a b c d" /> `e</p>\n',
+    );
+    // The `` run in the label does not close at the `` run after the label.
+    expect(Markdown.html("```x [[t|`a` ``b]] ``c\n", { wikiLinks: true })).toBe(
+      '<p>```x <x-wikilink data-target="t"><code>a</code> ``b</x-wikilink> ``c</p>\n',
+    );
+  });
+
+  test("code spans after a run with no closer in a wiki link label", () => {
+    // The label's runs are indexed first. The block after the label is not
+    // part of that index.
+    expect(Markdown.html("[[t|`a ``b]] `c` ``d ```e\n", { wikiLinks: true })).toBe(
+      '<p><x-wikilink data-target="t">`a ``b</x-wikilink> <code>c</code> ``d ```e</p>\n',
+    );
+    expect(Markdown.html("[[t|`a]] x [[u|``b]] `c ``d\n", { wikiLinks: true })).toBe(
+      '<p><x-wikilink data-target="t">`a</x-wikilink> x <x-wikilink data-target="u">``b</x-wikilink> `c ``d</p>\n',
+    );
+    expect(Markdown.html("[[t|``a ![`b` ```c](u) `d]] ``e` ```\n", { wikiLinks: true })).toBe(
+      '<p><x-wikilink data-target="t">``a <img src="u" alt="b ```c" /> `d</x-wikilink> ``e` ```</p>\n',
+    );
+  });
+});
+
 describe("inputs the parser cannot address", () => {
   // The parser addresses its input with u32 offsets and probes up to 9 bytes
   // past an offset (the `<![CDATA[` check), so everything longer than

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1224,10 +1224,11 @@ describe("pathological autolink opener inputs", () => {
 // pathological_tests.py "backticks"). No run has a closer, and every opener
 // used to walk to the end of the block looking for one, in each pass that
 // tokenizes the block, so R runs cost O(R x bytes): an 8 MB paragraph took
-// 14 s in a release build. The first walk that finds no closer now indexes
-// the backtick runs of the slice it walked, and later openers look their
-// closer up there. The child process is killed after 30s so a regression
-// fails fast instead of hanging the test runner.
+// 14 s in a release build. md4c's row, a backslash-escaped backtick before
+// each backtick, took as long at 120 KB. The first walk that finds no closer
+// now indexes the backtick runs of the whole block, and later openers look
+// their closer up there. The child process is killed after 30s so a
+// regression fails fast instead of hanging the test runner.
 // ============================================================================
 
 describe("pathological code span inputs", () => {
@@ -1249,8 +1250,12 @@ describe("pathological code span inputs", () => {
           }
           return buf.toString("latin1");
         };
+        const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
         const r = runs(4000, 1);
         const r2 = runs(4000, 2);
+        // Nested image labels with a wiki link in each. Neither "\`a" in the wiki link label nor
+        // "\`b" in the image label around it has a closer inside its label.
+        const nested = fill(16000, "![") + "z" + fill(16000, " [[u|\`a]] \`b ]]](u)");
         const cases = [
           ["paragraph", r, {}, "<p>" + r + "</p>\\n"],
           ["paragraph with a bracket pair", "[x] " + r, {}, "<p>[x] " + r + "</p>\\n"],
@@ -1263,11 +1268,16 @@ describe("pathological code span inputs", () => {
           // The bracket map reads the destination's backtick as a code span up to
           // the last backtick, so the link parser scans for this "]" itself.
           ["brackets inside a code span of the bracket map", "[x](\`y) [" + r2 + "] \`", {}, '<p><a href="%60y">x</a> [' + r2 + "] \`</p>\\n"],
+          // md4c's pathological input: the escaped backtick makes every opener one shorter than every run.
+          ["escaped backtick before each backtick", fill(40000, "\\\\\`\`"), {}, "<p>" + fill(40000, "\`\`") + "</p>\\n"],
+          ["nested image labels around wiki links", nested, { wikiLinks: true }, '<p><img src="u" alt="z' + fill(16000, " \`a \`b ]]") + '" /></p>\\n'],
         ];
         for (const [name, input, options, expected] of cases) {
           if (Bun.markdown.html(input, options) !== expected) throw new Error("unexpected html for " + name);
           console.log("OK " + name);
         }
+        if (Bun.markdown.ansi(nested, { colors: false, columns: 0 }) !== "[img] z" + fill(16000, " [[\`a]] \`b ]]") + "\\n") throw new Error("unexpected ansi() output");
+        console.log("OK ansi");
         if (Bun.markdown.render(r, {}) !== r) throw new Error("unexpected render() output");
         console.log("OK render");
         if (Bun.markdown.react(r).props.children[0].props.children.join("") !== r) throw new Error("unexpected react() output");
@@ -1291,6 +1301,9 @@ describe("pathological code span inputs", () => {
         "OK wiki link label, then the same runs",
         "OK table cell",
         "OK brackets inside a code span of the bracket map",
+        "OK escaped backtick before each backtick",
+        "OK nested image labels around wiki links",
+        "OK ansi",
         "OK render",
         "OK react",
         "",


### PR DESCRIPTION
### Problem

- `Bun.markdown` is quadratic in the number of backtick runs that have no closer. md4c's pathological row (a backslash-escaped backtick before each backtick) takes 3.6 s at 60 KB and 14.5 s at 120 KB. cmark's row "backticks" takes 14 s at 8 MB.
- `find_code_span_end` (`src/md/inlines.rs:643`) walks from an opener to the end of the block when no run of the same length follows. Three passes repeat it, so R such runs cost R x block bytes.

### Fix

- The first walk in a block that finds no closer indexes the block's backtick runs, sorted by `(length, start)`. Every later opener in the block or in a link label is one binary search. A block in which every code span closes never builds the index.
- Correct because the walk and the index return the same run: the first later run of the opener's length. Output is byte-identical to main on 32.3 M exhaustive and 40 k random inputs.
- Verified: `test/js/bun/md/md-edge-cases.test.ts`, block "pathological code span inputs": killed at 30 s without the fix, 6 s with it on debug+ASAN. All of `test/js/bun/md/` passes.
- Self-reviewed: 7 concerns raised, 7 addressed. The main one: indexing only the slice that missed made nested labels quadratic, so the first miss indexes the whole block.

### Background

- A code span opens with a run of N backticks and closes at the next run of exactly N. A run with no closer is literal text.
- The inline parser tokenizes a block three times (brackets, emphasis delimiters, render), and a link label again as a sub-slice at offset `base`.

<details><summary>Notes</summary>

All timings are release builds of the same commit with and without the fix, same toolchain, same machine, `Bun.markdown.html`, best of 3.

**md4c's row** (`\` + 2 backticks, repeated; every opener is one backtick shorter than every run):

| bytes | main | this PR |
|---|---|---|
| 30 KB | 888 ms | 1.1 ms |
| 60 KB | 3569 ms | 2.6 ms |
| 120 KB | 14464 ms | 5.5 ms |

**cmark's row "backticks"** (`e` + 1 backtick, `e` + 2 backticks, up to n runs):

| n | bytes | main | this PR |
|---|---|---|---|
| 1000 | 0.5 MB | 375 ms | 1.8 ms |
| 2000 | 2.0 MB | 3053 ms | 7.6 ms |
| 3000 | 4.5 MB | 10276 ms | 16 ms |
| 4000 | 8.0 MB | not rerun (14 s in the report) | 32 ms |
| 8000 | 32 MB | not run | 144 ms |

Main: x8.2 per x4 bytes. This PR: x4.2, x4.2, x4.6 per x4 bytes. `render` and `react` match `html` within 10%. On a debug+ASAN build the 2 MB input went from 11.7 s (the report) to 0.11 s.

**Other shapes.** The same runs placed where another pass or a sub-slice tokenizes them. All are cases of the new test.

| shape | main, 2 MB | this PR, 2 MB | 8 MB | 32 MB |
|---|---|---|---|---|
| paragraph | 3441 ms | 7.8 ms | 31 ms | 135 ms |
| paragraph with a `[x]` pair (bracket-map pass runs) | 5964 ms | 7.9 ms | 43 ms | 162 ms |
| link label | 9161 ms | 9.0 ms | 36 ms | 164 ms |
| image label | 5315 ms | 7.9 ms | 34 ms | 151 ms |
| wiki link label | 7406 ms | 10.2 ms | 41 ms | 210 ms |
| wiki link label, then the same runs (4 / 16 / 64 MB) | 9418 ms | 16.5 ms | 70 ms | 355 ms |
| table cell | 3279 ms | 8.8 ms | 37 ms | 164 ms |
| brackets the bracket map hides in a code span | 6573 ms | 10.0 ms | 41 ms | 175 ms |

**Why the index is built only after a miss.** The first version built the index for every block before tokenizing it. On a document made of paragraphs with many short code spans it was 34% slower than main (353 us to 475 us for 38 KB): a `memchr` walk to a closer a few bytes away is cheaper than the index. So a block in which every code span closes keeps the old walk. What it pays is one store per block, and one load and one call per opener.

**Why the whole block is indexed, not the slice that missed.** The second version indexed the slice whose walk missed, which can be a link label. A wiki link label is tokenized on its own, so in ``[[u|`a]] `b`` the run in the label misses although the block-level walk finds a closer after the label. With nested image labels that each hold such a wiki link (`![![![z [[u|`a]] `b ]]](u) [[u|`a]] `b ]]](u) ...`) the miss in each wiki link label replaced the index of the image label around it, and each image label indexed its whole slice again. That shape is linear on main and became quadratic: 336 KB through `Bun.markdown.ansi` went from 11 ms to 2552 ms with identical output. Now the first miss indexes the block once and nothing replaces the index, and the shape takes 13 ms. It is a case of the new test at 840 KB, where the second version needed 20 s per call in a release build.

**Normal documents**, min of 250 runs per cell, binaries alternated. `small`, `medium`, `large` are the documents of `bench/snippets/markdown.mjs`. `codeHeavy` is 200 paragraphs with about 11 code spans each. `tableHeavy` is a 400-row table. `prose` has no backticks.

| document | main | this PR |
|---|---|---|
| small (121 B) | 4.47 us | 4.42 us |
| medium (1 KB) | 14.35 us | 14.39 us |
| large (21 KB) | 220.6 us | 221.9 us |
| codeHeavy (38 KB) | 351.9 us | 369.4 us |
| tableHeavy (11 KB) | 202.4 us | 204.3 us |
| prose (39 KB) | 228.1 us | 242.1 us |

`codeHeavy` pays for one call per opener: main inlines the walk into its five callers, and this PR keeps `find_code_span_end` out of line. I tried it inlined, with the two index functions marked `#[cold]`. The walk then cost nothing extra (a paragraph of 5000 two-byte code spans: 308 us on main, 310 us), but `prose`, `tableHeavy` and `large` got 15%, 8% and 4% slower, so the callers' loops are better off without it. I cannot attribute the 6% on `prose` to the change: it has no backticks, and two builds of main that differ only in unrelated commits (b99371011f and f04caca828) measure 237 us and 228 us on it.

**Cost of a miss.** A block that has a run with no closer builds the index once, and after that every opener in the block pays a binary search where main pays a short `memchr`. On a synthetic 34 KB document where every paragraph has four closed code spans and one unclosed run, that is 281 us to 334 us (+19%). With one stray backtick per paragraph and nothing else it is 164 us to 177 us (+7%). The worst case I found is one 4.9 MB paragraph that starts with an unclosed run and then holds 700 k closed two-byte code spans: 95 ms on main, 218 ms with the fix (2.3x). The same paragraph with prose in place of the code spans is 20 ms on both.

**Differential check.** `Bun.markdown.html` output is byte-identical between main and the fix for every sequence of up to 7 atoms over six 9-atom alphabets (32.3 M inputs: backtick runs of length 1 to 3, `[`, `]`, `![`, `](u)`, `[[t|`, `]]`, `|`, `\`, newline, a table delimiter row, a link whose destination contains a backtick), and for 40 k random inputs through `html` with three option sets, `ansi` and `render`. The debug build asserts on every call that `content` is `block[base..]`.

**Plumbing.** `BracketMatches` now carries the block slice, so `find_code_span_end` can index the block when the miss happens inside a link label. The debug build asserts that `content` is `block[base..]` on every call.

**Not in this PR.** The review also suggested one shared table-driven file for the pathological-input tests of this parser. That is a separate change.

**Why not a length cap.** cmark keeps the last position per run length and ignores runs over 1000 backticks. md4c ignores runs of 32 or more. Both change output for long runs. The index keeps every length exact.

**Still quadratic after this PR**, each with its own open PR: brackets that the bracket map hides inside a code span cost one `scan_bracket_close` walk each (#32720, `[x](`` `y) `` + 40 k `[` + `` ` `` takes about 6 s). Same-line nested list markers (#42246). Deeply nested blocks through `Bun.markdown.render` (#42244). With this fix a `scan_bracket_close` walk no longer multiplies by the number of unmatched runs: 0.5 MB of hidden brackets over unmatched runs went from 80 s to 0.14 s.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-edge-cases.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [102.62ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [14.40ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [3.03ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [11.51ms]
(pass) fuzzer-like edge cases > control characters in input [2.55ms]
(pass) fuzzer-like edge cases > Buffer input works [2.10ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [5.83ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [8.32ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [2.34ms]
(pass) fuzzer-like edge cases > deeply nested lists [8.24ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [224.97ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [171.40ms]

... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (4f8b74a25)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [1.19ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [0.13ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [0.04ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [0.09ms]
(pass) fuzzer-like edge cases > control characters in input [0.02ms]
(pass) fuzzer-like edge cases > Buffer input works [0.03ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [0.05ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [0.12ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [0.04ms]
(pass) fuzzer-like edge cases > deeply nested lists [0.09ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [6.06ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [4.76ms]
(pass) fuzzer-like edge cases > deeply nested emphasis [0.06ms]
(pass) fuzzer-like edge cases > deeply nested links [0.05ms]
(pass) fuzzer-like edge cases > very long s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-edge-cases.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [73.99ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [9.69ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [1.77ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [7.63ms]
(pass) fuzzer-like edge cases > control characters in input [1.62ms]
(pass) fuzzer-like edge cases > Buffer input works [2.49ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [4.93ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [8.15ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [2.44ms]
(pass) fuzzer-like edge cases > deeply nested lists [8.33ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [156.00ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [103.15ms]
(pa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 757ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/md/inlines.rs                    |  79 ++++++++++++++-
 src/md/links.rs                      |  45 ++++++---
 src/md/parser.rs                     |   5 +-
 test/js/bun/md/md-edge-cases.test.ts | 187 +++++++++++++++++++++++++++++++++++
 4 files changed, 297 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/md/inlines.rs                         3      1     27
src/md/links.rs                           4      0     26
src/md/parser.rs                          1      0     26
test/js/bun/md/md-edge-cases.test.ts      4      1     26
```

</details>

<!-- robobun:evidence:end -->