### PR TITLE
Deliver a main-thread postMessage() to the global's own message listeners

### DIFF
--- a/docs/runtime/workers.mdx
+++ b/docs/runtime/workers.mdx
@@ -192,6 +192,8 @@ postMessage({ hello: "world" });
 worker.postMessage({ hello: "world" });
 ```
 
+The main thread has no parent, so a global `postMessage()` there works like `window.postMessage()` in a browser: it dispatches a `message` event on `globalThis`.
+
 To receive messages, use the [`message` event handler](https://developer.mozilla.org/en-US/docs/Web/API/Worker/message_event) on the worker and main thread.
 
 ```js

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1412,11 +1412,15 @@ declare var module: NodeModule;
 declare function structuredClone<T>(value: T, options?: Bun.StructuredSerializeOptions): T;
 
 /**
- * Post a message to the parent thread.
+ * In a worker, post a message to the parent thread.
  *
- * Only useful in a worker thread; calling this from the main thread does nothing.
+ * The main thread has no parent. There it works like `window.postMessage()` and dispatches a
+ * `message` event on `globalThis`, when `targetOrigin` is `"*"` or `"/"` (the default). The
+ * transfer list goes in the third argument or in `options.transfer`, as for `window.postMessage()`.
  */
 declare function postMessage(message: any, transfer?: Bun.Transferable[]): void;
