### PR TITLE
sliceAnsi: keep the truncated string within the range when a wide cluster straddles the ellipsis cut

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -905,7 +905,10 @@ declare module "bun" {
      * insert this string at the cut edge(s). The ellipsis is counted against
      * the visible-width budget and is emitted *inside* any active SGR styles
      * (color, bold, etc.) so it inherits them, but *outside* any active OSC 8
-     * hyperlink.
+     * hyperlink. If the ellipsis itself fits the range, the result is never
+     * wider than the range: a wide character that does not fit in the columns
+     * left beside the ellipsis is dropped. (A plain slice without `ellipsis`
+     * keeps a wide character that starts before `end`.)
      *
      * This turns `sliceAnsi` into a drop-in `cli-truncate` replacement:
      * - truncate-end: `sliceAnsi(str, 0, max, { ellipsis: "\u2026" })`

--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -993,16 +993,50 @@ static WTF::String emitSliceStreaming(
     SgrStyleState specStyles;
     bool specHyperlink = false;
     String specHyperlinkClosePrefix, specHyperlinkTerminator;
-    auto enterSpecZone = [&]() {
-        if (inSpecZone) return;
-        inSpecZone = true;
-        specZoneMark = result.length();
+    auto snapshotStyles = [&]() {
         specStyles = activeStyles;
         specHyperlink = activeHyperlink;
         specHyperlinkClosePrefix = activeHyperlinkClosePrefix;
         specHyperlinkTerminator = activeHyperlinkTerminator;
     };
+    auto enterSpecZone = [&]() {
+        if (inSpecZone) return;
+        inSpecZone = true;
+        specZoneMark = result.length();
+        snapshotStyles();
+    };
     const size_t specEnd = (ellipsisEndBudget > 0) ? end + ellipsisEndBudget : end;
+
+    // With an ellipsis in the output the content has to END by `contentEnd`,
+    // or the result is wider than the requested range. A cluster's width is
+    // known only once it is complete (joiners, VS16, conjuncts), so the fit
+    // is checked after that width lands in `position`: a cluster that started
+    // before `end` but extends past `contentEnd` opens the zone at its own
+    // start, on every path. It is discarded with a cut and kept when the
+    // whole string fits. The check can only fire once `position >= end`, so
+    // the walk up to there pays one store per cluster (clusterMark).
+    const bool clusterMustFit = needStartEllipsis || needEndEllipsis;
+    // `end`, plus the columns a wide cluster straddling `start` left unused.
+    size_t contentEnd = end;
+    unsigned clusterMark = 0; // result.length() before the open cluster's first codepoint
+    // clusterMark of the cluster whose snapshot (taken before ANSI inside it was applied) is in spec*.
+    unsigned stylesSavedForCluster = std::numeric_limits<unsigned>::max();
+    // Call while `gs` still holds the cluster whose width was just added.
+    auto checkClusterFit = [&]() {
+        if (!clusterMustFit || !include || inSpecZone) return;
+        if (position > contentEnd && position - gs.width() < end) {
+            inSpecZone = true;
+            specZoneMark = clusterMark;
+            if (stylesSavedForCluster != clusterMark) snapshotStyles();
+        }
+    };
+    auto beginInclude = [&]() {
+        include = true;
+        if (!endUnbounded) contentEnd = end + (position - start);
+        activeStyles.emitOpenCodes(result);
+        if (needStartEllipsis) result.append(ellipsis);
+        if (activeHyperlink) result.append(activeHyperlinkCode);
+    };
 
     // ------------------------------------------------------------------------
     // ASCII prefix fast-forward: every char is width 1, no ANSI, always a
@@ -1044,36 +1078,36 @@ static WTF::String emitSliceStreaming(
         if (shouldBreak) {
             if (hasPrev) position += gs.width();
 
-            if (!endUnbounded && position >= specEnd) {
-                // A visible cut needs width past specEnd: the prior cluster
-                // overflowed, or this cp is visible. A zero-width cp exactly at
-                // specEnd (LF/CR/ZWSP) is not a cut; keep scanning, don't emit.
-                // Without an ellipsis the distinction is unobservable, so break
-                // immediately and keep the O(slice-length) scan bound.
-                if (ellipsisWidth == 0 || position > specEnd
-                    || Bun__codepointWidth(cp, ambiguousIsWide) > 0) {
-                    sawCutEnd = true;
-                    flushPending(/*filterCloseOnly=*/true);
-                    return false; // signal break
+            if (!endUnbounded && position >= end) {
+                if (hasPrev) checkClusterFit();
+                if (position >= specEnd) {
+                    // A visible cut needs width past specEnd: the prior cluster
+                    // overflowed, or this cp is visible. A zero-width cp exactly at
+                    // specEnd (LF/CR/ZWSP) is not a cut; keep scanning, don't emit.
+                    // Without an ellipsis the distinction is unobservable, so break
+                    // immediately and keep the O(slice-length) scan bound.
+                    if (ellipsisWidth == 0 || position > specEnd
+                        || Bun__codepointWidth(cp, ambiguousIsWide) > 0) {
+                        sawCutEnd = true;
+                        flushPending(/*filterCloseOnly=*/true);
+                        return false; // signal break
+                    }
+                    pastSpecEnd = true;
+                    gs.reset(cp, ambiguousIsWide);
+                    prevVisCp = cp;
+                    hasPrev = true;
+                    p += charLen;
+                    return true;
                 }
-                pastSpecEnd = true;
-                gs.reset(cp, ambiguousIsWide);
-                prevVisCp = cp;
-                hasPrev = true;
-                p += charLen;
-                return true;
             }
 
-            if (!include && position >= start) {
-                include = true;
-                activeStyles.emitOpenCodes(result);
-                if (needStartEllipsis) result.append(ellipsis);
-                if (activeHyperlink) result.append(activeHyperlinkCode);
-            }
+            if (!include && position >= start)
+                beginInclude();
             if (include) {
                 flushPending(/*filterCloseOnly=*/false);
                 if (!endUnbounded && position >= end && ellipsisEndBudget > 0)
                     enterSpecZone();
+                clusterMark = result.length();
                 result.append(std::span { p, charLen });
             } else {
                 pending.clear();
@@ -1083,7 +1117,13 @@ static WTF::String emitSliceStreaming(
         } else {
             // JOIN: continuation, position unchanged. Pending is inside cluster.
             if (include && !pastSpecEnd) {
-                flushPending(/*filterCloseOnly=*/false);
+                if (!pending.isEmpty()) {
+                    if (clusterMustFit && !inSpecZone && stylesSavedForCluster != clusterMark) {
+                        snapshotStyles();
+                        stylesSavedForCluster = clusterMark;
+                    }
+                    flushPending(/*filterCloseOnly=*/false);
+                }
                 result.append(std::span { p, charLen });
             } else if (!include) {
                 pending.clear();
@@ -1158,10 +1198,13 @@ static WTF::String emitSliceStreaming(
                 if (hasPrev) {
                     position += gs.width();
                     hasPrev = false;
-                    if (!endUnbounded && position >= specEnd) {
-                        sawCutEnd = true;
-                        flushPending(/*filterCloseOnly=*/true);
-                        goto walkDone;
+                    if (!endUnbounded && position >= end) {
+                        checkClusterFit();
+                        if (position >= specEnd) {
+                            sawCutEnd = true;
+                            flushPending(/*filterCloseOnly=*/true);
+                            goto walkDone;
+                        }
                     }
                 }
                 // position now = column of the first ASCII char.
@@ -1172,12 +1215,8 @@ static WTF::String emitSliceStreaming(
                     position += skipN;
                     bulkN -= skipN;
                 }
-                if (bulkN > 0 && !include && position >= start) {
-                    include = true;
-                    activeStyles.emitOpenCodes(result);
-                    if (needStartEllipsis) result.append(ellipsis);
-                    if (activeHyperlink) result.append(activeHyperlinkCode);
-                }
+                if (bulkN > 0 && !include && position >= start)
+                    beginInclude();
                 if (bulkN > 0 && include) {
                     flushPending(/*filterCloseOnly=*/false);
                     // How many can we emit before specEnd?
@@ -1285,7 +1324,10 @@ walkDone:;
     // last cluster, i.e. the highest break column the walk reached.
     const size_t lastClusterCol = position;
     if (reachedEOF) {
-        if (hasPrev) position += gs.width();
+        if (hasPrev) {
+            position += gs.width();
+            if (!endUnbounded && position >= end) checkClusterFit();
+        }
         // The last cluster may have overflowed specEnd (wide char straddling
         // the boundary, or a Prepend-led cluster that started zero-width).
         if (!endUnbounded && position > specEnd) sawCutEnd = true;
@@ -1305,23 +1347,21 @@ walkDone:;
     // Resolve the lazy cutEnd BEFORE trailing pending ANSI so close codes
     // land after the last spec-zone column, not before it.
     bool discardedZone = false;
-    if (ellipsisEndBudget > 0) {
-        if (sawCutEnd) {
-            // Cut confirmed: discard spec-zone content and restore the style
-            // state from the zone boundary, so the ellipsis and close codes
-            // below reflect only what remains in result.
-            if (inSpecZone) {
-                result.shrink(specZoneMark);
-                activeStyles = std::move(specStyles);
-                activeHyperlink = specHyperlink;
-                activeHyperlinkClosePrefix = std::move(specHyperlinkClosePrefix);
-                activeHyperlinkTerminator = std::move(specHyperlinkTerminator);
-                discardedZone = true;
-            }
-        } else {
-            // No cut: spec-zone content is already in result. Cancel ellipsis.
-            needEndEllipsis = false;
+    if (sawCutEnd) {
+        // Cut confirmed: discard spec-zone content and restore the style
+        // state from the zone boundary, so the ellipsis and close codes
+        // below reflect only what remains in result.
+        if (inSpecZone) {
+            result.shrink(specZoneMark);
+            activeStyles = std::move(specStyles);
+            activeHyperlink = specHyperlink;
+            activeHyperlinkClosePrefix = std::move(specHyperlinkClosePrefix);
+            activeHyperlinkTerminator = std::move(specHyperlinkTerminator);
+            discardedZone = true;
         }
+    } else if (ellipsisEndBudget > 0) {
+        // No cut: spec-zone content is already in result. Cancel ellipsis.
+        needEndEllipsis = false;
     }
 
     // Trailing ANSI: close-only when the last column reached the user's

--- a/src/jsc/bindings/sliceAnsi.cpp
+++ b/src/jsc/bindings/sliceAnsi.cpp
@@ -1007,32 +1007,20 @@ static WTF::String emitSliceStreaming(
     };
     const size_t specEnd = (ellipsisEndBudget > 0) ? end + ellipsisEndBudget : end;
 
-    // With an ellipsis in the output the content has to END by `contentEnd`,
-    // or the result is wider than the requested range. A cluster's width is
-    // known only once it is complete (joiners, VS16, conjuncts), so the fit
-    // is checked after that width lands in `position`: a cluster that started
-    // before `end` but extends past `contentEnd` opens the zone at its own
-    // start, on every path. It is discarded with a cut and kept when the
-    // whole string fits. The check can only fire once `position >= end`, so
-    // the walk up to there pays one store per cluster (clusterMark).
-    const bool clusterMustFit = needStartEllipsis || needEndEllipsis;
-    // `end`, plus the columns a wide cluster straddling `start` left unused.
-    size_t contentEnd = end;
+    // With an ellipsis, a kept cluster that ends past `contentEnd` makes the result too wide: it opens the zone at its own start.
+    const bool clusterMustFit = (needStartEllipsis || needEndEllipsis) && !endUnbounded;
+    size_t contentEnd = SIZE_MAX; // set with the first kept cluster: `end`, plus the columns a cluster straddling `start` left unused
     unsigned clusterMark = 0; // result.length() before the open cluster's first codepoint
-    // clusterMark of the cluster whose snapshot (taken before ANSI inside it was applied) is in spec*.
-    unsigned stylesSavedForCluster = std::numeric_limits<unsigned>::max();
-    // Call while `gs` still holds the cluster whose width was just added.
-    auto checkClusterFit = [&]() {
-        if (!clusterMustFit || !include || inSpecZone) return;
-        if (position > contentEnd && position - gs.width() < end) {
-            inSpecZone = true;
-            specZoneMark = clusterMark;
-            if (stylesSavedForCluster != clusterMark) snapshotStyles();
-        }
+    unsigned stylesSavedForCluster = std::numeric_limits<unsigned>::max(); // clusterMark whose pre-ANSI snapshot is in spec*
+    auto checkClusterFit = [&]() { // `position` just passed `contentEnd`; `gs` still holds the cluster that did it
+        if (inSpecZone || position - gs.width() >= end) return;
+        inSpecZone = true;
+        specZoneMark = clusterMark;
+        if (stylesSavedForCluster != clusterMark) snapshotStyles();
     };
     auto beginInclude = [&]() {
         include = true;
-        if (!endUnbounded) contentEnd = end + (position - start);
+        if (clusterMustFit) contentEnd = end + (position - start);
         activeStyles.emitOpenCodes(result);
         if (needStartEllipsis) result.append(ellipsis);
         if (activeHyperlink) result.append(activeHyperlinkCode);
@@ -1076,29 +1064,29 @@ static WTF::String emitSliceStreaming(
             shouldBreak = Bun__graphemeBreak(prevVisCp, cp, &breakState);
 
         if (shouldBreak) {
-            if (hasPrev) position += gs.width();
+            if (hasPrev) {
+                position += gs.width();
+                if (position > contentEnd) checkClusterFit();
+            }
 
-            if (!endUnbounded && position >= end) {
-                if (hasPrev) checkClusterFit();
-                if (position >= specEnd) {
-                    // A visible cut needs width past specEnd: the prior cluster
-                    // overflowed, or this cp is visible. A zero-width cp exactly at
-                    // specEnd (LF/CR/ZWSP) is not a cut; keep scanning, don't emit.
-                    // Without an ellipsis the distinction is unobservable, so break
-                    // immediately and keep the O(slice-length) scan bound.
-                    if (ellipsisWidth == 0 || position > specEnd
-                        || Bun__codepointWidth(cp, ambiguousIsWide) > 0) {
-                        sawCutEnd = true;
-                        flushPending(/*filterCloseOnly=*/true);
-                        return false; // signal break
-                    }
-                    pastSpecEnd = true;
-                    gs.reset(cp, ambiguousIsWide);
-                    prevVisCp = cp;
-                    hasPrev = true;
-                    p += charLen;
-                    return true;
+            if (!endUnbounded && position >= specEnd) {
+                // A visible cut needs width past specEnd: the prior cluster
+                // overflowed, or this cp is visible. A zero-width cp exactly at
+                // specEnd (LF/CR/ZWSP) is not a cut; keep scanning, don't emit.
+                // Without an ellipsis the distinction is unobservable, so break
+                // immediately and keep the O(slice-length) scan bound.
+                if (ellipsisWidth == 0 || position > specEnd
+                    || Bun__codepointWidth(cp, ambiguousIsWide) > 0) {
+                    sawCutEnd = true;
+                    flushPending(/*filterCloseOnly=*/true);
+                    return false; // signal break
                 }
+                pastSpecEnd = true;
+                gs.reset(cp, ambiguousIsWide);
+                prevVisCp = cp;
+                hasPrev = true;
+                p += charLen;
+                return true;
             }
 
             if (!include && position >= start)
@@ -1197,14 +1185,12 @@ static WTF::String emitSliceStreaming(
                 // Finalize any pending cluster first (first ASCII is a break).
                 if (hasPrev) {
                     position += gs.width();
+                    if (position > contentEnd) checkClusterFit();
                     hasPrev = false;
-                    if (!endUnbounded && position >= end) {
-                        checkClusterFit();
-                        if (position >= specEnd) {
-                            sawCutEnd = true;
-                            flushPending(/*filterCloseOnly=*/true);
-                            goto walkDone;
-                        }
+                    if (!endUnbounded && position >= specEnd) {
+                        sawCutEnd = true;
+                        flushPending(/*filterCloseOnly=*/true);
+                        goto walkDone;
                     }
                 }
                 // position now = column of the first ASCII char.
@@ -1326,7 +1312,7 @@ walkDone:;
     if (reachedEOF) {
         if (hasPrev) {
             position += gs.width();
-            if (!endUnbounded && position >= end) checkClusterFit();
+            if (position > contentEnd) checkClusterFit();
         }
         // The last cluster may have overflowed specEnd (wide char straddling
         // the boundary, or a Prepend-led cluster that started zero-width).
@@ -1347,21 +1333,24 @@ walkDone:;
     // Resolve the lazy cutEnd BEFORE trailing pending ANSI so close codes
     // land after the last spec-zone column, not before it.
     bool discardedZone = false;
-    if (sawCutEnd) {
-        // Cut confirmed: discard spec-zone content and restore the style
-        // state from the zone boundary, so the ellipsis and close codes
-        // below reflect only what remains in result.
-        if (inSpecZone) {
-            result.shrink(specZoneMark);
-            activeStyles = std::move(specStyles);
-            activeHyperlink = specHyperlink;
-            activeHyperlinkClosePrefix = std::move(specHyperlinkClosePrefix);
-            activeHyperlinkTerminator = std::move(specHyperlinkTerminator);
-            discardedZone = true;
+    if (ellipsisEndBudget > 0 || inSpecZone) {
+        if (sawCutEnd) {
+            // Cut confirmed: discard spec-zone content and restore the style
+            // state from the zone boundary, so the ellipsis and close codes
+            // below reflect only what remains in result.
+            if (inSpecZone) {
+                result.shrink(specZoneMark);
+                activeStyles = std::move(specStyles);
+                activeHyperlink = specHyperlink;
+                activeHyperlinkClosePrefix = std::move(specHyperlinkClosePrefix);
+                activeHyperlinkTerminator = std::move(specHyperlinkTerminator);
+                discardedZone = true;
+            }
+        } else {
+            // No cut: spec-zone content is already in result. Cancel ellipsis.
+            ASSERT(ellipsisEndBudget > 0); // without a budget the zone only opens past specEnd, which is a cut
+            needEndEllipsis = false;
         }
-    } else if (ellipsisEndBudget > 0) {
-        // No cut: spec-zone content is already in result. Cancel ellipsis.
-        needEndEllipsis = false;
     }
 
     // Trailing ANSI: close-only when the last column reached the user's

--- a/test/js/bun/util/sliceAnsi-fuzz.test.ts
+++ b/test/js/bun/util/sliceAnsi-fuzz.test.ts
@@ -36,9 +36,10 @@ describe("sliceAnsi invariants", () => {
       const b = a + Math.floor(rng() * (w + 5));
       const out = Bun.sliceAnsi(s, a, b);
       // +1 tolerance: a wide cluster (width 2) whose START is inside the range
-      // is emitted in full even if it extends 1 col past `end`. This matches
-      // upstream slice-ansi semantics (clusters are atomic; a wide char at
-      // the cut boundary either goes in whole or not at all).
+      // is emitted in full even if it extends 1 col past `end`. This is the
+      // slice-ansi <= 8 rule for a plain slice (clusters are atomic; a wide
+      // char at the cut boundary either goes in whole or not at all).
+      // slice-ansi 9 drops that cluster; only the ellipsis path does so here.
       expect(visibleWidth(out)).toBeLessThanOrEqual(Math.max(0, b - a) + 1);
     }
   });
@@ -136,12 +137,32 @@ describe("sliceAnsi invariants", () => {
       const n = Math.floor(rng() * 40) + 1;
       const e = ellipses[Math.floor(rng() * ellipses.length)];
       const out = Bun.sliceAnsi(s, 0, n, e);
-      // +1 tolerance for wide cluster at the cut boundary (same as above).
-      // Also: if ellipsis itself is wider than n (degenerate), it's returned
-      // as-is — output may exceed n by up to ellipsisWidth-1.
+      // The ellipsis is counted against the range: a wide cluster that does
+      // not fit beside it is dropped, so there is no +1 here. An empty
+      // ellipsis is a plain slice and keeps the +1 from above. If the
+      // ellipsis itself is wider than n (degenerate), it's returned as-is.
       const ew = visibleWidth(e);
-      const tolerance = Math.max(1, ew > n ? ew - n : 0);
+      const tolerance = ew === 0 ? 1 : Math.max(0, ew - n);
       expect(visibleWidth(out)).toBeLessThanOrEqual(n + tolerance);
+    }
+  });
+
+  test("ellipsis output width respects budget for any range", () => {
+    const rng = makeRng(0xe112);
+    const ellipses = ["…", "...", ">>", "漢"];
+    for (let i = 0; i < 300; i++) {
+      const s = randomWideString(rng, 2, 24);
+      const w = Bun.stringWidth(s);
+      const e = ellipses[Math.floor(rng() * ellipses.length)];
+      const ew = Bun.stringWidth(e);
+      // A range of at least ew + 1 columns of the string, so the ellipsis fits.
+      if (w < ew + 1) continue;
+      const a = Math.floor(rng() * (w - ew));
+      const b = a + ew + 1 + Math.floor(rng() * (w - a - ew + 1));
+      const budget = Math.min(b, w) - a;
+      expect(Bun.stringWidth(Bun.sliceAnsi(s, a, b, e))).toBeLessThanOrEqual(budget);
+      // Negative indices resolve the same range through the pre-pass.
+      if (b < w) expect(Bun.stringWidth(Bun.sliceAnsi(s, a - w, b - w, e))).toBeLessThanOrEqual(budget);
     }
   });
 });
@@ -475,6 +496,31 @@ function randomAnsiAscii(rng: () => number, minLen: number, maxLen: number): str
   return pieces.join("");
 }
 
+// Dense in wide clusters (CJK, emoji, ZWJ sequence, flag, skin tone, a width-3
+// conjunct) with some ASCII and SGR / OSC 8 codes between them, so most cut
+// columns land inside a cluster. Lengths are in pieces, not columns.
+function randomWideString(rng: () => number, minLen: number, maxLen: number): string {
+  const clusters = [
+    "\u{1F469}\u200D\u{1F4BB}",
+    "\u{1F1FA}\u{1F1F8}",
+    "\u{1F44D}\u{1F3FF}",
+    "\u0915\u094D\u0937\u094D\u092E",
+  ];
+  const len = minLen + Math.floor(rng() * (maxLen - minLen + 1));
+  const pieces: string[] = [];
+  for (let i = 0; i < len; i++) {
+    const r = rng();
+    if (r < 0.3) pieces.push(String.fromCharCode(0x21 + Math.floor(rng() * 94)));
+    else if (r < 0.55) pieces.push(String.fromCodePoint(0x4e00 + Math.floor(rng() * 0x5000)));
+    else if (r < 0.65) pieces.push(String.fromCodePoint(0x1f600 + Math.floor(rng() * 50)));
+    else if (r < 0.8) pieces.push(clusters[Math.floor(rng() * clusters.length)]);
+    else if (r < 0.9) pieces.push(`\x1b[${30 + Math.floor(rng() * 10)}m`);
+    else if (r < 0.95) pieces.push(`\x1b]8;;http://e.x/${Math.floor(rng() * 10)}\x07`);
+    else pieces.push("\x1b]8;;\x07");
+  }
+  return pieces.join("");
+}
+
 // ============================================================================
 // Negative-index / computeTotalWidth property tests
 // ============================================================================
@@ -519,8 +565,8 @@ describe("sliceAnsi negative indices", () => {
       const w = Bun.stringWidth(Bun.stripANSI(s));
       // [0, -5) with ellipsis — cutEnd is KNOWN (negative end forces pre-pass).
       const out = Bun.sliceAnsi(s, 0, -5, "\u2026");
-      // Should be at most w-5+1 cols (+1 for wide-at-boundary).
-      expect(visibleWidth(out)).toBeLessThanOrEqual(Math.max(0, w - 5) + 1);
+      // Should be at most w-5 cols: the ellipsis is counted against the range.
+      expect(visibleWidth(out)).toBeLessThanOrEqual(Math.max(0, w - 5));
     }
   });
 });
@@ -677,8 +723,8 @@ describe("sliceAnsi speculative zone", () => {
 
   test("spec zone fuzz: lazy cutEnd never produces invalid width", () => {
     // Property: for random strings with ellipsis and non-negative indices,
-    // width of output is ALWAYS ≤ budget + 1 (atomic wide cluster). The lazy
-    // cutEnd path must never leak spec-zone content into the result.
+    // width of output is ALWAYS ≤ budget. The lazy cutEnd path must never
+    // leak spec-zone content into the result.
     const rng = makeRng(0x5bec);
     for (let i = 0; i < 300; i++) {
       const s = randomAnsiAscii(rng, 5, 80);
@@ -686,7 +732,7 @@ describe("sliceAnsi speculative zone", () => {
       const e = rng() < 0.5 ? "\u2026" : "...";
       const out = Bun.sliceAnsi(s, 0, n, e);
       const ow = Bun.stringWidth(Bun.stripANSI(out));
-      expect(ow).toBeLessThanOrEqual(n + 1);
+      expect(ow).toBeLessThanOrEqual(n);
       // And the output is well-formed ANSI (stripANSI doesn't throw).
       expect(typeof Bun.stripANSI(out)).toBe("string");
     }

--- a/test/js/bun/util/sliceAnsi.test.ts
+++ b/test/js/bun/util/sliceAnsi.test.ts
@@ -1304,7 +1304,7 @@ describe("Bun.sliceAnsi", () => {
       expect(Bun.sliceAnsi(red + "ab漢\x1b[0m", 0, 3, { ellipsis: E })).toBe(red + "ab" + E + reset);
       // A close that lands BEFORE the cut cluster is passed through in
       // order and the ellipsis follows it (matches the known-cutEnd path).
-      expect(Bun.sliceAnsi(red + "ab漢" + reset + "xy", 0, 4, { ellipsis: E })).toBe(red + "ab漢" + reset + E);
+      expect(Bun.sliceAnsi(red + "ab漢" + reset + "xy", 0, 5, { ellipsis: E })).toBe(red + "ab漢" + reset + E);
       // start > 0: start ellipsis budgeted first, same EOF overflow detection.
       expect(Bun.sliceAnsi("xyab漢", 2, 5, { ellipsis: E })).toBe(E + "b" + E);
       expect(Bun.sliceAnsi("xyab漢", 2, 6, { ellipsis: E })).toBe(E + "b漢");
@@ -1327,6 +1327,110 @@ describe("Bun.sliceAnsi", () => {
         Bun.sliceAnsi(red + "ab漢" + reset + "x", 0, -2, { ellipsis: E }),
       );
       expect(Bun.stringWidth(Bun.sliceAnsi("ab漢", 0, 3, { ellipsis: E }))).toBe(3);
+    });
+
+    test("a cluster that does not fit beside the ellipsis goes with the cut", () => {
+      // The ellipsis is counted against the range, so the content has to end
+      // by `end - width(ellipsis)`. A wide cluster that starts before that
+      // column and extends past it is dropped, as cli-truncate does, and the
+      // result is never wider than the range.
+      expect(Bun.sliceAnsi("安宁哈", 0, 4, { ellipsis: E })).toBe("安" + E);
+      expect(Bun.sliceAnsi("安宁哈", 0, 2, { ellipsis: E })).toBe(E);
+      expect(Bun.sliceAnsi("a安宁哈", 0, 3, { ellipsis: E })).toBe("a" + E);
+      expect(Bun.sliceAnsi("🙂🙂🙂", 0, 4, { ellipsis: E })).toBe("🙂" + E);
+      expect(Bun.sliceAnsi("ab漢xy", 0, 4, { ellipsis: E })).toBe("ab" + E);
+      expect(Bun.sliceAnsi("abc漢xy", 0, 6, { ellipsis: ">>" })).toBe("abc>>");
+      // The dropped cluster is kept when nothing is cut.
+      expect(Bun.sliceAnsi("安宁", 0, 4, { ellipsis: E })).toBe("安宁");
+      expect(Bun.sliceAnsi("a安宁", 0, 5, { ellipsis: E })).toBe("a安宁");
+      expect(Bun.sliceAnsi("a安\n", 0, 3, { ellipsis: E })).toBe("a安");
+      // Negative end (the cut is known up front) agrees.
+      expect(Bun.sliceAnsi("安宁哈", 0, -2, { ellipsis: E })).toBe("安" + E);
+      expect(Bun.sliceAnsi("a漢b", 0, -1, { ellipsis: E })).toBe("a" + E);
+      expect(Bun.sliceAnsi("漢x", 0, -1, { ellipsis: E })).toBe(E);
+      // A conjunct is one cluster that is wider than 2 columns.
+      const conjunct = "\u0915\u094D\u0937\u094D\u092E\u094D\u092F"; // क्ष्म्य, width 4
+      expect(Bun.stringWidth(conjunct)).toBe(4);
+      expect(Bun.sliceAnsi(conjunct + "xyz", 0, 3, { ellipsis: E })).toBe(E);
+      expect(Bun.sliceAnsi(conjunct + "xyz", 0, 5, { ellipsis: E })).toBe(conjunct + E);
+      expect(Bun.sliceAnsi("a" + conjunct, 0, -1, { ellipsis: E })).toBe("a" + E);
+      // Both edges cut.
+      expect(Bun.sliceAnsi("xy安宁", 1, 5, { ellipsis: E })).toBe(E + "安" + E);
+      expect(Bun.sliceAnsi("xy安宁", 1, 6, { ellipsis: E })).toBe(E + "安宁");
+      expect(Bun.sliceAnsi("xy安宁哈", 1, 4, { ellipsis: E })).toBe(E + E);
+      expect(Bun.sliceAnsi("xy安宁哈", 1, -4, { ellipsis: E })).toBe(E + E);
+      // Start ellipsis only (no room for an end ellipsis): same rule at `end`.
+      expect(Bun.sliceAnsi("xy安宁哈", 1, 3, { ellipsis: E })).toBe(E);
+      // A wide cluster dropped at `start` leaves a column the content may use.
+      expect(Bun.sliceAnsi("abc🙂漢,🙂", 1, 9, { ellipsis: "..." })).toBe("...漢...");
+      expect(Bun.sliceAnsi("abc🙂漢,🙂", 1, -1, { ellipsis: "..." })).toBe("...漢...");
+      // Only a cluster that was kept can be dropped. This one starts before
+      // `start`, is not kept, and is wide enough to end past the content end.
+      const wide7 = ["\u0915", "\u0937", "\u092E", "\u092F", "\u0930", "\u0932", "\u0935"].join("\u094D");
+      expect(Bun.stringWidth(wide7)).toBe(7);
+      expect(Bun.sliceAnsi(wide7 + "abcdefgh", 1, 9, { ellipsis: "..." })).toBe("......");
+      // Only a cluster that starts before the content end counts. One that
+      // starts AT that column with a zero-width Prepend (U+0600) and turns
+      // wide when 漢 joins it is a plain cut, as before.
+      expect(Bun.sliceAnsi("ЖЗИ\u0600漢К", 0, -2, { ellipsis: E })).toBe("ЖЗИ" + E);
+      // 8-bit input: U+00A7 is 2 columns under ambiguousIsNarrow: false.
+      expect(Bun.sliceAnsi("a\u00A7\u00A7\u00A7", 0, 3, { ellipsis: ".", ambiguousIsNarrow: false })).toBe("a.");
+      // A run of ASCII after the dropped cluster (bulk path).
+      expect(Bun.sliceAnsi("\x1b[0ma漢bcdefgh", 0, 3, { ellipsis: E })).toBe("a" + E);
+      expect(Bun.sliceAnsi("\x1b[0ma漢bcdefgh", 0, -7, { ellipsis: E })).toBe("a" + E);
+
+      // The ellipsis takes the style that was active where the dropped
+      // cluster started, and ANSI inside or after that cluster goes with it.
+      const red = "\x1b[31m",
+        reset = "\x1b[39m";
+      const coder = "\u{1F469}\u200D\u{1F4BB}"; // 👩‍💻, one cluster, width 2
+      expect(Bun.sliceAnsi(red + "ab漢" + reset + "xy", 0, 4, { ellipsis: E })).toBe(red + "ab" + E + reset);
+      expect(Bun.sliceAnsi("ab" + red + "漢xy" + reset, 0, 4, { ellipsis: E })).toBe("ab" + red + E + reset);
+      expect(Bun.sliceAnsi("ab\u{1F469}" + red + "\u200D\u{1F4BB}xyz", 0, 4, { ellipsis: E })).toBe("ab" + E);
+      expect(Bun.sliceAnsi(red + "ab\u{1F469}" + reset + "\u200D\u{1F4BB}xyz", 0, 4, { ellipsis: E })).toBe(
+        red + "ab" + E + reset,
+      );
+      expect(Bun.sliceAnsi(red + "ab\u{1F469}" + reset + "\u200D\u{1F4BB}xyz", 0, -3, { ellipsis: E })).toBe(
+        red + "ab" + E + reset,
+      );
+      expect(Bun.sliceAnsi("ab\u{1F469}" + red + "\u200D\u{1F4BB}", 0, 4, { ellipsis: E })).toBe(
+        "ab\u{1F469}" + red + "\u200D\u{1F4BB}" + reset,
+      );
+      // Same for an OSC 8 hyperlink that opens or closes inside that cluster.
+      const linkOpen = "\x1b]8;;http://x\x07",
+        linkClose = "\x1b]8;;\x07";
+      expect(Bun.sliceAnsi(linkOpen + "ab" + coder + "xyz" + linkClose, 0, 4, { ellipsis: E })).toBe(
+        linkOpen + "ab" + linkClose + E,
+      );
+      expect(Bun.sliceAnsi("ab\u{1F469}" + linkOpen + "\u200D\u{1F4BB}xyz" + linkClose, 0, 4, { ellipsis: E })).toBe(
+        "ab" + E,
+      );
+      expect(Bun.sliceAnsi(linkOpen + "ab\u{1F469}" + linkClose + "\u200D\u{1F4BB}xyz", 0, 4, { ellipsis: E })).toBe(
+        linkOpen + "ab" + linkClose + E,
+      );
+
+      // The law: when the ellipsis fits the range, the result fits the range.
+      const samples = [
+        "安宁哈世界",
+        "a安宁哈世界",
+        "🙂🙂🙂🙂",
+        "ab" + coder + "漢c" + conjunct + "d",
+        red + "a安b宁c哈" + reset,
+      ];
+      for (const s of samples) {
+        const total = Bun.stringWidth(s);
+        for (const e of [E, "..", "漢"]) {
+          const ew = Bun.stringWidth(e);
+          for (let start = 0; start < total; start++) {
+            for (let end = start + ew + 1; end <= total; end++) {
+              const budget = end - start;
+              expect(Bun.stringWidth(Bun.sliceAnsi(s, start, end, e))).toBeLessThanOrEqual(budget);
+              if (end < total)
+                expect(Bun.stringWidth(Bun.sliceAnsi(s, start, end - total, e))).toBeLessThanOrEqual(budget);
+            }
+          }
+        }
+      }
     });
 
     test("degenerate ranges return the bare ellipsis (matches ASCII fast path)", () => {


### PR DESCRIPTION
### Problem
- `sliceAnsi("安宁哈", 0, 4, "…")` is `"安宁…"`, 5 columns for a range of 4. `bun.d.ts` counts the ellipsis against the budget.
- Cause: `emitSliceStreaming` (`src/jsc/bindings/sliceAnsi.cpp`) keeps a cluster when its START column is before `end - width(ellipsis)`, the slice-ansi 8 / cli-truncate 5 rule. Upstream got the same report (sindresorhus/cli-truncate#28) and changed the rule in slice-ansi 9.0.0. cli-truncate 6.1.1 returns `"安…"`.

### Fix
- With an ellipsis in the output, a cluster that extends past the content end becomes tentative output from its own start. A confirmed cut removes it. No cut keeps it: `sliceAnsi("安宁", 0, 4, "…")` is still `"安宁"`.
- A plain slice does not change. Of 180,000 generated cases against 1.4.3-canary, 9,970 changed. All were over budget before, 0 are now.
- One existing expectation encoded the overflow: `sliceAnsi(red + "ab漢" + reset + "xy", 0, 4, "…")` expected 5 columns. It moved to `(0, 5)`.
- Verified: `test/js/bun/util/sliceAnsi.test.ts` and `sliceAnsi-fuzz.test.ts` (1.4.3-canary fails 3 tests). Release A/B against main on 30 rows: no measurable change (Notes). Self-reviewed: 3 concerns raised, 3 addressed.

### Background
- A grapheme cluster (CJK character, emoji sequence, Indic conjunct) is atomic and can be 2 or more columns wide.
- The walk is one pass. `position` is the start column of the open cluster. Its width is added when the next cluster starts, because a joiner can still change it.
- The walk does not know up front if the string is cut. It writes columns `[end - ew, end)` as tentative output (the speculative zone) and records a mark. A cut shrinks the result to the mark and appends the ellipsis. No cut keeps the zone.

<details><summary>Notes</summary>

**Before and after** (`W` is `Bun.stringWidth` of the result):

| call | 1.4.3-canary | this PR |
|---|---|---|
| `sliceAnsi("安宁哈", 0, 4, "…")` | `"安宁…"` W 5 | `"安…"` W 3 |
| `sliceAnsi("安宁哈", 0, 2, "…")` | `"安…"` W 3 | `"…"` W 1 |
| `sliceAnsi("a安宁哈", 0, 3, "…")` | `"a安…"` W 4 | `"a…"` W 2 |
| `sliceAnsi("🙂🙂🙂", 0, 4, "…")` | `"🙂🙂…"` W 5 | `"🙂…"` W 3 |
| `sliceAnsi("安宁哈", 0, -2, "…")` | `"安宁…"` W 5 | `"安…"` W 3 |
| `sliceAnsi("क्ष्म्य" + "xyz", 0, 2, "…")` | `"क्ष्म्य…"` W 5 | `"…"` W 1 |
| `sliceAnsi("安宁", 0, 4, "…")` | `"安宁"` | `"安宁"` |
| `sliceAnsi("安宁哈", 0, 3)` (no ellipsis) | `"安宁"` | `"安宁"` |

**Where the old rule came from.** The `+1` was not a slip. `sliceAnsi` follows slice-ansi 8 and cli-truncate 5.1.1 (the pair in `bench/package.json`), where the end of a slice keeps a wide character that starts before the cut, and `sliceAnsi-fuzz.test.ts` recorded that as a `+1` tolerance for the ellipsis case too. cli-truncate 5 had the same overflow and got it as a bug report: sindresorhus/cli-truncate#28. slice-ansi 9.0.0 fixed it as a breaking change ("Make `endSlice` exclude partial wide graphemes"), and cli-truncate 6 uses it. This PR applies that end rule only when an ellipsis is in the output, because that is where `bun.d.ts` promises a width budget and names cli-truncate.

**Not changed: the plain slice rule.** Without an ellipsis a cluster that starts before `end` is kept whole, so `sliceAnsi("安宁哈", 0, 3)` is `"安宁"`. That has its own tests. slice-ansi 9 returns `"安"`. A move of the plain path to the slice-ansi 9 rule is a separate, breaking decision for a maintainer. The check added here (`checkClusterFit`, `clusterMark`) is what that change would use.

**Not changed: an ellipsis that does not fit the range.** `sliceAnsi("abcdef", 0, 2, "...")` is still `"..."`. The `bun.d.ts` sentence says "if the ellipsis itself fits the range".

**Paths covered.** The lazy path (non-negative `end`, cut detected during the walk), the known-cut path (negative indices, one width pre-pass), and a range that has room only for a start ellipsis all run the same check (`checkClusterFit()`). The mark also snapshots the active SGR and OSC 8 hyperlink state, so the ellipsis and the close codes match what stays in the result.

**Clusters wider than 2.** An Indic conjunct is one cluster and can be 3 or more columns. The check uses the real cluster width, not a fixed window before the cut.

**Slack after a cluster dropped at `start`.** When a wide cluster straddles `start` it is dropped whole, so the first kept cluster starts one column late. The content may end that much later and still fit. `contentEnd = end + (firstKeptColumn - start)` keeps those results as they were: `sliceAnsi("abc🙂漢,🙂", 1, 9, "...")` stays `"...漢..."` (8 columns for a range of 8).

**ANSI inside the dropped cluster.** ANSI does not break a cluster, so `👩 ESC[31m ZWJ 💻` is one cluster with an SGR inside. The zone needs the style state from the start of the cluster. The walk takes that snapshot only when ANSI is flushed inside an open cluster, which is rare.

**Nothing fits between two ellipses.** `sliceAnsi("xy安宁哈", 1, 4, "…")` is now `"……"` (2 columns for a range of 3). Before it was `"…安…"` (4 columns). The lazy path already returned two ellipses when the first candidate cluster starts at the content end.

**Performance.** The fit check is one compare per cluster, `position > contentEnd`, right after the cluster width is added. `contentEnd` stays `SIZE_MAX` unless an ellipsis is in the output and a cluster was kept, so a plain slice never takes the branch. The only other per-cluster cost is one `result.length()` store. A first version ran a five-term condition and two stores for every cluster and was 5 to 15% slower on CJK and emoji rows. Release builds of main and of this branch, same toolchain, one changed translation unit, interleaved runs pinned with `taskset`, 6 rounds, best-of-round minimum and median p10 in ns per call. Rows and fixtures are the Bun side of `bench/snippets/slice-ansi.mjs` plus longer CJK, emoji and Latin-1 rows:

| row | main (ns) | this PR (ns) | delta min | delta p10 |
|---|---:|---:|---:|---:|
| ascii-short [0,20) | 52 | 52 | +0.2% | -1.9% |
| ascii-long [0,1000) | 208 | 217 | +4.4% | +12.2% |
| ansi-short [0,30) | 1333 | 1350 | +1.3% | -4.7% |
| ansi-medium [10,200) | 4140 | 4147 | +0.2% | -0.5% |
| ansi-long [0,2000) | 41000 | 41135 | +0.3% | +1.3% |
| ansi-dense [0,100) | 18770 | 18633 | -0.7% | -0.6% |
| cjk [0,100) | 1245 | 1243 | -0.2% | -1.2% |
| cjk+ansi [0,100) | 1857 | 1867 | +0.5% | -1.1% |
| emoji [0,100) | 2016 | 1998 | -0.9% | -3.1% |
| zwj-family [0,100) | 2631 | 2547 | -3.2% | -4.8% |
| skin-tone [0,100) | 2160 | 2183 | +1.1% | -2.6% |
| combining-marks [0,100) | 2653 | 2637 | -0.6% | -1.8% |
| hyperlinks [0,100) | 1595 | 1589 | -0.4% | -3.8% |
| truncate-end ascii-short | 91 | 89 | -2.1% | -0.9% |
| truncate-end ansi-long | 4695 | 4662 | -0.7% | -1.0% |
| truncate-start ansi-long | 136842 | 134229 | -1.9% | -2.8% |
| truncate-end emoji | 1111 | 1125 | +1.3% | +2.5% |
| truncate no-cut (fits) | 47 | 45 | -6.2% | +4.2% |
| ink-clip (80-col) | 1415 | 1406 | -0.6% | +0.9% |
| cjk-long [0,800) plain | 8429 | 8371 | -0.7% | -1.6% |
| emoji-long [0,400) plain | 7647 | 7735 | +1.2% | -1.3% |
| cjk-long trunc-end 800 | 8503 | 8428 | -0.9% | -1.8% |
| latin1 [0,200) plain | 3467 | 3564 | +2.8% | -0.6% |
| latin1 trunc-end 200 | 3730 | 3800 | +1.9% | +0.2% |
| emoji-long trunc-end 400 | 7713 | 7798 | +1.1% | -0.7% |
| zwj trunc-end 100 | 2699 | 2601 | -3.6% | -3.6% |
| skin-tone trunc-end 100 | 2273 | 2241 | -1.4% | -0.3% |
| combining trunc-end 100 | 2711 | 2684 | -1.0% | +0.1% |
| cjk+ansi trunc-end 100 | 1939 | 1934 | -0.3% | -0.2% |
| cjk trunc-start 100 | 9207 | 9079 | -1.4% | -6.8% |

`ascii-short`, `ascii-long` and `truncate no-cut` take the ASCII fast path, which this PR does not touch, so their deltas (up to +4.4% and -6.2%) show the noise floor of a shared machine. The largest delta on a row that runs the changed code is +2.8% (`latin1 plain`), inside that floor. The ZWJ and combining rows are a little faster because the join branch no longer calls `flushPending` when nothing is pending.

**Differential check.** A script generated 180,000 `(string, start, end, ellipsis, ambiguousIsNarrow)` cases from ASCII, CJK, emoji, ZWJ sequences, flags, conjuncts of width 2 and 3, combining marks, variation selectors, Prepend, zero-width characters, SGR and OSC 8 codes, with non-negative and negative indices. It ran each case on 1.4.3-canary and on this branch. Results: 9,970 changed, all of them over budget before. 0 over budget after. 0 plain-slice results changed. The kept text of each changed result is a prefix of the old kept text. The script skipped 2,198 inputs where `Bun.stringWidth` and `sliceAnsi` disagree on the width of a Prepend-led cluster that carries a variation selector (`stringWidth("\u0600\u53c0\ufe0f")` is 2, `sliceAnsi` counts 0). That mismatch exists on 1.4.3 and is in the area #41525 reworks. The final version in this PR produces byte-identical output to the first version on all 180,000 cases.

**Tests.** The new unit test holds the ledger cases, the no-cut cases, negative indices, a width-4 conjunct, both edges cut, start ellipsis only, the slack case, 8-bit input, the bulk ASCII path, and SGR and OSC 8 inside or after the dropped cluster. It ends with an exhaustive width law over 5 strings, 3 ellipses, every range, both index forms. Mutants of the fit condition (drop the slack term, drop "was kept", drop "starts before the content end", drop "an ellipsis is in the output") each fail at least one test. `sliceAnsi-fuzz.test.ts` loses the `+1` for ellipsis cases and gains a property over wide-dense random strings.

**Self-review.** Concerns: per-cluster cost on the plain path (restructured, table above), the upstream lineage missing from the text (added), the `bun.d.ts` sentence and stale test comments (qualified and updated). One suggestion not taken: a tracking issue for the plain slice rule. It is stated above as an open decision instead.

**Suites run on the debug build:** `sliceAnsi.test.ts`, `sliceAnsi-fuzz.test.ts`, `stringWidth.test.ts`, `wrapAnsi.test.ts`, `stripANSI.test.ts`: 933 pass.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/sliceAnsi-fuzz.test.ts test/js/bun/util/sliceAnsi.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/66] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/66] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/66] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/run
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/bun/util/sliceAnsi-fuzz.test.ts:
(pass) sliceAnsi invariants > output width never exceeds requested range [4.90ms]
(pass) sliceAnsi invariants > slice of stripped equals stripped slice (for 1-width chars) [2.62ms]
(pass) sliceAnsi invariants > adjacent slices cover full visible string [1.48ms]
(pass) sliceAnsi invariants > output is always well-formed UTF-16 [3.37ms]
(pass) sliceAnsi invariants > full slice preserves visible content [1.58ms]
(pass) sliceAnsi invariants > slicing a slice is idempotent on visible content [1.59ms]
141 |       // not fit beside it is dropped, so there is no +1 here. An empty
142 |       // ellipsis is a plain slice and keeps the +1 from above. If the
143 |       // ellipsis itself is wider than n (degenerate), it's returned as-is.
144 |       const ew = visibleWidth(e);
145 |       const tolerance = ew === 0 ? 1 : Math.max(0, ew - n);
146 |       expect(visibleWidth(out)).toBeLessThanOrEqual(n + tolerance);
                                      ^
error: expect(received).toBeLessThanOrEqual(expected)

Expected: <= 31
Received: 32

      at <anonymous> (/workspace/bun/test/js/bun/util/sliceAns
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/util/sliceAnsi-fuzz.test.ts test/js/bun/util/sliceAnsi.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/util/sliceAnsi-fuzz.test.ts:
(pass) sliceAnsi invariants > output width never exceeds requested range [987.30ms]
(pass) sliceAnsi invariants > slice of stripped equals stripped slice (for 1-width chars) [684.28ms]
(pass) sliceAnsi invariants > adjacent slices cover full visible string [359.76ms]
(pass) sliceAnsi invariants > output is always well-formed UTF-16 [888.51ms]
(pass) sliceAnsi invariants > full slice preserves visible content [296.25ms]
(pass) sliceAnsi invariants > slicing a slice is idempotent on visible content [352.06ms]
(pass) sliceAnsi invariants > ellipsis output width respects budget [619.07ms]
(pass) sliceAnsi invariants > ellipsis output width respects budget for any range [416.53ms]
(pass) sliceAnsi adversarial > inputs near SIMD stride boundaries [19.65ms]
(pass) sliceAnsi adversarial > C1 ST at SIMD boundary positions [8.47ms]
(pass) sliceAnsi adversarial > unterminated CSI sequences don't hang or o
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 725ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/60] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/60] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/60] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/bun.d.ts             |   5 +-
 src/jsc/bindings/sliceAnsi.cpp          |  69 +++++++++++++++------
 test/js/bun/util/sliceAnsi-fuzz.test.ts |  70 +++++++++++++++++----
 test/js/bun/util/sliceAnsi.test.ts      | 106 +++++++++++++++++++++++++++++++-
 4 files changed, 216 insertions(+), 34 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
packages/bun-types/bun.d.ts                  1      2     28
src/jsc/bindings/sliceAnsi.cpp               9     18     29
test/js/bun/util/sliceAnsi-fuzz.test.ts      3      6     21
test/js/bun/util/sliceAnsi.test.ts           3      7     26
```

</details>

<!-- robobun:evidence:end -->