### PR TITLE
bun:test: box a primitive receiver in toContainKeys and toContainAnyKeys

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1227,6 +1227,7 @@ declare module "bun:test" {
      * Asserts that an `object` contains all the provided keys.
      *
      * A primitive is converted to an object first, so a string has its indices and `length`.
+     * A falsy value, such as `null`, `0` or `""`, has no keys.
      *
      * @example
      * expect({ a: 'foo', b: 'bar', c: 'baz' }).toContainKeys(['a', 'b']);

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1129,7 +1129,8 @@ declare module "bun:test" {
     /**
      * Asserts that an `object` contains at least one of the provided keys.
      *
-     * The value must be an object.
+     * A primitive is converted to an object first, so a string has its indices and `length`.
+     * `null` and `undefined` have no keys.
      *
      * @example
      * expect({ a: 'hello', b: 'world' }).toContainAnyKeys(['a']);
@@ -1224,6 +1225,8 @@ declare module "bun:test" {
 
     /**
      * Asserts that an `object` contains all the provided keys.
+     *
+     * A primitive is converted to an object first, so a string has its indices and `length`.
      *
      * @example
      * expect({ a: 'foo', b: 'bar', c: 'baz' }).toContainKeys(['a', 'b']);

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1368,9 +1368,10 @@ impl JSValue {
         })?;
         Ok(if v.is_empty() { None } else { Some(v) })
     }
-    /// `Object.hasOwnProperty(key)`. `self` **must** be an object — the C++ side
-    /// `uncheckedDowncast`s. `key.toPropertyKey()` and Proxy `ownKeys` traps
-    /// can throw, so this is routed through `from_js_host_call_generic`.
+    /// `Object.prototype.hasOwnProperty.call(self, key)`. ToObject boxes a
+    /// primitive `self` and throws for undefined and null. `key.toPropertyKey()`
+    /// and Proxy traps can throw too, so this is routed through
+    /// `from_js_host_call_generic`.
     #[track_caller]
     pub fn has_own_property_value(self, global: &JSGlobalObject, key: JSValue) -> JsResult<bool> {
         host_fn::from_js_host_call_generic(global, || {

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1368,10 +1368,7 @@ impl JSValue {
         })?;
         Ok(if v.is_empty() { None } else { Some(v) })
     }
-    /// `Object.prototype.hasOwnProperty.call(self, key)`. ToObject boxes a
-    /// primitive `self` and throws for undefined and null. `key.toPropertyKey()`
-    /// and Proxy traps can throw too, so this is routed through
-    /// `from_js_host_call_generic`.
+    /// `Object.prototype.hasOwnProperty.call(self, key)`: boxes a primitive, throws for undefined and null.
     #[track_caller]
     pub fn has_own_property_value(self, global: &JSGlobalObject, key: JSValue) -> JsResult<bool> {
         host_fn::from_js_host_call_generic(global, || {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2894,8 +2894,10 @@ JSC__JSObject__create(JSC::JSGlobalObject* globalObject, size_t initialCapacity,
 bool JSC__JSValue__hasOwnPropertyValue(JSC::EncodedJSValue value, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue ownKey)
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
-    auto* object = uncheckedDowncast<JSC::JSObject>(JSC::JSValue::decode(value));
     auto propertyKey = JSC::JSValue::decode(ownKey).toPropertyKey(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    // Object.prototype.hasOwnProperty.call(value, ownKey): ToObject boxes a primitive and throws for undefined and null.
+    auto* object = JSC::JSValue::decode(value).toObject(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
     const bool result = JSC::objectPrototypeHasOwnProperty(globalObject, object, propertyKey);

--- a/src/runtime/test_runner/expect/toContainAnyKeys.rs
+++ b/src/runtime/test_runner/expect/toContainAnyKeys.rs
@@ -6,7 +6,7 @@ impl Expect {
     pub(crate) fn to_contain_any_keys(&self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         self.contain_matcher(global, frame, "toContainAnyKeys", ExpectedArray::AfterValue, ContainMsgs::CONTAIN,
             |g, value, expected| {
-                if !value.is_object() { return Ok(ContainOutcome::pass(false)); }
+                if value.is_undefined_or_null() { return Ok(ContainOutcome::pass(false)); }
                 let count = expected.get_length(g)?;
                 let mut i: u32 = 0;
                 while u64::from(i) < count {

--- a/src/runtime/test_runner/expect/toContainKeys.rs
+++ b/src/runtime/test_runner/expect/toContainKeys.rs
@@ -7,8 +7,8 @@ impl Expect {
         self.contain_matcher(global, frame, "toContainKeys", ExpectedArray::AfterValue, ContainMsgs::CONTAIN,
             |g, value, expected| {
                 let count = expected.get_length(g)?;
-                // jest-extended checks truthiness before hasOwnProperty; non-object passes only on empty expected.
-                if !value.is_object() { return Ok(ContainOutcome::pass(count == 0)); }
+                // jest-extended checks truthiness before hasOwnProperty; a falsy value passes only on empty expected.
+                if !value.to_boolean() { return Ok(ContainOutcome::pass(count == 0)); }
                 let mut i: u32 = 0;
                 while u64::from(i) < count {
                     if !value.has_own_property_value(g, expected.get_index(g, i)?)? {

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -540,9 +540,33 @@ describe("jest-extended", () => {
   // test("toBeObject()")
   // test("toBeEmptyObject()")
   // test("toContainKey()")
-  // test("toContainKeys()")
+
+  test("toContainKeys() boxes a primitive, like hasOwnProperty", () => {
+    // A string owns its indices and "length".
+    expect("abc").toContainKeys(["0", "length"]);
+    expect("abc").toContainKeys([0, 1, 2]);
+    expect("abc").not.toContainKeys(["3"]);
+    expect("abc").not.toContainKeys(["0", "toString"]);
+    expect(42).not.toContainKeys(["toFixed"]);
+    expect(Symbol.iterator).not.toContainKeys(["description"]);
+    expect(() => expect("abc").not.toContainKeys(["0", "length"])).toThrow("toContainKeys");
+    expect(() => expect("abc").toContainKeys(["3"])).toThrow("toContainKeys");
+  });
+
   // test("toContainAllKeys()")
-  // test("toContainAnyKeys()")
+
+  test("toContainAnyKeys() boxes a primitive, like hasOwnProperty", () => {
+    // A string owns its indices and "length".
+    expect("abc").toContainAnyKeys(["z", "length"]);
+    expect("abc").toContainAnyKeys([2]);
+    expect("").toContainAnyKeys(["length"]);
+    expect("abc").not.toContainAnyKeys(["3", "toString"]);
+    expect(42).not.toContainAnyKeys(["toFixed"]);
+    expect(Symbol.iterator).not.toContainAnyKeys(["description"]);
+    expect(() => expect("abc").not.toContainAnyKeys(["length"])).toThrow("toContainAnyKeys");
+    expect(() => expect("abc").toContainAnyKeys(["3"])).toThrow("toContainAnyKeys");
+  });
+
   // test("toContainValue()")
   // test("toContainValues()")
   // test("toContainAllValues()")

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -547,6 +547,8 @@ describe("jest-extended", () => {
     expect("abc").toContainKeys([0, 1, 2]);
     expect("abc").not.toContainKeys(["3"]);
     expect("abc").not.toContainKeys(["0", "toString"]);
+    // jest-extended 4.0.0 tests `actual && ...`, so a falsy value has no keys. 7.0.0 tests `actual != null`.
+    expect("").not.toContainKeys(["length"]);
     expect(42).not.toContainKeys(["toFixed"]);
     expect(Symbol.iterator).not.toContainKeys(["description"]);
     expect(() => expect("abc").not.toContainKeys(["0", "length"])).toThrow("toContainKeys");


### PR DESCRIPTION
### Problem
- `expect("abc").toContainKeys(["0", "length"])` and `expect("abc").toContainAnyKeys(["length"])` fail, although `Object.prototype.hasOwnProperty.call("abc", "length")` is `true`. Both matchers return early for a receiver that is not an object (`toContainKeys.rs:11`, `toContainAnyKeys.rs:9`).
- The early return protects `JSC__JSValue__hasOwnPropertyValue` (`src/jsc/bindings/bindings.cpp:2897`), which casts the receiver with `uncheckedDowncast<JSObject>`. Rust declares it a `safe fn` (`src/jsc/JSValue.rs:2042`), so a caller without the guard has undefined behavior.
- #9125 made `toContainKeys` box the receiver (`toObject()` in the binding). #11698 replaced the binding with one that casts to `JSObject`, so a truthy primitive crashed. #22977 fixed the crash with the `is_object()` guards. No step decided that a string has no keys.

### Fix
- `JSC__JSValue__hasOwnPropertyValue` runs the steps of `Object.prototype.hasOwnProperty`: ToPropertyKey, ToObject, then the own property test. `undefined` and `null` throw a TypeError. Each other primitive is boxed.
- `toContainKeys` has the truthiness test of #9125 again: a falsy receiver has no keys. `toContainAnyKeys` returns false for `undefined` and `null`. Each other receiver reaches the binding.
- `toContainKey` is not changed. It throws `Expected value must be an object` for a primitive.
- Verified: two new blocks in `test/js/bun/test/jest-extended.test.js` fail on Bun 1.4.3. Also `test/regression/issue/11677.test.ts` and the keys blocks of `expect.test.js`.

### Background
- `toContainKeys(keys)` passes when the value owns each key. `toContainAnyKeys(keys)` passes when it owns one or more. jest-extended calls `Object.prototype.hasOwnProperty.call(actual, key)` (4.0.0) or `Object.hasOwn(actual, key)` (7.0.0).
- ToObject converts a primitive to its wrapper object. A String object owns each index and `length`. Number, Boolean, Symbol and BigInt objects own nothing.

<details><summary>Notes</summary>

- Found by differential testing against jest-extended 4.0.0. No user report.
- Assertions that now pass: `toContainKeys` and `toContainAnyKeys` on a string receiver with keys that the String object owns (an index below the length, `"length"`). Also `expect("").toContainAnyKeys(["length"])`.
- Assertions that now fail: the `.not` mirror of those. No other receiver changes: a number, boolean, symbol or bigint owns no key before and after.
- Decision for a maintainer, the receiver test. jest-extended 4.0.0 writes `actual && ...` in `toContainKeys` only, so the two matchers test the receiver differently. This PR keeps that rule, which #9125 copied on purpose (`toContainKeys`: truthy, `toContainAnyKeys`: not nullish). jest-extended 7.0.0 uses `actual != null` in both. The one cell that differs is `expect("").toContainKeys(["length"])`: it fails here and in 4.0.0, and passes in 7.0.0.
- Decision for a maintainer, `toContainKey`. jest-extended 4.0.0 boxes a string there too. 7.0.0 requires `typeof actual === "object"` and also rejects an array. Bun throws for a primitive, the JSDoc says "The value must be an object", and `expect.test.js` asserts the throw. The two upstream versions disagree, so this PR leaves it.
- `toContainAnyKeys` on `undefined` or `null` throws a TypeError in jest-extended 4.0.0 and fails in 7.0.0. Bun fails, and `expect.test.js` asserts that. Not changed.
- The binding now follows the order of `objectProtoFuncHasOwnProperty` in JavaScriptCore: the key conversion runs before ToObject. The three callers are the three keys matchers.
- JSDoc: `toContainAnyKeys` said "The value must be an object". Both matchers now say that a primitive is converted first, and `toContainKeys` says that a falsy value has no keys. The new block asserts `expect("").not.toContainKeys(["length"])`.
- `BUN_JSC_validateExceptionChecks=1` passes on the new blocks and on `11677.test.ts`. The new blocks also pass with `FORCE_COLOR=1`.
- The verdict lines of the new blocks also pass when `expect.extend(require("jest-extended"))` replaces the native matchers with the 4.0.0 implementations. The two `toThrow` lines of each block check Bun's failure message and cannot run that way.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/jest-extended.test.js
bun test v1.4.3 (6a92015fc)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [13.27ms]
(pass) jest-extended > fail() [13.33ms]
(pass) jest-extended > toBeEmpty() > "" [1.43ms]
(pass) jest-extended > toBeEmpty() > [] [0.42ms]
(pass) jest-extended > toBeEmpty() > {} [0.26ms]
(pass) jest-extended > toBeEmpty() > Set {} [0.17ms]
(pass) jest-extended > toBeEmpty() > Map {} [0.15ms]
(pass) jest-extended > toBeEmpty() > "" [0.17ms]
(pass) jest-extended > toBeEmpty() > [] [0.18ms]
(pass) jest-extended > toBeEmpty() > Uint8Array(0) [] [0.16ms]
(pass) jest-extended > toBeEmpty() > {} [0.22ms]
(pass) jest-extended > toBeEmpty() > <Buffer > [0.16ms]
(pass) jest-extended > toBeEmpty() > Headers {} [0.18ms]
(pass) jest-extended > toBeEmpty() > URLSearchParams {} [0.16ms]
(pass) jest-extended > toBeEmpty() > {} [0.16ms]
(pass) jest-extended > toBeEmpty() > {} [7.44ms]
(pass) jest-extended > toBeEmpty() > FileRef ("/tmp/jest-extended-euIHTm/empty.txt") {  type: "text/plain;charset=utf-8"} [0.
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (59c2a0c82)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [0.12ms]
(pass) jest-extended > fail() [0.06ms]
(pass) jest-extended > toBeEmpty() > ""
(pass) jest-extended > toBeEmpty() > []
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extended > toBeEmpty() > Set {}
(pass) jest-extended > toBeEmpty() > Map {}
(pass) jest-extended > toBeEmpty() > ""
(pass) jest-extended > toBeEmpty() > []
(pass) jest-extended > toBeEmpty() > Uint8Array(0) []
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extended > toBeEmpty() > <Buffer >
(pass) jest-extended > toBeEmpty() > Headers {}
(pass) jest-extended > toBeEmpty() > URLSearchParams {}
(pass) jest-extended > toBeEmpty() > {}
(pass) jest-extended > toBeEmpty() > {} [0.11ms]
(pass) jest-extended > toBeEmpty() > FileRef ("/tmp/jest-extended-QRPujV/empty.txt") {  type: "text/plain;charset=utf-8"} [0.01ms]
(pass) jest-extended > not.toBeEmpty() > " " [0.01ms]
(pass) jest-extended > not.toBeEmpty() > [ "" ]
(pass) jest-extended > not.toBeEmpty() > [ undefined ]
(pass) jest-extended > not.toBeEmpty() > {  "": "",}
(pass) jest-extended > not.toBeEmpty() > Set(1) {  "",}
(pass) je
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/jest-extended.test.js
bun test v1.4.3 (6a92015fc)

test/js/bun/test/jest-extended.test.js:
(pass) jest-extended > pass() [18.52ms]
(pass) jest-extended > fail() [16.03ms]
(pass) jest-extended > toBeEmpty() > "" [2.17ms]
(pass) jest-extended > toBeEmpty() > [] [0.51ms]
(pass) jest-extended > toBeEmpty() > {} [0.41ms]
(pass) jest-extended > toBeEmpty() > Set {} [0.26ms]
(pass) jest-extended > toBeEmpty() > Map {} [0.23ms]
(pass) jest-extended > toBeEmpty() > "" [0.24ms]
(pass) jest-extended > toBeEmpty() > [] [0.25ms]
(pass) jest-extended > toBeEmpty() > Uint8Array(0) [] [0.22ms]
(pass) jest-extended > toBeEmpty() > {} [0.33ms]
(pass) jest-extended > toBeEmpty() > <Buffer > [0.23ms]
(pass) jest-extended > toBeEmpty() > Headers {} [0.22ms]
(pass) jest-extended > toBeEmpty() > URLSearchParams {} [0.25ms]
(pass) jest-extended > toBeEmpty() > {} [0.25ms]
(pass) jest-extended > toBeEmpty() > {} [9.04ms]
(pass) jest-extended > toBeEmpty() > FileRef ("/tmp/jest-extended-pO6Rmf/empty.txt") {  type: "text/plain;charset=utf-8"} [0.
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 732ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/8] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/8] gen cpp.rs (cppbind)
[2/8] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/test.d.ts                       |  6 ++++-
 src/jsc/JSValue.rs                                 |  4 +--
 src/jsc/bindings/bindings.cpp                      |  4 ++-
 src/runtime/test_runner/expect/toContainAnyKeys.rs |  2 +-
 src/runtime/test_runner/expect/toContainKeys.rs    |  4 +--
 test/js/bun/test/jest-extended.test.js             | 30 ++++++++++++++++++++--
 6 files changed, 40 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
packages/bun-types/test.d.ts                            1      1     36
src/jsc/JSValue.rs                                      3      3     35
src/jsc/bindings/bindings.cpp                           0      0     35
src/runtime/test_runner/expect/toContainAnyKeys.rs      0      0     34
src/runtime/test_runner/expect/toContainKeys.rs         0      0     34
test/js/bun/test/jest-extended.test.js                  3      5     34
```

</details>

<!-- robobun:evidence:end -->