### PR TITLE
markdown: use one link destination scanner that follows CommonMark 6.3

### DIFF
--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -70,8 +70,9 @@ pub(crate) struct ParsedDest<'a> {
 ///
 /// `<...>` form: no line ending and no unescaped `<` before the closing `>`.
 /// Bare form: may be empty, ends at whitespace or at a `)` that closes nothing,
-/// and its unescaped parentheses must balance. A backslash escapes ASCII
-/// punctuation only, so `\` before a space or a line ending hides nothing.
+/// holds no ASCII control character, and its unescaped parentheses must
+/// balance. A backslash escapes ASCII punctuation only, so `\` before a space
+/// or a line ending hides nothing.
 pub(crate) fn scan_link_destination(text: &[u8], start: usize) -> Option<ParsedDest<'_>> {
     let escapes_next = |p: usize| p + 1 < text.len() && helpers::is_ascii_punctuation(text[p + 1]);
     let mut p = start;
@@ -114,6 +115,7 @@ pub(crate) fn scan_link_destination(text: &[u8], start: usize) -> Option<ParsedD
                 }
                 paren_depth -= 1;
             }
+            c if c.is_ascii_control() => return None,
             _ => {}
         }
         p += 1;

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -8,10 +8,10 @@ use crate::types::{OFF, SpanDetail, SpanType, TextType};
 type Span = SpanType;
 type SpanAttrs<'a> = SpanDetail<'a>;
 
-/// Maximum parenthesis nesting depth inside a bare inline-link destination.
+/// Maximum parenthesis nesting depth inside a bare link destination.
 /// CommonMark allows implementations to impose such a limit ("at least three
-/// levels of nesting should be supported"); cmark and commonmark.js both use
-/// 32. Without a cap, an unclosed destination is rescanned for every candidate
+/// levels of nesting should be supported"); cmark and md4c both use 32.
+/// Without a cap, an unclosed destination is rescanned for every candidate
 /// link, which is quadratic on inputs like `"[a](b"` repeated.
 const MAX_LINK_DEST_PAREN_DEPTH: u32 = 32;
 
@@ -54,6 +54,77 @@ pub(crate) enum LabelLeave {
 pub(crate) struct Autolink {
     pub(crate) end_pos: usize,
     pub(crate) is_email: bool,
+}
+
+/// Result of `scan_link_destination`.
+pub(crate) struct ParsedDest<'a> {
+    /// Raw destination, without the `<` `>` of the angle-bracket form.
+    pub(crate) dest: &'a [u8],
+    /// Position just past the destination (past the `>` of the angle-bracket form).
+    pub(crate) end_pos: usize,
+}
+
+/// Scan the link destination that starts at `start` (CommonMark §6.3). Inline
+/// links, the link lookahead and reference definitions all call this, so they
+/// cannot disagree on what a destination is.
+///
+/// `<...>` form: no line ending and no unescaped `<` before the closing `>`.
+/// Bare form: may be empty, ends at whitespace or at a `)` that closes nothing,
+/// and its unescaped parentheses must balance. A backslash escapes ASCII
+/// punctuation only, so `\` before a space or a line ending hides nothing.
+pub(crate) fn scan_link_destination(text: &[u8], start: usize) -> Option<ParsedDest<'_>> {
+    let escapes_next = |p: usize| p + 1 < text.len() && helpers::is_ascii_punctuation(text[p + 1]);
+    let mut p = start;
+
+    if p < text.len() && text[p] == b'<' {
+        p += 1;
+        let dest_start = p;
+        while p < text.len() {
+            match text[p] {
+                b'>' => {
+                    return Some(ParsedDest {
+                        dest: &text[dest_start..p],
+                        end_pos: p + 1,
+                    });
+                }
+                b'<' | b'\n' | b'\r' => return None,
+                b'\\' if escapes_next(p) => p += 2,
+                _ => p += 1,
+            }
+        }
+        return None;
+    }
+
+    let mut paren_depth: u32 = 0;
+    while p < text.len() && !helpers::is_whitespace(text[p]) {
+        match text[p] {
+            b'\\' if escapes_next(p) => {
+                p += 2;
+                continue;
+            }
+            b'(' => {
+                paren_depth += 1;
+                if paren_depth > MAX_LINK_DEST_PAREN_DEPTH {
+                    return None;
+                }
+            }
+            b')' => {
+                if paren_depth == 0 {
+                    break;
+                }
+                paren_depth -= 1;
+            }
+            _ => {}
+        }
+        p += 1;
+    }
+    if paren_depth != 0 {
+        return None;
+    }
+    Some(ParsedDest {
+        dest: &text[start..p],
+        end_pos: p,
+    })
 }
 
 /// Characters that can affect bracket matching: the brackets themselves,
