### PR TITLE
node:fs: build statfs results with one reachable StatFs class

### DIFF
--- a/src/jsc/bindings/NodeFSStatFSBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatFSBinding.cpp
@@ -22,34 +22,22 @@
 namespace Bun {
 
 class JSStatFSPrototype;
-class JSBigIntStatFSPrototype;
 class JSStatFSConstructor;
-class JSBigIntStatFSConstructor;
 using namespace JSC;
 using namespace WebCore;
 
 JSC_DECLARE_HOST_FUNCTION(callStatFS);
-JSC_DECLARE_HOST_FUNCTION(callBigIntStatFS);
 JSC_DECLARE_HOST_FUNCTION(constructStatFS);
-JSC_DECLARE_HOST_FUNCTION(constructBigIntStatFS);
 
-template<bool isBigInt>
-Structure* getStatFSStructure(Zig::GlobalObject* globalObject)
+// Node has one StatFs class. The number result and the bigint result share it:
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L705-L722
+static Structure* getStatFSStructure(Zig::GlobalObject* globalObject)
 {
-    if (isBigInt) {
-        return globalObject->m_JSStatFSBigIntClassStructure.getInitializedOnMainThread(globalObject);
-    }
-
     return globalObject->m_JSStatFSClassStructure.getInitializedOnMainThread(globalObject);
 }
 
-template<bool isBigInt>
-JSObject* getStatFSConstructor(Zig::GlobalObject* globalObject)
+static JSObject* getStatFSConstructor(Zig::GlobalObject* globalObject)
 {
-    if (isBigInt) {
-        return globalObject->m_JSStatFSBigIntClassStructure.constructorInitializedOnMainThread(globalObject);
-    }
-
     return globalObject->m_JSStatFSClassStructure.constructorInitializedOnMainThread(globalObject);
 }
 
@@ -90,43 +78,6 @@ private:
     void finishCreation(JSC::VM& vm);
 };
 
-class JSBigIntStatFSPrototype final : public JSC::JSNonFinalObject {
-public:
-    using Base = JSC::JSNonFinalObject;
-    static constexpr unsigned StructureFlags = Base::StructureFlags;
-
-    static JSBigIntStatFSPrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
-    {
-        JSBigIntStatFSPrototype* prototype = new (NotNull, Bun::allocatePlainObjectCell(vm, sizeof(JSBigIntStatFSPrototype))) JSBigIntStatFSPrototype(vm, structure);
-        prototype->finishCreation(vm);
-        return prototype;
-    }
-
-    DECLARE_INFO;
-
-    template<typename CellType, JSC::SubspaceAccess>
-    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
-    {
-        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSBigIntStatFSPrototype, Base);
-        return &vm.plainObjectSpace();
-    }
-
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        auto* structure = Bun::createClassStructure(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
-        structure->setMayBePrototype(true);
-        return structure;
-    }
-
-private:
-    JSBigIntStatFSPrototype(JSC::VM& vm, JSC::Structure* structure)
-        : Base(vm, structure)
-    {
-    }
-
-    void finishCreation(JSC::VM& vm);
-};
-
 class JSStatFSConstructor final : public JSC::InternalFunction {
 public:
     using Base = JSC::InternalFunction;
@@ -160,74 +111,16 @@ private:
 
     void finishCreation(JSC::VM& vm, JSC::JSObject* prototype)
     {
-        Base::finishCreation(vm, 0, "StatFs"_s);
+        Base::finishCreation(vm, 8, "StatFs"_s);
         putDirectWithoutTransition(vm, vm.propertyNames->prototype, prototype, JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly);
     }
 };
 
