### PR TITLE
YAML.stringify: keep visited collections alive so a reused address is not taken for an alias

### DIFF
--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -63,10 +63,7 @@ struct Stringifier<'a> {
     builder: wtf::StringBuilder,
     indent: usize,
 
-    /// Keyed by cell address, so every key is also appended to
-    /// `known_collection_roots`. A getter or Proxy trap can return a collection
-    /// that nothing else references; once collected, its address can be reused
-    /// by an unrelated collection, which would then look already seen.
+    /// Keyed by cell address. `known_collection_roots` keeps the keys alive so none gets reused.
     known_collections: HashMap<JSValue, AnchorAlias>,
     known_collection_roots: &'a mut MarkedArgumentBuffer,
     array_item_counter: usize,

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -23,6 +23,14 @@ pub(crate) fn create(global_this: &JSGlobalObject) -> JSValue {
 
 #[bun_jsc::host_fn]
 fn stringify(global: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValue> {
+    MarkedArgumentBuffer::new(|roots| stringify_impl(global, call_frame, roots))
+}
+
+fn stringify_impl(
+    global: &JSGlobalObject,
+    call_frame: &CallFrame,
+    roots: &mut MarkedArgumentBuffer,
+) -> JsResult<JSValue> {
     let [value, replacer, space_value] = call_frame.arguments_as_array::<3>();
 
     value.ensure_still_alive();
@@ -37,7 +45,7 @@ fn stringify(global: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValu
         )));
     }
 
-    let mut stringifier = Stringifier::init(global, space_value)?;
+    let mut stringifier = Stringifier::init(global, space_value, roots)?;
 
     stringifier
         .find_anchors_and_aliases(global, value, ValueOrigin::Root)
@@ -50,12 +58,17 @@ fn stringify(global: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValu
     stringifier.builder.to_string(global)
 }
 
