### PR TITLE
node:fs: remove Symbol.toStringTag from the Stats, BigIntStats, Dirent and StatFs prototypes

### DIFF
--- a/src/jsc/bindings/NodeDirent.cpp
+++ b/src/jsc/bindings/NodeDirent.cpp
@@ -90,7 +90,6 @@ private:
     {
         Base::finishCreation(vm);
         Bun::reifyStaticPropertyTable(vm, JSDirentPrototype::info(), JSDirentPrototypeTableValues, *this);
-        Bun::putToStringTagWithoutTransition(vm, this, info());
     }
 };
 

--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -413,7 +413,6 @@ private:
         ASSERT(inherits(info()));
 
         Bun::reifyStaticPropertyTable(vm, this->classInfo(), JSStatsPrototypeTableValues, *this);
-        Bun::putToStringTagWithoutTransition(vm, this, info());
     }
 };
 
@@ -457,7 +456,6 @@ private:
         ASSERT(inherits(info()));
 
         Bun::reifyStaticPropertyTable(vm, this->classInfo(), JSBigIntStatsPrototypeTableValues, *this);
-        Bun::putToStringTagWithoutTransition(vm, this, info());
     }
 };
 

--- a/src/jsc/bindings/NodeFSStatFSBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatFSBinding.cpp
@@ -433,14 +433,12 @@ void JSStatFSPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
-    Bun::putToStringTagWithoutTransition(vm, this, info());
 }
 
 void JSBigIntStatFSPrototype::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
-    Bun::putToStringTagWithoutTransition(vm, this, info());
 }
 
 void initJSStatFSClassStructure(JSC::LazyClassStructure::Initializer& init)

--- a/test/js/node/fs/fs-stats-constructor.test.ts
+++ b/test/js/node/fs/fs-stats-constructor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import assert from "node:assert";
-import { readdirSync, Stats, statfsSync, statSync } from "node:fs";
+import { readdirSync, statfsSync, Stats, statSync } from "node:fs";
 import { inspect, isDeepStrictEqual } from "node:util";
 
 // Node.js's Stats constructor signature (deprecated, DEP0180):

--- a/test/js/node/fs/fs-stats-constructor.test.ts
+++ b/test/js/node/fs/fs-stats-constructor.test.ts
@@ -143,6 +143,7 @@ describe("fs result prototypes have no Symbol.toStringTag", () => {
     BigIntStats: statSync(import.meta.path, { bigint: true }),
     Dirent: readdirSync(import.meta.dir, { withFileTypes: true })[0],
     StatFs: statfsSync(import.meta.dir),
+    BigIntStatFs: statfsSync(import.meta.dir, { bigint: true }),
   });
 
   test.each(Object.keys(values()))("%s", name => {

--- a/test/js/node/fs/fs-stats-constructor.test.ts
+++ b/test/js/node/fs/fs-stats-constructor.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
-import { Stats, statSync } from "node:fs";
+import assert from "node:assert";
+import { readdirSync, Stats, statfsSync, statSync } from "node:fs";
+import { inspect, isDeepStrictEqual } from "node:util";
 
 // Node.js's Stats constructor signature (deprecated, DEP0180):
 //   Stats(dev, mode, nlink, uid, gid, rdev, blksize, ino, size, blocks, atimeMs, mtimeMs, ctimeMs, birthtimeMs)
@@ -129,5 +131,43 @@ describe("Stats methods and accessors called without a receiver", () => {
       stderr: "",
       exitCode: 0,
     });
+  });
+});
+
+// Node's Stats, BigIntStats, Dirent and StatFs are plain JS classes. Their prototypes have no
+// Symbol.toStringTag, so Object.prototype.toString gives "[object Object]" and deep-equality
+// code treats an instance like a plain object. Bun's native prototypes used to carry a tag.
+describe("fs result prototypes have no Symbol.toStringTag", () => {
+  const values = () => ({
+    Stats: statSync(import.meta.path),
+    BigIntStats: statSync(import.meta.path, { bigint: true }),
+    Dirent: readdirSync(import.meta.dir, { withFileTypes: true })[0],
+    StatFs: statfsSync(import.meta.dir),
+  });
+
+  test.each(Object.keys(values()))("%s", name => {
+    const value = values()[name as keyof ReturnType<typeof values>];
+    const proto = Object.getPrototypeOf(value);
+    expect({
+      ownTag: Object.hasOwn(proto, Symbol.toStringTag),
+      tag: Symbol.toStringTag in value,
+      toString: Object.prototype.toString.call(value),
+      deepEqualCopy: isDeepStrictEqual(value, { ...value }, true),
+    }).toEqual({
+      ownTag: false,
+      tag: false,
+      toString: "[object Object]",
+      deepEqualCopy: true,
+    });
+    expect(() => assert.partialDeepStrictEqual(value, {})).not.toThrow();
+  });
+
+  test("inspect still prints the class name", () => {
+    const { Stats: stats, BigIntStats: bigint, Dirent: dirent } = values();
+    expect([inspect(stats), inspect(bigint), inspect(dirent)].map(s => s.split(" {")[0])).toEqual([
+      "Stats",
+      "BigIntStats",
+      "Dirent",
+    ]);
   });
 });


