### PR TITLE
install: keep a git cache folder that another install published first

### DIFF
--- a/src/install/git_runner.rs
+++ b/src/install/git_runner.rs
@@ -91,8 +91,14 @@ impl Finalize {
             }),
             Finalize::PublishRepo(staging) => {
                 let name = task.request_git_clone().name.slice().to_vec();
+                // A bare clone has no completion marker: like `begin_clone`, take any folder for one.
                 staging
-                    .publish(&mut task.log, &name, &bare_repo_folder_name(task.id))
+                    .publish(
+                        &mut task.log,
+                        &name,
+                        &bare_repo_folder_name(task.id),
+                        |_| true,
+                    )
                     .map(|dir| Task::Data {
                         git_clone: ManuallyDrop::new(dir.into_raw()),
                     })
@@ -184,7 +190,7 @@ fn finish_checkout(task: &mut Task::Task<'_>, staging: CacheStaging) -> Result<E
     }
 
     let folder_name = checkout_folder_name(&resolved);
-    let package_dir = staging.publish(&mut task.log, &name, &folder_name)?;
+    let package_dir = staging.publish(&mut task.log, &name, &folder_name, is_tagged_checkout)?;
     read_package_json(task, package_dir)
 }
 
@@ -298,39 +304,78 @@ impl CacheStaging {
         let _ = bun_sys::Dir::borrow(&self.cache_dir).delete_tree(&self.tmp_name);
     }
 
+    /// Renames the staging folder to `folder_name` and opens it.
+    ///
+    /// Another install that shares the cache may publish `folder_name` first and
+    /// already be reading it. A folder there that passes `is_complete` is kept and
+    /// opened, and the staging folder is discarded. Only one that fails it is replaced.
     fn publish(
         self,
         log: &mut bun_ast::Log,
         name: &[u8],
         folder_name: &[u8],
+        is_complete: fn(&bun_sys::Dir) -> bool,
     ) -> Result<bun_sys::Dir, Error> {
-        let renamed = bun_sys::renameat_concurrently_a(
-            self.cache_dir,
-            &self.tmp_name,
-            self.cache_dir,
-            folder_name,
-            bun_sys::RenameatConcurrentlyOptions {
-                move_fallback: false,
-            },
-        );
-        // After an exchange the temporary name holds the folder that was replaced.
+        const MAX_ATTEMPTS: u32 = 4;
+        let cache_dir = bun_sys::Dir::borrow(&self.cache_dir);
+        let from = bun_core::ZBox::from_bytes(&self.tmp_name);
+        let to = bun_core::ZBox::from_bytes(folder_name);
+        let mut attempts = 0;
+        let err = loop {
+            // `rename` replaces a directory only when it is empty, so this never
+            // overwrites a published folder.
+            let Err(err) = bun_sys::renameat(self.cache_dir, &from, self.cache_dir, &to) else {
+                return cache_dir.open_at(folder_name).map_err(Error::from);
+            };
+            attempts += 1;
+            // What takes the name is removed in ways that cannot remove a published
+            // folder, one that appears under the name meanwhile included.
+            match cache_dir.open_at_with(
+                folder_name,
+                bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NOFOLLOW,
+            ) {
+                Ok(published) if is_complete(&published) => {
+                    self.discard();
+                    return Ok(published);
+                }
+                _ if attempts == MAX_ATTEMPTS => break err,
+                // Emptied through its own handle; `rmdir` only removes an empty folder.
+                Ok(incomplete) => {
+                    delete_children(&incomplete);
+                    incomplete.close();
+                    let _ = bun_sys::rmdirat(self.cache_dir, &to);
+                }
+                // Not a folder, or gone by now; `unlink` never removes a folder.
+                Err(_) => {
+                    let _ = bun_sys::unlinkat(self.cache_dir, &to);
+                }
+            }
+        };
         self.discard();
-        if let Err(err) = renamed {
-            log.add_error_fmt(
-                None,
-                bun_ast::Loc::EMPTY,
-                format_args!(
-                    "moving \"{}\" to cache dir failed: {}",
-                    BStr::new(name),
-                    err
-                ),
-            );
-            return Err(Error::InstallFailed);
-        }
-        bun_sys::Dir::borrow(&self.cache_dir)
-            .open_at(folder_name)
-            .map_err(Error::from)
+        log.add_error_fmt(
+            None,
+            bun_ast::Loc::EMPTY,
+            format_args!(
+                "moving \"{}\" to cache dir failed: {}",
+                BStr::new(name),
+                err
+            ),
+        );
+        Err(Error::InstallFailed)
     }