-class JSBigIntStatFSConstructor final : public JSC::InternalFunction {
-public:
-    using Base = JSC::InternalFunction;
-    static constexpr unsigned StructureFlags = Base::StructureFlags;
-
-    static JSBigIntStatFSConstructor* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSObject* prototype)
-    {
-        JSBigIntStatFSConstructor* constructor = new (NotNull, JSC::allocateCell<JSBigIntStatFSConstructor>(vm)) JSBigIntStatFSConstructor(vm, structure);
-        constructor->finishCreation(vm, prototype);
-        return constructor;
-    }
-
-    DECLARE_INFO;
-
-    template<typename CellType, JSC::SubspaceAccess>
-    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
-    {
-        return &vm.internalFunctionSpace();
-    }
-
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return Bun::createClassStructure(vm, globalObject, prototype, JSC::TypeInfo(JSC::InternalFunctionType, StructureFlags), info());
-    }
-
-private:
-    JSBigIntStatFSConstructor(JSC::VM& vm, JSC::Structure* structure)
-        : Base(vm, structure, callBigIntStatFS, constructBigIntStatFS)
-    {
-    }
-
-    void finishCreation(JSC::VM& vm, JSC::JSObject* prototype)
-    {
-        Base::finishCreation(vm, 0, "BigIntStatFs"_s);
-        putDirectWithoutTransition(vm, vm.propertyNames->prototype, prototype, JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly);
-    }
-};
-
-JSC::Structure* createJSStatFSObjectStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+JSC::Structure* createJSStatFSObjectStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSObject* prototype)
 {
-    auto* prototype = JSStatFSPrototype::create(vm, globalObject, JSStatFSPrototype::createStructure(vm, globalObject, globalObject->objectPrototype()));
     auto structure = Bun::createClassStructure(vm, globalObject, prototype, JSC::TypeInfo(JSC::FinalObjectType, 0), JSFinalObject::info(), NonArray, 8);
 
     // Add property transitions for all statfs fields
-    PropertyOffset offset = 0;
-    structure = structure->addPropertyTransition(vm, structure, vm.propertyNames->type, 0, offset);
-    structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "bsize"_s), 0, offset);
-    structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "frsize"_s), 0, offset);
-    structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "blocks"_s), 0, offset);
-    structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "bfree"_s), 0, offset);
-    structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "bavail"_s), 0, offset);
-    structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "files"_s), 0, offset);
-    structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "ffree"_s), 0, offset);
-
-    return structure;
-}
-
-JSC::Structure* createJSBigIntStatFSObjectStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
-{
-    auto prototype = JSBigIntStatFSPrototype::create(vm, globalObject, JSBigIntStatFSPrototype::createStructure(vm, globalObject, globalObject->objectPrototype()));
-    auto structure = Bun::createClassStructure(vm, globalObject, prototype, JSC::TypeInfo(JSC::FinalObjectType, 0), JSFinalObject::info(), NonArray, 8);
-
-    // Add property transitions for all bigint statfs fields
     PropertyOffset offset = 0;
     structure = structure->addPropertyTransition(vm, structure, vm.propertyNames->type, 0, offset);
     structure = structure->addPropertyTransition(vm, structure, JSC::Identifier::fromString(vm, "bsize"_s), 0, offset);
@@ -262,7 +155,7 @@ extern "C" JSC::EncodedJSValue Bun__createJSStatFSObject(Zig::GlobalObject* glob
     JSC::JSValue js_files = JSC::jsNumber(files);
     JSC::JSValue js_ffree = JSC::jsNumber(ffree);
 
-    auto* structure = getStatFSStructure<false>(globalObject);
+    auto* structure = getStatFSStructure(globalObject);
     auto* object = JSC::JSFinalObject::create(vm, structure);
 
     object->putDirectOffset(vm, 0, js_fstype);
@@ -290,7 +183,7 @@ extern "C" JSC::EncodedJSValue Bun__createJSBigIntStatFSObject(Zig::GlobalObject
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* structure = getStatFSStructure<true>(globalObject);
+    auto* structure = getStatFSStructure(globalObject);
     JSC::JSValue js_fstype = JSC::JSBigInt::createFrom(globalObject, fstype);
     RETURN_IF_EXCEPTION(scope, {});
     JSC::JSValue js_bsize = JSC::JSBigInt::createFrom(globalObject, bsize);
@@ -323,57 +216,23 @@ extern "C" JSC::EncodedJSValue Bun__createJSBigIntStatFSObject(Zig::GlobalObject
 }
 
 const JSC::ClassInfo JSStatFSPrototype::s_info = { "StatFs"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSStatFSPrototype) };
-const JSC::ClassInfo JSBigIntStatFSPrototype::s_info = { "BigIntStatFs"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSBigIntStatFSPrototype) };
 const JSC::ClassInfo JSStatFSConstructor::s_info = { "StatFs"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSStatFSConstructor) };