+declare function postMessage(message: any, targetOrigin: string, transfer?: Bun.Transferable[]): void;
+declare function postMessage(message: any, options?: Bun.StructuredSerializeOptions & { targetOrigin?: string }): void;
 
 interface EventSourceInit {
   withCredentials?: boolean;

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -46,6 +46,7 @@
 #include "CloseEvent.h"
 #include "JSDOMConvertObject.h"
 #include "JSDOMConvertSequences.h"
+#include "JSDOMConvertStrings.h"
 #include "JSMessagePort.h"
 #include "JSMessageChannel.h"
 #include "JSWorker.h"
@@ -411,6 +412,104 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionSetParentPort, (JSGlobalObject * lexicalGloba
     return JSValue::encode(jsUndefined());
 }
 
+// Serializes a postMessage() payload with its transfer list and disentangles the transferred ports.
+static std::optional<MessageWithMessagePorts> serializeMessage(Zig::GlobalObject& globalObject, JSC::JSValue value, Vector<JSC::Strong<JSC::JSObject>>&& transferList, SerializationContext serializationContext)
+{
+    auto scope = DECLARE_THROW_SCOPE(globalObject.vm());
+
+    Vector<RefPtr<MessagePort>> ports;
+    ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(globalObject, value, WTF::move(transferList), ports, SerializationForStorage::No, serializationContext);
+    RETURN_IF_EXCEPTION(scope, std::nullopt);
+    if (serialized.hasException()) {
+        WebCore::propagateException(globalObject, scope, serialized.releaseException());
+        RELEASE_AND_RETURN(scope, std::nullopt);
+    }
+
+    ExceptionOr<Vector<TransferredMessagePort>> disentangledPorts = MessagePort::disentanglePorts(WTF::move(ports));
+    if (disentangledPorts.hasException()) {
+        WebCore::propagateException(globalObject, scope, disentangledPorts.releaseException());
+        RELEASE_AND_RETURN(scope, std::nullopt);
+    }
+
+    return MessageWithMessagePorts { serialized.releaseReturnValue(), disentangledPorts.releaseReturnValue() };
+}
+
+// The main thread has no parent, so postMessage() acts like window.postMessage() and queues the
+// message for this global's own listeners: https://html.spec.whatwg.org/multipage/web-messaging.html#window-post-message-steps
+static JSC::EncodedJSValue postMessageToSelf(Zig::GlobalObject* globalObject, JSC::CallFrame* callFrame)
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // postMessage(message, targetOrigin, transfer) and postMessage(message, { transfer, targetOrigin }), per WebIDL overload resolution.
+    JSC::JSValue targetOriginOrOptions = callFrame->argument(1);
+    String targetOrigin = "/"_s;
+    Vector<JSC::Strong<JSC::JSObject>> transferList;
+    if (callFrame->argumentCount() < 3 && (targetOriginOrOptions.isUndefinedOrNull() || targetOriginOrOptions.isObject())) {
+        auto options = convertDictionary<StructuredSerializeOptions>(*globalObject, targetOriginOrOptions);
+        RETURN_IF_EXCEPTION(scope, {});
+        transferList = WTF::move(options.transfer);
+        if (targetOriginOrOptions.isObject()) {
+            JSC::JSValue targetOriginValue = asObject(targetOriginOrOptions)->get(globalObject, JSC::Identifier::fromString(vm, "targetOrigin"_s));
+            RETURN_IF_EXCEPTION(scope, {});
+            if (!targetOriginValue.isUndefined()) {
+                targetOrigin = convert<IDLUSVString>(*globalObject, targetOriginValue);
+                RETURN_IF_EXCEPTION(scope, {});
+            }
+        }
+    } else {
+        targetOrigin = convert<IDLUSVString>(*globalObject, targetOriginOrOptions);
+        RETURN_IF_EXCEPTION(scope, {});
+        JSC::JSValue transfer = callFrame->argument(2);
+        if (!transfer.isUndefined()) {
+            transferList = convert<IDLSequence<IDLObject>>(*globalObject, transfer);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+    }
+
+    // The main thread's origin is opaque, so only "*" and "/" match it. A message to any other origin is serialized, then dropped.
+    bool targetsSelf = targetOrigin == "*"_s || targetOrigin == "/"_s;
+    if (!targetsSelf && !URL { targetOrigin }.isValid()) {
+        propagateException(*globalObject, scope, Exception { SyntaxError, makeString("Invalid target origin '"_s, targetOrigin, "' in a call to 'postMessage'"_s) });
+        RELEASE_AND_RETURN(scope, {});
+    }
+
+    auto message = serializeMessage(*globalObject, callFrame->argument(0), WTF::move(transferList), SerializationContext::WindowPostMessage);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (!targetsSelf)
+        return JSValue::encode(jsUndefined());
+
+    globalObject->scriptExecutionContext()->postTask([message = WTF::move(*message)](ScriptExecutionContext& context) mutable {
+        if (!context.globalObject())
+            return;
+        auto* globalObject = defaultGlobalObject(context.globalObject());
+        auto& vm = globalObject->vm();
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
+        if (Zig::GlobalObject::scriptExecutionStatus(globalObject, globalObject) != ScriptExecutionStatus::Running)
+            return;
+
+        auto ports = MessagePort::entanglePorts(context, WTF::move(message.transferredPorts));
+        if (scope.exception()) [[unlikely]] {
+            RELEASE_ASSERT(vm.hasPendingTerminationException());
+            return;
+        }
+
+        // Per the window post message steps, a message that fails to deserialize fires messageerror.
+        auto event = MessageEvent::create(*globalObject, message.message.releaseNonNull(), "null"_s, {}, nullptr, WTF::move(ports));
+        if (scope.exception()) [[unlikely]] {
+            if (vm.hasPendingTerminationException())
+                return;
+            scope.clearException();
+            globalObject->globalEventScope->dispatchEvent(MessageEvent::create(eventNames().messageerrorEvent, MessageEvent::Init { {}, jsNull(), "null"_s }, MessageEvent::IsTrusted::Yes));
+            return;
+        }
+        globalObject->globalEventScope->dispatchEvent(event->event);
+    });
+    return JSValue::encode(jsUndefined());
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsFunctionPostMessage,
     (JSC::JSGlobalObject * leixcalGlobalObject, JSC::CallFrame* callFrame))
 {
@@ -423,7 +522,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionPostMessage,
 
     auto* proxy = WebWorker__getMessagingProxy(globalObject->bunVM());
     if (!proxy)
-        return JSValue::encode(jsUndefined());
+        RELEASE_AND_RETURN(scope, postMessageToSelf(globalObject, callFrame));
 
     JSC::JSValue value = callFrame->argument(0);
     JSC::JSValue options = callFrame->argument(1);
@@ -446,23 +545,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionPostMessage,
         }
     }
 