### PR DESCRIPTION
### Problem

- The prototypes of `fs.Stats`, `BigIntStats`, `fs.Dirent` and `StatFs` have an own `Symbol.toStringTag`. Node does not set one. So `Object.prototype.toString.call(fs.statSync("."))` is `[object Stats]` in Bun and `[object Object]` in Node.
- Deep-equality code compares that string as the type of a value. `assert.partialDeepStrictEqual(fs.statSync("."), {})` throws `ERR_ASSERTION` in Bun and passes in Node. `util.isDeepStrictEqual(s, { ...s }, true)` with `s = fs.statfsSync(".")` is `false` in Bun and `true` in Node.
- The cause is `Bun::putToStringTagWithoutTransition` in the prototype `finishCreation` of each class: `NodeFSStatBinding.cpp:416` and `:460`, `NodeDirent.cpp:93`, `NodeFSStatFSBinding.cpp:436` and `:443`.

### Fix

- Remove the five calls. The prototypes now have the same own properties as Node's, and the tag is gone from the instances too.
- `util.inspect` and `Bun.inspect` still print `Stats {`, `BigIntStats {` and `Dirent {`. They read the name from `constructor.name`, not from the tag.
- Verified: `test/js/node/fs/fs-stats-constructor.test.ts` (one new describe block, 5 of its 6 tests fail on bun 1.4.3). Also `fs.test.ts`, `dir.test.ts`, and Node's `test-fs-stat.js`, `test-fs-stat-bigint.js`, `test-fs-statfs.js`, `test-fs-readdir-types.js`, `test-fs-opendir.js`.

### Background

- `Symbol.toStringTag` is the well-known symbol that `Object.prototype.toString` reads to build `[object X]`. Built-in classes such as `Map` and `Promise` have one on their prototype. A class written in JS does not, unless the author adds it.
- Node defines `Stats`, `BigIntStats`, `Dirent` and `StatFs` as plain JS classes in `lib/internal/fs/utils.js`. Bun implements them as native classes in `src/jsc/bindings/`.
- `Bun::putToStringTagWithoutTransition` is a helper that writes the `ClassInfo` name as the tag onto a prototype. Most of Bun's native prototypes use it because their Web or Bun counterparts have a tag.

<details><summary>Notes</summary>

Probe, run with `bun probe.js` and `node probe.js`:

```js
const fs = require("node:fs");
const assert = require("node:assert");
const util = require("node:util");
const values = {
  Stats: fs.statSync("."),
  BigIntStats: fs.statSync(".", { bigint: true }),
  Dirent: fs.readdirSync(".", { withFileTypes: true })[0],
  StatFs: fs.statfsSync("."),
};
for (const [name, value] of Object.entries(values)) {
  const proto = Object.getPrototypeOf(value);
  let partial = "passes";
  try { assert.partialDeepStrictEqual(value, {}); } catch (e) { partial = "throws " + e.code; }
  console.log(name, Object.hasOwn(proto, Symbol.toStringTag), Object.prototype.toString.call(value), partial);
}
const s = fs.statfsSync(".");
console.log("isDeepStrictEqual statfs copy:", util.isDeepStrictEqual(s, { ...s }, true));
```

bun 1.4.3 prints `true [object Stats] throws ERR_ASSERTION` (and the same for the other three) and `false`. Node v26.3.0 and this branch print `false [object Object] passes` and `true`.

Inspect output:

- `Stats`, `BigIntStats`, `Dirent`: unchanged, `Stats {`, `BigIntStats {`, `Dirent {`. `JSC__JSValue__getName` in `bindings.cpp` reads `getCalculatedDisplayName` (the constructor name) first and falls back to the tag only when that is empty.
- `StatFs`: bun 1.4.3 prints `Object [StatFs] {`. This branch prints `{`. The fallback no longer finds a tag, and the constructor of a statfs result is `Object` today. #42554 makes the constructor the `StatFs` class, and with it the output is `StatFs {`, as in Node. The two PRs touch the same file and merge in either order with a trivial conflict in `JSStatFSPrototype::finishCreation`.

No test in `test/` asserts `[object Stats]`, `[object Dirent]` or the tag on these prototypes. No `bun:test` snapshot in the repo contains one of these objects.

`test-fs-stat-abort-test.js` fails on main and on this branch for the same reason (a `node:test` option it uses). Not related.

</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/fs/fs-stats-constructor.test.ts
bun test v1.4.3 (b99371011)

