### PR TITLE
js_parser: keep function, base class and static `name` names through standard decorator lowering

### DIFF
--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -497,7 +497,8 @@ function emitRuntimeJs({ n, cfg, o, dirStamp }: Ctx): void {
   n.build({
     outputs: [out],
     rule: "esbuild",
-    inputs: [src],
+    // runtime.bun.js re-exports runtime.js, which holds most of the helpers.
+    inputs: [src, resolve(cfg.cwd, "src", "runtime.js")],
     implicitInputs: [o.rootInstall],
     orderOnlyInputs: [dirStamp],
     vars: {

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -821,12 +821,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         } else {
             Ref::NONE
         };
-        let mut base_ref: Option<Ref> = None;
-        if has_decorators && let Some(extends) = class.extends {
-            let base = p.declared_temp(b"_base");
-            class.extends = Some(p.assign_to(base, extends, extends.loc));
-            base_ref = Some(base);
-        }
 
         let mut members = BumpVec::<Property>::with_capacity_in(class.properties.len() + 4, bump);
         let mut key_effects = BumpVec::<Expr>::new_in(bump);
@@ -977,8 +971,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     next_initializer[group] += 1;
                 }
                 private_lowered_map.insert(private_index, info);
-                let effects =
-                    p.storage_init_effects(storage, prop.initializer, initializer_index, loc);
+                let effects = p.storage_init_effects(
+                    storage,
+                    prop.initializer,
+                    FieldName::Key(name_expr),
+                    initializer_index,
+                    loc,
+                );
                 if is_static {
                     members.push(p.make_static_block(&effects, loc));
                 } else {
@@ -1039,8 +1038,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     initializer_index = Some((init_ref, next_initializer[group]));
                     next_initializer[group] += 1;
                 }
-                let effects =
-                    p.storage_init_effects(storage, prop.initializer, initializer_index, loc);
+                let field_name = if is_constant_key(&name_expr) {
+                    FieldName::Key(name_expr)
+                } else {
+                    FieldName::Computed(name_expr)
+                };
+                let effects = p.storage_init_effects(
+                    storage,
+                    prop.initializer,
+                    field_name,
+                    initializer_index,
+                    loc,
+                );
                 if is_static {
                     members.push(p.make_static_block(&effects, loc));
                 } else {
@@ -1058,10 +1067,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let name: &'a [u8] = p.symbols[private_index as usize].original_name.slice();
                 field_name = FieldName::Key(p.new_expr(E::EString::init(name), loc));
             } else {
-                // Only a field that may carry effects has to name its function itself.
+                // Only a field that is decorated or may carry effects has to
+                // name its function itself.
                 let names_function = !is_method
-                    && !is_static
-                    && (!instance_effects.is_empty() || first_instance_host.is_none())
+                    && (dec_ref.is_some()
+                        || !is_static
+                            && (!instance_effects.is_empty() || first_instance_host.is_none()))
                     && prop
                         .initializer
                         .is_some_and(|value| value.is_anonymous_named());
@@ -1089,6 +1100,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         init_ref,
                         next_initializer[group],
                         prop.initializer,
+                        field_name,
                         loc,
                     );
                     next_initializer[group] += 1;
@@ -1166,11 +1178,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         leading.extend_from_slice(&static_brands);
         let mut class_decorators_result: Option<ClassDecorators> = None;
         if has_decorators {
-            let base = match base_ref {
-                Some(base) => p.use_ref(base, loc),
-                None => p.new_expr(E::Undefined {}, loc),
+            // The metadata of a derived class inherits from that of the class it
+            // extends, which `__decoratorStart` reads off the prototype of `this`.
+            let undefined = p.new_expr(E::Undefined {}, loc);
+            let start = if class.extends.is_some() {
+                let this = p.new_expr(E::This {}, loc);
+                p.call_rt(loc, b"__decoratorStart", &[undefined, this])
+            } else {
+                p.call_rt(loc, b"__decoratorStart", &[undefined])
             };
-            let start = p.call_rt(loc, b"__decoratorStart", &[base]);
             leading.push(p.assign_to(init_ref, start, loc));
             let has_static_method_decorators = !decorate[0].is_empty();
             for group in &decorate {
@@ -1394,17 +1410,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         prop.flags.insert(Flags::Property::IsComputed);
     }
 
-    /// The initializer of a field that is about to go behind a comma. There an
-    /// anonymous function or class is not named by the field any more.
+    /// The initializer of a field that is about to go behind a comma.
     fn hosted_initializer(
         &mut self,
         initializer: Option<Expr>,
         field_name: FieldName,
         loc: bun_ast::Loc,
     ) -> Expr {
-        let Some(value) = initializer else {
-            return self.new_expr(E::Undefined {}, loc);
-        };
+        match initializer {
+            Some(value) => self.named_by_field(value, field_name),
+            None => self.new_expr(E::Undefined {}, loc),
+        }
+    }
+
+    /// `value` for a place where the field no longer names it: behind a comma
+    /// or as a call argument, an anonymous function or class stays anonymous.
+    fn named_by_field(&mut self, value: Expr, field_name: FieldName) -> Expr {
         if !value.is_anonymous_named() {
             return value;
         }
@@ -1457,13 +1478,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         init_ref: Ref,
         index: usize,
         initializer: Option<Expr>,
+        field_name: FieldName,
         loc: bun_ast::Loc,
     ) -> DecoratedInitializer {
         let mut args = BumpVec::<Expr>::with_capacity_in(4, self.arena);
         args.push(self.use_ref(init_ref, loc));
         args.push(self.new_expr(E::Number::new(((4 + 2 * index) << 1) as f64), loc));
         args.push(self.new_expr(E::This {}, loc));
-        args.extend(initializer);
+        args.extend(initializer.map(|value| self.named_by_field(value, field_name)));
         let value = self.call_runtime(loc, b"__runInitializers", ExprNodeList::from_bump_vec(args));
         let this = self.new_expr(E::This {}, loc);
         let extra = self.run_initializers(init_ref, (((5 + 2 * index) << 1) | 1) as f64, this, loc);
@@ -1476,19 +1498,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         storage: Ref,
         initializer: Option<Expr>,
+        field_name: FieldName,
         decorated: Option<(Ref, usize)>,
         loc: bun_ast::Loc,
     ) -> BumpVec<'a, Expr> {
         let mut effects = BumpVec::<Expr>::with_capacity_in(2, self.arena);
         let (value, extra) = match decorated {
             Some((init_ref, index)) => {
-                let decorated = self.decorated_initializer(init_ref, index, initializer, loc);
+                let decorated =
+                    self.decorated_initializer(init_ref, index, initializer, field_name, loc);
                 (decorated.value, Some(decorated.extra))
             }
-            None => (
-                initializer.unwrap_or_else(|| self.new_expr(E::Undefined {}, loc)),
-                None,
-            ),
+            None => (self.hosted_initializer(initializer, field_name, loc), None),
         };
         let this = self.new_expr(E::This {}, loc);
         let storage = self.use_ref(storage, loc);

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -60,7 +60,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 30: String enum members are stored flat, so folds no longer append onto an inlined member.
 /// Version 31: Standard decorator lowering temporaries have a per-file counter in their name (`_init$1`).
 /// Version 32: Standard decorator lowering keeps class members in place.
-const EXPECTED_VERSION: u32 = 32;
+/// Version 33: Standard decorator lowering names the function a decorated field or accessor is initialized with, and no longer names an anonymous base class.
+const EXPECTED_VERSION: u32 = 33;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -240,7 +240,12 @@ export var __privateSet = (obj, member, value, setter) => (
 );
 export var __privateMethod = (obj, member, method) => (__accessCheck(obj, member, "access private method"), method);
 
-export var __decoratorStart = base => [, , , __create(base?.[__knownSymbol("metadata")] ?? null)];
+// `target` is a derived class: its metadata inherits from that of its prototype,
+// the class it extends. Output of older versions passes that class as `base`.
+export var __decoratorStart = (base, target) => (
+  target && (base = __getProtoOf(target)),
+  [, , , __create(base?.[__knownSymbol("metadata")] ?? null)]
+);
 var __decoratorStrings = ["class", "method", "getter", "setter", "accessor", "field", "value", "get", "set"];
 var __expectFn = fn => (fn !== void 0 && typeof fn !== "function" ? __typeError("Function expected") : fn);
 var __decoratorContext = (kind, name, done, metadata, fns) => ({
@@ -286,7 +291,10 @@ export var __decorateElement = (array, flags, name, decorators, target, extra) =
             },
         name,
       ));
-  k ? p && k < 4 && __name(extra, (k > 2 ? "set " : k > 1 ? "get " : "") + name) : __name(target, name);
+  // A static member called `name` has already replaced the string every class starts with.
+  k
+    ? p && k < 4 && __name(extra, (k > 2 ? "set " : k > 1 ? "get " : "") + name)
+    : typeof __getOwnPropDesc(target, "name")?.value == "string" && __name(target, name);
 
   for (var i = decorators.length - 1; i >= 0; i--) {
     ctx = __decoratorContext(k, name, (done = {}), array[3], extraInitializers);

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -2495,13 +2495,13 @@ const extraSections = `
   }
   class N2 extends class {} { @none m() {} }
   class N3 extends (function () {}) { accessor a = 1; }
-  @none class N4 { static name() { return "N4.name"; } }
+  @none class N4 { static name() {} }
   const N5 = @none class { static get name() { return "N5.name"; } };
   const n1 = new N1();
   out.names = [
     [n1.f.name, N1.g.name, n1.h.name, n1.i.name, n1.p()],
     [Object.getPrototypeOf(N2).name, Object.getPrototypeOf(N3).name],
-    [N4.name(), N5.name],
+    [typeof N4.name, N5.name],
   ];
 }
 `;
@@ -2550,7 +2550,7 @@ const extraExpected = {
   names: [
     ["f", "g", "h", "i", "#p"],
     ["", ""],
-    ["N4.name", "N5.name"],
+    ["function", "N5.name"],
   ],
 };
 

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1584,6 +1584,94 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
 
+    test.concurrent("a decorated field or an accessor names the function it is initialized with", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v, ctx) => {};
+        const k = "dyn", sym = Symbol("desc");
+        class A {
+          @dec f = () => {}; @dec static g = function () {}; @dec h = class {};
+          @dec static [k] = () => {}; @dec [sym] = function () {}; @dec 123 = class {}; @dec "q r" = () => {}; @dec ["__proto__"] = function () {};
+          @dec own = class { static name() {} }; @dec named = function keep() {};
+          @dec #p = () => {}; @dec static #sp = class {};
+          accessor a1 = () => {}; @dec accessor a2 = function () {}; static accessor a3 = class {}; @dec static accessor [k + "2"] = () => {};
+          accessor #a4 = () => {}; @dec accessor #a5 = () => {}; @dec static accessor #a6 = class {};
+          privateNames() { return [this.#p.name, A.#sp.name, this.#a4.name, this.#a5.name, A.#a6.name] }
+        }
+        const a = new A();
+        console.log(JSON.stringify([a.f.name, A.g.name, a.h.name, A[k].name, a[sym].name, a[123].name, a["q r"].name, a["__proto__"].name, typeof a.own.name, a.named.name]));
+        console.log(JSON.stringify([a.privateNames(), a.a1.name, a.a2.name, A.a3.name, A[k + "2"].name, Object.getPrototypeOf(a) === A.prototype]));
+        // The \`init\` functions of the decorators get the function already named.
+        const seen = [];
+        const init = (v, ctx) => { const f = (x) => (seen.push(x.name), x); return ctx.kind === "accessor" ? { init: f } : f };
+        class B { @init f = () => {}; @init static g = class {}; @init accessor h = function () {}; @init #p = () => {}; }
+        new B();
+        console.log(JSON.stringify(seen));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(
+        '["f","g","h","dyn","[desc]","123","q r","__proto__","function","keep"]\n' +
+          '[["#p","#sp","#a4","#a5","#a6"],"a1","a2","a3","dyn2",true]\n' +
+          '["g","f","h","#p"]\n',
+      );
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("an anonymous class or function in the extends clause stays anonymous", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const dec = (v, ctx) => { if (ctx.kind !== "class") ctx.metadata[ctx.name] = true };
+        const base = (C) => Object.getPrototypeOf(C);
+        const metadata = Symbol.metadata ?? Symbol.for("Symbol.metadata");
+        class A extends class {} { @dec m() {} }
+        class B extends (function () {}) { @dec m() {} }
+        class C extends class Named {} { @dec m() {} }
+        class D extends class { static name() {} } { @dec m() {} }
+        class E extends class { @dec x() {} } { @dec m() {} }
+        const F = class extends class {} { @dec m() {} };
+        @dec class G extends class {} {}
+        class H extends class { accessor y = 1 } { accessor x = 2 }
+        console.log(JSON.stringify([A, B, C, D, E, F, G, H].map(K => base(K).name)));
+        // The metadata of the class still inherits from the metadata of what it extends.
+        class Nul extends null { @dec static s() {} }
+        class Top { @dec t() {} }
+        console.log(JSON.stringify([
+          Object.getPrototypeOf(E[metadata]) === base(E)[metadata], Object.keys(E[metadata]), E[metadata].x,
+          Object.getPrototypeOf(Nul[metadata]), Object.getPrototypeOf(Top[metadata]),
+        ]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["","","Named",null,"","","",""]\n[true,["m"],true,null,null]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test.concurrent("a class decorator leaves a static member called name alone", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const seen = [];
+        const dec = (v, ctx) => {};
+        const see = (v, ctx) => { seen.push(typeof v.name + ":" + ctx.name) };
+        @see class A { static name() { return "method" } }
+        const B = @see class { static name() { return "method" } };
+        @see class C { static get name() { return "getter" } }
+        @dec class D { static accessor name = "accessor" }
+        @dec class E { @dec static accessor name = "decorated accessor" }
+        @dec class F { static ["na" + "me"]() { return "computed" } }
+        @dec class G { static name = 1 }
+        // Without such a member the class keeps its name, or gets the one its context gives it.
+        @see class H {}
+        const I = @see class {};
+        const J = @see class Inner {};
+        console.log(JSON.stringify([A.name(), B.name(), C.name, D.name, E.name, F.name(), G.name, H.name, I.name, J.name]));
+        console.log(JSON.stringify([A, C, H, I].map(K => Object.getOwnPropertyDescriptor(K, "name")).map(d => [typeof (d.value ?? d.get), d.writable, d.enumerable, d.configurable])));
+        console.log(seen.join(" "));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(
+        '["method","method","getter","accessor","decorated accessor","computed",1,"H","I","Inner"]\n' +
+          '[["function",true,false,true],["function",null,false,true],["string",false,false,true],["string",false,false,true]]\n' +
+          "function:A function:B string:C string:H string:I string:Inner\n",
+      );
+      expect(exitCode).toBe(0);
+    });
+
     test.concurrent(
       "a class with no key for its decorator lists: private names, extends and the inner name",
       async () => {
@@ -2391,6 +2479,31 @@ const extraSections = `
   const desc = Object.getOwnPropertyDescriptor(N.prototype, "k");
   out.accessorStorage = [nn.a, N.a, nn.priv(), nn.k, mm.k, n, typeof desc.get, typeof desc.set, Outer.make().a];
 }
+
+// Names are the ones the class would have without decorators: of the function
+// a decorated field or an accessor is initialized with, of an anonymous class
+// in the extends clause, and of a class with a static member called \`name\`.
+{
+  const none = (value, ctx) => {};
+  class N1 {
+    @none f = () => {};
+    @none static g = function () {};
+    @none accessor h = class {};
+    accessor i = () => {};
+    @none #p = () => {};
+    p() { return this.#p.name; }
+  }
+  class N2 extends class {} { @none m() {} }
+  class N3 extends (function () {}) { accessor a = 1; }
+  @none class N4 { static name() { return "N4.name"; } }
+  const N5 = @none class { static get name() { return "N5.name"; } };
+  const n1 = new N1();
+  out.names = [
+    [n1.f.name, N1.g.name, n1.h.name, n1.i.name, n1.p()],
+    [Object.getPrototypeOf(N2).name, Object.getPrototypeOf(N3).name],
+    [N4.name(), N5.name],
+  ];
+}
 `;
 
 const extraExpected = {
@@ -2434,6 +2547,11 @@ const extraExpected = {
   accessorKeys: [11, 2, 3, 4],
   issue31921: ["a", 1, "a", "b", [5, "a", "block", "b"]],
   accessorStorage: [12, 13, 1, 14, 15, 2, "function", "function", 6],
+  names: [
+    ["f", "g", "h", "i", "#p"],
+    ["", ""],
+    ["N4.name", "N5.name"],
+  ],
 };
 
 function buildFixture() {


### PR DESCRIPTION
### Problem

- `@dec class C { static name() {} }; C.name()` throws `TypeError: C.name is not a function`. A class decorator replaces a static method or getter called `name` with the class name. All releases with standard decorators do this.
- Two more `.name` values differ from the undecorated class. `class A { @dec onClick = () => {} }` gives `""`, so a stack frame reads `at <anonymous>`, not `at onClick`. `class B extends class {} { @dec m() {} }` names the base class `"_base$2"`.
- Causes (`src/js_parser/lower/lower_decorators.rs`, `src/runtime.js`): `__decorateElement` runs `__name(target, name)` after the static methods exist. A decorated initializer becomes a call argument. The extends clause becomes `_base = class {}`.

### Fix

- Static `name`: `__decorateElement` calls `__name` on a class only while its own `name` is still a string. No emitted code changes.
- Initializers: `decorated_initializer` and `storage_init_effects` emit `{ f: () => {} }["f"]`, the form that `hosted_initializer` (#40833) uses.
- Extends: no `_base` temporary. The leading static block calls `__decoratorStart(undefined, this)`, and the helper uses `Object.getPrototypeOf(this)`.
- Verified: `test/bundler/transpiler/es-decorators.test.ts`, 6 of 424 fail with `src/` from main. `scripts/build/codegen.ts` makes `runtime.js` an input of `runtime.out.js` (a part of #38096). Self-reviewed: 3 concerns raised, 2 addressed (Notes).

### Background

- `x = () => {}` and `class { x = () => {} }` name an anonymous function or class after `x`. A call argument does not.
- Every class starts with an own `name` string. A static method or accessor called `name` replaces it.
- `__decoratorStart` creates the `Symbol.metadata` object of a class. It inherits from the metadata of the extended class.

<details><summary>Notes</summary>

**Where this comes from**

- No user reported these. A comparison of each decorated class with its undecorated twin found them. esbuild 0.21.5 gives the same three values (`""`, `"_a"`, `"string"`), and tsc 5.9 gives the same empty initializer names. Babel keeps the initializer names.
- #40833 set the rule that lowering does not change `.name` (its tests pin `h = (effects, { h: () => {} }.h)`). This PR applies the rule to the sites where the value is a call argument.

**Emitted code, before and after**

```js
// before
class D extends (_base = class {}) {
  static { _init = __decoratorStart(_base); __decorateElement(_init, 5, "f", _dec, this); … }
  [(_dec = [dec], "f")] = __runInitializers(_init, 8, this, () => {});
}
// after
class D extends class {} {
  static { _init = __decoratorStart(undefined, this); __decorateElement(_init, 5, "f", _dec, this); … }
  [(_dec = [dec], "f")] = __runInitializers(_init, 8, this, { f: () => {} }["f"]);
}
```

**Which initializers are wrapped**

- A decorated public field, static or not: `FieldName::Key` for a string or number key, `FieldName::Computed` with the `_computedKey` temporary for any other computed key (a symbol key gives `[description]`).
- A decorated `#private` field or accessor: the key is the string `"#p"`, so the name is `#p` as it is natively.
- A public `accessor`, decorated or not. Its value goes through `__privateAdd(this, _storage, value)`, so it lost the name without any decorator in the class. An undecorated `accessor #x` is a plain `#x` field and was already right.
- `__proto__` keys are emitted as computed (`{ ["__proto__"]: fn }`), as `hosted_initializer` already did.
- A value that has its own name (`function keep() {}`, `class { static name() {} }`) keeps it, because this is real NamedEvaluation and not a `defineProperty` on `name`.
- Not covered: a class that has class decorators itself, as the value of a `#private`, computed, numeric or symbol-keyed field (`#p = @dec class {}`). It is lowered to a comma expression before the field sees it, and its name comes from `decorator_class_name`, which knows identifier keys only. It is `""` before and after this PR, with or without a decorator on the field. #38787 is the open PR for that.

**`__decoratorStart`**

- `__decoratorStart(base)` becomes `__decoratorStart(base, target)`. With `target`, `base` is `Object.getPrototypeOf(target)`. For `extends null` that is `Function.prototype`, which has no `Symbol.metadata`, so the metadata parent is `null` as before. A class with no extends clause still gets `__decoratorStart(undefined)`.
- I first tried `_base = (0, class {})`. It is correct in `bun run` and in a bundle that node runs. It is not correct in a bundle that Bun runs, because the syntax minifier of the runtime transpiler folds `(0, class {})` back to `class {}`. Without a temporary there is nothing to fold, and `bun build` and `bun build --minify` output give `""` too.
- Output of an older Bun (`bun build --no-bundle`, which imports the helpers from `bun:wrap`) still passes `_base` as the only argument. I ran such a file from 1.4.3-canary on this build: the metadata chain is the same.

**`__name` on a class**

- Natively the name is set before the class elements are defined, so a static method, getter, setter or `accessor` called `name` replaces it. A static field called `name` was already right, because static fields run after the leading static block.
- The check is `typeof Object.getOwnPropertyDescriptor(target, "name")?.value == "string"`. It does not read `target.name`, so a static getter is not called.
- Also covered: a computed key that evaluates to `"name"`, an anonymous class expression (`const B = @dec class { static name() {} }`), and the decorator seeing `typeof value.name === "function"`.

**Related open PRs**

- #42585: when Bun runs output that it transpiled before (`bun build --no-bundle`, `--target=node`, `Bun.Transpiler`; not `--target=bun`), the runtime syntax minifier folds `{ f: () => {} }["f"]` to `() => {}`. In that lane the initializer names of this PR and the hosted names of #40833 are lost again. #42585 removes that fold. The static `name` and extends fixes do not depend on it.
- #42585 also sets `RuntimeTranspilerCache` to 33. The PR that lands second takes 34.
- #38096 lists every file that the `runtime.out.js` and bake bundles read. The one-line `codegen.ts` change here is its `runtime.out.js` part. If #38096 lands first, this hunk goes away.

**Self-review**

- Concern 1: #42585 bumps the same cache version and adds tests at the same place in `es-decorators.test.ts`, and this body did not link it. Addressed: linked above, with what depends on it and who takes version 34.
- Concern 2: the body led with the cosmetic names and did not say who asked, what esbuild and tsc do, or what stays unnamed. Addressed: the body now leads with the `TypeError`, and "Where this comes from" and "Not covered" say the rest.
- Concern 3 (optional): carve the static `name` guard into its own PR without a cache bump. Not done: the three fixes share tests and one rule, and the same review recommends one PR.

**Other**

- `RuntimeTranspilerCache` version 32 → 33, because the emitted code changes.
- Suites run with the debug build: `es-decorators.test.ts` (424), `es-decorators-esbuild.test.ts` (147), `decorators.test.ts` (24), `decorator-metadata.test.ts` (5), `ts-use-define-for-class-fields.test.ts` (11), `regression/issue/27526`, `regression/issue/27575`.
- With `git checkout origin/main -- src/`, the 6 failures are the 3 new tests in "members stay where they are written" and the new `names` fixture section in `.js`, `.ts` and bundled mode. The other 418 pass.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.3 (b99371011)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [397.33ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [433.34ms]
(pass) ES Decorators > class decorators > class decorator can replace class [423.80ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [489.46ms]
(pass) ES Decorators > method decorators > instance method decorator [664.95ms]
(pass) ES Decorators > method decorators > static method decorator [522.57ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [403.03ms]
(pass) ES Decorators > getter decorators > getter decorator [408.03ms]
(pass) ES Decorators > setter decorators > setter decorator [292.96ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [378.08ms]
(pass) ES Decorators > field decorators > multiple field decorators [302.42ms]
(
... (truncated)

release without fix: 358 FAILED
bun test v1.4.3-canary.1 (b99371011)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [15.52ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [13.73ms]
(pass) ES Decorators > class decorators > class decorator can replace class [13.81ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [12.51ms]
(pass) ES Decorators > method decorators > instance method decorator [11.06ms]
(pass) ES Decorators > method decorators > static method decorator [10.08ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [9.54ms]
(pass) ES Decorators > getter decorators > getter decorator [13.63ms]
(pass) ES Decorators > setter decorators > setter decorator [9.32ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [12.61ms]
(pass) ES Decorators > field decorators > multiple field decorators [9.75ms]
(pass) ES Decorators > field decorators > static field decorator [13.70ms]
(pass) ES Decorators > non-ASCII string-literal keys > Bun.Transpiler output preserves the key [0.71ms]
(pass
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/es-decorators.test.ts
bun test v1.4.3 (b99371011)

test/bundler/transpiler/es-decorators.test.ts:
(pass) ES Decorators > class decorators > basic class decorator [548.89ms]
(pass) ES Decorators > class decorators > class decorator receives correct context [536.99ms]
(pass) ES Decorators > class decorators > class decorator can replace class [412.34ms]
(pass) ES Decorators > class decorators > multiple class decorators apply in reverse order [404.62ms]
(pass) ES Decorators > method decorators > instance method decorator [389.75ms]
(pass) ES Decorators > method decorators > static method decorator [412.22ms]
(pass) ES Decorators > method decorators > method decorator context has correct access [301.39ms]
(pass) ES Decorators > getter decorators > getter decorator [303.49ms]
(pass) ES Decorators > setter decorators > setter decorator [414.11ms]
(pass) ES Decorators > field decorators > field decorator receives undefined value [452.60ms]
(pass) ES Decorators > field decorators > multiple field decorators [369.59ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3d24661356
  features     baseline

23 deps, 131 codegen, 1176 objects in 686ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] install /workspace/bun
bun install v1.4.3-canary.1 (b99371011)

Checked 22 installs across 61 packages (no changes) [11.00ms]
[2/1248] gen ErrorCode+*.h
[3/1248] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (b99371011)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1248] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (b99371011)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[5/1248] gen bindgenv2
[6/1248] fetch tinycc
[tinycc] up to date
[7/1247] fetch zlib
[zlib] up to date
[8/1247] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1247] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[10/1247] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1247] esbuild bun-error

 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/codegen.ts                      |   3 +-
 src/js_parser/lower/lower_decorators.rs       |  74 ++++++++++------
 src/jsc/RuntimeTranspilerCache.rs             |   3 +-
 src/runtime.js                                |  11 ++-
 test/bundler/transpiler/es-decorators.test.ts | 118 ++++++++++++++++++++++++++
 5 files changed, 177 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
scripts/build/codegen.ts                           1      1     19
src/js_parser/lower/lower_decorators.rs            4      4     17
src/jsc/RuntimeTranspilerCache.rs                  1      2     17
src/runtime.js                                     2      3     18
test/bundler/transpiler/es-decorators.test.ts      1      5     17
```

</details>

<!-- robobun:evidence:end -->