### PR TITLE
install: reuse the package of a file: folder that several packages declare

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2924,6 +2924,16 @@ fn get_or_put_resolved_package(
                     }
                 }
 
+                // Several packages can declare the same folder. They share one package,
+                // as they do after a bun.lock reload (`append_package_dedupe`).
+                if let Some(existing_id) = this.lockfile.get_package_id(
+                    name_hash,
+                    None,
+                    &Resolution::init(ResolutionTagged::Folder(folder)),
+                ) {
+                    break 'res FolderResolutionValue::PackageId(existing_id);
+                }
+
                 let mut package = Package::default();
 
                 {
@@ -2954,7 +2964,6 @@ fn get_or_put_resolved_package(
                     builder.clamp();
                 }
 
-                // these are always new
                 package = this.lockfile.append_package(&package).unwrap_or_oom();
 
                 break 'res FolderResolutionValue::NewPackageId(package.meta.id);

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2924,8 +2924,7 @@ fn get_or_put_resolved_package(
                     }
                 }
 
-                // Several packages can declare the same folder. They share one package,
-                // as they do after a bun.lock reload (`append_package_dedupe`).
+                // See if another declarer already loaded this folder package in-memory
                 if let Some(existing_id) = this.lockfile.get_package_id(
                     name_hash,
                     None,

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -4925,7 +4925,7 @@ describe("transitive file dependencies", () => {
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
       "",
-      "14 packages installed",
+      "13 packages installed",
     ]);
 
     await checkHoistedFiles();
@@ -4940,7 +4940,7 @@ describe("transitive file dependencies", () => {
     expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
       expect.stringContaining("bun install v1."),
       "",
-      "14 packages installed",
+      "13 packages installed",
     ]);
 
     await checkHoistedFiles();
@@ -4974,7 +4974,7 @@ describe("transitive file dependencies", () => {
       "+ missing-file-dep@1.0.0",
       "+ self-file-dep@1.0.0",
       "",
-      "14 packages installed",
+      "13 packages installed",
     ]);
 
     await checkHoistedFiles();
@@ -5005,7 +5005,7 @@ describe("transitive file dependencies", () => {
       "+ missing-file-dep@1.0.0",
       "+ self-file-dep@1.0.0",
       "",
-      "14 packages installed",
+      "13 packages installed",
     ]);
   });
 
@@ -5067,7 +5067,7 @@ describe("transitive file dependencies", () => {
       "+ missing-file-dep@1.0.1",
       "+ self-file-dep@1.0.1",
       "",
-      "15 packages installed",
+      "14 packages installed",
     ]);
 
     await checkUnhoistedFiles();
@@ -5090,7 +5090,7 @@ describe("transitive file dependencies", () => {
       "+ missing-file-dep@1.0.1",
       "+ self-file-dep@1.0.1",
       "",
-      "15 packages installed",
+      "14 packages installed",
     ]);
 
     await checkUnhoistedFiles();
@@ -5125,7 +5125,7 @@ describe("transitive file dependencies", () => {
       "+ missing-file-dep@1.0.0",
       "+ self-file-dep@1.0.0",
       "",
-      "15 packages installed",
+      "14 packages installed",
     ]);
 
     await checkUnhoistedFiles();
@@ -5156,7 +5156,7 @@ describe("transitive file dependencies", () => {
       "+ missing-file-dep@1.0.0",
       "+ self-file-dep@1.0.0",
       "",
-      "15 packages installed",
+      "14 packages installed",
     ]);
   });
 
