### PR TITLE
js_parser: do not fold `{ f: () => {} }.f` to the bare function

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -549,13 +549,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if FeatureFlags::INLINE_PROPERTIES_IN_TRANSPILER {
                         if p.options.features.minify_syntax {
                             // Rewrite a property access like this:
-                            //   { f: () => {} }.f
+                            //   { f: x }.f
                             // To:
-                            //   () => {}
+                            //   x
                             //
                             // To avoid thinking too much about edgecases, only do this for:
                             //   1) Objects with a single property
                             //   2) Not a method, not a computed property
+                            //   3) Not an anonymous function or class: `{ f: () => {} }.f.name` is "f"
                             if obj.properties.len_u32() == 1
                                 && !identifier_opts.is_delete_target()
                                 && identifier_opts.assign_target() == js_ast::AssignTarget::None
@@ -573,6 +574,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         )
                                         && name != b"__proto__"
                                         && value.can_be_inlined_from_property_access()
+                                        && !value.is_anonymous_named()
                                     {
                                         return Some(value);
                                     }

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -60,7 +60,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 30: String enum members are stored flat, so folds no longer append onto an inlined member.
 /// Version 31: Standard decorator lowering temporaries have a per-file counter in their name (`_init$1`).
 /// Version 32: Standard decorator lowering keeps class members in place.
-const EXPECTED_VERSION: u32 = 32;
+/// Version 33: `({ f: () => {} }).f` is no longer folded to the bare function, which lost the name `f`.
+const EXPECTED_VERSION: u32 = 33;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 
 // ES standard decorators are used for .js files (always) and for .ts files
 // when experimentalDecorators is NOT set in tsconfig.
@@ -1583,6 +1584,37 @@ describe("ES Decorators", () => {
       );
       expect(exitCode).toBe(0);
     });
+
+    // Output that does not start with "// @bun" goes through the transpiler
+    // again when bun runs it.
+    test.concurrent.each([
+      ["bun build --no-bundle", ["build", "--no-bundle", "test.js", "--outfile=out.js"]],
+      ["bun build --target=node", ["build", "--target=node", "test.js", "--outfile=out.js"]],
+      ["Bun.Transpiler", null],
+    ])(
+      "a field that carries the effects of its neighbors keeps naming its function when bun runs the output of %s",
+      async (_, buildArgs) => {
+        const source = `
+          const dec = (v, ctx) => {};
+          class A { @dec x = 1; afterField = () => {}; plain = () => {}; accessor a = 1; afterAccessor = class {}; @dec #p = 1; afterPrivate = function () {}; }
+          class B { @dec m() {} first = async () => {}; }
+          class C { accessor a = 1; #q = () => {}; privateName() { return this.#q.name } }
+          const a = new A();
+          console.log(JSON.stringify([a.afterField.name, a.plain.name, a.afterAccessor.name, a.afterPrivate.name, new B().first.name, new C().privateName()]));
+        `;
+        using dir = tempDir("es-dec-twice", { "test.js": source });
+        if (buildArgs) {
+          const build = await runIn(String(dir), buildArgs);
+          expect({ stderr: filterStderr(build.stderr), exitCode: build.exitCode }).toEqual({ stderr: "", exitCode: 0 });
+        } else {
+          await Bun.write(join(String(dir), "out.js"), new Bun.Transpiler({ loader: "js" }).transformSync(source));
+        }
+        const { stdout, stderr, exitCode } = await runIn(String(dir), ["out.js"]);
+        expect(filterStderr(stderr)).toBe("");
+        expect(stdout).toBe('["afterField","plain","afterAccessor","afterPrivate","first","#q"]\n');
+        expect(exitCode).toBe(0);
+      },
+    );
 
     test.concurrent(
       "a class with no key for its decorator lists: private names, extends and the inner name",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -257,6 +257,41 @@ describe("Bun.Transpiler", () => {
       ]);
       expect(exitCode).toBe(0);
     });
