### PR TITLE
node:string_decoder: construct subclasses of StringDecoder

### DIFF
--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -77,7 +77,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:string_decoder`](https://nodejs.org/api/string_decoder.html)
 
-🟢 Fully implemented. 100% of Node.js's test suite passes. `end()` does not accept a string argument, and `StringDecoder` cannot be subclassed with `class extends`.
+🟢 Fully implemented. 100% of Node.js's test suite passes. `end()` does not accept a string argument.
 
 ### [`node:timers`](https://nodejs.org/api/timers.html)
 

--- a/src/jsc/bindings/JSStringDecoder.cpp
+++ b/src/jsc/bindings/JSStringDecoder.cpp
@@ -553,36 +553,56 @@ void JSStringDecoderConstructor::finishCreation(VM& vm, JSC::JSGlobalObject* glo
 
 JSStringDecoderConstructor* JSStringDecoderConstructor::create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSStringDecoderPrototype* prototype)
 {
-    JSStringDecoderConstructor* ptr = new (NotNull, JSC::allocateCell<JSStringDecoderConstructor>(vm)) JSStringDecoderConstructor(vm, structure, construct);
+    JSStringDecoderConstructor* ptr = new (NotNull, JSC::allocateCell<JSStringDecoderConstructor>(vm)) JSStringDecoderConstructor(vm, structure);
     ptr->finishCreation(vm, globalObject, prototype);
     return ptr;
 }
 
-JSC::EncodedJSValue JSStringDecoderConstructor::construct(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
+// Shared by call() and construct(). `newTarget` is null for a [[Call]]. Returns nullptr with an exception pending.
+static JSStringDecoder* createDecoder(JSC::JSGlobalObject* lexicalGlobalObject, JSValue jsEncoding, JSC::JSObject* newTarget)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    Structure* structure = globalObject->JSStringDecoderStructure();
+
+    // `class Sub extends StringDecoder` and `Reflect.construct(StringDecoder, args, newTarget)`.
+    if (newTarget && newTarget != globalObject->JSStringDecoder()) [[unlikely]] {
+        // A ShadowRealm or node:vm function belongs to a different global object.
+        auto* functionGlobalObject = defaultGlobalObject(getFunctionRealm(lexicalGlobalObject, newTarget));
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
+        structure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, functionGlobalObject->JSStringDecoderStructure());
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
+    }
+
     auto encoding = BufferEncodingType::utf8;
-    auto jsEncoding = callFrame->argument(0);
     if (!jsEncoding.isUndefinedOrNull()) {
         std::optional<BufferEncodingType> opt = parseEnumeration<BufferEncodingType>(*lexicalGlobalObject, jsEncoding);
-        RETURN_IF_EXCEPTION(throwScope, {});
+        RETURN_IF_EXCEPTION(throwScope, nullptr);
         if (opt.has_value()) {
             encoding = opt.value();
         } else {
             auto* encodingString = jsEncoding.toString(lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(throwScope, {});
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
             const auto& view = encodingString->view(lexicalGlobalObject);
-            RETURN_IF_EXCEPTION(throwScope, {});
-            return Bun::ERR::UNKNOWN_ENCODING(throwScope, lexicalGlobalObject, view);
+            RETURN_IF_EXCEPTION(throwScope, nullptr);
+            Bun::ERR::UNKNOWN_ENCODING(throwScope, lexicalGlobalObject, view);
+            return nullptr;
         }
     }
+    return JSStringDecoder::create(vm, lexicalGlobalObject, structure, encoding);
+}
+
+JSC::EncodedJSValue JSStringDecoderConstructor::call(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto* constructor = globalObject->JSStringDecoder();
-    Structure* structure = globalObject->JSStringDecoderStructure();
 
-    JSStringDecoder* jsObject = JSStringDecoder::create(
-        vm, lexicalGlobalObject, structure, encoding);
+    JSStringDecoder* jsObject = createDecoder(lexicalGlobalObject, callFrame->argument(0), nullptr);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    auto encoding = jsObject->m_encoding;
 
     // StringDecodeer is a Weird one
     // This is a hack to make express' body-parser work
@@ -599,6 +619,11 @@ JSC::EncodedJSValue JSStringDecoderConstructor::construct(JSC::JSGlobalObject* l
     }
 
     return JSC::JSValue::encode(jsObject);
+}
+
+JSC::EncodedJSValue JSStringDecoderConstructor::construct(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
+{
+    return JSC::JSValue::encode(createDecoder(lexicalGlobalObject, callFrame->argument(0), asObject(callFrame->newTarget())));
 }
 
 const ClassInfo JSStringDecoderConstructor::s_info = { "StringDecoder"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSStringDecoderConstructor) };

--- a/src/jsc/bindings/JSStringDecoder.h
+++ b/src/jsc/bindings/JSStringDecoder.h
@@ -110,12 +110,13 @@ public:
     }
 
     // Must be defined for each specialization class.
+    static JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES call(JSC::JSGlobalObject*, JSC::CallFrame*);
     static JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES construct(JSC::JSGlobalObject*, JSC::CallFrame*);
     DECLARE_EXPORT_INFO;
 
 private:
-    JSStringDecoderConstructor(JSC::VM& vm, JSC::Structure* structure, JSC::NativeFunction nativeFunction)
-        : Base(vm, structure, nativeFunction, nativeFunction)
+    JSStringDecoderConstructor(JSC::VM& vm, JSC::Structure* structure)
+        : Base(vm, structure, call, construct)
     {
     }
 

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, withoutAggressiveGC } from "harness";
+import vm from "node:vm";
 
 const RealStringDecoder = require("string_decoder").StringDecoder;
 
@@ -16,8 +17,9 @@ function FakeStringDecoderCall() {
 }
 require("util").inherits(FakeStringDecoderCall, RealStringDecoder);
 
-// extending StringDecoder is not supported
-for (const StringDecoder of [FakeStringDecoderCall, RealStringDecoder]) {
+class SubStringDecoder extends RealStringDecoder {}
+
+for (const StringDecoder of [FakeStringDecoderCall, RealStringDecoder, SubStringDecoder]) {
   describe(StringDecoder.name, () => {
     it("StringDecoder-utf8", () => {
       test("utf-8", Buffer.from("$", "utf-8"), "$");
@@ -305,6 +307,114 @@ describe("StringDecoder called without new", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "true\n", stderr: "", exitCode: 0 });
+  });
+});
+
+// A native constructor receives new.target in the this slot. One function served both [[Call]] and
+// [[Construct]], so `new Sub()` looked like `StringDecoder.call(Sub)`: it wrote the decoder state
+// onto the class and returned the class.
+describe("StringDecoder constructed with another new.target", () => {
+  it("new Sub() returns an instance of Sub", () => {
+    class Sub extends RealStringDecoder {}
+    const decoder = new Sub("utf16le");
+    expect({
+      isTheClass: decoder === Sub,
+      type: typeof decoder,
+      hasSubPrototype: Object.getPrototypeOf(decoder) === Sub.prototype,
+      instanceOfBase: decoder instanceof RealStringDecoder,
+      classKeys: Reflect.ownKeys(Sub),
+      encoding: decoder.encoding,
+      decoded: decoder.write(Buffer.from("hi", "utf16le")),
+    }).toEqual({
+      isTheClass: false,
+      type: "object",
+      hasSubPrototype: true,
+      instanceOfBase: true,
+      classKeys: ["length", "name", "prototype"],
+      encoding: "utf16le",
+      decoded: "hi",
+    });
+  });
+
+  it("a subclass can add a constructor, fields and methods", () => {
+    class Sub extends RealStringDecoder {
+      chunks = 0;
+      constructor(encoding, label) {
+        super(encoding);
+        this.label = label;
+      }
+      write(buf) {
+        this.chunks++;
+        return super.write(buf);
+      }
+    }
+    const decoder = new Sub("utf8", "euro");
+    expect(decoder.write(Buffer.from([0xe2, 0x82]))).toBe("");
+    expect({ lastNeed: decoder.lastNeed, lastTotal: decoder.lastTotal, lastChar: [...decoder.lastChar] }).toEqual({
+      lastNeed: 1,
+      lastTotal: 3,
+      lastChar: [0xe2, 0x82, 0, 0],
+    });
+    expect(decoder.write(Buffer.from([0xac]))).toBe("€");
+    expect(decoder.end()).toBe("");
+    expect({ label: decoder.label, chunks: decoder.chunks }).toEqual({ label: "euro", chunks: 2 });
+    expect(() => new Sub("bogus")).toThrow(expect.objectContaining({ code: "ERR_UNKNOWN_ENCODING" }));
+  });
+
+  // The shape of Babel's _callSuper helper: an ES5 constructor that forwards its own new.target.
+  it("Reflect.construct takes the prototype from new.target", () => {
+    function Legacy(encoding) {
+      return Reflect.construct(RealStringDecoder, [encoding], new.target);
+    }
+    Object.setPrototypeOf(Legacy.prototype, RealStringDecoder.prototype);
+    Object.setPrototypeOf(Legacy, RealStringDecoder);
+    const decoder = new Legacy("hex");
+    expect(decoder).toBeInstanceOf(Legacy);
+    expect(decoder.write(Buffer.from([0xab]))).toBe("ab");
+    expect(Object.hasOwn(Legacy, "encoding")).toBe(false);
+
+    function Unrelated() {}
+    const other = Reflect.construct(RealStringDecoder, ["latin1"], Unrelated);
+    expect(other).not.toBe(Unrelated);
+    expect(Object.getPrototypeOf(other)).toBe(Unrelated.prototype);
+    expect(Object.hasOwn(Unrelated, "encoding")).toBe(false);
+    expect(RealStringDecoder.prototype.write.call(other, Buffer.from([0xe9]))).toBe("é");
+  });
+
+  // An unfixed build writes `encoding` onto the global Object here. The delete keeps that out of other tests.
+  it("Reflect.construct with Object as new.target does not return or change Object", () => {
+    try {
+      const decoder = Reflect.construct(RealStringDecoder, ["utf8"], Object);
+      expect({
+        isObject: decoder === Object,
+        hasObjectPrototype: Object.getPrototypeOf(decoder) === Object.prototype,
+        objectHasEncoding: Object.hasOwn(Object, "encoding"),
+        decoded: RealStringDecoder.prototype.write.call(decoder, Buffer.from("hi")),
+      }).toEqual({ isObject: false, hasObjectPrototype: true, objectHasEncoding: false, decoded: "hi" });
+    } finally {
+      delete Object.encoding;
+    }
+  });
+
+  it("reads the prototype through a Proxy new.target", () => {
+    class Sub extends RealStringDecoder {}
+    const decoder = Reflect.construct(RealStringDecoder, ["utf8"], new Proxy(Sub, {}));
+    expect(decoder).toBeInstanceOf(Sub);
+    expect(decoder.write(Buffer.from("hi"))).toBe("hi");
+
+    const { proxy, revoke } = Proxy.revocable(Sub, {});
+    revoke();
+    expect(() => Reflect.construct(RealStringDecoder, ["utf8"], proxy)).toThrow(TypeError);
+  });
+
+  it("a class from a node:vm context can extend StringDecoder", () => {
+    const result = vm.runInNewContext(
+      `class Sub extends StringDecoder {}
+       const decoder = new Sub("utf8");
+       [decoder instanceof Sub, decoder instanceof StringDecoder, decoder.write(bytes)];`,
+      { StringDecoder: RealStringDecoder, bytes: Buffer.from("hi") },
+    );
+    expect([...result]).toEqual([true, true, "hi"]);
   });
 });
 


### PR DESCRIPTION
### Problem
- `class Sub extends StringDecoder {}; new Sub("utf8")` returns the class `Sub` itself. `s.write` is `undefined`, and `Sub` gains an own `encoding` property. `Reflect.construct(StringDecoder, ["utf8"], Object)` returns `Object`. Node returns an instance.
- `JSStringDecoderConstructor` registers one native function for [[Call]] and [[Construct]] (`src/jsc/bindings/JSStringDecoder.h:118`). JSC passes new.target in the `this` slot of a native constructor, so the branch for `StringDecoder.call(receiver, encoding)` (`JSStringDecoder.cpp:592`) takes `Sub` as the receiver.
- Found by an audit. No issue reports it.

### Fix
- Register separate `call` and `construct` functions that share one `createDecoder` body. For a [[Construct]] it takes the structure from new.target with `InternalFunction::createSubclassStructure`, as `JSHash` and the generated classes do. `call` keeps the receiver branch unchanged.
- The Node.js compatibility page no longer lists this gap. Not in this PR: `JSMockFunction.cpp:459` has the same cause, and #34575 and #41398 carry it.
- `new StringDecoder()` costs the same as before (ThinLTO A/B in the notes).
- Verified: `test/js/node/string_decoder/string-decoder.test.js` (143 pass, released bun fails the 45 new cases), Node's `test-string-decoder*.js`, `express-body-parser-test.test.ts`. Self-reviewed: 4 concerns raised, 4 addressed.

### Background
- [[Call]] is `f()`. [[Construct]] is `new f()` or `Reflect.construct`. A JSC `InternalFunction` takes one native function for each.
- new.target is the constructor that `new` was applied to: `Sub` for `new Sub()`. The new object takes its prototype from it.
- A JSC `Structure` holds the prototype of an object. `createSubclassStructure` returns the base structure with the prototype of new.target.
- The receiver branch serves iconv-lite 0.4 (under express body-parser), which runs `StringDecoder.call(this, enc)` on a plain object. It stores the native decoder on that object.

<details><summary>Notes</summary>

**Repro**

```js
const { StringDecoder } = require("string_decoder");
class Sub extends StringDecoder {}
const s = new Sub("utf8");
console.log(s === Sub, typeof s, s instanceof Sub, Reflect.ownKeys(Sub));
// bun 1.4.3:    true function false [ "length", "name", "prototype", "encoding" ]
// node v26.3.0: false object true [ 'length', 'name', 'prototype' ]
// this branch:  false object true [ "length", "name", "prototype" ]
```

**Sibling sites** (every place that registers one function for both [[Call]] and [[Construct]])

- `src/jsc/bindings/JSMockFunction.cpp:459`: `jsMockFunctionCall` reads `thisValue()`, so `new mockFn()` sees new.target as `this`. Same root cause. Excluded here because #34575 and #41398 already change that function. This PR does not fix `mock()` or `spyOn()`.
- These never read `this` or new.target, so the confusion cannot happen there: the seven sink constructors from `src/codegen/generate-jssink.ts:59` (`js_construct` ignores the frame), `JSDOMConstructorNotConstructable` (throws on both paths), the `ObjectTemplate` `DummyCallback` in the V8 shim, `jsNodeVmWasmDisallowed` (`NodeVM.cpp:1046`, throws on both paths), `vm.createContext` (`NodeVM.cpp:1714`), and `SlowBuffer`.
- #42528 makes other native constructors honor new.target. It does not cover `StringDecoder`.

**Cost of `new StringDecoder()`**

A first version had a parse helper and called `JSStringDecoder::create` from both `call` and `construct`. With two call sites, `allocateCell<JSStringDecoder>` went out of line and `new StringDecoder()` got slower. One shared `createDecoder` keeps a single call site for the allocation, and `construct` compiles to 9 instructions that end in `jmp createDecoder`.

ThinLTO release build, only this translation unit replaced, one pinned core, 300 reps of 200000 constructions, p50 in ns over 5 alternating rounds:

| variant | `new StringDecoder()` | `new StringDecoder("utf8")` |
| --- | --- | --- |
| main | 11.6 to 12.3 | 19.5 to 21.1 |
| first version | 14.9 to 16.1 | 19.8 to 20.9 |
| this PR | 11.4 to 12.6 | 18.0 to 19.3 |

**Behavior details**

- Order matches Node: the `prototype` of new.target is read before the encoding is parsed (probed with a Proxy new.target and an encoding object with a `toString`).
- `call` is unchanged, including the `thisValue != constructor` check, so `StringDecoder.call(StringDecoder, enc)` still returns a fresh decoder. The two `putDirect` lines in the receiver branch are textually untouched, so #34609 and other work on that branch should merge without a conflict.
- A new.target whose `prototype` is not an object gets `StringDecoder.prototype`, as for every JSC built-in class. Node gives `Object.prototype` there, because its `StringDecoder` is an ordinary function.
- Cross-realm: a class defined in a `node:vm` context or a ShadowRealm can extend `StringDecoder`. The function realm of new.target is not always a `Zig::GlobalObject`, so the code goes through `defaultGlobalObject()`. A revoked Proxy as new.target throws a TypeError.
- Remaining difference, not changed here: Node's `end(buf)` and `text()` call `this.write()`, so a subclass that overrides `write` sees those calls. Bun's native `end` and `text` call the native write directly. A plain instance with a patched `write` shows the same difference today.
- Not changed here: `lastNeed`, `lastTotal` and `lastChar` throw on a `StringDecoder.call(this)` receiver, because the prototype accessors have a class check. Instances of a subclass are real `JSStringDecoder` cells, so the accessors work on them.

**Suites run with the debug (ASAN) build**

- `test/js/node/string_decoder/string-decoder.test.js`: 143 pass. The whole decode suite now also runs against `class SubStringDecoder extends StringDecoder`. Released bun 1.4.3: 98 pass, 45 fail.
- The same file and a script of every throw path under `BUN_JSC_validateExceptionChecks=1`: clean.
- `test/js/node/test/parallel/`: `test-string-decoder.js`, `test-string-decoder-end.js`, `test-string-decoder-fuzz.js`, `test-crypto-hash.js`, `test-fs-read-stream-encoding.js`, `test-readline-keys.js`, `test-stream-decoder-objectmode.js`, `test-stream-push-strings.js`, `test-stream-readable-setEncoding-existing-buffers.js`, `test-stream-readable-setEncoding-null.js`, `test-stream2-decode-partial.js`, `test-stream2-set-encoding.js`.
- `test/js/third_party/body-parser/express-body-parser-test.test.ts`, and iconv-lite 0.4.24 (`StringDecoder.call(this, enc)` with `InternalDecoder.prototype = StringDecoder.prototype`) by hand.

**Self-review**

The review asked for four changes. All are in this PR: the stale docs line, the sibling-sites list, the slower `new StringDecoder()` of the first version, and multi-line comments in `src/`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/string_decoder/string-decoder.test.js
ninja: Entering directory `/workspace/bun/build/debug'
[1/164] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/164] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/164] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes
... (truncated)

