### PR TITLE
yaml: count a string `space` as its length in YAML.stringify

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1521,10 +1521,13 @@ declare module "bun" {
      *
      * @param input The JavaScript value to stringify.
      * @param replacer Not supported.
-     * @param space A number for how many spaces each level of indentation gets, or a string used as indentation.
+     * @param space How many spaces a nested value is indented from its key: a number, or a string, which counts as its length.
+     *              YAML indentation can only be spaces, so the characters of a string are never written: `"\t"` means `1`.
      *              Without this parameter, outputs flow-style (single-line) YAML.
      *              With this parameter, outputs block-style (multi-line) YAML.
-     *              The number is clamped between 0 and 10, and the first 10 characters of the string are used.
+     *              The number or the length is clamped between 0 and 10.
+     *              Inside a sequence item, the entries of a collection start 2 columns to the right of the dash,
+     *              whatever `space` is.
      * @returns A string containing the YAML document.
      *
      * @example

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -95,8 +95,7 @@ impl Space {
         }
 
         if space.is_string() {
-            // Only U+0020 can indent YAML, so a string gives the width (its length, as in
-            // the `yaml` package) and none of its characters are written.
+            // Only spaces can indent YAML, so a string counts as its length (like npm `yaml`).
             return Ok(match space.as_string().length().min(10) {
                 0 => Space::Minified,
                 width => Space::Number(width as u32),

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -66,7 +66,6 @@ struct Stringifier {
 enum Space {
     Minified,
     Number(u32),
-    Str(bun_core::String),
 }
 
 /// How far a block collection indents the lines inside one of its entries.
@@ -96,11 +95,12 @@ impl Space {
         }
 
         if space.is_string() {
-            let str = space.to_bun_string(global)?;
-            if str.length() == 0 {
-                return Ok(Space::Minified);
-            }
-            return Ok(Space::Str(str));
+            // Only U+0020 can indent YAML, so a string gives the width (its length, as in
+            // the `yaml` package) and none of its characters are written.
+            return Ok(match space.as_string().length().min(10) {
+                0 => Space::Minified,
+                width => Space::Number(width as u32),
+            });
         }
 
         Ok(Space::Minified)
@@ -441,7 +441,7 @@ impl Stringifier {
                 Space::Minified => {
                     self.builder.append_lchar(b' ');
                 }
-                Space::Number(_) | Space::Str(_) => {
+                Space::Number(_) => {
                     self.newline();
                 }
             }
@@ -473,7 +473,7 @@ impl Stringifier {
                     }
                     self.builder.append_lchar(b']');
                 }
-                Space::Number(_) | Space::Str(_) => {
+                Space::Number(_) => {
                     self.builder
                         .ensure_unused_capacity(iter.len as usize * b"- ".len());
                     let mut first = true;
@@ -538,7 +538,7 @@ impl Stringifier {
                 }
                 self.builder.append_lchar(b'}');
             }
-            Space::Number(_) | Space::Str(_) => {
+            Space::Number(_) => {
                 self.builder.ensure_unused_capacity(iter.len * b": ".len());
 
                 let mut first = true;
@@ -594,22 +594,6 @@ impl Stringifier {
                 self.builder.ensure_unused_capacity(columns);
                 for _ in 0..columns {
                     self.builder.append_lchar(b' ');
-                }
-            }
-            Space::Str(space_str) => {
-                self.builder.append_lchar(b'\n');
-
-                let clamped = space_str.trunc(10);
-
-                self.builder
-                    .ensure_unused_capacity(self.indent_len(clamped.length()));
-                for step in &self.indent {
-                    match step {
-                        IndentStep::MappingValue => self.builder.append_string(&clamped),
-                        IndentStep::SequenceItem => {
-                            self.builder.append_latin1(SEQUENCE_ITEM_INDENT)
-                        }
-                    }
                 }
             }
         }

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2796,6 +2796,72 @@ config:
       expect(YAML.stringify({ a: 1 }, null, new String("") as any)).toEqual(YAML.stringify({ a: 1 }, null, ""));
     });
 
+    // Only spaces can indent YAML, so a string `space` counts as its length and none of its characters are written.
+    describe("space parameter with a string", () => {
+      const value = {
+        order: { item: ["Tea", "Mug"], paid: null },
+        records: [
+          { name: "a", tags: ["x", "y"] },
+          { name: "b", nested: { deep: [1, [2, 3]] } },
+        ],
+      };
+
+      test.each([
+        ["\t", 1],
+        ["x", 1],
+        ["#", 1],
+        // a digit string counts as its length too, not as its value
+        ["4", 1],
+        ["- ", 2],
+        [" \t", 2],
+        ["\n\n\n", 3],
+        ["é✓", 2],
+        // one astral character is two UTF-16 code units, as in `.length`
+        ["😀", 2],
+        ["\t\t\t\t\t\t\t\t\t\t", 10],
+        ["0123456789abcdef", 10],
+      ])("%j indents like %d", (space, width) => {
+        const text = YAML.stringify(value, null, space);
+        expect(text).toBe(YAML.stringify(value, null, width));
+        expect(YAML.parse(text)).toEqual(value);
+      });
+
+      test("a tab, the JSON.stringify habit, gives one space for each level", () => {
+        const text = YAML.stringify({ order: { item: ["Tea", "Mug"], paid: null } }, null, "\t");
+        // This test is about indentation, so each line is compared without its trailing whitespace.
+        expect(text.split("\n").map(line => line.trimEnd())).toEqual([
+          "order:",
+          " item:",
+          "  - Tea",
+          "  - Mug",
+          " paid: null",
+        ]);
+      });
+
+      test("a string of spaces indents by that many spaces, at most 10", () => {
+        for (let width = 1; width <= 12; width++) {
+          const spaces = Buffer.alloc(width, " ").toString();
+          expect(YAML.stringify(value, null, spaces)).toBe(YAML.stringify(value, null, Math.min(width, 10)));
+        }
+      });
+
+      test("the empty string gives flow style", () => {
+        expect(YAML.stringify({ a: { b: [1] } }, null, "")).toBe("{a: {b: [1]}}");
+        expect(YAML.stringify({ a: { b: [1] } }, null, new String("") as any)).toBe("{a: {b: [1]}}");
+      });
+
+      test("a boxed String and a concatenated string count as their length", () => {
+        class Indent extends String {}
+        let concatenated = "";
+        for (const part of ["\t", "-", "#"]) concatenated += part;
+
+        const expected = YAML.stringify(value, null, 3);
+        expect(YAML.stringify(value, null, new String("\t-#") as any)).toBe(expected);
+        expect(YAML.stringify(value, null, new Indent("\t-#") as any)).toBe(expected);
+        expect(YAML.stringify(value, null, concatenated)).toBe(expected);
+      });
+    });
+
     test("all-undefined properties produces empty object", () => {
       expect(YAML.stringify({ a: undefined, b: undefined }, null, 2)).toBe("{}");
       expect(YAML.stringify({ a: () => {}, b: () => {} }, null, 2)).toBe("{}");


### PR DESCRIPTION
Stacked on #42483. Merge that first.

### Problem
- `Bun.YAML.stringify(value, null, space)` writes a string `space` as the indentation. `"\t"` gives `YAML Parse error: Tab characters cannot be used as indentation`. `"- "` and `"#"` give output that parses to other data, with no error.
- The cause is `Space::init` (`src/runtime/api/YAMLObject.rs:98`). It keeps the string, and `newline()` appends it for each level. #22183 took this from `JSON.stringify`, where each indent string is legal.

### Fix
- A string `space` now sets the width to its length, at most 10. None of its characters are written. The `@param space` text in `bun.d.ts` gives the new rule.
- The `yaml` package does the same (`options = options.length`). A string of spaces and the empty string give the same output as before.
- No maintainer made this behaviour call, and no user reported the bug. The Notes give the other options: throw, or only document.
- Verified: `test/js/bun/yaml/yaml.test.ts`, block "space parameter with a string": 13 of 15 tests fail without the change, 2 are controls. All of `test/js/bun/yaml/` passes. Self-reviewed: 2 concerns addressed (Notes).

### Background
- In block style YAML the indentation gives the structure, and only spaces are legal there. A tab is an error, `-` starts an item, `#` a comment.
- `space` is the third argument, as in `JSON.stringify`: a count of spaces for each level. Without it the output is one line of flow style.
- #42483 lines up a collection inside a sequence item at each width. Without it only width 2 round-trips, and `"\t"` is now width 1.

<details><summary>Notes</summary>

**Reproduction** (1.4.3-canary 6a92015fc8 and main):

```js
const v = { order: { item: ["Tea", "Mug"], paid: null } };
for (const space of [2, "\t", "x", "- ", "#"]) {
  let text, back;
  try { text = Bun.YAML.stringify(v, null, space); back = JSON.stringify(Bun.YAML.parse(text)); }
  catch (e) { back = "ERROR: " + e.message; }
  console.log(JSON.stringify(space), JSON.stringify(text), "->", back);
}
```

| `space` | before | after |
|---|---|---|
| `2` | round-trips | same output |
| `"\t"` | `order: \n\titem: \n\t\t- Tea...`, `Tab characters cannot be used as indentation` | same output as `1`, round-trips |
| `"x"` | `order: \nxitem: \nxx- Tea...`, `Unexpected token` | same output as `1` |
| `"- "` | parses to `{"order":[{"item":null},[["Tea"]],[["Mug"]],{"paid":null}]}` | same output as `2` |
| `"#"` | parses to `{"order":null}` | same output as `1` |

**The three options.** No maintainer has ruled on a string `space`, so here they are.

- A: throw a `TypeError` for a string that has a character other than U+0020. "Every accepted option does what it claims or fails loudly" (`.claude/docs/landing-prs.md`) supports it. It is the shape of the `Bun.XML.stringify` fix, where the declaration promises well-formed output. It makes `YAML.stringify(v, null, "\t")` throw in programs that run today with a flat object, where no indentation is written. The one public caller that was found (see below) catches errors and keeps the source text, so with A it leaves the file as it is.
- B, this PR: count the string as its length. The `yaml` package does this "for JSON compatibility" (its docs), and Prettier 3.6.2 with `useTabs: true` also writes spaces in a YAML file, with no error. Each other `space` outside the domain (NaN, a negative number, more than 10, an object) is already normalised with no error (`YAMLObject.rs:86-106`). The JSDoc now says that a string counts as its length, so the option does what it claims.
- C: keep the raw write and document it. #42526 adds the sentence "YAML indentation must be spaces, so use a string of spaces" to `docs/runtime/yaml.mdx`. The output for `"- "` and `"#"` stays wrong with no error.

If #42526 lands first, its `space` bullet needs the new wording. I left a comment there.

**What changes for a caller.** Only a string that has a character other than a space changes, and only on lines inside a nested collection. A flat mapping, a top-level sequence of scalars and a sequence of one-key mappings never wrote `space`, so they give the same output as before. Each other shape wrote the string. For `"\t"`, `"#"` and `"Z"` the result was a parse error or other data in all six such shapes of a probe (a sequence under a key, a mapping in a mapping, a sequence of mappings, a sequence of sequences, and two more). One accident did round-trip: a string of line breaks (`"\n"`, `"\r\n"`, `" \n"`) with a sequence of scalars under a key, because the items landed at column 0. It now gives spaces and parses to the same value. A search of public code found one caller that passes `"\t"`: the `pickier` formatter (`packages/pickier/src/format.ts`, `formatYaml`) when its indent style is tabs. It writes the result back to the file, so today it gives a file that does not parse. With this PR it gives 1-space indentation.

**Length unit.** UTF-16 code units, as `.length` and as the `yaml` package: `"😀"` is 2. The old code clamped with `trunc(10)`, the same unit. The length comes from `JSString::length()`, so a rope is not flattened.

**Round-trip probe.** 3,001 values (3,000 seeded random values to depth 5 with strings that need quotes, plus one with shared references) at 31 `space` strings (`"\t"`, `"- "`, `"#"`, `": "`, `"&a "`, `"? "`, `"| "`, `"\n"`, `"\r\n"`, U+00A0, U+2028, `"\0"`, quotes, brackets, `"---"`, 16 characters and more): 93,031 round trips. This branch: 0 fail, and each output is the same as for the number. 1.4.3: 36,426 fail (this bug and the one that #42483 fixes).

**Workaround on a released version.** Pass a number: `Bun.YAML.stringify(v, null, typeof s === "string" ? Math.min(10, s.length) : s)`.

**Self-review.** Two concerns changed this PR. The first JSDoc text said that each level of indentation gets `space`. With #42483 a sequence item is always 2 columns, so `[[1,[2,3]],[4]]` gives the same text at 1 and at 8. The text now says that `space` indents a nested value from its key, and it has the sentence about sequence items that #42483 left for this change (084b6f35a7). The first Notes text said that no old output with such a string parsed. One shape did, see "What changes for a caller".

**Other open PRs.** #41116 and #39925 each add a `Space::Str` arm. The one that lands after this PR drops that arm.

**Not changed.** `Bun.JSON5.stringify` writes `space` as it is, which is correct for JSON5 and the same as the `json5` package. `Bun.XML.stringify` has its own fix. The two tests that already pass `"\t"` (`space parameter with boxed String`, and the loop over `[2, 4, "\t", undefined]`) compare one stringify output with another and pass with no edit.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [3.21ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.66ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.69ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [1.98ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.30ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.21ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [4.05ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [3.12ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [2.83ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [3.15ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [2.95ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [2.90ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [3.07ms]
(pass) Bun
... (truncated)

release without fix: 18 skipped
bun test v1.4.3-canary.1 (2a352b459)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [0.07ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [0.03ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [0.02ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [0.04ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [0.03ms]
(pass) Bun.YAML > parse > input types > parses from DataView [0.03ms]
(pass) Bun.YAML > parse > input types > parses from Blob [0.05ms]
(pass) Bun.YAML > parse > i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.3 (6a92015fc)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [3.52ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [2.71ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [3.32ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [2.09ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [3.41ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [2.39ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [4.06ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [3.17ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [2.95ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [3.23ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [3.20ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [3.08ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [2.85ms]
(pass) Bun
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 668ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-types/bun.d.ts   |  7 +++--
 src/runtime/api/YAMLObject.rs | 33 ++++++----------------
 test/js/bun/yaml/yaml.test.ts | 66 +++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 79 insertions(+), 27 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
packages/bun-types/bun.d.ts        2      2     26
src/runtime/api/YAMLObject.rs      4      5     25
test/js/bun/yaml/yaml.test.ts      6      5     25
```

</details>

<!-- robobun:evidence:end -->