### PR TITLE
bake: re-arm the memory visualizer timer on tick and disarm it on the right counter

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1069,10 +1069,7 @@ impl Drop for DevServer {
             debug_assert!(self.active_websocket_connections.is_empty());
         }
 
-        if self.memory_visualizer_timer.state == EventLoopTimerState::ACTIVE {
-            let timer_ptr: *mut EventLoopTimer = &raw mut self.memory_visualizer_timer;
-            self.timer_heap().remove(timer_ptr);
-        }
+        self.disarm_memory_visualizer_timer();
         self.graph_safety_lock.lock();
         // Hand ownership of the heap allocation to the watcher thread (which frees it in
         // `thread_main` once `running` flips false). Auto-dropping the `Box`
@@ -5498,10 +5495,34 @@ impl DevServer {
         crate::jsc_hooks::timer_all_mut()
     }
 
-    pub fn emit_memory_visualizer_message_timer(
-        _timer: &mut EventLoopTimer,
-        _: &bun_core::Timespec,
-    ) {
+    const MEMORY_VISUALIZER_TICK_MS: i64 = 1000;
+
+    pub(crate) fn arm_memory_visualizer_timer(&mut self) {
+        let next = bun_core::Timespec::ms_from_now(
+            bun_core::TimespecMockMode::ForceRealTime,
+            Self::MEMORY_VISUALIZER_TICK_MS,
+        );
+        let timer_ptr: *mut EventLoopTimer = &raw mut self.memory_visualizer_timer;
+        self.timer_heap().update(timer_ptr, &next);
+    }
+
+    pub(crate) fn disarm_memory_visualizer_timer(&mut self) {
+        if self.memory_visualizer_timer.state != EventLoopTimerState::ACTIVE {
+            return;
+        }
+        let timer_ptr: *mut EventLoopTimer = &raw mut self.memory_visualizer_timer;
+        self.timer_heap().remove(timer_ptr);
+    }
+
+    /// SAFETY: `timer` must be the `memory_visualizer_timer` field of a live, boxed `DevServer`.
+    pub(crate) unsafe fn emit_memory_visualizer_message_timer(timer: *mut EventLoopTimer) {
+        // SAFETY: caller contract; `from_timer_ptr` recovers the owning DevServer.
+        let dev: &mut DevServer = unsafe { &mut *DevServer::from_timer_ptr(timer) };
+        debug_assert!(dev.magic == Magic::Valid);
+        // Already popped by the event loop; left ACTIVE, `disarm` would remove() it again.
+        dev.memory_visualizer_timer.state = EventLoopTimerState::FIRED;
+        dev.emit_memory_visualizer_message();
+        dev.arm_memory_visualizer_timer();
     }
 
     pub fn emit_memory_visualizer_message_if_needed(&mut self) {}

--- a/src/runtime/bake/dev_server/hmr_socket.rs
+++ b/src/runtime/bake/dev_server/hmr_socket.rs
@@ -124,23 +124,7 @@ impl HmrSocket {
                                             dev.memory_visualizer_timer.state
                                                 != EventLoopTimerState::ACTIVE
                                         );
-                                        // Note (jsc/runtime crate cycle): `vm.timer` is `()` on the
-                                        // low-tier `VirtualMachine`; the real `timer::All`
-                                        // lives in `RuntimeState` (see jsc_hooks.rs).
-                                        let state = crate::jsc_hooks::runtime_state();
-                                        let next = bun_core::Timespec::ms_from_now(
-                                            bun_core::TimespecMockMode::ForceRealTime,
-                                            1000,
-                                        );
-                                        // SAFETY: `runtime_state()` is non-null after
-                                        // `bun_runtime::init()`; JS-thread only, sole
-                                        // `&mut` to `timer` in this scope.
-                                        unsafe {
-                                            (*state).timer.update(
-                                                &raw mut dev.memory_visualizer_timer,
-                                                &next,
-                                            );
-                                        }
+                                        dev.arm_memory_visualizer_timer();
                                     }
                                 }
                                 _ => {}