release without fix: 45 FAILED
bun test v1.4.3-canary.1 (6a92015fc)

test/js/node/string_decoder/string-decoder.test.js:
(pass) require('string_decoder') [0.10ms]
(pass) Bun.inspect(StringDecoder) [0.09ms]
(pass) FakeStringDecoderCall > StringDecoder-utf8 [1.88ms]
(pass) FakeStringDecoderCall > StringDecoder-ucs-2 [0.94ms]
(pass) FakeStringDecoderCall > StringDecoder-utf16le [0.04ms]
(pass) FakeStringDecoderCall > StringDecoder-utf8-additional [0.11ms]
(pass) FakeStringDecoderCall > StringDecoder-utf16le-additional [0.06ms]
(pass) FakeStringDecoderCall > StringDecoder.end > base64 testbuf [0.18ms]
(pass) FakeStringDecoderCall > StringDecoder.end > base64url testbuf [0.10ms]
(pass) FakeStringDecoderCall > StringDecoder.end > hex testbuf [0.11ms]
(pass) FakeStringDecoderCall > StringDecoder.end > utf8 testbuf [0.06ms]
(pass) FakeStringDecoderCall > StringDecoder.end > utf16le testbuf [0.04ms]
(pass) FakeStringDecoderCall > StringDecoder.end > ucs2 testbuf [0.05ms]
(pass) FakeStringDecoderCall > StringDecoder.end > utf8 partial "�a" [0.03ms]
(pass) FakeStringDecoderCall > StringDecoder.end > utf8 partial "��"
(pass) FakeStringDecoderCall > StringDecoder.end > utf8 partial "��"
(pass) FakeS
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/string_decoder/string-decoder.test.js
bun test v1.4.3 (6a92015fc)

