### PR TITLE
bun:test: make this.utils and this.equals plain functions, port Jest's matcherHint

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1965,14 +1965,26 @@ declare module "bun:test" {
     //customTesters: Array<Tester>;
     //dontThrow(): void; // (internally used by jest snapshot)
     equals: EqualsFunction;
+    /**
+     * Helpers to build a failure message. They are plain functions, so a matcher can destructure them:
+     * `const { matcherHint, printReceived } = this.utils`.
+     */
     utils: Readonly<{
       stringify(value: unknown): string;
       printReceived(value: unknown): string;
       printExpected(value: unknown): string;
+      /**
+       * Returns the one-line call signature that starts a failure message, for example
+       * `expect(received).toBeFoo(expected)`.
+       *
+       * @param matcherName The matcher name. A name that contains a period (`".toBeFoo"`, `".not.toBeFoo"`) is printed as it is.
+       * @param received The label in `expect(...)`. The default is `"received"`. An empty string prints `expect` without parentheses.
+       * @param expected The label in the matcher call. The default is `"expected"`. An empty string prints `()`.
+       */
       matcherHint(
         matcherName: string,
-        received?: unknown,
-        expected?: unknown,
+        received?: string,
+        expected?: string,
         options?: {
           isNot?: boolean;
           promise?: string;

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -6,7 +6,7 @@ use bun_core::Output;
 use bun_jsc::bun_string_jsc;
 use bun_jsc::{
     CallFrame, JSGlobalObject, JSValue, JsError, JsResult,
-    ConsoleObject, JSFunction, JSPropertyIterator, JSString,
+    ConsoleObject, JSFunction, JSPropertyIterator,
 };
 use bun_jsc::{JsClass as _, StringJsc as _};
 use bun_jsc::js_promise;
@@ -2703,27 +2703,47 @@ impl ExpectMatcherContext {
         JSValue::FALSE
     }
 
-    #[bun_jsc::host_fn(method)]
-    pub(crate) fn equals(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        let args = callframe.arguments();
-        if args.len() < 2 {
-            return Err(global_this.throw2(
-                "expect.extends matcher: this.util.equals expects at least 2 arguments",
-                (),
-            ));
-        }
-        Ok(JSValue::from(args[0].jest_deep_equals(args[1], global_this)?))
+    /// Jest puts the plain `equals` function of `@jest/expect-utils` on the context, and matchers
+    /// call it unbound (`const { equals } = this`). A prototype method would check its receiver.
+    #[bun_jsc::host_fn(getter)]
+    pub(crate) fn get_equals(_this: &Self, global_this: &JSGlobalObject) -> JSValue {
+        JSFunction::create(global_this, "equals", __jsc_host_matcher_context_equals, 3, Default::default())
     }
 }
 
-/// Reference: `MatcherUtils` in https://github.com/jestjs/jest/blob/main/packages/expect/src/types.ts
-#[bun_jsc::JsClass(no_construct, no_constructor)]
-pub struct ExpectMatcherUtils {}
+#[bun_jsc::host_fn]
+fn matcher_context_equals(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+    let args = callframe.arguments();
+    if args.len() < 2 {
+        return Err(global_this.throw2(
+            "expect.extends matcher: this.util.equals expects at least 2 arguments",
+            (),
+        ));
+    }
+    Ok(JSValue::from(args[0].jest_deep_equals(args[1], global_this)?))
+}
 
-impl ExpectMatcherUtils {
+/// `this.utils` of a custom matcher. Jest builds it from the plain functions that
+/// `jest-matcher-utils` exports, and matchers call them unbound
+/// (`const { matcherHint, printReceived } = this.utils`), so it is a table of host functions.
+///
+/// Reference: `MatcherUtils` in https://github.com/jestjs/jest/blob/main/packages/expect/src/types.ts
+mod matcher_utils {
+    use super::*;
+
     #[unsafe(no_mangle)]
     pub(crate) extern "C" fn ExpectMatcherUtils_createSigleton(global_this: &JSGlobalObject) -> JSValue {
-        ExpectMatcherUtils {}.to_js(global_this)
+        bun_jsc::create_host_function_object(
+            global_this,
+            &[
+                ("stringify", __jsc_host_stringify, 1),
+                ("printExpected", __jsc_host_print_expected, 1),
+                ("printReceived", __jsc_host_print_received, 1),
+                ("EXPECTED_COLOR", __jsc_host_print_expected, 1),
+                ("RECEIVED_COLOR", __jsc_host_print_received, 1),
+                ("matcherHint", __jsc_host_matcher_hint, 1),
+            ],
+        )
     }
 
     fn print_value(
@@ -2751,106 +2771,168 @@ impl ExpectMatcherUtils {
         bun_string_jsc::create_utf8_for_js(global_this, mutable_string.slice())
     }
 
-    #[bun_jsc::host_fn(method)]
-    pub(crate) fn stringify(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        let arguments = callframe.arguments();
-        let value = if arguments.is_empty() { JSValue::UNDEFINED } else { arguments[0] };
-        Self::print_value(global_this, value, None)
+    #[bun_jsc::host_fn]
+    fn stringify(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        print_value(global_this, callframe.argument(0), None)
     }
 
-    #[bun_jsc::host_fn(method)]
-    pub(crate) fn print_expected(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        let arguments = callframe.arguments();
-        let value = if arguments.is_empty() { JSValue::UNDEFINED } else { arguments[0] };
-        Self::print_value(global_this, value, Some("<green>"))
+    #[bun_jsc::host_fn]
+    fn print_expected(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        print_value(global_this, callframe.argument(0), Some("<green>"))
     }
 
-    #[bun_jsc::host_fn(method)]
-    pub(crate) fn print_received(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        let arguments = callframe.arguments();
-        let value = if arguments.is_empty() { JSValue::UNDEFINED } else { arguments[0] };
-        Self::print_value(global_this, value, Some("<red>"))
+    #[bun_jsc::host_fn]
+    fn print_received(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        print_value(global_this, callframe.argument(0), Some("<red>"))
     }
 
-    #[bun_jsc::host_fn(method)]
-    pub(crate) fn matcher_hint(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-        let arguments = callframe.arguments();
+    /// The hint under construction. Like Jest, it joins adjacent dim text in `dim` and writes
+    /// it as one span.
+    struct Hint {
+        out: Vec<u8>,
+        dim: Vec<u8>,
+        colors: bool,
+    }
 
-        if arguments.is_empty() || !arguments[0].is_string() {
+    impl Hint {
+        /// `hint += DIM_COLOR(dimString + tail); dimString = ''`
+        fn flush_dim(&mut self, tail: &[u8]) {
+            self.dim.extend_from_slice(tail);
+            if self.dim.is_empty() {
+                return;
+            }
+            if self.colors {
+                self.out.extend_from_slice(bun_core::pretty_fmt!("<d>", true).as_bytes());
+            }
+            self.out.append(&mut self.dim);
+            if self.colors {
+                self.out.extend_from_slice(bun_core::pretty_fmt!("<r>", true).as_bytes());
+            }
+        }
+
+        /// `hint += color(label)`. `color` is the caller's `option`, or `undefined` for `default_color`.
+        fn push_label(
+            &mut self,
+            global_this: &JSGlobalObject,
+            label: JSValue,
+            color: JSValue,
+            option: &'static str,
+            default_color: &'static str,
+        ) -> JsResult<()> {
+            if !color.is_undefined() {
+                if !color.is_callable() {
+                    return Err(global_this.throw_invalid_arguments(format_args!(
+                        "matcherHint: options.{option} must be a function",
+                    )));
+                }
+                let painted = color.call(global_this, JSValue::UNDEFINED, &[label])?;
+                self.out.extend_from_slice(&painted.to_utf8(global_this)?);
+                return Ok(());
+            }
+            let text = label.to_utf8(global_this)?;
+            if self.colors {
+                self.out.extend_from_slice(default_color.as_bytes());
+            }
+            self.out.extend_from_slice(&text);
+            if self.colors {
+                self.out.extend_from_slice(bun_core::pretty_fmt!("<r>", true).as_bytes());
+            }
+            Ok(())
+        }
+    }
+
+    /// `value === ''`
+    fn is_empty_string(value: JSValue) -> bool {
+        value.is_string_literal() && value.as_string().length() == 0
+    }
+
+    /// Port of `matcherHint` in `jest-matcher-utils`. It returns the one-line call signature.
+    /// `received` and `expected` are labels, not values.
+    /// https://github.com/jestjs/jest/blob/v30.2.0/packages/jest-matcher-utils/src/index.ts#L524-L587
+    #[bun_jsc::host_fn]
+    fn matcher_hint(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        let [matcher_name, received, expected, options] = callframe.arguments_as_array::<4>();
+
+        if !matcher_name.is_string() {
             return Err(global_this.throw2(
                 "matcherHint: the first argument (matcher name) must be a string",
                 (),
             ));
         }
-        let matcher_name = arguments[0].to_bun_string(global_this)?;
+        let matcher_name = matcher_name.to_utf8(global_this)?;
 
-        let received = if arguments.len() > 1 { arguments[1] } else { bun_core::String::static_("received").to_js(global_this)? };
-        let expected = if arguments.len() > 2 { arguments[2] } else { bun_core::String::static_("expected").to_js(global_this)? };
-        let options = if arguments.len() > 3 { arguments[3] } else { JSValue::UNDEFINED };
+        let received = if received.is_undefined() { bun_core::String::static_("received").to_js(global_this)? } else { received };
+        let expected = if expected.is_undefined() { bun_core::String::static_("expected").to_js(global_this)? } else { expected };
 
-        let mut is_not = false;
-        let mut comment: Option<&JSString> = None; // TODO support
-        let mut promise: Option<&JSString> = None; // TODO support
-        let mut second_argument: Option<&JSString> = None; // TODO support
-        // TODO support "chalk" colors (they are actually functions like: (value: string) => string;)
-        //var second_argument_color: ?string = null;
-        //var expected_color: ?string = null;
-        //var received_color: ?string = null;
-
-        if !options.is_undefined_or_null() {
-            if !options.is_object() {
-                return Err(global_this.throw2(
-                    "matcherHint: options must be an object (or undefined)",
-                    (),
-                ));
-            }
-            if let Some(val) = options.get(global_this, "isNot")? {
-                is_not = val.to_boolean();
-            }
-            if let Some(val) = options.get(global_this, "comment")? {
-                comment = Some(val.to_js_string(global_this)?);
-            }
-            if let Some(val) = options.get(global_this, "promise")? {
-                promise = Some(val.to_js_string(global_this)?);
-            }
-            if let Some(val) = options.get(global_this, "secondArgument")? {
-                second_argument = Some(val.to_js_string(global_this)?);
-            }
+        if !options.is_undefined_or_null() && !options.is_object() {
+            return Err(global_this.throw2(
+                "matcherHint: options must be an object (or undefined)",
+                (),
+            ));
         }
-        let _ = (comment, promise, second_argument);
-
-        let diff_formatter = DiffFormatter::new(global_this, received, expected, is_not)?;
-
-        // Builds `getSignature("{f}", "<green>expected<r>", is_not) ++ "\n\n{f}\n"`
-        // and substitutes `(matcher_name, diff_formatter)` into the two `{f}`
-        // slots, then runs `Output.prettyFmt` over the *template* before
-        // substitution. `pretty_fmt!` rewrites only the `<tag>` markers in
-        // the static `RECEIVED`/`expected` literals — `matcher_name` and
-        // `diff_formatter` are spliced in afterwards (matches `throw_pretty`'s
-        // render-then-rewrite ordering, since Display output here contains no
-        // `<tag>` literals).
-        let colors = Output::enable_ansi_colors_stderr();
-        let head: &'static str = if colors {
-            bun_core::pretty_fmt!("<d>expect(<r><red>received<r><d>).<r>", true)
-        } else {
-            bun_core::pretty_fmt!("<d>expect(<r><red>received<r><d>).<r>", false)
+        // A missing or `undefined` option reads as `undefined`, which selects the default.
+        let option = |name: &'static str| -> JsResult<JSValue> {
+            Ok(options.get(global_this, name)?.unwrap_or(JSValue::UNDEFINED))
         };
-        let not: &'static str = if is_not {
-            if colors {
-                bun_core::pretty_fmt!("not<d>.<r>", true)
-            } else {
-                bun_core::pretty_fmt!("not<d>.<r>", false)
+        let comment = option("comment")?;
+        let expected_color = option("expectedColor")?;
+        let is_direct_expect_call = option("isDirectExpectCall")?.to_boolean();
+        let is_not = option("isNot")?.to_boolean();
+        let promise = option("promise")?;
+        let received_color = option("receivedColor")?;
+        let second_argument = option("secondArgument")?;
+        let second_argument_color = option("secondArgumentColor")?;
+
+        let mut hint = Hint {
+            out: Vec::new(),
+            dim: b"expect".to_vec(),
+            colors: Output::enable_ansi_colors_stderr(),
+        };
+
+        if !is_direct_expect_call && !is_empty_string(received) {
+            hint.flush_dim(b"(");
+            hint.push_label(global_this, received, received_color, "receivedColor", bun_core::pretty_fmt!("<red>", true))?;
+            hint.dim.push(b')');
+        }
+
+        if !promise.is_undefined() && !is_empty_string(promise) {
+            hint.flush_dim(b".");
+            hint.out.extend_from_slice(&promise.to_utf8(global_this)?);
+        }
+
+        if is_not {
+            hint.flush_dim(b".");
+            hint.out.extend_from_slice(b"not");
+        }
+
+        if strings::contains_char(&matcher_name, b'.') {
+            // Old format: the name carries its own periods (`.toBe`, `.not.toBe`).
+            hint.dim.extend_from_slice(&matcher_name);
+        } else {
+            hint.flush_dim(b".");
+            hint.out.extend_from_slice(&matcher_name);
+        }
+
+        if is_empty_string(expected) {
+            hint.dim.extend_from_slice(b"()");
+        } else {
+            hint.flush_dim(b"(");
+            hint.push_label(global_this, expected, expected_color, "expectedColor", bun_core::pretty_fmt!("<green>", true))?;
+            if second_argument.to_boolean() {
+                hint.flush_dim(b", ");
+                hint.push_label(global_this, second_argument, second_argument_color, "secondArgumentColor", bun_core::pretty_fmt!("<green>", true))?;
             }
-        } else {
-            ""
-        };
-        let expected_hint: &'static str = if colors {
-            bun_core::pretty_fmt!("<d>(<r><green>expected<r><d>)<r>", true)
-        } else {
-            bun_core::pretty_fmt!("<d>(<r><green>expected<r><d>)<r>", false)
-        };
-        let buf = format!("{head}{not}{matcher_name}{expected_hint}\n\n{diff_formatter}\n");
-        bun_string_jsc::create_utf8_for_js(global_this, buf.as_bytes())
+            hint.dim.push(b')');
+        }
+
+        if !comment.is_undefined() && !is_empty_string(comment) {
+            hint.dim.extend_from_slice(b" // ");
+            hint.dim.extend_from_slice(&comment.to_utf8(global_this)?);
+        }
+
+        hint.flush_dim(b"");
+
+        bun_string_jsc::create_utf8_for_js(global_this, &hint.out)
     }
 }
 

--- a/src/runtime/test_runner/jest.classes.ts
+++ b/src/runtime/test_runner/jest.classes.ts
@@ -124,44 +124,8 @@ export default [
         getter: "getExpand",
       },
       equals: {
-        fn: "equals",
-        length: 3,
-      },
-    },
-  }),
-  define({
-    name: "ExpectMatcherUtils",
-    construct: false,
-    noConstructor: true,
-    call: false,
-    finalize: true,
-    JSType: "0b11101110",
-    configurable: false,
-    klass: {},
-    proto: {
-      stringify: {
-        fn: "stringify",
-        length: 1,
-      },
-      printExpected: {
-        fn: "printExpected",
-        length: 1,
-      },
-      printReceived: {
-        fn: "printReceived",
-        length: 1,
-      },
-      EXPECTED_COLOR: {
-        fn: "printExpected",
-        length: 1,
-      },
-      RECEIVED_COLOR: {
-        fn: "printReceived",
-        length: 1,
-      },
-      matcherHint: {
-        fn: "matcherHint",
-        length: 1,
+        getter: "getEquals",
+        cache: true,
       },
     },
   }),

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -494,7 +494,7 @@ cfg_jsc! {
     pub use done_callback::DoneCallback;
     pub use expect::{
         Expect, ExpectAny, ExpectAnything, ExpectArrayContaining, ExpectCloseTo,
-        ExpectCustomAsymmetricMatcher, ExpectMatcherContext, ExpectMatcherUtils,
+        ExpectCustomAsymmetricMatcher, ExpectMatcherContext,
         ExpectObjectContaining, ExpectStatic, ExpectStringContaining, ExpectStringMatching,
         ExpectTypeOf,
     };

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -7,7 +7,7 @@
  *  `NODE_OPTIONS=--experimental-vm-modules npx jest test/js/bun/test/expect-extend.test.js`
  */
 
-import { withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, withoutAggressiveGC } from "harness";
 import test_interop from "./test-interop.js";
 var { isBun, expect, describe, test, it } = await test_interop();
 
@@ -391,6 +391,82 @@ test("expect.extend with numeric index keys does not crash", () => {
 });
 
 describe("MatcherContext", () => {
+  const stripAnsi = (/** @type {string} */ text) => text.replace(/\x1b\[[0-9;]*m/g, "");
+  const utilNames = ["stringify", "printExpected", "printReceived", "EXPECTED_COLOR", "RECEIVED_COLOR", "matcherHint"];
+
+  /** @returns {any} the `this.utils` that a matcher sees */
+  function getUtils() {
+    let utils;
+    expect.extend({
+      _toExposeUtils() {
+        utils = this.utils;
+        return { pass: true };
+      },
+    });
+    expect(0)._toExposeUtils();
+    return utils;
+  }
+
+  // Jest gives a matcher plain functions, and published matchers call them without a receiver.
+  // jest-extended starts every matcher with `const { printReceived, matcherHint } = this.utils`
+  // and passes `this.equals` to its helpers as a callback.
+  test("equals works without a receiver", () => {
+    let results;
+    expect.extend({
+      _toUseDestructuredEquals(actual) {
+        const { equals } = this;
+        results = {
+          same: equals(actual, { a: 1 }),
+          different: equals(actual, { a: 2 }),
+          asymmetric: equals(actual, { a: expect.any(Number) }),
+          stable: this.equals === equals,
+        };
+        return { pass: true };
+      },
+    });
+
+    expect({ a: 1 })._toUseDestructuredEquals();
+    expect(results).toEqual({ same: true, different: false, asymmetric: true, stable: true });
+  });
+
+  test.skipIf(!isBun)("matchers from the jest-extended package run through expect.extend", async () => {
+    // The package replaces the built-in matchers of the same name, so it runs in a child process.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          import { expect } from "bun:test";
+          import matchers from "jest-extended";
+          expect.extend(matchers);
+
+          expect([1, 2]).toIncludeAllMembers([2]);
+          expect({ a: 1 }).toContainEntry(["a", 1]);
+          let message;
+          try {
+            expect("zz").toBeHexadecimal();
+          } catch (e) {
+            message = e.message;
+          }
+          console.log(JSON.stringify(message));
+        `,
+      ],
+      env: bunEnv,
+      cwd: import.meta.dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ message: stdout && JSON.parse(stdout), stderr, exitCode }).toEqual({
+      message:
+        "expect(received).toBeHexadecimal()\n\n" +
+        'expect(received).toBeHexadecimal()\n\nExpected value to be a hexadecimal, received:\n  "zz"',
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   describe("utils", () => {
     test("RECEIVED_COLOR is a function", () => {
       expect.extend({
@@ -401,6 +477,174 @@ describe("MatcherContext", () => {
       });
 
       expect(123).toBeCustomColor(456);
+    });
+
+    test("the failure message can use functions destructured from utils", () => {
+      expect.extend({
+        _toFailWithDestructuredUtils(actual, expected) {
+          const { matcherHint, printExpected, printReceived, stringify } = this.utils;
+          return {
+            pass: false,
+            message: () =>
+              matcherHint("._toFailWithDestructuredUtils") +
+              `\n\nExpected: ${printExpected(expected)}\nReceived: ${printReceived(actual)} (${stringify(actual)})`,
+          };
+        },
+      });
+
+      let message;
+      try {
+        expect("a")._toFailWithDestructuredUtils("b");
+      } catch (e) {
+        message = stripAnsi(e.message);
+      }
+      // bun:test puts its own signature line above the matcher's message. Jest does not.
+      expect(message).toBe(
+        (isBun ? "expect(received)._toFailWithDestructuredUtils(expected)\n\n" : "") +
+          'expect(received)._toFailWithDestructuredUtils(expected)\n\nExpected: "b"\nReceived: "a" ("a")',
+      );
+    });
+
+    test("every function works without a receiver", () => {
+      const withReceiver = {};
+      const withoutReceiver = {};
+      expect.extend({
+        _toCallUtilsWithoutReceiver(actual) {
+          for (const name of utilNames) {
+            const fn = this.utils[name];
+            withReceiver[name] = this.utils[name](actual);
+            withoutReceiver[name] = fn(actual);
+          }
+          return { pass: true };
+        },
+      });
+
+      expect("toFoo")._toCallUtilsWithoutReceiver();
+      expect(Object.keys(withoutReceiver)).toEqual(utilNames);
+      expect(withoutReceiver).toEqual(withReceiver);
+    });
+
+    test("is a plain object that owns its functions", () => {
+      const utils = getUtils();
+      expect(Object.getPrototypeOf(utils)).toBe(Object.prototype);
+      expect(Object.keys(utils)).toEqual(expect.arrayContaining(utilNames));
+      const copy = { ...utils };
+      expect(utilNames.map(name => typeof copy[name])).toEqual(utilNames.map(() => "function"));
+    });
+
+    describe("matcherHint", () => {
+      const E = (/** @type {string} */ text) => `<E:${text}>`;
+      const R = (/** @type {string} */ text) => `<R:${text}>`;
+      const S = (/** @type {string} */ text) => `<S:${text}>`;
+
+      // The expected values are the output of jest-matcher-utils 30.2.0 with colors off.
+      /** @type {[any[], string][]} */
+      const cases = [
+        [["toFoo"], "expect(received).toFoo(expected)"],
+        // A name with a period is the old format. jest-extended passes ".toX" and ".not.toX".
+        [[".toFoo"], "expect(received).toFoo(expected)"],
+        [[".not.toFoo"], "expect(received).not.toFoo(expected)"],
+        [[".toFoo", "received", ""], "expect(received).toFoo()"],
+        [[".not.toFoo", "received", ""], "expect(received).not.toFoo()"],
+        [["a.b.c"], "expect(received)a.b.c(expected)"],
+        // `received` and `expected` are labels.
+        [["toFoo", "a", "b"], "expect(a).toFoo(b)"],
+        [["toFoo", "", ""], "expect.toFoo()"],
+        [["toFoo", "", "x"], "expect.toFoo(x)"],
+        [["toFoo", 1, 2], "expect(1).toFoo(2)"],
+        [["toFoo", null, null], "expect(null).toFoo(null)"],
+        [["toFoo", undefined, undefined, {}], "expect(received).toFoo(expected)"],
+        [["toFoo", undefined, undefined, { isNot: true }], "expect(received).not.toFoo(expected)"],
+        [[".toFoo", undefined, undefined, { isNot: true }], "expect(received).not.toFoo(expected)"],
+        [["toFoo", undefined, undefined, { promise: "resolves" }], "expect(received).resolves.toFoo(expected)"],
+        [
+          ["toFoo", undefined, undefined, { promise: "rejects", isNot: true }],
+          "expect(received).rejects.not.toFoo(expected)",
+        ],
+        [
+          [".toFoo", undefined, undefined, { promise: "rejects", isNot: true }],
+          "expect(received).rejects.not.toFoo(expected)",
+        ],
+        [["toFoo", undefined, undefined, { isDirectExpectCall: true }], "expect.toFoo(expected)"],
+        [["toFoo", "a", "b", { secondArgument: "c" }], "expect(a).toFoo(b, c)"],
+        [["toFoo", "a", "", { secondArgument: "c" }], "expect(a).toFoo()"],
+        [
+          ["toFoo", undefined, undefined, { comment: "deep equality" }],
+          "expect(received).toFoo(expected) // deep equality",
+        ],
+        [["toFoo", undefined, "", { comment: "deep equality" }], "expect(received).toFoo() // deep equality"],
+        [
+          ["toFoo", "a", "b", { receivedColor: R, expectedColor: E, secondArgument: "c", secondArgumentColor: S }],
+          "expect(<R:a>).toFoo(<E:b>, <S:c>)",
+        ],
+        [["toFoo", 0, 0, { comment: 0, promise: 0, secondArgument: 0 }], "expect(0).0.toFoo(0) // 0"],
+        [
+          ["toFoo", undefined, undefined, { isNot: undefined, comment: undefined, promise: undefined }],
+          "expect(received).toFoo(expected)",
+        ],
+      ];
+
+      test("returns the one-line signature that Jest returns", () => {
+        const utils = getUtils();
+        expect(cases.map(([args]) => stripAnsi(utils.matcherHint(...args)))).toEqual(
+          cases.map(([, expected]) => expected),
+        );
+      });
+
+      test("a color option that is not a function is a TypeError", () => {
+        const utils = getUtils();
+        let error;
+        try {
+          utils.matcherHint("toFoo", "a", "b", { expectedColor: "green" });
+        } catch (e) {
+          error = e;
+        }
+        expect(error).toBeInstanceOf(TypeError);
+        expect(error.message).toBe(
+          isBun ? "matcherHint: options.expectedColor must be a function" : "expectedColor is not a function",
+        );
+      });
+
+      test.skipIf(!isBun)("colors the labels and joins adjacent dim text", async () => {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `
+              import { expect } from "bun:test";
+              expect.extend({
+                _toPrintHints() {
+                  const { matcherHint } = this.utils;
+                  console.log(
+                    JSON.stringify([
+                      matcherHint(".not.toFoo", "received", ""),
+                      matcherHint("toFoo", "a", "b", { isNot: true, secondArgument: "c", comment: "why" }),
+                      matcherHint("toFoo", "a", "b", { receivedColor: text => "<" + text + ">" }),
+                    ]),
+                  );
+                  return { pass: true };
+                },
+              });
+              expect(0)._toPrintHints();
+            `,
+          ],
+          env: { ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: "1" },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        const [dim, red, green, reset] = ["\x1b[2m", "\x1b[31m", "\x1b[32m", "\x1b[0m"];
+        expect({ hints: stdout && JSON.parse(stdout), stderr, exitCode }).toEqual({
+          hints: [
+            `${dim}expect(${reset}${red}received${reset}${dim}).not.toFoo()${reset}`,
+            `${dim}expect(${reset}${red}a${reset}${dim}).${reset}not${dim}.${reset}toFoo${dim}(${reset}${green}b${reset}${dim}, ${reset}${green}c${reset}${dim}) // why${reset}`,
+            `${dim}expect(${reset}<a>${dim}).${reset}toFoo${dim}(${reset}${green}b${reset}${dim})${reset}`,
+          ],
+          stderr: "",
+          exitCode: 0,
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
### Problem

- A custom matcher that calls a `this.utils` function or `this.equals` without a receiver throws `TypeError: Expected this to be instanceof ExpectMatcherUtils` (or `ExpectMatcherContext`). Every jest-extended matcher destructures `this.utils`, so each failing assertion loses its message. 15 of them pass `this.equals` to a helper, so they throw on a passing assertion too.
- The cause: `ExpectMatcherUtils` was a generated class (`src/runtime/test_runner/jest.classes.ts`) and `equals` was a prototype method. A generated method checks its receiver (`src/codegen/generate-classes.ts:953`). Jest passes plain functions.
- `matcherHint(".toX")` returned `expect(received)..toX(expected)` plus the lines `Expected: "expected"` and `Received: "received"`. `EXPECTED_COLOR` and `RECEIVED_COLOR` quoted their text, which jest-dom formats itself.

### Fix

- `this.utils` is a plain object of host functions (`bun_jsc::create_host_function_object`). The class is gone. `this.equals` is a getter that returns a plain host function.
- `matcherHint` is a port of Jest's function: one-line signature, names with a period, all eight options.
- `EXPECTED_COLOR` and `RECEIVED_COLOR` color `String(text)` without quotes, like `chalk.green`.
- Verified: `test/js/bun/test/expect-extend.test.js`. The 9 new tests fail on the unfixed build. 7 of them also pass under Jest 30.2.0 and Vitest 4.1.9. Also ran `expect.test.js`, `jest-extended.test.js`, the bun-types test and the source lints.

### Background

- `expect.extend({ toX() {} })` registers a matcher. Bun calls it with a context as `this`: `isNot`, `promise`, `equals`, `utils`.
- A class from a `*.classes.ts` file gets C++ prototype methods. Each one downcasts `this` and throws `ERR_INVALID_THIS` if the cast fails.
- Jest's `matcherHint(name, received, expected, options)` returns only the signature line, for example `expect(received).toX(expected)`. `received` and `expected` are labels.
- Vitest exposes 14 of Jest's `this.utils` names. jest-extended and jest-dom use only those. Bun has 6. Each missing name is now one table row.

<details><summary>Notes</summary>

Repro, from the report. It prints `Expected this to be instanceof ExpectMatcherUtils` on Bun 1.4.3-canary.1 and on main f04caca828:

```js
const { expect, test } = require("bun:test");
expect.extend({
  toFoo(actual) {
    const { printReceived, matcherHint } = this.utils;
    return { pass: false, message: () => matcherHint(".toFoo") + " " + printReceived(actual) };
  },
});
test("utils", () => {
  try { expect(1).toFoo(); } catch (e) { console.log(e.message); }
});
```

With the real package, `expect.extend(require("jest-extended"))`:

| assertion | before | after |
| --- | --- | --- |
| `expect("zz").toBeHexadecimal()` | `Expected this to be instanceof ExpectMatcherUtils` | Bun's signature line, then the same text as Jest: `expect(received).toBeHexadecimal()`, blank line, `Expected value to be a hexadecimal, received:`, `  "zz"` |
| `expect([1, 2]).toIncludeAllMembers([2])` | throws `Expected this to be instanceof ExpectMatcherContext` | passes |

`jest-extended` 4.0.0 is already a dependency of `test/package.json`. The new end-to-end test runs it in a child process, because it replaces the built-in matchers of the same name.

The tests compare only the end of a failure message. bun:test puts its own signature line above the message of a custom matcher (`throw_pretty_matcher_error`), so the signature shows twice with a matcher that calls `matcherHint`. This PR does not change that line, and the tests do not pin it.

`matcherHint`:

- Reference: https://github.com/jestjs/jest/blob/v30.2.0/packages/jest-matcher-utils/src/index.ts#L524-L587
- I ran 29 argument lists through `jest-matcher-utils` 30.2.0 and through this build, with colors off and with colors on. The output is the same, except that Bun resets with `ESC[0m` where chalk writes `ESC[22m` and `ESC[39m`. 25 of the lists are in the test.
- One difference stays: a primitive `options` argument (for example `5`) still throws `matcherHint: options must be an object (or undefined)`. Jest ignores it. `null` is still accepted. I did not change this validation.
- Labels go through `ToString` and a UTF-8 copy. Jest concatenates with `+`. The two differ only for a label that is an object with both `valueOf` and `toString`, and for a lone surrogate, which becomes U+FFFD.
- An option `expectedColor`, `receivedColor` or `secondArgumentColor` that is not a function throws a `TypeError` at the point where Jest calls it. The message names the option. Without the check, JSC builds the message from the caller's source text and says that `matcherHint` is not a function.
- `packages/bun-types/test.d.ts`: `received` and `expected` are `string`, as in Jest's types. They were `unknown`, which matched the old value semantics. `EXPECTED_COLOR` and `RECEIVED_COLOR` are now declared.

`this.equals`:

- The getter uses `cache: true`, so one context returns the same function each time. Two contexts return two functions. A shared function needs a per-global slot, and a new field on `ZigGlobalObject` is not worth it for this.
- The property is now a read-only accessor on the prototype. It was a writable data property.
- Its argument-count error said `this.util.equals`. It now says `this.equals`.

`this.utils`:

- It is still one object per global (`m_testMatcherUtilsObject`). Jest builds a new object for each matcher call. A matcher that writes to `this.utils` sees the write in later calls, as before.
- `Object.keys(this.utils)` and `{ ...this.utils }` now list the functions. They were on the prototype before, so both were empty.
- The 14 names that Vitest exposes: `stringify`, `printExpected`, `printReceived`, `EXPECTED_COLOR`, `RECEIVED_COLOR`, `matcherHint` (Bun has these), and `diff`, `printDiffOrStringify`, `printWithType`, `iterableEquality`, `subsetEquality`, `DIM_COLOR`, `INVERTED_COLOR`, `BOLD_WEIGHT` (still missing). jest-extended needs `printWithType` and `INVERTED_COLOR` in 5 of its 72 matchers. jest-dom needs `diff` for `toHaveStyle` and `toHaveFormValues` (#10286) and `printWithType` for its type errors. They are outside this change.
- History: #18500 reported the missing `EXPECTED_COLOR` with jest-dom, and #22862 added both names as aliases of `printExpected` and `printReceived`. That stopped the `TypeError` but quoted the text.

Overlap with open PRs. Each needs a rebase if this lands first:

- #32936 adds `diff`, `iterableEquality` and `subsetEquality` as methods of the `ExpectMatcherUtils` class. As class methods they have the same receiver check. They become rows in the table.
- #40235 moves `ExpectMatcherUtils_createSigleton` and the `impl ExpectMatcherUtils` block.
- #34649 and #40919 add tests that pass values to `matcherHint` and expect a diff in the result.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect-extend.test.js
bun test v1.4.3 (b99371011)

test/js/bun/test/expect-extend.test.js:
(pass) is available globally when matcher is unary [10.32ms]
(pass) is available globally when matcher is variadic [6.90ms]
(pass) exposes matcherUtils in context [2.91ms]
(pass) is ok if there is no message specified [4.61ms]
(pass) works with empty matcher name [2.17ms]
(pass) exposes an equality function to custom matchers [4.40ms]
(pass) defines asymmetric unary matchers [8.78ms]
(pass) defines asymmetric unary matchers that can be prefixed by not [6.03ms]
(pass) defines asymmetric variadic matchers [5.48ms]
(pass) defines asymmetric variadic matchers that can be prefixed by not [5.59ms]
(pass) prints the Symbol into the error message [5.62ms]
(pass) allows overriding existing extension [4.39ms]
(pass) throws descriptive errors for invalid matchers [9.05ms]
(pass) invalid matcher implementations errors > handles correctly when matcher throws [4.34ms]
(pass) invalid matcher implementations errors > throws when returns undefined
... (truncated)

release without fix: 9 FAILED
bun test v1.4.3-canary.1 (b99371011)

test/js/bun/test/expect-extend.test.js:
(pass) is available globally when matcher is unary [0.16ms]
(pass) is available globally when matcher is variadic [0.09ms]
(pass) exposes matcherUtils in context [0.03ms]
(pass) is ok if there is no message specified [0.04ms]
(pass) works with empty matcher name [0.02ms]
(pass) exposes an equality function to custom matchers [0.06ms]
(pass) defines asymmetric unary matchers [0.14ms]
(pass) defines asymmetric unary matchers that can be prefixed by not [0.05ms]
(pass) defines asymmetric variadic matchers [0.04ms]
(pass) defines asymmetric variadic matchers that can be prefixed by not [0.05ms]
(pass) prints the Symbol into the error message [0.08ms]
(pass) allows overriding existing extension [0.04ms]
(pass) throws descriptive errors for invalid matchers [0.07ms]
(pass) invalid matcher implementations errors > handles correctly when matcher throws [0.03ms]
(pass) invalid matcher implementations errors > throws when returns undefined [0.05ms]
(pass) invalid matcher implementations errors > throws when returns not an object [0.03ms]
(pass) invalid matcher implementations errors > throws when re
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect-extend.test.js
bun test v1.4.3 (b99371011)

test/js/bun/test/expect-extend.test.js:
(pass) is available globally when matcher is unary [10.52ms]
(pass) is available globally when matcher is variadic [7.71ms]
(pass) exposes matcherUtils in context [3.18ms]
(pass) is ok if there is no message specified [4.88ms]
(pass) works with empty matcher name [2.65ms]
(pass) exposes an equality function to custom matchers [5.76ms]
(pass) defines asymmetric unary matchers [13.74ms]
(pass) defines asymmetric unary matchers that can be prefixed by not [8.76ms]
(pass) defines asymmetric variadic matchers [8.62ms]
(pass) defines asymmetric variadic matchers that can be prefixed by not [8.05ms]
(pass) prints the Symbol into the error message [8.91ms]
(pass) allows overriding existing extension [8.59ms]
(pass) throws descriptive errors for invalid matchers [13.49ms]
(pass) invalid matcher implementations errors > handles correctly when matcher throws [5.60ms]
(pass) invalid matcher implementations errors > throws when returns undefin
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     bb53d65cfa
  features     baseline

23 deps, 131 codegen, 1176 objects in 742ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] install /workspace/bun
bun install v1.4.3-canary.1 (b99371011)

Checked 22 installs across 61 packages (no changes) [7.00ms]
[2/1248] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (b99371011)

Checked 1 install across 2 packages (no changes) [5.00ms]
[3/1248] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1248] fetch zlib
[zlib] up to date
[5/1248] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (b99371011)

Checked 111 installs across 104 packages (no changes) [19.00ms]
[6/1248] gen bindgenv2
[7/1248] gen node-fallbacks/react-refresh.js
Bundled 1 module in 15ms

  react-refresh.js  4.81 KB  (entry point)

[8/1248] gen .bind.ts → GeneratedBindings.cpp
[9/1248] fetch tinycc
[tinycc] up to date
[10/1247] gen ErrorCode+*.h
[11/1247] esbuild bun-error

  ../../build/release/codegen/bun-error/inde
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/test.d.ts            |  20 ++-
 src/runtime/test_runner/expect.rs       | 293 +++++++++++++++++++++-----------
 src/runtime/test_runner/jest.classes.ts |  40 +----
 src/runtime/test_runner/mod.rs          |   2 +-
 test/js/bun/test/expect-extend.test.js  | 259 +++++++++++++++++++++++++++-
 5 files changed, 475 insertions(+), 139 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
packages/bun-types/test.d.ts                 3      2     31
src/runtime/test_runner/expect.rs            9      5     30
src/runtime/test_runner/jest.classes.ts      1      1     30
src/runtime/test_runner/mod.rs               1      0     30
test/js/bun/test/expect-extend.test.js       1      0     30
```

</details>

<!-- robobun:evidence:end -->