### PR TITLE
node:os: fix os.cpus() on Linux when the online CPU ids have a gap

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -707,6 +707,14 @@ export const memoryPressureWatcherHasOsBackend: () => boolean = $newRustFunction
 // null where there is no PSI backend (everything except Linux).
 export const memoryPressurePsiTrigger: () => Buffer | null = $newRustFunction("memory_pressure.rs", "jsPsiTrigger", 0);
 
+// os.cpus() on Linux with /proc and /sys read from under `root`, so a test can
+// stage a CPU layout that the host does not have. undefined on other platforms.
+export const linuxCpusFromRoot: (root: string) => import("node:os").CpuInfo[] | undefined = $newRustFunction(
+  "node_os.rs",
+  "jsLinuxCpusFromRoot",
+  1,
+);
+
 export const getEventLoopStats: () => {
   activeTasks: number;
   tasks: number;

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -707,8 +707,7 @@ export const memoryPressureWatcherHasOsBackend: () => boolean = $newRustFunction
 // null where there is no PSI backend (everything except Linux).
 export const memoryPressurePsiTrigger: () => Buffer | null = $newRustFunction("memory_pressure.rs", "jsPsiTrigger", 0);
 
-// os.cpus() on Linux with /proc and /sys read from under `root`, so a test can
-// stage a CPU layout that the host does not have. undefined on other platforms.
+// os.cpus() on Linux with /proc and /sys read from under `root`. undefined on other platforms.
 export const linuxCpusFromRoot: (root: string) => import("node:os").CpuInfo[] | undefined = $newRustFunction(
   "node_os.rs",
   "jsLinuxCpusFromRoot",

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -239,9 +239,7 @@ mod _impl {
         global.throw_value(err.to_error_instance(global))
     }
 
-    /// `linuxCpusFromRoot(root)` in `bun:internal-for-testing`: `os.cpus()` with `/proc` and
-    /// `/sys` read from under `root`, so a test can stage a CPU layout that the host does not
-    /// have. `undefined` on other platforms.
+    /// `bun:internal-for-testing`: Linux `os.cpus()` with `/proc` and `/sys` read from under `root`.
     #[bun_jsc::host_fn]
     pub(crate) fn js_linux_cpus_from_root(
         global: &JSGlobalObject,
@@ -259,8 +257,7 @@ mod _impl {
         }
     }
 
-    /// Reads the file at `path` (absolute) under `root` into `buf`. `None` if the file cannot be
-    /// opened or read. `root` is empty for `os.cpus()`.
+    /// Reads the file at `root` + `path` into `buf`. `root` is empty for `os.cpus()`.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn read_under_root<'a>(
         buf: &'a mut Vec<u8>,
@@ -286,8 +283,7 @@ mod _impl {
         // Create the return array
         let values = JSValue::create_empty_array(global_this, 0)?;
         let mut num_cpus: u32 = 0;
-        // /proc/stat, /proc/cpuinfo and sysfs name a CPU by its kernel id. The ids of the online
-        // CPUs can have gaps (`cpu0..cpu63, cpu128..cpu191`), so an id is not a slot of `values`.
+        // CPU ids can have gaps (`cpu0..cpu63, cpu128..cpu191`), so an id is not a slot of `values`.
         let mut slot_by_cpu_id: bun_collections::HashMap<u32, u32> =
             bun_collections::HashMap::new();
 
@@ -378,8 +374,7 @@ mod _impl {
             const KEY_PROCESSOR: &[u8] = b"processor\t: ";
             const KEY_MODEL_NAME: &[u8] = b"model name\t: ";
 
-            // The slot of the processor that the current line describes. `None` for a processor
-            // that /proc/stat did not list.
+            // `None` for a processor that /proc/stat did not list.
             let mut slot: Option<u32> = None;
             while let Some(line) = line_iter.next() {
                 if line.starts_with(KEY_PROCESSOR) {

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -227,24 +227,16 @@ mod _impl {
         #[cfg(windows)]
         let result = cpus_impl_windows(global);
 
-        cpus_result_to_js(global, result)
+        result.map_err(|_| throw_cpus_error(global))
     }
 
-    fn cpus_result_to_js(
-        global: &JSGlobalObject,
-        result: Result<JSValue, OsError>,
-    ) -> JsResult<JSValue> {
-        match result {
-            Ok(v) => Ok(v),
-            Err(_) => {
-                let err = SystemError {
-                    message: BunString::static_("Failed to get CPU information"),
-                    code: BunString::static_("ERR_SYSTEM_ERROR"),
-                    ..Default::default()
-                };
-                Err(global.throw_value(err.to_error_instance(global)))
-            }
-        }
+    fn throw_cpus_error(global: &JSGlobalObject) -> bun_jsc::JsError {
+        let err = SystemError {
+            message: BunString::static_("Failed to get CPU information"),
+            code: BunString::static_("ERR_SYSTEM_ERROR"),
+            ..Default::default()
+        };
+        global.throw_value(err.to_error_instance(global))
     }
 
     /// `linuxCpusFromRoot(root)` in `bun:internal-for-testing`: `os.cpus()` with `/proc` and
@@ -258,7 +250,7 @@ mod _impl {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             let root = frame.argument(0).to_utf8(global)?;
-            cpus_result_to_js(global, cpus_impl_linux(global, &root))
+            cpus_impl_linux(global, &root).map_err(|_| throw_cpus_error(global))
         }
         #[cfg(not(any(target_os = "linux", target_os = "android")))]
         {

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -219,7 +219,7 @@ mod _impl {
 
     pub(crate) fn cpus(global: &JSGlobalObject) -> JsResult<JSValue> {
         #[cfg(any(target_os = "linux", target_os = "android"))]
-        let result = cpus_impl_linux(global);
+        let result = cpus_impl_linux(global, b"");
         #[cfg(target_os = "macos")]
         let result = cpus_impl_darwin(global);
         #[cfg(target_os = "freebsd")]
@@ -227,6 +227,13 @@ mod _impl {
         #[cfg(windows)]
         let result = cpus_impl_windows(global);
 
+        cpus_result_to_js(global, result)
+    }
+
+    fn cpus_result_to_js(
+        global: &JSGlobalObject,
+        result: Result<JSValue, OsError>,
+    ) -> JsResult<JSValue> {
         match result {
             Ok(v) => Ok(v),
             Err(_) => {
@@ -240,51 +247,90 @@ mod _impl {
         }
     }
 
+    /// `linuxCpusFromRoot(root)` in `bun:internal-for-testing`: `os.cpus()` with `/proc` and
+    /// `/sys` read from under `root`, so a test can stage a CPU layout that the host does not
+    /// have. `undefined` on other platforms.
+    #[bun_jsc::host_fn]
+    pub(crate) fn js_linux_cpus_from_root(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            let root = frame.argument(0).to_utf8(global)?;
+            cpus_result_to_js(global, cpus_impl_linux(global, &root))
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        {
+            let _ = (global, frame);
+            Ok(JSValue::UNDEFINED)
+        }
+    }
+
+    /// Reads the file at `path` (absolute) under `root` into `buf`. `None` if the file cannot be
+    /// opened or read. `root` is empty for `os.cpus()`.
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    fn cpus_impl_linux(global_this: &JSGlobalObject) -> Result<JSValue, OsError> {
+    fn read_under_root<'a>(
+        buf: &'a mut Vec<u8>,
+        root: &[u8],
+        path: core::fmt::Arguments<'_>,
+    ) -> Option<&'a [u8]> {
+        let mut path_buf = bun_paths::path_buffer_pool::get();
+        let mut cursor = &mut path_buf[..];
+        cursor.write_all(root).ok()?;
+        write!(cursor, "{path}\0").ok()?;
+        let remaining = cursor.len();
+        let len = path_buf.len() - remaining - 1;
+        let file =
+            bun_sys::File::open(ZStr::from_buf(&path_buf[..], len), bun_sys::O::RDONLY, 0).ok()?;
+        buf.clear();
+        file.read_to_end_with_array_list(buf, bun_sys::SizeHint::ProbablySmall)
+            .ok()?;
+        Some(buf.as_slice())
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn cpus_impl_linux(global_this: &JSGlobalObject, root: &[u8]) -> Result<JSValue, OsError> {
         // Create the return array
         let values = JSValue::create_empty_array(global_this, 0)?;
         let mut num_cpus: u32 = 0;
+        // /proc/stat, /proc/cpuinfo and sysfs name a CPU by its kernel id. The ids of the online
+        // CPUs can have gaps (`cpu0..cpu63, cpu128..cpu191`), so an id is not a slot of `values`.
+        let mut slot_by_cpu_id: bun_collections::HashMap<u32, u32> =
+            bun_collections::HashMap::new();
 
         let mut file_buf: Vec<u8> = Vec::new();
 
         // Read /proc/stat to get number of CPUs and times
         {
-            let file =
-                match bun_sys::File::open(bun_core::zstr!("/proc/stat"), bun_sys::O::RDONLY, 0) {
-                    Ok(f) => f,
-                    Err(_) => {
-                        // hidepid mounts (common on Android) deny /proc/stat. lazyCpus in os.ts
-                        // pre-creates hostCpuCount lazy proxies, so return that many stub
-                        // entries (zeroed times / unknown model / speed 0) — matches Node.
-                        // SAFETY: pure FFI getter
-                        let count: u32 =
-                            u32::try_from(1i32.max(bun_sysconf__SC_NPROCESSORS_ONLN())).unwrap();
-                        let stubs = JSValue::create_empty_array(global_this, count as usize)?;
-                        let mut i: u32 = 0;
-                        while i < count {
-                            let cpu = JSValue::create_empty_object(global_this, 3);
-                            cpu.put(
-                                global_this,
-                                b"times",
-                                CPUTimes::default().to_value(global_this),
-                            );
-                            cpu.put(
-                                global_this,
-                                b"model",
-                                global_this.common_strings().unknown(),
-                            );
-                            cpu.put(global_this, b"speed", JSValue::js_number(0.0));
-                            stubs.put_index(global_this, i, cpu)?;
-                            i += 1;
-                        }
-                        return Ok(stubs);
-                    }
-                };
-            // file closed on Drop
-
-            file.read_to_end_with_array_list(&mut file_buf, bun_sys::SizeHint::ProbablySmall)?;
-            let contents = file_buf.as_slice();
+            let Some(contents) = read_under_root(&mut file_buf, root, format_args!("/proc/stat"))
+            else {
+                // hidepid mounts (common on Android) deny /proc/stat. lazyCpus in os.ts
+                // pre-creates hostCpuCount lazy proxies, so return that many stub
+                // entries (zeroed times / unknown model / speed 0) — matches Node.
+                // SAFETY: pure FFI getter
+                let count: u32 =
+                    u32::try_from(1i32.max(bun_sysconf__SC_NPROCESSORS_ONLN())).unwrap();
+                let stubs = JSValue::create_empty_array(global_this, count as usize)?;
+                let mut i: u32 = 0;
+                while i < count {
+                    let cpu = JSValue::create_empty_object(global_this, 3);
+                    cpu.put(
+                        global_this,
+                        b"times",
+                        CPUTimes::default().to_value(global_this),
+                    );
+                    cpu.put(
+                        global_this,
+                        b"model",
+                        global_this.common_strings().unknown(),
+                    );
+                    cpu.put(global_this, b"speed", JSValue::js_number(0.0));
+                    stubs.put_index(global_this, i, cpu)?;
+                    i += 1;
+                }
+                return Ok(stubs);
+            };
 
             let mut line_iter = strings::tokenize(contents, b"\n");
 
@@ -295,10 +341,13 @@ mod _impl {
             while let Some(line) = line_iter.next() {
                 // CPU lines are formatted as `cpu0 user nice sys idle iowait irq softirq`
                 let mut toks = strings::tokenize_any(line, b" \t");
-                let cpu_name = toks.next();
-                if cpu_name.is_none() || !cpu_name.unwrap().starts_with(b"cpu") {
+                let Some(cpu_id) = toks
+                    .next()
+                    .and_then(|name| name.strip_prefix(b"cpu"))
+                    .and_then(|id| parse_u32(id).ok())
+                else {
                     break; // done with CPUs
-                }
+                };
 
                 //NOTE: libuv assumes this is fixed on Linux, not sure that's actually the case
                 let scale: u64 = 10;
@@ -315,117 +364,64 @@ mod _impl {
                 };
 
                 // Actually create the JS object representing the CPU
-                let cpu = JSValue::create_empty_object(global_this, 1);
+                let cpu = JSValue::create_empty_object(global_this, 3);
                 cpu.put(global_this, b"times", times.to_value(global_this));
+                cpu.put(
+                    global_this,
+                    b"model",
+                    global_this.common_strings().unknown(),
+                );
                 values.put_index(global_this, num_cpus, cpu)?;
 
+                slot_by_cpu_id.insert(cpu_id, num_cpus);
                 num_cpus += 1;
             }
-
-            file_buf.clear();
         }
 
         // Read /proc/cpuinfo to get model information (optional)
-        if let Ok(file) =
-            bun_sys::File::open(bun_core::zstr!("/proc/cpuinfo"), bun_sys::O::RDONLY, 0)
+        if let Some(contents) = read_under_root(&mut file_buf, root, format_args!("/proc/cpuinfo"))
         {
-            // file closed on Drop
-
-            file.read_to_end_with_array_list(&mut file_buf, bun_sys::SizeHint::ProbablySmall)?;
-            let contents = file_buf.as_slice();
-
             let mut line_iter = strings::tokenize(contents, b"\n");
 
             const KEY_PROCESSOR: &[u8] = b"processor\t: ";
             const KEY_MODEL_NAME: &[u8] = b"model name\t: ";
 
-            let mut cpu_index: u32 = 0;
-            let mut has_model_name = true;
+            // The slot of the processor that the current line describes. `None` for a processor
+            // that /proc/stat did not list.
+            let mut slot: Option<u32> = None;
             while let Some(line) = line_iter.next() {
                 if line.starts_with(KEY_PROCESSOR) {
-                    if !has_model_name {
-                        let cpu = values.get_index(global_this, cpu_index)?;
-                        cpu.put(
-                            global_this,
-                            b"model",
-                            global_this.common_strings().unknown(),
-                        );
-                    }
-                    // If this line starts a new processor, parse the index from the line
+                    // If this line starts a new processor, parse the id from the line
                     let digits = strings::trim(&line[KEY_PROCESSOR.len()..], b" \t\n");
-                    cpu_index = parse_u32(digits)?;
-                    if cpu_index >= num_cpus {
-                        return Err(OsError::Any);
-                    }
-                    has_model_name = false;
+                    slot = parse_u32(digits)
+                        .ok()
+                        .and_then(|cpu_id| slot_by_cpu_id.get(&cpu_id).copied());
                 } else if line.starts_with(KEY_MODEL_NAME) {
                     // If this is the model name, extract it and store on the current cpu
+                    let Some(slot) = slot else { continue };
                     let model_name = &line[KEY_MODEL_NAME.len()..];
-                    let cpu = values.get_index(global_this, cpu_index)?;
+                    let cpu = values.get_index(global_this, slot)?;
                     cpu.put(
                         global_this,
                         b"model",
                         bun_string_jsc::create_utf8_for_js(global_this, model_name)?,
                     );
-                    has_model_name = true;
                 }
-            }
-            if !has_model_name {
-                let cpu = values.get_index(global_this, cpu_index)?;
-                cpu.put(
-                    global_this,
-                    b"model",
-                    global_this.common_strings().unknown(),
-                );
-            }
-
-            file_buf.clear();
-        } else {
-            // Initialize model name to "unknown"
-            let mut it = values.array_iterator(global_this)?;
-            while let Some(cpu) = it.next()? {
-                cpu.put(
-                    global_this,
-                    b"model",
-                    global_this.common_strings().unknown(),
-                );
             }
         }
 
         // Read /sys/devices/system/cpu/cpu{}/cpufreq/scaling_cur_freq to get current frequency (optional)
-        for cpu_index in 0..num_cpus as usize {
-            let cpu = values.get_index(global_this, cpu_index as u32)?;
+        for (&cpu_id, &slot) in &slot_by_cpu_id {
+            let speed = read_under_root(
+                &mut file_buf,
+                root,
+                format_args!("/sys/devices/system/cpu/cpu{cpu_id}/cpufreq/scaling_cur_freq"),
+            )
+            .and_then(|contents| parse_u64(strings::trim(contents, b" \n")).ok())
+            .map_or(0, |khz| khz / 1000);
 
-            let mut path_buf = [0u8; 128];
-            let path: &ZStr = {
-                let mut cursor = &mut path_buf[..];
-                write!(
-                    cursor,
-                    "/sys/devices/system/cpu/cpu{}/cpufreq/scaling_cur_freq\0",
-                    cpu_index
-                )
-                .map_err(|_| crate::Error::fmt)?;
-                let remaining = cursor.len();
-                let written = path_buf.len() - remaining;
-                // SAFETY: we wrote a NUL terminator at path_buf[written-1]
-                ZStr::from_buf(&path_buf[..], written - 1)
-            };
-            if let Ok(file) = bun_sys::File::open(path, bun_sys::O::RDONLY, 0) {
-                // file closed on Drop
-
-                file.read_to_end_with_array_list(&mut file_buf, bun_sys::SizeHint::ProbablySmall)?;
-                let contents = file_buf.as_slice();
-
-                let digits = strings::trim(contents, b" \n");
-                let speed = parse_u64(digits).unwrap_or(0) / 1000;
-
-                cpu.put(global_this, b"speed", JSValue::js_number(speed as f64));
-
-                file_buf.clear();
-            } else {
-                // Initialize CPU speed to 0
-                cpu.put(global_this, b"speed", JSValue::js_number(0.0));
-            }
+            let cpu = values.get_index(global_this, slot)?;
+            cpu.put(global_this, b"speed", JSValue::js_number(speed as f64));
         }
 
         Ok(values)

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -1,6 +1,7 @@
+import { linuxCpusFromRoot } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
 import { realpathSync } from "fs";
-import { isWindows } from "harness";
+import { isLinux, isWindows, tempDir } from "harness";
 import { isIPv4, isIPv6 } from "node:net";
 import * as os from "node:os";
 
@@ -81,7 +82,9 @@ it("tmpdir", () => {
 
     process.env.TMPDIR = "/boop";
     expect(os.tmpdir()).toBe("/boop");
-    process.env.TMPDIR = originalEnv;
+    // Assigning undefined would leave TMPDIR="undefined" for every later test.
+    if (originalEnv === undefined) delete process.env.TMPDIR;
+    else process.env.TMPDIR = originalEnv;
   }
 });
 
@@ -141,6 +144,75 @@ it("cpus", () => {
     expect(typeof cpu.times.sys === "number").toBe(true);
     expect(typeof cpu.times.user === "number").toBe(true);
   }
+});
+
+// linuxCpusFromRoot(root) is os.cpus() with /proc and /sys read from under `root`.
+// Each file gives every CPU id its own value, so a slot filled from the wrong id fails.
+describe.skipIf(!isLinux)("cpus on Linux", () => {
+  function procfs(statIds, cpuinfoIds, freqIds, overrides = {}) {
+    const files = {
+      "proc/stat":
+        "cpu  100 0 100 1000 0 0 0 0 0 0\n" +
+        statIds.map(id => `cpu${id} ${id + 1} 0 10 100 0 0 0 0 0 0\n`).join("") +
+        "intr 0\nctxt 1\nbtime 1700000000\nprocesses 1\nprocs_running 1\nprocs_blocked 0\n",
+      "proc/cpuinfo": cpuinfoIds
+        .map(id => `processor\t: ${id}\nvendor_id\t: AuthenticAMD\nmodel name\t: EPYC 7713 (cpu ${id})\n\n`)
+        .join(""),
+    };
+    for (const id of freqIds) {
+      files[`sys/devices/system/cpu/cpu${id}/cpufreq/scaling_cur_freq`] = `${(id + 1) * 1000}\n`;
+    }
+    return tempDir("os-cpus", { ...files, ...overrides });
+  }
+  const times = id => ({ user: (id + 1) * 10, nice: 0, sys: 100, idle: 1000, irq: 0 });
+
+  // https://github.com/oven-sh/bun/issues/29689
+  // The host in the issue (a dual-socket EPYC 7713) has CPUs 0-63 and 128-191.
+  it("handles a gap in the CPU ids", () => {
+    const ids = [0, 1, 2, 3, 8, 9, 10, 11];
+    using root = procfs(ids, ids, ids);
+    expect(linuxCpusFromRoot(String(root))).toEqual(
+      ids.map(id => ({ times: times(id), model: `EPYC 7713 (cpu ${id})`, speed: id + 1 })),
+    );
+  });
+
+  it("ignores a /proc/cpuinfo processor that /proc/stat does not list", () => {
+    using root = procfs([0, 2], [0, 1, 2, 7], [0]);
+    expect(linuxCpusFromRoot(String(root))).toEqual([
+      { times: times(0), model: "EPYC 7713 (cpu 0)", speed: 1 },
+      { times: times(2), model: "EPYC 7713 (cpu 2)", speed: 0 },
+    ]);
+  });
+
+  it("reports an unknown model for a CPU that /proc/cpuinfo does not list", () => {
+    using root = procfs([0, 4], [4], []);
+    expect(linuxCpusFromRoot(String(root))).toEqual([
+      { times: times(0), model: "unknown", speed: 0 },
+      { times: times(4), model: "EPYC 7713 (cpu 4)", speed: 0 },
+    ]);
+  });
+
+  it("ignores a /proc/cpuinfo processor line that is not a number", () => {
+    using root = procfs([0, 1], [], [], {
+      "proc/cpuinfo": "processor\t: 0\nmodel name\t: A\n\nprocessor\t: x\nmodel name\t: B\n\n",
+    });
+    expect(linuxCpusFromRoot(String(root))).toEqual([
+      { times: times(0), model: "A", speed: 0 },
+      { times: times(1), model: "unknown", speed: 0 },
+    ]);
+  });
+
+  it("keeps the defaults when /proc/cpuinfo or scaling_cur_freq cannot be read", () => {
+    // A directory opens for reading, and then read() fails with EISDIR.
+    using root = procfs([0, 1], [], [1], {
+      "proc/cpuinfo": {},
+      "sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq": {},
+    });
+    expect(linuxCpusFromRoot(String(root))).toEqual([
+      { times: times(0), model: "unknown", speed: 0 },
+      { times: times(1), model: "unknown", speed: 2 },
+    ]);
+  });
 });
 
 it("networkInterfaces", () => {


### PR DESCRIPTION
Fixes #29689

### Problem
- On Linux, the first read of `model`, `speed` or `times` on an `os.cpus()` entry throws `ERR_SYSTEM_ERROR: Failed to get CPU information` when the online CPU ids have a gap. The issue's host has CPUs 0-63 and 128-191.
- `cpus_impl_linux` (`src/runtime/node/node_os.rs`) makes one slot per `cpuN` line of `/proc/stat`, then indexes the slots by the `/proc/cpuinfo` `processor` number. `if cpu_index >= num_cpus { return Err(OsError::Any) }` fires on `processor: 128`. The cpufreq path used the slot index too.

### Fix
- Parse the id from each `cpuN` line and keep an id to slot map. `/proc/cpuinfo` looks up its slot there, and the sysfs path uses the id. libuv does the same.
- A `/proc/cpuinfo` processor that `/proc/stat` does not list is ignored. Every slot starts with `model: "unknown"`. The two optional passes no longer throw on a read error or a bad `processor` value.
- Verified: `test/js/node/os/os.test.js`, 5 new cases. With the test hook but no fix, all 5 throw. Also `test-os*.js` and a `cargo check` per platform.
- Self-reviewed: 12 concerns raised, 12 addressed.

### Background
- `/proc/stat`, `/proc/cpuinfo` and sysfs name each online CPU by kernel id. A CPU that goes offline in the middle leaves a gap.
- `os.cpus()` returns lazy entries (`lazyCpus` in `src/js/node/os.ts`). The native call runs on the first property read, so the call itself and `.length` do not throw.
- `linuxCpusFromRoot(root)` in `bun:internal-for-testing` runs the same code with `/proc` and `/sys` read from under `root`. Bun reads these files with raw syscalls, so a test has no other way in.

<details><summary>Notes</summary>

**Proof that the tests exercise the bug.** A build with only the test hook (no fix), fixture ids `0-3,8-11`:
```
contig ok 8 [["0",1,10],["1",2,20],...,["7",8,80]]
gap THROW ERR_SYSTEM_ERROR Failed to get CPU information
```
The same build fails the first 3 new tests with `error: Failed to get CPU information`. A build with the id map but with the old `?` on the optional passes fails the last 2 new tests with the same error. On `main` the test file does not load, because `linuxCpusFromRoot` does not exist there.

**With the fix**, the gap fixture gives 8 entries, each with the model, speed and times of its own id: `gap ok 8 [["0",1,10],["1",2,20],["2",3,30],["3",4,40],["8",9,90],["9",10,100],["10",11,110],["11",12,120]]`. On the real host (128 contiguous CPUs) the output is the same as before: 128 entries, same model, key order `times, model, speed`.

**Behavior changes besides the gap.**
- A CPU that is in `/proc/stat` but not in `/proc/cpuinfo` had no `model` property. It now has `"unknown"`, as in libuv.
- Where `/proc/stat` and `/proc/cpuinfo` number the CPUs differently (some container setups), the entries whose ids do not match keep `"unknown"`. The old code either threw or wrote the model to the slot with that index. libuv gives `"unknown"` there too.
- If `/proc/stat` opens but cannot be read, the result is the same stub list as when it cannot be opened. Before, that threw.
- The cpufreq pass visits the CPUs in hash order. Each step writes only its own slot, so the result does not depend on the order.

**Scope.** Only #29689 is claimed. #10877 (closed) shows the same message from a cloud container, but it has no `/proc` data to confirm the cause.

**Overlap with open PRs.**
- #35652 (plain objects from `os.cpus()`) edits the same function and keeps the `cpu_index >= num_cpus` guard. It maps the error to an empty array and drops `lazyCpus`. If it lands alone, the throw on these hosts turns into `os.cpus().length === 0`. This PR should land first. After a rebase, #35652 has no guard left to map.
- #39625 removes the `TMPDIR` mutation from the `tmpdir` test. This PR only corrects the restore (`process.env.TMPDIR = undefined` stores the string `"undefined"`), because the new tests call `tempDir()` later in the same file and fail without it when `TMPDIR` is unset. If #39625 lands first, that hunk goes away on rebase.
- #40244 deletes `// SAFETY` comment lines inside `cpus_impl_linux`. The conflict is textual only.

**Not in this PR.** Each item went to its own follow-up.
- FreeBSD: `cpus_impl_freebsd` sizes the `kern.cp_times` buffer from `hw.ncpu`. The kernel writes `mp_maxid + 1` blocks, so sparse ids give `ENOMEM` and the same throw. libuv sizes it from `kern.smp.maxcpus`. FreeBSD has no test lane in CI, so it is not folded in here.
- Linux arm64: `/proc/cpuinfo` has no `model name` line there, so `model` is always `"unknown"`. libuv decodes `CPU part`.
- `scaling_cur_freq` costs about 20 ms per CPU on some AMD hosts. libuv moved to `scaling_max_freq` on its `v1.x` branch (commit `2594240e79`). That is not in a release yet, so Node still reads the same file as Bun.

**History.** #29690 had this fix for the Zig file and was closed unmerged when the file moved to Rust. It used a `BUN_DEBUG_CPUS_PROCFS_ROOT` env var as the test hook. `REVIEW.md` asks for `bun:internal-for-testing` in place of production code that exists only for a test, so this PR uses that.

**Self-review.** It asked for: no throw from the two optional passes (done, 2 tests), the landing order and overlap notes above, the scope statement above, and follow-ups for the three items under "Not in this PR". None was rejected.

**Unrelated local failure.** `userInfo` in `os.test.js` fails when `USER` is unset in the environment (see #33481). CI sets `USER`.

**Suites run.** `bun bd test test/js/node/os/os.test.js` (59 pass with `USER` set), `test/js/node/test/parallel/test-os.js`, `test-os-eol.js`, `test-os-homedir-no-envvar.js`, `test-os-process-priority.js`, `test-os-userinfo-handles-getter-errors.js`, and the source lints in `test/internal/source-lints/` that scan Rust files.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/os/os.test.js

<!-- robobun:evidence:end -->