### PR TITLE
Keep an error's stack frames alive while Error.prepareStackTrace runs

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -637,10 +637,34 @@ void computeLineColumnWithSourcemap(JSC::VM& vm, JSC::SourceProvider* _Nonnull s
     }
 }
 
+// An ErrorInstance holds the callee and the code block of each frame weakly, and formatting runs
+// user JS (Error.prepareStackTrace, a "message" getter) that can collect synchronously.
+static void protectFrameCells(JSC::MarkedArgumentBuffer& cells, const Vector<StackFrame>& stackTrace)
+{
+    cells.ensureCapacity(stackTrace.size() * 2);
+    for (auto& frame : stackTrace) {
+        if (auto* callee = frame.callee())
+            cells.append(callee);
+        if (auto* codeBlock = frame.codeBlock())
+            cells.append(codeBlock);
+    }
+}
+
 JSC::JSValue computeErrorInfoWrapperToJSValue(JSC::VM& vm, Vector<StackFrame>& stackTrace, unsigned int& line_in, unsigned int& column_in, String& sourceURL, JSObject* errorInstance, void* bunErrorData)
 {
     OrdinalNumber line = OrdinalNumber::fromOneBasedInt(line_in);
     OrdinalNumber column = OrdinalNumber::fromOneBasedInt(column_in);
+
+    // stackTrace is still installed on errorInstance, which is already flagged as materialized.
+    // A collection that finds one of these frames dead makes
+    // ErrorInstance::reconcileWeakReferencesAtGCEnd render and free the trace under the formatter.
+    JSC::MarkedArgumentBuffer protectedFrameCells;
+    protectFrameCells(protectedFrameCells, stackTrace);
+    if (protectedFrameCells.hasOverflowed()) [[unlikely]] {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        throwOutOfMemoryError(errorInstance->globalObject(), scope);
+        return jsUndefined();
+    }
 
     JSValue result = computeErrorInfoToJSValue(vm, stackTrace, line, column, sourceURL, errorInstance, bunErrorData);
 
@@ -666,6 +690,12 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
     if (!source || !destination) {
         throwTypeError(lexicalGlobalObject, scope, "First & second argument must be an Error object"_s);
         return {};
+    }
+
+    // A destination whose .stack was read, or is being formatted right now, never renders frames
+    // again. The next GC that finds an installed frame dead would format the trace a second time.
+    if (destination->hasMaterializedErrorInfo()) {
+        return JSC::JSValue::encode(jsUndefined());
     }
 
     if (!destination->stackTrace()) {
@@ -726,13 +756,7 @@ JSC_DEFINE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter, (JSGlobalObject * g
     } else {
         auto ownedStackTrace = makeUnique<WTF::Vector<JSC::StackFrame>>(WTF::move(*stackTrace));
         JSC::MarkedArgumentBuffer protectedFrameCells;
-        protectedFrameCells.ensureCapacity(ownedStackTrace->size() * 2);
-        for (auto& frame : *ownedStackTrace) {
-            if (auto* callee = frame.callee())
-                protectedFrameCells.append(callee);
-            if (auto* codeBlock = frame.codeBlock())
-                protectedFrameCells.append(codeBlock);
-        }
+        protectFrameCells(protectedFrameCells, *ownedStackTrace);
         if (protectedFrameCells.hasOverflowed()) [[unlikely]] {
             throwOutOfMemoryError(globalObject, scope);
             return {};

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -654,8 +654,7 @@ JSC::JSValue computeErrorInfoWrapperToJSValue(JSC::VM& vm, Vector<StackFrame>& s
     OrdinalNumber line = OrdinalNumber::fromOneBasedInt(line_in);
     OrdinalNumber column = OrdinalNumber::fromOneBasedInt(column_in);
 
-    // stackTrace is still installed on errorInstance. A GC in the formatter that finds one of its
-    // frames dead frees it (ErrorInstance::reconcileWeakReferencesAtGCEnd).
+    // stackTrace stays installed on errorInstance: a GC that finds one of its frames dead frees it mid-format.
     JSC::MarkedArgumentBuffer protectedFrameCells;
     protectFrameCells(protectedFrameCells, stackTrace);
     if (protectedFrameCells.hasOverflowed()) [[unlikely]] {
@@ -690,8 +689,7 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
         return {};
     }
 
-    // A destination that is materialized, or is being formatted right now, never renders frames
-    // again, and the next GC that finds an installed frame dead formats the trace a second time.
+    // A destination that is materialized, or is being formatted right now, never renders frames again.
     if (destination->hasMaterializedErrorInfo()) {
         return JSC::JSValue::encode(jsUndefined());
     }
@@ -752,8 +750,7 @@ JSC_DEFINE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter, (JSGlobalObject * g
         WTF::Vector<JSC::StackFrame> emptyTrace;
         result = computeErrorInfoToJSValue(vm, emptyTrace, line, column, sourceURL, errorObject, nullptr);
     } else {
-        // User JS in materializeErrorInfoIfNeeded's formatter can re-enter here, and that formatter
-        // still reads *stackTrace: copy the frames and leave the vector installed.
+        // Re-entered from materializeErrorInfoIfNeeded's formatter, which still reads *stackTrace: copy, do not move.
         bool isBeingMaterialized = errorObject->hasMaterializedErrorInfo();
         auto ownedStackTrace = isBeingMaterialized
             ? makeUnique<WTF::Vector<JSC::StackFrame>>(*stackTrace)

--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -637,8 +637,7 @@ void computeLineColumnWithSourcemap(JSC::VM& vm, JSC::SourceProvider* _Nonnull s
     }
 }
 
-// An ErrorInstance holds the callee and the code block of each frame weakly, and formatting runs
-// user JS (Error.prepareStackTrace, a "message" getter) that can collect synchronously.
+// ErrorInstance holds a frame's callee and code block weakly. Root them while user JS can run.
 static void protectFrameCells(JSC::MarkedArgumentBuffer& cells, const Vector<StackFrame>& stackTrace)
 {
     cells.ensureCapacity(stackTrace.size() * 2);
@@ -655,9 +654,8 @@ JSC::JSValue computeErrorInfoWrapperToJSValue(JSC::VM& vm, Vector<StackFrame>& s
     OrdinalNumber line = OrdinalNumber::fromOneBasedInt(line_in);
     OrdinalNumber column = OrdinalNumber::fromOneBasedInt(column_in);
 
-    // stackTrace is still installed on errorInstance, which is already flagged as materialized.
-    // A collection that finds one of these frames dead makes
-    // ErrorInstance::reconcileWeakReferencesAtGCEnd render and free the trace under the formatter.
+    // stackTrace is still installed on errorInstance. A GC in the formatter that finds one of its
+    // frames dead frees it (ErrorInstance::reconcileWeakReferencesAtGCEnd).
     JSC::MarkedArgumentBuffer protectedFrameCells;
     protectFrameCells(protectedFrameCells, stackTrace);
     if (protectedFrameCells.hasOverflowed()) [[unlikely]] {
@@ -692,8 +690,8 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
         return {};
     }
 
-    // A destination whose .stack was read, or is being formatted right now, never renders frames
-    // again. The next GC that finds an installed frame dead would format the trace a second time.
+    // A destination that is materialized, or is being formatted right now, never renders frames
+    // again, and the next GC that finds an installed frame dead formats the trace a second time.
     if (destination->hasMaterializedErrorInfo()) {
         return JSC::JSValue::encode(jsUndefined());
     }
@@ -754,7 +752,12 @@ JSC_DEFINE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter, (JSGlobalObject * g
         WTF::Vector<JSC::StackFrame> emptyTrace;
         result = computeErrorInfoToJSValue(vm, emptyTrace, line, column, sourceURL, errorObject, nullptr);
     } else {
-        auto ownedStackTrace = makeUnique<WTF::Vector<JSC::StackFrame>>(WTF::move(*stackTrace));
+        // User JS in materializeErrorInfoIfNeeded's formatter can re-enter here, and that formatter
+        // still reads *stackTrace: copy the frames and leave the vector installed.
+        bool isBeingMaterialized = errorObject->hasMaterializedErrorInfo();
+        auto ownedStackTrace = isBeingMaterialized
+            ? makeUnique<WTF::Vector<JSC::StackFrame>>(*stackTrace)
+            : makeUnique<WTF::Vector<JSC::StackFrame>>(WTF::move(*stackTrace));
         JSC::MarkedArgumentBuffer protectedFrameCells;
         protectFrameCells(protectedFrameCells, *ownedStackTrace);
         if (protectedFrameCells.hasOverflowed()) [[unlikely]] {
@@ -762,7 +765,8 @@ JSC_DEFINE_CUSTOM_GETTER(errorInstanceLazyStackCustomGetter, (JSGlobalObject * g
             return {};
         }
         result = computeErrorInfoToJSValue(vm, *ownedStackTrace, line, column, sourceURL, errorObject, nullptr);
-        errorObject->setStackFrames(vm, {});
+        if (!isBeingMaterialized)
+            errorObject->setStackFrames(vm, {});
     }
     RETURN_IF_EXCEPTION(scope, {});
     errorObject->putDirect(vm, vm.propertyNames->stack, result, JSC::PropertyAttribute::DontEnum | 0);

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1173,7 +1173,18 @@ test.concurrent.each([
      console.log(/at (\\w+)/.exec(other.stack)[1]);`,
     "formatted inner\ninner",
   ],
-])("a synchronous GC while .stack is being formatted keeps the trace: %s", async (_, source, expected) => {
+  [
+    "a node:vm Error.prepareStackTrace getter reads the lazy .stack accessor of the same error",
+    `import vm from "node:vm";
+     let e, entered = false;
+     const context = vm.createContext({ readStack() { if (entered) return; entered = true; return e.stack; } });
+     e = vm.runInContext('new Error("x")', context);
+     (function capture() { Error.captureStackTrace(e); })();
+     vm.runInContext('Object.defineProperty(Error, "prepareStackTrace", { get() { readStack(); } })', context);
+     console.log(e.stack.split("\\n")[0] + " | " + /at (\\w+)/.exec(e.stack)?.[1]);`,
+    "Error: x | capture",
+  ],
+])("user JS that runs while .stack is being formatted cannot invalidate the trace: %s", async (_, source, expected) => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", source],
     env: bunEnv,

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1156,7 +1156,7 @@ test.concurrent.each([
   ],
   [
     "Bun.gc(true) in a node:vm Error.prepareStackTrace getter",
-    `const vm = require("node:vm");
+    `import vm from "node:vm";
      const context = vm.createContext({ collect: () => Bun.gc(true) });
      const e = vm.runInContext(${JSON.stringify(errorWithDeadFrames)}, context);
      vm.runInContext('Object.defineProperty(Error, "prepareStackTrace", { get() { collect(); } })', context);

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1122,6 +1122,69 @@ test("lazy error-info materialization does not store an empty stack value when t
   expect(exitCode).toBe(0);
 });
 
+// An error holds the functions in its trace weakly. These functions are strict, so the call sites do
+// not retain them either, and they are garbage by the time `.stack` is first read. The `finally`
+// blocks keep each `return` out of tail position, so every frame stays in the trace.
+const errorWithDeadFrames = `new Function('"use strict"; function inner() { try { return new Error("x"); } finally {} } try { return inner(); } finally {}')()`;
+test.concurrent.each([
+  [
+    "Bun.gc(true) in Error.prepareStackTrace",
+    `const e = ${errorWithDeadFrames};
+     Error.prepareStackTrace = (err, callSites) => { Bun.gc(true); return "formatted " + callSites[0].getFunctionName(); };
+     console.log(e.stack);`,
+    "formatted inner",
+  ],
+  [
+    "v8.getHeapStatistics() in Error.prepareStackTrace, error from an arrow that has returned",
+    `import v8 from "node:v8";
+     Error.prepareStackTrace = (err, callSites) => { v8.getHeapStatistics(); return "formatted " + callSites[1].getFunctionName(); };
+     async function handler() {
+       const e = (() => { try { return new Error("request failed"); } finally {} })();
+       await 1;
+       return e.stack;
+     }
+     console.log(await handler());`,
+    "formatted handler",
+  ],
+  [
+    "Bun.gc(true) in a message getter",
+    `const e = ${errorWithDeadFrames};
+     Object.defineProperty(e, "message", { get() { Bun.gc(true); return "from getter"; } });
+     Error.prepareStackTrace = (err, callSites) => err.stack.split("\\n")[0] + " | " + callSites[0].getFunctionName();
+     console.log(e.stack);`,
+    "Error: from getter | inner",
+  ],
+  [
+    "Bun.gc(true) in a node:vm Error.prepareStackTrace getter",
+    `const vm = require("node:vm");
+     const context = vm.createContext({ collect: () => Bun.gc(true) });
+     const e = vm.runInContext(${JSON.stringify(errorWithDeadFrames)}, context);
+     vm.runInContext('Object.defineProperty(Error, "prepareStackTrace", { get() { collect(); } })', context);
+     console.log(e.stack.split("\\n")[0] + " | " + /at (\\w+)/.exec(e.stack)[1]);`,
+    "Error: x | inner",
+  ],
+  [
+    "Error.appendStackTrace onto the error being formatted, then Bun.gc(true)",
+    `const e = ${errorWithDeadFrames};
+     const other = ${errorWithDeadFrames};
+     Error.prepareStackTrace = (err, callSites) => { Error.appendStackTrace(other, err); Bun.gc(true); return "formatted " + callSites[0].getFunctionName(); };
+     console.log(e.stack);
+     Error.prepareStackTrace = undefined;
+     console.log(/at (\\w+)/.exec(other.stack)[1]);`,
+    "formatted inner\ninner",
+  ],
+])("a synchronous GC while .stack is being formatted keeps the trace: %s", async (_, source, expected) => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), signalCode: proc.signalCode }).toEqual({ stdout: expected, signalCode: null });
+  expect(exitCode).toBe(0);
+});
+
 test("Error.prepareStackTrace call sites keep their own file when a hidden frame is on the stack", async () => {
   // A bound function call is a frame with private implementation visibility. JSC omits it from the
   // trace unless showPrivateScriptsInStackTraces is on (debug builds turn it on); Bun then has to


### PR DESCRIPTION
### Problem
- A synchronous GC (`Bun.gc(true)`, a heap snapshot) inside `Error.prepareStackTrace` crashes the first `.stack` read of an error whose creating function is already garbage. Release: `panic(main thread): Segmentation fault at address 0x8`. Debug: `ASSERTION FAILED: !m_errorInfoMaterialized` in `ErrorInstance::computeErrorInfo` (`ErrorInstance.cpp:398`).
- `materializeErrorInfoIfNeeded` (WebKit fork, `ErrorInstance.cpp:441`) sets `m_errorInfoMaterialized`, then calls Bun's formatter with `*m_stackTrace` still installed. A GC in there finds a dead frame, so `reconcileWeakReferencesAtGCEnd` renders the trace and frees the vector. The `m_stackTrace->clear()` that follows dereferences null.
- A GC-stress fuzz run found this. There is no user report.

### Fix
- `computeErrorInfoWrapperToJSValue` (`src/jsc/bindings/FormatStackTraceForJS.cpp`) roots every frame's callee and code block in a `MarkedArgumentBuffer` while it formats, as the lazy `Error.captureStackTrace` getter already does (#31495). This covers the callback, a `message` getter and a `node:vm` `Error.prepareStackTrace` getter.
- `Error.appendStackTrace` returns early for a destination flagged as materialized (the guard from #37370). Inside the callback it appended unrooted frames to the vector being formatted.
- The lazy getter can run re-entrantly for the error being formatted. It now copies the frames and leaves the vector installed. It freed the vector that the `node:vm` path still reads.
- Verified: `test/js/node/v8/capture-stack-trace.test.js`, 6 new cases, all fail on 1.4.3 canary and on a debug build of main. Self-reviewed: 3 concerns raised, 3 addressed.

### Background
- `error.stack` is lazy. `new Error()` stores a `Vector<StackFrame>`. The first read calls Bun's formatter, which builds `CallSite` objects and calls `Error.prepareStackTrace`.
- The error holds each frame's callee and code block weakly. `reconcileWeakReferencesAtGCEnd` runs on every live error at the end of each GC.
- A `MarkedArgumentBuffer` is a stack-allocated list of GC roots.

<details><summary>Notes</summary>

Minimal script (prints `formatted` on Node and with this change):

```js
const e = new Function('"use strict"; function inner() { try { return new Error("x"); } finally {} } try { return inner(); } finally {}')();
Error.prepareStackTrace = (err, callSites) => { Bun.gc(true); return "formatted"; };
console.log(e.stack);
```

A more ordinary shape that crashes the same way (ESM):

```js
import v8 from "node:v8";
Error.prepareStackTrace = (err, callSites) => { v8.getHeapStatistics(); return "formatted " + callSites.length; };
async function handler() {
  const e = (() => { try { return new Error("request failed"); } finally {} })();
  await 1;
  return e.stack;
}
console.log(await handler());
```

The `finally` blocks keep each `return` out of tail position. A `CallSite` for a strict-mode frame does not keep the function (the V8 rule for `getFunction()`), so nothing else keeps such a frame alive during the callback. A sloppy-mode trace does not crash, because its call sites retain the functions.

`materializeErrorInfoIfNeeded` holds a `DeferGCForAWhile`, so only an explicit synchronous collection runs in the formatter. Calls that collect synchronously and reach this: `Bun.gc(true)`, `bun:jsc` `fullGC()` and `edenGC()`, `Bun.generateHeapSnapshot()`, `v8.writeHeapSnapshot()`. `v8.getHeapStatistics()` and `bun:jsc` `heapStats()` collect only while `vm.heap.size() == 0` (`src/jsc/modules/BunJSCModule.h:233`), so they reach this only before the first collection of the process. `Bun.gc(false)` and allocation pressure do not reach it.

The lazy getter case needs no GC. `Error.captureStackTrace(e)` on an error from a `node:vm` context installs the lazy `stack` accessor. The first `e.stack` read runs `materializeErrorInfoIfNeeded`, whose formatter reads the context's `Error.prepareStackTrace`. If that is a getter that reads `e.stack` again, `materializeErrorInfoIfNeeded` returns at once (the flag is set) and the accessor runs `errorInstanceLazyStackCustomGetter` for the same error. It moved the frames out and called `setStackFrames(vm, {})`, which deleted the vector the outer formatter holds by reference. ASAN with `Malloc=1` reports `heap-use-after-free` in `Bun::formatStackTrace` (`FormatStackTraceForJS.cpp:168`). A release build reads a size of zero and prints a trace with no frames. `Reflect.get(otherError, "stack", e)` reaches the same getter with `e` as the receiver.

This PR does not close every way to reach `ASSERT(!m_errorInfoMaterialized)`. #37370 covers `Error.appendStackTrace` onto a destination whose `.stack` was read earlier, outside the callback, with its own tests, plus two other `appendStackTrace` crashes. The early return here is the same hunk. Whichever PR lands second needs a trivial rebase.

Relation to #40354 with oven-sh/WebKit#511: that change makes `ErrorInstance::visitChildren` mark the frames while `m_stackTrace` is installed. The vector is still installed during the callback, so it would also keep the frames marked there and make the buffer here redundant but harmless. It is a retention change with a WebKit pin bump, and it has no test for this crash. The cases here stay valid as its regression coverage.

A change on the WebKit side alone is not enough. If `materializeErrorInfoIfNeeded` moves the vector out of the instance before the call, the GC end phase skips the error, but the frames are then unrooted and the `node:vm` path reads them after user JS ran. If `reconcileWeakReferencesAtGCEnd` skips materialized instances, `Bun.inspect(err)` inside the callback reads dead frames through `stackTrace()`. Both shapes still need the frames rooted for the duration of the call.

Cost: one `MarkedArgumentBuffer` per first `.stack` read, two slots per frame. It spills to the heap above four frames.

Suites run on the debug build: `capture-stack-trace.test.js` (52 pass, also with `BUN_JSC_validateExceptionChecks=1`), `stack.test.ts`, `prepare-stack-trace-crash.test.ts`, `fix-bindings-stack-trace.test.ts`, `inspect-error.test.js`, `node/vm/vm.test.ts`, `external-sourcemap-stack-leak.test.ts`, and the Node tests `test-error-prepare-stack-trace.js`, `test-util-getcallsites-preparestacktrace.js`, `test-shadow-realm-prepare-stack-trace.js`.
</details>