+}
+
+/// Deletes what `dir` holds. Nothing is looked up through the name of `dir`.
+fn delete_children(dir: &bun_sys::Dir) {
+    let mut entries = bun_sys::iterate_dir(dir.fd());
+    while let Ok(Some(entry)) = entries.next() {
+        let _ = dir.delete_tree(entry.name.slice_u8());
+    }
+}
+
+/// `.bun-tag` is written last, so a checkout that has it is complete.
+fn is_tagged_checkout(dir: &bun_sys::Dir) -> bool {
+    bun_sys::exists_at(dir.fd(), bun_core::zstr!(".bun-tag"))
 }
 
 /// `<hex(clone task id)>.git`: the cache folder of a bare clone.
@@ -560,7 +605,7 @@ impl GitSubprocess {
 
         match bun_sys::Dir::borrow(&this.cache_dir).open_at(&checkout_folder_name(&resolved)) {
             Ok(dir) => {
-                if bun_sys::exists_at(dir.fd(), bun_core::zstr!(".bun-tag")) {
+                if is_tagged_checkout(&dir) {
                     Self::finish_on_pool(this, Finalize::CachedCheckout(dir));
                     return Ok(());
                 }

--- a/test/cli/install/bun-install-git-deps.test.ts
+++ b/test/cli/install/bun-install-git-deps.test.ts
@@ -5,7 +5,7 @@
 // a bare repo on disk (served over git's dumb HTTP protocol by Bun.serve
 // when an http URL is needed) or tarballs built in memory.
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { bunEnv, bunExe, isLinux, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "path";
 import { pathToFileURL } from "url";
@@ -37,6 +37,9 @@ async function run(cwd: string, cmd: string[], what: string, stdin?: string) {
 function git(cwd: string, ...args: string[]) {
   return run(cwd, ["git", ...args], `git ${args.join(" ")}`);
 }
+
+// `path` as one word of a `sh` script.
+const quote = (path: string) => `'${path.replaceAll("'", "'\\''")}'`;
 
 // The fixture packages are `@scope/pkg-<letter>`. Each one's branch or tarball
 // is named `pkg-<letter>`, and so is the marker its index.js exports, which is
@@ -587,6 +590,163 @@ test.concurrent("installs a git+file:// dependency", async () => {
   expect(exitCode).toBe(0);
 });
 
+// Two installs of different projects that share a cold cache both clone the
+// repository of a git dependency. The one that finishes second finds the
+// other's clone in the cache already. It used to swap its own clone in and
+// delete the other one, which the first install still had open: its checkout
+// then failed with "fatal: repository '<cache>/.<id>.tmp (deleted)' does not
+// exist". The same applies to the checkout folder.
+test.concurrent.skipIf(isWindows)(
+  "an install keeps the git cache folders that another install published first",
+  async () => {
+    using dir = tempDir("git-dep-publish-race", {});
+    const root = String(dir);
+    const bin = join(root, "bin");
+    const steps = join(root, "steps");
+    mkdirSync(bin);
+    mkdirSync(steps);
+    // A git that puts the two installs in the order of the race. A folder is
+    // published when the git command that fills it has exited, and the next
+    // git command of that install starts after that.
+    writeFileSync(
+      join(bin, "git"),
+      `#!/bin/sh
+steps=${quote(steps)}
+reach() { : > "$steps/$1"; }
+wait_for() { i=0; while [ ! -e "$steps/$1" ] && [ $i -lt 200 ]; do sleep 0.05; i=$((i+1)); done; }
+case "$INSTALL $*" in
+  # Both look for the bare clone in the cache before "first" publishes its own.
+  "first clone "*" --bare "*) wait_for second-clones-bare ;;
+  # "second" publishes its bare clone after "first" did, and before "first" uses its own.
+  "second clone "*" --bare "*) reach second-clones-bare; wait_for first-runs-log ;;
+  "first -C "*" log "*) reach first-runs-log; wait_for second-runs-log ;;
+  "second -C "*" log "*) reach second-runs-log ;;
+  # Both look for the checkout in the cache before either publishes its own.
+  "first clone "*" --no-checkout "*) reach first-clones-checkout; wait_for second-clones-checkout ;;
+  "second clone "*" --no-checkout "*) reach second-clones-checkout; wait_for first-clones-checkout ;;
+esac
+exec ${quote(Bun.which("git", { PATH: gitEnv.PATH })!)} "$@"
+`,
+      { mode: 0o755 },
+    );
+
+    const repoUrl = `git+${pathToFileURL(sharedBare)}`;
+    const { resolutions, locked } = expectedGitPackages(repoUrl, sharedCommits, ["c"]);
+    const cache = join(root, "cache");
+    const installs = ["first", "second"].map(async which => {
+      const project = writeProject(join(root, which), { [nameOf("c")]: `${repoUrl}#pkg-c` });
+      const result = await runInstall(project, cache, { INSTALL: which, PATH: `${bin}:${gitEnv.PATH}` });
+      return { project, ...result };
+    });
+
+    for (const { project, stdout, stderr, exitCode } of await Promise.all(installs)) {
+      expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+        "Resolving dependencies
+        Resolved, downloaded and extracted [2]
+        Saved lockfile"
+      `);
+      expectInstalled(stdout, resolutions);
+      expect(await installedVersions(project, [nameOf("c")])).toEqual(markers(["c"]));
+      expect(await lockedPackages(project)).toEqual(locked);
+      expect(exitCode).toBe(0);
+    }
+    // The installs met at every step, and the cache holds one bare clone and
+    // one checkout: an install that lost removed the folder it had built.
+    expect(readdirSync(steps).sort()).toEqual([
+      "first-clones-checkout",
+      "first-runs-log",
+      "second-clones-bare",
+      "second-clones-checkout",
+      "second-runs-log",
+    ]);
+    expect(
+      readdirSync(cache)
+        .map(name => name.replace(/^[0-9a-f]{16}(?=\.git$)/, "<clone id>"))
+        .sort(),
+    ).toEqual(["<clone id>.git", `@G@${sharedCommits["pkg-c"]}`]);
+  },
+  30_000,
+);
+
+// The same race on Windows, where a script cannot stand in for git, so nothing
+// orders the installs. There the install that lost deleted the published
+// folder by its name, and three of four installs failed, with "fatal:
+// 'C:\$Extend\$Deleted\<id>' does not appear to be a git repository" or
+// "moving <name> to cache dir failed: ENOTEMPTY".
+test.concurrent.skipIf(!isWindows)(
+  "installs that share a cold cache and a git dependency all succeed",
+  async () => {
+    using dir = tempDir("git-dep-shared-cache", {});
+    const root = String(dir);
+    // An install that starts late finds the bare clone and runs `git fetch`
+    // in it, which needs a HEAD that names a branch.
+    const bare = await makeSharedRepo(root, [{ name: nameOf("e"), branch: "pkg-e" }], "race-repo.git");
+    await git(bare, "symbolic-ref", "HEAD", "refs/heads/pkg-e");
+    const repoUrl = `git+${pathToFileURL(bare)}`;
+    const { resolutions } = expectedGitPackages(repoUrl, branchCommits(bare), ["e"]);
+
+    for (let round = 0; round < 2; round++) {
+      const cache = join(root, `cache-${round}`);
+      const installs = [0, 1, 2, 3].map(async i => {
+        const project = writeProject(join(root, `round-${round}`, `${i}`), { [nameOf("e")]: `${repoUrl}#pkg-e` });
+        return { project, ...(await runInstall(project, cache, {})) };
+      });
+      for (const { project, stdout, stderr, exitCode } of await Promise.all(installs)) {
+        expect(stderr.split(/\r?\n/).filter(line => /error|fatal/.test(line))).toEqual([]);
+        expectInstalled(stdout, resolutions);
+        expect(await installedVersions(project, [nameOf("e")])).toEqual(markers(["e"]));
+        expect(exitCode).toBe(0);
+      }
+      expect(readdirSync(cache).filter(name => name.endsWith(".tmp"))).toEqual([]);
+    }
+  },
+  30_000,
+);
+
+// Only a folder with `.bun-tag` is a complete checkout. A folder without it
+// (what a killed install of an older version left) is replaced, and so is a
+// link to one. What the link points to is left alone.
+test.concurrent.each(["folder", "link"] as const)(
+  "replaces a %s that has the cache name of a git checkout and no .bun-tag",
+  async kind => {
+    using dir = tempDir(`git-dep-untagged-${kind}`, {});
+    const root = String(dir);
+    const repoUrl = `git+${pathToFileURL(sharedBare)}`;
+    const project = writeProject(root, { [nameOf("d")]: `${repoUrl}#pkg-d` });
+    const { resolutions, locked } = expectedGitPackages(repoUrl, sharedCommits, ["d"]);
+    const cache = join(root, "cache");
+    const checkout = join(cache, `@G@${sharedCommits["pkg-d"]}`);
+    const untagged = kind === "link" ? join(root, "elsewhere") : checkout;
+    mkdirSync(join(untagged, "lib"), { recursive: true });
+    writeFileSync(join(untagged, "package.json"), JSON.stringify({ name: nameOf("d"), version: "0.0.0-untagged" }));
+    writeFileSync(join(untagged, "lib", "untagged.js"), "");
+    if (kind === "link") {
+      mkdirSync(cache);
+      symlinkSync(untagged, checkout, "junction");
+    }
+
+    const { stdout, stderr, exitCode } = await runInstall(project, cache, {});
+    expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
+      "Resolving dependencies
+      Resolved, downloaded and extracted [2]
+      Saved lockfile"
+    `);
+    expectInstalled(stdout, resolutions);
+    expect(await installedVersions(project, [nameOf("d")])).toEqual(markers(["d"]));
+    expect(await lockedPackages(project)).toEqual(locked);
+    expect(lstatSync(checkout).isDirectory()).toBe(true);
+    expect(readdirSync(checkout).sort()).toEqual([".bun-tag", "index.js", "package.json"]);
+    if (kind === "link")
+      expect(readdirSync(untagged, { recursive: true }).sort()).toEqual([
+        "lib",
+        join("lib", "untagged.js"),
+        "package.json",
+      ]);
+    expect(readdirSync(cache).filter(name => name.endsWith(".tmp"))).toEqual([]);
+    expect(exitCode).toBe(0);
+  },
+);
+
 // issue #40803: `bun install <git url>` (no alias) sorted the workspace dep
 // under its version literal. The real name is only known once the repo is
 // fetched; it is rewritten in place after resolution, so the written key
@@ -636,7 +796,6 @@ test.concurrent.skipIf(isWindows)(
     const running = join(root, "git-running");
     const exited = join(root, "git-exited");
     const gotSigint = join(root, "git-got-sigint");
-    const quote = (path: string) => `'${path.replaceAll("'", "'\\''")}'`;
     const lineCount = (file: string) => (existsSync(file) ? readFileSync(file, "utf8").split("\n").length - 1 : 0);
     // A fake git. Each process appends a line to `running` when it starts, to
     // `exited` when it ends, and blocks until the test deletes `running`. A


### PR DESCRIPTION
Overlap: #33979 also fixes this race, with a `keep_existing_destination` option on the shared rename helper, as part of a larger change to the tarball and patch arms. `CacheStaging::publish` needs only one of the two. The Notes compare them.

### Problem

- Two `bun install` runs share a cold cache and one git dependency. The install that publishes its cache folder second breaks the first: `fatal: repository '<cache>/.<id>.tmp (deleted)' does not exist`, then `error: "git clone" for "<name>" failed`. On Windows: `fatal: 'C:\$Extend\$Deleted\<id>' does not appear to be a git repository`.
- `CacheStaging::publish` (`src/install/git_runner.rs:301`) called `renameat_concurrently_a`, then `discard()`. When the name is taken, that helper swaps the two folders (`RENAME_EXCHANGE`). `discard()` then deleted the folder that the first install still used. On Windows the helper deletes that folder by name.

### Fix

- `publish` uses a plain `rename`, which never replaces a folder that has entries.
- If the rename fails, `publish` opens what has the name. It returns a complete folder (any bare clone, a checkout with `.bun-tag`) and deletes its own staging folder.
- A checkout folder without `.bun-tag` is still replaced: emptied through its own handle, then `rmdir`. Neither step can remove a published folder.
- Verified: `test/cli/install/bun-install-git-deps.test.ts` (the unfixed build fails the race test on every run). Also the git tests of `bun-install`, `bun-add`, `bun-patch`. Linux and Windows.

### Background

- A git dependency has two cache folders: a bare clone `<id>.git` and one checkout per commit, `@G@<sha>`.
- Since #38269 each is built under a temporary name (`CacheStaging`) and renamed when complete. "Publish" is that rename.
- `.bun-tag` is written last in a checkout, so it marks a complete one.

<details><summary>Notes</summary>

**Relation to #33979.** Both PRs stop `publish` from removing a folder that another install published.
- #33979 adds `keep_existing_destination` to `RenameatConcurrentlyOptions` and sets it in `publish`. With it the helper deletes the source when the destination exists. The helper still tries `renameat2` first. For a filesystem where the flags fail with `EINVAL`, a patch proposed there (53e5ab3) makes a plain `rename` the arbiter, which is the primitive used here. An untagged checkout folder is deleted by name in `begin_checkout`, before the clone. A comment there reports 64 of 160 failed installs on main and 0 of 160 with #33979 (4 cold concurrent installs of one git dependency).
- This PR does not call the helper. `publish` renames with `renameat`, looks at what has the name only when the rename fails, and removes an untagged folder through its own handle at that point.
- If #33979 lands first, what is left of this PR is the tests (the ordered race test, the Windows test, the link test) and the removal by handle. If this PR lands first, #33979 can drop its `git_runner.rs` hunk.

**Numbers.** One script, cold cache each round, `git+file://` dependency, no network.

| build | installs per round | failed installs |
| --- | --- | --- |
| Linux release 1.4.3-canary.1+b99371011 | 4 | 68 of 160 |
| Linux debug, without the fix | 4 | 42 of 160 |
| Linux debug, with the fix | 4 | 0 of 160 |
| Linux debug, without the fix | 2 | 12 of 50 |
| Linux debug, with the fix | 2 | 0 of 50 |
| Linux release, `renameat2` flags forced to `EINVAL` | 4 | 67 of 120 |
| Linux debug, with the fix, same `EINVAL` | 4 | 0 of 120 |
| Windows release 1.4.3-canary.1+09bb54630 | 4 | 30 of 40 |
| Windows debug, with the fix | 4 and 6 | 0 of 270 |

The `EINVAL` rows use an `LD_PRELOAD` shim that fails `renameat2` when flags are set, like a filesystem that has no support for them. There the old code went to the `delete_tree(<cache name>)` plus `rename` fallback of the helper (`moving "gdep" to cache dir failed: ENOTEMPTY`). The new `publish` never calls `renameat2`.

**Mechanism, per platform.** On Linux and macOS the loser ran `renameat2(RENAME_NOREPLACE)` (`EEXIST`), then `renameat2(RENAME_EXCHANGE)`, then `delete_tree(<its tmp name>)`. The winner holds the bare clone by fd (`repo_dir`) and `begin_checkout` turns that fd back into a path for `git clone --no-checkout`, hence the `(deleted)` suffix. The same swap on the checkout folder gives `ENOENT: failed copying files from cache to destination`. On Windows `renameat2` ignores the flags, so the loser went straight to `delete_tree(<cache name>)` plus `rename`.

**Tests.**
- `an install keeps the git cache folders that another install published first` (POSIX). A script named `git` comes first in `PATH` and orders the two installs. The second install finishes its bare clone only when the first has published its own and runs `git log` in it. That `git log` goes on only when the second install has published too. Both then clone the checkout before either publishes one. The unfixed build fails it on every run (8 of 8 release, also debug). The fixed debug build passed the whole file 30 of 30 times.
- `installs that share a cold cache and a git dependency all succeed` (Windows only, a script cannot stand in for `git` there). Four installs, two rounds, nothing orders them. Canary fails it 3 of 3, the fixed build passed the file 12 of 12.
- `replaces a folder / a link that has the cache name of a git checkout and no .bun-tag`. These pass on the unfixed build too. They pin the replace path that this PR rewrites. Without `O_NOFOLLOW` the link case fails, because the folder that the link points to is emptied.

**What `rename` does.** `commit_global_store_entry` (isolated installs, `src/install/isolated_install/Installer.rs`) already publishes with a plain `rename` and keeps the folder of the install that renamed first. POSIX `rename` of a directory onto a directory that has entries fails with `ENOTEMPTY` or `EEXIST`. It replaces an empty directory. Windows (`FileRenameInformationEx`) reports `ENOTEMPTY` too, as the Windows numbers above show. So no `RENAME_NOREPLACE` is needed, and a filesystem that has no `renameat2` flags behaves the same.

**Not in this PR.**
- The tarball and patch arms (`extract_tarball.rs`, `patch_install.rs`, `patchPackage.rs`) call the same helper. They leak the swapped folder and do not delete it, so the winner keeps working. #33884, #38702 and #33979 change those arms. #41579 adds a `delete_tree` of the temporary name after the exchange on the tarball arm, which is the shape that this PR removes from the git arm.
- An older bun that runs at the same time still exchanges and deletes.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-install-git-deps.test.ts

<!-- robobun:evidence:end -->