### PR TITLE
node:stream: close or error the web stream when a native Readable.fromWeb ends

### DIFF
--- a/src/js/internal/streams/native-readable.ts
+++ b/src/js/internal/streams/native-readable.ts
@@ -11,8 +11,14 @@ const transferToNativeReadable = $newCppFunction(
   "jsFunctionTransferToNativeReadableStream",
   1,
 );
+const closeTransferredReadableStream = $newCppFunction(
+  "streams/BunStreamConsumers.cpp",
+  "jsFunctionCloseTransferredReadableStream",
+  1,
+);
 const { errorOrDestroy } = require("internal/streams/destroy");
 
+const kWebStream = Symbol("webStream");
 const kRefCount = Symbol("refCount");
 const kCloseState = Symbol("closeState");
 const kConstructed = Symbol("constructed");
@@ -31,6 +37,7 @@ type NativeReadable = typeof import("node:stream").Readable &
   typeof import("node:stream").Stream & {
     push: (chunk: any) => boolean;
     $bunNativePtr?: NativePtr;
+    [kWebStream]: ReadableStream | undefined;
     [kRefCount]: number;
     [kCloseState]: [boolean];
     [kPendingRead]: boolean;
@@ -91,10 +98,41 @@ function constructNativeReadable(readableStream: ReadableStream, options): Nativ
   // We can't update those handles to point to the NativeReadable from JS
   // So we instead mark it as no longer usable, and create a new NativeReadable
   transferToNativeReadable(readableStream);
+  stream[kWebStream] = readableStream;
+  // Node: `reader.closed` rejects and the Readable fails with that error, for example the abort reason of a fetch().
+  $webStreamClosedPromise(readableStream).$then(undefined, error => errorOrDestroy(stream, error));
 
   $debug(`[${stream.debugId}] constructed!`);
 
   return stream;
+}
+
+// The transferred web stream has no reader and no controller: only this Readable can close or error it, as a reader does in Node.
+function closeWebStream(stream: NativeReadable) {
+  const webStream = stream[kWebStream];
+  if (webStream === undefined) return;
+  stream[kWebStream] = undefined;
+  closeTransferredReadableStream(webStream);
+}
+
+function errorWebStream(stream: NativeReadable, error: unknown) {
+  const webStream = stream[kWebStream];
+  if (webStream === undefined) return;
+  stream[kWebStream] = undefined;
+  $webStreamControllerError(webStream, error);
+}
+
+function endOfSource(stream: NativeReadable) {
+  const webStream = stream[kWebStream];
+  if (webStream !== undefined) {
+    // A fetch() abort errors the web stream, then ends its source: not an EOF, and it can get here before the handler above runs.
+    const closed = $webStreamClosedPromise(webStream);
+    if ($isPromiseRejected(closed)) return errorOrDestroy(stream, $peekPromiseSettledValue(closed));
+  }
+  closeWebStream(stream);
+  process.nextTick(() => {
+    stream.push(null);
+  });
 }
 
 function ensureConstructed(this: NativeReadable, cb: null | (() => void)) {
@@ -123,7 +161,17 @@ function getRemainingChunk(stream: NativeReadable, maxToRead?: number) {
   return chunk;
 }
 
+// start() and pull() throw when the source fails. Readable.read() catches the rethrow and destroys this stream with it.
 function read(this: NativeReadable, maxToRead: number) {
+  try {
+    return readFromHandle.$call(this, maxToRead);
+  } catch (error) {
+    errorWebStream(this, error);
+    throw error;
+  }
+}
+
+function readFromHandle(this: NativeReadable, maxToRead: number) {
   $debug(`[${this.debugId}] read${this[kPendingRead] ? ", is already pending" : ""}`);
   var ptr = this.$bunNativePtr;
   // Readable called `_read`, so it wants data: make sure the native reader is
@@ -135,6 +183,7 @@ function read(this: NativeReadable, maxToRead: number) {
   }
   if (!ptr) {
     $debug(`[${this.debugId}] read, no ptr`);
+    closeWebStream(this);
     this.push(null);
     return;
   }
@@ -172,6 +221,7 @@ function read(this: NativeReadable, maxToRead: number) {
         this[kRemainingChunk] = handleResult(this, result, chunk, this[kCloseState][0]);
       },
       reason => {
+        errorWebStream(this, reason);
         errorOrDestroy(this, reason);
       },
     );
@@ -189,9 +239,7 @@ function handleResult(stream: NativeReadable, result: any, chunk: Buffer, isClos
     return handleNumberResult(stream, result, chunk, isClosed);
   } else if (typeof result === "boolean") {
     $debug(`[${stream.debugId}] handleResult(${result})`, chunk, isClosed);
-    process.nextTick(() => {
-      stream.push(null);
-    });
+    endOfSource(stream);
     return (chunk?.byteLength ?? 0) > 0 ? chunk : undefined;
   } else if ($isTypedArrayView(result)) {
     if (result.byteLength >= stream[kHighWaterMark] && !stream[kHasResized] && !isClosed) {
@@ -223,9 +271,7 @@ function handleNumberResult(stream: NativeReadable, result: number, chunk: any, 
   }
 
   if (isClosed) {
-    process.nextTick(() => {
-      stream.push(null);
-    });
+    endOfSource(stream);
   }
 
   return chunk;
@@ -237,9 +283,7 @@ function handleArrayBufferViewResult(stream: NativeReadable, result: any, chunk:
   }
 
   if (isClosed) {
-    process.nextTick(() => {
-      stream.push(null);
-    });
+    endOfSource(stream);
   }
 
   return chunk;
@@ -251,6 +295,8 @@ function adjustHighWaterMark(stream: NativeReadable) {
 }
 
 function destroy(this: NativeReadable, error: any, cb: () => void) {
+  // A cancel closes a web stream whatever the reason is. It never errors it.
+  closeWebStream(this);
   const ptr = this.$bunNativePtr;
   if (ptr) {
     ptr.cancel(error);

--- a/src/js/internal/webstreams_adapters.ts
+++ b/src/js/internal/webstreams_adapters.ts
@@ -12,9 +12,10 @@ const Writable = require("internal/streams/writable");
 const Readable = require("internal/streams/readable");
 const Duplex = require("internal/streams/duplex");
 const { destroyer } = require("internal/streams/destroy");
+const { addAbortSignal } = require("internal/streams/add-abort-signal");
 const { isDestroyed, isReadable, isWritable, isWritableEnded } = require("internal/streams/utils");
 const { kEmptyObject } = require("internal/shared");
-const { validateBoolean, validateObject, validateOneOf } = require("internal/validators");
+const { validateAbortSignal, validateBoolean, validateObject, validateOneOf } = require("internal/validators");
 const { isAnyArrayBuffer } = require("node:util/types");
 const eos = require("internal/streams/end-of-stream");
 const { kEosNodeSynchronousCallback } = eos;
@@ -46,13 +47,13 @@ class ReadableFromWeb extends Readable {
   #closed;
   #stream;
 
+  // No `signal`: an aborted one would run _destroy inside super(), before the private fields exist.
   constructor(options, stream) {
-    const { objectMode, highWaterMark, encoding, signal } = options;
+    const { objectMode, highWaterMark, encoding } = options;
     super({
       objectMode,
       highWaterMark,
       encoding,
-      signal,
     });
     this.#reader = undefined;
     this.#stream = stream;
@@ -558,21 +559,22 @@ function newStreamReadableFromReadableStream(readableStream, options: Record<str
 
   // Node acquires the reader at this point, so a locked stream throws here too.
   if (readableStream.locked) throw $ERR_INVALID_STATE_TypeError("ReadableStream is locked");
+  if (signal) validateAbortSignal(signal, "signal");
 
-  const nativeStream = tryTransferToNativeReadable(readableStream, options);
-
-  return (
-    nativeStream ||
-    new ReadableFromWeb(
-      {
-        highWaterMark,
-        encoding,
-        objectMode,
-        signal,
-      },
-      readableStream,
-    )
-  );
+  const readableOptions = { highWaterMark, encoding, objectMode };
+  const readable =
+    tryTransferToNativeReadable(readableStream, readableOptions) ||
+    new ReadableFromWeb(readableOptions, readableStream);
+  if (signal) {
+    try {
+      // Added last: an aborted signal destroys the Readable inside its constructor, before either adapter can cancel the web stream.
+      addAbortSignal(signal, readable);
+    } catch (error) {
+      readable.destroy();
+      throw error;
+    }
+  }
+  return readable;
 }
 
 let dep0201Warned = false;

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -1405,6 +1405,19 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionTransferToNativeReadableStream, (JSGlobalObje
     return JSValue::encode(jsUndefined());
 }
 
+// A transferred stream has no reader and no controller: the NativeReadable that drives its handle reports the end. The lock (m_transferred) stays.
+JSC_DEFINE_HOST_FUNCTION(jsFunctionCloseTransferredReadableStream, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto* stream = dynamicDowncast<JSReadableStream>(callFrame->argument(0));
+    if (!stream || !stream->m_transferred)
+        return JSValue::encode(jsUndefined());
+    Bun::WebStreams::readableStreamCloseIfPossible(globalObject, stream);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(jsUndefined());
+}
+
 // [reaction-convention] handlers (FOR_EACH_WEB_STREAMS_REACTION_HANDLER_BUN_CONSUMERS).
 
 JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onBufferedFastPathRejected, (JSGlobalObject * globalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.h
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.h
@@ -20,5 +20,7 @@ JSC_DECLARE_HOST_FUNCTION(jsFunctionReadableStreamToFormData);
 // body: dynamicDowncast<JSReadableStream>(arg0)->{m_transferred = true, m_disturbed = true}.
 // Referenced by src/js/internal/streams/native-readable.ts via $newCppFunction.
 JSC_DECLARE_HOST_FUNCTION(jsFunctionTransferToNativeReadableStream);
+// body: readableStreamCloseIfPossible(arg0) when arg0 is a transferred JSReadableStream. Also for native-readable.ts.
+JSC_DECLARE_HOST_FUNCTION(jsFunctionCloseTransferredReadableStream);
 
 } // namespace WebCore

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -3,7 +3,19 @@ import { describe, expect, it, jest } from "bun:test";
 import { bunEnv, bunExe, bunRun, isGlibcVersionAtLeast, isMacOS, tempDir, tmpdirSync } from "harness";
 import { createReadStream, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { Duplex, duplexPair, finished, PassThrough, Readable, Stream, Transform, Writable } from "node:stream";
+import {
+  addAbortSignal,
+  Duplex,
+  duplexPair,
+  finished,
+  isErrored,
+  isReadable,
+  PassThrough,
+  Readable,
+  Stream,
+  Transform,
+  Writable,
+} from "node:stream";
 import { finished as finishedP } from "node:stream/promises";
 import { join } from "path";
 
@@ -561,6 +573,229 @@ it("Readable.fromWeb async iteration rejects with the web stream error", async (
   expect(r.destroyed).toBe(true);
 });
 
+// Readable.fromWeb takes the native handle of a Blob, Bun.file(), fetch() or Bun.spawn() stream
+// and drives it itself. The web stream stays locked, with no reader and no controller, so only
+// that Readable can take it out of the readable state. Node reads through a reader: the web
+// stream closes or errors with its source, and a cancel closes it.
+describe.concurrent("Readable.fromWeb over a native stream ends the web stream", () => {
+  const { _ReadableFromWeb: ReadableFromWeb } = exposedInternals["internal/webstreams/adapters"];
+  // Every source below delivers this in more than one chunk, except an already buffered fetch() body.
+  const payload = Buffer.alloc(512 * 1024, "a");
+
+  const state = web => ({
+    readable: isReadable(web),
+    errored: isErrored(web),
+    locked: web.locked,
+    inspect: /state: '(\w+)'/.exec(Bun.inspect(web))?.[1],
+  });
+  const readable = { readable: true, errored: false, locked: true, inspect: "readable" };
+  const closed = { readable: false, errored: false, locked: true, inspect: "closed" };
+  const errored = { readable: false, errored: true, locked: true, inspect: "errored" };
+
+  const event = (emitter, name) => new Promise(resolve => emitter.once(name, resolve));
+
+  // The native path returns a plain Readable. The reader-based adapter is a ReadableFromWeb.
+  const fromWebNative = (web, options) => {
+    const node = Readable.fromWeb(web, options);
+    expect(node).not.toBeInstanceOf(ReadableFromWeb);
+    return node;
+  };
+
+  const sources = {
+    "new Blob().stream()": () => new Blob([payload]).stream(),
+    "new Response(bytes).body": () => new Response(payload).body,
+    "Bun.file().stream()": ({ file }) => Bun.file(file).stream(),
+    "a fetch() body": async ({ url }) => (await fetch(url)).body,
+  };
+
+  it.each(Object.keys(sources))("%s closes when the Readable reads it to the end", async name => {
+    using dir = tempDir("fromweb-native-end", { "payload.bin": payload });
+    await using server = Bun.serve({ port: 0, fetch: () => new Response(payload) });
+    const web = await sources[name]({ file: join(String(dir), "payload.bin"), url: server.url });
+    // Requested while the stream is readable, so the stream has to settle it later.
+    const early = finishedP(web);
+    let length = 0;
+    for await (const chunk of fromWebNative(web)) length += chunk.length;
+    expect(length).toBe(payload.length);
+    expect(state(web)).toEqual(closed);
+    await early;
+    await finishedP(web);
+  });
+
+  it("Bun.spawn().stdout closes when the Readable reads it to the end", async () => {
+    await using child = Bun.spawn({
+      cmd: [bunExe(), "-e", `process.stdout.write(Buffer.alloc(${payload.length}, "a"))`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const web = child.stdout;
+    let length = 0;
+    for await (const chunk of fromWebNative(web)) length += chunk.length;
+    expect(length).toBe(payload.length);
+    expect(state(web)).toEqual(closed);
+    await finishedP(web);
+    expect(await child.exited).toBe(0);
+  });
+
+  it("a fetch() body stays readable until its last chunk arrives", async () => {
+    const { promise: released, resolve: release } = Promise.withResolvers();
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () =>
+        new Response(
+          new ReadableStream({
+            async pull(controller) {
+              controller.enqueue(new TextEncoder().encode("first "));
+              await released;
+              controller.enqueue(new TextEncoder().encode("last"));
+              controller.close();
+            },
+          }),
+        ),
+    });
+    const web = (await fetch(server.url)).body;
+    const node = fromWebNative(web);
+    const chunks = [];
+    node.on("data", chunk => chunks.push(chunk));
+    await event(node, "data");
+    expect(state(web)).toEqual(readable);
+    release();
+    await event(node, "end");
+    expect(Buffer.concat(chunks).toString()).toBe("first last");
+    expect(state(web)).toEqual(closed);
+  });
+
+  // Every early stop cancels the source. A cancel closes a web stream whatever the reason is:
+  // Node leaves the stream closed, not errored, after destroy(error) too.
+  const stops = {
+    "destroy() before the first read": node => node.destroy(),
+    "destroy(error) before the first read": node => node.destroy(new Error("consumer gone")),
+    "destroy() after a chunk": async node => {
+      await event(node, "data");
+      node.destroy();
+    },
+    "destroy(error) after a chunk": async node => {
+      await event(node, "data");
+      node.destroy(new Error("consumer gone"));
+    },
+    "a break out of for await": async node => {
+      for await (const _ of node) break;
+    },
+    "its abort signal": async (node, abort) => {
+      await event(node, "data");
+      abort.abort();
+    },
+  };
+
+  describe.each(["new Blob().stream()", "Bun.file().stream()"])("%s closes when the Readable stops with", source => {
+    it.each(Object.keys(stops))("%s", async stop => {
+      using dir = tempDir("fromweb-native-end", { "payload.bin": payload });
+      const web = await sources[source]({ file: join(String(dir), "payload.bin") });
+      const early = finishedP(web);
+      const abort = new AbortController();
+      const node = fromWebNative(web, { signal: abort.signal });
+      node.on("error", () => {});
+      const stopped = event(node, "close");
+      await stops[stop](node, abort);
+      await stopped;
+      expect(state(web)).toEqual(closed);
+      await early;
+      await finishedP(web);
+    });
+
+    // The Readable constructor handles such a signal before fromWeb has set the Readable up.
+    it("a signal that is already aborted", async () => {
+      using dir = tempDir("fromweb-native-end", { "payload.bin": payload });
+      const web = await sources[source]({ file: join(String(dir), "payload.bin") });
+      const node = fromWebNative(web, { signal: AbortSignal.abort() });
+      const [error] = await Promise.all([event(node, "error"), event(node, "close")]);
+      expect(error.name).toBe("AbortError");
+      expect(state(web)).toEqual(closed);
+      await finishedP(web);
+    });
+  });
+
+  // Node watches reader.closed. Whatever errors the web stream also fails the Readable.
+  it("the Readable fails when something else errors the web stream", async () => {
+    const web = new Blob([payload]).stream();
+    const abort = new AbortController();
+    addAbortSignal(abort.signal, web);
+    const node = fromWebNative(web);
+    const outcome = Promise.race([event(node, "error"), event(node, "end").then(() => "end")]);
+    // Paused: the Readable stops at its highWaterMark, so the source has not ended yet.
+    await event(node, "readable");
+    abort.abort();
+    node.resume();
+    expect((await outcome).name).toBe("AbortError");
+    expect(state(web)).toEqual(errored);
+  });
+
+  // An abort errors the body stream of the Response and then ends its source. The Readable must
+  // not take that for the end of the body.
+  it("a fetch() body fails with the abort reason of its fetch", async () => {
+    // Serves the first chunk of a chunked body and never the rest.
+    using upstream = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        data(socket) {
+          socket.write("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n6\r\nfirst \r\n");
+        },
+      },
+    });
+    const abort = new AbortController();
+    const response = await fetch(`http://127.0.0.1:${upstream.port}/`, { signal: abort.signal });
+    const web = response.body;
+    const node = fromWebNative(web);
+    const outcome = Promise.race([event(node, "error"), event(node, "end").then(() => "end")]);
+    expect(String(await event(node, "data"))).toBe("first ");
+    const reason = new Error("stop the download");
+    abort.abort(reason);
+    expect(await outcome).toBe(reason);
+    expect(state(web)).toEqual(errored);
+    expect(await finishedP(web).catch(error => error)).toBe(reason);
+  });
+
+  it("Bun.file().stream() errors when its file does not open", async () => {
+    using dir = tempDir("fromweb-native-end", {});
+    const web = Bun.file(join(String(dir), "missing")).stream();
+    const early = finishedP(web).catch(error => error);
+    const node = fromWebNative(web);
+    const failed = event(node, "error");
+    node.resume();
+    const error = await failed;
+    expect(error.code).toBe("ENOENT");
+    expect(state(web)).toEqual(errored);
+    expect(await early).toBe(error);
+    expect(await finishedP(web).catch(error => error)).toBe(error);
+  });
+
+  it("a fetch() body errors when its connection drops", async () => {
+    // Serves a chunked body and drops the connection in the middle of it.
+    const connections = [];
+    using upstream = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        data(socket) {
+          socket.write("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n6\r\nfirst \r\n");
+          connections.push(socket);
+        },
+      },
+    });
+    const web = (await fetch(`http://127.0.0.1:${upstream.port}/`)).body;
+    const node = fromWebNative(web);
+    const failed = event(node, "error");
+    expect(String(await event(node, "data"))).toBe("first ");
+    for (const connection of connections) connection.end();
+    const error = await failed;
+    expect(error.code).toBe("ECONNRESET");
+    expect(state(web)).toEqual(errored);
+    expect(await finishedP(web).catch(error => error)).toBe(error);
+  });
+});
+
 it("Readable.fromWeb destroyed before the first read cancels the web stream", async () => {
   let cancelReason;
   const web = new ReadableStream({
@@ -576,6 +811,40 @@ it("Readable.fromWeb destroyed before the first read cancels the web stream", as
   await promise;
   expect(cancelReason?.message).toBe("user-destroy");
   expect(r.destroyed).toBe(true);
+});
+
+it("Readable.fromWeb with a signal that is already aborted cancels the web stream", async () => {
+  let cancelReason;
+  const web = new ReadableStream({
+    cancel(reason) {
+      cancelReason = reason;
+    },
+  });
+  const r = Readable.fromWeb(web, { signal: AbortSignal.abort() });
+  const [error] = await Promise.all([
+    new Promise(resolve => r.once("error", resolve)),
+    new Promise(resolve => r.once("close", resolve)),
+  ]);
+  expect(error.name).toBe("AbortError");
+  expect(cancelReason).toBe(error);
+  await finishedP(web);
+});
+
+it("Readable.fromWeb rejects an invalid signal before it takes the web stream", () => {
+  for (const web of [new ReadableStream({}), new Blob(["payload"]).stream()]) {
+    expect(() => Readable.fromWeb(web, { signal: {} })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+    expect(web.locked).toBe(false);
+  }
+});
+
+it("Readable.fromWeb cancels the web stream when it cannot listen to the signal", () => {
+  for (const web of [new ReadableStream({}), new Blob(["payload"]).stream()]) {
+    // Has the `aborted` that the check of the option looks for, but no addEventListener().
+    expect(() => Readable.fromWeb(web, { signal: { aborted: false } })).toThrow(TypeError);
+    expect(isReadable(web)).toBe(false);
+  }
 });
 
 it("Readable.fromWeb: breaking out of for-await cancels the web source with ABORT_ERR", async () => {

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -1,6 +1,7 @@
 import { exposedInternals } from "bun:internal-for-testing";
 import { describe, expect, it, jest } from "bun:test";
 import { bunEnv, bunExe, bunRun, isGlibcVersionAtLeast, isMacOS, tempDir, tmpdirSync } from "harness";
+import { once } from "node:events";
 import { createReadStream, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import {
@@ -592,6 +593,8 @@ describe.concurrent("Readable.fromWeb over a native stream ends the web stream",
   const closed = { readable: false, errored: false, locked: true, inspect: "closed" };
   const errored = { readable: false, errored: true, locked: true, inspect: "errored" };
 
+  // Only for "error", and for a "close" that can follow an "error". Every other wait uses once(),
+  // which rejects when "error" comes first, so that the wait cannot hang.
   const event = (emitter, name) => new Promise(resolve => emitter.once(name, resolve));
 
   // The native path returns a plain Readable. The reader-based adapter is a ReadableFromWeb.
@@ -658,10 +661,10 @@ describe.concurrent("Readable.fromWeb over a native stream ends the web stream",
     const node = fromWebNative(web);
     const chunks = [];
     node.on("data", chunk => chunks.push(chunk));
-    await event(node, "data");
+    await once(node, "data");
     expect(state(web)).toEqual(readable);
     release();
-    await event(node, "end");
+    await once(node, "end");
     expect(Buffer.concat(chunks).toString()).toBe("first last");
     expect(state(web)).toEqual(closed);
   });
@@ -672,18 +675,18 @@ describe.concurrent("Readable.fromWeb over a native stream ends the web stream",
     "destroy() before the first read": node => node.destroy(),
     "destroy(error) before the first read": node => node.destroy(new Error("consumer gone")),
     "destroy() after a chunk": async node => {
-      await event(node, "data");
+      await once(node, "data");
       node.destroy();
     },
     "destroy(error) after a chunk": async node => {
-      await event(node, "data");
+      await once(node, "data");
       node.destroy(new Error("consumer gone"));
     },
     "a break out of for await": async node => {
       for await (const _ of node) break;
     },
     "its abort signal": async (node, abort) => {
-      await event(node, "data");
+      await once(node, "data");
       abort.abort();
     },
   };
@@ -724,7 +727,7 @@ describe.concurrent("Readable.fromWeb over a native stream ends the web stream",
     const node = fromWebNative(web);
     const outcome = Promise.race([event(node, "error"), event(node, "end").then(() => "end")]);
     // Paused: the Readable stops at its highWaterMark, so the source has not ended yet.
-    await event(node, "readable");
+    await once(node, "readable");
     abort.abort();
     node.resume();
     expect((await outcome).name).toBe("AbortError");
@@ -749,7 +752,7 @@ describe.concurrent("Readable.fromWeb over a native stream ends the web stream",
     const web = response.body;
     const node = fromWebNative(web);
     const outcome = Promise.race([event(node, "error"), event(node, "end").then(() => "end")]);
-    expect(String(await event(node, "data"))).toBe("first ");
+    expect(String((await once(node, "data"))[0])).toBe("first ");
     const reason = new Error("stop the download");
     abort.abort(reason);
     expect(await outcome).toBe(reason);
@@ -787,7 +790,7 @@ describe.concurrent("Readable.fromWeb over a native stream ends the web stream",
     const web = (await fetch(`http://127.0.0.1:${upstream.port}/`)).body;
     const node = fromWebNative(web);
     const failed = event(node, "error");
-    expect(String(await event(node, "data"))).toBe("first ");
+    expect(String((await once(node, "data"))[0])).toBe("first ");
     for (const connection of connections) connection.end();
     const error = await failed;
     expect(error.code).toBe("ECONNRESET");


### PR DESCRIPTION
### Problem
- After `Readable.fromWeb(stream)` ends or is destroyed, a native `stream` (`Blob`, `Bun.file()`, `fetch()` body, `Bun.spawn()` stdout) stays `readable`. `Bun.inspect(stream)` prints `state: 'readable'`, `finished(stream)` never settles, and `isReadable(stream)` is `true` (since #42416, not released). Node v26.3.0 closes it.
- `fromWeb` gives the stream's native handle to a `NativeReadable` (`src/js/internal/streams/native-readable.ts`). `jsFunctionTransferToNativeReadableStream` (`BunStreamConsumers.cpp:1399`) only sets `m_transferred` and `m_disturbed`. Nothing reports the end of the handle to the stream.
- A `fetch()` abort errors the body stream, then ends its source. The `Readable` emits `end`: a truncated download looks complete.

### Fix
- The `NativeReadable` keeps the web stream. It closes the stream at the last chunk and on `destroy()` (Node: `reader.cancel(err)`, and a cancel closes a stream). It errors the stream when `start()` or `pull()` fail.
- It watches the stream's closed promise, as Node watches `reader.closed`: an error of the web stream fails the `Readable`.
- `fromWeb` adds `signal` last. An already aborted signal ran `destroy()` inside the constructor, before an adapter could cancel the web stream.
- Verified: `test/js/node/stream/node-stream.test.js` (27 new tests, 26 fail on main).

### Background
- A native `ReadableStream` holds a handle to a Rust source in `m_nativePtr`. A JS reader builds a controller over it, which closes or errors the stream.
- `fromWeb` skips the reader. A `NativeReadable` is a plain `Readable` whose `_read` calls `handle.pull()`. `child_process` uses it for `stdout` and `stderr`.
- `m_transferred` makes `stream.locked` true without a reader.
- `finished(webStream)` waits on a closed promise that each change of `m_state` settles.

<details><summary>Notes</summary>

**Origin.** A differential run against node v26.3.0 after #42416 found this. No user reported it. The `readable` state and the pending `finished()` are the same on 1.4.2. #42516 and #42477 (merged) fix the same symptom for the two other takers of a native stream: a body method that lifts the payload, and a native sink. #42516 names this change as its follow-up.

**Reproduction.**

```js
import { Readable, isReadable } from "node:stream";
import { finished } from "node:stream/promises";
const web = new Blob(["hello"]).stream();
for await (const chunk of Readable.fromWeb(web)) {
}
isReadable(web); // main: true, node and this branch: false
Bun.inspect(web); // main: state: 'readable', this branch: state: 'closed'
await finished(web); // main: never settles
```

**State of the web stream**, checked against node v26.3.0:

| event | node | main | this branch |
| --- | --- | --- | --- |
| read to the end | closed | readable | closed |
| `destroy()` or `destroy(err)`, before the first read or after a chunk | closed | readable | closed |
| `break` out of `for await` | closed | readable | closed |
| abort of the `signal` option | closed | readable | closed |
| `signal` already aborted | closed | readable | closed |
| the source fails (missing file, dropped connection) | errored | readable | errored |

`stream.locked` is `true` in every row. `finished(stream)` settles for a promise requested before or after the end.

**Outcome of the `Readable`:**

| event | node | main | this branch |
| --- | --- | --- | --- |
| `fetch(url, { signal })` aborted while `Readable.fromWeb(res.body)` reads | `AbortError` | `end` while `res` is alive, `AbortError` once `res` is collected | `AbortError` |
| `addAbortSignal(signal, web)` aborts under the `Readable` | `AbortError` | all the data, then `end` | `AbortError` |
| `signal` already aborted, JS source | `AbortError`, source cancelled | `TypeError`, source not cancelled | `AbortError`, source cancelled |

**Why `destroy(err)` closes and does not error.** Node's `_destroy` runs `reader.cancel(error)`. `ReadableStreamCancel` runs `ReadableStreamClose` whatever the reason is. Bun's reader-based `ReadableFromWeb` already does the same for a JS source. Only a failure of the source errors the stream. The `NativeReadable` sees such a failure as a throw from `start()`/`pull()` inside `_read` (`Start::Err`, `streams::Result::Err`), or as a rejected `pull()` promise. It reports both before `Readable` destroys it, so the later close in `_destroy` is a no-op. The web stream stores the same error object that the `Readable` emits.

**The abort.** `BodyAbortListener::on_abort` (`src/runtime/webcore/Response.rs`) calls `ReadableStream::error()`: `ReadableStream__error`, then `done()`, which cancels the source. `ByteStream::on_cancel` resolves the pending `pull()` as done. A JS reader never sees that, because the controller rejected its reads first. The `NativeReadable` is the consumer of that `pull()`, so it got a clean EOF. On main this depends on the GC: `Locked.readable` is a `JSC::Weak`, and once the stream is collected the abort reaches the source as `on_data(Err)`. Now the `Readable` holds the stream, and it takes the error from the stream in two places. The rejection handler of the closed promise destroys the `Readable`. `endOfSource` checks the same promise, because `process.nextTick` work can reach the EOF before that handler runs.

**The reference to the web stream is strong on purpose.** A weak one would keep the old GC behavior, but a pending `await finished(web)` does not root `web`. The `NativeReadable` is what settles that promise, so it has to keep the stream alive, as the reader does in Node.

**The stream closes when the handle reports done**, not when the `Readable` emits `end`. A `Blob` stream of 9 chunks is closed when the consumer gets chunk 9. Node closes a byte stream when its queue drains, at the same point.

A transferred stream has no reader, so `readableStreamCloseIfPossible` and `readableStreamError` only change `m_state` and settle the closed promise. No user code runs. The closed promise rejects with `rejectAsHandled`, so an errored stream that nothing observes reports no unhandled rejection.

Body methods after `fromWeb` consumed `response.body` give the same results as before (`bodyUsed`, `text()`, `clone()`, `new Response(body)`, `tee()`, `pipeTo()`, `getReader()`, `Bun.write`). The lock decides them, not the state.

**The `signal` option.** `fromWeb` checks the shape of `signal` before it takes the stream, so an invalid value leaves the stream usable, as on main. A value that passes the check but has no `addEventListener()` makes `addAbortSignal` throw after the adapter exists. `fromWeb` then destroys the adapter, which cancels the web stream, and throws the error again. `fromWeb` now passes only `highWaterMark`, `encoding` and `objectMode` to the native path, as it already did for the reader path and as Node does. Before, the native path gave the raw options object to `new Readable()`, so it also honored `emitClose`, `autoDestroy` and `construct`.

**Not changed.** `isDisturbed(stream)` is `true` right after `fromWeb()` (the transfer sets `m_disturbed`). Node reports `false` until the first read. `fetch()` passes `abort(null)` on as a `null` reason, so the `Readable` closes without an `error` event there. Node reports an `AbortError`.

**Overlap with #42281 (open).** That PR moves the claim of the handle into `transferToNativeReadable` and builds the `Readable` in a new `fromNativeHandle`. A self-review asked to stack this branch on it. That is not possible yet: its branch is older than #42416, which these tests need. Both PRs edit the same lines of `constructNativeReadable` and `newStreamReadableFromReadableStream`, so the second one to merge gets a conflict on purpose. The resolution: pass the web stream into `fromNativeHandle`, set `kWebStream` and the closed-promise handler there, close the web stream in its `catch`, and keep `signal` out of the options bag.

**Self-review.** It raised 8 concerns. Addressed: the abort that read as a clean end, the already aborted signal (two concerns, fixed once in `newStreamReadableFromReadableStream`), and the history in this text. Not done: the stack on #42281 (two concerns, see above) and a second copy of the tests for `node --test` (two concerns, optional).

**Fail before.** With `src/` from main (f04caca828) and `bun bd`, 26 of the 27 new tests fail and none hangs: each state assertion runs before the `await finished()`. The control that passes pins the validation of an invalid `signal`.

**Suites run on the debug build:** all of `test/js/node/stream/`, `test/js/web/streams/streams.test.js`, `test/js/web/fetch/{body,body-stream,fetch-backpressure,fetch-abort-stream-body,fetch-abort-queued,fetch-abort-socket-close-race}.test.ts`, `test/regression/issue/09555.test.ts`, `test/js/node/child_process/{child_process,child_process-node}`, `test/js/first_party/undici/`, `test/js/node/http/node-fetch*.test.*`, and upstream `test-stream-readable-from-web-termination`, `test-readable-from-web-enqueue-then-close`, `test-webstream-readable-from`, `test-webstreams-finished`, `test-stream-finished`, `test-stream-add-abort-signal`, `test-webstreams-abort-controller`, `test-filehandle-readablestream`, `test-whatwg-readablestream`, `test-whatwg-webstreams-adapters-to-{readablestream,readablewritablepair,streamduplex}`, `test-whatwg-webstreams-coverage`, `test-stream-readable-to-web`, `test-stream-duplex-from`, `test-child-process-{stdio,stdout-flush,stdout-flush-exit,exec-maxbuf,flush-stdio,stdio-big-write-end,spawn-event}`. The new tests also pass with `BUN_JSC_validateExceptionChecks=1`.

**Failures in this container with and without the change:** `child_process.test.ts` "spawn in the default shell" (`$SHELL` is unset) and "extra stdio pipes are not double-closed on GC" (20 debug spawns exceed 5 s), and the S3 and h3 cases of `fetch-backpressure.test.ts` (no egress, and a timeout when the whole file runs on a debug build).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/stream/node-stream.test.js

<!-- robobun:evidence:end -->