test/js/node/fs/fs-stats-constructor.test.ts:
(pass) new Stats(...) assigns fields in Node's order [4.65ms]
(pass) Stats(...) without new assigns fields in Node's order [1.94ms]
(pass) Stats instances share Stats.prototype [8.38ms]
(pass) Stats methods and accessors called without a receiver > a mode method called through a captured binding is treated like an undefined receiver [6.60ms]
(pass) Stats methods and accessors called without a receiver > a date getter called through a captured binding is treated like an undefined receiver [8.43ms]
(pass) Stats methods and accessors called without a receiver > calls through a scope whose `mode` and `atimeMs` bindings are in their TDZ do not crash [501.75ms]
152 |     expect({
153 |       ownTag: Object.hasOwn(proto, Symbol.toStringTag),
154 |       tag: Symbol.toStringTag in value,
155 |       toString: Object.prototype.toString.call(value),
156 |       deepEqualCopy: isDeepStrictEqual(value, { ...value }, true),
157 |  
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (416800aea)

test/js/node/fs/fs-stats-constructor.test.ts:
(pass) new Stats(...) assigns fields in Node's order [0.05ms]
(pass) Stats(...) without new assigns fields in Node's order [0.02ms]
(pass) Stats instances share Stats.prototype [0.08ms]
(pass) Stats methods and accessors called without a receiver > a mode method called through a captured binding is treated like an undefined receiver [0.08ms]
(pass) Stats methods and accessors called without a receiver > a date getter called through a captured binding is treated like an undefined receiver [0.09ms]
(pass) Stats methods and accessors called without a receiver > calls through a scope whose `mode` and `atimeMs` bindings are in their TDZ do not crash [7.89ms]
(pass) fs result prototypes have no Symbol.toStringTag > Stats [0.32ms]
(pass) fs result prototypes have no Symbol.toStringTag > BigIntStats [0.09ms]
(pass) fs result prototypes have no Symbol.toStringTag > Dirent [0.07ms]
(pass) fs result prototypes have no Symbol.toStringTag > StatFs [0.08ms]
(pass) fs result prototypes have no Symbol.toStringTag > BigIntStatFs [0.05ms]
(pass) fs result prototypes have no Symbol.toStringTag > inspec
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/fs/fs-stats-constructor.test.ts
bun test v1.4.3 (b99371011)

test/js/node/fs/fs-stats-constructor.test.ts:
(pass) new Stats(...) assigns fields in Node's order [5.22ms]
(pass) Stats(...) without new assigns fields in Node's order [2.11ms]
(pass) Stats instances share Stats.prototype [8.58ms]
(pass) Stats methods and accessors called without a receiver > a mode method called through a captured binding is treated like an undefined receiver [7.64ms]
(pass) Stats methods and accessors called without a receiver > a date getter called through a captured binding is treated like an undefined receiver [7.44ms]
(pass) Stats methods and accessors called without a receiver > calls through a scope whose `mode` and `atimeMs` bindings are in their TDZ do not crash [452.95ms]
(pass) fs result prototypes have no Symbol.toStringTag > Stats [11.07ms]
(pass) fs result prototypes have no Symbol.toStringTag > BigIntStats [3.30ms]
(pass) fs result prototypes have no Symbol.toStringTag > Dirent [2.54ms]
(pass) fs result prototypes have no Symbol.t
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 658ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 50s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.3-canary.1+88b76467f
[build] done
bun test v1.4.3-canary.1 (88b76467f)

test/js/node/fs/fs-stats-constructor.test.ts:
(pass) new Stats(...) assigns fields in Node's order [0.06ms]
(pass) Stats(...) without new assigns fields in Node's order [0.02ms]
(pass) Stats instances share Stats.prototype [0.09ms]
(pass) Stats methods and accessors called without a receiver > a mode method called through a captured binding is treated like an undefined receiver [0.11ms]
(pass) Stats methods and accessors called without a receiver > a date getter called through a captured binding is treated like an undefined receiver [0.10ms]
(pass) Stats methods and accessors
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeDirent.cpp              |  1 -
 src/jsc/bindings/NodeFSStatBinding.cpp       |  2 --
 src/jsc/bindings/NodeFSStatFSBinding.cpp     |  2 --
 test/js/node/fs/fs-stats-constructor.test.ts | 43 +++++++++++++++++++++++++++-
 4 files changed, 42 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/bindings/NodeDirent.cpp                   0      0      9
src/jsc/bindings/NodeFSStatBinding.cpp            0      0      9
src/jsc/bindings/NodeFSStatFSBinding.cpp          0      0     10
test/js/node/fs/fs-stats-constructor.test.ts      2      3      8
```

</details>

**root cause** · written by the author bot

In Bun the prototypes for Stats, BigIntStats, Dirent and StatFs (and BigIntStatFs) had an own Symbol.toStringTag installed during finishCreation, whereas Node defines them as ordinary JS classes with no tag. That tag changed the output of Object.prototype.toString, so deep-equality helpers such as assert.partialDeepStrictEqual and util.isDeepStrictEqual treated these objects as a different type from plain objects and failed where Node passes. The fix removes the putToStringTagWithoutTransition calls from those prototypes so the objects stringify as [object Object] and compare like Node, wit…

<!-- robobun:evidence:end -->