### PR TITLE
bun:test: root the return values toHaveReturnedWith collects

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -967,8 +967,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         debug_assert!(!callback.is_empty());
         // PERF: stable Rust forbids `ARG_COUNT + 1` in const-generic array lengths.
-        // The conservative GC scan reaches the heap allocation as well as the
-        // stack, so a small Vec is sound.
+        // The GC does not scan a Vec. This one is sound because nothing allocates before
+        // `callback.call` copies the arguments into a MarkedArgumentBuffer.
         let mut args: Vec<JSValue> = Vec::with_capacity(ARG_COUNT + 1);
         args.push(prepared.js_request);
         args.extend_from_slice(&extra_args);

--- a/src/runtime/test_runner/expect/toHaveReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveReturnedWith.rs
@@ -1,4 +1,4 @@
-use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult, MarkedArgumentBuffer};
 
 use super::DiffFormatter;
 use super::mock;
@@ -9,6 +9,17 @@ pub(crate) fn to_have_returned_with(
     this: &Expect,
     global: &JSGlobalObject,
     frame: &CallFrame,
+) -> JsResult<JSValue> {
+    MarkedArgumentBuffer::new(|return_roots| {
+        to_have_returned_with_impl(this, global, frame, return_roots)
+    })
+}
+
+fn to_have_returned_with_impl(
+    this: &Expect,
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+    return_roots: &mut MarkedArgumentBuffer,
 ) -> JsResult<JSValue> {
     let expected = frame.arguments_as_array::<1>()[0];
     let (this, returns, _value) = this.mock_prologue(
@@ -22,9 +33,9 @@ pub(crate) fn to_have_returned_with(
     let calls_count = u32::try_from(returns.get_length(global)?).unwrap();
     let mut pass = false;
 
-    // A heap-backed Vec<JSValue> is not stack-scanned by JSC's conservative GC;
-    // however every value pushed here is also reachable via the `returns` JSArray (kept live on the
-    // stack), so a plain Vec is safe. SuccessfulReturnsFormatter expects &Vec.
+    // `returns` does not keep these values alive: `jest_deep_equals` runs user code, which can
+    // empty `mock.results` or overwrite a result's `value`. `return_roots` holds every value
+    // pushed here; the Vec is only the slice view SuccessfulReturnsFormatter reads.
     let mut successful_returns: Vec<JSValue> = Vec::new();
 
     let mut has_errors = false;
@@ -40,6 +51,7 @@ pub(crate) fn to_have_returned_with(
 
                 if type_str.eq_ascii(b"return") {
                     let result_value = result.get(global, "value")?.unwrap_or(JSValue::UNDEFINED);
+                    return_roots.append(result_value);
                     successful_returns.push(result_value);
 
                     // Check for pass condition only if not already passed

--- a/test/js/bun/test/expect/toHaveReturnedWith.test.ts
+++ b/test/js/bun/test/expect/toHaveReturnedWith.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, jest, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 
 // Example functions for testing toHaveReturnedWith
 export function add(a: number, b: number): number {
@@ -231,6 +232,54 @@ describe("toHaveReturnedWith Examples", () => {
       expect(() => {
         expect(fn).toHaveReturnedWith(42);
       }).toThrow();
+    });
+
+    // The matcher keeps every return value it has compared for the "Received:" list.
+    // `door` runs from a getter on `expected` while the 45th value is compared, so the
+    // first 44 values are no longer reachable from the mock when the GC runs.
+    test.concurrent.each([
+      ["mock.results is emptied", "results.length = 0;"],
+      ["the value of each result is overwritten", "for (const result of results) result.value = null;"],
+    ])("failure message lists the compared return values after %s", async (_, door) => {
+      const script = `
+        import { expect, mock } from "bun:test";
+
+        const m = mock(i => ({ tag: "ret-" + i, payload: [i] }));
+        for (let i = 0; i < 50; i++) m(i);
+
+        let reads = 0;
+        const expected = {
+          get tag() {
+            if (++reads === 45) {
+              const { results } = m.mock;
+              ${door}
+              Bun.gc(true);
+            }
+            return "no match";
+          },
+          payload: [],
+        };
+
+        let message = "";
+        try {
+          expect(m).toHaveReturnedWith(expected);
+        } catch (e) {
+          message = e.message;
+        }
+        console.log(message);
+      `;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+      const tags = Array.from(stdout.matchAll(/tag: "(ret-\d+)"/g), match => match[1]);
+      expect(tags).toEqual(Array.from({ length: 45 }, (_, i) => `ret-${i}`));
+      expect(exitCode).toBe(0);
     });
   });
 


### PR DESCRIPTION
### Problem
- A failing `expect(mockFn).toHaveReturnedWith(expected)` can crash: `panic(main thread): Segmentation fault at address 0x8` (1.4.2, canary), `ASSERTION FAILED: decontaminate()` at `StructureID.h(76)` (debug).
- The matcher keeps each return value it compares in `successful_returns: Vec<JSValue>` (`src/runtime/test_runner/expect/toHaveReturnedWith.rs:28`) for the "Received:" list. The GC does not scan a `Vec`. A comment there says `mock.results` keeps the values alive.
- `jest_deep_equals` runs user code (a getter in `expected`). It can run `mock.results.length = 0`, or set `value = null` on each result. A GC then frees the values, and the failure message formats freed cells.

### Fix
- The matcher body runs inside `MarkedArgumentBuffer::new`. Each value goes into the buffer when it goes into the `Vec`, so it stays rooted until the matcher returns.
- The `Vec` stays as the slice view that `SuccessfulReturnsFormatter` reads. `ScopeFunctions.rs:181` and `parse_args.rs:489` use the same pair.
- The comment at `src/runtime/server/mod.rs:969` made the same false claim. It is corrected. The site itself is sound (see Notes).
- Verified: `test/js/bun/test/expect/toHaveReturnedWith.test.ts` (2 new cases, both fail on 1.4.3-canary.1). Also `spyMatchers.test.ts`, `mock-fn.test.js`, `expect.test.js`.

### Background
- JSC finds live objects from the stack, registers, and other live objects. It does not scan `malloc` memory, so a `JSValue` held only in a `Vec` keeps nothing alive.
- `MarkedArgumentBuffer` is the rooted list type of JSC. It keeps 8 values inline on the stack and registers larger storage with the GC.
- `mockFn.mock.results` is the live array the native mock pushes `{ type, value }` objects into. User code can change both.

<details><summary>Notes</summary>

Repro (plain script, `bun repro.mjs`):

```js
import { expect, mock } from "bun:test";
const m = mock(() => ({ payload: new Array(64).fill("x"), tag: "ret" + Math.random() }));
for (let i = 0; i < 50; i++) m();
let reads = 0;
const expected = {
  tag: 1,
  get payload() {
    if (++reads === 45) { m.mock.results.length = 0; Bun.gc(true); }
    return 1;
  },
};
try { expect(m).toHaveReturnedWith(expected); } catch (e) { console.log(String(e.message).slice(0, 300)); }
console.log("survived");
```

- 1.4.3-canary.1+b99371011 release: 3/3 `Segmentation fault at address 0x8`. With this change the debug build prints the 45 collected values and `survived`, also with `BUN_JSC_useZombieMode=1 BUN_JSC_scribbleFreeCells=1`.
- Why a copy of `mock.results` in the prologue is not enough: `for (const r of m.mock.results) r.value = null` in the getter leaves the array intact. The values are still unreachable, and the release build crashes the same way. The second test case covers it.
- The bug predates the Rust port. The Zig matcher used `std.array_list.Managed(JSValue)` the same way.
- Sibling matchers: `toHaveLastReturnedWith`, `toHaveNthReturnedWith`, `toHaveBeenCalledWith`, `toHaveBeenLastCalledWith` and `toHaveBeenNthCalledWith` hold their values in stack locals or read through the live array with a revalidating iterator. Each of them ran on the release build against `results.length = 0`, `results[i].value = null`, `results.fill(...)`, `calls.length = 0`, `calls[i].length = 0`, `calls[i].fill(1)` and `calls.splice(0)`, with the GC hook at read 1, 3 and 45. None of them crashes.
- The hook at read 1 does not crash `toHaveReturnedWith` either. The only collected value is still on the native stack.
- When `results.length = 0` removes an entry that would have matched later, `pass` stays false and the matcher takes the same failure path. When the matching entry stays, the matcher passes and never reads the `Vec`.
- The other `Vec<JSValue>` sites in `expect.rs` (`apply_custom_matcher`, `ExpectCustomAsymmetricMatcher::execute_impl`, `custom_print`) copy values that stay reachable from the call frame or from the internal `capturedArgs` array. User code cannot reach that array, and no user code runs between the copy and the call. They are not changed here.
- `src/runtime/server/mod.rs:969`: the handler argument `Vec<JSValue>` is sound because nothing allocates between the pushes and `callback.call`, and `Bun__JSValue__call` (`src/jsc/bindings/bindings.cpp:3283`) copies the arguments into a `MarkedArgumentBuffer` before any JS runs. `prepared.js_request` also stays on the native stack, because the function reads it again after the call. Only the comment changes.
- The new test spawns a child process, because a crash in the test process would take the other 42 tests of the file with it.
- Suites run on the debug build: `expect/toHaveReturnedWith.test.ts` (44 pass), `spyMatchers.test.ts` (150 pass), `mock-fn.test.js` (87 pass), `expect-toHaveReturnedWith.test.js` (13 pass), `expect.test.js` (416 pass).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect/toHaveReturnedWith.test.ts
bun test v1.4.3 (b99371011)

test/js/bun/test/expect/toHaveReturnedWith.test.ts:
Hello via Bun!
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass when function returns expected number [37.98ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass when function returns expected string [3.36ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass when function returns expected object [3.24ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass when function returns expected value after multiple calls [4.59ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass with exact array match [3.63ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass with null return value [6.11ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass with undefined return value [3
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (b99371011)

test/js/bun/test/expect/toHaveReturnedWith.test.ts:
Hello via Bun!
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass when function returns expected number [0.10ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass when function returns expected string [0.03ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass when function returns expected object [0.06ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass when function returns expected value after multiple calls [0.04ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass with exact array match [0.03ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass with null return value [0.03ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass with undefined return value [0.03ms]
(pass) toHaveReturnedWith Examples > Fail Cases - toHaveReturnedWith > should fail when function returns different number [0.06ms]
(pass) toHaveReturnedWith Examples > 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/test/expect/toHaveReturnedWith.test.ts
bun test v1.4.3 (b99371011)

test/js/bun/test/expect/toHaveReturnedWith.test.ts:
Hello via Bun!
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass when function returns expected number [9.48ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass when function returns expected string [3.39ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass when function returns expected object [3.31ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass when function returns expected value after multiple calls [4.04ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass with exact array match [3.40ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass with null return value [3.41ms]
(pass) toHaveReturnedWith Examples > Success Cases - toHaveReturnedWith > should pass with undefined return value [3.
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 864ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_js
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/mod.rs                          |  4 +-
 .../test_runner/expect/toHaveReturnedWith.rs       | 20 +++++++--
 test/js/bun/test/expect/toHaveReturnedWith.test.ts | 49 ++++++++++++++++++++++
 3 files changed, 67 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/runtime/server/mod.rs                                 1      1     11
src/runtime/test_runner/expect/toHaveReturnedWith.rs      2      3     11
test/js/bun/test/expect/toHaveReturnedWith.test.ts        2      1     11
```

</details>

<!-- robobun:evidence:end -->