### PR TITLE
minify-syntax: keep this for ns["tag"]`x` on a lifted CommonJS export

### DIFF
--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -872,6 +872,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if is_call_target {
                         p.call_target = dot.data;
                     }
+                    if is_template_tag {
+                        p.template_tag = dot.data;
+                    }
                     if is_delete_target {
                         p.delete_target = dot.data;
                     }

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -1410,6 +1410,43 @@ describe("bundler", () => {
       stdout: "helped:x helped:y helped:z true",
     },
   });
+  // `--minify-syntax` rewrites `X["name"]` to `X.name`. The new node is still the
+  // call target or the template tag, so the call still passes `X` as `this`.
+  itBundled("cjs2esm/DefaultImportComputedMemberKeepsThisMinifySyntax", {
+    files: {
+      "/entry.js": /* js */ `
+        import st from "./lib.cjs";
+        console.log(st["parse"]("y"), st["tag"]\`z\`);
+      `,
+      ...thisReadingLib,
+    },
+    cjs2esm: true,
+    minifySyntax: true,
+    onAfterBundle(api) {
+      expect(api.readFile("/out.js")).toContain('console.log(exports_lib.parse("y"), exports_lib.tag`z`);');
+    },
+    run: {
+      stdout: "helped:y helped:z",
+    },
+  });
+  itBundled("cjs2esm/StarImportComputedMemberKeepsThisMinifySyntax", {
+    files: {
+      "/entry.js": /* js */ `
+        import * as ns from "./lib.cjs";
+        console.log(ns["parse"]("y"), ns["tag"]\`z\`);
+      `,
+      ...thisReadingLib,
+    },
+    cjs2esm: true,
+    minifySyntax: true,
+    onAfterBundle(api) {
+      // Each access keeps a receiver. The printed name of `ns` is not part of this test.
+      expect(api.readFile("/out.js")).toMatch(/console\.log\(\w+\.parse\("y"\), \w+\.tag`z`\);/);
+    },
+    run: {
+      stdout: "helped:y helped:z",
+    },
+  });
   itBundled("cjs2esm/StarImportMethodCallThroughExportStarKeepsThis", {
     files: {
       "/entry.js": /* js */ `
@@ -1530,6 +1567,31 @@ describe("bundler", () => {
     },
     run: {
       stdout: "helped:in helped:module helped:tag",
+    },
+  });
+  itBundled("cjs2esm/SelfComputedMemberKeepsThisMinifySyntax", {
+    files: {
+      "/entry.js": /* js */ `
+        import { internal, viaTag } from "./lib.cjs";
+        console.log(internal(), viaTag());
+      `,
+      "/lib.cjs": /* js */ `
+        exports.parse = function (s) { return this._helper(s); };
+        exports._helper = function (s) { return "helped:" + s; };
+        exports.tag = function (strings) { return this._helper(strings[0]); };
+        exports.internal = function () { return exports["parse"]("in"); };
+        exports.viaTag = function () { return exports["tag"]\`tag\`; };
+      `,
+    },
+    cjs2esm: true,
+    minifySyntax: true,
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      expect(out).toContain('return exports_lib.parse("in");');
+      expect(out).toContain("return exports_lib.tag`tag`;");
+    },
+    run: {
+      stdout: "helped:in helped:tag",
     },
   });
   itBundled("cjs2esm/SelfMethodCallWithoutThisBindsDirectly", {


### PR DESCRIPTION
### Problem
- With `bun build --minify-syntax`, ``ns["tag"]`z` `` prints as ``$tag`z` `` when `tag` is a lifted CommonJS export. The tag then runs with `this === undefined`: `TypeError: undefined is not an object (evaluating 'this._helper')`. ``st["tag"]`z` `` on a default import and ``exports["tag"]`z` `` inside the CommonJS file break too.
- The cause is the `a["b"]` to `a.b` rewrite in `e_index` (`src/js_parser/visit/visit_expr.rs:858`). It moves `p.call_target` and `p.delete_target` to the new `E::Dot`, then visits it. It does not move `p.template_tag` (added in #41251). So `e_dot` sees no tag, and the linker binds the export directly.

### Fix
- The rewrite also points `p.template_tag` at the new `E::Dot`. esbuild does the same (`p.templateTag = dot`).
- The second rewrite in `e_index` (`a["x" + "y"]`) is unchanged. It returns the new `E::Dot` without a visit, so nothing reads the marker. That form already works.
- Verified: `test/bundler/bundler_cjs2esm.test.ts` (3 new tests, all fail on main). Also 11 other bundler suites (see the notes).
- Self-reviewed: 2 concerns raised, 2 addressed.

### Background
- Lifting turns `exports.foo = x` in a CommonJS file into `var $foo = x` plus an ES export. The namespace object (`exports_lib`) stands in for `module.exports`.
- ``X.name`z` `` passes `X` as `this`, like a method call. ``$name`z` `` passes `undefined`. #41251 makes the linker keep `X.name` as written when the file calls it or tags a template with it.
- `e_template` stores the tag node in `p.template_tag`. `e_dot` and `e_index` compare their own node with it by address. A rewrite that replaces the node must move the marker.

<details><summary>Notes</summary>

Repro (fails on 1.4.3-canary.1+6a92015fc and on main b99371011f). `git tag --contains f31440d21d` lists bun-v1.4.1 and bun-v1.4.2, so both releases have the same code:

```sh
cat > lib.cjs <<'EOF'
exports._helper = function (s) { return "helped:" + s[0]; };
exports.tag = function (s) { return this._helper(s); };
EOF
cat > entry.mjs <<'EOF'
import * as ns from "./lib.cjs";
console.log(ns["tag"]`z`);
EOF
bun build entry.mjs --minify-syntax --outfile out/min.js --target bun && bun out/min.js
# TypeError: undefined is not an object (evaluating 'this._helper')  at $tag
```

`out/min.js` on main holds ``console.log($tag`z`)``. With this change it holds ``console.log(exports_lib.tag`z`)`` and prints `helped:z`.

The marker reaches three consumers, all through `IdentifierOpts::is_template_tag` set in `e_dot`:

- `maybe_rewrite_property_access` (`src/js_parser/fold.rs:271`) for `import * as ns`.
- `record_import_property_use` (`src/js_parser/p.rs:6712`) for a default import.
- `note_commonjs_export_use` (`src/js_parser/p.rs:5955`) for `exports.name` in the lifted file itself.

Each new test covers one consumer. Each test also has the computed method call (`X["parse"]("y")`), which already worked, so both markers are covered under `minifySyntax`. The name `tag` appears only in computed form in each entry, because one marked use of a name keeps every `X.name` of that file as written and would hide the fault.

The second rewrite (`ns["ta" + "g"]`, or an inlined TypeScript enum key) does not go through `maybe_rewrite_property_access` at all. It prints ``exports_lib.tag`z` `` on main and with this change. In esbuild that rewrite happens after `maybeRewritePropertyAccess` and carries no marker.

Checked by hand with `--minify-syntax` and `--minify`, all print `helped:z`: `const ns = await import("./lib.cjs")`, `require("./lib.cjs")["tag"]`, `const ns = require("./lib.cjs")`, `import * as ns` through an `export *` barrel, and `import { default as st }`.

Sites this change leaves alone:

- Other folds check only for a call target, not for a template tag: the comma fold in `e_binary`, the ternary fold in `e_if`, and the `[x][0]` fold in `e_index`. They turn ``(0, o.f)`x` `` into ``o.f`x` ``. That is the opposite fault (the tag gains a receiver). It also reaches plain `bun run`: ``(0, o.f)`x` `` sees `this === o` there, and `undefined` in node. #42452 (section 4) tracks them.
- #40829 (open, conflicts with main) is the candidate fix for those folds. Its diff has the same three lines as this change, as one hunk of 26 files. It predates #41251. If this change lands first, #40829 drops that hunk on its rebase.
- #42402 (open) changes `has_value_for_this_in_call` at the fold sites. It does not touch this rewrite or `p.template_tag`.

The star import test matches the receiver with `\w+` and does not pin `exports_lib`, because #41820 (open) gives `import *` of a lifted module a namespace object of its own, with another name. The default import test and the self test pin the exact output.

Suites run on the debug build: `bundler_cjs2esm`, `bundler_minify`, `bundler_cjs`, `bundler_edgecase`, `bundler_dynamic_import_dce`, `esbuild/default`, `esbuild/dce`, `esbuild/importstar`, `esbuild/importstar_ts`, `esbuild/ts`, `transpiler/transpiler`, `transpiler/macro-test`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
ninja: Entering directory `/workspace/bun/build/debug'
[1/66] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/66] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 9 classes from /workspace/bun/src
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [29.67ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [13.37ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [14.05ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [12.90ms]
(pass) bundler > cjs2esm/ExportsFunction [12.86ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [14.55ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [14.10ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [14.87ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [12.71ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [11.37ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [12.24ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [14.95ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [15.54ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [11.08ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [14.33ms]
(pass) bundler > cjs2esm/Unwrap
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.3 (6a92015fc)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [956.60ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [435.19ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [376.00ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [410.55ms]
(pass) bundler > cjs2esm/ExportsFunction [350.96ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [570.76ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [366.45ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [483.54ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [421.50ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [435.10ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [423.59ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [613.50ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [603
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 739ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/61] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/61] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/61] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/visit/visit_expr.rs    |  3 ++
 test/bundler/bundler_cjs2esm.test.ts | 62 ++++++++++++++++++++++++++++++++++++
 2 files changed, 65 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/js_parser/visit/visit_expr.rs         3      1     12
test/bundler/bundler_cjs2esm.test.ts      3      4     12
```

</details>

<!-- robobun:evidence:end -->