### PR TITLE
bun:test: accept a BigInt in toBeWithin

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1698,12 +1698,17 @@ declare module "bun:test" {
     toBeNegative(): void;
 
     /**
-     * Asserts that a value is a number between a start and end value.
+     * Asserts that a value is a `number` or a `bigint` between a start and end value.
+     *
+     * @example
+     * expect(3).toBeWithin(1, 5);
+     * expect(5).not.toBeWithin(1, 5);
+     * expect(3n).toBeWithin(1, 5);
      *
      * @param start the start number (inclusive)
      * @param end the end number (exclusive)
      */
-    toBeWithin(start: number, end: number): void;
+    toBeWithin(start: number | bigint, end: number | bigint): void;
 
     /**
      * Asserts that a value is equal to the expected string, ignoring any whitespace.

--- a/src/runtime/test_runner/expect/toBeWithin.rs
+++ b/src/runtime/test_runner/expect/toBeWithin.rs
@@ -1,6 +1,6 @@
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
-use super::{throw, Expect};
+use super::{throw, Expect, OrderingRelation};
 
 impl Expect {
     #[bun_jsc::host_fn(method)]
@@ -27,26 +27,24 @@ impl Expect {
         let start_value = arguments[0];
         start_value.ensure_still_alive();
 
-        if !start_value.is_number() {
+        if !start_value.is_number() && !start_value.is_big_int() {
             return Err(global.throw(format_args!(
-                "toBeWithin() requires the first argument to be a number"
+                "toBeWithin() requires the first argument to be a number or a bigint"
             )));
         }
 
         let end_value = arguments[1];
         end_value.ensure_still_alive();
 
-        if !end_value.is_number() {
+        if !end_value.is_number() && !end_value.is_big_int() {
             return Err(global.throw(format_args!(
-                "toBeWithin() requires the second argument to be a number"
+                "toBeWithin() requires the second argument to be a number or a bigint"
             )));
         }
 
-        let mut pass = value.is_number();
-        if pass {
-            let num = value.as_number();
-            pass = num >= start_value.as_number() && num < end_value.as_number();
-        }
+        let mut pass = (value.is_number() || value.is_big_int())
+            && OrderingRelation::Ge.holds(global, value, start_value)
+            && OrderingRelation::Lt.holds(global, value, end_value);
 
         if not {
             pass = !pass;

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -339,6 +339,16 @@ pub mod expect {
                 Self::Le => matches!(r, GreaterThan | Equal),
             }
         }
+        /// `a <rel> b`. The caller checked that each side is a Number or a BigInt.
+        pub(super) fn holds(self, global: &JSGlobalObject, a: JSValue, b: JSValue) -> bool {
+            if !a.is_big_int() && !b.is_big_int() {
+                self.cmp_f64(a.as_number(), b.as_number())
+            } else if a.is_big_int() {
+                self.cmp_bigint_fwd(JSValueTestExt::as_big_int_compare(a, b, global))
+            } else {
+                self.cmp_bigint_rev(JSValueTestExt::as_big_int_compare(b, a, global))
+            }
+        }
     }
 
     impl Expect {
@@ -382,13 +392,7 @@ pub mod expect {
             }
 
             let not = this.flags.get().not();
-            let mut pass = if !value.is_big_int() && !other_value.is_big_int() {
-                rel.cmp_f64(value.as_number(), other_value.as_number())
-            } else if value.is_big_int() {
-                rel.cmp_bigint_fwd(JSValueTestExt::as_big_int_compare(value, other_value, global))
-            } else {
-                rel.cmp_bigint_rev(JSValueTestExt::as_big_int_compare(other_value, value, global))
-            };
+            let mut pass = rel.holds(global, value, other_value);
 
             if not { pass = !pass; }
             if pass { return Ok(JSValue::UNDEFINED); }

--- a/test/integration/bun-types/fixture/test.ts
+++ b/test/integration/bun-types/fixture/test.ts
@@ -73,6 +73,8 @@ describe("bun:test", () => {
     expect(Math.PI).toBeGreaterThan(3n);
     expect(Math.PI).toBeGreaterThanOrEqual(3.14);
     expect(Math.PI).toBeGreaterThanOrEqual(3n);
+    expect(Math.PI).toBeWithin(3, 4);
+    expect(3n).toBeWithin(3n, 4);
     expect(NaN).toBeNaN();
     expect(null).toBeNull();
     expect(undefined).toBeUndefined();

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -358,6 +358,25 @@ describe("jest-extended", () => {
     expect(Infinity).not.toBeWithin(-Infinity, Infinity);
   });
 
+  test("toBeWithin() compares a BigInt the way >= and < do", () => {
+    expect(1n).toBeWithin(0, 5);
+    expect(0n).toBeWithin(0, 5);
+    expect(5n).not.toBeWithin(0, 5);
+    expect(-1n).not.toBeWithin(0, 5);
+    expect(4n).toBeWithin(0.5, 4.5);
+    expect(1n).toBeWithin(0n, 5n);
+    expect(1).toBeWithin(0n, 5n);
+    expect(4.5).toBeWithin(0n, 5);
+    expect(5).not.toBeWithin(0, 5n);
+    expect(2n ** 70n).toBeWithin(-Infinity, Infinity);
+    expect(2n ** 70n).toBeWithin(2n ** 70n, 2n ** 70n + 1n);
+    expect(2n ** 70n).not.toBeWithin(0, Number.MAX_SAFE_INTEGER);
+    expect(1n).not.toBeWithin(NaN, 5);
+    expect(NaN).not.toBeWithin(0n, 5n);
+    expect(() => expect(1n).not.toBeWithin(0, 5)).toThrow("toBeWithin");
+    expect(() => expect(5n).toBeWithin(0, 5)).toThrow("toBeWithin");
+  });
+
   test("toBeEven()", () => {
     expect(1).not.toBeEven();
     expect(2).toBeEven();


### PR DESCRIPTION
### Problem
- `expect(1n).toBeWithin(0, 5)` fails with `Expected: between 0 (inclusive) and 5 (exclusive)` / `Received: 1n`. `expect(1).toBeWithin(0n, 5n)` throws `toBeWithin() requires the first argument to be a number`.
- `toBeGreaterThan`, `toBeGreaterThanOrEqual`, `toBeLessThan`, `toBeLessThanOrEqual`, `toBeEven` and `toBeOdd` accept a BigInt. `toBeWithin` is `>=` and `<` together, and it does not.
- The cause is `src/runtime/test_runner/expect/toBeWithin.rs:30-48`. It tests `is_number()` on the value, the start and the end, then compares `f64` values.

### Fix
- `toBeWithin` accepts a number or a BigInt as the value, the start and the end. Another kind of value still fails. Another kind of start or end still throws.
- The comparison is `OrderingRelation::holds`, moved out of `numeric_ordering_matcher` (`src/runtime/test_runner/mod.rs`). `toBeGreaterThan` and its three siblings call the same function, so all five matchers agree on each pair of operands.
- `bun-types`: `toBeWithin(start: number | bigint, end: number | bigint)`.
- Verified: `test/js/bun/test/jest-extended.test.js`. The new block fails on Bun 1.4.3. Also the ordering blocks of `expect.test.js` and the `toBeWithin` argument test in `bun-test.test.ts`.

### Background
- `toBeWithin(start, end)` comes from jest-extended. It passes when `start <= value < end`. jest-extended 4.0.0 computes `actual >= start && actual < end`. 7.0.0 first tests `typeof actual` for `"number"` or `"bigint"`. Both pass a BigInt.
- JavaScript compares a BigInt with a number by mathematical value. `1n < 1.5` is true. A comparison with `NaN` is false.
- `OrderingRelation` names one of `>`, `>=`, `<`, `<=`. `as_big_int_compare` orders a BigInt against a BigInt or a number.

<details><summary>Notes</summary>

- Found by differential testing against jest-extended 4.0.0. No user report.
- Assertions that now pass: `expect(b).toBeWithin(start, end)` where `b` is a BigInt in the range, and each call where `start` or `end` is a BigInt (those threw).
- Assertions that now fail: the `.not` mirror. `expect(1n).not.toBeWithin(0, 5)` passed before, because each BigInt was "not within".
- Not changed: `toBePositive` and `toBeNegative` also reject a BigInt, and jest-extended 7.0.0 accepts one in both. #42494 is open on those two lines, so that change waits for it. `toBeFinite`, `toBeInteger` and `toBeNumber` reject a BigInt in jest-extended too (`Number.isFinite(1n)` is false).
- Not followed: jest-extended 4.0.0 passes `expect("1").toBeWithin(0, 5)`, and `null`, `true` and `[1]`, because `>=` and `<` coerce. 7.0.0 removed that.
- The error text for a bad start or end is now `... to be a number or a bigint`. The test in `bun-test.test.ts` matches the old, shorter text as a substring and still passes.
- The verdict lines of the new test block also pass when `expect.extend(require("jest-extended"))` replaces the native matchers with the 4.0.0 implementations. The two `toThrow` lines check Bun's failure message and cannot run that way. The block passes with `FORCE_COLOR=1`.
- `test/integration/bun-types/bun-types.test.ts` has the same 10 failures with and without this change in my container. The two new fixture lines add no diagnostic.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/jest-extended.test.js
bun test v1.4.3 (6a92015fc)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [11.12ms]
(pass) jest-extended > fail() [9.07ms]
(pass) jest-extended > toBeEmpty() > "" [1.58ms]
(pass) jest-extended > toBeEmpty() > [] [0.31ms]
(pass) jest-extended > toBeEmpty() > {} [0.22ms]
(pass) jest-extended > toBeEmpty() > Set {} [0.18ms]
(pass) jest-extended > toBeEmpty() > Map {} [0.15ms]
(pass) jest-extended > toBeEmpty() > "" [0.17ms]
(pass) jest-extended > toBeEmpty() > [] [0.15ms]
(pass) jest-extended > toBeEmpty() > Uint8Array(0) [] [0.17ms]
(pass) jest-extended > toBeEmpty() > {} [0.21ms]
(pass) jest-extended > toBeEmpty() > <Buffer > [0.17ms]
(pass) jest-extended > toBeEmpty() > Headers {} [0.15ms]
(pass) jest-extended > toBeEmpty() > URLSearchParams {} [0.19ms]
(pass) jest-extended > toBeEmpty() > {} [0.17ms]
(pass) jest-extended > toBeEmpty() > {} [7.36ms]
(pass) jest-extended > toBeEmpty() > FileRef ("/tmp/jest-extended-SL85Gg/empty.txt") {  type: "text/plain;charset=utf-8"} [0.3
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (b761b0007)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [0.17ms]
(pass) jest-extended > fail() [0.08ms]
(pass) jest-extended > toBeEmpty() > "" [0.01ms]
(pass) jest-extended > toBeEmpty() > []
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extended > toBeEmpty() > Set {}
(pass) jest-extended > toBeEmpty() > Map {}
(pass) jest-extended > toBeEmpty() > ""
(pass) jest-extended > toBeEmpty() > []
(pass) jest-extended > toBeEmpty() > Uint8Array(0) []
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extended > toBeEmpty() > <Buffer >
(pass) jest-extended > toBeEmpty() > Headers {}
(pass) jest-extended > toBeEmpty() > URLSearchParams {}
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extended > toBeEmpty() > {} [0.10ms]
(pass) jest-extended > toBeEmpty() > FileRef ("/tmp/jest-extended-nCZDGT/empty.txt") {  type: "text/plain;charset=utf-8"} [0.01ms]
(pass) jest-extended > not.toBeEmpty() > " " [0.02ms]
(pass) jest-extended > not.toBeEmpty() > [ "" ]
(pass) jest-extended > not.toBeEmpty() > [ undefined ]
(pass) jest-extended > not.toBeEmpty() > {  "": "",}
(pass) jest-extended > not.toBeEmpty() > Set(1) {  "",}

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/jest-extended.test.js
bun test v1.4.3 (6a92015fc)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [15.67ms]
(pass) jest-extended > fail() [13.19ms]
(pass) jest-extended > toBeEmpty() > "" [1.65ms]
(pass) jest-extended > toBeEmpty() > [] [0.48ms]
(pass) jest-extended > toBeEmpty() > {} [0.35ms]
(pass) jest-extended > toBeEmpty() > Set {} [0.26ms]
(pass) jest-extended > toBeEmpty() > Map {} [0.86ms]
(pass) jest-extended > toBeEmpty() > "" [0.24ms]
(pass) jest-extended > toBeEmpty() > [] [0.23ms]
(pass) jest-extended > toBeEmpty() > Uint8Array(0) [] [0.25ms]
(pass) jest-extended > toBeEmpty() > {} [0.31ms]
(pass) jest-extended > toBeEmpty() > <Buffer > [0.23ms]
(pass) jest-extended > toBeEmpty() > Headers {} [0.26ms]
(pass) jest-extended > toBeEmpty() > URLSearchParams {} [0.25ms]
(pass) jest-extended > toBeEmpty() > {} [0.25ms]
(pass) jest-extended > toBeEmpty() > {} [10.78ms]
(pass) jest-extended > toBeEmpty() > FileRef ("/tmp/jest-extended-xt9fEW/empty.txt") {  type: "text/plain;charset=utf-8"} [0
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 775ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/src/jsc/bindings/bindings.cpp.o
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/8] gen cpp.rs (cppbind)
[3/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/test.d.ts                 |  9 +++++++--
 src/runtime/test_runner/expect/toBeWithin.rs | 18 ++++++++----------
 src/runtime/test_runner/mod.rs               | 18 +++++++++++-------
 test/integration/bun-types/fixture/test.ts   |  2 ++
 test/js/bun/test/jest-extended.test.js       | 19 +++++++++++++++++++
 5 files changed, 47 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
packages/bun-types/test.d.ts                      1      1     36
src/runtime/test_runner/expect/toBeWithin.rs      0      0     36
src/runtime/test_runner/mod.rs                    1      0     35
test/integration/bun-types/fixture/test.ts        1      2     37
test/js/bun/test/jest-extended.test.js            3      5     34
```

</details>

<!-- robobun:evidence:end -->