### PR TITLE
bun:test: a negative count never matches in toIncludeRepeated

### DIFF
--- a/src/runtime/test_runner/expect/toIncludeRepeated.rs
+++ b/src/runtime/test_runner/expect/toIncludeRepeated.rs
@@ -42,7 +42,7 @@ impl Expect {
             )));
         }
 
-        let count_as_num = count.to_u32();
+        let count_as_num = count.to_int64();
 
         let Some(expect_string) = super::js::captured_value_get_cached(this_value) else {
             return Err(global.throw(format_args!(
@@ -72,7 +72,7 @@ impl Expect {
 
         // Non-overlapping occurrence count.
         let actual_count = bun_core::strings::count(expect_string_as_str, sub_string_as_str);
-        let mut pass = actual_count == count_as_num as usize;
+        let mut pass = usize::try_from(count_as_num) == Ok(actual_count);
 
         if not {
             pass = !pass;

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -610,6 +610,12 @@ describe("jest-extended", () => {
     expect("abc abc abc").toIncludeRepeated("abc", 3);
     expect("abc abc abc").not.toIncludeRepeated("abc", 4);
 
+    // A negative count never matches
+    expect("abc").not.toIncludeRepeated("x", -1);
+    expect("abc").not.toIncludeRepeated("a", -1);
+    expect("").not.toIncludeRepeated("a", -2);
+    expect("abc").not.toIncludeRepeated("x", -(2 ** 32));
+
     // Emojis/Unicode
     expect("😘🥳😤😘🥳").toIncludeRepeated("😘", 2);
     expect("😘🥳😤😘🥳").toIncludeRepeated("🥳", 2);
@@ -635,6 +641,9 @@ describe("jest-extended", () => {
     expect(() => tstErr(Infinity)).toThrow();
     expect(() => tstErr(NaN)).toThrow();
     expect(() => tstErr(-0)).toThrow(); // -0 and below (-1, -2, ...)
+    // These fail the assertion. They are not argument errors.
+    expect(() => tstErr(-1)).toThrow(/Expected (string )?to include/);
+    expect(() => tstErr(-2)).toThrow(/Expected (string )?to include/);
     expect(() => tstErr(null)).toThrow();
     expect(() => tstErr(undefined)).toThrow();
     expect(() => tstErr({})).toThrow();

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -640,8 +640,8 @@ describe("jest-extended", () => {
     expect(() => tstErr(1.23)).toThrow();
     expect(() => tstErr(Infinity)).toThrow();
     expect(() => tstErr(NaN)).toThrow();
-    expect(() => tstErr(-0)).toThrow(); // -0 and below (-1, -2, ...)
-    // These fail the assertion. They are not argument errors.
+    expect(() => tstErr(-0)).toThrow();
+    // -1 and -2 fail the assertion. They are not argument errors.
     expect(() => tstErr(-1)).toThrow(/Expected (string )?to include/);
     expect(() => tstErr(-2)).toThrow(/Expected (string )?to include/);
     expect(() => tstErr(null)).toThrow();


### PR DESCRIPTION
### Problem
- `expect("abc").toIncludeRepeated("x", -1)` passes. Each negative count passes when the substring is absent, and `expect("abc").not.toIncludeRepeated("x", -1)` fails with `Expected to include: "x"`.
- The cause is `src/runtime/test_runner/expect/toIncludeRepeated.rs:45`. The count goes through `to_u32()`, which clamps a negative number to 0 (`src/jsc/JSValue.rs:796`). The matcher then tests for 0 occurrences.

### Fix
- The count is read with `to_int64()`. The argument check before it (`is_any_int()`) only accepts an integer of at most 52 bits, so no value is lost.
- The comparison is `usize::try_from(count) == Ok(actual_count)`. A negative count does not convert, so it never matches. There is no narrowing cast left.
- A negative count fails the assertion. It is not an argument error, so `.not.toIncludeRepeated(s, -1)` passes, as in jest-extended.
- Verified: the `toIncludeRepeated()` block of `test/js/bun/test/jest-extended.test.js` fails on Bun 1.4.3 and passes with this change. Also `test/regression/issue/issue-12276.test.ts`.

### Background
- `toIncludeRepeated(substring, times)` comes from jest-extended. It passes when the string contains the substring exactly `times` times, without overlap.
- jest-extended computes `(actual.match(new RegExp(expected, "g")) || []).length === occurrences`. A length is never negative, so a negative `occurrences` is always a failure.
- `to_u32()` is `to_int64().clamp(0, u32::MAX)`.

<details><summary>Notes</summary>

- Found by differential testing against jest-extended 4.0.0. No user report.
- Assertions that now fail: `expect(s).toIncludeRepeated(x, n)` with `n < 0` and `x` absent from `s`.
- Assertions that now pass: the `.not` mirror of those.
- The existing test had the comment `-0 and below (-1, -2, ...)` next to `expect(() => tstErr(-0)).toThrow()`, but -1 and -2 did not throw. The new lines add them, and the stale comment is gone.
- Not changed: `-0`, a fraction and an integer above 2^51 still throw `requires the second argument to be a number`. jest-extended gives a verdict for them.
- #42503 (open) changes the line above the comparison, so the two PRs conflict in one hunk of `toIncludeRepeated.rs`. Resolution: keep `CodeUnitPair::new(..).count()` from #42503 for `actual_count`, and keep the `usize::try_from` comparison and the `to_int64()` line from this PR. #41241 (open) edits other lines of the file and merges cleanly.
- The four `.not` lines also pass when `expect.extend(require("jest-extended"))` replaces the native matcher with the 4.0.0 implementation. The two `toThrow` lines check the failure message and cannot run that way. All new lines pass with `FORCE_COLOR=1`.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/jest-extended.test.js
bun test v1.4.3 (6a92015fc)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [17.14ms]
(pass) jest-extended > fail() [14.32ms]
(pass) jest-extended > toBeEmpty() > "" [2.47ms]
(pass) jest-extended > toBeEmpty() > [] [0.46ms]
(pass) jest-extended > toBeEmpty() > {} [0.41ms]
(pass) jest-extended > toBeEmpty() > Set {} [0.24ms]
(pass) jest-extended > toBeEmpty() > Map {} [0.24ms]
(pass) jest-extended > toBeEmpty() > "" [0.26ms]
(pass) jest-extended > toBeEmpty() > [] [0.22ms]
(pass) jest-extended > toBeEmpty() > Uint8Array(0) [] [0.22ms]
(pass) jest-extended > toBeEmpty() > {} [0.34ms]
(pass) jest-extended > toBeEmpty() > <Buffer > [0.23ms]
(pass) jest-extended > toBeEmpty() > Headers {} [0.23ms]
(pass) jest-extended > toBeEmpty() > URLSearchParams {} [0.27ms]
(pass) jest-extended > toBeEmpty() > {} [0.26ms]
(pass) jest-extended > toBeEmpty() > {} [11.96ms]
(pass) jest-extended > toBeEmpty() > FileRef ("/tmp/jest-extended-kgiSAa/empty.txt") {  type: "text/plain;charset=utf-8"} [0
... (truncated)

release without fix: 1 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [0.21ms]
(pass) jest-extended > fail() [0.10ms]
(pass) jest-extended > toBeEmpty() > "" [0.01ms]
(pass) jest-extended > toBeEmpty() > []
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extended > toBeEmpty() > Set {}
(pass) jest-extended > toBeEmpty() > Map {}
(pass) jest-extended > toBeEmpty() > ""
(pass) jest-extended > toBeEmpty() > []
(pass) jest-extended > toBeEmpty() > Uint8Array(0) []
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extended > toBeEmpty() > <Buffer >
(pass) jest-extended > toBeEmpty() > Headers {}
(pass) jest-extended > toBeEmpty() > URLSearchParams {}
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extended > toBeEmpty() > {} [0.13ms]
(pass) jest-extended > toBeEmpty() > FileRef ("/tmp/jest-extended-I1BCHB/empty.txt") {  type: "text/plain;charset=utf-8"} [0.02ms]
(pass) jest-extended > not.toBeEmpty() > " " [0.02ms]
(pass) jest-extended > not.toBeEmpty() > [ "" ]
(pass) jest-extended > not.toBeEmpty() > [ undefined ]
(pass) jest-extended > not.toBeEmpty() > {  "": "",}
(pass) jest-extended > not.toBeEmpty() > Set(1) {  "",}

... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/jest-extended.test.js
bun test v1.4.3 (6a92015fc)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [11.48ms]
(pass) jest-extended > fail() [8.56ms]
(pass) jest-extended > toBeEmpty() > "" [1.17ms]
(pass) jest-extended > toBeEmpty() > [] [0.27ms]
(pass) jest-extended > toBeEmpty() > {} [0.28ms]
(pass) jest-extended > toBeEmpty() > Set {} [0.18ms]
(pass) jest-extended > toBeEmpty() > Map {} [0.16ms]
(pass) jest-extended > toBeEmpty() > "" [0.15ms]
(pass) jest-extended > toBeEmpty() > [] [0.16ms]
(pass) jest-extended > toBeEmpty() > Uint8Array(0) [] [0.14ms]
(pass) jest-extended > toBeEmpty() > {} [0.19ms]
(pass) jest-extended > toBeEmpty() > <Buffer > [0.15ms]
(pass) jest-extended > toBeEmpty() > Headers {} [0.17ms]
(pass) jest-extended > toBeEmpty() > URLSearchParams {} [0.16ms]
(pass) jest-extended > toBeEmpty() > {} [0.16ms]
(pass) jest-extended > toBeEmpty() > {} [6.85ms]
(pass) jest-extended > toBeEmpty() > FileRef ("/tmp/jest-extended-Y09mVv/empty.txt") {  type: "text/plain;charset=utf-8"} [0.2
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 804ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 6m 32s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.3-canary.1+59c2a0c82
[build] done
bun test v1.4.3-canary.1 (59c2a0c82)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [0.19ms]
(pass) jest-extended > fail() [0.11ms]
(pass) jest-extended > toBeEmpty() > "" [0.01ms]
(pass) jest-extended > toBeEmpty() > []
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extended > toBeEmpty() > Set {}
(pass) jest-extended > toBeEmpty() > Map {}
(pass) jest-extended > toBeEmpty() > ""
(pass) jest-extended > toBeEmpty() > []
(pass) jest-extended > toBeEmpty() > Uint8Array(0) []
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extend
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/expect/toIncludeRepeated.rs |  4 ++--
 test/js/bun/test/jest-extended.test.js              | 11 ++++++++++-
 2 files changed, 12 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/runtime/test_runner/expect/toIncludeRepeated.rs      0      0     34
test/js/bun/test/jest-extended.test.js                   3      5     34
```

</details>

<!-- robobun:evidence:end -->