-const JSC::ClassInfo JSBigIntStatFSConstructor::s_info = { "BigIntStatFs"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSBigIntStatFSConstructor) };
 
-template<bool isBigInt>
-inline JSValue callJSStatFSFunction(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
-{
-    auto& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* structure = getStatFSStructure<isBigInt>(defaultGlobalObject(globalObject));
-
-    JSValue type = callFrame->argument(0);
-    JSValue bsize = callFrame->argument(1);
-    JSValue frsize = callFrame->argument(2);
-    JSValue blocks = callFrame->argument(3);
-    JSValue bfree = callFrame->argument(4);
-    JSValue bavail = callFrame->argument(5);
-    JSValue files = callFrame->argument(6);
-    JSValue ffree = callFrame->argument(7);
-
-    auto* object = JSC::JSFinalObject::create(vm, structure);
-
-    object->putDirectOffset(vm, 0, type);
-    object->putDirectOffset(vm, 1, bsize);
-    object->putDirectOffset(vm, 2, frsize);
-    object->putDirectOffset(vm, 3, blocks);
-    object->putDirectOffset(vm, 4, bfree);
-    object->putDirectOffset(vm, 5, bavail);
-    object->putDirectOffset(vm, 6, files);
-    object->putDirectOffset(vm, 7, ffree);
-
-    return object;
-}
-
-template<bool isBigInt>
-inline JSValue constructJSStatFSObject(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
+JSC_DEFINE_HOST_FUNCTION(constructStatFS, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     Zig::GlobalObject* globalObject = defaultGlobalObject(lexicalGlobalObject);
 
-    auto* structure = getStatFSStructure<isBigInt>(globalObject);
-    auto* constructor = getStatFSConstructor<isBigInt>(globalObject);
+    auto* structure = getStatFSStructure(globalObject);
+    auto* constructor = getStatFSConstructor(globalObject);
     JSObject* newTarget = asObject(callFrame->newTarget());
 
     if (constructor != newTarget) {
-        auto* functionGlobalObject = static_cast<Zig::GlobalObject*>(
-            // ShadowRealm functions belong to a different global object.
-            getFunctionRealm(lexicalGlobalObject, newTarget));
+        // ShadowRealm functions belong to a different global object.
+        auto* functionGlobalObject = defaultGlobalObject(getFunctionRealm(lexicalGlobalObject, newTarget));
         RETURN_IF_EXCEPTION(scope, {});
-        structure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, getStatFSStructure<isBigInt>(functionGlobalObject));
+        structure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, getStatFSStructure(functionGlobalObject));
         RETURN_IF_EXCEPTION(scope, {});
     }
 
@@ -396,37 +255,15 @@ inline JSValue constructJSStatFSObject(JSC::JSGlobalObject* lexicalGlobalObject,
     object->putDirect(vm, Identifier::fromString(vm, "files"_s), files, 0);
     object->putDirect(vm, Identifier::fromString(vm, "ffree"_s), ffree, 0);
 
-    return object;
-}
-
-JSC_DEFINE_HOST_FUNCTION(constructStatFS, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
-{
-    return JSValue::encode(constructJSStatFSObject<false>(lexicalGlobalObject, callFrame));
-}
-
-JSC_DEFINE_HOST_FUNCTION(constructBigIntStatFS, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
-{
-    return JSValue::encode(constructJSStatFSObject<true>(lexicalGlobalObject, callFrame));
+    return JSValue::encode(object);
 }
 
 JSC_DEFINE_HOST_FUNCTION(callStatFS, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
-    return JSValue::encode(callJSStatFSFunction<false>(lexicalGlobalObject, callFrame));
-}
-
-JSC_DEFINE_HOST_FUNCTION(callBigIntStatFS, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
-{
-    return JSValue::encode(callJSStatFSFunction<true>(lexicalGlobalObject, callFrame));
-}
-
-extern "C" JSC::EncodedJSValue Bun__JSBigIntStatFSObjectConstructor(Zig::GlobalObject* globalobject)
-{
-    return JSValue::encode(globalobject->m_JSStatFSBigIntClassStructure.constructor(globalobject));
-}
-
-extern "C" JSC::EncodedJSValue Bun__JSStatFSObjectConstructor(Zig::GlobalObject* globalobject)
-{
-    return JSValue::encode(globalobject->m_JSStatFSClassStructure.constructor(globalobject));
+    auto& vm = lexicalGlobalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    throwTypeError(lexicalGlobalObject, scope, "Class constructor StatFs cannot be invoked without 'new'"_s);
+    return {};
 }
 
 void JSStatFSPrototype::finishCreation(VM& vm)
@@ -436,28 +273,11 @@ void JSStatFSPrototype::finishCreation(VM& vm)
     Bun::putToStringTagWithoutTransition(vm, this, info());
 }
 
-void JSBigIntStatFSPrototype::finishCreation(VM& vm)
-{
-    Base::finishCreation(vm);
-    ASSERT(inherits(info()));
-    Bun::putToStringTagWithoutTransition(vm, this, info());
-}
-
 void initJSStatFSClassStructure(JSC::LazyClassStructure::Initializer& init)
 {
     auto* prototype = JSStatFSPrototype::create(init.vm, init.global, JSStatFSPrototype::createStructure(init.vm, init.global, init.global->objectPrototype()));
-    auto* structure = createJSStatFSObjectStructure(init.vm, init.global);
+    auto* structure = createJSStatFSObjectStructure(init.vm, init.global, prototype);
     auto* constructor = JSStatFSConstructor::create(init.vm, JSStatFSConstructor::createStructure(init.vm, init.global, init.global->functionPrototype()), prototype);
-    init.setPrototype(prototype);
-    init.setStructure(structure);
-    init.setConstructor(constructor);
-}
-
-void initJSBigIntStatFSClassStructure(JSC::LazyClassStructure::Initializer& init)
-{
-    auto* prototype = JSBigIntStatFSPrototype::create(init.vm, init.global, JSBigIntStatFSPrototype::createStructure(init.vm, init.global, init.global->objectPrototype()));
-    auto* structure = createJSBigIntStatFSObjectStructure(init.vm, init.global);
-    auto* constructor = JSBigIntStatFSConstructor::create(init.vm, JSBigIntStatFSConstructor::createStructure(init.vm, init.global, init.global->functionPrototype()), prototype);
     init.setPrototype(prototype);
     init.setStructure(structure);
     init.setConstructor(constructor);

--- a/src/jsc/bindings/NodeFSStatFSBinding.h
+++ b/src/jsc/bindings/NodeFSStatFSBinding.h
@@ -3,6 +3,5 @@
 namespace Bun {
 
 void initJSStatFSClassStructure(JSC::LazyClassStructure::Initializer& init);
-void initJSBigIntStatFSClassStructure(JSC::LazyClassStructure::Initializer& init);
 
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2152,9 +2152,6 @@ void GlobalObject::finishCreation(VM& vm)
         { OBJECT_OFFSETOF(GlobalObject, m_JSStatFSClassStructure), [](LazyClassStructure::Initializer& init) {
              Bun::initJSStatFSClassStructure(init);
          } },
-        { OBJECT_OFFSETOF(GlobalObject, m_JSStatFSBigIntClassStructure), [](LazyClassStructure::Initializer& init) {
-             Bun::initJSBigIntStatFSClassStructure(init);
-         } },
         { OBJECT_OFFSETOF(GlobalObject, m_NapiClassStructure), [](LazyClassStructure::Initializer& init) {
              init.setStructure(Zig::NapiClass::createStructure(init.vm, init.global, init.global->functionPrototype()));
          } },

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -547,7 +547,6 @@ public:
     V(public, JSC::LazyClassStructure, m_JSStatsClassStructure)                                              \
     V(public, JSC::LazyClassStructure, m_JSStatsBigIntClassStructure)                                        \
     V(public, JSC::LazyClassStructure, m_JSStatFSClassStructure)                                             \
-    V(public, JSC::LazyClassStructure, m_JSStatFSBigIntClassStructure)                                       \
     V(public, JSC::LazyClassStructure, m_JSDirentClassStructure)                                             \
                                                                                                              \
     V(private, std::unique_ptr<WebCore::JSBuiltinInternalFunctions>, m_builtinInternalFunctions)             \

--- a/src/runtime/node/StatFS.rs
+++ b/src/runtime/node/StatFS.rs
@@ -1,4 +1,4 @@
-//! StatFS and BigIntStatFS classes from node:fs
+//! The `StatFs` class from node:fs. The number result and the bigint result share it.
 
 use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 // On POSIX this is `libc::statfs`; on Windows it's `uv_statfs_t` (the value

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6080,6 +6080,133 @@ it("fs.statfs (callback) should work with bigint", async () => {
   }
 });
 
+// Node builds every statfs result, number or bigint, with one class:
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L705-L722
+describe("StatFs, the class of a fs.statfs result", () => {
+  const fields = { type: 1, bsize: 2, frsize: 3, blocks: 4, bfree: 5, bavail: 6, files: 7, ffree: 8 };
+  const args = Object.values(fields);
+
+  it("is the constructor of the result of every statfs function", async () => {
+    const results = {
+      "statfsSync": statfsSync(import.meta.path),
+      "statfsSync bigint": statfsSync(import.meta.path, { bigint: true }),
+      "statfs": await promisify(fs.statfs)(import.meta.path),
+      "statfs bigint": await promisify(fs.statfs)(import.meta.path, { bigint: true }),
+      "promises.statfs": await fs.promises.statfs(import.meta.path),
+      "promises.statfs bigint": await fs.promises.statfs(import.meta.path, { bigint: true }),
+    };
+    const StatFs = results.statfsSync.constructor;
+
+    expect({ name: StatFs.name, length: StatFs.length }).toEqual({ name: "StatFs", length: 8 });
+    expect(Object.getOwnPropertyDescriptor(StatFs.prototype, "constructor")).toEqual({
+      value: StatFs,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+
+    const observed = Object.entries(results).map(([from, result]) => ({
+      from,
+      constructor: result.constructor === StatFs,
+      prototype: Object.getPrototypeOf(result) === StatFs.prototype,
+      instanceof: result instanceof StatFs,
+      label: inspect(result).slice(0, inspect(result).indexOf("{") + 1),
+    }));
+    expect(observed).toEqual(
+      Object.keys(results).map(from => ({
+        from,
+        constructor: true,
+        prototype: true,
+        instanceof: true,
+        label: "StatFs {",
+      })),
+    );
+  });
+
+  it("builds an object with the eight fields", () => {
+    const StatFs = statfsSync(import.meta.path).constructor as new (...args: unknown[]) => Record<string, unknown>;
+
+    const constructed = new StatFs(...args);
+    expect(Object.getPrototypeOf(constructed)).toBe(StatFs.prototype);
+    expect(Object.entries(constructed)).toEqual(Object.entries(fields));
+
+    expect(Object.entries(new StatFs())).toEqual(Object.keys(fields).map(key => [key, undefined]));
+
+    // @ts-expect-error
+    expect(() => StatFs(...args)).toThrow(new TypeError("Class constructor StatFs cannot be invoked without 'new'"));
+  });
+
+  it("gives a subclass instance and a Reflect.construct result the prototype of newTarget", () => {
+    const StatFs = statfsSync(import.meta.path).constructor as new (...args: unknown[]) => Record<string, unknown>;
+
+    class Sub extends StatFs {
+      get custom() {
+        return 42;
+      }
+    }
+    const sub = new Sub(...args);
+    expect(Object.getPrototypeOf(sub)).toBe(Sub.prototype);
+    expect(sub).toBeInstanceOf(StatFs);
+    expect({ ...sub, custom: sub.custom }).toEqual({ ...fields, custom: 42 });
+
+    function F() {}
+    const reflected = Reflect.construct(StatFs, args, F);
+    expect(Object.getPrototypeOf(reflected)).toBe(F.prototype);
+    expect({ ...reflected }).toEqual(fields);
+  });
+
+  // The realm of a function defined in a context is the context's global object. That is not
+  // the Bun global that holds the StatFs structure.
+  it("accepts a newTarget that belongs to a node:vm context", async () => {
+    const script = /*js*/ `
+      const vm = require("node:vm");
+      const StatFs = require("node:fs").statfsSync(".").constructor;
+      const args = ${JSON.stringify(args)};
+      const context = vm.createContext({ StatFs, args });
+      const [S, s] = vm.runInContext(
+        "class S extends StatFs { get custom() { return 42; } }; [S, new S(...args)]",
+        context,
+      );
+      const result = {
+        "class extends": {
+          prototype: Object.getPrototypeOf(s) === S.prototype,
+          instanceof: s instanceof StatFs,
+          ffree: s.ffree,
+          custom: s.custom,
+        },
+      };
+      // A bound function has no "prototype", so the object gets the prototype of the constructor.
+      for (const source of ["(function F() {})", "(function F() {}).bind(null)", "new Proxy(function F() {}, {})"]) {
+        const newTarget = vm.runInContext(source, context);
+        const object = Reflect.construct(StatFs, args, newTarget);
+        result[source] = {
+          prototype: Object.getPrototypeOf(object) === (newTarget.prototype ?? StatFs.prototype),
+          ffree: object.ffree,
+        };
+      }
+      console.log(JSON.stringify(result));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: JSON.stringify({
+        "class extends": { prototype: true, instanceof: true, ffree: 8, custom: 42 },
+        "(function F() {})": { prototype: true, ffree: 8 },
+        "(function F() {}).bind(null)": { prototype: true, ffree: 8 },
+        "new Proxy(function F() {}, {})": { prototype: true, ffree: 8 },
+      }),
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+});
+
 // Regression for oven-sh/bun#31510: the non-bigint statfs path stored block
 // counts as i32, so values above i32::MAX (e.g. `bavail` on a filesystem past
 // ~8 TiB) wrapped negative. We can't mount a multi-TiB filesystem in CI, so we


### PR DESCRIPTION
### Problem

- `fs.statfsSync(".").constructor` is `Object`. Node returns the `StatFs` class. `util.inspect` prints `Object [StatFs] {` where Node prints `StatFs {`. No JS code can reach the `StatFs` constructor.
- Cause: `createJSStatFSObjectStructure` (`src/jsc/bindings/NodeFSStatFSBinding.cpp:206`) creates its own prototype for the result structure. `initJSStatFSClassStructure` (line 446) creates a second prototype and gives it to the constructor. The `BigIntStatFs` twin does the same (lines 225, 455).

### Fix

- `initJSStatFSClassStructure` builds one prototype and passes it to `createJSStatFSObjectStructure`, as `NodeFSStatBinding.cpp` does for `fs.Stats`.
- Remove the `BigIntStatFs` class. Node builds both results with one `StatFs` class ([utils.js#L705-L722](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L705-L722)), so both now share one structure. This also removes `m_JSStatFSBigIntClassStructure` and two exports with no caller.
- The constructor is reachable now. Its `length` is 8 and a call without `new` throws `Class constructor StatFs cannot be invoked without 'new'`, as in Node. It reads the realm of `newTarget` through `defaultGlobalObject`, the same change that #42520 makes and could not test.
- Verified: `test/js/node/fs/fs.test.ts` (4 new tests, all fail on bun 1.4.3). Also all of `fs.test.ts`, `promises.test.js`, Node's `test-fs-statfs.js`. Self-reviewed: 6 concerns raised, 5 addressed here, 1 rejected (it is about `fs.Stats`).

### Background

- A `LazyClassStructure` holds the prototype, the constructor, and the `Structure` (hidden class) of a native class. `setConstructor` writes `constructor` on the prototype it receives.
- A statfs result is a plain `JSFinalObject`. Its class comes only from the prototype that its `Structure` stores.
- `getFunctionRealm` returns the global object that owns a function. For a function from `vm.createContext`, that is a `NodeVMGlobalObject`, not a `Zig::GlobalObject`.

<details><summary>Notes</summary>

Probe, run with `bun probe.js` and `node probe.js`:

```js
const fs = require("fs");
const s = fs.statfsSync("."), b = fs.statfsSync(".", { bigint: true });
console.log(s.constructor.name, b.constructor.name, s.constructor === b.constructor, s.constructor.length);
console.log(Object.getPrototypeOf(s) === s.constructor.prototype, require("util").inspect(b).split(" ")[0]);
try { s.constructor(1); console.log("(no throw)"); } catch (e) { console.log(e.message); }
```

| | line 1 | line 2 | line 3 |
| --- | --- | --- | --- |
| node v26.3.0 | `StatFs StatFs true 8` | `true StatFs` | `Class constructor StatFs cannot be invoked without 'new'` |
| bun 1.2.7 | `StatFs BigIntStatFs false 0` | `true BigIntStatFs` | (no throw) |
| bun 1.2.8 | `Object Object true 1` | `false Object` | (no throw) |
| bun 1.4.3 | `Object Object true 1` | `false Object` | (no throw) |
| this branch | `StatFs StatFs true 8` | `true StatFs` | `Class constructor StatFs cannot be invoked without 'new'` |

History:

- Up to bun 1.2.7, `StatFs` and `BigIntStatFs` were generated classes (`construct: true` in `node.classes.ts`), and the constructor was reachable. #18578 (bun 1.2.8) replaced them with this hand-written binding. The double `JSStatFSPrototype::create` is in that first commit. No issue reports this, so the tests are in `fs.test.ts`.
- `NodeDirent.cpp` has the same two-step shape but reuses `structure->storedPrototypeObject()`, so `Dirent` is correct. No other binding has this defect.

Not changed:

- The prototype keeps its `Symbol.toStringTag`, as do the prototypes of Bun's `Stats`, `BigIntStats` and `Dirent`. Node has no tag there. So `Object.prototype.toString.call(result)` is `[object StatFs]` where Node gives `[object Object]`, and `assert.partialDeepStrictEqual(result, {})` throws where Node passes. This is the same before and after this PR. #42553 tracks it for the four classes.
- `util.inspect(StatFs)` prints `[Function: StatFs]`. Node prints `[class StatFs]`. Bun's other native constructors do the same, for example `fs.Dirent`.
- `fs.StatFs` is `undefined`, as in Node.

Checks:

- Load-bearing check for the `defaultGlobalObject` line: with the old `static_cast` restored on top of the prototype fix, the `node:vm` test fails. The child exits with `Structure.h:415:21: runtime error: member call on null pointer of type 'const JSC::Structure *'`.
- `BUN_JSC_validateExceptionChecks=1` is clean for `new`, a call without `new`, a subclass, `Reflect.construct` with a revoked Proxy, and a Proxy whose `prototype` getter throws.
- A Worker gets its own `StatFs` per global, with the same identity properties.
- The two removed exports are `Bun__JSStatFSObjectConstructor` and `Bun__JSBigIntStatFSObjectConstructor`. #40232 removes the same two. #42520 changes the same `getFunctionRealm` line in the same way. Whichever merges second needs a trivial conflict resolution in this file.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->