### PR TITLE
shell: make $.env() reject a value that is not an object

### DIFF
--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -272,7 +272,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     env(newEnv: Record<string, string | undefined>) {
       if (typeof newEnv === "undefined" || newEnv === originalDefaultEnv) {
         this[envSymbol] = originalDefaultEnv;
-      } else if (newEnv) {
+      } else if ($isObject(newEnv)) {
         this[envSymbol] = Object.assign({}, newEnv);
       } else {
         throw new TypeError("env must be an object or undefined");

--- a/test/js/bun/shell/bunshell-instance.test.ts
+++ b/test/js/bun/shell/bunshell-instance.test.ts
@@ -89,6 +89,14 @@ describe("$.env() argument validation", () => {
       expect(() => $$.env(value)).not.toThrow();
     });
 
+    test("$.env() accepts it", () => {
+      try {
+        expect(() => $.env(value)).not.toThrow();
+      } finally {
+        $.env(undefined);
+      }
+    });
+
     test("$`cmd`.env() accepts it", () => {
       expect(() => {
         $`true`.env(value);

--- a/test/js/bun/shell/bunshell-instance.test.ts
+++ b/test/js/bun/shell/bunshell-instance.test.ts
@@ -53,13 +53,13 @@ test("$$", async () => {
   expect((await $`echo $BUN`).stdout.toString()).toBe("bun2\n");
 });
 
+// $.env() sets the default that $`cmd`.env() sets for one command, so both take the same values: any object.
 describe("$.env() argument validation", () => {
-  // `undefined` is not in this list: it restores process.env.
-  const notObjects = [5, 0, NaN, 1n, "str", "", true, false, null, Symbol("env")];
   const error = expect.objectContaining({ name: "TypeError", message: "env must be an object or undefined" });
 
-  for (const value of notObjects) {
-    test(`new $.Shell().env(${Bun.inspect(value)}) throws and keeps the previous env`, async () => {
+  // `undefined` is not in this list: it restores process.env.
+  describe.each([5, 0, NaN, 1n, "str", "", true, false, null, Symbol("env")])("%p is not an object", value => {
+    test("new $.Shell().env() throws and keeps the previous env", async () => {
       const $$ = new $.Shell();
       $$.env({ BUN: "bun" });
 
@@ -67,33 +67,33 @@ describe("$.env() argument validation", () => {
       expect(() => $$.env(value)).toThrow(error);
       expect(await $$`echo $BUN`.text()).toBe("bun\n");
     });
-  }
 
-  test("the global $ rejects the same values", () => {
-    for (const value of notObjects) {
+    test("$.env() throws", () => {
       // @ts-expect-error
       expect(() => $.env(value)).toThrow(error);
-    }
-  });
+    });
 
-  // $.env() sets the default that $`cmd`.env() sets for one command, so both take the same values.
-  // A block body keeps expect() from waiting on the returned ShellPromise, which never starts.
-  test("accepts what $`cmd`.env() accepts: any object", () => {
-    const $$ = new $.Shell();
-    for (const value of [{}, Object.create(null), [], new Map(), () => {}]) {
-      expect(() => {
-        $$`true`.env(value);
-      }).not.toThrow();
-      expect(() => {
-        $$.env(value);
-      }).not.toThrow();
-    }
-    for (const value of notObjects) {
+    test("$`cmd`.env() throws", () => {
+      // A block body keeps expect() from waiting on the returned ShellPromise, which never starts.
       expect(() => {
         // @ts-expect-error
-        $$`true`.env(value);
+        $`true`.env(value);
       }).toThrow("env must be an object");
-    }
+    });
+  });
+
+  // Each value is in its own array, because describe.each() spreads an array row into arguments.
+  describe.each([[{}], [Object.create(null)], [[]], [new Map()], [() => {}]])("%p is an object", value => {
+    test("new $.Shell().env() accepts it", () => {
+      const $$ = new $.Shell();
+      expect(() => $$.env(value)).not.toThrow();
+    });
+
+    test("$`cmd`.env() accepts it", () => {
+      expect(() => {
+        $`true`.env(value);
+      }).not.toThrow();
+    });
   });
 });
 

--- a/test/js/bun/shell/bunshell-instance.test.ts
+++ b/test/js/bun/shell/bunshell-instance.test.ts
@@ -53,6 +53,50 @@ test("$$", async () => {
   expect((await $`echo $BUN`).stdout.toString()).toBe("bun2\n");
 });
 
+describe("$.env() argument validation", () => {
+  // `undefined` is not in this list: it restores process.env.
+  const notObjects = [5, 0, NaN, 1n, "str", "", true, false, null, Symbol("env")];
+  const error = expect.objectContaining({ name: "TypeError", message: "env must be an object or undefined" });
+
+  for (const value of notObjects) {
+    test(`new $.Shell().env(${Bun.inspect(value)}) throws and keeps the previous env`, async () => {
+      const $$ = new $.Shell();
+      $$.env({ BUN: "bun" });
+
+      // @ts-expect-error
+      expect(() => $$.env(value)).toThrow(error);
+      expect(await $$`echo $BUN`.text()).toBe("bun\n");
+    });
+  }
+
+  test("the global $ rejects the same values", () => {
+    for (const value of notObjects) {
+      // @ts-expect-error
+      expect(() => $.env(value)).toThrow(error);
+    }
+  });
+
+  // $.env() sets the default that $`cmd`.env() sets for one command, so both take the same values.
+  // A block body keeps expect() from waiting on the returned ShellPromise, which never starts.
+  test("accepts what $`cmd`.env() accepts: any object", () => {
+    const $$ = new $.Shell();
+    for (const value of [{}, Object.create(null), [], new Map(), () => {}]) {
+      expect(() => {
+        $$`true`.env(value);
+      }).not.toThrow();
+      expect(() => {
+        $$.env(value);
+      }).not.toThrow();
+    }
+    for (const value of notObjects) {
+      expect(() => {
+        // @ts-expect-error
+        $$`true`.env(value);
+      }).toThrow("env must be an object");
+    }
+  });
+});
+
 test("$.text", async () => {
   expect(await $`echo hello`.text()).toBe("hello\n");
 });


### PR DESCRIPTION
### Problem

- `$.env(value)` and `new $.Shell().env(value)` accept every truthy value. `$.env(5)` and `$.env(true)` give every later command an empty environment (no `PATH`). `$.env("str")` gives it `0=s`, `1=t`, `2=r`. No call throws.
- The cause is `else if (newEnv)` in `ShellPrototype.env` (`src/js/builtins/shell.ts:275`). That branch runs `Object.assign({}, newEnv)`, and `Object.assign({}, 5)` is `{}`.

### Fix

- The branch is now `else if ($isObject(newEnv))`. A value that is not an object and not `undefined` throws `TypeError: env must be an object or undefined`. The previous default stays in effect.
- `` $`cmd`.env() `` (`set_env`, `src/runtime/shell/ParsedShellScript.rs:131`) and `Bun.spawn({ env })` use `JSValue::get_object()`, which is the same test. So `$.env()` and `` $`cmd`.env() `` now take the same values.
- Both still accept every object (Array, Map, function). Only own enumerable string keys become variables, so a Map gives an empty environment.
- Verified: `test/js/bun/shell/bunshell-instance.test.ts` (10 of 45 new cases fail without the fix). Also ran `bunshell.test.ts` and 7 more files in `test/js/bun/shell/`. Self-reviewed: no concern survived.

### Background

- `$` is the tagged template function of Bun Shell. `new $.Shell()` makes an independent one. Both inherit `env()` from `ShellPrototype`.
- `$.env(obj)` stores a copy of `obj` as the default environment for later commands. `$.env(undefined)` restores `process.env`.
- `` $`cmd`.env(obj) `` sets the environment of one command through the native `setEnv`. It already throws `env must be an object` for `5`.
- `$isObject` is a JavaScriptCore intrinsic for builtin code. It is true for objects and functions. It is false for `null` and primitives.

<details><summary>Notes</summary>

Found by fuzzing. There is no user report.

Repro, before the fix (bun 1.4.3-canary.1, Linux x64):

```js
import { $ } from "bun";
for (const v of [5, "str", true, 1n, Symbol("x")]) {
  $.env(v);
  console.log(String(v), (await $`env | wc -l`.text()).trim());
}
// 5 -> 0, str -> 3, true -> 0, 1 -> 0, Symbol(x) -> 0
```

After the fix each call throws `TypeError: env must be an object or undefined`.

Values that already threw, and still do: `null`, `0`, `NaN`, `0n`, `""`, `false`.

Not changed here:

- `$.env({ "A=B": "1" })` exports `A=B=1`. Node's `child_process` builds `${key}=${value}` the same way.
- The `TypeError` from `$.env()` has no `code`. The one from `` $`cmd`.env() `` has `code: "ERR_INVALID_ARG_TYPE"` and the message `env must be an object`.
- `$.env(new Map([["A", "1"]]))` gives an empty environment in both setters and in `Bun.spawn({ env })`.

Test files run with the debug build: `bunshell-instance`, `bunshell`, `bunshell-default`, `pipeline_stack`, `exec`, `throw`, `lazy`, `env.positionals`, `shelloutput`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/shell/bunshell-instance.test.ts
bun test v1.4.3 (b99371011)

test/js/bun/shell/bunshell-instance.test.ts:
(pass) new $.Shell() inherits process.env and throws on non-zero exit by default [363.67ms]
bun

bun
bun2
(pass) $$ [46.72ms]
62 |     test("new $.Shell().env() throws and keeps the previous env", async () => {
63 |       const $$ = new $.Shell();
64 |       $$.env({ BUN: "bun" });
65 | 
66 |       // @ts-expect-error
67 |       expect(() => $$.env(value)).toThrow(error);
                                       ^
error: expect(received).toThrow(expected)

Expected constructor: ExpectObjectContaining

Received function did not throw
Received value: [Function: Shell]

      at <anonymous> (/workspace/bun/test/js/bun/shell/bunshell-instance.test.ts:67:35)
      at <anonymous> (/workspace/bun/test/js/bun/shell/bunshell-instance.test.ts:62:67)
(fail) $.env() argument validation > 5 is not an object > new $.Shell().env() throws and keeps the previous env [9.11ms]
68 |       expect(await $$`echo $BUN`.text()).toBe("bun\n");
69 |
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (62cf331b0)

test/js/bun/shell/bunshell-instance.test.ts:
(pass) new $.Shell() inherits process.env and throws on non-zero exit by default [6.91ms]
bun

bun
bun2
(pass) $$ [0.87ms]
(pass) $.env() argument validation > 5 is not an object > new $.Shell().env() throws and keeps the previous env [0.29ms]
(pass) $.env() argument validation > 5 is not an object > $.env() throws [0.03ms]
(pass) $.env() argument validation > 5 is not an object > $`cmd`.env() throws [0.09ms]
(pass) $.env() argument validation > 0 is not an object > new $.Shell().env() throws and keeps the previous env [0.08ms]
(pass) $.env() argument validation > 0 is not an object > $.env() throws [0.01ms]
(pass) $.env() argument validation > 0 is not an object > $`cmd`.env() throws [0.02ms]
(pass) $.env() argument validation > NaN is not an object > new $.Shell().env() throws and keeps the previous env [0.07ms]
(pass) $.env() argument validation > NaN is not an object > $.env() throws
(pass) $.env() argument validation > NaN is not an object > $`cmd`.env() throws [0.02ms]
(pass) $.env() argument validation > 1n is not an object > new $.Shell().env() throws and keeps the previous en
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/shell/bunshell-instance.test.ts
bun test v1.4.3 (b99371011)

test/js/bun/shell/bunshell-instance.test.ts:
(pass) new $.Shell() inherits process.env and throws on non-zero exit by default [383.69ms]
bun

bun
bun2
(pass) $$ [46.37ms]
(pass) $.env() argument validation > 5 is not an object > new $.Shell().env() throws and keeps the previous env [16.15ms]
(pass) $.env() argument validation > 5 is not an object > $.env() throws [2.55ms]
(pass) $.env() argument validation > 5 is not an object > $`cmd`.env() throws [5.56ms]
(pass) $.env() argument validation > 0 is not an object > new $.Shell().env() throws and keeps the previous env [3.74ms]
(pass) $.env() argument validation > 0 is not an object > $.env() throws [0.65ms]
(pass) $.env() argument validation > 0 is not an object > $`cmd`.env() throws [1.77ms]
(pass) $.env() argument validation > NaN is not an object > new $.Shell().env() throws and keeps the previous env [3.13ms]
(pass) $.env() argument validation > NaN is not an object > $.env() throws [0.46ms]
(pass) $.env() argum
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 652ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7387ms)
Bundle modules (89ms)
Postprocesss modules (183ms)
Bundle Functions (406ms)
Generate Code (36ms)

[8.11s] Bundled "src/js" for production
  2600 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compil
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/shell.ts                    |  2 +-
 test/js/bun/shell/bunshell-instance.test.ts | 52 +++++++++++++++++++++++++++++
 2 files changed, 53 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/js/builtins/shell.ts                         1      1     18
test/js/bun/shell/bunshell-instance.test.ts      4      6     18
```

</details>

<!-- robobun:evidence:end -->