+    it("bails out when the key names an anonymous function or class", () => {
+      // `({ f: () => {} }).f.name` is "f". The bare value has no name, or takes
+      // the name of whatever it is assigned to.
+      ts.expectPrintedMin_("x = ({ f: () => {} }).f", "x = { f: () => {} }.f");
+      ts.expectPrintedMin_("x = ({ f: async () => {} }).f", "x = { f: async () => {} }.f");
+      ts.expectPrintedMin_("x = ({ f: function() {} }).f", "x = { f: function() {} }.f");
+      ts.expectPrintedMin_("x = ({ f: class {} }).f", "x = { f: class {\n} }.f");
+      ts.expectPrintedMin_('x = ({ f: () => {} })["f"]', "x = { f: () => {} }.f");
+      ts.expectPrintedMin_('x = ({ "a-b": () => {} })["a-b"]', 'x = { "a-b": () => {} }["a-b"]');
+      ts.expectPrintedMin_("x = new ({ f: class {} }).f()", "x = new { f: class {\n} }.f");
+
+      // A value that has a name of its own is still inlined.
+      ts.expectPrintedMin_("x = ({ f: function g() {} }).f", "x = function g() {}");
+      ts.expectPrintedMin_("x = ({ f: class C {} }).f", "x = class C {\n}");
+      ts.expectPrintedMin_("x = ({ f: [() => {}] }).f", "x = [() => {}]");
+    });
+    it("keeps the name an object literal key gives an anonymous function or class", async () => {
+      const src = `
+        const a = ({ aa: async () => {} }).aa;
+        function f() { return ({ bb: () => {} }).bb; }
+        const c = ({ "c-c": function () {} })["c-c"];
+        const d = ({ dd: class {} }).dd;
+        const e = ({ ee: function own() {} }).ee;
+        console.log(JSON.stringify([a.name, f().name, c.name, d.name, e.name, ({ h: () => {} }).h.name]));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", src],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(["aa", "bb", "c-c", "dd", "own", "h"]);
+      expect(exitCode).toBe(0);
+    });
     it("bails out on optional-chain index into enum", () => {
       const pre = "enum Foo { A }\nenum Bar { 'a-b' = 1 }\n";
       const lastLine = out => out.trimEnd().split("\n").at(-1);


### PR DESCRIPTION
### Problem

- Since #40833, the field after a decorated member loses its function name when bun runs lowered output. Build `class A { @dec x = 1; h = () => {} }` with `bun build --no-bundle`, `--target=node` or `Bun.Transpiler`, then run it with bun: `new A().h.name` is `""`. `bun a.mjs` and node print `"h"`.
- The lowering emits `h = (__runInitializers(_init, 11, this), { h: () => {} }["h"])` (`hosted_initializer`, `lower_decorators.rs:1399`). The object literal fold (`src/js_parser/fold.rs:548`) turns `{ h: () => {} }["h"]` into `() => {}`.
- The fold alone is old: `({ h: () => {} }).h.name` is `""` under `bun run` on 1.4.2, `"h"` in node.

### Fix

- The fold skips a value that `is_anonymous_named()`: an arrow, an unnamed function or class. A named one is still inlined.
- Correct because the key names such a value. The bare value has no name, or takes the name of its new position.
- `RuntimeTranspilerCache` version 32 to 33: the runtime transpiler output changes.
- Verified: `test/bundler/transpiler/es-decorators.test.ts` (3 new tests), `transpiler.test.js` (2 new tests). All 5 fail on main. Other suites: see Notes.

### Background

- NamedEvaluation: `{ f: () => {} }` names the arrow `"f"`. Behind a comma, `(0, () => {})`, it gets no name.
- #40833 keeps class fields in place. Extra initializers of a decorated field ride in the next instance field, before a comma. The lowering wraps the value in `{ key: value }[key]` to keep its name.
- The runtime transpiler forces `minify_syntax` on. This fold runs on every file bun loads, except one that starts with `// @bun`.

<details><summary>Notes</summary>

**Repro**

```js
// a.mjs
const dec = (v, c) => {};
class A { @dec x = 1; h = () => {}; k = class {} }
console.log(JSON.stringify([new A().h.name, new A().k.name, ({ h: () => {} }).h.name]));
```

| lane | main a22b2aa90e | this branch | node v26.3.0 |
| --- | --- | --- | --- |
| `bun a.mjs` | `["h","k",""]` | `["h","k","h"]` | `["h","k","h"]` |
| `bun build --no-bundle a.mjs --outfile=b.mjs && bun b.mjs` | `["","k",""]` | `["h","k","h"]` | |
| `bun build --target=node a.mjs --outfile=c.mjs && bun c.mjs` | `["","k",""]` | `["h","k","h"]` | `["h","k","h"]` (node c.mjs) |
| `Bun.Transpiler({ loader: "js" }).transformSync(src)`, written to a file and run | `["","k",""]` | `["h","k","h"]` | |
| `bun build --target=bun` (starts with `// @bun`) | `["h","k","h"]` | `["h","k","h"]` | |

Only the first field after a decorated field, an accessor, or a lowered `#private` member carries effects. That is why `k` kept its name on main.

**Which hosted shapes the fold reaches.** A constant string key that is not computed: an identifier key, a string key, a `#private` name (`{ "#p": () => {} }["#p"]`). A computed key, a numeric key and `__proto__` never matched the fold.

**Overlap with #35593.** That PR guards about 10 fold sites against NamedEvaluation changes and contains this same condition. It conflicts with main in `fold.rs`, `visit_binary.rs` and `visit_expr.rs` since #36730 and has no human review yet. This PR takes only the object literal site, because #40833 made bun's own output depend on it. The other sites in #35593 go the other way (a fold gives a name to a value that must have none) and are not changed here.

**Not changed: output run by an older bun.** Output that this lowering produces still loses these names when bun 1.4.2 or older runs it, because that runtime has the fold. A form the old fold does not match (for example a computed key, `{ ["h"]: () => {} }["h"]`) would cover that case. It makes JSC set the name at run time for every construction, so I left the lowering as it is.

**Suites run with the debug build (all pass):** `test/bundler/transpiler/transpiler.test.js`, `es-decorators.test.ts` (421), `es-decorators-esbuild.test.ts` (147), `decorators.test.ts`, `decorator-metadata.test.ts`, `runtime-transpiler.test.ts`, `test/bundler/bundler_minify.test.ts`, `test/bundler/bundler_edgecase.test.ts`, `test/cli/run/transpiler-cache.test.ts`.

**Fail before.** With `src/` at main, the 3 new decorator tests print `["","plain","","","",""]` in place of `["afterField","plain","afterAccessor","afterPrivate","first","#q"]`. The printed-shape test gets `x = () => {}` for `x = ({ f: () => {} }).f`. The run-time test gets `["a","","c","d","own",""]` in place of `["aa","bb","c-c","dd","own","h"]`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/es-decorators.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (b99371011)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [7.87ms]
(pass) Bun.Transpiler > normalizes \r\n [7.46ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [6.26ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [8.61ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.68ms]
(pass) Bun.Transpiler > property access inlining > works [3.81ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.59ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [56.30ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [26.83ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [415.91ms]
76 |     transpiledOutput: 
... (truncated)

release without fix: 22 skipped
bun test v1.4.3-canary.1 (f1783c722)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.08ms]
(pass) Bun.Transpiler > normalizes \r\n [0.13ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.09ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.10ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.03ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.02ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [1.31ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.24ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [6.99ms]
(pass) Bun.Transpiler > property access inlining > bails out when the key names an anonymous function or class [0.29ms]
(pass) Bun.Transpiler > property access inlining > keeps the name an object literal key gives an anonymous function or clas
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/es-decorators.test.ts test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (b99371011)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [6.77ms]
(pass) Bun.Transpiler > normalizes \r\n [7.11ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [4.74ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [8.27ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.84ms]
(pass) Bun.Transpiler > property access inlining > works [3.16ms]
(pass) Bun.Transpiler > property access inlining > works nested [3.58ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [53.68ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [24.52ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [324.27ms]
(pass) Bun.Transpiler > pro
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 634ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/fold.rs                         |  6 +++--
 src/jsc/RuntimeTranspilerCache.rs             |  3 ++-
 test/bundler/transpiler/es-decorators.test.ts | 32 ++++++++++++++++++++++++
 test/bundler/transpiler/transpiler.test.js    | 35 +++++++++++++++++++++++++++
 4 files changed, 73 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/js_parser/fold.rs                              3      3     20
src/jsc/RuntimeTranspilerCache.rs                  1      1     18
test/bundler/transpiler/es-decorators.test.ts      3      2     13
test/bundler/transpiler/transpiler.test.js         2      1      9
```

</details>

<!-- robobun:evidence:end -->