### PR TITLE
terminal: throw when a termios flag is set to a value that is not a uint32

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8718,7 +8718,10 @@ declare module "bun" {
      * Terminal input flags (c_iflag from termios).
      * Controls input processing behavior like ICRNL, IXON, etc.
      * Returns 0 if the terminal is closed.
-     * Setting returns true on success, false on failure.
+     *
+     * Setting is a no-op on a closed terminal and on Windows. Otherwise the value must
+     * be an integer from 0 to 4294967295. A value that is not a number throws a
+     * `TypeError`, and any other number throws a `RangeError`.
      */
     inputFlags: number;
 
@@ -8726,7 +8729,10 @@ declare module "bun" {
      * Terminal output flags (c_oflag from termios).
      * Controls output processing behavior like OPOST, ONLCR, etc.
      * Returns 0 if the terminal is closed.
-     * Setting returns true on success, false on failure.
+     *
+     * Setting is a no-op on a closed terminal and on Windows. Otherwise the value must
+     * be an integer from 0 to 4294967295. A value that is not a number throws a
+     * `TypeError`, and any other number throws a `RangeError`.
      */
     outputFlags: number;
 
@@ -8734,7 +8740,12 @@ declare module "bun" {
      * Terminal local flags (c_lflag from termios).
      * Controls local processing like ICANON, ECHO, ISIG, etc.
      * Returns 0 if the terminal is closed.
-     * Setting returns true on success, false on failure.
+     *
+     * Setting is a no-op on a closed terminal and on Windows. Otherwise the value must
+     * be an integer from 0 to 4294967295. A value that is not a number throws a
+     * `TypeError`, and any other number throws a `RangeError`.
+     * A bitwise expression that leaves bit 31 set (`NOFLSH` on macOS) is negative in
+     * JavaScript. Convert it with `>>> 0` before you assign it.
      */
     localFlags: number;
 
@@ -8742,7 +8753,12 @@ declare module "bun" {
      * Terminal control flags (c_cflag from termios).
      * Controls hardware characteristics like CSIZE, PARENB, etc.
      * Returns 0 if the terminal is closed.
-     * Setting returns true on success, false on failure.
+     *
+     * Setting is a no-op on a closed terminal and on Windows. Otherwise the value must
+     * be an integer from 0 to 4294967295. A value that is not a number throws a
+     * `TypeError`, and any other number throws a `RangeError`.
+     * A bitwise expression that leaves bit 31 set (`CRTSCTS` on Linux) is negative in
+     * JavaScript. Convert it with `>>> 0` before you assign it.
      */
     controlFlags: number;
   }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -1335,15 +1335,17 @@ impl Terminal {
             if self.flags.get().contains(Flags::CLOSED) || self.master_fd.get() == Fd::INVALID {
                 return Ok(());
             }
-            let num = value.coerce_f64(global_object)?;
+            let name = match FIELD {
+                TermiosField::Iflag => "inputFlags",
+                TermiosField::Oflag => "outputFlags",
+                TermiosField::Lflag => "localFlags",
+                TermiosField::Cflag => "controlFlags",
+            };
+            let bits = crate::node::validators::validate_uint32(global_object, value, name, false)?
+                as libc::tcflag_t;
             let Some(mut termios_data) = get_termios(self.master_fd.get()) else {
                 return Ok(());
             };
-            let max_val: f64 = libc::tcflag_t::MAX as f64;
-            // Match Zig's `@max(0, @min(num, max_val))`: apply min first so NaN
-            // resolves to max_val (f64::min returns the non-NaN operand), not 0.
-            let clamped = num.min(max_val).max(0.0);
-            let bits = clamped as libc::tcflag_t;
             match FIELD {
                 TermiosField::Iflag => termios_data.c_iflag = bits,
                 TermiosField::Oflag => termios_data.c_oflag = bits,

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -474,20 +474,98 @@ describe("Bun.Terminal", () => {
       expect(terminal.inputFlags).toBe(0);
     });
 
-    test.skipIf(isWindows)("NaN clamps to tcflag_t max, same as Infinity", async () => {
-      // Assigning NaN must clamp to the same value as Infinity (tcflag_t::MAX),
-      // matching the reference `@max(0, @min(num, max))` semantics. The kernel
-      // may mask some bits per field, so compare NaN against Infinity rather
-      // than a hard-coded constant.
-      await using terminal = new Bun.Terminal({ cols: 80, rows: 24 });
+    type FlagProp = "inputFlags" | "outputFlags" | "localFlags" | "controlFlags";
+    const flagProps: FlagProp[] = ["inputFlags", "outputFlags", "localFlags", "controlFlags"];
 
-      for (const prop of ["inputFlags", "outputFlags", "localFlags", "controlFlags"] as const) {
-        terminal[prop] = Infinity;
-        const fromInfinity = terminal[prop];
-        terminal[prop] = NaN;
-        const fromNaN = terminal[prop];
-        expect({ prop, fromNaN }).toEqual({ prop, fromNaN: fromInfinity });
-        expect(fromNaN).toBeGreaterThan(0);
+    // Assigns `value` and reports what the assignment threw. The shared
+    // validator owns the message text, so only check that it names the property.
+    function assign(terminal: Bun.Terminal, prop: FlagProp, value: unknown) {
+      try {
+        terminal[prop] = value as number;
+      } catch (e: any) {
+        return { threw: e.name, code: e.code, namesProperty: String(e.message).includes(`"${prop}"`) };
+      }
+      return { threw: null };
+    }
+    const invalidType = { threw: "TypeError", code: "ERR_INVALID_ARG_TYPE", namesProperty: true };
+    const outOfRange = { threw: "RangeError", code: "ERR_OUT_OF_RANGE", namesProperty: true };
+    const accepted = { threw: null };
+
+    // There is no termios on Windows, so the setters never look at the value.
+    describe.skipIf(isWindows)("setting a value that is not an unsigned 32-bit integer", () => {
+      test.each(flagProps)("%s throws a TypeError for a value that is not a number", async prop => {
+        await using terminal = new Bun.Terminal({});
+        const before = terminal[prop];
+        // The setter does not coerce, so it never calls into the object.
+        const toPrimitive = mock(() => 8);
+
+        const notNumbers: [string, unknown][] = [
+          ["undefined", undefined],
+          ["null", null],
+          ['"bogus"', "bogus"],
+          ['"8"', "8"],
+          ["{}", {}],
+          ["[]", []],
+          ["true", true],
+          ["8n", 8n],
+          ["Symbol()", Symbol("flags")],
+          ["() => 8", () => 8],
+          ["{ valueOf }", { valueOf: toPrimitive }],
+          ["{ [Symbol.toPrimitive] }", { [Symbol.toPrimitive]: toPrimitive }],
+        ];
+        for (const [label, value] of notNumbers) {
+          expect({ label, ...assign(terminal, prop, value) }).toEqual({ label, ...invalidType });
+        }
+
+        expect(toPrimitive).not.toHaveBeenCalled();
+        expect(terminal[prop]).toBe(before);
+      });
+
+      test.each(flagProps)("%s throws a RangeError for a number that is not an integer", async prop => {
+        await using terminal = new Bun.Terminal({});
+        const before = terminal[prop];
+
+        for (const value of [NaN, Infinity, -Infinity, 1.5]) {
+          const label = String(value);
+          expect({ label, ...assign(terminal, prop, value) }).toEqual({ label, ...outOfRange });
+        }
+
+        expect(terminal[prop]).toBe(before);
+      });
+
+      test.each(flagProps)("%s accepts 0 and 0xffffffff and throws a RangeError one past each", async prop => {
+        await using terminal = new Bun.Terminal({});
+        const before = terminal[prop];
+
+        // A bitwise expression returns a signed 32-bit number, so it is
+        // negative when bit 31 is set.
+        const bit31Set = 0x80000000 | 8;
+        for (const value of [-1, bit31Set, 2 ** 32, Number.MAX_SAFE_INTEGER]) {
+          const label = String(value);
+          expect({ label, ...assign(terminal, prop, value) }).toEqual({ label, ...outOfRange });
+        }
+        expect(terminal[prop]).toBe(before);
+
+        // The kernel keeps or drops some bits per field, so compare the two
+        // accepted assignments with each other, not with a constant.
+        expect(assign(terminal, prop, 0xffffffff)).toEqual(accepted);
+        const allBitsRequested = terminal[prop];
+        expect(assign(terminal, prop, 0)).toEqual(accepted);
+        const noBitsRequested = terminal[prop];
+        expect(allBitsRequested).toBeGreaterThan(noBitsRequested);
+
+        expect(assign(terminal, prop, bit31Set >>> 0)).toEqual(accepted);
+      });
+    });
+
+    test("setting a value that is not a number on a closed terminal is still a no-op", () => {
+      const terminal = new Bun.Terminal({});
+      terminal.close();
+
+      for (const prop of flagProps) {
+        expect(assign(terminal, prop, undefined)).toEqual(accepted);
+        expect(assign(terminal, prop, NaN)).toEqual(accepted);
+        expect(terminal[prop]).toBe(0);
       }
     });
   });


### PR DESCRIPTION
### Problem
- Assigning `undefined`, `NaN`, `"bogus"` or `{}` to `inputFlags`, `outputFlags`, `localFlags` or `controlFlags` of an open `Bun.Terminal` writes `tcflag_t::MAX` (every bit) to the PTY and throws nothing.
- The cause is `set_termios_flag` (`src/runtime/api/bun/Terminal.rs:1338`). It coerces with ToNumber, then clamps with `num.min(max_val).max(0.0)`. `f64::min` returns the operand that is not NaN, so NaN becomes the maximum. #32354 chose that order to match the Zig code.
- The clamp also turns a negative number into `0`. JS bitwise operators return signed 32-bit numbers, so `flags & ~ECHO` clears every flag when bit 31 is set.

### Fix
- The setter validates with the in-tree `validate_uint32` and does not coerce. A value that is not a number throws a `TypeError` (`ERR_INVALID_ARG_TYPE`). NaN, an infinity, a fraction, a negative number and a number above `0xffffffff` throw a `RangeError` (`ERR_OUT_OF_RANGE`), before any syscall.
- Assignment on a closed terminal and on Windows stays a no-op. Every defined termios flag fits in 32 bits. All 16 assignments in the repo pass such a value.
- Verified: `test/js/bun/terminal/terminal.test.ts` (13 new tests, 12 fail on 1.4.3-canary), and all of `test/js/bun/terminal/`.
- Self-reviewed: 4 concerns raised, 4 addressed. Notes has one question for a maintainer.

### Background
- termios is the POSIX terminal attribute struct. Its four flag words have the type `tcflag_t`: 32 bits everywhere except macOS (64 bits).
- A flag setter reads the struct from the PTY master with `tcgetattr`, replaces one word, and writes it back with `tcsetattr`.
- `validate_uint32` (`src/runtime/node/util/validators.rs:169`) ports Node's `validateUint32`. It never runs user JS.

<details><summary>Notes</summary>

**Question for a maintainer: strict uint32, or accept a negative int32 as its bit pattern?**

This PR is strict. `t.localFlags = t.localFlags & ~ECHO` throws `ERR_OUT_OF_RANGE` when bit 31 is set (`CRTSCTS` in `c_cflag` on Linux, `NOFLSH` in `c_lflag` on macOS and the BSDs), because the expression is negative. The caller must write `(t.localFlags & ~ECHO) >>> 0`. The new JSDoc says so, and a test pins it.

- For strict: `Buffer.writeUInt32LE(1 << 31)`, `zlib.crc32("x", -1)`, `fs.chmodSync(p, ~0o22)` and `process.umask(-1)` all throw `ERR_OUT_OF_RANGE` for a negative int32, with the same message. The released build already breaks this idiom: it writes `0`, which clears every flag without an error. A later change from strict to lenient does not break anyone. The reverse does.
- For lenient (accept `-2147483648..4294967295`, take a negative value as its unsigned 32-bit pattern): the read-modify-write idiom then works with no `>>> 0`, as it does in C. It is `validate_integer` with a different range plus one cast.

Say which one you want and I will switch it.

**Order with #39162.** #39162 is open and edits the same function. It makes `tcgetattr` and `tcsetattr` failures throw. The two PRs conflict in `Terminal.rs` and in the test file. If this PR lands first, #39162 keeps its syscall error throws and drops three things that no longer apply: the `coerce_f64` call with the closed check moved after it, the test `setting flags on a terminal closed while coercing the value is a no-op` (an object is now a `TypeError`, `valueOf()` is never called), and its edit of the NaN test.

**Replaced test.** `NaN clamps to tcflag_t max, same as Infinity` came from #32354 and pinned the behaviour this PR removes. The 13 new tests replace it.

**JSDoc.** The four properties said "Setting returns true on success, false on failure". A setter cannot return a value, so that sentence is gone. The new text gives the range, the two error types, the no-op cases, and the `>>> 0` rule on the two properties where a defined flag uses bit 31. #39162 rewrites the same sentence, so that hunk needs a manual merge too.

**Why `validate_uint32` and not `global.validate_integer_range`.** `validate_integer_range` maps `undefined` and NaN to a default, so a setter needs two checks in front of it, and it reports a fraction as `must be of type integer. Received number`. `validate_uint32` covers every case in one call and gives the same messages as `fs.chmodSync` and `process.umask` for the same kind of value. The tests pin the error class, the code, and that the message names the property. They do not pin the full text, because #38663, #35423 and #35429 rewrite the `ERR_INVALID_ARG_TYPE` wording of the shared validators.

**Before and after, open terminal on Linux x64 (`localFlags`, initial `0x8a3b`).**

| assigned | 1.4.3-canary | this PR |
| --- | --- | --- |
| `undefined`, `"bogus"`, `{}` | `0xffffffff` | `TypeError` `ERR_INVALID_ARG_TYPE` |
| `null`, `[]` | `0` | `TypeError` `ERR_INVALID_ARG_TYPE` |
| `"8"`, `true` | `8`, `1` | `TypeError` `ERR_INVALID_ARG_TYPE` |
| `{ valueOf() {...} }` | calls `valueOf()` | `TypeError`, `valueOf()` not called |
| `NaN`, `Infinity`, `2**32` | `0xffffffff` | `RangeError` `ERR_OUT_OF_RANGE` |
| `-Infinity`, `-1` | `0` | `RangeError` `ERR_OUT_OF_RANGE` |
| `1.5` | `1` | `RangeError` `ERR_OUT_OF_RANGE` |
| `0` to `0xffffffff` (integers) | applied | applied |

**Other checks.** `cargo clippy -p bun_runtime --no-deps` and `cargo check -p bun_runtime` are clean for `x86_64-unknown-linux-gnu` and `aarch64-apple-darwin` (the cast to `tcflag_t` widens on macOS). macOS can hold flag bits above 31, but no flag is defined there and JS bitwise operators cannot produce them.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/terminal/terminal.test.ts

<!-- robobun:evidence:end -->