### PR TITLE
mimalloc: a forced purge waits for the pass in progress, and what is freed during a pass is purged by the next

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "6a64e1ba7f5b2130d4efccb67ec87fd0003f0f6a";
+const MIMALLOC_COMMIT = "707d90be8a0cd283c4fb1e8318c3ef5c715c9352";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/test/js/bun/gc/gc-controller-cadence.test.ts
+++ b/test/js/bun/gc/gc-controller-cadence.test.ts
@@ -288,3 +288,43 @@ test.skipIf(!isLinux || isASAN)("Bun.gc(true) returns what it freed to the OS be
   expect(JSON.parse(stdout).released).toBeGreaterThan(200);
   expect(exitCode).toBe(0);
 });
+
+// One thread at a time hands the allocator's free ranges back, and its own purge thread is often the one: it starts on what
+// was freed once the purge delay has passed, and a few hundred MB keep it busy for tens of milliseconds. Bun.gc(true) in the
+// middle of that found the purge taken, skipped its own, and returned with all of it still resident.
+test.skipIf(!isLinux || isASAN)(
+  "Bun.gc(true) returns what is free to the OS while the purge thread is at work",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const rss = () => process.memoryUsage.rss() / 1048576;
+          // The allocator starts its purge thread the first time a thread blocks.
+          await Bun.sleep(1);
+          const rounds = [];
+          for (let round = 0; round < 3; round++) {
+            const arrays = [];
+            for (let i = 0; i < 48; i++) arrays.push(new Uint8Array(8 * 1024 * 1024).fill(1));
+            const held = rss();
+            // transfer(0) frees the 8 MB here and now, no collection involved. They stay resident until they are purged.
+            for (const array of arrays) array.buffer.transfer(0);
+            // Wait for the purge thread to start on them. If it never does, Bun.gc(true) has all of it to return by itself.
+            const deadline = performance.now() + 1000;
+            while (rss() > held - 32 && performance.now() < deadline);
+            Bun.gc(true);
+            rounds.push({ held, released: held - rss() });
+          }
+          console.log(JSON.stringify(rounds));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    for (const { released } of JSON.parse(stdout)) expect(released, stdout).toBeGreaterThan(300);
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/jsc/heapStats-mimalloc.test.ts
+++ b/test/js/bun/jsc/heapStats-mimalloc.test.ts
@@ -141,10 +141,12 @@ describe("heapStats() mimalloc integration", () => {
           let deadline = performance.now() + 1000;
           while (rss() > held - 64 && performance.now() < deadline);
           for (const array of second) array.buffer.transfer(0);
-          // The next pass comes 100 ms later.
+          // The next pass comes 100 ms later. What RSS fell by is taken before heapStats() runs again: that call polls the
+          // allocator, and a poll runs a pass that is due by itself.
           deadline = performance.now() + 2000;
-          while (rss() > held - 352 && performance.now() < deadline);
-          console.log(JSON.stringify({ released: held - rss(), purged: purged() - purgedBefore }));
+          let released;
+          while ((released = held - rss()) < 336 && performance.now() < deadline);
+          console.log(JSON.stringify({ released, purged: purged() - purgedBefore }));
         `,
         ],
         env: { ...bunEnv, Malloc: "1" },
@@ -153,7 +155,9 @@ describe("heapStats() mimalloc integration", () => {
       });
       const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
       // 384 MB were freed. The first pass alone takes the first 256 MB, and up to 32 MB of the rest.
-      expect(JSON.parse(stdout).purged, stdout).toBeGreaterThanOrEqual(352);
+      const { released, purged } = JSON.parse(stdout);
+      expect(released, stdout).toBeGreaterThanOrEqual(336);
+      expect(purged, stdout).toBeGreaterThanOrEqual(336);
       expect(exitCode).toBe(0);
     },
   );

--- a/test/js/bun/jsc/heapStats-mimalloc.test.ts
+++ b/test/js/bun/jsc/heapStats-mimalloc.test.ts
@@ -1,6 +1,6 @@
 import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isMacOS } from "harness";
+import { bunEnv, bunExe, isASAN, isLinux, isMacOS } from "harness";
 
 describe("heapStats() mimalloc integration", () => {
   test("mimalloc aggregate stats are present", () => {
@@ -110,4 +110,51 @@ describe("heapStats() mimalloc integration", () => {
     expect(appTag).toBeGreaterThan(64);
     expect(exitCode).toBe(0);
   });
+
+  // The allocator's purge thread takes back what was freed 100 ms after the free. What a thread freed while the purge thread
+  // was in the middle of a pass was left out for good: it stayed resident until the event loop went idle or something forced
+  // a collection. A script that keeps its thread busy does neither. It took a pass in which each of the allocator's arenas
+  // had something to hand back. JSC's structure heap is an arena of its own that rarely has, so Malloc=1 here: JSC then
+  // allocates through malloc (mimalloc as well) and there is one arena. Linux only: the wait reads RSS. Not ASAN: malloc is
+  // not mimalloc there.
+  test.skipIf(!isLinux || isASAN)(
+    "memory freed while the purge thread is at work is purged without an idle event loop",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          import { heapStats } from "bun:jsc";
+          const rss = () => process.memoryUsage.rss() / 1048576;
+          // the bytes the allocator handed back to the OS so far
+          const purged = () => heapStats().mimalloc.purged / 1048576;
+          // The allocator starts its purge thread the first time a thread blocks.
+          await Bun.sleep(1);
+          const first = [], second = [];
+          for (let i = 0; i < 32; i++) first.push(new Uint8Array(8 * 1024 * 1024).fill(1));
+          for (let i = 0; i < 16; i++) second.push(new Uint8Array(8 * 1024 * 1024).fill(1));
+          const held = rss(), purgedBefore = purged();
+          // transfer(0) frees the 8 MB here and now, no collection involved. No await from here on.
+          for (const array of first) array.buffer.transfer(0);
+          // Spin until the purge thread is in the middle of its pass over them (heapStats() would run that pass itself).
+          let deadline = performance.now() + 1000;
+          while (rss() > held - 64 && performance.now() < deadline);
+          for (const array of second) array.buffer.transfer(0);
+          // The next pass comes 100 ms later.
+          deadline = performance.now() + 2000;
+          while (rss() > held - 352 && performance.now() < deadline);
+          console.log(JSON.stringify({ released: held - rss(), purged: purged() - purgedBefore }));
+        `,
+        ],
+        env: { ...bunEnv, Malloc: "1" },
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      // 384 MB were freed. The first pass alone takes the first 256 MB, and up to 32 MB of the rest.
+      expect(JSON.parse(stdout).purged, stdout).toBeGreaterThanOrEqual(352);
+      expect(exitCode).toBe(0);
+    },
+  );
 });


