### PR TITLE
pm: add bun pm cache prune to remove cache entries by age

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -3453,6 +3453,10 @@
             "rm": {
               "name": "rm",
               "description": "clear the cache"
+            },
+            "prune": {
+              "name": "prune",
+              "description": "remove packages downloaded more than 30 days ago"
             }
           }
         },

--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -3456,7 +3456,21 @@
             },
             "prune": {
               "name": "prune",
-              "description": "remove packages downloaded more than 30 days ago"
+              "description": "remove packages downloaded more than 30 days ago",
+              "flags": [
+                {
+                  "name": "max-age",
+                  "description": "Remove packages downloaded more than this many days ago (default 30)",
+                  "hasValue": true,
+                  "valueType": "days",
+                  "defaultValue": "30"
+                },
+                {
+                  "name": "dry-run",
+                  "description": "Print what would be removed without deleting anything",
+                  "hasValue": false
+                }
+              ]
             }
           }
         },

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -277,7 +277,7 @@ _bun_pm_completion() {
             _arguments -s -C \
                 '1: :->cmd' \
                 '2: :->cmd2' \
-                ':::(rm)' &&
+                ':::(rm prune)' &&
                 ret=0
 
             ;;

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -274,10 +274,16 @@ _bun_pm_completion() {
     args)
         case $line[2] in
         cache)
+            pmargs=(
+                "--max-age[remove packages downloaded more than this many days ago (prune, default 30)]:days"
+                "--dry-run[print what would be removed without deleting anything (prune)]"
+            )
+
             _arguments -s -C \
                 '1: :->cmd' \
                 '2: :->cmd2' \
-                ':::(rm prune)' &&
+                ':::(rm prune)' \
+                $pmargs &&
                 ret=0
 
             ;;

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -470,6 +470,8 @@ bun pm cache rm
 rm -rf ~/.bun/install/cache
 ```
 
+To delete only the packages downloaded more than 30 days ago, see [`bun pm cache prune`](/pm/cli/pm#cache).
+
 ## Platform-specific backends
 
 For performance, `bun install` uses different system calls to install dependencies depending on the platform. You can force a specific backend with the `--backend` flag.

--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -332,6 +332,16 @@ To clear Bun's global module cache:
 bun pm cache rm
 ```
 
+To remove only the packages that were downloaded more than 30 days ago:
+
+```bash terminal icon="terminal"
+bun pm cache prune
+bun pm cache prune --max-age 7   # packages downloaded more than 7 days ago
+bun pm cache prune --dry-run     # list what would be removed without deleting anything
+```
+
+The age of a package is the time since Bun downloaded it. Bun does not record when a cached package was last used, so a package that an install still uses is removed too once it is old enough. The next `bun install` downloads it again. Keep this in mind before you run `bun install --offline`. The command does not touch the [global store](/pm/global-store) in `<cache>/links/`, cached git clones, or package manifests. The size in the summary is the size of the removed files. A file that a `node_modules` tree hardlinks stays on disk until that tree is removed too.
+
 ## migrate
 
 To migrate another package manager's lockfile without installing anything:

--- a/docs/pm/cli/prune.mdx
+++ b/docs/pm/cli/prune.mdx
@@ -70,4 +70,4 @@ bun prune --production --filter app
 - Works on a pruned monorepo checkout (e.g. `turbo prune` output) the same way `bun install --frozen-lockfile` does.
 - If any entry fails to delete, the command still removes the rest and exits `1`.
 - `--global` is not supported.
