### PR TITLE
node-fetch, undici: end the body stream when a body method took the response

### DIFF
--- a/src/js/internal/webstreams_adapters.ts
+++ b/src/js/internal/webstreams_adapters.ts
@@ -45,7 +45,7 @@ class ReadableFromWeb extends Readable {
   #reader;
   #closed;
   #stream;
-  // node-fetch, undici: `stream` is the body of a Response, whose text(), json(), ... read it too.
+  // node-fetch, undici: `stream` is a Response body, which text(), json(), ... lock for good.
   #responseBody;
 
   constructor(options, stream) {
@@ -62,9 +62,7 @@ class ReadableFromWeb extends Readable {
     this.#responseBody = responseBody;
   }
 
-  // A lock on a Response body that this wrapper has not opened belongs to a body method, or to
-  // another consumer of the Response. It is never released: getReader() and cancel() throw, and
-  // nothing is left to read.
+  // Locked before this wrapper opened it: a body method has the contents, nothing to read or cancel.
   #takenByResponse(stream) {
     return this.#responseBody && stream.locked;
   }

--- a/src/js/internal/webstreams_adapters.ts
+++ b/src/js/internal/webstreams_adapters.ts
@@ -45,9 +45,11 @@ class ReadableFromWeb extends Readable {
   #reader;
   #closed;
   #stream;
+  // node-fetch, undici: `stream` is the body of a Response, whose text(), json(), ... read it too.
+  #responseBody;
 
   constructor(options, stream) {
-    const { objectMode, highWaterMark, encoding, signal } = options;
+    const { objectMode, highWaterMark, encoding, signal, responseBody = false } = options;
     super({
       objectMode,
       highWaterMark,
@@ -57,6 +59,14 @@ class ReadableFromWeb extends Readable {
     this.#reader = undefined;
     this.#stream = stream;
     this.#closed = false;
+    this.#responseBody = responseBody;
+  }
+
+  // A lock on a Response body that this wrapper has not opened belongs to a body method, or to
+  // another consumer of the Response. It is never released: getReader() and cancel() throw, and
+  // nothing is left to read.
+  #takenByResponse(stream) {
+    return this.#responseBody && stream.locked;
   }
 
   #handleDone(reader) {
@@ -86,6 +96,12 @@ class ReadableFromWeb extends Readable {
     var reader = this.#reader;
     var stream = this.#stream;
     if (stream) {
+      if (this.#takenByResponse(stream)) {
+        this.#stream = undefined;
+        this.#closed = true;
+        this.push(null);
+        return;
+      }
       reader = this.#reader = stream.getReader();
       this.#stream = undefined;
     }
@@ -119,12 +135,14 @@ class ReadableFromWeb extends Readable {
       var stream = this.#stream;
       if (stream) {
         this.#stream = undefined;
-        PromisePrototypeThen.$call(
-          stream.cancel(error),
-          () => callback(error),
-          cancelError => callback(error ?? cancelError),
-        );
-        return;
+        if (!this.#takenByResponse(stream)) {
+          PromisePrototypeThen.$call(
+            stream.cancel(error),
+            () => callback(error),
+            cancelError => callback(error ?? cancelError),
+          );
+          return;
+        }
       }
     }
     try {

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -76,8 +76,7 @@ class Response extends WebResponse {
 
   clone() {
     const cloned = Object.setPrototypeOf(super.clone(this), ResponsePrototype);
-    // The body moved to a new web stream, and the old one stays locked. As in node-fetch,
-    // `body` is a new node stream after clone().
+    // clone() moved the body to a new web stream, so `body` gets a new node stream, as in node-fetch.
     this[kBody] = undefined;
     if (this[kFetched]) cloned[kFetched] = true;
     return cloned;

--- a/src/js/thirdparty/node-fetch.ts
+++ b/src/js/thirdparty/node-fetch.ts
@@ -64,7 +64,7 @@ class Response extends WebResponse {
         if (!this[kFetched]) return null;
         web = new ReadableStream({ start: closeEmptyBody });
       }
-      body = this[kBody] = new (require("internal/webstreams_adapters")._ReadableFromWeb)({}, web);
+      body = this[kBody] = new (require("internal/webstreams_adapters")._ReadableFromWeb)({ responseBody: true }, web);
     }
 
     return body;
@@ -76,46 +76,17 @@ class Response extends WebResponse {
 
   clone() {
     const cloned = Object.setPrototypeOf(super.clone(this), ResponsePrototype);
+    // The body moved to a new web stream, and the old one stays locked. As in node-fetch,
+    // `body` is a new node stream after clone().
+    this[kBody] = undefined;
     if (this[kFetched]) cloned[kFetched] = true;
     return cloned;
-  }
-
-  async arrayBuffer() {
-    // load the getter
-    void this.body;
-    return await super.arrayBuffer();
-  }
-
-  async blob() {
-    // load the getter
-    void this.body;
-    return await super.blob();
-  }
-
-  async formData() {
-    // load the getter
-    void this.body;
-    return await super.formData();
-  }
-
-  async json() {
-    // load the getter
-    void this.body;
-    return await super.json();
   }
 
   // This is a deprecated function in node-fetch
   // but is still used by some libraries and frameworks (like Astro)
   async buffer() {
-    // load the getter
-    void this.body;
     return new $Buffer(await super.arrayBuffer());
-  }
-
-  async text() {
-    // load the getter
-    void this.body;
-    return await super.text();
   }
 
   get type() {

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -63,7 +63,7 @@ class BodyReadable extends ReadableFromWeb {
   constructor(response, options = {}) {
     // A response with no body (204, HEAD) still gets a body, as in undici:
     // https://github.com/nodejs/undici/blob/v6.21.3/lib/api/api-request.js#L118-L126
-    super(options, response.body ?? new ReadableStream({ start: closeEmptyBody }));
+    super({ ...options, responseBody: true }, response.body ?? new ReadableStream({ start: closeEmptyBody }));
 
     this.#response = response;
     this.#bodyUsed = response.bodyUsed;

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -41,6 +41,133 @@ describe("undici", () => {
       }
     });
 
+    describe("body stream when a body method took the response", () => {
+      // Starts `body` with `start` and resolves with what it emits until "close".
+      function eventsUntilClose(body: Readable, start: () => void) {
+        const events: unknown[] = [];
+        const { promise, resolve } = Promise.withResolvers<unknown[]>();
+        body.on("end", () => events.push("end"));
+        body.on("error", error => events.push(error));
+        body.on("close", () => {
+          events.push("close");
+          resolve(events);
+        });
+        start();
+        return promise;
+      }
+
+      // Serves "first ", then "second" once `secondChunk` resolves.
+      function serveTwoChunks(secondChunk: Promise<void>) {
+        return Bun.serve({
+          port: 0,
+          fetch() {
+            return new Response(
+              new ReadableStream({
+                async start(controller) {
+                  controller.enqueue(new TextEncoder().encode("first "));
+                  await secondChunk;
+                  controller.enqueue(new TextEncoder().encode("second"));
+                  controller.close();
+                },
+              }),
+            );
+          },
+        });
+      }
+
+      const bodyActions = [
+        ["resume", ["end", "close"]],
+        ["destroy", ["close"]],
+      ] as const;
+
+      // A body method reads the web stream under `body` and keeps it locked. Nothing is left
+      // for the node stream, so it ends, as the already-read body of undici does.
+      it.each(["arrayBuffer", "blob", "formData", "json", "text"] as const)(
+        "ends without an error after %s() consumed it",
+        async method => {
+          await using server = Bun.serve({
+            port: 0,
+            fetch(req) {
+              if (new URL(req.url).pathname === "/formData") {
+                return new Response("a=1", { headers: { "content-type": "application/x-www-form-urlencoded" } });
+              }
+              return Response.json({ a: 1 });
+            },
+          });
+          const url = new URL(method, server.url).href;
+
+          for (const [action, expected] of bodyActions) {
+            const { body } = await request(url);
+            await body[method]();
+            expect(await eventsUntilClose(body, () => body[action]())).toEqual([...expected]);
+          }
+          {
+            const { body } = await request(url);
+            await body[method]();
+            expect(await Array.fromAsync(body)).toEqual([]);
+          }
+        },
+      );
+
+      it.each(bodyActions)("%s() leaves a body method that is still reading alone", async (action, expected) => {
+        const secondChunk = Promise.withResolvers<void>();
+        await using server = serveTwoChunks(secondChunk.promise);
+
+        const { body } = await request(server.url.href);
+        const text = body.text();
+        const events = await eventsUntilClose(body, () => body[action]());
+        secondChunk.resolve();
+        expect({ events, text: await text }).toEqual({ events: [...expected], text: "first second" });
+      });
+
+      // A body method that rejects still took the stream.
+      it.each(bodyActions)("%s() after an aborted text() does not emit an error", async (action, expected) => {
+        const secondChunk = Promise.withResolvers<void>();
+        await using server = serveTwoChunks(secondChunk.promise);
+        const controller = new AbortController();
+
+        const { body } = await request(server.url.href, { signal: controller.signal });
+        const text = body.text().then(
+          () => "resolved",
+          error => error.name,
+        );
+        controller.abort();
+        const outcome = await text;
+        const events = await eventsUntilClose(body, () => body[action]());
+        secondChunk.resolve();
+        expect({ outcome, events }).toEqual({ outcome: "AbortError", events: [...expected] });
+      });
+
+      it.each(bodyActions)(
+        "%s() after formData() rejected the content type does not emit an error",
+        async (action, expected) => {
+          await using server = Bun.serve({ port: 0, fetch: () => Response.json({ a: 1 }) });
+
+          const { body } = await request(server.url.href);
+          const outcome = await body.formData().then(
+            () => "resolved",
+            error => error.name,
+          );
+          const events = await eventsUntilClose(body, () => body[action]());
+          expect({ outcome, events }).toEqual({ outcome: "TypeError", events: [...expected] });
+        },
+      );
+
+      // The lock that the node stream takes itself must not end it.
+      it("delivers every chunk of a streamed response", async () => {
+        const secondChunk = Promise.withResolvers<void>();
+        await using server = serveTwoChunks(secondChunk.promise);
+
+        const { body } = await request(server.url.href);
+        const chunks: string[] = [];
+        for await (const chunk of body) {
+          chunks.push(chunk.toString());
+          secondChunk.resolve();
+        }
+        expect(chunks.join("")).toBe("first second");
+      });
+    });
+
     it("should make a POST request when provided a body and POST method", async () => {
       const { body } = await request(`${hostUrl}/post`, {
         method: "POST",

--- a/test/js/node/http/node-fetch.test.js
+++ b/test/js/node/http/node-fetch.test.js
@@ -127,6 +127,156 @@ test("node-fetch gives a fetched response without a body an empty stream", async
   expect(new Response(null, { status: 204 }).clone().body).toBeNull();
 });
 
+// Starts `body` with `start` and resolves with what it emits until "close".
+function eventsUntilClose(body, start) {
+  const events = [];
+  const { promise, resolve } = Promise.withResolvers();
+  body.on("end", () => events.push("end"));
+  body.on("error", error => events.push(error));
+  body.on("close", () => {
+    events.push("close");
+    resolve(events);
+  });
+  start();
+  return promise;
+}
+
+// Serves "first ", then "second" once `secondChunk` resolves.
+function serveTwoChunks(secondChunk) {
+  return Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(
+        new ReadableStream({
+          async start(controller) {
+            controller.enqueue(new TextEncoder().encode("first "));
+            await secondChunk;
+            controller.enqueue(new TextEncoder().encode("second"));
+            controller.close();
+          },
+        }),
+      );
+    },
+  });
+}
+
+const bodyActions = [
+  ["resume", ["end", "close"]],
+  ["destroy", ["close"]],
+];
+
+// A body method reads the web stream under `res.body` and keeps it locked. Nothing is
+// left for the node stream, so it ends, as the already-read stream of node-fetch does.
+test.each(["arrayBuffer", "blob", "buffer", "bytes", "formData", "json", "text"])(
+  "node-fetch body stream ends without an error after %s() consumed the response",
+  async method => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        if (new URL(req.url).pathname === "/formData") {
+          return new Response("a=1", { headers: { "content-type": "application/x-www-form-urlencoded" } });
+        }
+        return Response.json({ a: 1 });
+      },
+    });
+    const url = new URL(method, server.url);
+
+    for (const [action, expected] of bodyActions) {
+      const res = await fetch2(url);
+      const body = res.body;
+      await res[method]();
+      expect(await eventsUntilClose(body, () => body[action]())).toEqual(expected);
+    }
+    {
+      // `body` is read for the first time after the body method.
+      const res = await fetch2(url);
+      await res[method]();
+      expect(await Array.fromAsync(res.body)).toEqual([]);
+    }
+  },
+);
+
+test.each(bodyActions)(
+  "node-fetch body.%s() leaves a body method that is still reading alone",
+  async (action, expected) => {
+    const secondChunk = Promise.withResolvers();
+    using server = serveTwoChunks(secondChunk.promise);
+
+    const res = await fetch2(server.url);
+    const body = res.body;
+    const text = res.text();
+    const events = await eventsUntilClose(body, () => body[action]());
+    secondChunk.resolve();
+    expect({ events, text: await text }).toEqual({ events: expected, text: "first second" });
+  },
+);
+
+// A body method that rejects still took the stream.
+test.each(bodyActions)(
+  "node-fetch body.%s() after an aborted text() does not emit an error",
+  async (action, expected) => {
+    const secondChunk = Promise.withResolvers();
+    using server = serveTwoChunks(secondChunk.promise);
+    const controller = new AbortController();
+
+    const res = await fetch2(server.url, { signal: controller.signal });
+    const body = res.body;
+    const text = res.text().then(
+      () => "resolved",
+      error => error.name,
+    );
+    controller.abort();
+    const outcome = await text;
+    const events = await eventsUntilClose(body, () => body[action]());
+    secondChunk.resolve();
+    expect({ outcome, events }).toEqual({ outcome: "AbortError", events: expected });
+  },
+);
+
+test.each(bodyActions)(
+  "node-fetch body.%s() after formData() rejected the content type does not emit an error",
+  async (action, expected) => {
+    using server = Bun.serve({ port: 0, fetch: () => Response.json({ a: 1 }) });
+
+    const res = await fetch2(server.url);
+    const body = res.body;
+    const outcome = await res.formData().then(
+      () => "resolved",
+      error => error.name,
+    );
+    const events = await eventsUntilClose(body, () => body[action]());
+    expect({ outcome, events }).toEqual({ outcome: "TypeError", events: expected });
+  },
+);
+
+// The lock that the node stream takes itself must not end it.
+test("node-fetch body stream delivers every chunk of a streamed response", async () => {
+  const secondChunk = Promise.withResolvers();
+  using server = serveTwoChunks(secondChunk.promise);
+
+  const res = await fetch2(server.url);
+  const chunks = [];
+  for await (const chunk of res.body) {
+    chunks.push(chunk.toString());
+    secondChunk.resolve();
+  }
+  expect(chunks.join("")).toBe("first second");
+});
+
+// clone() moves the body to a new web stream. As in node-fetch, `body` is a new node stream then.
+test("node-fetch body taken before clone() does not break the body after clone()", async () => {
+  using server = Bun.serve({ port: 0, fetch: () => new Response("hello world") });
+
+  const res = await fetch2(server.url);
+  const before = res.body;
+  const cloned = res.clone();
+  expect(res.body).not.toBe(before);
+  expect({
+    original: Buffer.concat(await Array.fromAsync(res.body)).toString(),
+    clone: Buffer.concat(await Array.fromAsync(cloned.body)).toString(),
+  }).toEqual({ original: "hello world", clone: "hello world" });
+});
+
 test("node-fetch request body streams properly", async () => {
   let responseResolve;
   const responsePromise = new Promise(resolve => {


### PR DESCRIPTION
### Problem

- With the built-in `node-fetch` and `undici` shims, `res.body` emits `'error'` after a body method: `Invalid state: ReadableStream is locked` from `resume()`, `pipe()`, `for await`, and `Cannot cancel a locked ReadableStream` from `destroy()` (for example `finally { body.destroy() }`). Bun 1.4.2 and Node emit `'end'`, `'close'`. Regression from #42116 (not released). No user reported it.
- Cause: `ReadableFromWeb` (`src/js/internal/webstreams_adapters.ts`) calls `stream.getReader()` in the first `_read()` and `stream.cancel()` in `_destroy()`. Since #42116 a body method keeps the web stream locked, so both throw.

### Fix

- `ReadableFromWeb` takes a `responseBody` option. Both shims set it, `Readable.fromWeb()` does not. If the wrapper has not opened the web stream and the stream is locked, the Response took the body: `_read()` pushes `null`, `_destroy()` skips `cancel()`.
- The check reads `stream.locked`, not `bodyUsed`: after an aborted `text()`, `bodyUsed` is `false` and the stream is locked.
- `node-fetch`: the body methods no longer read `this.body` first, so the five overrides are deleted. `clone()` drops the cached node stream, because the body moves to a new web stream.
- Verified: `test/js/node/http/node-fetch.test.js`, `test/js/first_party/undici/undici.test.ts` (27 new tests, 25 fail with main's `src/`). Self-reviewed: 3 concerns raised, 3 addressed.

### Background

- Both shims hand out the body as a node `Readable` (`ReadableFromWeb`) around the web `ReadableStream` of a Bun `Response`. `text()`, `json()`, ... are the native methods and read the web stream directly.
- `ReadableFromWeb` opens the web stream lazily, so a body method can take it while the wrapper has no reader.
- Real `node-fetch` and `undici` read that node stream in `text()`, so it is ended afterwards.

<details><summary>Notes</summary>

**Origin.** Found during the review of #42516. That PR lists this symptom as tracked separately.

**Reproduction.**

```js
import nodeFetch from "node-fetch";
await using server = Bun.serve({ port: 0, fetch: () => new Response("hello") });
const res = await nodeFetch(server.url);
const body = res.body;
await res.arrayBuffer();
body.on("error", e => console.log("error:", e.message)).on("end", () => console.log("end"));
body.resume();
// 1.4.2: end
// main:  error: Invalid state: ReadableStream is locked
```

**Behaviour per case**, both shims, checked against a 1.4.2 binary. "clean" means `end`, `close` for `resume()`, `close` for `destroy()`, and no chunks for `for await`.

| case | 1.4.2 | main | this PR |
| --- | --- | --- | --- |
| `body` taken, then `text()` / `json()` / `arrayBuffer()` / `blob()` / `formData()` / `buffer()` / `bytes()`, then `resume()`, `destroy()` or `for await` | clean | `error` | clean |
| body method first, then `res.body` for the first time | clean (`bytes()` throws) | `error` | clean |
| `text()` aborted by the signal (or `AbortSignal.timeout()`), then `resume()` / `destroy()` | clean | `error` | clean |
| `formData()` rejects the content type, then `resume()` / `destroy()` | clean | `error` | clean |
| `json()` rejects with a `SyntaxError`, then `resume()` / `destroy()` | clean | `error` | clean |
| `text()` still pending, then `resume()` / `destroy()` | `error` (locked) | `error` | clean, and `text()` resolves with the full body |
| `body` taken, then `res.clone()`, then read `res.body` | throws (locked by `tee()`) | throws | `res.body` is a new node stream and delivers the body. The old node stream ends. |
| `res.body` streamed with `for await`, `on("data")`, `pipe()` | works | works | works |
| `destroy()` on a body that nothing read | cancels the fetch | same | same |

**Why `stream.locked`.** The first version of this change asked the Response for `bodyUsed`. That misses every body method that rejects after it took the stream: on main `bodyUsed` stays `false` there while the stream stays locked (node reports `true` and locked). The lock of the stream itself is what makes `getReader()` and `cancel()` throw, so the wrapper checks that.

**Why the overrides are deleted.** #6983 (for #6200) made `text()`, `json()`, `arrayBuffer()`, `blob()`, `formData()` read `this.body` first, because a wrapper made after the consume crashed in the stream code of that time. Such a wrapper now ends without an error, and the test for each body method reads `res.body` for the first time after the method. Without the preload a plain `await res.json()` does not create a web stream and a node stream that nothing reads.

**`clone()`.** `super.clone()` moves the body of the original to a new web stream (a `tee()` branch, or a fresh stream over the same bytes). The cached wrapper held the old stream, so `res.body` taken before `clone()` threw `ReadableStream is locked` on read after it, also on 1.4.2. With the lock check it would have ended without data instead. `clone()` now clears the cache. Real `node-fetch` also replaces `body` with a new `PassThrough` in `clone()`.

**A body method that fails** (abort, network error, bad JSON) leaves the node stream ended without an error. The rejected promise of the body method carries the error.

**Not in this PR.** On main `bodyUsed` is `false` after a body method that rejects when `.body` was read before it. That is native (`src/runtime/webcore/Body.rs`) and #35847 covers the `formData()` part.

**Suites run** on the debug build: `node-fetch.test.js`, `undici.test.ts`, `node-fetch-cjs.test.js`, `node-fetch-primordials.test.ts`, `undici-primordials.test.ts`, `node-stream.test.js`, `node-http-agent-free-socket.test.ts`, regression `26225`, `014865`, `04947`, and the Node `test-stream-readable-from-web-termination.js`, `test-readable-from-web-enqueue-then-close.js`, `test-whatwg-webstreams-adapters-to-*.js` files.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 25 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/first_party/undici/undici.test.ts test/js/node/http/node-fetch.test.js
bun test v1.4.3 (6a92015fc)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [68.88ms]
(pass) undici > request > should error when body has already been consumed [13.68ms]
 97 |           const url = new URL(method, server.url).href;
 98 | 
 99 |           for (const [action, expected] of bodyActions) {
100 |             const { body } = await request(url);
101 |             await body[method]();
102 |             expect(await eventsUntilClose(body, () => body[action]())).toEqual([...expected]);
                                                                             ^
error: expect(received).toEqual(expected)

  [
-   "end",
+   [TypeError: Invalid state: ReadableStream is locked],
    "close",
  ]

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/first_party/undici/undici.test.ts:102:72)
(fail) undici > request > body stream when a body method took the r
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (7b5b9c101)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [2.61ms]
(pass) undici > request > should error when body has already been consumed [0.37ms]
(pass) undici > request > body stream when a body method took the response > ends without an error after arrayBuffer() consumed it [5.40ms]
(pass) undici > request > body stream when a body method took the response > ends without an error after blob() consumed it [1.87ms]
(pass) undici > request > body stream when a body method took the response > ends without an error after formData() consumed it [2.11ms]
(pass) undici > request > body stream when a body method took the response > ends without an error after json() consumed it [2.05ms]
(pass) undici > request > body stream when a body method took the response > ends without an error after text() consumed it [1.75ms]
(pass) undici > request > body stream when a body method took the response > resume() leaves a body method that is still reading alone [2.04ms]
(pass) undici > request > body stream when a body method took the response > destroy() leaves a body method that 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/first_party/undici/undici.test.ts test/js/node/http/node-fetch.test.js
bun test v1.4.3 (6a92015fc)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [78.45ms]
(pass) undici > request > should error when body has already been consumed [15.95ms]
(pass) undici > request > body stream when a body method took the response > ends without an error after arrayBuffer() consumed it [258.02ms]
(pass) undici > request > body stream when a body method took the response > ends without an error after blob() consumed it [57.58ms]
(pass) undici > request > body stream when a body method took the response > ends without an error after formData() consumed it [50.54ms]
(pass) undici > request > body stream when a body method took the response > ends without an error after json() consumed it [48.81ms]
(pass) undici > request > body stream when a body method took the response > ends without an error after text() consumed it [48.04ms]
(pass) undici > request > body stream when a bo
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 639ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (7038ms)
Bundle modules (48ms)
Postprocesss modules (24ms)
Bundle Functions (489ms)
Generate Code (42ms)

[7.65s] Bundled "src/js" for production
  2600 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compili
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/webstreams_adapters.ts    |  30 ++++--
 src/js/thirdparty/node-fetch.ts           |  36 +------
 src/js/thirdparty/undici.js               |   2 +-
 test/js/first_party/undici/undici.test.ts | 127 +++++++++++++++++++++++++
 test/js/node/http/node-fetch.test.js      | 150 ++++++++++++++++++++++++++++++
 5 files changed, 304 insertions(+), 41 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/internal/webstreams_adapters.ts         5     11     17
src/js/thirdparty/node-fetch.ts                3      3     17
src/js/thirdparty/undici.js                    2      3     17
test/js/first_party/undici/undici.test.ts      1      1     12
test/js/node/http/node-fetch.test.js           2      3     17
```

</details>

<!-- robobun:evidence:end -->