### PR TITLE
node:fs: convert Stats date fields like Node.js

### DIFF
--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -20,6 +20,8 @@
 #include <JavaScriptCore/PropertyNameArray.h>
 #include "ZigGlobalObject.h"
 #include "JavaScriptCore/DateInstance.h"
+#include <JavaScriptCore/JSBigIntInlines.h>
+#include <JavaScriptCore/MathCommon.h>
 #include <wtf/Int128.h>
 #if !OS(WINDOWS)
 #include <sys/stat.h>
@@ -230,8 +232,12 @@ inline JSC::JSValue getDateField(JSC::JSGlobalObject* globalObject, JSC::Encoded
         RETURN_IF_EXCEPTION(scope, {});
     }
 
-    double internalNumber = isBigInt ? value.toBigInt64(globalObject) : value.toNumber(globalObject);
+    // Node.js: `new Date(MathRound(Number(ms)))`. Either class accepts a Number or a BigInt.
+    JSValue numeric = value.toNumeric(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
+    if (numeric.isBigInt())
+        numeric = JSC::JSBigInt::toNumber(numeric);
+    double internalNumber = JSC::jsRound(numeric.asNumber());
 
     JSValue result = JSC::DateInstance::create(vm, globalObject->dateStructure(), internalNumber);
     if (!thisObject->structure()->mayBePrototype()) {

--- a/test/js/node/fs/fs-stats-constructor.test.ts
+++ b/test/js/node/fs/fs-stats-constructor.test.ts
@@ -68,14 +68,16 @@ describe("Stats date getters convert *Ms like Node.js", () => {
 
     const stats = statSync(file);
     const bigint = statSync(file, { bigint: true });
+    // The stored fraction depends on the filesystem's timestamp resolution
+    // (789.5999 with nanoseconds on Linux, 789.6 with 100 ns on Windows).
+    expect(stats.mtimeMs).toBeGreaterThanOrEqual(1700000000789.5);
+    expect(stats.mtimeMs).toBeLessThan(1700000000790);
     expect({
-      mtimeMs: stats.mtimeMs,
       mtime: stats.mtime.getTime(),
       atime: stats.atime.getTime(),
       bigintMtimeMs: bigint.mtimeMs,
       bigintMtime: bigint.mtime.getTime(),
     }).toEqual({
-      mtimeMs: 1700000000789.5999,
       mtime: 1700000000790,
       atime: 1700000000790,
       bigintMtimeMs: 1700000000789n,

--- a/test/js/node/fs/fs-stats-constructor.test.ts
+++ b/test/js/node/fs/fs-stats-constructor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { Stats, statSync, utimesSync, writeFileSync } from "node:fs";
+import { Stats, statSync, utimesSync } from "node:fs";
 import path from "node:path";
 
 // Node.js's Stats constructor signature (deprecated, DEP0180):

--- a/test/js/node/fs/fs-stats-constructor.test.ts
+++ b/test/js/node/fs/fs-stats-constructor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
-import { Stats, statSync } from "node:fs";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { Stats, statSync, utimesSync, writeFileSync } from "node:fs";
+import path from "node:path";
 
 // Node.js's Stats constructor signature (deprecated, DEP0180):
 //   Stats(dev, mode, nlink, uid, gid, rdev, blksize, ino, size, blocks, atimeMs, mtimeMs, ctimeMs, birthtimeMs)
@@ -54,6 +55,91 @@ test("Stats instances share Stats.prototype", () => {
   const bigint = statSync(import.meta.path, { bigint: true });
   expect(Object.getPrototypeOf(bigint).constructor.name).toBe("BigIntStats");
   expect(bigint instanceof Object.getPrototypeOf(bigint).constructor).toBe(true);
+});
+
+// Node.js computes every date field as `new Date(MathRound(Number(this.<field>Ms)))`, in one
+// getter shared by Stats and BigIntStats. The Date constructor truncates, so without the round
+// a real stat with a fraction of 0.5 ms or more comes out 1 ms early.
+describe("Stats date getters convert *Ms like Node.js", () => {
+  test("a real stat rounds the fraction instead of truncating it", () => {
+    using dir = tempDir("stats-date", { "file.txt": "x" });
+    const file = path.join(String(dir), "file.txt");
+    utimesSync(file, 1700000000.7896, 1700000000.7896);
+
+    const stats = statSync(file);
+    const bigint = statSync(file, { bigint: true });
+    expect({
+      mtimeMs: stats.mtimeMs,
+      mtime: stats.mtime.getTime(),
+      atime: stats.atime.getTime(),
+      bigintMtimeMs: bigint.mtimeMs,
+      bigintMtime: bigint.mtime.getTime(),
+    }).toEqual({
+      mtimeMs: 1700000000789.5999,
+      mtime: 1700000000790,
+      atime: 1700000000790,
+      bigintMtimeMs: 1700000000789n,
+      bigintMtime: 1700000000789,
+    });
+  });
+
+  test("a Number *Ms rounds like Math.round", () => {
+    const inputs = [0.5, 1.4999, -0.5, -1.5, -1.6, 8.64e15 + 0.4, 8.64e15 + 0.6, Infinity, NaN];
+    const results = inputs.map(ms => {
+      // The getter caches the Date on the instance, so each input needs its own Stats.
+      const stats = statSync(import.meta.path);
+      stats.atimeMs = ms;
+      return stats.atime.getTime();
+    });
+    expect(results).toEqual([1, 1, 0, -1, -2, 8.64e15, NaN, NaN, NaN]);
+  });
+
+  test("a BigInt *Ms past 64 bits is an Invalid Date, not a wrapped value", () => {
+    const bigint = statSync(import.meta.path, { bigint: true });
+    bigint.atimeMs = 2n ** 64n + 5n;
+    bigint.mtimeMs = -(2n ** 63n) - 1n;
+    bigint.ctimeMs = 8_640_000_000_000_000n;
+    bigint.birthtimeMs = 8_640_000_000_000_001n;
+    expect([
+      bigint.atime.getTime(),
+      bigint.mtime.getTime(),
+      bigint.ctime.getTime(),
+      bigint.birthtime.getTime(),
+    ]).toEqual([NaN, NaN, 8.64e15, NaN]);
+  });
+
+  test("both classes accept a Number or a BigInt *Ms", () => {
+    const stats = statSync(import.meta.path);
+    const bigint = statSync(import.meta.path, { bigint: true });
+    // @ts-expect-error Node.js accepts the other numeric type too
+    stats.ctimeMs = 5n;
+    // @ts-expect-error Node.js accepts the other numeric type too
+    bigint.ctimeMs = 5.5;
+    const statsCtime = Object.getOwnPropertyDescriptor(Stats.prototype, "ctime")!.get!;
+    const bigintCtime = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(bigint), "ctime")!.get!;
+    expect({
+      numberClassWithBigInt: stats.ctime.getTime(),
+      bigintClassWithNumber: bigint.ctime.getTime(),
+      statsGetterWithBigInt: statsCtime.call({ ctimeMs: 7n }).getTime(),
+      bigintGetterWithNumber: bigintCtime.call({ ctimeMs: 7.5 }).getTime(),
+    }).toEqual({
+      numberClassWithBigInt: 5,
+      bigintClassWithNumber: 6,
+      statsGetterWithBigInt: 7,
+      bigintGetterWithNumber: 8,
+    });
+  });
+
+  test("a *Ms that is not numeric still throws from the coercion", () => {
+    const stats = statSync(import.meta.path);
+    const bigint = statSync(import.meta.path, { bigint: true });
+    // @ts-expect-error a Symbol cannot convert to a number
+    stats.atimeMs = Symbol("x");
+    // @ts-expect-error a Symbol cannot convert to a number
+    bigint.atimeMs = Symbol("x");
+    expect(() => stats.atime).toThrow(TypeError);
+    expect(() => bigint.atime).toThrow(TypeError);
+  });
 });
 
 // A call resolved through a binding that a closure captures is compiled with the scope object


### PR DESCRIPTION
### Problem
- The `atime`, `mtime`, `ctime` and `birthtime` getters of `fs.Stats` and `BigIntStats` convert `*Ms` to a `Date` differently from Node.js. A real `fs.stat()` result with a fraction of 0.5 ms or more gives a `Date` 1 ms early. A BigInt at or past 2^63 wraps to 64 bits. A Number `*Ms` on `BigIntStats`, or a BigInt `*Ms` on `Stats`, throws `TypeError: Conversion from 'BigInt' to 'number' is not allowed.`
- The cause is `getDateField` in `src/jsc/bindings/NodeFSStatBinding.cpp:233`. It calls `toBigInt64` for one class and `toNumber` for the other, with no round. `DateInstance::create` then truncates.

### Fix
- `getDateField` now does what Node's `dateFromMs` does: `new Date(MathRound(Number(ms)))`. It calls `toNumeric`, converts a BigInt result with `JSBigInt::toNumber`, and rounds with `jsRound` (the `Math.round` implementation, so `-0.5` gives `0` and `-1.5` gives `-1`).
- A BigInt past 2^63 becomes a double past the `Date` range, so TimeClip gives an Invalid Date. Both classes accept a Number or a BigInt, and each getter works on an object of the other class.
- Verified: `test/js/node/fs/fs-stats-constructor.test.ts` (4 new tests fail on 1.4.3, pass with the fix). Also `fs.test.ts`, `fs-stats-truncate.test.ts`, and the upstream `test-fs-stat.js`, `test-fs-stat-bigint.js` and `test-fs-stat-date.mjs`.

### Background
- `Stats` and `BigIntStats` store `atimeMs` and friends as own properties. The `Date` getters live on the prototype, compute the `Date` from the `*Ms` field, and cache it on the instance. Node does the same with `ObjectDefineProperty` in `lib/internal/fs/utils.js`.
- `toNumeric` is the ECMAScript ToNumeric operation. It returns a Number or a BigInt and throws for a Symbol. `Number(x)` is ToNumeric followed by a BigInt to double conversion, which is what `JSBigInt::toNumber` does.
- `jsRound` is the function behind `Math.round` in JavaScriptCore. `std::round` differs for negative halves.

<details><summary>Notes</summary>

Node reference: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L459-L469

The `BigIntStats` `*Ms` fields are integer BigInts (the fraction lives in `*Ns`), so a real BigInt stat is not affected by the round. The test asserts that too.

#42518 changes how the getters store the cached `Date` on the instance. It does not touch the conversion, so the two changes do not overlap in behaviour.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/fs/fs-stats-constructor.test.ts
bun test v1.4.3 (b99371011)

test/js/node/fs/fs-stats-constructor.test.ts:
(pass) new Stats(...) assigns fields in Node's order [12.95ms]
(pass) Stats(...) without new assigns fields in Node's order [3.13ms]
(pass) Stats instances share Stats.prototype [28.00ms]
75 |     expect({
76 |       mtime: stats.mtime.getTime(),
77 |       atime: stats.atime.getTime(),
78 |       bigintMtimeMs: bigint.mtimeMs,
79 |       bigintMtime: bigint.mtime.getTime(),
80 |     }).toEqual({
            ^
error: expect(received).toEqual(expected)

  {
-   "atime": 1700000000790,
+   "atime": 1700000000789,
    "bigintMtime": 1700000000789,
    "bigintMtimeMs": 1700000000789n,
-   "mtime": 1700000000790,
+   "mtime": 1700000000789,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/node/fs/fs-stats-constructor.test.ts:80:8)
(fail) Stats date getters convert *Ms like Node.js > a real stat rounds the fraction instead of truncating it [42.69ms]
91 |       // The getter caches the Date o
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (08fa3e246)

test/js/node/fs/fs-stats-constructor.test.ts:
(pass) new Stats(...) assigns fields in Node's order [0.05ms]
(pass) Stats(...) without new assigns fields in Node's order [0.06ms]
(pass) Stats instances share Stats.prototype [0.17ms]
(pass) Stats date getters convert *Ms like Node.js > a real stat rounds the fraction instead of truncating it [0.87ms]
(pass) Stats date getters convert *Ms like Node.js > a Number *Ms rounds like Math.round [0.11ms]
(pass) Stats date getters convert *Ms like Node.js > a BigInt *Ms past 64 bits is an Invalid Date, not a wrapped value [0.06ms]
(pass) Stats date getters convert *Ms like Node.js > both classes accept a Number or a BigInt *Ms [0.09ms]
(pass) Stats date getters convert *Ms like Node.js > a *Ms that is not numeric still throws from the coercion [0.11ms]
(pass) Stats methods and accessors called without a receiver > a mode method called through a captured binding is treated like an undefined receiver [0.09ms]
(pass) Stats methods and accessors called without a receiver > a date getter called through a captured binding is treated like an undefined receiver [0.08ms]
(pass) Stats methods and ac
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/fs/fs-stats-constructor.test.ts
bun test v1.4.3 (b99371011)

test/js/node/fs/fs-stats-constructor.test.ts:
(pass) new Stats(...) assigns fields in Node's order [11.28ms]
(pass) Stats(...) without new assigns fields in Node's order [2.54ms]
(pass) Stats instances share Stats.prototype [25.29ms]
(pass) Stats date getters convert *Ms like Node.js > a real stat rounds the fraction instead of truncating it [33.02ms]
(pass) Stats date getters convert *Ms like Node.js > a Number *Ms rounds like Math.round [6.08ms]
(pass) Stats date getters convert *Ms like Node.js > a BigInt *Ms past 64 bits is an Invalid Date, not a wrapped value [4.01ms]
(pass) Stats date getters convert *Ms like Node.js > both classes accept a Number or a BigInt *Ms [6.13ms]
(pass) Stats date getters convert *Ms like Node.js > a *Ms that is not numeric still throws from the coercion [7.40ms]
(pass) Stats methods and accessors called without a receiver > a mode method called through a captured binding is treated like an undefined receiver [7.20ms]
(pass) Stats m
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 752ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[2/7] gen cpp.rs (cppbind)
[2/7] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeFSStatBinding.cpp       |  8 ++-
 test/js/node/fs/fs-stats-constructor.test.ts | 92 +++++++++++++++++++++++++++-
 2 files changed, 97 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/bindings/NodeFSStatBinding.cpp            1      2     10
test/js/node/fs/fs-stats-constructor.test.ts      2      7     10
```

</details>

**root cause** · written by the author bot

The date getters of `fs.Stats` and `BigIntStats` in `NodeFSStatBinding.cpp` converted the `*Ms` field with `toBigInt64` for BigInt stats and `toNumber` for Number stats, then handed the result straight to the `Date` constructor. That meant the millisecond value was truncated rather than rounded, BigInt values at or beyond 2^63 wrapped to 64 bits instead of producing an Invalid Date, and a `*Ms` value of the other numeric type threw a conversion error. The fix uses a single shared coercion for both classes that converts a BigInt to a Number the way `Number(x)` does, applies `Math.round`, and…

<!-- robobun:evidence:end -->