### PR TITLE
fix(worker_threads): preserve async context for worker events

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -2,6 +2,7 @@ declare const self: typeof globalThis;
 type WebWorker = InstanceType<typeof globalThis.Worker>;
 
 const EventEmitter = require("node:events");
+const AsyncContextFrame = require("internal/async_context_frame");
 const { SafeMap } = require("internal/primordials");
 const { throwNotImplemented, warnNotImplementedOnce } = require("internal/shared");
 const {
@@ -813,6 +814,7 @@ class Worker extends EventEmitter {
   #stdin;
   #stdout;
   #stderr;
+  #asyncContextFrame;
 
   // this is used by terminate();
   // either is the exit code if exited, a promise resolving to the exit code, or undefined if we haven't sent .terminate() yet
@@ -823,6 +825,7 @@ class Worker extends EventEmitter {
 
   constructor(filename: string, options: NodeWorkerOptions = {}) {
     super();
+    this.#asyncContextFrame = AsyncContextFrame.current();
 
     // The `= {}` default only covers undefined; normalize null too so the
     // option accesses below don't throw on `new Worker(file, null)`.
@@ -956,17 +959,29 @@ class Worker extends EventEmitter {
     // `[worker N] <name>` thread-name metadata event. No-op when tracing is
     // off — the agent module is a tiny one-time load.
     require("internal/trace_events").emitWorkerThreadName(options.name, this.#worker.threadId);
-    this.#worker.addEventListener("close", this.#onClose.bind(this), { once: true });
-    this.#worker.addEventListener("error", this.#onError.bind(this));
-    this.#worker.addEventListener("open", this.#onOpen.bind(this), {
+    const inWorkerAsyncContext = listener => event =>
+      AsyncContextFrame.run(this.#asyncContextFrame, listener, this, event);
+    this.#worker.addEventListener(
+      "close",
+      event => {
+        try {
+          return AsyncContextFrame.run(this.#asyncContextFrame, this.#onClose, this, event);
+        } finally {
+          this.#asyncContextFrame = undefined;
+        }
+      },
+      { once: true },
+    );
+    this.#worker.addEventListener("error", inWorkerAsyncContext(this.#onError));
+    this.#worker.addEventListener("open", inWorkerAsyncContext(this.#onOpen), {
       once: true,
     });
     // Messages from parentPort.postMessage() arrive on the public port. Listening
     // starts the port. Node's setupPortReferencing: the port counts toward the
     // parent's liveness only while this Worker has 'message' listeners (and
     // ref()/unref() also touch it, together with the handle).
-    this.#publicPort.addEventListener("message", this.#onMessage.bind(this));
-    this.#publicPort.addEventListener("messageerror", this.#onMessageError.bind(this));
+    this.#publicPort.addEventListener("message", inWorkerAsyncContext(this.#onMessage));
+    this.#publicPort.addEventListener("messageerror", inWorkerAsyncContext(this.#onMessageError));
     this.#publicPort.unref();
     const publicPort = this.#publicPort;
     this.on("newListener", function (this: Worker, name) {
@@ -977,8 +992,8 @@ class Worker extends EventEmitter {
     });
     // A worker may also use the Web Worker global `postMessage()` / `self.onmessage`
     // pair, which travels through the Worker object itself; surface those too.
-    this.#worker.addEventListener("message", this.#onMessage.bind(this));
-    this.#worker.addEventListener("messageerror", this.#onMessageError.bind(this));
+    this.#worker.addEventListener("message", inWorkerAsyncContext(this.#onMessage));
+    this.#worker.addEventListener("messageerror", inWorkerAsyncContext(this.#onMessageError));
 
     if (this.#urlToRevoke) {
       if (!urlRevokeRegistry) {

--- a/test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts
@@ -6,7 +6,7 @@ import { basename, join } from "path";
 describe.concurrent("AsyncLocalStorage passes context to callbacks", () => {
   let files = [...new Glob(join(import.meta.dir, "async-context", "async-context-*.js")).scanSync()];
 
-  let todos = ["async-context-worker_threads-message.js"];
+  let todos: string[] = [];
   if (isASAN && isBroken && isLinux) {
     todos.push("async-context-dns-resolveTxt.js");
   }

--- a/test/js/node/async_hooks/async-context/async-context-worker_threads-message.js
+++ b/test/js/node/async_hooks/async-context/async-context-worker_threads-message.js
@@ -1,33 +1,73 @@
 process.exitCode = 1;
 const { AsyncLocalStorage } = require("async_hooks");
-const { Worker, isMainThread, parentPort } = require("worker_threads");
+const { Worker, isMainThread, parentPort, workerData } = require("worker_threads");
 
 const asyncLocalStorage = new AsyncLocalStorage();
+const workerStore = { test: "worker_threads" };
+const registrationStore = { test: "listener-registration" };
+
+function assertWorkerContext(event) {
+  if (asyncLocalStorage.getStore() !== workerStore) {
+    console.error(`FAIL: worker ${event} event lost context`);
+    process.exit(1);
+  }
+}
 
 if (isMainThread) {
-  asyncLocalStorage.run({ test: "worker_threads" }, () => {
-    const worker = new Worker(__filename);
+  let worker;
+  asyncLocalStorage.run(workerStore, () => {
+    worker = new Worker(__filename, { workerData: "message" });
+  });
 
-    worker.on("message", msg => {
-      if (asyncLocalStorage.getStore()?.test !== "worker_threads") {
-        console.error("FAIL: worker message event lost context");
-        process.exit(1);
-      }
+  asyncLocalStorage.run(registrationStore, () => {
+    worker.on("message", () => {
+      assertWorkerContext("message");
       worker.terminate();
     });
 
+    worker.on("error", error => {
+      console.error(`FAIL: message worker emitted error: ${error.message}`);
+      process.exit(1);
+    });
+
     worker.on("exit", () => {
-      if (asyncLocalStorage.getStore()?.test !== "worker_threads") {
-        console.error("FAIL: worker exit event lost context");
-        process.exit(1);
-      }
-      process.exit(0);
+      assertWorkerContext("exit");
+
+      let errorWorker;
+      asyncLocalStorage.run(workerStore, () => {
+        errorWorker = new Worker(__filename, { workerData: "error" });
+      });
+
+      let sawError = false;
+      asyncLocalStorage.run(registrationStore, () => {
+        errorWorker.on("error", error => {
+          assertWorkerContext("error");
+          if (error.message !== "worker error") {
+            console.error(`FAIL: unexpected worker error: ${error.message}`);
+            process.exit(1);
+          }
+          sawError = true;
+        });
+
+        errorWorker.on("exit", () => {
+          assertWorkerContext("error exit");
+          if (!sawError) {
+            console.error("FAIL: error worker exited without emitting error");
+            process.exit(1);
+          }
+          process.exit(0);
+        });
+      });
     });
 
     worker.postMessage("test");
   });
 } else {
-  parentPort.on("message", msg => {
-    parentPort.postMessage("response");
-  });
+  if (workerData === "error") {
+    throw new Error("worker error");
+  } else {
+    parentPort.on("message", () => {
+      parentPort.postMessage("response");
+    });
+  }
 }


### PR DESCRIPTION
### What does this PR do?

Preserves the `AsyncLocalStorage` context active when a Node `Worker` is constructed across its public `message`, `messageerror`, `online`, `error`, and `exit` events.

Bun's Node Worker adapter funnels native Web Worker and public `MessagePort` events through internal EventTarget callbacks. Those callbacks previously emitted Node Worker events in the ambient native dispatch context, so listeners observed no Worker-construction async frame. Node owns these events through the Worker's async resource, independently of the context where listeners are later registered.

The adapter now captures the current internal async-context frame at construction, restores it around every native event bridge, and clears it after close in a `finally` block so a retained completed Worker cannot pin the store.

AI-assisted: yes. Codex helped isolate the runtime boundary, implement the patch, and expand the conformance regression. I reviewed the code and validation results.

### How did you verify your code works?

- Node 26.8.2 passes the existing Worker async-context fixture; Bun 1.4.2 fails it with `worker message event lost context`.
- Patched debug Bun: `bun bd test test/js/node/async_hooks` — 149 passed, 1 existing todo, 0 failed.
- Patched debug Bun: `bun bd test test/js/node/worker_threads/worker_threads.test.ts` — 142 passed, 0 failed.
- Durable integration build `1.4.3-canary.1+91b28c4bf` (SHA-256 `f4758d0b76df3ab71934b021b074fa3f3d58bd82b5e03d55cb46169ea8a644fc`): the same async-hooks suite passed 149 with 1 existing todo, and the Worker event suite passed 142 with no failures.
- OpenClaw current main `d534c3153d3`: `scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-worker-request.test.ts` passed its request-context regression with the durable build (1 test, 0 failures). This exercises a reused SQLite Worker reply under the requesting operation's async context.
- The Bun regression distinguishes Worker-construction context from listener-registration context and covers normal message/exit plus error/exit.
- A lifetime probe confirms the captured store becomes collectible after Worker close.
- `bun run lint`, changed-file Prettier, root `tsc --noEmit`, and `git diff --check` pass.
- Fresh independent exact-head P0-P2 review of `f72285db962bf27b0606d93f5835f666547987fd` found no actionable findings.

The broader worker directory still has one timeout in `worker-shutdown-post-leak.test.ts`; reverting this patch reproduces that same timeout on current upstream, so it is unrelated.

OpenClaw integration context: https://github.com/openclaw/openclaw/pull/146807 and https://github.com/openclaw/openclaw/pull/147085