@@ -369,66 +440,20 @@ impl Parser<'_> {
                 pos += 1;
             }
 
-            // Parse destination
-            let mut dest_start = pos;
-            let dest_end;
-            let mut dest_valid = true;
-
-            if pos < content.len() && content[pos] == b'<' {
-                // Angle-bracket destination (no newlines or unescaped '<' allowed)
-                dest_start = pos + 1;
-                pos += 1;
-                let mut angle_valid = true;
-                while pos < content.len() && content[pos] != b'>' {
-                    if content[pos] == b'\n' || content[pos] == b'\r' || content[pos] == b'<' {
-                        angle_valid = false;
-                        break;
-                    }
-                    if content[pos] == b'\\' && pos + 1 < content.len() {
-                        pos += 2;
-                    } else {
-                        pos += 1;
-                    }
+            let dest: &[u8] = match scan_link_destination(content, pos) {
+                Some(parsed) => {
+                    pos = parsed.end_pos;
+                    parsed.dest
                 }
-                if !angle_valid {
-                    return Ok(None);
+                None => {
+                    // Not an inline link (cmark rejects it too). Skip the
+                    // title and ')' checks, so that a '(' of the rejected
+                    // destination is not reparsed as a title opener, but keep
+                    // the reference/shortcut fallback below reachable.
+                    pos = content.len();
+                    b""
                 }
-                dest_end = pos;
-                if pos < content.len() {
-                    pos += 1; // skip >
-                }
-            } else {
-                // Bare destination — balance parentheses (nesting depth is capped)
-                let mut paren_depth: u32 = 0;
-                while pos < content.len() && !helpers::is_whitespace(content[pos]) {
-                    if content[pos] == b'(' {
-                        paren_depth += 1;
-                        if paren_depth > MAX_LINK_DEST_PAREN_DEPTH {
-                            dest_valid = false;
-                            break;
-                        }
-                    } else if content[pos] == b')' {
-                        if paren_depth == 0 {
-                            break;
-                        }
-                        paren_depth -= 1;
-                    }
-                    if content[pos] == b'\\' && pos + 1 < content.len() {
-                        pos += 2;
-                    } else {
-                        pos += 1;
-                    }
-                }
-                dest_end = pos;
-            }
-
-            if !dest_valid {
-                // Destination exceeded the paren-nesting cap: not an inline
-                // link (cmark rejects it too). Skip the title and ')' checks —
-                // the offending '(' must not be reparsed as a title opener —
-                // but keep the reference/shortcut fallback below reachable.
-                pos = content.len();
-            }
+            };
 
             // Skip whitespace (including newlines)
             while pos < content.len()
@@ -487,7 +512,6 @@ impl Parser<'_> {
             // Must end with ')'
             if pos < content.len() && content[pos] == b')' {
                 pos += 1;
-                let dest = &content[dest_start..dest_end];
 
                 // Link nesting prohibition: links cannot contain other links (CommonMark §6.7)
                 if !is_image
@@ -637,57 +661,13 @@ impl Parser<'_> {
             {
                 p += 1;
             }
-            // Parse dest (no line endings or unescaped '<' allowed, matching
-            // process_link: the lookahead and the parser must agree on what
-            // is a link or emphasis collection desyncs from rendering)
-            if p < content.len() && content[p] == b'<' {
-                p += 1;
-                while p < content.len()
-                    && content[p] != b'>'
-                    && content[p] != b'\n'
-                    && content[p] != b'\r'
-                    && content[p] != b'<'
-                {
-                    if content[p] == b'\\' && p + 1 < content.len() {
-                        p += 2;
-                    } else {
-                        p += 1;
-                    }
-                }
-                if p < content.len() && content[p] == b'>' {
-                    p += 1;
-                } else {
-                    return BracketLinkMatch {
-                        is_link: false,
-                        label_end,
-                        link_end: label_end + 1,
-                    };
-                }
-            } else {
-                let mut paren_depth: u32 = 0;
-                while p < content.len() && !helpers::is_whitespace(content[p]) {
-                    if content[p] == b'(' {
-                        paren_depth += 1;
-                        if paren_depth > MAX_LINK_DEST_PAREN_DEPTH {
-                            // Not an inline link; skip the title/')' checks but
-                            // keep the reference/shortcut fallback reachable
-                            // (mirrors process_link).
-                            p = content.len();
-                            break;
-                        }
-                    } else if content[p] == b')' {
-                        if paren_depth == 0 {
-                            break;
-                        }
-                        paren_depth -= 1;
-                    }
-                    if content[p] == b'\\' && p + 1 < content.len() {
-                        p += 2;
-                    } else {
-                        p += 1;
-                    }
-                }
-            }
+            // Same destination scan and same fallback as process_link: the
+            // lookahead and the parser must agree on what is a link or
+            // emphasis collection desyncs from rendering.
+            p = match scan_link_destination(content, p) {
+                Some(parsed) => parsed.end_pos,
+                None => content.len(),
+            };
             // Skip whitespace
             while p < content.len()
                 && (helpers::is_blank(content[p]) || content[p] == b'\n' || content[p] == b'\r')

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -10,8 +10,8 @@ type SpanAttrs<'a> = SpanDetail<'a>;
 
 /// Maximum parenthesis nesting depth inside a bare link destination.
 /// CommonMark allows implementations to impose such a limit ("at least three
-/// levels of nesting should be supported"); cmark and md4c both use 32.
-/// Without a cap, an unclosed destination is rescanned for every candidate
+/// levels of nesting should be supported"); cmark and md4c both use
+/// 32. Without a cap, an unclosed destination is rescanned for every candidate
 /// link, which is quadratic on inputs like `"[a](b"` repeated.
 const MAX_LINK_DEST_PAREN_DEPTH: u32 = 32;
 
@@ -64,15 +64,7 @@ pub(crate) struct ParsedDest<'a> {
     pub(crate) end_pos: usize,
 }
 
-/// Scan the link destination that starts at `start` (CommonMark §6.3). Inline
-/// links, the link lookahead and reference definitions all call this, so they
-/// cannot disagree on what a destination is.
-///
-/// `<...>` form: no line ending and no unescaped `<` before the closing `>`.
-/// Bare form: may be empty, ends at whitespace or at a `)` that closes nothing,
-/// holds no ASCII control character, and its unescaped parentheses must
-/// balance. A backslash escapes ASCII punctuation only, so `\` before a space
-/// or a line ending hides nothing.
+/// CommonMark §6.3 link destination, shared by inline links, the link lookahead and reference definitions.
 pub(crate) fn scan_link_destination(text: &[u8], start: usize) -> Option<ParsedDest<'_>> {
     let escapes_next = |p: usize| p + 1 < text.len() && helpers::is_ascii_punctuation(text[p + 1]);
     let mut p = start;
@@ -448,10 +440,7 @@ impl Parser<'_> {
                     parsed.dest
                 }
                 None => {
-                    // Not an inline link (cmark rejects it too). Skip the
-                    // title and ')' checks, so that a '(' of the rejected
-                    // destination is not reparsed as a title opener, but keep
-                    // the reference/shortcut fallback below reachable.
+                    // Not an inline link: skip the title and ')' checks, keep the reference/shortcut fallback.
                     pos = content.len();
                     b""
                 }
@@ -663,9 +652,7 @@ impl Parser<'_> {
             {
                 p += 1;
             }
-            // Same destination scan and same fallback as process_link: the
-            // lookahead and the parser must agree on what is a link or
-            // emphasis collection desyncs from rendering.
+            // Must agree with process_link, or emphasis collection desyncs from rendering.
             p = match scan_link_destination(content, p) {
                 Some(parsed) => parsed.end_pos,
                 None => content.len(),

--- a/src/md/ref_defs.rs
+++ b/src/md/ref_defs.rs
@@ -3,6 +3,7 @@ use core::mem::{align_of, size_of};
 use bun_alloc::AllocError;
 
 use crate::helpers;
+use crate::links::{ParsedDest, scan_link_destination};
 use crate::parser::{BlockHeader, Parser};
 use crate::types::{self, VerbatimLine};
 use crate::unicode;
@@ -21,11 +22,6 @@ pub(crate) struct ParsedRefDef<'a> {
     pub(crate) label: &'a [u8],
     pub(crate) dest: &'a [u8],
     pub(crate) title: &'a [u8],
-}
-
-pub(crate) struct ParsedDest<'a> {
-    pub(crate) dest: &'a [u8],
-    pub(crate) end_pos: usize,
 }
 
 pub(crate) struct ParsedTitle<'a> {