@@ -5211,7 +5211,7 @@ describe("transitive file dependencies", () => {
       "+ missing-file-dep@1.0.0",
       "+ self-file-dep@1.0.0",
       "",
-      "13 packages installed",
+      "12 packages installed",
     ]);
     expect(await exited).toBe(0);
     assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -10811,9 +10811,9 @@ it("installs file: dependencies that depend on each other", async () => {
 
         "b": ["b@file:packages/b", { "dependencies": { "a": "file:../a" } }],
 
-        "a/b": ["b@file:packages/b", {}],
+        "a/b": ["b@file:packages/b", { "dependencies": { "a": "file:../a" } }],
 
-        "b/a": ["a@file:packages/a", {}],
+        "b/a": ["a@file:packages/a", { "dependencies": { "b": "file:../b" } }],
       }
     }"
   `);
@@ -10857,6 +10857,85 @@ it("installs file: dependencies that depend on each other from a lockfile that o
         "a/b": ["b@file:packages/b", { "dependencies": { "a": "file:../a" } }],
 
         "b/a": ["a@file:packages/a", { "dependencies": { "b": "file:../b" } }],
+      }
+    }"
+  `);
+});
+
+it("reloads the lockfile it wrote when a file: dependency and the root declare the same folder", async () => {
+  using dir = tempDir("shared-file-dep", {
+    "package.json": JSON.stringify({
+      name: "my-app",
+      version: "1.0.0",
+      dependencies: {
+        lib: "file:./vendor/lib",
+        shared: "file:./vendor/shared",
+      },
+    }),
+    "vendor/lib/package.json": JSON.stringify({
+      name: "lib",
+      version: "1.0.0",
+      dependencies: { shared: "file:../shared" },
+    }),
+    "vendor/shared/package.json": JSON.stringify({
+      name: "shared",
+      version: "1.0.0",
+      dependencies: { nested: "file:../nested" },
+    }),
+    "vendor/nested/package.json": JSON.stringify({ name: "nested", version: "1.0.0" }),
+  });
+
+  const install = async (...args: string[]) => {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", ...args],
+      cwd: String(dir),
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  };
+
+  const [, err, exitCode] = await install();
+  expect(err).toContain("Saved lockfile");
+  expect(err).not.toContain("error:");
+  expect(exitCode).toBe(0);
+  const lock = await file(join(String(dir), "bun.lock")).text();
+
+  // `lib/shared` was a second `shared` package with no dependencies. The parser
+  // makes one package of the two rows, so it looked for a `lib/shared/nested` row:
+  // "Failed to resolve prod dependency 'nested' for package 'lib/shared'".
+  await rm(join(String(dir), "node_modules"), { recursive: true, force: true });
+  const [, err2, exitCode2] = await install("--frozen-lockfile");
+  expect(err2).not.toContain("error:");
+  expect(err2).not.toContain("Ignoring lockfile");
+  expect(exitCode2).toBe(0);
+  expect(await file(join(String(dir), "bun.lock")).text()).toBe(lock);
+
+  expect(normalizeBunSnapshot(lock, dir)).toMatchInlineSnapshot(`
+    "{
+      "lockfileVersion": 2,
+      "configVersion": 1,
+      "workspaces": {
+        "": {
+          "name": "my-app",
+          "dependencies": {
+            "lib": "file:./vendor/lib",
+            "shared": "file:./vendor/shared",
+          },
+        },
+      },
+      "packages": {
+        "lib": ["lib@file:vendor/lib", { "dependencies": { "shared": "file:../shared" } }],
+
+        "shared": ["shared@file:vendor/shared", { "dependencies": { "nested": "file:../nested" } }],
+
+        "lib/shared": ["shared@file:vendor/shared", { "dependencies": { "nested": "file:../nested" } }],
+
+        "shared/nested": ["nested@file:vendor/nested", {}],
+
+        "lib/shared/nested": ["nested@file:vendor/nested", {}],
       }
     }"
   `);

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -554,6 +554,56 @@ test("can install folder dependencies on root package", async () => {
   ]);
 });
 