-struct Stringifier {
+struct Stringifier<'a> {
     stack_check: StackCheck,
     builder: wtf::StringBuilder,
     indent: usize,
 
+    /// Keyed by cell address, so every key is also appended to
+    /// `known_collection_roots`. A getter or Proxy trap can return a collection
+    /// that nothing else references; once collected, its address can be reused
+    /// by an unrelated collection, which would then look already seen.
     known_collections: HashMap<JSValue, AnchorAlias>,
+    known_collection_roots: &'a mut MarkedArgumentBuffer,
     array_item_counter: usize,
     prop_names: StringHashMap<usize>,
 
@@ -183,8 +196,12 @@ impl StringifyError {
 
 bun_core::oom_from_alloc!(StringifyError);
 
-impl Stringifier {
-    fn init(global: &JSGlobalObject, space_value: JSValue) -> JsResult<Stringifier> {
+impl<'a> Stringifier<'a> {
+    fn init(
+        global: &JSGlobalObject,
+        space_value: JSValue,
+        known_collection_roots: &'a mut MarkedArgumentBuffer,
+    ) -> JsResult<Stringifier<'a>> {
         let mut prop_names: StringHashMap<usize> = StringHashMap::default();
         // always rename anchors named "root" to avoid collision with
         // root anchor/alias
@@ -195,6 +212,7 @@ impl Stringifier {
             builder: wtf::StringBuilder::init(),
             indent: 0,
             known_collections: HashMap::default(),
+            known_collection_roots,
             array_item_counter: 0,
             prop_names,
             space: Space::init(global, space_value)?,
@@ -278,6 +296,7 @@ impl Stringifier {
         }
 
         *object_entry.value_ptr = AnchorAlias::init(origin);
+        self.known_collection_roots.append(unwrapped);
 
         if unwrapped.is_array() {
             let mut iter = unwrapped.array_iterator(global)?;

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -3294,6 +3294,48 @@ config:
         expect(reparsed).toEqual(value);
         expect(reparsed["\\u{10FFFF}a"]).toBe(reparsed.b);
       });
+
+      // A collection that only a getter or a Proxy trap returned is garbage as soon as the
+      // stringifier leaves it, so a later collection can be allocated at the same address.
+      describe("does not alias distinct collections that reuse the address of a collected one", () => {
+        const count = 12;
+
+        test.each([undefined, 2])("returned by getters (space: %p)", space => {
+          const plain = {};
+          const lazy = {};
+          for (let i = 0; i < count; i++) {
+            const make = () => ({ id: i, rows: [i * 10, i * 10 + 1] });
+            plain["k" + i] = make();
+            Object.defineProperty(lazy, "k" + i, {
+              enumerable: true,
+              get() {
+                if (i % 3 === 0) Bun.gc(true);
+                return make();
+              },
+            });
+          }
+
+          expect(YAML.stringify(lazy, null, space)).toBe(YAML.stringify(plain, null, space));
+        });
+
+        test.each([undefined, 2])("returned by Proxy traps (space: %p)", space => {
+          let wrapped = 0;
+          const readonly = (target: object): object =>
+            new Proxy(target, {
+              get(target, key, receiver) {
+                const value = Reflect.get(target, key, receiver);
+                if (typeof value !== "object" || value === null) return value;
+                if (++wrapped % 3 === 0) Bun.gc(true);
+                return readonly(value);
+              },
+            });
+
+          const plain = {};
+          for (let i = 0; i < count; i++) plain["r" + i] = { id: i, tags: { a: "a" + i, b: "b" + i } };
+
+          expect(YAML.stringify(readonly(plain), null, space)).toBe(YAML.stringify(plain, null, space));
+        });
+      });
     });
 
     // Edge cases and error handling

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -3297,45 +3297,48 @@ config:
 
       // A collection that only a getter or a Proxy trap returned is garbage as soon as the
       // stringifier leaves it, so a later collection can be allocated at the same address.
-      describe("does not alias distinct collections that reuse the address of a collected one", () => {
-        const count = 12;
+      describe.each([undefined, 2])(
+        "does not alias distinct collections that reuse the address of a collected one (space: %p)",
+        space => {
+          const count = 12;
 
-        test.each([undefined, 2])("returned by getters (space: %p)", space => {
-          const plain = {};
-          const lazy = {};
-          for (let i = 0; i < count; i++) {
-            const make = () => ({ id: i, rows: [i * 10, i * 10 + 1] });
-            plain["k" + i] = make();
-            Object.defineProperty(lazy, "k" + i, {
-              enumerable: true,
-              get() {
-                if (i % 3 === 0) Bun.gc(true);
-                return make();
-              },
-            });
-          }
+          test("returned by getters", () => {
+            const plain = {};
+            const lazy = {};
+            for (let i = 0; i < count; i++) {
+              const make = () => ({ id: i, rows: [i * 10, i * 10 + 1] });
+              plain["k" + i] = make();
+              Object.defineProperty(lazy, "k" + i, {
+                enumerable: true,
+                get() {
+                  if (i % 3 === 0) Bun.gc(true);
+                  return make();
+                },
+              });
+            }
 
-          expect(YAML.stringify(lazy, null, space)).toBe(YAML.stringify(plain, null, space));
-        });
+            expect(YAML.stringify(lazy, null, space)).toBe(YAML.stringify(plain, null, space));
+          });
 
-        test.each([undefined, 2])("returned by Proxy traps (space: %p)", space => {
-          let wrapped = 0;
-          const readonly = (target: object): object =>
-            new Proxy(target, {
-              get(target, key, receiver) {
-                const value = Reflect.get(target, key, receiver);
-                if (typeof value !== "object" || value === null) return value;
-                if (++wrapped % 3 === 0) Bun.gc(true);
-                return readonly(value);
-              },
-            });
+          test("returned by Proxy traps", () => {
+            let wrapped = 0;
+            const readonly = (target: object): object =>
+              new Proxy(target, {
+                get(target, key, receiver) {
+                  const value = Reflect.get(target, key, receiver);
+                  if (typeof value !== "object" || value === null) return value;
+                  if (++wrapped % 3 === 0) Bun.gc(true);
+                  return readonly(value);
+                },
+              });
 
-          const plain = {};
-          for (let i = 0; i < count; i++) plain["r" + i] = { id: i, tags: { a: "a" + i, b: "b" + i } };
+            const plain = {};
+            for (let i = 0; i < count; i++) plain["r" + i] = { id: i, tags: { a: "a" + i, b: "b" + i } };
 
-          expect(YAML.stringify(readonly(plain), null, space)).toBe(YAML.stringify(plain, null, space));
-        });
-      });
+            expect(YAML.stringify(readonly(plain), null, space)).toBe(YAML.stringify(plain, null, space));
+          });
+        },
+      );
     });
 
     // Edge cases and error handling


### PR DESCRIPTION
### Problem
- `Bun.YAML.stringify` writes `*alias` in place of an unrelated collection, with no error. Trigger: own getters or a Proxy `get` trap that return a new collection on each read. 20000 such getters give 2770 wrong values on 1.4.3-canary.
- `known_collections: HashMap<JSValue, AnchorAlias>` (`src/runtime/api/YAMLObject.rs:58`) is keyed by cell address and does not keep the cell alive. A collection that only a getter returned is garbage when the walker leaves it. After a GC, a new collection can get that address, and `get_or_put` (:240) reports it as seen.

### Fix
- `stringify` runs inside `MarkedArgumentBuffer::new`. `find_anchors_and_aliases` appends each key it inserts into `known_collections` to that buffer.
- Correct because a live cell keeps its address. No other collection can equal a rooted key.
- Cost: one `append` per visited collection, about 1% on 400k collections (Notes). Getter-made collections now live until the call returns.
- Verified: 4 new tests in `test/js/bun/yaml/yaml.test.ts` fail on 1.4.3-canary and on an unfixed debug build. Also ran all of `test/js/bun/yaml/`.

### Background
- In YAML, `&name` marks a node and `*name` refers to it. Pass 1 flags each collection it meets twice. Pass 2 writes `&name` at the first occurrence and `*name` after that.
- Both passes read values through `JSPropertyIterator`. It runs own accessors and Proxy traps, so a GC can run during the walk.
- A `JSValue` for an object is the address of its GC cell. JSC reuses the address of a collected cell.
- A `MarkedArgumentBuffer` is a JSC list whose entries are GC roots while the list exists. `YAML.parse` in the same file uses one.

<details><summary>Notes</summary>

Small deterministic repro:

```js
const N = 200;
const o = {};
for (let i = 0; i < N; i++)
  Object.defineProperty(o, "k" + i, {
    enumerable: true,
    get() {
      if (i % 3 === 0) Bun.gc(true);
      return { id: i, rows: Array.from({ length: 40 }, (_, j) => i * 100 + j) };
    },
  });
console.log(Bun.YAML.stringify(o).slice(0, 120));
// before: {k0: &k0 {id: 0,rows: [...]},k1: &k1 {...},k2: &k2 {...},k3: *k0,k4: *k1,...
```

Results as `aliases / anchors / wrong values after YAML.parse`. The expected result is `0 / 0 / 0` because every read returns a distinct collection.

1.4.3-canary (b99371011), release:
- 200 getters, `Bun.gc(true)` in every third: 193 / 7 / 193
- 20000 getters, no explicit GC: 2770 / 7091 / 2770
- a Proxy that wraps each nested read in a new Proxy, 60 rows, `Bun.gc(true)` on every third read: 59 / 4 / 59

Debug + ASAN build with the fix: all three scripts give 0 / 0 / 0.

Debug + ASAN build without the fix: the 4 new tests fail (7 to 9 of 12 values become aliases).

Control: the 20000-getter script with every getter result also pushed to a global array gives 0 / 0 / 0 on the same canary. So the aliases come from address reuse, not from the walker logic.

Cost and the alternative that review asked about: a `JSMap` in place of the `HashMap` and the `MarkedArgumentBuffer`. `JSMap` is the one JSC container that hashes a cell by identity and also marks its keys (`JSWeakMap` holds keys weakly, `WeakGCMap` holds values weakly). Its values must be JSValues, so it stores an index into a `Vec<AnchorAlias>`. Each lookup in both passes is then a call into C++, and each `stringify` call allocates a Map. Release builds at 09bb546, best of 2 rounds of 15 runs, in ms (run-to-run noise is about 3%):

| case | main | this PR | `JSMap` |
| --- | --- | --- | --- |
| 400k small collections, minified | 271 | 274 | 295 |
| 400k small collections, `space: 2` | 279 | 289 | 312 |
| 1k collections x 100 strings | 38.2 | 37.8 | 37.7 |
| 200k references to 100 shared objects | 14.4 | 13.8 | 15.8 |
| small config document x 100k calls | 483 | 490 | 526 |
| `YAML.stringify(i)` x 1M calls | 138 | 148 | 146 |

The last row is the cost of `MarkedArgumentBuffer::new` itself, about 10 ns per call. WebKit's structured clone has the same problem and uses the same pair as this PR: `CloneSerializer::recordObject` adds to `m_objectPool` and appends to `m_gcBuffer` (`src/jsc/bindings/webcore/SerializedScriptValue.cpp:821`).

Retention: collections that are reachable from the input are alive for the whole call anyway, so the buffer changes nothing for them. Collections that a getter or a trap made are now kept until the call returns. That is the price of an identity table that two passes share. A table with weak keys would avoid it, but it needs a C++ weak map and a call into C++ for each lookup.

Not changed here:
- Each pass calls the getters again, so pass 2 can see collections that pass 1 never saw. They are not in the table, so pass 2 writes them in full. That is correct output.
- The macro runner has the same kind of table (`visited: HashMap<JSValue, Expr>`, `src/js_parser_jsc/Macro.rs:491`). A macro that returns 300 getter-backed values with `Bun.gc(true)` in every third gives 295 of 300 wrong properties on 1.4.3-canary. That is a separate change.
- #34887 is about the anchor name string in the same table. It does not overlap.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.3 (09bb54630)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [3.17ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.51ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.80ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [1.90ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.26ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.22ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [3.14ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [3.22ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [3.13ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [3.05ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [3.47ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [2.87ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [2.76ms]
(pass) Bun
... (truncated)

release without fix: 18 skipped
bun test v1.4.3-canary.1 (09bb54630)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [0.83ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [0.06ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [0.06ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [0.06ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [1.39ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [0.08ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [0.08ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [0.72ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [0.08ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from DataView [0.06ms]
(pass) Bun.YAML > parse > input types > parses from Blob [0.07ms]
(pass) Bun.YAML > parse > i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.3 (09bb54630)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [4.05ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.72ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.71ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [2.23ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.59ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.41ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [3.45ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [3.00ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [3.70ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [3.77ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [3.25ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [3.33ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [3.08ms]
(pass) Bun
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     16492dc1b7
  features     lto, baseline

23 deps, 131 codegen, 1176 objects in 839ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1254] mkdir codegen
[2/1254] mkdir stamps
[3/1254] mkdir pch
[4/1254] mkdir obj
[5/1254] install /workspace/bun
bun install v1.4.3-canary.1 (09bb54630)

Checked 22 installs across 61 packages (no changes) [4.00ms]
[6/1254] gen ErrorCode+*.h
[7/1254] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (09bb54630)

Checked 1 install across 2 packages (no changes) [4.00ms]
[8/1254] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (09bb54630)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[9/1254] gen bindgenv2
[10/1254] gen node-fallbacks/react-refresh.js
Bundled 1 module in 9ms

  react-refresh.js  4.81 KB  (entry point)

[11/1254] fetch tinycc
[tinycc] up to date
[12/1254] fetch picohttpparser
[picohttpparser] up to date
[13/1254] gen bake.{client,server,error}.js
-> bake.client.js, bake.s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/YAMLObject.rs | 24 +++++++++++++++++++----
 test/js/bun/yaml/yaml.test.ts | 45 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 65 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/runtime/api/YAMLObject.rs      4      4     35
test/js/bun/yaml/yaml.test.ts      3      3     35
```

</details>

<!-- robobun:evidence:end -->
