### PR TITLE
node:fs: compute the BigIntStats *Ms fields with BigInt division

### DIFF
--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -749,6 +749,23 @@ const JSC::ClassInfo JSBigIntStatsPrototype::s_info = { "BigIntStats"_s, &Base::
 const JSC::ClassInfo JSStatsConstructor::s_info = { "Stats"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSStatsConstructor) };
 const JSC::ClassInfo JSBigIntStatsConstructor::s_info = { "BigIntStats"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSBigIntStatsConstructor) };
 
+// Node: `this.atimeMs = atimeNs / kNsPerMsBigInt`, then mtime, ctime and birthtime. jsDiv is the
+// `/` operator: the quotient stays a BigInt of any size, and an operand that ToNumeric does not
+// turn into a BigInt throws a TypeError.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L624-L627
+static void divideNsIntoMs(JSC::JSGlobalObject* globalObject, JSValue& atime, JSValue& mtime, JSValue& ctime, JSValue& birthtime)
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue nsPerMs = JSC::JSBigInt::createFrom(globalObject, kNsPerMs);
+    RETURN_IF_EXCEPTION(scope, );
+    for (JSValue* time : { &atime, &mtime, &ctime, &birthtime }) {
+        *time = jsDiv(globalObject, *time, nsPerMs);
+        RETURN_IF_EXCEPTION(scope, );
+    }
+}
+
 template<bool isBigInt>
 inline JSValue callJSStatsFunction(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callFrame)
 {
@@ -785,18 +802,7 @@ inline JSValue callJSStatsFunction(JSC::JSGlobalObject* globalObject, JSC::CallF
     JSValue birthtimeMs = birthtimeNs;
 
     if constexpr (isBigInt) {
-        // this.atimeMs = atimeNs / kNsPerMsBigInt;
-        // this.mtimeMs = mtimeNs / kNsPerMsBigInt;
-        // this.ctimeMs = ctimeNs / kNsPerMsBigInt;
-        // this.birthtimeMs = birthtimeNs / kNsPerMsBigInt;
-        const double kNsPerMsBigInt = 1000000;
-        atimeMs = jsDoubleNumber(atimeNs.toBigInt64(globalObject) / kNsPerMsBigInt);
-        RETURN_IF_EXCEPTION(scope, {});
-        mtimeMs = jsDoubleNumber(mtimeNs.toBigInt64(globalObject) / kNsPerMsBigInt);
-        RETURN_IF_EXCEPTION(scope, {});
-        ctimeMs = jsDoubleNumber(ctimeNs.toBigInt64(globalObject) / kNsPerMsBigInt);
-        RETURN_IF_EXCEPTION(scope, {});
-        birthtimeMs = jsDoubleNumber(birthtimeNs.toBigInt64(globalObject) / kNsPerMsBigInt);
+        divideNsIntoMs(globalObject, atimeMs, mtimeMs, ctimeMs, birthtimeMs);
         RETURN_IF_EXCEPTION(scope, {});
     }
 
@@ -869,18 +875,7 @@ inline JSValue constructJSStatsObject(JSC::JSGlobalObject* lexicalGlobalObject, 
     JSValue birthtimeMs = birthtimeNs;
 
     if constexpr (isBigInt) {
-        // this.atimeMs = atimeNs / kNsPerMsBigInt;
-        // this.mtimeMs = mtimeNs / kNsPerMsBigInt;
-        // this.ctimeMs = ctimeNs / kNsPerMsBigInt;
-        // this.birthtimeMs = birthtimeNs / kNsPerMsBigInt;
-        const double kNsPerMsBigInt = 1000000;
-        atimeMs = jsDoubleNumber(atimeNs.toBigInt64(globalObject) / kNsPerMsBigInt);
-        RETURN_IF_EXCEPTION(scope, {});
-        mtimeMs = jsDoubleNumber(mtimeNs.toBigInt64(globalObject) / kNsPerMsBigInt);
-        RETURN_IF_EXCEPTION(scope, {});
-        ctimeMs = jsDoubleNumber(ctimeNs.toBigInt64(globalObject) / kNsPerMsBigInt);
-        RETURN_IF_EXCEPTION(scope, {});
-        birthtimeMs = jsDoubleNumber(birthtimeNs.toBigInt64(globalObject) / kNsPerMsBigInt);
+        divideNsIntoMs(globalObject, atimeMs, mtimeMs, ctimeMs, birthtimeMs);
         RETURN_IF_EXCEPTION(scope, {});
     }
 

--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -15,6 +15,7 @@
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/Identifier.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/JSBigIntInlines.h>
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/PropertyNameArray.h>
@@ -211,6 +212,17 @@ static const Identifier& identifier(JSC::VM& vm, DateFieldType dateField)
     ASSERT_NOT_REACHED();
 }
 
+// Not toBigInt64(): it wraps a value outside the int64 range, which then reads as a valid date.
+static double bigIntToDouble(JSC::JSGlobalObject* globalObject, JSValue value)
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue bigInt = value.toBigInt(globalObject);
+    RETURN_IF_EXCEPTION(scope, 0);
+    return JSBigInt::toNumber(bigInt).asNumber();
+}
+
 template<DateFieldType field, bool isBigInt>
 inline JSC::JSValue getDateField(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue thisValue, JSC::PropertyName propertyName)
 {
@@ -230,7 +242,7 @@ inline JSC::JSValue getDateField(JSC::JSGlobalObject* globalObject, JSC::Encoded
         RETURN_IF_EXCEPTION(scope, {});
     }
 
-    double internalNumber = isBigInt ? value.toBigInt64(globalObject) : value.toNumber(globalObject);
+    double internalNumber = isBigInt ? bigIntToDouble(globalObject, value) : value.toNumber(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
     JSValue result = JSC::DateInstance::create(vm, globalObject->dateStructure(), internalNumber);

--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -749,10 +749,7 @@ const JSC::ClassInfo JSBigIntStatsPrototype::s_info = { "BigIntStats"_s, &Base::
 const JSC::ClassInfo JSStatsConstructor::s_info = { "Stats"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSStatsConstructor) };
 const JSC::ClassInfo JSBigIntStatsConstructor::s_info = { "BigIntStats"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSBigIntStatsConstructor) };
 
-// Node: `this.atimeMs = atimeNs / kNsPerMsBigInt`, then mtime, ctime and birthtime. jsDiv is the
-// `/` operator: the quotient stays a BigInt of any size, and an operand that ToNumeric does not
-// turn into a BigInt throws a TypeError.
-// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L624-L627
+// Node divides with the JS `/` operator: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L624-L627
 static void divideNsIntoMs(JSC::JSGlobalObject* globalObject, JSValue& atime, JSValue& mtime, JSValue& ctime, JSValue& birthtime)
 {
     auto& vm = globalObject->vm();

--- a/test/js/node/fs/fs-stats-constructor.test.ts
+++ b/test/js/node/fs/fs-stats-constructor.test.ts
@@ -122,6 +122,11 @@ describe("BigIntStats constructor", () => {
       birthtimeMs: -9_223_372_036_854n,
     });
     expect(stats.atime).toEqual(new Date(1_180_591_620_717_411));
+
+    // A *Ms value outside the int64 range is outside the Date range too. The getter must not wrap it into a valid date.
+    const wide = construct(...fields, 2n ** 64n * 1_000_000n, -(2n ** 64n) * 1_000_000n, 0n, 0n);
+    expect({ atimeMs: wide.atimeMs, mtimeMs: wide.mtimeMs }).toEqual({ atimeMs: 2n ** 64n, mtimeMs: -(2n ** 64n) });
+    expect({ atime: wide.atime.getTime(), mtime: wide.mtime.getTime() }).toEqual({ atime: NaN, mtime: NaN });
   });
 
   test.each(constructors)("%s throws a TypeError if a *Ns argument does not convert to a BigInt", (_, construct) => {

--- a/test/js/node/fs/fs-stats-constructor.test.ts
+++ b/test/js/node/fs/fs-stats-constructor.test.ts
@@ -56,6 +56,121 @@ test("Stats instances share Stats.prototype", () => {
   expect(bigint instanceof Object.getPrototypeOf(bigint).constructor).toBe(true);
 });
 
+// Node.js computes the four `*Ms` fields of BigIntStats in JS: `this.atimeMs = atimeNs / 1_000_000n`.
+// That is BigInt division: the result is a BigInt, truncated toward zero, with no 64-bit limit, and
+// an operand that does not convert to a BigInt throws a TypeError. The native constructor used to
+// divide `BigInt.asIntN(64, atimeNs)` as a double and store a Number, which the date getters reject.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L619-L632
+describe("BigIntStats constructor", () => {
+  const BigIntStats = Object.getPrototypeOf(statSync(import.meta.path, { bigint: true })).constructor;
+  class Subclass extends BigIntStats {}
+  // BigIntStats(dev, mode, nlink, uid, gid, rdev, blksize, ino, size, blocks, atimeNs, mtimeNs, ctimeNs, birthtimeNs)
+  const fields = [0n, 1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n, 9n];
+  const constructors: [string, (...args: unknown[]) => any][] = [
+    ["new BigIntStats(...)", (...args) => new BigIntStats(...args)],
+    ["new (class extends BigIntStats)(...)", (...args) => new Subclass(...args)],
+    // Node.js throws for a call without new. Bun accepts it, for Stats too.
+    ["BigIntStats(...)", (...args) => BigIntStats(...args)],
+  ];
+
+  test.each(constructors)("%s divides the *Ns arguments into BigInt *Ms fields", (_, construct) => {
+    const stats = construct(...fields, 2_500_000n, 3_999_999n, -2_500_000n, -1n);
+    expect({ ...stats }).toEqual({
+      dev: 0n,
+      mode: 1n,
+      nlink: 2n,
+      uid: 3n,
+      gid: 4n,
+      rdev: 5n,
+      blksize: 6n,
+      ino: 7n,
+      size: 8n,
+      blocks: 9n,
+      atimeMs: 2n,
+      mtimeMs: 3n,
+      ctimeMs: -2n,
+      birthtimeMs: 0n,
+      atimeNs: 2_500_000n,
+      mtimeNs: 3_999_999n,
+      ctimeNs: -2_500_000n,
+      birthtimeNs: -1n,
+    });
+    expect({
+      atime: stats.atime,
+      mtime: stats.mtime,
+      ctime: stats.ctime,
+      birthtime: stats.birthtime,
+    }).toEqual({
+      atime: new Date(2),
+      mtime: new Date(3),
+      ctime: new Date(-2),
+      birthtime: new Date(0),
+    });
+  });
+
+  test.each(constructors)("%s keeps the precision of *Ns arguments outside the int64 range", (_, construct) => {
+    const stats = construct(...fields, 2n ** 70n, -(2n ** 70n), 2n ** 63n, -(2n ** 63n) - 1n);
+    expect({
+      atimeMs: stats.atimeMs,
+      mtimeMs: stats.mtimeMs,
+      ctimeMs: stats.ctimeMs,
+      birthtimeMs: stats.birthtimeMs,
+    }).toEqual({
+      atimeMs: 1_180_591_620_717_411n,
+      mtimeMs: -1_180_591_620_717_411n,
+      ctimeMs: 9_223_372_036_854n,
+      birthtimeMs: -9_223_372_036_854n,
+    });
+    expect(stats.atime).toEqual(new Date(1_180_591_620_717_411));
+  });
+
+  test.each(constructors)("%s throws a TypeError if a *Ns argument does not convert to a BigInt", (_, construct) => {
+    for (const notBigInt of [2_500_000, "2500000", true, null, undefined, { valueOf: () => 2_500_000 }]) {
+      for (let i = 0; i < 4; i++) {
+        const times: unknown[] = [0n, 0n, 0n, 0n];
+        times[i] = notBigInt;
+        expect(() => construct(...fields, ...times)).toThrow(TypeError);
+      }
+    }
+  });
+
+  test.each(constructors)("%s converts object *Ns arguments with valueOf, once each, in order", (_, construct) => {
+    const order: string[] = [];
+    const argument = (name: string, value: unknown) => ({
+      valueOf() {
+        order.push(name);
+        return value;
+      },
+    });
+    const atimeNs = argument("atimeNs", 1_999_999n);
+    const mtimeNs = argument("mtimeNs", 2_000_000n);
+    const ctimeNs = argument("ctimeNs", 3_000_000n);
+    const birthtimeNs = argument("birthtimeNs", 4_000_000n);
+    const stats = construct(...fields, atimeNs, mtimeNs, ctimeNs, birthtimeNs);
+    expect(order).toEqual(["atimeNs", "mtimeNs", "ctimeNs", "birthtimeNs"]);
+    expect({
+      atimeMs: stats.atimeMs,
+      mtimeMs: stats.mtimeMs,
+      ctimeMs: stats.ctimeMs,
+      birthtimeMs: stats.birthtimeMs,
+    }).toEqual({ atimeMs: 1n, mtimeMs: 2n, ctimeMs: 3n, birthtimeMs: 4n });
+    // The *Ns fields hold the arguments as given.
+    expect(stats.atimeNs).toBe(atimeNs);
+    expect(stats.mtimeNs).toBe(mtimeNs);
+    expect(stats.ctimeNs).toBe(ctimeNs);
+    expect(stats.birthtimeNs).toBe(birthtimeNs);
+
+    // The first argument that does not convert to a BigInt ends the conversion.
+    order.length = 0;
+    const notBigInt = argument("mtimeNs", 2_000_000);
+    expect(() => construct(...fields, atimeNs, notBigInt, ctimeNs, birthtimeNs)).toThrow(TypeError);
+    expect(order).toEqual(["atimeNs", "mtimeNs"]);
+
+    // A BigInt wrapper object converts too.
+    expect(construct(...fields, Object(2_500_000n), 0n, 0n, 0n).atimeMs).toBe(2n);
+  });
+});
+
 // A call resolved through a binding that a closure captures is compiled with the scope object
 // itself in the this slot, and native functions see it raw. isFile() and friends used to read
 // `mode` out of that scope object (the date getters, once pulled out of their property descriptor,


### PR DESCRIPTION
### Problem
- `new BigIntStats(...)` and `BigIntStats(...)` without `new` store the four `*Ms` fields as Number: `2.5` for `atimeNs = 2500000n`, where Node.js stores `2n`. The date getters then throw `TypeError: Invalid argument type in ToBigInt operation`.
- The cause: both constructor paths (`src/jsc/bindings/NodeFSStatBinding.cpp:787`, `:871`) compute `jsDoubleNumber(atimeNs.toBigInt64(globalObject) / 1000000.0)`. `toBigInt64` also cuts the value to 64 bits, so `2n ** 70n` gives `0`.
- The date getters (`:233`) cut `*Ms` the same way. At or past `2n ** 63n` they return a wrong date, where Node.js gives an Invalid Date.

### Fix
- Both constructor paths call one helper, `divideNsIntoMs`. It applies the JS `/` operator (`jsDiv`) with `1000000n`, as Node.js does: `this.atimeMs = atimeNs / kNsPerMsBigInt` ([source](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L619-L632)).
- The quotient is a BigInt with no 64-bit limit. An argument that does not convert to a BigInt throws a `TypeError`, as in Node.js. Before, bun accepted a string or a boolean.
- The `BigIntStats` date getters convert the whole BigInt to a double, as `Number(ms)` does in Node.js. A value that fits in 64 bits gives the same date as before.
- Verified: 12 new tests in `test/js/node/fs/fs-stats-constructor.test.ts`, all fail without the fix. Also ran the stat, utimes and watchfile suites listed in the notes.

### Background
- `BigIntStats` is the class of the object that `fs.stat(path, { bigint: true })` returns. `node:fs` does not export it, so code reaches it through `.constructor`. Its constructor takes four times in nanoseconds (`*Ns`) and derives the millisecond fields (`*Ms`).
- The date fields are lazy accessors on the prototype. The first read converts `*Ms` with ToBigInt, which rejects a Number.
- `jsDiv` is the JavaScriptCore function behind `/`. It throws a `TypeError` when a BigInt meets another type.

<details><summary>Notes</summary>

Repro (`bun big.js`):

```js
const fs = require("fs");
const B = fs.statSync(".", { bigint: true }).constructor;
const s = new B(1n, 0o100644n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 0n, 2500000n, 0n, 0n, 0n);
console.log(typeof s.atimeMs, String(s.atimeMs), typeof s.atimeNs, String(s.atimeNs));
try { console.log(s.atime.toISOString()); } catch (e) { console.log("atime threw:", e.message); }
```

| | output |
| --- | --- |
| bun 1.4.3-canary.1 (6a92015fc) | `number 2.5 bigint 2500000`, then `atime threw: Invalid argument type in ToBigInt operation` |
| Node.js v26.3.0 | `bigint 2 bigint 2500000`, then `1970-01-01T00:00:00.002Z` |
| this branch | `bigint 2 bigint 2500000`, then `1970-01-01T00:00:00.002Z` |

Inputs compared with Node.js v26.3.0 (`new`, a subclass, and for bun the plain call):

| `atimeNs` | Node.js `atimeMs` | bun before | bun after |
| --- | --- | --- | --- |
| `2500000n` | `2n` | `2.5` | `2n` |
| `-2500000n` | `-2n` | `-2.5` | `-2n` |
| `-1n` | `0n` | `-0.000001` | `0n` |
| `2n ** 70n` | `1180591620717411n` | `0` | `1180591620717411n` |
| `2n ** 63n` | `9223372036854n` | `-9223372036854.775` | `9223372036854n` |
| `Object(2500000n)`, `{ valueOf: () => 2500000n }` | `2n` | `2.5` | `2n` |
| `2500000`, `undefined`, `null`, `{ valueOf: () => 2500000 }` | TypeError | TypeError | TypeError |
| `"2500000"`, `true` | TypeError | `2.5`, `0.000001` | TypeError |

The date getter, for a `*Ms` outside the int64 range:

| | Node.js | bun before | bun after |
| --- | --- | --- | --- |
| `new BigIntStats(..., 2n ** 64n * 1000000n, ...)`, then `atime.getTime()` | `NaN` | `atime` threw (Number `*Ms`) | `NaN` |
| `stats.atimeMs = 2n ** 64n + 5n` on an object from `fs.statSync(path, { bigint: true })`, then `atime.getTime()` | `NaN` | `5` | `NaN` |

- The two functions are `callJSStatsFunction<true>` (the plain call) and `constructJSStatsObject<true>` (`new` and subclasses). A subclass (`class S extends BigIntStats`) had the same fault and has the same tests.
- A differential run of the getter gives identical `getTime()` results on this branch and on Node.js v26.3.0 for 29 `*Ms` values, through the constructor and through a plain assignment: the Date range limits `±8640000000000000n` and their neighbors, and values around `2n ** 53n`, `2n ** 63n`, `2n ** 64n`, `2n ** 100n`, `2n ** 1024n` and `2n ** 5000n`.
- The four conversions run in the order atime, mtime, ctime, birthtime, once each, and stop at the first one that throws, as in Node.js. The `*Ns` fields keep the arguments as given, as before.
- The `TypeError` text is the engine's text for `1 / 1n`. JavaScriptCore: `Invalid mix of BigInt and other type in division.` V8: `Cannot mix BigInt and other types, use explicit conversions`.
- Objects from `fs.stat(path, { bigint: true })` come from `Bun__createJSBigIntStatsObject`. Their fields were correct and are not changed. Their date getters are the same getters, so they get the non-wrapping conversion too.
- Upstream `test-fs-watchfile-bigint.js` compares the stats of a missing file with `new BigIntStats(0n, ...)` through `assert.deepStrictEqual`. With the native class that comparison fails on 1.4.3-canary.1 (`atimeMs` is the Number `0`) and passes on this branch. bun's copy of that test does not construct the object, so no Node.js test changes status.
- Reach: the class is not exported and direct construction is deprecated (DEP0180). The double division dates from #16694 (bun v1.2.1). No issue reports it, and no code in the repository calls this constructor. A read of the code found the bug.

Sites in the same file that are not changed:

- `BigIntStats(...)` without `new` still returns an object, like `Stats(...)` does in bun. Node.js throws for both.
- `modeStatFunction<_, true>` (`:150`) reads `mode` with `toBigInt64`. Only bits 12 to 15 (`S_IFMT`) decide the answer, so the cut to 64 bits cannot change it. A fuzz of 5950 BigInt modes (1 to 300 bits, both signs) gives byte-identical `isFile()` ... `isSocket()` answers on this branch and on Node.js v26.3.0.
- `getDateField` still differs from Node.js in two ways. It does not round, so `mtime.getTime()` of a real stat can be 1 ms lower. It rejects the other numeric type: a Number in a `BigIntStats` or a BigInt in a `Stats` throws, where Node.js returns a Date. The fix for both is a port of Node's `dateFromMs`, which changes the dates of real files. #42562 tracks it. #42518 changes how the getters store the Date, not how they convert `*Ms`.
- Node.js v26.2.0 changed the Number class `fs.Stats` to 18 constructor arguments and added `*Instant` getters to both classes (nodejs/node#60789). bun has neither. `BigIntStats` still takes the same 14 arguments in v26.3.0, so this change targets the current signature.
- #42520 changes the realm cast a few lines above the `new` path (`:843`). The two diffs do not overlap.

Suites run with the debug build: `test/js/node/fs/fs-stats-constructor.test.ts` (also with `BUN_JSC_validateExceptionChecks=1`), `test/js/node/fs/fs.test.ts -t stat` (35 pass), and in `test/js/node/test/parallel/`: `test-fs-stat.js`, `test-fs-stat-bigint.js`, `test-fs-stat-date.mjs`, `test-fs-stat-temporal.mjs`, `test-fs-stat-abort-test.js`, `test-fs-statfs.js`, `test-fs-watchfile.js`, `test-fs-watchfile-bigint.js`, `test-fs-utimes.js`, `test-fs-utimes-y2K38.js`, `test-fs-promises.js`, `test-fs-promises-file-handle-stat.js`, `test-worker-fs-stat-watcher.js`.

Self-reviewed: 2 concerns raised, 2 addressed. The order test now records all four conversions and checks that a failing one stops the rest. The text says "does not convert to a BigInt", because a wrapper object or a `valueOf` that returns a BigInt is accepted. The getter change came from review on this PR.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/fs/fs-stats-constructor.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/67] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/67] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/67] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - G
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (e7f0f79be)

test/js/node/fs/fs-stats-constructor.test.ts:
(pass) new Stats(...) assigns fields in Node's order [0.93ms]
(pass) Stats(...) without new assigns fields in Node's order [0.04ms]
(pass) Stats instances share Stats.prototype [0.12ms]
(pass) BigIntStats constructor > new BigIntStats(...) divides the *Ns arguments into BigInt *Ms fields [0.09ms]
(pass) BigIntStats constructor > new (class extends BigIntStats)(...) divides the *Ns arguments into BigInt *Ms fields [0.04ms]
(pass) BigIntStats constructor > BigIntStats(...) divides the *Ns arguments into BigInt *Ms fields [0.02ms]
124 |     expect(stats.atime).toEqual(new Date(1_180_591_620_717_411));
125 | 
126 |     // A *Ms value outside the int64 range is outside the Date range too. The getter must not wrap it into a valid date.
127 |     const wide = construct(...fields, 2n ** 64n * 1_000_000n, -(2n ** 64n) * 1_000_000n, 0n, 0n);
128 |     expect({ atimeMs: wide.atimeMs, mtimeMs: wide.mtimeMs }).toEqual({ atimeMs: 2n ** 64n, mtimeMs: -(2n ** 64n) });
129 |     expect({ atime: wide.atime.getTime(), mtime: wide.mtime.getTime() }).toEqual({ atime: NaN, mtime: NaN });
                 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/fs/fs-stats-constructor.test.ts
bun test v1.4.3 (6a92015fc)

test/js/node/fs/fs-stats-constructor.test.ts:
(pass) new Stats(...) assigns fields in Node's order [6.54ms]
(pass) Stats(...) without new assigns fields in Node's order [3.21ms]
(pass) Stats instances share Stats.prototype [10.23ms]
(pass) BigIntStats constructor > new BigIntStats(...) divides the *Ns arguments into BigInt *Ms fields [7.78ms]
(pass) BigIntStats constructor > new (class extends BigIntStats)(...) divides the *Ns arguments into BigInt *Ms fields [6.51ms]
(pass) BigIntStats constructor > BigIntStats(...) divides the *Ns arguments into BigInt *Ms fields [2.93ms]
(pass) BigIntStats constructor > new BigIntStats(...) keeps the precision of *Ns arguments outside the int64 range [9.17ms]
(pass) BigIntStats constructor > new (class extends BigIntStats)(...) keeps the precision of *Ns arguments outside the int64 range [3.32ms]
(pass) BigIntStats constructor > BigIntStats(...) keeps the precision of *Ns arguments outside the int64 range [2.17ms]
(pass) BigInt
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 901ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/60] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/60] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/60] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeFSStatBinding.cpp       |  54 ++++++------
 test/js/node/fs/fs-stats-constructor.test.ts | 120 +++++++++++++++++++++++++++
 2 files changed, 149 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/bindings/NodeFSStatBinding.cpp            6     10     23
test/js/node/fs/fs-stats-constructor.test.ts      4      7     23
```

</details>

<!-- robobun:evidence:end -->