@@ -250,55 +246,12 @@ impl Parser<'_> {
         text: &'a [u8],
         start: usize,
     ) -> Option<ParsedDest<'a>> {
-        let mut p = start;
-        if p >= text.len() {
+        let parsed = scan_link_destination(text, start)?;
+        // A reference definition needs a destination: only `<>` may be empty.
+        if parsed.end_pos == start {
             return None;
         }
-
-        if text[p] == b'<' {
-            // Angle-bracket destination
-            p += 1;
-            let dest_start = p;
-            while p < text.len() && text[p] != b'>' && text[p] != b'\n' {
-                if text[p] == b'\\' && p + 1 < text.len() {
-                    p += 2;
-                } else {
-                    p += 1;
-                }
-            }
-            if p >= text.len() || text[p] != b'>' {
-                return None;
-            }
-            let dest = &text[dest_start..p];
-            p += 1; // skip >
-            Some(ParsedDest { dest, end_pos: p })
-        } else {
-            // Bare destination — balance parentheses
-            let dest_start = p;
-            let mut paren_depth: u32 = 0;
-            while p < text.len() && !helpers::is_whitespace(text[p]) {
-                if text[p] == b'(' {
-                    paren_depth += 1;
-                } else if text[p] == b')' {
-                    if paren_depth == 0 {
-                        break;
-                    }
-                    paren_depth -= 1;
-                }
-                if text[p] == b'\\' && p + 1 < text.len() {
-                    p += 2;
-                } else {
-                    p += 1;
-                }
-            }
-            if p == dest_start {
-                return None; // empty dest not allowed for bare
-            }
-            Some(ParsedDest {
-                dest: &text[dest_start..p],
-                end_pos: p,
-            })
-        }
+        Some(parsed)
     }
 
     pub(crate) fn parse_ref_def_title<'a>(

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -651,11 +651,81 @@ describe("pathological bracket inputs", () => {
     const overflowIntoTitle = Markdown.html("[a](" + "(".repeat(33) + "))\n");
     expect(overflowIntoTitle).not.toContain("<a href=");
     expect(overflowIntoTitle).toContain("[a](");
+    // Reference definitions use the same scanner, so the same cap (cmark too).
+    const refNest = (n: number) => "[a]: " + "(".repeat(n) + "b" + ")".repeat(n) + "\n\n[a]\n";
+    expect(Markdown.html(refNest(32))).toContain("<a href=");
+    expect(Markdown.html(refNest(33))).not.toContain("<a href=");
   });
 
   test("angle-bracket destination may not contain an unescaped '<'", () => {
     expect(Markdown.html("[a](<b<c>)\n")).not.toContain("<a href=");
     expect(Markdown.html("[a](<b\\<c>)\n")).toContain('<a href="b%3Cc"');
+  });
+
+  // CommonMark §6.3 link destinations. Every expected string below is the
+  // output of commonmark.js 0.31.2, keyed by its input.
+  const renderAll = (cases: Record<string, string>) =>
+    Object.fromEntries(Object.keys(cases).map(md => [md, Markdown.html(md)]));
+
+  test("a backslash in a link destination escapes ASCII punctuation only", () => {
+    const cases = {
+      // cmark-gfm test/regression.txt, issues #192 and #530: a space, tab or
+      // line ending after a backslash still ends a bare destination.
+      "[a](te\\ st)\n": "<p>[a](te\\ st)</p>\n",
+      "[a](\\ b)\n": "<p>[a](\\ b)</p>\n",
+      "[a](b\\\nc)\n": "<p>[a](b<br />\nc)</p>\n",
+      "![a](te\\ st)\n": "<p>![a](te\\ st)</p>\n",
+      "[a]: te\\ st\n\n[a]\n": "<p>[a]: te\\ st</p>\n<p>[a]</p>\n",
+      // The backslash ends the destination, so the title still parses.
+      '[a](b\\ "t")\n': '<p><a href="b%5C" title="t">a</a></p>\n',
+      // A line ending after a backslash still invalidates a <...> destination.
+      "[a](<te\\\nst>)\n": "<p>[a](&lt;te<br />\nst&gt;)</p>\n",
+      "[a]: <te\\\nst>\n\n[a]\n": "<p>[a]: &lt;te<br />\nst&gt;</p>\n<p>[a]</p>\n",
+      // The emphasis lookahead rejects the same destination as the link parser.
+      "*foo [a](te\\ st*) bar*\n": "<p><em>foo [a](te\\ st</em>) bar*</p>\n",
+      // Controls: punctuation is escaped, other bytes keep a literal backslash.
+      "[a](foo\\)bar)\n": '<p><a href="foo)bar">a</a></p>\n',
+      "[a](foo\\bar)\n": '<p><a href="foo%5Cbar">a</a></p>\n',
+      "[a](<te\\ st>)\n": '<p><a href="te%5C%20st">a</a></p>\n',
+    };
+    expect(renderAll(cases)).toEqual(cases);
+  });
+
+  test("reference definition <...> destination may not contain an unescaped '<'", () => {
+    const cases = {
+      // cmark-gfm test/regression.txt, issue #193.
+      "[a]\n\n[a]: <te<st>\n": "<p>[a]</p>\n<p>[a]: &lt;te<st></p>\n",
+      "[a]: <te\\<st>\n\n[a]\n": '<p><a href="te%3Cst">a</a></p>\n',
+    };
+    expect(renderAll(cases)).toEqual(cases);
+  });
+
+  test("bare link destination needs balanced parentheses", () => {
+    const cases = {
+      "[a](foo(bar )\n": "<p>[a](foo(bar )</p>\n",
+      '[a](foo(bar "t")\n': "<p>[a](foo(bar &quot;t&quot;)</p>\n",
+      "[a]: foo(bar\n\n[a]\n": "<p>[a]: foo(bar</p>\n<p>[a]</p>\n",
+      // Controls: balanced or escaped parentheses.
+      "[a](foo(bar))\n": '<p><a href="foo(bar)">a</a></p>\n',
+      "[a](foo\\(bar )\n": '<p><a href="foo(bar">a</a></p>\n',
+      "[a]: foo(bar)\n\n[a]\n": '<p><a href="foo(bar)">a</a></p>\n',
+    };
+    expect(renderAll(cases)).toEqual(cases);
+  });
+
+  test("a rejected inline destination falls back to the shortcut reference", () => {
+    const cases = {
+      "[a]: /url\n\n[a](<b<c>)\n": '<p><a href="/url">a</a>(&lt;b<c>)</p>\n',
+      "[a]: /url\n\n[a](te\\ st)\n": '<p><a href="/url">a</a>(te\\ st)</p>\n',
+      // The emphasis lookahead and label_contains_link take the same fallback.
+      "[a]: /url\n\n*[a](<b*<c>)\n": '<p><em><a href="/url">a</a>(&lt;b</em><c>)</p>\n',
+      "[a]: /url\n\n[x [a](<b<c>) y](/u)\n": '<p>[x <a href="/url">a</a>(&lt;b<c>) y](/u)</p>\n',
+      // An unclosed <...> at the end of the text. The lookahead used to give up
+      // where the parser fell back, so the '*' in the label opened an <em>
+      // that nothing closed.
+      "[a*]: /url\n\n*[a*](<b\n": '<p>*<a href="/url">a*</a>(&lt;b</p>\n',
+    };
+    expect(renderAll(cases)).toEqual(cases);
   });
 
   test("()-delimited title may not contain an unescaped '('", () => {

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -652,7 +652,8 @@ describe("pathological bracket inputs", () => {
     expect(overflowIntoTitle).not.toContain("<a href=");
     expect(overflowIntoTitle).toContain("[a](");
     // Reference definitions use the same scanner, so the same cap (cmark too).
-    const refNest = (n: number) => "[a]: " + "(".repeat(n) + "b" + ")".repeat(n) + "\n\n[a]\n";
+    const refNest = (n: number) =>
+      "[a]: " + Buffer.alloc(n, "(").toString() + "b" + Buffer.alloc(n, ")").toString() + "\n\n[a]\n";
     expect(Markdown.html(refNest(32))).toContain("<a href=");
     expect(Markdown.html(refNest(33))).not.toContain("<a href=");
   });
@@ -662,8 +663,9 @@ describe("pathological bracket inputs", () => {
     expect(Markdown.html("[a](<b\\<c>)\n")).toContain('<a href="b%3Cc"');
   });
 
-  // CommonMark §6.3 link destinations. Every expected string below is the
-  // output of commonmark.js 0.31.2, keyed by its input.
+  // CommonMark §6.3 link destinations. Each table is keyed by its input. The
+  // expected strings are the output of commonmark.js 0.31.2, except in the
+  // control-character test, which says why.
   const renderAll = (cases: Record<string, string>) =>
     Object.fromEntries(Object.keys(cases).map(md => [md, Markdown.html(md)]));
 
@@ -709,6 +711,21 @@ describe("pathological bracket inputs", () => {
       "[a](foo(bar))\n": '<p><a href="foo(bar)">a</a></p>\n',
       "[a](foo\\(bar )\n": '<p><a href="foo(bar">a</a></p>\n',
       "[a]: foo(bar)\n\n[a]\n": '<p><a href="foo(bar)">a</a></p>\n',
+    };
+    expect(renderAll(cases)).toEqual(cases);
+  });
+
+  // The spec says a bare destination "does not include ASCII control
+  // characters", and md4c stops at one. cmark, cmark-gfm and commonmark.js do
+  // not check this, so the expected strings here come from the spec text.
+  test("bare link destination may not contain an ASCII control character", () => {
+    const cases = {
+      "[a](b\x01c)\n": "<p>[a](b\x01c)</p>\n",
+      "[a](b\x7fc)\n": "<p>[a](b\x7fc)</p>\n",
+      "[a]: b\x1bc\n\n[a]\n": "<p>[a]: b\x1bc</p>\n<p>[a]</p>\n",
+      "[a]: /url\n\n[a](b\x01c)\n": '<p><a href="/url">a</a>(b\x01c)</p>\n',
+      // Control: the <...> form has no such rule.
+      "[a](<b\x01c>)\n": '<p><a href="b%01c">a</a></p>\n',
     };
     expect(renderAll(cases)).toEqual(cases);
   });


### PR DESCRIPTION
### Problem
- `Bun.markdown` scans link destinations in three places: `process_link`, its lookahead `try_match_bracket_link` (both `src/md/links.rs`) and `parse_ref_def_dest` (`src/md/ref_defs.rs`). md4c, which this code ports, has one function. #31241 hardened two copies and missed the third.
- Disagreement gives malformed HTML. `[a*]: /url` followed by `*[a*](<b` renders `<p><em><a href="/url">a*</a>(&lt;b</p>` on 1.4.3, with no `</em>`.
- Every copy skips the byte after any backslash, so `[a](te\ st)` renders `<a href="te%5C%20st">a</a>`. CommonMark 6.3, md4c and cmark-gfm print the literal text. No user reported this: the cmark-gfm test files found it.

### Fix
- Add `scan_link_destination` with md4c's rules and call it from all three places. A backslash escapes ASCII punctuation only. `<...>` rejects a line ending and an unescaped `<`. A bare destination needs balanced parentheses (nesting capped at 32) and no ASCII control character.
- When the scanner rejects an inline destination, the parser and the lookahead both continue to the reference and shortcut forms.
- Three rules differ from GitHub on purpose. cmark-gfm 0.29 accepts unbalanced parentheses, a line ending after `\` inside `<...>`, and control characters in a bare destination. The spec and md4c reject all three.
- Verified: `test/js/bun/md/md-edge-cases.test.ts`, six tests fail on 1.4.3. `test/js/bun/md/` and `test/cli/run/markdown-entrypoint.test.ts` pass.

### Background
- A link destination is the URL part of `[text](dest "title")` or of a definition `[label]: dest`. It is `<...>` or a bare run without whitespace.
- The emphasis collector and `label_contains_link` call the lookahead to step over links. It must accept exactly what `process_link` accepts.
- A shortcut reference is `[a]` alone, resolved through `[a]: /url`. It applies when `[a](...)` is not a valid inline link.

<details><summary>Notes</summary>

Scope. This PR changes the destination production of CommonMark 6.3 and nothing else. Two nearby rules stay as they are:
- The title and label scanners also skip the byte after any backslash. That is harmless there, because only punctuation bytes can end or invalidate a title or a label.
- `[a](<b>"t")` is a link with title `t` in Bun. The spec wants whitespace between the destination and the title. commonmark.js and cmark print literal text.

Known interaction, tracked in #42561. `label_contains_link` steps over a bracket pair that is not a link and misses a link inside it. `[[x [a](/i) y] z](/u)` nests `<a>` in `<a>` on main today. This PR does not touch that function, but it changes which inputs reach the bug. `[[x [a](/i) y](te\ st) z](/u)` is valid HTML on 1.4.3, only because the old destination scan called `(te\ st)` a destination. On this branch it nests `<a>`.

Where GitHub differs. cmark-gfm is a fork of cmark 0.29. Its bare scanner has no balance check, so `[wiki]: https://en.wikipedia.org/wiki/Rust_(programming_language` is a definition on github.com and on bun 1.4.3. On this branch, in commonmark.js 0.31.2, in cmark 0.31.1 and in md4c it is a paragraph. cmark and cmark-gfm also skip the byte after any backslash inside `<...>`, so they accept a line ending there. The spec says that `<...>` contains no line endings. commonmark.js rejects it too.

Control characters. The spec says that a bare destination does not include ASCII control characters, and md4c stops at one (`ISCNTRL`). cmark, cmark-gfm and commonmark.js do not check this, so `[a](b\x01c)` with a raw U+0001 is a link there and on bun 1.4.3. On this branch it is literal text. The `<...>` form still accepts control characters, as the spec allows.

Real documents. I rendered 5,908 distinct Markdown files (28.6 MB, about 54,000 inline link tails and 7,600 definitions: the bun repo, vendored dependencies, WebKit, package READMEs) with bun 1.4.3 and with this branch. No output changes.

Conformance files, before and after:
- cmark-gfm `test/regression.txt`: 18/26, now 21/26. Examples 6, 7 and 15 now pass (cmark issues 193, 192 and 530). The other five are footnotes.
- cmark `test/regression.txt`: 21/29, now 24/29 (6, 7, 9).
- CommonMark `spec.txt` 0.31.2: no change, all pass.

Generated inputs. 60,000 link-shaped inputs (two seeds), rendered with commonmark.js 0.31.2, cmark 0.31.1, cmark-gfm 0.29.0.gfm.13, bun 1.4.3 and this branch:
- commonmark.js and cmark agree on 56,556 inputs. On those, 6,633 outputs now match and did not before. 11 matched before and do not now. All 11 are the #42561 interaction above.
- Against cmark-gfm alone, 5,977 outputs move to its output and 1,581 move away. The 1,581 are the unbalanced parentheses and the line ending inside `<...>`, plus the #42561 inputs.
- The generated inputs hold no control characters, so that rule does not move these counts.

Other effects of the shared scanner:
- Reference definitions now get the same cap of 32 nested parentheses as inline links. cmark and md4c do the same. commonmark.js has no cap, so the old comment that named it was wrong.
- An unclosed `<...>` at the end of the text made the lookahead return early while `process_link` fell through to the shortcut form. That is the unclosed `<em>` above. Both now fall through.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-edge-cases.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/66] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/66] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/66] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 f
... (truncated)