-- To clean the global cache instead, use [`bun pm cache rm`](/pm/cli/pm#cache).
+- To clean the global cache instead, use [`bun pm cache rm`](/pm/cli/pm#cache) or [`bun pm cache prune`](/pm/cli/pm#cache).

--- a/docs/pm/global-store.mdx
+++ b/docs/pm/global-store.mdx
@@ -136,7 +136,7 @@ Tools that scan `node_modules` without following symlinks, or that compare file 
 
 ### Disk usage
 
-Each unique `(package, version, resolved-dependency-set)` triple gets one directory in `<cache>/links/`. Across many projects that's a large net win: one copy on disk instead of one per checkout. But the store does grow over time as new versions and new peer-dependency combinations land. Run `bun pm cache rm` to clear the cache including the global store; the next install repopulates only what that project needs.
+Each unique `(package, version, resolved-dependency-set)` triple gets one directory in `<cache>/links/`. Across many projects that's a large net win: one copy on disk instead of one per checkout. But the store does grow over time as new versions and new peer-dependency combinations land. Run `bun pm cache rm` to clear the cache including the global store; the next install repopulates only what that project needs. [`bun pm cache prune`](/pm/cli/pm#cache) removes old downloaded packages but leaves the global store alone.
 
 ### Concurrency
 

--- a/misctools/generate-cli-completions.ts
+++ b/misctools/generate-cli-completions.ts
@@ -18,7 +18,7 @@
  */
 
 import { spawn } from "bun";
-import { mkdirSync, writeFileSync, mkdtempSync, rmSync } from "fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 
 interface FlagInfo {
@@ -350,6 +350,20 @@ function parsePmSubcommands(helpText: string): Record<string, SubcommandInfo> {
             prune: {
               name: "prune",
               description: "remove packages downloaded more than 30 days ago",
+              flags: [
+                {
+                  name: "max-age",
+                  description: "Remove packages downloaded more than this many days ago (default 30)",
+                  hasValue: true,
+                  valueType: "days",
+                  defaultValue: "30",
+                },
+                {
+                  name: "dry-run",
+                  description: "Print what would be removed without deleting anything",
+                  hasValue: false,
+                },
+              ],
             },
           };
         } else if (name === "pkg") {

--- a/misctools/generate-cli-completions.ts
+++ b/misctools/generate-cli-completions.ts
@@ -347,6 +347,10 @@ function parsePmSubcommands(helpText: string): Record<string, SubcommandInfo> {
               name: "rm",
               description: "clear the cache",
             },
+            prune: {
+              name: "prune",
+              description: "remove packages downloaded more than 30 days ago",
+            },
           };
         } else if (name === "pkg") {
           subcommands[name].subcommands = {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -204,15 +204,16 @@ pub use super::package_installer::PackageInstaller;
 pub use self::package_manager_directories as directories;
 use directories::attempt_to_create_package_json_and_open;
 pub use directories::{
-    attempt_to_create_package_json, cached_git_folder_name, cached_git_folder_name_print,
-    cached_git_folder_name_print_auto, cached_github_folder_name, cached_github_folder_name_print,
-    cached_github_folder_name_print_auto, cached_npm_package_folder_name,
-    cached_npm_package_folder_name_print, cached_npm_package_folder_print_basename,
-    cached_tarball_folder_name, cached_tarball_folder_name_print, compute_cache_dir_and_subpath,
-    fetch_cache_directory_path, get_cache_directory, get_cache_directory_and_abs_path,
-    get_temporary_directory, global_link_dir, global_link_dir_path, is_folder_in_cache,
-    path_for_cached_npm_path, path_for_resolution, save_lockfile, setup_global_dir,
-    update_lockfile_if_needed, write_yarn_lock,
+    CacheEntryKind, attempt_to_create_package_json, cached_git_folder_name,
+    cached_git_folder_name_print, cached_git_folder_name_print_auto, cached_github_folder_name,
+    cached_github_folder_name_print, cached_github_folder_name_print_auto,
+    cached_npm_package_folder_name, cached_npm_package_folder_name_print,
+    cached_npm_package_folder_print_basename, cached_tarball_folder_name,
+    cached_tarball_folder_name_print, compute_cache_dir_and_subpath, fetch_cache_directory_path,
+    get_cache_directory, get_cache_directory_and_abs_path, get_temporary_directory,
+    global_link_dir, global_link_dir_path, is_folder_in_cache, path_for_cached_npm_path,
+    path_for_resolution, save_lockfile, setup_global_dir, update_lockfile_if_needed,
+    write_yarn_lock,
 };
 
 pub use self::package_manager_enqueue as enqueue;
@@ -1652,7 +1653,7 @@ pub fn init(
                 }
             }
             if cli.no_project_ok {
-                // Registry-only commands (`bun pm diff a b`) run fine from any folder: no root file, no workspaces.
+                // Project-independent commands (`bun pm diff a b`, `bun pm cache prune`) run fine from any folder: no root file, no workspaces.
                 this_cwd = original_cwd;
                 no_project = true;
                 break 'child bun_sys::File::from_fd(bun_sys::Fd::INVALID);

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -255,6 +255,9 @@ pub(crate) static PM_PARAMS: &[ParamType] = concat_params![
         clap::param!(
             "--depth <NUM>                          Maximum depth of the dependency tree to display"
         ),
+        clap::param!(
+            "--max-age <NUM>                        Remove cache entries downloaded more than this many days ago (bun pm cache prune, default 30)"
+        ),
         clap::param!("<POS> ...                         "),
     ]
 ];
@@ -595,6 +598,9 @@ pub struct CommandLineArguments {
     pub diff_stat: bool,
     pub diff_context: Option<usize>,
 
+    // `bun pm cache prune` options
+    pub cache_max_age_days: Option<u32>,
+
     // `bun audit` options
     pub audit_level: Option<AuditLevel>,
     pub audit_ignore_list: &'static [&'static [u8]],
@@ -692,6 +698,8 @@ impl Default for CommandLineArguments {
             diff_ignore_space: false,
             diff_stat: false,
             diff_context: None,
+
+            cache_max_age_days: None,
 
             audit_level: None,
             audit_ignore_list: &[],
@@ -1786,7 +1794,9 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             cli.diff_name_only = args.flag(b"--name-only");
             cli.diff_raw = args.flag(b"--raw") || args.flag(b"--unformatted");
             cli.no_project_ok = cli.positionals.first().is_some_and(|p| *p == b"pm")
-                && cli.positionals.get(1).is_some_and(|p| *p == b"diff");
+                && (cli.positionals.get(1).is_some_and(|p| *p == b"diff")
+                    || (cli.positionals.get(1).is_some_and(|p| *p == b"cache")
+                        && cli.positionals.get(2).is_some_and(|p| *p == b"prune")));
             cli.diff_unminify = args.flag(b"--unminify");
             cli.diff_minify = args.flag(b"--minify");
             cli.diff_ignore_space = args.flag(b"--ignore-space");
@@ -1797,6 +1807,18 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
                     Err(_) => {
                         Output::err_generic(
                             "invalid --unified value: {}, expected a non-negative integer",
+                            (bstr::BStr::new(n),),
+                        );
+                        Global::exit(1);
+                    }
+                }
+            }
+            if let Some(n) = args.option(b"--max-age") {
+                match strings::parse_int::<u32>(n, 10) {
+                    Ok(v) => cli.cache_max_age_days = Some(v),
+                    Err(_) => {
+                        Output::err_generic(
+                            "invalid --max-age value: {}, expected a number of days",
                             (bstr::BStr::new(n),),
                         );
                         Global::exit(1);

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -420,31 +420,19 @@ pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Optio
 
 // ─────────────────────── cached folder name printers ──────────────────────────
 //
-// The printers below, `ExtractTarball` (index symlinks), `GitRunner` (bare
-// clones), `PackageManifestMap` (`.npm` manifests), the isolated installer
-// (`links/`), `StandaloneModuleGraph` (`bun-<os>-<arch>-v*` binaries) and
-// `RuntimeTranspilerCache` (`@t@`) all write into the cache root.
-// `CacheEntryKind::from_name` is the one reader of that layout.
-
-/// What a top-level cache directory entry (or an entry of a `@scope`
-/// directory) is, judged by its name. `bun pm cache prune` removes `Package`
-/// entries and cleans `Index` entries; everything else is left alone.
+/// What a cache root entry (or an entry of a `@scope` directory) is, by name.
+/// Every writer into the cache root is listed next to its variant.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CacheEntryKind {
-    /// An extracted package: `<name>@<version>[@@<host>][@@@<N>][_patch_hash=<x>]`
-    /// (`cached_npm_package_folder_name_print`), `@G@<sha>` (`cached_git_folder_name_print`),
-    /// `@GH@<resolved>@@@<N>` (`cached_github_folder_name_print`) or
-    /// `@T@<hash>@@@<N>` (`cached_tarball_folder_name_print`).
+    /// `<name>@<version>...`, `@G@...`, `@GH@...`, `@T@...` (the printers below).
     Package,
-    /// `@<scope>`: holds the `Package` and `Index` entries of scoped packages.
+    /// `@<scope>`: holds scoped `Package` and `Index` entries.
     Scope,
-    /// `<name>`: holds one symlink (junction on Windows) per cached version,
-    /// `<version>[@@@<N>]` -> the `Package` directory (`ExtractTarball::extract`).
+    /// `<name>/<version>...` symlinks to `Package` directories (`ExtractTarball::extract`).
     Index,
-    /// Not a package: `links/` (the global store), `<hex>.git` (bare clones),
-    /// `@t@` (the runtime transpiler cache), `.<hex>-<n>.<name>` (extraction
-    /// staging) and any non-directory (`<hex>.npm` manifests, `bun-<os>-<arch>-v*`
-    /// binaries for `bun build --compile --target`).
+    /// `links/` (isolated installer), `<hex>.git` (`GitRunner`), `@t@`
+    /// (`RuntimeTranspilerCache`), `.<tmp>` staging, and non-directories
+    /// (`.npm` manifests, `bun-<os>-<arch>-v*` from `StandaloneModuleGraph`).
     Other,
 }
 

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -420,6 +420,59 @@ pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Optio
 
 // ─────────────────────── cached folder name printers ──────────────────────────
 //
+// The printers below, `ExtractTarball` (index symlinks), `GitRunner` (bare
+// clones), `PackageManifestMap` (`.npm` manifests), the isolated installer
+// (`links/`), `StandaloneModuleGraph` (`bun-<os>-<arch>-v*` binaries) and
+// `RuntimeTranspilerCache` (`@t@`) all write into the cache root.
+// `CacheEntryKind::from_name` is the one reader of that layout.
+
+/// What a top-level cache directory entry (or an entry of a `@scope`
+/// directory) is, judged by its name. `bun pm cache prune` removes `Package`
+/// entries and cleans `Index` entries; everything else is left alone.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CacheEntryKind {
+    /// An extracted package: `<name>@<version>[@@<host>][@@@<N>][_patch_hash=<x>]`
+    /// (`cached_npm_package_folder_name_print`), `@G@<sha>` (`cached_git_folder_name_print`),
+    /// `@GH@<resolved>@@@<N>` (`cached_github_folder_name_print`) or
+    /// `@T@<hash>@@@<N>` (`cached_tarball_folder_name_print`).
+    Package,
+    /// `@<scope>`: holds the `Package` and `Index` entries of scoped packages.
+    Scope,
+    /// `<name>`: holds one symlink (junction on Windows) per cached version,
+    /// `<version>[@@@<N>]` -> the `Package` directory (`ExtractTarball::extract`).
+    Index,
+    /// Not a package: `links/` (the global store), `<hex>.git` (bare clones),
+    /// `@t@` (the runtime transpiler cache), `.<hex>-<n>.<name>` (extraction
+    /// staging) and any non-directory (`<hex>.npm` manifests, `bun-<os>-<arch>-v*`
+    /// binaries for `bun build --compile --target`).
+    Other,
+}
+
+impl CacheEntryKind {
+    pub fn from_name(name: &[u8], kind: bun_sys::EntryKind, in_scope: bool) -> CacheEntryKind {
+        if kind != bun_sys::EntryKind::Directory || name.is_empty() || name[0] == b'.' {
+            return CacheEntryKind::Other;
+        }
+        if name[0] == b'@' {
+            if in_scope || name.starts_with(b"@t@") {
+                return CacheEntryKind::Other;
+            }
+            return if bun_core::strings::contains_char(&name[1..], b'@') {
+                CacheEntryKind::Package
+            } else {
+                CacheEntryKind::Scope
+            };
+        }
+        if bun_core::strings::contains_char(name, b'@') {
+            return CacheEntryKind::Package;
+        }
+        if name == b"links" || name.ends_with(b".git") {
+            return CacheEntryKind::Other;
+        }
+        CacheEntryKind::Index
+    }
+}
+
 // PERF: an earlier version used `core::fmt::write` over a `format_args!` of
 // `bun_fmt::s` / `hex_int_*` pieces. In Rust that is *dynamic* dispatch — every `{}` argument is a
 // `&dyn Display` whose vtable lives in `.data.rel.ro`, and every

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -354,6 +354,8 @@ pub mod pack_command;
 pub(crate) mod patch_command;
 #[path = "patch_commit_command.rs"]
 pub(crate) mod patch_commit_command;
+#[path = "pm_cache_prune_command.rs"]
+pub(crate) mod pm_cache_prune_command;
 #[path = "pm_diff_command.rs"]
 pub mod pm_diff_command;
 pub mod pm_diff_normalize;

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -18,6 +18,7 @@ use bun_resolver::fs as Fs;
 use bun_sys::{self, Dir, Fd, File};
 
 use crate::cli::Command;
+use crate::cli::pm_cache_prune_command::{DEFAULT_MAX_AGE_DAYS, PmCachePruneCommand};
 use crate::cli::pm_diff_command as PmDiffCommand;
 use crate::cli::pm_licenses_command::{LicensesFlags, PmLicensesCommand};
 use crate::cli::pm_pkg_command::PmPkgCommand;
@@ -217,6 +218,9 @@ impl PackageManagerCommand {
   <b><green>bun pm<r> <blue>hash-print<r>           print the hash stored in the current lockfile\n\
   <b><green>bun pm<r> <blue>cache<r>                print the path to the cache folder\n\
   <b><green>bun pm<r> <blue>cache rm<r>             clear the cache\n\
+  <b><green>bun pm<r> <blue>cache prune<r>          remove packages downloaded more than 30 days ago\n\
+  <d>├<r> <cyan>--max-age<r> <d>\\<days\\><r>          age threshold in days (default 30)\n\
+  <d>└<r> <cyan>--dry-run<r>                 print what would be removed without deleting anything\n\
   <b><green>bun pm<r> <blue>migrate<r>              migrate another package manager's lockfile without installing anything\n\
   <b><green>bun pm<r> <blue>untrusted<r>            print current untrusted dependencies with scripts\n\
   <b><green>bun pm<r> <blue>trust<r> <d>names ...<r>      run scripts for untrusted dependencies and add to `trustedDependencies`\n\
@@ -261,6 +265,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             context: cli.diff_context.unwrap_or(3),
         };
         let diff_args: Vec<&'static [u8]> = cli.diff_args.clone();
+        let cache_max_age_days = cli.cache_max_age_days.unwrap_or(DEFAULT_MAX_AGE_DAYS);
         let (pm, cwd) = match PackageManager::init(&mut *ctx, cli, Subcommand::Pm) {
             Ok(v) => v,
             Err(err) => {
@@ -432,6 +437,31 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 .has_meta_hash_changed(true, pm.lockfile.packages.len())?;
             Global::exit(0);
         } else if strings::eql_comptime(subcommand, b"cache") {
+            if pm.options.positionals.len() > 1
+                && strings::eql_comptime(pm.options.positionals[1], b"prune")
+            {
+                let mut process_env = bun_dotenv::Loader::init();
+                process_env.load_process()?;
+                let cache_dir = fetch_cache_directory_path(&mut process_env, None);
+                // An empty `BUN_INSTALL_CACHE_DIR` resolves to the working directory.
+                if strings::eql(&cache_dir.path, Fs::FileSystem::get().top_level_dir) {
+                    Output::err_generic(
+                        "refusing to prune \"{s}\": the cache directory resolves to the working directory",
+                        (bstr::BStr::new(&cache_dir.path),),
+                    );
+                    bun_core::note!(
+                        "the cache directory comes from $BUN_INSTALL_CACHE_DIR or $BUN_INSTALL. Point it at the bun install cache."
+                    );
+                    Global::exit(1);
+                }
+                let exit_code = PmCachePruneCommand::exec(
+                    &cache_dir.path,
+                    cache_max_age_days,
+                    pm.options.dry_run,
+                );
+                Global::exit(u32::from(exit_code));
+            }
+
             if pm.options.positionals.len() > 1
                 && strings::eql_comptime(pm.options.positionals[1], b"rm")
             {

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -443,17 +443,6 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 let mut process_env = bun_dotenv::Loader::init();
                 process_env.load_process()?;
                 let cache_dir = fetch_cache_directory_path(&mut process_env, None);
-                // An empty `BUN_INSTALL_CACHE_DIR` resolves to the working directory.
-                if strings::eql(&cache_dir.path, Fs::FileSystem::get().top_level_dir) {
-                    Output::err_generic(
-                        "refusing to prune \"{s}\": the cache directory resolves to the working directory",
-                        (bstr::BStr::new(&cache_dir.path),),
-                    );
-                    bun_core::note!(
-                        "the cache directory comes from $BUN_INSTALL_CACHE_DIR or $BUN_INSTALL. Point it at the bun install cache."
-                    );
-                    Global::exit(1);
-                }
                 let exit_code = PmCachePruneCommand::exec(
                     &cache_dir.path,
                     cache_max_age_days,

--- a/src/runtime/cli/pm_cache_prune_command.rs
+++ b/src/runtime/cli/pm_cache_prune_command.rs
@@ -1,8 +1,6 @@
-//! `bun pm cache prune`: remove cache entries whose directory mtime is older
-//! than `--max-age` days. Bun never touches an entry after extraction, so the
-//! mtime is the download time, not the last use. `CacheEntryKind` (next to
-//! the cache folder name printers in `bun_install`) says which entries are
-//! packages.
+//! `bun pm cache prune`: remove `CacheEntryKind::Package` directories whose
+//! mtime (the extraction time, bun never touches them later) is older than
+//! `--max-age` days.
 
 use bstr::BStr;
 use bun_core::{Output, ZBox, fmt as bun_fmt};
@@ -74,8 +72,7 @@ struct Prune {
 }
 
 impl Prune {
-    /// `prefix` is the display path of `dir` relative to the cache root
-    /// (empty for the root, `@scope/` for a scope directory).
+    /// `prefix` is `dir` relative to the cache root: `` or `@scope/`.
     fn prune_dir(&mut self, dir: &Dir, prefix: &[u8], in_scope: bool) {
         let Some(entries) = read_entries(dir, prefix) else {
             self.failed += 1;
@@ -128,9 +125,7 @@ impl Prune {
         }
     }
 
-    /// Remove every symlink (junction on Windows) in `index` whose target is
-    /// gone. The index entries point at package directories, so this runs
-    /// after the package pass of the same directory.
+    /// Remove the index links whose `Package` directory is gone.
     fn remove_dangling_links(&mut self, index: &Dir, prefix: &[u8]) {
         let Some(entries) = read_entries(index, prefix) else {
             self.failed += 1;
@@ -211,7 +206,6 @@ impl PmCachePruneCommand {
         };
 
         // An empty `BUN_INSTALL_CACHE_DIR` resolves to the working directory.
-        // Compare the opened directory, not the path, so a symlink is caught too.
         if let (Ok(cache_st), Ok(cwd_st)) = (
             bun_sys::fstat(cache_dir.fd()),
             bun_sys::stat(bun_core::zstr!(".")),

--- a/src/runtime/cli/pm_cache_prune_command.rs
+++ b/src/runtime/cli/pm_cache_prune_command.rs
@@ -25,10 +25,19 @@ fn read_entries(dir: &Dir, path: &[u8]) -> Option<Vec<Entry>> {
     let mut entries = Vec::new();
     loop {
         match iter.next() {
-            Ok(Some(entry)) => entries.push(Entry {
-                name: ZBox::from_bytes(entry.name.slice_u8()),
-                kind: entry.kind,
-            }),
+            Ok(Some(entry)) => {
+                let name = ZBox::from_bytes(entry.name.slice_u8());
+                // DT_UNKNOWN: NFS, FUSE and bind mounts do not fill d_type.
+                let kind = if entry.kind == EntryKind::Unknown {
+                    match bun_sys::lstatat(dir.fd(), &name) {
+                        Ok(st) => bun_sys::kind_from_mode(st.st_mode as bun_sys::Mode),
+                        Err(_) => EntryKind::Unknown,
+                    }
+                } else {
+                    entry.kind
+                };
+                entries.push(Entry { name, kind });
+            }
             Ok(None) => return Some(entries),
             Err(err) => {
                 Output::err(err, "Could not read {s}", (BStr::new(path),));
@@ -63,6 +72,7 @@ fn tree_size(dir: &Dir, path: &[u8]) -> u64 {
 }
 
 struct Prune {
+    root: Vec<u8>,
     cutoff_sec: i64,
     dry_run: bool,
     checked: usize,
@@ -74,7 +84,12 @@ struct Prune {
 impl Prune {
     /// `prefix` is `dir` relative to the cache root: `` or `@scope/`.
     fn prune_dir(&mut self, dir: &Dir, prefix: &[u8], in_scope: bool) {
-        let Some(entries) = read_entries(dir, prefix) else {
+        let read_path: &[u8] = if prefix.is_empty() {
+            &self.root
+        } else {
+            prefix
+        };
+        let Some(entries) = read_entries(dir, read_path) else {
             self.failed += 1;
             return;
         };
@@ -236,6 +251,7 @@ impl PmCachePruneCommand {
         let now = bun_core::time::timestamp();
         let max_age_sec = i64::from(max_age_days) * i64::from(bun_core::time::S_PER_DAY);
         let mut prune = Prune {
+            root: cache_path.to_vec(),
             cutoff_sec: now.saturating_sub(max_age_sec),
             dry_run,
             checked: 0,

--- a/src/runtime/cli/pm_cache_prune_command.rs
+++ b/src/runtime/cli/pm_cache_prune_command.rs
@@ -1,0 +1,248 @@
+//! `bun pm cache prune`: remove cache entries whose directory mtime is older
+//! than `--max-age` days. Bun never touches an entry after extraction, so the
+//! mtime is the download time, not the last use. `CacheEntryKind` (next to
+//! the cache folder name printers in `bun_install`) says which entries are
+//! packages.
+
+use bstr::BStr;
+use bun_core::{Output, ZBox, fmt as bun_fmt};
+use bun_install::package_manager_real::CacheEntryKind as Kind;
+use bun_sys::{self, Dir, E, EntryKind, PosixStat};
+
+pub(crate) struct PmCachePruneCommand;
+
+pub(crate) const DEFAULT_MAX_AGE_DAYS: u32 = 30;
+
+fn plural(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
+}
+
+struct Entry {
+    name: ZBox,
+    kind: EntryKind,
+}
+
+fn read_entries(dir: &Dir, path: &[u8]) -> Option<Vec<Entry>> {
+    let mut iter = bun_sys::iterate_dir(dir.fd());
+    let mut entries = Vec::new();
+    loop {
+        match iter.next() {
+            Ok(Some(entry)) => entries.push(Entry {
+                name: ZBox::from_bytes(entry.name.slice_u8()),
+                kind: entry.kind,
+            }),
+            Ok(None) => return Some(entries),
+            Err(err) => {
+                Output::err(err, "Could not read {s}", (BStr::new(path),));
+                return None;
+            }
+        }
+    }
+}
+
+/// Sum of the file sizes under `dir`. Symlinks are not followed.
+fn tree_size(dir: &Dir, path: &[u8]) -> u64 {
+    let Some(entries) = read_entries(dir, path) else {
+        return 0;
+    };
+    let mut total: u64 = 0;
+    for entry in &entries {
+        match entry.kind {
+            EntryKind::Directory => {
+                if let Ok(sub) = dir.open_at(entry.name.as_bytes()) {
+                    total += tree_size(&sub, path);
+                }
+            }
+            EntryKind::File => {
+                if let Ok(st) = bun_sys::lstatat(dir.fd(), &entry.name) {
+                    total += PosixStat::init(&st).size;
+                }
+            }
+            _ => {}
+        }
+    }
+    total
+}
+
+struct Prune {
+    cutoff_sec: i64,
+    dry_run: bool,
+    checked: usize,
+    removed: usize,
+    failed: usize,
+    bytes: u64,
+}
+
+impl Prune {
+    /// `prefix` is the display path of `dir` relative to the cache root
+    /// (empty for the root, `@scope/` for a scope directory).
+    fn prune_dir(&mut self, dir: &Dir, prefix: &[u8], in_scope: bool) {
+        let Some(entries) = read_entries(dir, prefix) else {
+            return;
+        };
+
+        for entry in &entries {
+            let name = entry.name.as_bytes();
+            match Kind::from_name(name, entry.kind, in_scope) {
+                Kind::Package => self.prune_package(dir, entry, prefix),
+                Kind::Scope => {
+                    let Ok(sub) = dir.open_at(name) else {
+                        continue;
+                    };
+                    let sub_prefix = [prefix, name, b"/"].concat();
+                    self.prune_dir(&sub, &sub_prefix, true);
+                    drop(sub);
+                    if !self.dry_run {
+                        let _ = bun_sys::rmdirat(dir.fd(), &entry.name);
+                    }
+                }
+                Kind::Index | Kind::Other => {}
+            }
+        }
+
+        if self.dry_run {
+            return;
+        }
+        for entry in &entries {
+            if Kind::from_name(entry.name.as_bytes(), entry.kind, in_scope) == Kind::Index {
+                if let Ok(index) = dir.open_at(entry.name.as_bytes()) {
+                    remove_dangling_links(&index);
+                }
+                // Fails with ENOTEMPTY when versions remain.
+                let _ = bun_sys::rmdirat(dir.fd(), &entry.name);
+            }
+        }
+    }
+
+    fn prune_package(&mut self, dir: &Dir, entry: &Entry, prefix: &[u8]) {
+        let name = entry.name.as_bytes();
+        let st = match bun_sys::lstatat(dir.fd(), &entry.name) {
+            Ok(st) => st,
+            Err(err) => {
+                if err.get_errno() != E::ENOENT {
+                    Output::err(err, "Could not stat {s}", (BStr::new(name),));
+                    self.failed += 1;
+                }
+                return;
+            }
+        };
+        self.checked += 1;
+        if bun_sys::stat_mtime(&st).sec > self.cutoff_sec {
+            return;
+        }
+
+        let display = [prefix, name].concat();
+        let size = match dir.open_at(name) {
+            Ok(sub) => tree_size(&sub, &display),
+            Err(_) => 0,
+        };
+
+        if self.dry_run {
+            bun_core::prettyln!(
+                "<r><red>-<r> {} <d>({})<r>",
+                BStr::new(&display),
+                bun_fmt::size(size as usize, Default::default())
+            );
+        } else if let Err(err) = dir.delete_tree(name) {
+            Output::err(err, "Could not delete {s}", (BStr::new(&display),));
+            self.failed += 1;
+            return;
+        }
+        self.removed += 1;
+        self.bytes += size;
+    }
+}
+
+/// Remove every symlink (junction on Windows) in `index` whose target is gone.
+/// The index entries point at package directories, so this runs after the
+/// package pass of the same directory.
+fn remove_dangling_links(index: &Dir) {
+    let Some(entries) = read_entries(index, b"") else {
+        return;
+    };
+    for entry in &entries {
+        if entry.kind != EntryKind::SymLink {
+            continue;
+        }
+        match bun_sys::fstatat(index.fd(), &entry.name) {
+            Ok(_) => {}
+            Err(err) if err.get_errno() == E::ENOENT => {
+                if bun_sys::unlinkat(index.fd(), &entry.name).is_err() {
+                    let _ = bun_sys::rmdirat(index.fd(), &entry.name);
+                }
+            }
+            Err(_) => {}
+        }
+    }
+}
+
+impl PmCachePruneCommand {
+    /// Returns the process exit code.
+    pub(crate) fn exec(cache_path: &[u8], max_age_days: u32, dry_run: bool) -> u8 {
+        let cache_dir = match Dir::open(cache_path) {
+            Ok(dir) => dir,
+            Err(err) if err.get_errno() == E::ENOENT => {
+                bun_core::prettyln!(
+                    "<r><green>Done<r>! No cache directory <d>(nothing to prune)<r>"
+                );
+                return 0;
+            }
+            Err(err) => {
+                Output::err(err, "Could not open {s}", (BStr::new(cache_path),));
+                return 1;
+            }
+        };
+
+        let now = bun_core::time::timestamp();
+        let max_age_sec = i64::from(max_age_days) * i64::from(bun_core::time::S_PER_DAY);
+        let mut prune = Prune {
+            cutoff_sec: now.saturating_sub(max_age_sec),
+            dry_run,
+            checked: 0,
+            removed: 0,
+            failed: 0,
+            bytes: 0,
+        };
+        prune.prune_dir(&cache_dir, b"", false);
+        Output::flush();
+
+        let checked = prune.checked;
+        let n = prune.removed;
+        let size = bun_fmt::size(prune.bytes as usize, Default::default());
+        if n == 0 && prune.failed == 0 {
+            bun_core::prettyln!(
+                "<r><green>Done<r>! Checked <green>{} package{}<r>, none older than {} day{} <d>(nothing to prune)<r>",
+                checked,
+                plural(checked),
+                max_age_days,
+                plural(max_age_days as usize)
+            );
+        } else if dry_run {
+            bun_core::prettyln!(
+                "<r><b>{}<r> package{} older than {} day{} can be removed <d>({}, checked {})<r>",
+                n,
+                plural(n),
+                max_age_days,
+                plural(max_age_days as usize),
+                size,
+                checked
+            );
+            bun_core::prettyln!("<d>Run without --dry-run to remove them.<r>");
+        } else {
+            bun_core::pretty!(
+                "<r>Removed <b>{}<r> package{} older than {} day{} <d>({})<r>",
+                n,
+                plural(n),
+                max_age_days,
+                plural(max_age_days as usize),
+                size
+            );
+            if prune.failed > 0 {
+                bun_core::pretty!(", <red>{} failed<r>", prune.failed);
+            }
+            bun_core::prettyln!("");
+        }
+        Output::flush();
+        u8::from(prune.failed > 0)
+    }
+}

--- a/src/runtime/cli/pm_cache_prune_command.rs
+++ b/src/runtime/cli/pm_cache_prune_command.rs
@@ -96,7 +96,7 @@ impl Prune {
                     self.prune_dir(&sub, &sub_prefix, true);
                     drop(sub);
                     if !self.dry_run {
-                        let _ = bun_sys::rmdirat(dir.fd(), &entry.name);
+                        self.remove_if_empty(dir, entry, &sub_prefix);
                     }
                 }
                 Kind::Index | Kind::Other => {}
@@ -120,8 +120,18 @@ impl Prune {
                     continue;
                 }
             }
-            // Fails with ENOTEMPTY when versions remain.
-            let _ = bun_sys::rmdirat(dir.fd(), &entry.name);
+            self.remove_if_empty(dir, entry, &display);
+        }
+    }
+
+    fn remove_if_empty(&mut self, dir: &Dir, entry: &Entry, display: &[u8]) {
+        match bun_sys::rmdirat(dir.fd(), &entry.name) {
+            Ok(()) => {}
+            Err(err) if matches!(err.get_errno(), E::ENOTEMPTY | E::EEXIST | E::ENOENT) => {}
+            Err(err) => {
+                Output::err(err, "Could not delete {s}", (BStr::new(display),));
+                self.failed += 1;
+            }
         }
     }
 

--- a/src/runtime/cli/pm_cache_prune_command.rs
+++ b/src/runtime/cli/pm_cache_prune_command.rs
@@ -78,6 +78,7 @@ impl Prune {
     /// (empty for the root, `@scope/` for a scope directory).
     fn prune_dir(&mut self, dir: &Dir, prefix: &[u8], in_scope: bool) {
         let Some(entries) = read_entries(dir, prefix) else {
+            self.failed += 1;
             return;
         };
 
@@ -86,10 +87,15 @@ impl Prune {
             match Kind::from_name(name, entry.kind, in_scope) {
                 Kind::Package => self.prune_package(dir, entry, prefix),
                 Kind::Scope => {
-                    let Ok(sub) = dir.open_at(name) else {
-                        continue;
-                    };
                     let sub_prefix = [prefix, name, b"/"].concat();
+                    let sub = match dir.open_at(name) {
+                        Ok(sub) => sub,
+                        Err(err) => {
+                            Output::err(err, "Could not open {s}", (BStr::new(&sub_prefix),));
+                            self.failed += 1;
+                            continue;
+                        }
+                    };
                     self.prune_dir(&sub, &sub_prefix, true);
                     drop(sub);
                     if !self.dry_run {
@@ -104,12 +110,46 @@ impl Prune {
             return;
         }
         for entry in &entries {
-            if Kind::from_name(entry.name.as_bytes(), entry.kind, in_scope) == Kind::Index {
-                if let Ok(index) = dir.open_at(entry.name.as_bytes()) {
-                    remove_dangling_links(&index);
+            let name = entry.name.as_bytes();
+            if Kind::from_name(name, entry.kind, in_scope) != Kind::Index {
+                continue;
+            }
+            let display = [prefix, name].concat();
+            match dir.open_at(name) {
+                Ok(index) => self.remove_dangling_links(&index, &display),
+                Err(err) => {
+                    Output::err(err, "Could not open {s}", (BStr::new(&display),));
+                    self.failed += 1;
+                    continue;
                 }
-                // Fails with ENOTEMPTY when versions remain.
-                let _ = bun_sys::rmdirat(dir.fd(), &entry.name);
+            }
+            // Fails with ENOTEMPTY when versions remain.
+            let _ = bun_sys::rmdirat(dir.fd(), &entry.name);
+        }
+    }
+
+    /// Remove every symlink (junction on Windows) in `index` whose target is
+    /// gone. The index entries point at package directories, so this runs
+    /// after the package pass of the same directory.
+    fn remove_dangling_links(&mut self, index: &Dir, prefix: &[u8]) {
+        let Some(entries) = read_entries(index, prefix) else {
+            self.failed += 1;
+            return;
+        };
+        for entry in &entries {
+            if entry.kind != EntryKind::SymLink {
+                continue;
+            }
+            match bun_sys::fstatat(index.fd(), &entry.name) {
+                Err(err) if err.get_errno() == E::ENOENT => {}
+                _ => continue,
+            }
+            if let Err(err) = bun_sys::unlinkat(index.fd(), &entry.name)
+                .or_else(|_| bun_sys::rmdirat(index.fd(), &entry.name))
+            {
+                let display = [prefix, b"/", entry.name.as_bytes()].concat();
+                Output::err(err, "Could not delete {s}", (BStr::new(&display),));
+                self.failed += 1;
             }
         }
     }
@@ -153,29 +193,6 @@ impl Prune {
     }
 }
 
-/// Remove every symlink (junction on Windows) in `index` whose target is gone.
-/// The index entries point at package directories, so this runs after the
-/// package pass of the same directory.
-fn remove_dangling_links(index: &Dir) {
-    let Some(entries) = read_entries(index, b"") else {
-        return;
-    };
-    for entry in &entries {
-        if entry.kind != EntryKind::SymLink {
-            continue;
-        }
-        match bun_sys::fstatat(index.fd(), &entry.name) {
-            Ok(_) => {}
-            Err(err) if err.get_errno() == E::ENOENT => {
-                if bun_sys::unlinkat(index.fd(), &entry.name).is_err() {
-                    let _ = bun_sys::rmdirat(index.fd(), &entry.name);
-                }
-            }
-            Err(_) => {}
-        }
-    }
-}
-
 impl PmCachePruneCommand {
     /// Returns the process exit code.
     pub(crate) fn exec(cache_path: &[u8], max_age_days: u32, dry_run: bool) -> u8 {
@@ -192,6 +209,25 @@ impl PmCachePruneCommand {
                 return 1;
             }
         };
+
+        // An empty `BUN_INSTALL_CACHE_DIR` resolves to the working directory.
+        // Compare the opened directory, not the path, so a symlink is caught too.
+        if let (Ok(cache_st), Ok(cwd_st)) = (
+            bun_sys::fstat(cache_dir.fd()),
+            bun_sys::stat(bun_core::zstr!(".")),
+        ) {
+            let (cache_st, cwd_st) = (PosixStat::init(&cache_st), PosixStat::init(&cwd_st));
+            if cache_st.dev == cwd_st.dev && cache_st.ino == cwd_st.ino {
+                Output::err_generic(
+                    "refusing to prune \"{s}\": the cache directory is the working directory",
+                    (BStr::new(cache_path),),
+                );
+                bun_core::note!(
+                    "the cache directory comes from $BUN_INSTALL_CACHE_DIR or $BUN_INSTALL. Point it at the bun install cache."
+                );
+                return 1;
+            }
+        }
 
         let now = bun_core::time::timestamp();
         let max_age_sec = i64::from(max_age_days) * i64::from(bun_core::time::S_PER_DAY);

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -1,8 +1,8 @@
 import { spawn } from "bun";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, it, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { exists, mkdir, writeFile } from "fs/promises";
 import { bunEnv, bunExe, bunEnv as env, normalizeBunSnapshot, readdirSorted, tempDir, tmpdirSync } from "harness";
-import { cpSync } from "node:fs";
+import { cpSync, mkdirSync, readdirSync, rmSync, symlinkSync, utimesSync, writeFileSync } from "node:fs";
 import { join } from "path";
 import {
   dummyAfterAll,
@@ -1083,4 +1083,240 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stdout).toInclude("Cleared 'bun install' cache");
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
+});
+
+function seedPruneCache(cache: string) {
+  const old = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+  const isWindows = process.platform === "win32";
+  const link = (target: string, path: string) => symlinkSync(target, path, isWindows ? "junction" : "dir");
+
+  mkdirSync(join(cache, "old-pkg@1.0.0@@@1"), { recursive: true });
+  writeFileSync(join(cache, "old-pkg@1.0.0@@@1", "index.js"), "old");
+  mkdirSync(join(cache, "old-pkg"));
+  link(join(cache, "old-pkg@1.0.0@@@1"), join(cache, "old-pkg", "1.0.0@@@1"));
+
+  mkdirSync(join(cache, "new-pkg@2.0.0@@@1"));
+  writeFileSync(join(cache, "new-pkg@2.0.0@@@1", "index.js"), "new");
+  mkdirSync(join(cache, "new-pkg"));
+  link(join(cache, "new-pkg@2.0.0@@@1"), join(cache, "new-pkg", "2.0.0@@@1"));
+
+  mkdirSync(join(cache, "@scope", "old-scoped@1.0.0@@@1"), { recursive: true });
+  writeFileSync(join(cache, "@scope", "old-scoped@1.0.0@@@1", "index.js"), "scoped");
+  mkdirSync(join(cache, "@scope", "old-scoped"));
+  link(join(cache, "@scope", "old-scoped@1.0.0@@@1"), join(cache, "@scope", "old-scoped", "1.0.0@@@1"));
+
+  mkdirSync(join(cache, "@GH@owner-repo-abc123@@@1"));
+  writeFileSync(join(cache, "@GH@owner-repo-abc123@@@1", "index.js"), "github");
+
+  // Never pruned: the global store, bare git clones, manifests and extraction staging dirs.
+  mkdirSync(join(cache, "links", "store-pkg@1.0.0-abcdef"), { recursive: true });
+  writeFileSync(join(cache, "links", "store-pkg@1.0.0-abcdef", "index.js"), "store");
+  mkdirSync(join(cache, "0123456789abcdef.git"));
+  writeFileSync(join(cache, "0123456789abcdef.git", "HEAD"), "ref");
+  writeFileSync(join(cache, "0123456789abcdef.npm"), "manifest");
+  mkdirSync(join(cache, ".deadbeef-1.old-pkg"));
+  writeFileSync(join(cache, ".deadbeef-1.old-pkg", "index.js"), "staging");
+  mkdirSync(join(cache, "@t@"));
+  writeFileSync(join(cache, "@t@", "0123456789abcdef.pile"), "transpiled");
+
+  for (const stale of [
+    "old-pkg@1.0.0@@@1",
+    "@scope/old-scoped@1.0.0@@@1",
+    "@GH@owner-repo-abc123@@@1",
+    "links/store-pkg@1.0.0-abcdef",
+    "0123456789abcdef.git",
+    "0123456789abcdef.npm",
+    ".deadbeef-1.old-pkg",
+    "@t@",
+  ]) {
+    utimesSync(join(cache, stale), old, old);
+  }
+}
+
+async function runCachePrune(cwd: string, cache: string, ...args: string[]) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pm", "cache", "prune", ...args],
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: cache },
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("bun pm cache prune", () => {
+  test("removes packages older than --max-age and their index links", async () => {
+    using dir = tempDir("pm-cache-prune", {
+      "package.json": JSON.stringify({ name: "cache-prune", version: "1.0.0" }),
+    });
+    const cache = join(String(dir), "cache");
+    seedPruneCache(cache);
+
+    const { stdout, stderr, exitCode } = await runCachePrune(String(dir), cache);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("Removed 3 packages older than 30 days (15 bytes)\n");
+    expect(exitCode).toBe(0);
+
+    expect(await readdirSorted(cache)).toEqual([
+      ".deadbeef-1.old-pkg",
+      "0123456789abcdef.git",
+      "0123456789abcdef.npm",
+      "@t@",
+      "links",
+      "new-pkg",
+      "new-pkg@2.0.0@@@1",
+    ]);
+    expect(await readdirSorted(join(cache, "new-pkg"))).toEqual(["2.0.0@@@1"]);
+    expect(await readdirSorted(join(cache, "links"))).toEqual(["store-pkg@1.0.0-abcdef"]);
+
+    const again = await runCachePrune(String(dir), cache);
+    expect(again.stderr).toBe("");
+    expect(again.stdout).toBe("Done! Checked 1 package, none older than 30 days (nothing to prune)\n");
+    expect(again.exitCode).toBe(0);
+  });
+
+  test("--dry-run lists the stale packages and removes nothing", async () => {
+    using dir = tempDir("pm-cache-prune-dry", {
+      "package.json": JSON.stringify({ name: "cache-prune-dry", version: "1.0.0" }),
+    });
+    const cache = join(String(dir), "cache");
+    seedPruneCache(cache);
+    const before = await readdirSorted(cache);
+
+    const { stdout, stderr, exitCode } = await runCachePrune(String(dir), cache, "--dry-run");
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").slice(0, 3).sort()).toEqual([
+      "- @GH@owner-repo-abc123@@@1 (6 bytes)",
+      "- @scope/old-scoped@1.0.0@@@1 (6 bytes)",
+      "- old-pkg@1.0.0@@@1 (3 bytes)",
+    ]);
+    expect(stdout).toEndWith(
+      "3 packages older than 30 days can be removed (15 bytes, checked 4)\nRun without --dry-run to remove them.\n",
+    );
+    expect(exitCode).toBe(0);
+
+    expect(await readdirSorted(cache)).toEqual(before);
+    expect(await readdirSorted(join(cache, "old-pkg"))).toEqual(["1.0.0@@@1"]);
+    expect(await readdirSorted(join(cache, "@scope"))).toEqual(["old-scoped", "old-scoped@1.0.0@@@1"]);
+  });
+
+  test("--max-age selects the age threshold", async () => {
+    using dir = tempDir("pm-cache-prune-age", {
+      "package.json": JSON.stringify({ name: "cache-prune-age", version: "1.0.0" }),
+    });
+    const cache = join(String(dir), "cache");
+    seedPruneCache(cache);
+
+    const keep = await runCachePrune(String(dir), cache, "--max-age", "60");
+    expect(keep.stderr).toBe("");
+    expect(keep.stdout).toBe("Done! Checked 4 packages, none older than 60 days (nothing to prune)\n");
+    expect(keep.exitCode).toBe(0);
+
+    const all = await runCachePrune(String(dir), cache, "--max-age", "0");
+    expect(all.stderr).toBe("");
+    expect(all.stdout).toBe("Removed 4 packages older than 0 days (18 bytes)\n");
+    expect(all.exitCode).toBe(0);
+    expect(await readdirSorted(cache)).toEqual([
+      ".deadbeef-1.old-pkg",
+      "0123456789abcdef.git",
+      "0123456789abcdef.npm",
+      "@t@",
+      "links",
+    ]);
+
+    const bad = await runCachePrune(String(dir), cache, "--max-age", "soon");
+    expect(bad.stderr).toContain("invalid --max-age value: soon");
+    expect(bad.exitCode).toBe(1);
+  });
+
+  test("runs outside a project and with no cache directory", async () => {
+    using dir = tempDir("pm-cache-prune-no-project", {});
+    const cache = join(String(dir), "cache");
+    seedPruneCache(cache);
+
+    const { stdout, stderr, exitCode } = await runCachePrune(String(dir), cache);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("Removed 3 packages older than 30 days (15 bytes)\n");
+    expect(exitCode).toBe(0);
+
+    const missing = await runCachePrune(String(dir), join(String(dir), "missing"));
+    expect(missing.stderr).toBe("");
+    expect(missing.stdout).toBe("Done! No cache directory (nothing to prune)\n");
+    expect(missing.exitCode).toBe(0);
+    expect(await exists(join(String(dir), "missing"))).toBeFalse();
+
+    // An empty BUN_INSTALL_CACHE_DIR resolves to the working directory.
+    const empty = await runCachePrune(String(dir), "");
+    expect(empty.stderr).toContain("refusing to prune");
+    expect(empty.exitCode).toBe(1);
+  });
+});
+
+it("bun pm cache prune removes packages that bun install cached and leaves the rest of the cache alone", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: { "bar": "0.0.2", "@scope/bar": "0.0.2" },
+    }),
+  );
+  // dummyBeforeEach writes `cache = false`, which sends packages to node_modules/.cache.
+  const cache = join(package_dir, "bun-cache");
+  await writeFile(
+    join(package_dir, "bunfig.toml"),
+    Bun.TOML.stringify({ install: { registry: `${root_url}/`, saveTextLockfile: false } }),
+  );
+  const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: cache };
+
+  async function install() {
+    await using proc = Bun.spawn({ cmd: [bunExe(), "install"], cwd: package_dir, stdout: "pipe", stderr: "pipe", env });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(stdout).toContain("2 packages installed");
+    expect(exitCode).toBe(0);
+  }
+
+  await install();
+  const tarballs = () => urls.filter(url => url.endsWith(".tgz")).length;
+  expect(tarballs()).toBe(2);
+
+  // Things that live next to the packages in the cache root and must survive a prune.
+  mkdirSync(join(cache, "@t@"));
+  writeFileSync(join(cache, "@t@", "0123456789abcdef.pile"), "transpiled");
+  mkdirSync(join(cache, "links", "store-pkg@1.0.0-abcdef"), { recursive: true });
+  writeFileSync(join(cache, "links", "store-pkg@1.0.0-abcdef", "index.js"), "store");
+
+  const old = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+  for (const entry of readdirSync(cache, { recursive: true, withFileTypes: true })) {
+    const path = join(entry.parentPath, entry.name);
+    if (!entry.isSymbolicLink()) utimesSync(path, old, old);
+  }
+
+  const before = await readdirSorted(cache);
+  expect(before).toContain("bar");
+  expect(before).toContain("@scope");
+  expect(before.some(name => name.startsWith("bar@0.0.2"))).toBeTrue();
+  const scopedBefore = await readdirSorted(join(cache, "@scope"));
+  expect(scopedBefore).toContain("bar");
+  expect(scopedBefore.some(name => name.startsWith("bar@0.0.2"))).toBeTrue();
+
+  const { stdout, stderr, exitCode } = await runCachePrune(package_dir, cache);
+  expect(stderr).toBe("");
+  expect(stdout).toStartWith("Removed 2 packages older than 30 days (");
+  expect(exitCode).toBe(0);
+
+  const after = await readdirSorted(cache);
+  expect(after.filter(name => !name.endsWith(".npm"))).toEqual(["@t@", "links"]);
+  expect(after.filter(name => name.endsWith(".npm"))).toHaveLength(2);
+  expect(await readdirSorted(join(cache, "@t@"))).toEqual(["0123456789abcdef.pile"]);
+  expect(await readdirSorted(join(cache, "links"))).toEqual(["store-pkg@1.0.0-abcdef"]);
+
+  // A fresh install downloads the pruned packages again.
+  rmSync(join(package_dir, "node_modules"), { recursive: true });
+  await install();
+  expect(tarballs()).toBe(4);
 });


### PR DESCRIPTION
### Problem
- `~/.bun/install/cache` only grows. Old versions of a package stay after every upgrade. The reporter of #42586 has a 30 GB cache. The only built-in option is `bun pm cache rm`, which also wipes the global store.
- Every peer tool ships a partial cleanup (`pnpm store prune`, `cargo cache gc`, `uv cache prune`). Bun has none.

### Fix
- Adds `bun pm cache prune [--max-age <days>] [--dry-run]` (default 30 days) as a third branch of the `cache` dispatch in `src/runtime/cli/package_manager_command.rs`. It removes package directories whose mtime is older than the threshold and deletes the index symlinks that pointed at them. It prints a count and size summary and exits 1 if a delete fails.
- `CacheEntryKind::from_name` (`src/install/PackageManager/PackageManagerDirectories.rs`, next to the cache folder name printers) decides what an entry is. It leaves `links/`, `<hex>.git` clones, `.npm` manifests, the `@t@` transpiler cache, staging directories and every non-directory alone.
- Age is the time since download. Bun never touches a cache entry on reuse, so there is no last-use signal. The docs say this, and that an offline install re-downloads a pruned package. No automatic sweep on `bun install`, no bunfig keys.
- Verified: `test/cli/install/bun-pm.test.ts` (5 new tests, including install, prune, reinstall against the dummy registry). Also the rest of that file, `test/internal/source-lints`, and `cargo check` for the Windows and macOS targets.

### Background
- The cache root holds `<name>@<version>@@@<N>` directories, `@<scope>/` directories with the same shape inside, `@G@`, `@GH@` and `@T@` entries for git, github and tarball packages, and one `<name>/` index directory per package with a `<version>@@@<N>` symlink (junction on Windows) per cached version (`src/install/extract_tarball.rs:811`).
- `<cache>/links/` is the global store of isolated installs. Its entries are live symlink targets for every `globalStore = true` project, and nothing records who uses them. Prune skips it.
- `bun pm cache prune` works without a `package.json` in the working directory. `no_project_ok` (`CommandLineArguments.rs`) now covers it, as it covers `bun pm diff`. It refuses a cache directory that is the working directory, compared by device and inode (an empty `BUN_INSTALL_CACHE_DIR` resolves there).
- Self-reviewed: 7 concerns raised, 7 addressed (classifier moved beside the writers, `@t@` skip, end-to-end test, working-directory guard, `no_project_ok` narrowed to prune, size clause in the docs).

<details><summary>Notes</summary>

Output:

```
$ bun pm cache prune --dry-run
- @scope/old-scoped@1.0.0@@@1 (6 bytes)
- old-pkg@1.0.0@@@1 (3 bytes)
2 packages older than 30 days can be removed (9 bytes, checked 4)
Run without --dry-run to remove them.

$ bun pm cache prune
Removed 2 packages older than 30 days (9 bytes)

$ bun pm cache prune
Done! Checked 2 packages, none older than 30 days (nothing to prune)
```

The cache directory comes from the process environment only, the same as `bun pm cache rm` since #31495. A project `.env` or `.npmrc` cannot choose what prune deletes. #39750 adds empty-value handling to `fetch_cache_directory_path` for every caller. Until it lands, prune refuses the working directory, which is what an empty `BUN_INSTALL_CACHE_DIR` resolves to. The check compares the opened directory with `.` by device and inode, so a symlink to the working directory is refused too.

The cache directory is read the same way `bun pm cache rm` reads it: process environment only, no `--cache-dir`, bunfig or `.npmrc`. Project config must not choose what a delete command removes.

A scope or index directory that does not open, and an index link that does not unlink, print an error and count as a failure. The exit code is 1 when any of them happen.

Index cleanup removes a symlink whose target no longer exists and removes the index directory when it becomes empty. An index directory that `bun install` creates again later starts from `make_open_path`, so an absent one is fine.

The reported size is the sum of `st_size` over the removed files, symlinks excluded. With the hardlink backend a file that a `node_modules` tree still links stays on disk.

Manual check with the real registry: `bun install` of `is-number` and `@types/is-number` into a fresh `BUN_INSTALL_CACHE_DIR`, `bun pm cache prune --max-age 0` removed both (12.76 KB), `rm -rf node_modules && bun install` downloaded them again.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-pm.test.ts

<!-- robobun:evidence:end -->