### PR TITLE
bundler: keep the CommonJS wrapper when a file reads top-level `arguments` or `new.target`

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -307,6 +307,9 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// A module-scope `var` has the name of a top-level function, which module code rejects.
     pub(crate) has_top_level_function_merged_with_var: bool,
 
+    /// A `new.target` outside every function and class element, which module code rejects.
+    pub(crate) has_top_level_new_target: bool,
+
     pub(crate) is_file_considered_to_have_esm_exports: bool,
 
     pub(crate) has_called_runtime: bool,
@@ -2009,6 +2012,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub(crate) fn is_deoptimized_common_js(&self) -> bool {
         self.commonjs_named_exports_deoptimized && self.commonjs_named_exports.count() > 0
+    }
+
+    /// Module-scope code reads `new.target` or an `arguments` that nothing
+    /// declares. In a CommonJS file those are the ones of the function that
+    /// wraps the file. Module code has neither.
+    pub(crate) fn reads_wrapper_arguments_or_new_target(&self) -> bool {
+        self.has_top_level_new_target
+            || self
+                .module_scope()
+                .members
+                .get(b"arguments")
+                .is_some_and(|member| {
+                    let symbol = &self.symbols[member.ref_.inner_index() as usize];
+                    symbol.kind == js_ast::symbol::Kind::Unbound && symbol.use_count_estimate > 0
+                })
     }
 
     pub(crate) fn record_usage(&mut self, ref_: Ref) {
@@ -9810,6 +9828,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             hoisted_ref_for_sloppy_mode_block_fn: Default::default(),
             has_with_scope: false,
             has_top_level_function_merged_with_var: false,
+            has_top_level_new_target: false,
             is_file_considered_to_have_esm_exports: false,
             has_called_runtime: false,
             symbol_uses,

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1459,7 +1459,10 @@ impl<'a> Parser<'a> {
                             }
                         }
 