release without fix: 6 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [1.13ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [0.10ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [0.04ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [0.11ms]
(pass) fuzzer-like edge cases > control characters in input [0.02ms]
(pass) fuzzer-like edge cases > Buffer input works [0.02ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [0.05ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [0.12ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [0.04ms]
(pass) fuzzer-like edge cases > deeply nested lists [0.07ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [7.40ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [5.18ms]
(pass) fuzzer-like edge cases > deeply nested emphasis [0.07ms]
(pass) fuzzer-like edge cases > deeply nested links [0.05ms]
(pass) fuzzer-like edge cases > very long s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-edge-cases.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [84.57ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [10.12ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [2.43ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [8.08ms]
(pass) fuzzer-like edge cases > control characters in input [2.29ms]
(pass) fuzzer-like edge cases > Buffer input works [2.79ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [5.18ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [9.29ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [2.97ms]
(pass) fuzzer-like edge cases > deeply nested lists [8.90ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [147.50ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [97.55ms]
(pa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 621ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/61] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/61] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/61] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/md/links.rs                      | 193 +++++++++++++++--------------------
 src/md/ref_defs.rs                   |  57 +----------
 test/js/bun/md/md-edge-cases.test.ts |  87 ++++++++++++++++
 3 files changed, 173 insertions(+), 164 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/md/links.rs                           5     12     12
src/md/ref_defs.rs                        1      2     12
test/js/bun/md/md-edge-cases.test.ts      1      6     12
```

</details>

<!-- robobun:evidence:end -->