+test("a folder dependency shared by several folder dependencies is one package", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  const siblings = Array.from({ length: 6 }, (_, i) => `sib${i}`);
+
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-shared-folder-dep",
+        dependencies: {
+          shared: "file:./vend/shared",
+          ...Object.fromEntries(siblings.map(name => [name, `file:./vend/${name}`])),
+        },
+      }),
+    ),
+    write(join(packageDir, "vend", "shared", "package.json"), JSON.stringify({ name: "shared", version: "1.0.0" })),
+    write(join(packageDir, "vend", "shared", "index.js"), "module.exports = 'shared';"),
+    ...siblings.flatMap(name => [
+      write(
+        join(packageDir, "vend", name, "package.json"),
+        JSON.stringify({ name, version: "1.0.0", dependencies: { shared: "file:../shared" } }),
+      ),
+      write(join(packageDir, "vend", name, "index.js"), "module.exports = require('shared');"),
+    ]),
+  ]);
+
+  // A fresh resolve made one `shared` package per declarer. Each one linked
+  // into the same store entry at the same time: EEXIST from link().
+  const { out } = await runBunInstall(bunEnv, packageDir);
+  expect(out).toContain(`${siblings.length + 1} packages installed`);
+
+  const store = join(packageDir, "node_modules", ".bun");
+  expect(readlinkSync(join(packageDir, "node_modules", "shared"))).toBe(
+    join(".bun", "shared@file+vend+shared", "node_modules", "shared"),
+  );
+  expect(
+    await Promise.all(
+      siblings.map(name => readlink(join(store, `${name}@file+vend+${name}`, "node_modules", "shared"))),
+    ),
+  ).toEqual(siblings.map(() => join("..", "..", "shared@file+vend+shared", "node_modules", "shared")));
+  expect(await readdirSorted(join(store, "shared@file+vend+shared", "node_modules", "shared"))).toEqual([
+    "index.js",
+    "package.json",
+  ]);
+
+  const requireFromRoot = createRequire(packageJson);
+  expect(siblings.map(name => requireFromRoot(name))).toEqual(siblings.map(() => "shared"));
+});
+
 describe("isolated workspaces", () => {
   test("basic", async () => {
     const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -628,7 +628,10 @@ test("a file: override that several registry packages depend on is one package",
     write(join(packageDir, "vendor", "no-deps", "package.json"), JSON.stringify({ name: "no-deps", version: "9.9.9" })),
   ]);
 
-  const { out } = await runBunInstall(bunEnv, packageDir);
+  // CI exports one BUN_INSTALL_CACHE_DIR for the whole file. Manifests cached here
+  // would change the order in which later tests resolve the same packages.
+  const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(packageDir, ".bun-cache") };
+  const { out } = await runBunInstall(env, packageDir);
   expect(out).toContain(`${Object.keys(dependents).length + 1} packages installed`);
 
   const store = join(packageDir, "node_modules", ".bun");

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -604,6 +604,48 @@ test("a folder dependency shared by several folder dependencies is one package",
   expect(siblings.map(name => requireFromRoot(name))).toEqual(siblings.map(() => "shared"));
 });
 
+test("a file: override that several registry packages depend on is one package", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  // Each of these declares `no-deps`.
+  const dependents = {
+    "one-dep": "1.0.0",
+    "one-fixed-dep": "1.0.0",
+    "one-range-dep": "1.0.0",
+    "one-range-dep-too": "1.0.0",
+    "normal-dep-and-dev-dep": "1.0.2",
+  };
+
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-file-override",
+        dependencies: dependents,
+        overrides: { "no-deps": "file:./vendor/no-deps" },
+      }),
+    ),
+    write(join(packageDir, "vendor", "no-deps", "package.json"), JSON.stringify({ name: "no-deps", version: "9.9.9" })),
+  ]);
+
+  const { out } = await runBunInstall(bunEnv, packageDir);
+  expect(out).toContain(`${Object.keys(dependents).length + 1} packages installed`);
+
+  const store = join(packageDir, "node_modules", ".bun");
+  expect(
+    await Promise.all(
+      Object.entries(dependents).map(([name, version]) =>
+        readlink(join(store, `${name}@${version}`, "node_modules", "no-deps")),
+      ),
+    ),
+  ).toEqual(
+    Object.keys(dependents).map(() => join("..", "..", "no-deps@file+.+vendor+no-deps", "node_modules", "no-deps")),
+  );
+  expect(
+    await file(join(store, "no-deps@file+.+vendor+no-deps", "node_modules", "no-deps", "package.json")).json(),
+  ).toEqual({ name: "no-deps", version: "9.9.9" });
+});
+
 describe("isolated workspaces", () => {
   test("basic", async () => {
     const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });


### PR DESCRIPTION
### Problem
- Any linker: the root and a `file:` package declare one `file:` folder, and that folder has a `file:` dependency. Bun rejects the `bun.lock` it wrote: `Failed to resolve prod dependency 'nested' for package 'lib/shared'`, `InvalidLockfile`. `--frozen-lockfile` exits 1.
- `--linker=isolated`: a fresh install fails at random with `EEXIST: File exists: failed to link package: shared@vend/shared (link)` when several `file:` packages, or registry packages under a `file:` override, depend on one folder.
- Cause: `get_or_put_resolved_package` (`PackageManagerEnqueue.rs:2957`) appends a new stub package for each `file:` dependency that the root or a workspace does not declare. N declarers make N packages with one name and resolution.

### Fix
- The Folder arm first looks up a package with the same name hash and resolution (`Lockfile::get_package_id`) and reuses it.
- Correct: the `bun.lock` parser and the isolated store path identify a package by name and resolution. For `file:` folders, a fresh resolve now equals a reload of its lockfile.
- Excluded: the appender after a github download (`processDependencyList.rs:223`). Several `github:` refs on one commit still collide. A follow-up owns it.
- Verified: three new tests, red on 1.4.3. Notes: suites, output changes, #38814.

### Background
- A `file:` directory becomes a `Resolution::Folder` package. The root and workspaces read its `package.json`. Other declarers get a stub: name and path only (#10445).
- The isolated linker runs one task per package id, and each hardlinks into `node_modules/.bun/<name>@file+<path>`.
- The `bun.lock` parser (`append_package_dedupe`) merges rows with the same name and resolution. A stub row `{}` takes the full row's dependencies, which have no rows under the stub's key.

<details><summary>Notes</summary>

**New tests.** `isolated-install.test.ts`: `a folder dependency shared by several folder dependencies is one package` (6 local dependents) and `a file: override that several registry packages depend on is one package` (5 registry dependents of `no-deps`, root `overrides: { "no-deps": "file:./vendor/no-deps" }`). `bun-install.test.ts`: `reloads the lockfile it wrote when a file: dependency and the root declare the same folder`. The two isolated tests also assert the `N packages installed` count, so they fail on 1.4.3 when the race does not fire.

**What a user sees change.** Only a fresh resolve of `file:` folders changes. Rows already in a lockfile are not resolved again.

- A transitive row for a folder that the root or a workspace also declares prints that package's data on the first save, not `{}`. Its `file:` dependencies get their own rows (`lib/shared/nested`), and its bins are linked for the declarer. This is the graph that 1.4.3 builds when it loads such a lockfile. `installs file: dependencies that depend on each other` in `bun-install.test.ts` now has the same `packages` snapshot as its twin that starts from a lockfile.
- The hoisted linker installs each tree position as before (`PackageInstaller.rs:1456`). Its summary counts unique package ids (`PackageInstaller.rs:1918`), so `N packages installed` drops by the number of merged stubs.
- Stubs that registry packages declare with the same name and the same path as written now share one package too. See the next section.

**Relation to #38814 and #39403.** A comment on #38814 (2026-09-06) describes this race and says of this exact change: "A narrower guard (an unscoped `get_package_id` lookup in the stub branch) is not safe: it also merges registry-declared `file:` stubs with the same package-relative path and fails 3 of the 4 `transitive file dependencies` tests in `bun-install-registry.test.ts`." I checked what fails in those tests:

- All nine edits in `bun-install-registry.test.ts` change only the `N packages installed` line (14 to 13, 15 to 14, 13 to 12). `@scoped/file-dep` and `@another-scope/file-dep` both declare `@scoped/files: file:./the-files`, and the two stubs are now one package.
- `checkHoistedFiles` and `checkUnhoistedFiles` pass unchanged. Both copies of `@scoped/files` are linked, each from its own parent, because the hoisted installer works per tree position.
- 1.4.3 already merges these rows when it loads `bun.lock`: the same two packages give `4 packages installed` on the fresh install and `3 packages installed` on the reinstall from the lockfile. That block uses `bun.lockb`, which does not merge on load. That is why its counts did not move before.
- The isolated linker does not install a `file:` folder that a registry package ships (`ENOENT ... (open)`, it reads the path relative to the project), with or without this change. #38856 is about that.
- Caveat: for a registry declarer, a stub is a lockfile placeholder (the alias plus the path as written), not one physical folder. `bun.lock` cannot tell two such stubs apart, and no linker uses the stub's id to find the files.

#38814 reads the `package.json` of a folder that a local `file:` package declares, through `get_or_put`, which also gives one package for local declarers. It keeps the stub for registry, git and tarball declarers, so the `overrides` case above still makes N stubs there. This change does not depend on it. If #38814 lands, the lookup stays as the guard of the remaining stub path. #39403 is the draft that folds #38814 with other PRs.

**Sibling sites.** The other `append_package` callers: the root and workspaces (one each), npm packages (lookup in `get_or_put_resolved_package_with_find_result`), `read_package_json_from_disk` (lookup, then replaces the package in place), and the appenders that run after a download in `process_extracted_tarball_package`. The Git, Github and Tarball arms of the enqueue function do the same `get_package_id` lookup before they start a download. A tarball task is keyed by its URL, which is also the resolution, so it cannot make duplicates. A plain git URL keys its checkout by the resolved commit: three refs of a `git+file://` repo on one commit give one package. `github:` refs download by ref, so several refs on one commit append several packages with an equal resolution. With a fake `GITHUB_API_URL` server, 10 of 10 isolated installs fail with the same `EEXIST` on 1.4.3, and 9 of 10 with this PR. The commit is known only after the download, so that guard belongs in the task completion path. A separate change owns it.

**Existing lockfiles.** A `bun.lock` from 1.4.3 with the unreadable rows is still ignored with a warning and resolved again. The new one is readable. Under `--frozen-lockfile` it fails until it is regenerated. A `bun.lockb` from 1.4.3 keeps its duplicate packages, because the binary format does not merge on load.

**Other symptom.** When the entry that loses the race carries trusted lifecycle scripts, its `postinstall` does not run (from the #38814 comment).

**Escape check.** The lookup runs after the `..` escape check, so a transitive declarer still cannot reach a folder outside the project through a package that the root declared.

**Why the lockfile reload did not fail in the reported tree.** `shared` had no dependencies there, so the merged package needed no extra rows. With an existing `bun.lock`, 0 of 20 installs fail on 1.4.3, because the parser already merged the rows into one package.

**Order.** Before, the result depended on resolve order. `read_package_json_from_disk` replaces an existing package with the same name and resolution in place, so a stub made before the full package became full, and a stub made after it did not.

**Measurements** (fresh tree each run). Reported: 1.4.2 fails 12 of 20 installs with 3 local dependents, 0 of 20 with `--linker=hoisted`. Debug ASAN build: 6 of 10 failed before the change, 0 of 20 after, and 0 of 10 with 6 dependents. `overrides` case with 6 registry dependents: 1.4.3 fails 7 of 10, this branch 0 of 10.

**Suites run with the debug build:** `isolated-install`, `bun-install`, `bun-install-registry`, `bun-lock`, `bun-lockb`, `bun-workspaces`, `bun-workspaces-self-contained`, `overrides`, `nested-overrides`, `bun-add`, `bun-add-catalog`, `bun-add-filter`, `bun-remove`, `bun-update`, `bun-pm`, `bun-prune`, `bun-dedupe`, `bun-link`, `hoist`, `catalogs`, `config-version`, `lockfile-only`, `lockfile-version-2`, `shebang-normalize`, `migration/migrate`, `bun-install-lifecycle-scripts`. The only failures need network access or `node` (bitbucket, gitlab and external URL tests, `node -p` and `node-gyp` scripts), or compare stdout that the debug build adds a stack trace to (`bun-link`: `should link dependency without crashing`).

Self-reviewed: 3 groups of concerns raised, 3 addressed (the #38814 comment answered above, scope claims narrowed and the github site named as excluded, `overrides` test added and the Problem section reordered).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts, test/cli/install/bun-install.test.ts, test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->