### PR TITLE
test(sql): prestart postgres for postgres-bytea-bind, run its tests concurrently, assert the bytes read back

### DIFF
--- a/test/docker/prestart-map.mjs
+++ b/test/docker/prestart-map.mjs
@@ -17,6 +17,7 @@ export const prestartMap = {
   "js/sql/sql.test": ["postgres_plain"],
   "js/sql/sql-postgres-datetime": ["postgres_plain"],
   "js/sql/postgres-binary-numeric": ["postgres_plain"],
+  "js/sql/postgres-bytea-bind": ["postgres_plain"],
   "js/sql/postgres-multi-statement-fields": ["postgres_plain"],
   "js/sql/postgres-simple-query-pipeline": ["postgres_plain"],
   "js/sql/sql-onconnect-onclose-throw": ["postgres_plain", "mysql_plain"],

--- a/test/js/sql/postgres-bytea-bind.test.ts
+++ b/test/js/sql/postgres-bytea-bind.test.ts
@@ -4,17 +4,29 @@
 // parsed by the server). Anything else (a `number[]` of bytes, a
 // JSON-revived `{ type: "Buffer", data }`, a Date, a plain object) used to be
 // written as a zero-length value and stored as `\x` with no error.
+//
+// Each test opens its own connection, so the tests run concurrently. Do not
+// hoist one connection into beforeAll: the query that follows a rejected bind
+// on the same connection fails with ERR_POSTGRES_CONNECTION_CLOSED (#34732).
 
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
 
-describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+describeWithContainer("postgres", { image: "postgres_plain", concurrent: true }, container => {
   const connect = () =>
     new SQL({
       url: `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`,
       max: 1,
     });
+
+  // Settles to the error. If the server accepted the value instead, settles to
+  // the rows, so the failed assertion shows what was stored.
+  const rejection = (query: Promise<unknown>): Promise<any> =>
+    query.then(
+      rows => ({ resolved: rows }),
+      err => err,
+    );
 
   const rejected: [string, unknown, string][] = [
     ["number[]", [1, 2, 3], "an instance of Array"],
@@ -26,10 +38,7 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
   test.each(rejected)("%s bound to a bytea parameter rejects", async (_, value, received) => {
     await container.ready;
     await using sql = connect();
-    const err: any = await sql`select ${value}::bytea as x`.then(
-      () => null,
-      e => e,
-    );
+    const err = await rejection(sql`select ${value}::bytea as x`);
     expect(err).toBeInstanceOf(TypeError);
     expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
     expect(err.message).toBe(
@@ -40,28 +49,32 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
   test("the error names the position of the offending parameter", async () => {
     await container.ready;
     await using sql = connect();
-    const err: any = await sql.unsafe("select $1::int4 as a, $2::bytea as b", [7, [1, 2, 3]]).then(
-      () => null,
-      e => e,
-    );
+    const err = await rejection(sql.unsafe("select $1::int4 as a, $2::bytea as b", [7, [1, 2, 3]]));
     expect(err).toBeInstanceOf(TypeError);
     expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
-    expect(err.message).toStartWith("Query parameter $2 of type bytea must be");
+    expect(err.message).toBe(
+      "Query parameter $2 of type bytea must be a Buffer, TypedArray, ArrayBuffer or string. Received an instance of Array",
+    );
   });
 
   test("BufferSource, string and null values bound to a bytea parameter round-trip", async () => {
     await container.ready;
     await using sql = connect();
-    const hex = async (value: unknown) => {
-      const [row] = await sql`select encode(${value}::bytea, 'hex') as hex`;
-      return row.hex;
+    // `hex` is the server's own rendering of the bytes it received, so it does
+    // not depend on how Bun decodes a bytea result. `bytes` is the value read back.
+    const roundTrip = async (value: unknown) => {
+      const [row] = await sql`select encode(${value}::bytea, 'hex') as hex, ${value}::bytea as bytes`;
+      return row;
     };
-    expect(await hex(new Uint8Array([1, 2, 3]))).toBe("010203");
-    expect(await hex(Buffer.from([4, 5]))).toBe("0405");
-    expect(await hex(new Uint8Array([6, 7, 8, 9]).buffer)).toBe("06070809");
-    expect(await hex(new Uint8Array([0, 10, 11, 0]).subarray(1, 3))).toBe("0a0b");
-    expect(await hex(new Uint8Array(0))).toBe("");
-    expect(await hex("\\x0c0d")).toBe("0c0d");
-    expect(await hex(null)).toBe(null);
+    const stored = (hex: string) => ({ hex, bytes: Buffer.from(hex, "hex") });
+    expect(await roundTrip(new Uint8Array([1, 2, 3]))).toEqual(stored("010203"));
+    expect(await roundTrip(Buffer.from([4, 5]))).toEqual(stored("0405"));
+    expect(await roundTrip(new Uint8Array([6, 7, 8, 9]).buffer)).toEqual(stored("06070809"));
+    expect(await roundTrip(new Uint8Array([0, 10, 11, 0]).subarray(1, 3))).toEqual(stored("0a0b"));
+    // a wider element type goes out as its underlying bytes, not as element values
+    expect(await roundTrip(new Uint16Array(new Uint8Array([16, 17, 18, 19]).buffer))).toEqual(stored("10111213"));
+    expect(await roundTrip(new Uint8Array(0))).toEqual(stored(""));
+    expect(await roundTrip("\\x0c0d")).toEqual(stored("0c0d"));
+    expect(await roundTrip(null)).toEqual({ hex: null, bytes: null });
   });
 });


### PR DESCRIPTION
### Problem
- `test/js/sql/postgres-bytea-bind.test.ts` took 18.46 s on alpine 3.23 x64 (build 114889). On the same lane `sql-prepare-false.test.ts` (eight tests, same container) took 183 ms.
- The file has no entry in `test/docker/prestart-map.mjs`. Its shard logged `coordinator: ensuring postgres_plain` only when this file asked, so the cold start ran inside the file's `beforeAll`.

### Fix
- Add `"js/sql/postgres-bytea-bind": ["postgres_plain"]` to the map. The coordinator then starts the container at shard launch, and the runner runs the file after the non-docker files. Same pattern as #35912, #40193, #41104.
- The describe block is concurrent. Each test owns its connection and no test creates state.
- The position test compares the whole message, not a prefix. The round-trip test also reads the `bytea` value back, compares the bytes, and covers a `Uint16Array`. A rejected case that wrongly resolves prints the stored rows. No test was removed.
- Verified: `bun bd test test/js/sql/postgres-bytea-bind.test.ts`, 6 pass in 11 debug runs. Local Postgres already runs on 127.0.0.1, so local times contain no container start. Medians: debug 4.63 s before, 4.41 s after. Release 159 ms before, 130 ms after.

### Background
- `describeWithContainer` (`test/harness.ts`) is a describe block whose `beforeAll` asks the docker coordinator for a service. The first file to ask pays the container start.
- `test/docker/prestart-map.mjs` maps test-path prefixes to services. `test/docker/coordinator.ts` starts mapped services at shard launch. `scripts/runner.node.mjs` runs mapped files last, outside the parallel bucket.
- The tests do not share one connection. The query after a rejected bind on the same connection fails with `ERR_POSTGRES_CONNECTION_CLOSED` (see open PR #34732).

<details><summary>Notes</summary>

**CI attribution.** Build 114889, job `01a097c4-9deb-426c-8da6-65829219437c` (`:alpine: 3.23 x64 - test-bun`, shard 2). At launch the log has `coordinator: ensuring minio` and `coordinator: ensuring redis_unified`. `coordinator: ensuring postgres_plain` appears about 1200 lines later, and `coordinator: postgres_plain ready` is the line before the file's header. The file is reported as `[78/295] test/js/sql/postgres-bytea-bind.test.ts (18.46s)`. It ran inside the parallel bucket (`Ran 1258 tests across 80 files. [47.99s]`).

Same build, same lane, for comparison:

| file | in the map | coordinator log | time |
|---|---|---|---|
| `sql-prepare-false.test.ts` (shard 18) | yes | `postgres_plain ready (cached)` | `Ran 8 tests across 1 file. [183.00ms]` |
| `postgres-multi-statement-fields.test.ts` (shard 19) | yes | `postgres_plain ready (cached)` | `Ran 5 tests across 1 file. [103.00ms]` |
| `postgres-bytea-bind.test.ts` (shard 2) | no | `ensuring postgres_plain` on request | 18.46 s |
| `sql-reserve-abort.test.ts` (shard 17, #41104) | no | `ensuring postgres_plain` on request | 19.02 s |

**How the entry removes the wait.** `coordinator.ts` calls `testPath.startsWith(prefix)` on each test path of the shard and starts every matched service when the shard starts. `runner.node.mjs` uses the same check in `needsDockerService`. That check excludes the file from `isBucketCandidate` and sorts it to the end of the serial list. The container start then overlaps with the tests that run first. I checked the new key against both path separator styles. It matches this file and does not match `postgres-bool-bind.test.ts`.

The runner runs modified test files first in their shard. So in this PR's own CI run the file can still wait for the container. The gain shows on later builds.

`test/parallel-allowlist.json` was generated on 2026-08-17, before this file existed, so the file is not in `excludeFiles`. The generator excludes every `describeWithContainer` caller. The map entry gives the same result at run time.

**Local timing.** Postgres already runs on 127.0.0.1 (`BUN_TEST_SERVICE_postgres_plain` is set), so no number here contains a container start. The host had a load average near 100 on 16 cores, so absolute values are high. Runs are interleaved (before, after, before, after). Values are the runner's own `Ran N tests` time, median (minimum) of 9 rounds.

| | before | after |
|---|---|---|
| debug ASAN build (`bun bd test`) | 4630 ms (4000) | 4410 ms (3840) |
| release build (`USE_SYSTEM_BUN=1`, 1.4.3-canary.1+b99371011) | 159 ms (147) | 130 ms (106) |

The debug number is all fixed cost. A `describeWithContainer` file with one test and no query took 3.0 to 3.2 s at a time when the old file took 2.9 to 3.0 s. On the release build that empty file takes 103 ms. Without `concurrent: true` the new file measures 4430 ms debug and 150 ms release. With it, the release run was faster in 9 of 9 rounds.

**Levers I measured and did not apply.**
- One connection in `beforeAll`. After a rejected bind on a `max: 1` pool, `select 1` fails with `PostgresError: Connection closed`. The same happens for an older case (an object whose `toString` throws, bound to `text`) and on the 1.4.3 canary. #34732 has the cause and a fix.
- One test per accepted value, each with its own connection (13 tests). Release: 138 ms. Debug: 100 to 170 ms slower than before. Seven more connections cost more under ASAN than concurrency saves.

**Assertion details.**
- `hex` is `encode(value, 'hex')`, computed by the server, so it does not depend on how Bun decodes a `bytea` result. `bytes` is the same parameter selected back. It arrives as a `Buffer`. NULL gives `{ hex: null, bytes: null }`.
- The `Uint16Array` is a view over the bytes `10 11 12 13`, so the expected value does not depend on endianness.
- `expect(query).rejects` is not used. A Bun SQL query starts on `.then()` or `.execute()`. The matcher calls neither, and the test hangs past its timeout (related: #33261). The `rejection` helper calls `.then()`.
- `toMatchObject({ code, message })` is not used. On a `code` mismatch its diff prints the error as `[TypeError: message]` and hides the received `code`.
- Mutation checks, release build. Each of these made exactly one test fail: one extra byte in the expected bytes, an empty `Buffer` expected for NULL, a valid `Buffer` in the rejected table, a cut tail of the position message, a swapped `Uint16Array` byte order.

Open PRs #35912, #40193, #41104, #40537 and #41176 add their own lines to `prestart-map.mjs`. This PR inserts at a different line. No other open PR touches this test file.
</details>

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/sql/postgres-bytea-bind.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/sql/postgres-bytea-bind.test.ts
bun test v1.4.3 (b99371011)

test/js/sql/postgres-bytea-bind.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) postgres > number[] bound to a bytea parameter rejects [431.00ms]
(pass) postgres > JSON-revived Buffer bound to a bytea parameter rejects [284.41ms]
(pass) postgres > the error names the position of the offending parameter [261.12ms]
(pass) postgres > Date bound to a bytea parameter rejects [274.24ms]
(pass) postgres > plain object bound to a bytea parameter rejects [267.77ms]
(pass) postgres > BufferSource, string and null values bound to a bytea parameter round-trip [214.90ms]

 6 pass
 0 fail
 23 expect() calls
Ran 6 tests across 1 file. [6.78s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/docker/prestart-map.mjs            |  1 +
 test/js/sql/postgres-bytea-bind.test.ts | 53 ++++++++++++++++++++-------------
 2 files changed, 34 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
test/docker/prestart-map.mjs                 1      1     19
test/js/sql/postgres-bytea-bind.test.ts      2      5     19
```

</details>

<!-- robobun:evidence:end -->
