### PR TITLE
http(h3): do not replay a non-idempotent request that was already sent

### DIFF
--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -219,13 +219,8 @@ impl ClientSession {
     /// already be consumed), re-enqueue it on a fresh session — this is the
     /// standard h2/h3 client behavior for the GOAWAY / stateless-reset /
     /// port-reuse race where a pooled session goes stale between the
-    /// `matches()` check and the first stream open.
-    ///
-    /// Once any of the request was written to a stream the origin may already
-    /// have acted on it, so from then on only an idempotent method is re-sent
-    /// (RFC 9110 §9.2.2), like the HTTP/1.1 client's `on_close`. A peer
-    /// RESET_STREAM(H3_REQUEST_REJECTED) or a GOAWAY below the stream id also
-    /// proves the origin did not act on it; neither reaches this function yet.
+    /// `matches()` check and the first stream open. Once part of the request
+    /// was written, only an idempotent method is re-sent (RFC 9110 §9.2.2).
     pub(crate) fn retry_or_fail(&mut self, stream: *mut Stream, err: crate::Error) {
         // Shaped for Stacked Borrows like `fail` below — `detach()`
         // re-derives `&mut HTTPClient` from the same raw ptr to null `h3`, which
@@ -236,8 +231,8 @@ impl ClientSession {
             return self.fail(stream, err);
         };
         // `Stream.client` is a live backref while attached; `ParentRef::from`
-        // (NonNull → shared deref) reads the Copy `flags`/`method` fields
-        // without forming `&mut HTTPClient` across the `detach()` below.
+        // (NonNull → shared deref) reads the Copy `flags` field without
+        // forming `&mut HTTPClient` across the `detach()` below.
         let client_ref = bun_ptr::ParentRef::from(client_ptr);
         let replay_safe = !st.headers_sent || client_ref.method.is_idempotent();
         if client_ref.flags.h3_retried || st.is_streaming_body || !replay_safe {

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -220,6 +220,12 @@ impl ClientSession {
     /// standard h2/h3 client behavior for the GOAWAY / stateless-reset /
     /// port-reuse race where a pooled session goes stale between the
     /// `matches()` check and the first stream open.
+    ///
+    /// Once any of the request was written to a stream the origin may already
+    /// have acted on it, so from then on only an idempotent method is re-sent
+    /// (RFC 9110 §9.2.2), like the HTTP/1.1 client's `on_close`. A peer
+    /// RESET_STREAM(H3_REQUEST_REJECTED) or a GOAWAY below the stream id also
+    /// proves the origin did not act on it; neither reaches this function yet.
     pub(crate) fn retry_or_fail(&mut self, stream: *mut Stream, err: crate::Error) {
         // Shaped for Stacked Borrows like `fail` below — `detach()`
         // re-derives `&mut HTTPClient` from the same raw ptr to null `h3`, which
@@ -230,9 +236,11 @@ impl ClientSession {
             return self.fail(stream, err);
         };
         // `Stream.client` is a live backref while attached; `ParentRef::from`
-        // (NonNull → shared deref) reads the Copy `flags` field without
-        // forming `&mut HTTPClient` across the `detach()` below.
-        if bun_ptr::ParentRef::from(client_ptr).flags.h3_retried || st.is_streaming_body {
+        // (NonNull → shared deref) reads the Copy `flags`/`method` fields
+        // without forming `&mut HTTPClient` across the `detach()` below.
+        let client_ref = bun_ptr::ParentRef::from(client_ptr);
+        let replay_safe = !st.headers_sent || client_ref.method.is_idempotent();
+        if client_ref.flags.h3_retried || st.is_streaming_body || !replay_safe {
             return self.fail(stream, err);
         }
         let Some(ctx) = ClientContext::get() else {

--- a/src/http/h3_client/ClientSession.rs
+++ b/src/http/h3_client/ClientSession.rs
@@ -219,8 +219,7 @@ impl ClientSession {
     /// already be consumed), re-enqueue it on a fresh session — this is the
     /// standard h2/h3 client behavior for the GOAWAY / stateless-reset /
     /// port-reuse race where a pooled session goes stale between the
-    /// `matches()` check and the first stream open. Once part of the request
-    /// was written, only an idempotent method is re-sent (RFC 9110 §9.2.2).
+    /// `matches()` check and the first stream open.
     pub(crate) fn retry_or_fail(&mut self, stream: *mut Stream, err: crate::Error) {
         // Shaped for Stacked Borrows like `fail` below — `detach()`
         // re-derives `&mut HTTPClient` from the same raw ptr to null `h3`, which
@@ -234,6 +233,7 @@ impl ClientSession {
         // (NonNull → shared deref) reads the Copy `flags` field without
         // forming `&mut HTTPClient` across the `detach()` below.
         let client_ref = bun_ptr::ParentRef::from(client_ptr);
+        // RFC 9110 §9.2.2: the origin may have acted on a request that was written.
         let replay_safe = !st.headers_sent || client_ref.method.is_idempotent();
         if client_ref.flags.h3_retried || st.is_streaming_body || !replay_safe {
             return self.fail(stream, err);

--- a/test/js/web/fetch/fetch-http3-client.test.ts
+++ b/test/js/web/fetch/fetch-http3-client.test.ts
@@ -694,34 +694,37 @@ test.each(["POST", "PATCH"])("does not replay a %s that was already sent", async
       return new Response("a");
     },
   });
-  const port = a.port;
-  expect(await fetch(`https://127.0.0.1:${port}/`, h3).then(r => r.text())).toBe("a");
-  const inflight = fetch(`https://127.0.0.1:${port}/`, { ...h3, method, body: "payload" });
-  await received.promise;
-  // This continuation runs in the microtask drain of A's handler, with A's
-  // lsquic engine still on the stack. Stop A from a fresh event-loop turn.
-  await new Promise<void>(resolve => setImmediate(resolve));
-  const b = Bun.serve({
-    port,
-    reusePort: true,
-    tls,
-    http3: true,
-    http1: false,
-    fetch: req => {
-      hits.push(`b ${req.method}`);
-      return new Response("b");
-    },
-  });
-  a.stop(true);
-  release.resolve();
+  let b: Server | undefined;
   try {
+    const port = a.port;
+    expect(await fetch(`https://127.0.0.1:${port}/`, h3).then(r => r.text())).toBe("a");
+    const inflight = fetch(`https://127.0.0.1:${port}/`, { ...h3, method, body: "payload" });
+    await received.promise;
+    // This continuation runs in the microtask drain of A's handler, with A's
+    // lsquic engine still on the stack. Stop A from a fresh event-loop turn.
+    await new Promise<void>(resolve => setImmediate(resolve));
+    b = Bun.serve({
+      port,
+      reusePort: true,
+      tls,
+      http3: true,
+      http1: false,
+      fetch: req => {
+        hits.push(`b ${req.method}`);
+        return new Response("b");
+      },
+    });
+    a.stop(true);
+    release.resolve();
     const outcome = await inflight.then(r => r.text()).catch(e => e.code);
     expect(outcome).toBe("HTTP3StreamReset");
     // The origin is reachable: a new request lands on B, the first one never did.
     expect(await fetch(`https://127.0.0.1:${port}/`, h3).then(r => r.text())).toBe("b");
     expect(hits).toEqual(["a GET", `a ${method}`, "b GET"]);
   } finally {
-    void b.stop(true);
+    release.resolve();
+    void a.stop(true);
+    void b?.stop(true);
   }
 });
 

--- a/test/js/web/fetch/fetch-http3-client.test.ts
+++ b/test/js/web/fetch/fetch-http3-client.test.ts
@@ -671,6 +671,101 @@ test("retries on a fresh session when a pooled session is stale (port reuse)", a
   }
 });
 
+// Same shape as the retry above, but the in-flight request is not idempotent
+// and A's handler has already received it. The origin may have acted on it, so
+// the client must surface the failure instead of sending it a second time
+// (RFC 9110 §9.2.2); the HTTP/1.1 and HTTP/2 clients apply the same rule.
+test.each(["POST", "PATCH"])("does not replay a %s that was already sent", async method => {
+  const hits: string[] = [];
+  const received = Promise.withResolvers<void>();
+  const release = Promise.withResolvers<void>();
+  const a = Bun.serve({
+    port: 0,
+    reusePort: true,
+    tls,
+    http3: true,
+    http1: false,
+    fetch: async req => {
+      hits.push(`a ${req.method}`);
+      if (req.method === method) {
+        received.resolve();
+        await release.promise;
+      }
+      return new Response("a");
+    },
+  });
+  const port = a.port;
+  expect(await fetch(`https://127.0.0.1:${port}/`, h3).then(r => r.text())).toBe("a");
+  const inflight = fetch(`https://127.0.0.1:${port}/`, { ...h3, method, body: "payload" });
+  await received.promise;
+  // This continuation runs in the microtask drain of A's handler, with A's
+  // lsquic engine still on the stack. Stop A from a fresh event-loop turn.
+  await new Promise<void>(resolve => setImmediate(resolve));
+  const b = Bun.serve({
+    port,
+    reusePort: true,
+    tls,
+    http3: true,
+    http1: false,
+    fetch: req => {
+      hits.push(`b ${req.method}`);
+      return new Response("b");
+    },
+  });
+  a.stop(true);
+  release.resolve();
+  try {
+    const outcome = await inflight.then(r => r.text()).catch(e => e.code);
+    expect(outcome).toBe("HTTP3StreamReset");
+    // The origin is reachable: a new request lands on B, the first one never did.
+    expect(await fetch(`https://127.0.0.1:${port}/`, h3).then(r => r.text())).toBe("b");
+    expect(hits).toEqual(["a GET", `a ${method}`, "b GET"]);
+  } finally {
+    void b.stop(true);
+  }
+});
+
+// A request that never left the client is safe to send again whatever its
+// method. The fake server answers each Initial with a Version Negotiation
+// packet that lists only a reserved version, so the handshake fails before the
+// request is written. Each connection attempt uses a new connection ID.
+test.each(["GET", "POST"])("re-sends a %s once when the connection failed before it was sent", async method => {
+  const attempts = new Set<string>();
+  const server = await Bun.udpSocket({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      data(socket, packet, port, address) {
+        if (packet.length < 7 || (packet[0] & 0x80) === 0) return;
+        const dcidLength = packet[5];
+        const dcid = packet.subarray(6, 6 + dcidLength);
+        const scidLength = packet[6 + dcidLength];
+        const scid = packet.subarray(7 + dcidLength, 7 + dcidLength + scidLength);
+        attempts.add(dcid.toString("hex"));
+        socket.send(
+          Buffer.concat([
+            Buffer.from([0xc0, 0, 0, 0, 0, scidLength]),
+            scid,
+            Buffer.from([dcidLength]),
+            dcid,
+            Buffer.from([0x0a, 0x0a, 0x0a, 0x0a]),
+          ]),
+          port,
+          address,
+        );
+      },
+    },
+  });
+  try {
+    const init = method === "GET" ? {} : { method, body: "payload" };
+    const outcome = await fetch(`https://127.0.0.1:${server.port}/`, { ...h3, ...init }).catch(e => e.code);
+    expect(outcome).toBe("HTTP3HandshakeFailed");
+    expect(attempts.size).toBe(2);
+  } finally {
+    server.close();
+  }
+});
+
 // Subprocess so the experimental flag is process-scoped and the in-process
 // server above (http1: false) doesn't interfere — this server keeps http1 on
 // so the first fetch goes over TCP and reads Alt-Svc.


### PR DESCRIPTION
### Problem
- `fetch(url, { protocol: "http3" })` sends a POST twice when the connection goes away before the response headers. Repro: a POST is in the handler, `server.stop(true)` runs, and a new server binds the same port. Both handlers see it (`hits: ["A POST /slow","B POST /slow"]`).
- The cause is `ClientSession::retry_or_fail` (`src/http/h3_client/ClientSession.rs:223`). It re-sends any request once when its stream closes before the headers, whatever the method.
- The HTTP/1.1 client re-sends only idempotent methods (`src/http/lib.rs:2141`). The HTTP/2 client re-sends only a stream that the server refused.

### Fix
- `retry_or_fail` re-sends only when no part of the request was written to a stream (`!headers_sent`), or when the method is idempotent (RFC 9110 section 9.2.2).
- A non-idempotent request that was written fails with `HTTP3StreamReset`, as this path already does when no retry is left.
- Verified: `test/js/web/fetch/fetch-http3-client.test.ts` (4 new tests, main fails 2 with `Received: "b"`), plus the other HTTP/3 suites.
- Self-reviewed: 3 concerns raised, 3 addressed. The Notes give the limits and the order with #40598 and #41564.

### Background
- The fetch HTTP/3 client pools one `ClientSession` (one QUIC connection) per origin.
- A pooled session can be dead before the client knows it (server restart, GOAWAY). `retry_or_fail` moves the request to a fresh session, one time.
- The client cannot tell that case from a server that closed the connection while the handler ran. Both look like a stream that closed before the headers. A second send is only safe for an idempotent method.

<details><summary>Notes</summary>

**How this was found.** An in-flight HTTP/3 `fetch()` takes 10 s to reject after `server.stop(true)` when nothing listens on the port any more, and rejects with `HTTP3HandshakeFailed`. The server does send CONNECTION_CLOSE and the client sees it at once (`conn_close status=8`). The client then re-sends the request on a fresh session. That handshake goes to the closed UDP port and ends at lsquic's 10 s handshake timeout, so the error belongs to the second connection. HTTP/1.1 does the same single retry for a GET on a reused socket, but the kernel answers the connect with RST, so it fails at once with `ConnectionRefused`. For an idempotent method this retry is intended and tested (`retries on a fresh session when a pooled session is stale (port reuse)`). This PR does not change it.

```
[h3_client] stream_close status=0 delivered=false
[h3_client] retry 127.0.0.1:35495 after HTTP3StreamReset
[h3_client] connect 127.0.0.1:35495 (sync)
[h3_client] conn_close status=8 ''
[h3_client] conn_close status=4 ''        (10 s later)
```

**Behaviour, server stops with the request in the handler, old port dead**

| request | HTTP/1.1 | HTTP/3 before | HTTP/3 after |
| --- | --- | --- | --- |
| GET, pooled connection | retry, `ConnectionRefused` at once | retry, `HTTP3HandshakeFailed` after 10 s | same |
| POST, pooled connection | `ECONNRESET` at once | retry (second send), then 10 s | `HTTP3StreamReset` at once |
| POST, fresh connection | `ECONNRESET` at once | retry (second send), then 10 s | `HTTP3StreamReset` at once |

**Known limits.** After this change a POST or PATCH that was written is also not re-sent in two cases where the server does prove that it did not process the request. Main re-sends both today, and the HTTP/2 client re-sends the analogous cases for any method (`src/http/h2_client/ClientSession.rs:1105`).
- A pre-header RESET_STREAM or STOP_SENDING with `H3_REQUEST_REJECTED` (0x10B). The code is available from `lsquic_stream_get_error_code` (`vendor/lsquic/include/lsquic.h`), but `us_quic_on_reset` (`packages/bun-usockets/src/quic.c`) drops it. #40598 carries that plumbing.
- A graceful GOAWAY with an id below the request's stream id (RFC 9114 section 5.2). lsquic does not give the GOAWAY id to the application.

**Target rule and order of the open PRs in this function.** `replay_safe = !headers_sent || peer_rejected(H3_REQUEST_REJECTED) || method.is_idempotent()`. This PR supplies the first and the third term. #40598 owns the second: on rebase it must OR its `peer_reset == RequestRejected` into `replay_safe`, or its test `RESET_STREAM(H3_REQUEST_REJECTED) before the headers re-sends the request once` (a POST) fails while the Rust merges clean. #41564 (retry budget) gates retries after the first on `not_applied || idempotent`. It must drop its `retries == 0 ||` escape so that the first retry takes the same gate.

**Tests.** `does not replay a POST|PATCH that was already sent` is the case above with a live server on the same port: the handler of the first server sees the request, the second server never does. `re-sends a GET|POST once when the connection failed before it was sent` uses a fake UDP server that answers each Initial with a Version Negotiation packet for a reserved version, so the handshake fails before the request is written. It counts connection IDs: 2 for both methods. With the `!headers_sent` term removed the POST case counts 1.

**Suites run on the debug ASAN build:** `fetch-http3-client` (60 pass), `serve-http3` (55 pass), `serve-protocols` (20), `fetch-http3-adversarial` (27), `fetch-http3-cold-post` (2), `fetch-http3-syscall-fault` (3).

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/web/fetch/fetch-http3-client.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/web/fetch/fetch-http3-client.test.ts:
(pass) fetch protocol: http3 > GET text [33.19ms]
(pass) fetch protocol: http3 > 'h3' alias [13.59ms]
(pass) fetch protocol: http3 > POST echo with headers [21.51ms]
(pass) fetch protocol: http3 > JSON + query string [13.99ms]
(pass) fetch protocol: http3 > route params [12.17ms]
(pass) fetch protocol: http3 > large response body (multi-packet) [19.34ms]
(pass) fetch protocol: http3 > large request body [49.23ms]
(pass) fetch protocol: http3 > compress: gzip request body — small (shared-buffer fast path) [23.42ms]
(pass) fetch protocol: http3 > compress: gzip request body — large (zlib-streaming spill path) [12.03ms]
(pass) fetch protocol: http3 > status 200 [12.15ms]
(pass) fetch protocol: http3 > status 204 [5.74ms]
(pass) fetch protocol: http3 > status 404 [4.89ms]
(pass) fetch protocol: http3 > status 500 [5.52ms]
(pass) fetch protocol: http3 > HEAD has no body [11.85ms]
(pass) fetch protocol: http3 > the res
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/web/fetch/fetch-http3-client.test.ts:
(pass) fetch protocol: http3 > GET text [4.81ms]
(pass) fetch protocol: http3 > 'h3' alias [0.30ms]
(pass) fetch protocol: http3 > POST echo with headers [0.49ms]
(pass) fetch protocol: http3 > JSON + query string [1.26ms]
(pass) fetch protocol: http3 > route params [0.28ms]
(pass) fetch protocol: http3 > large response body (multi-packet) [1.77ms]
(pass) fetch protocol: http3 > large request body [2.00ms]
(pass) fetch protocol: http3 > compress: gzip request body — small (shared-buffer fast path) [5.03ms]
(pass) fetch protocol: http3 > compress: gzip request body — large (zlib-streaming spill path) [2.05ms]
(pass) fetch protocol: http3 > status 200 [0.40ms]
(pass) fetch protocol: http3 > status 204 [0.12ms]
(pass) fetch protocol: http3 > status 404 [0.10ms]
(pass) fetch protocol: http3 > status 500 [0.11ms]
(pass) fetch protocol: http3 > HEAD has no body [0.24ms]
(pass) fetch protocol: http3 > the response to a 204 has a null body [0.26ms]
(pass) fetch protocol: http3 > the response to a 304 has a null body [0.10ms]
(pass) fetch protocol: http3 > the response to a HEAD request h
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/web/fetch/fetch-http3-client.test.ts"
bun test v1.4.3 (6a92015fc)

test/js/web/fetch/fetch-http3-client.test.ts:
(pass) fetch protocol: http3 > GET text [42.79ms]
(pass) fetch protocol: http3 > 'h3' alias [12.94ms]
(pass) fetch protocol: http3 > POST echo with headers [27.77ms]
(pass) fetch protocol: http3 > JSON + query string [24.71ms]
(pass) fetch protocol: http3 > route params [15.07ms]
(pass) fetch protocol: http3 > large response body (multi-packet) [18.46ms]
(pass) fetch protocol: http3 > large request body [22.27ms]
(pass) fetch protocol: http3 > compress: gzip request body — small (shared-buffer fast path) [31.66ms]
(pass) fetch protocol: http3 > compress: gzip request body — large (zlib-streaming spill path) [17.43ms]
(pass) fetch protocol: http3 > status 200 [17.63ms]
(pass) fetch protocol: http3 > status 204 [11.04ms]
(pass) fetch protocol: http3 > status 404 [6.70ms]
(pass) fetch protocol: http3 > status 500 [7.19ms]
(pass) fetch protocol: http3 > HEAD has no body [23.00ms]
(pass) fetch protocol: http3 > the re
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 642ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/h3_client/ClientSession.rs          |  5 +-
 test/js/web/fetch/fetch-http3-client.test.ts | 98 ++++++++++++++++++++++++++++
 2 files changed, 102 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/http/h3_client/ClientSession.rs               3      3     29
test/js/web/fetch/fetch-http3-client.test.ts      3      2     29
```

</details>

<!-- robobun:evidence:end -->