-    Vector<RefPtr<MessagePort>> ports;
-    ExceptionOr<Ref<SerializedScriptValue>> serialized = SerializedScriptValue::create(*globalObject, value, WTF::move(transferList), ports, SerializationForStorage::No, SerializationContext::WorkerPostMessage);
-    RETURN_IF_EXCEPTION(scope, {});
-    if (serialized.hasException()) {
-        WebCore::propagateException(*globalObject, scope, serialized.releaseException());
-        RELEASE_AND_RETURN(scope, {});
-    }
+    auto message = serializeMessage(*globalObject, value, WTF::move(transferList), SerializationContext::WorkerPostMessage);
     RETURN_IF_EXCEPTION(scope, {});
 
-    ExceptionOr<Vector<TransferredMessagePort>> disentangledPorts = MessagePort::disentanglePorts(WTF::move(ports));
-    if (disentangledPorts.hasException()) {
-        WebCore::propagateException(*globalObject, scope, disentangledPorts.releaseException());
-        RELEASE_AND_RETURN(scope, {});
-    }
-    RETURN_IF_EXCEPTION(scope, {});
-
-    proxy->postMessageToWorkerObject(MessageWithMessagePorts { serialized.releaseReturnValue(), disentangledPorts.releaseReturnValue() });
+    proxy->postMessageToWorkerObject(WTF::move(*message));
 
     return JSValue::encode(jsUndefined());
 }

--- a/test/integration/bun-types/fixture/worker.ts
+++ b/test/integration/bun-types/fixture/worker.ts
@@ -44,6 +44,10 @@ postMessage({ hello: "world" });
 // On the main thread
 nodeWorker.postMessage({ hello: "world" });
 
+// On the main thread, a global `postMessage` dispatches to `globalThis`, like `window.postMessage`.
+postMessage({ hello: "world" }, "*");
+postMessage({ hello: "world" }, { targetOrigin: "/" });
+
 // ...some time later
 
 await nodeWorker.terminate();

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -173,6 +173,158 @@ test.concurrent("worker: global 'message' listener keeps the worker alive until 
   expect(exitCode).toBe(0);
 });
 