@@ -307,17 +291,8 @@ impl HmrSocket {
             }
             if field.contains(HmrTopic::MemoryVisualizer.as_bit()) {
                 dev.emit_memory_visualizer_events -= 1;
-                if dev.emit_incremental_visualizer_events == 0
-                    && dev.memory_visualizer_timer.state == EventLoopTimerState::ACTIVE
-                {
-                    // Note (jsc/runtime crate cycle): `vm.timer` is `()` on the low-tier
-                    // `VirtualMachine`; the real `timer::All` lives in `RuntimeState`.
-                    let state = crate::jsc_hooks::runtime_state();
-                    // SAFETY: `runtime_state()` is non-null after `bun_runtime::init()`;
-                    // JS-thread only, sole `&mut` to `timer` in this scope.
-                    unsafe {
-                        (*state).timer.remove(&raw mut dev.memory_visualizer_timer);
-                    }
+                if dev.emit_memory_visualizer_events == 0 {
+                    dev.disarm_memory_visualizer_timer();
                 }
             }
         }

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1095,7 +1095,7 @@ pub(crate) unsafe fn __bun_fire_timer(
         EventLoopTimerTag::DevServerMemoryVisualizerTick => {
             // SAFETY: per fn contract; `t` is the `memory_visualizer_timer`
             // field of a live DevServer.
-            DevServer::emit_memory_visualizer_message_timer(unsafe { &mut *t }, unsafe { &*now });
+            unsafe { DevServer::emit_memory_visualizer_message_timer(t) };
             Ok(())
         }
         EventLoopTimerTag::BunTest => {

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -1,7 +1,8 @@
 // Hot tests ensure that the `import.meta.hot` interface is functional
 import { expect } from "bun:test";
+import { isDebug } from "harness";
 import { renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { devTest, emptyHtmlFile } from "../bake-harness";
+import { Dev, devTest, emptyHtmlFile, WAIT_MULTIPLIER } from "../bake-harness";
 
 devTest("import.meta.hot.accept basic", {
   files: {
@@ -611,6 +612,208 @@ devTest("hot update frames are not delivered to application websocket topics", {
     }
   },
 });
+
+// The `M` (memory visualizer) and `v` (incremental visualizer) HMR topics only
+// exist in builds with `BAKE_DEBUGGING_FEATURES` (canary or debug). A stable
+// release accepts the subscription but never emits a frame, so there is
+// nothing to observe there.
+const hasBakeDebuggingFeatures = isDebug || Bun.version_with_sha.includes("-canary.");
+
+const memoryVisualizerApp = {
+  "index.html": emptyHtmlFile({}),
+  "bun.app.ts": `
+    import html from "./index.html";
+    // Always armed in the dev server's timer heap; /tick answers on its next fire.
+    const waiters = [];
+    setInterval(() => {
+      for (const resolve of waiters.splice(0)) resolve();
+    }, 20);
+    export default {
+      static: {
+        "/": html,
+      },
+      async fetch(req) {
+        if (new URL(req.url).pathname === "/tick") {
+          await new Promise(resolve => waiters.push(resolve));
+          return new Response("ticked");
+        }
+        return new Response("Not Found", { status: 404 });
+      },
+    };
+  `,
+};
+
+/**
+ * Opens an extra `/_bun/hmr` socket and counts the `M` (memory visualizer)
+ * frames it receives. The server answers an `M` subscription with one frame
+ * immediately and then sends one per timer tick.
+ */
+async function openVisualizerSocket(dev: Dev) {
+  const ws = new WebSocket(dev.baseUrl + "/_bun/hmr");
+  ws.binaryType = "arraybuffer";
+  let open = false;
+  let frames = 0;
+  // Set when the socket errors or closes unexpectedly; fails the step being
+  // awaited at that moment and every step started afterwards.
+  let failure: Error | null = null;
+  // The step currently being awaited: socket progress resolves it, socket
+  // failure or the deadline rejects it.
+  let step: { what: string; done: () => boolean; resolve: () => void; reject: (err: Error) => void } | null = null;
+  const check = () => {
+    if (step === null || !step.done()) return;
+    const { resolve } = step;
+    step = null;
+    resolve();
+  };
+  const fail = (reason: string) => {
+    const err = new Error(
+      `${reason}${step ? ` while ${step.what}` : ""} (received ${frames} memory visualizer frames)`,
+    );
+    failure ??= err;
+    if (step === null) return;
+    const { reject } = step;
+    step = null;
+    reject(err);
+  };
+  ws.onopen = () => {
+    open = true;
+    check();
+  };
+  ws.onerror = () => fail("hmr socket errored");
+  ws.onclose = event => fail(`hmr socket closed unexpectedly with code ${event.code}`);
+  ws.onmessage = event => {
+    if (new Uint8Array(event.data as ArrayBuffer)[0] !== "M".charCodeAt(0)) return;
+    frames++;
+    check();
+  };
+  const waitUntil = (what: string, done: () => boolean) =>
+    new Promise<void>((resolve, reject) => {
+      if (failure) return reject(failure);
+      const deadline = setTimeout(() => fail("timed out"), 5_000 * WAIT_MULTIPLIER);
+      step = {
+        what,
+        done,
+        resolve: () => {
+          clearTimeout(deadline);
+          resolve();
+        },
+        reject: err => {
+          clearTimeout(deadline);
+          reject(err);
+        },
+      };
+      check();
+    });
+
+  const handle = {
+    get frames() {
+      return frames;
+    },
+    /** Replaces this socket's topic set: `s` followed by one character per topic. */
+    subscribe: (topics: string) => ws.send("s" + topics),
+    /** Resolves once this socket has received `count` memory visualizer frames in total. */
+    waitForFrames: (count: number) => waitUntil(`waiting for memory visualizer frame #${count}`, () => frames >= count),
+    /** Closes the socket, which unsubscribes it on the server, and waits for the close handshake. */
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        if (failure) return reject(failure);
+        ws.onerror = () => reject(new Error("hmr socket errored during the close handshake"));
+        ws.onclose = () => resolve();
+        ws.close();
+      }),
+  };
+
+  await waitUntil("opening the hmr socket", () => open);
+  return handle;
+}
+
+/** Opens a socket that subscribes to the memory visualizer topic and waits for the frame that answers it. */
+async function subscribeMemoryVisualizer(dev: Dev) {
+  const socket = await openVisualizerSocket(dev);
+  socket.subscribe("M");
+  await socket.waitForFrames(1);
+  return socket;
+}
+
+if (hasBakeDebuggingFeatures) {
+  devTest("memory visualizer topic ticks while subscribed and unsubscribes without disturbing other timers", {
+    files: memoryVisualizerApp,
+    htmlFiles: [],
+    async test(dev) {
+      const start = performance.now();
+      const subscriber = await subscribeMemoryVisualizer(dev);
+      // Frame 1 is sent synchronously on subscribe and frame 2 by the timer
+      // armed at that point; frame 3 only arrives if the tick handler
+      // re-armed the timer after firing.
+      await subscriber.waitForFrames(3);
+      // Two real ticks take at least 2s. A handler that re-inserted the timer
+      // without moving its deadline would deliver frame 3 right after frame 2,
+      // i.e. at roughly 1s; 1.5s keeps clear of both.
+      expect(performance.now() - start).toBeGreaterThanOrEqual(1500);
+
+      // The fixture's interval is pending in the same heap while the subscriber
+      // leaves. Unsubscribing removes the visualizer timer from the heap; when
+      // the tick had left that node marked as still in the heap, the removal
+      // discarded whichever timer was at the root instead (debug builds assert),
+      // and the interval never fired again.
+      await dev.fetch("/tick").equals("ticked");
+      await subscriber.close();
+      await dev.fetch("/tick").equals("ticked");
+
+      // The timer can be re-armed after being disarmed. This socket is left
+      // open on purpose: the harness's graceful exit closes it while the timer
+      // is armed, covering the teardown path.
+      await subscribeMemoryVisualizer(dev);
+    },
+  });
+
+  devTest("memory visualizer timer stays armed while another subscriber remains", {
+    files: memoryVisualizerApp,
+    htmlFiles: [],
+    async test(dev) {
+      const first = await subscribeMemoryVisualizer(dev);
+      const second = await subscribeMemoryVisualizer(dev);
+      await first.close();
+      // A frame published by a tick just before the close can still be in
+      // flight, so only the second frame from here on proves the timer is
+      // still armed for the remaining subscriber.
+      await second.waitForFrames(second.frames + 2);
+    },
+  });
+
+  // The timer belongs to the `M` subscriber count alone. When the unsubscribe
+  // path consulted the `v` count instead, a `v` holder kept the timer armed
+  // with no `M` subscriber left, and the next `M` subscription armed it a
+  // second time (debug builds assert; otherwise the armed node could already
+  // be popped and its removal discarded an unrelated timer).
+  devTest("memory visualizer timer is disarmed with its last subscriber while the incremental visualizer is held", {
+    files: memoryVisualizerApp,
+    htmlFiles: [],
+    async test(dev) {
+      // One socket narrows {M, v} to {v} and then asks for M again. A socket's
+      // frames are handled in order, so nothing has to be awaited in between.
+      const socket = await openVisualizerSocket(dev);
+      socket.subscribe("Mv");
+      socket.subscribe("v");
+      socket.subscribe("M");
+      // Frames 1 and 2 answer the two M subscriptions. Frame 3 only arrives if
+      // the second subscription armed the timer again.
+      await socket.waitForFrames(3);
+      await socket.close();
+
+      // The same through the close path. `holder` sends its subscription
+      // before `leaver` connects, so the server counts it first.
+      const holder = await openVisualizerSocket(dev);
+      holder.subscribe("v");
+      const leaver = await subscribeMemoryVisualizer(dev);
+      await leaver.close();
+      const returner = await subscribeMemoryVisualizer(dev);
+      await returner.waitForFrames(2);
+      await dev.fetch("/tick").equals("ticked");
+      await holder.close();
+    },
+  });
+}
 
 devTest("dev.write resolves only after the new module body has run", {
   files: {


### PR DESCRIPTION
### Problem
- On canary and debug builds, a WebSocket client of `/_bun/hmr` can damage the dev server's timer heap. On 1.4.3-canary.1 an unrelated `setTimeout` never fires. Debug builds abort with `panic: assertion failed: dev.memory_visualizer_timer.state != EventLoopTimerState::ACTIVE` (`hmr_socket.rs:123`) or `assertion failed: self.root == v`.
- Cause 1: `DevServer::emit_memory_visualizer_message_timer` (`src/runtime/bake/DevServer.rs:5501`) is an empty stub. It leaves the popped timer node marked `ACTIVE`, so the next `remove()` discards the heap root.
- Cause 2: `on_unsubscribe` (`hmr_socket.rs:310`) removes the timer when the `v` subscriber count is zero, not the `M` subscriber count.

### Fix
- The tick handler sets `FIRED`, publishes the `M` frame and arms the timer again, like `SourceMapStore::sweep_weak_refs`.
- `on_unsubscribe` disarms the timer when `emit_memory_visualizer_events` reaches zero.
- Verified: three new tests in `test/bake/dev/hot.test.ts`. All fail on 1.4.3-canary.1 and pass here. With the tick fix alone, the two counter tests still fail.
- Self-reviewed: 4 notes raised, 3 addressed in Notes. Rejected: one shared server for the tests, because each test depends on the server-wide subscriber counts.

### Background
- `M` (memory visualizer) and `v` (incremental visualizer) are HMR topics of canary and debug builds. While an `M` subscriber exists, the server sends one frame per second.
- `EventLoopTimer` is an intrusive node in a pairing heap, `timer::All.timers`. The event loop pops a due node, then calls its handler. The handler must set `FIRED` or insert the node again.
- Same change as #37936, closed in favor of #39488, which now conflicts with main. The `v` holder test is new.

<details><summary>Notes</summary>

**Reach**

- Canary and debug builds only (`BAKE_DEBUGGING_FEATURES` is `IS_CANARY || IS_DEBUG`). A stable build never arms the timer.
- There is no user report. Nothing in the tree subscribes to `M` or `v`: #36184 removed the routes for the two visualizer pages and #40066 deleted the pages. The topics stay reachable for any client that can open a WebSocket to the dev server.
- The damage does not stop at one timer. Each later `remove()` of the stale node discards the heap root again.

**Two ways to reach the damage on main**

1. One socket sends `sM`, waits more than 1 s, then closes. The stub tick leaves the popped node `ACTIVE`. `on_close -> on_unsubscribe -> All::remove` then runs on a node that is not in the heap. `All::remove` trusts `state`, and the heap's `remove` reads the missing links of the node as "this node is the root". This is the report behind #37936.
2. Socket A sends `sv`. Socket B sends `sM` and closes. Because of the wrong counter the timer stays armed with no `M` subscriber. More than 1 s later socket C sends `sM`, and `All::update` does remove + insert on the popped node. On a debug build the second `sM` trips the assert at `hmr_socket.rs:123` at once, with no wait. One socket that sends `sMv`, `sv`, `sM` does the same.

Script for the second way. It exits 0 and prints `user timers fired: 4/5` on 1.4.3-canary.1, and `5/5` on this branch:

```js
import { mkdtempSync, writeFileSync } from "node:fs";
import { join } from "node:path";
import { tmpdir } from "node:os";
const dir = mkdtempSync(join(tmpdir(), "fx-"));
writeFileSync(join(dir, "index.html"), `<!doctype html><html><body><script type="module" src="./app.ts"></script></body></html>`);
writeFileSync(join(dir, "app.ts"), `console.log("hi");`);
const html = (await import(join(dir, "index.html"))).default;
const srv = Bun.serve({ routes: { "/": html }, development: true, port: 0, hostname: "127.0.0.1" });
await (await fetch(`http://127.0.0.1:${srv.port}/`)).text();
const open = () => new Promise(r => { const w = new WebSocket(`ws://127.0.0.1:${srv.port}/_bun/hmr`); w.onopen = () => r(w); });
const a = await open(); a.send("sv");
const b = await open(); b.send("sM"); await Bun.sleep(30); b.close();
await Bun.sleep(1500);
let fired = 0; for (let i = 1; i <= 5; i++) setTimeout(() => fired++, i * 100);
const c = await open(); c.send("sM");
const end = Date.now() + 2500; while (Date.now() < end) await new Promise(r => setImmediate(r));
console.log(`user timers fired: ${fired}/5`); process.exit(0);
```

**History**

- The Zig handler published the frame, set `.FIRED` and called `timer.update`. The Rust body sat behind a cargo feature that nothing enabled. #36184 deleted that body and left the stub. The subscribe hook that arms the timer stayed live.
- The wrong counter in `on_unsubscribe` is the same in the Zig version. With a working tick it only left a timer that ticked with no subscriber. With the stub it reaches the heap.

**Shape**

- `DevServer::arm_memory_visualizer_timer` and `disarm_memory_visualizer_timer` replace the inline `runtime_state()` copies in `hmr_socket.rs` and the copy in `Drop`. The handler takes the raw timer pointer and recovers the owner with `from_timer_ptr`, like `sweep_weak_refs`, so the dispatch arm no longer forms a `&mut EventLoopTimer` that aliases the `&mut DevServer`.
- The src hunks are the same text as the hunks in #39488.
- Smaller alternative, if the 1 Hz frame must stay off until the pages return: the stub only sets `state = FIRED`, and `on_unsubscribe` takes the counter line. That closes both ways to the heap damage and sends no frame. Only the third test then has a failing form, and only on debug builds.

**Overlap with open PRs**

- #39488 carries this change and is `CONFLICTING` since 2026-08-28.
- #40187 sets `FIRED` in the dispatch arm and makes the heap refuse a `remove()` of an unlinked node. That is the fix for the whole class. It keeps the stub empty and the `v` counter.
- #40255 and #33196 carry the counter line and keep the stub empty.
- Each of #40187, #40255 and #33196 has a mechanical rebase of about 10 lines after this PR, or this PR after them.

**Tests**

- "ticks while subscribed and unsubscribes without disturbing other timers": three `M` frames (the third needs the second arm), at least 1.5 s after the start. Then a `/tick` route backed by a 20 ms `setInterval` in the fixture must answer before and after the subscriber closes. The test subscribes once more at the end and leaves that socket open, so the harness teardown runs `Drop` with the timer armed.
- "stays armed while another subscriber remains": two `M` subscribers and no `v` holder. One closes. The other must keep its frames.
- "is disarmed with its last subscriber while the incremental visualizer is held": `sMv`, `sv`, `sM` on one socket, then the same through the close path with three sockets.
- Each test needs its own server. The first and third need the `M` count to reach zero, the second needs no `v` holder, and all three read counters that belong to the whole `DevServer`.
- `USE_SYSTEM_BUN=1 bun test test/bake/dev/hot.test.ts -t "memory visualizer"` on 1.4.3-canary.1+6a92015fc: 0 pass, 3 fail (`timed out while waiting for memory visualizer frame #3`).
- `bun bd test test/bake/dev/hot.test.ts`: 14 pass, 0 fail.
- Debug build with the tick fix and the old counter: the first test passes, the second times out after one frame, the third aborts with the assert at `hmr_socket.rs:123`.
- The tests are inside a canary-or-debug check. A stable build accepts the subscription and never sends a frame.

**Not in this PR**

- `emit_memory_visualizer_message_if_needed` and `emit_visualizer_message_if_needed` stay empty. #39488 restores both together with the visualizer pages.
- The unreachable `else if` in the subscribe handler (a dropped topic is never unsubscribed at the uWS level) is the subject of #37878, which #39488 also carries.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bake/dev/hot.test.ts

<!-- robobun:evidence:end -->