### PR TITLE
markdown: reject a link nested anywhere inside a link label

### DIFF
--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -802,6 +802,9 @@ impl Parser<'_> {
         // Image tails nest like the brackets do, so the innermost pending tail
         // is always on top.
         let mut image_tails: Vec<(usize, usize)> = Vec::new();
+        // End of the last backslash escape, so `\![a](/i)` is a link after a
+        // literal `!`, not an image.
+        let mut escape_end: usize = 0;
         while pos < label.len() {
             while let Some(&(tail_start, tail_end)) = image_tails.last() {
                 if pos < tail_start {
@@ -817,6 +820,7 @@ impl Parser<'_> {
             }
             if label[pos] == b'\\' && pos + 1 < label.len() {
                 pos += 2;
+                escape_end = pos;
                 continue;
             }
             // Skip code spans
@@ -849,7 +853,7 @@ impl Parser<'_> {
                 // opener (cmark deactivates every earlier `[` when a link
                 // forms). So the scan steps into every bracket pair and only
                 // skips the `(url)` / `[ref]` tail of an inner image.
-                let is_inner_image = pos > 0 && label[pos - 1] == b'!';
+                let is_inner_image = pos > 0 && label[pos - 1] == b'!' && pos != escape_end;
                 let inner = self.try_match_bracket_link(label, pos, brackets, base);
                 if inner.is_link {
                     if !is_inner_image {

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -798,7 +798,23 @@ impl Parser<'_> {
         base: usize,
     ) -> bool {
         let mut pos: usize = 0;
+        // `(url)` / `[ref]` tails of inner images, as `(tail_start, tail_end)`.
+        // Image tails nest like the brackets do, so the innermost pending tail
+        // is always on top.
+        let mut image_tails: Vec<(usize, usize)> = Vec::new();
         while pos < label.len() {
+            while let Some(&(tail_start, tail_end)) = image_tails.last() {
+                if pos < tail_start {
+                    break;
+                }
+                image_tails.pop();
+                if pos < tail_end {
+                    pos = tail_end;
+                }
+            }
+            if pos >= label.len() {
+                break;
+            }
             if label[pos] == b'\\' && pos + 1 < label.len() {
                 pos += 2;
                 continue;
@@ -827,17 +843,21 @@ impl Parser<'_> {
                 }
             }
             if label[pos] == b'[' {
-                // Skip images (![...]) — images are allowed inside links
+                // Images (![...]) are allowed inside links, but a link nested
+                // anywhere in the label (inside a bracket pair that is not a
+                // link, or inside an image's alt text) still closes the outer
+                // opener (cmark deactivates every earlier `[` when a link
+                // forms). So the scan steps into every bracket pair and only
+                // skips the `(url)` / `[ref]` tail of an inner image.
                 let is_inner_image = pos > 0 && label[pos - 1] == b'!';
-                // Try to find matching ] and check for link syntax
                 let inner = self.try_match_bracket_link(label, pos, brackets, base);
-                if inner.is_link && !is_inner_image {
-                    return true;
-                }
-                if inner.link_end > pos {
-                    // Skip past entire construct (including (url) or [ref] for images)
-                    pos = inner.link_end;
-                    continue;
+                if inner.is_link {
+                    if !is_inner_image {
+                        return true;
+                    }
+                    if inner.link_end > inner.label_end + 1 {
+                        image_tails.push((inner.label_end + 1, inner.link_end));
+                    }
                 }
             }
             pos += 1;

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -693,7 +693,10 @@ describe("pathological bracket inputs", () => {
         const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
         const cases = [
           ["nested inline images", fill(43000, "![") + fill(43000, "](u)"), out => out === '<p><img src="u" alt="" /></p>\\n'],
-          ["link/image alternation", fill(36000, "[![") + fill(36000, "](u)"), out => out.endsWith('<a href="u"><img src="u" alt="" /></a></p>\\n')],
+          // The innermost [..](u) is a link, so every outer [ opener is
+          // deactivated: the outer half stays text and the closed half is
+          // one image whose alt flattens the levels in between.
+          ["link/image alternation", fill(36000, "[![") + fill(36000, "](u)"), out => out === "<p>" + fill(18000, "[![") + '[<img src="u" alt="' + fill(17998, "[") + fill(17998, "](u)") + '" />](u)</p>\\n'],
           ["nested reference images", "[r]: /u\\n\\n" + fill(40000, "![") + fill(40000, "][r]"), out => out === '<p><img src="/u" alt="" /></p>\\n'],
           ["nested images, unclosed tail", fill(60000, "![") + "x", out => out.includes("![![")],
         ];
@@ -745,6 +748,34 @@ describe("pathological bracket inputs", () => {
     expect(Markdown.html("[ref]: /u\n\n[foo](bar [ref])\n")).toBe('<p>[foo](bar <a href="/u">ref</a>)</p>\n');
     expect(Markdown.html("[ref]: /u\n\n[foo][ref]\n")).toBe('<p><a href="/u">foo</a></p>\n');
     expect(Markdown.html("[ref]: /u\n\n[foo](/x)[ref]\n")).toBe('<p><a href="/x">foo</a><a href="/u">ref</a></p>\n');
+  });
+
+  // A link nested anywhere in the label rejects the outer candidate, not
+  // only a link that is a direct child. The lookahead used to skip whole
+  // non-link bracket pairs and image tails, so a link inside them was
+  // missed and the output had an <a> inside an <a>.
+  test("a link nested inside a bracket pair or an image alt rejects the outer link", () => {
+    expect(Markdown.html("[[x [a](/i) y] z](/u)\n")).toBe('<p>[[x <a href="/i">a</a> y] z](/u)</p>\n');
+    expect(Markdown.html("[x [y [a](/i)] z](/u)\n")).toBe('<p>[x [y <a href="/i">a</a>] z](/u)</p>\n');
+    expect(Markdown.html("[a]: /url\n\n[[x [a] y] z](/u)\n")).toBe('<p>[[x <a href="/url">a</a> y] z](/u)</p>\n');
+    expect(Markdown.html("[![x [a](/i) y](/img) z](/u)\n")).toBe('<p>[<img src="/img" alt="x a y" /> z](/u)</p>\n');
+    expect(Markdown.html("[x ![a ![b [c](/k) d](/j) e](/i) y](/u)\n")).toBe(
+      '<p>[x <img src="/i" alt="a b c d e" /> y](/u)</p>\n',
+    );
+    expect(Markdown.html("*[x [y [a](/i)] z](/u)*\n")).toBe('<p><em>[x [y <a href="/i">a</a>] z](/u)</em></p>\n');
+    expect(Markdown.html("[![[![[![[![](u)](u)](u)](u)\n")).toBe('<p>[![[![[<img src="u" alt="" />](u)</p>\n');
+    // Controls: a bracket pair without a link, and an image, are still
+    // allowed inside a link. Only the image's (url) / [ref] tail is skipped.
+    expect(Markdown.html("[x [y] z](/u)\n")).toBe('<p><a href="/u">x [y] z</a></p>\n');
+    expect(Markdown.html("[x ![a ![b](/j) c](/i) y](/u)\n")).toBe(
+      '<p><a href="/u">x <img src="/i" alt="a b c" /> y</a></p>\n',
+    );
+    expect(Markdown.html("[r]: /u\n\n[x ![a][r] y](/u)\n")).toBe(
+      '<p><a href="/u">x <img src="/u" alt="a" /> y</a></p>\n',
+    );
+    expect(Markdown.html('[x ![a](/i "[b](/c)") y](/u)\n')).toBe(
+      '<p><a href="/u">x <img src="/i" alt="a" title="[b](/c)" /> y</a></p>\n',
+    );
   });
 });
 

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -764,6 +764,9 @@ describe("pathological bracket inputs", () => {
     );
     expect(Markdown.html("*[x [y [a](/i)] z](/u)*\n")).toBe('<p><em>[x [y <a href="/i">a</a>] z](/u)</em></p>\n');
     expect(Markdown.html("[![[![[![[![](u)](u)](u)](u)\n")).toBe('<p>[![[![[<img src="u" alt="" />](u)</p>\n');
+    // An escaped `!` is text, so the bracket after it is a link, not an image.
+    expect(Markdown.html("[\\![a](/i)](/u)\n")).toBe('<p>[!<a href="/i">a</a>](/u)</p>\n');
+    expect(Markdown.html("[\\\\![a](/i)](/u)\n")).toBe('<p><a href="/u">\\<img src="/i" alt="a" /></a></p>\n');
     // Controls: a bracket pair without a link, and an image, are still
     // allowed inside a link. Only the image's (url) / [ref] tail is skipped.
     expect(Markdown.html("[x [y] z](/u)\n")).toBe('<p><a href="/u">x [y] z</a></p>\n');


### PR DESCRIPTION
### Problem
- `Bun.markdown.html("[[x [a](/i) y] z](/u)")` renders `<a href="/u">[x <a href="/i">a</a> y] z</a>`, an `<a>` inside an `<a>`. CommonMark 6.3 says links may not contain other links at any nesting level. commonmark.js and cmark leave the outer candidate as text. `render`, `react` and `ansi` share the parser and have the same bug.
- The cause is `label_contains_link` in `src/md/links.rs:794`. For each `[` in the label it asked `try_match_bracket_link` whether that pair is a link. When it was not, the scan jumped to `link_end`, past the whole pair. A link nested inside that pair, or inside the alt text of an inner image, was never seen.

### Fix
- The scan now steps into every bracket pair. For an inner image it only skips the `(url)` or `[ref]` tail. Pending tails are kept on a small stack, because images nest like their brackets do.
- A backslash escape before `!` (`[\![a](/i)](/u)`) now counts as text, so the bracket after it is a link and not an image.
- This matches cmark, which deactivates every earlier `[` opener when a link forms, but leaves `![` openers active. A differential run of 80,000 random bracket inputs against commonmark.js changed 229 outputs, all of them to the commonmark.js output, and changed nothing else.
- Verified: `test/js/bun/md/md-edge-cases.test.ts` (new test, fails on the released bun). Also `md-spec.test.ts` and `gfm-compat.test.ts`. The "link/image alternation" expectation in the linear-time test encoded the old output and now matches cmark.

### Background
- `process_link` parses a link candidate when it meets `[`. Before it commits, it calls `label_contains_link` on the label text to enforce the no-nested-links rule. The emphasis collector in `src/md/inlines.rs:731` calls it too, so emphasis and links agree on what is a link.
- `try_match_bracket_link` is an O(1) lookup in the precomputed `BracketMatches` map plus a parse of the `(url)` or `[ref]` tail. Stepping into non-link pairs therefore keeps the scan linear. The pathological bracket tests still pass and timings on 40,000-deep nested inputs scale linearly.

<details><summary>Notes</summary>

Inputs from the issue, all now equal to commonmark.js 0.31.2:

```
[[x [a](/i) y] z](/u)        -> <p>[[x <a href="/i">a</a> y] z](/u)</p>
[x [y [a](/i)] z](/u)        -> <p>[x [y <a href="/i">a</a>] z](/u)</p>
[a]: /url + [[x [a] y] z](/u) -> <p>[[x <a href="/url">a</a> y] z](/u)</p>
[![x [a](/i) y](/img) z](/u) -> <p>[<img src="/img" alt="x a y" /> z](/u)</p>
```

The `[![` x 36000 + `](u)` x 36000 input in the linear-time test: the innermost `[..](u)` is a link, so every outer `[` is deactivated. The closed half collapses to one image whose alt text flattens the levels in between. The old expectation (`<a><img></a>` at the end) was the buggy output.

Remaining differences against commonmark.js in the fuzz run (994 of 80,000) are about link destinations with unbalanced parentheses and reference definition edge cases. They exist on main and are not touched here.

Self-reviewed: 5 concerns raised, 1 addressed (the escaped `!` case). The rest asked for a closer-ordered link resolution pass that replaces this lookahead. That is a larger refactor and out of scope for this fix.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-edge-cases.test.ts
bun test v1.4.3 (b99371011)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [75.29ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [9.63ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [1.98ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [7.33ms]
(pass) fuzzer-like edge cases > control characters in input [1.97ms]
(pass) fuzzer-like edge cases > Buffer input works [1.98ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [4.76ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [7.86ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [2.28ms]
(pass) fuzzer-like edge cases > deeply nested lists [8.42ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [146.06ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [99.20ms]
(pas
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (b99371011)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [1.22ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [0.12ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [0.04ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [0.09ms]
(pass) fuzzer-like edge cases > control characters in input [0.02ms]
(pass) fuzzer-like edge cases > Buffer input works [0.03ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [0.05ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [0.12ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [0.03ms]
(pass) fuzzer-like edge cases > deeply nested lists [0.10ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [6.48ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [4.77ms]
(pass) fuzzer-like edge cases > deeply nested emphasis [0.08ms]
(pass) fuzzer-like edge cases > deeply nested links [0.06ms]
(pass) fuzzer-like edge cases > very long s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/md/md-edge-cases.test.ts
bun test v1.4.3 (b99371011)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [73.46ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [9.64ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [1.81ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [7.60ms]
(pass) fuzzer-like edge cases > control characters in input [1.32ms]
(pass) fuzzer-like edge cases > Buffer input works [2.11ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [4.83ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [11.28ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [2.38ms]
(pass) fuzzer-like edge cases > deeply nested lists [8.70ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [144.91ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [95.94ms]
(pa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     17b93186b6
  features     baseline

23 deps, 131 codegen, 1176 objects in 746ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] install /workspace/bun
bun install v1.4.3-canary.1 (b99371011)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[2/1248] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (b99371011)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1248] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (b99371011)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[4/1248] fetch tinycc
[tinycc] up to date
[5/1247] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1247] gen ErrorCode+*.h
[7/1247] fetch zlib
[zlib] up to date
[8/1247] gen bindgenv2
[9/1247] gen .bind.ts → GeneratedBindings.cpp
[10/1247] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1247] gen node-fallbacks/react-refresh.js
Bundled 1 module in 69ms

  react-refresh.js  4.81 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/md/links.rs                      | 44 ++++++++++++++++++++++++++++--------
 test/js/bun/md/md-edge-cases.test.ts | 36 ++++++++++++++++++++++++++++-
 2 files changed, 69 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/md/links.rs                           5      5      6
test/js/bun/md/md-edge-cases.test.ts      2      4      6
```

</details>

**root cause** · written by the author bot

`label_contains_link` in `src/md/links.rs` skipped past the whole bracket pair whenever `try_match_bracket_link` reported that a `[` was not a link, so a link nested inside a non-link bracket group in a link label was never seen and the outer link was still formed, producing an `<a>` inside an `<a>` contrary to CommonMark 0.31.2. The fix steps into non-link bracket pairs and into image alt text, skipping only an inner image's `(url)` or `[ref]` tail via a small tail stack, and tracks escape state so escaped brackets are not misread as openers. Because `try_match_bracket_link` is O(1) per `[…

<!-- robobun:evidence:end -->