### PR TITLE
fix(node:os): observe runtime HOME changes

### DIFF
--- a/src/js/node/os.ts
+++ b/src/js/node/os.ts
@@ -1,4 +1,6 @@
 // Hardcoded module "node:os"
+const ObjectHasOwn = Object.hasOwn;
+
 var tmpdir = function () {
   var env = Bun.env;
 
@@ -103,7 +105,13 @@ function bound(binding) {
     },
     freemem: binding.freemem,
     getPriority: binding.getPriority,
-    homedir: binding.homedir,
+    homedir:
+      process.platform === "win32"
+        ? binding.homedir
+        : function () {
+            const env = Bun.env;
+            return ObjectHasOwn(env, "HOME") ? env.HOME : binding.homedir();
+          },
     hostname: binding.hostname,
     loadavg: binding.loadavg,
     networkInterfaces: binding.networkInterfaces,

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -670,14 +670,6 @@ mod _impl {
         }
         #[cfg(not(windows))]
         {
-            // The posix implementation of uv_os_homedir first checks the HOME
-            // environment variable, then falls back to reading the passwd entry.
-            if let Some(home) = env_var::HOME.get() {
-                if !home.is_empty() {
-                    return Ok(BunString::from_bytes(home));
-                }
-            }
-
             // From libuv:
             // > Calling sysconf(_SC_GETPW_R_SIZE_MAX) would get the suggested size, but it
             // > is frequently 1024 or 4096, so we can just use that directly. The pwent

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -62,6 +62,28 @@ it("homedir", () => {
   expect(os.homedir() !== "unknown").toBe(true);
 });
 
+it.skipIf(isWindows)("homedir reflects HOME changes", () => {
+  const originalHome = process.env.HOME;
+  const userHome = os.userInfo().homedir;
+  try {
+    process.env.HOME = "/tmp/bun-runtime-home";
+    expect(os.homedir()).toBe("/tmp/bun-runtime-home");
+    expect(os.userInfo().homedir).toBe(userHome);
+
+    process.env.HOME = "";
+    expect(os.homedir()).toBe("");
+
+    delete process.env.HOME;
+    expect(os.homedir()).toBe(userHome);
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+  }
+});
+
 it("tmpdir", () => {
   if (isWindows) {
     expect(


### PR DESCRIPTION
### What does this PR do?

Makes POSIX `os.homedir()` observe the current `HOME` value, matching Node when user code changes or deletes `process.env.HOME` after startup.

Bun's native POSIX binding read a startup-cached environment value before falling back to the passwd database. Runtime `process.env` and `Bun.env` mutations live in the JavaScript environment object, so `os.homedir()` kept returning the old home. The JavaScript adapter now owns the live POSIX environment lookup, including explicitly empty and whitespace-only values, while the native binding provides a passwd-only fallback. `os.userInfo().homedir` remains passwd-derived. Windows stays on the existing libuv binding.

Fixes #29244.

AI-assisted: yes. Codex helped isolate the environment ownership boundary, implement the patch, and design the cross-runtime regression. I reviewed the code and validation results.

### How did you verify your code works?

- Bun 1.4.2 fails the focused runtime-`HOME` regression for the intended stale-value reason.
- Patched debug runtime: `test/js/node/os/os.test.js` — 55 passed, 0 failed.
- Vendored Node `test-os.js` and `test-os-homedir-no-envvar.js` both exit successfully.
- Host and `x86_64-pc-windows-msvc` `bun_runtime` Rust checks pass.
- `bun run lint`, targeted Prettier, `cargo fmt --check`, root `tsc --noEmit`, and `git diff --check` pass.
- A custom integration build at `1.4.3-canary.1+91b28c4bf` contains a patch-equivalent copy of this exact change. The PR commit and integration-stack commit have the same stable patch ID.
- The prior Node-compatible `node:test` conformance suite plus a set/empty/whitespace/unset spawn matrix passes 7/7 under Node and 7/7 under that Bun build.
- OpenClaw's adjacent iMessage path, account, runtime, and remote-host tests pass 76/76 under that Bun build. This includes the real `os.userInfo().homedir` regression with whitespace-only `HOME`.
- A fresh independent P0-P2 review of the exact PR head found no actionable findings.

A clean full debug build of current main is independently blocked on this macOS host by existing SDK/compiler failures. The source patch passed the current-main Rust checks, and runtime validation used previously built debug and integration binaries containing the patch.

OpenClaw integration context: https://github.com/openclaw/openclaw/pull/146807