test/js/node/string_decoder/string-decoder.test.js:
(pass) require('string_decoder') [6.27ms]
(pass) Bun.inspect(StringDecoder) [5.39ms]
(pass) FakeStringDecoderCall > StringDecoder-utf8 [340.80ms]
(pass) FakeStringDecoderCall > StringDecoder-ucs-2 [239.90ms]
(pass) FakeStringDecoderCall > StringDecoder-utf16le [4.82ms]
(pass) FakeStringDecoderCall > StringDecoder-utf8-additional [9.54ms]
(pass) FakeStringDecoderCall > StringDecoder-utf16le-additional [8.09ms]
(pass) FakeStringDecoderCall > StringDecoder.end > base64 testbuf [25.18ms]
(pass) FakeStringDecoderCall > StringDecoder.end > base64url testbuf [17.47ms]
(pass) FakeStringDecoderCall > StringDecoder.end > hex testbuf [13.70ms]
(pass) FakeStringDecoderCall > StringDecoder.end > utf8 testbuf [15.44ms]
(pass) FakeStringDecoderCall > StringDecoder.end > utf16le testbuf [11.48ms]
(pass) FakeStringDecoderCall > StringDecoder.end > ucs2 testbuf [12.16ms]
(pass) FakeStringDecoderCall > StringDecoder.end > utf
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 706ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/125] cc obj/src/jsc/bindings/sqlite/sqlite3.c.o
[2/125] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/125] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/nodejs-compat.mdx                     |   2 +-
 src/jsc/bindings/JSStringDecoder.cpp               |  45 ++++++--
 src/jsc/bindings/JSStringDecoder.h                 |   5 +-
 test/js/node/string_decoder/string-decoder.test.js | 114 ++++++++++++++++++++-
 4 files changed, 151 insertions(+), 15 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
docs/runtime/nodejs-compat.mdx                          1      1     18
src/jsc/bindings/JSStringDecoder.cpp                    5     12     18
src/jsc/bindings/JSStringDecoder.h                      1      1     18
test/js/node/string_decoder/string-decoder.test.js      2      5     18
```

</details>

<!-- robobun:evidence:end -->