-                        if needs_decl_count > 0 || p.has_top_level_function_merged_with_var {
+                        if needs_decl_count > 0
+                            || p.has_top_level_function_merged_with_var
+                            || p.reads_wrapper_arguments_or_new_target()
+                        {
                             p.symbols.as_mut_slice()[p.exports_ref.inner_index() as usize]
                                 .use_count_estimate += export_refs_len as u32;
                             p.deoptimize_commonjs_named_exports();
@@ -1610,6 +1613,7 @@ impl<'a> Parser<'a> {
             && !p.has_top_level_return
             && !p.has_with_scope
             && !p.has_top_level_function_merged_with_var
+            && !p.reads_wrapper_arguments_or_new_target()
             && p.symbols.as_slice()[p.module_ref.inner_index() as usize].use_count_estimate == 1
             && p.symbols.as_slice()[p.exports_ref.inner_index() as usize].use_count_estimate == 0
         {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -87,9 +87,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     // Private associated fns on this impl so they can see the const-generic
     // feature params.
 
-    fn e_new_target(_: &mut Self, _e: &mut Expr, _: ExprIn) {
+    fn e_new_target(p: &mut Self, _e: &mut Expr, _: ExprIn) {
         // The "Cannot use \"new.target\" here" range error is intentionally
         // not emitted: it is not necessary and it was causing breakages.
+        // `new.target` has the scope of `this`.
+        if !p.fn_only_data_visit.is_this_nested {
+            p.has_top_level_new_target = true;
+        }
     }
 
     fn e_string(_: &mut Self, _e: &mut Expr, _: ExprIn) {

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -2404,4 +2404,114 @@ describe("bundler", () => {
       stdout: "var\nmain",
     },
   });
+  // `arguments` and `new.target` at the module scope of a CommonJS file are
+  // those of the function that wraps the file. An arrow function and a
+  // computed class key read them from the enclosing scope. Module code has
+  // neither, so these files keep their `__commonJS` wrapper.
+  itBundled("cjs2esm/TopLevelArgumentsKeepsWrapper", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from "./default-import.cjs";
+        import { first } from "./named-import.cjs";
+        import { type } from "./typeof.cjs";
+        import { read } from "./arrow.cjs";
+        console.log(lib.first === lib, first, type, read());
+      `,
+      "/default-import.cjs": /* js */ `
+        exports.first = arguments[0];
+      `,
+      "/named-import.cjs": /* js */ `
+        exports.first = typeof arguments[0];
+      `,
+      "/typeof.cjs": /* js */ `
+        module.exports.type = typeof arguments;
+      `,
+      "/arrow.cjs": /* js */ `
+        exports.read = () => arguments.length > 0;
+      `,
+    },
+    cjs2esm: {
+      unhandled: ["/default-import.cjs", "/named-import.cjs", "/typeof.cjs", "/arrow.cjs"],
+    },
+    run: {
+      stdout: "true object object true",
+    },
+  });
+  itBundled("cjs2esm/TopLevelNewTargetKeepsWrapper", {
+    files: {
+      "/entry.js": /* js */ `
+        import lib from "./default-import.cjs";
+        import { type } from "./named-import.cjs";
+        import { read } from "./arrow.cjs";
+        import { Keyed } from "./class-key.cjs";
+        console.log(lib.type, type, read(), Keyed.undefined);
+      `,
+      "/default-import.cjs": /* js */ `
+        exports.type = typeof new.target;
+      `,
+      "/named-import.cjs": /* js */ `
+        exports.type = typeof new.target;
+      `,
+      "/arrow.cjs": /* js */ `
+        exports.read = () => typeof new.target;
+      `,
+      "/class-key.cjs": /* js */ `
+        exports.Keyed = class { static [typeof new.target] = "key"; };
+      `,
+    },
+    cjs2esm: {
+      unhandled: ["/default-import.cjs", "/named-import.cjs", "/arrow.cjs", "/class-key.cjs"],
+    },
+    run: {
+      stdout: "undefined undefined undefined key",
+    },
+  });
+  // A function has its own `arguments` and `new.target`, and a class field
+  // initializer has its own `new.target`. The bundler removes the dead
+  // `arguments`. This file is still lifted.
+  itBundled("cjs2esm/ArgumentsAndNewTargetOfAFunctionAreStillLifted", {
+    files: {
+      "/entry.js": /* js */ `
+        import { count, Target, Field } from "./lib.cjs";
+        console.log(count(1, 2), new Target().own, new Field().type);
+      `,
+      "/lib.cjs": /* js */ `
+        if (false) console.log(arguments);
+        exports.count = function () { return (() => arguments.length)(); };
+        exports.Target = function Target() { this.own = new.target === Target; };
+        exports.Field = class { type = typeof new.target; };
+      `,
+    },
+    cjs2esm: true,
+    run: {
+      stdout: "2 true undefined",
+    },
+  });
+  itBundled("cjs2esm/ReactSpecificUnwrappingTopLevelArgumentsOrNewTargetKeepsWrapper", {
+    files: {
+      "/entry.js": /* js */ `
+        import { value } from "react";
+        import { value as other } from "scheduler";
+        console.log(value, other);
+      `,
+      "/node_modules/react/index.js": /* js */ `
+        console.log(typeof arguments);
+        module.exports = require('./main');
+      `,
+      "/node_modules/react/main.js": /* js */ `
+        exports.value = "react";
+      `,
+      "/node_modules/scheduler/index.js": /* js */ `
+        console.log(typeof new.target);
+        module.exports = require('./main');
+      `,
+      "/node_modules/scheduler/main.js": /* js */ `
+        exports.value = "scheduler";
+      `,
+    },
+    cjs2esm: { unhandled: ["/node_modules/react/index.js", "/node_modules/scheduler/index.js"] },
+    run: {
+      stdout: "object\nundefined\nreact scheduler",
+    },
+  });
 });


### PR DESCRIPTION
### Problem
- With ES module output, `bun build` lifts a CommonJS file out of its `__commonJS` wrapper. If the file reads top-level `arguments` or `new.target`, the bundle fails at load: `ReferenceError: arguments is not defined` or `SyntaxError: new.target is only valid inside functions or static blocks.` The build exits 0.
- The two lifts in `src/js_parser/parse/parse_entry.rs` (`:1462`, `:1608`) do not check for these reads.
- A named import fails in 1.4.0 too. Since #41162 (1.4.1), a default import fails as well.

### Fix
- `P::reads_wrapper_arguments_or_new_target` (`src/js_parser/p.rs:2020`) is true when module-scope code uses an `arguments` that the file does not declare, or has a `new.target` outside every function and class element. The visitor finds the latter with the rule `value_for_this` uses for `this`.
- With that, the `exports.foo` lift takes its existing deoptimization, and the `export *` lift does not run. The file keeps its wrapper, a regular function (`generateCodeForFileInChunkJS.rs:590`) that has both bindings.
- Verified: `test/bundler/bundler_cjs2esm.test.ts` (four new tests, three fail on 1.4.3 canary). The Notes list the other suites.
- Self-reviewed: no blocking concern. The Notes cover the scope concerns (no user report, no measured package affected, plain `.js` files).

### Background
- The lift turns `exports.foo = value` into `var $foo = value` plus an ES export, so the file becomes module code. It runs only for ES module output.
- A CommonJS file runs in a function, and top-level `arguments` and `new.target` are that function's. Arrow functions and computed class keys read them from the enclosing scope.
- #40840 covers the top-level `return`. This PR does not change it.

<details><summary>Notes</summary>

No GitHub issue reports this. A differential test of `bun run` against `bun build` output found it.

The build prints no warning. `typeof arguments` alone changes from `"object"` to `"undefined"` with no error at all. 1.4.0 kept the wrapper for a default import, because the linker put the wrapper back for that import form. #41162 made a default import of a lifted file bind to its namespace, so the linker no longer does that.

The parser puts an identifier that the file does not declare in the module scope as an unbound symbol. The check looks up `arguments` there and reads its use count, the same way `uses_exports_ref` and `uses_module_ref` read theirs.

Repro (1.4.1, 1.4.2, 1.4.3 canary, and main):

```js
// args.cjs
exports.n = arguments.length;
exports.t = typeof arguments[0];
// nt.cjs
exports.nt = typeof new.target;
// e1.mjs
import a from "./args.cjs";
console.log("arguments:", a.n, a.t);
// e2.mjs
import b from "./nt.cjs";
console.log("new.target:", b.nt);
```

`bun build e1.mjs --target=bun --outfile=o.mjs && bun o.mjs`

| | e1 | e2 |
| --- | --- | --- |
| `bun run`, node | `arguments: 5 object` | `new.target: undefined` |
| bundle from 1.4.0 | `arguments: 2 object` | `new.target: undefined` |
| bundle from 1.4.1 to main | `ReferenceError: arguments is not defined` | `SyntaxError: new.target is only valid inside functions or static blocks.` |
| bundle from this branch | `arguments: 2 object` | `new.target: undefined` |

The count is 2 in a bundle because `__commonJS` calls the wrapper with `(exports, module)`.

Also checked by hand on this branch: `--target=node` and `--target=browser`, `--minify`, `--splitting`, `--format=iife`, a named import, `require()` of the file, `import()` of the file with and without `--splitting`, and the file as the entry point. All print the 1.4.0 result. `--format=cjs` never lifted.

Reach: two scans of published npm packages during self-review (919 packages with 62,704 files, and about 1,127 packages with 30,715 files) found no file that takes the new path. So the bundle of every measured package is unchanged, and the only bundles that change are ones that fail to load today.

What the check does not do:
- It does not change how bun classifies a file. A `.js` file with no CommonJS marker and no `package.json` `"type"` is still module code, so `bun plain.js` with a top-level `new.target` still fails. That is the plain-script decision that #41269 already lists as a follow-up.
- A dead `arguments` reference (`if (false) arguments`) does not keep the wrapper, because the use count ignores dead code and the bundler removes the branch. This is how `uses_exports_ref` and `uses_module_ref` work. `new.target` has no symbol, so a flag records it, and the flag also counts dead code. A `new.target` that stays in the output is a parse error, so the flag is conservative.
- A file that declares its own `arguments` (`var arguments = 1`) is not affected. That binding is a strict-mode error in an ES module bundle with or without the wrapper. #34361 (open) renames it.
- The third lift, the `module.exports = require("x")` redirect (`parse_entry.rs:1486`), needs that statement to be the only one in the file, so it cannot contain either read.
- A direct `eval` that reads them already keeps the wrapper.

Tests:

| Test | `USE_SYSTEM_BUN=1` (1.4.3 canary) | `bun bd` with this PR |
| --- | --- | --- |
| `TopLevelArgumentsKeepsWrapper` | fail (0 of 4 wrappers) | pass |
| `TopLevelNewTargetKeepsWrapper` | fail (0 of 4 wrappers) | pass |
| `ArgumentsAndNewTargetOfAFunctionAreStillLifted` | pass | pass |
| `ReactSpecificUnwrappingTopLevelArgumentsOrNewTargetKeepsWrapper` | fail (0 of 2 wrappers) | pass |

Other suites that pass on this branch (debug, ASAN): all of `bundler_cjs2esm`, `bundler_cjs`, `bundler_edgecase`, `esbuild/default`, `bundler_regressions`, `bundler_npm`.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.3 (b99371011)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [846.01ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [443.29ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [559.61ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [407.35ms]
(pass) bundler > cjs2esm/ExportsFunction [479.78ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [362.79ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [611.76ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [661.18ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [510.01ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [521.41ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [544.32ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [569.83ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [796
... (truncated)

release without fix: 3 FAILED
bun test v1.4.3-canary.1 (b99371011)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [65.19ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [17.97ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [18.02ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [39.39ms]
(pass) bundler > cjs2esm/ExportsFunction [15.87ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [18.54ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [14.20ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [93.27ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [18.10ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [21.52ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [19.95ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [19.99ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [17.22ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [15.33ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [20.08ms]
(pass) bundler > cjs2esm/Unwrap
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.3 (b99371011)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [864.54ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [396.62ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [520.08ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [532.13ms]
(pass) bundler > cjs2esm/ExportsFunction [419.16ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [411.24ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [374.34ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPoint [468.80ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPoint [465.36ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireEntryPointImportedByEntryPointSplitting [527.44ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequireTwoEntryPoints [425.73ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [652.09ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [584
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     144ad5f5ed
  features     baseline

23 deps, 131 codegen, 1176 objects in 790ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1248] gen ErrorCode+*.h
[2/1248] install /workspace/bun
bun install v1.4.3-canary.1 (b99371011)

Checked 22 installs across 61 packages (no changes) [33.00ms]
[3/1248] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (b99371011)

Checked 1 install across 2 packages (no changes) [12.00ms]
[4/1248] fetch zlib
[zlib] up to date
[5/1248] fetch tinycc
[tinycc] up to date
[6/1247] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (b99371011)

Checked 111 installs across 104 packages (no changes) [48.00ms]
[7/1247] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1247] gen node-fallbacks/react-refresh.js
Bundled 1 module in 28ms

  react-refresh.js  4.81 KB  (entry point)

[9/1247] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[10/1247] gen bindgenv2
[11/1247] gen .bind.ts → 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                   |  19 ++++++
 src/js_parser/parse/parse_entry.rs   |   6 +-
 src/js_parser/visit/visit_expr.rs    |   6 +-
 test/bundler/bundler_cjs2esm.test.ts | 110 +++++++++++++++++++++++++++++++++++
 4 files changed, 139 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/js_parser/p.rs                        7      3     14
src/js_parser/parse/parse_entry.rs        4      2     14
src/js_parser/visit/visit_expr.rs         1      1     14
test/bundler/bundler_cjs2esm.test.ts      2      5     14
```

</details>

<!-- robobun:evidence:end -->