### PR TITLE
bun:test: toBeEmptyObject rejects a function and an array

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2849,14 +2849,39 @@ impl JSValue {
         JSC__JSValue__isConstructor(self)
     }
 
+    /// `Array.isArray(self)`, but a revoked `Proxy` is `false` instead of a TypeError.
+    pub fn is_array_or_proxied_array(self) -> bool {
+        let mut value = self;
+        while value.is_cell() {
+            let ty = value.js_type();
+            if ty.is_array() {
+                return true;
+            }
+            // `revoke()` clears the handler and keeps the target.
+            if ty != JSType::ProxyObject
+                || value
+                    .get_proxy_internal_field(ProxyField::Handler)
+                    .is_undefined_or_null()
+            {
+                return false;
+            }
+            value = value.get_proxy_internal_field(ProxyField::Target);
+        }
+        false
+    }
+
     // ── Jest "is empty object". ────────────────────────
-    /// `JSValue.isObjectEmpty` — Jest-extended `toBeEmptyObject` semantics:
-    /// Map/Set/RegExp/Date are *not* empty objects; otherwise an object with
-    /// zero own-enumerable keys.
+    /// jest-extended `toBeEmptyObject`: a `jest-get-type` "object" with no own enumerable keys.
     pub fn is_object_empty(self, global: &JSGlobalObject) -> JsResult<bool> {
         let ty = self.js_type();
         // https://github.com/jestjs/jest/blob/main/packages/jest-get-type/src/index.ts#L26
-        if ty.is_map() || ty.is_set() || ty == JSType::RegExpObject || self.is_date() {
+        if self.is_array_or_proxied_array()
+            || self.is_callable()
+            || ty.is_map()
+            || ty.is_set()
+            || ty == JSType::RegExpObject
+            || self.is_date()
+        {
             return Ok(false);
         }
         Ok(ty.is_object() && self.keys(global)?.get_length(global)? == 0)

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3818,7 +3818,7 @@ describe("expect()", () => {
     expect(new Map()).not.toBeEmptyObject();
     expect(new Set()).not.toBeEmptyObject();
     expect(new Set().add("1")).not.toBeEmptyObject();
-    expect([]).toBeEmptyObject();
+    expect([]).not.toBeEmptyObject();
     expect({}).toBeEmptyObject();
     expect([1, 2]).not.toBeEmptyObject();
     expect({ a: "hello" }).not.toBeEmptyObject();
@@ -3844,6 +3844,28 @@ describe("expect()", () => {
 
     // jest-extended return false for RegExp
     expect(/(foo|bar)/g).not.toBeEmptyObject();
+  });
+
+  test("toBeEmptyObject() rejects a function and an array", () => {
+    // jest-get-type reports "function" and "array" for these, not "object".
+    expect(function () {}).not.toBeEmptyObject();
+    expect(() => {}).not.toBeEmptyObject();
+    expect(async () => {}).not.toBeEmptyObject();
+    expect(class {}).not.toBeEmptyObject();
+    expect(Symbol).not.toBeEmptyObject();
+    expect(function () {}.bind(null)).not.toBeEmptyObject();
+    expect(new Proxy(function () {}, {})).not.toBeEmptyObject();
+    expect([]).not.toBeEmptyObject();
+    expect(new Array(3)).not.toBeEmptyObject();
+    expect(new Proxy([], {})).not.toBeEmptyObject();
+    expect(() => expect(function () {}).toBeEmptyObject()).toThrow("toBeEmptyObject");
+    expect(() => expect([]).toBeEmptyObject()).toThrow("toBeEmptyObject");
+
+    expect(Object.create(null)).toBeEmptyObject();
+    expect(new (class {})()).toBeEmptyObject();
+    expect(new Proxy({}, {})).toBeEmptyObject();
+    expect(new Proxy({ a: 1 }, {})).not.toBeEmptyObject();
+    expect(() => expect({}).not.toBeEmptyObject()).toThrow("toBeEmptyObject");
   });
 
   test("toBeNil()", () => {


### PR DESCRIPTION
**To decide on:** this PR turns a pass into a fail. `expect([]).toBeEmptyObject()` and `expect(function () {}).toBeEmptyObject()` pass today, and `expect.test.js` asserted the array case. jest-extended fails both, in 4.0.0 (pinned in `test/package.json`) and in 7.0.0. #42541 asks the same question for `toBeEmpty`.

### Problem
- `expect(function () {}).toBeEmptyObject()`, `expect(class {}).toBeEmptyObject()` and `expect([]).toBeEmptyObject()` pass. A function and an array are not an empty object.
- jest-extended 4.x needs `getType(actual) === "object"` (jest-get-type). 5.x and later need `typeof actual === "object" && !Array.isArray(actual)`. Both fail these values.
- The cause: `is_object_empty` (`src/jsc/JSValue.rs`) copies the jest-get-type exclusions for Map, Set, RegExp and Date only. It accepts every other object cell that has no own enumerable keys.

### Fix
- `is_object_empty` also returns `false` for a callable value (a function, a class, a bound function, a `Proxy` of a function) and for an array or a `Proxy` of an array.
- `JSValue::is_array_or_proxied_array` is the same helper as in #42504, at the same place, so the two PRs merge without a conflict.
- The existing assertion `expect([]).toBeEmptyObject()` in `expect.test.js` becomes `.not`.
- Verified: `test/js/bun/test/expect.test.js`. Bun 1.4.3 fails the changed block and the new block. Also `cluster.test.ts` and `structuredClone-classes.test.ts`, which use `toBeEmptyObject`.

### Background
- `JSType` is the type byte of a JavaScriptCore cell. Functions and arrays are objects for that byte, so `is_object()` is true for them.
- `Array.isArray` is true for a `Proxy` whose target is an array. The helper follows the target the same way. It reads the internal fields, so no trap runs.

<details><summary>Notes</summary>

- Found by an automated census of rarely tested APIs. No user report. This change was part of #42504 at first. It moved here because it is the only one that can make a passing test fail.
- Reach: `toBeEmptyObject` has few users. The ones I found call it on plain objects. In this repo, `cluster.test.ts` and `structuredClone-classes.test.ts` do.
- Not changed: Map, Set, Date and RegExp stay "not an empty object". That equals jest-extended 4.x. 5.x and later accept them when they have no own enumerable keys.
- Not changed: `toBeObject` accepts functions, arrays and Maps. An existing test asserts that, and jest-extended rejects them. That is the same kind of question as this PR.
- `packages/bun-types/test.d.ts` is not changed. The JSDoc of `toBeEmptyObject` says "Asserts that a value is an empty `object`", which stays true.
- A revoked `Proxy` still throws from `Object.keys`, as before.
- `cargo clippy -p bun_jsc -p bun_runtime --no-deps` and `cargo fmt --all -- --check` are clean.

</details>