### PR DESCRIPTION
Both fork PRs are merged: oven-sh/mimalloc#38 and oven-sh/mimalloc#39. The pin `707d90be` is on `bun-dev3-v2` (they were merged with merge commits, so the sha did not change). This PR now carries both bumps and both tests; it replaces #42543.

### Two fixes in the fork

**1. A forced purge waits for the pass in progress (oven-sh/mimalloc#38).**
- `Bun.gc(true)` ends with `mi_collect(true)` since #42428. mimalloc dropped that purge when another thread held its purge guard, and the purge thread holds it for 36 to 47 ms while it purges what was already freed. `Bun.gc(true)` then returned with all of it still resident.
- `test/js/bun/spawn/spawn-pipe-leak.test.ts` fails on main because of it: `Peak RSS: warmup 46 MB -> main 312 MB (573%)`, 7 of 10 runs pass. With this pin: 25 of 25.
- Only a forced collect waits. bun's one caller is `garbage_collect_from_js`. It takes 29 to 47 ms in place of 1 to 2 ms when it collides with a pass over 384 MB, and the memory is back with the OS when it returns.
- Test: `test/js/bun/gc/gc-controller-cadence.test.ts`, "Bun.gc(true) returns what is free to the OS while the purge thread is at work". Fails 3 of 3 on main's release build (38 to 42 MB released, expected more than 300).

**2. What is freed during a purge pass is purged by the next pass (oven-sh/mimalloc#39).** The rest of this description.

### Problem
- Memory freed while mimalloc's purge thread (the scavenger) is in a pass can stay resident until the event loop goes idle or something forces a collection. With one arena (`Malloc=1`) a busy script keeps 110 of 384 MB: `{"released":262.6,"purged":274.4}`.
- In the fork, `_mi_arenas_try_purge` (`src/arena.c`) keeps its old `subproc->purge_expire` during a pass, so a free in that time arms the arena only. The scavenger then clears the value, and no later free sets it again.
- It reaches bun's default configuration. JSC's structure heap is a second arena that rarely purges, which hides the case of one busy thread. With several busy threads and no ticking event loop it shows each time: 8 workers that churn `ArrayBuffer`s and then spin hold 578 MB RSS on main's release build and fall to 91 MB with this pin.

### Fix
- Bump `MIMALLOC_COMMIT` to `707d90be` (oven-sh/mimalloc#39, which contains oven-sh/mimalloc#38). The bump also picks up `0fecc729`, a 32-bit shift fix in `src/prof.c` that was already on `bun-dev3-v2`.
- In the fork a pass now resets `subproc->purge_expire` first and puts back what is pending at its end, so a free behind the pass schedules the next one.
- Verified: the new test in `test/js/bun/jsc/heapStats-mimalloc.test.ts` fails 3 of 3 on main's release build, passes 20 of 20 with this pin. `bun bd test` skips it (ASAN).

### Background
- A purge returns freed mimalloc arena memory to the OS (`madvise`), 100 ms after the free.
- The scavenger is the fork's thread that runs those purges. It sleeps until `subproc->purge_expire`.
- The first free into an arena after a pass arms it (`arena->purge_expire`). Only that free looks at `subproc->purge_expire`.

<details><summary>Notes</summary>

**The two commits of oven-sh/mimalloc#39.**
- `1b894afe` arena: what is freed during a purge pass is purged by the next pass (the fix)
- `707d90be` init: release the purge guard at process exit on Windows

**The free path (`mi_arena_schedule_purge`) is unchanged.** Only the pass and the scavenger loop change.

**The defect in full.** A free arms its arena (`arena->purge_expire`) and, only if the arena was not armed yet, arms the subprocess (`subproc->purge_expire`, 0 -> set), which is what the scavenger sleeps on. A pass resets the arena expire when it goes into the arena, but it kept its old subprocess expire until its end. The first free into the arena behind the pass armed the arena again, found the subprocess expire still set, and left it alone. Then `_mi_arenas_try_purge` skipped its update (the break for `max_purge_count` also fires on the last arena, so a pass in which each arena purged ended with `all_visited = false`), and `mi_scavenger_run` set `subproc->purge_expire` to 0. The arena was armed and the subprocess was not. Each later free into that arena saw an armed arena and stopped there. The 30 s timeout of the scavenger did not help: with nothing scheduled it only waits again.

**Reach in bun.** JSC registers its structure heap as an exclusive mimalloc arena (`mi_manage_os_memory_ex` in `StructureAlignedMemoryAllocator.cpp`). A pass over two arenas in which only the main one purges ends with `all_visited = true`, reads the re-armed expire of the main arena after its walk, and installs it. So the same script that loses 128 MB with one arena gets its second pass on time with two (traced on main's release build: first pass at 107 to 123 ms, second at 207 ms). It shows when both arenas purge in the same pass, when a process has more arenas (more than 1 GiB of mimalloc memory) and each purges, and with `Malloc=1`. The event loop's `mi_on_thread_idle_start` on each `epoll_wait` heals it when the sweep runs to its end. Under load the owner wakes first and the sweep stops before `_mi_arenas_purge_now`.

The state is absorbing: once an arena is armed and the subprocess is not, nothing but a park or a forced collect ends it. So a low chance per pass is enough for a process whose threads stay busy. Measured with stock two arena bun (release, Linux x64): 8 workers allocate and free 1 to 8 MB `ArrayBuffer`s for 3 s (`transfer(0)` frees at once), free everything, and spin, while the main thread sits in `Atomics.wait`. After a quiet 2.5 s RSS is 578 MB on main and 91 MB with this pin (`arena_count` 2 in both). The same happens with only the one line fix for `all_visited` in the fork, which is why the pass resets the subprocess expire first.

**The test.** A child frees 256 MB with `ArrayBuffer.prototype.transfer(0)` (no collection involved), spins until RSS fell by 64 MB (the purge thread is in its pass), frees 128 MB more, and spins without an `await` until RSS fell by 336 MB, for at most 2 s. It reports that drop and the growth of `heapStats().mimalloc.purged`. Both have to be at least 336 MB. The drop in RSS is taken before the last `heapStats()` call, because that call polls the allocator (`mi_collect(false)`), and a poll runs a pass that is due by itself. `Malloc=1` makes JSC allocate through `malloc`, which is mimalloc on Linux, so there is one arena. Linux only (the wait reads RSS) and not ASAN (malloc is not mimalloc there).

| build | result |
| --- | --- |
| release build of main (`6a92015fc`, pin `6a64e1ba`) | fails 3 of 3: `{"released":262.6,"purged":274.4}`, expected >= 336 |
| `bun run build:release` with this pin | passes 20 of 20, about 450 ms |
| `bun bd test` with this pin (debug, ASAN) | new test skipped, the other 4 tests in the file pass |

The change is under `scripts/`, so a checkout of `src/` from main does not undo it. The fail-before check needs a release build of main.

**About `707d90be`.** `1b894afe` alone failed the 5 Windows jobs of the fork's CI. Its new test returns from `main` while the scavenger is in its last pass. On Windows `mi_process_done` runs in the process detach callback, after the system terminated every other thread, so the purge guard stays held, and the forced collect at exit waits for it without end (that wait is what oven-sh/mimalloc#38 adds). `707d90be` releases the guard there. bun builds mimalloc with `MI_NO_PROCESS_DETACH` and `MI_SKIP_COLLECT_ON_EXIT`, so bun does not reach that code on any platform. Fork CI at `707d90be`: 15 of 15 jobs pass (Windows x64 and arm64, mingw, macOS, Linux x64 and arm64 with ASAN, UBSAN, TSAN and guarded builds, FreeBSD).

**In the fork.** New `test/test-purge-behind-pass.c`: 5 of 5 runs fail before (`266 of 320 MiB`), 30 of 30 pass after. A stress harness with 8 to 16 busy threads: 15 of 15 rounds end stuck before, with about 530 MiB of free committed ranges unpurged. After: 750 rounds, 0 stuck. Details are in oven-sh/mimalloc#39.

**Effect on purge activity.** Ranges that stayed resident by accident are now purged 100 ms after the free, which is what `purge_delay` promises.

**Suites run with a release build of this branch (Linux x64).** `test/js/bun/jsc/heapStats-mimalloc.test.ts`, `test/js/bun/gc/gc-controller-cadence.test.ts` (11 pass), `test/js/bun/spawn/spawn-pipe-leak.test.ts` (3 pass), `test/js/bun/spawn/spawn-noread-leak.test.ts`, `test/js/bun/jsc/bun-jsc.test.ts` (38 pass). Nothing here was run on macOS or Windows.

</details>




### Now pins the merged upstream sync

`MIMALLOC_COMMIT` is `ab13501334a8da2b64ab2e5f4f552c3a39b96350`: the merge of oven-sh/mimalloc#37 on `bun-dev3-v2`. It contains `707d90be` (both fixes above), so everything in this description still holds.

**What it adds beyond oven-sh/mimalloc#38 and oven-sh/mimalloc#39**
- microsoft/mimalloc `dev3` through v3.5.2 (301 commits): always-on statistics (`MI_STATS=1`), sampled profiler hooks (`mi_profiler_t`, `MI_PROFILE=1`), codegen work in free/zalloc/memzero, double-free detection through the padding canary.
- The fork's own heap profiler is gone (`src/prof.c`, `mi_prof_*`, `MIMALLOC_PROF_*`); upstream's hooks replace it. bun referenced none of it.
- `fork()`: no arena purge pass runs across it any more. That was the macOS Debug SIGBUS of a forked child in the fork's CI, and a whole class of torn purge state in the child.
- `mi_heap_destroy` of a heap that still has a block on a page's thread-free list no longer reports corrupted meta-data.
- Two slips in upstream's `free.c` are fixed: `mi_usable_size` always took its slow path, and an overflow could be reported as a double free.
- The malloc/free fast paths update upstream's packed used count with one instruction (`decw` / `addq` on memory).

**One new define: `MI_FREE_USE_PAGEMAP=1`**
- Upstream's new default keeps page meta data at 256 MiB boundaries so that `mi_free` needs no page map. Every arena then has to start on such a boundary.
- JSC gives mimalloc its structure heap as an arena (`mi_manage_os_memory_ex(start + 16 KiB, ...)`, under a `RELEASE_ASSERT`), and halves that reservation when address space is short. With the new default `mi_manage_os_memory_ex` refuses it once the reservation is 256 MiB or less.
- Measured with a release build of the new pin without the define: `ulimit -v 3000000; bun -e 1` aborts on startup, and so does `BUN_JSC_structureHeapSizeInKB=262144`. The old pin runs both. With the default 4 GiB reservation it works but loses the first 256 MiB of structure address space.
- With the define, `mi_free` looks the page up through the page map as it does today, and the structure heap works down to 64 MiB as before. The fork's CI runs this configuration (debug and release) on Linux x64 and arm64.
- The aligned layout is worth another 1.1% of instructions on the malloc/free benchmark below. Getting it needs WebKit to hand mimalloc an aligned region (`mi_arena_min_alignment()`), which is a separate change.

**Not changed: `MI_PROFILE` stays at its default of 1.** Nothing in bun attaches a profiler yet, and `MI_PROFILE=0` would save about 1.4% of instructions on the same benchmark. The hooks are what a `Bun.pprof.heap` API would build on, so they stay compiled in.

**Bindings.** Every `mi_*` function that `src/mimalloc_sys/mimalloc.rs` and the C++ side declare is exported with an unchanged declaration. `mi_heap_area_t` has the same layout. `mi_option_t` 0..46 did not move (47 is `collect_merges_stats` now, `snapshot_on_exit` 48); bun sets option 0 only. The `heapStats().mimalloc` keys the tests read (`purged`, `page_bins`, `pages`, `committed`) are emitted as before.

**Allocator micro benchmark** (25 M `mi_malloc` + 25 M `mi_free` of 16..1039 bytes, bun's compile flags, user-mode instructions):

| | instructions |
| --- | --- |
| old pin (`707d90be`) | 2.2463 G |
| this pin, `MI_FREE_USE_PAGEMAP=1` (what this PR builds) | **2.2403 G** (-0.3%) |
| this pin, upstream's aligned layout | 2.2153 G (-1.4%) |

**bun, release build, old pin against this commit** (same tree, only the pin and the define differ; 5 interleaved runs pinned to 8 cores; user-mode instructions and peak RSS, medians):

| | old pin | this commit |
| --- | --- | --- |
| `bun -e 1` | 9.17 M, 25.9 MB | 9.16 M (-0.06%), 25.7 MB |
| `Bun.serve` hello, per request (20000 sequential `fetch`) | 51748, 48.2 MB | 51787 (+0.08%), 48.5 MB |
| `JSON.stringify` + `JSON.parse` of a 200-user object, 3000 times | 5102.3 M, 42.6 MB | 5102.9 M (+0.01%), 42.6 MB |
| string concat + `Buffer.from` + `split`, 300 x 5000 | 1939.8 M, 58.9 MB | 1904.3 M (-1.8%, the spread between runs is 2%), 57.8 MB |
| idle after start (`Bun.sleep`), RSS from `smaps_rollup` | 32.4 MB (anon 3.85) | 32.5 MB (anon 3.96) |

Nothing is slower by more than 0.1%.

**Tests with a release build of this commit (Linux x64)**
- `test/js/bun/spawn/spawn-pipe-leak.test.ts`: 25 of 25 runs pass. `test/js/bun/jsc/heapStats-mimalloc.test.ts` and `test/js/bun/gc/gc-controller-cadence.test.ts`: 10 of 10 each.
- 137 test files, 4280 tests pass: the two files of this PR, `spawn-noread-leak`, `require-cache`, `heap-snapshot`, `bun-jsc`, `socket-retention`, `serve.test.ts`, all of `test/js/node/child_process`, `node-net`, `bunshell`, `fetch.test.ts`, `bun-install.test.ts`, `bundler_edgecase`, all of `test/js/web/workers` and `test/js/node/worker_threads`, `test/js/bun/resolve`, `test/js/bun/jsc`, the `--compile` and bundler files, `test/bake/dev`.
- 8 tests fail, and the same 8 fail with a release build of the old pin: they need a non-root user (a port below 1024 that must be refused, `EPERM` after dropping privileges, unreadable files and directories).
- Small structure heaps: `BUN_JSC_structureHeapSizeInKB` = 262144, 131072, 65536 and `ulimit -v` = 3000000, 2000000, 1500000 all start.
- Debug (ASAN) build: `heapStats-mimalloc`, `gc-controller-cadence`, `test/js/web/workers/worker.test.ts` pass; `child_process.test.ts` has the one root-only failure.
- `src/static.c` compiles with the new define and bun's flags for macOS arm64/x64 and Windows x64/arm64 (release and debug). Nothing here was run on macOS or Windows.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/jsc/heapStats-mimalloc.test.ts, test/js/bun/gc/gc-controller-cadence.test.ts

<!-- robobun:evidence:end -->