### PR TITLE
bundler: report a split import() as a bundled import in --metafile-md

### DIFF
--- a/src/bundler/linker_context/MetafileBuilder.rs
+++ b/src/bundler/linker_context/MetafileBuilder.rs
@@ -781,6 +781,19 @@ struct PathOnly<'a> {
     path: &'a [u8],
 }
 
+/// The target of an `inputs[..].imports[..]` edge and whether the edge is external.
+/// A split `import()` / `require()` has the output chunk in "path" and `"external": true`;
+/// its "entryPoint" is the bundled input it loads, so it is reported as that input.
+fn import_target(imp: &JsonObject) -> (Option<&JsonValue>, bool) {
+    match imp.get(b"entryPoint") {
+        Some(entry_point) => (Some(entry_point), false),
+        None => (
+            imp.get(b"path"),
+            matches!(imp.get(b"external"), Some(JsonValue::Bool(true))),
+        ),
+    }
+}
+
 /// Generates a markdown visualization of the module graph from metafile JSON.
 /// This is a post-processing step that parses the JSON and produces LLM-friendly output.
 /// Designed to help diagnose bundle bloat, dependency chains, and entry point analysis.
@@ -915,13 +928,12 @@ pub fn generate_markdown(metafile_json: &[u8]) -> crate::Result<Box<[u8]>> {
                 info.import_count = u32::try_from(imps_arr.len()).expect("int cast");
                 for imp in imps_arr.iter() {
                     if let JsonValue::Object(imp_obj) = imp {
-                        if let Some(ext) = imp_obj.get(b"external") {
-                            if let JsonValue::Bool(true) = ext {
-                                external_count += 1;
-                                continue;
-                            }
+                        let (imp_path, is_external) = import_target(imp_obj);
+                        if is_external {
+                            external_count += 1;
+                            continue;
                         }
-                        if let Some(imp_path) = imp_obj.get(b"path") {
+                        if let Some(imp_path) = imp_path {
                             if let JsonValue::String(target) = imp_path {
                                 // Try to find the matching input key for this import
                                 // The import path may be absolute while input keys are relative
@@ -1373,7 +1385,8 @@ pub fn generate_markdown(metafile_json: &[u8]) -> crate::Result<Box<[u8]>> {
                     md.extend_from_slice(b"- **Imports**:\n");
                     for imp in imps_arr.iter() {
                         if let JsonValue::Object(imp_obj) = imp {
-                            let Some(path) = imp_obj.get(b"path") else {
+                            let (path, is_external) = import_target(imp_obj);
+                            let Some(path) = path else {
                                 continue;
                             };
                             let Some(kind) = imp_obj.get(b"kind") else {
@@ -1383,15 +1396,6 @@ pub fn generate_markdown(metafile_json: &[u8]) -> crate::Result<Box<[u8]>> {
                                 (path, kind)
                             else {
                                 continue;
-                            };
-
-                            let is_external = 'blk: {
-                                if let Some(ext) = imp_obj.get(b"external") {
-                                    if let JsonValue::Bool(b) = ext {
-                                        break 'blk *b;
-                                    }
-                                }
-                                false
                             };
 
                             let original: Option<&[u8]> = 'blk: {
@@ -1557,16 +1561,9 @@ pub fn generate_markdown(metafile_json: &[u8]) -> crate::Result<Box<[u8]>> {
             if let JsonValue::Array(imps_arr) = imps {
                 for imp in imps_arr.iter() {
                     if let JsonValue::Object(imp_obj) = imp {
-                        let is_ext = 'blk: {
-                            if let Some(ext) = imp_obj.get(b"external") {
-                                if let JsonValue::Bool(b) = ext {
-                                    break 'blk *b;
-                                }
-                            }
-                            false
-                        };
+                        let (imp_path, is_ext) = import_target(imp_obj);
 
-                        if let Some(imp_path) = imp_obj.get(b"path") {
+                        if let Some(imp_path) = imp_path {
                             if let JsonValue::String(imp_path_str) = imp_path {
                                 if is_ext {
                                     writeln!(

--- a/test/bundler/metafile.test.ts
+++ b/test/bundler/metafile.test.ts
@@ -1149,6 +1149,68 @@ describe("bun build --metafile-md", () => {
     expect(content).toContain("require-call");
   });
 
+  test("markdown reports a split import() / require() as an import of the input it loads", async () => {
+    using dir = tempDir("metafile-md-split-imports", {
+      "entry.js": `
+        import("./lazy.js").then(m => console.log(m.value));
+        import("external-pkg").then(m => console.log(m));
+        export const load = () => require("./required.js").value;
+      `,
+      "lazy.js": `export const value = 1;`,
+      "required.js": `export const value = 2;`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "entry.js",
+        "--metafile-md",
+        "--outdir=dist",
+        "--splitting",
+        "--target=bun",
+        "--external=external-pkg",
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const lines = (await Bun.file(`${dir}/meta.md`).text()).split("\n");
+
+    // lazy.js and required.js are bundled into chunks of their own. Only external-pkg is external.
+    expect(lines.filter(line => /^\[(IMPORT|EXTERNAL):/.test(line))).toEqual([
+      "[IMPORT: entry.js -> lazy.js]",
+      "[EXTERNAL: entry.js imports external-pkg]",
+      "[IMPORT: entry.js -> required.js]",
+    ]);
+    expect(lines.filter(line => line.startsWith("[IMPORTED_BY:")).sort()).toEqual([
+      "[IMPORTED_BY: lazy.js <- entry.js]",
+      "[IMPORTED_BY: required.js <- entry.js]",
+    ]);
+    expect(lines.filter(line => line.includes("External imports"))).toEqual(["| External imports | 1 |"]);
+
+    // The module graph lists the same edges.
+    expect(lines.filter(line => line.startsWith("- **Imported by**")).sort()).toEqual([
+      "- **Imported by** (1 files): `entry.js`",
+      "- **Imported by** (1 files): `entry.js`",
+      "- **Imported by**: (entry point or orphan)",
+    ]);
+    expect(
+      lines.filter(line => line.startsWith("  - `")).map(line => line.replace(/contributes [^,]+/, "contributes N")),
+    ).toEqual([
+      "  - `lazy.js` (dynamic-import, contributes N, specifier: `./lazy.js`)",
+      "  - `external-pkg` (dynamic-import, **external**)",
+      "  - `required.js` (require-call, contributes N, specifier: `./required.js`)",
+    ]);
+  });
+
   test("markdown shows commonly imported modules", async () => {
     using dir = tempDir("metafile-md-common-imports", {
       "a.js": `import { shared } from "./shared.js"; console.log("a", shared);`,


### PR DESCRIPTION
### Problem

- With `--splitting`, `--metafile-md` reports an `import()` of a bundled file as external. It prints `[EXTERNAL: entry.js imports ./lazy-6ngx7bj8.js]`, counts the edge under "External imports", and lists the imported module as "(entry point or orphan)". A split `require()` (`--target=bun`) has the same problem.
- `generate_markdown` (`src/bundler/linker_context/MetafileBuilder.rs:801`) reads only `path` and `external` of each `inputs[file].imports[]` edge. For a split import these hold the output chunk and `true`. #42423 added `entryPoint` (the bundled input) to the edge but did not change `--metafile-md`.

### Fix

- The new helper `import_target` reads one edge. An edge that has `entryPoint` is an import of that input and is not external. All other edges keep `path` and `external`.
- All three readers of an edge in `generate_markdown` call the helper. The metafile JSON does not change.
- Correct because `entryPoint` is a key of `inputs`, and the bundler writes it only for a record that the linker pointed at a chunk. The chunk stays visible under "Loads these chunks".
- Verified: `test/bundler/metafile.test.ts` (the new test fails on main, 50/50 pass with the change). Also `test/bundler/esbuild/metafile.test.ts`. Self-reviewed: 8 concerns raised, all about code outside this diff (see Notes).

### Background

- The metafile is the esbuild-format build report. `inputs` maps each source file to its import edges.
- `--metafile-md` renders that JSON as markdown. `generate_markdown` sees only the JSON, not the linker state.
- With `--splitting`, the target of an `import()` becomes an entry point with its own chunk. The linker points the import record at that chunk. So the JSON edge has the chunk in `path` and `"external": true`.

<details><summary>Notes</summary>

- Follow-up to #42423, whose body says `--metafile-md` does not use the field yet. #38465 (closed in favor of #42423) had the same markdown test idea.
- The three readers are the reverse dependency map with the external count, the "Imports" list of each module, and the raw `[IMPORT:` / `[EXTERNAL:` lines.
- Test fixture output before the change: `| External imports | 3 |`, `[EXTERNAL: entry.js imports ./lazy-6ngx7bj8.js]`, `[EXTERNAL: entry.js imports external-pkg]`, `[EXTERNAL: entry.js imports ./required-0dd5m4wr.js]`, no `[IMPORTED_BY:` line.
- Test fixture output after the change: `| External imports | 1 |`, `[IMPORT: entry.js -> lazy.js]`, `[EXTERNAL: entry.js imports external-pkg]`, `[IMPORT: entry.js -> required.js]`, `[IMPORTED_BY: lazy.js <- entry.js]`, `[IMPORTED_BY: required.js <- entry.js]`.
- The "Imports" list of `entry.js` now reads `lazy.js (dynamic-import, contributes 15 bytes, specifier: ./lazy.js)`. Before, it read `./lazy-6ngx7bj8.js (dynamic-import, **external**, specifier: ./lazy.js)`.
- The chunk also stays visible in `[ENTRY: lazy.js -> ./lazy-6ngx7bj8.js (54 bytes)]`. Those sections read `outputs`, which this diff does not touch.
- `cargo clippy -p bun_bundler --no-deps` and `cargo fmt --check` are clean. `prettier --check` is clean on the test file.

Not changed here. These are in the JSON writer (`generate`) or in code next to this diff:

- The JSON edge of a split `import()` of a JSON, TOML or text file has no `with`. The writer derives `with` from `record.source_index`, which the linker clears for a split import. So the report has no `with type:` line for that edge.
- The writer marks an unused import as `"external": true`, for example a type-only `import { Foo } from "./types"` in a TypeScript file. The report still counts that edge under "External imports".
- #34531 (open) changes the key matching inside the reverse dependency loop of the same function. The two changes touch adjacent lines.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/metafile.test.ts

<!-- robobun:evidence:end -->