+// The main thread has no parent, so postMessage() queues the message for its own global, like
+// window.postMessage(): https://html.spec.whatwg.org/multipage/web-messaging.html#window-post-message-steps
+test.concurrent("main thread: postMessage() dispatches a message event to globalThis", async () => {
+  const script = `
+    const sent = { hello: 1 };
+    onmessage = e => console.log("onmessage", JSON.stringify(e.data));
+    addEventListener("message", e => {
+      const { data, origin, source, ports, isTrusted } = e;
+      console.log(JSON.stringify({ data, cloned: data !== sent, origin, source, ports: ports.length, isTrusted }));
+    });
+    postMessage(sent, "*");
+    console.log("posted");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe(
+    'posted\nonmessage {"hello":1}\n{"data":{"hello":1},"cloned":true,"origin":"null","source":null,"ports":0,"isTrusted":true}\n',
+  );
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("main thread: postMessage() delivers only to the '*' and '/' target origins", async () => {
+  const script = `
+    const got = [];
+    addEventListener("message", e => got.push(e.data));
+    postMessage("no target origin");
+    postMessage("*", "*");
+    postMessage("/", "/");
+    postMessage("options *", { targetOrigin: "*" });
+    postMessage("empty options", {});
+    postMessage("null options", null);
+    postMessage("other origin", "https://example.com");
+    postMessage("other origin in options", { targetOrigin: "https://example.com" });
+    process.on("beforeExit", () => console.log(JSON.stringify(got)));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual(["no target origin", "*", "/", "options *", "empty options", "null options"]);
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("main thread: postMessage() transfers and throws like window.postMessage()", async () => {
+  const script = `
+    addEventListener("message", e => console.log("received", e.data.byteLength));
+    const [a, b, c] = [new ArrayBuffer(8), new ArrayBuffer(8), new ArrayBuffer(8)];
+    postMessage(a, "*", [a]);
+    postMessage(b, { transfer: [b] });
+    postMessage(c, "https://example.com", [c]);
+    console.log("detached", a.byteLength, b.byteLength, c.byteLength);
+    for (const args of [["x", "not a url"], ["x", {}, []]]) {
+      try {
+        postMessage(...args);
+        console.log("no error");
+      } catch (e) {
+        console.log(e.constructor.name, e.message);
+      }
+    }
+    for (const args of [[() => {}], ["x", "*", [null]], ["x", { transfer: 1 }]]) {
+      try {
+        postMessage(...args);
+        console.log("no error");
+      } catch (e) {
+        console.log(e.constructor.name, e.name);
+      }
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe(
+    "detached 0 0 0\n" +
+      // bun throws a JS SyntaxError for ExceptionCode::SyntaxError, where the spec has a DOMException.
+      "SyntaxError Invalid target origin 'not a url' in a call to 'postMessage'\n" +
+      "SyntaxError Invalid target origin '[object Object]' in a call to 'postMessage'\n" +
+      "DOMException DataCloneError\n" +
+      "TypeError TypeError\n" +
+      "TypeError TypeError\n" +
+      "received 8\n" +
+      "received 8\n",
+  );
+  expect(exitCode).toBe(0);
+});
+
+// Serializes fine but fails to deserialize: the DataView's offset is only in bounds after a getter
+// resized the buffer, and the buffer was serialized before that.
+test.concurrent("main thread: a postMessage() that fails to deserialize fires messageerror on globalThis", async () => {
+  const script = `
+    addEventListener("messageerror", e => {
+      const { type, data, origin, isTrusted } = e;
+      console.log(JSON.stringify({ type, data, origin, isTrusted }));
+    });
+    addEventListener("message", e => console.log("message", e.data));
+    const ab = new ArrayBuffer(8, { maxByteLength: 65536 });
+    postMessage({ ab, get grow() { ab.resize(65536); return 1; }, get view() { return new DataView(ab, 4096, 16); } }, "*");
+    postMessage("after", "*");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe('{"type":"messageerror","data":null,"origin":"null","isTrusted":true}\nmessage after\n');
+  expect(exitCode).toBe(0);
+});
+
+// @dbml/core bundles VS Code's scheduler, which uses postMessage() as setImmediate() when
+// globalThis.postMessage exists (#42512).
+test.concurrent("main thread: a postMessage-based setImmediate shim runs its callbacks and exits", async () => {
+  const script = `
+    const useMessageShim = typeof globalThis.postMessage == "function" && !globalThis.importScripts;
+    if (!useMessageShim) throw new Error("the message shim is not used");
+    const pending = [];
+    globalThis.addEventListener("message", e => {
+      if (e.data && e.data.vscodeScheduleAsyncWork) pending.shift()();
+    });
+    const schedule = cb => {
+      pending.push(cb);
+      globalThis.postMessage({ vscodeScheduleAsyncWork: pending.length }, "*");
+    };
+    schedule(() => console.log("one"));
+    schedule(() => {
+      console.log("two");
+      schedule(() => console.log("three"));
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("one\ntwo\nthree\n");
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent("worker: onmessage assignment through a Proxy of self", async () => {
   using dir = tempDir("worker-proxy-onmessage", {
     "worker.js": `


### PR DESCRIPTION
Stacked on #41731. #41731 fixes the hang of #42512. This PR fixes its other half: the message is delivered. Together they fix #42512.

### Problem

- On the main thread, `postMessage(x)` does nothing and returns `undefined`. `jsFunctionPostMessage` (`src/jsc/bindings/webcore/Worker.cpp`) finds no messaging proxy and returns. A global `message` listener never gets the message.
- Code that finds `globalThis.postMessage` uses it as `setImmediate`. `@dbml/core` bundles VS Code's scheduler, which does this. On bun its callbacks never run. With #41731 alone the process exits, but the callbacks are still dropped.
- In a browser, `window.postMessage(x, "*")` queues a `message` event on the window. Node has no global `postMessage`, so the same code takes its `setTimeout` path there.

### Fix

- With no messaging proxy, `jsFunctionPostMessage` runs the [window post message steps](https://html.spec.whatwg.org/multipage/web-messaging.html#window-post-message-steps) against the global itself. It serializes the message with its transfer list, then posts a task that dispatches a `MessageEvent` on `globalEventScope`.
- The call forms are Window's: `postMessage(message, targetOrigin, transfer)` and `postMessage(message, { targetOrigin, transfer })`. The worker form throws a `TypeError` on the shim's `postMessage(x, "*")` (checked in a worker on bun 1.4.2).
- The main thread's origin is opaque, so `"*"` and `"/"` (the default: the caller's own origin) deliver. Any other valid URL names a different origin: the message is serialized, its buffers are transferred, and it is dropped. A string that does not parse throws a `SyntaxError` (step 5).
- The posted task keeps the loop alive until it runs (`el.tasks` counts in `is_event_loop_alive_excluding_immediates`). The listener itself does not, after #41731. Microtasks drain between two messages, as in a browser (`message 1, microtask 1, message 2, microtask 2` on a debug build).
- Serializing and disentangling the ports moves into `serializeMessage`, which the worker path now calls too. That drops two `RETURN_IF_EXCEPTION` checks from the worker path that could not fire: they followed branches that already returned on an exception, and `disentanglePorts` reports through `ExceptionOr`, not the VM.
- `event.origin` is `"null"`, the serialization of an opaque origin. `event.source` is `null`: bun's `MessageEvent.source` holds only a `MessagePort`, where a browser sets the `WindowProxy`.
- Types: `globals.d.ts` gets the two Window overloads and no longer says the call does nothing on the main thread. Docs: one sentence in `docs/runtime/workers.mdx`.
- Verified: 5 new tests in `test/js/web/web-globals.test.js`. On a debug build of this branch the file passes (30 tests). With only `Worker.cpp` reverted, so #41731 alone, the 5 new tests fail on their assertions: no event, `[]` instead of the 6 delivered messages, `detached 8 8 8` and no errors, and empty output where `messageerror` and the shim's callbacks should print. On bun 1.4.2 they time out, because the listener still holds the process open. Also ran `test/js/web/workers/worker-postmessage-transfer.test.ts` and `test/js/web/workers/worker.test.ts` (77 tests across the 3 files pass). Under `BUN_JSC_validateExceptionChecks=1`, a script that runs every new path on the main thread and one that runs the worker path through `serializeMessage` report no findings.

### Background

- `jsFunctionPostMessage` is the global `postMessage` of every `Zig::GlobalObject`. In a worker, `WebWorker__getMessagingProxy` returns the proxy to the parent. On the main thread it returns null.
- `GlobalEventScope` is the `EventTarget` behind `globalThis.addEventListener`. Worker messages reach it through `WorkerMessagingProxy::drainInbox`. The new task mirrors that path, including `messageerror` when deserialization throws.

<details><summary>Notes</summary>

**Why stacked on #41731.** Without #41731, a global `message` listener holds the main thread open forever, so every new test hangs instead of failing on its assertion. After #41731 merges I rebase this branch on main.

**The design choice.** #41731 left it open: "Whether it should throw or self-dispatch (browser `window.postMessage` semantics) is a separate decision." Throwing, or removing `globalThis.postMessage` on the main thread as in Node, breaks code that calls it today without an error. This PR takes the browser behavior. If another option is preferred, the tests show every behavior that changes.

**Differences from a browser.** `event.source` is `null` (see above). An invalid `targetOrigin` throws a JS `SyntaxError`, where the spec has a `DOMException` named `"SyntaxError"`: `ExceptionCode::SyntaxError` maps to a JS `SyntaxError` everywhere in bun, on purpose (`src/jsc/bindings/JSDOMExceptionHandling.cpp`, the comment above `case ExceptionCode::SyntaxError`), and `new WebSocket("not a url")` throws the same. A message to another origin is dropped before the task is posted, where the spec drops it inside the task. The two are not observably different.

**The `messageerror` test** uses the payload from #39408's tests: a resizable `ArrayBuffer` and a `DataView` whose offset is only in bounds after a getter resized the buffer. It serializes, then fails to deserialize.

**Overlap with #41818.** #41818 also rewrites the global `postMessage` declaration in `globals.d.ts` and adds lines to `test/integration/bun-types/fixture/worker.ts`. Whichever lands second rebases. The combined declaration set is #41818's `(message, transfer)` and `(message, options?)` for a worker, plus this PR's `(message, targetOrigin, transfer?)` and `targetOrigin` in `options`.

**Local runs.** `test/integration/bun-types/bun-types.test.ts` has 10 failures in my environment, the same set with and without this diff. None of them mention `postMessage`. They come from the `@types/node` the fixtures resolve here (`fs/promises` `exists`, `tls` `BunConnectionOptions`). The new fixture lines in `test/integration/bun-types/fixture/worker.ts` type-check.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019n9mLkdcWtSLUNt9XeJUs4
